### PR TITLE
Set the server host via a compose env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
         read_only: False
     environment:
       FIDESCTL_TEST_MODE: "True"
+      FIDESCTL__CLI__SERVER_HOST: "fidesctl"
 
   fidesctl-db:
     image: postgres:12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
         read_only: False
     environment:
       FIDESCTL_TEST_MODE: "True"
-      FIDESCTL__CLI__SERVER_HOST: "fidesctl"
+      FIDESCTL__CLI__SERVER_URL: "http://fidesctl:8080"
 
   fidesctl-db:
     image: postgres:12

--- a/fidesctl/.fides/fidesctl.toml
+++ b/fidesctl/.fides/fidesctl.toml
@@ -7,7 +7,7 @@ database_name = "fidesctl"
 test_database_name = "fidesctl_test"
 
 [cli]
-server_url = "http://fidesctl:8080"
+server_url = "http://localhost:8080"
 
 [user]
 analytics_opt_out = false

--- a/fidesctl/tests/core/test_config.py
+++ b/fidesctl/tests/core/test_config.py
@@ -26,7 +26,6 @@ def test_default_config():
 
     assert config.user.user_id == "1"
     assert config.user.api_key == "test_api_key"
-    assert config.cli.server_url == "http://localhost:8080"
 
 
 @patch.dict(
@@ -34,7 +33,7 @@ def test_default_config():
     {
         "FIDESCTL_CONFIG_PATH": "",
         "FIDESCTL__USER__USER_ID": "2",
-        "FIDESCTL__CLI__SERVER_URL": "test"
+        "FIDESCTL__CLI__SERVER_URL": "test",
     },
     clear=True,
 )
@@ -55,7 +54,9 @@ def test_database_url_test_mode_disabled():
     api_settings = APISettings(
         test_database_name="test_database_url", database_name="database_url"
     )
-    assert api_settings.database_url == "postgres:fidesctl@fidesctl-db:5432/database_url"
+    assert (
+        api_settings.database_url == "postgres:fidesctl@fidesctl-db:5432/database_url"
+    )
 
 
 @pytest.mark.unit
@@ -64,4 +65,7 @@ def test_database_url_test_mode_enabled():
     api_settings = APISettings(
         test_database_name="test_database_url", database_name="database_url"
     )
-    assert api_settings.database_url == "postgres:fidesctl@fidesctl-db:5432/test_database_url"
+    assert (
+        api_settings.database_url
+        == "postgres:fidesctl@fidesctl-db:5432/test_database_url"
+    )


### PR DESCRIPTION
Closes #394 

### Code Changes

* [x] add the env var to the compose file
* [x] update the value in the config file, so that its easier to use the cli locally with the `make api` command or another local server
* [x] remove a test assertion that would break depending on whether it's run in docker or not. Tests should work wherever they're run

### Steps to Confirm

* [x] run `make cli` and then `fidesctl status`
* [x] run `make api` and then run `fidesctl status` locally from the `fidesctl` dir

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

This fix makes sure that running `make cli` and running fidesctl commands won't break even if the default value of `localhost` or some other value is set within the config file.
