### PR TITLE
Add a local mode for Evaluations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ xenon: compose-build
 	--max-modules A \
 	--max-average A \
 	--ignore "data, tests, docs" \
-	--exclude "src/fidesctl/core/annotate_dataset.py,src/fidesctl/_version.py"
+	--exclude "src/fidesctl/core/annotate_dataset.py,src/fidesctl/_version.py,src/fidesctl/cli/__init__.py"
 
 ####################
 # Utils

--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,10 @@ xenon: compose-build
 	@docker-compose run --rm $(IMAGE_NAME) \
 	xenon src \
 	--max-absolute B \
-	--max-modules A \
+	--max-modules B \
 	--max-average A \
 	--ignore "data, tests, docs" \
-	--exclude "src/fidesctl/core/annotate_dataset.py,src/fidesctl/_version.py,src/fidesctl/cli/__init__.py"
+	--exclude "src/fidesctl/core/annotate_dataset.py,src/fidesctl/_version.py"
 
 ####################
 # Utils

--- a/docs/fides/docs/installation/installation.md
+++ b/docs/fides/docs/installation/installation.md
@@ -28,7 +28,7 @@ More details: [Installation from PyPI](pypi.md)
 **What the Fidesctl community provides for this method**
 
 * You have [Installation from PyPI](pypi.md) on how to install the software but due to various environments and tools you might want to use, you might expect that there will be problems which are specific to your deployment and environment that you will have to diagnose and solve.
-* You have the [Running fidesctl locally](../quickstart/local_full.md) guide where you can see an example of running fidesctl with minimal dependencies and setup. You can use this guide to start fidesctl quickly for local testing and development, however this is only intended to provide inspiration, not to represent a production-grade installation.
+* You have the [Running fidesctl Locally](../quickstart/local_full.md) guide where you can see an example of running fidesctl with minimal dependencies and setup. You can use this guide to start fidesctl quickly for local testing and development, however this is only intended to provide inspiration, not to represent a production-grade installation.
 
 **Where to ask for help**
 

--- a/docs/fides/docs/installation/installation.md
+++ b/docs/fides/docs/installation/installation.md
@@ -28,7 +28,7 @@ More details: [Installation from PyPI](pypi.md)
 **What the Fidesctl community provides for this method**
 
 * You have [Installation from PyPI](pypi.md) on how to install the software but due to various environments and tools you might want to use, you might expect that there will be problems which are specific to your deployment and environment that you will have to diagnose and solve.
-* You have [Running fidesctl locally](../quickstart/local_full.md) where you can see an example of running fidesctl locally with minimal dependencies and setup. You can use this guide to start fidesctl quickly for local testing and development, however this is only intended to provide inspiration, not to represent a product-grade installation.
+* You have the [Running fidesctl locally](../quickstart/local_full.md) guide where you can see an example of running fidesctl with minimal dependencies and setup. You can use this guide to start fidesctl quickly for local testing and development, however this is only intended to provide inspiration, not to represent a product-grade installation.
 
 **Where to ask for help**
 

--- a/docs/fides/docs/installation/installation.md
+++ b/docs/fides/docs/installation/installation.md
@@ -28,11 +28,11 @@ More details: [Installation from PyPI](pypi.md)
 **What the Fidesctl community provides for this method**
 
 * You have [Installation from PyPI](pypi.md) on how to install the software but due to various environments and tools you might want to use, you might expect that there will be problems which are specific to your deployment and environment that you will have to diagnose and solve.
-* You have [Running fidesctl locally](../quickstart/local.md) where you can see an example of running fidesctl locally. You can use this guide to start fidesctl quickly for local testing and development. However this is just an inspiration.
+* You have [Running fidesctl locally](../quickstart/local_full.md) where you can see an example of running fidesctl locally with minimal dependencies and setup. You can use this guide to start fidesctl quickly for local testing and development, however this is only intended to provide inspiration, not to represent a product-grade installation.
 
 **Where to ask for help**
 
