### PR TITLE
`fidesctl apply` "upserts" resources

### DIFF
--- a/fidesctl/src/fidesapi/database/crud.py
+++ b/fidesctl/src/fidesapi/database/crud.py
@@ -2,17 +2,17 @@
 Contains all of the generic CRUD endpoints that can be
 generated programmatically for each resource.
 """
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from loguru import logger as log
-from sqlalchemy import update as _update, delete as _delete
-from sqlalchemy.future import select
+from sqlalchemy import column, delete as _delete, update as _update
 from sqlalchemy.dialects.postgresql import Insert as _insert
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.future import select
 
-from fidesapi.utils import errors
 from fidesapi.database.session import async_session
 from fidesapi.sql_models import SqlAlchemyBase
+from fidesapi.utils import errors
 
 
 # CRUD Functions
@@ -129,11 +129,14 @@ async def update_resource(sql_model: SqlAlchemyBase, resource_dict: Dict) -> Dic
 
 
 async def upsert_resources(
-    sql_model: SqlAlchemyBase, resource_dicts: List[Dict]
-) -> None:
+    sql_model: SqlAlchemyBase,
+    resource_dicts: List[Dict],
+) -> Tuple[int, int]:
     """
     Insert new resources into the database. If a resource already exists,
     update it by it's fides_key.
+
+    Returns a Tuple containing the counts of inserted and updated rows.
     """
 
     with log.contextualize(
@@ -144,12 +147,29 @@ async def upsert_resources(
             async with session.begin():
                 try:
                     log.debug("Upserting resources")
-                    insert_stmt = _insert(sql_model).values(resource_dicts)
-                    await session.execute(
-                        insert_stmt.on_conflict_do_nothing(
-                            index_elements=["fides_key"],
+                    insert_stmt = (
+                        _insert(sql_model)
+                        .values(resource_dicts)
+                        .returning(
+                            (column("xmax") == 0),  # Row was inserted
+                            (column("xmax") != 0),  # Row was updated
                         )
                     )
+
+                    result = await session.execute(
+                        insert_stmt.on_conflict_do_update(
+                            index_elements=["fides_key"],
+                            set_=insert_stmt.excluded,
+                        )
+                    )
+
+                    inserts, updates = 0, 0
+                    for xmax in result:
+                        inserts += 1 if xmax[0] else 0
+                        updates += 1 if xmax[1] else 0
+
+                    return (inserts, updates)
+
                 except SQLAlchemyError:
                     error = errors.QueryError()
                     log.bind(error=error.detail["error"]).error(

--- a/fidesctl/src/fidesapi/database/crud.py
+++ b/fidesctl/src/fidesapi/database/crud.py
@@ -27,7 +27,7 @@ async def create_resource(
         try:
             await get_resource(sql_model, resource_dict["fides_key"])
         except errors.NotFoundError:
-            log.debug("Resource not found. Inserting.")
+            pass
         else:
             error = errors.AlreadyExistsError(
                 sql_model.__name__, resource_dict["fides_key"]

--- a/fidesctl/src/fidesapi/database/database.py
+++ b/fidesctl/src/fidesapi/database/database.py
@@ -1,7 +1,7 @@
 """
 Contains all of the logic related to the database including connections, setup, teardown, etc.
 """
-import os
+from os import path
 
 from alembic import command
 from alembic.config import Config
@@ -22,9 +22,9 @@ def get_alembic_config(database_url: str) -> Config:
     Do lots of magic to make alembic work programmatically from the CLI.
     """
 
-    migrations_dir = os.path.dirname(os.path.abspath(__file__))
-    directory = os.path.join(migrations_dir, "../migrations")
-    config = Config(os.path.join(migrations_dir, "../alembic.ini"))
+    migrations_dir = path.dirname(path.abspath(__file__))
+    directory = path.join(migrations_dir, "../migrations")
+    config = Config(path.join(migrations_dir, "../alembic.ini"))
     config.set_main_option("script_location", directory.replace("%", "%%"))
     config.set_main_option("sqlalchemy.url", database_url)
     return config

