### PR TITLE
Add isort

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -62,6 +62,26 @@ jobs:
       - name: Scan fidesctl db
         run: make fidesctl-db-scan
 
+
+  isort:
+    needs: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download fidesctl container
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.CONTAINER }}
+          path: /tmp/
+
+      - name: Load fidesctl image
+        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run sorter
+        run: make isort
+
   Black:
     needs: Build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,12 @@ push: build
 black:
 	@$(RUN_NO_DEPS) black --check src/
 
+isort:
+	@$(RUN_NO_DEPS) isort src tests --check-only
+
 # The order of dependent targets here is intentional
-check-all: teardown build-local-prod check-install fidesctl fidesctl-db-scan black \
-			pylint mypy xenon pytest-unit pytest-integration
+check-all: teardown build-local-prod check-install fidesctl fidesctl-db-scan isort \
+			black pylint mypy xenon pytest-unit pytest-integration
 	@echo "Running formatter, linter, typechecker and tests..."
 
 check-install:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 black==20.8b1
 ipython
+isort
 mypy==0.910
 packaging==20.9
 pre-commit==2.9.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,14 @@ exclude = '''
 )/
 '''
 
+#######
+# isort
+#######
+[tool.isort]
+profile = "black"
+line_length = 88
+src_paths = ["src", "tests"]
+
 ########
 # Pylint
 ########

--- a/src/fidesapi/database/crud.py
+++ b/src/fidesapi/database/crud.py
@@ -5,7 +5,9 @@ generated programmatically for each resource.
 from typing import Dict, List, Tuple
 
 from loguru import logger as log
-from sqlalchemy import column, delete as _delete, update as _update
+from sqlalchemy import column
+from sqlalchemy import delete as _delete
+from sqlalchemy import update as _update
 from sqlalchemy.dialects.postgresql import Insert as _insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.future import select

--- a/src/fidesapi/database/session.py
+++ b/src/fidesapi/database/session.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import sessionmaker
 
 from fidesctl.core.config import get_config
 
