### PR TITLE
[#862] recommend/replace pip installs with pipx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The types of changes are:
 * Initial configuration wizard UI view
   * Refactored step & form results management to use Redux Toolkit slice.
 
+### Docs
+* recommend/replace pip installs with pipx [#874](https://github.com/ethyca/fides/pull/874)
+
 ### Fixed
 
 * CustomSelect input tooltips appear next to selector instead of wrapping to a new row.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Fides (_fee-dhez_, Latin: Fidēs) is an open-source tool that allows you to easi
 
 ### System Requirements
 
-1. [Docker](https://www.docker.com/products/docker-desktop) (20.10.8+) and [Docker Compose](https://docs.docker.com/compose/install/) (1.29.0+)
-2. [Python](https://www.python.org/downloads/) (3.8+)
-3. [Nox](https://nox.thea.codes/en/stable/) (`pip install nox`)
+* **Optional:** [`pipx`](https://pypa.github.io/pipx/) for environment isolation. The following documentation assumes `pipx` is installed, but `pip` commands can be substituted when needed.
+* [Docker](https://www.docker.com/products/docker-desktop) (20.10.8+) and [Docker Compose](https://docs.docker.com/compose/install/) (1.29.0+)
+* [Python](https://www.python.org/downloads/) (3.8+)
+* [Nox](https://nox.thea.codes/en/stable/) (`pipx install nox`)
 
 ### Getting Started
 

--- a/docs/fides/docs/development/overview.md
+++ b/docs/fides/docs/development/overview.md
@@ -27,7 +27,7 @@ There are a few different ways to develop Fidesctl, they are listed below _in or
     1. The containers will now spin up and VS Code will be running inside of the containers. The bottom left of the IDE will now say `Dev Container: Fidesctl`.
     1. When you open a new VS Code shell, it will be inside of the `fidesctl` container, and you'll have access to all of the `fidesctl` commands as well as any Python commands like `pytest`, `black`, `mypy`, etc.
 1. If you're using an editor besides VS Code, then the next best way to work on Fidesctl is by utilizing the `Noxfile` commands:
-    1. Make sure that you have `docker`, `docker-compose` and `nox` (`pip install nox`) installed.
+    1. Make sure that you have `docker`, `docker-compose` and `nox` (`pipx install nox`) installed.
     1. Once you have everything set up, run `nox -s cli` to spin up a shell within the `fidesctl` container.
     1. You can and should run all of your various development commands from within this shell, such as `pytest`, `black`, etc.
 1. Finally, the least-recommended method would be to install the project in your local environment and develop directly.

--- a/docs/fides/docs/installation/installation.md
+++ b/docs/fides/docs/installation/installation.md
@@ -8,7 +8,7 @@ When you install fidesctl, you need to [setup the database](database.md) which m
 
 ## Installation Tools
 
-Only `pip` installations are currently officially supported. For more details see [Installation from PyPI](pypi.md)
+Only `pip`/`pipx` installations are currently officially supported. For more details see [Installation from PyPI](pypi.md) For environment isolation, the Fides team recommends using [`pipx`](https://pypa.github.io/pipx/) when possible.
 
 In some cases a lightweight installation might be desired, for instance, if the webserver is not needed. If this is the case, our `pip` installation supports optional dependencies.
 
@@ -17,7 +17,7 @@ While there are some successes with using other tools like poetry or pip-tools, 
 **When this option works best**
 
 * This installation method is useful when you are not familiar with containers and Docker and want to install fidesctl on physical or virtual machines and you are used to installing and running software using custom deployment mechanism.
-* The only officially supported mechanisms of installation is pip.
+* The only officially supported mechanism of installation is pip.
 
 **Intended users**
 

--- a/docs/fides/docs/installation/pypi.md
+++ b/docs/fides/docs/installation/pypi.md
@@ -4,9 +4,11 @@ This page describes installations using the `fidesctl` package [published on PyP
 
 ## Basic Installation
 
+The Fides team recommends using [`pipx`](https://pypa.github.io/pipx/) over `pip` for environment isolation. The following documentation assumes `pipx` is installed, but `pip` commands can be substituted when needed.
+  
 To install Fidesctl, run:
 
-`pip install fidesctl`
+`pipx install fidesctl`
 
 With the default installation fidesctl is designed to be as lightweight as possible. It ships with the ability to do most things you would do via the standalone CLI, such as `evaluate` and `parse` without the need to run a webserver. For interacting directly with databases and running the webserver, see the optional dependencies below.
 
@@ -14,7 +16,7 @@ With the default installation fidesctl is designed to be as lightweight as possi
 
 Fidesctl ships with a number of optional dependencies that extend its functionality. To install these, use the following syntax:
 
-`pip install "fidesctl[extra_1, extra_2]"`
+`pipx install "fidesctl[extra_1, extra_2]"`
 
 The optional dependencies are as follows:
 

--- a/docs/fides/docs/quickstart/local_full.md
+++ b/docs/fides/docs/quickstart/local_full.md
@@ -10,13 +10,13 @@ See the [Prerequisites and Dependencies](../installation/prerequisites_dependenc
 
 ## Fidesctl installation
 
-The next step is to install fidesctl via pip with the required extras:
+The next step is to install fidesctl via [`pipx`](https://pypa.github.io/pipx/) with the required extras:
 
 ```sh
-pip install "fidesctl[webserver]"
+pipx install "fidesctl[webserver]"
 ```
 
-For more information on pip installing fidesctl as well as the other potential extras, see the [Installation from PyPI](../installation/pypi.md) guide.
+For more information on pipx, installing fidesctl, and other potential extras, see the [Installation from PyPI](../installation/pypi.md) guide.
 
 ## Database installation
 

--- a/docs/fides/docs/quickstart/local_standalone.md
+++ b/docs/fides/docs/quickstart/local_standalone.md
@@ -21,13 +21,13 @@ See the Python section of the [Prerequisites and Dependencies](../installation/p
 
 ## Fidesctl Installation
 
-The next step is to install fidesctl via pip:
+The next step is to install fidesctl via [`pipx`](https://pypa.github.io/pipx/):
 
 ```sh
-pip install fidesctl
+pipx install fidesctl
 ```
 
-For more information on installing fidesctl with pip, as well as the other potential extras, see the [Installation from PyPI](../installation/pypi.md) guide.
+For more information on pipx, installing fidesctl, and other potential extras, see the [Installation from PyPI](../installation/pypi.md) guide.
 
 ## Verifying the Installation
 

--- a/docs/fides/docs/tutorial/add.md
+++ b/docs/fides/docs/tutorial/add.md
@@ -13,7 +13,7 @@ fidesctl>=1.0.0
 Then, install the dependencies by running:
 
 ```sh
-pip install -r requirements.txt
+pipx install -r requirements.txt
 ```
 
 ## Initializing Fidesctl


### PR DESCRIPTION
Closes #862 

### Code Changes

* Update all the docs uses of `pip` to recommend, link to, or also include `pipx` installations.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md