### PR TITLE
Fix psycopg2 binary dependency

### DIFF
--- a/fidesctl/Dockerfile
+++ b/fidesctl/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.8-slim-buster
 
 # Install auxiliary software
 RUN apt-get update
-    
 RUN apt-get install -y \
     git \
     ipython \


### PR DESCRIPTION
Closes #100 

### Code Changes

* [x] install libpq-dev and gcc, see - https://pypi.org/project/libpq-dev/

### Steps to Confirm

* [x] tested  `make compose-build` command

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated

### Description Of Changes

It's not clear why this happened specifically on my setup but having libpq-dev will make sure that we have the binaries we need for psycopg2.
