### PR TITLE
Add an additional check for running the webserver from the CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ check-install:
 
 .PHONY: fidesctl
 fidesctl:
-	@$(RUN_NO_DEPS) fidesctl --local evaluate && python -c "from fidesapi.main import start_webserver"
+	@$(RUN_NO_DEPS) fidesctl --local evaluate
 
 mypy:
 	@$(RUN_NO_DEPS) mypy

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ check-install:
 
 .PHONY: fidesctl
 fidesctl:
-	@$(RUN_NO_DEPS) fidesctl --local evaluate 
+	@$(RUN_NO_DEPS) fidesctl --local evaluate && python -c "from fidesapi.main import start_webserver"
 
 mypy:
 	@$(RUN_NO_DEPS) mypy

--- a/fidesctl/src/fidesctl.egg-info/entry_points.txt
+++ b/fidesctl/src/fidesctl.egg-info/entry_points.txt
@@ -1,3 +1,2 @@
 [console_scripts]
 fidesctl = fidesctl.cli:cli
-

--- a/fidesctl/tests/cli/test_cli.py
+++ b/fidesctl/tests/cli/test_cli.py
@@ -25,6 +25,17 @@ def test_init(test_cli_runner: CliRunner):
 
 
 @pytest.mark.unit
+def test_webserver():
+    """
+    This is specifically meant to catch when the webserver command breaks,
+    without spinning up an additional instance.
+    """
+    from fidesapi.main import start_webserver
+
+    assert True
+
+
+@pytest.mark.unit
 def test_parse(test_config_path: str, test_cli_runner: CliRunner):
     result = test_cli_runner.invoke(
         cli, ["-f", test_config_path, "parse", "demo_resources/"]


### PR DESCRIPTION
Closes #378 

### Code Changes

* [x] add a check that verifies the webserver can be started from the CLI

### Steps to Confirm

* [x] webserver can be started from the CLI

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

Small change to make sure we don't regress and break the webserver being run from the CLI
