### PR TITLE
[#981] update readme subsections to display as plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ This guide will walk through generating a mock RoPA using predefined resources i
 
 4. View the newly-generated data map generated from the provided resources.
 
-#### Controller
+    #### **Controller**
 
     The header block at the top of the data map is composed of properties found in the [Organization resource](/demo_resources/demo_organization.yml). In a production deployment, this would be composed of publicly available information for your company or organization.
 
-#### Article 30 Record of Processing Activities
+    #### **Article 30 Record of Processing Activities**
 
-    The remainder of the information on the data map is generated from the provided [configuration resources](https://ethyca.github.io/fides/language/resources/system.md). In a production environment, these could be [automatically generated](https://ethyca.github.io/fides/guides/generate_resources/) from your databases and system resources.
+    The remainder of the information on the data map is generated from the provided [configuration resources](https://ethyca.github.io/fides/language/resources/system). In a production environment, these could be [automatically generated](https://ethyca.github.io/fides/guides/generate_resources/) from your databases and system resources.
 
     The [Dataset resource](demo_resources/demo_dataset.yml) is primarily used to provide a list of categories of personal data, recorded here using the [Fides taxonomy](https://github.com/ethyca/fideslang), that your systems store or process, as well as their retention policies. Any Datasets referenced by a System will have this information included as rows of your data map.
 


### PR DESCRIPTION
Closes <issue>

### Code Changes

* [x] Updated the Controller and RoPA subsections in the readme to display as plain text, and not in code blocks. 

### Steps to Confirm
<img width="887" alt="Screen Shot 2022-08-12 at 7 50 55 AM" src="https://user-images.githubusercontent.com/82131455/184348339-9a024921-77d3-49b2-ab79-2c067112591e.png">

