### PR TITLE
Run migrations on API initialization, add `/admin/db/{action}` endpoints

### DIFF
--- a/docs/fides/docs/api/index.md
+++ b/docs/fides/docs/api/index.md
@@ -14,17 +14,19 @@ The `fidesctl` API is almost completely programmatic, so it's easier to grasp th
 
 * Except for the `DELETE`, the endpoints accept and/or return JSON objects that represent the named resource. The structure of these objects is given in the [Fides Language: Resources chapter](/language/resources/organization/) -- it's the same structure that's used in the resource manifest files.
 
-That's about all there is to it. There are an additional four endpoints that we'll look at below, but the sets of quintuplet endpoints listed above make up the core of the `fidesctl` API.
+That's about all there is to it. There are an additional six endpoints that we'll look at below, but the sets of quintuplet endpoints listed above make up the core of the `fidesctl` API.
 
-After a brief review of the four addition endpoints, we'll provide a complete API reference followed by a set of cURL calls that you can use to exercise the API on your system.
+After a brief review of the six additional endpoints, we'll provide a complete API reference followed by a set of cURL calls that you can use to exercise the API on your system.
 
 ## Other endpoints
 
-The four additional endpoints are:
+The six additional endpoints are:
 
 * `GET /health` pings the API server to see if it's up and running. The call returns `200` if it's up and ready to receive messages, and `404` if not.
 
 * Three of the taxonomic resources, `/data_category`, `/data_use`, and `/data_qualifier` (but  _not_ `/data_subject`) define a `GET /resource_type/visualize/{figure_type}` endpoint that returns a graph of the resource's taxonomy.  For details, see the **API Reference**, below.
+
+* `POST admin/db/init` and `POST admin/db/reset` reinitialize the database and reset the database, respectfully. They also repopulate the database with the default fideslang taxonomy.
 
 ## API Reference
 

