### PR TITLE
Include default_organization in data map export if no Organization found

### DIFF
--- a/src/fidesctl/core/export_helpers.py
+++ b/src/fidesctl/core/export_helpers.py
@@ -300,11 +300,18 @@ def get_datamap_fides_keys(taxonomy: Taxonomy) -> Dict:
     Gathers all fides keys for an organization, systems,
     and datasets based on the resources found in the
     provided taxonomy built from manifests.
+
+    If no Organization is found, ensure the 'default_organization'
+    is applied. This is a temporary measure put in place until a
+    more thorough change is made to pull all resources from the
+    server.
     """
     taxonomy_keys_dict = {}
     taxonomy_keys_dict["organization"] = [
         resource.fides_key for resource in taxonomy.organization
     ]
+    if not taxonomy_keys_dict["organization"]:
+        taxonomy_keys_dict["organization"] = ["default_organization"]
     taxonomy_keys_dict["system"] = [resource.fides_key for resource in taxonomy.system]
     taxonomy_keys_dict["dataset"] = [
         resource.fides_key for resource in taxonomy.dataset

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -245,8 +245,15 @@ def test_evaluate_with_dataset_collection_failed(
 @pytest.mark.parametrize(
     "export_resource", ["system", "dataset", "organization", "datamap"]
 )
+@pytest.mark.parametrize(
+    "manifest_dir",
+    ["demo_resources/", ".fides/"],
+)
 def test_export_resources(
-    test_config_path: str, test_cli_runner: CliRunner, export_resource: str
+    test_config_path: str,
+    test_cli_runner: CliRunner,
+    export_resource: str,
+    manifest_dir: str,
 ) -> None:
     """
     Tests that each resource is successfully exported
@@ -259,7 +266,7 @@ def test_export_resources(
             test_config_path,
             "export",
             export_resource,
-            "demo_resources/",
+            manifest_dir,
             "--dry",
         ],
     )


### PR DESCRIPTION
Closes #651

### Code Changes

* [x] Include `default_organization` as required when no custom organiztion has been authored
* [x] Include `.fides/` as part of our CI tests as this would have caught the bug

### Steps to Confirm

* [x] Confirmed this bug also affects exporting the data map for `.fides/` and resolves it there

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

This is a near-term workaround until we include all resources on the server as part of the export. This fix will ensure that the default_organization is included at minimum, which is in line with our documentation around being able to utilize default_organization behind the scenes.

This will unblock users from currently hitting an error when trying to utilize an organization not defined in the manifest directory.

