### PR TITLE
Sync version of fastapi in setup.py with optional-requirement.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The types of changes are:
 * Migrate all endpoints to be prefixed by `/api/v1` [#623](https://github.com/ethyca/fides/issues/623)
 * Allow credentials to be passed to the generate systems from aws functionality via the API [#645](https://github.com/ethyca/fides/pull/645)
 * Update the export of a datamap to load resources from the server instead of a manifest directory[#662](https://github.com/ethyca/fides/pull/662)
+* Bump version of FastAPI in `setup.py` to 0.77.1 to match `optional-requirements.txt` [#734](https://github.com/ethyca/fides/pull/734)
 
 ### Developer Experience
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import pathlib
-from setuptools import setup, find_packages
+
 import versioneer
+from setuptools import find_packages, setup
 
 here = pathlib.Path(__file__).parent.resolve()
 long_description = open("README.md").read()
@@ -19,7 +20,7 @@ mysql_connector = "pymysql==1.0.0"
 mssql_connector = "pyodbc==4.0.32"
 snowflake_connector = "snowflake-sqlalchemy==1.3.4"
 redshift_connector = "sqlalchemy-redshift==0.8.8"
-fastapi = "fastapi==0.75.2"
+fastapi = "fastapi==0.77.1"
 uvicorn = "uvicorn==0.17.6"
 aws_connector = "boto3==1.20.54"
 okta_connector = "okta==2.5.0"


### PR DESCRIPTION
Closes #732

### Code Changes

* [x] Bump version of FastAPI in `setup.py` to 0.77.1 to match `optional-requirements.txt`

### Steps to Confirm

* [x] Run `nox -s build_local`
* [x] Run test suite

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes


