### PR TITLE
Remove usage of event.ref in release workflow for publishing docs

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -8,6 +8,7 @@ on:
     types: [published]
 
 env:
+  TAG: ${{ github.event.release.tag_name }}
   PROD_PUBLISH: true
 
 jobs:
@@ -47,27 +48,13 @@ jobs:
       # Deploys docs without a version in the URL for legacy links
       # This will match the "stable" version of the versioned docs
 
-      - name: Check Prod Tag
-        id: check-tag
-        run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=match::true
-          fi
-
-      - name: Get Version
-        id: get-version
-        if: steps.check-tag.outputs.match == 'true'
-        run: |
-          version=$(echo ${{ github.event.ref }} | cut -d/ -f3)
-          echo "::set-output name=version::$version"
-
       - name: Deploy the Legacy Docs if a Release is Published
-        if: steps.check-tag.outputs.match == 'true'
+        if: ${{ env.TAG }}
         run: mkdocs gh-deploy -v -f docs/fides/mkdocs.yml --force
 
       - name: Deploy Stable Docs if a Release is Published
-        if: steps.check-tag.outputs.match == 'true'
-        run: mike deploy --config-file docs/fides/mkdocs.yml --push --update-aliases ${{ steps.get-version.outputs.version }} stable
+        if: ${{ env.TAG }}
+        run: mike deploy --config-file docs/fides/mkdocs.yml --push --update-aliases ${{ env.TAG }} stable
 
       # This will match "stable" when a new release is cut
       - name: Deploy Dev Docs


### PR DESCRIPTION
Closes #947 

### Code Changes

* [x] Revert to using `github.event.release.tag_name` as the docs workflow relies on a release event which does not include `github.event.ref` used now 

### Steps to Confirm

* [x] Not sure how to confirm but this used to work

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

https://github.com/ethyca/fides/pull/901 Fixed the docker release not working. This was not working before because the docker logic was depending on a release event github.event.release.tag_name. This didnt work because the docker event is actually a push event, not a release event. Unfortunately this fix was also applied to the docs workflow but this one actually is triggered by a release event.
