### PR TITLE
Delete taxonomy UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The types of changes are:
 
 * Added the ability to edit taxonomy fields via the UI [#977](https://github.com/ethyca/fides/pull/977)
 * New column `is_default` added to DataCategory, DataUse, DataSubject, and DataQualifier tables [#976](https://github.com/ethyca/fides/pull/976)
+* Added the ability to delete taxonomy fields via the UI [#1006](https://github.com/ethyca/fides/pull/1006)
 
 ### Changed
 

--- a/clients/ctl/admin-ui/src/features/common/AccordionTree.tsx
+++ b/clients/ctl/admin-ui/src/features/common/AccordionTree.tsx
@@ -20,16 +20,27 @@ interface ActionButtonProps {
   onEdit: (node: TaxonomyEntityNode) => void;
   onDelete: (node: TaxonomyEntityNode) => void;
 }
-const ActionButtons = ({ node, onEdit, onDelete }: ActionButtonProps) => (
-  <ButtonGroup size="xs" isAttached variant="outline" data-testid="action-btns">
-    <Button data-testid="edit-btn" onClick={() => onEdit(node)}>
-      Edit
-    </Button>
-    <Button data-testid="delete-btn" onClick={() => onDelete(node)}>
-      Delete
-    </Button>
-  </ButtonGroup>
-);
+const ActionButtons = ({ node, onEdit, onDelete }: ActionButtonProps) => {
+  const showDelete = node.children.length === 0;
+  return (
+    <ButtonGroup
+      size="xs"
+      isAttached
+      variant="outline"
+      data-testid="action-btns"
+      mr="2"
+    >
+      <Button data-testid="edit-btn" onClick={() => onEdit(node)}>
+        Edit
+      </Button>
+      {showDelete ? (
+        <Button data-testid="delete-btn" onClick={() => onDelete(node)}>
+          Delete
+        </Button>
+      ) : null}
+    </ButtonGroup>
+  );
+};
 
 interface Props {
   nodes: TreeNode[];

--- a/clients/ctl/admin-ui/src/features/common/AccordionTree.tsx
+++ b/clients/ctl/admin-ui/src/features/common/AccordionTree.tsx
@@ -6,8 +6,6 @@ import {
   AccordionPanel,
   Box,
   BoxProps,
-  Button,
-  ButtonGroup,
   Text,
 } from "@fidesui/react";
 import { Fragment, useState } from "react";
@@ -15,40 +13,12 @@ import { Fragment, useState } from "react";
 import { TaxonomyEntityNode } from "../taxonomy/types";
 import { TreeNode } from "./types";
 
-interface ActionButtonProps {
-  node: TaxonomyEntityNode;
-  onEdit: (node: TaxonomyEntityNode) => void;
-  onDelete: (node: TaxonomyEntityNode) => void;
-}
-const ActionButtons = ({ node, onEdit, onDelete }: ActionButtonProps) => {
-  const showDelete = node.children.length === 0;
-  return (
-    <ButtonGroup
-      size="xs"
-      isAttached
-      variant="outline"
-      data-testid="action-btns"
-      mr="2"
-    >
-      <Button data-testid="edit-btn" onClick={() => onEdit(node)}>
-        Edit
-      </Button>
-      {showDelete ? (
-        <Button data-testid="delete-btn" onClick={() => onDelete(node)}>
-          Delete
-        </Button>
-      ) : null}
-    </ButtonGroup>
-  );
-};
-
 interface Props {
   nodes: TreeNode[];
-  onEdit: (node: TaxonomyEntityNode) => void;
-  onDelete: (node: TaxonomyEntityNode) => void;
   focusedKey?: string;
+  renderHover?: (node: TaxonomyEntityNode) => React.ReactNode;
 }
-const AccordionTree = ({ nodes, onEdit, onDelete, focusedKey }: Props) => {
+const AccordionTree = ({ nodes, focusedKey, renderHover }: Props) => {
   const [hoverNode, setHoverNode] = useState<TreeNode | undefined>(undefined);
   /**
    * Recursive function to generate the accordion tree
@@ -73,6 +43,7 @@ const AccordionTree = ({ nodes, onEdit, onDelete, focusedKey }: Props) => {
         setHoverNode(undefined);
       },
     };
+    const hoverContent = isHovered && renderHover ? renderHover(node) : null;
 
     if (node.children.length === 0) {
       return (
@@ -83,13 +54,7 @@ const AccordionTree = ({ nodes, onEdit, onDelete, focusedKey }: Props) => {
           >
             {node.label}
           </Text>
-          {isHovered ? (
-            <ActionButtons
-              node={hoverNode}
-              onEdit={onEdit}
-              onDelete={onDelete}
-            />
-          ) : null}
+          {hoverContent}
         </Box>
       );
     }
@@ -109,13 +74,7 @@ const AccordionTree = ({ nodes, onEdit, onDelete, focusedKey }: Props) => {
             <AccordionIcon />
             {node.label}
           </AccordionButton>
-          {isHovered ? (
-            <ActionButtons
-              node={hoverNode}
-              onEdit={onEdit}
-              onDelete={onDelete}
-            />
-          ) : null}
+          {hoverContent}
         </Box>
 
         <AccordionPanel p={0}>

--- a/clients/ctl/admin-ui/src/features/common/AccordionTree.tsx
+++ b/clients/ctl/admin-ui/src/features/common/AccordionTree.tsx
@@ -18,22 +18,26 @@ import { TreeNode } from "./types";
 interface ActionButtonProps {
   node: TaxonomyEntityNode;
   onEdit: (node: TaxonomyEntityNode) => void;
+  onDelete: (node: TaxonomyEntityNode) => void;
 }
-const ActionButtons = ({ node, onEdit }: ActionButtonProps) => (
+const ActionButtons = ({ node, onEdit, onDelete }: ActionButtonProps) => (
   <ButtonGroup size="xs" isAttached variant="outline" data-testid="action-btns">
     <Button data-testid="edit-btn" onClick={() => onEdit(node)}>
       Edit
     </Button>
-    <Button data-testid="delete-btn">Delete</Button>
+    <Button data-testid="delete-btn" onClick={() => onDelete(node)}>
+      Delete
+    </Button>
   </ButtonGroup>
 );
 
 interface Props {
   nodes: TreeNode[];
   onEdit: (node: TaxonomyEntityNode) => void;
+  onDelete: (node: TaxonomyEntityNode) => void;
   focusedKey?: string;
 }
-const AccordionTree = ({ nodes, onEdit, focusedKey }: Props) => {
+const AccordionTree = ({ nodes, onEdit, onDelete, focusedKey }: Props) => {
   const [hoverNode, setHoverNode] = useState<TreeNode | undefined>(undefined);
   /**
    * Recursive function to generate the accordion tree
@@ -69,7 +73,11 @@ const AccordionTree = ({ nodes, onEdit, focusedKey }: Props) => {
             {node.label}
           </Text>
           {isHovered ? (
-            <ActionButtons node={hoverNode} onEdit={onEdit} />
+            <ActionButtons
+              node={hoverNode}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
           ) : null}
         </Box>
       );
@@ -91,7 +99,11 @@ const AccordionTree = ({ nodes, onEdit, focusedKey }: Props) => {
             {node.label}
           </AccordionButton>
           {isHovered ? (
-            <ActionButtons node={hoverNode} onEdit={onEdit} />
+            <ActionButtons
+              node={hoverNode}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
           ) : null}
         </Box>
 

--- a/clients/ctl/admin-ui/src/features/common/AccordionTree.tsx
+++ b/clients/ctl/admin-ui/src/features/common/AccordionTree.tsx
@@ -10,13 +10,12 @@ import {
 } from "@fidesui/react";
 import { Fragment, useState } from "react";
 
-import { TaxonomyEntityNode } from "../taxonomy/types";
 import { TreeNode } from "./types";
 
 interface Props {
   nodes: TreeNode[];
   focusedKey?: string;
-  renderHover?: (node: TaxonomyEntityNode) => React.ReactNode;
+  renderHover?: (node: TreeNode) => React.ReactNode;
 }
 const AccordionTree = ({ nodes, focusedKey, renderHover }: Props) => {
   const [hoverNode, setHoverNode] = useState<TreeNode | undefined>(undefined);

--- a/clients/ctl/admin-ui/src/features/data-qualifier/data-qualifier.slice.ts
+++ b/clients/ctl/admin-ui/src/features/data-qualifier/data-qualifier.slice.ts
@@ -38,11 +38,22 @@ export const dataQualifierApi = createApi({
       }),
       invalidatesTags: ["Data Qualifiers"],
     }),
+    deleteDataQualifier: build.mutation<string, string>({
+      query: (key) => ({
+        url: `data_qualifier/${key}`,
+        params: { resource_type: "data_qualifier" },
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Data Qualifiers"],
+    }),
   }),
 });
 
-export const { useGetAllDataQualifiersQuery, useUpdateDataQualifierMutation } =
-  dataQualifierApi;
+export const {
+  useGetAllDataQualifiersQuery,
+  useUpdateDataQualifierMutation,
+  useDeleteDataQualifierMutation,
+} = dataQualifierApi;
 
 export const dataQualifierSlice = createSlice({
   name: "dataQualifier",

--- a/clients/ctl/admin-ui/src/features/data-subjects/data-subject.slice.ts
+++ b/clients/ctl/admin-ui/src/features/data-subjects/data-subject.slice.ts
@@ -37,11 +37,22 @@ export const dataSubjectsApi = createApi({
       }),
       invalidatesTags: ["Data Subjects"],
     }),
+    deleteDataSubject: build.mutation<string, string>({
+      query: (key) => ({
+        url: `data_subject/${key}`,
+        params: { resource_type: "data_subject" },
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Data Subjects"],
+    }),
   }),
 });
 
-export const { useGetAllDataSubjectsQuery, useUpdateDataSubjectMutation } =
-  dataSubjectsApi;
+export const {
+  useGetAllDataSubjectsQuery,
+  useUpdateDataSubjectMutation,
+  useDeleteDataSubjectMutation,
+} = dataSubjectsApi;
 
 export const dataSubjectsSlice = createSlice({
   name: "dataSubjects",

--- a/clients/ctl/admin-ui/src/features/data-use/data-use.slice.ts
+++ b/clients/ctl/admin-ui/src/features/data-use/data-use.slice.ts
@@ -37,10 +37,22 @@ export const dataUseApi = createApi({
       }),
       invalidatesTags: ["Data Uses"],
     }),
+    deleteDataUse: build.mutation<string, string>({
+      query: (key) => ({
+        url: `data_use/${key}`,
+        params: { resource_type: "data_use" },
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Data Uses"],
+    }),
   }),
 });
 
-export const { useGetAllDataUsesQuery, useUpdateDataUseMutation } = dataUseApi;
+export const {
+  useGetAllDataUsesQuery,
+  useUpdateDataUseMutation,
+  useDeleteDataUseMutation,
+} = dataUseApi;
 
 export const dataUseSlice = createSlice({
   name: "dataUse",

--- a/clients/ctl/admin-ui/src/features/taxonomy/ActionButtons.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/ActionButtons.tsx
@@ -1,0 +1,32 @@
+import { Button, ButtonGroup } from "@fidesui/react";
+
+import { TaxonomyEntityNode } from "./types";
+
+interface ActionButtonProps {
+  node: TaxonomyEntityNode;
+  onEdit: (node: TaxonomyEntityNode) => void;
+  onDelete: (node: TaxonomyEntityNode) => void;
+}
+const ActionButtons = ({ node, onEdit, onDelete }: ActionButtonProps) => {
+  const showDelete = node.children.length === 0;
+  return (
+    <ButtonGroup
+      size="xs"
+      isAttached
+      variant="outline"
+      data-testid="action-btns"
+      mr="2"
+    >
+      <Button data-testid="edit-btn" onClick={() => onEdit(node)}>
+        Edit
+      </Button>
+      {showDelete ? (
+        <Button data-testid="delete-btn" onClick={() => onDelete(node)}>
+          Delete
+        </Button>
+      ) : null}
+    </ButtonGroup>
+  );
+};
+
+export default ActionButtons;

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyFormBase.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyFormBase.tsx
@@ -18,7 +18,7 @@ import { successToastParams } from "~/features/common/toast";
 import { RTKErrorResult } from "~/types/errors";
 
 import TaxonomyEntityTag from "./TaxonomyEntityTag";
-import { Labels, TaxonomyEntity, TaxonomyRTKResult } from "./types";
+import { Labels, RTKResult, TaxonomyEntity } from "./types";
 
 export type FormValues = Partial<TaxonomyEntity> &
   Pick<TaxonomyEntity, "fides_key">;
@@ -27,7 +27,7 @@ interface Props {
   entity: TaxonomyEntity;
   labels: Labels;
   onCancel: () => void;
-  onEdit: (entity: TaxonomyEntity) => TaxonomyRTKResult;
+  onEdit: (entity: TaxonomyEntity) => RTKResult<TaxonomyEntity>;
   extraFormFields?: ReactNode;
   initialValues: FormValues;
 }

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -14,6 +14,7 @@ import { isErrorResult } from "~/types/errors";
 import AccordionTree from "../common/AccordionTree";
 import { getErrorMessage } from "../common/helpers";
 import { errorToastParams, successToastParams } from "../common/toast";
+import ActionButtons from "./ActionButtons";
 import { transformTaxonomyEntityToNodes } from "./helpers";
 import { TaxonomyHookData } from "./hooks";
 import TaxonomyFormBase from "./TaxonomyFormBase";
@@ -90,9 +91,14 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
       <SimpleGrid columns={2} spacing={2}>
         <AccordionTree
           nodes={taxonomyNodes}
-          onEdit={handleSetEditEntity}
-          onDelete={handleSetDeleteKey}
           focusedKey={editEntity?.fides_key}
+          renderHover={(node) => (
+            <ActionButtons
+              onDelete={handleSetDeleteKey}
+              onEdit={handleSetEditEntity}
+              node={node}
+            />
+          )}
         />
         {editEntity ? (
           <TaxonomyFormBase

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -8,12 +8,12 @@ import {
 } from "@fidesui/react";
 import { useMemo, useState } from "react";
 
+import AccordionTree from "~/features/common/AccordionTree";
 import ConfirmationModal from "~/features/common/ConfirmationModal";
+import { getErrorMessage } from "~/features/common/helpers";
+import { errorToastParams, successToastParams } from "~/features/common/toast";
 import { isErrorResult } from "~/types/errors";
 
-import AccordionTree from "../common/AccordionTree";
-import { getErrorMessage } from "../common/helpers";
-import { errorToastParams, successToastParams } from "../common/toast";
 import ActionButtons from "./ActionButtons";
 import { transformTaxonomyEntityToNodes } from "./helpers";
 import { TaxonomyHookData } from "./hooks";

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -29,8 +29,8 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
     isLoading,
     data,
     labels,
-    onEdit,
-    onDelete,
+    handleEdit,
+    handleDelete: deleteEntity,
     extraFormFields,
     transformEntityToInitialValues,
   } = useTaxonomy();
@@ -76,7 +76,7 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
 
   const handleDelete = async () => {
     if (deleteKey) {
-      const result = await onDelete(deleteKey);
+      const result = await deleteEntity(deleteKey);
       if (isErrorResult(result)) {
         toast(errorToastParams(getErrorMessage(result.error)));
       } else {
@@ -105,7 +105,7 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
             labels={labels}
             entity={editEntity}
             onCancel={() => setEditEntity(null)}
-            onEdit={onEdit}
+            onEdit={handleEdit}
             extraFormFields={extraFormFields}
             initialValues={transformEntityToInitialValues(editEntity)}
           />

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -83,6 +83,7 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
         toast(successToastParams(`Successfully deleted ${taxonomyType}`));
       }
       onDeleteClose();
+      setEditEntity(null);
     }
   };
 

--- a/clients/ctl/admin-ui/src/features/taxonomy/data-categories.slice.ts
+++ b/clients/ctl/admin-ui/src/features/taxonomy/data-categories.slice.ts
@@ -37,11 +37,22 @@ export const dataCategoriesApi = createApi({
       }),
       invalidatesTags: ["Data Categories"],
     }),
+    deleteDataCategory: build.mutation<string, string>({
+      query: (key) => ({
+        url: `data_category/${key}`,
+        params: { resource_type: "data_category" },
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Data Categories"],
+    }),
   }),
 });
 
-export const { useGetAllDataCategoriesQuery, useUpdateDataCategoryMutation } =
-  dataCategoriesApi;
+export const {
+  useGetAllDataCategoriesQuery,
+  useUpdateDataCategoryMutation,
+  useDeleteDataCategoryMutation,
+} = dataCategoriesApi;
 
 export const dataCategoriesSlice = createSlice({
   name: "dataCategories",

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -18,29 +18,34 @@ import {
   CustomTextInput,
 } from "../common/form/inputs";
 import {
+  useDeleteDataQualifierMutation,
   useGetAllDataQualifiersQuery,
   useUpdateDataQualifierMutation,
 } from "../data-qualifier/data-qualifier.slice";
 import {
+  useDeleteDataSubjectMutation,
   useGetAllDataSubjectsQuery,
   useUpdateDataSubjectMutation,
 } from "../data-subjects/data-subject.slice";
 import {
+  useDeleteDataUseMutation,
   useGetAllDataUsesQuery,
   useUpdateDataUseMutation,
 } from "../data-use/data-use.slice";
 import {
+  useDeleteDataCategoryMutation,
   useGetAllDataCategoriesQuery,
   useUpdateDataCategoryMutation,
 } from "./data-categories.slice";
 import type { FormValues } from "./TaxonomyFormBase";
-import { Labels, TaxonomyEntity, TaxonomyRTKResult } from "./types";
+import { Labels, RTKResult, TaxonomyEntity } from "./types";
 
 export interface TaxonomyHookData<T extends TaxonomyEntity> {
   data?: TaxonomyEntity[];
   isLoading: boolean;
   labels: Labels;
-  edit: (entity: T) => TaxonomyRTKResult;
+  onEdit: (entity: T) => RTKResult<TaxonomyEntity>;
+  onDelete: (key: string) => RTKResult<string>;
   extraFormFields?: ReactNode;
   transformEntityToInitialValues: (entity: T) => FormValues;
 }
@@ -69,13 +74,15 @@ export const useDataCategory = (): TaxonomyHookData<DataCategory> => {
     parent_key: "Parent category",
   };
 
-  const [edit] = useUpdateDataCategoryMutation();
+  const [editDataCategory] = useUpdateDataCategoryMutation();
+  const [deleteDataCategory] = useDeleteDataCategoryMutation();
 
   return {
     data,
     isLoading,
     labels,
-    edit,
+    onEdit: editDataCategory,
+    onDelete: deleteDataCategory,
     transformEntityToInitialValues: transformTaxonomyBaseToInitialValues,
   };
 };
@@ -96,9 +103,10 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
       "Legitimate interest impact assessment",
   };
 
-  const [edit] = useUpdateDataUseMutation();
+  const [onEdit] = useUpdateDataUseMutation();
+  const [onDelete] = useDeleteDataUseMutation();
   const handleEdit = (entity: DataUse) =>
-    edit({
+    onEdit({
       ...entity,
       // text inputs don't like having undefined, so we originally converted
       // to "", but on submission we need to convert back to undefined
@@ -152,7 +160,8 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
     data,
     isLoading,
     labels,
-    edit: handleEdit,
+    onEdit: handleEdit,
+    onDelete,
     extraFormFields,
     transformEntityToInitialValues,
   };
@@ -171,7 +180,8 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     automatic_decisions: "Automatic decisions or profiling",
   };
 
-  const [edit] = useUpdateDataSubjectMutation();
+  const [onEdit] = useUpdateDataSubjectMutation();
+  const [onDelete] = useDeleteDataSubjectMutation();
 
   const handleEdit = (entity: TaxonomyEntity) => {
     const transformedEntity = {
@@ -185,7 +195,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     };
     // @ts-ignore for the same reason as above
     delete transformedEntity.strategy;
-    return edit(transformedEntity);
+    return onEdit(transformedEntity);
   };
 
   const transformEntityToInitialValues = (ds: DataSubject) => {
@@ -218,7 +228,8 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     data,
     isLoading,
     labels,
-    edit: handleEdit,
+    onEdit: handleEdit,
+    onDelete,
     extraFormFields,
     transformEntityToInitialValues,
   };
@@ -234,13 +245,15 @@ export const useDataQualifier = (): TaxonomyHookData<DataQualifier> => {
     parent_key: "Parent data qualifier",
   };
 
-  const [edit] = useUpdateDataQualifierMutation();
+  const [onEdit] = useUpdateDataQualifierMutation();
+  const [onDelete] = useDeleteDataQualifierMutation();
 
   return {
     data,
     isLoading,
     labels,
-    edit,
+    onEdit,
+    onDelete,
     transformEntityToInitialValues: transformTaxonomyBaseToInitialValues,
   };
 };

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -44,8 +44,8 @@ export interface TaxonomyHookData<T extends TaxonomyEntity> {
   data?: TaxonomyEntity[];
   isLoading: boolean;
   labels: Labels;
-  onEdit: (entity: T) => RTKResult<TaxonomyEntity>;
-  onDelete: (key: string) => RTKResult<string>;
+  handleEdit: (entity: T) => RTKResult<TaxonomyEntity>;
+  handleDelete: (key: string) => RTKResult<string>;
   extraFormFields?: ReactNode;
   transformEntityToInitialValues: (entity: T) => FormValues;
 }
@@ -81,8 +81,8 @@ export const useDataCategory = (): TaxonomyHookData<DataCategory> => {
     data,
     isLoading,
     labels,
-    onEdit: editDataCategory,
-    onDelete: deleteDataCategory,
+    handleEdit: editDataCategory,
+    handleDelete: deleteDataCategory,
     transformEntityToInitialValues: transformTaxonomyBaseToInitialValues,
   };
 };
@@ -103,10 +103,10 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
       "Legitimate interest impact assessment",
   };
 
-  const [onEdit] = useUpdateDataUseMutation();
-  const [onDelete] = useDeleteDataUseMutation();
+  const [edit] = useUpdateDataUseMutation();
+  const [handleDelete] = useDeleteDataUseMutation();
   const handleEdit = (entity: DataUse) =>
-    onEdit({
+    edit({
       ...entity,
       // text inputs don't like having undefined, so we originally converted
       // to "", but on submission we need to convert back to undefined
@@ -160,8 +160,8 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
     data,
     isLoading,
     labels,
-    onEdit: handleEdit,
-    onDelete,
+    handleEdit,
+    handleDelete,
     extraFormFields,
     transformEntityToInitialValues,
   };
@@ -180,8 +180,8 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     automatic_decisions: "Automatic decisions or profiling",
   };
 
-  const [onEdit] = useUpdateDataSubjectMutation();
-  const [onDelete] = useDeleteDataSubjectMutation();
+  const [edit] = useUpdateDataSubjectMutation();
+  const [handleDelete] = useDeleteDataSubjectMutation();
 
   const handleEdit = (entity: TaxonomyEntity) => {
     const transformedEntity = {
@@ -195,7 +195,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     };
     // @ts-ignore for the same reason as above
     delete transformedEntity.strategy;
-    return onEdit(transformedEntity);
+    return edit(transformedEntity);
   };
 
   const transformEntityToInitialValues = (ds: DataSubject) => {
@@ -228,8 +228,8 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     data,
     isLoading,
     labels,
-    onEdit: handleEdit,
-    onDelete,
+    handleEdit,
+    handleDelete,
     extraFormFields,
     transformEntityToInitialValues,
   };
@@ -245,15 +245,15 @@ export const useDataQualifier = (): TaxonomyHookData<DataQualifier> => {
     parent_key: "Parent data qualifier",
   };
 
-  const [onEdit] = useUpdateDataQualifierMutation();
-  const [onDelete] = useDeleteDataQualifierMutation();
+  const [handleEdit] = useUpdateDataQualifierMutation();
+  const [handleDelete] = useDeleteDataQualifierMutation();
 
   return {
     data,
     isLoading,
     labels,
-    onEdit,
-    onDelete,
+    handleEdit,
+    handleDelete,
     transformEntityToInitialValues: transformTaxonomyBaseToInitialValues,
   };
 };

--- a/clients/ctl/admin-ui/src/features/taxonomy/types.ts
+++ b/clients/ctl/admin-ui/src/features/taxonomy/types.ts
@@ -22,9 +22,9 @@ export interface Labels {
   parent_key: string;
 }
 
-export type TaxonomyRTKResult = Promise<
+export type RTKResult<T> = Promise<
   | {
-      data: TaxonomyEntity;
+      data: T;
     }
   | { error: RTKErrorResult["error"] }
 >;


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/859

### Code Changes

* [x] Add delete calls to each taxonomy slice
* [x] Wire up delete button with confirmation modal
* [x] Only show delete button on nodes without children (related to https://github.com/ethyca/fides/issues/1005)
* [x] Cypress tests for deleting taxonomy fields

### Steps to Confirm

* [ ] Go to `/taxonomy` and try deleting some fields

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
  * https://github.com/ethyca/fides/issues/1005
* [x] Update `CHANGELOG.md`

### Description Of Changes


https://user-images.githubusercontent.com/24641006/186188681-8f9ef046-b3d8-4bce-9489-ce2481cb879c.mov

Error state

https://user-images.githubusercontent.com/24641006/186188950-3f03be3d-bc8e-4cf2-b46f-fafaaa8aa2d1.mov

Parent nodes do not render the delete button
![image](https://user-images.githubusercontent.com/24641006/186189163-70efbe39-da8a-437c-ae7f-161bb90ab921.png)

