### PR TITLE
Bump fideslog to v1.1.3, update usage patterns

### DIFF
--- a/fidesctl/requirements.txt
+++ b/fidesctl/requirements.txt
@@ -3,7 +3,7 @@ click>=7.1.2,<8
 colorama>=0.4.3
 cryptography>=36
 deepdiff==5.5
-fideslog==1.1.0
+fideslog==1.1.1
 loguru>=0.5,<0.6
 openpyxl==3.0.9
 pandas==1.4

--- a/fidesctl/requirements.txt
+++ b/fidesctl/requirements.txt
@@ -3,7 +3,7 @@ click>=7.1.2,<8
 colorama>=0.4.3
 cryptography>=36
 deepdiff==5.5
-fideslog==1.0.1
+fideslog==1.1.0
 loguru>=0.5,<0.6
 openpyxl==3.0.9
 pandas==1.4

--- a/fidesctl/requirements.txt
+++ b/fidesctl/requirements.txt
@@ -3,7 +3,7 @@ click>=7.1.2,<8
 colorama>=0.4.3
 cryptography>=36
 deepdiff==5.5
-fideslog==1.1.1
+fideslog==1.1.2
 loguru>=0.5,<0.6
 openpyxl==3.0.9
 pandas==1.4

--- a/fidesctl/requirements.txt
+++ b/fidesctl/requirements.txt
@@ -3,7 +3,7 @@ click>=7.1.2,<8
 colorama>=0.4.3
 cryptography>=36
 deepdiff==5.5
-fideslog==1.1.2
+fideslog==1.1.3
 loguru>=0.5,<0.6
 openpyxl==3.0.9
 pandas==1.4

--- a/fidesctl/src/fidesctl/cli/commands/util.py
+++ b/fidesctl/src/fidesctl/cli/commands/util.py
@@ -2,8 +2,9 @@
 import os
 
 import click
-from fideslog.sdk.python.utils import OPT_OUT_COPY
 import toml
+
+from fideslog.sdk.python.utils import OPT_OUT_COPY, OPT_OUT_PROMPT
 
 import fidesctl
 from fidesctl.cli.utils import check_server, with_analytics
@@ -62,7 +63,8 @@ def init(ctx: click.Context, fides_directory_location: str) -> None:
         config_docs_url = "https://ethyca.github.io/fides/installation/configuration/"
         config_message = f"""Created a config file at '{config_path}'. To learn more, see:
             {config_docs_url}"""
-        config.user.analytics_opt_out = bool(input(OPT_OUT_COPY).lower() == "n")
+        click.echo(OPT_OUT_COPY)
+        config.user.analytics_opt_out = bool(input(OPT_OUT_PROMPT).lower() == "n")
         with open(config_path, "w") as config_file:
             config_dict = config.dict(include=included_values)
             toml.dump(config_dict, config_file)

--- a/fidesctl/src/fidesctl/cli/utils.py
+++ b/fidesctl/src/fidesctl/cli/utils.py
@@ -10,7 +10,7 @@ import click
 import requests
 from fideslog.sdk.python.event import AnalyticsEvent
 from fideslog.sdk.python.exceptions import AnalyticsException
-from fideslog.sdk.python.utils import OPT_OUT_COPY
+from fideslog.sdk.python.utils import OPT_OUT_COPY, OPT_OUT_PROMPT
 
 from fidesctl.core import api as _api
 from fidesctl.core.config.utils import get_config_from_file, update_config_file
@@ -73,8 +73,9 @@ def check_and_update_analytics_config(ctx: click.Context, config_path: str) -> N
 
     config_updates: Dict[str, Dict] = {}
     if ctx.obj["CONFIG"].user.analytics_opt_out is None:
+        click.echo(OPT_OUT_COPY)
         ctx.obj["CONFIG"].user.analytics_opt_out = bool(
-            input(OPT_OUT_COPY).lower() == "n"
+            input(OPT_OUT_PROMPT).lower() == "n"
         )
 
         config_updates.update(

--- a/fidesctl/src/fidesctl/cli/utils.py
+++ b/fidesctl/src/fidesctl/cli/utils.py
@@ -2,7 +2,6 @@
 
 import json
 import sys
-from asyncio import run
 from datetime import datetime, timezone
 from os import getenv
 from typing import Any, Callable, Dict
@@ -138,6 +137,6 @@ def with_analytics(ctx: click.Context, command_handler: Callable, **kwargs: Dict
             )
 
             try:
-                run(ctx.meta["ANALYTICS_CLIENT"].send(event))
+                ctx.meta["ANALYTICS_CLIENT"].send(event)
             except AnalyticsException:
                 pass  # cli analytics should fail silently

--- a/fidesctl/src/fidesctl/cli/utils.py
+++ b/fidesctl/src/fidesctl/cli/utils.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict
 import click
 import requests
 from fideslog.sdk.python.event import AnalyticsEvent
-from fideslog.sdk.python.exceptions import AnalyticsException
+from fideslog.sdk.python.exceptions import AnalyticsError
 from fideslog.sdk.python.utils import OPT_OUT_COPY, OPT_OUT_PROMPT
 
 from fidesctl.core import api as _api
@@ -139,5 +139,5 @@ def with_analytics(ctx: click.Context, command_handler: Callable, **kwargs: Dict
 
             try:
                 ctx.meta["ANALYTICS_CLIENT"].send(event)
-            except AnalyticsException:
+            except AnalyticsError:
                 pass  # cli analytics should fail silently


### PR DESCRIPTION
Related to ethyca/fideslog#50
Related to ethyca/fideslog#51

### Code Changes

* [x] Bump fideslog to v1.1.3
* [x] Remove the usage of `asyncio.run` when sending `AnalyticsEvent`s
* [x] `AnalyticsException` --> `AnalyticsError`
* [x] Separately print `OPT_OUT_COPY` and retrieve input using `OPT_OUT_PROMPT`

### Steps to Confirm

* [x] Run `make cli`
* [x] Execute any command that sends analytics
* [x] Observe no errors, and improved command latency
* [x] Query the fideslog database to ensure your event was written successfully

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded

### Description Of Changes

Fideslog v1.1.3 includes the following changes
- The `AnalyticsClient.send` interface automatically executes the request in a separate event loop. There is no longer a need to manually wrap the call in `asyncio.run` or similar.
- `AnalyticsException` has been renamed to `AnalyticsError`, to better align with Python convention
- The SDK's `utils.py` file now separately exposes `OPT_OUT_COPY` and `OPT_OUT_PROMPT`, to better enable non-CLI applications to display `OPT_OUT_COPY` without automatically assuming a user will respond with their keyboard.