### PR TITLE
Update taxonomy forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/1.8.2...main)
 
+### Added
+
+* Added more taxonomy fields that can be edited via the UI [#1000](https://github.com/ethyca/fides/pull/1000)
+
 ## [1.8.2](https://github.com/ethyca/fides/compare/1.8.1...1.8.2) - 2022-08-18
 
 ### Added

--- a/clients/ctl/admin-ui/cypress/fixtures/data_subjects.json
+++ b/clients/ctl/admin-ui/cypress/fixtures/data_subjects.json
@@ -14,8 +14,11 @@
     "tags": null,
     "name": "Citizen Voter",
     "description": "An individual registered to voter with a state or authority.",
-    "rights": null,
-    "automated_decisions_or_profiling": null
+    "rights": {
+      "strategy": "INCLUDE",
+      "values": ["Informed", "Access", "Rectification", "Erasure", "Object"]
+    },
+    "automated_decisions_or_profiling": true
   },
   {
     "fides_key": "commuter",

--- a/clients/ctl/admin-ui/cypress/fixtures/data_uses.json
+++ b/clients/ctl/admin-ui/cypress/fixtures/data_uses.json
@@ -6,11 +6,11 @@
     "name": "Provide the capability",
     "description": "Provide, give, or make available the product, service, application or system.",
     "parent_key": null,
-    "legal_basis": null,
-    "special_category": null,
-    "recipients": null,
-    "legitimate_interest": false,
-    "legitimate_interest_impact_assessment": null
+    "legal_basis": "Legitimate Interests",
+    "special_category": "Vital Interests",
+    "recipients": ["marketing team", "dog shelter"],
+    "legitimate_interest": true,
+    "legitimate_interest_impact_assessment": "https://example.org/legitimate_interest_assessment"
   },
   {
     "fides_key": "provide.service",

--- a/clients/ctl/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/ctl/admin-ui/src/features/common/form/inputs.tsx
@@ -308,6 +308,7 @@ export const CustomCreatableMultiSelect = ({
   isSearchable,
   isClearable,
   options,
+  size,
   ...props
 }: SelectProps & FieldHookConfig<string[]>) => {
   const [field, meta] = useField(props);
@@ -322,6 +323,7 @@ export const CustomCreatableMultiSelect = ({
         <CreatableSelect
           name={props.name}
           chakraStyles={{
+            container: (provided) => ({ ...provided, mr: 2, flexGrow: 1 }),
             dropdownIndicator: (provided) => ({
               ...provided,
               background: "white",
@@ -356,6 +358,7 @@ export const CustomCreatableMultiSelect = ({
               newValue.map((v) => v.value)
             );
           }}
+          size={size}
         />
       </Grid>
       {isInvalid ? <FormErrorMessage>{meta.error}</FormErrorMessage> : null}

--- a/clients/ctl/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/ctl/admin-ui/src/features/common/form/inputs.tsx
@@ -264,39 +264,41 @@ export const CustomCreatableSingleSelect = ({
     <FormControl isInvalid={isInvalid}>
       <Grid templateColumns="1fr 3fr">
         <FormLabel htmlFor={props.id || props.name}>{label}</FormLabel>
-        <CreatableSelect
-          options={options}
-          onBlur={(option) => {
-            if (option) {
-              field.onBlur(props.name);
-            }
-          }}
-          onChange={(newValue) => {
-            if (newValue) {
-              field.onChange(props.name)(newValue.value);
-            } else {
-              field.onChange(props.name)("");
-            }
-          }}
-          name={props.name}
-          value={selected}
-          chakraStyles={{
-            dropdownIndicator: (provided) => ({
-              ...provided,
-              background: "white",
-            }),
-            multiValue: (provided) => ({
-              ...provided,
-              background: "primary.400",
-              color: "white",
-            }),
-            multiValueRemove: (provided) => ({
-              ...provided,
-              display: "none",
-              visibility: "hidden",
-            }),
-          }}
-        />
+        <Box data-testid={`input-${field.name}`}>
+          <CreatableSelect
+            options={options}
+            onBlur={(option) => {
+              if (option) {
+                field.onBlur(props.name);
+              }
+            }}
+            onChange={(newValue) => {
+              if (newValue) {
+                field.onChange(props.name)(newValue.value);
+              } else {
+                field.onChange(props.name)("");
+              }
+            }}
+            name={props.name}
+            value={selected}
+            chakraStyles={{
+              dropdownIndicator: (provided) => ({
+                ...provided,
+                background: "white",
+              }),
+              multiValue: (provided) => ({
+                ...provided,
+                background: "primary.400",
+                color: "white",
+              }),
+              multiValueRemove: (provided) => ({
+                ...provided,
+                display: "none",
+                visibility: "hidden",
+              }),
+            }}
+          />
+        </Box>
       </Grid>
       {isInvalid ? <FormErrorMessage>{meta.error}</FormErrorMessage> : null}
     </FormControl>
@@ -320,46 +322,49 @@ export const CustomCreatableMultiSelect = ({
     <FormControl isInvalid={isInvalid}>
       <Grid templateColumns="1fr 3fr">
         <FormLabel htmlFor={props.id || props.name}>{label}</FormLabel>
-        <CreatableSelect
-          name={props.name}
-          chakraStyles={{
-            container: (provided) => ({ ...provided, mr: 2, flexGrow: 1 }),
-            dropdownIndicator: (provided) => ({
-              ...provided,
-              background: "white",
-            }),
-            multiValue: (provided) => ({
-              ...provided,
-              background: "primary.400",
-              color: "white",
-            }),
-            multiValueRemove: (provided) => ({
-              ...provided,
-              display: "none",
-              visibility: "hidden",
-            }),
-          }}
-          components={{
-            Menu: () => null,
-            DropdownIndicator: () => null,
-          }}
-          isClearable={isClearable}
-          isMulti
-          options={options}
-          value={selected}
-          onBlur={(option) => {
-            if (option) {
-              field.onBlur(props.name);
-            }
-          }}
-          onChange={(newValue) => {
-            setFieldValue(
-              field.name,
-              newValue.map((v) => v.value)
-            );
-          }}
-          size={size}
-        />
+        <Box data-testid={`input-${field.name}`}>
+          <CreatableSelect
+            data-testid={`input-${field.name}`}
+            name={props.name}
+            chakraStyles={{
+              container: (provided) => ({ ...provided, mr: 2, flexGrow: 1 }),
+              dropdownIndicator: (provided) => ({
+                ...provided,
+                background: "white",
+              }),
+              multiValue: (provided) => ({
+                ...provided,
+                background: "primary.400",
+                color: "white",
+              }),
+              multiValueRemove: (provided) => ({
+                ...provided,
+                display: "none",
+                visibility: "hidden",
+              }),
+            }}
+            components={{
+              Menu: () => null,
+              DropdownIndicator: () => null,
+            }}
+            isClearable={isClearable}
+            isMulti
+            options={options}
+            value={selected}
+            onBlur={(option) => {
+              if (option) {
+                field.onBlur(props.name);
+              }
+            }}
+            onChange={(newValue) => {
+              setFieldValue(
+                field.name,
+                newValue.map((v) => v.value)
+              );
+            }}
+            size={size}
+          />
+        </Box>
       </Grid>
       {isInvalid ? <FormErrorMessage>{meta.error}</FormErrorMessage> : null}
     </FormControl>

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyFormBase.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyFormBase.tsx
@@ -17,10 +17,11 @@ import { isErrorResult, parseError } from "~/features/common/helpers";
 import { successToastParams } from "~/features/common/toast";
 import { RTKErrorResult } from "~/types/errors";
 
-import TaxonomyEntityTag from "../TaxonomyEntityTag";
-import { Labels, TaxonomyEntity, TaxonomyRTKResult } from "../types";
+import TaxonomyEntityTag from "./TaxonomyEntityTag";
+import { Labels, TaxonomyEntity, TaxonomyRTKResult } from "./types";
 
-type FormValues = Partial<TaxonomyEntity> & Pick<TaxonomyEntity, "fides_key">;
+export type FormValues = Partial<TaxonomyEntity> &
+  Pick<TaxonomyEntity, "fides_key">;
 
 interface Props {
   entity: TaxonomyEntity;
@@ -28,6 +29,7 @@ interface Props {
   onCancel: () => void;
   onEdit: (entity: TaxonomyEntity) => TaxonomyRTKResult;
   extraFormFields?: ReactNode;
+  initialValues: FormValues;
 }
 const EditTaxonomyForm = ({
   entity,
@@ -35,15 +37,9 @@ const EditTaxonomyForm = ({
   onCancel,
   onEdit,
   extraFormFields,
+  initialValues,
 }: Props) => {
   const toast = useToast();
-  const initialValues: FormValues = {
-    fides_key: entity.fides_key,
-    name: entity.name ?? "",
-    description: entity.description ?? "",
-    parent_key: entity.parent_key ?? "",
-    is_default: entity.is_default ?? false,
-  };
   const [formError, setFormError] = useState<string | null>(null);
 
   const handleError = (error: RTKErrorResult["error"]) => {
@@ -53,9 +49,12 @@ const EditTaxonomyForm = ({
 
   const handleSubmit = async (newValues: FormValues) => {
     setFormError(null);
-    // ensure parent key stays the same, as it cannot be changed by the user
-    // and because the backend requires it to be undefined over an empty string
-    const payload = { ...newValues, parent_key: entity.parent_key };
+    // parent_key and fides_keys are immutable
+    const payload = {
+      ...newValues,
+      parent_key: entity.parent_key,
+      fides_key: entity.fides_key,
+    };
     const result = await onEdit(payload);
     if (isErrorResult(result)) {
       handleError(result.error);

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -2,7 +2,7 @@ import { Center, SimpleGrid, Spinner, Text } from "@fidesui/react";
 import { useMemo, useState } from "react";
 
 import AccordionTree from "../common/AccordionTree";
-import EditTaxonomyForm from "./EditTaxonomyForm";
+import TaxonomyFormBase from "./forms/TaxonomyFormBase";
 import { transformTaxonomyEntityToNodes } from "./helpers";
 import { TaxonomyHookData } from "./hooks";
 import { TaxonomyEntity, TaxonomyEntityNode } from "./types";
@@ -12,7 +12,13 @@ interface Props {
 }
 
 const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
-  const { isLoading, data, labels, edit: onEdit } = useTaxonomy();
+  const {
+    isLoading,
+    data,
+    labels,
+    edit: onEdit,
+    extraFormFields,
+  } = useTaxonomy();
   const taxonomyNodes = useMemo(() => {
     if (data) {
       return transformTaxonomyEntityToNodes(data);
@@ -46,11 +52,12 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
         focusedKey={editEntity?.fides_key}
       />
       {editEntity ? (
-        <EditTaxonomyForm
+        <TaxonomyFormBase
           labels={labels}
           entity={editEntity}
           onCancel={() => setEditEntity(null)}
           onEdit={onEdit}
+          extraFormFields={extraFormFields}
         />
       ) : null}
     </SimpleGrid>

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -2,13 +2,13 @@ import { Center, SimpleGrid, Spinner, Text } from "@fidesui/react";
 import { useMemo, useState } from "react";
 
 import AccordionTree from "../common/AccordionTree";
-import TaxonomyFormBase from "./forms/TaxonomyFormBase";
 import { transformTaxonomyEntityToNodes } from "./helpers";
 import { TaxonomyHookData } from "./hooks";
+import TaxonomyFormBase from "./TaxonomyFormBase";
 import { TaxonomyEntity, TaxonomyEntityNode } from "./types";
 
 interface Props {
-  useTaxonomy: () => TaxonomyHookData;
+  useTaxonomy: () => TaxonomyHookData<TaxonomyEntity>;
 }
 
 const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
@@ -18,6 +18,7 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
     labels,
     edit: onEdit,
     extraFormFields,
+    transformEntityToInitialValues,
   } = useTaxonomy();
   const taxonomyNodes = useMemo(() => {
     if (data) {
@@ -58,6 +59,7 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
           onCancel={() => setEditEntity(null)}
           onEdit={onEdit}
           extraFormFields={extraFormFields}
+          initialValues={transformEntityToInitialValues(editEntity)}
         />
       ) : null}
     </SimpleGrid>

--- a/clients/ctl/admin-ui/src/features/taxonomy/forms/TaxonomyFormBase.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/forms/TaxonomyFormBase.tsx
@@ -10,15 +10,15 @@ import {
   useToast,
 } from "@fidesui/react";
 import { Form, Formik } from "formik";
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 
+import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
 import { isErrorResult, parseError } from "~/features/common/helpers";
+import { successToastParams } from "~/features/common/toast";
 import { RTKErrorResult } from "~/types/errors";
 
-import { CustomTextArea, CustomTextInput } from "../common/form/inputs";
-import { successToastParams } from "../common/toast";
-import TaxonomyEntityTag from "./TaxonomyEntityTag";
-import { Labels, TaxonomyEntity, TaxonomyRTKResult } from "./types";
+import TaxonomyEntityTag from "../TaxonomyEntityTag";
+import { Labels, TaxonomyEntity, TaxonomyRTKResult } from "../types";
 
 type FormValues = Partial<TaxonomyEntity> & Pick<TaxonomyEntity, "fides_key">;
 
@@ -27,8 +27,15 @@ interface Props {
   labels: Labels;
   onCancel: () => void;
   onEdit: (entity: TaxonomyEntity) => TaxonomyRTKResult;
+  extraFormFields?: ReactNode;
 }
-const EditTaxonomyForm = ({ entity, labels, onCancel, onEdit }: Props) => {
+const EditTaxonomyForm = ({
+  entity,
+  labels,
+  onCancel,
+  onEdit,
+  extraFormFields,
+}: Props) => {
   const toast = useToast();
   const initialValues: FormValues = {
     fides_key: entity.fides_key,
@@ -84,6 +91,7 @@ const EditTaxonomyForm = ({ entity, labels, onCancel, onEdit }: Props) => {
                 label={labels.parent_key}
                 disabled
               />
+              {extraFormFields}
             </Stack>
 
             {formError ? (

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -183,6 +183,8 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
       // to properly type just for this special case
       rights: { values: entity.rights, strategy: entity.strategy },
     };
+    // @ts-ignore for the same reason as above
+    delete transformedEntity.strategy;
     return edit(transformedEntity);
   };
 

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -118,6 +118,9 @@ export const useDataSubject = (): TaxonomyHookData => {
     name: "Data subject name",
     description: "Data subject description",
     parent_key: "Parent data subject",
+    rights: "Rights",
+    strategy: "Strategy",
+    automatic_decisions: "Automatic decisions or profiling",
   };
 
   const [edit] = useUpdateDataSubjectMutation();

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -1,3 +1,12 @@
+import { ReactNode } from "react";
+
+import { LegalBasisEnum, SpecialCategoriesEnum } from "~/types/api";
+
+import {
+  CustomCreatableMultiSelect,
+  CustomSelect,
+  CustomTextInput,
+} from "../common/form/inputs";
 import {
   useGetAllDataQualifiersQuery,
   useUpdateDataQualifierMutation,
@@ -21,7 +30,21 @@ export interface TaxonomyHookData {
   isLoading: boolean;
   labels: Labels;
   edit: (entity: TaxonomyEntity) => TaxonomyRTKResult;
+  extraFormFields?: ReactNode;
 }
+
+const enumToOptions = (e: { [s: number]: string }) =>
+  Object.entries(e).map((entry) => ({
+    value: entry[1],
+    label: entry[1],
+  }));
+
+// const enumToOptions = (enum: str) => {
+//   return Object.entries(enum).map((entry) => ({
+//     value: entry[1],
+//     label: entry[1],
+//   }));
+// }
 
 export const useDataCategory = (): TaxonomyHookData => {
   const { data, isLoading } = useGetAllDataCategoriesQuery();
@@ -46,11 +69,45 @@ export const useDataUse = (): TaxonomyHookData => {
     name: "Data use name",
     description: "Data use description",
     parent_key: "Parent data use",
+    legal_basis: "Legal basis",
+    special_category: "Special category",
+    recipient: "Recipient",
+    legitimate_interest: "Legitimate interest",
+    legitimate_interest_impact_assessment:
+      "Legitimate interest impact assessment",
   };
 
   const [edit] = useUpdateDataUseMutation();
 
-  return { data, isLoading, labels, edit };
+  const legalBases = enumToOptions(LegalBasisEnum);
+  const specialCategories = enumToOptions(SpecialCategoriesEnum);
+
+  const extraFormFields = (
+    <>
+      <CustomSelect
+        name="legal_basis"
+        label={labels.legal_basis}
+        options={legalBases}
+      />
+      <CustomSelect
+        name="special_categories"
+        label={labels.special_category}
+        options={specialCategories}
+      />
+      {/* <CustomCreatableMultiSelect
+        name="recipient"
+        label="Recipients"
+        options={[]}
+      /> */}
+      {/* TODO: legitimate interest: boolean field */}
+      <CustomTextInput
+        name="legitimate_interest_impact_assessment"
+        label={labels.legitimate_interest_impact_assessment}
+      />
+    </>
+  );
+
+  return { data, isLoading, labels, edit, extraFormFields };
 };
 
 export const useDataSubject = (): TaxonomyHookData => {
@@ -65,7 +122,9 @@ export const useDataSubject = (): TaxonomyHookData => {
 
   const [edit] = useUpdateDataSubjectMutation();
 
-  return { data, isLoading, labels, edit };
+  const extraFormFields = <div>hi</div>;
+
+  return { data, isLoading, labels, edit, extraFormFields };
 };
 
 export const useDataQualifier = (): TaxonomyHookData => {

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -40,7 +40,7 @@ export interface TaxonomyHookData<T extends TaxonomyEntity> {
   data?: TaxonomyEntity[];
   isLoading: boolean;
   labels: Labels;
-  edit: (entity: TaxonomyEntity) => TaxonomyRTKResult;
+  edit: (entity: T) => TaxonomyRTKResult;
   extraFormFields?: ReactNode;
   transformEntityToInitialValues: (entity: T) => FormValues;
 }
@@ -97,6 +97,14 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
   };
 
   const [edit] = useUpdateDataUseMutation();
+  const handleEdit = (entity: DataUse) =>
+    edit({
+      ...entity,
+      // text inputs don't like having undefined, so we originally converted
+      // to "", but on submission we need to convert back to undefined
+      legitimate_interest_impact_assessment:
+        entity.legitimate_interest_impact_assessment ?? undefined,
+    });
 
   const transformEntityToInitialValues = (du: DataUse) => {
     const base = transformTaxonomyBaseToInitialValues(du);
@@ -107,7 +115,7 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
       recipients: du.recipients ?? [],
       legitimate_interest: du.legitimate_interest,
       legitimate_interest_impact_assessment:
-        du.legitimate_interest_impact_assessment,
+        du.legitimate_interest_impact_assessment ?? "",
     };
   };
 
@@ -130,6 +138,7 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
         name="recipients"
         label="Recipients"
         options={[]}
+        size="sm"
       />
       {/* TODO: legitimate interest: boolean field */}
       <CustomTextInput
@@ -143,7 +152,7 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
     data,
     isLoading,
     labels,
-    edit,
+    edit: handleEdit,
     extraFormFields,
     transformEntityToInitialValues,
   };


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/998

### Code Changes

* [x] Extends the forms for DataSubjects and DataUses based on the [updated requirements](https://github.com/ethyca/fides/issues/858#issuecomment-1219558924)
  * [x] Adds a new prop `extraFormFields` and renames the original form to `TaxonomyFormBase` so other forms can build off of it
  * [x] Adds more props to the hooks now that there are more unique fields between taxonomy types
    * [x] Does this via typescript generics... this is my first time somewhat successfully using them, so very open to suggestions if I'm doing it weirdly 😅 
* [x] Updates a few of the form inputs to take data-testid the same way as everyone else
* [x] Adds cypress tests

### Steps to Confirm

* [ ] Go to the /taxonomy page and try editing the forms for DataSubjects and DataUses

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
  * https://github.com/ethyca/fides/issues/1001
* [x] Update `CHANGELOG.md`

### Description Of Changes

https://github.com/ethyca/fides/pull/977 was clever about reusing the same component and isolating unique attributes to hooks. This worked well back when the edit form was the same across every taxonomy type. Now that they're no longer the same, we are still able to use the same pattern, but it might make things a little harder to grok, in exchange for cleaner components.

![image](https://user-images.githubusercontent.com/24641006/185708239-02e79ed2-c2d1-4d86-abde-177989bd476b.png)

![image](https://user-images.githubusercontent.com/24641006/185708287-2959df5a-14c1-4eff-9ff8-7a47832c53eb.png)

DataCategory and DataQualifier forms still look the same.
