### PR TITLE
Add the TOC to the Nav Sidebar

### DIFF
--- a/docs/fides/mkdocs.yml
+++ b/docs/fides/mkdocs.yml
@@ -94,6 +94,7 @@ theme:
   features:
     - navigation.top
     - navigation.instant
+    - toc.integrate
   custom_dir: overrides
 
 markdown_extensions:


### PR DESCRIPTION
Closes <issue>

### Code Changes

* [x] move the table of contents to the sidebar nav instead of the right-hand side

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created

### Description Of Changes

This small change moves the TOC to be embedded within the sidebar nav instead of on the opposite side as its own thing
