### PR TITLE
Install fidesctl from source instead of pulling from pypi

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -1,12 +1,6 @@
 name: Publish Docs
 
 on:
-  #For testing this PR
-  pull_request:
-    branches:
-      - main
-    paths:
-      - .github/**
   push:
     branches:
       - main

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -1,6 +1,12 @@
 name: Publish Docs
 
 on:
+  #For testing this PR
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/**
   push:
     branches:
       - main
@@ -31,6 +37,9 @@ jobs:
 
       - name: Install Docs Requirements
         run: pip install -r docs/fides/requirements.txt
+
+      - name: Install fidesctl
+        run: pip install -e fidesctl/
 
       - name: Checkout the gh-pages branches
         run: git fetch origin gh-pages --depth=1

--- a/docs/fides/requirements.txt
+++ b/docs/fides/requirements.txt
@@ -4,4 +4,3 @@ mkdocs-render-swagger-plugin==0.0.3
 mkdocs-click==0.5.0
 mkdocs-git-revision-date-plugin
 mike==1.1.2
-fidesctl # We always want the latest version


### PR DESCRIPTION
Closes #406

### Code Changes

* [x] update `publish_docs` job to not depend on pypi build of fidesctl. Instead use latest from source

### Steps to Confirm

* [x] This PR also changes the workflow to run on this PR. Can remove once fix is confirmed

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated

### Description Of Changes

New step in job:
```
      - name: Install fidesctl
        run: pip install -e fidesctl/
```

