### PR TITLE
Taxonomy nested dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The types of changes are:
 * Added user auth tables [915](https://github.com/ethyca/fides/pull/915)
 * Standardized API error parsing under `~/types/errors`
 * Added taxonomy page to UI [#902](https://github.com/ethyca/fides/pull/902)
+  * Added a nested accordion component for displaying taxonomy data [#910](https://github.com/ethyca/fides/pull/910)
 
 ### Changed
 

--- a/clients/admin-ui/__tests__/features/taxonomy-transform.test.tsx
+++ b/clients/admin-ui/__tests__/features/taxonomy-transform.test.tsx
@@ -1,9 +1,9 @@
-import { transformDataCategoriesToNodes } from "~/features/taxonomy/helpers";
-import { MOCK_DATA_CATEGORIES } from "~/mocks/data";
+import { transformTaxonomyEntityToNodes } from "~/features/taxonomy/helpers";
+import { MOCK_DATA_CATEGORIES, MOCK_DATA_SUBJECTS } from "~/mocks/data";
 
 describe("data category transform", () => {
   it("should convert a list of dot strings to nodes", () => {
-    const nodes = transformDataCategoriesToNodes(MOCK_DATA_CATEGORIES);
+    const nodes = transformTaxonomyEntityToNodes(MOCK_DATA_CATEGORIES);
     expect(nodes).toEqual([
       {
         children: [
@@ -88,6 +88,33 @@ describe("data category transform", () => {
           "Data related to the user of the system, either provided directly or derived based on their usage.",
         label: "User Data",
         value: "user",
+      },
+    ]);
+  });
+
+  it("should handle items without parent keys as just a flat list", () => {
+    const nodes = transformTaxonomyEntityToNodes(MOCK_DATA_SUBJECTS);
+    expect(nodes).toEqual([
+      {
+        label: "Anonymous User",
+        value: "anonymous_user",
+        description:
+          "An individual that is unidentifiable to the systems. Note - This should only be applied to truly anonymous users where there is no risk of re-identification",
+        children: [],
+      },
+      {
+        label: "Citizen Voter",
+        value: "citizen_voter",
+        description:
+          "An individual registered to voter with a state or authority.",
+        children: [],
+      },
+      {
+        label: "Commuter",
+        value: "commuter",
+        description:
+          "An individual that is traveling or transiting in the context of location tracking.",
+        children: [],
       },
     ]);
   });

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -25,8 +25,10 @@ describe("Taxonomy management page", () => {
   });
 
   describe("Can view data", () => {
-    it("Can navigate between tabs and load data", () => {
+    beforeEach(() => {
       cy.visit("/taxonomy");
+    });
+    it("Can navigate between tabs and load data", () => {
       cy.getByTestId("tab-Data Uses").click();
       cy.wait("@getDataUses");
       cy.getByTestId("tab-Data Subjects").click();
@@ -35,6 +37,34 @@ describe("Taxonomy management page", () => {
       cy.wait("@getDataQualifiers");
       cy.getByTestId("tab-Data Categories").click();
       cy.wait("@getDataCategories");
+    });
+
+    it("Can open up accordion to see taxonomy entities", () => {
+      // should only see the 3 root level taxonomy
+      cy.getByTestId("accordion-item-Account Data").should("be.visible");
+      cy.getByTestId("accordion-item-System Data").should("be.visible");
+      cy.getByTestId("accordion-item-User Data").should("be.visible");
+      cy.getByTestId("accordion-item-Payment Data").should("not.be.visible");
+
+      // clicking should open up accordions to render more items visible
+      cy.getByTestId("accordion-item-Account Data").click();
+      cy.getByTestId("accordion-item-Payment Data").should("be.visible");
+      cy.getByTestId("accordion-item-Payment Data").click();
+      cy.getByTestId("item-Account Payment Financial Account Number").should(
+        "be.visible"
+      );
+    });
+
+    it("Can render accordion elements on flat structures", () => {
+      cy.getByTestId("tab-Data Subjects").click();
+      cy.getByTestId("item-Anonymous User").should("be.visible");
+      cy.getByTestId("item-Shareholder").should("be.visible");
+    });
+
+    it("Can render action buttons on hover", () => {
+      cy.getByTestId("action-btns").should("not.exist");
+      cy.getByTestId("accordion-item-Account Data").trigger("mouseover");
+      cy.getByTestId("action-btns").should("exist");
     });
   });
 });

--- a/clients/admin-ui/src/features/common/AccordionTree.tsx
+++ b/clients/admin-ui/src/features/common/AccordionTree.tsx
@@ -42,6 +42,9 @@ const AccordionTree = ({ nodes }: Props) => {
       onMouseEnter: () => {
         setHoverNode(node);
       },
+      onMouseLeave: () => {
+        setHoverNode(undefined);
+      },
     };
 
     if (node.children.length === 0) {

--- a/clients/admin-ui/src/features/common/AccordionTree.tsx
+++ b/clients/admin-ui/src/features/common/AccordionTree.tsx
@@ -9,7 +9,7 @@ import {
   ButtonGroup,
   Text,
 } from "@fidesui/react";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 
 import { TreeNode } from "./types";
 
@@ -24,44 +24,48 @@ interface Props {
   nodes: TreeNode[];
 }
 const AccordionTree = ({ nodes }: Props) => {
+  const [hoverNode, setHoverNode] = useState<TreeNode | undefined>(undefined);
   /**
    * Recursive function to generate the accordion tree
    */
   const createTree = (node: TreeNode) => {
-    // TODO: these borders are cut a little short, need to figure out CSS
-    const borderProps = {
+    // some nodes render as AccordionItems and some as just Boxes, but
+    // we want to keep their styling similar, so pass them the same props
+    const itemProps = {
+      // TODO: these borders are cut a little short, need to figure out CSS
       borderBottom: "1px solid",
       borderColor: "gray.200",
+      display: "flex",
+      justifyContent: "space-between",
+      alignItems: "center",
+      _hover: { bg: "gray.50" },
+      onMouseEnter: () => {
+        setHoverNode(node);
+      },
     };
+
     if (node.children.length === 0) {
       return (
         <Box
           pl={9}
           py={2}
-          _hover={{ bg: "gray.50" }}
-          {...borderProps}
+          {...itemProps}
           display="flex"
           justifyContent="space-between"
         >
           <Text>{node.label}</Text>
-          <ActionButtons />
+          {hoverNode?.value === node.value ? <ActionButtons /> : null}
         </Box>
       );
     }
     return (
       <AccordionItem py={0} border="none">
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          alignItems="center"
-          {...borderProps}
-        >
+        <Box {...itemProps}>
           <AccordionButton _expanded={{ color: "complimentary.500" }}>
             <AccordionIcon />
             {node.label}
           </AccordionButton>
-          {/* TODO: only show action buttons on hover */}
-          <ActionButtons />
+          {hoverNode?.value === node.value ? <ActionButtons /> : null}
         </Box>
 
         <AccordionPanel py={0} pr={0}>

--- a/clients/admin-ui/src/features/common/AccordionTree.tsx
+++ b/clients/admin-ui/src/features/common/AccordionTree.tsx
@@ -14,9 +14,9 @@ import { Fragment, useState } from "react";
 import { TreeNode } from "./types";
 
 const ActionButtons = () => (
-  <ButtonGroup size="xs" isAttached variant="outline">
-    <Button>Edit</Button>
-    <Button>Delete</Button>
+  <ButtonGroup size="xs" isAttached variant="outline" data-testid="action-btns">
+    <Button data-testid="edit-btn">Edit</Button>
+    <Button data-testid="delete-btn">Delete</Button>
   </ButtonGroup>
 );
 
@@ -46,20 +46,18 @@ const AccordionTree = ({ nodes }: Props) => {
 
     if (node.children.length === 0) {
       return (
-        <Box
-          pl={9}
-          py={2}
-          {...itemProps}
-          display="flex"
-          justifyContent="space-between"
-        >
+        <Box pl={9} py={2} {...itemProps} data-testid={`item-${node.label}`}>
           <Text>{node.label}</Text>
           {hoverNode?.value === node.value ? <ActionButtons /> : null}
         </Box>
       );
     }
     return (
-      <AccordionItem py={0} border="none">
+      <AccordionItem
+        py={0}
+        border="none"
+        data-testid={`accordion-item-${node.label}`}
+      >
         <Box {...itemProps}>
           <AccordionButton _expanded={{ color: "complimentary.500" }}>
             <AccordionIcon />

--- a/clients/admin-ui/src/features/common/AccordionTree.tsx
+++ b/clients/admin-ui/src/features/common/AccordionTree.tsx
@@ -1,0 +1,86 @@
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Button,
+  ButtonGroup,
+  Text,
+} from "@fidesui/react";
+import { Fragment } from "react";
+
+import { TreeNode } from "./types";
+
+const ActionButtons = () => (
+  <ButtonGroup size="xs" isAttached variant="outline">
+    <Button>Edit</Button>
+    <Button>Delete</Button>
+  </ButtonGroup>
+);
+
+interface Props {
+  nodes: TreeNode[];
+}
+const AccordionTree = ({ nodes }: Props) => {
+  /**
+   * Recursive function to generate the accordion tree
+   */
+  const createTree = (node: TreeNode) => {
+    // TODO: these borders are cut a little short, need to figure out CSS
+    const borderProps = {
+      borderBottom: "1px solid",
+      borderColor: "gray.200",
+    };
+    if (node.children.length === 0) {
+      return (
+        <Box
+          pl={9}
+          py={2}
+          _hover={{ bg: "gray.50" }}
+          {...borderProps}
+          display="flex"
+          justifyContent="space-between"
+        >
+          <Text>{node.label}</Text>
+          <ActionButtons />
+        </Box>
+      );
+    }
+    return (
+      <AccordionItem py={0} border="none">
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+          {...borderProps}
+        >
+          <AccordionButton _expanded={{ color: "complimentary.500" }}>
+            <AccordionIcon />
+            {node.label}
+          </AccordionButton>
+          {/* TODO: only show action buttons on hover */}
+          <ActionButtons />
+        </Box>
+
+        <AccordionPanel py={0} pr={0}>
+          {node.children.map((childNode) => (
+            <Fragment key={childNode.value}>{createTree(childNode)}</Fragment>
+          ))}
+        </AccordionPanel>
+      </AccordionItem>
+    );
+  };
+  return (
+    <Box boxSizing="border-box">
+      <Accordion allowMultiple>
+        {nodes.map((child) => (
+          <Box key={child.value}>{createTree(child)}</Box>
+        ))}
+      </Accordion>
+    </Box>
+  );
+};
+
+export default AccordionTree;

--- a/clients/admin-ui/src/features/common/AccordionTree.tsx
+++ b/clients/admin-ui/src/features/common/AccordionTree.tsx
@@ -5,6 +5,7 @@ import {
   AccordionItem,
   AccordionPanel,
   Box,
+  BoxProps,
   Button,
   ButtonGroup,
   Text,
@@ -28,16 +29,16 @@ const AccordionTree = ({ nodes }: Props) => {
   /**
    * Recursive function to generate the accordion tree
    */
-  const createTree = (node: TreeNode) => {
+  const createTree = (node: TreeNode, level: number = 0) => {
     // some nodes render as AccordionItems and some as just Boxes, but
     // we want to keep their styling similar, so pass them the same props
-    const itemProps = {
-      // TODO: these borders are cut a little short, need to figure out CSS
+    const itemProps: BoxProps = {
       borderBottom: "1px solid",
       borderColor: "gray.200",
       display: "flex",
       justifyContent: "space-between",
       alignItems: "center",
+      pl: level * 3,
       _hover: { bg: "gray.50" },
       onMouseEnter: () => {
         setHoverNode(node);
@@ -49,29 +50,39 @@ const AccordionTree = ({ nodes }: Props) => {
 
     if (node.children.length === 0) {
       return (
-        <Box pl={9} py={2} {...itemProps} data-testid={`item-${node.label}`}>
-          <Text>{node.label}</Text>
+        <Box py={2} {...itemProps} data-testid={`item-${node.label}`}>
+          <Text
+            pl={5} // AccordionButton's caret is 20px, so use 5 to line this up
+          >
+            {node.label}
+          </Text>
           {hoverNode?.value === node.value ? <ActionButtons /> : null}
         </Box>
       );
     }
     return (
       <AccordionItem
-        py={0}
+        p={0}
         border="none"
         data-testid={`accordion-item-${node.label}`}
       >
         <Box {...itemProps}>
-          <AccordionButton _expanded={{ color: "complimentary.500" }}>
+          <AccordionButton
+            _expanded={{ color: "complimentary.500" }}
+            _hover={{ bg: "gray.50" }}
+            pl={0}
+          >
             <AccordionIcon />
             {node.label}
           </AccordionButton>
           {hoverNode?.value === node.value ? <ActionButtons /> : null}
         </Box>
 
-        <AccordionPanel py={0} pr={0}>
+        <AccordionPanel p={0}>
           {node.children.map((childNode) => (
-            <Fragment key={childNode.value}>{createTree(childNode)}</Fragment>
+            <Fragment key={childNode.value}>
+              {createTree(childNode, level + 1)}
+            </Fragment>
           ))}
         </AccordionPanel>
       </AccordionItem>

--- a/clients/admin-ui/src/features/common/CheckboxTree.tsx
+++ b/clients/admin-ui/src/features/common/CheckboxTree.tsx
@@ -11,6 +11,7 @@ import { Box, Checkbox, IconButton } from "@fidesui/react";
 import { Fragment, ReactNode, useEffect, useState } from "react";
 
 import { ArrowDownLineIcon, ArrowUpLineIcon } from "./Icon";
+import { TreeNode } from "./types";
 
 export const getAncestorsAndCurrent = (nodeName: string) => {
   const splitNames = nodeName.split(".");
@@ -36,11 +37,11 @@ export const ancestorIsSelected = (selected: string[], nodeName: string) => {
 };
 
 export const getDescendantsAndCurrent = (
-  nodes: CheckboxNode[],
+  nodes: TreeNode[],
   nodeName: string,
-  result?: CheckboxNode[]
+  result?: TreeNode[]
 ) => {
-  const descendants: CheckboxNode[] = result ?? [];
+  const descendants: TreeNode[] = result ?? [];
   nodes.forEach((node) => {
     if (node.children) {
       getDescendantsAndCurrent(node.children, nodeName, descendants);
@@ -52,18 +53,12 @@ export const getDescendantsAndCurrent = (
   return descendants;
 };
 
-interface CheckboxNode {
-  label: string;
-  value: string;
-  children: CheckboxNode[] | null;
-}
-
 interface CheckboxItemProps {
-  node: CheckboxNode;
+  node: TreeNode;
   isChecked: boolean;
-  onChecked: (node: CheckboxNode) => void;
+  onChecked: (node: TreeNode) => void;
   isExpanded: boolean;
-  onExpanded: (node: CheckboxNode) => void;
+  onExpanded: (node: TreeNode) => void;
   isIndeterminate: boolean;
   isDisabled: boolean;
   children?: ReactNode;
@@ -118,7 +113,7 @@ const CheckboxItem = ({
 };
 
 interface CheckboxTreeProps {
-  nodes: CheckboxNode[];
+  nodes: TreeNode[];
   selected: string[];
   onSelected: (newSelected: string[]) => void;
 }
@@ -151,7 +146,7 @@ const CheckboxTree = ({ nodes, selected, onSelected }: CheckboxTreeProps) => {
     setChecked(nodeNames);
   }, [selected, nodes]);
 
-  const handleChecked = (node: CheckboxNode) => {
+  const handleChecked = (node: TreeNode) => {
     let newChecked: string[] = [];
     let newSelected: string[] = [];
     if (checked.indexOf(node.value) >= 0) {
@@ -171,7 +166,7 @@ const CheckboxTree = ({ nodes, selected, onSelected }: CheckboxTreeProps) => {
     onSelected(newSelected);
   };
 
-  const handleExpanded = (node: CheckboxNode) => {
+  const handleExpanded = (node: TreeNode) => {
     if (expanded.indexOf(node.value) >= 0) {
       // take advantage of dot notation here for unexpanding children
       setExpanded(expanded.filter((c) => !c.startsWith(node.value)));
@@ -183,7 +178,7 @@ const CheckboxTree = ({ nodes, selected, onSelected }: CheckboxTreeProps) => {
   /**
    * Recursive function to generate the checkbox tree
    */
-  const createTree = (node: CheckboxNode) => {
+  const createTree = (node: TreeNode) => {
     if (node.children) {
       const isChecked = checked.indexOf(node.value) >= 0;
       const isExpanded = expanded.indexOf(node.value) >= 0;

--- a/clients/admin-ui/src/features/common/DataTabs.tsx
+++ b/clients/admin-ui/src/features/common/DataTabs.tsx
@@ -21,14 +21,24 @@ const DataTabs = ({ data, ...other }: Props & Omit<TabsProps, "children">) => (
   <Tabs colorScheme="complimentary" {...other}>
     <TabList>
       {data.map((tab) => (
-        <Tab key={tab.label} data-testid={`tab-${tab.label}`}>
+        <Tab
+          key={tab.label}
+          data-testid={`tab-${tab.label}`}
+          _selected={{
+            fontWeight: "600",
+            color: "complimentary.500",
+            borderColor: "complimentary.500",
+          }}
+          fontWeight="500"
+          color="gray.500"
+        >
           {tab.label}
         </Tab>
       ))}
     </TabList>
     <TabPanels>
       {data.map((tab) => (
-        <TabPanel p={4} key={tab.label} data-testid={`tab-panel-${tab.label}`}>
+        <TabPanel px={0} key={tab.label} data-testid={`tab-panel-${tab.label}`}>
           {tab.content}
         </TabPanel>
       ))}

--- a/clients/admin-ui/src/features/common/types.tsx
+++ b/clients/admin-ui/src/features/common/types.tsx
@@ -1,0 +1,5 @@
+export interface TreeNode {
+  label: string;
+  value: string;
+  children: TreeNode[];
+}

--- a/clients/admin-ui/src/features/dataset/DataCategoryInput.tsx
+++ b/clients/admin-ui/src/features/dataset/DataCategoryInput.tsx
@@ -20,7 +20,7 @@ import CheckboxTree from "../common/CheckboxTree";
 import { ArrowDownLineIcon } from "../common/Icon";
 import QuestionTooltip from "../common/QuestionTooltip";
 import DataCategoryTag from "../taxonomy/DataCategoryTag";
-import { transformDataCategoriesToNodes } from "../taxonomy/helpers";
+import { transformTaxonomyEntityToNodes } from "../taxonomy/helpers";
 
 interface Props {
   dataCategories: DataCategory[];
@@ -35,7 +35,7 @@ const DataCategoryDropdown = ({
   onChecked,
 }: Omit<Props, "tooltip">) => {
   const dataCategoryNodes = useMemo(
-    () => transformDataCategoriesToNodes(dataCategories),
+    () => transformTaxonomyEntityToNodes(dataCategories),
     [dataCategories]
   );
 

--- a/clients/admin-ui/src/features/taxonomy/DataCategoryChecklist.tsx
+++ b/clients/admin-ui/src/features/taxonomy/DataCategoryChecklist.tsx
@@ -4,14 +4,14 @@ import { useMemo, useState } from "react";
 import { DataCategory } from "~/types/api";
 
 import CheckboxTree from "../common/CheckboxTree";
-import { transformDataCategoriesToNodes } from "./helpers";
+import { transformTaxonomyEntityToNodes } from "./helpers";
 
 interface Props {
   dataCategories: DataCategory[];
 }
 const DataCategoryChecklist = ({ dataCategories }: Props) => {
   const nodes = useMemo(
-    () => transformDataCategoriesToNodes(dataCategories),
+    () => transformTaxonomyEntityToNodes(dataCategories),
     [dataCategories]
   );
   const [checked, setChecked] = useState<string[]>([]);

--- a/clients/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -1,10 +1,6 @@
 import { Spinner, Text } from "@fidesui/react";
 
-interface TaxonomyEntity {
-  fides_key: string;
-  name?: string;
-  description?: string;
-}
+import { TaxonomyEntity } from "./types";
 
 interface Props {
   isLoading: boolean;

--- a/clients/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -1,5 +1,8 @@
-import { Spinner, Text } from "@fidesui/react";
+import { Box, Center, Spinner, Text } from "@fidesui/react";
+import { useMemo } from "react";
 
+import AccordionTree from "../common/AccordionTree";
+import { transformTaxonomyEntityToNodes } from "./helpers";
 import { TaxonomyEntity } from "./types";
 
 interface Props {
@@ -7,20 +10,28 @@ interface Props {
   data: TaxonomyEntity[] | undefined;
 }
 const TaxonomyTabContent = ({ isLoading, data }: Props) => {
+  const taxonomyNodes = useMemo(() => {
+    if (data) {
+      return transformTaxonomyEntityToNodes(data);
+    }
+    return null;
+  }, [data]);
+
   if (isLoading) {
-    return <Spinner />;
+    return (
+      <Center>
+        <Spinner />
+      </Center>
+    );
   }
-  if (!data) {
+  if (!taxonomyNodes) {
     return <Text>Could not find data.</Text>;
   }
 
-  // TODO: Build actual component, just render data simply for now (#853)
   return (
-    <>
-      {data.map((d) => (
-        <Text key={d.fides_key}>{d.name}</Text>
-      ))}
-    </>
+    <Box w={{ base: "100%", lg: "50%" }}>
+      <AccordionTree nodes={taxonomyNodes} />
+    </Box>
   );
 };
 

--- a/clients/admin-ui/src/features/taxonomy/helpers.ts
+++ b/clients/admin-ui/src/features/taxonomy/helpers.ts
@@ -1,22 +1,28 @@
-import { DataCategory } from "~/types/api";
+import { TaxonomyEntity, TaxonomyEntityNode } from "./types";
 
-import { DataCategoryNode } from "./types";
-
-export const transformDataCategoriesToNodes = (
-  categories: DataCategory[],
+export const transformTaxonomyEntityToNodes = (
+  entities: TaxonomyEntity[],
   parentKey?: string
-): DataCategoryNode[] => {
-  const keyToCompare = parentKey ?? null;
-  const thisLevel = categories.filter(
-    (category) => category.parent_key === keyToCompare
-  );
-  const nodes = thisLevel.map((thisLevelCategory) => {
-    const thisLevelKey = thisLevelCategory.fides_key;
+): TaxonomyEntityNode[] => {
+  let thisLevel: TaxonomyEntity[];
+  // handle the case where there are no parent keys, i.e. should just be a flat list (data subjects)
+  if (
+    parentKey == null &&
+    entities.every((entity) => entity.parent_key === undefined)
+  ) {
+    thisLevel = entities;
+  } else {
+    // handle the case where we have a nested tree structure
+    const keyToCompare = parentKey ?? null;
+    thisLevel = entities.filter((entity) => entity.parent_key === keyToCompare);
+  }
+  const nodes = thisLevel.map((thisLevelEntity) => {
+    const thisLevelKey = thisLevelEntity.fides_key;
     return {
-      value: thisLevelCategory.fides_key,
-      label: thisLevelCategory.name ?? thisLevelCategory.fides_key,
-      description: thisLevelCategory.description,
-      children: transformDataCategoriesToNodes(categories, thisLevelKey),
+      value: thisLevelEntity.fides_key,
+      label: thisLevelEntity.name ?? thisLevelEntity.fides_key,
+      description: thisLevelEntity.description,
+      children: transformTaxonomyEntityToNodes(entities, thisLevelKey),
     };
   });
   return nodes;

--- a/clients/admin-ui/src/features/taxonomy/types.ts
+++ b/clients/admin-ui/src/features/taxonomy/types.ts
@@ -1,6 +1,13 @@
-export interface DataCategoryNode {
+export interface TaxonomyEntityNode {
   value: string;
   label: string;
   description?: string;
-  children: DataCategoryNode[];
+  children: TaxonomyEntityNode[];
+}
+
+export interface TaxonomyEntity {
+  fides_key: string;
+  name?: string;
+  description?: string;
+  parent_key?: string | null;
 }

--- a/clients/admin-ui/src/mocks/data.ts
+++ b/clients/admin-ui/src/mocks/data.ts
@@ -124,6 +124,38 @@ export const MOCK_DATA_CATEGORIES = [
   },
 ];
 
+export const MOCK_DATA_SUBJECTS = [
+  {
+    fides_key: "anonymous_user",
+    organization_fides_key: "default_organization",
+    tags: null,
+    name: "Anonymous User",
+    description:
+      "An individual that is unidentifiable to the systems. Note - This should only be applied to truly anonymous users where there is no risk of re-identification",
+    rights: null,
+    automated_decisions_or_profiling: null,
+  },
+  {
+    fides_key: "citizen_voter",
+    organization_fides_key: "default_organization",
+    tags: null,
+    name: "Citizen Voter",
+    description: "An individual registered to voter with a state or authority.",
+    rights: null,
+    automated_decisions_or_profiling: null,
+  },
+  {
+    fides_key: "commuter",
+    organization_fides_key: "default_organization",
+    tags: null,
+    name: "Commuter",
+    description:
+      "An individual that is traveling or transiting in the context of location tracking.",
+    rights: null,
+    automated_decisions_or_profiling: null,
+  },
+];
+
 export const mockDatasetField = (
   partialField?: Partial<DatasetField>
 ): DatasetField => {


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/853

### Code Changes

* [x] Refactors some of the data category checkbox related code to be more generic so that we can also pass it different types of taxonomy, which often have a similar nested structure. "Data subjects" were trickier since they don't have a `parent_key`: they are not nested. So I had to update `transformTaxonomyEntityToNodes` to be able to handle when a thing is not actually nested.
* [x] New nested AccordionTree component
* [x] Hover state action buttons
* [x] Tests

### Steps to Confirm

* [ ] Visit `/taxonomy` and click around the accordion

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Only thing outstanding is this bit of CSS I'm struggling with: https://github.com/ethyca/fides/pull/910#discussion_r922477720

Other than that, good to review!

https://user-images.githubusercontent.com/24641006/179609287-cc68eceb-0652-4d88-a228-3051334e61c3.mov


