### PR TITLE
Bump fideslog to 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ The types of changes are:
 
 * Third-Country formatting on Data Map
 * Potential Duplication on Data Map
+* Exceptions are no longer raised when sending `AnalyticsEvent`s on Windows

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click>=7.1.2,<8
 colorama>=0.4.3
 cryptography>=36
 deepdiff==5.5
-fideslog==1.1.3
+fideslog==1.1.4
 loguru>=0.5,<0.6
 openpyxl==3.0.9
 pandas==1.4


### PR DESCRIPTION
Closes #513

### Code Changes

* [x] Bump fideslog to 1.1.4

### Steps to Confirm

On Windows:
* [x] `pip install fidesctl==1.5.3`
* [x] `fidesctl ls data_category`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

### Description Of Changes

Fideslog 1.1.4 includes a change to detect when the SDK is run in a Windows process, and sets the event loop policy as needed in order to avoid a bug in Python 3.8+.