### PR TITLE
Cascade delete taxonomy children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
+## [Unreleased](https://github.com/ethyca/fides/compare/1.8.3...main)
+
+### Changed
+
+* Deleting a taxonomy field with children will now cascade delete all of its children as well. [#1042](https://github.com/ethyca/fides/pull/1042)
+
 ## [1.8.3](https://github.com/ethyca/fides/compare/1.8.2...1.8.3) - 2022-09-06
 
 ### Added

--- a/clients/ctl/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -486,7 +486,7 @@ describe("Taxonomy management page", () => {
       );
     });
 
-    it("Only renders delete button on custom fields without children", () => {
+    it("Only renders delete button on custom fields", () => {
       cy.getByTestId(`tab-Data Categories`).click();
       // try default fields first
       cy.getByTestId("accordion-item-User Data").trigger("mouseover");
@@ -497,10 +497,15 @@ describe("Taxonomy management page", () => {
 
       // now try custom fields
       cy.getByTestId("accordion-item-Custom field").trigger("mouseover");
-      cy.getByTestId("delete-btn").should("not.exist");
+      cy.getByTestId("delete-btn").click();
+      // parent custom fields should render with a warning
+      cy.getByTestId("delete-children-warning");
+      cy.getByTestId("cancel-btn").click();
       cy.getByTestId("accordion-item-Custom field").click();
       cy.getByTestId("item-Custom foo").trigger("mouseover");
-      cy.getByTestId("delete-btn");
+      cy.getByTestId("delete-btn").click();
+      // leaf nodes do not need a warning though
+      cy.getByTestId("delete-children-warning").should("not.exist");
     });
 
     it("Can delete from each taxonomy type (except Data Subject)", () => {

--- a/clients/ctl/admin-ui/src/features/taxonomy/ActionButtons.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/ActionButtons.tsx
@@ -8,7 +8,7 @@ interface ActionButtonProps {
   onDelete: (node: TaxonomyEntityNode) => void;
 }
 const ActionButtons = ({ node, onEdit, onDelete }: ActionButtonProps) => {
-  const showDelete = node.children.length === 0 && !node.is_default;
+  const showDelete = !node.is_default;
   return (
     <ButtonGroup
       size="xs"

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -185,7 +185,7 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
                 from your taxonomy. Are you sure you would like to continue?
               </Text>
               {nodeToDelete.children.length ? (
-                <Text color="red">
+                <Text color="red" data-testid="delete-children-warning">
                   Deleting{" "}
                   <Text as="span" fontWeight="bold">
                     {nodeToDelete.value}

--- a/clients/ctl/admin-ui/src/pages/taxonomy/index.tsx
+++ b/clients/ctl/admin-ui/src/pages/taxonomy/index.tsx
@@ -1,4 +1,4 @@
-import { Heading, Text } from "@fidesui/react";
+import { Heading } from "@fidesui/react";
 import type { NextPage } from "next";
 
 import Layout from "~/features/common/Layout";
@@ -9,10 +9,6 @@ const DataSets: NextPage = () => (
     <Heading mb={2} fontSize="2xl" fontWeight="semibold">
       Taxonomy Management
     </Heading>
-    {/* TODO: get actual copy */}
-    <Text size="sm" mb={4}>
-      Placeholder instruction
-    </Text>
     <TaxonomyTabs />
   </Layout>
 );

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,7 @@ packaging==21.3
 pre-commit==2.18.1
 pylint==2.6.0
 pytest==7.1.2
+pytest-asyncio==0.19.0
 pytest-cov==3.0.0
 requests-mock==1.9.3
 setuptools>=64.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,4 @@ markers = [
     "mssql: only runs the integration tests for sqlserver/mssql",
     "mysql: only runs the integration tests for mysql"
 ]
+asyncio_mode = "auto"

--- a/src/fidesctl/api/ctl/database/crud.py
+++ b/src/fidesctl/api/ctl/database/crud.py
@@ -213,7 +213,6 @@ async def delete_resource(sql_model: Base, fides_key: str) -> Base:
                     print(query)
                     await session.execute(query)
                 except SQLAlchemyError:
-                    log.exception("??")
                     error = errors.QueryError()
                     log.bind(error=error.detail["error"]).error(
                         "Failed to delete resource"

--- a/src/fidesctl/api/ctl/database/crud.py
+++ b/src/fidesctl/api/ctl/database/crud.py
@@ -8,6 +8,7 @@ from fideslib.db.base import Base
 from loguru import logger as log
 from sqlalchemy import column
 from sqlalchemy import delete as _delete
+from sqlalchemy import or_
 from sqlalchemy import update as _update
 from sqlalchemy.dialects.postgresql import Insert as _insert
 from sqlalchemy.exc import SQLAlchemyError
@@ -181,18 +182,38 @@ async def upsert_resources(
 
 
 async def delete_resource(sql_model: Base, fides_key: str) -> Base:
-    """Delete a resource by its fides_key."""
+    """
+    Delete a resource by its fides_key.
+
+    If the resource has child keys referring to it, also delete those.
+    """
 
     with log.contextualize(sql_model=sql_model.__name__, fides_key=fides_key):
         sql_resource = await get_resource(sql_model, fides_key)
         async with async_session() as session:
             async with session.begin():
                 try:
-                    log.debug("Deleting resource")
-                    query = _delete(sql_model).where(sql_model.fides_key == fides_key)
+                    if hasattr(sql_model, "parent_key"):
+                        log.debug("Deleting resource and its children")
+                        query = (
+                            _delete(sql_model)
+                            .where(
+                                or_(
+                                    sql_model.fides_key == fides_key,
+                                    sql_model.fides_key.like(f"{fides_key}.%"),
+                                )
+                            )
+                            .execution_options(synchronize_session=False)
+                        )
+                    else:
+                        log.debug("Deleting resource")
+                        query = _delete(sql_model).where(
+                            sql_model.fides_key == fides_key
+                        )
                     print(query)
                     await session.execute(query)
                 except SQLAlchemyError:
+                    log.exception("??")
                     error = errors.QueryError()
                     log.bind(error=error.detail["error"]).error(
                         "Failed to delete resource"

--- a/tests/ctl/core/test_api_helpers.py
+++ b/tests/ctl/core/test_api_helpers.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring, redefined-outer-name
 import uuid
-from typing import TYPE_CHECKING, Dict, Generator, List, Optional
+from typing import Dict, Generator, List, Optional
 
 import pytest
 from fideslang import FidesModel, model_list
@@ -8,6 +8,7 @@ from fideslang import FidesModel, model_list
 from fidesctl.ctl.core import api as _api
 from fidesctl.ctl.core import api_helpers as _api_helpers
 from fidesctl.ctl.core.config import FidesctlConfig
+from tests.ctl.types import FixtureRequest
 
 RESOURCE_CREATION_COUNT = 5
 # These resources have tricky validation so the fides_key replacement doesn't work
@@ -16,15 +17,6 @@ PARAM_MODEL_LIST = [
     model for model in model_list if model not in EXCLUDED_RESOURCE_TYPES
 ]
 
-if TYPE_CHECKING:
-
-    class FixtureRequest:
-        param: str
-
-else:
-    from typing import Any
-
-    FixtureRequest = Any
 
 # Fixtures
 @pytest.fixture

--- a/tests/ctl/database/test_crud.py
+++ b/tests/ctl/database/test_crud.py
@@ -10,8 +10,8 @@ from fidesctl.ctl.core.config import FidesctlConfig
 from tests.ctl.types import FixtureRequest
 
 
-@pytest.fixture
-def created_resources(
+@pytest.fixture(name="created_resources")
+def fixture_created_resources(
     test_config: FidesctlConfig, request: FixtureRequest
 ) -> Generator:
     """
@@ -52,6 +52,7 @@ def created_resources(
     indirect=["created_resources"],
 )
 async def test_cascade_delete_taxonomy_children(created_resources: List) -> None:
+    """Deleting a parent taxonomy should delete all of its children too"""
     resource_type, keys = created_resources
     sql_model = sql_models.sql_model_map[resource_type]
     await delete_resource(sql_model, keys[0])

--- a/tests/ctl/database/test_crud.py
+++ b/tests/ctl/database/test_crud.py
@@ -1,0 +1,60 @@
+from json import dumps
+from typing import Generator, List
+
+import pytest
+
+from fidesctl.api.ctl import sql_models
+from fidesctl.api.ctl.database.crud import delete_resource, list_resource
+from fidesctl.ctl.core import api as _api
+from fidesctl.ctl.core.config import FidesctlConfig
+from tests.ctl.types import FixtureRequest
+
+
+@pytest.fixture
+def created_resources(
+    test_config: FidesctlConfig, request: FixtureRequest
+) -> Generator:
+    """
+    Fixture that creates and tears down a set of resources for each test run.
+    Only creates resources for a given type based on test parameter
+    """
+    created_keys = []
+    resource_type = request.param
+    to_create = ["foo", "foo.bar", "foo.bar.baz", "foo.boo"]
+
+    for key in to_create:
+        parent_key = ".".join(key.split(".")[:-1]) if "." in key else None
+
+        _api.create(
+            url=test_config.cli.server_url,
+            resource_type=resource_type,
+            json_resource=dumps({"fides_key": key, "parent_key": parent_key}),
+            headers=test_config.user.request_headers,
+        )
+        created_keys.append(key)
+
+    # Wait for test to finish before cleaning up resources
+    yield resource_type, created_keys
+
+    for created_key in created_keys:
+        _api.delete(
+            url=test_config.cli.server_url,
+            resource_type=resource_type,
+            resource_id=created_key,
+            headers=test_config.user.request_headers,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "created_resources",
+    ["data_category", "data_use", "data_qualifier"],
+    indirect=["created_resources"],
+)
+async def test_cascade_delete_taxonomy_children(created_resources: List) -> None:
+    resource_type, keys = created_resources
+    sql_model = sql_models.sql_model_map[resource_type]
+    await delete_resource(sql_model, keys[0])
+    resources = await list_resource(sql_model)
+    remaining_keys = {resource.fides_key for resource in resources}
+    assert len(set(keys).intersection(remaining_keys)) == 0

--- a/tests/ctl/types.py
+++ b/tests/ctl/types.py
@@ -1,0 +1,13 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+
+    class FixtureRequest:
+        """Type for pytest fixture arguments"""
+
+        param: str
+
+else:
+    from typing import Any
+
+    FixtureRequest = Any


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/1005

### Code Changes

* [x] Updates pytest to use asyncio (pretty much copied from a [fidesops commit](https://github.com/ethyca/fidesops/pull/1174/commits/21b9dd6389fd2957f6042f4054517a666211bfe2))
* [x] Adds a test for deleting children taxonomy items
* [x] Adds logic to cascade delete children fields
* [x] Updates the UI to remove placeholder text and also to add a warning when the user is deleting a taxonomy field that has children. I just put something easy together, but can definitely change it if we want it to say something different or want it to look different.
  * [x] Before the UI would not render the delete button at all on parent fields, but now it does and adds the warning
* [x] Update cypress tests

### Steps to Confirm

* [ ] Visit `/taxonomy` and add two custom fields, where one is the child of another (i.e. `custom` and `custom.foo`)
* [ ] Delete `custom` and both `custom` and `custom.foo` should delete


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

New warning message
![image](https://user-images.githubusercontent.com/24641006/188721891-1049394c-5655-43bb-862d-ba1cb75f190e.png)


https://user-images.githubusercontent.com/24641006/188721798-36ae05ce-d64e-40b0-8d3f-155bb4704fea.mov

