### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/1.6.0...main)
 
+### Added
+
+* Added dependabot to keep dependencies updated
+
 ### Developer Experience
 
 * Added Nox as an alternative to Make


### PR DESCRIPTION
Closes #544

### Code Changes

* [x] Added a dependabot.yaml file to the workflows.
* [x] Updated CHANGELOG.md

### Steps to Confirm

Unfortunately I don't know of any way to test this outside of letting it run. Since all it does is open PRs and doesn't make any code changes it's low risk. 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

By default dependabot runs daily, but this interval can be changed so if you think something else would be better let me know. The PRs that dependabot generates can also be auto labeled so if there are any specific labels that should be applied (i.e. `dependencies`) I can add that also.