-
 config = get_config()
 engine = create_async_engine(
     config.api.async_database_url,

--- a/src/fidesapi/migrations/versions/150f234ef1de_add_fidesctl_meta_to_organization_object.py
+++ b/src/fidesapi/migrations/versions/150f234ef1de_add_fidesctl_meta_to_organization_object.py
@@ -5,9 +5,8 @@ Revises: edcd28ede1f7
 Create Date: 2022-03-07 20:14:00.530408
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "150f234ef1de"

--- a/src/fidesapi/migrations/versions/1739aa4a4ab7_add_security_policy_link_and_erasure_.py
+++ b/src/fidesapi/migrations/versions/1739aa4a4ab7_add_security_policy_link_and_erasure_.py
@@ -5,9 +5,8 @@ Revises: 4c3693c289d0
 Create Date: 2022-01-28 20:41:20.065432
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "1739aa4a4ab7"

--- a/src/fidesapi/migrations/versions/26934c96ec80_initial_migration.py
+++ b/src/fidesapi/migrations/versions/26934c96ec80_initial_migration.py
@@ -5,9 +5,8 @@ Revises:
 Create Date: 2021-09-22 04:12:38.479740
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "26934c96ec80"

--- a/src/fidesapi/migrations/versions/312aff72b275_migrate_to_usage_of_evaluation_.py
+++ b/src/fidesapi/migrations/versions/312aff72b275_migrate_to_usage_of_evaluation_.py
@@ -5,8 +5,8 @@ Revises: 45c7a349db68
 Create Date: 2021-12-15 15:53:46.484775
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.

--- a/src/fidesapi/migrations/versions/327cd266f7b3_update_dataset_depth.py
+++ b/src/fidesapi/migrations/versions/327cd266f7b3_update_dataset_depth.py
@@ -5,8 +5,8 @@ Revises: 26934c96ec80
 Create Date: 2021-09-28 19:58:31.618442
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.

--- a/src/fidesapi/migrations/versions/45c7a349db68_remove_qualifier_lists_from_data_set_.py
+++ b/src/fidesapi/migrations/versions/45c7a349db68_remove_qualifier_lists_from_data_set_.py
@@ -5,8 +5,8 @@ Revises: 732105cd54e3
 Create Date: 2021-10-25 17:59:25.244689
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.

--- a/src/fidesapi/migrations/versions/4c3693c289d0_add_optional_contact_information_for_.py
+++ b/src/fidesapi/migrations/versions/4c3693c289d0_add_optional_contact_information_for_.py
@@ -5,10 +5,9 @@ Revises: 7c851d8a102a
 Create Date: 2022-01-21 15:56:53.519486
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
-
 from sqlalchemy.dialects.postgresql import BYTEA
 
 # revision identifiers, used by Alembic.

--- a/src/fidesapi/migrations/versions/50b3736634d2_extend_data_use_with_recipients_and_.py
+++ b/src/fidesapi/migrations/versions/50b3736634d2_extend_data_use_with_recipients_and_.py
@@ -5,10 +5,9 @@ Revises: 1739aa4a4ab7
 Create Date: 2022-02-03 18:03:16.120608
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
-
 
 # revision identifiers, used by Alembic.
 revision = "50b3736634d2"

--- a/src/fidesapi/migrations/versions/732105cd54e3_update_dataset_field_name.py
+++ b/src/fidesapi/migrations/versions/732105cd54e3_update_dataset_field_name.py
@@ -5,8 +5,8 @@ Revises: e576b6a80a49
 Create Date: 2021-10-01 06:48:22.449643
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.

--- a/src/fidesapi/migrations/versions/7a94527643a1_add_column_for_special_category_to_data_.py
+++ b/src/fidesapi/migrations/versions/7a94527643a1_add_column_for_special_category_to_data_.py
@@ -5,9 +5,8 @@ Revises: 150f234ef1de
 Create Date: 2022-03-18 03:22:23.975102
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "7a94527643a1"

--- a/src/fidesapi/migrations/versions/7c851d8a102a_add_created_at_and_updated_at.py
+++ b/src/fidesapi/migrations/versions/7c851d8a102a_add_created_at_and_updated_at.py
@@ -10,7 +10,6 @@ from sqlalchemy import Column, DateTime, text
 
 from fidesapi.sql_models import sql_model_map
 
-
 # revision identifiers, used by Alembic.
 revision = "7c851d8a102a"
 down_revision = "312aff72b275"

--- a/src/fidesapi/migrations/versions/a2b9b156ebaf_data_protection_impact_assessments_.py
+++ b/src/fidesapi/migrations/versions/a2b9b156ebaf_data_protection_impact_assessments_.py
@@ -5,9 +5,8 @@ Revises: adad3be6af08
 Create Date: 2022-04-01 18:42:58.961132
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a2b9b156ebaf"

--- a/src/fidesapi/migrations/versions/adad3be6af08_privacy_notice_attributes.py
+++ b/src/fidesapi/migrations/versions/adad3be6af08_privacy_notice_attributes.py
@@ -5,9 +5,8 @@ Revises: 7a94527643a1
 Create Date: 2022-03-22 19:22:15.248311
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "adad3be6af08"

--- a/src/fidesapi/migrations/versions/be432bd23596_add_fidesctl_meta_field_to_dataset.py
+++ b/src/fidesapi/migrations/versions/be432bd23596_add_fidesctl_meta_field_to_dataset.py
@@ -5,9 +5,8 @@ Revises: adad3be6af08
 Create Date: 2022-04-01 00:15:07.569104
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "be432bd23596"

--- a/src/fidesapi/migrations/versions/e576b6a80a49_add_parent_key_to_dataqualifier.py
+++ b/src/fidesapi/migrations/versions/e576b6a80a49_add_parent_key_to_dataqualifier.py
@@ -5,9 +5,8 @@ Revises: 327cd266f7b3
 Create Date: 2021-10-01 03:16:51.491505
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "e576b6a80a49"

--- a/src/fidesapi/migrations/versions/edcd28ede1f7_add_fidesctl_meta_to_system.py
+++ b/src/fidesapi/migrations/versions/edcd28ede1f7_add_fidesctl_meta_to_system.py
@@ -5,9 +5,8 @@ Revises: 50b3736634d2
 Create Date: 2022-02-17 00:41:41.595166
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "edcd28ede1f7"

--- a/src/fidesapi/migrations/versions/fdd28c39a679_add_responsibility_role_attribute_for_.py
+++ b/src/fidesapi/migrations/versions/fdd28c39a679_add_responsibility_role_attribute_for_.py
@@ -5,9 +5,8 @@ Revises: 7a94527643a1
 Create Date: 2022-03-21 17:37:23.855761
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "fdd28c39a679"

--- a/src/fidesapi/sql_models.py
+++ b/src/fidesapi/sql_models.py
@@ -14,9 +14,9 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
-    type_coerce,
     TypeDecorator,
     cast,
+    type_coerce,
 )
 from sqlalchemy.dialects.postgresql import BYTEA
 from sqlalchemy.ext.declarative import declarative_base

