### PR TITLE
Send "developer" analytics events in test mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,12 @@ ifeq "$(CI)" "true"
     CI_ARGS:=--no-TTY
 endif
 
+# If FIDESCTL__CLI__ANALYTICS_ID is set in the local environment, use its value as the analytics_id
+ANALYTICS_ID_OVERRIDE = -e FIDESCTL__CLI__ANALYTICS_ID
+
 # Run in Compose
-RUN = docker compose run --rm $(CI_ARGS) $(IMAGE_NAME)
-RUN_NO_DEPS = docker compose run --no-deps --rm $(CI_ARGS) $(IMAGE_NAME)
+RUN = docker compose run --rm $(ANALYTICS_ID_OVERRIDE) $(CI_ARGS) $(IMAGE_NAME)
+RUN_NO_DEPS = docker compose run --no-deps --rm $(ANALYTICS_ID_OVERRIDE) $(CI_ARGS) $(IMAGE_NAME)
 
 .PHONY: help
 help:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
         read_only: False
     environment:
       FIDESCTL_TEST_MODE: "True"
-      ANALYTICS_ID_OVERRIDE: ${FIDESCTL__CLI__ANALYTICS_ID:-}
 
   fidesctl-db:
     image: postgres:12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
         read_only: False
     environment:
       FIDESCTL_TEST_MODE: "True"
+      ANALYTICS_ID_OVERRIDE: ${FIDESCTL__CLI__ANALYTICS_ID:-}
 
   fidesctl-db:
     image: postgres:12

--- a/fidesctl/requirements.txt
+++ b/fidesctl/requirements.txt
@@ -3,7 +3,7 @@ click>=7.1.2,<8
 colorama>=0.4.3
 cryptography>=36
 deepdiff==5.5
-fideslog==1.0.0
+fideslog==1.0.1
 loguru>=0.5,<0.6
 openpyxl==3.0.9
 pandas==1.4

