### PR TITLE
Implement scan system aws command

### DIFF
--- a/fidesctl/src/fidesctl/cli/scan_commands.py
+++ b/fidesctl/src/fidesctl/cli/scan_commands.py
@@ -1,9 +1,7 @@
 """Contains the scan group of the commands for Fidesctl."""
 import click
 
-from fidesctl.core import (
-    dataset as _dataset,
-)
+from fidesctl.core import dataset as _dataset, system as _system
 
 
 @click.group(name="scan")
@@ -38,6 +36,40 @@ def scan_dataset(
     config = ctx.obj["CONFIG"]
     _dataset.scan_dataset(
         connection_string=connection_string,
+        manifest_dir=manifest_dir,
+        coverage_threshold=coverage_threshold,
+        url=config.cli.server_url,
+        headers=config.user.request_headers,
+    )
+
+
+@scan.group(name="system")
+@click.pass_context
+def scan_system(ctx: click.Context) -> None:
+    """
+    Scan fidesctl System resources
+    """
+
+
+@scan_system.command(name="aws")
+@click.pass_context
+@click.option("-m", "--manifest-dir", type=str, default="")
+@click.option("-c", "--coverage-threshold", type=click.IntRange(0, 100), default=100)
+def scan_system_aws(
+    ctx: click.Context,
+    manifest_dir: str,
+    coverage_threshold: int,
+) -> None:
+    """
+    Connect to an aws account by leveraging a valid boto3 environment varible
+    configuration and compares tracked resources to existing systems.
+    Tracked resources: [Redshift]
+
+    Outputs missing resources and has a non-zero exit if coverage is
+    under the stated threshold.
+    """
+    config = ctx.obj["CONFIG"]
+    _system.scan_system_aws(
         manifest_dir=manifest_dir,
         coverage_threshold=coverage_threshold,
         url=config.cli.server_url,

--- a/fidesctl/src/fidesctl/core/system.py
+++ b/fidesctl/src/fidesctl/core/system.py
@@ -1,11 +1,18 @@
 """Module that adds functionality for generating or scanning systems."""
-from typing import Dict, List
+from typing import Dict, List, Tuple, Callable
 
 import boto3
 
+from pydantic import AnyHttpUrl
+
+from fidesctl.cli.utils import handle_cli_response
+from fidesctl.core import api
+from fidesctl.core.parse import parse
+from fidesctl.core.api_helpers import get_server_resources
 from fideslang import manifests
 from fideslang.models import System, SystemMetadata
-from .utils import echo_green
+
+from .utils import echo_green, echo_red
 
 
 def describe_redshift_clusters() -> Dict[str, List[Dict]]:
@@ -76,3 +83,145 @@ def generate_system_aws(file_name: str, include_null: bool) -> str:
     )
     echo_green(f"Generated system manifest written to {file_name}")
     return file_name
+
+
+def get_redshift_arns(describe_clusters: Dict[str, List[Dict]]) -> List[str]:
+    """
+    Given a describe clusters response, build a list of cluster arns
+    """
+    redshift_arns = [
+        cluster["ClusterNamespaceArn"] for cluster in describe_clusters["Clusters"]
+    ]
+    return redshift_arns
+
+
+def scan_redshift_systems() -> Tuple[str, List[str]]:
+    """
+    Fetches Redshift clusters from AWS and returns a scan label and
+    list of cluster arns.
+    """
+    redshift_clusters = describe_redshift_clusters()
+    redshift_arns = get_redshift_arns(describe_clusters=redshift_clusters)
+    return "Redshift Clusters", redshift_arns
+
+
+def get_all_server_systems(
+    url: AnyHttpUrl, headers: Dict[str, str], exclude_systems: List[System]
+) -> List[System]:
+    """
+    Get a list of all of the Systems that exist on the server. Excludes any systems
+    provided in exclude_systems
+    """
+    ls_response = handle_cli_response(
+        api.ls(url=url, resource_type="system", headers=headers), verbose=False
+    )
+    exclude_system_keys = [system.fides_key for system in exclude_systems]
+    system_keys = [
+        resource["fides_key"]
+        for resource in ls_response.json()
+        if resource["fides_key"] not in exclude_system_keys
+    ]
+    system_list = get_server_resources(
+        url=url, resource_type="system", headers=headers, existing_keys=system_keys
+    )
+    return system_list
+
+
+def scan_aws_systems(
+    scan_system_functions: List[Callable[[], Tuple[str, List[str]]]],
+    existing_system_arns: List[str],
+) -> Tuple[str, int, int]:
+    """
+    Given a list of scan system functions, compares function result to
+    existing system arns. Returns missing resource text output, scanned
+    resource count, and missing resource count.
+    """
+    scan_text_output = ""
+    scanned_resource_count = 0
+    missing_resource_count = 0
+    for scan_system_function in scan_system_functions:
+        resource_label, resource_arns = scan_system_function()
+        missing_resources = set(resource_arns) - set(existing_system_arns)
+        scanned_resource_count += len(resource_arns)
+        missing_resource_count += len(missing_resources)
+        if missing_resource_count > 0:
+            scan_text_output += f"Missing {resource_label}:\n"
+            scan_text_output += "\t{}\n".format("\n\t".join(missing_resources))
+
+    return scan_text_output, scanned_resource_count, missing_resource_count
+
+
+def print_scan_system_aws_result(
+    scan_text_output: str,
+    scanned_resource_count: int,
+    missing_resource_count: int,
+    coverage_threshold: int,
+) -> None:
+    """
+    Prints uncategorized fields and raises an exception if coverage
+    is lower than provided threshold.
+    """
+    if missing_resource_count < 1:
+        echo_green(
+            f"Scanned {scanned_resource_count} resources and all were found in taxonomy."
+        )
+    else:
+        echo_red(
+            f"Scanned {scanned_resource_count} resource(s) and found {missing_resource_count} missing resource(s).\n"
+            + scan_text_output
+        )
+
+    coverage_percent = int(
+        ((scanned_resource_count - missing_resource_count) / scanned_resource_count)
+        * 100
+    )
+    annotation_output = "Resource coverage: {}%".format(coverage_percent)
+    if coverage_percent < coverage_threshold:
+        echo_red(annotation_output)
+        raise SystemExit(1)
+    echo_green(annotation_output)
+
+
+def scan_system_aws(
+    manifest_dir: str,
+    coverage_threshold: int,
+    url: AnyHttpUrl,
+    headers: Dict[str, str],
+) -> None:
+    """
+    Connect to an aws account by leveraging a valid boto3 environment varible
+    configuration and compares tracked resources to existing systems.
+    Tracked resources: [Redshift]
+    """
+    scan_system_functions = [scan_redshift_systems]
+
+    manifest_taxonomy = parse(manifest_dir) if manifest_dir else None
+    manifest_systems = manifest_taxonomy.system if manifest_taxonomy else []
+    server_systems = get_all_server_systems(
+        url=url, headers=headers, exclude_systems=manifest_systems
+    )
+    existing_system_arns = [
+        system.fidesctl_meta.resource_id
+        for system in manifest_systems + server_systems
+        if system.fidesctl_meta and system.fidesctl_meta.resource_id
+    ]
+
+    (
+        scan_text_output,
+        scanned_resource_count,
+        missing_resource_count,
+    ) = scan_aws_systems(
+        scan_system_functions=scan_system_functions,
+        existing_system_arns=existing_system_arns,
+    )
+
+    if scanned_resource_count < 1:
+        echo_red("Did not find any resources to scan in AWS account")
+        raise SystemExit(1)
+
+    print_scan_system_aws_result(
+        scan_text_output=scan_text_output,
+        scanned_resource_count=scanned_resource_count,
+        missing_resource_count=missing_resource_count,
+        coverage_threshold=coverage_threshold,
+    )

--- a/fidesctl/tests/core/test_system.py
+++ b/fidesctl/tests/core/test_system.py
@@ -1,11 +1,29 @@
 import pytest
 
-from fidesctl.core import system as _system
+from typing import List
+
+from fidesctl.core import system as _system, api
 from fideslang.models import System, SystemMetadata
 
 
-@pytest.mark.unit
-def test_transform_redshift_systems():
+def create_server_systems(test_config, systems: List[System]):
+    for system in systems:
+        api.delete(
+            url=test_config.cli.server_url,
+            resource_type="system",
+            resource_id=system.fides_key,
+            headers=test_config.user.request_headers,
+        )
+        api.create(
+            url=test_config.cli.server_url,
+            resource_type="system",
+            json_resource=system.json(exclude_none=True),
+            headers=test_config.user.request_headers,
+        )
+
+
+@pytest.fixture()
+def redshift_describe_clusters():
     describe_clusters = {
         "Clusters": [
             {
@@ -15,10 +33,23 @@ def test_transform_redshift_systems():
                     "Port": 5439,
                 },
                 "ClusterNamespaceArn": "arn:aws:redshift:us-east-1:910934740016:namespace:057d5b0e-7eaa-4012-909c-3957c7149176",
-            }
+            },
+            {
+                "ClusterIdentifier": "redshift-cluster-2",
+                "Endpoint": {
+                    "Address": "redshift-cluster-2.c2angfh5kpo4.us-east-1.redshift.amazonaws.com",
+                    "Port": 5439,
+                },
+                "ClusterNamespaceArn": "arn:aws:redshift:us-east-1:910934740016:namespace:057d5b0e-7eaa-4012-909c-3957c7149177",
+            },
         ]
     }
