### PR TITLE
fidesctl/datamap: Concise heading of Fides Key columns

### DIFF
--- a/src/fidesctl/api/ctl/routes/datamap.py
+++ b/src/fidesctl/api/ctl/routes/datamap.py
@@ -17,8 +17,8 @@ from fidesctl.ctl.core.export import build_joined_dataframe
 from fidesctl.ctl.core.export_helpers import DATAMAP_COLUMNS
 
 API_EXTRA_COLUMNS = {
-    "system.fides_key": "The fides key for the system",
-    "dataset.fides_key": "The fides key for the dataset (if applicable)",
+    "system.fides_key": "System Fides Key",
+    "dataset.fides_key": "Dataset Fides Key (if applicable)",
     "system.system_dependencies": "Related cross-system dependencies",
     "system.description": "Description of the System",
 }


### PR DESCRIPTION
### Code Changes

I noticed that the long description of the fides key column is almost always going
to be truncated in the UI. This is true for other columns, but they all try to be
concise and put most important words first (no "the") which is easier to follow
when hunting for information in a table.

Long-term we'll probably need to introduce a way of embedding help text in this API,
or another API/constants file with the column titles seperate fromt the help text.

### Steps to Confirm

* [x] Hit the datamap API

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes
Before:
![Screen Shot 2022-08-19 at 16 04 42](https://user-images.githubusercontent.com/2236777/185717709-58eed965-0dee-4e18-90e1-76b73a9f9768.png)

After:
![Screen Shot 2022-08-19 at 15 28 54](https://user-images.githubusercontent.com/2236777/185715212-350f76d0-0d15-444b-8082-a03b923772e2.png)

