### PR TITLE
Set Default data_responsibility_title with generate system

### DIFF
--- a/fidesctl/src/fidesctl/core/export.py
+++ b/fidesctl/src/fidesctl/core/export.py
@@ -179,7 +179,7 @@ def generate_system_records(
                 (
                     system.name,
                     system.description,
-                    system.data_responsibility_title.value,
+                    system.data_responsibility_title,
                     system.administrating_department,
                     third_country_list,
                     declaration.name,

--- a/fidesctl/src/fideslang/models.py
+++ b/fidesctl/src/fideslang/models.py
@@ -537,6 +537,10 @@ class System(FidesModel):
 
     _check_valid_country_code: classmethod = country_code_validator
 
+    class Config:
+        "Class for the System config"
+        use_enum_values = True
+
 
 # Taxonomy
 class Taxonomy(BaseModel):


### PR DESCRIPTION
Closes #458 

### Code Changes

* [x] Update the System model config to have `use_enum_values = True`

### Steps to Confirm

* [x] The default value is set as the enum value instead of the enum object

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created

### Description Of Changes

Originally we thought this may be resolved by setting the default to use the enum value, however this caused type issues with `mypy`

This config option should do it [per the pydantic docs](https://pydantic-docs.helpmanual.io/usage/model_config/#:~:text=hashable.%20(default%3A%20False)-,use_enum_values,-whether%20to%20populate)

To validate the new output, use the command from the issue:
`fidesctl generate system aws manifest.yml`

There are a few other places that this could likely be implemented (and provide some consistency) but feel like that can be a separate targeted PR as it will touch a bit more of the export functionality.