### PR TITLE
Modify default cli fields in fidesctl.toml on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,5 @@ The types of changes are:
 * Third-Country formatting on Data Map
 * Potential Duplication on Data Map
 * Exceptions are no longer raised when sending `AnalyticsEvent`s on Windows
+* Running `fidesctl init` now generates a `server_host` and `server_protocol`
+  rather than `server_url`

--- a/src/fidesctl/cli/commands/util.py
+++ b/src/fidesctl/cli/commands/util.py
@@ -42,7 +42,7 @@ def init(ctx: click.Context, fides_directory_location: str) -> None:
             "log_destination",
             "log_serialization",
         },
-        "cli": {"server_url", "analytics_id"},
+        "cli": {"server_protocol", "server_host", "server_port", "analytics_id"},
         "user": {"analytics_opt_out"},
     }
 


### PR DESCRIPTION
Relates to #512

### Code Changes

* [x] Default cli fields for `indclude_values` changed from  `"cli": {"server_url", "analytics_id"}` to `"cli": {"server_protocol", "server_host", "server_port", "analytics_id"}`

### Steps to Confirm

* [ ] Create an empty `.fides` directory
* [ ] Run `fidesctl init`
* [ ] Verify the generated `.fides/fidesctl.toml` file contains `server_protocol`, 'server_host`, and `analytics_id` as keys.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

The server port is included in the values to includes, however since it does not have a default value it doesn't get added to the resulting file. I included it anyways in case a default value is ever added, that way the resulting file will include it. I am not sure if #512 can be closed with this or not. The issue of the protocol being doubled seems to be fixed even without this update so I think it can.