### PR TITLE
update mkdocs-material version (#415)

### DIFF
--- a/docs/fides/docs/schemas/config_schema.json
+++ b/docs/fides/docs/schemas/config_schema.json
@@ -30,7 +30,7 @@
       "default": {
         "local_mode": false,
         "server_url": "http://localhost:8080",
-        "analytics_id": "6044ce70af305cf78969a3cd7a5371ba"
+        "analytics_id": ""
       },
       "allOf": [
         {
@@ -190,7 +190,7 @@
         },
         "analytics_id": {
           "title": "Analytics Id",
-          "default": "6044ce70af305cf78969a3cd7a5371ba",
+          "default": "",
           "env_names": [
             "fidesctl__cli__analytics_id"
           ],

--- a/docs/fides/docs/schemas/config_schema.json
+++ b/docs/fides/docs/schemas/config_schema.json
@@ -29,7 +29,8 @@
       "title": "Cli",
       "default": {
         "local_mode": false,
-        "server_url": "http://localhost:8080"
+        "server_url": "http://localhost:8080",
+        "analytics_id": "6044ce70af305cf78969a3cd7a5371ba"
       },
       "allOf": [
         {
@@ -47,7 +48,8 @@
           "user-id": "1",
           "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1aWQiOjF9.uZEytEk5nO7uxQgmk9mN0zND3qfM1Bl3mNp_GyYsiVE"
         },
-        "encryption_key": "test_encryption_key"
+        "encryption_key": "test_encryption_key",
+        "analytics_opt_out": null
       },
       "allOf": [
         {
@@ -185,6 +187,14 @@
             "fidesctl__cli__server_url"
           ],
           "type": "string"
+        },
+        "analytics_id": {
+          "title": "Analytics Id",
+          "default": "6044ce70af305cf78969a3cd7a5371ba",
+          "env_names": [
+            "fidesctl__cli__analytics_id"
+          ],
+          "type": "string"
         }
       },
       "additionalProperties": false
@@ -228,6 +238,13 @@
             "fidesctl__user__encryption_key"
           ],
           "type": "string"
+        },
+        "analytics_opt_out": {
+          "title": "Analytics Opt Out",
+          "env_names": [
+            "fidesctl__user__analytics_opt_out"
+          ],
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/docs/fides/requirements.txt
+++ b/docs/fides/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.2.1
+mkdocs-material==8.2.7
 mkdocs-minify-plugin==0.4.0
 mkdocs-render-swagger-plugin==0.0.3
 mkdocs-click==0.5.0


### PR DESCRIPTION
Closes #415

### Code Changes

* update mkdocs version to be compatible with recent jinja2 release 

### Description Of Changes

Mkdocs pushed [a patch](https://github.com/squidfunk/mkdocs-material/releases/tag/8.2.7) to limit the jinja version range. Updating the pinned version in the docs' `requirements.txt` will resolve the issue for now, but might not be the best strategy for versioning in the future.
