### PR TITLE
Bundle UI static files with the python package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,8 +30,8 @@ docs/
 # Ignore dev files
 .github/
 .devcontainer/
-node_modules/
+**/node_modules/
 
 # Ignore cypress artifacts
-videos/
-screenshots/
+**/videos/
+**/screenshots/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 build/
 dist/
 src/fidesctl.egg-info/
-ui-build/
+src/fidesctl/ui-build/
 
 # Ignore Python-Specific Files
 .mypy_cache/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 build/
 dist/
 src/fidesctl.egg-info/
-src/ui-build/
+ui-build/
 
 # Ignore Python-Specific Files
 .mypy_cache/

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -26,7 +26,9 @@ jobs:
           npm install
 
       - name: Build and export frontend files
-        run: npm run prod-export
+        run: |
+          cd clients/admin-ui
+          npm run prod-export
 
       - name: Install Twine
         run: pip install twine

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Twine Upload
         run: |
           python setup.py sdist bdist_wheel 
-          twine upload --repository testpypi dist/*
+          twine upload dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "*"
+  # TODO: REMOVE THIS!! for testing this workflow only
+  pull_request:
+    branches:
+      - main
 
 jobs:
   upload_to_pypi:

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -4,10 +4,6 @@ on:
   push:
     tags:
       - "*"
-  # TODO: REMOVE THIS!! for testing this workflow only
-  pull_request:
-    branches:
-      - main
 
 jobs:
   upload_to_pypi:

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -11,13 +11,26 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install node modules
+        run: |
+          cd clients/admin-ui
+          npm install
+
+      - name: Build and export frontend files
+        run: npm run prod-export
+
       - name: Install Twine
         run: pip install twine
 
       - name: Twine Upload
         run: |
-          python setup.py sdist 
-          twine upload dist/*
+          python setup.py sdist bdist_wheel 
+          twine upload --repository testpypi dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ The types of changes are:
 * Update `fideslang` to `1.1.0`, simplifying the default taxonomy and adding `tags` for resources [#865](https://github.com/ethyca/fides/pull/865)
 * Remove the `obscure` requirement from the `generate` endpoint [#819](https://github.com/ethyca/fides/pull/819)
 * Merge existing configurations with `fideslib` library [#913](https://github.com/ethyca/fides/pull/913)
-* Moved frontend static files to `src/ui-build/static` [#934](https://github.com/ethyca/fides/pull/934)
+* Moved frontend static files to `src/fidesctl/ui-build/static` [#934](https://github.com/ethyca/fides/pull/934)
 
 ### Developer Experience
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The types of changes are:
 * `fides` is now an alias for `fidesctl` as a CLI entrypoint [#926](https://github.com/ethyca/fides/pull/926)
 * Add user auth routes [929](https://github.com/ethyca/fides/pull/929)
 * Bump fideslib to 3.0.1 and remove patch code[931](https://github.com/ethyca/fides/pull/931)
+* Update the `fidesctl` python package to automatically serve the UI [#941](https://github.com/ethyca/fides/pull/941)
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ ENV PYTHONUNBUFFERED=TRUE
 ENV RUNNING_IN_DOCKER=TRUE
 
 # Make a static files directory
-RUN mkdir -p src/ui-build/static/admin
+RUN mkdir -p src/fidesctl/ui-build/static/admin
 
 EXPOSE 8080
 CMD ["fidesctl", "webserver"]
@@ -116,4 +116,4 @@ RUN python setup.py sdist
 RUN pip install dist/fidesctl-*.tar.gz
 
 # Copy frontend build over
-COPY --from=frontend /fides/clients/admin-ui/out/ /fides/src/ui-build/static/admin/
+COPY --from=frontend /fides/clients/admin-ui/out/ /fides/src/fidesctl/ui-build/static/admin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,9 +90,6 @@ ENV PYTHONUNBUFFERED=TRUE
 # Enable detection of running within Docker
 ENV RUNNING_IN_DOCKER=TRUE
 
-# Make a static files directory
-RUN mkdir -p src/fidesctl/ui-build/static/admin
-
 EXPOSE 8080
 CMD ["fidesctl", "webserver"]
 
@@ -112,7 +109,7 @@ RUN pip install -e ".[all,mssql]"
 FROM builder as prod
 
 # Copy frontend build over in order to be available in wheel package
-COPY --from=frontend /fides/clients/admin-ui/out/ /fides/src/ui-build/static/admin/
+COPY --from=frontend /fides/clients/admin-ui/out/ /fides/src/fidesctl/ui-build/static/admin/
 
 # Install without a symlink
 RUN python setup.py bdist_wheel 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,11 @@ FROM node:16 as frontend
 WORKDIR /fides/clients/admin-ui
 
 # install node modules
-COPY clients/admin-ui/package.json .
+COPY clients/admin-ui/ .
 RUN npm install
+
+# Build the frontend static files
+RUN npm run export
 
 #######################
 ## Tool Installation ##
@@ -108,9 +111,8 @@ RUN pip install -e ".[all,mssql]"
 
 FROM builder as prod
 
-# Install node in order for the wheel to compile the frontend
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -y nodejs rsync
+# Copy frontend build over in order to be available in wheel package
+COPY --from=frontend /fides/clients/admin-ui/out/ /fides/src/ui-build/static/admin/
 
 # Install without a symlink
 RUN python setup.py bdist_wheel 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,8 @@ FROM node:16 as frontend
 WORKDIR /fides/clients/admin-ui
 
 # install node modules
-COPY clients/admin-ui/ .
+COPY clients/admin-ui/package.json .
 RUN npm install
-
-# Build the frontend static files
-RUN npm run export
 
 #######################
 ## Tool Installation ##
@@ -111,9 +108,10 @@ RUN pip install -e ".[all,mssql]"
 
 FROM builder as prod
 
-# Install without a symlink
-RUN python setup.py sdist
-RUN pip install dist/fidesctl-*.tar.gz
+# Install node in order for the wheel to compile the frontend
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y nodejs rsync
 
-# Copy frontend build over
-COPY --from=frontend /fides/clients/admin-ui/out/ /fides/src/fidesctl/ui-build/static/admin/
+# Install without a symlink
+RUN python setup.py bdist_wheel 
+RUN pip install dist/fidesctl-*.whl

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include dev-requirements.txt
 include versioneer.py
 include src/fidesctl/api/ctl/alembic.ini
 include src/fidesctl/templates/fides_datamap_template.xlsx
+recursive-include src/ui-build *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ include dev-requirements.txt
 include versioneer.py
 include src/fidesctl/api/ctl/alembic.ini
 include src/fidesctl/templates/fides_datamap_template.xlsx
-recursive-include src/ui-build *
+recursive-include src/fidesctl/ui-build *

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -14,7 +14,7 @@
     "analyze:server": "cross-env BUNDLE_ANALYZE=server next build",
     "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build",
     "export": "next build && next export",
-    "copy-export": "rsync -a --delete out/ ../../src/ui-build/static/admin/",
+    "copy-export": "mkdir -p ../../src/fidesctl/ui-build/static/admin/ && rsync -a --delete out/ ../../src/fidesctl/ui-build/static/admin/",
     "prod-export": "npm run export && npm run copy-export",
     "cy:open": "cypress open",
     "cy:run": "cypress run",

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,6 @@ warn_untyped_fields = True
 
 [mypy-src.fidesctl._version]
 ignore_errors = True
+
+[bdist_wheel]
+universal = True

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,7 @@
 import pathlib
-import subprocess
-from distutils.cmd import Command
 
 import versioneer
 from setuptools import find_packages, setup
-from setuptools.command.build_py import build_py
-
-
-class NPMExportCommand(Command):
-    """Custom command to export our frontend UI"""
-
-    description = "build the UI via npm"
-    user_options = [("client-name=", None, "name of client to export")]
-
-    def initialize_options(self) -> None:
-        """Set default values for options. We only have the admin-ui
-        right now, so set that as the default."""
-        self.client_name = "admin-ui"
-
-    def finalize_options(self) -> None:
-        """Post-process options"""
-        return
-
-    def run(self) -> None:
-        """Run npm export"""
-        directory = f"clients/{self.client_name}"
-        install_command = "npm install"
-        build_command = "npm run prod-export"
-        subprocess.check_call(install_command.split(" "), cwd=directory)
-        subprocess.check_call(build_command.split(" "), cwd=directory)
-
-
-class BuildPyCommand(build_py):
-    """Extend the default build_py command to also call our custom npm export command"""
-
-    def run(self) -> None:
-        self.run_command("npm_export")
-        build_py.run(self)
-
 
 here = pathlib.Path(__file__).parent.resolve()
 long_description = open("README.md").read()
@@ -72,21 +36,15 @@ extras["all"] = sum(
     [value for key, value in extras.items() if key not in dangerous_extras], []
 )
 
-versioneer_cmdclass = versioneer.get_cmdclass()
-npm_export_cmdclass = {"npm_export": NPMExportCommand}
-build_py_cmdclass = {"build_py": BuildPyCommand}
-
 setup(
     name="fidesctl",
     version=versioneer.get_version(),
-    cmdclass={**versioneer_cmdclass, **npm_export_cmdclass, **build_py_cmdclass},
+    cmdclass=versioneer.get_cmdclass(),
     description="CLI for Fides",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ethyca/fides",
-    entry_points={
-        "console_scripts": ["fidesctl=fidesctl.cli:cli", "fides=fidesctl.cli:cli"]
-    },
+    entry_points={"console_scripts": ["fidesctl=fidesctl.cli:cli","fides=fidesctl.cli:cli"]},
     python_requires=">=3.8, <4",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/fidesctl/api/ctl/routes/util.py
+++ b/src/fidesctl/api/ctl/routes/util.py
@@ -6,7 +6,6 @@ from fastapi import HTTPException, status
 from fidesctl.api.ctl.utils.api_router import APIRouter
 
 API_PREFIX = "/api/v1"
-ADMIN_UI_DIRECTORY = "ui-build/static/admin/"
 
 
 def get_resource_type(router: APIRouter) -> str:

--- a/src/fidesctl/api/ctl/routes/util.py
+++ b/src/fidesctl/api/ctl/routes/util.py
@@ -1,5 +1,4 @@
 from functools import update_wrapper
-from pathlib import Path
 from typing import Any, Callable
 
 from fastapi import HTTPException, status
@@ -7,9 +6,7 @@ from fastapi import HTTPException, status
 from fidesctl.api.ctl.utils.api_router import APIRouter
 
 API_PREFIX = "/api/v1"
-FRONTEND_BUILD_DIRECTORY = Path("src/ui-build/static")
-WEBAPP_DIRECTORY = FRONTEND_BUILD_DIRECTORY / "admin"
-WEBAPP_INDEX = WEBAPP_DIRECTORY / "index.html"
+ADMIN_UI_DIRECTORY = "ui-build/static/admin/"
 
 
 def get_resource_type(router: APIRouter) -> str:

--- a/src/fidesctl/api/ctl/ui.py
+++ b/src/fidesctl/api/ctl/ui.py
@@ -1,0 +1,31 @@
+"""Various functions to help serve the UI from our server"""
+
+import importlib.util
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Response
+from fastapi.responses import FileResponse
+
+ADMIN_UI_DIRECTORY = "ui-build/static/admin/"
+
+
+def get_path_to_ui_file(package_name: str, path: str) -> Optional[Path]:
+    """Return a path to a UI file within a given package"""
+    spec = importlib.util.find_spec(package_name)
+    if spec is None:
+        return None
+    return Path(spec.origin).parent / path if spec.origin else None
+
+
+def get_path_to_admin_ui_file(path: str) -> Optional[Path]:
+    """Return a path to an admin UI file."""
+    return get_path_to_ui_file("fidesctl", ADMIN_UI_DIRECTORY + path)
+
+
+def get_admin_index_as_response() -> Response:
+    """Get just the frontend index file as a FileResponse.
+    If it does not exist, return a placeholder."""
+    placeholder = "<h1>Privacy is a Human Right!</h1>"
+    index = get_path_to_admin_ui_file("index.html")
+    return FileResponse(index) if index and index.is_file() else Response(placeholder)

--- a/src/fidesctl/api/ctl/ui.py
+++ b/src/fidesctl/api/ctl/ui.py
@@ -20,7 +20,8 @@ def get_path_to_ui_file(package_name: str, path: str) -> Optional[Path]:
 
 def get_path_to_admin_ui_file(path: str) -> Optional[Path]:
     """Return a path to an admin UI file."""
-    return get_path_to_ui_file("fidesctl", ADMIN_UI_DIRECTORY + path)
+    package_name = __package__.split(".")[0]
+    return get_path_to_ui_file(package_name, ADMIN_UI_DIRECTORY + path)
 
 
 def get_admin_index_as_response() -> Response:

--- a/src/fidesctl/api/main.py
+++ b/src/fidesctl/api/main.py
@@ -81,7 +81,7 @@ def get_ui_file(path: str) -> Optional[Path]:
 def get_index_response() -> Response:
     placeholder = "<h1>Privacy is a Human Right!</h1>"
     index = get_ui_file("index.html")
-    return FileResponse(index) if index and index.exists() else Response(placeholder)
+    return FileResponse(index) if index and index.is_file() else Response(placeholder)
 
 
 @app.on_event("startup")
@@ -130,7 +130,7 @@ def read_other_paths(request: Request) -> Response:
     # check first if requested file exists (for frontend assets)
     path = request.path_params["catchall"]
     ui_file = get_ui_file(path)
-    if ui_file and ui_file.exists():
+    if ui_file and ui_file.is_file():
         return FileResponse(ui_file)
 
     # raise 404 for anything that should be backend endpoint but we can't find it

--- a/src/fidesctl/api/main.py
+++ b/src/fidesctl/api/main.py
@@ -67,8 +67,6 @@ app.dependency_overrides[lib_verify_oauth_client] = verify_oauth_client
 
 def get_ui_file(path: str) -> Optional[Path]:
     """Return a path to a UI file within the package"""
-
-    # TODO: test in the actual package environment!!
     loader = pkgutil.get_loader(__package__)
     if loader:
         # will yield [...]/src/fidesctl/api/__init__.py


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/940

### Code Changes

* [x] Moves the frontend build to `src/fidesctl/ui-build`
* [x] Adds the built frontend files to `MANIFEST.in`
* [x] Updates the `package.json` `prod-export` command to make sure the directory is created if it isn't already
* [x] Build wheels along with sdist
* [x] Modify Dockerfile a bit to allow for building the frontend before the pip install in prod builds
* [x] Modify the publish package workflow to build the frontend before building the wheel and uploading to twine
* [x] Refactored the way we grabbed the static assets to host. Instead of using direct paths, looks into paths relative to the package using `importlib`. This is needed so that running just `fidesctl webserver` without the docker container will work. Note that this no longer writes out a placeholder `index.html` which I think is cleaner.

### Steps to Confirm

Via just building and installing the Python package
* [ ] In `clients/admin-ui`, run `npm prod-export`
* [ ] In the root of the repo, run `python setup.py sdist bdist_wheel`. This will build both an sdist and a wheel in your `dist/` directory
* [ ] In a clean virtual environment, install either the sdist or the wheel `pip install dist/fidesctl-*.whl`
* [ ] Run `fidesctl webserver` and you should be able to see the UI at localhost:8080

Via docker
* [ ] `nox -s "build(prod)"`
* [ ] In your docker-compose, replace `image: ethyca/fidesctl:local` with the name of the image that was built in the previous step. Also comment out the volume mount to be extra sure we're only looking at the built docker container and not our own files.
* [ ] `docker-compose up fidesctl`
* [ ] Wait for it to be ready, then check out the UI at localhost:8080

Via pypi
Haven't been able to fully test this yet, as I don't want to upload to the real pypi yet, and the creds don't seem to work in testpypi. But in theory you'd just do a `pip install fidesctl` and then you'd be able to run `fidesctl webserver` right away

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Fairly sure that the publish package workflow will work, since it got as far as uploading to twine before it failed (403) https://github.com/ethyca/fides/runs/7547449743?check_suite_focus=true