-    expected_result = [
+    yield describe_clusters
+
+
+@pytest.fixture()
+def redshift_systems():
+    redshift_systems = [
         System(
             fides_key="redshift-cluster-1",
             organization_fides_key="default_organization",
@@ -31,11 +62,79 @@ def test_transform_redshift_systems():
             ),
             system_type="redshift_cluster",
             privacy_declarations=[],
-        )
+        ),
+        System(
+            fides_key="redshift-cluster-2",
+            organization_fides_key="default_organization",
+            name="redshift-cluster-1",
+            description="Fides Generated Description for Cluster: redshift-cluster-1",
+            fidesctl_meta=SystemMetadata(
+                endpoint_address="redshift-cluster-2.c2angfh5kpo4.us-east-1.redshift.amazonaws.com",
+                endpoint_port="5439",
+                resource_id="arn:aws:redshift:us-east-1:910934740016:namespace:057d5b0e-7eaa-4012-909c-3957c7149177",
+            ),
+            system_type="redshift_cluster",
+            privacy_declarations=[],
+        ),
     ]
-    actual_result = _system.transform_redshift_systems(describe_clusters)
+    yield redshift_systems
+
+
+@pytest.mark.unit
+def test_transform_redshift_systems(redshift_describe_clusters, redshift_systems):
+    actual_result = _system.transform_redshift_systems(redshift_describe_clusters)
+    assert actual_result == redshift_systems
+
+
+@pytest.mark.unit
+def test_get_redshift_arns(redshift_describe_clusters):
+    expected_result = [
+        "arn:aws:redshift:us-east-1:910934740016:namespace:057d5b0e-7eaa-4012-909c-3957c7149176",
+        "arn:aws:redshift:us-east-1:910934740016:namespace:057d5b0e-7eaa-4012-909c-3957c7149177",
+    ]
+    actual_result = _system.get_redshift_arns(redshift_describe_clusters)
     assert actual_result == expected_result
 
