### PR TITLE
complex character handling in test_dataset.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ The types of changes are:
 * Resolved a failure with populating applicable data subject rights to a data map
 * Updated `fideslog` to v1.1.5, resolving an issue where some exceptions thrown by the SDK were not handled as expected
 * Host static files via fidesapi [#621](https://github.com/ethyca/fides/pull/621)
+* Handle complex characters in external tests  [#661](https://github.com/ethyca/fides/pull/661)
+
 
 ## [1.6.0](https://github.com/ethyca/fides/compare/1.5.3...1.6.0) - 2022-05-02
 

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring, redefined-outer-name
 import os
 from typing import Dict, Generator, List
+from urllib.parse import quote_plus
 
 import pytest
 import sqlalchemy
@@ -314,11 +315,13 @@ MASTER_MSSQL_URL = MSSQL_URL_TEMPLATE.format("master") + "&autocommit=True"
 # External databases require credentials passed through environment variables
 SNOWFLAKE_URL_TEMPLATE = "snowflake://FIDESCTL:{}@ZOA73785/FIDESCTL_TEST"
 SNOWFLAKE_URL = SNOWFLAKE_URL_TEMPLATE.format(
-    os.getenv("SNOWFLAKE_FIDESCTL_PASSWORD", "")
+    quote_plus(os.getenv("SNOWFLAKE_FIDESCTL_PASSWORD", ""))
 )
 
 REDSHIFT_URL_TEMPLATE = "redshift+psycopg2://fidesctl:{}@redshift-cluster-1.cohs2e5eq2e4.us-east-1.redshift.amazonaws.com:5439/fidesctl_test"
-REDSHIFT_URL = REDSHIFT_URL_TEMPLATE.format(os.getenv("REDSHIFT_FIDESCTL_PASSWORD", ""))
+REDSHIFT_URL = REDSHIFT_URL_TEMPLATE.format(
+    quote_plus(os.getenv("REDSHIFT_FIDESCTL_PASSWORD", ""))
+)
 
 
 TEST_DATABASE_PARAMETERS = {


### PR DESCRIPTION
Relates to #658 

### Code Changes

* [x] Use `quote_plus` in `test_dataset.py` to handle potentially complex characters

### Steps to Confirm

* [x] External Tests now pass

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Add character quoting to connection strings in `test_dataset.py`, originally found when testing #548 
