### PR TITLE
Resolve Xenon Failure

### DIFF
--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -35,9 +35,8 @@ API_COMMANDS = [
     status,
 ]
 ALL_COMMANDS = API_COMMANDS + LOCAL_COMMANDS
-SERVER_CHECK_COMMAND_NAMES = [
-    command.name for command in API_COMMANDS if command.name != "status"
-]
+SERVER_CHECK_COMMAND_NAMES = [command.name for command in API_COMMANDS]
+SERVER_CHECK_COMMAND_NAMES.remove("status")
 VERSION = fidesctl.__version__
 APP = fidesctl.__name__
 

--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -35,6 +35,9 @@ API_COMMANDS = [
     status,
 ]
 ALL_COMMANDS = API_COMMANDS + LOCAL_COMMANDS
+SERVER_CHECK_COMMAND_NAMES = [
+    command.name for command in API_COMMANDS if command.name != "status"
+]
 VERSION = fidesctl.__version__
 APP = fidesctl.__name__
 
@@ -82,10 +85,8 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
         click.echo(cli.get_help(ctx))
 
     # Check the server health and version if an API command is invoked
-    if (
-        ctx.invoked_subcommand in [command.name for command in API_COMMANDS]
-        and ctx.invoked_subcommand != "status"
-    ):
+
+    if ctx.invoked_subcommand in SERVER_CHECK_COMMAND_NAMES:
         check_server(VERSION, config.cli.server_url)
 
     if ctx.invoked_subcommand != "init":  # init also handles this workflow

--- a/fidesctl/src/fidesctl/cli/__init__.py
+++ b/fidesctl/src/fidesctl/cli/__init__.py
@@ -35,8 +35,9 @@ API_COMMANDS = [
     status,
 ]
 ALL_COMMANDS = API_COMMANDS + LOCAL_COMMANDS
-SERVER_CHECK_COMMAND_NAMES = [command.name for command in API_COMMANDS]
-SERVER_CHECK_COMMAND_NAMES.remove("status")
+SERVER_CHECK_COMMAND_NAMES = [
+    command.name for command in API_COMMANDS if command.name not in ["status"]
+]
 VERSION = fidesctl.__version__
 APP = fidesctl.__name__
 


### PR DESCRIPTION
Closes n/a

### Code Changes

* [x] create a new list constant of command names for the server/cli version check to use

### Steps to Confirm

* [x] xenon and all checks still pass

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

A Xenon failure foiled our CI checks, potentially from two bug PRs passing each other in the night. This is currently impacting any open PR, this should be a relatively simple modification that can unblock the open PRs