### PR TITLE
Create form for editing dataset fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The types of changes are:
 * Navigation bar for management UI
 * Dataset backend integration for management UI
 * Initial dataset collection UI view
+* Edit dataset fields through UI
 * Okta, aws and database credentials can now come from `fidesctl.toml` config [#694](https://github.com/ethyca/fides/pull/694)
 
 ### Changed

--- a/clients/admin-ui/__tests__/features/dataset-helpers.test.tsx
+++ b/clients/admin-ui/__tests__/features/dataset-helpers.test.tsx
@@ -1,18 +1,69 @@
 import {
-  getUpdatedCollectionField,
-  //   getUpdatedDatasetCollection,
+  getUpdatedCollectionFromField,
+  getUpdatedDatasetFromCollection,
+  getUpdatedDatasetFromField,
 } from "~/features/dataset/helpers";
-import { mockDatasetCollection, mockDatasetField } from "~/mocks/data";
+import {
+  mockDataset,
+  mockDatasetCollection,
+  mockDatasetField,
+} from "~/mocks/data";
 
 describe("dataset helpers", () => {
-  it("should update a dataset collection", () => {
+  it("should update a dataset collection from a field", () => {
     const newName = "a fancy email";
     const originalField = mockDatasetField();
     const newField = { ...originalField, ...{ name: newName } };
     const collection = mockDatasetCollection({ fields: [originalField] });
     expect(collection.fields[0].name).toEqual("created_at");
 
-    const updatedCollection = getUpdatedCollectionField(collection, newField);
+    const updatedCollection = getUpdatedCollectionFromField(
+      collection,
+      newField,
+      0
+    );
     expect(updatedCollection.fields[0].name).toEqual(newName);
+  });
+  it("should update a dataset from a collection", () => {
+    const newDescription = "updated description";
+    const originalCollection = mockDatasetCollection();
+    const updatedCollection = {
+      ...originalCollection,
+      ...{ description: newDescription },
+    };
+    const dataset = mockDataset({ collections: [originalCollection] });
+    const updatedDataset = getUpdatedDatasetFromCollection(
+      dataset,
+      updatedCollection,
+      0
+    );
+    expect(updatedDataset.collections[0].description).toEqual(newDescription);
+  });
+  it("should update a dataset from a field", () => {
+    const newName = "a fancy email";
+    const originalField = mockDatasetField({ name: "a regular email" });
+
+    const newField = { ...originalField, ...{ name: newName } };
+    const collection = mockDatasetCollection({
+      fields: [
+        mockDatasetCollection(),
+        mockDatasetCollection(),
+        mockDatasetCollection({ fields: [originalField] }),
+      ],
+    });
+    const dataset = mockDataset({
+      collections: [mockDatasetCollection(), collection],
+    });
+    const fieldIndex = 2;
+    const collectionIndex = 1;
+    const updatedDataset = getUpdatedDatasetFromField(
+      dataset,
+      newField,
+      collectionIndex,
+      fieldIndex
+    );
+    expect(
+      updatedDataset.collections[collectionIndex].fields[fieldIndex].name
+    ).toEqual(newName);
   });
 });

--- a/clients/admin-ui/__tests__/features/dataset-helpers.test.tsx
+++ b/clients/admin-ui/__tests__/features/dataset-helpers.test.tsx
@@ -1,0 +1,18 @@
+import {
+  getUpdatedCollectionField,
+  //   getUpdatedDatasetCollection,
+} from "~/features/dataset/helpers";
+import { mockDatasetCollection, mockDatasetField } from "~/mocks/data";
+
+describe("dataset helpers", () => {
+  it("should update a dataset collection", () => {
+    const newName = "a fancy email";
+    const originalField = mockDatasetField();
+    const newField = { ...originalField, ...{ name: newName } };
+    const collection = mockDatasetCollection({ fields: [originalField] });
+    expect(collection.fields[0].name).toEqual("created_at");
+
+    const updatedCollection = getUpdatedCollectionField(collection, newField);
+    expect(updatedCollection.fields[0].name).toEqual(newName);
+  });
+});

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -27,7 +27,7 @@ export const CustomTextInput = ({
         </FormLabel>
         <Input {...field} type={type} placeholder={placeholder} size="sm" />
       </SimpleGrid>
-      {isInvalid && <FormErrorMessage>{meta.error}</FormErrorMessage>}
+      {isInvalid ? <FormErrorMessage>{meta.error}</FormErrorMessage> : null}
     </FormControl>
   );
 };
@@ -47,7 +47,7 @@ export const CustomSelect = ({
         {/* @ts-ignore having trouble getting Formik and Chakra select to be happy together */}
         <Select {...field} {...props} size="sm" />
       </SimpleGrid>
-      {isInvalid && <FormErrorMessage>{meta.error}</FormErrorMessage>}
+      {isInvalid ? <FormErrorMessage>{meta.error}</FormErrorMessage> : null}
     </FormControl>
   );
 };

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -1,0 +1,53 @@
+import {
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Select,
+  SimpleGrid,
+} from "@fidesui/react";
+import { FieldHookConfig, useField } from "formik";
+
+interface InputProps {
+  label: string;
+}
+
+export const CustomTextInput = ({
+  label,
+  ...props
+}: InputProps & FieldHookConfig<string>) => {
+  const [field, meta] = useField(props);
+  const { type, placeholder } = props;
+  const isInvalid = !!(meta.touched && meta.error);
+  return (
+    <FormControl isInvalid={isInvalid}>
+      <SimpleGrid columns={[1, 2]}>
+        <FormLabel htmlFor={props.id || props.name} size="sm">
+          {label}
+        </FormLabel>
+        <Input {...field} type={type} placeholder={placeholder} size="sm" />
+      </SimpleGrid>
+      {isInvalid && <FormErrorMessage>{meta.error}</FormErrorMessage>}
+    </FormControl>
+  );
+};
+
+export const CustomSelect = ({
+  label,
+  ...props
+}: InputProps & FieldHookConfig<string>) => {
+  const [field, meta] = useField(props);
+  const isInvalid = !!(meta.touched && meta.error);
+  return (
+    <FormControl isInvalid={isInvalid}>
+      <SimpleGrid columns={[1, 2]}>
+        <FormLabel htmlFor={props.id || props.name} size="sm">
+          {label}
+        </FormLabel>
+        {/* @ts-ignore having trouble getting Formik and Chakra select to be happy together */}
+        <Select {...field} {...props} size="sm" />
+      </SimpleGrid>
+      {isInvalid && <FormErrorMessage>{meta.error}</FormErrorMessage>}
+    </FormControl>
+  );
+};

--- a/clients/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -103,12 +103,12 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
           onChange={setColumns}
         />
       </Box>
-      {activeCollection && (
+      {activeCollection ? (
         <DatasetFieldsTable
           fields={activeCollection.fields}
           columns={columns}
         />
-      )}
+      ) : null}
     </Box>
   );
 };

--- a/clients/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -1,12 +1,18 @@
 import { Box, Select, Spinner, Text, useToast } from "@fidesui/react";
 import { useRouter } from "next/router";
 import { ChangeEvent, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
 import { FidesKey } from "../common/fides-types";
 import ColumnDropdown from "./ColumnDropdown";
-import { useGetDatasetByKeyQuery } from "./dataset.slice";
+import {
+  selectActiveCollectionIndex,
+  setActiveCollectionIndex,
+  setActiveDataset,
+  useGetDatasetByKeyQuery,
+} from "./dataset.slice";
 import DatasetFieldsTable from "./DatasetFieldsTable";
-import { ColumnMetadata, DatasetCollection } from "./types";
+import { ColumnMetadata } from "./types";
 
 const ALL_COLUMNS: ColumnMetadata[] = [
   { name: "Field Name", attribute: "name" },
@@ -35,9 +41,9 @@ interface Props {
 }
 
 const DatasetCollectionView = ({ fidesKey }: Props) => {
+  const dispatch = useDispatch();
   const { dataset, isLoading } = useDataset(fidesKey);
-  const [activeCollection, setActiveCollection] =
-    useState<DatasetCollection | null>();
+  const activeCollectionIndex = useSelector(selectActiveCollectionIndex);
   const [columns, setColumns] = useState<ColumnMetadata[]>(ALL_COLUMNS);
 
   const router = useRouter();
@@ -46,11 +52,12 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
 
   useEffect(() => {
     if (dataset) {
-      setActiveCollection(dataset.collections[0]);
+      dispatch(setActiveDataset(dataset));
+      dispatch(setActiveCollectionIndex(0));
     } else {
-      setActiveCollection(null);
+      dispatch(setActiveCollectionIndex(null));
     }
-  }, [dataset]);
+  }, [dataset, dispatch]);
 
   useEffect(() => {
     if (fromLoad) {
@@ -74,12 +81,11 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
   }
 
   const { collections } = dataset;
+  const activeCollection =
+    activeCollectionIndex != null ? collections[activeCollectionIndex] : null;
 
   const handleChangeCollection = (event: ChangeEvent<HTMLSelectElement>) => {
-    const collection = collections.filter(
-      (c) => c.name === event.target.value
-    )[0];
-    setActiveCollection(collection);
+    dispatch(setActiveCollectionIndex(event.target.selectedIndex));
   };
 
   return (

--- a/clients/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -50,14 +50,13 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
   const toast = useToast();
   const { fromLoad } = router.query;
 
+  if (dataset) {
+    dispatch(setActiveDataset(dataset));
+  }
+
   useEffect(() => {
-    if (dataset) {
-      dispatch(setActiveDataset(dataset));
-      dispatch(setActiveCollectionIndex(0));
-    } else {
-      dispatch(setActiveCollectionIndex(null));
-    }
-  }, [dataset, dispatch]);
+    dispatch(setActiveCollectionIndex(0));
+  }, [dispatch]);
 
   useEffect(() => {
     if (fromLoad) {

--- a/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
@@ -48,9 +48,15 @@ const DatasetFieldsTable = ({ fields, columns }: Props) => {
               _hover={{ bg: "gray.50" }}
               cursor="pointer"
               onClick={() => handleClick(idx)}
+              tabIndex={0}
+              onKeyPress={(e) => {
+                if (e.key === "Enter") {
+                  handleClick(idx);
+                }
+              }}
             >
               {columns.map((c) => (
-                <Td key={`${field.name}-${field[c.attribute]}`} pl={0}>
+                <Td key={`${c.name}-${field.name}`} pl={0}>
                   {field[c.attribute]}
                 </Td>
               ))}

--- a/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
@@ -1,30 +1,59 @@
-import { Table, Tbody, Td, Th, Thead, Tr } from "@fidesui/react";
+import { Box, Table, Tbody, Td, Th, Thead, Tr } from "@fidesui/react";
+import { useState } from "react";
 
+import EditFieldDrawer from "./EditFieldDrawer";
 import { DatasetField } from "./types";
 
 interface Props {
   fields: DatasetField[];
 }
 
-const DatasetFieldsTable = ({ fields }: Props) => (
-  <Table size="sm">
-    <Thead>
-      <Tr>
-        <Th pl={0}>Field Name</Th>
-        <Th pl={0}>Description</Th>
-        <Th pl={0}>Identifiability</Th>
-      </Tr>
-    </Thead>
-    <Tbody>
-      {fields.map((field) => (
-        <Tr key={field.name}>
-          <Td pl={0}>{field.name}</Td>
-          <Td pl={0}>{field.description}</Td>
-          <Td pl={0}>{field.data_qualifier}</Td>
-        </Tr>
-      ))}
-    </Tbody>
-  </Table>
-);
+const DatasetFieldsTable = ({ fields }: Props) => {
+  const [editDrawerIsOpen, setEditDrawerIsOpen] = useState(false);
+  const [activeField, setActiveField] = useState<DatasetField | undefined>(
+    undefined
+  );
+  const handleClose = () => {
+    console.log("close");
+  };
+  const handleClick = (field: DatasetField) => {
+    setActiveField(field);
+    setEditDrawerIsOpen(true);
+  };
+  return (
+    <Box>
+      <Table size="sm">
+        <Thead>
+          <Tr>
+            <Th pl={0}>Field Name</Th>
+            <Th pl={0}>Description</Th>
+            <Th pl={0}>Identifiability</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {fields.map((field) => (
+            <Tr
+              key={field.name}
+              _hover={{ bg: "gray.50" }}
+              cursor="pointer"
+              onClick={() => handleClick(field)}
+            >
+              <Td pl={0}>{field.name}</Td>
+              <Td pl={0}>{field.description}</Td>
+              <Td pl={0}>{field.data_qualifier}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      {activeField && (
+        <EditFieldDrawer
+          isOpen={editDrawerIsOpen}
+          onClose={handleClose}
+          field={activeField}
+        />
+      )}
+    </Box>
+  );
+};
 
 export default DatasetFieldsTable;

--- a/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
@@ -15,15 +15,20 @@ const DatasetFieldsTable = ({ fields, columns }: Props) => {
   const dispatch = useDispatch();
   const [editDrawerIsOpen, setEditDrawerIsOpen] = useState(false);
   const activeFieldIndex = useSelector(selectActiveFieldIndex);
+
   const handleClose = () => {
     setEditDrawerIsOpen(false);
+    dispatch(setActiveFieldIndex(null));
   };
+
   const handleClick = (index: number) => {
     dispatch(setActiveFieldIndex(index));
     setEditDrawerIsOpen(true);
   };
+
   const activeField =
     activeFieldIndex != null ? fields[activeFieldIndex] : null;
+
   return (
     <Box>
       <Table size="sm">

--- a/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
@@ -1,6 +1,8 @@
 import { Box, Table, Tbody, Td, Th, Thead, Tr } from "@fidesui/react";
 import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
+import { selectActiveFieldIndex, setActiveFieldIndex } from "./dataset.slice";
 import EditFieldDrawer from "./EditFieldDrawer";
 import { ColumnMetadata, DatasetField } from "./types";
 
@@ -10,17 +12,18 @@ interface Props {
 }
 
 const DatasetFieldsTable = ({ fields, columns }: Props) => {
+  const dispatch = useDispatch();
   const [editDrawerIsOpen, setEditDrawerIsOpen] = useState(false);
-  const [activeField, setActiveField] = useState<DatasetField | undefined>(
-    undefined
-  );
+  const activeFieldIndex = useSelector(selectActiveFieldIndex);
   const handleClose = () => {
     setEditDrawerIsOpen(false);
   };
-  const handleClick = (field: DatasetField) => {
-    setActiveField(field);
+  const handleClick = (index: number) => {
+    dispatch(setActiveFieldIndex(index));
     setEditDrawerIsOpen(true);
   };
+  const activeField =
+    activeFieldIndex != null ? fields[activeFieldIndex] : null;
   return (
     <Box>
       <Table size="sm">
@@ -34,12 +37,12 @@ const DatasetFieldsTable = ({ fields, columns }: Props) => {
           </Tr>
         </Thead>
         <Tbody>
-          {fields.map((field) => (
+          {fields.map((field, idx) => (
             <Tr
               key={field.name}
               _hover={{ bg: "gray.50" }}
               cursor="pointer"
-              onClick={() => handleClick(field)}
+              onClick={() => handleClick(idx)}
             >
               {columns.map((c) => (
                 <Td key={`${field.name}-${field[c.attribute]}`} pl={0}>

--- a/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
@@ -64,13 +64,13 @@ const DatasetFieldsTable = ({ fields, columns }: Props) => {
           ))}
         </Tbody>
       </Table>
-      {activeField && (
+      {activeField ? (
         <EditFieldDrawer
           isOpen={editDrawerIsOpen}
           onClose={handleClose}
           field={activeField}
         />
-      )}
+      ) : null}
     </Box>
   );
 };

--- a/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
@@ -14,7 +14,7 @@ const DatasetFieldsTable = ({ fields }: Props) => {
     undefined
   );
   const handleClose = () => {
-    console.log("close");
+    setEditDrawerIsOpen(false);
   };
   const handleClick = (field: DatasetField) => {
     setActiveField(field);

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -41,18 +41,31 @@ const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
   const dataset = useSelector(selectActiveDataset);
   const collectionIndex = useSelector(selectActiveCollectionIndex);
   const fieldIndex = useSelector(selectActiveFieldIndex);
-  // const [updateDataset, updateDatasetResult] = useUpdateDatasetMutation();
+  const [updateDataset, updateDatasetResult] = useUpdateDatasetMutation();
+  console.log({ updateDatasetResult });
   const handleSubmit = (values: FieldValues) => {
-    console.log({ dataset });
     // merge the updated fields with the original dataset
     if (dataset && collectionIndex != null && fieldIndex != null) {
       const updatedField = { ...field, ...values };
-      const updatedDataset = { ...dataset };
-      const updatedCollections = [...updatedDataset.collections];
-      const updatedFields = [...updatedCollections[collectionIndex].fields];
-      updatedFields[fieldIndex] = updatedField;
-
-      console.log({ updatedDataset });
+      const newFields = dataset.collections[collectionIndex].fields.map(
+        (f, idx) => {
+          if (idx === fieldIndex) {
+            return updatedField;
+          }
+          return f;
+        }
+      );
+      const newCollections = dataset.collections.map((c, idx) => {
+        if (idx === collectionIndex) {
+          return {
+            ...dataset.collections[collectionIndex],
+            ...{ fields: newFields },
+          };
+        }
+        return c;
+      });
+      const updatedDataset = { ...dataset, ...{ collections: newCollections } };
+      updateDataset(updatedDataset);
     }
   };
   return (

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -55,7 +55,7 @@ const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
         fieldIndex
       );
       updateDataset(updatedDataset);
-      // onClose();
+      onClose();
     }
   };
 

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -49,7 +49,6 @@ const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
 
   const handleSubmit = (values: FieldValues) => {
     // merge the updated fields with the original dataset
-    console.log({ values });
     if (dataset && collectionIndex != null && fieldIndex != null) {
       const updatedField = { ...field, ...values };
       const updatedDataset = getUpdatedDatasetFromField(

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -9,9 +9,11 @@ import {
   Stack,
   Text,
 } from "@fidesui/react";
-import { ErrorMessage, Field, Form, Formik } from "formik";
+import { Form, Formik } from "formik";
 
+import { CustomSelect, CustomTextInput } from "../common/form/inputs";
 import CloseSolid from "../common/Icon/CloseSolid";
+import { DATA_QUALIFIERS } from "./constants";
 import { DatasetField } from "./types";
 
 interface FieldValues {
@@ -37,21 +39,18 @@ const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
       <Form>
         <Stack>
           <Box>
-            <label htmlFor="description">Description</label>
-            <Field name="description" type="text" className="form-input" />
-            <ErrorMessage name="description" />
+            <CustomTextInput name="description" label="Description" />
           </Box>
           <Box>
-            <label htmlFor="identifiability">Identifiability</label>
-            <Field name="identifiability" type="text" className="form-input" />
-            <ErrorMessage name="identifiability" />
+            <CustomSelect name="identifiability" label="Identifiability">
+              {DATA_QUALIFIERS.map((qualifier) => (
+                <option key={qualifier.key} value={qualifier.key}>
+                  {qualifier.label}
+                </option>
+              ))}
+            </CustomSelect>
           </Box>
-          <Box>
-            <label htmlFor="data_categories">Data Categories</label>
-            <Field name="data_categories" type="text" className="form-input" />
-            <ErrorMessage name="data_categories" />
-          </Box>
-
+          <Box>Data Categories (todo)</Box>
           <Box>
             <Button onClick={onClose} mr={2} size="sm" variant="outline">
               Cancel
@@ -78,13 +77,13 @@ const EditFieldDrawer = ({ field, isOpen, onClose }: Props) => (
     <DrawerContent>
       <Box py={2}>
         <Box display="flex" justifyContent="flex-end" mr={2}>
-          <Button variant="ghost">
+          <Button variant="ghost" onClick={onClose}>
             <CloseSolid />
           </Button>
         </Box>
         <DrawerHeader py={2}>Field Name: {field.name}</DrawerHeader>
         <DrawerBody>
-          <Text fontSize="sm">
+          <Text fontSize="sm" mb={4}>
             By providing a small amount of additional context for each system we
             can make reporting and understanding our tech stack much easier.
           </Text>

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -37,7 +37,7 @@ interface EditFieldFormProps {
 
 const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
   const initialValues: FieldValues = {
-    description: field.description,
+    description: field.description ?? "",
     data_qualifier: field.data_qualifier,
     data_categories: field.data_categories,
   };

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -21,6 +21,7 @@ import {
   selectActiveFieldIndex,
   useUpdateDatasetMutation,
 } from "./dataset.slice";
+import { getUpdatedDatasetFromField } from "./helpers";
 import { DatasetField } from "./types";
 
 interface FieldValues {
@@ -41,33 +42,23 @@ const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
   const dataset = useSelector(selectActiveDataset);
   const collectionIndex = useSelector(selectActiveCollectionIndex);
   const fieldIndex = useSelector(selectActiveFieldIndex);
-  const [updateDataset, updateDatasetResult] = useUpdateDatasetMutation();
-  console.log({ updateDatasetResult });
+  const [updateDataset] = useUpdateDatasetMutation();
+
   const handleSubmit = (values: FieldValues) => {
     // merge the updated fields with the original dataset
     if (dataset && collectionIndex != null && fieldIndex != null) {
       const updatedField = { ...field, ...values };
-      const newFields = dataset.collections[collectionIndex].fields.map(
-        (f, idx) => {
-          if (idx === fieldIndex) {
-            return updatedField;
-          }
-          return f;
-        }
+      const updatedDataset = getUpdatedDatasetFromField(
+        dataset,
+        updatedField,
+        collectionIndex,
+        fieldIndex
       );
-      const newCollections = dataset.collections.map((c, idx) => {
-        if (idx === collectionIndex) {
-          return {
-            ...dataset.collections[collectionIndex],
-            ...{ fields: newFields },
-          };
-        }
-        return c;
-      });
-      const updatedDataset = { ...dataset, ...{ collections: newCollections } };
       updateDataset(updatedDataset);
+      // onClose();
     }
   };
+
   return (
     <Formik initialValues={initialValues} onSubmit={handleSubmit}>
       <Form>

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -6,11 +6,54 @@ import {
   DrawerContent,
   DrawerHeader,
   DrawerOverlay,
+  Stack,
   Text,
 } from "@fidesui/react";
+import { ErrorMessage, Field, Form, Formik } from "formik";
 
 import CloseSolid from "../common/Icon/CloseSolid";
 import { DatasetField } from "./types";
+
+interface FieldValues {
+  description: DatasetField["description"];
+  identifiability: DatasetField["data_qualifier"];
+  data_categories: DatasetField["data_categories"];
+}
+const EditFieldForm = ({ field }: { field: DatasetField }) => {
+  const initialValues: FieldValues = {
+    description: field.description,
+    identifiability: field.data_qualifier,
+    data_categories: field.data_categories,
+  };
+  const handleSubmit = (values: FieldValues) => {
+    console.log("submitting!", values);
+  };
+  return (
+    <Formik initialValues={initialValues} onSubmit={handleSubmit}>
+      <Form>
+        <Stack>
+          <Box>
+            <label htmlFor="description">Description</label>
+            <Field name="description" type="text" className="form-input" />
+            <ErrorMessage name="description" />
+          </Box>
+          <Box>
+            <label htmlFor="identifiability">Identifiability</label>
+            <Field name="identifiability" type="text" className="form-input" />
+            <ErrorMessage name="identifiability" />
+          </Box>
+          <Box>
+            <label htmlFor="data_categories">Data Categories</label>
+            <Field name="data_categories" type="text" className="form-input" />
+            <ErrorMessage name="data_categories" />
+          </Box>
+        </Stack>
+
+        <Button type="submit">Save</Button>
+      </Form>
+    </Formik>
+  );
+};
 
 interface Props {
   field: DatasetField;
@@ -34,6 +77,7 @@ const EditFieldDrawer = ({ field, isOpen, onClose }: Props) => (
             By providing a small amount of additional context for each system we
             can make reporting and understanding our tech stack much easier.
           </Text>
+          <EditFieldForm field={field} />
         </DrawerBody>
       </Box>
     </DrawerContent>

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -14,6 +14,7 @@ import { Form, Formik } from "formik";
 import { CustomSelect, CustomTextInput } from "../common/form/inputs";
 import CloseSolid from "../common/Icon/CloseSolid";
 import { DATA_QUALIFIERS } from "./constants";
+import { useUpdateDatasetMutation } from "./dataset.slice";
 import { DatasetField } from "./types";
 
 interface FieldValues {
@@ -31,6 +32,7 @@ const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
     identifiability: field.data_qualifier,
     data_categories: field.data_categories,
   };
+  const [updateDataset, updateDatasetResult] = useUpdateDatasetMutation();
   const handleSubmit = (values: FieldValues) => {
     console.log("submitting!", values);
   };

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -26,19 +26,22 @@ import { DatasetField } from "./types";
 
 interface FieldValues {
   description: DatasetField["description"];
-  identifiability: DatasetField["data_qualifier"];
+  data_qualifier: DatasetField["data_qualifier"];
   data_categories: DatasetField["data_categories"];
 }
+
 interface EditFieldFormProps {
   field: DatasetField;
   onClose: () => void;
 }
+
 const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
   const initialValues: FieldValues = {
     description: field.description,
-    identifiability: field.data_qualifier,
+    data_qualifier: field.data_qualifier,
     data_categories: field.data_categories,
   };
+
   const dataset = useSelector(selectActiveDataset);
   const collectionIndex = useSelector(selectActiveCollectionIndex);
   const fieldIndex = useSelector(selectActiveFieldIndex);
@@ -46,6 +49,7 @@ const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
 
   const handleSubmit = (values: FieldValues) => {
     // merge the updated fields with the original dataset
+    console.log({ values });
     if (dataset && collectionIndex != null && fieldIndex != null) {
       const updatedField = { ...field, ...values };
       const updatedDataset = getUpdatedDatasetFromField(
@@ -67,7 +71,7 @@ const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
             <CustomTextInput name="description" label="Description" />
           </Box>
           <Box>
-            <CustomSelect name="identifiability" label="Identifiability">
+            <CustomSelect name="data_qualifier" label="Identifiability">
               {DATA_QUALIFIERS.map((qualifier) => (
                 <option key={qualifier.key} value={qualifier.key}>
                   {qualifier.label}

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -19,7 +19,11 @@ interface FieldValues {
   identifiability: DatasetField["data_qualifier"];
   data_categories: DatasetField["data_categories"];
 }
-const EditFieldForm = ({ field }: { field: DatasetField }) => {
+interface EditFieldFormProps {
+  field: DatasetField;
+  onClose: () => void;
+}
+const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
   const initialValues: FieldValues = {
     description: field.description,
     identifiability: field.data_qualifier,
@@ -47,9 +51,16 @@ const EditFieldForm = ({ field }: { field: DatasetField }) => {
             <Field name="data_categories" type="text" className="form-input" />
             <ErrorMessage name="data_categories" />
           </Box>
-        </Stack>
 
-        <Button type="submit">Save</Button>
+          <Box>
+            <Button onClick={onClose} mr={2} size="sm" variant="outline">
+              Cancel
+            </Button>
+            <Button type="submit" colorScheme="primary" size="sm">
+              Save
+            </Button>
+          </Box>
+        </Stack>
       </Form>
     </Formik>
   );
@@ -77,7 +88,7 @@ const EditFieldDrawer = ({ field, isOpen, onClose }: Props) => (
             By providing a small amount of additional context for each system we
             can make reporting and understanding our tech stack much easier.
           </Text>
-          <EditFieldForm field={field} />
+          <EditFieldForm field={field} onClose={onClose} />
         </DrawerBody>
       </Box>
     </DrawerContent>

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -1,0 +1,43 @@
+import {
+  Box,
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  Text,
+} from "@fidesui/react";
+
+import CloseSolid from "../common/Icon/CloseSolid";
+import { DatasetField } from "./types";
+
+interface Props {
+  field: DatasetField;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const EditFieldDrawer = ({ field, isOpen, onClose }: Props) => (
+  <Drawer placement="right" isOpen={isOpen} onClose={onClose} size="md">
+    <DrawerOverlay />
+    <DrawerContent>
+      <Box py={2}>
+        <Box display="flex" justifyContent="flex-end" mr={2}>
+          <Button variant="ghost">
+            <CloseSolid />
+          </Button>
+        </Box>
+        <DrawerHeader py={2}>Field Name: {field.name}</DrawerHeader>
+        <DrawerBody>
+          <Text fontSize="sm">
+            By providing a small amount of additional context for each system we
+            can make reporting and understanding our tech stack much easier.
+          </Text>
+        </DrawerBody>
+      </Box>
+    </DrawerContent>
+  </Drawer>
+);
+
+export default EditFieldDrawer;

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -10,11 +10,17 @@ import {
   Text,
 } from "@fidesui/react";
 import { Form, Formik } from "formik";
+import { useSelector } from "react-redux";
 
 import { CustomSelect, CustomTextInput } from "../common/form/inputs";
 import CloseSolid from "../common/Icon/CloseSolid";
 import { DATA_QUALIFIERS } from "./constants";
-import { useUpdateDatasetMutation } from "./dataset.slice";
+import {
+  selectActiveCollectionIndex,
+  selectActiveDataset,
+  selectActiveFieldIndex,
+  useUpdateDatasetMutation,
+} from "./dataset.slice";
 import { DatasetField } from "./types";
 
 interface FieldValues {
@@ -32,9 +38,22 @@ const EditFieldForm = ({ field, onClose }: EditFieldFormProps) => {
     identifiability: field.data_qualifier,
     data_categories: field.data_categories,
   };
-  const [updateDataset, updateDatasetResult] = useUpdateDatasetMutation();
+  const dataset = useSelector(selectActiveDataset);
+  const collectionIndex = useSelector(selectActiveCollectionIndex);
+  const fieldIndex = useSelector(selectActiveFieldIndex);
+  // const [updateDataset, updateDatasetResult] = useUpdateDatasetMutation();
   const handleSubmit = (values: FieldValues) => {
-    console.log("submitting!", values);
+    console.log({ dataset });
+    // merge the updated fields with the original dataset
+    if (dataset && collectionIndex != null && fieldIndex != null) {
+      const updatedField = { ...field, ...values };
+      const updatedDataset = { ...dataset };
+      const updatedCollections = [...updatedDataset.collections];
+      const updatedFields = [...updatedCollections[collectionIndex].fields];
+      updatedFields[fieldIndex] = updatedField;
+
+      console.log({ updatedDataset });
+    }
   };
   return (
     <Formik initialValues={initialValues} onSubmit={handleSubmit}>

--- a/clients/admin-ui/src/features/dataset/constants.ts
+++ b/clients/admin-ui/src/features/dataset/constants.ts
@@ -1,0 +1,20 @@
+// eslint-disable-next-line import/prefer-default-export
+export const DATA_QUALIFIERS = [
+  { key: "aggregated", label: "Aggregated", color: "green" },
+  { key: "anonymized", label: "Anonymized", color: "green" },
+  {
+    key: "aggregated.anonymized",
+    label: "Unlinked Pseudonymized",
+    color: "yellow",
+  },
+  {
+    key: "aggregated.anonymized.unlinked_pseudonymized",
+    label: "Pseudonymized",
+    color: "yellow",
+  },
+  {
+    key: "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
+    label: "Identified",
+    color: "red",
+  },
+];

--- a/clients/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/admin-ui/src/features/dataset/dataset.slice.ts
@@ -3,7 +3,7 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { HYDRATE } from "next-redux-wrapper";
 
 import { FidesKey } from "../common/fides-types";
-import { Dataset } from "./types";
+import { Dataset, DatasetField } from "./types";
 
 export interface State {
   datasets: Dataset[];
@@ -28,10 +28,25 @@ export const datasetApi = createApi({
       query: (key) => ({ url: `dataset/${key}` }),
       providesTags: () => ["Dataset"],
     }),
+    updateDataset: build.mutation<
+      Dataset,
+      Partial<Dataset> & Pick<Dataset, "fides_key">
+    >({
+      query: (dataset) => ({
+        url: `dataset/${dataset.fides_key}`,
+        method: "PUT",
+        body: dataset,
+      }),
+      invalidatesTags: ["Dataset"],
+    }),
   }),
 });
 
-export const { useGetAllDatasetsQuery, useGetDatasetByKeyQuery } = datasetApi;
+export const {
+  useGetAllDatasetsQuery,
+  useGetDatasetByKeyQuery,
+  useUpdateDatasetMutation,
+} = datasetApi;
 
 export const datasetSlice = createSlice({
   name: "dataset",

--- a/clients/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/admin-ui/src/features/dataset/dataset.slice.ts
@@ -42,7 +42,8 @@ export const datasetApi = createApi({
       Partial<Dataset> & Pick<Dataset, "fides_key">
     >({
       query: (dataset) => ({
-        url: `dataset/${dataset.fides_key}`,
+        url: `dataset/`,
+        params: { resource_type: "dataset" },
         method: "PUT",
         body: dataset,
       }),

--- a/clients/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/admin-ui/src/features/dataset/dataset.slice.ts
@@ -5,16 +5,21 @@ import { HYDRATE } from "next-redux-wrapper";
 import type { AppState } from "~/app/store";
 
 import { FidesKey } from "../common/fides-types";
-import { Dataset, DatasetField } from "./types";
+import { Dataset } from "./types";
 
 export interface State {
   datasets: Dataset[];
   activeDataset: Dataset | null;
+  // collections and fields don't have unique IDs, so we have to use their index
+  activeCollectionIndex: number | null;
+  activeFieldIndex: number | null;
 }
 
 const initialState: State = {
   datasets: [],
   activeDataset: null,
+  activeCollectionIndex: null,
+  activeFieldIndex: null,
 };
 
 export const datasetApi = createApi({
@@ -64,6 +69,17 @@ export const datasetSlice = createSlice({
       ...state,
       activeDataset: action.payload,
     }),
+    setActiveCollectionIndex: (
+      state,
+      action: PayloadAction<number | null>
+    ) => ({
+      ...state,
+      activeCollectionIndex: action.payload,
+    }),
+    setActiveFieldIndex: (state, action: PayloadAction<number | null>) => ({
+      ...state,
+      activeFieldIndex: action.payload,
+    }),
   },
   extraReducers: {
     [HYDRATE]: (state, action) => ({
@@ -73,8 +89,17 @@ export const datasetSlice = createSlice({
   },
 });
 
-export const { setDatasets, setActiveDataset } = datasetSlice.actions;
+export const {
+  setDatasets,
+  setActiveDataset,
+  setActiveCollectionIndex,
+  setActiveFieldIndex,
+} = datasetSlice.actions;
 export const selectActiveDataset = (state: AppState) =>
   state.dataset.activeDataset;
+export const selectActiveCollectionIndex = (state: AppState) =>
+  state.dataset.activeCollectionIndex;
+export const selectActiveFieldIndex = (state: AppState) =>
+  state.dataset.activeFieldIndex;
 
 export const { reducer } = datasetSlice;

--- a/clients/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/admin-ui/src/features/dataset/dataset.slice.ts
@@ -66,17 +66,32 @@ export const datasetSlice = createSlice({
       ...state,
       datasets: action.payload,
     }),
-    setActiveDataset: (state, action: PayloadAction<Dataset | null>) => ({
-      ...state,
-      activeDataset: action.payload,
-    }),
-    setActiveCollectionIndex: (
-      state,
-      action: PayloadAction<number | null>
-    ) => ({
-      ...state,
-      activeCollectionIndex: action.payload,
-    }),
+    setActiveDataset: (state, action: PayloadAction<Dataset | null>) => {
+      if (action.payload != null) {
+        return { ...state, activeDataset: action.payload };
+      }
+      // clear out child fields when a dataset becomes null
+      return {
+        ...state,
+        activeDataset: action.payload,
+        activeCollectionIndex: null,
+        activeFieldIndex: null,
+      };
+    },
+    setActiveCollectionIndex: (state, action: PayloadAction<number | null>) => {
+      if (action.payload != null) {
+        return {
+          ...state,
+          activeCollectionIndex: action.payload,
+        };
+      }
+      // clear our child fields when a collection becomes null
+      return {
+        ...state,
+        activeCollectionIndex: action.payload,
+        activeFieldIndex: null,
+      };
+    },
     setActiveFieldIndex: (state, action: PayloadAction<number | null>) => ({
       ...state,
       activeFieldIndex: action.payload,

--- a/clients/admin-ui/src/features/dataset/helpers.ts
+++ b/clients/admin-ui/src/features/dataset/helpers.ts
@@ -1,25 +1,48 @@
 import { Dataset, DatasetCollection, DatasetField } from "./types";
 
-export const getUpdatedDatasetCollection = (
+export const getUpdatedDatasetFromCollection = (
   dataset: Dataset,
-  collection: DatasetCollection
+  collection: DatasetCollection,
+  collectionIndex: number
 ) => {
-  const updatedDataset = { ...dataset };
-  const idx = dataset.collections.map((c) => c.name).indexOf(collection.name);
-  if (idx !== -1) {
-    updatedDataset.collections[idx] = collection;
-  }
-  return updatedDataset;
+  const newCollections = dataset.collections.map((c, idx) => {
+    if (idx === collectionIndex) {
+      return collection;
+    }
+    return c;
+  });
+  return { ...dataset, ...{ collections: newCollections } };
 };
 
-export const getUpdatedCollectionField = (
+export const getUpdatedCollectionFromField = (
   collection: DatasetCollection,
-  field: DatasetField
+  field: DatasetField,
+  fieldIndex: number
 ) => {
-  const updatedCollection = { ...collection };
-  const idx = collection.fields.map((f) => f.name).indexOf(field.name);
-  if (idx !== -1) {
-    updatedCollection.fields[idx] = field;
-  }
-  return updatedCollection;
+  const newFields = collection.fields.map((f, idx) => {
+    if (idx === fieldIndex) {
+      return field;
+    }
+    return f;
+  });
+  return { ...collection, ...{ fields: newFields } };
+};
+
+export const getUpdatedDatasetFromField = (
+  dataset: Dataset,
+  field: DatasetField,
+  collectionIndex: number,
+  fieldIndex: number
+) => {
+  const collection = dataset.collections[collectionIndex];
+  const updatedCollection = getUpdatedCollectionFromField(
+    collection,
+    field,
+    fieldIndex
+  );
+  return getUpdatedDatasetFromCollection(
+    dataset,
+    updatedCollection,
+    collectionIndex
+  );
 };

--- a/clients/admin-ui/src/features/dataset/helpers.ts
+++ b/clients/admin-ui/src/features/dataset/helpers.ts
@@ -1,3 +1,14 @@
+/**
+ * Because there is only one /dataset endpoint which handles dataset, collection,
+ * and field modifications, and always takes a whole dataset object, it is convenient
+ * to have helper functions which, given a field or collection, recreates the
+ * entire dataset object to send to the backend.
+ *
+ * Right now, there are no guaranteed unique attributes on a field or collection, and
+ * so we have to use their index in the array. If they ever get a unique ID, we should
+ * use that instead.
+ */
+
 import { Dataset, DatasetCollection, DatasetField } from "./types";
 
 export const getUpdatedDatasetFromCollection = (

--- a/clients/admin-ui/src/features/dataset/helpers.ts
+++ b/clients/admin-ui/src/features/dataset/helpers.ts
@@ -1,0 +1,25 @@
+import { Dataset, DatasetCollection, DatasetField } from "./types";
+
+export const getUpdatedDatasetCollection = (
+  dataset: Dataset,
+  collection: DatasetCollection
+) => {
+  const updatedDataset = { ...dataset };
+  const idx = dataset.collections.map((c) => c.name).indexOf(collection.name);
+  if (idx !== -1) {
+    updatedDataset.collections[idx] = collection;
+  }
+  return updatedDataset;
+};
+
+export const getUpdatedCollectionField = (
+  collection: DatasetCollection,
+  field: DatasetField
+) => {
+  const updatedCollection = { ...collection };
+  const idx = collection.fields.map((f) => f.name).indexOf(field.name);
+  if (idx !== -1) {
+    updatedCollection.fields[idx] = field;
+  }
+  return updatedCollection;
+};

--- a/clients/admin-ui/src/mocks/data.ts
+++ b/clients/admin-ui/src/mocks/data.ts
@@ -1,4 +1,8 @@
-import { DatasetCollection, DatasetField } from "~/features/dataset/types";
+import {
+  Dataset,
+  DatasetCollection,
+  DatasetField,
+} from "~/features/dataset/types";
 import { System } from "~/features/system/types";
 
 /**
@@ -53,4 +57,18 @@ export const mockDatasetCollection = (
     fields: [mockDatasetField()],
   };
   return Object.assign(collection, partialCollection);
+};
+
+export const mockDataset = (partialDataset?: Partial<Dataset>): Dataset => {
+  const dataset: Dataset = {
+    fides_key: "sample_dataset",
+    organization_fides_key: "mock_organization",
+    name: "created_at",
+    data_qualifier: "aggregated",
+    description: "User's creation timestamp",
+    data_categories: ["system.operations"],
+    retention: "Account termination",
+    collections: [mockDatasetCollection()],
+  };
+  return Object.assign(dataset, partialDataset);
 };

--- a/clients/admin-ui/src/mocks/data.ts
+++ b/clients/admin-ui/src/mocks/data.ts
@@ -1,3 +1,4 @@
+import { DatasetCollection, DatasetField } from "~/features/dataset/types";
 import { System } from "~/features/system/types";
 
 /**
@@ -26,3 +27,30 @@ export const mockSystems = (number: number) =>
       fides_key: `analytics_system_${i}`,
     })
   );
+
+export const mockDatasetField = (
+  partialField?: Partial<DatasetField>
+): DatasetField => {
+  const field: DatasetField = {
+    name: "created_at",
+    data_qualifier: "aggregated",
+    description: "User's creation timestamp",
+    data_categories: ["system.operations"],
+    retention: "Account termination",
+  };
+  return Object.assign(field, partialField);
+};
+
+export const mockDatasetCollection = (
+  partialCollection?: Partial<DatasetCollection>
+): DatasetCollection => {
+  const collection: DatasetCollection = {
+    name: "created_at",
+    data_qualifier: "aggregated",
+    description: "User's creation timestamp",
+    data_categories: ["system.operations"],
+    retention: "Account termination",
+    fields: [mockDatasetField()],
+  };
+  return Object.assign(collection, partialCollection);
+};

--- a/clients/admin-ui/src/pages/dataset/index.tsx
+++ b/clients/admin-ui/src/pages/dataset/index.tsx
@@ -9,11 +9,13 @@ import {
 import type { NextPage } from "next";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
-import { useSelector } from "react-redux";
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
 import Layout from "~/features/common/Layout";
 import {
   selectActiveDataset,
+  setActiveDataset,
   useGetAllDatasetsQuery,
 } from "~/features/dataset/dataset.slice";
 import DatasetsTable from "~/features/dataset/DatasetTable";
@@ -31,6 +33,11 @@ const DataSets: NextPage = () => {
   const { isLoading, datasets } = useDatasetsTable();
   const activeDataset = useSelector(selectActiveDataset);
   const router = useRouter();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setActiveDataset(null));
+  }, [dispatch]);
 
   const handleLoadDataset = () => {
     // use the router to let the page know we loaded the dataset from this view


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/703

### Code Changes

* [x] Component to display a field to edit dataset fields
* [x] Integrate formik
* [x] Redux to send PUT request to backend

### Steps to Confirm

* [x] Visit http://localhost:3000/dataset/demo_users_dataset and edit some fields

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

https://user-images.githubusercontent.com/24641006/171722112-c6118f5e-8482-4a4b-b245-61441d079843.mov

There's some odd logic going on in this PR that is a result of `collections` and `fields` not having a unique key associated with them. It appears possible to add collections/fields of the same name. This means the only way to determine which field or collection the user has clicked on is to use the index in the array that the object is in. This is fairly cumbersome, but should mostly be isolated to a few helper functions I added. 

However, this is still an issue, since React requires `keys` for components that are rendered via arrays, and discourages using indexes. Not having unique keys makes React act funky. Right now I'm still using `name` as the key for React stuff, but this is not necessarily reliable. 