### PR TITLE
Export System & Dataset as csv

### DIFF
--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -6,6 +6,7 @@ from fidesctl.cli.cli import (
     apply,
     delete,
     evaluate,
+    export,
     generate_dataset,
     scan,
     annotate_dataset,
@@ -26,6 +27,7 @@ API_COMMANDS = [
     annotate_dataset,
     apply,
     delete,
+    export,
     generate_dataset,
     scan,
     get,
@@ -40,7 +42,6 @@ API_COMMANDS = [
 @click.group(
     context_settings=CONTEXT_SETTINGS,
     invoke_without_command=True,
-    chain=True,
     name="fidesctl",
 )
 @click.version_option(version=fidesctl.__version__)

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -135,7 +135,12 @@ def export(ctx: click.Context) -> None:
 @export.command(name="system")
 @click.pass_context
 @manifests_dir_argument
-def export_system(ctx: click.Context, manifests_dir: str) -> None:
+@dry_flag
+def export_system(
+    ctx: click.Context,
+    manifests_dir: str,
+    dry: bool,
+) -> None:
     """
     Simple export of a system to get the data map project started
     """
@@ -146,13 +151,19 @@ def export_system(ctx: click.Context, manifests_dir: str) -> None:
         system_list=taxonomy.system,
         headers=config.user.request_headers,
         manifests_dir=manifests_dir,
+        dry=dry,
     )
 
 
 @export.command(name="dataset")
 @click.pass_context
 @manifests_dir_argument
-def export_dataset(ctx: click.Context, manifests_dir: str) -> None:
+@dry_flag
+def export_dataset(
+    ctx: click.Context,
+    manifests_dir: str,
+    dry: bool,
+) -> None:
     """
     Simple export of datasets to get the data map project started
     """
@@ -163,6 +174,7 @@ def export_dataset(ctx: click.Context, manifests_dir: str) -> None:
         dataset_list=taxonomy.dataset,
         headers=config.user.request_headers,
         manifests_dir=manifests_dir,
+        dry=dry,
     )
 
 

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -123,13 +123,12 @@ def evaluate(
     )
 
 
-@click.group()
+@click.group(name="export")
 @click.pass_context
 def export(ctx: click.Context) -> None:
     """
     Parent export command to handle exporting of various datasets
     """
-    pass
 
 
 @export.command(name="system")
@@ -144,6 +143,23 @@ def export_system(ctx: click.Context, manifests_dir: str) -> None:
     _export.export_system(
         url=config.cli.server_url,
         system_list=taxonomy.system,
+        headers=config.user.request_headers,
+        manifests_dir=manifests_dir,
+    )
+
+
+@export.command(name="dataset")
+@click.pass_context
+@manifests_dir_argument
+def export_dataset(ctx: click.Context, manifests_dir: str) -> None:
+    """
+    Simple export of datasets to get the data map project started
+    """
+    config = ctx.obj["CONFIG"]
+    taxonomy = _parse.parse(manifests_dir)
+    _export.export_dataset(
+        url=config.cli.server_url,
+        dataset_list=taxonomy.dataset,
         headers=config.user.request_headers,
         manifests_dir=manifests_dir,
     )

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -128,11 +128,11 @@ def evaluate(
 @click.pass_context
 def export(ctx: click.Context) -> None:
     """
-    Parent export command to handle exporting of various datasets
+    Parent export command.
     """
 
 
-@export.command(name="system")
+@export.command(name="systems")
 @click.pass_context
 @manifests_dir_argument
 @dry_flag
@@ -142,7 +142,7 @@ def export_system(
     dry: bool,
 ) -> None:
     """
-    Simple export of a system to get the data map project started
+    Export a system in a data map format.
     """
     config = ctx.obj["CONFIG"]
     taxonomy = _parse.parse(manifests_dir)
@@ -155,7 +155,7 @@ def export_system(
     )
 
 
-@export.command(name="dataset")
+@export.command(name="datasets")
 @click.pass_context
 @manifests_dir_argument
 @dry_flag
@@ -165,7 +165,7 @@ def export_dataset(
     dry: bool,
 ) -> None:
     """
-    Simple export of datasets to get the data map project started
+    Export a dataset in a data map format.
     """
     config = ctx.obj["CONFIG"]
     taxonomy = _parse.parse(manifests_dir)

--- a/fidesctl/src/fidesctl/cli/cli.py
+++ b/fidesctl/src/fidesctl/cli/cli.py
@@ -18,6 +18,7 @@ from fidesctl.core import (
     api as _api,
     apply as _apply,
     evaluate as _evaluate,
+    export as _export,
     generate_dataset as _generate_dataset,
     parse as _parse,
 )
@@ -119,6 +120,32 @@ def evaluate(
         message=message,
         local=config.cli.local_mode,
         dry=dry,
+    )
+
+
+@click.group()
+@click.pass_context
+def export(ctx: click.Context) -> None:
+    """
+    Parent export command to handle exporting of various datasets
+    """
+    pass
+
+
+@export.command(name="system")
+@click.pass_context
+@manifests_dir_argument
+def export_system(ctx: click.Context, manifests_dir: str) -> None:
+    """
+    Simple export of a system to get the data map project started
+    """
+    config = ctx.obj["CONFIG"]
+    taxonomy = _parse.parse(manifests_dir)
+    _export.export_system(
+        url=config.cli.server_url,
+        system_list=taxonomy.system,
+        headers=config.user.request_headers,
+        manifests_dir=manifests_dir,
     )
 
 

--- a/fidesctl/src/fidesctl/core/export.py
+++ b/fidesctl/src/fidesctl/core/export.py
@@ -1,31 +1,34 @@
 """This module handles the logic required for applying manifest files to the server."""
 from datetime import datetime
-from pprint import pprint
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple, Set
 
 import csv
 
-from fidesctl.cli.utils import handle_cli_response
-from fidesctl.core import api
 from fidesctl.core.api_helpers import get_server_resources
-from fidesctl.core.utils import echo_green
-from fideslang import FidesModel, Taxonomy
+from fidesctl.core.utils import echo_green, get_all_level_fields
 
 
-def list_fides_keys(resources: List):
+def list_fides_keys(resources: List) -> List:
+    """
+    Returns a list of fides_keys found in the manifest dir
+    """
     existing_keys = [resource.fides_key for resource in resources]
     return existing_keys
 
 
-def export_csv(
-    list_to_export: List[Tuple], output_type: str, manifests_dir: str
-) -> None:
+def export_to_csv(list_to_export: List, output_type: str, manifests_dir: str) -> None:
+    """
+    Exports a list of Tuples of any length back to the manifest
+    directory as a csv.
+    """
     utc_datetime = datetime.utcnow().strftime("%Y-%m-%d-T%H%M%S")
     filename = "".join([utc_datetime, "_", output_type, ".csv"])
     filepath = "/".join([manifests_dir, filename])
     with open(filepath, "w") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerows(list_to_export)
+
+    echo_green(filename + " successfully exported.")
 
 
 # def export(
@@ -38,19 +41,112 @@ def export_csv(
 #     """
 
 #     export_list = export_system(url, taxonomy.system, headers)
-#     export_csv(export_list)
+#     export_to_csv(export_list)
+
+
+def export_dataset(
+    url: str, dataset_list: List, headers: Dict[str, str], manifests_dir: str
+) -> None:
+    """
+    Exports the required fields from a dataset resource to csv
+    The resource is extracted from the server prior to being
+    flattened as needed for exporting
+    """
+    resource_type = "dataset"
+    existing_keys = list_fides_keys(dataset_list)
+    server_resource_list = get_server_resources(
+        url, resource_type, existing_keys, headers
+    )
+    # load the output list with expected headers for the csv
+    output_list = [
+        (
+            "dataset.name",
+            "dataset.description",
+            "dataset.data_categories",  # from Kelly - unique data categories per data qualifier, per data use per for the entire dataset, per row.
+            # "dataset.data_uses",
+            # "dataset.data_subjects",
+            "dataset.data_qualifier",
+        )
+    ]
+    # using a set here to preserve uniqueness of categories and qualifiers across fields
+    unique_data_categories: set = set()
+
+    for dataset in server_resource_list:
+        dataset_name = dataset.name
+        dataset_description = dataset.description
+        if dataset.data_categories:
+            dataset_rows = generate_data_category_rows(
+                dataset_name,
+                dataset_description,
+                dataset.data_qualifier,
+                dataset.data_categories,
+            )
+            unique_data_categories = unique_data_categories.union(dataset_rows)
+        for collection in dataset.collections:
+            if collection.data_categories:
+                dataset_rows = generate_data_category_rows(
+                    dataset_name,
+                    dataset_description,
+                    collection.data_qualifier,
+                    collection.data_categories,
+                )
+                unique_data_categories = unique_data_categories.union(dataset_rows)
+            for field in get_all_level_fields(collection.fields):
+                if field.data_categories:
+                    dataset_rows = generate_data_category_rows(
+                        dataset_name,
+                        dataset_description,
+                        field.data_qualifier,
+                        field.data_categories,
+                    )
+                    unique_data_categories = unique_data_categories.union(dataset_rows)
+
+    output_list += list(unique_data_categories)
+    export_to_csv(output_list, resource_type, manifests_dir)
+
+
+def generate_data_category_rows(
+    dataset_name: str,
+    dataset_description: str,
+    data_qualifier: str,
+    data_categories: List,
+) -> Set[Tuple[str, str, str, str]]:
+    """
+    Set comprehension to capture categories from any
+    of the possible levels in a dataset resource.
+
+    Returns a set of tuples to be unioned with the
+    overall set to be exported.
+    """
+    dataset_rows = {
+        (
+            dataset_name,
+            dataset_description,
+            category,
+            data_qualifier,
+        )
+        for category in data_categories
+    }
+
+    return dataset_rows
 
 
 def export_system(
     url: str, system_list: List, headers: Dict[str, str], manifests_dir: str
 ) -> None:
+    """
+    Exports the required fields from a system resource to csv
+    The resource is extracted from the server prior to being
+    flattened as needed for exporting
+    """
     resource_type = "system"
     existing_keys = list_fides_keys(system_list)
     server_resource_list = get_server_resources(
         url, resource_type, existing_keys, headers
     )
 
-    system_headers = [
+    # load the output list with expected headers for the csv
+    output_list = [
         (
             "system.name",
             "system.description",
@@ -63,13 +159,7 @@ def export_system(
         )
     ]
 
-    output_list = []
-    output_list += system_headers
-
-    for system in system_list:
-
-        system_name = system.name
-        system_description = system.description
+    for system in server_resource_list:
 
         for declaration in system.privacy_declarations:
             data_categories = declaration.data_categories or []
@@ -77,8 +167,8 @@ def export_system(
             dataset_references = declaration.dataset_references or []
             cartesian_product_of_declaration = [
                 (
-                    system_name,
-                    system_description,
+                    system.name,
+                    system.description,
                     declaration.name,
                     category,
                     declaration.data_use,
@@ -92,7 +182,7 @@ def export_system(
             ]
             output_list += cartesian_product_of_declaration
 
-    export_csv(output_list, resource_type, manifests_dir)
+    export_to_csv(output_list, resource_type, manifests_dir)
 
     ### Other method I was testing using pandas,
     ### it seems overly complicated at this point but keeping for PR conversation

--- a/fidesctl/src/fidesctl/core/export.py
+++ b/fidesctl/src/fidesctl/core/export.py
@@ -1,0 +1,130 @@
+"""This module handles the logic required for applying manifest files to the server."""
+from datetime import datetime
+from pprint import pprint
+from typing import Dict, List, Tuple, Optional
+
+import csv
+
+from fidesctl.cli.utils import handle_cli_response
+from fidesctl.core import api
+from fidesctl.core.api_helpers import get_server_resources
+from fidesctl.core.utils import echo_green
+from fideslang import FidesModel, Taxonomy
+
+
+def list_fides_keys(resources: List):
+    existing_keys = [resource.fides_key for resource in resources]
+    return existing_keys
+
+
+def export_csv(
+    list_to_export: List[Tuple], output_type: str, manifests_dir: str
+) -> None:
+    utc_datetime = datetime.utcnow().strftime("%Y-%m-%d-T%H%M%S")
+    filename = "".join([utc_datetime, "_", output_type, ".csv"])
+    filepath = "/".join([manifests_dir, filename])
+    with open(filepath, "w") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerows(list_to_export)
+
+
+# def export(
+#     url: str,
+#     taxonomy: Taxonomy,
+#     headers: Dict[str, str],
+# ) -> None:
+#     """
+#     Planned to use this as a potential router for v1
+#     """
+
+#     export_list = export_system(url, taxonomy.system, headers)
+#     export_csv(export_list)
+
+
+def export_system(
+    url: str, system_list: List, headers: Dict[str, str], manifests_dir: str
+) -> None:
+    resource_type = "system"
+    existing_keys = list_fides_keys(system_list)
+    server_resource_list = get_server_resources(
+        url, resource_type, existing_keys, headers
+    )
+
+    system_headers = [
+        (
+            "system.name",
+            "system.description",
+            "system.privacy_declaration.name",
+            "system.privacy_declaration.data_categories",
+            "system.privacy_declaration.data_uses",
+            "system.privacy_declaration.data_subjects",
+            "system.privacy_declaration.data_qualifier",
+            "system.privacy_declaration.dataset_references",
+        )
+    ]
+
+    output_list = []
+    output_list += system_headers
+
+    for system in system_list:
+
+        system_name = system.name
+        system_description = system.description
+
+        for declaration in system.privacy_declarations:
+            data_categories = declaration.data_categories or []
+            data_subjects = declaration.data_subjects or []
+            dataset_references = declaration.dataset_references or []
+            cartesian_product_of_declaration = [
+                (
+                    system_name,
+                    system_description,
+                    declaration.name,
+                    category,
+                    declaration.data_use,
+                    subject,
+                    declaration.data_qualifier,
+                    dataset_reference,
+                )
+                for category in data_categories
+                for subject in data_subjects
+                for dataset_reference in dataset_references
+            ]
+            output_list += cartesian_product_of_declaration
+
+    export_csv(output_list, resource_type, manifests_dir)
+
+    ### Other method I was testing using pandas,
+    ### it seems overly complicated at this point but keeping for PR conversation
+
+    # system_list_of_dicts = []
+    # for system in server_resource_list:
+    #     system_list_of_dicts.append(system)
+
+    # system_df = pd.merge(
+    #     pd.json_normalize(
+    #         system_list_of_dicts,
+    #         ["privacy_declarations", "dataset_references"],
+    #         meta=[
+    #             "fides_key",
+    #             "name",
+    #             "description",
+    #             ["privacy_declarations", "data_use"],
+    #             ["privacy_declarations", "name"],
+    #             ["privacy_declaration", "data_qualifier"],
+    #         ],
+    #     ),
+    #     pd.json_normalize(
+    #         system_list_of_dicts,
+    #         ["privacy_declarations", "data_categories"],
+    #         meta="fides_key",
+    #     ),
+    #     on="fides_key",
+    # ).merge(
+    #     pd.json_normalize(
+    #         system_list_of_dicts,
+    #         ["privacy_declarations", "data_subjects"],
+    #         meta="fides_key",
+    #     ),
+    #     on="fides_key",
+    # )

--- a/fidesctl/src/fidesctl/core/export.py
+++ b/fidesctl/src/fidesctl/core/export.py
@@ -8,14 +8,6 @@ from fidesctl.core.api_helpers import get_server_resources
 from fidesctl.core.utils import echo_green, get_all_level_fields
 
 
-def list_fides_keys(resources: List) -> List:
-    """
-    Returns a list of fides_keys found in the manifest dir
-    """
-    existing_keys = [resource.fides_key for resource in resources]
-    return existing_keys
-
-
 def export_to_csv(
     list_to_export: List, resource_exported: str, manifests_dir: str
 ) -> str:
@@ -64,20 +56,20 @@ def generate_dataset_records(
 ) -> List[Tuple[str, str, str, str]]:
     """
     Returns a list of tuples as records (with expected headers)
-    to be exported as csv
+    to be exported as csv. The ouput rows consist of unique combinations
+    of data categories, data qualifiers, and data uses for the entire dataset
     """
 
     output_list = [
         (
             "dataset.name",
             "dataset.description",
-            "dataset.data_categories",  # from Kelly - unique data categories per data qualifier, per data use per for the entire dataset, per row.
-            # "dataset.data_uses",
-            # "dataset.data_subjects",
+            "dataset.data_categories",
             "dataset.data_qualifier",
         )
     ]
-    # using a set here to preserve uniqueness of categories and qualifiers across fields
+
+    # using a set to preserve uniqueness of categories and qualifiers across fields
     unique_data_categories: set = set()
 
     for dataset in server_dataset_list:
@@ -125,7 +117,7 @@ def export_dataset(
     flattened as needed for exporting
     """
     resource_type = "dataset"
-    existing_keys = list_fides_keys(dataset_list)
+    existing_keys = [resource.fides_key for resource in dataset_list]
 
     server_resource_list = get_server_resources(
         url, resource_type, existing_keys, headers
@@ -202,7 +194,7 @@ def export_system(
     """
     resource_type = "system"
 
-    existing_keys = list_fides_keys(system_list)
+    existing_keys = [resource.fides_key for resource in system_list]
     server_resource_list = get_server_resources(
         url, resource_type, existing_keys, headers
     )

--- a/fidesctl/src/fidesctl/core/export.py
+++ b/fidesctl/src/fidesctl/core/export.py
@@ -1,8 +1,10 @@
-"""This module handles the logic required for applying manifest files to the server."""
+"""
+Exports various resources as data maps.
+"""
+import csv
 from datetime import datetime
 from typing import Dict, List, Tuple, Set
 
-import csv
 
 from fidesctl.core.api_helpers import get_server_resources
 from fidesctl.core.utils import echo_green, get_all_level_fields
@@ -16,8 +18,8 @@ def export_to_csv(
     directory as a csv.
     """
     utc_datetime = datetime.utcnow().strftime("%Y-%m-%d-T%H%M%S")
-    filename = "".join([utc_datetime, "_", resource_exported, ".csv"])
-    filepath = "/".join([manifests_dir, filename])
+    filename = f"{utc_datetime}_{resource_exported}.csv"
+    filepath = f"{manifests_dir}/{filename}"
     with open(filepath, "w") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerows(list_to_export)
@@ -112,9 +114,10 @@ def export_dataset(
     url: str, dataset_list: List, headers: Dict[str, str], manifests_dir: str, dry: bool
 ) -> None:
     """
-    Exports the required fields from a dataset resource to csv
-    The resource is extracted from the server prior to being
-    flattened as needed for exporting
+    Exports the required fields from a dataset resource to a csv file.
+
+    The resource is flattened from the server prior to being
+    flattened as needed for exporting.
     """
     resource_type = "dataset"
     existing_keys = [resource.fides_key for resource in dataset_list]
@@ -188,9 +191,10 @@ def export_system(
     url: str, system_list: List, headers: Dict[str, str], manifests_dir: str, dry: bool
 ) -> None:
     """
-    Exports the required fields from a system resource to csv
-    The resource is extracted from the server prior to being
-    flattened as needed for exporting
+    Exports the required fields from a system resource to a csv file.
+
+    The resource is fetched from the server prior to being
+    flattened as needed for exporting.
     """
     resource_type = "system"
 

--- a/fidesctl/tests/cli/test_cli.py
+++ b/fidesctl/tests/cli/test_cli.py
@@ -230,7 +230,7 @@ def test_export_system(test_config_path: str, test_cli_runner: CliRunner):
             "-f",
             test_config_path,
             "export",
-            "system",
+            "systems",
             "demo_resources/",
             "--dry",
         ],

--- a/fidesctl/tests/cli/test_cli.py
+++ b/fidesctl/tests/cli/test_cli.py
@@ -219,6 +219,26 @@ def test_evaluate_with_dataset_collection_failed(
 
 
 @pytest.mark.integration
+def test_export_system(test_config_path: str, test_cli_runner: CliRunner):
+    """
+    Tests that a system is properly exported
+    """
+
+    result = test_cli_runner.invoke(
+        cli,
+        [
+            "-f",
+            test_config_path,
+            "export",
+            "system",
+            "demo_resources/",
+            "--dry",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
 def test_nested_field_fails_evaluation(
     test_config_path: str, test_cli_runner: CliRunner
 ):

--- a/fidesctl/tests/core/test_export.py
+++ b/fidesctl/tests/core/test_export.py
@@ -77,7 +77,8 @@ def test_sample_dataset_taxonomy():
 @pytest.mark.unit
 def test_system_records_to_export(test_sample_system_taxonomy):
     """
-    Asserts the correct number of system rows is returned, alon
+    Asserts that unique records are returned properly (including
+    the header row)
     """
     output_list = export.generate_system_records(test_sample_system_taxonomy)
 

--- a/fidesctl/tests/core/test_export.py
+++ b/fidesctl/tests/core/test_export.py
@@ -1,0 +1,133 @@
+from os import path
+
+import pytest
+
+from fidesctl.core import export
+from fideslang.models import (
+    Dataset,
+    DatasetCollection,
+    DatasetField,
+    PrivacyDeclaration,
+    System,
+)
+
+
+@pytest.fixture()
+def test_sample_system_taxonomy():
+    yield [
+        System(
+            fides_key="test_system",
+            system_type="test",
+            system_name="test system",
+            system_description="system used for testing exports",
+            privacy_declarations=[
+                PrivacyDeclaration(
+                    name="privacy_declaration_1",
+                    data_categories=["account.contact.email", "account.contact.name"],
+                    data_use="provide.system",
+                    data_qualifier="aggregated.anonymized",
+                    data_subjects=["customer"],
+                    dataset_references=["users_dataset"],
+                )
+            ],
+        )
+    ]
+
+
+@pytest.fixture()
+def test_sample_dataset_taxonomy():
+    yield [
+        Dataset(
+            fides_key="test_dataset",
+            name="test dataset",
+            description="dataset for testing",
+            dataset_categories=[],
+            collections=[
+                DatasetCollection(
+                    name="test_collection",
+                    data_categories=[],
+                    fields=[
+                        DatasetField(
+                            name="test_field_1",
+                            data_categories=["test_category_1"],
+                            data_qualifier="aggregated.anonymized",
+                        ),
+                        DatasetField(
+                            name="test_field_2",
+                            data_categories=["test_category_2", "test_category_3"],
+                            data_qualifier="aggregated.anonymized",
+                        ),
+                        DatasetField(
+                            name="test_field_3",
+                            data_categories=["test_category_3"],
+                            data_qualifier="aggregated.anonymized",
+                        ),
+                        DatasetField(
+                            name="test_field_4",
+                            data_categories=["test_category_2"],
+                            data_qualifier="aggregated.anonymized",
+                        ),
+                    ],
+                )
+            ],
+        )
+    ]
+
+
+@pytest.mark.unit
+def test_system_records_to_export(test_sample_system_taxonomy):
+    """
+    Asserts the correct number of system rows is returned, alon
+    """
+    output_list = export.generate_system_records(test_sample_system_taxonomy)
+
+    assert len(output_list) == 3
+
+
+@pytest.mark.unit
+def test_dataset_data_category_rows(test_sample_dataset_taxonomy):
+
+    dataset_name = test_sample_dataset_taxonomy[0].name
+    dataset_description = test_sample_dataset_taxonomy[0].description
+    test_field = test_sample_dataset_taxonomy[0].collections[0].fields[1]
+
+    dataset_rows = export.generate_data_category_rows(
+        dataset_name,
+        dataset_description,
+        test_field.data_qualifier,
+        test_field.data_categories,
+    )
+
+    assert len(dataset_rows) == 2
+
+
+@pytest.mark.unit
+def test_dataset_records_to_export(test_sample_dataset_taxonomy):
+    """
+    Asserts that unique records are returned properly (including
+    the header row)
+    """
+
+    output_list = export.generate_dataset_records(test_sample_dataset_taxonomy)
+
+    assert len(output_list) == 4
+
+
+@pytest.mark.unit
+def test_csv_export(tmpdir):
+    """
+    Asserts that the csv is successfully created
+    """
+
+    output_list = [("column_1", "column_2"), ("foo", "bar")]
+    resource_exported = "test"
+
+    exported_filename = export.export_to_csv(
+        list_to_export=output_list,
+        resource_exported=resource_exported,
+        manifests_dir=f"{tmpdir}",
+    )
+
+    exported_file = tmpdir.join(exported_filename)
+
+    assert path.exists(exported_file)


### PR DESCRIPTION
Closes #299 

### Code Changes

* [x] Allow grouped commands (i.e. `fidesctl export system`)
* [x] Add an `export` command to facilitate exporting a data map and ropa (eventually)

### Steps to Confirm

* [x] csv exports look as they should per the examples provided

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

As part of the crawl state, we want to be able to at least export some of the existing resources currently maintained in fides as csv.

I spent some time (probably too much tbf) looking at different options to try and flatten out the nested lists of data into something that aligned with the examples provided in the design/feature docs. Initially I thought this would be fairly straight forward to do using `json_normalize` in [pandas](https://pandas.pydata.org/docs/reference/api/pandas.json_normalize.html#). It ended up looking a bit over complicated by the time I had it (mostly) working so ended up using a list of tuples as records. I am not certain this is the right path forward by any means but as a starting point it felt the most clear. I'd love to learn more about if there is a way to use the default taxonomy class better or really what the rest of the team thinks in general