-* The #troubleshooting channel on the fidesctl Slack for quick general troubleshooting questions. The [GitHub discussions](https://github.com/ethyca/fides/discussions) if you look for longer discussion and have more information to share.
+* For quick and general troubleshooting questions, visit the #troubleshooting channel on the fidesctl Slack. For longer discussions or to share information, visit the [GitHub discussions](https://github.com/ethyca/fides/discussions) page.
 * If you can provide description of a reproducible problem with the fidesctl software, you can open issue in [GitHub issues](https://github.com/ethyca/fides/issues).
 
 ## Using Production Docker Images
@@ -62,5 +62,5 @@ More details: [Installation from Docker](pypi.md)
 
 **Where to ask for help**
 
-* The #troubleshooting channel on the fidesctl Slack for quick general troubleshooting questions. The [GitHub discussions](https://github.com/ethyca/fides/discussions) if you look for longer discussion and have more information to share.
+* For quick and general troubleshooting questions, visit the #troubleshooting channel on the fidesctl Slack. For longer discussions or to share information, visit the [GitHub discussions](https://github.com/ethyca/fides/discussions) page.
 * If you can provide description of a reproducible problem with the fidesctl software, you can open issue in [GitHub issues](https://github.com/ethyca/fides/issues).

--- a/docs/fides/docs/installation/pypi.md
+++ b/docs/fides/docs/installation/pypi.md
@@ -14,7 +14,7 @@ To install Fidesctl, run:
 
 `pip install fidesctl`
 
-With the basic installation fidesctl is designed to be as lightweight as possible. It ships with the ability to do most things you would do via the standalone CLI, such as `evaluate` and `parse` without the need to be running a webserver. For interacting directly with databases and running the webserver, see the optional dependencies below.
+With the default installation fidesctl is designed to be as lightweight as possible. It ships with the ability to do most things you would do via the standalone CLI, such as `evaluate` and `parse` without the need to be running a webserver. For interacting directly with databases and running the webserver, see the optional dependencies below.
 
 ## Installing Optional Dependencies
 

--- a/docs/fides/docs/installation/pypi.md
+++ b/docs/fides/docs/installation/pypi.md
@@ -14,7 +14,7 @@ To install Fidesctl, run:
 
 `pip install fidesctl`
 
-With the basic installation fidesctl is designed to be as lightweight as possible. It ships with the ability to do most things you would do via the CLI, such as `apply`, `evaluate`, and `parse`. For interacting directly with databases and running the webserver, see the optional dependencies below.
+With the basic installation fidesctl is designed to be as lightweight as possible. It ships with the ability to do most things you would do via the standalone CLI, such as `evaluate` and `parse` without the need to be running a webserver. For interacting directly with databases and running the webserver, see the optional dependencies below.
 
 ## Installing Optional Dependencies
 

--- a/docs/fides/docs/quickstart/local_full.md
+++ b/docs/fides/docs/quickstart/local_full.md
@@ -1,8 +1,8 @@
-# Running Fidesctl Locally
+# Running Fidesctl Locally (Full Installation)
 
 ---
 
-Fidesctl can be spun up locally without relying on Docker, but it is a bit more complicated. If you'd like something simpler, please see the [Running Fidesctl in Docker](docker.md) guide for the recommended setup experience.
+Fidesctl can be spun up locally in its entirety without relying on Docker, but it is a bit more complicated. If you'd like something simpler, please see the [Running Fidesctl in Docker](docker.md) guide for the recommended setup experience or [Running Fidesctl locally (Standalone)](local_standalone.md) for the simplest possible installation.
 
 ## System Requirements
 

--- a/docs/fides/docs/quickstart/local_full.md
+++ b/docs/fides/docs/quickstart/local_full.md
@@ -2,7 +2,7 @@
 
 ---
 
-Fidesctl can be spun up locally in its entirety without relying on Docker, but it is a bit more complicated. If you'd like something simpler, please see the [Running Fidesctl in Docker](docker.md) guide for the recommended setup experience or [Running Fidesctl locally (Standalone)](local_standalone.md) for the simplest possible installation.
+Fidesctl can be spun up locally in its entirety without relying on Docker, but it is a bit more complicated. If you'd like something simpler, please see the [Running Fidesctl in Docker](docker.md) guide for the recommended setup experience or [Running Fidesctl Locally (Standalone)](local_standalone.md) for the simplest possible installation.
 
 ## System Requirements
 

--- a/docs/fides/docs/quickstart/local_standalone.md
+++ b/docs/fides/docs/quickstart/local_standalone.md
@@ -1,8 +1,17 @@
-# Running Fidesctl locally (Standalone)
+# Running Fidesctl Locally (Standalone)
 
 This method of running fidesctl requires zero dependencies outside of Python and a default pip installation of fidesctl. It is intended as the fastest possible quick start and is not designed for production-grade deployments.
 
-In standalone mode most CLI commands will not work as they require webserver connectivity for persistence. Crucially though, the core evaluation functionality is still present. To run evaluations in standalone mode, use the `--local` flag, but note that the evaluation results won't be persisted.
+In standalone mode most CLI commands will not work as they require webserver connectivity for persistence. Crucially though, the core evaluation functionality is still present. To run in standalone mode, use one of the following methods:
+
+```sh title="CLI flag"
+fidesctl --local <subcommand>
+```
+
+```toml title="fidesctl.toml"
+[cli]
+local_mode = true
+```
 
 For more information on running a full fidesctl installation, see the [Running Fidesctl Locally (Full Installation)](local_full.md) or [Running Fidesctl in Docker](docker.md) pages.
 

--- a/docs/fides/docs/quickstart/local_standalone.md
+++ b/docs/fides/docs/quickstart/local_standalone.md
@@ -1,0 +1,39 @@
+# Running Fidesctl locally (Standalone)
+
+This method of running fidesctl requires zero dependencies outside of Python and a pip installation of fidesctl. It is intended as the fastest possible quick start and is not designed for production-grade deployments.
+
+In standalone mode most CLI commands will not work as they require webserver or database connectivity for persistence. Crucially though, the core evaluation functionality is still present. To run evaluations in standalone mode, use the `--local` flag, but note that the evaluation results won't be persisted.
+
+For more information on running a full fidesctl installation, see the [Running Fidesctl locally (Full Installation)](local_full.md) or [Running Fidesctl in Docker](docker.md) pages.
+
+## System Requirements
+
+See the Python section of the [Prerequisites and Dependencies](../installation/prerequisites_dependencies.md) page for more information.
+
+## Fidesctl installation
+
+The next step is to install fidesctl via pip with the required extras:
+
+```sh
+pip install fidesctl
+```
+
+For more information on pip installing fidesctl as well as the other potential extras, see the [Installation from PyPI](../installation/pypi.md) guide.
+
+## Using the CLI
+
+Now that we have fidesctl pip installed, let's verify the installation:
+
+```sh title="Command"
+fidesctl --version
+```
+
+```txt title="Expected Output"
+fidesctl, version 1.0.0
+```
+
+That's it! Your local standalone installation of fidesctl is completely up and running.
+
+## Next Steps
+
+See the [Tutorial](../tutorial/index.md) page for a step-by-step guide on setting up a Fides data privacy workflow.

--- a/docs/fides/docs/quickstart/local_standalone.md
+++ b/docs/fides/docs/quickstart/local_standalone.md
@@ -2,7 +2,7 @@
 
 This method of running fidesctl requires zero dependencies outside of Python and a default pip installation of fidesctl. It is intended as the fastest possible quick start and is not designed for production-grade deployments.
 
-In standalone mode most CLI commands will not work as they require webserver connectivity for persistence. Crucially though, the core evaluation functionality is still present. To run in standalone mode, use one of the following methods:
+In standalone mode most CLI commands will not work as they require webserver connectivity for persistence, and so those commands are not available. Crucially though, the core evaluation functionality is still present. To run in standalone mode, use one of the following methods:
 
 ```sh title="CLI flag"
 fidesctl --local <subcommand>

--- a/docs/fides/docs/quickstart/local_standalone.md
+++ b/docs/fides/docs/quickstart/local_standalone.md
@@ -1,6 +1,6 @@
 # Running Fidesctl locally (Standalone)
 
-This method of running fidesctl requires zero dependencies outside of Python and a pip installation of fidesctl. It is intended as the fastest possible quick start and is not designed for production-grade deployments.
+This method of running fidesctl requires zero dependencies outside of Python and a default pip installation of fidesctl. It is intended as the fastest possible quick start and is not designed for production-grade deployments.
 
 In standalone mode most CLI commands will not work as they require webserver or database connectivity for persistence. Crucially though, the core evaluation functionality is still present. To run evaluations in standalone mode, use the `--local` flag, but note that the evaluation results won't be persisted.
 
@@ -22,7 +22,7 @@ For more information on pip installing fidesctl as well as the other potential e
 
 ## Using the CLI
 
-Now that we have fidesctl pip installed, let's verify the installation:
+Now that we have fidesctl installed, let's verify the installation:
 
 ```sh title="Command"
 fidesctl --version
@@ -32,7 +32,7 @@ fidesctl --version
 fidesctl, version 1.0.0
 ```
 
-That's it! Your local standalone installation of fidesctl is completely up and running.
+That's it! Your local standalone installation of fidesctl is up and running.
 
 ## Next Steps
 

--- a/docs/fides/docs/quickstart/local_standalone.md
+++ b/docs/fides/docs/quickstart/local_standalone.md
@@ -27,7 +27,7 @@ The next step is to install fidesctl via pip:
 pip install fidesctl
 ```
 
-For more information on pip installing fidesctl as well as the other potential extras, see the [Installation from PyPI](../installation/pypi.md) guide.
+For more information on installing fidesctl with pip, as well as the other potential extras, see the [Installation from PyPI](../installation/pypi.md) guide.
 
 ## Using the CLI
 

--- a/docs/fides/docs/quickstart/overview.md
+++ b/docs/fides/docs/quickstart/overview.md
@@ -2,4 +2,4 @@
 
 ---
 
-The fastest way to get Fidesctl running is to launch it using the [Docker instructions here](docker.md), alternatively you can manually deploy and customize a production configuration using the [manual instructions here](local.md).
+The fastest way to get Fidesctl running is to launch it using the [Running Fidesctl locally (Standlone)](local_standalone.md) guide. For guides on setting up a complete installation, see the [Docker instructions here](docker.md) or the [local instructions here](local_full.md).

--- a/docs/fides/docs/quickstart/overview.md
+++ b/docs/fides/docs/quickstart/overview.md
@@ -2,4 +2,4 @@
 
 ---
 
-The fastest way to get Fidesctl running is to launch it using the [Running Fidesctl locally (Standlone)](local_standalone.md) guide. For guides on setting up a complete installation, see the [Docker instructions here](docker.md) or the [local instructions here](local_full.md).
+The fastest way to get fidesctl running is to launch it using the [fidesctl standlone)](local_standalone.md) guide. For guides on setting up a complete installation, see the [Docker instructions here](docker.md) or the [local full-installation instructions here](local_full.md).

--- a/docs/fides/mkdocs.yml
+++ b/docs/fides/mkdocs.yml
@@ -4,7 +4,8 @@ nav:
   - What is Fides?: index.md
   - Quick Start:
       - Overview: quickstart/overview.md
-      - Running Fidesctl locally: quickstart/local.md
+      - Running Fidesctl locally (Standalone): quickstart/local_standalone.md
+      - Running Fidesctl locally (Full Installation): quickstart/local_full.md
       - Running Fidesctl in Docker: quickstart/docker.md
   - Installation:
       - Installation Overview: installation/installation.md

--- a/fidesctl/demo_resources/demo_policy.yml
+++ b/fidesctl/demo_resources/demo_policy.yml
@@ -3,8 +3,7 @@ policy:
     name: Demo Privacy Policy
     description: The main privacy policy for the organization.
     rules:
-      - fides_key: reject_direct_marketing
-        name: Reject Direct Marketing
+      - name: Reject Direct Marketing
         description: Disallow collecting any user contact info to use for marketing.
         data_categories:
           inclusion: ANY

--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -59,13 +59,14 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
     ctx.ensure_object(dict)
     config = get_config(config_path)
 
-    if local or config.cli.local_mode:
-        config.cli.local_mode = True
-        for command in local_commands:
-            cli.add_command(command)
-    else:
-        for command in all_commands:
-            cli.add_command(command)
+	config.cli.local_mode = True
+    for command in local_commands:
+    	cli.add_command(command)
+    	
+    if not (local or config.cli.local_mode):
+    	config.cli.local_mode = False
+    	for command in api_commands:
+    		cli.add_command(command)
     ctx.obj["CONFIG"] = config
 
     if not ctx.invoked_subcommand:

--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -22,7 +22,7 @@ from fidesctl.core.config import get_config
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
+@click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True, chain=True)
 @click.version_option(version=fidesctl.__version__)
 @click.option(
     "--config-path",
@@ -31,26 +31,42 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     default="",
     help="Optional configuration file",
 )