--- a/fidesctl/src/fidesapi/database/database.py
+++ b/fidesctl/src/fidesapi/database/database.py
@@ -62,13 +62,12 @@ async def load_default_taxonomy() -> None:
         resources = list(map(dict, DEFAULT_TAXONOMY.dict()[resource_type]))
 
         try:
-            await upsert_resources(sql_model_map[resource_type], resources)
+            result = await upsert_resources(sql_model_map[resource_type], resources)
         except QueryError:
             pass  # The upsert_resources function will log the error
         else:
-            log.info(
-                f"Successfully UPSERTED {len(resources)} {resource_type} resources"
-            )
+            log.info(f"INSERTED {result[0]} {resource_type} resources")
+            log.info(f"UPDATED {result[1]} {resource_type} resources")
 
 
 def reset_db(database_url: str) -> None:

--- a/fidesctl/src/fidesapi/database/database.py
+++ b/fidesctl/src/fidesapi/database/database.py
@@ -75,7 +75,8 @@ async def load_default_taxonomy() -> None:
         except AlreadyExistsError:
             pass
 
-    log.info(f"INSERTED {inserted} organization resources")
+    log.info(f"INSERTED {inserted} organization resource(s)")
+    log.info(f"SKIPPED {len(organizations)-inserted} organization resource(s)")
 
     upsert_resource_types = list(DEFAULT_TAXONOMY.__fields_set__)
     upsert_resource_types.remove("organization")
@@ -90,8 +91,8 @@ async def load_default_taxonomy() -> None:
         except QueryError:
             pass  # The upsert_resources function will log the error
         else:
-            log.info(f"INSERTED {result[0]} {resource_type} resources")
-            log.info(f"UPDATED {result[1]} {resource_type} resources")
+            log.info(f"INSERTED {result[0]} {resource_type} resource(s)")
+            log.info(f"UPDATED {result[1]} {resource_type} resource(s)")
 
 
 def reset_db(database_url: str) -> None:

--- a/fidesctl/src/fidesctl/cli/core_commands.py
+++ b/fidesctl/src/fidesctl/cli/core_commands.py
@@ -19,13 +19,14 @@ from fidesctl.core import parse as _parse
 @click.option(
     "--diff",
     is_flag=True,
-    help="Print the diff between the server's old and new states in Python DeepDiff format",
+    help="Include any changes between server and local resources in the command output",
 )
 @manifests_dir_argument
 def apply(ctx: click.Context, dry: bool, diff: bool, manifests_dir: str) -> None:
     """
-    Validates local manifest files and then sends them to the server to be persisted.
+    Validate local manifest files and persist any changes via the API server.
     """
