### PR TITLE
Orphan Dataset Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/1.6.0...main)
 
+### Added
+
+* Include a warning for any orphan datasets as part of the `apply` command.
+
 ### Docs
 
 * Updated `Release Steps`

--- a/docs/fides/docs/language/resources/dataset.md
+++ b/docs/fides/docs/language/resources/dataset.md
@@ -19,6 +19,7 @@ While you can create Dataset objects by hand, you typically use the [generate](.
 
 You use your Datasets by adding them to Systems. A System can contain any number of Datasets, and a Dataset can be added to any number of Systems.
 When a dataset is referenced by a system, all applicable data categories set on the dataset are treated as part of the system.
+If a Dataset is not referenced by a System, a warning is surfaced denoting an orphan dataset exists.
 
 Datasets cannot contain other Datasets.
 

--- a/src/fidesctl/core/apply.py
+++ b/src/fidesctl/core/apply.py
@@ -8,7 +8,7 @@ from deepdiff import DeepDiff
 from fidesctl.cli.utils import handle_cli_response
 from fidesctl.core import api
 from fidesctl.core.api_helpers import get_server_resources
-from fidesctl.core.utils import echo_green
+from fidesctl.core.utils import echo_green, echo_red
 from fideslang import FidesModel, Taxonomy
 
 
@@ -67,6 +67,34 @@ def echo_results(action: str, resource_type: str, resource_count: int) -> None:
     echo_green(f"{action.upper()} {resource_count} {resource_type} resource(s).")
 
 
+def validate_dataset_usage(taxonomy: Taxonomy) -> list:
+    """
+    Validate all datasets are referenced at least one time
+    by comparing all datasets to a set of referenced datasets
+    within a privacy declaration.
+
+    Returns a list containing any orphan datasets.
+    """
+    referenced_datasets = set()
+    datasets = set()
+
+    referenced_datasets.update(
+        [
+            dataset_reference
+            for resource in taxonomy.system
+            for privacy_declaration in resource.privacy_declarations
+            if privacy_declaration.dataset_references is not None
+            for dataset_reference in privacy_declaration.dataset_references
+        ]
+    )
+
+    datasets.update([resource.fides_key for resource in taxonomy.dataset])
+
+    missing_datasets = list(datasets - referenced_datasets)
+
+    return missing_datasets
+
+
 def apply(
     url: str,
     taxonomy: Taxonomy,
@@ -77,6 +105,14 @@ def apply(
     """
     Apply the current manifest file state to the server.
     """
+
+    missing_datasets = validate_dataset_usage(taxonomy)
+    if len(missing_datasets) > 0:
+        echo_red(
+            "Orphan Dataset Warning: The following datasets are not found referenced on a System"
+        )
+        for dataset in missing_datasets:
+            print(dataset)
 
     for resource_type in taxonomy.__fields_set__:
         print("-" * 10)

--- a/tests/core/test_apply.py
+++ b/tests/core/test_apply.py
@@ -2,7 +2,7 @@
 import pytest
 
 import fideslang as models
-from fidesctl.core.apply import sort_create_update
+from fidesctl.core.apply import sort_create_update, validate_dataset_usage
 
 
 # Helpers
@@ -17,6 +17,26 @@ def server_resource_list():
 @pytest.fixture()
 def server_resource_key_pairs():
     yield {"testKey": 1, "anotherTestKey": 2}
+
+
+@pytest.fixture()
+def system_with_dataset_reference():
+    yield [
+        models.System(
+            organization_fides_key=1,
+            fides_key="test_system",
+            system_type="test",
+            privacy_declarations=[
+                models.PrivacyDeclaration(
+                    name="test_privacy_declaration",
+                    data_categories=[],
+                    data_use="test_data_use",
+                    data_subjects=[],
+                    dataset_references=["test_dataset"],
+                ),
+            ],
+        ),
+    ]
 
 
 # Unit
@@ -71,3 +91,84 @@ def test_sort_create_update_update():
     ) = sort_create_update(manifest_resource_list, server_resource_list)
     assert [] == create_result
     assert expected_update_result == update_result
+
+
+@pytest.mark.parametrize(
+    "taxonomies, expected_length",
+    [
+        (
+            {
+                "dataset": [
+                    models.Dataset(
+                        organization_fides_key=1,
+                        fides_key="test_dataset",
+                        collections=[],
+                    ),
+                ],
+            },
+            0,
+        ),
+        (
+            {
+                "dataset": [
+                    models.Dataset(
+                        organization_fides_key=1,
+                        fides_key="test_dataset_unused",
+                        collections=[],
+                    ),
+                ],
+            },
+            1,
+        ),
+        (
+            {
+                "dataset": [
+                    models.Dataset(
+                        organization_fides_key=1,
+                        fides_key="test_dataset",
+                        collections=[],
+                    ),
+                    models.Dataset(
+                        organization_fides_key=1,
+                        fides_key="test_dataset_unused",
+                        collections=[],
+                    ),
+                ],
+            },
+            1,
+        ),
+        (
+            {
+                "dataset": [
+                    models.Dataset(
+                        organization_fides_key=1,
+                        fides_key="test_dataset",
+                        collections=[],
+                    ),
+                    models.Dataset(
+                        organization_fides_key=1,
+                        fides_key="test_dataset_unused",
+                        collections=[],
+                    ),
+                    models.Dataset(
+                        organization_fides_key=1,
+                        fides_key="test_dataset_also_unused",
+                        collections=[],
+                    ),
+                ],
+            },
+            2,
+        ),
+    ],
+)
+@pytest.mark.unit
+def test_validate_dataset_usage(
+    taxonomies: dict, expected_length: int, system_with_dataset_reference: list
+):
+    """
+    Tests different scenarios for referenced datasets
+    """
+    taxonomies["system"] = system_with_dataset_reference
+    taxonomy = models.Taxonomy.parse_obj(taxonomies)
+    missing_datasets = validate_dataset_usage(taxonomy)
+    assert len(missing_datasets) == expected_length


### PR DESCRIPTION
Closes #507 

### Code Changes

* [x] Include a validation check for orphan datasets in `apply`

### Steps to Confirm

* [x] All orphaned datasets are returned (both when creating a new empty dataset in `demo_resources/` and commenting out the existing usage

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Decided to add this as part of the `apply` command initially. A comment on the issue also suggests adding this to the `fideslang` repo as part of `relationships.py` but having the work nearly completed here decided to follow through with a PR for review.

To validate the change, comment out the referenced dataset in `demo_system.py` and run `fidesctl apply demo_resources/`