--- a/src/fidesapi/view.py
+++ b/src/fidesapi/view.py
@@ -3,6 +3,7 @@ Contains api endpoints for fides web pages
 """
 from fastapi import APIRouter
 from fastapi.responses import HTMLResponse
+
 from fidesapi.routes.crud import list_resource
 from fidesapi.sql_models import Evaluation
 

--- a/src/fidesctl/cli/commands/scan.py
+++ b/src/fidesctl/cli/commands/scan.py
@@ -2,8 +2,8 @@
 
 import click
 
+from fidesctl.cli.options import coverage_threshold_option, manifests_dir_argument
 from fidesctl.cli.utils import with_analytics
-from fidesctl.cli.options import manifests_dir_argument, coverage_threshold_option
 from fidesctl.core import dataset as _dataset
 from fidesctl.core import system as _system
 

--- a/src/fidesctl/cli/commands/util.py
+++ b/src/fidesctl/cli/commands/util.py
@@ -3,7 +3,6 @@ import os
 
 import click
 import toml
-
 from fideslog.sdk.python.utils import OPT_OUT_COPY, OPT_OUT_PROMPT
 
 import fidesctl

--- a/src/fidesctl/connectors/okta.py
+++ b/src/fidesctl/connectors/okta.py
@@ -5,10 +5,7 @@ from okta.client import Client as OktaClient
 from okta.models import Application as OktaApplication
 
 from fidesctl.core.utils import echo_red
-from fideslang.models import (
-    Dataset,
-    DatasetMetadata,
-)
+from fideslang.models import Dataset, DatasetMetadata
 
 
 def get_okta_client(org_url: str) -> OktaClient:

--- a/src/fidesctl/core/annotate_dataset.py
+++ b/src/fidesctl/core/annotate_dataset.py
@@ -2,13 +2,14 @@
 This script is a utility for interactively annotating data categories in the dataset manifest
 """
 
-from typing import Union, List
+from typing import List, Union
 
 import click
 
-from fidesctl.core import parse as core_parse, api_helpers
+from fidesctl.core import api_helpers
+from fidesctl.core import parse as core_parse
 from fidesctl.core.config import FidesctlConfig
-from fidesctl.core.utils import get_all_level_fields, echo_green
+from fidesctl.core.utils import echo_green, get_all_level_fields
 from fideslang import manifests
 from fideslang.models import Dataset, DatasetCollection, DatasetField, FidesKey
 from fideslang.validation import FidesValidationError

