### PR TITLE
Fix `nox -s dev` to be able to run without first installing the node modules

### DIFF
--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev-docker": "npm install && npm run dev",
     "dev:mock": "echo '🚨 Running with mock API'; NEXT_PUBLIC_MOCK_API=true next dev",
     "build": "next build",
     "start": "next start",

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev-docker": "npm install && npm run dev",
+    "dev-docker": "test -d node_modules || npm install && npm run dev",
     "dev:mock": "echo '🚨 Running with mock API'; NEXT_PUBLIC_MOCK_API=true next dev",
     "build": "next build",
     "start": "next start",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   fidesctl-ui:
     image: ethyca/fidesctl:local-ui
-    command: ["npm", "run", "dev"]
+    command: npm run dev-docker
     depends_on:
       - fidesctl
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   fidesctl-ui:
     image: ethyca/fidesctl:local-ui
-    command: npm run dev
+    command: ["npm", "run", "dev"]
     depends_on:
       - fidesctl
     expose:


### PR DESCRIPTION
Closes #794 

### Code Changes

* [x] add a new npm command `dev-docker` that installs and then runs devs
* [x] update the compose file to use the new command

### Steps to Confirm

* [ ] delete `node_modules/`
* [ ] run `nox -s dev`
* [ ] confirm that the UI container is working as expected

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met

### Description Of Changes

Small update to fix the problem of `nox -s dev` not working on a first install due to the packages not being installed yet. One caveat here is that spinning up the UI still takes a long time and I'm not sure why, but it does work. As far as I can tell it isn't related to the `install` step, but instead the actual `run dev` step.