### PR TITLE
Serve static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 fidesapi/src/main/resources/application.conf
 docs/fides/docs/api/openapi.json
 docs/fides/docs/schemas/config_schema.json
+fidesapi/build/static
 
 ## generic files to ignore
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The types of changes are:
 * Added dependabot to keep dependencies updated
 * Include a warning for any orphan datasets as part of the `apply` command.
 
+### Changed
+
+* Comparing server and CLI versions ignores `.dirty` only differences, and is quiet on success when running general CLI commands
+
 ### Developer Experience
 
 * Replaced `make` with `nox`
@@ -35,6 +39,7 @@ The types of changes are:
 
 * Resolved a failure with populating applicable data subject rights to a data map
 * Updated `fideslog` to v1.1.5, resolving an issue where some exceptions thrown by the SDK were not handled as expected
+* Host static files via fidesapi [#621](https://github.com/ethyca/fides/pull/621)
 
 ## [1.6.0](https://github.com/ethyca/fides/compare/1.5.3...1.6.0) - 2022-05-02
 
@@ -43,13 +48,11 @@ The types of changes are:
 * CHANGELOG.md file
 * On API server startup, in-use config values are logged at the DEBUG level
 * Send a usage analytics event upon execution of the `fidesctl init` command
-* Host static files via fidesapi
 
 ### Developer Experience
 
 * added isort as a CI check
 * Include `tests/` in all static code checks (e.g. `mypy`, `pylint`)
-* Comparing server and CLI versions ignores `.dirty` only differences, and is quiet on success when running general CLI commands
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The types of changes are:
 * CHANGELOG.md file
 * On API server startup, in-use config values are logged at the DEBUG level
 * Send a usage analytics event upon execution of the `fidesctl init` command
+* Host static files via fidesapi
 
 ### Developer Experience
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,9 @@ ENV PYTHONUNBUFFERED=TRUE
 # Enable detection of running within Docker
 ENV RUNNING_IN_DOCKER=TRUE
 
+# Make a static files directory
+RUN mkdir -p src/fidesapi/build/static
+
 EXPOSE 8080
 CMD ["fidesctl", "webserver"]
 
@@ -107,5 +110,4 @@ RUN python setup.py sdist
 RUN pip install dist/fidesctl-*.tar.gz
 
 # Copy frontend build over
-RUN mkdir -p src/fidesapi/build/static
 COPY --from=frontend /tmp/index.html src/fidesapi/build/static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,14 @@ FROM --platform=linux/amd64 python:3.8-slim-buster as base
 # Update pip in the base image since we'll use it everywhere
 RUN pip install -U pip
 
+####################
+## Build frontend ##
+####################
+FROM base as frontend
+# Placeholder until we have a frontend app scaffolded
+RUN echo "<h1>Hello world!</h1>" > /tmp/index.html
+
+
 #######################
 ## Tool Installation ##
 #######################
@@ -97,3 +105,7 @@ FROM builder as prod
 # Install without a symlink
 RUN python setup.py sdist
 RUN pip install dist/fidesctl-*.tar.gz
+
+# Copy frontend build over
+RUN mkdir -p src/fidesapi/build/static
+COPY --from=frontend /tmp/index.html src/fidesapi/build/static/

--- a/src/fidesapi/main.py
+++ b/src/fidesapi/main.py
@@ -22,7 +22,7 @@ from fidesapi.utils.logger import setup as setup_logging
 from fidesctl.core.config import FidesctlConfig, get_config
 
 WEBAPP_DIRECTORY = Path("src/fidesapi/build/static")
-WEBAPP_INDEX = Path(WEBAPP_DIRECTORY / "index.html")
+WEBAPP_INDEX = WEBAPP_DIRECTORY / "index.html"
 
 app = FastAPI(title="fidesctl")
 CONFIG: FidesctlConfig = get_config()
@@ -138,8 +138,7 @@ def read_index() -> Response:
     """
     Return an index.html at the root path
     """
-    path = WEBAPP_DIRECTORY / "index.html"
-    return FileResponse(path)
+    return FileResponse(WEBAPP_INDEX)
 
 
 @app.get("/{catchall:path}", response_class=FileResponse)

--- a/src/fidesapi/main.py
+++ b/src/fidesapi/main.py
@@ -120,16 +120,21 @@ async def db_action(action: DBActions) -> Dict:
     return {"data": {"message": f"Fidesctl database {action_text}"}}
 
 
-# Configure the static file sink, adapted from https://github.com/tiangolo/fastapi/issues/130
-# Do this last since otherwise it will take over all paths
+# Configure the static file paths last since otherwise it will take over all paths
 @app.get("/")
 def read_index() -> Response:
+    """
+    Return an index.html at the root path
+    """
     path = WEBAPP_DIRECTORY / "index.html"
     return FileResponse(path)
 
 
 @app.get("/{catchall:path}", response_class=FileResponse)
 def read_other_paths(request: Request) -> FileResponse:
+    """
+    Return related frontend files. Adapted from https://github.com/tiangolo/fastapi/issues/130
+    """
     # check first if requested file exists
     path = request.path_params["catchall"]
     file = WEBAPP_DIRECTORY / Path(path)

--- a/src/fidesapi/main.py
+++ b/src/fidesapi/main.py
@@ -120,8 +120,10 @@ async def db_action(action: DBActions) -> Dict:
     return {"data": {"message": f"Fidesctl database {action_text}"}}
 
 
+# Configure the static file sink, adapted from https://github.com/tiangolo/fastapi/issues/130
+# Do this last since otherwise it will take over all paths
 @app.get("/")
-def read_index(request: Request) -> Response:
+def read_index() -> Response:
     path = WEBAPP_DIRECTORY / "index.html"
     return FileResponse(path)
 

--- a/src/fidesapi/main.py
+++ b/src/fidesapi/main.py
@@ -22,9 +22,9 @@ from fidesapi.utils.logger import setup as setup_logging
 from fidesctl.core.config import FidesctlConfig, get_config
 
 WEBAPP_DIRECTORY = Path("src/fidesapi/build/static")
+WEBAPP_INDEX = Path(WEBAPP_DIRECTORY / "index.html")
 
 app = FastAPI(title="fidesctl")
-app.mount("/static", StaticFiles(directory=WEBAPP_DIRECTORY), name="static")
 CONFIG: FidesctlConfig = get_config()
 
 
@@ -46,6 +46,18 @@ async def configure_db(database_url: str) -> None:
     "Set up the db to be used by the app."
     database.create_db_if_not_exists(database_url)
     await database.init_db(database_url)
+
+
+@app.on_event("startup")
+async def create_webapp_dir_if_not_exists() -> None:
+    """Creates the webapp directory if it doesn't exist."""
+
+    if not WEBAPP_INDEX.is_file():
+        WEBAPP_DIRECTORY.mkdir(parents=True, exist_ok=True)
+        with open(WEBAPP_DIRECTORY / "index.html", "w") as index_file:
+            index_file.write("<h1>Privacy is a Human Right!</h1>")
+
+    app.mount("/static", StaticFiles(directory=WEBAPP_DIRECTORY), name="static")
 
 
 @app.on_event("startup")

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -179,3 +179,10 @@ def test_visualize(test_config: FidesctlConfig, resource_type: str) -> None:
         f"{test_config.cli.server_url}/{resource_type}/visualize/graphs"
     )
     assert response.status_code == 200
+
+
+@pytest.mark.integration
+def test_static_sink(test_config: FidesctlConfig) -> None:
+    """Make sure we are hosting something at / and not getting a 404"""
+    response = requests.get(f"{test_config.cli.server_url}")
+    assert response.status_code == 200

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -179,10 +179,3 @@ def test_visualize(test_config: FidesctlConfig, resource_type: str) -> None:
         f"{test_config.cli.server_url}/{resource_type}/visualize/graphs"
     )
     assert response.status_code == 200
-
-
-@pytest.mark.integration
-def test_static_sink(test_config: FidesctlConfig) -> None:
-    """Make sure we are hosting something at / and not getting a 404"""
-    response = requests.get(f"{test_config.cli.server_url}")
-    assert response.status_code == 200


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/560

### Code Changes

* [x] Add static files to API server

### Steps to Confirm

* [x] Spin up the webserver and hit localhost:8080 to see a minimal frontend

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Adds a path where static files can be served from our existing python webserver.
