### PR TITLE
Add non-zero exit to CLI response failures

### DIFF
--- a/fidesctl/src/fidesctl/cli/utils.py
+++ b/fidesctl/src/fidesctl/cli/utils.py
@@ -1,6 +1,7 @@
 """Contains reusable utils for the CLI commands."""
 import json
 import os
+import sys
 from typing import Dict, Callable
 
 import click
@@ -18,14 +19,15 @@ def pretty_echo(dict_object: Dict, color: str = "white") -> None:
 
 def handle_cli_response(response: requests.Response) -> requests.Response:
     """Viewable CLI response"""
-    if response.status_code == 200:
+    if response.status_code >= 200 and response.status_code <= 299:
         pretty_echo(response.json(), "green")
     else:
         try:
             pretty_echo(response.json(), "red")
-            raise SystemExit
         except json.JSONDecodeError:
             click.secho(response.text, fg="red")
+        finally:
+            sys.exit(1)
     return response
 
 


### PR DESCRIPTION
Closes #23 

* update the `handle_cli_response` function to have a non-zero exit if the response status code is `>= 200 and <= 299`