### PR TITLE
ui/form: Fix select tooltip wraping grid row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The types of changes are:
 * Initial configuration wizard UI view
   * System scanning step: AWS credentials form and initial `generate` API usage.
 
+### Fixed
+
+* CustomSelect input tooltips appear next to selector instead of wrapping to a new row.
+
 ## [1.7.0](https://github.com/ethyca/fides/compare/1.6.1...1.7.0) - 2022-06-23
 
 ### Added

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -79,42 +79,46 @@ export const CustomSelect = ({
         <FormLabel htmlFor={props.id || props.name} size="sm">
           {label}
         </FormLabel>
-        <Select
-          options={options}
-          onBlur={(option) => {
-            if (option) {
-              field.onBlur(props.name);
-            }
-          }}
-          onChange={(newValue) => {
-            if (newValue) {
-              field.onChange(props.name)(newValue.value);
-            }
-          }}
-          name={props.name}
-          value={selected}
-          size={size}
-          chakraStyles={{
-            dropdownIndicator: (provided) => ({
-              ...provided,
-              bg: "transparent",
-              px: 2,
-              cursor: "inherit",
-            }),
-            indicatorSeparator: (provided) => ({
-              ...provided,
-              display: "none",
-            }),
-            multiValue: (provided) => ({
-              ...provided,
-              background: "primary.400",
-              color: "white",
-            }),
-          }}
-          isSearchable={isSearchable ?? false}
-          isClearable={isClearable}
-        />
-        {tooltip ? <QuestionTooltip label={tooltip} /> : null}
+        <Box display="flex" alignItems="center">
+          <Select
+            options={options}
+            onBlur={(option) => {
+              if (option) {
+                field.onBlur(props.name);
+              }
+            }}
+            onChange={(newValue) => {
+              if (newValue) {
+                field.onChange(props.name)(newValue.value);
+              }
+            }}
+            name={props.name}
+            value={selected}
+            size={size}
+            chakraStyles={{
+              container: (provided) => ({ ...provided, mr: 2, flexGrow: 1 }),
+              dropdownIndicator: (provided) => ({
+                ...provided,
+                bg: "transparent",
+                px: 2,
+                cursor: "inherit",
+              }),
+              indicatorSeparator: (provided) => ({
+                ...provided,
+                display: "none",
+              }),
+              multiValue: (provided) => ({
+                ...provided,
+                background: "primary.400",
+                color: "white",
+              }),
+            }}
+            isSearchable={isSearchable ?? false}
+            isClearable={isClearable}
+          />
+
+          {tooltip ? <QuestionTooltip label={tooltip} /> : null}
+        </Box>
       </Grid>
       {isInvalid ? <FormErrorMessage>{meta.error}</FormErrorMessage> : null}
     </FormControl>


### PR DESCRIPTION
### Code Changes

Wrap the select and tooltip in a flexbox so that they are in the same grid column.

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

I wonder if this was the result of a merge conflict that made a `Box` wrapping go away 🤔 . The multi-select does it correctly.

Before: 
![before](https://user-images.githubusercontent.com/2236777/176330981-93a62f7d-dee8-4027-9cdc-a51f3ee69593.png)

After:
![with-tooltip](https://user-images.githubusercontent.com/2236777/176331002-aedcfa21-e369-4071-ad09-40856bc4936a.png)

