### PR TITLE
ui/eslintrc: Turn off "import/prefer-default-export"

### DIFF
--- a/clients/admin-ui/.eslintrc.json
+++ b/clients/admin-ui/.eslintrc.json
@@ -46,6 +46,8 @@
           "^draft"
         ]
       }
-    ]
+    ],
+    // Default exports are slightly preferred for component files, but this rule has too many false positives.
+    "import/prefer-default-export": "off"
   }
 }

--- a/clients/admin-ui/src/features/organization/constants.ts
+++ b/clients/admin-ui/src/features/organization/constants.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export const DEFAULT_ORGANIZATION_FIDES_KEY = "default_organization";

--- a/clients/admin-ui/src/features/taxonomy/helpers.ts
+++ b/clients/admin-ui/src/features/taxonomy/helpers.ts
@@ -2,7 +2,6 @@ import { DataCategory } from "~/types/api";
 
 import { DataCategoryNode } from "./types";
 
-// eslint-disable-next-line import/prefer-default-export
 export const transformDataCategoriesToNodes = (
   categories: DataCategory[],
   parentKey?: string

--- a/clients/admin-ui/src/mocks/browser.ts
+++ b/clients/admin-ui/src/mocks/browser.ts
@@ -2,5 +2,4 @@ import { setupWorker } from "msw";
 
 import { handlers } from "./handlers";
 
-// eslint-disable-next-line import/prefer-default-export
 export const worker = setupWorker(...handlers);

--- a/clients/admin-ui/src/mocks/handlers.ts
+++ b/clients/admin-ui/src/mocks/handlers.ts
@@ -54,7 +54,6 @@ const mockSubjectRequestPreviewResponse = {
   ],
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export const handlers = [
   rest.get<SubjectRequestBody>(
     "http://localhost:8080/api/v1/privacy-request",

--- a/clients/admin-ui/src/mocks/server.ts
+++ b/clients/admin-ui/src/mocks/server.ts
@@ -2,5 +2,4 @@ import { setupServer } from "msw/node";
 
 import { handlers } from "./handlers";
 
-// eslint-disable-next-line import/prefer-default-export
 export const server = setupServer(...handlers);

--- a/clients/admin-ui/src/test-utils.tsx
+++ b/clients/admin-ui/src/test-utils.tsx
@@ -6,8 +6,6 @@ const useRouter = jest.spyOn(require("next/router"), "useRouter");
  * Mocks the useRouter React hook from Next.js on a test-case by test-case basis
  * Adapted from https://github.com/vercel/next.js/issues/7479#issuecomment-587145429
  */
-// we will probably have more than just this in this utils file, so keep it as a non-default export for now
-// eslint-disable-next-line import/prefer-default-export
 export function mockNextUseRouter({
   route = "/",
   pathname = "/",


### PR DESCRIPTION
### Description Of Changes

We keep bumping into this rule with utility modules, so it's doing more harm than good. I considered using [overrides](https://eslint.org/docs/latest/user-guide/configuring/rules#:~:text=syntactically%20valid%20JavaScript.-,Using%20configuration%20files,-To%20disable%20rules) to re-enable the rule for `.tsx` component files, but that's a bit tricky and I personally don't feel that strongly about that pattern anyway. We make good use of index files and `import { Foo as Bar }` when necessary which is usually more ergonomic.
