### PR TITLE
Re-add deprecated API settings for backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The types of changes are:
 * Added taxonomy page to UI [#902](https://github.com/ethyca/fides/pull/902)
   * Added a nested accordion component for displaying taxonomy data [#910](https://github.com/ethyca/fides/pull/910)
 * Add lru cache to get_config [927](https://github.com/ethyca/fides/pull/927)
+* Add support for deprecated API config values [#959](https://github.com/ethyca/fides/pull/959)
 * `fides` is now an alias for `fidesctl` as a CLI entrypoint [#926](https://github.com/ethyca/fides/pull/926)
 * Add user auth routes [929](https://github.com/ethyca/fides/pull/929)
 * Bump fideslib to 3.0.1 and remove patch code[931](https://github.com/ethyca/fides/pull/931)
@@ -59,14 +60,15 @@ The types of changes are:
 
 ### Docs
 
-
 ### Fixed
 
 * Dataset field columns show all columns by default in the UI [#898](https://github.com/ethyca/fides/pull/898)
 * Fixed the missing `.fides./` directory when locating the default config [#933](https://github.com/ethyca/fides/pull/933)
 
 ## [1.7.1](https://github.com/ethyca/fides/compare/1.7.0...1.7.1) - 2022-07-28
+
 ### Added
+
 * Add datasets via YAML in the UI [#813](https://github.com/ethyca/fides/pull/813)
 * Add datasets via database connection [#834](https://github.com/ethyca/fides/pull/834) [#889](https://github.com/ethyca/fides/pull/889)
 * Add delete confirmation when deleting a field or collection from a dataset [#809](https://github.com/ethyca/fides/pull/809)
@@ -78,15 +80,19 @@ The types of changes are:
 * Added OpenAPI TypeScript client generation for the UI app. See the [README](/clients/admin-ui/src/types/api/README.md) for more details.
 
 ### Changed
+
 * Remove the `obscure` requirement from the `generate` endpoint [#819](https://github.com/ethyca/fides/pull/819)
 
 ### Developer Experience
+
 * When releases are published, dispatch a repository webhook event to ethyca/fidesctl-plus [#938](https://github.com/ethyca/fides/pull/938)
 
 ### Docs
+
 * recommend/replace pip installs with pipx [#874](https://github.com/ethyca/fides/pull/874)
 
 ### Fixed
+
 * CustomSelect input tooltips appear next to selector instead of wrapping to a new row.
 * Datasets without the `third_country_transfer` will not cause the editing dataset form to not render.
 * Fixed a build issue causing an `unknown` version of `fidesctl` to be installed in published Docker images [#836](https://github.com/ethyca/fides/pull/836)
@@ -94,7 +100,6 @@ The types of changes are:
 * Endpoints now work with or without a trailing slash. [#886](https://github.com/ethyca/fides/pull/886)
 * Dataset field columns show all columns by default in the UI [#898](https://github.com/ethyca/fides/pull/898)
 * Fixed the `tag` specific GitHub Action workflows for Docker and publishing docs. [#901](https://github.com/ethyca/fides/pull/901)
-
 
 ## [1.7.0](https://github.com/ethyca/fides/compare/1.6.1...1.7.0) - 2022-06-23
 

--- a/src/fidesctl/cli/utils.py
+++ b/src/fidesctl/cli/utils.py
@@ -1,6 +1,7 @@
 """Contains reusable utils for the CLI commands."""
 
 import json
+import pprint
 import sys
 from datetime import datetime, timezone
 from functools import update_wrapper
@@ -74,7 +75,9 @@ def pretty_echo(dict_object: Dict, color: str = "white") -> None:
     """
     Given a dict-like object and a color, pretty click echo it.
     """
-    click.secho(json.dumps(dict_object, indent=2), fg=color)
+    click.secho(
+        pprint.pformat(dict_object, indent=2, width=80, compact=True, depth=2), fg=color
+    )
 
 
 def handle_cli_response(

--- a/src/fidesctl/ctl/core/config/__init__.py
+++ b/src/fidesctl/ctl/core/config/__init__.py
@@ -3,7 +3,7 @@ This module is responsible for combining all of the different
 config sections into a single config.
 """
 from functools import lru_cache
-from typing import Dict
+from typing import Dict, MutableMapping
 
 import toml
 from fideslib.core.config import load_toml
@@ -25,12 +25,20 @@ class FidesctlConfig(BaseModel):
     """Umbrella class that encapsulates all of the config subsections."""
 
     cli: FidesctlCLISettings = FidesctlCLISettings()
-    # Add the API settings back here
     user: FidesctlUserSettings = FidesctlUserSettings()
     credentials: Dict[str, Dict] = dict()
     database: FidesctlDatabaseSettings = FidesctlDatabaseSettings()
     security: FidesctlSecuritySettings = FidesctlSecuritySettings()
     logging: FidesctlLoggingSettings = FidesctlLoggingSettings()
+
+
+def handle_deprecated_fields(settings: MutableMapping) -> MutableMapping:
+    """Custom logic for handling deprecated values."""
+
+    if settings.get("api"):
+        api_settings = settings.pop("api")
+        print("The API settings are there.")
+    return settings
 
 
 @lru_cache(maxsize=1)

--- a/src/fidesctl/ctl/core/config/__init__.py
+++ b/src/fidesctl/ctl/core/config/__init__.py
@@ -38,12 +38,12 @@ def handle_deprecated_fields(settings: MutableMapping) -> MutableMapping:
     if settings.get("api") and not settings.get("database"):
         api_settings = settings.pop("api")
         database_settings = dict()
-        database_settings["user"] = api_settings["database_user"]
-        database_settings["password"] = api_settings["database_password"]
-        database_settings["server"] = api_settings["database_host"]
-        database_settings["port"] = api_settings["database_port"]
-        database_settings["db"] = api_settings["database_name"]
-        database_settings["test_db"] = api_settings["test_database_name"]
+        database_settings["user"] = api_settings.get("database_user")
+        database_settings["password"] = api_settings.get("database_password")
+        database_settings["server"] = api_settings.get("database_host")
+        database_settings["port"] = api_settings.get("database_port")
+        database_settings["db"] = api_settings.get("database_name")
+        database_settings["test_db"] = api_settings.get("test_database_name")
         settings["database"] = database_settings
 
     return settings

--- a/src/fidesctl/ctl/core/config/__init__.py
+++ b/src/fidesctl/ctl/core/config/__init__.py
@@ -25,6 +25,7 @@ class FidesctlConfig(BaseModel):
     """Umbrella class that encapsulates all of the config subsections."""
 
     cli: FidesctlCLISettings = FidesctlCLISettings()
+    # Add the API settings back here
     user: FidesctlUserSettings = FidesctlUserSettings()
     credentials: Dict[str, Dict] = dict()
     database: FidesctlDatabaseSettings = FidesctlDatabaseSettings()

--- a/src/fidesctl/ctl/core/config/__init__.py
+++ b/src/fidesctl/ctl/core/config/__init__.py
@@ -35,9 +35,17 @@ class FidesctlConfig(BaseModel):
 def handle_deprecated_fields(settings: MutableMapping) -> MutableMapping:
     """Custom logic for handling deprecated values."""
 
-    if settings.get("api"):
+    if settings.get("api") and not settings.get("database"):
         api_settings = settings.pop("api")
-        print("The API settings are there.")
+        database_settings = dict()
+        database_settings["user"] = api_settings["database_user"]
+        database_settings["password"] = api_settings["database_password"]
+        database_settings["server"] = api_settings["database_host"]
+        database_settings["port"] = api_settings["database_port"]
+        database_settings["db"] = api_settings["database_name"]
+        database_settings["test_db"] = api_settings["test_database_name"]
+        settings["database"] = database_settings
+
     return settings
 
 
@@ -60,6 +68,7 @@ def get_config(config_path_override: str = "") -> FidesctlConfig:
 
         # credentials specific logic for populating environment variable configs.
         # this is done to allow overrides without hard typed pydantic models
+        settings = handle_deprecated_fields(settings)
         config_environment_dict = settings.get("credentials", dict())
         settings["credentials"] = merge_credentials_environment(
             credentials_dict=config_environment_dict

--- a/tests/ctl/cli/test_cli.py
+++ b/tests/ctl/cli/test_cli.py
@@ -35,6 +35,14 @@ def test_init(test_cli_runner: CliRunner) -> None:
     print(result.output)
     assert result.exit_code == 0
 
+@pytest.mark.unit
+def test_view_config(test_cli_runner: CliRunner) -> None:
+    result = test_cli_runner.invoke(
+        cli, ["view","config"], env={"FIDESCTL__USER__ANALYTICS_OPT_OUT": "true"}
+    )
+    print(result.output)
+    assert result.exit_code == 0
+
 
 @pytest.mark.unit
 def test_webserver() -> None:

--- a/tests/ctl/cli/test_cli.py
+++ b/tests/ctl/cli/test_cli.py
@@ -35,10 +35,11 @@ def test_init(test_cli_runner: CliRunner) -> None:
     print(result.output)
     assert result.exit_code == 0
 
+
 @pytest.mark.unit
 def test_view_config(test_cli_runner: CliRunner) -> None:
     result = test_cli_runner.invoke(
-        cli, ["view","config"], env={"FIDESCTL__USER__ANALYTICS_OPT_OUT": "true"}
+        cli, ["view", "config"], env={"FIDESCTL__USER__ANALYTICS_OPT_OUT": "true"}
     )
     print(result.output)
     assert result.exit_code == 0

--- a/tests/ctl/conftest.py
+++ b/tests/ctl/conftest.py
@@ -33,11 +33,17 @@ from fidesctl.ctl.core.config import FidesctlConfig, get_config
 
 TEST_CONFIG_PATH = "tests/ctl/test_config.toml"
 TEST_INVALID_CONFIG_PATH = "tests/ctl/test_invalid_config.toml"
+TEST_DEPRECATED_CONFIG_PATH = "tests/ctl/test_deprecated_config.toml"
 
 
 @pytest.fixture(scope="session")
 def test_config_path() -> Generator:
     yield TEST_CONFIG_PATH
+
+
+@pytest.fixture(scope="session")
+def test_deprecated_config_path() -> Generator:
+    yield TEST_DEPRECATED_CONFIG_PATH
 
 
 @pytest.fixture(scope="session")

--- a/tests/ctl/core/test_config.py
+++ b/tests/ctl/core/test_config.py
@@ -15,16 +15,35 @@ from fidesctl.ctl.core.config.database_settings import FidesctlDatabaseSettings
     clear=True,
 )
 @pytest.mark.unit
-def test_get_config() -> None:
+def test_get_config(test_config_path) -> None:
     """Test that the actual config matches what the function returns."""
-    config = get_config("tests/ctl/test_config.toml")
+    config = get_config(test_config_path)
     assert config.user.user_id == "1"
     assert config.user.api_key == "test_api_key"
+    assert config.database.user == "postgres"
     assert config.cli.server_url == "http://fidesctl:8080"
     assert (
         config.credentials["postgres_1"]["connection_string"]
         == "postgresql+psycopg2://postgres:fidesctl@fidesctl-db:5432/fidesctl_test"
     )
+
+
+@patch.dict(
+    os.environ,
+    {},
+    clear=True,
+)
+@pytest.mark.unit
+def test_get_deprecated_api_config(test_deprecated_config_path) -> None:
+    """
+    Test that the deprecated API config values get written as database values.
+    """
+    config = get_config(test_deprecated_config_path)
+    assert config.database.user == "postgres_deprecated"
+    assert config.database.password == "fidesctl_deprecated"
+    assert config.database.port == "5431"
+    assert config.database.db == "fidesctl_deprecated"
+    assert config.database.test_db == "fidesctl_test_deprecated"
 
 
 @patch.dict(
@@ -107,20 +126,4 @@ def test_database_url_test_mode_disabled() -> None:
     assert (
         database_settings.async_database_uri
         == "postgresql+asyncpg://postgres:fidesctl@fidesctl-db:5432/database"
-    )
-
-@pytest.mark.unit
-def test_database_url_test_mode_enabled() -> None:
-    os.environ["FIDESCTL_TEST_MODE"] = "True"
-    database_settings = FidesctlDatabaseSettings(
-        user="postgres",
-        password="fidesctl",
-        server="fidesctl-db",
-        port="5432",
-        db="database",
-        test_db="test_database",
-    )
-    assert (
-        database_settings.async_database_uri
-        == "postgresql+asyncpg://postgres:fidesctl@fidesctl-db:5432/test_database"
     )

--- a/tests/ctl/core/test_config.py
+++ b/tests/ctl/core/test_config.py
@@ -15,7 +15,7 @@ from fidesctl.ctl.core.config.database_settings import FidesctlDatabaseSettings
     clear=True,
 )
 @pytest.mark.unit
-def test_get_config(test_config_path) -> None:
+def test_get_config(test_config_path: str) -> None:
     """Test that the actual config matches what the function returns."""
     config = get_config(test_config_path)
     assert config.user.user_id == "1"
@@ -34,7 +34,7 @@ def test_get_config(test_config_path) -> None:
     clear=True,
 )
 @pytest.mark.unit
-def test_get_deprecated_api_config(test_deprecated_config_path) -> None:
+def test_get_deprecated_api_config(test_deprecated_config_path: str) -> None:
     """
     Test that the deprecated API config values get written as database values.
     """

--- a/tests/ctl/core/test_config.py
+++ b/tests/ctl/core/test_config.py
@@ -109,7 +109,6 @@ def test_database_url_test_mode_disabled() -> None:
         == "postgresql+asyncpg://postgres:fidesctl@fidesctl-db:5432/database"
     )
 
-
 @pytest.mark.unit
 def test_database_url_test_mode_enabled() -> None:
     os.environ["FIDESCTL_TEST_MODE"] = "True"

--- a/tests/ctl/test_config.toml
+++ b/tests/ctl/test_config.toml
@@ -6,6 +6,14 @@ port="5432"
 db="fidesctl"
 test_db="fidesctl_test"
 
+[api]
+database_user = "postgres_deprecated"
+database_password = "fidesctl_deprecated"
+database_host = "localhost_deprecated"
+database_port = "5432_deprecated"
+database_name = "fidesctl_deprecated"
+test_database_name = "fidesctl_test_deprecated"
+
 [logging]
 level = "INFO"
 

--- a/tests/ctl/test_deprecated_config.toml
+++ b/tests/ctl/test_deprecated_config.toml
@@ -1,0 +1,7 @@
+[api]
+database_user = "postgres_deprecated"
+database_password = "fidesctl_deprecated"
+database_host = "localhost_deprecated"
+database_port = "5431"
+database_name = "fidesctl_deprecated"
+test_database_name = "fidesctl_test_deprecated"


### PR DESCRIPTION
Closes #957 

### Code Changes

* [x] add a special function to handle deprecated config values
* [x] Update tests to confirm expected behavior of deprecated values
* [x] fix the `fides view config` command

### Steps to Confirm

* [x] removing the `database` section and using the `api` section instead works
* [x] run `fides view config` and confirm that 1) it works and that 2) no `api` section is present

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] ~~Relevant Follow-Up Issues Created~~ (We already have one for deprecation procedures)
* [x] Update `CHANGELOG.md`

### Description Of Changes

This PR adds a special handler function that will update new config values with older, deprecated ones. This is a short-term stop-gap solution until we implement a proper procedure for deprecating config values or other code features.

Note specifically that if the `database` section exists, this overwrite will get skipped, however if the `api` section (the deprecated one) exists and the `database` section does _not_ exist than the API values will get mapped to the new database section.

This PR is designed to also be minimally invasive, so this should be a pretty safe change to make to support our users. Tests have been updated accordingly to make sure things are being written as intended.

As a side note, I realized that `fides view config` was broken and that we weren't testing for it, so I fixed it and added a test to check it.