### PR TITLE
FileNotFound from pip install

### DIFF
--- a/fidesctl/MANIFEST.in
+++ b/fidesctl/MANIFEST.in
@@ -3,5 +3,6 @@ include README.md
 include requirements.txt
 include dev-requirements.txt
 include versioneer.py
-include src/fidesctl/_version.py
 include src/fidesapi/alembic.ini
+include src/fidesctl/_version.py
+include src/fidesctl/templates/fides_datamap_template.xlsx

--- a/fidesctl/src/fidesctl/core/export_helpers.py
+++ b/fidesctl/src/fidesctl/core/export_helpers.py
@@ -1,6 +1,7 @@
 import csv
 from datetime import datetime
 from enum import Enum
+from os.path import dirname, join
 import shutil
 
 from typing import Dict, List, Tuple, Set
@@ -12,7 +13,11 @@ from fidesctl.core.api_helpers import get_server_resource, get_server_resources
 from fidesctl.core.utils import echo_red
 
 
-DATAMAP_TEMPLATE = "src/fidesctl/templates/fides_datamap_template.xlsx"
+DATAMAP_TEMPLATE = join(
+    dirname(__file__),
+    "../templates",
+    "fides_datamap_template.xlsx",
+)
 
 
 def export_to_csv(


### PR DESCRIPTION
Closes #452 

### Code Changes

* [x] Include the datamap template in `manifest.ini`
* [x] Update the `DATAMAP_TEMPLATE` path to use `__file__` to work both in Docker and installed via pip

### Steps to Confirm

* [x] Installed the current branch as a local pip package (detailed steps below) and verified the export works via pip install and in Docker (also verified the failure to start)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

To validate this, the following steps were followed:

1. Pull this branch and run `make api`
2. Create a separate directory and virtual environment, then locally pip install this branch (i.e. `pip install -e ../fides/fidesctl/.`) - the subsequent steps are all in this new virtual env/directory
3. **Note:** I also needed to run `pip install okta`
4. Include the files from `demo_resources/` in the new directory
5. Apply the new resources `fidesctl apply demo_resources/`
6. Export the new resources `fidesctl export datamap demo_resources/`

This would previously have failed if installing the latest version from pip instead of the local branch (`pip install fidesctl==1.4.2`)
