### PR TITLE
minor editing to align fidesctl documented commands to actual commands

### DIFF
--- a/docs/fides/docs/cli.md
+++ b/docs/fides/docs/cli.md
@@ -10,10 +10,10 @@ This is a non-exhaustive list of available Fidesctl CLI commands:
 
 * `fidesctl apply <manifest_dir> [--dry] [--diff]` - Creates or Updates resources found within the YAML file(s) at the specified path.
 * `fidesctl evaluate [-k,--fides-key] [-m, --message] [--dry]` - Runs an evaluation of all policies, but a single policy can be specified using the `--fides-key` parameter.
-* `fidesctl initdb` - Sets up the database by running all missing migrations.
+* `fidesctl init-db` - Sets up the database by running all missing migrations.
 * `fidesctl get <resource_type> <fides_key>` - Looks up a specific resource on the server by its type and `fides_key`.
 * `fidesctl ls <resource_type>` - Shows a list of all resources of a certain type that exist on the server.
 * `fidesctl ping` - Pings the API's healthcheck endpoint to make sure that it is reachable and ready for requests.
-* `fidesctl resetdb` - Tears down the database, erasing all data.
+* `fidesctl reset-db` - Tears down the database, erasing all data.
 * `fidesctl version` - Shows the version of Fides that is installed.
 * `fidesctl view-config`- Show a JSON representation of the config that Fidesctl is using.


### PR DESCRIPTION
Closes _greg.swanson: hard-skills assessment. Job interview_

### Code Changes

* [x] `fidesctl initdb` typo. Should be `fidesctl init-db`
* [x] `fidesctl resetdb` typo. Should be `fidesctl reset-db`

### Steps to Confirm

* [x] did a compare of the actual `fidesctl` output to what was doc'd in the README

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded. _NA_
* [x] Documentation Updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_

To do a skills assessment on the cli docs, I needed to run through the setup/tutorial. Here' my feedback: 

## Section: *Getting Started with Fidesctl in Docker* ##

**make cli** the good! 
1. awesome that the setup is dockerized
2. no concerns with anything related to versioning here
3. makes sense this is preferred setup path

**make cli** the bad!  
1. `make cli` failed repeatedly. finally googled & set "docker buildx install" to resolve (macBigSur/docker 20.10.7)
2. `make init-db` was listed before `make cli`. not sure why.. `make cli` builds the db **as part of** total build 

## Section: *Tutorial* ##
   
**the good!**
nothing. whole thing needs to be refactored. 

**the bad**

1. the supplied yaml files just don’t work. The errors on `fidesctl apply fides_resources` do not reference which file is failing. Error messages are of little help here. This is the best error I got after fiddling: `pydantic.error_wrappers.ValidationError: 8 validation errors for Policy
 rules -> 0 -> data_categories`

2. it’s not clear to me why the images are not built with the policy.yml and system.yml file **in the image**!! `make cli` should add a step to include `fidesctl apply fides_resources` as part of the criteria for build success. Once that is done, the user has access to full suite of documented `fidesctl` commands. In its current state, only the following 4 documented CLI commands work: 

`fidesctl ls` `fidesctl ping` `fidesctl version` `fidesctl view-config`

## Recap & Final Thoughts: ##

The CLI docs are actually quite nice. The doco on the tutorial assumes a working docker setup, and that does not exist. So to evaluate and submit a substantive PR isn't exactly what you got. You can just merge this and fix a couple typos :) 


