### PR TITLE
1.6.1 changelog and docs updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fides/compare/1.6.0...main)
+## [Unreleased](https://github.com/ethyca/fides/compare/1.6.1...main)
 
 ### Added
 
@@ -53,7 +53,6 @@ The types of changes are:
 * Bump version of FastAPI in `setup.py` to 0.77.1 to match `optional-requirements.txt` [#734](https://github.com/ethyca/fides/pull/734)
 * Docker images are now only built and pushed on tags to match when we release to pypi [#740](https://github.com/ethyca/fides/pull/740)
 * Okta resource scanning and generation now works with systems instead of datasets [#751](https://github.com/ethyca/fides/pull/751)
-* Handle invalid characters when generating a `fides_key` [#761](https://github.com/ethyca/fides/pull/761)
 
 ### Developer Experience
 
@@ -64,18 +63,27 @@ The types of changes are:
 
 ### Docs
 
-* Updated `Release Steps`
 * Replaced all references to `make` with `nox` [#547](https://github.com/ethyca/fides/pull/547)
 * Removed config/schemas page [#613](https://github.com/ethyca/fides/issues/613)
 
 ### Fixed
 
-* Resolved a failure with populating applicable data subject rights to a data map
 * Updated `fideslog` to v1.1.5, resolving an issue where some exceptions thrown by the SDK were not handled as expected
 * Updated the webserver so that it won't fail if the database is inaccessible [#649](https://github.com/ethyca/fides/pull/649)
 * Handle complex characters in external tests  [#661](https://github.com/ethyca/fides/pull/661)
 * Evaluations now properly merge the default taxonomy into the user-defined taxonomy [#684](https://github.com/ethyca/fides/pull/684)
 * The CLI can be run without installing the webserver components [#715](https://github.com/ethyca/fides/pull/715)
+
+## [1.6.1](https://github.com/ethyca/fides/compare/1.6.0...1.6.1) - 2022-06-15
+
+### Docs
+
+* Updated `Release Steps`
+
+### Fixed
+
+* Resolved a failure with populating applicable data subject rights to a data map
+* Handle invalid characters when generating a `fides_key` [#761](https://github.com/ethyca/fides/pull/761)
 
 ## [1.6.0](https://github.com/ethyca/fides/compare/1.5.3...1.6.0) - 2022-05-02
 

--- a/docs/fides/docs/development/releases.md
+++ b/docs/fides/docs/development/releases.md
@@ -26,6 +26,7 @@ Fidesctl uses continuous delivery with a single `main` branch. All code changes 
 
 We use GitHub’s `release` feature to tag releases that then get automatically deployed to DockerHub & PyPi via GitHub Actions pipelines. We also use a `CHANGELOG.md` to make sure that our users are never surprised about an upcoming change and can plan upgrades accordingly. The release steps are as follows:
 
+### Major
 1. Open a PR that is titled the version of the release (i.e. `1.6.0`)
     * Rename the `Unreleased` section of `CHANGELOG.md` to the new version number and put a date next to it
     * Update the `compare` links for both the new version and for the new `Unreleased` section
@@ -36,3 +37,22 @@ We use GitHub’s `release` feature to tag releases that then get automatically 
 1. Add a link to the `CHANGELOG.md`
 1. Auto-populate the release notes
 1. Publish the release
+
+### Minor
+1. Create a new branch from the latest tagged release being patched (i.e. `1.6.0`)
+1. Use `git cherry-pick <commit>` to incorporate specific changes required for the minor release
+1. Copy the `Unreleased` section of `CHANGELOG.md` and paste above the release being patched
+    * Rename `Unreleased` to the new version number and put a date next to it
+    * Cut and paste the changes documented that are now included in the minor release in the correct section
+1. Open a PR that is titled the version of the release (i.e. `1.6.1`), add the `do not merge` label
+1. Due to potential merge conflicts when opening against main, checks may need to be run manually
+1. Create a new release, using the branch created in step 1
+1. Add the new version as the tag (i.e. `1.6.1`)
+1. Make the title the version with a `v` in front of it (i.e. `v1.6.1`)
+1. Add a link to the `CHANGELOG.md` (the changes are not merged yet but can be planned for)
+1. Auto-populate the release notes
+1. Publish the release
+1. Create a new branch from `main`
+1. Copy the changes from `CHANGELOG.md` for the minor release into the new branch
+1. Open a separate PR for the `CHANGELOG.md` updates for the minor release, once approved merge the PR
+1. Close the original PR made for the release (labeled `do not merge`) without merging


### PR DESCRIPTION
Closes n/a

### Code Changes

* [x] Added steps for a minor release to our docs
* [x] `CHANGELOG.md` updates for `1.6.1`
* [x] Close #763 without merging

### Steps to Confirm

* [x] Reviewed docs formatting

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

These are the steps that I followed for `1.6.1`, not necessarily what we should do exactly for future minor releases. Would love further opinions or ideas here!
