### PR TITLE
Fix third country formatting on data map

### DIFF
--- a/fidesctl/src/fidesctl/core/export.py
+++ b/fidesctl/src/fidesctl/core/export.py
@@ -17,7 +17,6 @@ from fidesctl.core.export_helpers import (
     get_formatted_data_protection_impact_assessment,
     get_formatted_data_subjects,
     get_formatted_data_use,
-    remove_duplicates_from_comma_separated_column,
     union_data_categories_in_joined_dataframe,
 )
 from fidesctl.core.utils import echo_green, get_all_level_fields

--- a/fidesctl/src/fidesctl/core/export.py
+++ b/fidesctl/src/fidesctl/core/export.py
@@ -5,20 +5,20 @@ Exports various resources as data maps.
 from typing import Dict, List, Tuple
 
 import pandas as pd
-
-from fideslang.models import Taxonomy, ContactDetails
+from fideslang.models import ContactDetails, Taxonomy
 
 from fidesctl.core.api_helpers import get_server_resources
 from fidesctl.core.export_helpers import (
-    export_to_csv,
+    convert_tuple_to_string,
     export_datamap_to_excel,
+    export_to_csv,
     generate_data_category_rows,
+    get_datamap_fides_keys,
+    get_formatted_data_protection_impact_assessment,
     get_formatted_data_subjects,
     get_formatted_data_use,
     remove_duplicates_from_comma_separated_column,
-    get_datamap_fides_keys,
     union_data_categories_in_joined_dataframe,
-    get_formatted_data_protection_impact_assessment,
 )
 from fidesctl.core.utils import echo_green, get_all_level_fields
 
