### PR TITLE
Fix local demo_resources evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The types of changes are:
 * Updated `fideslog` to v1.1.5, resolving an issue where some exceptions thrown by the SDK were not handled as expected
 * Updated the webserver so that it won't fail if the database is inaccessible [#649](https://github.com/ethyca/fides/pull/649)
 * Handle complex characters in external tests  [#661](https://github.com/ethyca/fides/pull/661)
+* Evaluations now properly merge the default taxonomy into the user-defined taxonomy [#684](https://github.com/ethyca/fides/pull/684)
 
 ## [1.6.0](https://github.com/ethyca/fides/compare/1.5.3...1.6.0) - 2022-05-02
 

--- a/src/fidesctl/core/evaluate.py
+++ b/src/fidesctl/core/evaluate.py
@@ -512,8 +512,8 @@ def evaluate(
     user_taxonomy = parse(manifests_dir)
     taxonomy = Taxonomy.parse_obj(
         {
-            **DEFAULT_TAXONOMY.dict(exclude_unset=True),
             **user_taxonomy.dict(exclude_unset=True),
+            **DEFAULT_TAXONOMY.dict(exclude_unset=True),
         }
     )
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -160,6 +160,24 @@ def test_local_evaluate(
 
 
 @pytest.mark.integration
+def test_local_evaluate_demo_resources(
+    test_invalid_config_path: str, test_cli_runner: CliRunner
+) -> None:
+    result = test_cli_runner.invoke(
+        cli,
+        [
+            "--local",
+            "-f",
+            test_invalid_config_path,
+            "evaluate",
+            "demo_resources/",
+        ],
+    )
+    print(result.output)
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
 def test_evaluate_with_key_pass(
     test_config_path: str, test_cli_runner: CliRunner
 ) -> None:

--- a/tests/core/test_evaluate.py
+++ b/tests/core/test_evaluate.py
@@ -554,3 +554,40 @@ def test_get_fides_key_parent_hierarchy_missing_parent() -> None:
             ),
             fides_key="data_category.parent",
         )
+
+
+@pytest.mark.unit
+class TestMergeTaxonomies:
+    def test_no_key_conflicts(self) -> None:
+        taxonomy_1 = Taxonomy(data_subject=[DataSubject(fides_key="foo", name="bar")])
+        taxonomy_2 = Taxonomy(data_subject=[DataSubject(fides_key="bar", name="baz")])
+        taxonomy_3 = Taxonomy(
+            data_subject=[
+                DataSubject(fides_key="foo", name="bar"),
+                DataSubject(fides_key="bar", name="baz"),
+            ]
+        )
+        assert evaluate.merge_taxonomies(taxonomy_1, taxonomy_2) == taxonomy_3
+
+    def test_key_conflicts(self) -> None:
+        taxonomy_1 = Taxonomy(data_subject=[DataSubject(fides_key="foo", name="bar")])
+        taxonomy_2 = Taxonomy(data_subject=[DataSubject(fides_key="foo", name="baz")])
+        taxonomy_3 = Taxonomy(
+            data_subject=[
+                DataSubject(fides_key="foo", name="bar"),
+            ]
+        )
+        assert evaluate.merge_taxonomies(taxonomy_1, taxonomy_2) == taxonomy_3
+
+    def test_no_same_resources(self) -> None:
+        taxonomy_1 = Taxonomy(data_subject=[DataSubject(fides_key="foo", name="bar")])
+        taxonomy_2 = Taxonomy(data_category=[DataCategory(fides_key="foo", name="bar")])
+        taxonomy_3 = Taxonomy(
+            data_subject=[
+                DataSubject(fides_key="foo", name="bar"),
+            ],
+            data_category=[
+                DataCategory(fides_key="foo", name="bar"),
+            ],
+        )
+        assert evaluate.merge_taxonomies(taxonomy_1, taxonomy_2) == taxonomy_3


### PR DESCRIPTION
Closes #683 

### Code Changes

* [x] merge the default taxonomy into the user taxonomy in a non-destructive way
* [x] increase test coverage for taxonomy merging and demo resource checks

### Steps to Confirm

* [x] `fidesctl --local evaluate demo_resources/` succeeds

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

The way that we were merging taxonomies for evaluations was incorrect and causing some overwrites. Typically this wouldn't cause an issue as the taxonomy would be able to rehydrate via the server, but this bug surfaced in `local` mode.

There is now a separate function that merges the taxonomies in a more specific way so as not to clobber user-defined elements