--- a/docs/fides/docs/getting_started/docker.md
+++ b/docs/fides/docs/getting_started/docker.md
@@ -29,14 +29,6 @@ The following commands should all be run from the top-level `fides` directory (w
     root@1a742083cedf:/fides/fidesctl#
     ```
 
-1. `fidesctl init-db` -> Builds the required images, spins up the database, and runs the initialization scripts:
-
-    ```bash
-    ~/git/fides% fidesctl init-db
-    INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
-    INFO  [alembic.runtime.migration] Will assume transactional DDL.
-    ```
-
 1. `fidesctl ping` -> This confirms that your `fidesctl` CLI can reach the server and everything is ready to go!
 
     ```bash
@@ -49,4 +41,4 @@ The following commands should all be run from the top-level `fides` directory (w
 
 Now that you're up and running, you can use `fidesctl` from the shell to get a list of all the possible CLI commands. You're now ready to start enforcing privacy with Fidesctl!
 
-See the [Tutorial](../tutorial/overview.md) page for a step-by-step guide on setting up a Fidesctl data privacy workflow.
+See the [Tutorial](../tutorial/index.md) page for a step-by-step guide on setting up a Fidesctl data privacy workflow.

--- a/fidesctl/Dockerfile
+++ b/fidesctl/Dockerfile
@@ -24,4 +24,7 @@ COPY . /fides/fidesctl
 WORKDIR /fides/fidesctl
 RUN pip install -e ".[all]"
 
+# Immediately flush to stdout, globally
+ENV PYTHONUNBUFFERED=TRUE
+
 CMD ["/bin/bash"]

--- a/fidesctl/src/fidesapi/crud.py
+++ b/fidesctl/src/fidesapi/crud.py
@@ -79,7 +79,7 @@ def update_resource(sql_model: SqlAlchemyBase, resource_dict: Dict, fides_key: s
 
 def upsert_resources(sql_model: SqlAlchemyBase, resource_dicts: List[Dict]) -> None:
     """
-    Insert a new resource into the database. If the resource already exists,
+    Insert new resources into the database. If a resource already exists,
     update it by it's fides_key.
     """
     session = db_session.create_session()

--- a/fidesctl/src/fidesapi/database.py
+++ b/fidesctl/src/fidesapi/database.py
@@ -44,7 +44,7 @@ def init_db(database_url: str) -> None:
 def load_default_taxonomy() -> None:
     "Upserts the default taxonomy into the database."
     print("UPSERTING the default fideslang taxonomy")
-    for resource_type in DEFAULT_TAXONOMY.__fields_set__:
+    for resource_type in list(DEFAULT_TAXONOMY.__fields_set__):
         print("-" * 10)
         print(f"Processing {resource_type} resources...")
         resources = list(map(dict, dict(DEFAULT_TAXONOMY)[resource_type]))

--- a/fidesctl/src/fidesapi/database.py
+++ b/fidesctl/src/fidesapi/database.py
@@ -7,11 +7,10 @@ from alembic import command
 from alembic.config import Config
 from alembic.migration import MigrationContext
 
-from fidesapi.sql_models import SqlAlchemyBase
-from fidesctl.core.apply import apply
-from fidesctl.core.config import FidesctlConfig
-from fidesctl.core.utils import get_db_engine
+from fidesapi.sql_models import sql_model_map, SqlAlchemyBase
+from fidesapi.crud import upsert_resources
 from fideslang import DEFAULT_TAXONOMY
+from fidesctl.core.utils import get_db_engine
 
 
 def get_alembic_config(database_url: str) -> Config:
@@ -33,23 +32,25 @@ def upgrade_db(alembic_config: Config, revision: str = "head") -> None:
     command.upgrade(alembic_config, revision)
 
 
-def init_db(database_url: str, fidesctl_config: FidesctlConfig) -> None:
+def init_db(database_url: str) -> None:
     """
     Runs the migrations and creates all of the database objects.
     """
     alembic_config = get_alembic_config(database_url)
     upgrade_db(alembic_config)
-    load_default_taxonomy(fidesctl_config)
+    load_default_taxonomy()
 
 
-def load_default_taxonomy(fidesctl_config: FidesctlConfig) -> None:
-    "Loads the default taxonomy into the database."
-    config = fidesctl_config
-    apply(
-        url=config.cli.server_url,
-        taxonomy=DEFAULT_TAXONOMY,
-        headers=config.user.request_headers,
-    )
+def load_default_taxonomy() -> None:
+    "Upserts the default taxonomy into the database."
+    print("UPSERTING the default fideslang taxonomy")
+    for resource_type in DEFAULT_TAXONOMY.__fields_set__:
+        print("-" * 10)
+        print(f"Processing {resource_type} resources...")
+        resources = list(map(dict, dict(DEFAULT_TAXONOMY)[resource_type]))
+        upsert_resources(sql_model_map[resource_type], resources)
+        print(f"UPSERTED {len(resources)} {resource_type} resources.")
+    print("-" * 10)
 
 
 def reset_db(database_url: str) -> None:

--- a/fidesctl/src/fidesapi/main.py
+++ b/fidesctl/src/fidesapi/main.py
@@ -33,6 +33,15 @@ async def health() -> Dict:
     "Confirm that the API is running and healthy."
     return {"data": {"message": "Fides service is healthy!"}}
 
+@app.post("/admin/init-db", tags=["Admin"])
+async def init_db(database_url: str) -> Dict:
+    """
+    Connect to the database, run any outstanding migrations,
+    and load the default taxonomy.
+    """
+    configure_db(database_url)
+    return {"data": {"message": "Fides database initialized"}}
+
 
 def start_webserver() -> None:
     "Run the webserver."

--- a/fidesctl/src/fidesapi/main.py
+++ b/fidesctl/src/fidesapi/main.py
@@ -33,14 +33,19 @@ async def health() -> Dict:
     "Confirm that the API is running and healthy."
     return {"data": {"message": "Fides service is healthy!"}}
 
-@app.post("/admin/init-db", tags=["Admin"])
-async def init_db(database_url: str) -> Dict:
+
+@app.post("/admin/db/{action}", tags=["Admin"])
+async def db_action(action: str, database_url: str) -> Dict:
     """
-    Connect to the database, run any outstanding migrations,
-    and load the default taxonomy.
+    Initiate either the init_db or reset_db action.
     """
+    action_text = "initialized"
+    if action == "reset":
+        database.reset_db(database_url)
+        action_text = action
+
     configure_db(database_url)
-    return {"data": {"message": "Fides database initialized"}}
+    return {"data": {"message": f"Fides database {action_text}"}}
 
 
 def start_webserver() -> None:

--- a/fidesctl/src/fidesapi/main.py
+++ b/fidesctl/src/fidesapi/main.py
@@ -22,10 +22,10 @@ def configure_routes() -> None:
         app.include_router(router)
 
 
-def configure_db(database_url: str) -> None:
+def configure_db() -> None:
     "Set up the db to be used by the app."
-    db_session.global_init(database_url)
-    database.init_db(database_url)
+    db_session.global_init(config.api.database_url)
+    database.init_db(config.api.database_url)
 
 
 @app.get("/health", tags=["Health"])
@@ -35,16 +35,16 @@ async def health() -> Dict:
 
 
 @app.post("/admin/db/{action}", tags=["Admin"])
-async def db_action(action: str, database_url: str) -> Dict:
+async def db_action(action: str) -> Dict:
     """
     Initiate either the init_db or reset_db action.
     """
     action_text = "initialized"
     if action == "reset":
-        database.reset_db(database_url)
+        database.reset_db(config.api.database_url)
         action_text = action
 
-    configure_db(database_url)
+    configure_db()
     return {"data": {"message": f"Fides database {action_text}"}}
 
 
@@ -55,4 +55,4 @@ def start_webserver() -> None:
 
 config = get_config()
 configure_routes()
-configure_db(config.api.database_url)
+configure_db()

--- a/fidesctl/src/fidesapi/main.py
+++ b/fidesctl/src/fidesapi/main.py
@@ -7,7 +7,7 @@ from typing import Dict
 import uvicorn
 from fastapi import FastAPI
 
-from fidesapi import crud, db_session, visualize
+from fidesapi import crud, database, db_session, visualize
 from fidesctl.core.config import get_config
 
 app = FastAPI(title="fidesctl")
@@ -25,6 +25,7 @@ def configure_routes() -> None:
 def configure_db(database_url: str) -> None:
     "Set up the db to be used by the app."
     db_session.global_init(database_url)
+    database.init_db(database_url)
 
 
 @app.get("/health", tags=["Health"])

--- a/fidesctl/src/fidesapi/main.py
+++ b/fidesctl/src/fidesapi/main.py
@@ -43,7 +43,7 @@ async def health() -> Dict:
 @app.post("/admin/db/{action}", tags=["Admin"])
 async def db_action(action: DBActions) -> Dict:
     """
-    Initiate either the init_db or reset_db action.
+    Initiate one of the enumerated DBActions.
     """
     action_text = "initialized"
     if action == DBActions.reset:

--- a/fidesctl/src/fidesapi/main.py
+++ b/fidesctl/src/fidesapi/main.py
@@ -37,7 +37,7 @@ def configure_db() -> None:
 @app.get("/health", tags=["Health"])
 async def health() -> Dict:
     "Confirm that the API is running and healthy."
-    return {"data": {"message": "Fides service is healthy!"}}
+    return {"data": {"message": "Fidesctl service is healthy!"}}
 
 
 @app.post("/admin/db/{action}", tags=["Admin"])
@@ -51,7 +51,7 @@ async def db_action(action: DBActions) -> Dict:
         action_text = DBActions.reset
 
     configure_db()
-    return {"data": {"message": f"Fides database {action_text}"}}
+    return {"data": {"message": f"Fidesctl database {action_text}"}}
 
 
 def start_webserver() -> None:

--- a/fidesctl/src/fidesapi/main.py
+++ b/fidesctl/src/fidesapi/main.py
@@ -2,15 +2,21 @@
 Contains the code that sets up the API.
 """
 
+from enum import Enum
 from typing import Dict
 
 import uvicorn
 from fastapi import FastAPI
-
 from fidesapi import crud, database, db_session, visualize
 from fidesctl.core.config import get_config
 
 app = FastAPI(title="fidesctl")
+
+
+class DBActions(str, Enum):
+    "The available path parameters for the `/admin/db/{action}` endpoint."
+    init = "init"
+    reset = "reset"
 
 
 def configure_routes() -> None:
@@ -35,14 +41,14 @@ async def health() -> Dict:
 
 
 @app.post("/admin/db/{action}", tags=["Admin"])
-async def db_action(action: str) -> Dict:
+async def db_action(action: DBActions) -> Dict:
     """
     Initiate either the init_db or reset_db action.
     """
     action_text = "initialized"
-    if action == "reset":
+    if action == DBActions.reset:
         database.reset_db(config.api.database_url)
-        action_text = action
+        action_text = DBActions.reset
 
     configure_db()
     return {"data": {"message": f"Fides database {action_text}"}}

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -217,8 +217,7 @@ def init_db(ctx: click.Context) -> None:
 
     """
     config = ctx.obj["CONFIG"]
-    init_url = config.cli.server_url + "/admin/db/init"
-    handle_cli_response(_api.db_action(init_url, config.api.database_url))
+    handle_cli_response(_api.db_action(config.cli.server_url, "init"))
 
 
 @click.command()
@@ -287,7 +286,6 @@ def reset_db(ctx: click.Context, yes: bool) -> None:
 
     """
     config = ctx.obj["CONFIG"]
-    database_url = config.api.database_url
     if yes:
         are_you_sure = "y"
     else:
@@ -297,8 +295,7 @@ def reset_db(ctx: click.Context, yes: bool) -> None:
         are_you_sure = input("Are you sure [y/n]? ")
 
     if are_you_sure.lower() == "y":
-        reset_url = config.cli.server_url + "/admin/db/reset"
-        handle_cli_response(_api.db_action(reset_url, database_url))
+        handle_cli_response(_api.db_action(config.cli.server_url, "reset"))
     else:
         print("Aborting!")
 

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -218,7 +218,8 @@ def init_db(ctx: click.Context) -> None:
 
     """
     config = ctx.obj["CONFIG"]
-    database.init_db(config.api.database_url, fidesctl_config=config)
+    init_url = config.cli.server_url + "/admin/init-db"
+    handle_cli_response(_api.init_db(init_url, config.api.database_url))
 
 
 @click.command()
@@ -296,7 +297,7 @@ def reset_db(ctx: click.Context, yes: bool) -> None:
 
     if are_you_sure.lower() == "y":
         database.reset_db(database_url)
-        database.init_db(database_url, config)
+        ctx.invoke(init_db)
         echo_green("Database reset!")
     else:
         print("Aborting!")

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -3,7 +3,6 @@ import pprint
 
 import click
 
-from fidesapi import database
 from fidesctl.cli.options import (
     dry_flag,
     fides_key_argument,
@@ -218,8 +217,8 @@ def init_db(ctx: click.Context) -> None:
 
     """
     config = ctx.obj["CONFIG"]
-    init_url = config.cli.server_url + "/admin/init-db"
-    handle_cli_response(_api.init_db(init_url, config.api.database_url))
+    init_url = config.cli.server_url + "/admin/db/init"
+    handle_cli_response(_api.db_action(init_url, config.api.database_url))
 
 
 @click.command()
@@ -292,13 +291,14 @@ def reset_db(ctx: click.Context, yes: bool) -> None:
     if yes:
         are_you_sure = "y"
     else:
-        echo_red("This will drop all data from the Fides database!")
-        are_you_sure = input("Are you sure [y/n]?")
+        echo_red(
+            "This will drop all data from the Fides database and reload the default taxonomy!"
+        )
+        are_you_sure = input("Are you sure [y/n]? ")
 
     if are_you_sure.lower() == "y":
-        database.reset_db(database_url)
-        ctx.invoke(init_db)
-        echo_green("Database reset!")
+        reset_url = config.cli.server_url + "/admin/db/reset"
+        handle_cli_response(_api.db_action(reset_url, database_url))
     else:
         print("Aborting!")
 

--- a/fidesctl/src/fidesctl/core/api.py
+++ b/fidesctl/src/fidesctl/core/api.py
@@ -99,3 +99,10 @@ def evaluate(
     resource_url = generate_resource_url(url, resource_type)
     url = f"{resource_url}evaluate/{fides_key}"
     return requests.get(url, headers=headers, params={"tag": tag, "message": message})
+
+
+def init_db(url: str, database_url: str) -> requests.Response:
+    """
+    Initialize the fides database.
+    """
+    return requests.post(url, params={"database_url": database_url})

--- a/fidesctl/src/fidesctl/core/api.py
+++ b/fidesctl/src/fidesctl/core/api.py
@@ -101,7 +101,7 @@ def evaluate(
     return requests.get(url, headers=headers, params={"tag": tag, "message": message})
 
 
-def init_db(url: str, database_url: str) -> requests.Response:
+def db_action(url: str, database_url: str) -> requests.Response:
     """
     Initialize the fides database.
     """

--- a/fidesctl/src/fidesctl/core/api.py
+++ b/fidesctl/src/fidesctl/core/api.py
@@ -103,6 +103,6 @@ def evaluate(
 
 def db_action(server_url: str, action: str) -> requests.Response:
     """
-    Initialize or reset the fides database.
+    Tell the API to perform a database action.
     """
     return requests.post(f"{server_url}/admin/db/{action}")

--- a/fidesctl/src/fidesctl/core/api.py
+++ b/fidesctl/src/fidesctl/core/api.py
@@ -101,8 +101,8 @@ def evaluate(
     return requests.get(url, headers=headers, params={"tag": tag, "message": message})
 
 
-def db_action(url: str, database_url: str) -> requests.Response:
+def db_action(server_url: str, action: str) -> requests.Response:
     """
-    Initialize the fides database.
+    Initialize or reset the fides database.
     """
-    return requests.post(url, params={"database_url": database_url})
+    return requests.post(f"{server_url}/admin/db/{action}")

--- a/fidesctl/tests/conftest.py
+++ b/fidesctl/tests/conftest.py
@@ -27,7 +27,7 @@ def setup_db(test_config):
     "Sets up the database for testing."
     database_url = test_config.api.database_url
     database.reset_db(database_url)
-    database.init_db(database_url, test_config)
+    database.init_db(database_url)
     yield
 
 

--- a/fidesctl/tests/conftest.py
+++ b/fidesctl/tests/conftest.py
@@ -6,8 +6,8 @@ import pytest
 import yaml
 
 from fideslang import models
-from fidesapi.main import db_action
 from fidesctl.core.config import get_config
+from fidesctl.core import api
 
 TEST_CONFIG_PATH = "tests/test_config.toml"
 
@@ -25,9 +25,7 @@ def test_config(test_config_path):
 @pytest.fixture(scope="session", autouse=True)
 def setup_db(test_config):
     "Sets up the database for testing."
-    database_url = test_config.api.database_url
-    db_action("reset", database_url)
-    yield
+    yield api.db_action(test_config.cli.server_url, "reset")
 
 
 @pytest.fixture(scope="session")

--- a/fidesctl/tests/conftest.py
+++ b/fidesctl/tests/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures to be used across tests."""
 from typing import Any, Dict
 
+import os
 import pytest
 import yaml
-import os
 
 from fideslang import models
+from fidesapi.main import db_action
 from fidesctl.core.config import get_config
-from fidesapi import database
 
 TEST_CONFIG_PATH = "tests/test_config.toml"
 
@@ -26,15 +26,14 @@ def test_config(test_config_path):
 def setup_db(test_config):
     "Sets up the database for testing."
     database_url = test_config.api.database_url
-    database.reset_db(database_url)
-    database.init_db(database_url)
+    db_action("reset", database_url)
     yield
 
 
 @pytest.fixture(scope="session")
 def resources_dict():
     """
-    Yields an resource containing sample representations of different
+    Yields a resource containing sample representations of different
     Fides resources.
     """
     resources_dict: Dict[str, Any] = {


### PR DESCRIPTION
Closes #202
Closes #204

### Code Changes

* [x] Automatically load the default taxonomy on API initialization
* [x] Update `fidesctl init-db` to be an API call
* [x] Update `fidesctl reset-db` to be an API call

### Steps to Confirm

* [x] `make cli` runs without errors
* [x] No errors printed to container logs
* [x] Manually run `fidesctl init-db`
* [x] Manually run `fidesctl reset-db`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

- The two endpoints added to the API are `/admin/db/{action}` where `action` may be either `init` or `reset`
- As a security best practice, and before this is merged, the `database_url` value should be passed from the CLI to the API via `POST` body, _not_ via query param (as it is at the time of opening this PR).