### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Set the fidesctl core team as the default codeowners
-* @ethyca/fides-control
+* @ethyca/fidesctl-team
 
 # Set the product/tech writing team as owners for the docs
 docs/ @ethyca/docs-authors


### PR DESCRIPTION
The team name was stealth changed which broke the codeowners auto-review assignment, this PR fixes the name