### PR TITLE
Fix the pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,11 @@
-# Fix This
+fail_fast: true
+minimum_pre_commit_version: "2"
+
 repos:
   - repo: local
     hooks:
       - id: black
         name: black
         entry: make black
-        language: python
+        language: system
         always_run: True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-fail_fast: true
 minimum_pre_commit_version: "2"
 
 repos:
@@ -7,23 +6,27 @@ repos:
       - id: black
         name: black
         entry: make black
-        files: "fidesctl/"
+        files: "^fidesctl/"
+        types_or: [file, python]
         language: system
 
       - id: mypy
         name: mypy
         entry: make mypy
-        files: "fidesctl/"
+        files: "^fidesctl/"
+        types_or: [file, python]
         language: system
 
       - id: xenon
         name: xenon
         entry: make xenon
-        files: "fidesctl/"
+        files: "^fidesctl/"
+        types_or: [file, python]
         language: system
 
       - id: pylint
         name: pylint
         entry: make pylint
-        files: "fidesctl/"
+        files: "^fidesctl/"
+        types_or: [file, python]
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,5 +7,23 @@ repos:
       - id: black
         name: black
         entry: make black
+        files: "fidesctl/"
         language: system
-        always_run: True
+
+      - id: mypy
+        name: mypy
+        entry: make mypy
+        files: "fidesctl/"
+        language: system
+
+      - id: xenon
+        name: xenon
+        entry: make xenon
+        files: "fidesctl/"
+        language: system
+
+      - id: pylint
+        name: pylint
+        entry: make pylint
+        files: "fidesctl/"
+        language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# Fix This
 repos:
   - repo: local
     hooks:

--- a/docs/fides/docs/development/code_style.md
+++ b/docs/fides/docs/development/code_style.md
@@ -78,9 +78,10 @@ foods_list: List[str] = ["apple", "banana"]
 
 Fidesctl includes a `.pre-commit-config.yaml` to facilitate running CI checks before pushing up to a PR. The `pre-commit` package is included in the `dev-requirements.txt`. Once that is installed, follow these steps to get up and running:
 
-1. `pre-commit install` - This is a one-time setup step to create the git pre-commit hooks
-2. `pre-commit run` - This step will run all of the pre-commit jobs. They should all pass.
-3. These pre-commit hooks will run now for you automatically.
+1. `pre-commit install` - This is a one-time setup step to create the git pre-commit hooks.
+1. These pre-commit hooks will now run automatically. However you can also use `pre-commit run` to run them manually once all of your changes have been staged.
+
+**NOTE**: A Python interpreter must be available from wherever the git commands are being run, as this is required to run the `pre-commit` package.
 
 ## CI Checks
 

--- a/docs/fides/docs/development/code_style.md
+++ b/docs/fides/docs/development/code_style.md
@@ -74,6 +74,14 @@ foods_list = ["apple", "banana"]
 foods_list: List[str] = ["apple", "banana"] 
 ```
 
+## Pre-Commit Hooks
+
+Fidesctl includes a `.pre-commit-config.yaml` to facilitate running CI checks before pushing up to a PR. The `pre-commit` package is included in the `dev-requirements.txt`. Once that is installed, follow these steps to get up and running:
+
+1. `pre-commit install` - This is a one-time setup step to create the git pre-commit hooks
+2. `pre-commit run` - This step will run all of the pre-commit jobs. They should all pass.
+3. These pre-commit hooks will run now for you automatically.
+
 ## CI Checks
 
 CI checks are stored as targets within the Makefile, and can be run from the top-level `fides` directory with the following pattern:


### PR DESCRIPTION
Closes #229 

### Code Changes

* [x] Get the pre-commit config working
* [x] Add all of the quick steps
* [x] ~~Add precommit to the dev reqs~~ it was already there
* [x] Document pre-commit as part of the dev process

### Steps to Confirm

* [ ] `pre-commit install`, `pre-commit run`
* [ ] change a file in `fidesctl/` and make sure that it runs
* [ ] revert the changes and make sure that it skips the checks

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

This PR adds the option to use pre-commit hooks while developing fidesctl. It requires the `pre-commit` package to be installed. Notes have also been added to the `development` section of the docs describing how to set it up
