### PR TITLE
[803] ui/errors: Standard location for API error type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The types of changes are:
 * Add Okta support to the `/generate` endpoint [#842](https://github.com/ethyca/fides/pull/842)
 * Add db support to `/generate` endpoint [849](https://github.com/ethyca/fides/pull/849)
 * Added OpenAPI TypeScript client generation for the UI app. See the [README](/clients/admin-ui/src/types/api/README.md) for more details.
+* Standardized API error parsing under `~/types/errors`
 
 ### Changed
 

--- a/clients/admin-ui/package-lock.json
+++ b/clients/admin-ui/package-lock.json
@@ -24,6 +24,7 @@
         "js-yaml": "^4.1.0",
         "lodash.debounce": "^4.0.8",
         "msw": "^0.43.0",
+        "narrow-minded": "^1.1.1",
         "next": "12.1.0",
         "next-auth": "^4.9.0",
         "next-redux-wrapper": "^7.0.5",
@@ -9252,6 +9253,15 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/narrow-minded": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/narrow-minded/-/narrow-minded-1.1.1.tgz",
+      "integrity": "sha512-X5wagoCtdl7kRn7vGgObAKDp447f5nuEi+kaa47gm5TGwnjTWaddMTI8FG06hdzZTtOCw8mQ+dSGT6MU+bhppg==",
+      "engines": {
+        "node": ">12.0",
+        "npm": ">6.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "license": "MIT"
@@ -17685,6 +17695,11 @@
     },
     "nanoid": {
       "version": "3.3.2"
+    },
+    "narrow-minded": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/narrow-minded/-/narrow-minded-1.1.1.tgz",
+      "integrity": "sha512-X5wagoCtdl7kRn7vGgObAKDp447f5nuEi+kaa47gm5TGwnjTWaddMTI8FG06hdzZTtOCw8mQ+dSGT6MU+bhppg=="
     },
     "natural-compare": {
       "version": "1.4.0"

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -40,6 +40,7 @@
     "js-yaml": "^4.1.0",
     "lodash.debounce": "^4.0.8",
     "msw": "^0.43.0",
+    "narrow-minded": "^1.1.1",
     "next": "12.1.0",
     "next-auth": "^4.9.0",
     "next-redux-wrapper": "^7.0.5",

--- a/clients/admin-ui/src/features/common/helpers.ts
+++ b/clients/admin-ui/src/features/common/helpers.ts
@@ -1,91 +1,35 @@
-/**
- * Taken from https://redux-toolkit.js.org/rtk-query/usage-with-typescript#inline-error-handling-example
- */
-
-import { SerializedError } from "@reduxjs/toolkit";
-import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { YAMLException } from "js-yaml";
+import { narrow } from "narrow-minded";
 
-// generic error of the structure we expect from the Fides backend
-interface ResponseError {
-  data: {
-    detail: string;
-  };
-}
+import {
+  isAlreadyExistsErrorData,
+  isAPIError,
+  isDetailStringErrorData,
+  isHTTPValidationErrorData,
+  RTKErrorResult,
+} from "~/types/errors/api";
 
-interface ErrorDetail {
-  loc: string[];
-  msg: string;
-  type: string;
-}
-interface ValidationError {
-  data: {
-    detail: ErrorDetail[];
-  };
-}
+export { isErrorResult } from "~/types/errors/api";
 
-interface ConflictError {
-  data: {
-    status: 409;
-    detail: {
-      error: string;
-      resource_type: string;
-      fides_key: string;
-    };
-  };
-}
+export const isYamlException = (error: unknown): error is YAMLException =>
+  narrow({ name: "string" }, error) && error.name === "YAMLException";
 
-/**
- * Custom type predicate to see if the error has details as returned by the Fides API
- * @param error
- * @returns
- */
-export function isErrorWithDetail(error: unknown): error is ResponseError {
-  return (
-    typeof error === "object" &&
-    error != null &&
-    "data" in error &&
-    typeof (error as any).data.detail === "string"
-  );
-}
-
-export function isErrorWithDetailArray(
-  error: unknown
-): error is ValidationError {
-  return (
-    typeof error === "object" &&
-    error != null &&
-    "data" in error &&
-    Array.isArray((error as any).data.detail)
-  );
-}
-
-export function isConflictError(error: unknown): error is ConflictError {
-  return (
-    typeof error === "object" &&
-    error != null &&
-    "data" in error &&
-    (error as any).status === 409
-  );
-}
-
-export function isYamlException(error: unknown): error is YAMLException {
-  return (
-    typeof error === "object" &&
-    error != null &&
-    "name" in error &&
-    (error as any).name === "YAMLException"
-  );
-}
-
-export function getErrorMessage(error: FetchBaseQueryError | SerializedError) {
-  let errorMsg = "An unexpected error occurred. Please try again.";
-  if (isErrorWithDetail(error)) {
-    errorMsg = error.data.detail;
-  } else if (isErrorWithDetailArray(error)) {
-    errorMsg = `${error.data.detail[0].msg}: ${error.data.detail[0].loc}`;
-  } else if (isConflictError(error)) {
-    errorMsg = `${error.data.detail.error} (${error.data.detail.fides_key})`;
+export const getErrorMessage = (
+  error: RTKErrorResult["error"],
+  defaultMsg = "An unexpected error occurred. Please try again."
+) => {
+  if (isAPIError(error)) {
+    if (isDetailStringErrorData(error.data)) {
+      return error.data.detail;
+    }
+    if (isHTTPValidationErrorData(error.data)) {
+      const firstError = error.data.detail?.[0];
+      return `${firstError?.msg}: ${firstError?.loc}`;
+    }
+    if (error.status === 409 && isAlreadyExistsErrorData(error.data)) {
+      return `${error.data.detail.error} (${error.data.detail.fides_key})`;
+    }
   }
-  return errorMsg;
-}
+
+  return defaultMsg;
+};

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
@@ -15,6 +15,7 @@ import * as Yup from "yup";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { CustomSelect, CustomTextInput } from "~/features/common/form/inputs";
+import { isErrorResult } from "~/features/common/helpers";
 import {
   Dataset,
   GenerateResponse,
@@ -74,7 +75,7 @@ const AuthenticateAwsForm = () => {
   const [generate, { isLoading }] = useGenerateMutation();
 
   const handleSubmit = async (values: FormValues) => {
-    const response = await generate({
+    const result = await generate({
       organization_key: organizationKey,
       generate: {
         config: values,
@@ -83,10 +84,10 @@ const AuthenticateAwsForm = () => {
       },
     });
 
-    if ("error" in response) {
-      handleError(response.error);
+    if (isErrorResult(result)) {
+      handleError(result.error);
     } else {
-      handleResults(response.data.generate_results);
+      handleResults(result.data.generate_results);
     }
   };
 

--- a/clients/admin-ui/src/features/config-wizard/DescribeSystemsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/DescribeSystemsForm.tsx
@@ -5,6 +5,7 @@ import { Form, Formik } from "formik";
 import React, { useState } from "react";
 
 import { useAppDispatch } from "~/app/hooks";
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { QuestionIcon } from "~/features/common/Icon";
 import { DEFAULT_ORGANIZATION_FIDES_KEY } from "~/features/organization";
 
@@ -13,7 +14,6 @@ import {
   CustomCreatableSingleSelect,
   CustomTextInput,
 } from "../common/form/inputs";
-import { isErrorWithDetail, isErrorWithDetailArray } from "../common/helpers";
 import { useCreateSystemMutation } from "../system/system.slice";
 import { System } from "../system/types";
 import { changeReviewStep, setSystemFidesKey } from "./config-wizard.slice";
@@ -65,15 +65,12 @@ const DescribeSystemsForm = ({
     const handleResult = (
       result: { data: {} } | { error: FetchBaseQueryError | SerializedError }
     ) => {
-      if ("error" in result) {
-        let errorMsg =
-          "An unexpected error occurred while creating system. Please try again.";
-        if (isErrorWithDetail(result.error)) {
-          errorMsg = result.error.data.detail;
-        } else if (isErrorWithDetailArray(result.error)) {
-          const { error } = result;
-          errorMsg = error.data.detail[0].msg;
-        }
+      if (isErrorResult(result)) {
+        const errorMsg = getErrorMessage(
+          result.error,
+          "An unexpected error occurred while creating the system. Please try again."
+        );
+
         toast({
           status: "error",
           description: errorMsg,

--- a/clients/admin-ui/src/features/config-wizard/OrganizationInfoForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/OrganizationInfoForm.tsx
@@ -14,6 +14,7 @@ import { useFormik } from "formik";
 import React, { useState } from "react";
 
 import { useAppDispatch } from "~/app/hooks";
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { QuestionIcon } from "~/features/common/Icon";
 import {
   DEFAULT_ORGANIZATION_FIDES_KEY,
@@ -23,7 +24,6 @@ import {
   useUpdateOrganizationMutation,
 } from "~/features/organization";
 
-import { isErrorWithDetail, isErrorWithDetailArray } from "../common/helpers";
 import { changeStep, setOrganization } from "./config-wizard.slice";
 
 const useOrganizationInfoForm = () => {
@@ -60,14 +60,9 @@ const useOrganizationInfoForm = () => {
           organizationBody
         );
 
-        if ("error" in createOrganizationResult) {
-          let errorMsg = "An unexpected error occurred. Please try again.";
-          if (isErrorWithDetail(createOrganizationResult.error)) {
-            errorMsg = createOrganizationResult.error.data.detail;
-          } else if (isErrorWithDetailArray(createOrganizationResult.error)) {
-            const { error } = createOrganizationResult;
-            errorMsg = error.data.detail[0].msg;
-          }
+        if (isErrorResult(createOrganizationResult)) {
+          const errorMsg = getErrorMessage(createOrganizationResult.error);
+
           toast({
             status: "error",
             description: errorMsg,
@@ -81,14 +76,9 @@ const useOrganizationInfoForm = () => {
           organizationBody
         );
 
-        if ("error" in updateOrganizationResult) {
-          let errorMsg = "An unexpected error occurred. Please try again.";
-          if (isErrorWithDetail(updateOrganizationResult.error)) {
-            errorMsg = updateOrganizationResult.error.data.detail;
-          } else if (isErrorWithDetailArray(updateOrganizationResult.error)) {
-            const { error } = updateOrganizationResult;
-            errorMsg = error.data.detail[0].msg;
-          }
+        if (isErrorResult(updateOrganizationResult)) {
+          const errorMsg = getErrorMessage(updateOrganizationResult.error);
+
           toast({
             status: "error",
             description: errorMsg,

--- a/clients/admin-ui/src/features/config-wizard/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/PrivacyDeclarationForm.tsx
@@ -22,6 +22,7 @@ import { Form, Formik } from "formik";
 import React, { useEffect, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { AddIcon, QuestionIcon } from "~/features/common/Icon";
 import {
   selectDataQualifier,
@@ -50,7 +51,6 @@ import {
   CustomSelect,
   CustomTextInput,
 } from "../common/form/inputs";
-import { isErrorWithDetail, isErrorWithDetailArray } from "../common/helpers";
 import {
   useGetSystemByFidesKeyQuery,
   useUpdateSystemMutation,
@@ -153,15 +153,12 @@ const PrivacyDeclarationForm = ({
     const handleResult = (
       result: { data: {} } | { error: FetchBaseQueryError | SerializedError }
     ) => {
-      if ("error" in result) {
-        let errorMsg =
-          "An unexpected error occurred while creating system. Please try again.";
-        if (isErrorWithDetail(result.error)) {
-          errorMsg = result.error.data.detail;
-        } else if (isErrorWithDetailArray(result.error)) {
-          const { error } = result;
-          errorMsg = error.data.detail[0].msg;
-        }
+      if (isErrorResult(result)) {
+        const errorMsg = getErrorMessage(
+          result.error,
+          "An unexpected error occurred while updating the system. Please try again."
+        );
+
         toast({
           status: "error",
           description: errorMsg,

--- a/clients/admin-ui/src/features/dataset/EditDatasetDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditDatasetDrawer.tsx
@@ -1,7 +1,9 @@
 import { Text, useToast } from "@fidesui/react";
 import { useRouter } from "next/router";
 
-import { errorToastParams, successToastParams } from "../common/toast";
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
+import { errorToastParams, successToastParams } from "~/features/common/toast";
+
 import {
   setActiveDataset,
   useDeleteDatasetMutation,
@@ -28,13 +30,8 @@ const EditDatasetDrawer = ({ dataset, isOpen, onClose }: Props) => {
     const updatedDataset = { ...dataset, ...values };
     try {
       const result = await updateDataset(updatedDataset);
-      // TODO: we should systematically coerce errors into their types (#803)
-      if ("error" in result && "data" in result.error) {
-        if ("data" in result.error) {
-          toast(errorToastParams(result.error.data as string));
-        } else {
-          toast(errorToastParams("An unknown error occurred"));
-        }
+      if (isErrorResult(result)) {
+        toast(errorToastParams(getErrorMessage(result.error)));
       } else {
         toast(successToastParams("Successfully modified dataset"));
       }
@@ -47,13 +44,9 @@ const EditDatasetDrawer = ({ dataset, isOpen, onClose }: Props) => {
   const handleDelete = async () => {
     const { fides_key: fidesKey } = dataset;
     const result = await deleteDataset(fidesKey);
-    // TODO: we should systematically coerce errors into their types (#803)
-    if ("error" in result && "data" in result.error) {
-      if ("data" in result.error) {
-        toast(errorToastParams(result.error.data as string));
-      } else {
-        toast(errorToastParams("An unknown error occurred"));
-      }
+
+    if (isErrorResult(result)) {
+      toast(errorToastParams(getErrorMessage(result.error)));
     } else {
       toast(successToastParams("Successfully deleted dataset"));
     }

--- a/clients/admin-ui/src/types/errors/api.ts
+++ b/clients/admin-ui/src/types/errors/api.ts
@@ -1,0 +1,93 @@
+import { SerializedError } from "@reduxjs/toolkit";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
+import { narrow } from "narrow-minded";
+
+import {
+  AlreadyExistsError,
+  DetailStringError,
+  HTTPException,
+  HTTPValidationError,
+} from "./models";
+
+/**
+ * From Redux Toolkit on query error types:
+ *  https://redux-toolkit.js.org/rtk-query/usage-with-typescript#inline-error-handling-example
+ */
+export interface RTKErrorResult {
+  error: FetchBaseQueryError | SerializedError;
+}
+
+export type RTKResult = { data: unknown } | RTKErrorResult;
+
+/**
+ * Use this predicate on an RTK query result to find out if the request returned an error.
+ */
+export const isErrorResult = (result: RTKResult): result is RTKErrorResult =>
+  "error" in result;
+
+/**
+ * This type is more specific than RTK's FetchBaseQueryError:
+ *  - The status must be a number (HTTP code) and not one of RTK's special strings.
+ *  - It must contain a `data` object, which will (probably) contain a `detail` property.
+ */
+export interface APIError {
+  status: number;
+  data: HTTPException;
+}
+
+/**
+ * Use this predicate on the `error` property of an RTK query result to find out if the error is one
+ * of the types we expect the backend to return.
+ */
+export const isAPIError = (error: RTKErrorResult["error"]): error is APIError =>
+  narrow(
+    {
+      status: "number",
+      data: {},
+    },
+    error
+  );
+
+/**
+ * Use these predicates on the `data` property of an APIError.
+ */
+
+export const isDetailStringErrorData = (
+  data: unknown
+): data is DetailStringError =>
+  narrow(
+    {
+      detail: "string",
+    },
+    data
+  );
+
+export const isAlreadyExistsErrorData = (
+  data: unknown
+): data is AlreadyExistsError =>
+  narrow(
+    {
+      detail: {
+        error: "string",
+        resource_type: "string",
+        fides_key: "string",
+      },
+    },
+    data
+  );
+
+export const isHTTPValidationErrorData = (
+  data: unknown
+): data is HTTPValidationError =>
+  narrow(
+    {
+      detail: [
+        {
+          loc: ["string", "number"],
+          msg: "string",
+          type: "string",
+        },
+      ],
+    },
+    data
+  );

--- a/clients/admin-ui/src/types/errors/index.ts
+++ b/clients/admin-ui/src/types/errors/index.ts
@@ -1,0 +1,2 @@
+export * from "./api";
+export * from "./models";

--- a/clients/admin-ui/src/types/errors/models.ts
+++ b/clients/admin-ui/src/types/errors/models.ts
@@ -1,0 +1,32 @@
+/**
+ * The specific error types like these will be codified by a backend change:
+ *  https://github.com/ethyca/fides/issues/894
+ * Until then, this file contains error models we know the backend might return.
+ */
+export type { HTTPValidationError, ValidationError } from "~/types/api";
+
+/**
+ * This is the base error that any fastapi endpoint can return:
+ *  https://fastapi.tiangolo.com/tutorial/handling-errors/#use-httpexception
+ */
+export interface HTTPException {
+  detail?: unknown;
+}
+
+/**
+ * Some endpoints return a plain string as the detail.
+ */
+export interface DetailStringError {
+  detail: string;
+}
+
+/**
+ * Source: https://github.com/ethyca/fides/blob/main/src/fidesapi/utils/errors.py#L4
+ */
+export interface AlreadyExistsError {
+  detail: {
+    error: string;
+    resource_type: string;
+    fides_key: string;
+  };
+}


### PR DESCRIPTION
Closes 803

### Code Changes

- Use standard error message helpers everywhere
- Standard location for API error type checking
- ui/package.json: Add narrow-minded 1.1.0
  - This is a general-purpose tool for typechecking objects.

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This introduces a new set of files for defining API error interfaces and functions for checking whether a response matches one of the known types. The error message helpers then use these type checkers to cleanly dig through an RTK result to find a user-visible string. There will be more cases to handle, but this should be extensible.
