### PR TITLE
include fides_key in datamap api output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The types of changes are:
 
 * Upgraded base Docker version to Python 3.9 and updated all other references from 3.8 -> 3.9 [#974](https://github.com/ethyca/fides/pull/974)
 * Moved the `admin-ui` code down one level into a `ctl` subdir [#970](https://github.com/ethyca/fides/pull/970)
+* Extended the `/datamap` endpoint to include extra metadata [#992](https://github.com/ethyca/fides/pull/992)
 
 ## [1.8.1](https://github.com/ethyca/fides/compare/1.8.0...1.8.1) - 2022-08-08
 

--- a/demo_resources/demo_system.yml
+++ b/demo_resources/demo_system.yml
@@ -30,6 +30,8 @@ system:
     system_type: Service
     administrating_department: Marketing
     data_responsibility_title: Processor
+    system_dependencies:
+    - demo_analytics_system
     privacy_declarations:
       - name: Collect data for marketing
         data_categories:

--- a/src/fidesctl/api/ctl/routes/datamap.py
+++ b/src/fidesctl/api/ctl/routes/datamap.py
@@ -21,6 +21,7 @@ router = APIRouter(tags=["Datamap"], prefix=f"{API_PREFIX}/datamap")
 DATAMAP_COLUMNS["system.fides_key"] = "The fides key for the system"
 DATAMAP_COLUMNS["dataset.fides_key"] = "The fides key for the dataset (if applicable)"
 DATAMAP_COLUMNS["system.system_dependencies"] = "Related cross-system dependencies"
+DATAMAP_COLUMNS["system.description"] = "Description of the System"
 
 
 @router.get(
@@ -59,6 +60,7 @@ DATAMAP_COLUMNS["system.system_dependencies"] = "Related cross-system dependenci
                             "system.fides_key": "",
                             "dataset.fides_key": "",
                             "system.system_dependencies": "",
+                            "system.description": "",
                         },
                     ]
                 }
@@ -130,6 +132,7 @@ def format_datamap_values(joined_system_dataset_df: DataFrame) -> List[Dict[str,
     """
     Formats the joined DataFrame to return the data as records.
     """
+
     limited_columns_df = DataFrame(
         joined_system_dataset_df,
         columns=list(DATAMAP_COLUMNS.keys()),

--- a/src/fidesctl/api/ctl/routes/datamap.py
+++ b/src/fidesctl/api/ctl/routes/datamap.py
@@ -16,12 +16,15 @@ from fidesctl.api.ctl.utils.errors import DatabaseUnavailableError, NotFoundErro
 from fidesctl.ctl.core.export import build_joined_dataframe
 from fidesctl.ctl.core.export_helpers import DATAMAP_COLUMNS
 
-router = APIRouter(tags=["Datamap"], prefix=f"{API_PREFIX}/datamap")
+API_EXTRA_COLUMNS = {
+    "system.fides_key": "The fides key for the system",
+    "dataset.fides_key": "The fides key for the dataset (if applicable)",
+    "system.system_dependencies": "Related cross-system dependencies",
+    "system.description": "Description of the System",
+}
+DATAMAP_COLUMNS_API = {**DATAMAP_COLUMNS, **API_EXTRA_COLUMNS}
 
-DATAMAP_COLUMNS["system.fides_key"] = "The fides key for the system"
-DATAMAP_COLUMNS["dataset.fides_key"] = "The fides key for the dataset (if applicable)"
-DATAMAP_COLUMNS["system.system_dependencies"] = "Related cross-system dependencies"
-DATAMAP_COLUMNS["system.description"] = "Description of the System"
+router = APIRouter(tags=["Datamap"], prefix=f"{API_PREFIX}/datamap")
 
 
 @router.get(
@@ -32,7 +35,7 @@ DATAMAP_COLUMNS["system.description"] = "Description of the System"
             "content": {
                 "application/json": {
                     "example": [
-                        DATAMAP_COLUMNS,
+                        DATAMAP_COLUMNS_API,
                         {
                             "system.name": "Demo Analytics System",
                             "system.data_responsibility_title": "Controller",
@@ -124,7 +127,7 @@ async def export_datamap(
     formatted_datamap = format_datamap_values(joined_system_dataset_df)
 
     # prepend column names
-    formatted_datamap = [DATAMAP_COLUMNS] + formatted_datamap
+    formatted_datamap = [DATAMAP_COLUMNS_API] + formatted_datamap
     return formatted_datamap
 
 
@@ -135,7 +138,7 @@ def format_datamap_values(joined_system_dataset_df: DataFrame) -> List[Dict[str,
 
     limited_columns_df = DataFrame(
         joined_system_dataset_df,
-        columns=list(DATAMAP_COLUMNS.keys()),
+        columns=list(DATAMAP_COLUMNS_API.keys()),
     )
 
     return limited_columns_df.to_dict("records")

--- a/src/fidesctl/api/ctl/routes/datamap.py
+++ b/src/fidesctl/api/ctl/routes/datamap.py
@@ -18,6 +18,9 @@ from fidesctl.ctl.core.export_helpers import DATAMAP_COLUMNS
 
 router = APIRouter(tags=["Datamap"], prefix=f"{API_PREFIX}/datamap")
 
+DATAMAP_COLUMNS["system.fides_key"] = "The fides key for the system"
+DATAMAP_COLUMNS["dataset.fides_key"] = "The fides key for the dataset (if applicable)"
+
 
 @router.get(
     "/{organization_fides_key}",
@@ -52,6 +55,8 @@ router = APIRouter(tags=["Datamap"], prefix=f"{API_PREFIX}/datamap")
                             "system.third_country_safeguards": "",
                             "system.link_to_processor_contract": "",
                             "organization.link_to_security_policy": "https://ethyca.com/privacy-policy/",
+                            "system.fides_key": "",
+                            "dataset.fides_key": "",
                         },
                     ]
                 }
@@ -123,7 +128,6 @@ def format_datamap_values(joined_system_dataset_df: DataFrame) -> List[Dict[str,
     """
     Formats the joined DataFrame to return the data as records.
     """
-
     limited_columns_df = DataFrame(
         joined_system_dataset_df,
         columns=list(DATAMAP_COLUMNS.keys()),

--- a/src/fidesctl/api/ctl/routes/datamap.py
+++ b/src/fidesctl/api/ctl/routes/datamap.py
@@ -20,6 +20,7 @@ router = APIRouter(tags=["Datamap"], prefix=f"{API_PREFIX}/datamap")
 
 DATAMAP_COLUMNS["system.fides_key"] = "The fides key for the system"
 DATAMAP_COLUMNS["dataset.fides_key"] = "The fides key for the dataset (if applicable)"
+DATAMAP_COLUMNS["system.system_dependencies"] = "Related cross-system dependencies"
 
 
 @router.get(
@@ -57,6 +58,7 @@ DATAMAP_COLUMNS["dataset.fides_key"] = "The fides key for the dataset (if applic
                             "organization.link_to_security_policy": "https://ethyca.com/privacy-policy/",
                             "system.fides_key": "",
                             "dataset.fides_key": "",
+                            "system.system_dependencies": "",
                         },
                     ]
                 }

--- a/src/fidesctl/ctl/core/export.py
+++ b/src/fidesctl/ctl/core/export.py
@@ -146,6 +146,7 @@ def generate_system_records(
             "system.data_responsibility_title",
             "system.administrating_department",
             "system.third_country_transfers",
+            "system.system_dependencies",
             "system.privacy_declaration.name",
             "system.privacy_declaration.data_categories",
             "system.privacy_declaration.data_use.name",
@@ -167,6 +168,7 @@ def generate_system_records(
 
     for system in server_resources["system"]:
         third_country_list = ", ".join(system.third_country_transfers or [])
+        system_dependencies = ", ".join(system.system_dependencies or [])
         data_protection_impact_assessment = (
             get_formatted_data_protection_impact_assessment(
                 system.data_protection_impact_assessment.dict()
@@ -188,6 +190,7 @@ def generate_system_records(
                     system.data_responsibility_title,
                     system.administrating_department,
                     third_country_list,
+                    system_dependencies,
                     declaration.name,
                     category,
                     data_use["name"],

--- a/src/fidesctl/ctl/core/export.py
+++ b/src/fidesctl/ctl/core/export.py
@@ -140,6 +140,7 @@ def generate_system_records(
     formatted_data_subjects = format_data_subjects(server_resources["data_subject"])
     output_list: List[Tuple[str, ...]] = [
         (
+            "system.fides_key",
             "system.name",
             "system.description",
             "system.data_responsibility_title",
@@ -181,6 +182,7 @@ def generate_system_records(
             dataset_references = declaration.dataset_references or ["N/A"]
             cartesian_product_of_declaration = [
                 (
+                    system.fides_key,
                     system.name,
                     system.description,
                     system.data_responsibility_title,

--- a/src/fidesctl/ctl/core/export_helpers.py
+++ b/src/fidesctl/ctl/core/export_helpers.py
@@ -293,7 +293,6 @@ def union_data_categories_in_joined_dataframe(joined_df: pd.DataFrame) -> pd.Dat
     # isolate the system data categories into a new dataframe and create a common column
     joined_df = joined_df.drop(
         [
-            "system.description",
             "system.privacy_declaration.name",
             "dataset.description",
         ],


### PR DESCRIPTION
Closes #987

### Code Changes

* [x] Include the `fides_key` for system and dataset rows returned by the `/datamap` enpoint

### Steps to Confirm

* [x] Validate the `fides_key` of items in the data map
* [x] Work with frontend to ensure it works for them

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This is not pretty but wanted to get a start out for this quickly as it sounds like a potential blocking item