@@ -348,7 +348,7 @@ def build_joined_dataframe(
     joined_df.fillna("N/A", inplace=True)
     ## create a set of third_country attrs to combine as a single entity
     joined_df["third_country_combined"] = [
-        ", ".join(i)
+        convert_tuple_to_string(i)
         for i in zip(
             joined_df["system.third_country_transfers"].map(str),
             joined_df["dataset.third_country_transfers"],

--- a/fidesctl/src/fidesctl/core/export.py
+++ b/fidesctl/src/fidesctl/core/export.py
@@ -355,10 +355,6 @@ def build_joined_dataframe(
         )
     ]
 
-    joined_df["third_country_combined"] = joined_df["third_country_combined"].transform(
-        remove_duplicates_from_comma_separated_column
-    )
-
     # restructure the joined dataframe to represent system and dataset data categories appropriately
     joined_df = union_data_categories_in_joined_dataframe(joined_df)
 

--- a/fidesctl/src/fidesctl/core/export_helpers.py
+++ b/fidesctl/src/fidesctl/core/export_helpers.py
@@ -245,23 +245,26 @@ def convert_tuple_to_string(values: Tuple[str, ...]) -> str:
     Takes a tuple of variable length strings and combines them into a comma seperated
     string.
 
-    During the conversion empty strings, "", are converted to "N/A", then if is checked
-    to see if all values in the tuple are "N/A" if them are the string "N/A" is returned.
-    If there are multiple strings presents and some are "N/A", the "N/A" is dropped in the
-    resulting string.
+    During the conversion empty strings, "", are converted to "N/A", duplicates are removed,
+    then if is checked to see if all values in the tuple are "N/A" if them are the string
+    "N/A" is returned. If there are multiple strings presents and some are "N/A", the
+    "N/A" is dropped in the resulting string.
 
     Example:
         - ("CAN", "GBR", "USA") returns "CAN, GBR, USA"
+        - ("CAN, GBR", "CAN", "GBR") returns "CAN GBR"
         - ("N/A", "CAN", "GBR") returns "CAN, GBR"
         - ("", "CAN") returns "CAN"
         - ("", "N/A") returns "N/A"
         - ("N/A", "N/A") returns "N/A"
     """
-    empty_replaced = ["N/A" if x == "" else x for x in values]
-    if set(empty_replaced) == {"N/A"}:
+    empty_replaced = {"N/A" if x == "" else x for x in values}
+    if empty_replaced == {"N/A"}:
         return "N/A"
 
-    return ", ".join((x for x in empty_replaced if x != "N/A"))
+    return remove_duplicates_from_comma_separated_column(
+        ", ".join((x for x in empty_replaced if x != "N/A"))
+    )
 
 
 def calculate_data_subject_rights(rights: Dict) -> str:

--- a/fidesctl/src/fidesctl/core/export_helpers.py
+++ b/fidesctl/src/fidesctl/core/export_helpers.py
@@ -1,17 +1,15 @@
 import csv
+import shutil
 from datetime import datetime
 from enum import Enum
 from os.path import dirname, join
-import shutil
-
-from typing import Dict, List, Tuple, Set
+from typing import Dict, List, Set, Tuple
 
 import pandas as pd
-
 from fideslang.models import DataSubjectRightsEnum, Taxonomy
+
 from fidesctl.core.api_helpers import get_server_resource, get_server_resources
 from fidesctl.core.utils import echo_red
-
 
 DATAMAP_TEMPLATE = join(
     dirname(__file__),
@@ -240,6 +238,30 @@ def get_formatted_data_subjects(
         formatted_data_subjects_list.append(formatted_data_subject)
 
     return formatted_data_subjects_list
+
+
+def convert_tuple_to_string(values: Tuple[str, ...]) -> str:
+    """
+    Takes a tuple of variable length strings and combines them into a comma seperated
+    string.
+
+    During the conversion empty strings, "", are converted to "N/A", then if is checked
+    to see if all values in the tuple are "N/A" if them are the string "N/A" is returned.
+    If there are multiple strings presents and some are "N/A", the "N/A" is dropped in the
+    resulting string.
+
+    Example:
+        - ("CAN", "GBR", "USA") returns "CAN, GBR, USA"
+        - ("N/A", "CAN", "GBR") returns "CAN, GBR"
+        - ("", "CAN") returns "CAN"
+        - ("", "N/A") returns "N/A"
+        - ("N/A", "N/A") returns "N/A"
+    """
+    empty_replaced = ["N/A" if x == "" else x for x in values]
+    if set(empty_replaced) == {"N/A"}:
+        return "N/A"
+
+    return ", ".join((x for x in empty_replaced if x != "N/A"))
 
 
 def calculate_data_subject_rights(rights: Dict) -> str:

--- a/fidesctl/tests/core/test_export_helpers.py
+++ b/fidesctl/tests/core/test_export_helpers.py
@@ -203,6 +203,4 @@ def test_get_formatted_data_protection_impact_assessment():
 @pytest.mark.unit
 def test_convert_tuple_to_string(test_vals, expected):
     result = export_helpers.convert_tuple_to_string(test_vals)
-    print(result)
-    print(sorted(result.split(", ")))
     assert sorted(result.split(", ")) == expected

--- a/fidesctl/tests/core/test_export_helpers.py
+++ b/fidesctl/tests/core/test_export_helpers.py
@@ -190,14 +190,19 @@ def test_get_formatted_data_protection_impact_assessment():
 @pytest.mark.parametrize(
     "test_vals, expected",
     [
-        (("CAN", "GBR", "USA"), "CAN, GBR, USA"),
-        (("CAN", "N/A"), "CAN"),
-        (("N/A", "N/A"), "N/A"),
-        (("N/A", ""), "N/A"),
-        (("", ""), "N/A"),
-        (("", "CAN"), "CAN"),
+        (("CAN", "GBR", "USA"), ["CAN", "GBR", "USA"]),
+        (("CAN", "N/A"), ["CAN"]),
+        (("N/A", "N/A"), ["N/A"]),
+        (("N/A", ""), ["N/A"]),
+        (("", ""), ["N/A"]),
+        (("", "CAN"), ["CAN"]),
+        (("CAN", "CAN", "GBR"), ["CAN", "GBR"]),
+        (("CAN", "GBR", "CAN", "GBR"), ["CAN", "GBR"]),
     ],
 )
 @pytest.mark.unit
 def test_convert_tuple_to_string(test_vals, expected):
-    assert export_helpers.convert_tuple_to_string(test_vals) == expected
+    result = export_helpers.convert_tuple_to_string(test_vals)
+    print(result)
+    print(sorted(result.split(", ")))
+    assert sorted(result.split(", ")) == expected

--- a/fidesctl/tests/core/test_export_helpers.py
+++ b/fidesctl/tests/core/test_export_helpers.py
@@ -1,16 +1,16 @@
 from os import path
 
-import pytest
 import pandas as pd
-
-from fidesctl.core import export_helpers
+import pytest
 from fideslang.models import (
+    DataProtectionImpactAssessment,
     Dataset,
     DatasetCollection,
     DatasetField,
     DataSubjectRights,
-    DataProtectionImpactAssessment,
 )
+
+from fidesctl.core import export_helpers
 
 
 @pytest.fixture()
@@ -185,3 +185,19 @@ def test_get_formatted_data_protection_impact_assessment():
     assert formatted_dict["is_required"] == False
     assert formatted_dict["progress"] == "N/A"
     assert formatted_dict["link"] == "N/A"
+
+
+@pytest.mark.parametrize(
+    "test_vals, expected",
+    [
+        (("CAN", "GBR", "USA"), "CAN, GBR, USA"),
+        (("CAN", "N/A"), "CAN"),
+        (("N/A", "N/A"), "N/A"),
+        (("N/A", ""), "N/A"),
+        (("", ""), "N/A"),
+        (("", "CAN"), "CAN"),
+    ],
+)
+@pytest.mark.unit
+def test_convert_tuple_to_string(test_vals, expected):
+    assert export_helpers.convert_tuple_to_string(test_vals) == expected


### PR DESCRIPTION
Closes #484

### Code Changes

* [x] Add a new function in export_helpers.py to handle the conversion of tuple values into a string.
* [x] Make `generate_dataset_records` call the new function when creating `joined_df["third_country_combined"]`.
* [x] Refactored `build_joined_dataframe` to only need one pass through the countries.
* [x] Add a new unit test to verify the conversion is working.


### Steps to Confirm

* [x] Run unit tests
* [x] : 

1.  Update the demo_marketing_system to include:

    
    ```yaml
    third_country_transfers:
    - USA
    ````
2. `fidesctl apply demo_resources/`
3. `fidesctl export datamap demo_resources/`
4. Verify the row for that resource in the data map shows `USA`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created

### Description Of Changes

I found a couple issues. Sometimes `system.third_country_transfers` contains an empty string `""`. In this case the empty string gets concatenated resulting in `, USA`. When the specific case mentioned in the issue the `N\A` value was kept even when a country was present.

When working on this I realized that the current code takes two passes through all the data in order to generate the third party country strings. I included a small refactor here to only need one pass through. 