+
+@pytest.mark.unit
+def test_scan_aws_systems():
+    (
+        scan_text_output,
+        scanned_resource_count,
+        missing_resource_count,
+    ) = _system.scan_aws_systems(
+        scan_system_functions=[
+            lambda: ("Scanned Resource Type 1", ["arn1", "arn2", "arn3"]),
+            lambda: ("Scanned Resource Type 2", ["arn4"]),
+            lambda: ("Scanned Resource Type 3", ["arn5"]),
+        ],
+        existing_system_arns=["arn4", "arn3"],
+    )
+    assert scan_text_output
+    assert scanned_resource_count == 5
+    assert missing_resource_count == 3
+
+
+@pytest.mark.integration
+def test_get_all_server_systems(test_config, redshift_systems):
+    create_server_systems(test_config, redshift_systems)
+    actual_result = _system.get_all_server_systems(
+        url=test_config.cli.server_url,
+        headers=test_config.user.request_headers,
+        exclude_systems=[],
+    )
+    assert actual_result
+
+
+@pytest.mark.external
+def test_scan_system_aws_passes(test_config):
+    create_server_systems(test_config, _system.generate_redshift_systems())
+    _system.scan_system_aws(
+        coverage_threshold=100,
+        manifest_dir="",
+        url=test_config.cli.server_url,
+        headers=test_config.user.request_headers,
+    )
 
 @pytest.mark.external
 def test_generate_system_aws(tmpdir):

--- a/fidesctl/tests/core/test_system.py
+++ b/fidesctl/tests/core/test_system.py
@@ -84,8 +84,8 @@ def redshift_systems():
         System(
             fides_key="redshift-cluster-2",
             organization_fides_key="default_organization",
-            name="redshift-cluster-1",
-            description="Fides Generated Description for Cluster: redshift-cluster-1",
+            name="redshift-cluster-2",
+            description="Fides Generated Description for Cluster: redshift-cluster-2",
             fidesctl_meta=SystemMetadata(
                 endpoint_address="redshift-cluster-2.c2angfh5kpo4.us-east-1.redshift.amazonaws.com",
                 endpoint_port="5439",


### PR DESCRIPTION
Closes #341 

### Code Changes

* [x] Created system command group under scan group
* [x] Created `scan system aws` command
* [x] Created a `scan_system_aws` function which can be expanded easily by adding functions like `scan_redshift_systems`

### Steps to Confirm

* [x] Manual testing
* [x] Unit testing, integration testing with external aws account
* [x] Verified auto generated cli documentation updated

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated

### Description Of Changes

Will add some sample output here. 

Given a manifest file which contains all the resources in a given aws account:
```
root@a713a3eed1dc:/fides/fidesctl# fidesctl scan system aws --manifest-dir manifest.yml
Loading resource manifests from: manifest.yml
Taxonomy successfully created.
Scanned 2 resources and all were found in taxonomy.
Resource coverage: 100%
```

Given an AWS account with two redshift clusters which are not found in taxonomy:
```
root@a713a3eed1dc:/fides/fidesctl# fidesctl scan system aws 
Scanned 2 resource(s) and found 2 missing resource(s).
Missing Redshift Clusters:
	arn:aws:redshift:us-east-1:910934740016:namespace:a3f04b4e-b044-4ba5-9aa9-57cddac54305
	arn:aws:redshift:us-east-1:910934740016:namespace:057d5b0e-7eaa-4012-909c-3957c7149176

Resource coverage: 0%
```
