### PR TITLE
Handling an invalidly generated fides_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ The types of changes are:
 * Initial dataset collection UI view
   * Add interaction for viewing a dataset collection
   * Add column picker
-  * Add a data category checklist tree  
+  * Add a data category checklist tree
   * Edit dataset fields
   * Edit dataset collections
   * Add a component for Identifiability tags
@@ -53,6 +53,7 @@ The types of changes are:
 * Bump version of FastAPI in `setup.py` to 0.77.1 to match `optional-requirements.txt` [#734](https://github.com/ethyca/fides/pull/734)
 * Docker images are now only built and pushed on tags to match when we release to pypi [#740](https://github.com/ethyca/fides/pull/740)
 * Okta resource scanning and generation now works with systems instead of datasets [#751](https://github.com/ethyca/fides/pull/751)
+* Handle invalid characters when generating a `fides_key`
 
 ### Developer Experience
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ The types of changes are:
 * Bump version of FastAPI in `setup.py` to 0.77.1 to match `optional-requirements.txt` [#734](https://github.com/ethyca/fides/pull/734)
 * Docker images are now only built and pushed on tags to match when we release to pypi [#740](https://github.com/ethyca/fides/pull/740)
 * Okta resource scanning and generation now works with systems instead of datasets [#751](https://github.com/ethyca/fides/pull/751)
-* Handle invalid characters when generating a `fides_key`
+* Handle invalid characters when generating a `fides_key` [#761](https://github.com/ethyca/fides/pull/761)
 
 ### Developer Experience
 

--- a/src/fidesctl/core/dataset.py
+++ b/src/fidesctl/core/dataset.py
@@ -86,9 +86,9 @@ def create_db_dataset(schema_name: str, db_tables: Dict[str, List[str]]) -> Data
 
     Placeholder values are use where needed.
     """
-    validated_fides_key = check_fides_key(schema_name)
+    sanitized_fides_key = check_fides_key(schema_name)
     dataset = Dataset(
-        fides_key=validated_fides_key,
+        fides_key=sanitized_fides_key,
         name=schema_name,
         description=f"Fides Generated Description for Schema: {schema_name}",
         data_categories=[],

--- a/src/fidesctl/core/dataset.py
+++ b/src/fidesctl/core/dataset.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from fidesctl.core.api_helpers import list_server_resources
 from fidesctl.core.parse import parse
 
-from .utils import echo_green, echo_red, get_db_engine
+from .utils import check_fides_key, echo_green, echo_red, get_db_engine
 
 SCHEMA_EXCLUSION = {
     "postgresql": ["information_schema"],
@@ -86,8 +86,9 @@ def create_db_dataset(schema_name: str, db_tables: Dict[str, List[str]]) -> Data
 
     Placeholder values are use where needed.
     """
+    validated_fides_key = check_fides_key(schema_name)
     dataset = Dataset(
-        fides_key=schema_name,
+        fides_key=validated_fides_key,
         name=schema_name,
         description=f"Fides Generated Description for Schema: {schema_name}",
         data_categories=[],

--- a/src/fidesctl/core/utils.py
+++ b/src/fidesctl/core/utils.py
@@ -98,14 +98,7 @@ def check_fides_key(proposed_fides_key: str) -> str:
         return proposed_fides_key
     except FidesValidationError as error:
         echo_red(error)
-        updated_fides_key = sanitize_fides_key(proposed_fides_key)
-        updated_key_copy = f"Do you accept the proposed fides_key of '{updated_fides_key}'? Type 'n' to manually update or any other key to accept.\n"
-        reject_sanitized = bool(input(updated_key_copy).lower() == "n")
-        if reject_sanitized:
-            updated_fides_key = input(
-                "populate a Fides Key manually, then hit return:\n"
-            )
-        return check_fides_key(updated_fides_key)
+        return sanitize_fides_key(proposed_fides_key)
 
 
 def sanitize_fides_key(proposed_fides_key: str) -> str:
@@ -113,5 +106,5 @@ def sanitize_fides_key(proposed_fides_key: str) -> str:
     Attempts to manually sanitize a fides key if restricted
     characters are discovered.
     """
-    sanitized_fides_key = re.sub(r"[^a-zA-Z0-9_.-]+$", "_", proposed_fides_key)
+    sanitized_fides_key = re.sub(r"[^a-zA-Z0-9_.-]", "_", proposed_fides_key)
     return sanitized_fides_key

--- a/src/fidesctl/core/utils.py
+++ b/src/fidesctl/core/utils.py
@@ -89,9 +89,8 @@ def get_all_level_fields(fields: list) -> Iterator[DatasetField]:
 
 def check_fides_key(proposed_fides_key: str) -> str:
     """
-    A helper function to either automatically sanitize
-    an invalid FidesKey or provide an option to manually
-    override.
+    A helper function to automatically sanitize
+    an invalid FidesKey.
     """
     try:
         FidesModel(fides_key=proposed_fides_key)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -56,3 +56,21 @@ def test_nested_fields_unpacked(
     for field in utils.get_all_level_fields(collection.fields):
         collected_field_names.append(field.name)
     assert len(collected_field_names) == 5
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "fides_key, sanitized_fides_key",
+    [("foo", "foo"), ("@foo#", "_foo_"), (":_foo)bar!123$", "__foo_bar_123_")],
+)
+def test_sanitize_fides_key(fides_key: str, sanitized_fides_key: str) -> None:
+    assert sanitized_fides_key == utils.sanitize_fides_key(fides_key)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "fides_key, sanitized_fides_key",
+    [("foo", "foo"), ("@foo#", "_foo_"), (":_foo)bar!123$", "__foo_bar_123_")],
+)
+def test_check_fides_key(fides_key: str, sanitized_fides_key: str) -> None:
+    assert sanitized_fides_key == utils.check_fides_key(fides_key)


### PR DESCRIPTION
Closes #749

### Code Changes

* [x] Validate the `fides_key` as part of generating a dataset
* [x] Provide an automated way to sanitize the `fides_key`
* [x] ~Provide an option to manually intervene with the `fides_key`~ removed from this for further thought (i.e. option for API)
* [x] ~provide a CLI option to accept all sanitized versions? (May be too early for this)~ yes, too early - see above for reasons pulled

### Steps to Confirm

* [x] So far my testing has been limited to importing the new function and throwing some invalid strings at it (i.e. `check_fides_key("sample@")`)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This bug was found while working with a design partner. Further steps may include looking at if the `fides_key` already exists and providing an option to accept all suggested values.


After chatting with the team, decided against providing a manual intervention option at this time. Two questions remain prior to merging:
1. Do we also apply this to the different `generate` command options (i.e. `systems`)
2. Can we put this in a minor release `1.6.1`