### PR TITLE
Add setuptools to dev-requirements to fix versioneer error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The types of changes are:
 * Deprecated config options will continue to be respected when set via environment variables [#965](https://github.com/ethyca/fides/pull/965)
 * The git cache is rebuilt within the Docker container [#962](https://github.com/ethyca/fides/pull/962)
 * The `wheel` pypi build no longer has a dirty version tag [#962](https://github.com/ethyca/fides/pull/962)
+* Add setuptools to dev-requirements to fix versioneer error [#983](https://github.com/ethyca/fides/pull/983)
 
 ## [1.8.0](https://github.com/ethyca/fides/compare/1.7.1...1.8.0) - 2022-08-04
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ pylint==2.6.0
 pytest==7.1.2
 pytest-cov==3.0.0
 requests-mock==1.9.3
+setuptools>=64.0.2
 sqlalchemy-stubs
 types-PyYAML
 types-requests


### PR DESCRIPTION
Closes <issue>

### Code Changes

* [x] Add setuptools >= 64.0.2 to dev requirements

### Steps to Confirm

* [ ] run `nox -s "build(dev)"`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

setuptools 64.0.2 includes a fix to the editable install error with versioneer.