--- a/src/fidesctl/core/api_helpers.py
+++ b/src/fidesctl/core/api_helpers.py
@@ -3,6 +3,7 @@ Reusable utilities meant to make repetitive api-related tasks easier.
 """
 
 from typing import Dict, List, Optional
+
 from requests import Response
 
 from fidesctl.core import api

--- a/src/fidesctl/core/config/__init__.py
+++ b/src/fidesctl/core/config/__init__.py
@@ -6,8 +6,8 @@ config sections into a single config.
 import toml
 from pydantic import BaseModel
 
-from fidesctl.core.utils import echo_red
 from fidesctl.core.config.utils import get_config_path
+from fidesctl.core.utils import echo_red
 
 from .api_settings import APISettings
 from .cli_settings import CLISettings

--- a/src/fidesctl/core/config/api_settings.py
+++ b/src/fidesctl/core/config/api_settings.py
@@ -4,7 +4,7 @@
 
 import os
 from logging import DEBUG, INFO, getLevelName
-from typing import Dict, Union, Optional
+from typing import Dict, Optional, Union
 
 from pydantic import validator
 

--- a/src/fidesctl/core/config/cli_settings.py
+++ b/src/fidesctl/core/config/cli_settings.py
@@ -1,8 +1,8 @@
 """This module defines the settings for everything related to the CLI."""
 from typing import Dict, Optional
 
-from fideslog.sdk.python.utils import generate_client_id, FIDESCTL_CLI
-from pydantic import validator, AnyHttpUrl
+from fideslog.sdk.python.utils import FIDESCTL_CLI, generate_client_id
+from pydantic import AnyHttpUrl, validator
 
 from .fides_settings import FidesSettings
 

--- a/src/fidesctl/core/config/user_settings.py
+++ b/src/fidesctl/core/config/user_settings.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional
 from pydantic import BaseModel, validator
 
 from fidesctl.core.utils import generate_request_headers
+
 from .fides_settings import FidesSettings
 
 

--- a/src/fidesctl/core/dataset.py
+++ b/src/fidesctl/core/dataset.py
@@ -1,16 +1,17 @@
 """Module that adds functionality for generating or scanning datasets."""
-from typing import Dict, List, Tuple, Optional
-
 import asyncio
+from typing import Dict, List, Optional, Tuple
+
 import sqlalchemy
-from sqlalchemy.engine import Engine
 from pydantic import AnyHttpUrl
+from sqlalchemy.engine import Engine
 
 from fidesctl.core.api_helpers import list_server_resources
 from fidesctl.core.parse import parse
 from fideslang import manifests
 from fideslang.models import Dataset, DatasetCollection, DatasetField
-from .utils import get_db_engine, echo_green, echo_red
+
+from .utils import echo_green, echo_red, get_db_engine
 
 SCHEMA_EXCLUSION = {
     "postgresql": ["information_schema"],

--- a/src/fidesctl/core/export.py
+++ b/src/fidesctl/core/export.py
@@ -5,7 +5,6 @@ Exports various resources as data maps.
 from typing import Dict, List, Tuple
 
 import pandas as pd
-from fideslang.models import ContactDetails, Taxonomy
 
 from fidesctl.core.api_helpers import get_server_resources
 from fidesctl.core.export_helpers import (
@@ -20,6 +19,7 @@ from fidesctl.core.export_helpers import (
     union_data_categories_in_joined_dataframe,
 )
 from fidesctl.core.utils import echo_green, get_all_level_fields
+from fideslang.models import ContactDetails, Taxonomy
 
 
 def generate_dataset_records(

--- a/src/fidesctl/core/export_helpers.py
+++ b/src/fidesctl/core/export_helpers.py
@@ -5,10 +5,10 @@ from os.path import dirname, join
 from typing import Dict, List, Set, Tuple
 
 import pandas as pd
-from fideslang.models import DataSubjectRightsEnum, Taxonomy
 
 from fidesctl.core.api_helpers import get_server_resource, get_server_resources
 from fidesctl.core.utils import echo_red
+from fideslang.models import DataSubjectRightsEnum, Taxonomy
 
 DATAMAP_TEMPLATE = join(
     dirname(__file__),

--- a/src/fidesctl/core/filters.py
+++ b/src/fidesctl/core/filters.py
@@ -1,5 +1,5 @@
 """Module that adds functionality for resource filtering."""
-from typing import List, Callable, Optional
+from typing import Callable, List, Optional
 
 from fideslang.models import Organization, System
 

--- a/src/fidesctl/core/system.py
+++ b/src/fidesctl/core/system.py
@@ -1,18 +1,18 @@
 """Module that adds functionality for generating or scanning systems."""
 from collections import defaultdict
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
 
 from pydantic import AnyHttpUrl
 
 from fidesctl.cli.utils import handle_cli_response
 from fidesctl.core import api
+from fidesctl.core.api_helpers import get_server_resource, get_server_resources
 from fidesctl.core.parse import parse
-from fidesctl.core.api_helpers import get_server_resources, get_server_resource
 from fideslang import manifests
 from fideslang.models import Organization, System, SystemMetadata
 
-from .utils import echo_green, echo_red
 from .filters import filter_aws_systems
+from .utils import echo_green, echo_red
 
 
 def describe_redshift_clusters() -> Dict[str, List[Dict]]:

--- a/src/fidesctl/core/visualize.py
+++ b/src/fidesctl/core/visualize.py
@@ -2,7 +2,7 @@
 Creates data visualizations for hierarchical Fides resource types.
 """
 
-from typing import Generator, List, Dict
+from typing import Dict, Generator, List
 
 import plotly
 import plotly.graph_objects as go

