### PR TITLE
Handle potential duplication in data map

### DIFF
--- a/fidesctl/src/fidesctl/core/export.py
+++ b/fidesctl/src/fidesctl/core/export.py
@@ -362,6 +362,21 @@ def build_joined_dataframe(
     # restructure the joined dataframe to represent system and dataset data categories appropriately
     joined_df = union_data_categories_in_joined_dataframe(joined_df)
 
+    delete_df = joined_df[["system.name", "unioned_data_categories"]][
+        joined_df.groupby(["system.name", "unioned_data_categories"])[
+            "dataset.name"
+        ].transform("count")
+        > 1
+    ].drop_duplicates()
+
+    delete_df["dataset.name"] = "N/A"
+
+    joined_df = (
+        pd.merge(joined_df, delete_df, indicator=True, how="outer")
+        .query('_merge=="left_only"')
+        .drop("_merge", axis=1)
+    )
+
     # model empty columns until implemented as part of appending to template
     joined_df["system.joint_controller"] = ""
     joined_df["system.third_country_safeguards"] = ""

--- a/fidesctl/src/fidesctl/core/export_helpers.py
+++ b/fidesctl/src/fidesctl/core/export_helpers.py
@@ -129,7 +129,7 @@ def export_datamap_to_excel(
         joined_system_dataset_df.sort_values(
             by=[
                 "system.name",
-                "dataset.name",
+                "unioned_data_categories",
             ]
         ).to_excel(
             export_file,

--- a/fidesctl/src/fidesctl/core/export_helpers.py
+++ b/fidesctl/src/fidesctl/core/export_helpers.py
@@ -126,7 +126,12 @@ def export_datamap_to_excel(
             startcol=2,
         )
 
-        joined_system_dataset_df.to_excel(
+        joined_system_dataset_df.sort_values(
+            by=[
+                "system.name",
+                "dataset.name",
+            ]
+        ).to_excel(
             export_file,
             sheet_name="sheet1",
             index=False,
@@ -301,23 +306,48 @@ def union_data_categories_in_joined_dataframe(joined_df: pd.DataFrame) -> pd.Dat
     """
 
     # isolate the system data categories into a new dataframe and create a common column
+    joined_df = joined_df.drop(
+        [
+            "system.description",
+            "system.privacy_declaration.name",
+            "dataset.description",
+        ],
+        axis=1,
+    )
     systems_categories_df = joined_df.drop(
-        ["dataset.data_categories", "dataset.retention"], axis=1
-    ).drop_duplicates()
+        [
+            "dataset.data_categories",
+            "dataset.retention",
+            "dataset.data_qualifier",
+        ],
+        axis=1,
+    )
+    systems_categories_df["dataset.name"] = "N/A"
     systems_categories_df["unioned_data_categories"] = systems_categories_df[
         "system.privacy_declaration.data_categories"
     ]
+    systems_categories_df["unioned_data_qualifiers"] = systems_categories_df[
+        "system.privacy_declaration.data_qualifier"
+    ]
     systems_categories_df["dataset.retention"] = "N/A"
+    systems_categories_df["dataset.data_qualifier"] = "N/A"
 
     # isolate the dataset data categories into a new dataframe and create a common column
     datasets_categories_df = joined_df.drop(
-        ["system.privacy_declaration.data_categories"], axis=1
-    ).drop_duplicates()
+        [
+            "system.privacy_declaration.data_categories",
+            "system.privacy_declaration.data_qualifier",
+        ],
+        axis=1,
+    )
 
     datasets_categories_df = datasets_categories_df[
         datasets_categories_df["dataset.name"] != "N/A"
     ]
 
+    datasets_categories_df["unioned_data_qualifiers"] = datasets_categories_df[
+        "dataset.data_qualifier"
+    ]
     datasets_categories_df["unioned_data_categories"] = datasets_categories_df[
         "dataset.data_categories"
     ]
@@ -330,7 +360,7 @@ def union_data_categories_in_joined_dataframe(joined_df: pd.DataFrame) -> pd.Dat
             ),
             datasets_categories_df.drop(["dataset.data_categories"], axis="columns"),
         ]
-    )
+    ).drop_duplicates()
 
 
 def get_formatted_data_protection_impact_assessment(


### PR DESCRIPTION
Closes #455 

### Code Changes

* [x] Sort ordering for the exported data map
* [x] Separate out `data_qualifier` from the dataset
* [x] Filter out data categories existing on the dataset and system

### Steps to Confirm

* [x] Using data from the `fidesdemo`, ensure there is no longer duplication in the exported data map
* [x] Look at having multiple data categories in the data map for the same system?

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

The duplication stemmed primarily from other populated properties that, when joined, would have a one to many relationship. Removing any non-essential values and cleaning the data seemed like an appropriate step here to keep iterating on this and resolve the issue.

Additionally, we needed to add some filtering for when a data category exists on both a system and dataset. We prefer the more detailed dataset in this scenario.

To validate the changes work for the `fidesdemo` resources, I ended up doing the following:
1. `make cli`
2. Copy the resources from the [fidesdemo pr for 1.5](https://github.com/ethyca/fidesdemo/pull/11) into a new directory (`fidesdemo/`)
3. `fidesctl apply fidesdemo && fidesctl export datamap fidesdemo`
4. Validate the duplication from 1.5.2 no longer exists

Alternatively, you can run through `fidesdemo` using the [fidesdemo pr for 1.5](https://github.com/ethyca/fidesdemo/pull/11) and see the existing duplication. Then install the PR for this branch for fidesctl instead and validate the differences.