### PR TITLE
Refactor generate/scan dataset commands so dataset is a command group

### DIFF
--- a/docs/fides/docs/guides/generate_resources.md
+++ b/docs/fides/docs/guides/generate_resources.md
@@ -8,7 +8,7 @@ The `scan` and `generate` commands work best when used in tandem as they follow 
 
 # Working With a Database
 
-The `generate dataset` command can connect to a database and automatically generate resource YAML file based on the database schema.
+The `generate` command can connect to a database and automatically generate resource YAML file based on the database schema.
 
 ## Generating a Dataset
 
@@ -23,9 +23,9 @@ flaskr=# SELECT * FROM users;
 (2 rows)
 ```
 
-We can invoke the `generate dataset` by providing a connection url for this database:
+We can invoke the `generate` command by providing a connection url for this database:
 ```sh
-./venv/bin/fidesctl generate dataset \
+./venv/bin/fidesctl generate dataset db \
   postgresql://postgres:postgres@localhost:5432/flaskr \
   fides_resources/flaskr_postgres_dataset.yml
 ```
@@ -77,8 +77,14 @@ The resulting file still requires annotating the dataset with data categories to
 
 ## Scanning the Dataset
 
-The `scan dataset` command can then connect to your database and compare its schema to your already defined datasets. The command output confirms our database resource is covered fully!
+The `scan` command can then connect to your database and compare its schema to your already defined datasets:
+```sh
+./venv/bin/fidesctl scan dataset db \
+  postgresql://postgres:postgres@localhost:5432/flaskr \
+  --manifest-dir fides_resources/flaskr_postgres_dataset.yml
+```
 
+The command output confirms our database resource is covered fully:
 ```sh
 Loading resource manifests from: dataset.yml
 Taxonomy successfully created.
@@ -90,7 +96,7 @@ Annotation coverage: 100%
 
 # Working With an AWS Account
 
-The `generate system aws` command can connect to an AWS account and automatically generate resource YAML file based on tracked resources.
+The `generate` command can connect to an AWS account and automatically generate resource YAML file based on tracked resources.
 
 ## Providing Credentials
 
@@ -181,8 +187,13 @@ system:
 ```
 ## Scanning the Systems
 
-The `scan system aws` command can then connect to your AWS account and compare its resources to your already defined systems. The command output confirms our resources are covered fully!
+The `scan` command can then connect to your AWS account and compare its resources to your already defined systems:
+```sh
+./venv/bin/fidesctl scan system aws \
+  --manifest-dir fides_resources/aws_systems.yml
+```
 
+The command output confirms our resources are covered fully:
 ```sh
 Loading resource manifests from: manifest.yml
 Taxonomy successfully created.

--- a/docs/fides/docs/language/resources/dataset.md
+++ b/docs/fides/docs/language/resources/dataset.md
@@ -15,7 +15,7 @@ A Dataset takes a database schema (tables and columns) and adds Fides privacy ca
 
 * At each level -- Dataset, collection, and field, you can assign one or more Data Categories and Data Qualifiers. The Categories and Qualifiers declared at each child level is additive, for example, if you declare a collection with category `user.derived`, and a field with category `user.provided.identifiable.name`, your dataset will contain both user-derived and user-provided name data.
 
-While you can create Dataset objects by hand, you typically use the `fidesctl generate dataset`  command to create rudimentary Dataset manifest files that are based on your real-world databases. After you run the command, which creates the schema components, you add your Data Categories and Data Qualifiers to the manifest.
+While you can create Dataset objects by hand, you typically use the [generate](../../guides/generate_resources.md) command to create rudimentary Dataset manifest files that are based on your real-world databases. After you run the command, which creates the schema components, you add your Data Categories and Data Qualifiers to the manifest.
 
 You use your Datasets by adding them to Systems. A System can contain any number of Datasets, and a Dataset can be added to any number of Systems.
 

--- a/docs/fides/docs/tutorial/add.md
+++ b/docs/fides/docs/tutorial/add.md
@@ -65,7 +65,7 @@ fidesctl-evaluate: compose-up
 
 fidesctl-generate-dataset: compose-up
 	@echo "Generating dataset with fidesctl..."