+@click.option(
+    "--local",
+    is_flag=True,
+    help="Runs in a local mode that doesn't utilize server calls.",
+)
 @click.pass_context
-def cli(ctx: click.Context, config_path: str) -> None:
+def cli(ctx: click.Context, config_path: str, local: bool) -> None:
     """
-    The parent group for the Fides CLI.
-    Loads the config and passes it within the context.
+    The parent group for the Fidesctl CLI.
     """
+
+    local_commands = [evaluate, parse, view_config]
+    all_commands = [
+        annotate_dataset,
+        apply,
+        delete,
+        generate_dataset,
+        get,
+        init_db,
+        ls,
+        ping,
+        reset_db,
+        webserver,
+    ] + local_commands
+
     ctx.ensure_object(dict)
-    ctx.obj["CONFIG"] = get_config(config_path)
+    config = get_config(config_path)
 
+    if local or config.cli.local_mode:
+        config.cli.local_mode = True
+        for command in local_commands:
+            cli.add_command(command)
+    else:
+        for command in all_commands:
+            cli.add_command(command)
+    ctx.obj["CONFIG"] = config
 
-cli.add_command(apply)
-cli.add_command(delete)
-cli.add_command(evaluate)
-cli.add_command(generate_dataset)
-cli.add_command(annotate_dataset)
-cli.add_command(get)
-cli.add_command(init_db)
-cli.add_command(ls)
-cli.add_command(parse)
-cli.add_command(ping)
-cli.add_command(reset_db)
-cli.add_command(view_config)
-cli.add_command(webserver)
+    if not ctx.invoked_subcommand:
+        click.echo(cli.get_help(ctx))

