### PR TITLE
Dispatch a repository event on new published releases

### DIFF
--- a/.github/workflows/release_event.yml
+++ b/.github/workflows/release_event.yml
@@ -1,0 +1,17 @@
+name: Release Dispatch Event
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  Notify-of-New-Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+          repository: ethyca/fidesctl-plus
+          event-type: new-fidesctl-release
+          client-payload: '{"tag": "${{ github.event.release.tag_name }}", "url": "${{ github.event.release.html_url }}"}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The types of changes are:
 ### Developer Experience
 
 * Remove `API_PREFIX` from fidesctl/core/utils.py and change references to `API_PREFIX` in fidesctl/api/reoutes/util.py [922](https://github.com/ethyca/fides/pull/922)
+* When releases are published, dispatch a repository webhook event to ethyca/fidesctl-plus [#938](https://github.com/ethyca/fides/pull/938)
 
 ### Docs
 


### PR DESCRIPTION
Related to ethyca/fidesctl-plus#27
Blocks ethyca/fidesctl-plus#44

### Code Changes

* [x] Add a new GH Actions workflow to dispatch an event on new releases

### Steps to Confirm

* [ ] Publish a new release
* [ ] ???
* [ ] Observe that the dispatched webhook event was received by the associated ethyca/fidesctl-plus GH Actions workflow

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

### Description Of Changes

There is no way for a GH Actions workflow to read the releases in another repository. In order for an issue to be automatically created in the fidesctl-plus repository whenever a new fidesctl release is published, the act of publishing the fidesctl release must dispatch a repository event to the fidesctl-plus repo. This event is used to trigger a separate GH Actions workflow in the fidesctl-plus repository, which creates the desired issue.