-	./venv/bin/fidesctl generate dataset postgresql://postgres:postgres@localhost:5432/flaskr example.yml
+	./venv/bin/fidesctl generate dataset db postgresql://postgres:postgres@localhost:5432/flaskr example.yml
 ```
 
 > **Note:** There are additional `Makefile` changes included in the `fidesdemo` repository, but they are only intended to enable cleaner usage of this project for demonstration purposes.

--- a/docs/fides/docs/tutorial/dataset.md
+++ b/docs/fides/docs/tutorial/dataset.md
@@ -69,10 +69,10 @@ dataset:
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized
 ```
 
-As an alternative to manually authoring the resource file, you can also use the [generate](../language/resources/policy.md) CLI command. The CLI will connect to the database and automatically generate a non-annotated resource YAML file in the specified location, based on the database schema. For this project, the command is:
+As an alternative to manually authoring the resource file, you can also use the [generate](../guides/generate_resources.md) CLI command. The CLI will connect to the database and automatically generate a non-annotated resource YAML file in the specified location, based on the database schema. For this project, the command is:
 
 ```sh
-./venv/bin/fidesctl generate dataset \
+./venv/bin/fidesctl generate dataset db \
   postgresql://postgres:postgres@localhost:5432/flaskr \
   fides_resources/flaskr_postgres_dataset.yml
 ```

--- a/fidesctl/src/fidesctl/cli/generate_commands.py
+++ b/fidesctl/src/fidesctl/cli/generate_commands.py
@@ -16,12 +16,20 @@ def generate(ctx: click.Context) -> None:
     """
 
 
-@generate.command(name="dataset")
+@generate.group(name="dataset")
+@click.pass_context
+def generate_dataset(ctx: click.Context) -> None:
+    """
+    Generate fidesctl Dataset resources
+    """
+
+
+@generate_dataset.command(name="db")
 @click.pass_context
 @click.argument("connection_string", type=str)
 @click.argument("output_filename", type=str)
 @include_null_flag
-def generate_dataset(
+def generate_dataset_db(
     ctx: click.Context, connection_string: str, output_filename: str, include_null: bool
 ) -> None:
     """