--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -43,7 +43,7 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
     """
 
     local_commands = [evaluate, parse, view_config]
-    all_commands = [
+    api_commands = [
         annotate_dataset,
         apply,
         delete,
@@ -59,14 +59,14 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
     ctx.ensure_object(dict)
     config = get_config(config_path)
 
-	config.cli.local_mode = True
     for command in local_commands:
-    	cli.add_command(command)
-    	
+        cli.add_command(command)
+
+    # If local_mode is enabled, don't add unsupported commands
     if not (local or config.cli.local_mode):
-    	config.cli.local_mode = False
-    	for command in api_commands:
-    		cli.add_command(command)
+        config.cli.local_mode = False
+        for command in api_commands:
+            cli.add_command(command)
     ctx.obj["CONFIG"] = config
 
     if not ctx.invoked_subcommand:

--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -34,7 +34,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 @click.option(
     "--local",
     is_flag=True,
-    help="Runs in a local mode that doesn't utilize server calls.",
+    help="Do not make any API calls to the webserver.",
 )
 @click.pass_context
 def cli(ctx: click.Context, config_path: str, local: bool) -> None:

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -102,6 +102,7 @@ def evaluate(
     """
     Assess your data's compliance to policies.
 
+    TODO: Make this runnable locally
     This command will first `apply` the resources defined in MANIFESTS_DIR to your server and then assess your data's compliance to your policies or single policy.
 
     """

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -116,8 +116,7 @@ def evaluate(
 
     if local:
         dry = True
-
-    if not local:
+    else:
         taxonomy = _parse.parse(manifests_dir)
         _apply.apply(
             url=config.cli.server_url,

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -130,7 +130,7 @@ def evaluate(
         url=config.cli.server_url,
         headers=config.user.request_headers,
         manifests_dir=manifests_dir,
-        fides_key=fides_key,
+        policy_fides_key=fides_key,
         message=message,
         local=local,
         dry=dry,

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -91,30 +91,40 @@ def delete(ctx: click.Context, resource_type: str, fides_key: str) -> None:
     "--message",
     help="A message that you can supply to describe the purpose of this evaluation.",
 )
+@click.option(
+    "--local",
+    is_flag=True,
+    help="Runs in a local mode that doesn't utilize server calls.",
+)
 @dry_flag
 def evaluate(
     ctx: click.Context,
     manifests_dir: str,
     fides_key: str,
     message: str,
+    local: bool,
     dry: bool,
 ) -> None:
     """
     Assess your data's compliance to policies.
 
