### PR TITLE
Add legacy docs URL support

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -43,6 +43,9 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+          
+      - name: Deploy the docs without a version in the URL for legacy links
+        run: mkdocs gh-deploy -v -f docs/fidesctl/mkdocs.yml --force
 
       - name: Deploy Stable Docs if a Release is Tagged
         if: ${{ env.TAG }}


### PR DESCRIPTION
Closes #382 

### Code Changes

* [ ] add an additional workflow step that publishes docs to the legacy URL (no version support) in addition to the new ones

### Steps to Confirm

* [ ] production docs site includes both version, i.e. https://ethyca.github.io/fides/cli/ works

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
