### PR TITLE
CI Production Workflows for Docker and Docs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,6 +35,12 @@ jobs:
       - name: Push Fidesctl Dev Tag
         run: nox -s "push(dev)"
 
+      - name: Check Prod Tag
+        id: check-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=match::true
+          fi
       - name: Push Fidesctl Prod Tags
-        if: ${{ env.TAG }}
+        if: steps.check-tag.outputs.match == 'true'
         run: nox -s "push(prod)"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,7 +10,6 @@ on:
 env:
   DOCKER_USER: ethycaci
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-  TAG: ${{ github.event.release.tag_name }}
 
 jobs:
   push-fidesctl:

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -47,13 +47,28 @@ jobs:
 
       # Deploys docs without a version in the URL for legacy links
       # This will match the "stable" version of the versioned docs
+
+      - name: Check Prod Tag
+        id: check-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=match::true
+          fi
+
+      - name: Get Version
+        id: get-version
+        if: steps.check-tag.outputs.match == 'true'
+        run: |
+          version=$(echo ${{ github.event.ref }} | cut -d/ -f3)
+          echo "::set-output name=version::$version"
+
       - name: Deploy the Legacy Docs if a Release is Published
-        if: ${{ env.TAG }}
+        if: steps.check-tag.outputs.match == 'true'
         run: mkdocs gh-deploy -v -f docs/fides/mkdocs.yml --force
 
       - name: Deploy Stable Docs if a Release is Published
-        if: ${{ env.TAG }}
-        run: mike deploy --config-file docs/fides/mkdocs.yml --push --update-aliases ${{ env.TAG }} stable
+        if: steps.check-tag.outputs.match == 'true'
+        run: mike deploy --config-file docs/fides/mkdocs.yml --push --update-aliases ${{ steps.get-version.outputs.version }} stable
 
       # This will match "stable" when a new release is cut
       - name: Deploy Dev Docs

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -8,7 +8,6 @@ on:
     types: [published]
 
 env:
-  TAG: ${{ github.event.release.tag_name }}
   PROD_PUBLISH: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The types of changes are:
 * Fixed a build issue causing an `unknown` version of `fidesctl` to be installed in published Docker images [#836](https://github.com/ethyca/fides/pull/836)
 * Fixed an M1-related SQLAlchemy bug [#816](https://github.com/ethyca/fides/pull/891)
 * Endpoints now work with or without a trailing slash. [#886](https://github.com/ethyca/fides/pull/886)
+* Fixed the `tag` specific GitHub Action workflows for Docker and publishing docs. [#901](https://github.com/ethyca/fides/pull/901)
 
 ## [1.7.0](https://github.com/ethyca/fides/compare/1.6.1...1.7.0) - 2022-06-23
 

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -69,4 +69,4 @@ def push(session: nox.Session, tag: str) -> None:
     # Only push the tagged version if its for prod
     # Example: "ethyca/fidesctl:1.7.0"
     if tag == "prod":
-        session.run("docker", "push", IMAGE, external=True)
+        session.run("docker", "push", f"{IMAGE}:{get_current_tag()}", external=True)


### PR DESCRIPTION
Closes #807

### Code Changes

* [x] Add a conditional step to check if the tag used matches a release
* [x] Include the current image when pushing a production image
* [x] Parse the  `github.event.ref` to publish the version specific docs
* [x] Mimic the conditional step for docs publishing 

### Steps to Confirm

* [x] Set up a testing repo to ensure the workflow worked
* [x] Add a test nox command to print out the update `IMAGE` constant with version

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Spent some time in a test repo to ensure the workflow updates should work for us.

I'm unsure still if the nox changes are sufficient, or if there should be a separate constant used for the current working version.

Another additional question is if we want to retroactively publish docs versions that were missed 🤔 
