### PR TITLE
Add boolean fields and use them in taxonomy forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The types of changes are:
 
 ### Added
 
-* Added the ability to edit taxonomy fields via the UI [#977](https://github.com/ethyca/fides/pull/977)
+* Added the ability to edit taxonomy fields via the UI [#977](https://github.com/ethyca/fides/pull/977) [#1028](https://github.com/ethyca/fides/pull/1028)
 * New column `is_default` added to DataCategory, DataUse, DataSubject, and DataQualifier tables [#976](https://github.com/ethyca/fides/pull/976)
 * Added the ability to add taxonomy fields via the UI [#1019](https://github.com/ethyca/fides/pull/1019)
 * Added the ability to delete taxonomy fields via the UI [#1006](https://github.com/ethyca/fides/pull/1006)

--- a/clients/ctl/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -200,6 +200,13 @@ describe("Taxonomy management page", () => {
       );
       cy.getByTestId("input-recipients").should("contain", "marketing team");
       cy.getByTestId("input-recipients").should("contain", "dog shelter");
+      cy.getByTestId("input-legitimate_interest").within(() => {
+        cy.getByTestId("option-false").should("have.attr", "data-checked");
+        cy.getByTestId("option-true").click();
+        cy.getByTestId("option-true").should("have.attr", "data-checked");
+        cy.getByTestId("option-false").should("not.have.attr", "data-checked");
+      });
+
       cy.getByTestId("input-legitimate_interest_impact_assessment").should(
         "have.value",
         "https://example.org/legitimate_interest_assessment"
@@ -236,8 +243,7 @@ describe("Taxonomy management page", () => {
       cy.getByTestId("input-special_category").should("contain", "Select...");
       cy.getByTestId("input-recipients").should("contain", "Select...");
       cy.getByTestId("input-legitimate_interest_impact_assessment").should(
-        "have.value",
-        ""
+        "not.exist"
       );
     });
 
@@ -258,6 +264,12 @@ describe("Taxonomy management page", () => {
         cy.getByTestId("input-rights").should("contain", v);
       });
       cy.getByTestId("input-strategy").should("contain", "INCLUDE");
+      cy.getByTestId("input-automatic_decisions_or_profiling").within(() => {
+        cy.getByTestId("option-true").should("have.attr", "data-checked");
+        cy.getByTestId("option-false").click();
+        cy.getByTestId("option-false").should("have.attr", "data-checked");
+        cy.getByTestId("option-true").should("not.have.attr", "data-checked");
+      });
 
       // trigger a PUT
       cy.getByTestId("input-name").clear().type("foo");
@@ -265,7 +277,7 @@ describe("Taxonomy management page", () => {
       cy.wait("@putDataSubject").then((interception) => {
         const { body } = interception.request;
         const expected = {
-          automatic_decisions: true,
+          automatic_decisions_or_profiling: false,
           description:
             "An individual registered to voter with a state or authority.",
           fides_key: "citizen_voter",
@@ -283,7 +295,7 @@ describe("Taxonomy management page", () => {
       cy.getByTestId("item-Anonymous User").trigger("mouseover");
       cy.getByTestId("edit-btn").click();
       cy.getByTestId("input-rights").should("contain", "Select...");
-      cy.getByTestId("input-strategy").should("contain", "Select...");
+      cy.getByTestId("input-strategy").should("not.exist");
     });
 
     it("Can trigger an error", () => {

--- a/clients/ctl/admin-ui/cypress/fixtures/data_uses.json
+++ b/clients/ctl/admin-ui/cypress/fixtures/data_uses.json
@@ -9,7 +9,7 @@
     "legal_basis": "Legitimate Interests",
     "special_category": "Vital Interests",
     "recipients": ["marketing team", "dog shelter"],
-    "legitimate_interest": true,
+    "legitimate_interest": false,
     "legitimate_interest_impact_assessment": "https://example.org/legitimate_interest_assessment",
     "is_default": true
   },

--- a/clients/ctl/admin-ui/src/features/common/constants.tsx
+++ b/clients/ctl/admin-ui/src/features/common/constants.tsx
@@ -1,0 +1,4 @@
+export const YesNoOptions = [
+  { label: "Yes", value: "true" },
+  { label: "No", value: "false" },
+];

--- a/clients/ctl/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/ctl/admin-ui/src/features/common/form/inputs.tsx
@@ -8,6 +8,9 @@ import {
   Input,
   InputGroup,
   InputRightElement,
+  Radio,
+  RadioGroup,
+  Stack,
   Textarea,
   TextareaProps,
 } from "@fidesui/react";
@@ -403,6 +406,53 @@ export const CustomTextArea = ({
       ) : (
         InnerTextArea
       )}
+      {isInvalid ? (
+        <FormErrorMessage data-testid={`error-${field.name}`}>
+          {meta.error}
+        </FormErrorMessage>
+      ) : null}
+    </FormControl>
+  );
+};
+
+interface CustomRadioGroupProps {
+  label: string;
+  options: Option[];
+}
+export const CustomRadioGroup = ({
+  label,
+  options,
+  ...props
+}: CustomRadioGroupProps & FieldHookConfig<string>) => {
+  const [field, meta] = useField(props);
+  const isInvalid = !!(meta.touched && meta.error);
+  const selected = options.find((o) => o.value === field.value) ?? options[0];
+
+  const handleChange = (o: string) => {
+    field.onChange(props.name)(o);
+  };
+
+  return (
+    <FormControl isInvalid={isInvalid}>
+      <Grid templateColumns="1fr 3fr">
+        <FormLabel htmlFor={props.id || props.name} size="sm">
+          {label}
+        </FormLabel>
+        <RadioGroup
+          onChange={handleChange}
+          value={selected.value}
+          data-testid={`input-${field.name}`}
+          colorScheme="secondary"
+        >
+          <Stack direction="row">
+            {options.map((o) => (
+              <Radio key={o.value} value={o.value}>
+                {o.label}
+              </Radio>
+            ))}
+          </Stack>
+        </RadioGroup>
+      </Grid>
       {isInvalid ? (
         <FormErrorMessage data-testid={`error-${field.name}`}>
           {meta.error}

--- a/clients/ctl/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/ctl/admin-ui/src/features/common/form/inputs.tsx
@@ -446,7 +446,11 @@ export const CustomRadioGroup = ({
         >
           <Stack direction="row">
             {options.map((o) => (
-              <Radio key={o.value} value={o.value}>
+              <Radio
+                key={o.value}
+                value={o.value}
+                data-testid={`option-${o.value}`}
+              >
                 {o.label}
               </Radio>
             ))}

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyFormBase.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyFormBase.tsx
@@ -30,14 +30,14 @@ interface Props {
   labels: Labels;
   onCancel: () => void;
   onSubmit: (entity: TaxonomyEntity) => RTKResult<TaxonomyEntity>;
-  extraFormFields?: ReactNode;
+  renderExtraFormFields?: (entity: FormValues) => ReactNode;
   initialValues: FormValues;
 }
 const TaxonomyFormBase = ({
   labels,
   onCancel,
   onSubmit,
-  extraFormFields,
+  renderExtraFormFields,
   initialValues,
 }: Props) => {
   const toast = useToast();
@@ -140,7 +140,7 @@ const TaxonomyFormBase = ({
                     disabled={!isCreate}
                   />
                 ))}
-              {extraFormFields}
+              {renderExtraFormFields ? renderExtraFormFields(values) : null}
             </Stack>
 
             {formError ? (

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -43,7 +43,7 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
     handleCreate: createEntity,
     handleEdit,
     handleDelete: deleteEntity,
-    extraFormFields,
+    renderExtraFormFields,
     transformEntityToInitialValues,
   } = useTaxonomy();
   const taxonomyNodes = useMemo(() => {
@@ -135,7 +135,7 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
             labels={labels}
             onCancel={() => setEditEntity(null)}
             onSubmit={handleEdit}
-            extraFormFields={extraFormFields}
+            renderExtraFormFields={renderExtraFormFields}
             initialValues={transformEntityToInitialValues(editEntity)}
           />
         ) : null}
@@ -144,7 +144,7 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
             labels={labels}
             onCancel={closeAddForm}
             onSubmit={createEntity}
-            extraFormFields={extraFormFields}
+            renderExtraFormFields={renderExtraFormFields}
             initialValues={transformEntityToInitialValues(
               DEFAULT_INITIAL_VALUES
             )}

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -124,8 +124,7 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
         ? undefined
         : formValues.legitimate_interest_impact_assessment,
     legitimate_interest: !!(
-      formValues.legitimate_interest &&
-      formValues.legitimate_interest.toString() === "true"
+      formValues.legitimate_interest?.toString() === "true"
     ),
   });
 
@@ -144,7 +143,7 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
       special_category: du.special_category,
       recipients: du.recipients ?? [],
       legitimate_interest:
-        du.legitimate_interest == null
+        du.legitimate_interest === undefined
           ? "false"
           : du.legitimate_interest.toString(),
       legitimate_interest_impact_assessment:
@@ -178,8 +177,7 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
         label={labels.legitimate_interest}
         options={YesNoOptions}
       />
-      {formValues.legitimate_interest &&
-      formValues.legitimate_interest.toString() === "true" ? (
+      {formValues.legitimate_interest?.toString() === "true" ? (
         <CustomTextInput
           name="legitimate_interest_impact_assessment"
           label={labels.legitimate_interest_impact_assessment}
@@ -231,8 +229,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
             { values: entity.rights, strategy: entity.strategy }
           : undefined,
       automatic_decisions_or_profiling: !!(
-        entity.automated_decisions_or_profiling &&
-        entity.automated_decisions_or_profiling.toString() === "true"
+        entity.automated_decisions_or_profiling?.toString() === "true"
       ),
     };
     // @ts-ignore for the same reason as above
@@ -253,7 +250,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
       rights: ds.rights?.values ?? [],
       strategy: ds.rights?.strategy,
       automatic_decisions_or_profiling:
-        ds.automated_decisions_or_profiling == null
+        ds.automated_decisions_or_profiling === undefined
           ? "false"
           : ds.automated_decisions_or_profiling.toString(),
     };

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -11,9 +11,11 @@ import {
   SpecialCategoriesEnum,
 } from "~/types/api";
 
+import { YesNoOptions } from "../common/constants";
 import {
   CustomCreatableMultiSelect,
   CustomMultiSelect,
+  CustomRadioGroup,
   CustomSelect,
   CustomTextInput,
 } from "../common/form/inputs";
@@ -137,7 +139,10 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
       legal_basis: du.legal_basis,
       special_category: du.special_category,
       recipients: du.recipients ?? [],
-      legitimate_interest: du.legitimate_interest,
+      legitimate_interest:
+        du.legitimate_interest == null
+          ? "false"
+          : du.legitimate_interest.toString(),
       legitimate_interest_impact_assessment:
         du.legitimate_interest_impact_assessment ?? "",
     };
@@ -160,11 +165,15 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
       />
       <CustomCreatableMultiSelect
         name="recipients"
-        label="Recipients"
+        label={labels.recipient}
         options={[]}
         size="sm"
       />
-      {/* TODO: legitimate interest: boolean field */}
+      <CustomRadioGroup
+        name="legitimate_interest"
+        label={labels.legitimate_interest}
+        options={YesNoOptions}
+      />
       <CustomTextInput
         name="legitimate_interest_impact_assessment"
         label={labels.legitimate_interest_impact_assessment}
@@ -203,12 +212,16 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
   const transformFormValuesToEntity = (entity: TaxonomyEntity) => {
     const transformedEntity = {
       ...entity,
-      // @ts-ignore because DataSubjects have their rights field nested, which
-      // does not work well when being passed into a form. We unnest them in
-      // transformEntityToInitialValues, and it is the unnested value we get back
-      // here, but it would make the types of our other components much more complicated
-      // to properly type just for this special case
-      rights: { values: entity.rights, strategy: entity.strategy },
+      rights:
+        // @ts-ignore because DataSubjects have their rights field nested, which
+        // does not work well when being passed into a form. We unnest them in
+        // transformEntityToInitialValues, and it is the unnested value we get back
+        // here, but it would make the types of our other components much more complicated
+        // to properly type just for this special case
+        entity.rights.length
+          ? // @ts-ignore for the same reason as above
+            { values: entity.rights, strategy: entity.strategy }
+          : undefined,
     };
     // @ts-ignore for the same reason as above
     delete transformedEntity.strategy;
@@ -227,7 +240,10 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
       ...base,
       rights: ds.rights?.values ?? [],
       strategy: ds.rights?.strategy,
-      automatic_decisions: ds.automated_decisions_or_profiling,
+      automatic_decisions:
+        ds.automated_decisions_or_profiling == null
+          ? "false"
+          : ds.automated_decisions_or_profiling.toString(),
     };
   };
 
@@ -243,7 +259,11 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
         label={labels.strategy}
         options={enumToOptions(IncludeExcludeEnum)}
       />
-      {/* TODO: automatic decisions: boolean field */}
+      <CustomRadioGroup
+        name="automatic_decisions"
+        label={labels.automatic_decisions}
+        options={YesNoOptions}
+      />
     </>
   );
 

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -123,6 +123,10 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
       formValues.legitimate_interest_impact_assessment === ""
         ? undefined
         : formValues.legitimate_interest_impact_assessment,
+    legitimate_interest: !!(
+      formValues.legitimate_interest &&
+      formValues.legitimate_interest.toString() === "true"
+    ),
   });
 
   const [handleDelete] = useDeleteDataUseMutation();
@@ -212,29 +216,34 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
   const [create] = useCreateDataSubjectMutation();
   const [handleDelete] = useDeleteDataSubjectMutation();
 
-  const transformFormValuesToEntity = (entity: TaxonomyEntity) => {
-    const transformedEntity = {
+  const transformFormValuesToEntity = (entity: DataSubject) => {
+    const transformedEntity: DataSubject = {
       ...entity,
+      // @ts-ignore because DataSubjects have their rights field nested, which
+      // does not work well when being passed into a form. We unnest them in
+      // transformEntityToInitialValues, and it is the unnested value we get back
+      // here, but it would make the types of our other components much more complicated
+      // to properly type just for this special case
       rights:
-        // @ts-ignore because DataSubjects have their rights field nested, which
-        // does not work well when being passed into a form. We unnest them in
-        // transformEntityToInitialValues, and it is the unnested value we get back
-        // here, but it would make the types of our other components much more complicated
-        // to properly type just for this special case
+        // @ts-ignore for the same reason as above
         entity.rights.length
           ? // @ts-ignore for the same reason as above
             { values: entity.rights, strategy: entity.strategy }
           : undefined,
+      automatic_decisions_or_profiling: !!(
+        entity.automated_decisions_or_profiling &&
+        entity.automated_decisions_or_profiling.toString() === "true"
+      ),
     };
     // @ts-ignore for the same reason as above
     delete transformedEntity.strategy;
     return transformedEntity;
   };
 
-  const handleEdit = (entity: TaxonomyEntity) =>
+  const handleEdit = (entity: DataSubject) =>
     edit(transformFormValuesToEntity(entity));
 
-  const handleCreate = (entity: TaxonomyEntity) =>
+  const handleCreate = (entity: DataSubject) =>
     create(transformFormValuesToEntity(entity));
 
   const transformEntityToInitialValues = (ds: DataSubject) => {
@@ -243,7 +252,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
       ...base,
       rights: ds.rights?.values ?? [],
       strategy: ds.rights?.strategy,
-      automatic_decisions:
+      automatic_decisions_or_profiling:
         ds.automated_decisions_or_profiling == null
           ? "false"
           : ds.automated_decisions_or_profiling.toString(),
@@ -266,7 +275,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
         />
       ) : null}
       <CustomRadioGroup
-        name="automatic_decisions"
+        name="automatic_decisions_or_profiling"
         label={labels.automatic_decisions}
         options={YesNoOptions}
       />

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -143,7 +143,7 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
       special_category: du.special_category,
       recipients: du.recipients ?? [],
       legitimate_interest:
-        du.legitimate_interest === undefined
+        du.legitimate_interest == null
           ? "false"
           : du.legitimate_interest.toString(),
       legitimate_interest_impact_assessment:
@@ -250,7 +250,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
       rights: ds.rights?.values ?? [],
       strategy: ds.rights?.strategy,
       automatic_decisions_or_profiling:
-        ds.automated_decisions_or_profiling === undefined
+        ds.automated_decisions_or_profiling == null
           ? "false"
           : ds.automated_decisions_or_profiling.toString(),
     };

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -53,7 +53,7 @@ export interface TaxonomyHookData<T extends TaxonomyEntity> {
   handleCreate: (entity: T) => RTKResult<TaxonomyEntity>;
   handleEdit: (entity: T) => RTKResult<TaxonomyEntity>;
   handleDelete: (key: string) => RTKResult<string>;
-  extraFormFields?: ReactNode;
+  renderExtraFormFields?: (entity: T) => ReactNode;
   transformEntityToInitialValues: (entity: T) => FormValues;
 }
 
@@ -151,7 +151,7 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
   const legalBases = enumToOptions(LegalBasisEnum);
   const specialCategories = enumToOptions(SpecialCategoriesEnum);
 
-  const extraFormFields = (
+  const renderExtraFormFields = (formValues: DataUse) => (
     <>
       <CustomSelect
         name="legal_basis"
@@ -174,10 +174,13 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
         label={labels.legitimate_interest}
         options={YesNoOptions}
       />
-      <CustomTextInput
-        name="legitimate_interest_impact_assessment"
-        label={labels.legitimate_interest_impact_assessment}
-      />
+      {formValues.legitimate_interest &&
+      formValues.legitimate_interest.toString() === "true" ? (
+        <CustomTextInput
+          name="legitimate_interest_impact_assessment"
+          label={labels.legitimate_interest_impact_assessment}
+        />
+      ) : null}
     </>
   );
 
@@ -188,7 +191,7 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
     handleCreate,
     handleEdit,
     handleDelete,
-    extraFormFields,
+    renderExtraFormFields,
     transformEntityToInitialValues,
   };
 };
@@ -247,18 +250,21 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     };
   };
 
-  const extraFormFields = (
+  const renderExtraFormFields = (entity: DataSubject) => (
     <>
       <CustomMultiSelect
         name="rights"
         label={labels.rights}
         options={enumToOptions(DataSubjectRightsEnum)}
       />
-      <CustomSelect
-        name="strategy"
-        label={labels.strategy}
-        options={enumToOptions(IncludeExcludeEnum)}
-      />
+      {/* @ts-ignore because of discrepancy between form and entity type, again */}
+      {entity.rights && entity.rights.length ? (
+        <CustomSelect
+          name="strategy"
+          label={labels.strategy}
+          options={enumToOptions(IncludeExcludeEnum)}
+        />
+      ) : null}
       <CustomRadioGroup
         name="automatic_decisions"
         label={labels.automatic_decisions}
@@ -274,7 +280,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     handleCreate,
     handleEdit,
     handleDelete,
-    extraFormFields,
+    renderExtraFormFields,
     transformEntityToInitialValues,
   };
 };


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/1001

### Code Changes

* [x] Add a new component `CustomRadioGroup` for radio buttons that work with formik and all that
* [x] Use the new component to render the `legitimate_interest` and `automatic_decisions_or_profiling` fields
* [x] Changed the `extraFormFields` prop to `renderExtraFormFields` so that the form values can be passed in the case we want to conditionally render form fields. This was useful for `legitimate_interest` since only if that field is `true` do you need to fill in `legitimate_interest_impact_assessment`
* [x] Update tests

### Steps to Confirm

* [ ] New fields should show up when editing and adding taxonomy entities

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

https://user-images.githubusercontent.com/24641006/187709355-6bd6307b-e6df-452f-bb17-c26dc69ca8fb.mov

