### PR TITLE
add example connection string formatting for convenience

### DIFF
--- a/docs/fides/docs/guides/generate_resources.md
+++ b/docs/fides/docs/guides/generate_resources.md
@@ -22,7 +22,7 @@ A connection string can be supplied using the `connection-string` option:
 ...
 ```
 
-The appropriate `connection-string` format for your database connector can be found in the [Sqlalchemy Documentation](https://docs.sqlalchemy.org/en/14/dialects/mysql.html#dialect-mysql-aiomysql-connect).
+The appropriate `connection-string` format for your database connector can be found in the [SQLAlchemy Documentation](https://docs.sqlalchemy.org/en/14/dialects/).
 
 #### Fides Config
 A connection string can also be defined within your fides config under the credentials section.

--- a/docs/fides/docs/guides/generate_resources.md
+++ b/docs/fides/docs/guides/generate_resources.md
@@ -22,6 +22,7 @@ A connection string can be supplied using the `connection-string` option:
 ...
 ```
 
+The appropriate `connection-string` format for your database connector can be found in the [Sqlalchemy Documentation](https://docs.sqlalchemy.org/en/14/dialects/mysql.html#dialect-mysql-aiomysql-connect).
 
 #### Fides Config
 A connection string can also be defined within your fides config under the credentials section.


### PR DESCRIPTION
Closes #528

### Code Changes

* Quick fix to add a link out to the sqlalchemy documentation to assist in finding your db connection string.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
* [x] Issue Requirements are Met
