### PR TITLE
[942] fctl/api: Serve static files using route maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
+## [Unreleased](https://github.com/ethyca/fides/compare/1.8.3...main)
+
+### Fixed
+* Fixed navigating directly to frontend routes loading index page instead of the correct static page for the route.
+
 ## [1.8.3](https://github.com/ethyca/fides/compare/1.8.2...1.8.3) - 2022-09-06
 
 ### Added

--- a/src/fidesctl/api/main.py
+++ b/src/fidesctl/api/main.py
@@ -28,7 +28,13 @@ from fidesctl.api.ctl.routes import (
     visualize,
 )
 from fidesctl.api.ctl.routes.util import API_PREFIX
-from fidesctl.api.ctl.ui import get_admin_index_as_response, get_path_to_admin_ui_file
+from fidesctl.api.ctl.ui import (
+    get_admin_index_as_response,
+    get_local_file_map,
+    get_package_file_map,
+    get_path_to_admin_ui_file,
+    match_route,
+)
 from fidesctl.api.ctl.utils.logger import setup as setup_logging
 from fidesctl.ctl.core.config import FidesctlConfig, get_config
 
@@ -109,7 +115,19 @@ def read_other_paths(request: Request) -> Response:
     """
     # check first if requested file exists (for frontend assets)
     path = request.path_params["catchall"]
-    ui_file = get_path_to_admin_ui_file(path)
+
+    # First search in the local (dev) build for for a matching route.
+    ui_file = match_route(get_local_file_map(), path)
+
+    # Next, search for a matching route in the packaged files.
+    if not ui_file:
+        ui_file = match_route(get_package_file_map(), path)
+
+    # Finally, try to find the exact path as a packaged file.
+    if not ui_file:
+        ui_file = get_path_to_admin_ui_file(path)
+
+    # If any of those worked, serve the file.
     if ui_file and ui_file.is_file():
         return FileResponse(ui_file)
 

--- a/tests/ctl/api/test_ui.py
+++ b/tests/ctl/api/test_ui.py
@@ -1,0 +1,63 @@
+# pylint: disable=missing-docstring, redefined-outer-name
+import re
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from fidesctl.api.ctl.ui import generate_route_file_map, match_route
+
+# Path segments of temporary files whose routes are tested.
+STATIC_FILES = (
+    "index.html",
+    "404.html",
+    "dataset.html",
+    "dataset/new.html",
+    "dataset/[id].html",
+    "nested/[...slug].html",
+)
+
+
+@pytest.fixture(scope="session")
+def tmp_static(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return tmp_path_factory.mktemp("static")
+
+
+@pytest.fixture(scope="session")
+def route_file_map(tmp_static: Path) -> Dict[re.Pattern, Path]:
+    # Generate the temporary files to test against.
+    for static_segment in STATIC_FILES:
+        static_path = tmp_static / static_segment
+        static_path.parent.mkdir(parents=True, exist_ok=True)
+        static_path.touch()
+
+    return generate_route_file_map(str(tmp_static))
+
+
+@pytest.mark.unit
+def test_generate_route_file_map(route_file_map: Dict[re.Pattern, Path]) -> None:
+    # Ensure all paths in the map are real files.
+    for path in route_file_map.values():
+        assert path.exists()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "route,expected",
+    [
+        ("index", "index.html"),
+        ("dataset", "dataset.html"),
+        ("dataset/", "dataset.html"),
+        ("dataset/new", "dataset/new.html"),
+        ("dataset/1234", "dataset/[id].html"),
+        ("dataset/G00d-Times_R011/", "dataset/[id].html"),
+        ("nested/you/me/and", "nested/[...slug].html"),
+        ("nested/the_devil/makes/3/", "nested/[...slug].html"),
+    ],
+)
+def test_match_route(
+    tmp_static: Path, route_file_map: Dict[re.Pattern, Path], route: str, expected: str
+) -> None:
+
+    # Test example routes.
+    assert match_route(route_file_map, route) == tmp_static / expected


### PR DESCRIPTION
Closes #942 

### Code Changes
- Adapt generate_route_file_map from Ops and unit test it
- Serve static files using route maps

### Steps to Confirm

* [ ] Local UI
    * Should just work with regular export. Maybe throw something into admin-ui that makes it clear you're serving what was exported
* [ ] Packaged UI
    * I have a branch with a nox command for building the package in docker: https://github.com/ethyca/fides/compare/ssangervasi/nox-python-build
    * And a branch with a make command that installs local wheel into fidesctl-plus: https://github.com/ethyca/fidesctl-plus/compare/ssangervasi/local-python-build
    * So, build _this_ branch's wheel using that nox command (or equivalent), then build Plus using that make command.
* [ ] Then try navigating directly to a page's route:
    * http://localhost:8080/taxonomy
    * http://localhost:8080/dataset/demo_users_dataset
    * http://localhost:8080/datamap (in Plus)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This adapts the [POC](https://github.com/ethyca/fidesops/pull/1033/files) used in Ops, makes it a bit more generic so that
we can pass in other UI paths, and tests the route map with some temporary files.

With a local build:
![with-local-build](https://user-images.githubusercontent.com/2236777/188241704-c958bfda-e9f6-47cb-b394-2e28b5639aef.gif)

Built into Plus:
![with-packaged-ctl](https://user-images.githubusercontent.com/2236777/188241700-4c02d13e-590b-46e9-860c-1cd3660ad04d.gif)


