### PR TITLE
Remove old env vars

### DIFF
--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -2,6 +2,8 @@ name: Publish fidesctl
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "*"
 
@@ -10,6 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # This is required to properly tag packages
+
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
       - name: Use Node.js 16
         uses: actions/setup-node@v2
@@ -26,13 +35,28 @@ jobs:
           cd clients/admin-ui
           npm run prod-export
 
-      - name: Install Twine
-        run: pip install twine
+      - name: Install Twine and wheel
+        run: pip install twine wheel
 
-      - name: Twine Upload
+      - name: Build the package
+        run: python setup.py sdist bdist_wheel
+
+      - name: Upload to test pypi
+        run: twine upload --repository testpypi dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+
+      - name: Check Prod Tag
+        id: check-tag
         run: |
-          python setup.py sdist bdist_wheel 
-          twine upload dist/*
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=match::true
+          fi
+
+      - name: Upload to pypi
+        if: steps.check-tag.outputs.match == 'true'
+        run: twine upload dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ The types of changes are:
 
 ### Changed
 
+### Developer Experience
+
+* The included `docker-compose.yml` no longer references outdated ENV variables [#964](https://github.com/ethyca/fides/pull/964)
+
+### Docs
+
+* Updated references to ENV variables [#964](https://github.com/ethyca/fides/pull/964)
+
 ## [1.8.0](https://github.com/ethyca/fides/compare/1.7.1...1.8.0) - 2022-08-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The types of changes are:
 * Update the `fidesctl` python package to automatically serve the UI [#941](https://github.com/ethyca/fides/pull/941)
 * Add `push` cli command alias for `apply` and deprecate `apply` [943](https://github.com/ethyca/fides/pull/943)
 * Add resource groups tagging api as a source of system generation [939](https://github.com/ethyca/fides/pull/939)
+* Add GitHub Action to publish the `fidesctl` package to testpypi on pushes to main [#951](https://github.com/ethyca/fides/pull/951)
 
 ### Changed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,12 +26,12 @@ services:
         target: /fides
         read_only: False
     environment:
-      FIDESCTL_TEST_MODE: "True"
       FIDES__CONFIG_PATH: "/fides/.fides/"
+      FIDESCTL__CLI__ANALYTICS_ID: ${FIDESCTL__CLI__ANALYTICS_ID}
       FIDESCTL__CLI__SERVER_HOST: "fidesctl"
       FIDESCTL__CLI__SERVER_PORT: "8080"
-      FIDESCTL__CLI__ANALYTICS_ID: ${FIDESCTL__CLI__ANALYTICS_ID}
-      FIDESCTL__API__DATABASE_HOST: "fidesctl-db"
+      FIDESCTL__DATABASE__SERVER: "fidesctl-db"
+      FIDESCTL_TEST_MODE: "True"
 
   fidesctl-ui:
     image: ethyca/fidesctl:local-ui

--- a/docs/fides/docs/quickstart/docker.md
+++ b/docs/fides/docs/quickstart/docker.md
@@ -12,7 +12,7 @@ Docker and Docker-Compose are the only requirements here.
 
 ## Docker Setup
 
-This is a reference file that you can copy/paste into a local `docker-compose.yml` file, which should be created in your project's root folder. It will create a database and spin up the fidesctl webserver. 
+This is a reference file that you can copy/paste into a local `docker-compose.yml` file, which should be created in your project's root folder. It will create a database and spin up the fidesctl webserver.
 
 Make sure that you don't have anything else running on port `5432` or `8080` before using this file.
 
@@ -34,10 +34,10 @@ services:
     ports:
       - "8080:8080"
     environment:
-      FIDESCTL_TEST_MODE: "True"
       FIDESCTL__CLI__SERVER_HOST: "fidesctl"
       FIDESCTL__CLI__SERVER_PORT: "8080"
-      FIDESCTL__API__DATABASE_HOST: "fidesctl-db"
+      FIDESCTL__DATABASE__SERVER: "fidesctl-db"
+      FIDESCTL_TEST_MODE: "True"
     volumes:
       - type: bind
         source: .
@@ -86,7 +86,7 @@ Now you can start interacting with your installation. Run the following commands
     ```
 
 1. `fidesctl status` -> This confirms that your `fidesctl` CLI can reach the server and everything is ready to go!
-   
+
 
 Once your installation is running, you can use `fidesctl` from the shell to get a list of all the possible [CLI commands](../cli.md).
 

--- a/docs/fides/docs/tutorial/add.md
+++ b/docs/fides/docs/tutorial/add.md
@@ -57,7 +57,11 @@ fidesctl:
   ports:
     - "8080:8080"
   environment:
-    - FIDESCTL__API__DATABASE_URL=postgres:postgres@db:5432/fidesctl
+    FIDESCTL__DATABASE__DB: "fidesctl"
+    FIDESCTL__DATABASE__PASSWORD: "postgres"
+    FIDESCTL__DATABASE__PORT: 5432
+    FIDESCTL__DATABASE__SERVER: "db"
+    FIDESCTL__DATABASE__USER: "postgres"
 ```
 
 > See [the fidesctl installation guide](../installation/installation.md) for a more detailed fidesctl server setup walkthrough, and [the `docker-compose` documentation](https://docs.docker.com/compose/compose-file/) for an explanation of the above configuration options.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [versioneer]
 VCS = git
-style = pep440
+style = pep440-pre
 versionfile_source = src/fidesctl/_version.py
 versionfile_build = fidesctl/_version.py
 tag_prefix =


### PR DESCRIPTION
Closes #963

### Code Changes

* [ ] Remove references to the `FIDESCTL__API__DATABASE_HOST` ENV variable, replace it with `FIDESCTL__DATABASE__SERVER`
* [ ] Modernize ENV variable references in documentation

### Steps to Confirm

* [ ] Run `nox -s dev`
* [ ] Observe that the server starts and can correctly connect to the database

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] ~documentation issue created (tag docs-team to complete issue separately)~
* [x] Issue Requirements are Met
* [ ] ~Relevant Follow-Up Issues Created~
* [x] Update `CHANGELOG.md`