-    TODO: Make this runnable locally
     This command will first `apply` the resources defined in MANIFESTS_DIR to your server and then assess your data's compliance to your policies or single policy.
 
     """
 
     config = ctx.obj["CONFIG"]
-    taxonomy = _parse.parse(manifests_dir)
-    _apply.apply(
-        url=config.cli.server_url,
-        taxonomy=taxonomy,
-        headers=config.user.request_headers,
-        dry=dry,
-    )
+
+    if local:
+        dry = True
+
+    if not local:
+        taxonomy = _parse.parse(manifests_dir)
+        _apply.apply(
+            url=config.cli.server_url,
+            taxonomy=taxonomy,
+            headers=config.user.request_headers,
+            dry=dry,
+        )
 
     _evaluate.evaluate(
         url=config.cli.server_url,
@@ -122,6 +132,7 @@ def evaluate(
         manifests_dir=manifests_dir,
         fides_key=fides_key,
         message=message,
+        local=local,
         dry=dry,
     )
 

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -91,18 +91,12 @@ def delete(ctx: click.Context, resource_type: str, fides_key: str) -> None:
     "--message",
     help="A message that you can supply to describe the purpose of this evaluation.",
 )
-@click.option(
-    "--local",
-    is_flag=True,
-    help="Runs in a local mode that doesn't utilize server calls.",
-)
 @dry_flag
 def evaluate(
     ctx: click.Context,
     manifests_dir: str,
     fides_key: str,
     message: str,
-    local: bool,
     dry: bool,
 ) -> None:
     """
