### PR TITLE
Skip invalid manifest files

### DIFF
--- a/fidesctl/src/fideslang/manifests.py
+++ b/fidesctl/src/fideslang/manifests.py
@@ -4,6 +4,7 @@ from functools import reduce
 from typing import Dict, List, Set, Union
 
 import yaml
+from fidesctl.core.utils import echo_red
 
 
 def write_manifest(
@@ -26,7 +27,12 @@ def load_yaml_into_dict(file_path: str) -> Dict:
     This loads yaml files into a dictionary to be used in API calls.
     """
     with open(file_path, "r") as yaml_file:
-        return yaml.load(yaml_file, Loader=yaml.FullLoader)
+        loaded = yaml.safe_load(yaml_file)
+        if isinstance(loaded, dict):
+            return loaded
+
+    echo_red(f"Failed to parse invalid manifest: {file_path.split('/')[-1]}. Skipping.")
+    return {}
 
 
 def filter_manifest_by_type(


### PR DESCRIPTION
Closes #169 

### Code Changes

* [x] `load_yaml_into_dict` always returns a `dict`
* [x] Log the name of skipped invalid manifest files

### Steps to Confirm

* [x] Create an invalid manifest file
* [x] Place the file in the `demo_resources/` dir
* [x] Run `fidesctl evaluate demo_resources/`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

Type-checking missed that the `yaml.load`/`yaml.safe_load` functions return `Any` type, but downstream code always expects a `Dict`.
