### PR TITLE
Check for boto before running AWS commands

### DIFF
--- a/docs/fides/docs/installation/pypi.md
+++ b/docs/fides/docs/installation/pypi.md
@@ -18,13 +18,14 @@ Fidesctl ships with a number of optional dependencies that extend its functional
 
 The optional dependencies are as follows:
 
-* `webserver`: includes FastAPI and the Postgres database connector. Enables `fidesctl webserver`.
-* `postgres`: includes the Postgres database connector.
-* `mysql`: includes the MySQL database connector.
-* `mssql`: includes the MSSQL database connector.
-* `snowflake`: includes the Snowflake database connector.
-* `redshift`: includes the Redshift database connector.
 * `all`: includes all of the optional dependencies except for `mssql` due to platform-specific issues.
+* `aws`: includes the boto3 package to connect to AWS.
+* `mssql`: includes the MSSQL database connector.
+* `mysql`: includes the MySQL database connector.
+* `postgres`: includes the Postgres database connector.
+* `redshift`: includes the Redshift database connector.
+* `snowflake`: includes the Snowflake database connector.
+* `webserver`: includes FastAPI and the Postgres database connector. Enables `fidesctl webserver`.
 
 **NOTE:** When installing database adapters there may be other dependencies, such as the [pg_hba.conf](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html) file that usually requires a Postgres installation or the [Microsoft ODBC Driver for SQL Server](https://docs.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server)
 

--- a/fidesctl/src/fidesctl/cli/commands/generate.py
+++ b/fidesctl/src/fidesctl/cli/commands/generate.py
@@ -3,7 +3,7 @@
 import click
 
 from fidesctl.cli.options import include_null_flag
-from fidesctl.cli.utils import with_analytics
+from fidesctl.cli.utils import with_analytics, echo_red
 from fidesctl.core import dataset as _dataset
 from fidesctl.core import system as _system
 
@@ -100,8 +100,13 @@ def generate_system_aws(
     This is a one-time operation that does not track the state of the aws resources.
     It will need to be run again if the tracked resources change.
     """
-    
-    # Do a boto check here
+
+    try:
+        import boto3
+    except ModuleNotFoundError:
+        echo_red('Packages not found, try: pip install "fidesctl[aws]"')
+        raise SystemExit
+
     config = ctx.obj["CONFIG"]
     with_analytics(
         ctx,

--- a/fidesctl/src/fidesctl/cli/commands/generate.py
+++ b/fidesctl/src/fidesctl/cli/commands/generate.py
@@ -100,6 +100,8 @@ def generate_system_aws(
     This is a one-time operation that does not track the state of the aws resources.
     It will need to be run again if the tracked resources change.
     """
+    
+    # Do a boto check here
     config = ctx.obj["CONFIG"]
     with_analytics(
         ctx,

--- a/fidesctl/src/fidesctl/cli/commands/scan.py
+++ b/fidesctl/src/fidesctl/cli/commands/scan.py
@@ -2,7 +2,7 @@
 
 import click
 
-from fidesctl.cli.utils import with_analytics
+from fidesctl.cli.utils import with_analytics, echo_red
 from fidesctl.cli.options import manifests_dir_argument
 from fidesctl.core import dataset as _dataset
 from fidesctl.core import system as _system
@@ -84,6 +84,13 @@ def scan_system_aws(
     Outputs missing resources and has a non-zero exit if coverage is
     under the stated threshold.
     """
+
+    try:
+        import boto3
+    except ModuleNotFoundError:
+        echo_red('Packages not found, try: pip install "fidesctl[aws]"')
+        raise SystemExit
+
     config = ctx.obj["CONFIG"]
     with_analytics(
         ctx,


### PR DESCRIPTION
Closes #451 

### Code Changes

* [x] update the `CLI` docs for AWS commands that the AWS dependencies are required
* [x] add a check before any CLI command runs

### Steps to Confirm

* [x] uninstall boto3 and run the AWS commands

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

Add a check to catch if someone forgot to install the AWS dependencies before running the commands. Also updates the docs to list the `aws` option

### Ouput

```txt
root@2b4764366623:/fides/fidesctl# pip uninstall boto3
Found existing installation: boto3 1.20.54
Uninstalling boto3-1.20.54:
  Would remove:
    /usr/local/lib/python3.8/site-packages/boto3-1.20.54.dist-info/*
    /usr/local/lib/python3.8/site-packages/boto3/*
Proceed (Y/n)? y
  Successfully uninstalled boto3-1.20.54
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv 
root@2b4764366623:/fides/fidesctl# fidesctl scan system aws
Packages not found, try: pip install "fidesctl[aws]"
```
