### PR TITLE
Log in-use API server config values on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 ### Added
 
 * CHANGELOG.md file
+* On API server startup, in-use config values are logged at the DEBUG level
 
 ### Changed
 

--- a/src/fidesapi/main.py
+++ b/src/fidesapi/main.py
@@ -50,6 +50,8 @@ async def setup_server() -> None:
         serialize=CONFIG.api.log_serialization,
         desination=CONFIG.api.log_destination,
     )
+
+    log.bind(api_config=CONFIG.api.json()).debug("Configuration options in use")
     await configure_db(CONFIG.api.sync_database_url)
 
 

--- a/src/fidesctl/core/config/api_settings.py
+++ b/src/fidesctl/core/config/api_settings.py
@@ -4,9 +4,9 @@
 
 import os
 from logging import DEBUG, INFO, getLevelName
-from typing import Dict, Union, Optional
+from typing import Dict, Optional, Union
 
-from pydantic import validator
+from pydantic import Field, validator
 
 from .fides_settings import FidesSettings
 
@@ -16,14 +16,14 @@ class APISettings(FidesSettings):
 
     # Database
     database_user: str = "postgres"
-    database_password: str = "fidesctl"
+    database_password: str = Field("fidesctl", exclude=True)
     database_host: str = "fidesctl-db"
     database_port: str = "5432"
     database_name: str = "fidesctl"
     test_database_name: str = "fidesctl_test"
-    database_url: Optional[str]
-    sync_database_url: Optional[str]
-    async_database_url: Optional[str]
+    database_url: Optional[str] = Field(None, exclude=True)
+    sync_database_url: Optional[str] = Field(None, exclude=True)
+    async_database_url: Optional[str] = Field(None, exclude=True)
 
     # Logging
     log_destination: str = ""


### PR DESCRIPTION
Closes #326

### Code Changes

* [x] Log in-use API server config values on startup
* [x] Exclude sensitive config values

### Steps to Confirm

* [x] `make api`
* [x] Observe the new log line:
	```
	2022-04-27 00:09:14.674 [DEBUG] (main:setup_server:54): Configuration options in use | {'api_config': '{"database_user": "postgres", "database_host": "fidesctl-db", "database_port": "5432", "database_name": "fidesctl", "test_database_name": "fidesctl_test", "log_destination": "", "log_level": "DEBUG", "log_serialization": ""}'}
	```

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

### Description Of Changes

The original goal involved differentiating between default/unset values (logged at the `WARNING` level) and user-defined options (logged at the `DEBUG` level). It was difficult and verbose to create log entries this way, so the server simply logs all of the `APISettings` in use at startup time.