### PR TITLE
updating links in documentation

### DIFF
--- a/docs/fides/docs/cli/cli.md
+++ b/docs/fides/docs/cli/cli.md
@@ -11,7 +11,7 @@
       -f/--config-path <i>config_file</i> 
     </div>
     <div class="content">
-      Identifies a file that you can use to configure the <code>fidesctl</code> environment. For more information about the file, see <a href="/api/configuration-file">fidesctl Configuration File</a>. To see the current configuration file, do <code>fidesctl&nbsp;view&#8209;config</code>.
+      Identifies a file that you can use to configure the <code>fidesctl</code> environment. For more information about the file, see <a href="/fides/installation/configuration">fidesctl Configuration File</a>. To see the current configuration file, do <code>fidesctl&nbsp;view&#8209;config</code>.
     </div>
   </div>
   <div class="content">

--- a/docs/fides/docs/cli/evaluate.md
+++ b/docs/fides/docs/cli/evaluate.md
@@ -14,7 +14,7 @@
   <div class="label">DESCRIPTION</div>
 
   <div class="content">
-    The <code>evaluate</code> command applies the resources defined in <i>manifest_dir</i> to your server (by calling <a href="/cli/apply/"><code>apply</code></a>), and then assesses your data's compliance to your policies. A failure means that you're trying to publish data that shouldn't be published; it's expected that you'll correct the data (or adjust the policy) before your next app deployment.
+    The <code>evaluate</code> command applies the resources defined in <i>manifest_dir</i> to your server (by calling <a href="/fides/cli/apply/"><code>apply</code></a>), and then assesses your data's compliance to your policies. A failure means that you're trying to publish data that shouldn't be published; it's expected that you'll correct the data (or adjust the policy) before your next app deployment.
     <p>If you want to evaluate a single policy, use the <code>&#8209;&#8209;fides&#8209;key</code> option, passing the fides key of the policy you wish to evaluate.
     </p>
     <p>

--- a/docs/fides/docs/tutorial/add.md
+++ b/docs/fides/docs/tutorial/add.md
@@ -49,7 +49,7 @@ fidesctl:
     - FIDESCTL__API__DATABASE_URL=postgresql://postgres:postgres@db:5432/fidesctl
 ```
 
-> See [the fidesctl deployment guide](../deployment#step-2-setup-the-fidesctl-web-server) for a more detailed fidesctl server setup walkthrough, and [the `docker-compose` documentation](https://docs.docker.com/compose/compose-file/) for an explanation of the above configuration options.
+> See [the fidesctl deployment guide](../installation/installation.md) for a more detailed fidesctl server setup walkthrough, and [the `docker-compose` documentation](https://docs.docker.com/compose/compose-file/) for an explanation of the above configuration options.
 
 ## Add `Makefile` Commands
 

--- a/docs/fides/docs/tutorial/add.md
+++ b/docs/fides/docs/tutorial/add.md
@@ -49,7 +49,7 @@ fidesctl:
     - FIDESCTL__API__DATABASE_URL=postgresql://postgres:postgres@db:5432/fidesctl
 ```
 
-> See [the fidesctl deployment guide](../installation/installation.md) for a more detailed fidesctl server setup walkthrough, and [the `docker-compose` documentation](https://docs.docker.com/compose/compose-file/) for an explanation of the above configuration options.
+> See [the fidesctl installation guide](../installation/installation.md) for a more detailed fidesctl server setup walkthrough, and [the `docker-compose` documentation](https://docs.docker.com/compose/compose-file/) for an explanation of the above configuration options.
 
 ## Add `Makefile` Commands
 

--- a/docs/fides/docs/tutorial/google.md
+++ b/docs/fides/docs/tutorial/google.md
@@ -87,7 +87,7 @@ The two declarations reflect the separate purposes for which data is collected a
 
 ## Check Your Progress
 
-After making the above changes, your app should resemble the state of the [`ethyca/fidesdemo` repository](https://github.com/ethyca/fidesdemo) at the [`fidesctl-add-google-analytics` tag](https://github.com/ethyca/fidesdemo/releases/).
+After making the above changes, your app should resemble the state of the [`ethyca/fidesdemo` repository](https://github.com/ethyca/fidesdemo) at the [`fidesctl-add-google-analytics` tag](https://github.com/ethyca/fidesdemo/releases/tag/fidesctl-add-google-analytics).
 
 ## Next: Manage Google Analytics with Fidesctl
 

--- a/docs/fides/docs/tutorial/google.md
+++ b/docs/fides/docs/tutorial/google.md
@@ -87,7 +87,7 @@ The two declarations reflect the separate purposes for which data is collected a
 
 ## Check Your Progress
 
-After making the above changes, your app should resemble the state of the [`ethyca/fidesdemo` repository](https://github.com/ethyca/fidesdemo) at the [`fidesctl-add-google-analytics`](https://github.com/ethyca/fidesdemo/releases/tag/fidesctl-add-google-analytics) tag.
+After making the above changes, your app should resemble the state of the [`ethyca/fidesdemo` repository](https://github.com/ethyca/fidesdemo) at the [`fidesctl-add-google-analytics` tag](https://github.com/ethyca/fidesdemo/releases/).
 
 ## Next: Manage Google Analytics with Fidesctl
 

--- a/docs/fides/docs/tutorial/policy.md
+++ b/docs/fides/docs/tutorial/policy.md
@@ -94,7 +94,7 @@ As global privacy laws change and businesses scale, a company's policies will ev
 
 ## Check Your Progress
 
-After making the above changes and the changes in the previous two steps, your app should resemble the state of the [`ethyca/fidesdemo` repository](https://github.com/ethyca/fidesdemo) at the [`fidesctl-manifests` tag](https://github.com/ethyca/fidesdemo/releases/).
+After making the above changes and the changes in the previous two steps, your app should resemble the state of the [`ethyca/fidesdemo` repository](https://github.com/ethyca/fidesdemo) at the [`fidesctl-manifests` tag](https://github.com/ethyca/fidesdemo/releases/tag/fidesctl-manifests).
 
 ## Next: Add Google Analytics
 

--- a/docs/fides/docs/tutorial/policy.md
+++ b/docs/fides/docs/tutorial/policy.md
@@ -94,7 +94,7 @@ As global privacy laws change and businesses scale, a company's policies will ev
 
 ## Check Your Progress
 
-After making the above changes and the changes in the previous two steps, your app should resemble the state of the [`ethyca/fidesdemo` repository](https://github.com/ethyca/fidesdemo) at the [`fidesctl-manifests`](https://github.com/ethyca/fidesdemo/releases/tag/fidesctl-manifests) tag.
+After making the above changes and the changes in the previous two steps, your app should resemble the state of the [`ethyca/fidesdemo` repository](https://github.com/ethyca/fidesdemo) at the [`fidesctl-manifests` tag](https://github.com/ethyca/fidesdemo/releases/).
 
 ## Next: Add Google Analytics
 


### PR DESCRIPTION
Closes #227 

### Code Changes

* [ ] updated url in cli documentation 

### Steps to Confirm

* [ ] visit ethyca.github.com/fides/cli/cli/
* [ ] click "fidesctl Configuration file" in first paragraph
* [ ] ensure it goes to the right page

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated

### Description Of Changes
Small update of link in cli docs