--- a/src/fideslang/__init__.py
+++ b/src/fideslang/__init__.py
@@ -4,27 +4,28 @@ Exports various fideslang objects for easier use elsewhere.
 
 from typing import Dict, Type, Union
 
+from .default_fixtures import COUNTRY_CODES
+from .default_taxonomy import DEFAULT_TAXONOMY
+
 # Export the Models
 from .models import (
     DataCategory,
     DataQualifier,
-    DataSubject,
-    DataUse,
     Dataset,
     DatasetField,
+    DataSubject,
+    DataUse,
     Evaluation,
     FidesModel,
     Organization,
     Policy,
     PolicyRule,
+    PrivacyDeclaration,
     PrivacyRule,
     Registry,
-    PrivacyDeclaration,
     System,
     Taxonomy,
 )
-from .default_taxonomy import DEFAULT_TAXONOMY
-from .default_fixtures import COUNTRY_CODES
 
 FidesModelType = Union[Type[FidesModel], Type[Evaluation]]
 model_map: Dict[str, FidesModelType] = {

--- a/src/fideslang/default_taxonomy.py
+++ b/src/fideslang/default_taxonomy.py
@@ -1,12 +1,12 @@
 """This module contains the the default resources that Fideslang ships with."""
 
-from fideslang import (
-    Taxonomy,
+from .models import (
     DataCategory,
     DataQualifier,
-    DataUse,
     DataSubject,
+    DataUse,
     Organization,
+    Taxonomy,
 )
 
 DEFAULT_TAXONOMY = Taxonomy(

--- a/src/fideslang/manifests.py
+++ b/src/fideslang/manifests.py
@@ -4,6 +4,7 @@ from functools import reduce
 from typing import Dict, List, Set, Union
 
 import yaml
+
 from fidesctl.core.utils import echo_red
 
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -6,14 +6,14 @@ from __future__ import annotations
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import root_validator, validator, BaseModel, Field, AnyUrl, HttpUrl
+from pydantic import AnyUrl, BaseModel, Field, HttpUrl, root_validator, validator
 
 from fideslang.validation import (
     FidesKey,
-    sort_list_objects_by_name,
-    no_self_reference,
-    matching_parent_key,
     check_valid_country_code,
+    matching_parent_key,
+    no_self_reference,
+    sort_list_objects_by_name,
 )
 
 # Reusable components

--- a/src/fideslang/parse.py
+++ b/src/fideslang/parse.py
@@ -2,10 +2,10 @@
 This module handles everything related to parsing resources into Pydantic models,
 either from local files or the server.
 """
-from typing import List, Dict
+from typing import Dict, List
 
-from fideslang import model_map, FidesModel, Taxonomy
 from fidesctl.core.utils import echo_red
+from fideslang import FidesModel, Taxonomy, model_map
 
 
 def parse_dict(

--- a/src/fideslang/relationships.py
+++ b/src/fideslang/relationships.py
@@ -5,16 +5,12 @@ by each other and building a dependency graph of relationships.
 
 import inspect
 from functools import reduce
-from typing import List, Set, Dict
+from typing import Dict, List, Set
 
 from pydantic import AnyHttpUrl
 
 from fidesctl.core.api_helpers import get_server_resources
-from fideslang.models import (
-    FidesKey,
-    Taxonomy,
-    BaseModel,
-)
+from fideslang.models import BaseModel, FidesKey, Taxonomy
 from fideslang.utils import get_resource_by_fides_key
 
 

--- a/src/fideslang/validation.py
+++ b/src/fideslang/validation.py
@@ -3,12 +3,11 @@ Contains all of the additional validation for the resource models.
 """
 
 import re
-from typing import List, Dict, Pattern
+from typing import Dict, List, Pattern
 
 from pydantic import ConstrainedStr
 
 from fideslang.default_fixtures import COUNTRY_CODES
-
 
 VALID_COUNTRY_CODES = [country["alpha3Code"] for country in COUNTRY_CODES]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures to be used across tests."""
+import os
 from typing import Any, Dict
 
-import os
 import pytest
 import yaml
 
-from fideslang import models
-from fidesctl.core.config import get_config
 from fidesctl.core import api
+from fidesctl.core.config import get_config
+from fideslang import models
 
 TEST_CONFIG_PATH = "tests/test_config.toml"
 TEST_INVALID_CONFIG_PATH = "tests/test_invalid_config.toml"

--- a/tests/connectors/test_okta.py
+++ b/tests/connectors/test_okta.py
@@ -1,5 +1,4 @@
 import pytest
-
 from okta.models import Application as OktaApplication
 
 import fidesctl.connectors.okta as okta_connector

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -1,11 +1,13 @@
 """Integration tests for the API module."""
 
-import pytest
-import requests
 from json import loads
 
+import pytest
+import requests
+
 from fidesctl.core import api as _api
-from fideslang import parse, model_list
+from fideslang import model_list, parse
+
 
 # Helper Functions
 def get_existing_key(test_config, resource_type: str) -> int:

--- a/tests/core/test_api_helpers.py
+++ b/tests/core/test_api_helpers.py
@@ -1,12 +1,11 @@
 import uuid
-from typing import Optional, List
+from typing import List, Optional
 
 import pytest
 
-from fidesctl.core import api_helpers as _api_helpers
 from fidesctl.core import api as _api
-
-from fideslang import model_list, FidesModel
+from fidesctl.core import api_helpers as _api_helpers
+from fideslang import FidesModel, model_list
 
 RESOURCE_CREATION_COUNT = 5
 # These resources have tricky validation so the fides_key replacement doesn't work

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1,9 +1,11 @@
-import sqlalchemy
-import pytest
 import os
 from typing import List
 
-from fidesctl.core import dataset as _dataset, api
+import pytest
+import sqlalchemy
+
+from fidesctl.core import api
+from fidesctl.core import dataset as _dataset
 from fideslang.manifests import write_manifest
 from fideslang.models import Dataset, DatasetCollection, DatasetField, DatasetMetadata
 

--- a/tests/core/test_export_helpers.py
+++ b/tests/core/test_export_helpers.py
@@ -2,6 +2,8 @@ from os import path
 
 import pandas as pd
 import pytest
+
+from fidesctl.core import export_helpers
 from fideslang.models import (
     DataProtectionImpactAssessment,
     Dataset,
@@ -9,8 +11,6 @@ from fideslang.models import (
     DatasetField,
     DataSubjectRights,
 )
-
-from fidesctl.core import export_helpers
 
 
 @pytest.fixture()

--- a/tests/core/test_filters.py
+++ b/tests/core/test_filters.py
@@ -1,14 +1,14 @@
-import pytest
-
 from typing import List
+
+import pytest
 
 from fidesctl.core import filters as _filters
 from fideslang.models import (
-    System,
-    SystemMetadata,
     Organization,
     OrganizationMetadata,
     ResourceFilter,
+    System,
+    SystemMetadata,
 )
 
 

--- a/tests/core/test_system.py
+++ b/tests/core/test_system.py
@@ -1,8 +1,9 @@
-import pytest
-
 from typing import List
 
-from fidesctl.core import system as _system, api
+import pytest
+
+from fidesctl.core import api
+from fidesctl.core import system as _system
 from fideslang.models import System, SystemMetadata
 
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,11 +1,9 @@
 import os
 
-from fidesctl.core.config import get_config
-
 import pytest
 
 from fidesctl.core import utils
-
+from fidesctl.core.config import get_config
 from fideslang.models import DatasetCollection, DatasetField
 
 

--- a/tests/lang/test_validation.py
+++ b/tests/lang/test_validation.py
@@ -11,7 +11,6 @@ from fideslang.models import (
     PrivacyRule,
     System,
 )
-
 from fideslang.validation import FidesValidationError, check_valid_country_code
 
 


### PR DESCRIPTION
Closes #517

### Code Changes

* [x] Added isort as a dev dependency
* [x] Added isort settings to `pyproject.toml` 
* [x] Added isort to the Makefile
* [x] Added an isort step to the pr_checks workflow
* [x] Ran isort on the `src` and `tests` directories
* [x] Fixed circular import issue in `src/fideslang/default_taxonomy.py`

### Steps to Confirm

* [ ] Run CI and verify isort check runs
* [ ] Put imports in a file in the incorrect order then run `isort src tests` and verify they get sorted
* [ ] Put imports in a file in the incorrect order then run `make isort` and verify an error is reported

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Running isort uncovered a circular import issue in `src/fideslang/default_taxonomy.py` because it was importing from `__init__.py` so I also fixed that error.
