### PR TITLE
Integration with SnowFlake connector

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -160,4 +160,4 @@ jobs:
       - name: Run integration test suite
         run: make pytest-integration
         env:
-        SNOWFLAKE_FIDESCTL_PASSWORD: ${{ secrets.SNOWFLAKE_FIDESCTL_PASSWORD }}
+          SNOWFLAKE_FIDESCTL_PASSWORD: ${{ secrets.SNOWFLAKE_FIDESCTL_PASSWORD }}

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -159,3 +159,5 @@ jobs:
 
       - name: Run integration test suite
         run: make pytest-integration
+        env:
+        SNOWFLAKE_FIDESCTL_PASSWORD: ${{ secrets.SNOWFLAKE_FIDESCTL_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ pytest-unit:
 
 pytest-integration:
 	@docker compose -f docker-compose.yml -f docker-compose.integration-tests.yml up -d $(IMAGE_NAME)
-	@$(RUN) pytest -x -m integration
+	@docker compose run -e SNOWFLAKE_FIDESCTL_PASSWORD --rm $(IMAGE_NAME) pytest -x -m integration
 	@make teardown
 
 xenon:

--- a/docs/fides/docs/development/testing.md
+++ b/docs/fides/docs/development/testing.md
@@ -74,6 +74,14 @@ The `--sw` flag will exit `pytest` the first time it encounters an error; subseq
 
 For more information on available Pytest invocation options, see the documentation [here](https://docs.pytest.org/en/6.2.x/usage.html#usage-and-invocations).
 
+### Excluding external tests
+
+Integration tests also test integration with external services like Snowflake which require internet access and authentication. It is possible to skip these tests by excluding the `external` mark. 
+
+```bash
+# run all tests except those marked as external
+pytest -m "not external"
+```
 ## CI Workflows
 
 CI will run automatically against any PR you open. Please run your tests locally first to avoid "debugging in CI", as this takes up resources that could be used by other contributors and is generally an inefficient usage of your time!

--- a/docs/fides/docs/guides/scan_resource.md
+++ b/docs/fides/docs/guides/scan_resource.md
@@ -59,9 +59,6 @@ dataset:
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
 ```
 
-fidesctl scan --manifest-dir dataset.yml database postgresql+psycopg2://postgres:fidesctl@fidesctl-db:5432/postgres 
-
-
 We can invoke the `scan` by simply providing a connection url for this database:
 ```sh
 ./venv/bin/fidesctl scan \

--- a/fidesctl/setup.py
+++ b/fidesctl/setup.py
@@ -16,6 +16,7 @@ psycopg_connector = "psycopg2-binary==2.9.1"
 asyncpg = "asyncpg==0.25.0"
 mysql_connector = "pymysql==1.0.0"
 mssql_connector = "pyodbc==4.0.32"
+snowflake_connector = "snowflake-sqlalchemy==1.3.3"
 fastapi = "fastapi==0.68"
 uvicorn = "uvicorn==0.15"
 
@@ -23,6 +24,7 @@ extras = {
     "postgres": [psycopg_connector],
     "mysql": [mysql_connector],
     "mssql": [mssql_connector],
+    "snowflake": [snowflake_connector],
     "webserver": [fastapi, uvicorn, psycopg_connector, asyncpg],
 }
 dangerous_extras = ["mssql"]  # These extras break on certain platforms

--- a/fidesctl/src/fidesctl/core/generate_dataset.py
+++ b/fidesctl/src/fidesctl/core/generate_dataset.py
@@ -85,6 +85,30 @@ def get_mssql_collections_and_fields(engine: Engine) -> Dict[str, Dict[str, List
     return db_tables
 
 
+def get_snowfake_collections_and_fields(
+    engine: Engine,
+) -> Dict[str, Dict[str, List[str]]]:
+    """
+    Snowflake-specific implementation that to ingest all of the
+    schemas and tables from a database.
+
+    Returns a mapping of schemas to its tables and all of the table's fields.
+    """
+    inspector = sqlalchemy.inspect(engine)
+    schema_exclusion_list = ["information_schema"]
+
+    db_tables: Dict[str, Dict[str, List]] = {}
+    for schema in inspector.get_schema_names():
+        if schema not in schema_exclusion_list:
+            db_tables[schema] = {}
+            for table in inspector.get_table_names(schema=schema):
+                db_tables[schema][table] = [
+                    column["name"]
+                    for column in inspector.get_columns(table, schema=schema)
+                ]
+    return db_tables
+
+
 def get_db_collections_and_fields(engine: Engine) -> Dict[str, Dict[str, List[str]]]:
     """
     Returns a database collections and fields, delegating to a specific engine dialect function
@@ -95,6 +119,7 @@ def get_db_collections_and_fields(engine: Engine) -> Dict[str, Dict[str, List[st
         "postgresql": get_postgres_collections_and_fields,
         "mysql": get_mysql_collections_and_fields,
         "mssql": get_mssql_collections_and_fields,
+        "snowflake": get_snowfake_collections_and_fields,
     }
     collections_and_fields = database_ingestion_functions[engine.dialect.name](engine)
     return collections_and_fields

--- a/fidesctl/tests/core/test_generate_dataset.py
+++ b/fidesctl/tests/core/test_generate_dataset.py
@@ -21,7 +21,7 @@ MASTER_MSSQL_URL = MSSQL_URL_TEMPLATE.format("master") + "&autocommit=True"
 
 # External databases require credentials passed through environment variables
 SNOWFLAKE_URL_TEMPLATE = "snowflake://FIDESCTL:{}@ZOA73785/FIDESCTL_TEST"
-SNOWFLAKE_URL = SNOWFLAKE_URL_TEMPLATE.format(os.environ["SNOWFLAKE_FIDESCTL_PASSWORD"], "")
+SNOWFLAKE_URL = SNOWFLAKE_URL_TEMPLATE.format(os.getenv('SNOWFLAKE_FIDESCTL_PASSWORD', ""))
 
 def create_server_datasets(test_config, datasets: List[Dataset]):
     for dataset in datasets:

--- a/fidesctl/tests/core/test_generate_dataset.py
+++ b/fidesctl/tests/core/test_generate_dataset.py
@@ -1,5 +1,6 @@
 import sqlalchemy
 import pytest
+import os
 from typing import List, Dict
 
 from fidesctl.core import generate_dataset, api
@@ -18,6 +19,9 @@ MSSQL_URL_TEMPLATE = "mssql+pyodbc://sa:SQLserver1@sqlserver-test:1433/{}?driver
 MSSQL_URL = MSSQL_URL_TEMPLATE.format("sqlserver_example")
 MASTER_MSSQL_URL = MSSQL_URL_TEMPLATE.format("master") + "&autocommit=True"
 
+# External databases require credentials passed through environment variables
+SNOWFLAKE_URL_TEMPLATE = "snowflake://FIDESCTL:{}@ZOA73785/FIDESCTL_TEST"
+SNOWFLAKE_URL = SNOWFLAKE_URL_TEMPLATE.format(os.environ["SNOWFLAKE_FIDESCTL_PASSWORD"], "")
 
 def create_server_datasets(test_config, datasets: List[Dataset]):
     for dataset in datasets:
@@ -520,6 +524,94 @@ class TestSQLServer:
         create_server_datasets(test_config, datasets)
         generate_dataset.database_coverage(
             connection_string=MSSQL_URL,
+            manifest_dir=f"{tmpdir}",
+            coverage_threshold=100,
+            url=test_config.cli.server_url,
+            headers=test_config.user.request_headers,
+        )
+
+@pytest.mark.snowflake
+@pytest.mark.external
+class TestSnowflake:
+    EXPECTED_COLLECTION = {
+        "public": {
+            "visit": ["email", "last_visit"],
+            "login": ["id", "customer_id", "time"],
+        }
+    }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def snowflake_setup(self):
+        """
+        Set up the Snowflake Database for testing.
+
+        The query file must have each query on a separate line.
+        Initial connection must be done to the master database.
+        """
+        engine = sqlalchemy.create_engine(SNOWFLAKE_URL)
+        with open("tests/data/example_sql/snowflake_example.sql", "r") as query_file:
+            queries = [query for query in query_file.read().splitlines() if query != ""]
+        print(queries)
+        for query in queries:
+            engine.execute(sqlalchemy.sql.text(query))
+        yield
+
+    @pytest.mark.integration
+    def test_get_db_tables_snowflake(self):
+        engine = sqlalchemy.create_engine(SNOWFLAKE_URL)
+        actual_result = generate_dataset.get_snowfake_collections_and_fields(engine)
+        assert actual_result == TestSnowflake.EXPECTED_COLLECTION
+
+    @pytest.mark.integration
+    def test_generate_dataset_snowflake(self, tmpdir):
+        actual_result = generate_dataset.generate_dataset(
+            SNOWFLAKE_URL, f"{tmpdir}/test_file.yml"
+        )
+        assert actual_result
+
+    @pytest.mark.integration
+    def test_generate_dataset_passes_snowflake(self, test_config):
+        datasets: List[Dataset] = generate_dataset.create_dataset_collections(
+            TestSnowflake.EXPECTED_COLLECTION
+        )
+        set_field_data_categories(datasets, "system.operations")
+        create_server_datasets(test_config, datasets)
+        generate_dataset.database_coverage(
+            connection_string=SNOWFLAKE_URL,
+            manifest_dir="",
+            coverage_threshold=100,
+            url=test_config.cli.server_url,
+            headers=test_config.user.request_headers,
+        )
+
+    @pytest.mark.integration
+    def test_generate_dataset_coverage_failure_snowflake(self, test_config):
+        datasets: List[Dataset] = generate_dataset.create_dataset_collections(
+            TestSnowflake.EXPECTED_COLLECTION
+        )
+        create_server_datasets(test_config, datasets)
+        with pytest.raises(SystemExit):
+            generate_dataset.database_coverage(
+                connection_string=SNOWFLAKE_URL,
+                manifest_dir="",
+                coverage_threshold=100,
+                url=test_config.cli.server_url,
+                headers=test_config.user.request_headers,
+            )
+
+    @pytest.mark.integration
+    def test_dataset_coverage_manifest_passes_snowflake(self, test_config, tmpdir):
+        datasets: List[Dataset] = generate_dataset.create_dataset_collections(
+            TestSnowflake.EXPECTED_COLLECTION
+        )
+        set_field_data_categories(datasets, "system.operations")
+
+        file_name = tmpdir.join("dataset.yml")
+        write_manifest(file_name, [i.dict() for i in datasets], "dataset")
+
+        create_server_datasets(test_config, datasets)
+        generate_dataset.database_coverage(
+            connection_string=SNOWFLAKE_URL,
             manifest_dir=f"{tmpdir}",
             coverage_threshold=100,
             url=test_config.cli.server_url,

--- a/fidesctl/tests/data/example_sql/snowflake_example.sql
+++ b/fidesctl/tests/data/example_sql/snowflake_example.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS public.visit;
+DROP TABLE IF EXISTS public.login;
+
+CREATE TABLE public.visit ( email varchar(100), last_visit DATETIME);
+CREATE TABLE public.login ( id INT, customer_id INT, time DATETIME);
+
+
+INSERT INTO public.visit VALUES ('customer-1@example.com', '2021-01-06 01:00:00'), ('customer-2@example.com', '2021-01-06 01:00:00');
+INSERT INTO public.login VALUES (1, 1, '2021-01-01 01:00:00'), (2, 1, '2021-01-02 01:00:00'), (3, 1, '2021-01-03 01:00:00');


### PR DESCRIPTION
Closes #253 

### Code Changes

* [x] Add usage of snowflake-sqlalchemy 
* [x] Add snowflake dataset collection function
* [x] Add integration test for snowflake integration
* [x] Add new mark `external` which can be excluded
* [x] Add `SNOWFLAKE_FIDESCTL_PASSWORD ` secret to env while running pytest

### Steps to Confirm

* [x] Verified dataset generation on test snowflake db `EARMENDA_TEST`
* [x] Added integration tests for working with snowflake

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

Created a `FIDESCTL` user and role in Snowflake which only has access to edit the database `FIDESCTL_TEST`. This was done with the following queries:
```
GRANT USAGE ON WAREHOUSE COMPUTE_WH TO ROLE FIDESCTL;
GRANT ALL ON DATABASE FIDESCTL_TEST TO ROLE FIDESCTL;
GRANT ALL ON SCHEMA FIDESCTL_TEST.PUBLIC TO ROLE FIDESCTL;
GRANT ALL ON FUTURE TABLES IN SCHEMA FIDESCTL_TEST.PUBLIC to ROLE FIDESCTL;
```

This is safe way to grant our CI access to a Snowflake user without risking anything else in our ethyca account. Also added some documentation for excluding external tests if needed(maybe if repo is forked or something like that)

Verified creating a database `EARMENDA_TEST` with a `public` schema generated the expected dataset:
```
fidesctl generate-dataset "snowflake://FIDESCTL:$SNOWFLAKE_FIDESCTL_PASSWORD@ZOA73785/EARMENDA_TEST" dataset.yml
```
```
dataset:
- fides_key: public
  organization_fides_key: default_organization
  name: public
  description: 'Fides Generated Description for Schema: public'
  meta: null
  data_categories: []
  data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
  collections:
  - name: table1
    description: 'Fides Generated Description for Table: table1'
    data_categories: []
    data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
    fields:
    - name: test
      description: 'Fides Generated Description for Column: test'
      data_categories: []
      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
      fields: null
```