@@ -114,7 +108,7 @@ def evaluate(
 
     config = ctx.obj["CONFIG"]
 
-    if local:
+    if config.cli.local_mode:
         dry = True
     else:
         taxonomy = _parse.parse(manifests_dir)
@@ -131,7 +125,7 @@ def evaluate(
         manifests_dir=manifests_dir,
         policy_fides_key=fides_key,
         message=message,
-        local=local,
+        local=config.cli.local_mode,
         dry=dry,
     )
 

--- a/fidesctl/src/fidesctl/core/config.py
+++ b/fidesctl/src/fidesctl/core/config.py
@@ -50,6 +50,7 @@ class UserSettings(FidesSettings):
 class CLISettings(FidesSettings):
     """Class used to store values from the 'cli' section of the config."""
 
+    local_mode: bool = False
     server_url: str = "http://localhost:8080"
 
     class Config:

--- a/fidesctl/src/fidesctl/core/evaluate.py
+++ b/fidesctl/src/fidesctl/core/evaluate.py
@@ -570,10 +570,7 @@ def evaluate(
         echo_red(str(missing_resources))
         echo_red("Not all referenced resources exist locally!")
         raise SystemExit(1)
-    else:
-        populate_referenced_keys(
-            taxonomy=taxonomy, url=url, headers=headers, last_keys=[]
-        )
+    populate_referenced_keys(taxonomy=taxonomy, url=url, headers=headers, last_keys=[])
 
     echo_green("Executing Policy evaluation(s)...")
     evaluation = execute_evaluation(taxonomy)

--- a/fidesctl/src/fidesctl/core/evaluate.py
+++ b/fidesctl/src/fidesctl/core/evaluate.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Callable, cast
 import uuid
 import time
 from pydantic import AnyHttpUrl
-from pydantic.utils import deep_update
 
 from fidesctl.cli.utils import handle_cli_response, pretty_echo
 from fidesctl.core import api
@@ -527,12 +526,14 @@ def evaluate(
     )
 
     # Populate all of the policies to evaluate
-    taxonomy.policy = get_evaluation_policies(
-        local_policies=taxonomy.policy,
-        evaluate_fides_key=fides_key,
-        url=url,
-        headers=headers,
-    )
+    if not local:
+        taxonomy.policy = get_evaluation_policies(
+            local_policies=taxonomy.policy,
+            evaluate_fides_key=fides_key,
+            url=url,
+            headers=headers,
+        )
+
     validate_policies_exist(policies=taxonomy.policy, evaluate_fides_key=fides_key)
     validate_supported_policy_rules(policies=taxonomy.policy)
 
@@ -551,7 +552,7 @@ def evaluate(
     echo_green("Checking for missing resources...")
     populate_referenced_keys(taxonomy=taxonomy, url=url, headers=headers, last_keys=[])
 
-    echo_green("Executing evaluations...")
+    echo_green("Executing evaluation...")
     evaluation = execute_evaluation(taxonomy)
     evaluation.message = message
     if not dry:

--- a/fidesctl/src/fidesctl/core/evaluate.py
+++ b/fidesctl/src/fidesctl/core/evaluate.py
@@ -540,7 +540,7 @@ def evaluate(
     server-definitions if available.
     """
 
-    # Combine the User-defined taxonomy with the Default Taxonomy
+    # Merge the User-defined taxonomy & Default Taxonomy
     user_taxonomy = parse(manifests_dir)
     taxonomy = Taxonomy.parse_obj(
         {
@@ -549,6 +549,7 @@ def evaluate(
         }
     )
 
+    # Determine which Policies will be evaluated
     taxonomy.policy = populate_evaluation_policies(
         policies=taxonomy.policy,
         policy_fides_key=policy_fides_key,
@@ -557,21 +558,24 @@ def evaluate(
         local=local,
     )
     echo_green(
-        "Evaluating the following policies:\n{}".format(
+        "Evaluating the following Policies:\n{}".format(
             "\n".join([key.fides_key for key in taxonomy.policy])
         )
     )
     print("-" * 10)
 
+    echo_green("Checking for missing resources...")
     missing_resources = get_referenced_missing_keys(taxonomy)
     if local and missing_resources:
         echo_red(str(missing_resources))
         echo_red("Not all referenced resources exist locally!")
         raise SystemExit(1)
-    echo_green("Checking for missing resources...")
-    populate_referenced_keys(taxonomy=taxonomy, url=url, headers=headers, last_keys=[])
+    else:
+        populate_referenced_keys(
+            taxonomy=taxonomy, url=url, headers=headers, last_keys=[]
+        )
 
-    echo_green("Executing evaluation...")
+    echo_green("Executing Policy evaluation(s)...")
     evaluation = execute_evaluation(taxonomy)
     evaluation.message = message
     if not dry:

--- a/fidesctl/src/fideslang/models.py
+++ b/fidesctl/src/fideslang/models.py
@@ -8,7 +8,6 @@ from pydantic import validator, BaseModel, Field
 
 from fideslang.validation import (
     FidesKey,
-    sort_list_objects_by_key,
     sort_list_objects_by_name,
     no_self_reference,
     matching_parent_key,
@@ -204,7 +203,7 @@ class PrivacyRule(BaseModel):
     values: List[FidesKey]
 
 
-class PolicyRule(FidesModel):
+class PolicyRule(BaseModel):
     """
     The PolicyRule resource model.
 
@@ -212,6 +211,7 @@ class PolicyRule(FidesModel):
     and what action that combination constitutes.
     """
 
+    name: str
     data_categories: PrivacyRule
     data_uses: PrivacyRule
     data_subjects: PrivacyRule
@@ -231,7 +231,7 @@ class Policy(FidesModel):
     rules: List[PolicyRule]
 
     _sort_rules: classmethod = validator("rules", allow_reuse=True)(
-        sort_list_objects_by_key
+        sort_list_objects_by_name
     )
 
 

--- a/fidesctl/src/fideslang/validation.py
+++ b/fidesctl/src/fideslang/validation.py
@@ -38,15 +38,6 @@ def sort_list_objects_by_name(values: List) -> List:
     return values
 
 
-def sort_list_objects_by_key(values: List) -> List:
-    """
-    Sort objects in a list by their fides_key.
-    This makes resource comparisons deterministic.
-    """
-    values.sort(key=lambda value: value.fides_key)
-    return values
-
-
 def no_self_reference(value: FidesKey, values: Dict) -> FidesKey:
     """
     Check to make sure that the fides_key doesn't match other fides_key

--- a/fidesctl/tests/cli/test_cli.py
+++ b/fidesctl/tests/cli/test_cli.py
@@ -128,6 +128,22 @@ def test_evaluate_demo_resources_pass(
 
 
 @pytest.mark.integration
+def test_local_evaluate(test_config_path: str, test_cli_runner: CliRunner):
+    result = test_cli_runner.invoke(
+        cli,
+        [
+            "-f",
+            test_config_path,
+            "evaluate",
+            "tests/data/passing_dataset_taxonomy.yml",
+            "--local",
+        ],
+    )
+    print(result.output)
+    assert result.exit_code == 1
+
+
+@pytest.mark.integration
 def test_evaluate_with_key_pass(test_config_path: str, test_cli_runner: CliRunner):
     result = test_cli_runner.invoke(
         cli,

--- a/fidesctl/tests/cli/test_cli.py
+++ b/fidesctl/tests/cli/test_cli.py
@@ -128,12 +128,12 @@ def test_evaluate_demo_resources_pass(
 
 
 @pytest.mark.integration
-def test_local_evaluate(test_config_path: str, test_cli_runner: CliRunner):
+def test_local_evaluate(test_invalid_config_path: str, test_cli_runner: CliRunner):
     result = test_cli_runner.invoke(
         cli,
         [
             "-f",
-            test_config_path,
+            test_invalid_config_path,
             "evaluate",
             "tests/data/passing_dataset_taxonomy.yml",
             "--local",

--- a/fidesctl/tests/cli/test_cli.py
+++ b/fidesctl/tests/cli/test_cli.py
@@ -52,7 +52,7 @@ def test_apply(test_config_path: str, test_cli_runner: CliRunner):
 @pytest.mark.integration
 def test_dry_apply(test_config_path: str, test_cli_runner: CliRunner):
     result = test_cli_runner.invoke(
-        cli, ["-f", test_config_path, "apply", "demo_resources/", "--dry"]
+        cli, ["-f", test_config_path, "apply", "--dry", "demo_resources/"]
     )
     print(result.output)
     assert result.exit_code == 0
@@ -61,7 +61,7 @@ def test_dry_apply(test_config_path: str, test_cli_runner: CliRunner):
 @pytest.mark.integration
 def test_diff_apply(test_config_path: str, test_cli_runner: CliRunner):
     result = test_cli_runner.invoke(
-        cli, ["-f", test_config_path, "apply", "demo_resources/", "--diff"]
+        cli, ["-f", test_config_path, "apply", "--diff", "demo_resources/"]
     )
     print(result.output)
     assert result.exit_code == 0
@@ -70,7 +70,7 @@ def test_diff_apply(test_config_path: str, test_cli_runner: CliRunner):
 @pytest.mark.integration
 def test_dry_diff_apply(test_config_path: str, test_cli_runner: CliRunner):
     result = test_cli_runner.invoke(
-        cli, ["-f", test_config_path, "apply", "demo_resources/", "--dry", "--diff"]
+        cli, ["-f", test_config_path, "apply", "--dry", "--diff", "demo_resources/"]
     )
     print(result.output)
     assert result.exit_code == 0
@@ -91,11 +91,6 @@ def test_ls(test_config_path: str, test_cli_runner: CliRunner):
     result = test_cli_runner.invoke(cli, ["-f", test_config_path, "ls", "system"])
     print(result.output)
     assert result.exit_code == 0
-
-
-@pytest.mark.integration
-def test_generate_dataset(test_config_path: str, test_cli_runner: CliRunner):
-    assert True
 
 
 @pytest.mark.integration
@@ -134,9 +129,9 @@ def test_local_evaluate(test_invalid_config_path: str, test_cli_runner: CliRunne
         [
             "-f",
             test_invalid_config_path,
+            "--local",
             "evaluate",
             "tests/data/passing_dataset_taxonomy.yml",
-            "--local",
         ],
     )
     print(result.output)
@@ -151,9 +146,9 @@ def test_evaluate_with_key_pass(test_config_path: str, test_cli_runner: CliRunne
             "-f",
             test_config_path,
             "evaluate",
-            "tests/data/passing_declaration_taxonomy.yml",
             "-k",
             "primary_privacy_policy",
+            "tests/data/passing_declaration_taxonomy.yml",
         ],
     )
     print(result.output)

--- a/fidesctl/tests/conftest.py
+++ b/fidesctl/tests/conftest.py
@@ -20,6 +20,12 @@ def test_config_path():
 
 @pytest.fixture(scope="session")
 def test_invalid_config_path():
+    """
+    This config file contains url/connection strings that are invalid.
+
+    This ensures that the CLI isn't calling out to those resources
+    directly during certain tests.
+    """
     yield TEST_INVALID_CONFIG_PATH
 
 

--- a/fidesctl/tests/conftest.py
+++ b/fidesctl/tests/conftest.py
@@ -111,11 +111,7 @@ def resources_dict():
             rules=[],
         ),
         "policy_rule": models.PolicyRule(
-            organization_fides_key=1,
-            policyId=1,
-            fides_key="test_policy",
             name="Test Policy",
-            description="Test Policy",
             data_categories=models.PrivacyRule(inclusion="NONE", values=[]),
             data_uses=models.PrivacyRule(inclusion="NONE", values=["provide.system"]),
             data_subjects=models.PrivacyRule(inclusion="ANY", values=[]),

--- a/fidesctl/tests/conftest.py
+++ b/fidesctl/tests/conftest.py
@@ -10,11 +10,17 @@ from fidesctl.core.config import get_config
 from fidesctl.core import api
 
 TEST_CONFIG_PATH = "tests/test_config.toml"
+TEST_INVALID_CONFIG_PATH = "tests/test_invalid_config.toml"
 
 
 @pytest.fixture(scope="session")
 def test_config_path():
     yield TEST_CONFIG_PATH
+
+
+@pytest.fixture(scope="session")
+def test_invalid_config_path():
+    yield TEST_INVALID_CONFIG_PATH
 
 
 @pytest.fixture(scope="session")

--- a/fidesctl/tests/core/test_evaluate.py
+++ b/fidesctl/tests/core/test_evaluate.py
@@ -66,7 +66,7 @@ def create_policy_rule_with_action(
     policy_rule_key: str, action: ActionEnum
 ) -> PolicyRule:
     return PolicyRule(
-        fides_key=policy_rule_key,
+        name=policy_rule_key,
         action=action,
         data_categories={
             "values": ["data_category_1"],
@@ -90,7 +90,7 @@ def create_policy_rule_with_keys(
     data_qualifier: str,
 ) -> PolicyRule:
     return PolicyRule(
-        fides_key="policy_rule_1",
+        name="policy_rule_1",
         data_categories={
             "values": data_categories,
             "inclusion": InclusionEnum.ANY,

--- a/fidesctl/tests/data/passing_declaration_taxonomy.yml
+++ b/fidesctl/tests/data/passing_declaration_taxonomy.yml
@@ -18,7 +18,7 @@ policy:
     name: Primary Privacy Policy
     description: The main privacy policy for the organization.
     rules:
-      - fides_key: reject_targeted_marketing
+      - name: reject_targeted_marketing
         description: Disallow advertising of customer data
         data_categories:
           inclusion: ANY

--- a/fidesctl/tests/lang/test_relationships.py
+++ b/fidesctl/tests/lang/test_relationships.py
@@ -119,7 +119,7 @@ def test_get_referenced_missing_policy_keys():
                 fides_key="policy_1",
                 rules=[
                     PolicyRule(
-                        fides_key="policy_rule_1",
+                        name="policy_rule_1",
                         action=ActionEnum.REJECT,
                         data_categories={
                             "values": ["policy_rule_data_category_1"],
@@ -141,7 +141,6 @@ def test_get_referenced_missing_policy_keys():
     )
     expected_referenced_key = {
         "default_organization",
-        "policy_rule_1",
         "policy_rule_data_category_1",
         "policy_rule_data_use_1",
         "policy_rule_data_subject_1",

--- a/fidesctl/tests/test_bad_config.toml
+++ b/fidesctl/tests/test_bad_config.toml
@@ -1,0 +1,5 @@
+[cli]
+server_url = "http://invalid:8080"
+
+[api]
+database_url = "postgresql+psycopg2://postgres:fidesctl@invalid:5432/fidesctl"


### PR DESCRIPTION
Closes #210 

### Code Changes

* [x] add a `local` flag to the `evaluate`command
* [x] update `evaluate.py` so that it doesn't call out to a server to check for missing resources
* [x] update the PolicyRule model so that it doesn't use a fides_key, but instead uses a `name` (fides_key should only be for top-level resources)
* [x] add a test with bad credentials for the webserver to make sure no call is being made
* [x] add a minimalist (standalone) installation guide
* [x] hide commands in the CLI if `local_mode` is on

### Steps to Confirm

* [x] `pip install -e .` and then run `fidesctl --local evalute demo_resources `

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

The overall purpose of this PR is to allow people to run evaluations without needing to have a webserver and database spun up. This lowers the barrier to entry, especially on simpler projects and creates a faster "getting started". It is functionally similar to --dry but also prevents checking the server for missing resources. It will throw an error if a resource is referenced but not found locally (since otherwise it would have to check the server)

There is a new config option under the `cli` section called `local_mode`. If this is set to `true`, then the CLI will only show/run commands that can be run without any API/Database calls.

```sh
(base) PS C:\Users\tal10\Documents\Git> fidesctl --local
Usage: fidesctl [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...

  The parent group for the Fidesctl CLI.

Options:
  --version               Show the version and exit.
  -f, --config-path TEXT  Optional configuration file
  --local                 Runs in a local mode that doesn't utilize server
                          calls.

  -h, --help              Show this message and exit.

Commands:
  evaluate     Assess your data's compliance to policies.
  parse        Validate the taxonomy described by the manifest files.
  view-config  Prints the current fidesctl configuration.
(base) PS C:\Users\tal10\Documents\Git>
```

**WARNING** This makes a potentially breaking change, as the PolicyRule model has now changed. This doesn't require a database update since child objects are stored as JSON, but this _could_ create an issue when reading from the database. That being said, as long as the user has specified a name for their PolicyRule, it would work as expected