### PR TITLE
Catch-all route applies only to front-end assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The types of changes are:
 * Webserver dependencies now come as a standard part of the package [#881](https://github.com/ethyca/fides/pull/881)
 * Initial configuration wizard UI view
   * Refactored step & form results management to use Redux Toolkit slice.
+* The "catch-all" route now applies to front-end asset requests only [#890](https://github.com/ethyca/fides/pull/890)
 
 ### Docs
 

--- a/src/fidesapi/main.py
+++ b/src/fidesapi/main.py
@@ -169,25 +169,20 @@ def read_index() -> Response:
     return FileResponse(WEBAPP_INDEX)
 
 
-@app.get("/{catchall:path}", response_class=FileResponse, tags=["Default"])
+@app.get(
+    str(WEBAPP_DIRECTORY) + "/{catchall:path}",
+    response_class=FileResponse,
+    tags=["Default"],
+)
 def read_other_paths(request: Request) -> FileResponse:
     """
-    Return related frontend files. Adapted from https://github.com/tiangolo/fastapi/issues/130
+    Return related frontend files.
     """
-    # check first if requested file exists (for frontend assets)
+
     path = request.path_params["catchall"]
     file = WEBAPP_DIRECTORY / Path(path)
-    if file.exists():
-        return FileResponse(file)
 
-    # raise 404 for anything that should be backend endpoint but we can't find it
-    if path.startswith(API_PREFIX[1:]):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Item not found"
-        )
-
-    # otherwise return the index
-    return FileResponse(WEBAPP_INDEX)
+    return FileResponse(file) if file.exists() else FileResponse(WEBAPP_INDEX)
 
 
 def start_webserver() -> None:


### PR DESCRIPTION
Closes #848

### Code Changes

* [x] Remove validation of non-front-end paths from the catch-all route

### Steps to Confirm

* [ ] Start the fidesapi server
* [ ] `curl` a non-existent, non-front-end path (ex. `http://localhost:8080/api/v1/phil/rules`)
* [ ] Observe that the route is not caught by the catch-all handler

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

### Description Of Changes

The catch-all endpoint is intended to stand in for a custom 404 page when navigating the UI, but also intercepts "invalid" endpoint URLs that are not related to front-end assets. This is preventing users of fidesctl-plus from accessing `/plus` endpoints as expected.

The catch-all endpoint no longer intercepts endpoint requests unrelated to front-end assets.