@@ -34,9 +42,9 @@ def generate_dataset(
 
     with_analytics(
         ctx,
-        _dataset.generate_dataset,
+        _dataset.generate_dataset_db,
         connection_string=connection_string,
-        filename=output_filename,
+        file_name=output_filename,
         include_null=include_null,
     )
 

--- a/fidesctl/src/fidesctl/cli/scan_commands.py
+++ b/fidesctl/src/fidesctl/cli/scan_commands.py
@@ -15,12 +15,20 @@ def scan(ctx: click.Context) -> None:
     """
 
 
-@scan.command(name="dataset")
+@scan.group(name="dataset")
+@click.pass_context
+def scan_dataset(ctx: click.Context) -> None:
+    """
+    Scan fidesctl Dataset resources
+    """
+
+
+@scan_dataset.command(name="db")
 @click.pass_context
 @click.argument("connection_string", type=str)
 @click.option("-m", "--manifest-dir", type=str, default="")
 @click.option("-c", "--coverage-threshold", type=click.IntRange(0, 100), default=100)
-def scan_dataset(
+def scan_dataset_db(
     ctx: click.Context,
     connection_string: str,
     manifest_dir: str,
@@ -39,7 +47,7 @@ def scan_dataset(
     config = ctx.obj["CONFIG"]
     with_analytics(
         ctx,
-        _dataset.scan_dataset,
+        _dataset.scan_dataset_db,
         connection_string=connection_string,
         manifest_dir=manifest_dir,
         coverage_threshold=coverage_threshold,

--- a/fidesctl/src/fidesctl/core/dataset.py
+++ b/fidesctl/src/fidesctl/core/dataset.py
@@ -51,7 +51,7 @@ def get_db_collections_and_fields(
     return db_tables
 
 
-def create_dataset_collections(
+def create_dataset_db_collections(
     db_tables: Dict[str, Dict[str, List[str]]]
 ) -> List[Dataset]:
     """
@@ -87,7 +87,7 @@ def create_dataset_collections(
     return table_manifests
 
 
-def find_uncategorized_dataset_fields(
+def find_uncategorized_dataset_db_fields(
     dataset_key: str, dataset: Optional[Dataset], db_dataset: Dict[str, List[str]]
 ) -> Tuple[List[str], int]:
     """
@@ -129,7 +129,7 @@ def find_uncategorized_dataset_fields(
     return uncategorized_fields, total_field_count
 
 
-def find_all_uncategorized_dataset_fields(
+def find_all_uncategorized_dataset_db_fields(
     manifest_taxonomy: Optional[Taxonomy],
     db_collections: Dict[str, Dict[str, List[str]]],
     url: AnyHttpUrl,
@@ -163,7 +163,7 @@ def find_all_uncategorized_dataset_fields(
         (
             current_uncategorized_keys,
             current_field_count,
-        ) = find_uncategorized_dataset_fields(
+        ) = find_uncategorized_dataset_db_fields(
             dataset_key=db_dataset_key, dataset=dataset, db_dataset=db_dataset
         )
         total_field_count += current_field_count
@@ -172,7 +172,7 @@ def find_all_uncategorized_dataset_fields(
     return uncategorized_fields, total_field_count
 
 
-def print_dataset_scan_result(
+def print_dataset_db_scan_result(
     datasets: List[str],
     uncategorized_fields: List[str],
     coverage_percent: int,
@@ -199,7 +199,7 @@ def print_dataset_scan_result(
     echo_green(annotation_output)
 
 
-def scan_dataset(
+def scan_dataset_db(
     connection_string: str,
     manifest_dir: Optional[str],
     coverage_threshold: int,
@@ -217,7 +217,7 @@ def scan_dataset(
     db_engine = get_db_engine(connection_string)
     db_collections = get_db_collections_and_fields(db_engine)
 
-    uncategorized_fields, db_field_count = find_all_uncategorized_dataset_fields(
+    uncategorized_fields, db_field_count = find_all_uncategorized_dataset_db_fields(
         manifest_taxonomy=manifest_taxonomy,
         db_collections=db_collections,
         url=url,
@@ -230,7 +230,7 @@ def scan_dataset(
     coverage_percent = int(
         ((db_field_count - len(uncategorized_fields)) / db_field_count) * 100
     )
-    print_dataset_scan_result(
+    print_dataset_db_scan_result(
         datasets=list(db_collections.keys()),
         uncategorized_fields=uncategorized_fields,
         coverage_percent=coverage_percent,
@@ -238,7 +238,9 @@ def scan_dataset(
     )
 
 
-def generate_dataset(connection_string: str, file_name: str, include_null: bool) -> str:
+def generate_dataset_db(
+    connection_string: str, file_name: str, include_null: bool
+) -> str:
     """
     Given a database connection string, extract all tables/fields from it
     and write out a boilerplate dataset manifest, excluding optional null attributes.
@@ -248,7 +250,7 @@ def generate_dataset(connection_string: str, file_name: str, include_null: bool)
     """
     db_engine = get_db_engine(connection_string)
     db_collections = get_db_collections_and_fields(db_engine)
-    collections = create_dataset_collections(db_collections)
+    collections = create_dataset_db_collections(db_collections)
     manifests.write_manifest(
         file_name,
         [i.dict(exclude_none=not include_null) for i in collections],

--- a/fidesctl/tests/cli/test_cli.py
+++ b/fidesctl/tests/cli/test_cli.py
@@ -283,3 +283,73 @@ def test_nested_field_fails_evaluation(
     )
     print(result.output)
     assert result.exit_code == 1
+
+@pytest.mark.integration
+def test_generate_dataset_db(test_config_path: str, test_cli_runner: CliRunner, tmpdir):
+    tmp_file=tmpdir.join("dataset.yml")
+    result = test_cli_runner.invoke(
+        cli,
+        [
+            "-f",
+            test_config_path,
+            "generate",
+            "dataset",
+            "db",
+            "postgresql+psycopg2://postgres:fidesctl@fidesctl-db:5432/fidesctl_test",
+            f"{tmp_file}"
+        ],
+    )
+    print(result.output)
+    assert result.exit_code == 0
+
+@pytest.mark.integration
+def test_scan_dataset_db(test_config_path: str, test_cli_runner: CliRunner):
+    result = test_cli_runner.invoke(
+        cli,
+        [
+            "-f",
+            test_config_path,
+            "scan",
+            "dataset",
+            "db",
+            "postgresql+psycopg2://postgres:fidesctl@fidesctl-db:5432/fidesctl_test",
+            "--coverage-threshold",
+            "0",
+        ],
+    )
+    print(result.output)
+    assert result.exit_code == 0
+
+@pytest.mark.external
+def test_generate_system_aws(test_config_path: str, test_cli_runner: CliRunner, tmpdir):
+    tmp_file=tmpdir.join("dataset.yml")
+    result = test_cli_runner.invoke(
+        cli,
+        [
+            "-f",
+            test_config_path,
+            "generate",
+            "system",
+            "aws",
+            f"{tmp_file}"
+        ],
+    )
+    print(result.output)
+    assert result.exit_code == 0
+
+@pytest.mark.external
+def test_scan_system_aws(test_config_path: str, test_cli_runner: CliRunner):
+    result = test_cli_runner.invoke(
+        cli,
+        [
+            "-f",
+            test_config_path,
+            "scan",
+            "system",
+            "aws",
+            "--coverage-threshold",
+            "0",
+        ],
+    )
+    print(result.output)
+    assert result.exit_code == 0

--- a/fidesctl/tests/core/test_dataset.py
+++ b/fidesctl/tests/core/test_dataset.py
@@ -129,7 +129,7 @@ def test_generate_dataset_collections():
             ],
         )
     ]
-    actual_result = _dataset.create_dataset_collections(test_resource)
+    actual_result = _dataset.create_dataset_db_collections(test_resource)
     assert actual_result == expected_result
 
 
@@ -168,7 +168,7 @@ def test_find_uncategorized_dataset_fields_all_categorized():
     (
         uncategorized_keys,
         total_field_count,
-    ) = _dataset.find_uncategorized_dataset_fields(
+    ) = _dataset.find_uncategorized_dataset_db_fields(
         dataset_key="ds", dataset=dataset, db_dataset=test_resource.get("ds")
     )
     assert not uncategorized_keys
@@ -199,7 +199,7 @@ def test_find_uncategorized_dataset_fields_uncategorized_fields():
     (
         uncategorized_keys,
         total_field_count,
-    ) = _dataset.find_uncategorized_dataset_fields(
+    ) = _dataset.find_uncategorized_dataset_db_fields(
         dataset_key="ds", dataset=dataset, db_dataset=test_resource.get("ds")
     )
     assert set(uncategorized_keys) == {"ds.foo.2"}
@@ -227,7 +227,7 @@ def test_find_uncategorized_dataset_fields_missing_field():
     (
         uncategorized_keys,
         total_field_count,
-    ) = _dataset.find_uncategorized_dataset_fields(
+    ) = _dataset.find_uncategorized_dataset_db_fields(
         dataset_key="ds", dataset=dataset, db_dataset=test_resource.get("ds")
     )
     assert set(uncategorized_keys) == {"ds.bar.5"}
@@ -259,7 +259,7 @@ def test_find_uncategorized_dataset_fields_missing_collection():
     (
         uncategorized_keys,
         total_field_count,
-    ) = _dataset.find_uncategorized_dataset_fields(
+    ) = _dataset.find_uncategorized_dataset_db_fields(
         dataset_key="ds", dataset=dataset, db_dataset=test_resource.get("ds")
     )
     assert set(uncategorized_keys) == {"ds.foo.1", "ds.foo.2"}
@@ -270,7 +270,7 @@ def test_find_uncategorized_dataset_fields_missing_collection():
 def test_unsupported_dialect_error():
     test_url = "foo+psycopg2://fidesdb:fidesdb@fidesdb:5432/fidesdb"
     with pytest.raises(SystemExit):
-        _dataset.generate_dataset(test_url, "test_file.yml", False)
+        _dataset.generate_dataset_db(test_url, "test_file.yml", False)
 
 
 # Generate Dataset Database Integration Tests
@@ -389,19 +389,19 @@ class TestDatabase:
 
     def test_generate_dataset(self, tmpdir, database_type):
         database_parameters = TEST_DATABASE_PARAMETERS.get(database_type)
-        actual_result = _dataset.generate_dataset(
+        actual_result = _dataset.generate_dataset_db(
             database_parameters.get("url"), f"{tmpdir}/test_file.yml", False
         )
         assert actual_result
 
     def test_generate_dataset_passes_(self, test_config, database_type):
         database_parameters = TEST_DATABASE_PARAMETERS.get(database_type)
-        datasets: List[Dataset] = _dataset.create_dataset_collections(
+        datasets: List[Dataset] = _dataset.create_dataset_db_collections(
             database_parameters.get("expected_collection")
         )
         set_field_data_categories(datasets, "system.operations")
         create_server_datasets(test_config, datasets)
-        _dataset.scan_dataset(
+        _dataset.scan_dataset_db(
             connection_string=database_parameters.get("url"),
             manifest_dir="",
             coverage_threshold=100,
@@ -411,12 +411,12 @@ class TestDatabase:
 
     def test_generate_dataset_coverage_failure(self, test_config, database_type):
         database_parameters = TEST_DATABASE_PARAMETERS.get(database_type)
-        datasets: List[Dataset] = _dataset.create_dataset_collections(
+        datasets: List[Dataset] = _dataset.create_dataset_db_collections(
             database_parameters.get("expected_collection")
         )
         create_server_datasets(test_config, datasets)
         with pytest.raises(SystemExit):
-            _dataset.scan_dataset(
+            _dataset.scan_dataset_db(
                 connection_string=database_parameters.get("url"),
                 manifest_dir="",
                 coverage_threshold=100,
@@ -426,7 +426,7 @@ class TestDatabase:
 
     def test_dataset_coverage_manifest_passes(self, test_config, tmpdir, database_type):
         database_parameters = TEST_DATABASE_PARAMETERS.get(database_type)
-        datasets: List[Dataset] = _dataset.create_dataset_collections(
+        datasets: List[Dataset] = _dataset.create_dataset_db_collections(
             database_parameters.get("expected_collection")
         )
         set_field_data_categories(datasets, "system.operations")
@@ -435,7 +435,7 @@ class TestDatabase:
         write_manifest(file_name, [i.dict() for i in datasets], "dataset")
 
         create_server_datasets(test_config, datasets)
-        _dataset.scan_dataset(
+        _dataset.scan_dataset_db(
             connection_string=database_parameters.get("url"),
             manifest_dir=f"{tmpdir}",
             coverage_threshold=100,


### PR DESCRIPTION
Closes #398

### Code Changes

* [x] Added a new cli group `dataset` under the `scan` and `generate` commands

### Steps to Confirm

* [x] Added new integration tests for cli integration
* [x] Manual testing of new command structure

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

This change was already made for the infrastructure scanning work but needed to be made for older dataset commands as well. 

Old Commands:
```sh
./venv/bin/fidesctl generate dataset \
  postgresql://postgres:postgres@localhost:5432/flaskr \
  fides_resources/flaskr_postgres_dataset.yml
```

```sh
./venv/bin/fidesctl scan dataset \
  postgresql://postgres:postgres@localhost:5432/flaskr 
```

New Commands:
```sh
./venv/bin/fidesctl generate dataset db \
  postgresql://postgres:postgres@localhost:5432/flaskr \
  fides_resources/flaskr_postgres_dataset.yml
```

```sh
./venv/bin/fidesctl scan dataset db \
  postgresql://postgres:postgres@localhost:5432/flaskr 
```

* Also it looks like the `generate dataset` was previously broken due to a parameter filename which was incorrectly named. I added new cli integration tests so that this is caught in CI from now on. 