### PR TITLE
Update typescript types for taxonomy `is_default`

### DIFF
--- a/clients/ctl/admin-ui/src/features/taxonomy/EditTaxonomyForm.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/EditTaxonomyForm.tsx
@@ -35,6 +35,7 @@ const EditTaxonomyForm = ({ entity, labels, onCancel, onEdit }: Props) => {
     name: entity.name ?? "",
     description: entity.description ?? "",
     parent_key: entity.parent_key ?? "",
+    is_default: entity.is_default ?? false,
   };
   const [formError, setFormError] = useState<string | null>(null);
 

--- a/clients/ctl/admin-ui/src/features/taxonomy/types.ts
+++ b/clients/ctl/admin-ui/src/features/taxonomy/types.ts
@@ -12,6 +12,7 @@ export interface TaxonomyEntity {
   name?: string;
   description?: string;
   parent_key?: string;
+  is_default?: boolean;
 }
 
 export interface Labels {

--- a/clients/ctl/admin-ui/src/types/api/index.ts
+++ b/clients/ctl/admin-ui/src/types/api/index.ts
@@ -2,7 +2,9 @@
 /* tslint:disable */
 /* eslint-disable */
 
+export type { AccessToken } from './models/AccessToken';
 export type { AWSConfig } from './models/AWSConfig';
+export type { BigQueryConfig } from './models/BigQueryConfig';
 export type { ContactDetails } from './models/ContactDetails';
 export type { DatabaseConfig } from './models/DatabaseConfig';
 export type { DataCategory } from './models/DataCategory';
@@ -26,11 +28,13 @@ export type { GenerateResponse } from './models/GenerateResponse';
 export { GenerateTypes } from './models/GenerateTypes';
 export type { HTTPValidationError } from './models/HTTPValidationError';
 export { IncludeExcludeEnum } from './models/IncludeExcludeEnum';
+export type { KeyfileCreds } from './models/KeyfileCreds';
 export { LegalBasisEnum } from './models/LegalBasisEnum';
 export { MatchesEnum } from './models/MatchesEnum';
 export type { OktaConfig } from './models/OktaConfig';
 export type { Organization } from './models/Organization';
 export type { OrganizationMetadata } from './models/OrganizationMetadata';
+export type { Page_UserResponse_ } from './models/Page_UserResponse_';
 export type { Policy } from './models/Policy';
 export type { PolicyRule } from './models/PolicyRule';
 export type { PrivacyDeclaration } from './models/PrivacyDeclaration';
@@ -41,6 +45,13 @@ export { SpecialCategoriesEnum } from './models/SpecialCategoriesEnum';
 export { StatusEnum } from './models/StatusEnum';
 export type { System } from './models/System';
 export type { SystemMetadata } from './models/SystemMetadata';
+export type { UserCreate } from './models/UserCreate';
+export type { UserCreateResponse } from './models/UserCreateResponse';
+export type { UserLogin } from './models/UserLogin';
+export type { UserLoginResponse } from './models/UserLoginResponse';
+export type { UserPasswordReset } from './models/UserPasswordReset';
+export type { UserResponse } from './models/UserResponse';
+export type { UserUpdate } from './models/UserUpdate';
 export type { ValidateRequest } from './models/ValidateRequest';
 export type { ValidateResponse } from './models/ValidateResponse';
 export type { ValidationError } from './models/ValidationError';

--- a/clients/ctl/admin-ui/src/types/api/models/AccessToken.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/AccessToken.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * A wrapper for the access_code returned upon successful authentication
+ */
+export type AccessToken = {
+  access_token: string;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/BigQueryConfig.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/BigQueryConfig.ts
@@ -1,0 +1,13 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { KeyfileCreds } from './KeyfileCreds';
+
+/**
+ * The model for the connection config for BigQuery
+ */
+export type BigQueryConfig = {
+  dataset?: string;
+  keyfile_creds: KeyfileCreds;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/DataCategory.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/DataCategory.ts
@@ -24,4 +24,8 @@ export type DataCategory = {
    */
   description?: string;
   parent_key?: string;
+  /**
+   * Denotes whether the resource is part of the default taxonomy or not.
+   */
+  is_default?: boolean;
 };

--- a/clients/ctl/admin-ui/src/types/api/models/DataQualifier.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/DataQualifier.ts
@@ -24,4 +24,8 @@ export type DataQualifier = {
    */
   description?: string;
   parent_key?: string;
+  /**
+   * Denotes whether the resource is part of the default taxonomy or not.
+   */
+  is_default?: boolean;
 };

--- a/clients/ctl/admin-ui/src/types/api/models/DataSubject.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/DataSubject.ts
@@ -39,4 +39,8 @@ export type DataSubject = {
    * A boolean value to annotate whether or not automated decisions/profiling exists for the data subject.
    */
   automated_decisions_or_profiling?: boolean;
+  /**
+   * Denotes whether the resource is part of the default taxonomy or not.
+   */
+  is_default?: boolean;
 };

--- a/clients/ctl/admin-ui/src/types/api/models/DataUse.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/DataUse.ts
@@ -47,4 +47,8 @@ export type DataUse = {
    * A url pointing to the legitimate interest impact assessment. Required if the legal bases used is legitimate interest.
    */
   legitimate_interest_impact_assessment?: string;
+  /**
+   * Denotes whether the resource is part of the default taxonomy or not.
+   */
+  is_default?: boolean;
 };

--- a/clients/ctl/admin-ui/src/types/api/models/Generate.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/Generate.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { AWSConfig } from './AWSConfig';
+import type { BigQueryConfig } from './BigQueryConfig';
 import type { DatabaseConfig } from './DatabaseConfig';
 import type { GenerateTypes } from './GenerateTypes';
 import type { OktaConfig } from './OktaConfig';
@@ -12,7 +13,7 @@ import type { ValidTargets } from './ValidTargets';
  * Defines attributes for generating resources included in a request.
  */
 export type Generate = {
-  config: (AWSConfig | OktaConfig | DatabaseConfig);
+  config: (AWSConfig | OktaConfig | DatabaseConfig | BigQueryConfig);
   target: ValidTargets;
   type: GenerateTypes;
 };

--- a/clients/ctl/admin-ui/src/types/api/models/KeyfileCreds.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/KeyfileCreds.ts
@@ -1,0 +1,19 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * The model for BigQuery credential keyfiles.
+ */
+export type KeyfileCreds = {
+  type?: string;
+  project_id: string;
+  private_key_id?: string;
+  private_key?: string;
+  client_email?: string;
+  client_id?: string;
+  auth_uri?: string;
+  token_uri?: string;
+  auth_provider_x509_cert_url?: string;
+  client_x509_cert_url?: string;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/Page_UserResponse_.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/Page_UserResponse_.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { UserResponse } from './UserResponse';
+
+export type Page_UserResponse_ = {
+  items: Array<UserResponse>;
+  total: number;
+  page: number;
+  size: number;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/UserCreate.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/UserCreate.ts
@@ -1,0 +1,13 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Data required to create a FidesUser.
+ */
+export type UserCreate = {
+  username: string;
+  password: string;
+  first_name?: string;
+  last_name?: string;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/UserCreateResponse.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/UserCreateResponse.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Response after creating a FidesUser
+ */
+export type UserCreateResponse = {
+  id: string;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/UserLogin.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/UserLogin.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Similar to UserCreate except we do not need the extra validation on
+ * username and password.
+ */
+export type UserLogin = {
+  username: string;
+  password: string;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/UserLoginResponse.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/UserLoginResponse.ts
@@ -1,0 +1,14 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { AccessToken } from './AccessToken';
+import type { UserResponse } from './UserResponse';
+
+/**
+ * Similar to UserResponse except with an access token
+ */
+export type UserLoginResponse = {
+  user_data: UserResponse;
+  token_data: AccessToken;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/UserPasswordReset.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/UserPasswordReset.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Contains both old and new passwords when resetting a password
+ */
+export type UserPasswordReset = {
+  old_password: string;
+  new_password: string;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/UserResponse.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/UserResponse.ts
@@ -1,0 +1,14 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Response after requesting a User
+ */
+export type UserResponse = {
+  id: string;
+  username: string;
+  created_at: string;
+  first_name?: string;
+  last_name?: string;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/UserUpdate.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/UserUpdate.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Data required to update a FidesopsUser
+ */
+export type UserUpdate = {
+  first_name?: string;
+  last_name?: string;
+};

--- a/clients/ctl/admin-ui/src/types/api/models/ValidTargets.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/ValidTargets.ts
@@ -9,4 +9,5 @@ export enum ValidTargets {
   AWS = 'aws',
   DB = 'db',
   OKTA = 'okta',
+  BIGQUERY = 'bigquery',
 }

--- a/clients/ctl/admin-ui/src/types/api/models/ValidateRequest.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/ValidateRequest.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { AWSConfig } from './AWSConfig';
+import type { BigQueryConfig } from './BigQueryConfig';
 import type { OktaConfig } from './OktaConfig';
 import type { ValidationTarget } from './ValidationTarget';
 
@@ -10,6 +11,6 @@ import type { ValidationTarget } from './ValidationTarget';
  * Validate endpoint request object
  */
 export type ValidateRequest = {
-  config: (AWSConfig | OktaConfig);
+  config: (AWSConfig | BigQueryConfig | OktaConfig);
   target: ValidationTarget;
 };

--- a/clients/ctl/admin-ui/src/types/api/models/ValidationTarget.ts
+++ b/clients/ctl/admin-ui/src/types/api/models/ValidationTarget.ts
@@ -8,4 +8,5 @@
 export enum ValidationTarget {
   AWS = 'aws',
   OKTA = 'okta',
+  BIGQUERY = 'bigquery',
 }


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/988

### Code Changes

* [x] Regenerate openapi types
* [x] Add `is_default` field where relevant in taxonomy form

### Steps to Confirm

* [ ] Editing a taxonomy field should still work as expected

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Should just be a small types related change, so nothing noticeable. It looks like we haven't run the generate command in a bit though, so there are a few new models that are unrelated to taxonomy.
