### PR TITLE
Filter Okta datasets so only applications with ACTIVE status are accounted for

### DIFF
--- a/fidesctl/src/fidesctl/connectors/okta.py
+++ b/fidesctl/src/fidesctl/connectors/okta.py
@@ -58,5 +58,6 @@ def create_okta_datasets(okta_applications: List[OktaApplication]) -> List[Datas
             collections=[],
         )
         for application in okta_applications
+        if application.status and application.status == "ACTIVE"
     ]
     return datasets

--- a/fidesctl/tests/connectors/test_okta.py
+++ b/fidesctl/tests/connectors/test_okta.py
@@ -10,14 +10,25 @@ from fideslang.models import Dataset, DatasetMetadata
 def okta_list_applications():
     okta_applications = [
         OktaApplication(
-            config={"id": "okta_id_1", "name": "okta_id_1", "label": "okta_label_1"}
+            config={"id": "okta_id_1", "name": "okta_id_1", "label": "okta_label_1", "status": "ACTIVE"}
         ),
         OktaApplication(
-            config={"id": "okta_id_2", "name": "okta_id_2", "label": "okta_label_2"}
+            config={"id": "okta_id_2", "name": "okta_id_2", "label": "okta_label_2", "status": "ACTIVE"}
         ),
     ]
     yield okta_applications
 
+@pytest.fixture()
+def okta_list_applications_with_inactive():
+    okta_applications = [
+        OktaApplication(
+            config={"id": "okta_id_1", "name": "okta_id_1", "label": "okta_label_1", "status": "ACTIVE"}
+        ),
+        OktaApplication(
+            config={"id": "okta_id_2", "name": "okta_id_2", "label": "okta_label_2", "status": "INACTIVE"}
+        ),
+    ]
+    yield okta_applications
 
 # Unit
 @pytest.mark.unit
@@ -49,6 +60,24 @@ def test_create_okta_datasets(okta_list_applications):
     )
     assert okta_datasets == expected_result
 
+@pytest.mark.unit
+def test_create_okta_datasets_filters_inactive(okta_list_applications_with_inactive):
+    expected_result = [
+        Dataset(
+            fides_key="okta_id_1",
+            name="okta_id_1",
+            fidesctl_meta=DatasetMetadata(
+                resource_id="okta_id_1",
+            ),
+            description=f"Fides Generated Description for Okta Application: okta_label_1",
+            data_categories=[],
+            collections=[],
+        ),
+    ]
+    okta_datasets = okta_connector.create_okta_datasets(
+        okta_applications=okta_list_applications_with_inactive
+    )
+    assert okta_datasets == expected_result
 
 # Integration
 @pytest.mark.external


### PR DESCRIPTION
Closes #469 

### Code Changes

* [x] Add check for `ACTIVE` status when creating Okta datasets

### Steps to Confirm

* [x] Added unit tests for status check
* [x] Manually tested change

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

An application can be deactivated in Okta before it is deleted. These inactive applications should not be tracked.  