### PR TITLE
Fix Installation Check to catch uninstalled module errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The types of changes are:
 * Updated the webserver so that it won't fail if the database is inaccessible [#649](https://github.com/ethyca/fides/pull/649)
 * Handle complex characters in external tests  [#661](https://github.com/ethyca/fides/pull/661)
 * Evaluations now properly merge the default taxonomy into the user-defined taxonomy [#684](https://github.com/ethyca/fides/pull/684)
+* The CLI can be run without installing the webserver components [#715](https://github.com/ethyca/fides/pull/715)
 
 ## [1.6.0](https://github.com/ethyca/fides/compare/1.5.3...1.6.0) - 2022-05-02
 

--- a/noxfiles/ci_nox.py
+++ b/noxfiles/ci_nox.py
@@ -107,15 +107,12 @@ def xenon(session: nox.Session) -> None:
 
 
 # Fidesctl Checks
-# Make sure that this installs fidesctl in an isolated environment
 @nox.session()
 def check_install(session: nox.Session) -> None:
     """Check that fidesctl is installed."""
-    if session.posargs == ["docker"]:
-        run_command = (*RUN_STATIC_ANALYSIS, "check_install")
-    else:
-        run_command = ("fidesctl", *(WITH_TEST_CONFIG), "--version")
-    session.run(*run_command, external=True)
+    session.install(".")
+    run_command = ("fidesctl", *(WITH_TEST_CONFIG), "--version")
+    session.run(*run_command)
 
 
 @nox.session()

--- a/noxfiles/ci_nox.py
+++ b/noxfiles/ci_nox.py
@@ -107,6 +107,7 @@ def xenon(session: nox.Session) -> None:
 
 
 # Fidesctl Checks
+# Make sure that this installs fidesctl in an isolated environment
 @nox.session()
 def check_install(session: nox.Session) -> None:
     """Check that fidesctl is installed."""

--- a/src/fidesapi/routes/util.py
+++ b/src/fidesapi/routes/util.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
 from fastapi import APIRouter
+from fidesctl.core.utils import API_PREFIX as _API_PREFIX
 
-API_PREFIX = "/api/v1"
+API_PREFIX = _API_PREFIX
 WEBAPP_DIRECTORY = Path("src/fidesapi/build/static")
 WEBAPP_INDEX = WEBAPP_DIRECTORY / "index.html"
 

--- a/src/fidesapi/routes/util.py
+++ b/src/fidesapi/routes/util.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from fastapi import APIRouter
+
 from fidesctl.core.utils import API_PREFIX as _API_PREFIX
 
 API_PREFIX = _API_PREFIX

--- a/src/fidesctl/cli/utils.py
+++ b/src/fidesctl/cli/utils.py
@@ -24,7 +24,7 @@ from fideslog.sdk.python.utils import (
 import fidesctl
 from fidesctl.core import api as _api
 from fidesctl.core.config.utils import get_config_from_file, update_config_file
-from fidesctl.core.utils import check_response, echo_green, echo_red, API_PREFIX
+from fidesctl.core.utils import API_PREFIX, check_response, echo_green, echo_red
 
 
 def check_server(cli_version: str, server_url: str, quiet: bool = False) -> None:

--- a/src/fidesctl/cli/utils.py
+++ b/src/fidesctl/cli/utils.py
@@ -22,10 +22,9 @@ from fideslog.sdk.python.utils import (
 )
 
 import fidesctl
-from fidesapi.routes.util import API_PREFIX
 from fidesctl.core import api as _api
 from fidesctl.core.config.utils import get_config_from_file, update_config_file
-from fidesctl.core.utils import check_response, echo_green, echo_red
+from fidesctl.core.utils import check_response, echo_green, echo_red, API_PREFIX
 
 
 def check_server(cli_version: str, server_url: str, quiet: bool = False) -> None:

--- a/src/fidesctl/core/api.py
+++ b/src/fidesctl/core/api.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 import requests
 
-from fidesapi.routes.util import API_PREFIX
+from fidesctl.core.utils import API_PREFIX
 
 
 def generate_resource_url(

--- a/src/fidesctl/core/utils.py
+++ b/src/fidesctl/core/utils.py
@@ -16,6 +16,10 @@ logger = logging.getLogger("server_api")
 echo_red = partial(click.secho, fg="red", bold=True)
 echo_green = partial(click.secho, fg="green", bold=True)
 
+# This duplicates a constant in `fidesapi/routes/utils.py`
+# To avoid import errors
+API_PREFIX = "/api/v1"
+
 
 def check_response(response: requests.Response) -> requests.Response:
     """

--- a/tests/cli/test_cli_utils.py
+++ b/tests/cli/test_cli_utils.py
@@ -3,7 +3,7 @@ import pytest
 from requests_mock import Mocker
 
 import fidesctl.cli.utils as utils
-from fidesapi.routes.util import API_PREFIX
+from fidesctl.core.utils import API_PREFIX
 
 
 @pytest.mark.unit

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -10,7 +10,7 @@ from pytest import MonkeyPatch
 from starlette.testclient import TestClient
 
 from fidesapi import main
-from fidesapi.routes.util import API_PREFIX
+from fidesctl.core.utils import API_PREFIX
 from fidesctl.core import api as _api
 from fidesctl.core.config import FidesctlConfig
 

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -10,9 +10,9 @@ from pytest import MonkeyPatch
 from starlette.testclient import TestClient
 
 from fidesapi import main
-from fidesctl.core.utils import API_PREFIX
 from fidesctl.core import api as _api
 from fidesctl.core.config import FidesctlConfig
+from fidesctl.core.utils import API_PREFIX
 
 
 @pytest.fixture()


### PR DESCRIPTION
Closes #681 

### Code Changes

* [x] `nox` check installs fidesctl in a virtualenv
* [x] fix imports so that the check doesn't fail

### Steps to Confirm

* [ ] import from `fidesapi` somewhere in the CLI
* [ ] run `nox -s check_install`
* [ ] confirm that an error gets thrown

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This PR fixes the import issue that would cause the CLI to be broken if not installed with certain optional dependencies. It also updates an existing CI check to catch this bug if it were to happen again
