### PR TITLE
Add RDS as an aws source

### DIFF
--- a/fidesctl/src/fidesctl/cli/generate_commands.py
+++ b/fidesctl/src/fidesctl/cli/generate_commands.py
@@ -55,7 +55,7 @@ def generate_system_aws(
     """
     Connect to an aws account by leveraging a boto3 environment variable
     configuration and generate a system manifest file that consists of every
-    tracked resource. Tracked resources: [Redshift]
+    tracked resource. Tracked resources: [Redshift, RDS]
 
     This is a one-time operation that does not track the state of the aws resources.
     It will need to be run again if the tracked resources change.

--- a/fidesctl/src/fidesctl/cli/scan_commands.py
+++ b/fidesctl/src/fidesctl/cli/scan_commands.py
@@ -63,7 +63,7 @@ def scan_system_aws(
     """
     Connect to an aws account by leveraging a valid boto3 environment varible
     configuration and compares tracked resources to existing systems.
-    Tracked resources: [Redshift]
+    Tracked resources: [Redshift, RDS]
 
     Outputs missing resources and has a non-zero exit if coverage is
     under the stated threshold.

--- a/fidesctl/src/fidesctl/core/system.py
+++ b/fidesctl/src/fidesctl/core/system.py
@@ -93,7 +93,8 @@ def transform_rds_systems(
     Given a describe clusters and describe instances responses, build a system object
     which represents each cluster or instance.
 
-    A system is created for each cluster but for instances 
+    A system is created for each cluster, but for instances we only create a system if
+    it is not part of a cluster
     """
     rds_cluster_systems = [
         System(

--- a/fidesctl/src/fidesctl/core/system.py
+++ b/fidesctl/src/fidesctl/core/system.py
@@ -30,7 +30,7 @@ def transform_redshift_systems(
     describe_clusters: Dict[str, List[Dict]]
 ) -> List[System]:
     """
-    Given a describe clusters response, build a system object which represents
+    Given a "describe_clusters" response, build a system object which represents
     each cluster.
     """
     redshift_systems = [
@@ -90,7 +90,7 @@ def transform_rds_systems(
     describe_clusters: Dict[str, List[Dict]], describe_instances: Dict[str, List[Dict]]
 ) -> List[System]:
     """
-    Given a describe clusters and describe instances responses, build a system object
+    Given "describe_clusters" and "describe_instances" responses, build a system object
     which represents each cluster or instance.
 
     A system is created for each cluster, but for instances we only create a system if
@@ -169,7 +169,7 @@ def generate_system_aws(file_name: str, include_null: bool) -> str:
 
 def get_system_arns(systems: List[System]) -> List[str]:
     """
-    Given a list of systems, build a list of aws arns
+    Given a list of systems, build a list of AWS ARNs
     """
     system_arns = [
         system.fidesctl_meta.resource_id

--- a/fidesctl/src/fidesctl/core/system.py
+++ b/fidesctl/src/fidesctl/core/system.py
@@ -37,14 +37,14 @@ def transform_redshift_systems(
         System(
             fides_key=cluster["ClusterIdentifier"],
             name=cluster["ClusterIdentifier"],
-            description=f"Fides Generated Description for Cluster: {cluster['ClusterIdentifier']}",
+            description=f"Fides Generated Description for Redshift Cluster: {cluster['ClusterIdentifier']}",
             system_type="redshift_cluster",
             fidesctl_meta=SystemMetadata(
                 endpoint_address=cluster["Endpoint"]["Address"]
-                if cluster["Endpoint"]
+                if cluster.get("Endpoint")
                 else None,
                 endpoint_port=cluster["Endpoint"]["Port"]
-                if cluster["Endpoint"]
+                if cluster.get("Endpoint")
                 else None,
                 resource_id=cluster["ClusterNamespaceArn"],
             ),
@@ -64,13 +64,94 @@ def generate_redshift_systems() -> List[System]:
     return redshift_systems
 
 
+def describe_rds_clusters() -> Dict[str, List[Dict]]:
+    """
+    Creates boto3 rds client and returns describe_db_clusters response.
+    """
+    rds_client = boto3.client(
+        "rds",
+    )
+    describe_clusters = rds_client.describe_db_clusters()
+    return describe_clusters
+
+
+def describe_rds_instances() -> Dict[str, List[Dict]]:
+    """
+    Creates boto3 rds client and returns describe_db_instances response.
+    """
+    rds_client = boto3.client(
+        "rds",
+    )
+    describe_instances = rds_client.describe_db_instances()
+    return describe_instances
+
+
+def transform_rds_systems(
+    describe_clusters: Dict[str, List[Dict]], describe_instances: Dict[str, List[Dict]]
+) -> List[System]:
+    """
+    Given a describe clusters and describe instances responses, build a system object
+    which represents each cluster or instance.
+
+    A system is created for each cluster but for instances 
+    """
+    rds_cluster_systems = [
+        System(
+            fides_key=cluster["DBClusterIdentifier"],
+            name=cluster["DBClusterIdentifier"],
+            description=f"Fides Generated Description for RDS Cluster: {cluster['DBClusterIdentifier']}",
+            system_type="rds_cluster",
+            fidesctl_meta=SystemMetadata(
+                endpoint_address=cluster["Endpoint"],
+                endpoint_port=cluster["Port"],
+                resource_id=cluster["DBClusterArn"],
+            ),
+            privacy_declarations=[],
+        )
+        for cluster in describe_clusters["DBClusters"]
+    ]
+    rds_instances_systems = [
+        System(
+            fides_key=instance["DBInstanceIdentifier"],
+            name=instance["DBInstanceIdentifier"],
+            description=f"Fides Generated Description for RDS Instance: {instance['DBInstanceIdentifier']}",
+            system_type="rds_instance",
+            fidesctl_meta=SystemMetadata(
+                endpoint_address=instance["Endpoint"]["Address"]
+                if instance.get("Endpoint")
+                else None,
+                endpoint_port=instance["Endpoint"]["Port"]
+                if instance.get("Endpoint")
+                else None,
+                resource_id=instance["DBInstanceArn"],
+            ),
+            privacy_declarations=[],
+        )
+        for instance in describe_instances["DBInstances"]
+        if not instance.get("DBClusterIdentifier")
+    ]
+    return rds_cluster_systems + rds_instances_systems
+
+
+def generate_rds_systems() -> List[System]:
+    """
+    Fetches RDS clusters and instances from AWS and returns the transformed Sytem representations.
+    """
+    describe_clusters = describe_rds_clusters()
+    describe_instances = describe_rds_instances()
+    rds_systems = transform_rds_systems(
+        describe_clusters=describe_clusters, describe_instances=describe_instances
+    )
+    return rds_systems
+
+
 def generate_system_aws(file_name: str, include_null: bool) -> str:
     """
     Connect to an aws account by leveraging a valid boto3 environment varible
     configuration and extract tracked resource to write a System manifest with.
-    Tracked resources: [Redshift]
+    Tracked resources: [Redshift, RDS]
     """
-    generate_system_functions = [generate_redshift_systems]
+    generate_system_functions = [generate_redshift_systems, generate_rds_systems]
     aws_systems = [
         found_system
         for generate_function in generate_system_functions
@@ -85,14 +166,16 @@ def generate_system_aws(file_name: str, include_null: bool) -> str:
     return file_name
 
 
-def get_redshift_arns(describe_clusters: Dict[str, List[Dict]]) -> List[str]:
+def get_system_arns(systems: List[System]) -> List[str]:
     """
-    Given a describe clusters response, build a list of cluster arns
+    Given a list of systems, build a list of aws arns
     """
-    redshift_arns = [
-        cluster["ClusterNamespaceArn"] for cluster in describe_clusters["Clusters"]
+    system_arns = [
+        system.fidesctl_meta.resource_id
+        for system in systems
+        if system.fidesctl_meta and system.fidesctl_meta.resource_id
     ]
-    return redshift_arns
+    return system_arns
 
 
 def scan_redshift_systems() -> Tuple[str, List[str]]:
@@ -100,9 +183,19 @@ def scan_redshift_systems() -> Tuple[str, List[str]]:
     Fetches Redshift clusters from AWS and returns a scan label and
     list of cluster arns.
     """
-    redshift_clusters = describe_redshift_clusters()
-    redshift_arns = get_redshift_arns(describe_clusters=redshift_clusters)
+    redshift_systems = generate_redshift_systems()
+    redshift_arns = get_system_arns(systems=redshift_systems)
     return "Redshift Clusters", redshift_arns
+
+
+def scan_rds_systems() -> Tuple[str, List[str]]:
+    """
+    Fetches RDS clusters from AWS and returns a scan label and
+    list of cluster arns.
+    """
+    rds_systems = generate_rds_systems()
+    rds_arns = get_system_arns(systems=rds_systems)
+    return "RDS Databases", rds_arns
 
 
 def get_all_server_systems(
@@ -191,20 +284,16 @@ def scan_system_aws(
     """
     Connect to an aws account by leveraging a valid boto3 environment varible
     configuration and compares tracked resources to existing systems.
-    Tracked resources: [Redshift]
+    Tracked resources: [Redshift, RDS]
     """
-    scan_system_functions = [scan_redshift_systems]
+    scan_system_functions = [scan_redshift_systems, scan_rds_systems]
 
     manifest_taxonomy = parse(manifest_dir) if manifest_dir else None
     manifest_systems = manifest_taxonomy.system if manifest_taxonomy else []
     server_systems = get_all_server_systems(
         url=url, headers=headers, exclude_systems=manifest_systems
     )
-    existing_system_arns = [
-        system.fidesctl_meta.resource_id
-        for system in manifest_systems + server_systems
-        if system.fidesctl_meta and system.fidesctl_meta.resource_id
-    ]
+    existing_system_arns = get_system_arns(systems=manifest_systems + server_systems)
 
     (
         scan_text_output,


### PR DESCRIPTION
Closes #342 

### Code Changes

* [x] Add support for generating RDS systems
* [x] Add support for scanning RDS systems

### Steps to Confirm

* [x] Manual testing
* [x] Added unit tests for new cases

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes
* One weird thing is that RDS has a concept for clusters and instances. Clusters are made up of instances but an instance does not necessarily have to be part of a cluster. To account for both we create a system for every cluster and for any instances which are not part of a cluster. 

Sample generate command
```
generate system aws manifest.yml
```

```
- fides_key: database-2
  organization_fides_key: default_organization
  name: database-2
  description: 'Fides Generated Description for RDS Cluster: database-2'
  fidesctl_meta:
    resource_id: arn:aws:rds:us-east-1:910934740016:cluster:database-2
    endpoint_address: database-2.cluster-ckrdpkkb4ukm.us-east-1.rds.amazonaws.com
    endpoint_port: '3306'
  system_type: rds_cluster
  privacy_declarations: []
  administrating_department: Not defined
- fides_key: database-1
  organization_fides_key: default_organization
  name: database-1
  description: 'Fides Generated Description for RDS Instance: database-1'
  fidesctl_meta:
    resource_id: arn:aws:rds:us-east-1:910934740016:db:database-1
    endpoint_address: database-1.ckrdpkkb4ukm.us-east-1.rds.amazonaws.com
    endpoint_port: '3306'
  system_type: rds_instance
  privacy_declarations: []
  administrating_department: Not defined
```

Sample scan command
```
root@afeec8763729:/fides/fidesctl# fidesctl scan system aws --manifest-dir manifest.yml

Loading resource manifests from: manifest.yml
Taxonomy successfully created.
Scanned 4 resource(s) and found 1 missing resource(s).
Missing RDS Databases:
	arn:aws:rds:us-east-1:910934740016:db:database-1

Resource coverage: 75%
```