### PR TITLE
adjust where routes are configured

### DIFF
--- a/fidesctl/src/fidesapi/main.py
+++ b/fidesctl/src/fidesapi/main.py
@@ -29,6 +29,10 @@ def configure_routes() -> None:
     app.include_router(view.router)
 
 
+# Configure the routes here so we can generate the openapi json file
+configure_routes()
+
+
 def configure_db(database_url: str) -> None:
     "Set up the db to be used by the app."
     database.create_db_if_not_exists(database_url)
@@ -44,7 +48,6 @@ def setup_server() -> None:
         serialize=CONFIG.api.log_serialization,
         desination=CONFIG.api.log_destination,
     )
-    configure_routes()
     configure_db(CONFIG.api.database_url)
 
 


### PR DESCRIPTION
Closes N/A

### Code Changes

* [x] call the `configure_routes` function when the `main.py` module is loaded

### Steps to Confirm

* [x] ran `make docs-serve` and confirmed that the new auto-generated openapi file is correct

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

The auto-generated openapi docs are incorrect, due to where the routes are configured in `main.py`. This PR fixes that by calling it whenever the module is imported instead of whenever the app is started up