### PR TITLE
Fix truncated evaluation error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fides/compare/1.8.3...main)
 
 ### Fixed
+
 * Fixed navigating directly to frontend routes loading index page instead of the correct static page for the route.
+* Fix truncated evaluation error messages [#1053](https://github.com/ethyca/fides/pull/1053)
 
 ## [1.8.3](https://github.com/ethyca/fides/compare/1.8.2...1.8.3) - 2022-09-06
 
@@ -40,7 +42,6 @@ The types of changes are:
 * Fixed failing mypy tests [#1030](https://github.com/ethyca/fides/pull/1030)
 * Fixed an issue where `fides push --diff` would return a false positive diff [#1026](https://github.com/ethyca/fides/pull/1026)
 * Pinned pydantic version to < 1.10.0 to fix an error in finding referenced fides keys [#1045](https://github.com/ethyca/fides/pull/1045)
-
 
 ## [1.8.2](https://github.com/ethyca/fides/compare/1.8.1...1.8.2) - 2022-08-18
 

--- a/src/fidesctl/cli/utils.py
+++ b/src/fidesctl/cli/utils.py
@@ -75,9 +75,7 @@ def pretty_echo(dict_object: Dict, color: str = "white") -> None:
     """
     Given a dict-like object and a color, pretty click echo it.
     """
-    click.secho(
-        pprint.pformat(dict_object, indent=2, width=80, compact=True), fg=color
-    )
+    click.secho(pprint.pformat(dict_object, indent=2, width=80, compact=True), fg=color)
 
 
 def handle_cli_response(

--- a/src/fidesctl/cli/utils.py
+++ b/src/fidesctl/cli/utils.py
@@ -76,7 +76,7 @@ def pretty_echo(dict_object: Dict, color: str = "white") -> None:
     Given a dict-like object and a color, pretty click echo it.
     """
     click.secho(
-        pprint.pformat(dict_object, indent=2, width=80, compact=True, depth=2), fg=color
+        pprint.pformat(dict_object, indent=2, width=80, compact=True), fg=color
     )
 
 

--- a/src/fidesctl/ctl/core/evaluate.py
+++ b/src/fidesctl/ctl/core/evaluate.py
@@ -30,7 +30,7 @@ from fidesctl.ctl.core.utils import echo_green, echo_red, get_all_level_fields
 
 def get_evaluation_policies(
     local_policies: List[Policy],
-    evaluate_fides_key: str,
+    evaluate_fides_key: Optional[str],
     url: AnyHttpUrl,
     headers: Dict[str, str],
 ) -> List[Policy]:
@@ -518,11 +518,11 @@ def merge_taxonomies(
 def evaluate(
     url: AnyHttpUrl,
     manifests_dir: str,
-    policy_fides_key: str,
     headers: Dict[str, str],
-    message: str,
-    local: bool,
-    dry: bool,
+    policy_fides_key: str = "",
+    message: str = "",
+    local: bool = False,
+    dry: bool = False,
 ) -> Evaluation:
     """
     Perform evaluation for a given Policy. If a policy key is not

--- a/tests/ctl/core/test_evaluate.py
+++ b/tests/ctl/core/test_evaluate.py
@@ -562,6 +562,48 @@ def test_get_fides_key_parent_hierarchy_missing_parent() -> None:
 
 
 @pytest.mark.unit
+def test_failed_evaluation_error_message(test_config, capsys) -> None:
+    """
+    Check that the returned error message matches what is expected.
+
+    Due to fides_keys being randomized here, we want to check that
+    the violations specifically are in the output.
+    """
+    string_cleaner = lambda x: x.replace("\n", "").replace("\t", "").replace(" ", "")
+    expected_error_message = string_cleaner(
+        """
+  'message': '',
+  'status': <StatusEnum.FAIL: 'FAIL'>,
+  'violations': [ { 'detail': 'Declaration (Share Political Opinions) of '
+                              'system (customer_data_sharing_system) failed '
+                              'rule (reject_targeted_marketing) from policy '
+                              '(primary_privacy_policy). Violated usage of '
+                              'data categories (user.political_opinion) with '
+                              'qualifier '
+                              '(aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified) '
+                              'for data uses '
+                              '(third_party_sharing.payment_processing) and '
+                              'subjects (customer)',
+                    'violating_attributes': { 'data_categories': [ 'user.political_opinion'],
+                                              'data_qualifier': 'aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified',
+                                              'data_subjects': ['customer'],
+                                              'data_uses': [ 'third_party_sharing.payment_processing']}}]}
+                                              """
+    )
+    with pytest.raises(SystemExit):
+        evaluate.evaluate(
+            url=test_config.cli.server_url,
+            manifests_dir="tests/ctl/data/failing_declaration_taxonomy.yml",
+            headers=test_config.user.request_headers,
+            local=True,
+        )
+    captured_out = string_cleaner(capsys.readouterr().out)
+    print(f"Expected output:\n{expected_error_message}")
+    print(f"Captured output:\n{captured_out}")
+    assert expected_error_message in captured_out
+
+
+@pytest.mark.unit
 class TestMergeTaxonomies:
     def test_no_key_conflicts(self) -> None:
         taxonomy_1 = Taxonomy(data_subject=[DataSubject(fides_key="foo", name="bar")])

--- a/tests/ctl/core/test_evaluate.py
+++ b/tests/ctl/core/test_evaluate.py
@@ -562,7 +562,9 @@ def test_get_fides_key_parent_hierarchy_missing_parent() -> None:
 
 
 @pytest.mark.unit
-def test_failed_evaluation_error_message(test_config, capsys) -> None:
+def test_failed_evaluation_error_message(
+    test_config: FidesctlConfig, capsys: pytest.CaptureFixture
+) -> None:
     """
     Check that the returned error message matches what is expected.
 


### PR DESCRIPTION
Closes #1048 

### Code Changes

* [x] Update `pretty_echo` to not truncate at a certain depth
* [x] add a test to verify the evaluation output message

### Steps to Confirm

* [x] in `.fides/policy.yml` change `data_subjects` to `customer` and run `fides --local evaluate` to confirm the error message isn't truncated

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] ~~Relevant Follow-Up Issues Created~~
* [x] Update `CHANGELOG.md`

### Description Of Changes

Quick fix for a small bug caused by a refactor of the `pretty_echo` function