--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -86,7 +86,7 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
     if ctx.obj["CONFIG"].user.analytics_opt_out is False:  # requires explicit opt-in
         ctx.meta["ANALYTICS_CLIENT"] = AnalyticsClient(
             client_id=ctx.obj["CONFIG"].cli.analytics_id,
-            developer_mode=(getenv("FIDESCTL_TEST_MODE") == "True"),
+            developer_mode=bool(getenv("FIDESCTL_TEST_MODE") == "True"),
             os=system(),
             product_name=fidesctl.__name__ + "-cli",
             production_version=version(fidesctl.__name__),

--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -1,7 +1,7 @@
 """Contains the groups and setup for the CLI."""
 from importlib.metadata import version
+from os import getenv
 from platform import system
-from typing import Dict
 
 import click
 from fideslog.sdk.python.client import AnalyticsClient
@@ -86,6 +86,7 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
     if ctx.obj["CONFIG"].user.analytics_opt_out is False:  # requires explicit opt-in
         ctx.meta["ANALYTICS_CLIENT"] = AnalyticsClient(
             client_id=ctx.obj["CONFIG"].cli.analytics_id,
+            developer_mode=(getenv("FIDESCTL_TEST_MODE") == "True"),
             os=system(),
             product_name=fidesctl.__name__ + "-cli",
             production_version=version(fidesctl.__name__),

--- a/fidesctl/src/fidesctl/cli/utils.py
+++ b/fidesctl/src/fidesctl/cli/utils.py
@@ -58,7 +58,12 @@ def check_and_update_analytics_config(ctx: click.Context, config_path: str) -> N
 
     if (
         ctx.obj["CONFIG"].user.analytics_opt_out is False
-        and get_config_from_file(config_path, "cli", "analytics_id") is None
+        and get_config_from_file(
+            config_path,
+            "cli",
+            "analytics_id",
+        )
+        in ("", None)
     ):
         config_updates.update(cli={"analytics_id": ctx.obj["CONFIG"].cli.analytics_id})
 

--- a/fidesctl/src/fidesctl/core/config/cli_settings.py
+++ b/fidesctl/src/fidesctl/core/config/cli_settings.py
@@ -1,6 +1,4 @@
 """This module defines the settings for everything related to the CLI."""
-from os import getenv
-from typing import Optional
 
 from fideslog.sdk.python.utils import generate_client_id, FIDESCTL_CLI
 from pydantic import validator
@@ -15,21 +13,13 @@ class CLISettings(FidesSettings):
 
     local_mode: bool = False
     server_url: str = "http://localhost:8080"
-    analytics_id: Optional[str]
+    analytics_id: str = generate_client_id(FIDESCTL_CLI)
 
     @validator("analytics_id", always=True)
-    def ensure_analytics_id_override(cls, value: str) -> str:
+    def ensure_not_empty(cls, value: str) -> str:
         """
-        Resolves the `analytics_id` value in the following order of priority:
-        1. The value of the `ANALYTICS_ID_OVERRIDE` environment variable
-        2. The value of the `FIDESCTL__CLI__ANALYTICS_ID` environment variable
-        3. The value included in the config file
-        4. A newly generated value
+        Validate that the `analytics_id` is not `""`.
         """
-
-        override_id = getenv("ANALYTICS_ID_OVERRIDE")
-        if override_id is not None and override_id != "":
-            return override_id
 
         return value if value != "" else generate_client_id(FIDESCTL_CLI)
 

--- a/fidesctl/src/fidesctl/core/config/cli_settings.py
+++ b/fidesctl/src/fidesctl/core/config/cli_settings.py
@@ -1,5 +1,9 @@
 """This module defines the settings for everything related to the CLI."""
+from os import getenv
+from typing import Optional
+
 from fideslog.sdk.python.utils import generate_client_id, FIDESCTL_CLI
+from pydantic import validator
 
 from .fides_settings import FidesSettings
 
@@ -11,7 +15,23 @@ class CLISettings(FidesSettings):
 
     local_mode: bool = False
     server_url: str = "http://localhost:8080"
-    analytics_id: str = generate_client_id(FIDESCTL_CLI)
+    analytics_id: Optional[str]
+
+    @validator("analytics_id", always=True)
+    def ensure_analytics_id_override(cls, value: str) -> str:
+        """
+        Resolves the `analytics_id` value in the following order of priority:
+        1. The value of the `ANALYTICS_ID_OVERRIDE` environment variable
+        2. The value of the `FIDESCTL__CLI__ANALYTICS_ID` environment variable
+        3. The value included in the config file
+        4. A newly generated value
+        """
+
+        override_id = getenv("ANALYTICS_ID_OVERRIDE")
+        if override_id is not None and override_id != "":
+            return override_id
+
+        return value if value != "" else generate_client_id(FIDESCTL_CLI)
 
     class Config:
         env_prefix = "FIDESCTL__CLI__"


### PR DESCRIPTION
Closes #401

### Code Changes

* [x] When `FIDESCTL_TEST_MODE` is set to `"True"`, any created `AnalyticsEvent`s are sent with the `developer` property set to `True`.
* [x] When running the fidesctl CLI using Makefile targets, respect the value of `FIDESCTL__CLI__ANALYTICS_ID`, if set in a user's local ENV.
* [x] Disallow the use of `""` as an `analytics_id` value.

### Steps to Confirm

With `FIDESCTL__CLI__ANALYTICS_ID` set in your local ENV:
* [x] Running `make cli` results in an `analytics_id` value equal to the local `FIDESCTL__CLI__ANALYTICS_ID` value

With `FIDESCTL__CLI__ANALYTICS_ID` **not** set in your local ENV:
- AND no `analytics_id` value in your config file:
	* [x] A new `analytics_id` value is generated and written to the config file
- AND an `analytics_id` value of `""` in your config file:
	* [x] A new `analytics_id` value is generated and written to the config file
- AND a valid `analytics_id` value already in your config file:
	* [x] The existing `analytics_id` value is respected

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded

### Description Of Changes

We require the ability to distinguish `AnalyticsEvent`s written by users performing local development on fidesctl. This change ensures that if fidesctl is started with `FIDESCTL__CLI__ANALYTICS_ID` set to `"True"`, any generated `AnalyticsEvent`s are flagged as "developer" events.