### PR TITLE
Update demo_system.yml to make the quickstart work again

### DIFF
--- a/fidesctl/demo_resources/demo_system.yml
+++ b/fidesctl/demo_resources/demo_system.yml
@@ -12,7 +12,7 @@ system:
         data_categories:
           - user.provided.identifiable.contact
           - user.derived.identifiable.device.cookie_id
-        data_uses: improve.system
+        data_use: improve.system
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
@@ -28,7 +28,7 @@ system:
         data_categories:
           #- user.provided.identifiable.contact # uncomment to add this category to the system
           - user.derived.identifiable.device.cookie_id
-        data_uses: third_party_sharing.personalized_advertising.direct_marketing
+        data_use: advertising
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified

--- a/fidesctl/demo_resources/demo_system.yml
+++ b/fidesctl/demo_resources/demo_system.yml
@@ -12,7 +12,7 @@ system:
         data_categories:
           - user.provided.identifiable.contact
           - user.derived.identifiable.device.cookie_id
-        data_use: improve.system
+        data_uses: improve.system
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified

--- a/fidesctl/demo_resources/demo_system.yml
+++ b/fidesctl/demo_resources/demo_system.yml
@@ -28,7 +28,7 @@ system:
         data_categories:
           #- user.provided.identifiable.contact # uncomment to add this category to the system
           - user.derived.identifiable.device.cookie_id
-        data_use: third_party_sharing.personalized_advertising.direct_marketing
+        data_uses: third_party_sharing.personalized_advertising.direct_marketing
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified


### PR DESCRIPTION
vengeance for #366 @screwlewse


### Code Changes

* ~updated the attribute "data_use" --> "data_uses"~
* [x] Revert the Demo Marketing System `data_use` from a custom one to `advertising`

### Steps to Confirm

* [x] run the quickstart 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

Updated the `demo_system.yml` to use the previously identified `data_use` of `advertising`. 

This was originally changed as part of the work around an extended `data_use` and _should_ have been updated accordingly. Some testing to ensure future updates to the demo_resources have no unintended impacts (i.e. quickstart) should be handled in a follow-on issue to get this shipped.
