### PR TITLE
Fix SQLAlchemy M1 `greenlet` missing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The types of changes are:
 * CustomSelect input tooltips appear next to selector instead of wrapping to a new row.
 * Datasets without the `third_country_transfer` will not cause the editing dataset form to not render.
 * Fixed a build issue causing an `unknown` version of `fidesctl` to be installed in published Docker images [#836](https://github.com/ethyca/fides/pull/836)
+* Fixed an M1-related SQLAlchemy bug [816](https://github.com/ethyca/fides/pull/891)
 
 ## [1.7.0](https://github.com/ethyca/fides/compare/1.6.1...1.7.0) - 2022-06-23
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pydantic>=1.8.1,<2.0.0 # Required by fastapi
 PyJWT==2.4.0
 pyyaml>=5,<6
 requests>=2,<3
-sqlalchemy==1.4.36
+sqlalchemy[asyncio]==1.4.36
 SQLAlchemy-Utils==0.38.2
 toml>=0.10.1
 uvicorn==0.17.6


### PR DESCRIPTION
Closes #816 

### Code Changes

* [x] add the `asyncio` option to `sqlalchemy`

### Steps to Confirm

* [ ] someone with an M1 mac confirms this fixes it

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

### Description Of Changes

Quick fix for a bug reported by an internal user, turns out to be an issue the M1 macs specifically and this should fix it, as suggested by [this thread](https://github.com/sqlalchemy/sqlalchemy/issues/7714)