### PR TITLE
Fix docstring quotes

### DIFF
--- a/src/fidesctl/cli/utils.py
+++ b/src/fidesctl/cli/utils.py
@@ -18,7 +18,7 @@ from fidesctl.core.utils import check_response, echo_green, echo_red
 
 
 def check_server(cli_version: str, server_url: str) -> None:
-    "Runs a health check and a version check against the server."
+    """Runs a health check and a version check against the server."""
 
     healthcheck_url = server_url + "/health"
     try:


### PR DESCRIPTION
Closes N/A

### Code Changes

* [x] Changed doc string for using one set of quotes to using 3.

### Steps to Confirm

* [x] View the docstring for `check_server`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

I noticed the docstring on `check_server` only had a single set of quotes so it isn't really treated as a docstring by Python `"Runs a health check and a version check against the server."`
