### PR TITLE
Switch from docker-compose to docker compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The types of changes are:
 * Comparing server and CLI versions ignores `.dirty` only differences, and is quiet on success when running general CLI commands
 * Migrate all endpoints to be prefixed by `/api/v1` [#623](https://github.com/ethyca/fides/issues/623)
 * Allow credentials to be passed to the generate systems from aws functionality via the API [#645](https://github.com/ethyca/fides/pull/645)
+* Noxfiles now use `docker compose` instead of `docker-compose`
 
 ### Developer Experience
 

--- a/noxfiles/constants_nox.py
+++ b/noxfiles/constants_nox.py
@@ -34,9 +34,10 @@ CI_ARGS = "-T" if getenv("CI") else "--user=root"
 ANALYTICS_ID_OVERRIDE = ("-e", "FIDESCTL__CLI__ANALYTICS_ID")
 
 # Reusable Commands
-RUN = ("docker-compose", "run", "--rm", *ANALYTICS_ID_OVERRIDE, CI_ARGS, IMAGE_NAME)
+RUN = ("docker", "compose", "run", "--rm", *ANALYTICS_ID_OVERRIDE, CI_ARGS, IMAGE_NAME)
 RUN_NO_DEPS = (
-    "docker-compose",
+    "docker",
+    "compose",
     "run",
     "--no-deps",
     "--rm",
@@ -44,4 +45,4 @@ RUN_NO_DEPS = (
     CI_ARGS,
     IMAGE_NAME,
 )
-START_APP = ("docker-compose", "up", "-d", IMAGE_NAME)
+START_APP = ("docker", "compose", "up", "-d", IMAGE_NAME)


### PR DESCRIPTION
Closes <issue>

### Code Changes

* [ ] Convert `docker-compose` in the nox files to `docker compose`

### Steps to Confirm

* [ ] `nox -s cli` works
* [ ] all other nox commands work


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Was running into some weird failures when using `docker-compose` (which has mostly been deprecated in favor of docker compose), figured it was time to switch over to the new command