### PR TITLE
Refactor Export to remove CLI specific request methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The types of changes are:
 * Migrate all endpoints to be prefixed by `/api/v1` [#623](https://github.com/ethyca/fides/issues/623)
 * Allow credentials to be passed to the generate systems from aws functionality via the API [#645](https://github.com/ethyca/fides/pull/645)
 * Update the export of a datamap to load resources from the server instead of a manifest directory[#662](https://github.com/ethyca/fides/pull/662)
+* Refactor `export` to remove CLI specific uses from the core modules and load resources[#725](https://github.com/ethyca/fides/pull/725)
 
 ### Developer Experience
 

--- a/src/fidesctl/core/export.py
+++ b/src/fidesctl/core/export.py
@@ -237,7 +237,7 @@ def export_system(
         for privacy_declaration in system.privacy_declarations
     ]
     server_resources["data_use"] = get_server_resources(
-        url, "data_use", set(data_use_fides_keys), headers
+        url, "data_use", list(set(data_use_fides_keys)), headers
     )
 
     data_subject_fides_keys = [
@@ -248,7 +248,7 @@ def export_system(
     ]
 
     server_resources["data_subject"] = get_server_resources(
-        url, "data_subject", set(data_subject_fides_keys), headers
+        url, "data_subject", list(set(data_subject_fides_keys)), headers
     )
 
     output_list = generate_system_records(server_resources)

--- a/src/fidesctl/core/export_helpers.py
+++ b/src/fidesctl/core/export_helpers.py
@@ -212,7 +212,10 @@ def format_data_subjects(data_subjects: List[DataSubject]) -> Dict[str, Dict[str
         else:
             data_subject_dict["rights_available"] = "No data subject rights listed"
 
-        formatted_data_subject = {attribute: data_subject_dict.get(attribute) or "N/A" for attribute in formatted_data_subject_attributes_list}
+        formatted_data_subject = {
+            attribute: data_subject_dict.get(attribute) or "N/A"
+            for attribute in formatted_data_subject_attributes_list
+        }
 
         formatted_data_subjects[data_subject.fides_key] = formatted_data_subject
 

--- a/src/fidesctl/core/export_helpers.py
+++ b/src/fidesctl/core/export_helpers.py
@@ -212,8 +212,7 @@ def format_data_subjects(data_subjects: List[DataSubject]) -> Dict[str, Dict[str
         else:
             data_subject_dict["rights_available"] = "No data subject rights listed"
 
-        for attribute in formatted_data_subject_attributes_list:
-            formatted_data_subject[attribute] = data_subject_dict[attribute] or "N/A"
+        formatted_data_subject = {attribute: data_subject_dict.get(attribute) or "N/A" for attribute in formatted_data_subject_attributes_list}
 
         formatted_data_subjects[data_subject.fides_key] = formatted_data_subject
 

--- a/src/fidesctl/core/export_helpers.py
+++ b/src/fidesctl/core/export_helpers.py
@@ -5,10 +5,7 @@ from os.path import dirname, join
 from typing import Dict, List, Set, Tuple
 
 import pandas as pd
-from fideslang.models import DataSubjectRightsEnum
-
-from fidesctl.core.api_helpers import get_server_resource, get_server_resources
-from fidesctl.core.utils import echo_red
+from fideslang.models import DataSubject, DataSubjectRightsEnum, DataUse
 
 DATAMAP_TEMPLATE = join(
     dirname(__file__),
@@ -140,30 +137,26 @@ def export_datamap_to_excel(
     return filename
 
 
-def get_formatted_data_use(
-    url: str, headers: Dict[str, str], data_use_fides_key: str
-) -> Dict[str, str]:
+def format_data_uses(data_uses: List[DataUse]) -> Dict[str, Dict[str, str]]:
     """
-    This function retrieves the data use from the server
-    and formats the results, returning the necessary values
-    as a dict. Formatting differences exist due to various
-    types allowed across attributes.
+    This function formats data uses for use when exporting,
+    returning the necessary values as a dict. Formatting
+    differences exist due to various types allowed across attributes.
     """
 
-    data_use = get_server_resource(url, "data_use", data_use_fides_key, headers)
+    formatted_data_uses = dict()
+    for data_use in data_uses:
+        formatted_data_use = {
+            "name": data_use.name,
+        }
 
-    formatted_data_use = {
-        "name": data_use.name,
-    }
-
-    for attribute in [
-        "legal_basis",
-        "special_category",
-        "recipients",
-        "legitimate_interest_impact_assessment",
-        "legitimate_interest",
-    ]:
-        try:
+        for attribute in [
+            "legal_basis",
+            "special_category",
+            "recipients",
+            "legitimate_interest_impact_assessment",
+            "legitimate_interest",
+        ]:
             attribute_value = getattr(data_use, attribute)
             if attribute_value is None:
                 attribute_value = "N/A"
@@ -176,18 +169,14 @@ def get_formatted_data_use(
                     attribute_value = "N/A"
 
             formatted_data_use[attribute] = attribute_value
-        except AttributeError:
-            echo_red(f"{attribute} undefined for specified Data Use, setting as N/A.")
 
-    return formatted_data_use
+        formatted_data_uses[data_use.fides_key] = formatted_data_use
+    return formatted_data_uses
 
 
-def get_formatted_data_subjects(
-    url: str, headers: Dict[str, str], data_subjects_fides_keys: List[str]
-) -> List[Dict[str, str]]:
+def format_data_subjects(data_subjects: List[DataSubject]) -> Dict[str, Dict[str, str]]:
     """
-    This function retrieves the data subjects from the server
-    and formats the results, returning the necessary values
+    This function formats data subjects from the server, returning the necessary values
     as a list of dicts.
 
     rights_available is treated differently due to the
@@ -195,17 +184,13 @@ def get_formatted_data_subjects(
     the available data subject rights.
     """
 
-    data_subjects = get_server_resources(
-        url, "data_subject", data_subjects_fides_keys, headers
-    )
-
     formatted_data_subject_attributes_list = [
         "name",
         "rights_available",
         "automated_decisions_or_profiling",
     ]
 
-    formatted_data_subjects_list = []  # empty list to populate and return
+    formatted_data_subjects = dict()  # empty dict to populate and return
 
     for data_subject in data_subjects:
         data_subject_dict = data_subject.dict()
@@ -228,18 +213,11 @@ def get_formatted_data_subjects(
             data_subject_dict["rights_available"] = "No data subject rights listed"
 
         for attribute in formatted_data_subject_attributes_list:
-            try:
-                formatted_data_subject[attribute] = (
-                    data_subject_dict[attribute] or "N/A"
-                )
-            except AttributeError:
-                echo_red(
-                    f"{attribute} undefined for specified Data Subject, setting as N/A."
-                )
+            formatted_data_subject[attribute] = data_subject_dict[attribute] or "N/A"
 
-        formatted_data_subjects_list.append(formatted_data_subject)
+        formatted_data_subjects[data_subject.fides_key] = formatted_data_subject
 
-    return formatted_data_subjects_list
+    return formatted_data_subjects
 
 
 def convert_tuple_to_string(values: Tuple[str, ...]) -> str:

--- a/tests/core/test_export.py
+++ b/tests/core/test_export.py
@@ -6,6 +6,8 @@ from fideslang.models import (
     Dataset,
     DatasetCollection,
     DatasetField,
+    DataSubject,
+    DataUse,
     Organization,
     PrivacyDeclaration,
     System,
@@ -17,24 +19,33 @@ from fidesctl.core.config import FidesctlConfig
 
 @pytest.fixture()
 def test_sample_system_taxonomy() -> Generator:
-    yield [
-        System(
-            fides_key="test_system",
-            system_type="test",
-            system_name="test system",
-            system_description="system used for testing exports",
-            privacy_declarations=[
-                PrivacyDeclaration(
-                    name="privacy_declaration_1",
-                    data_categories=["account.contact.email", "account.contact.name"],
-                    data_use="provide.system",
-                    data_qualifier="aggregated.anonymized",
-                    data_subjects=["customer"],
-                    dataset_references=["users_dataset"],
-                )
-            ],
-        )
-    ]
+    yield {
+        "system": [
+            System(
+                fides_key="test_system",
+                system_type="test",
+                system_name="test system",
+                system_description="system used for testing exports",
+                privacy_declarations=[
+                    PrivacyDeclaration(
+                        name="privacy_declaration_1",
+                        data_categories=[
+                            "account.contact.email",
+                            "account.contact.name",
+                        ],
+                        data_use="provide.system",
+                        data_qualifier="aggregated.anonymized",
+                        data_subjects=["customer"],
+                        dataset_references=["users_dataset"],
+                    )
+                ],
+            )
+        ],
+        "data_subject": [DataSubject(fides_key="customer", name="customer")],
+        "data_use": [
+            DataUse(fides_key="provide.system", name="System", parent_key="provide")
+        ],
+    }
 
 
 @pytest.fixture()
@@ -86,11 +97,8 @@ def test_system_records_to_export(
     Asserts that unique records are returned properly (including
     the header row)
     """
-    output_list = export.generate_system_records(
-        test_sample_system_taxonomy,
-        url=test_config.cli.server_url,
-        headers=test_config.user.request_headers,
-    )
+
+    output_list = export.generate_system_records(test_sample_system_taxonomy)
     print(output_list)
     assert len(output_list) == 3
 


### PR DESCRIPTION
Closes #720

### Code Changes

* [x] gather all server resources at entry level function
* [x] allow for use of dictionary values and `fides_key` in place of dedicated API calls


### Steps to Confirm

* [x] Exported resources (using extended taxonomy) are identical from both `main` and this PR

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This went through a few iterations trying to find the right placement and balance for the formatting of the taxonomy components. In the end moving them as close to their uses seemed to make the most sense. This change should allow for improved reuse of the core functions and helpers that exist as part of exporting resources data from fides.