### PR TITLE
`make clean` target should only clean up fidesctl-related resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ xenon:
 # Utils
 ####################
 
+# This only touches things prefixed with `fides_`
 .PHONY: clean
 clean:
 	@echo "Cleaning project temporary files and installed dependencies..."

--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,8 @@ xenon:
 # This only touches things prefixed with `fides_`
 .PHONY: clean
 clean:
-	@echo "Cleaning project temporary files and installed dependencies..."
-	@docker system prune -a --volumes
+	@echo "Doing docker cleanup..."
+	@docker compose -f docker-compose.yml -f docker-compose.integration-tests.yml down --remove-orphans -v --rmi all
 	@echo "Clean complete!"
 
 .PHONY: teardown

--- a/Makefile
+++ b/Makefile
@@ -158,11 +158,11 @@ xenon:
 # Utils
 ####################
 
-# This only touches things prefixed with `fides_`
 .PHONY: clean
 clean:
-	@echo "Doing docker cleanup..."
-	@docker compose -f docker-compose.yml -f docker-compose.integration-tests.yml down --remove-orphans -v --rmi all
+	@echo "Doing docker cleanup for this project..."
+	@docker compose -f docker-compose.yml -f docker-compose.integration-tests.yml down --remove-orphans --volumes --rmi all
+	@docker system prune --force
 	@echo "Clean complete!"
 
 .PHONY: teardown


### PR DESCRIPTION
Closes #417 

### Code Changes

* [x] uses `docker compose` to surgically remove the docker resources only related to this project

### Steps to Confirm

* [x] run the command locally and make sure that the only containers that are cleaned are ours

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

This PR changes `make clean` to be less destructive to resources outside of the project. It leverages docker compose to remove all of the resources specific to our project and then removes any dangling cached layers. Removing dangling cached layers would potentially get rid of resources from other projects but given that they're dangling it shouldn't be a big issue 

### Testing

I went to the fidescls repo, spun up the container there, then went back to fidesctl and ran the `make clean` command and confirmed that the fidescls image was untouched