### PR TITLE
Add additional functionality to docs

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -19,4 +19,4 @@ jobs:
       - name: Publish docs
         run: mkdocs gh-deploy -v -f docs/fides/mkdocs.yml --force
         env:
-          CI: true
+          PROD_PUBLISH: true

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -18,3 +18,5 @@ jobs:
         run: make docs-build
       - name: Publish docs
         run: mkdocs gh-deploy -v -f docs/fides/mkdocs.yml --force
+        env:
+          CI: true

--- a/docs/fides/mkdocs.yml
+++ b/docs/fides/mkdocs.yml
@@ -1,5 +1,12 @@
+# Site Configuration
 site_name: Fides
 site_url: https://ethyca.github.io/fides/
+
+# GitHub Configuration
+repo_url: https://github.com/ethyca/fides
+edit_uri: blob/main/docs/fides/docs/
+
+# Navigation
 nav:
   - What is Fides?: index.md
   - Quick Start:
@@ -56,6 +63,7 @@ nav:
   - About Ethyca: ethyca.md
   - License: license.md
 
+# Theme
 theme:
   palette:
     - scheme: default
@@ -67,6 +75,9 @@ theme:
         icon: material/toggle-switch
         name: Switch to light mode
   name: material
+  # GitHub Icon
+  icon:
+    repo: fontawesome/brands/github
   favicon: img/favicon.ico
   logo: img/fides-logo.svg
   font:
@@ -87,10 +98,6 @@ markdown_extensions:
   - pymdownx.highlight:
       linenums: true
       linenums_style: table
-      
-extra:
-  social:
-    - icon: fontawesome/brands/github
 
 extra_javascript:
   - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js
@@ -103,5 +110,8 @@ extra_css:
   - css/taxonomy.css
 
 plugins:
+  # The "Last Update" footer only shows in production
+  - git-revision-date:
+      enabled_if_env: CI
   - render_swagger
   - search

--- a/docs/fides/mkdocs.yml
+++ b/docs/fides/mkdocs.yml
@@ -87,6 +87,10 @@ markdown_extensions:
   - pymdownx.highlight:
       linenums: true
       linenums_style: table
+      
+extra:
+  social:
+    - icon: fontawesome/brands/github
 
 extra_javascript:
   - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js

--- a/docs/fides/mkdocs.yml
+++ b/docs/fides/mkdocs.yml
@@ -112,6 +112,6 @@ extra_css:
 plugins:
   # The "Last Update" footer only shows in production
   - git-revision-date:
-      enabled_if_env: CI
+      enabled_if_env: PROD_PUBLISH
   - render_swagger
   - search

--- a/docs/fides/requirements.txt
+++ b/docs/fides/requirements.txt
@@ -2,4 +2,5 @@ mkdocs-material==7.2.5
 mkdocs-minify-plugin==0.4.0
 mkdocs-render-swagger-plugin==0.0.3
 mkdocs-click==0.5.0
+mkdocs-git-revision-date-plugin
 fidesctl # We always want the latest version


### PR DESCRIPTION
Closes #260 

### Code Changes

* [x] add a github link
* [x] add an "edit this page" link
* [x] add an "update at" section

### Steps to Confirm

* [x] run the docs locally, test the new buttons

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

Footer functionality is currently overwritten by our theme, but mkdocs supports all of the functionality we want without needing to add it explicitly to the footer. Here is a list of the changes:

* Top-right corner now has a link to our GitHub repository and also shows release version, stars and forks
* there is now a pencil icon at the top of every page that links directly to that page on github for easier editing
* The bottom of every page now has a `Last update: December 2, 2021` style footer that shows the last time the file was updated according to git. This is turned off when running locally because no git information exists, but when built for prod this will be included.
