### PR TITLE
Remove duplicate API_PREFIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ The types of changes are:
 * Update `fideslang` to `1.1.0`, simplifying the default taxonomy and adding `tags` for resources [#865](https://github.com/ethyca/fides/pull/865)
 * Remove the `obscure` requirement from the `generate` endpoint [#819](https://github.com/ethyca/fides/pull/819)
 
+### Developer Experience
+
+* Remove `API_PREFIX` from fidesctl/core/utils.py and change references to `API_PREFIX` in fidesctl/api/reoutes/util.py [922](https://github.com/ethyca/fides/pull/922)
+
 ### Docs
 
 * recommend/replace pip installs with pipx [#874](https://github.com/ethyca/fides/pull/874)

--- a/src/fidesctl/api/routes/util.py
+++ b/src/fidesctl/api/routes/util.py
@@ -5,9 +5,8 @@ from typing import Any, Callable
 from fastapi import HTTPException, status
 
 from fidesctl.api.utils.api_router import APIRouter
-from fidesctl.core.utils import API_PREFIX as _API_PREFIX
 
-API_PREFIX = _API_PREFIX
+API_PREFIX = "/api/v1"
 WEBAPP_DIRECTORY = Path("src/fidesctl/api/build/static")
 WEBAPP_INDEX = WEBAPP_DIRECTORY / "index.html"
 

--- a/src/fidesctl/cli/utils.py
+++ b/src/fidesctl/cli/utils.py
@@ -22,6 +22,7 @@ from fideslog.sdk.python.utils import (
 )
 
 import fidesctl
+from fidesctl.api.routes.util import API_PREFIX
 from fidesctl.connectors.models import AWSConfig, BigQueryConfig, OktaConfig
 from fidesctl.core import api as _api
 from fidesctl.core.config import FidesctlConfig
@@ -32,7 +33,7 @@ from fidesctl.core.config.credentials_settings import (
     get_config_okta_credentials,
 )
 from fidesctl.core.config.utils import get_config_from_file, update_config_file
-from fidesctl.core.utils import API_PREFIX, check_response, echo_green, echo_red
+from fidesctl.core.utils import check_response, echo_green, echo_red
 
 
 def check_server(cli_version: str, server_url: str, quiet: bool = False) -> None:

--- a/src/fidesctl/core/api.py
+++ b/src/fidesctl/core/api.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 import requests
 
-from fidesctl.core.utils import API_PREFIX
+from fidesctl.api.routes.util import API_PREFIX
 
 
 def generate_resource_url(

--- a/src/fidesctl/core/utils.py
+++ b/src/fidesctl/core/utils.py
@@ -20,10 +20,6 @@ logger = logging.getLogger("server_api")
 echo_red = partial(click.secho, fg="red", bold=True)
 echo_green = partial(click.secho, fg="green", bold=True)
 
-# This duplicates a constant in `fidesctl/api/routes/utils.py`
-# To avoid import errors
-API_PREFIX = "/api/v1"
-
 
 def check_response(response: requests.Response) -> requests.Response:
     """

--- a/tests/cli/test_cli_utils.py
+++ b/tests/cli/test_cli_utils.py
@@ -4,8 +4,8 @@ import pytest
 from requests_mock import Mocker
 
 import fidesctl.cli.utils as utils
+from fidesctl.api.routes.util import API_PREFIX
 from fidesctl.core.config import FidesctlConfig
-from fidesctl.core.utils import API_PREFIX
 
 
 @pytest.mark.unit

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -10,9 +10,9 @@ from pytest import MonkeyPatch
 from starlette.testclient import TestClient
 
 from fidesctl.api.routes import health
+from fidesctl.api.routes.util import API_PREFIX
 from fidesctl.core import api as _api
 from fidesctl.core.config import FidesctlConfig
-from fidesctl.core.utils import API_PREFIX
 
 
 # Helper Functions


### PR DESCRIPTION
Closes <issue>

### Code Changes

* [x] Remove `API_PREFIX` from fidesctl/core/utils.py and change references to `API_PREFIX` in fidesctl/api/reoutes/util.py

### Steps to Confirm

* [ ] Run test suite

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

`API_PREFIX` was originally duplicated in fidesctl/core/utils.py because the `api` was installed as an extra, and when it was not installed the `API_PREFIX` was not available causing an error. Now that `api` has been moved into fidesctl and is always included this is no longer needed, and removing the duplicate makes maintenance easier.
