### PR TITLE
Ignore Docs/README changes in certain workflows

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -1,11 +1,11 @@
-name: PR Checks
+name: Code Checks
 
 on:
   pull_request:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 env:
   CONTAINER: fidesctl-local

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
 
 env:
   CONTAINER: fidesctl-local


### PR DESCRIPTION
Closes <issue>

### Code Changes

* [x] PR checks shouldn't run on markdown-only changes

### Description Of Changes

Noticed that PR checks were running in docs-only/markdown-only changes, this seemed unnecessary so I made this PR to fix it 