### PR TITLE
Update fideslog to v1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The types of changes are:
 ### Fixed
 
 * Resolved a failure with populating applicable data subject rights to a data map
+* Updated `fideslog` to v1.1.5, resolving an issue where some exceptions thrown by the SDK were not handled as expected
 
 ## [1.6.0](https://github.com/ethyca/fides/compare/1.5.3...1.6.0) - 2022-05-02
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click>=8.1
 colorama>=0.4.3
 cryptography>=36
 deepdiff==5.8.0
-fideslog==1.1.4
+fideslog==1.1.5
 loguru>=0.5,<0.6
 openpyxl==3.0.9
 pandas==1.4


### PR DESCRIPTION
Closes #608

### Code Changes

* [x] Update the fideslog dependency to v1.1.5

### Steps to Confirm

* [ ] `pip install fidesctl`, and confirm that fideslog v1.1.5 is included

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

### Description Of Changes

Fideslog v1.1.5 includes a fix for an issue where some exceptions thrown by the SDK are not wrapped in the `AnalyticsError` type, breaking the intended exception handling workflow for consumers.

For a complete changelog, see: https://github.com/ethyca/fideslog/compare/v1.1.4...v1.1.5