### PR TITLE
move init to LOCAL_COMMANDS

### DIFF
--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -21,7 +21,7 @@ from .commands.util import init, status, webserver
 from .commands.view import view
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
-LOCAL_COMMANDS = [evaluate, parse, view, webserver]
+LOCAL_COMMANDS = [evaluate, init, parse, view, webserver]
 API_COMMANDS = [
     annotate,
     apply,
@@ -30,7 +30,6 @@ API_COMMANDS = [
     export,
     generate,
     get,
-    init,
     ls,
     scan,
     status,


### PR DESCRIPTION
Closes #475 

### Code Changes

* [x] move `init` to `LOCAL_COMMANDS`

### Steps to Confirm

* [x] `init` works with a local installation from this branch in line with the quickstart (in addition to the fix in #473)
* [x] Validate the `fidesdemo` works as required as well (potentially open an issue there as required to check this box)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

This was discovered while resolving the missing commands for a pip installation. It appears that the server/cli check was running when trying to use the init command. This caused an error to be returned when using the quickstart. 

I'd also like to do some further testing against fidesdemo.
