### PR TITLE
Fixed link in community docs

### DIFF
--- a/docs/fides/docs/community/overview.md
+++ b/docs/fides/docs/community/overview.md
@@ -2,4 +2,4 @@
 
 We believe the only way to solve privacy is as a community of likeminded developers that care to solve these problems for the rest of the world. To make it easier to connect and share ideas, we've created a set of community channels which we'd love to hear from you on:
 
-[Start Contributing](#){ .md-button .md-button--secondary .md-button-github}&emsp;[Chat on Slack](https://fidescommunity.slack.com){ .md-button .md-button--secondary .md-button-slack}&emsp;[Chat on Discord](https://discord.gg/6bKp5qVnSR){ .md-button .md-button--secondary .md-button-discord}
+[Start Contributing](https://github.com/ethyca/fides){ .md-button .md-button--secondary .md-button-github}&emsp;[Chat on Slack](https://fidescommunity.slack.com){ .md-button .md-button--secondary .md-button-slack}&emsp;[Chat on Discord](https://discord.gg/6bKp5qVnSR){ .md-button .md-button--secondary .md-button-discord}


### PR DESCRIPTION
Closes #966

### Code Changes

* [x] Changed the link for the "Start contributing" button in [fides](https://github.com/ethyca/fides)/[docs](https://github.com/ethyca/fides/tree/main/docs)/[fides](https://github.com/ethyca/fides/tree/main/docs/fides)/[docs](https://github.com/ethyca/fides/tree/main/docs/fides/docs)/[community](https://github.com/ethyca/fides/tree/main/docs/fides/docs/community)/overview.md from  "#" to "https://github.com/ethyca/fides"

### Steps to Confirm

* [x] Button now leads to the Github 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

See the code changes section above. I  apologise for any deviation from the expected pull request template, I don't have much experience with Github yet and appreciate your understanding.
