### PR TITLE
add missing __init__.py

### DIFF
--- a/fidesctl/src/fidesctl/cli/commands/generate.py
+++ b/fidesctl/src/fidesctl/cli/commands/generate.py
@@ -65,7 +65,7 @@ def generate_dataset_okta(
     It will need to be run again if the tracked resources change.
     """
     try:
-        import okta
+        import okta  # pylint: disable=unused-import
     except ModuleNotFoundError:
         echo_red('Packages not found, try: pip install "fidesctl[okta]"')
         raise SystemExit
@@ -108,7 +108,7 @@ def generate_system_aws(
     """
 
     try:
-        import boto3
+        import boto3  # pylint: disable=unused-import
     except ModuleNotFoundError:
         echo_red('Packages not found, try: pip install "fidesctl[aws]"')
         raise SystemExit

--- a/fidesctl/src/fidesctl/cli/commands/generate.py
+++ b/fidesctl/src/fidesctl/cli/commands/generate.py
@@ -3,7 +3,7 @@
 import click
 
 from fidesctl.cli.options import include_null_flag
-from fidesctl.cli.utils import with_analytics, echo_red
+from fidesctl.cli.utils import with_analytics
 from fidesctl.core import dataset as _dataset
 from fidesctl.core import system as _system
 
@@ -64,11 +64,6 @@ def generate_dataset_okta(
     This is a one-time operation that does not track the state of the okta resources.
     It will need to be run again if the tracked resources change.
     """
-    try:
-        import okta  # pylint: disable=unused-import
-    except ModuleNotFoundError:
-        echo_red('Packages not found, try: pip install "fidesctl[okta]"')
-        raise SystemExit
 
     with_analytics(
         ctx,
@@ -106,12 +101,6 @@ def generate_system_aws(
     This is a one-time operation that does not track the state of the aws resources.
     It will need to be run again if the tracked resources change.
     """
-
-    try:
-        import boto3  # pylint: disable=unused-import
-    except ModuleNotFoundError:
-        echo_red('Packages not found, try: pip install "fidesctl[aws]"')
-        raise SystemExit
 
     config = ctx.obj["CONFIG"]
     with_analytics(

--- a/fidesctl/src/fidesctl/cli/commands/scan.py
+++ b/fidesctl/src/fidesctl/cli/commands/scan.py
@@ -77,7 +77,7 @@ def scan_dataset_okta(
     under the stated threshold.
     """
     try:
-        import okta
+        import okta  # pylint: disable=unused-import
     except ModuleNotFoundError:
         echo_red('Packages not found, try: pip install "fidesctl[okta]"')
         raise SystemExit
@@ -123,7 +123,7 @@ def scan_system_aws(
     """
 
     try:
-        import boto3
+        import boto3  # pylint: disable=unused-import
     except ModuleNotFoundError:
         echo_red('Packages not found, try: pip install "fidesctl[aws]"')
         raise SystemExit

--- a/fidesctl/src/fidesctl/cli/commands/scan.py
+++ b/fidesctl/src/fidesctl/cli/commands/scan.py
@@ -2,7 +2,7 @@
 
 import click
 
-from fidesctl.cli.utils import with_analytics, echo_red
+from fidesctl.cli.utils import with_analytics
 from fidesctl.cli.options import manifests_dir_argument, coverage_threshold_option
 from fidesctl.core import dataset as _dataset
 from fidesctl.core import system as _system
@@ -76,11 +76,6 @@ def scan_dataset_okta(
     Outputs missing resources and has a non-zero exit if coverage is
     under the stated threshold.
     """
-    try:
-        import okta  # pylint: disable=unused-import
-    except ModuleNotFoundError:
-        echo_red('Packages not found, try: pip install "fidesctl[okta]"')
-        raise SystemExit
 
     config = ctx.obj["CONFIG"]
     with_analytics(
@@ -121,12 +116,6 @@ def scan_system_aws(
     Outputs missing resources and has a non-zero exit if coverage is
     under the stated threshold.
     """
-
-    try:
-        import boto3  # pylint: disable=unused-import
-    except ModuleNotFoundError:
-        echo_red('Packages not found, try: pip install "fidesctl[aws]"')
-        raise SystemExit
 
     config = ctx.obj["CONFIG"]
     with_analytics(

--- a/fidesctl/src/fidesctl/core/dataset.py
+++ b/fidesctl/src/fidesctl/core/dataset.py
@@ -353,6 +353,9 @@ def scan_dataset_okta(
     Given an organization url, fetches Okta applications and compares them
     against existing datasets in the server and manifest supplied.
     """
+
+    _check_okta_import()
+
     manifest_taxonomy = parse(manifest_dir) if manifest_dir else None
     manifest_datasets = manifest_taxonomy.dataset if manifest_taxonomy else []
     server_datasets = get_all_server_datasets(
@@ -420,6 +423,9 @@ def generate_dataset_okta(org_url: str, file_name: str, include_null: bool) -> s
     Given an organization url, generates a dataset manifest from existing Okta
     applications.
     """
+
+    _check_okta_import()
+
     import fidesctl.connectors.okta as okta_connector
 
     okta_client = okta_connector.get_okta_client(org_url)
@@ -433,3 +439,12 @@ def generate_dataset_okta(org_url: str, file_name: str, include_null: bool) -> s
         file_name=file_name, include_null=include_null, datasets=okta_datasets
     )
     return file_name
+
+
+def _check_okta_import() -> None:
+    "Validate okta can be imported"
+    try:
+        import okta  # pylint: disable=unused-import
+    except ModuleNotFoundError:
+        echo_red('Packages not found, try: pip install "fidesctl[okta]"')
+        raise SystemExit

--- a/fidesctl/src/fidesctl/core/system.py
+++ b/fidesctl/src/fidesctl/core/system.py
@@ -221,6 +221,9 @@ def generate_system_aws(
     configuration and extract tracked resource to write a System manifest with.
     Tracked resources: [Redshift, RDS]
     """
+
+    _check_boto3_import()
+
     aws_systems = generate_aws_systems(organization_key=organization_key)
     organization = get_organization(
         organization_key=organization_key,
@@ -361,6 +364,9 @@ def scan_system_aws(
     configuration and compares tracked resources to existing systems.
     Tracked resources: [Redshift, RDS]
     """
+
+    _check_boto3_import()
+
     manifest_taxonomy = parse(manifest_dir) if manifest_dir else None
     manifest_systems = manifest_taxonomy.system if manifest_taxonomy else []
     server_systems = get_all_server_systems(
@@ -400,3 +406,12 @@ def scan_system_aws(
         missing_resource_count=missing_resource_count,
         coverage_threshold=coverage_threshold,
     )
+
+
+def _check_boto3_import() -> None:
+    "Validates boto3 is installed and can be imported"
+    try:
+        import boto3  # pylint: disable=unused-import
+    except ModuleNotFoundError:
+        echo_red('Packages not found, try: pip install "fidesctl[aws]"')
+        raise SystemExit


### PR DESCRIPTION
Closes #474 

### Code Changes

* [x] Add missing `__init__.py` to `fidesctl/cli/commands/`
* [x] Ignore newly surfaced unused import errors for `boto3` and `okta` 

### Steps to Confirm

* [x] The package includes the commands directory when running `python setup.py sdist`
* [x] A pip install from this branch no longer returns the same error

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

Found when trying to run the `fidesdemo` using 1.5.0

To test the fix:
```sh
$ python3 -m venv env && source env/bin/activate
$ pip install git+https://github.com/ethyca/fides.git@SteveDMurphy-missing-init#subdirectory=fidesctl
$ fidesctl --help
```

To see the error, just replace the pip installation with `1.5.0`