### PR TITLE
Add push command to deprecate apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The types of changes are:
 * `fides` is now an alias for `fidesctl` as a CLI entrypoint [#926](https://github.com/ethyca/fides/pull/926)
 * Add user auth routes [929](https://github.com/ethyca/fides/pull/929)
 * Bump fideslib to 3.0.1 and remove patch code[931](https://github.com/ethyca/fides/pull/931)
+* Add `push` cli command alias for `apply` and deprecate `apply` [943](https://github.com/ethyca/fides/pull/943)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ This guide will walk through generating a mock RoPA using predefined resources i
 3. Use the `export datamap` command to generate a [data map](/docs/fides/docs/guides/generating_datamap.md) of the provided [demo resources](demo_resources/):
 
     ```sh
-    fidesctl apply demo_resources/
+    fidesctl push demo_resources/
     fidesctl export datamap --output-dir demo_resources/
     ```
 
-    This will `apply` the provided demo resources, and `export` an `.xlsx` file of their contents to the `demo_resources/` directory.
+    This will `push` the provided demo resources, and `export` an `.xlsx` file of their contents to the `demo_resources/` directory.
 
 4. View the newly-generated data map generated from the provided resources.
 
@@ -120,7 +120,7 @@ This guide will walk through generating a mock RoPA using predefined resources i
 
     `--audit` flags any empty fields, along with the System or Organization they belong to, and returns where or not the system is incomplete or fully compliant. In the above example, the Organization resource is compliant, but both the Marketing and Analytics systems are missing information that would be required in your RoPA.
 
-Now that you've seen how Fides can generate a data map from your resources and assess them for compliance, learn how you can [extend the Fides taxonomy](https://ethyca.github.io/fides/guides/generating_datamap/#extend-the-default-taxonomy) to replace the missing values revealed by `--audit` with additional data, and apply your changes to generate an [Article 30-compliant RoPA](https://ethyca.github.io/fides/guides/generating_datamap/#generate-a-ropa).
+Now that you've seen how Fides can generate a data map from your resources and assess them for compliance, learn how you can [extend the Fides taxonomy](https://ethyca.github.io/fides/guides/generating_datamap/#extend-the-default-taxonomy) to replace the missing values revealed by `--audit` with additional data, and push your changes to generate an [Article 30-compliant RoPA](https://ethyca.github.io/fides/guides/generating_datamap/#generate-a-ropa).
 
 ## :book: Learn More
 

--- a/docs/fides/docs/cicd/overview.md
+++ b/docs/fides/docs/cicd/overview.md
@@ -20,7 +20,7 @@ Implementing Fidesctl is possible in nearly any CI pipeline, including those not
 To integrate Fidesctl with your CI pipeline, you should plan to implement at least two CI actions:
 
 1. `fidesctl evaluate --dry <resource_dir>`
-    - `evaluate --dry` checks if code changes will be accepted without applying those changes to the fidesctl server.
+    - `evaluate --dry` checks if code changes will be accepted without pushing those changes to the fidesctl server.
     - Run this against the latest commit on code changesets (pull requests, merge requests, etc).
 2. `fidesctl evaluate <resource_dir>`
     - `evaluate` synchronizes the latest changes to the fidesctl server.

--- a/docs/fides/docs/guides/generating_datamap.md
+++ b/docs/fides/docs/guides/generating_datamap.md
@@ -7,10 +7,10 @@ To follow along, ensure you have the Fides repository cloned and fidesctl instal
 
 First, ensure `fidesctl` is running with `nox -s dev`.
 
-To apply and export the provided `demo_resources`, run the following commands:
+To push and export the provided `demo_resources`, run the following commands:
 
-```sh title="Apply and Export Defaults"
-fidesctl apply demo_resources/
+```sh title="Push and Export Defaults"
+fidesctl push demo_resources/
 fidesctl export datamap --output-dir demo_resources/
 ```
 
@@ -271,7 +271,7 @@ system:
         automated_decisions_or_profiling: true
 ```
 
-Running `fidesctl apply demo_resources/` will apply your changes.
+Running `fidesctl push demo_resources/` will push your changes.
 
 Now, auditing this resource with `fidesctl evaluate demo_resources --audit` will show the Demo Marketing System issues are resolved:
 ```bash
@@ -307,8 +307,8 @@ automated_decisions_or_profiling for potential_customer in Demo Marketing System
 
 Now that you have added the additional information around privacy notices and data subject rights, you can export a fresh copy of your data map:
 
-```sh title="Apply and Export Defaults"
-$ fidesctl apply demo_resources/
+```sh title="Push and Export Defaults"
+$ fidesctl push demo_resources/
 $ fidesctl export datamap --output_dir demo_resources/
 ```
 

--- a/src/fidesctl/cli/__init__.py
+++ b/src/fidesctl/cli/__init__.py
@@ -11,7 +11,7 @@ from fidesctl.cli.utils import check_and_update_analytics_config, check_server
 from fidesctl.ctl.core.config import get_config
 
 from .commands.annotate import annotate
-from .commands.core import apply, evaluate, parse, pull
+from .commands.core import apply, evaluate, parse, pull, push
 from .commands.crud import delete, get, ls
 from .commands.db import database
 from .commands.export import export
@@ -25,17 +25,7 @@ LOCAL_COMMANDS = [evaluate, generate, init, scan, parse, view, webserver]
 LOCAL_COMMAND_DICT = {
     command.name or str(command): command for command in LOCAL_COMMANDS
 }
-API_COMMANDS = [
-    annotate,
-    apply,
-    database,
-    delete,
-    export,
-    get,
-    ls,
-    status,
-    pull,
-]
+API_COMMANDS = [annotate, apply, database, delete, export, get, ls, status, pull, push]
 API_COMMAND_DICT = {command.name or str(command): command for command in API_COMMANDS}
 ALL_COMMANDS = API_COMMANDS + LOCAL_COMMANDS
 SERVER_CHECK_COMMAND_NAMES = [

--- a/src/fidesctl/cli/commands/core.py
+++ b/src/fidesctl/cli/commands/core.py
@@ -18,7 +18,7 @@ from fidesctl.ctl.core import pull as _pull
 from fidesctl.ctl.core.utils import git_is_dirty
 
 
-@click.command()
+@click.command(deprecated=True)
 @click.pass_context
 @dry_flag
 @click.option(
@@ -31,6 +31,7 @@ from fidesctl.ctl.core.utils import git_is_dirty
 def apply(ctx: click.Context, dry: bool, diff: bool, manifests_dir: str) -> None:
     """
     Validate local manifest files and persist any changes via the API server.
+    Deprecated in favor of `fidesctl push` command.
     """
 
     config = ctx.obj["CONFIG"]
@@ -42,6 +43,23 @@ def apply(ctx: click.Context, dry: bool, diff: bool, manifests_dir: str) -> None
         dry=dry,
         diff=diff,
     )
+
+
+@click.command()
+@click.pass_context
+@dry_flag
+@click.option(
+    "--diff",
+    is_flag=True,
+    help="Include any changes between server and local resources in the command output",
+)
+@manifests_dir_argument
+@with_analytics
+def push(ctx: click.Context, dry: bool, diff: bool, manifests_dir: str) -> None:
+    """
+    Validate local manifest files and persist any changes via the API server.
+    """
+    apply(ctx=ctx, dry=dry, diff=diff, manifests_dir=manifests_dir)
 
 
 @click.command()

--- a/src/fidesctl/cli/commands/core.py
+++ b/src/fidesctl/cli/commands/core.py
@@ -10,11 +10,11 @@ from fidesctl.cli.options import (
     verbose_flag,
 )
 from fidesctl.cli.utils import echo_red, pretty_echo, print_divider, with_analytics
-from fidesctl.ctl.core import push as _push
 from fidesctl.ctl.core import audit as _audit
 from fidesctl.ctl.core import evaluate as _evaluate
 from fidesctl.ctl.core import parse as _parse
 from fidesctl.ctl.core import pull as _pull
+from fidesctl.ctl.core import push as _push
 from fidesctl.ctl.core.utils import git_is_dirty
 
 
@@ -112,7 +112,7 @@ def evaluate(
         dry = True
     else:
         taxonomy = _parse.parse(manifests_dir)
-        _apply.apply(
+        _push.push(
             url=config.cli.server_url,
             taxonomy=taxonomy,
             headers=config.user.request_headers,

--- a/src/fidesctl/cli/commands/core.py
+++ b/src/fidesctl/cli/commands/core.py
@@ -10,7 +10,7 @@ from fidesctl.cli.options import (
     verbose_flag,
 )
 from fidesctl.cli.utils import echo_red, pretty_echo, print_divider, with_analytics
-from fidesctl.ctl.core import apply as _apply
+from fidesctl.ctl.core import push as _push
 from fidesctl.ctl.core import audit as _audit
 from fidesctl.ctl.core import evaluate as _evaluate
 from fidesctl.ctl.core import parse as _parse
@@ -34,9 +34,10 @@ def apply(ctx: click.Context, dry: bool, diff: bool, manifests_dir: str) -> None
     Deprecated in favor of `fidesctl push` command.
     """
 
+    echo_red("Use the 'push' command instead.")
     config = ctx.obj["CONFIG"]
     taxonomy = _parse.parse(manifests_dir)
-    _apply.apply(
+    _push.push(
         url=config.cli.server_url,
         taxonomy=taxonomy,
         headers=config.user.request_headers,
@@ -62,7 +63,7 @@ def push(ctx: click.Context, dry: bool, diff: bool, manifests_dir: str) -> None:
 
     config = ctx.obj["CONFIG"]
     taxonomy = _parse.parse(manifests_dir)
-    _apply.apply(
+    _push.push(
         url=config.cli.server_url,
         taxonomy=taxonomy,
         headers=config.user.request_headers,

--- a/src/fidesctl/cli/commands/core.py
+++ b/src/fidesctl/cli/commands/core.py
@@ -59,7 +59,16 @@ def push(ctx: click.Context, dry: bool, diff: bool, manifests_dir: str) -> None:
     """
     Validate local manifest files and persist any changes via the API server.
     """
-    apply(ctx=ctx, dry=dry, diff=diff, manifests_dir=manifests_dir)
+
+    config = ctx.obj["CONFIG"]
+    taxonomy = _parse.parse(manifests_dir)
+    _apply.apply(
+        url=config.cli.server_url,
+        taxonomy=taxonomy,
+        headers=config.user.request_headers,
+        dry=dry,
+        diff=diff,
+    )
 
 
 @click.command()

--- a/src/fidesctl/ctl/core/push.py
+++ b/src/fidesctl/ctl/core/push.py
@@ -1,4 +1,4 @@
-"""This module handles the logic required for applying manifest files to the server."""
+"""This module handles the logic required for pushing manifest files to the server."""
 from json import loads
 from pprint import pprint
 from typing import Dict, List, Tuple
@@ -62,7 +62,7 @@ def sort_create_update(
 
 def echo_results(action: str, resource_type: str, resource_count: int) -> None:
     """
-    Echo out the results of the apply.
+    Echo out the results of the push.
     """
     echo_green(f"{action.upper()} {resource_count} {resource_type} resource(s).")
 
@@ -95,7 +95,7 @@ def get_orphan_datasets(taxonomy: Taxonomy) -> List:
     return missing_datasets
 
 
-def apply(
+def push(
     url: str,
     taxonomy: Taxonomy,
     headers: Dict[str, str],
@@ -103,7 +103,7 @@ def apply(
     diff: bool = False,
 ) -> None:
     """
-    Apply the current manifest file state to the server.
+    Push the current manifest file state to the server.
     """
 
     missing_datasets = get_orphan_datasets(taxonomy)
@@ -145,6 +145,6 @@ def apply(
             verbose=False,
         )
 
-        echo_results("applied", resource_type, len(resource_list))
+        echo_results("pushed", resource_type, len(resource_list))
 
     print("-" * 10)

--- a/tests/ctl/cli/test_cli.py
+++ b/tests/ctl/cli/test_cli.py
@@ -107,6 +107,42 @@ def test_dry_diff_apply(test_config_path: str, test_cli_runner: CliRunner) -> No
 
 
 @pytest.mark.integration
+def test_push(test_config_path: str, test_cli_runner: CliRunner) -> None:
+    result = test_cli_runner.invoke(
+        cli, ["-f", test_config_path, "push", "demo_resources/"]
+    )
+    print(result.output)
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_dry_push(test_config_path: str, test_cli_runner: CliRunner) -> None:
+    result = test_cli_runner.invoke(
+        cli, ["-f", test_config_path, "push", "--dry", "demo_resources/"]
+    )
+    print(result.output)
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_diff_push(test_config_path: str, test_cli_runner: CliRunner) -> None:
+    result = test_cli_runner.invoke(
+        cli, ["-f", test_config_path, "push", "--diff", "demo_resources/"]
+    )
+    print(result.output)
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_dry_diff_push(test_config_path: str, test_cli_runner: CliRunner) -> None:
+    result = test_cli_runner.invoke(
+        cli, ["-f", test_config_path, "push", "--dry", "--diff", "demo_resources/"]
+    )
+    print(result.output)
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
 class TestPull:
     def test_pull(
         self,

--- a/tests/ctl/core/test_apply.py
+++ b/tests/ctl/core/test_apply.py
@@ -5,7 +5,7 @@ from typing import Dict, Generator, List
 import fideslang as models
 import pytest
 
-from fidesctl.ctl.core.apply import get_orphan_datasets, sort_create_update
+from fidesctl.ctl.core.push import get_orphan_datasets, sort_create_update
 
 
 # Helpers


### PR DESCRIPTION
Closes #923 

### Code Changes

* [x] Add a `push` command which calls existing `apply` call
* [x] Added deprecated flag to `apply` command
* [x] Added integration tests for `push` which just follow same structure as apply. 

### Steps to Confirm

* [x] Manual Testing
* [x] Integration tests test new command and old still

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

I looked into using something fancy to solve this but it doesn't really seem worth it. This [library](https://github.com/click-contrib/click-aliases) provides the ability to add an alias to a command but the downside is that there is no option to deprecate the command. 

Open to trying a more complex change but this feels like a good bridge to eventually remove the `apply` command. 

#### Apply command output
```
fides> fides apply
DeprecationWarning: The command 'apply' is deprecated.
Use the 'push' command instead.
Loading resource manifests from: .fides/
Taxonomy successfully created.
----------
Processing system resource(s)...
PUSHED 1 system resource(s).
----------
Processing policy resource(s)...
PUSHED 2 policy resource(s).
----------
Processing dataset resource(s)...
PUSHED 1 dataset resource(s).
```
#### Push command output
```
fides> fides push 
Loading resource manifests from: .fides/
Taxonomy successfully created.
----------
Processing system resource(s)...
PUSHED 1 system resource(s).
----------
Processing dataset resource(s)...
PUSHED 1 dataset resource(s).
----------
Processing policy resource(s)...
PUSHED 2 policy resource(s).
```