### PR TITLE
Help text edit: scan and generate-dataset

### DIFF
--- a/fidesctl/src/fidesctl/cli/generate_commands.py
+++ b/fidesctl/src/fidesctl/cli/generate_commands.py
@@ -27,7 +27,7 @@ def generate_dataset(
     ctx: click.Context, connection_string: str, output_filename: str, include_null: bool
 ) -> None:
     """
-    Connect to a database directly via a SQLAlchemy-stlye connection string and
+    Connect to a database directly via a SQLAlchemy-style connection string and
     generate a dataset manifest file that consists of every schema/table/field.
 
     This is a one-time operation that does not track the state of the database.

--- a/fidesctl/src/fidesctl/cli/scan_commands.py
+++ b/fidesctl/src/fidesctl/cli/scan_commands.py
@@ -26,7 +26,7 @@ def scan_dataset(
     coverage_threshold: int,
 ) -> None:
     """
-    Connect to a database directly via a SQLAlchemy-stlye connection string and
+    Connect to a database directly via a SQLAlchemy-style connection string and
     compare the database objects to existing datasets.
 
     If there are fields within the database that aren't listed and categorized


### PR DESCRIPTION
Closes #361 

### Code Changes

* [x] _list your code changes here_

* Changed help text in Scan and Generate-dataset to correct spelling of style in "SQLAlchemy-stlye"

### Steps to Confirm

* [x] _list any manual steps taken to confirm the changes_

* `fidectl --help` should show correct spelling

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

Changes made to text within strings, should be fairly low-risk.
