### PR TITLE
Clarify log output from `fidesctl status`

### DIFF
--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -81,7 +81,10 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
         click.echo(cli.get_help(ctx))
 
     # Check the server health and version if an API command is invoked
-    if ctx.invoked_subcommand in [command.name for command in API_COMMANDS]:
+    if (
+        ctx.invoked_subcommand in [command.name for command in API_COMMANDS]
+        and ctx.invoked_subcommand != "status"
+    ):
         check_server(VERSION, config.cli.server_url)
 
     if ctx.invoked_subcommand != "init":  # init also handles this workflow

--- a/fidesctl/src/fidesctl/cli/commands/util.py
+++ b/fidesctl/src/fidesctl/cli/commands/util.py
@@ -96,7 +96,6 @@ def status(ctx: click.Context) -> None:
         cli_version=cli_version,
         server_url=server_url,
     )
-    echo_green("Server is reachable and the client/server application versions match.")
 
 
 @click.command()

--- a/fidesctl/src/fidesctl/cli/utils.py
+++ b/fidesctl/src/fidesctl/cli/utils.py
@@ -31,13 +31,13 @@ def check_server(cli_version: str, server_url: str) -> None:
         raise SystemExit(1)
 
     server_version = health_response.json()["version"]
-    if str(server_version) != str(cli_version):
-        echo_red(
-            f"Mismatched versions!\nServer Version: {server_version}\nCLI Version: {cli_version}"
-        )
-    else:
+    if str(server_version) == str(cli_version):
         echo_green(
             "Server is reachable and the client/server application versions match."
+        )
+    else:
+        echo_red(
+            f"Mismatched versions!\nServer Version: {server_version}\nCLI Version: {cli_version}"
         )
 
 

--- a/fidesctl/src/fidesctl/cli/utils.py
+++ b/fidesctl/src/fidesctl/cli/utils.py
@@ -13,9 +13,9 @@ from fideslog.sdk.python.event import AnalyticsEvent
 from fideslog.sdk.python.exceptions import AnalyticsException
 from fideslog.sdk.python.utils import OPT_OUT_COPY
 
-from fidesctl.core.config.utils import get_config_from_file, update_config_file
-from fidesctl.core.utils import echo_red, check_response
 from fidesctl.core import api as _api
+from fidesctl.core.config.utils import get_config_from_file, update_config_file
+from fidesctl.core.utils import check_response, echo_green, echo_red
 
 
 def check_server(cli_version: str, server_url: str) -> None:
@@ -34,6 +34,10 @@ def check_server(cli_version: str, server_url: str) -> None:
     if str(server_version) != str(cli_version):
         echo_red(
             f"Mismatched versions!\nServer Version: {server_version}\nCLI Version: {cli_version}"
+        )
+    else:
+        echo_green(
+            "Server is reachable and the client/server application versions match."
         )
 
 


### PR DESCRIPTION
### Code Changes

* [x] `fidesctl status` no longer logs success output regardless of errors
* [x] `check_server` is not executed when running `fidesctl status`

### Steps to Confirm

* [x] Run `fidesctl status`
* [x] Run any other API command (Ex: `fidesctl ls system`)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded