### PR TITLE
Properly Load Enum Values for DataSubjectRightsEnum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The types of changes are:
 
 * Updated `Release Steps`
 
+### Fixed
+
+* Resolved a failure with populating applicable data subject rights to a data map
+
 ## [1.6.0](https://github.com/ethyca/fides/compare/1.5.3...1.6.0) - 2022-05-02
 
 ### Added

--- a/src/fidesctl/core/export_helpers.py
+++ b/src/fidesctl/core/export_helpers.py
@@ -275,7 +275,7 @@ def calculate_data_subject_rights(rights: Dict) -> str:
 
     Loads all available rights
     """
-    all_rights = DataSubjectRightsEnum()
+    all_rights = DataSubjectRightsEnum
     strategy: str = rights["strategy"]
     data_subject_rights: str
     if strategy == "ALL":

--- a/tests/core/test_export_helpers.py
+++ b/tests/core/test_export_helpers.py
@@ -164,6 +164,7 @@ def test_xlsx_export(tmpdir):
         },
     ],
 )
+@pytest.mark.unit
 def test_calculate_data_subject_rights(data_subject_rights: dict):
     """Tests different strategy options for returning data subject rights."""
     rights = DataSubjectRights(**data_subject_rights)


### PR DESCRIPTION
Closes #539

This was found to be failing in #533, however the root cause of the failure was implemented in #510. Removing the parentheses loads the enum values properly for inspection.

### Code Changes

* [x] Correctly mark the test so it is run
* [x] Remove the `()` from the `DataSubjectRightsEnum` model to load the values appropriately

### Steps to Confirm

* [x] Tests now pass and are run
* [x] All permutations of the data subject rights selection export properly

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This ended up being a fairly simple change to solve this problem. It may make sense to cut a minor release for this bug.
