### PR TITLE
github/frontend: Run cypress in CI with app built

### DIFF
--- a/.github/workflows/frontend_pr_checks.yml
+++ b/.github/workflows/frontend_pr_checks.yml
@@ -65,5 +65,5 @@ jobs:
         with:
           working-directory: clients/admin-ui
           install: false
-          start: npm run dev
+          start: npm run cy:start
           wait-on: "http://localhost:3000"

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -18,6 +18,7 @@
     "prod-export": "npm run export && npm run copy-export",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
+    "cy:start": "next build && NODE_ENV=test next start",
     "openapi:generate": "openapi --input http://localhost:8080/openapi.json --output ./src/types/api --exportCore false --exportServices false --indent 2"
   },
   "dependencies": {


### PR DESCRIPTION
### Code Changes

* New package script for build & serve in test mode
* Start cypress with that instead of dev

### Steps to Confirm

* [ ] Workflow!

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

I ran into a surprise failure with on a PR and I got curious. Then I noticed [this comment](https://github.com/ethyca/fides/blob/40294f297f8f27209f26a82687af956a47bca231/clients/admin-ui/cypress/e2e/datasets.cy.ts#L36) where a timeout was happening because of routing I got a hunch: maybe next dev mode is hot loading routes is slowing it down. [This next documentation](https://nextjs.org/docs/testing#running-your-cypress-tests) also suggests running cypress against the built app.

👨‍🔬🧪 Experiment time (running cypress locally)
| App start |  Cypress time | Note |
| --- | --- | --- |
|`next dev` |~ 75 seconds | Faster after first run. Cache? |
|`next build && next start` | ~ 25 seconds | Takes time to build first. |

That's promising! Of course, we'll see if this PR builds happily 👓 
