### PR TITLE
Bump fideslib to 3.0.1 and remove patch code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The types of changes are:
   * Added a nested accordion component for displaying taxonomy data [#910](https://github.com/ethyca/fides/pull/910)
 * Add lru cache to get_config [927](https://github.com/ethyca/fides/pull/927)
 * Add user auth routes [929](https://github.com/ethyca/fides/pull/929)
+* Bump fideslib to 3.0.1 and remove patch code[931](https://github.com/ethyca/fides/pull/931)
 
 ### Changed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ deepdiff==5.8.0
 fastapi==0.77.1
 fastapi-pagination[sqlalchemy]==0.9.3
 fideslang==1.1.0
-fideslib==3.0.0
+fideslib==3.0.1
 fideslog==1.1.5
 GitPython==3.1
 loguru>=0.5,<0.6

--- a/src/fidesctl/api/deps.py
+++ b/src/fidesctl/api/deps.py
@@ -12,7 +12,7 @@ from fideslib.cryptography.schemas.jwt import (
 from fideslib.exceptions import AuthenticationError, AuthorizationError
 from fideslib.oauth.oauth_util import extract_payload, is_token_expired
 from fideslib.oauth.schemas.oauth import OAuth2ClientCredentialsBearer
-from fideslib.oauth.scopes import SCOPES, USER_PASSWORD_RESET
+from fideslib.oauth.scopes import SCOPES
 from sqlalchemy.orm import Session
 
 from fidesctl.api.database.session import sync_session

--- a/src/fidesctl/api/deps.py
+++ b/src/fidesctl/api/deps.py
@@ -74,9 +74,6 @@ async def verify_oauth_client(  # pylint: disable=invalid-name
         raise AuthorizationError(detail="Not Authorized for this action")
 
     # scopes param is only used if client is root client, otherwise we use the client's associated scopes
-
-    # Temporary fix until https://github.com/ethyca/fideslib/issues/54 is resolved
-    SCOPES.append(USER_PASSWORD_RESET)
     client = ClientDetail.get(db, object_id=client_id, config=config, scopes=SCOPES)
 
     if not client:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from fideslib.cryptography.schemas.jwt import (
 )
 from fideslib.models.client import ClientDetail
 from fideslib.oauth.jwt import generate_jwe
-from fideslib.oauth.scopes import PRIVACY_REQUEST_READ, SCOPES, USER_PASSWORD_RESET
+from fideslib.oauth.scopes import PRIVACY_REQUEST_READ, SCOPES
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import ObjectDeletedError
 from starlette.testclient import TestClient

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,9 +285,6 @@ def db() -> Generator:
 def oauth_client(db: Session) -> Generator:
     """Return a client for authentication purposes."""
 
-    # Temporary fix until https://github.com/ethyca/fideslib/issues/54 is resolved
-    SCOPES.append(USER_PASSWORD_RESET)
-
     client = ClientDetail(
         hashed_secret="thisisatest",
         salt="thisisstillatest",
@@ -338,9 +335,6 @@ def user(db: Session) -> Generator:
             "password": "TESTdcnG@wzJeu0&%3Qe2fGo7",
         },
     )
-
-    # Temporary fix until https://github.com/ethyca/fideslib/issues/54 is resolved
-    SCOPES.append(USER_PASSWORD_RESET)
 
     client = ClientDetail(
         hashed_secret="thisisatest",


### PR DESCRIPTION
Closes <issue>

### Code Changes

* [x] Bump fideslib to 3.0.1
* [x] Remove the patching of `SCOPES` which added `USER_PASSWORD_RESET` since it is now coming from fideslib

### Steps to Confirm

* [ ] Run test suite

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

The `USER_PASSWORD_RESET` scope was missing form the `SCOPES` list so I temporarily patched the list with the value. v3.0.1 now contains the value so the patch is no longer needed.
