### PR TITLE
Set pydantic < 1.10.0 to fix CI issues with fideslang functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ openpyxl==3.0.9
 pandas==1.4
 plotly==5.4
 psycopg2-binary==2.9.1
-pydantic>=1.8.1,<2.0.0 # Required by fastapi
+pydantic>=1.8.1,<1.10.0 # Required by fastapi
 PyJWT==2.4.0
 pyyaml>=5,<6
 requests>=2,<3


### PR DESCRIPTION
Should be able to revert after fideslang figures out why the latest pydantic causes failures

See https://github.com/ethyca/fideslang/pull/79

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
