### PR TITLE
Fix --manifest-dir usage documentation

### DIFF
--- a/docs/fides/docs/guides/generate_resources.md
+++ b/docs/fides/docs/guides/generate_resources.md
@@ -81,7 +81,7 @@ The `scan` command can then connect to your database and compare its schema to y
 ```sh
 ./venv/bin/fidesctl scan dataset db \
   postgresql://postgres:postgres@localhost:5432/flaskr \
-  --manifest-dir fides_resources/flaskr_postgres_dataset.yml
+  fides_resources/flaskr_postgres_dataset.yml
 ```
 
 The command output confirms our database resource is covered fully:
@@ -190,7 +190,7 @@ system:
 The `scan` command can then connect to your AWS account and compare its resources to your already defined systems:
 ```sh
 ./venv/bin/fidesctl scan system aws \
-  --manifest-dir fides_resources/aws_systems.yml
+  fides_resources/aws_systems.yml
 ```
 
 The command output confirms our resources are covered fully:


### PR DESCRIPTION
Closes #462

### Code Changes

* [x] Update `generate_resources.md` to not use `--manifest-dir` in example

### Steps to Confirm

* [x] Docs update eh

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

Tiny change