### PR TITLE
Replace config file string with a constant of the path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ The types of changes are:
 * Endpoints now work with or without a trailing slash. [#886](https://github.com/ethyca/fides/pull/886)
 * Dataset field columns show all columns by default in the UI [#898](https://github.com/ethyca/fides/pull/898)
 * Fixed the `tag` specific GitHub Action workflows for Docker and publishing docs. [#901](https://github.com/ethyca/fides/pull/901)
+* Fixed the missing `.fides./` directory when locating the default config [#933](https://github.com/ethyca/fides/pull/933)
 
 ## [1.7.0](https://github.com/ethyca/fides/compare/1.6.1...1.7.0) - 2022-06-23
 

--- a/src/fidesctl/core/config/__init__.py
+++ b/src/fidesctl/core/config/__init__.py
@@ -18,6 +18,8 @@ from .logging_settings import FidesctlLoggingSettings
 from .security_settings import FidesctlSecuritySettings
 from .user_settings import FidesctlUserSettings
 
+DEFAULT_CONFIG_PATH = ".fides/fidesctl.toml"
+
 
 class FidesctlConfig(BaseModel):
     """Umbrella class that encapsulates all of the config subsections."""
@@ -44,7 +46,7 @@ def get_config(config_path_override: str = "") -> FidesctlConfig:
         settings = (
             toml.load(config_path_override)
             if config_path_override
-            else load_toml(file_names=["fidesctl.toml"])
+            else load_toml(file_names=[DEFAULT_CONFIG_PATH])
         )
 
         # credentials specific logic for populating environment variable configs.

--- a/src/fidesctl/core/config/utils.py
+++ b/src/fidesctl/core/config/utils.py
@@ -4,6 +4,8 @@ from click import echo
 from fideslib.core.config import load_file
 from toml import dump, load
 
+from fidesctl.core.config import DEFAULT_CONFIG_PATH
+
 
 def get_config_from_file(
     config_path_override: str,
@@ -15,7 +17,9 @@ def get_config_from_file(
     """
 
     try:
-        config_path = config_path_override or load_file(file_names=["fidesctl.toml"])
+        config_path = config_path_override or load_file(
+            file_names=[DEFAULT_CONFIG_PATH]
+        )
     except FileNotFoundError as error:
         raise error
 
@@ -42,7 +46,9 @@ def update_config_file(  # type: ignore
     """
 
     try:
-        config_path = config_path_override or load_file(file_names=["fidesctl.toml"])
+        config_path = config_path_override or load_file(
+            file_names=[DEFAULT_CONFIG_PATH]
+        )
     except FileNotFoundError as error:
         raise error
 


### PR DESCRIPTION
Closes #932

### Code Changes

* [x] Replace `"fidesctl.toml"` with `DEFAULT_CONFIG_PATH`

### Steps to Confirm

* [x] A local install of `fidesctl` can read the config and start the webserver

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Another hangup that keeps being found here is the need to manually add the port to the default config. Maybe worth taking a look there to ease startup steps/pain?

I think a good test for this may be to try and validate the webserver without passing the config, but not sure if that makes sense or not as of yet

Testing this PR requires a running db, so executing `docker compose up -d fidesctl-db` is a prereq