### PR TITLE
remove exclude_unset=True to return clean diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ The types of changes are:
 
 * Added more taxonomy fields that can be edited via the UI [#1000](https://github.com/ethyca/fides/pull/1000)
 
+### Fixed
+
+* Fixed an issue where `fides push --diff` would return a false positive diff [#1026](https://github.com/ethyca/fides/pull/1026)
+
+
 ## [1.8.2](https://github.com/ethyca/fides/compare/1.8.1...1.8.2) - 2022-08-18
 
 ### Added

--- a/noxfiles/ci_nox.py
+++ b/noxfiles/ci_nox.py
@@ -161,7 +161,6 @@ def pytest(session: nox.Session, mark: str) -> None:
     run_command = (
         *RUN_NO_DEPS,
         "pytest",
-        "-x",
         "-m",
         mark,
     )
@@ -204,7 +203,6 @@ def pytest_external(session: nox.Session) -> None:
         CI_ARGS,
         IMAGE_NAME,
         "pytest",
-        "-x",
         "-m",
         "external",
     )

--- a/src/fidesctl/ctl/core/push.py
+++ b/src/fidesctl/ctl/core/push.py
@@ -22,7 +22,7 @@ def sort_create_update(
     new lists for resource creation or updating.
 
     The `diff` flag will print out the differences between the
-    server resources the local resource files.
+    server resources and the local resource files.
     """
 
     server_resource_dict = {
@@ -39,15 +39,15 @@ def sort_create_update(
             server_resource = server_resource_dict[resource_key]
 
             if diff:
-                print(
-                    f"\nUpdated resource with fides_key: {manifest_resource.fides_key}"
+                resource_diff = DeepDiff(
+                    manifest_resource.dict(),
+                    server_resource.dict(),
                 )
-                pprint(
-                    DeepDiff(
-                        manifest_resource.dict(exclude_unset=True),
-                        server_resource.dict(exclude_unset=True),
+                if resource_diff:
+                    print(
+                        f"\nUpdated resource with fides_key: {manifest_resource.fides_key}"
                     )
-                )
+                    pprint(resource_diff)
 
             update_list.append(manifest_resource)
 


### PR DESCRIPTION
Closes #985

### Code Changes

* [x] Remove `exclude_unset=True` to provide a commond comparison state

### Steps to Confirm

* [x] Pushing twice no longer results in a diff output, however changing the name of the demo organization and pushing does result in an accurate diff being returned

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

The output of a clean push still feels a little rough, would love some input (or maybe this can be improved later)

To test this, I followed the steps below:
1. `nox -s dev`
2. `fides db reset -y`
3. `fides push demo_resources/`
4. `fides push demo_resources/ --diff` (should result in nothing being reported)
5. Update the name of the organization defined in `demo_resources/demo_organization.yml`
6. `fides push demo_resources/ --diff` (should result in the diff for the organization)

### Before & After

#### Before

```
root@24fc18ebfce7:/fides# fides push --diff
Loading resource manifests from: .fides/
Taxonomy successfully created.
----------
Processing dataset resource(s)...

Updated resource with fides_key: public
{}
PUSHED 1 dataset resource(s).
----------
Processing system resource(s)...

Updated resource with fides_key: fidesctl_system
{'dictionary_item_added': [root['tags']]}
PUSHED 1 system resource(s).
----------
Processing policy resource(s)...

Updated resource with fides_key: fidesctl_policy
{}

Updated resource with fides_key: data_sharing_policy
{}
PUSHED 2 policy resource(s).
----------
```

#### After

```
root@0ca14d1d2bd3:/fides# fides push --diff
Loading resource manifests from: .fides/
Taxonomy successfully created.
----------
Processing dataset resource(s)...
PUSHED 1 dataset resource(s).
----------
Processing system resource(s)...
PUSHED 1 system resource(s).
----------
Processing policy resource(s)...
PUSHED 2 policy resource(s).
----------
```