+
     config = ctx.obj["CONFIG"]
     taxonomy = _parse.parse(manifests_dir)
     with_analytics(

--- a/fidesctl/src/fidesctl/cli/options.py
+++ b/fidesctl/src/fidesctl/cli/options.py
@@ -51,7 +51,7 @@ def manifests_dir_argument(command: Callable) -> Callable:
 def dry_flag(command: Callable) -> Callable:
     "Add a flag that prevents side-effects."
     command = click.option(
-        "--dry", is_flag=True, help="Does not send changes to the server."
+        "--dry", is_flag=True, help="Prevent the persistance of any changes."
     )(command)
     return command
 

--- a/fidesctl/src/fidesctl/core/api.py
+++ b/fidesctl/src/fidesctl/core/api.py
@@ -5,10 +5,13 @@ import requests
 
 
 def generate_resource_url(
-    url: str, resource_type: str = "", resource_id: str = "", version: str = "v1"
+    url: str,
+    resource_type: str = "",
+    resource_id: str = "",
 ) -> str:
     """
-    Generate a resource's URL using a base url, the resource type and a version.
+    Generate a resource's URL using a base url, the resource type,
+    and [optionally] the resource's ID.
     """
     return f"{url}/{resource_type}/{resource_id}"
 

--- a/fidesctl/src/fidesctl/core/api.py
+++ b/fidesctl/src/fidesctl/core/api.py
@@ -73,7 +73,7 @@ def update(
     Update an existing resource.
     """
     resource_url = generate_resource_url(url, resource_type)
-    return requests.put(resource_url, headers=headers, json=json_resource)
+    return requests.put(resource_url, headers=headers, data=json_resource)
 
 
 def upsert(

--- a/fidesctl/src/fidesctl/core/api.py
+++ b/fidesctl/src/fidesctl/core/api.py
@@ -1,5 +1,5 @@
 """A wrapper to make calling the API consistent across Fidesctl."""
-from typing import Dict
+from typing import Dict, List
 
 import requests
 
@@ -73,7 +73,21 @@ def update(
     Update an existing resource.
     """
     resource_url = generate_resource_url(url, resource_type)
-    return requests.put(resource_url, headers=headers, data=json_resource)
+    return requests.put(resource_url, headers=headers, json=json_resource)
+
+
+def upsert(
+    url: str,
+    resource_type: str,
+    resources: List[Dict],
+    headers: Dict[str, str],
+) -> requests.Response:
+    """
+    For each resource, insert the resource if it doesn't exist, update the resource otherwise.
+    """
+
+    resource_url = generate_resource_url(url, resource_type) + "upsert"
+    return requests.post(resource_url, headers=headers, json=resources)
 
 
 def dry_evaluate(

--- a/fidesctl/src/fidesctl/core/apply.py
+++ b/fidesctl/src/fidesctl/core/apply.py
@@ -99,7 +99,7 @@ def apply(
                 echo_results("would update", resource_type, len(update_list))
                 continue
 
-        raw = handle_cli_response(
+        handle_cli_response(
             api.upsert(
                 headers=headers,
                 resource_type=resource_type,
@@ -109,9 +109,6 @@ def apply(
             verbose=False,
         )
 
-        response = loads(raw.content)
-
-        echo_results("created", resource_type, response["inserted"])
-        echo_results("updated", resource_type, response["updated"])
+        echo_results("applied", resource_type, len(resource_list))
 
     print("-" * 10)

--- a/fidesctl/src/fidesctl/core/apply.py
+++ b/fidesctl/src/fidesctl/core/apply.py
@@ -1,6 +1,7 @@
 """This module handles the logic required for applying manifest files to the server."""
+from json import loads
 from pprint import pprint
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple
 
 from deepdiff import DeepDiff
 
@@ -57,47 +58,11 @@ def sort_create_update_unchanged(
     return create_list, update_list, unchanged_list
 
 
-def execute_create_update_unchanged(
-    url: str,
-    headers: Dict[str, str],
-    resource_type: str,
-    create_list: Optional[List[FidesModel]] = None,
-    update_list: Optional[List[FidesModel]] = None,
-    unchanged_list: Optional[List[FidesModel]] = None,
-) -> None:
-    """
-    Create, update, or just log resources based on which list they're in.
-    """
-    create_list = create_list or []
-    update_list = update_list or []
-
-    for create_resource in create_list:
-        handle_cli_response(
-            api.create(
-                url=url,
-                headers=headers,
-                resource_type=resource_type,
-                json_resource=create_resource.json(exclude_none=True),
-            ),
-            verbose=False,
-        )
-    for update_resource in update_list:
-        handle_cli_response(
-            api.update(
-                url=url,
-                headers=headers,
-                resource_type=resource_type,
-                json_resource=update_resource.json(exclude_none=True),
-            ),
-            verbose=False,
-        )
-
-
-def echo_results(action: str, resource_type: str, resource_list: List) -> None:
+def echo_results(action: str, resource_type: str, resource_count: int) -> None:
     """
     Echo out the results of the apply.
     """
-    echo_green(f"{action.upper()} {len(resource_list)} {resource_type} resources.")
+    echo_green(f"{action.upper()} {resource_count} {resource_type} resources.")
 
 
 def apply(
@@ -109,12 +74,11 @@ def apply(
 ) -> None:
     """
     Apply the current manifest file state to the server.
-    Excludes systems and registries.
     """
+
     for resource_type in taxonomy.__fields_set__:
-        # Doing some echos here to make a pretty output
         print("-" * 10)
-        echo_green(f"Processing {resource_type} resources...")
+        print(f"Processing {resource_type} resources...")
         resource_list = getattr(taxonomy, resource_type)
 
         existing_keys = [resource.fides_key for resource in resource_list]
@@ -126,22 +90,23 @@ def apply(
         create_list, update_list, unchanged_list = sort_create_update_unchanged(
             resource_list, server_resource_list, diff
         )
-
         if dry:
-            echo_results("would create", resource_type, create_list)
-            echo_results("would update", resource_type, update_list)
-            echo_results("would skip", resource_type, unchanged_list)
+            echo_results("would create", resource_type, len(create_list))
+            echo_results("would update", resource_type, len(update_list))
         else:
-            execute_create_update_unchanged(
-                url,
-                headers,
-                resource_type,
-                create_list,
-                update_list,
-                unchanged_list,
+            raw = handle_cli_response(
+                api.upsert(
+                    headers=headers,
+                    resource_type=resource_type,
+                    url=url,
+                    resources=[loads(resource.json()) for resource in resource_list],
+                ),
+                verbose=False,
             )
 
-            echo_results("created", resource_type, create_list)
-            echo_results("updated", resource_type, update_list)
-            echo_results("skipped", resource_type, unchanged_list)
+            response = loads(raw.content)
+
+            echo_results("created", resource_type, response["inserted"])
+            echo_results("updated", resource_type, response["updated"])
+
     print("-" * 10)

--- a/fidesctl/tests/core/test_api.py
+++ b/fidesctl/tests/core/test_api.py
@@ -2,6 +2,7 @@
 
 import pytest
 import requests
+from json import loads
 
 from fidesctl.core import api as _api
 from fideslang import parse, model_list
@@ -122,6 +123,20 @@ def test_api_update(test_config, resources_dict, endpoint):
         json_resource=manifest.json(exclude_none=True),
     )
     print(result.text)
+    assert result.status_code == 200
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("endpoint", model_list)
+def test_api_upsert(test_config, resources_dict, endpoint):
+    manifest = resources_dict[endpoint]
+    result = _api.upsert(
+        url=test_config.cli.server_url,
+        headers=test_config.user.request.headers,
+        resource_type=endpoint,
+        resources=[loads(manifest.json())],
+    )
+
     assert result.status_code == 200
 
 

--- a/fidesctl/tests/core/test_api.py
+++ b/fidesctl/tests/core/test_api.py
@@ -21,9 +21,7 @@ def test_generate_resource_urls_no_id(test_config):
     Test that the URL generator works as intended.
     """
     expected_url = f"{test_config}/test/"
-    result_url = _api.generate_resource_url(
-        url=test_config, resource_type="test", version="v1"
-    )
+    result_url = _api.generate_resource_url(url=test_config, resource_type="test")
     assert expected_url == result_url
 
 
@@ -34,7 +32,9 @@ def test_generate_resource_urls_with_id(test_config):
     """
     expected_url = f"{test_config}/test/1"
     result_url = _api.generate_resource_url(
-        url=test_config, resource_type="test", version="v1", resource_id="1"
+        url=test_config,
+        resource_type="test",
+        resource_id="1",
     )
     assert expected_url == result_url
 

--- a/fidesctl/tests/core/test_api.py
+++ b/fidesctl/tests/core/test_api.py
@@ -132,7 +132,7 @@ def test_api_upsert(test_config, resources_dict, endpoint):
     manifest = resources_dict[endpoint]
     result = _api.upsert(
         url=test_config.cli.server_url,
-        headers=test_config.user.request.headers,
+        headers=test_config.user.request_headers,
         resource_type=endpoint,
         resources=[loads(manifest.json())],
     )

--- a/fidesctl/tests/core/test_apply.py
+++ b/fidesctl/tests/core/test_apply.py
@@ -1,8 +1,8 @@
 """Unit tests for the Commands module."""
 import pytest
 
-from fidesctl.core import apply
 import fideslang as models
+from fidesctl.core.apply import sort_create_update
 
 
 # Helpers
@@ -21,7 +21,7 @@ def server_resource_key_pairs():
 
 # Unit
 @pytest.mark.unit
-def test_sort_create_update_unchanged_create():
+def test_sort_create_update_create():
     resource_1 = models.DataCategory(
         organization_fides_key=1,
         fides_key="some_resource",
@@ -41,13 +41,13 @@ def test_sort_create_update_unchanged_create():
     (
         create_result,
         update_result,
-    ) = apply.sort_create_update_unchanged(manifest_resource_list, server_resource_list)
+    ) = sort_create_update(manifest_resource_list, server_resource_list)
     assert create_result == expected_create_result
     assert update_result == []
 
 
 @pytest.mark.unit
-def test_sort_create_update_unchanged_update():
+def test_sort_create_update_update():
     resource_1 = models.DataCategory(
         id=1,
         organization_fides_key=1,
@@ -68,6 +68,6 @@ def test_sort_create_update_unchanged_update():
     (
         create_result,
         update_result,
-    ) = apply.sort_create_update_unchanged(manifest_resource_list, server_resource_list)
+    ) = sort_create_update(manifest_resource_list, server_resource_list)
     assert [] == create_result
     assert expected_update_result == update_result

--- a/fidesctl/tests/core/test_apply.py
+++ b/fidesctl/tests/core/test_apply.py
@@ -41,11 +41,9 @@ def test_sort_create_update_unchanged_create():
     (
         create_result,
         update_result,
-        unchanged_result,
     ) = apply.sort_create_update_unchanged(manifest_resource_list, server_resource_list)
     assert create_result == expected_create_result
     assert update_result == []
-    assert unchanged_result == []
 
 
 @pytest.mark.unit
@@ -70,45 +68,6 @@ def test_sort_create_update_unchanged_update():
     (
         create_result,
         update_result,
-        unchanged_result,
     ) = apply.sort_create_update_unchanged(manifest_resource_list, server_resource_list)
     assert [] == create_result
     assert expected_update_result == update_result
-    assert [] == unchanged_result
-
-
-@pytest.mark.unit
-def test_sort_create_update_unchanged_unchanged():
-    resource_1 = models.DataCategory(
-        id=1,
-        organization_fides_key=1,
-        fides_key="some_resource",
-        name="Test resource 1",
-        description="Test Description",
-    )
-    resource_2 = models.DataCategory(
-        organization_fides_key=1,
-        fides_key="some_resource",
-        name="Test resource 1",
-        description="Test Description",
-    )
-    expected_unchanged_result = [resource_2]
-    manifest_resource_list = [resource_2]
-    server_resource_list = [resource_1]
-
-    (
-        create_result,
-        update_result,
-        unchanged_result,
-    ) = apply.sort_create_update_unchanged(manifest_resource_list, server_resource_list)
-    assert [] == create_result
-    assert [] == update_result
-    assert expected_unchanged_result == unchanged_result
-
-
-@pytest.mark.unit
-def test_execute_create_update_unchanged_empty():
-    apply.execute_create_update_unchanged(
-        url="test", headers={"test": "test"}, resource_type="test"
-    )
-    assert True


### PR DESCRIPTION
Closes #279

### Code Changes

* [x] Revert `upsert_resources` changes such that it genuinely upserts resources
* [x] Prevent `default_organization` resources from being overwritten by default taxonomy upserts
* [x] Add an `/upsert` endpoint for each `resource_type` to fidesapi
* [x] Enable `fidesctl apply` to upsert resources

### Steps to Confirm

* [ ] Run `make cli` and ensure everything starts, no errors are logged
* [ ] Run `fidesctl apply --dry demo_resources/` and ensure things look correct compared to your local database
* [ ] Run `fidesctl apply demo_resources/` and ensure your local database is modified as expected

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met