### PR TITLE
Integrate generating a dataset from a database connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The types of changes are:
 
 ### Added
 * Add datasets via YAML in the UI [#813](https://github.com/ethyca/fides/pull/813)
-* Add datasets via database connection (UI only) [#834](https://github.com/ethyca/fides/pull/834)
+* Add datasets via database connection [#834](https://github.com/ethyca/fides/pull/834) [#889](https://github.com/ethyca/fides/pull/889)
 * Add delete confirmation when deleting a field or collection from a dataset [#809](https://github.com/ethyca/fides/pull/809)
 * Add ability to delete datasets from the UI
 * Initial configuration wizard UI view

--- a/clients/admin-ui/src/features/common/helpers.ts
+++ b/clients/admin-ui/src/features/common/helpers.ts
@@ -78,25 +78,14 @@ export function isYamlException(error: unknown): error is YAMLException {
   );
 }
 
-type RTKReturnType =
-  | {
-      data: any;
-    }
-  | {
-      error: FetchBaseQueryError | SerializedError;
-    };
-export function getErrorFromResult(result: RTKReturnType) {
-  if ("error" in result) {
-    const { error } = result;
-    let errorMsg = "An unexpected error occurred. Please try again.";
-    if (isErrorWithDetail(error)) {
-      errorMsg = error.data.detail;
-    } else if (isErrorWithDetailArray(error)) {
-      errorMsg = `${error.data.detail[0].msg}: ${error.data.detail[0].loc}`;
-    } else if (isConflictError(error)) {
-      errorMsg = `${error.data.detail.error} (${error.data.detail.fides_key})`;
-    }
-    return errorMsg;
+export function getErrorMessage(error: FetchBaseQueryError | SerializedError) {
+  let errorMsg = "An unexpected error occurred. Please try again.";
+  if (isErrorWithDetail(error)) {
+    errorMsg = error.data.detail;
+  } else if (isErrorWithDetailArray(error)) {
+    errorMsg = `${error.data.detail[0].msg}: ${error.data.detail[0].loc}`;
+  } else if (isConflictError(error)) {
+    errorMsg = `${error.data.detail.error} (${error.data.detail.fides_key})`;
   }
-  return null;
+  return errorMsg;
 }

--- a/clients/admin-ui/src/features/dataset/DatabaseConnectForm.tsx
+++ b/clients/admin-ui/src/features/dataset/DatabaseConnectForm.tsx
@@ -1,25 +1,87 @@
-import { Box, Button, Text } from "@fidesui/react";
-import { Form, Formik } from "formik";
+import { Box, Button, Spinner, Text, useToast } from "@fidesui/react";
+import { SerializedError } from "@reduxjs/toolkit";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
+import { Form, Formik, FormikErrors, FormikHelpers } from "formik";
+import { useRouter } from "next/router";
 import * as Yup from "yup";
 
+import { GenerateResponse, GenerateTypes, ValidTargets } from "~/types/api";
+
 import { CustomTextInput } from "../common/form/inputs";
+import { getErrorMessage } from "../common/helpers";
+import { successToastParams } from "../common/toast";
+import {
+  setActiveDataset,
+  useCreateDatasetMutation,
+  useGenerateDatasetMutation,
+} from "./dataset.slice";
+import { Dataset } from "./types";
 
 const initialValues = { url: "" };
+
+type FormValues = typeof initialValues;
 
 const ValidationSchema = Yup.object().shape({
   url: Yup.string().required().label("Database URL"),
 });
 
 const DatabaseConnectForm = () => {
-  const handleCreate = () => {
-    //   TODO when backend supports this (829)
+  // TODO: where should this come from?
+  const organizationKey = "default_organization";
+  const [generate, { isLoading: isGenerating }] = useGenerateDatasetMutation();
+  const [createDataset, { isLoading: isCreating }] = useCreateDatasetMutation();
+  const toast = useToast();
+  const router = useRouter();
+
+  const handleSubmit = async (
+    values: FormValues,
+    formikHelpers: FormikHelpers<FormValues>
+  ) => {
+    const { setErrors } = formikHelpers;
+
+    const handleError = (error: FetchBaseQueryError | SerializedError) => {
+      const errorMessage = getErrorMessage(error);
+      setErrors({ url: errorMessage });
+    };
+
+    const handleGenerateResults = async (
+      results: GenerateResponse["generate_results"]
+    ) => {
+      if (results && results.length) {
+        const newDataset = results[0] as Dataset;
+        const createResult = await createDataset(newDataset);
+        if ("error" in createResult) {
+          handleError(createResult.error);
+        } else {
+          toast(successToastParams("Successfully loaded new dataset"));
+          setActiveDataset(createResult.data);
+          router.push(`/dataset/${createResult.data.fides_key}`);
+        }
+      }
+    };
+
+    const response = await generate({
+      organization_key: organizationKey,
+      generate: {
+        config: { connection_string: values.url },
+        target: ValidTargets.DB,
+        type: GenerateTypes.DATASETS,
+      },
+    });
+
+    if ("error" in response) {
+      const errorMessage = getErrorMessage(response.error);
+      setErrors({ url: errorMessage });
+    } else {
+      handleGenerateResults(response.data.generate_results);
+    }
   };
 
   return (
     <Formik
       initialValues={initialValues}
       validationSchema={ValidationSchema}
-      onSubmit={handleCreate}
+      onSubmit={handleSubmit}
       validateOnChange={false}
       validateOnBlur={false}
     >
@@ -33,14 +95,18 @@ const DatabaseConnectForm = () => {
           <Box mb={8}>
             <CustomTextInput name="url" label="Database URL" />
           </Box>
-          <Button
-            size="sm"
-            colorScheme="primary"
-            type="submit"
-            disabled={isSubmitting}
-          >
-            Create dataset
-          </Button>
+          <Box display="flex" alignItems="center">
+            <Button
+              size="sm"
+              colorScheme="primary"
+              type="submit"
+              disabled={isSubmitting}
+              mr="2"
+            >
+              Create dataset
+            </Button>
+            {isGenerating || isCreating ? <Spinner /> : null}
+          </Box>
         </Form>
       )}
     </Formik>

--- a/clients/admin-ui/src/features/dataset/DatabaseConnectForm.tsx
+++ b/clients/admin-ui/src/features/dataset/DatabaseConnectForm.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Spinner, Text, useToast } from "@fidesui/react";
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
-import { Form, Formik, FormikErrors, FormikHelpers } from "formik";
+import { Form, Formik, FormikHelpers } from "formik";
 import { useRouter } from "next/router";
 import * as Yup from "yup";
 

--- a/clients/admin-ui/src/features/dataset/DatasetYamlForm.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetYamlForm.tsx
@@ -4,7 +4,7 @@ import yaml from "js-yaml";
 import { useRouter } from "next/router";
 
 import { CustomTextArea } from "../common/form/inputs";
-import { getErrorFromResult, isYamlException } from "../common/helpers";
+import { getErrorMessage, isYamlException } from "../common/helpers";
 import { successToastParams } from "../common/toast";
 import { setActiveDataset, useCreateDatasetMutation } from "./dataset.slice";
 import { Dataset } from "./types";
@@ -44,9 +44,9 @@ const DatasetYamlForm = () => {
     }
 
     const result = await createDataset(dataset);
-    const error = getErrorFromResult(result);
-    if (error) {
-      setErrors({ datasetYaml: error });
+    if ("error" in result) {
+      const errorMessage = getErrorMessage(result.error);
+      setErrors({ datasetYaml: errorMessage });
     } else if ("data" in result) {
       toast(successToastParams("Successfully loaded new dataset YAML"));
       setActiveDataset(result.data);

--- a/clients/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/admin-ui/src/features/dataset/dataset.slice.ts
@@ -3,6 +3,7 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { HYDRATE } from "next-redux-wrapper";
 
 import type { AppState } from "~/app/store";
+import { GenerateRequestPayload, GenerateResponse } from "~/types/api";
 
 import { FidesKey } from "../common/fides-types";
 import { Dataset } from "./types";
@@ -72,6 +73,13 @@ export const datasetApi = createApi({
       }),
       invalidatesTags: ["Datasets"],
     }),
+    generateDataset: build.mutation<GenerateResponse, GenerateRequestPayload>({
+      query: (payload) => ({
+        url: `generate/`,
+        method: "POST",
+        body: payload,
+      }),
+    }),
   }),
 });
 
@@ -81,6 +89,7 @@ export const {
   useUpdateDatasetMutation,
   useCreateDatasetMutation,
   useDeleteDatasetMutation,
+  useGenerateDatasetMutation,
 } = datasetApi;
 
 export const datasetSlice = createSlice({

--- a/clients/admin-ui/src/types/api/index.ts
+++ b/clients/admin-ui/src/types/api/index.ts
@@ -4,6 +4,7 @@
 
 export type { AWSConfig } from './models/AWSConfig';
 export type { ContactDetails } from './models/ContactDetails';
+export type { DatabaseConfig } from './models/DatabaseConfig';
 export type { DataCategory } from './models/DataCategory';
 export type { DataProtectionImpactAssessment } from './models/DataProtectionImpactAssessment';
 export type { DataQualifier } from './models/DataQualifier';

--- a/clients/admin-ui/src/types/api/models/DatabaseConfig.ts
+++ b/clients/admin-ui/src/types/api/models/DatabaseConfig.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * The model for the connection config for databases
+ */
+export type DatabaseConfig = {
+  connection_string: string;
+};

--- a/clients/admin-ui/src/types/api/models/Generate.ts
+++ b/clients/admin-ui/src/types/api/models/Generate.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { AWSConfig } from './AWSConfig';
+import type { DatabaseConfig } from './DatabaseConfig';
 import type { GenerateTypes } from './GenerateTypes';
 import type { OktaConfig } from './OktaConfig';
 import type { ValidTargets } from './ValidTargets';
@@ -11,7 +12,7 @@ import type { ValidTargets } from './ValidTargets';
  * Defines attributes for generating resources included in a request.
  */
 export type Generate = {
-  config: (AWSConfig | OktaConfig);
+  config: (AWSConfig | OktaConfig | DatabaseConfig);
   target: ValidTargets;
   type: GenerateTypes;
 };

--- a/clients/admin-ui/src/types/api/models/ValidTargets.ts
+++ b/clients/admin-ui/src/types/api/models/ValidTargets.ts
@@ -7,5 +7,6 @@
  */
 export enum ValidTargets {
   AWS = 'aws',
+  DB = 'db',
   OKTA = 'okta',
 }


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/829

### Code Changes

* [x] Runs openapi generate again to update types for latest backend changes to /generate endpoint (worked beautifully 💯 )
* [x] Add call to `/generate` endpoint from dataset.slice.ts
* [x] After a generate call, use the result to make a call to dataset POST 

### Steps to Confirm

* [x] Try to create a dataset by connecting to a database. I used a redshift db Eduardo had set up (message me for credentials!) or can also spin up a local database, i.e. the flaskr one in fidesdemo. Note if you do that, if you are on a Mac you'll want to use this postgres string: `postgresql://postgres:postgres@docker.for.mac.localhost:6432/flaskr` (because of docker networking stuff)


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
  * [x] https://github.com/ethyca/fides/issues/892 
* [x] Update `CHANGELOG.md`

### Description Of Changes

One thing I'm not sure how to approach is that we need an organization key to use the generate endpoint. I hard coded `default_organization` for now, but I'm not sure how we plan to go about getting that in the future (potentially related to config UI work? is it possible we can always have an organization key around, similar to how we'd have a user around?)

Success state

https://user-images.githubusercontent.com/24641006/178360582-79eb3996-149a-4f36-b7c7-2c21d889c2ee.mov


Errors

https://user-images.githubusercontent.com/24641006/178360701-15bc74bf-c103-42b3-9ce7-d257c21679cf.mov

Error if the string just doesn't work (not sure if the backend can give a better error than just a 500, or if there's any validation we should do on the frontend before sending it over)

![image](https://user-images.githubusercontent.com/24641006/178360868-5eae4756-7f55-4e98-9704-abbd0e66c37e.png)

