### PR TITLE
update the type param for docs_build nox command

### DIFF
--- a/noxfiles/docs_nox.py
+++ b/noxfiles/docs_nox.py
@@ -5,7 +5,9 @@ from docker_nox import build_local
 
 
 @nox.session()
-@nox.parametrize("type", [nox.param("local", id="local"), nox.param("ci", id="ci")])
+@nox.parametrize(
+    "build_type", [nox.param("local", id="local"), nox.param("ci", id="ci")]
+)
 def docs_build(session: nox.Session, build_type: str) -> None:
     """Build docs from the source code."""
     session.notify("teardown")


### PR DESCRIPTION
Closes n/a

### Code Changes

* [x] update old param name from `type` to `build_type`

### Steps to Confirm

* [x] The `docs_build` command failed previosuly and succeeds with this change

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This was missed in #558 as part of the static code validation updates. Updating the param should fix the docs build failure, no update to the check should be necessary at this point.
