### PR TITLE
Bump Python version to 3.9 in Docker and setup.py

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+
       - name: Install Nox
         run: pip install nox>=2022
 

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -15,10 +15,10 @@ jobs:
         with:
           fetch-depth: 0 # This is required to properly tag packages
 
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Use Node.js 16
         uses: actions/setup-node@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The types of changes are:
 
 ### Changed
 
+* Upgraded base Docker version to Python 3.9 and updated all other references from 3.8 -> 3.9 [#974](https://github.com/ethyca/fides/pull/974)
+
 ## [1.8.1](https://github.com/ethyca/fides/compare/1.8.0...1.8.1) - 2022-08-08
 
 ### Deprecated

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim-bullseye as base
+FROM --platform=linux/amd64 python:3.9-slim-bullseye as base
 
 # Update pip in the base image since we'll use it everywhere
 RUN pip install -U pip

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Fides (_fee-dhez_, Latin: Fidēs) is an open-source tool that allows you to easi
 
 * **Optional:** [`pipx`](https://pypa.github.io/pipx/) for environment isolation. The following documentation assumes `pipx` is installed, but `pip` commands can be substituted when needed.
 * [Docker](https://www.docker.com/products/docker-desktop) (20.10.8+) and [Docker Compose](https://docs.docker.com/compose/install/) (1.29.0+)
-* [Python](https://www.python.org/downloads/) (3.8+)
+* [Python](https://www.python.org/downloads/) (3.9+)
 * [Nox](https://nox.thea.codes/en/stable/) (`pipx install nox`)
 
 ### Getting Started
@@ -130,19 +130,19 @@ The Fides core team is committed to providing a variety of documentation to help
 
 For more information on getting started with Fides, how to configure and set up Fides, and more about the Fides ecosystem of open source projects:
 
-- Documentation: <https://ethyca.github.io/fides/>
-- Tutorial: <https://ethyca.github.io/fides/tutorial/>
-- Installation: <https://ethyca.github.io/fides/installation/installation/>
-- Roadmap: <https://github.com/ethyca/fides/projects>
-- Website: www.ethyca.com/fides
+* Documentation: <https://ethyca.github.io/fides/>
+* Tutorial: <https://ethyca.github.io/fides/tutorial/>
+* Installation: <https://ethyca.github.io/fides/installation/installation/>
+* Roadmap: <https://github.com/ethyca/fides/projects>
+* Website: www.ethyca.com/fides
 
 ### Support
 
 Join the conversation on:
 
-- [Slack](https://fid.es/join-slack)
-- [Twitter](https://twitter.com/ethyca)
-- [Discussions](https://github.com/ethyca/fides/discussions)
+* [Slack](https://fid.es/join-slack)
+* [Twitter](https://twitter.com/ethyca)
+* [Discussions](https://github.com/ethyca/fides/discussions)
 
 ### Contributing
 

--- a/docs/fides/Dockerfile
+++ b/docs/fides/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-bullseye
+FROM python:3.9-slim-bullseye
 
 # Install auxiliary software
 RUN apt-get update

--- a/docs/fides/docs/installation/prerequisites_dependencies.md
+++ b/docs/fides/docs/installation/prerequisites_dependencies.md
@@ -2,7 +2,7 @@
 
 Fidesctl supports the following Python versions:
 
-* Python: 3.9
+* Python: 3.9+
 
 Fidesctl supports the following databases as the application database:
 

--- a/docs/fides/docs/installation/prerequisites_dependencies.md
+++ b/docs/fides/docs/installation/prerequisites_dependencies.md
@@ -2,7 +2,7 @@
 
 Fidesctl supports the following Python versions:
 
-* Python: 3.8
+* Python: 3.9
 
 Fidesctl supports the following databases as the application database:
 

--- a/docs/fides/docs/tutorial/index.md
+++ b/docs/fides/docs/tutorial/index.md
@@ -18,7 +18,7 @@ The app itself is the [Flask tutorial app](https://flask.palletsprojects.com/en/
 Before beginning, ensure you have the following software installed and configured to your liking:
 
 * Docker (v12+)
-* Python (v3.8+)
+* Python (v3.9+)
 * `pg_config` (required for the Python project. Installed via Homebrew with `brew install libpq` or `brew install postgres`.)
 
 ### Installation

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,10 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ethyca/fides",
-    entry_points={"console_scripts": ["fidesctl=fidesctl.cli:cli","fides=fidesctl.cli:cli"]},
-    python_requires=">=3.8, <4",
+    entry_points={
+        "console_scripts": ["fidesctl=fidesctl.cli:cli", "fides=fidesctl.cli:cli"]
+    },
+    python_requires=">=3.9, <4",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     include_package_data=True,
@@ -58,8 +60,9 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries",
     ],
 )


### PR DESCRIPTION
Closes #973 

### Code Changes

* [x] update the dockerfile
* [x] update `setup.py`
* [x] update docs

### Steps to Confirm

* [ ] tests pass

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] ~~Relevant Follow-Up Issues Created~~
* [x] Update `CHANGELOG.md`

### Description Of Changes

Upgrade to 3.9, not expecting any changes that break backwards compatibility. Gets us in a better position to merge with fidesops
