### PR TITLE
Fix `fides --version` showing dirty in releases

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -2,8 +2,6 @@ name: Code Checks
 
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - "**.md"
 

--- a/.github/workflows/frontend_pr_checks.yml
+++ b/.github/workflows/frontend_pr_checks.yml
@@ -2,8 +2,6 @@ name: Frontend PR Checks
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - "clients/**"
       - ".github/workflows/frontend_pr_checks.yml"

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -2,8 +2,6 @@ name: Publish fidesctl
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   upload_to_pypi:

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -1,7 +1,9 @@
 name: Publish fidesctl
 
 on:
-  pull_request:
+  push:
+    tags:
+      - "*"
 
 jobs:
   upload_to_pypi:
@@ -34,7 +36,31 @@ jobs:
       - name: Install Twine and wheel
         run: pip install twine wheel
 
-      - name: Build the package
+      # The git reset is required here because the build modifies
+      # egg-info and the wheel becomes a dirty version
+      - name: Build the sdist
         run: |
           python setup.py sdist
-          git status
+          git reset --hard
+
+      - name: Build the wheel
+        run: bdist_wheel
+
+      - name: Upload to test pypi
+        run: twine upload --repository testpypi dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+
+      - name: Check Prod Tag
+        id: check-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=match::true
+          fi
+      - name: Upload to pypi
+        if: steps.check-tag.outputs.match == 'true'
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -1,9 +1,9 @@
 name: Publish fidesctl
 
 on:
-  push:
-    tags:
-      - "*"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   upload_to_pypi:
@@ -32,7 +32,4 @@ jobs:
       - name: Twine Upload
         run: |
           python setup.py sdist bdist_wheel 
-          twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          git status

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -1,11 +1,9 @@
 name: Publish fidesctl
 
 on:
-  push:
+  pull_request:
     branches:
       - main
-    tags:
-      - "*"
 
 jobs:
   upload_to_pypi:
@@ -39,24 +37,6 @@ jobs:
         run: pip install twine wheel
 
       - name: Build the package
-        run: python setup.py sdist bdist_wheel
-
-      - name: Upload to test pypi
-        run: twine upload --repository testpypi dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-
-      - name: Check Prod Tag
-        id: check-tag
         run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=match::true
-          fi
-
-      - name: Upload to pypi
-        if: steps.check-tag.outputs.match == 'true'
-        run: twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          python setup.py sdist
+          git status

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -46,7 +46,7 @@ jobs:
           git reset --hard
 
       - name: Build the wheel
-        run: bdist_wheel
+        run: python setup.py bdist_wheel
 
       - name: Upload to test pypi
         run: twine upload --repository testpypi dist/*

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -1,9 +1,9 @@
 name: Publish fidesctl
 
 on:
-  pull_request:
-    branches:
-      - main
+  push:
+    tags:
+      - "*"
 
 jobs:
   upload_to_pypi:
@@ -32,4 +32,7 @@ jobs:
       - name: Twine Upload
         run: |
           python setup.py sdist bdist_wheel 
-          git status
+          twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -3,7 +3,7 @@ name: Publish fidesctl
 on:
   push:
     branches:
-      - "*"
+      - main
     tags:
       - "*"
 

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -2,6 +2,8 @@ name: Publish fidesctl
 
 on:
   push:
+    branches:
+      - "*"
     tags:
       - "*"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # frontend
 ui-build/
+src/fidesctl/ui-build/static/admin/
 
 ## generic files to ignore
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # frontend
-ui-build/
-src/fidesctl/ui-build/static/admin/
+ui-build/*
 
 ## generic files to ignore
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # frontend
-ui-build/*
+ui-build/
 
 ## generic files to ignore
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-docs/fides/docs/api/openapi.json
-docs/fides/docs/schemas/config_schema.json
+
+# frontend
 ui-build/
 
 ## generic files to ignore
@@ -20,6 +20,8 @@ tmp/*
 
 # docs
 docs/fides/site/
+docs/fides/docs/api/openapi.json
+docs/fides/docs/schemas/config_schema.json
 
 # python specific
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # frontend
 ui-build/
 src/fidesctl/ui-build/static/admin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,13 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fides/compare/1.7.1...main)
+## [Unreleased](https://github.com/ethyca/fides/compare/1.8.0...main)
+
+### Added
+
+### Changed
+
+## [1.8.0](https://github.com/ethyca/fides/compare/1.7.1...1.8.0) - 2022-08-04
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The types of changes are:
 ### Fixed
 
 * Deprecated config options will continue to be respected when set via environment variables [#965](https://github.com/ethyca/fides/pull/965)
+* The git cache is rebuilt within the Docker container [#962](https://github.com/ethyca/fides/pull/962)
+* The `wheel` pypi build no longer has a dirty version tag [#962](https://github.com/ethyca/fides/pull/962)
 
 ## [1.8.0](https://github.com/ethyca/fides/compare/1.7.1...1.8.0) - 2022-08-04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ CMD ["fidesctl", "webserver"]
 FROM builder as dev
 
 # Install fidesctl as a symlink
-RUN pip install -e ".[all,mssql]"
+RUN pip install --no-deps -e ".[all,mssql]"
 
 ##################################
 ## Production Application Setup ##
@@ -116,4 +116,4 @@ COPY --from=frontend /fides/clients/admin-ui/out/ /fides/src/fidesctl/ui-build/s
 
 # Install without a symlink
 RUN python setup.py bdist_wheel 
-RUN pip install dist/fidesctl-*.whl
+RUN pip install --no-deps dist/fidesctl-*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,10 @@ RUN pip install -r optional-requirements.txt
 COPY . /fides
 WORKDIR /fides
 
+# Reset the busted git cache
+RUN git rm --cached -r .
+RUN git reset --hard
+
 # Immediately flush to stdout, globally
 ENV PYTHONUNBUFFERED=TRUE
 


### PR DESCRIPTION
Closes #961 

### Code Changes

* [x] add the UI files to `.gitignore`
* [x] add the `--no-deps` flag to the docker pip install since it is already installing the requirements separately
* [x] add a step in the dockerfile that resets the git cache
* [x] fix the `publish_package` workflow

### Steps to Confirm

* [ ] run `nox -s "build(test)" ; docker run -it ethyca/fidesctl:local fides --version` with and without modified files and confirm that the version isn't dirty
* [ ] run `nox -s "build(dev)" ; docker run -it ethyca/fidesctl:local fides --version` with and without modified files and confirm that the version isn't dirty
* [ ] `publish_package` CI runs don't show a dirty version for the wheel

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] ~~Relevant Follow-Up Issues Created~~
* [x] Update `CHANGELOG.md`

### Description Of Changes

There are two fundamental bugs fixed in this PR:
1. Whenever the git folder gets copied into the docker container it busts the git cache and then git thinks that _every_ file is new. A new docker build step has been added to fix this
2. When publishing the pypi package, the `sdist` build modifies a file so that when the `wheel` gets built it shows up as a dirty version. This is due to the `egg-info` file getting modified. This has been fixed by running a `git reset --hard` after the `sdist` builds
