### PR TITLE
[864] ui/config-wizard: Display AWS scanning errors to user.

### DIFF
--- a/clients/admin-ui/src/features/common/DocsLink.tsx
+++ b/clients/admin-ui/src/features/common/DocsLink.tsx
@@ -1,0 +1,10 @@
+import { Link } from "@fidesui/react";
+
+/**
+ * An external link to documentation.
+ */
+const DocsLink = (props: React.ComponentProps<typeof Link>) => (
+  <Link isExternal color="complimentary.500" {...props} />
+);
+
+export default DocsLink;

--- a/clients/admin-ui/src/features/common/helpers.ts
+++ b/clients/admin-ui/src/features/common/helpers.ts
@@ -6,6 +6,7 @@ import {
   isAPIError,
   isDetailStringErrorData,
   isHTTPValidationErrorData,
+  isParsingError,
   RTKErrorResult,
 } from "~/types/errors/api";
 
@@ -14,9 +15,11 @@ export { isErrorResult } from "~/types/errors/api";
 export const isYamlException = (error: unknown): error is YAMLException =>
   narrow({ name: "string" }, error) && error.name === "YAMLException";
 
+const DEFAULT_ERROR_MESSAGE = "An unexpected error occurred. Please try again.";
+
 export const getErrorMessage = (
   error: RTKErrorResult["error"],
-  defaultMsg = "An unexpected error occurred. Please try again."
+  defaultMsg = DEFAULT_ERROR_MESSAGE
 ) => {
   if (isAPIError(error)) {
     if (isDetailStringErrorData(error.data)) {
@@ -32,4 +35,37 @@ export const getErrorMessage = (
   }
 
   return defaultMsg;
+};
+
+export interface ParsedError {
+  status: number;
+  message: string;
+}
+
+export const parseError = (
+  error: RTKErrorResult["error"],
+  defaultError = {
+    status: 500,
+    message: DEFAULT_ERROR_MESSAGE,
+  }
+): ParsedError => {
+  if (isParsingError(error)) {
+    // This case is known to come up for Internal Server Errors which cannot be parsed as JSON.
+    // Ticket #892 will fix the ones produced by the generate endpoint.
+    return {
+      status: error.originalStatus,
+      message: error.data,
+    };
+  }
+
+  if (isAPIError(error)) {
+    const { status } = error;
+
+    return {
+      status,
+      message: getErrorMessage(error, defaultError.message),
+    };
+  }
+
+  return defaultError;
 };

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
@@ -52,8 +52,16 @@ const initialValues = {
 type FormValues = typeof initialValues;
 
 const ValidationSchema = Yup.object().shape({
-  aws_access_key_id: Yup.string().required().label("Access Key ID"),
-  aws_secret_access_key: Yup.string().required().label("Secret"),
+  aws_access_key_id: Yup.string()
+    .required()
+    .trim()
+    .matches(/^\w+$/, "Cannot contain spaces or special characters")
+    .label("Access Key ID"),
+  aws_secret_access_key: Yup.string()
+    .required()
+    .trim()
+    .matches(/^[^\s]+$/, "Cannot contain spaces")
+    .label("Secret"),
   region_name: Yup.string().required().label("Default Region"),
 });
 

--- a/clients/admin-ui/src/features/config-wizard/ScannerError.tsx
+++ b/clients/admin-ui/src/features/config-wizard/ScannerError.tsx
@@ -1,0 +1,80 @@
+import {
+  Badge,
+  Container,
+  Divider,
+  Heading,
+  HStack,
+  Stack,
+  Text,
+} from "@fidesui/react";
+
+import DocsLink from "~/features/common/DocsLink";
+import { ParsedError } from "~/features/common/helpers";
+
+import { DOCS_URL_AWS_PERMISSIONS, DOCS_URL_ISSUES } from "./constants";
+
+const ErrorLog = ({ message }: { message: string }) => (
+  <>
+    <Divider />
+    <Container maxH="50vh" overflow="auto">
+      <Text as="pre" data-testid="error-log">
+        {message}
+      </Text>
+    </Container>
+    <Divider />
+  </>
+);
+
+const ScannerError = ({ error }: { error: ParsedError }) => (
+  <Stack data-testid="scanner-error" spacing="4">
+    <HStack>
+      <Badge color="white" bg="red.500" py="2">
+        Error
+      </Badge>
+      <Heading color="red.500" size="lg">
+        Failed to Scan AWS
+      </Heading>
+    </HStack>
+
+    {error.status === 403 ? (
+      <>
+        <Text data-testid="permission-msg">
+          Fides was unable to scan AWS. It appears that the credentials were
+          valid to login but they did not have adequate permission to complete
+          the scan.
+        </Text>
+
+        {/* TODO(#892): A status of 403 should include a helpful log, which would appear here in an ErrorLog. */}
+
+        <Text>
+          To fix this issue, double check that you have granted{" "}
+          <DocsLink href={DOCS_URL_AWS_PERMISSIONS}>
+            the required permissions
+          </DocsLink>{" "}
+          to these credentials as part of your IAM policy. If you need more help
+          in configuring IAM policies, you can read about them{" "}
+          <DocsLink href="https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_access-management.html">
+            here
+          </DocsLink>
+          .
+        </Text>
+      </>
+    ) : (
+      <>
+        <Text data-testid="generic-msg">
+          Fides was unable to scan AWS. Please ensure your credentials are
+          accurate and inspect the error log below for more details.
+        </Text>
+
+        <ErrorLog message={error.message} />
+
+        <Text>
+          If this error does not clarify why scanning failed, please{" "}
+          <DocsLink href={DOCS_URL_ISSUES}>create a new issue</DocsLink>.
+        </Text>
+      </>
+    )}
+  </Stack>
+);
+
+export default ScannerError;

--- a/clients/admin-ui/src/features/config-wizard/constants.tsx
+++ b/clients/admin-ui/src/features/config-wizard/constants.tsx
@@ -49,6 +49,7 @@ export const DOCS_URL_AWS_PERMISSIONS =
   "https://ethyca.github.io/fides/guides/generate_resources/#required-permissions";
 export const DOCS_URL_IAM_POLICY =
   "https://ethyca.github.io/fides/guides/generate_resources/#sample-iam-policy";
+export const DOCS_URL_ISSUES = "https://github.com/ethyca/fides/issues";
 
 // Source: https://docs.aws.amazon.com/general/latest/gr/rande.html
 export const AWS_REGION_OPTIONS = [

--- a/clients/admin-ui/src/types/errors/api.ts
+++ b/clients/admin-ui/src/types/errors/api.ts
@@ -26,6 +26,20 @@ export const isErrorResult = (result: RTKResult): result is RTKErrorResult =>
   "error" in result;
 
 /**
+ * Use this predicate on the `error` property of an RTK query result to find out if the request
+ * returned an error that could not be parsed as JSON. For example, a 500 "Internal Server Error".
+ */
+export const isParsingError = (
+  error: RTKErrorResult["error"]
+): error is FetchBaseQueryError & { status: "PARSING_ERROR" } =>
+  narrow(
+    {
+      status: "string",
+    },
+    error
+  ) && error.status === "PARSING_ERROR";
+
+/**
  * This type is more specific than RTK's FetchBaseQueryError:
  *  - The status must be a number (HTTP code) and not one of RTK's special strings.
  *  - It must contain a `data` object, which will (probably) contain a `detail` property.


### PR DESCRIPTION
Closes 864

### Code Changes

- ui/common: DocsLink - A simple but handy component.
- ui/errors: Helper for 500 errors and getting errror status
- [864] ui/config-wizard: Tighten AWS credential validation
- [864] ui/config-wizard: Display AWS scanning errors to user.

### Steps to Confirm

- [ ] Enter the config wizard for AWS systems
- [ ] Try typing spaces and special characters in the fields
- [ ] Submit nonsense credentials
    - This will should hit the 403 error case
    - With the new field validation I don't know of a way to hit the 500 case anymore. 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

The error log and messages can't match the design perfectly because the [API doesn't return enough info](https://github.com/ethyca/fides/issues/892). For the Internal Server Error case I tried to make the instructions helpful.

<img width="284" alt="bad-input" src="https://user-images.githubusercontent.com/2236777/179127476-7d1c00a0-e4e3-41b5-b360-8644862803df.png">
<img width="689" alt="scan-500" src="https://user-images.githubusercontent.com/2236777/179127483-6c21336d-e7ba-42f0-a8dd-23192426e681.png">
<img width="694" alt="scan-403-nolog" src="https://user-images.githubusercontent.com/2236777/179127485-1efb5afb-7805-4ac7-9caa-d54ec2ccdf4c.png">

I threw some mock text in there to try out the scroll container in case we do start sending a detailed log:
<img width="709" alt="error-lorem" src="https://user-images.githubusercontent.com/2236777/179127479-537e4caa-c086-49d8-8803-0c1179a734aa.png">