### PR TITLE
Handle case of undefined third_party_transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The types of changes are:
 ### Fixed
 
 * CustomSelect input tooltips appear next to selector instead of wrapping to a new row.
+* Datasets without the `third_country_transfer` will not cause the editing dataset form to not render.
 
 ### Changed
 * Remove the `obscure` requirement from the `generate` endpoint [#819](https://github.com/ethyca/fides/pull/819)

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -169,9 +169,8 @@ export const CustomMultiSelect = ({
 }: SelectProps & FieldHookConfig<string[]>) => {
   const [field, meta] = useField(props);
   const isInvalid = !!(meta.touched && meta.error);
-  const selected = field.value
-    ? options.filter((o) => field.value.indexOf(o.value) >= 0)
-    : [];
+  const selected = options.filter((o) => field.value.indexOf(o.value) >= 0);
+
   // note: for Multiselect we have to do setFieldValue instead of field.onChange
   // because field.onChange only accepts strings or events right now, not string[]
   // https://github.com/jaredpalmer/formik/issues/1667

--- a/clients/admin-ui/src/features/dataset/EditDatasetForm.tsx
+++ b/clients/admin-ui/src/features/dataset/EditDatasetForm.tsx
@@ -34,7 +34,7 @@ const EditDatasetForm = ({ values, onClose, onSubmit }: Props) => {
     description: values.description ?? "",
     retention: values.retention ?? "",
     data_qualifier: values.data_qualifier,
-    third_country_transfers: values.third_country_transfers,
+    third_country_transfers: values.third_country_transfers ?? [],
     data_categories: values.data_categories,
   };
   const allDataCategories = useSelector(selectDataCategories);


### PR DESCRIPTION
Quick fix for the case where a third_party_transfer does not exist on a dataset which was causing an error to be thrown

### Code Changes

* [x] Revert the CustomMultiselect back to expecting a string array
* [x] Update the edit dataset form to make sure it's always passing an array

### Steps to Confirm

* [x] Add a dataset which does not have the `third_party_transfer` field at all
* [x] Go through the modify dataset flow and make sure it doesn't error

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This is a better solution than the one I stuffed in https://github.com/ethyca/fides/pull/827 (and which @ssangervasi had the right intuition on! https://github.com/ethyca/fides/pull/827/files#r911347651) 
