### PR TITLE
Update make commands to set no-TTY flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,15 @@ IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 IMAGE_LOCAL := $(REGISTRY)/$(IMAGE_NAME):local
 IMAGE_LATEST := $(REGISTRY)/$(IMAGE_NAME):latest
 
+# Disable TTY to perserve output within Github Actions logs
+# CI env variable is always set to true in Github Actions
+ifeq "$(CI)" "true"
+    CI_ARGS:=--no-TTY
+endif
+
 # Run in Compose
-RUN = docker compose run --rm $(IMAGE_NAME)
-RUN_NO_DEPS = docker compose run --no-deps --no-TTY --rm $(IMAGE_NAME)
+RUN = docker compose run --rm $(CI_ARGS) $(IMAGE_NAME)
+RUN_NO_DEPS = docker compose run --no-deps --rm $(CI_ARGS) $(IMAGE_NAME)
 
 .PHONY: help
 help:
@@ -113,7 +119,7 @@ pytest-unit:
 
 pytest-integration:
 	@docker compose -f docker-compose.yml -f docker-compose.integration-tests.yml up -d $(IMAGE_NAME)
-	@docker compose run --no-TTY --rm $(IMAGE_NAME) \
+	@docker compose run --rm $(CI_ARGS) $(IMAGE_NAME) \
 	pytest -x -m integration
 	@make teardown
 
@@ -125,8 +131,7 @@ pytest-external:
 	-e AWS_ACCESS_KEY_ID \
 	-e AWS_SECRET_ACCESS_KEY \
 	-e AWS_DEFAULT_REGION \
-	--no-TTY \
-	--rm $(IMAGE_NAME) \
+	--rm $(CI_ARGS) $(IMAGE_NAME) \
 	pytest -x -m external
 	@make teardown
 
@@ -156,11 +161,11 @@ teardown:
 
 .PHONY: docs-build
 docs-build: build-local
-	@docker compose run --rm $(IMAGE_NAME) \
+	@docker compose run --rm $(CI_ARGS) $(IMAGE_NAME) \
 	python generate_docs.py ../docs/fides/docs/
 
 .PHONY: docs-serve
 docs-serve: docs-build
 	@docker compose build docs
-	@docker compose run --rm --service-ports docs \
+	@docker compose run --rm --service-ports $(CI_ARGS) docs \
 	/bin/bash -c "pip install -e /fidesctl && mkdocs serve --dev-addr=0.0.0.0:8000"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ IMAGE_LATEST := $(REGISTRY)/$(IMAGE_NAME):latest
 
 # Run in Compose
 RUN = docker compose run --rm $(IMAGE_NAME)
-RUN_NO_DEPS = docker compose run --no-deps --rm $(IMAGE_NAME)
+RUN_NO_DEPS = docker compose run --no-deps --no-TTY --rm $(IMAGE_NAME)
 
 .PHONY: help
 help:
@@ -113,7 +113,7 @@ pytest-unit:
 
 pytest-integration:
 	@docker compose -f docker-compose.yml -f docker-compose.integration-tests.yml up -d $(IMAGE_NAME)
-	@docker compose run --rm $(IMAGE_NAME) \
+	@docker compose run --no-TTY --rm $(IMAGE_NAME) \
 	pytest -x -m integration
 	@make teardown
 
@@ -125,6 +125,7 @@ pytest-external:
 	-e AWS_ACCESS_KEY_ID \
 	-e AWS_SECRET_ACCESS_KEY \
 	-e AWS_DEFAULT_REGION \
+	--no-TTY \
 	--rm $(IMAGE_NAME) \
 	pytest -x -m external
 	@make teardown

--- a/fidesctl/tests/core/test_api.py
+++ b/fidesctl/tests/core/test_api.py
@@ -149,4 +149,4 @@ def test_visualize(test_config, resource_type):
     response = requests.get(
         f"{test_config.cli.server_url}/{resource_type}/visualize/graphs"
     )
-    assert response.status_code == 200
+    assert response.status_code != 200

--- a/fidesctl/tests/core/test_api.py
+++ b/fidesctl/tests/core/test_api.py
@@ -149,4 +149,4 @@ def test_visualize(test_config, resource_type):
     response = requests.get(
         f"{test_config.cli.server_url}/{resource_type}/visualize/graphs"
     )
-    assert response.status_code != 200
+    assert response.status_code == 200


### PR DESCRIPTION
Closes #375 

### Code Changes

* [x] Set --no-TTY for targets called within github actions

### Steps to Confirm

* [x] Confirm this PR includes test output

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

Docker Compose version 2.2.2 used to guess whether to set the `no-TTY` flag when running the `docker compose run` command. As of 2.2.3 the flag is never set for you. 
 See the related PR - [docker-compose-9035](https://github.com/docker/compose/pull/9035)

To understand the flag better, see the following:
https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty

What I think was happening before was that when github actions ran our `docker compose run` command it would set the `no-TTY` flag for us, and when running locally it would not. 

I can't say i 100% understand how this flag works or why we don't see output without it but setting it should be the equivalent of our previous behavior. 
