### PR TITLE
ui/dataset: "Classify" toggle for fidesctl-plus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,15 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/1.8.4...main)
 
-* Changed behavior of `load_default_taxonomy` to append instead of upsert [#1040](https://github.com/ethyca/fides/pull/1040)
+### Added
+
+* Dataset generation enhancements using Fides Classify for Plus users:
+  * Added toggle for enabling classify during generation. [#1057](https://github.com/ethyca/fides/pull/1057)
 * New page to add a system via yaml [#1062](https://github.com/ethyca/fides/pull/1062)
+
+### Changed
+
+* Changed behavior of `load_default_taxonomy` to append instead of upsert [#1040](https://github.com/ethyca/fides/pull/1040)
 
 ## [1.8.4](https://github.com/ethyca/fides/compare/1.8.3...1.8.4) - 2022-09-09
 

--- a/clients/ctl/admin-ui/cypress/e2e/datasets-classify.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/datasets-classify.cy.ts
@@ -1,0 +1,27 @@
+/**
+ * This test suite is a parallel of datests.cy.ts for testing Dataset features when the user has
+ * access to the  Fidescls API. This suite should cover the behavior that is different when a
+ * dataset is classified.
+ */
+describe("Datasets with Fides Classify", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "/api/v1/plus/health", {
+      statusCode: 200,
+      body: {
+        status: "healthy",
+        core_fidesctl_version: "1.8",
+      },
+    }).as("getPlusHealth");
+  });
+
+  describe("Creating datasets", () => {
+    it("Shows the classify switch", () => {
+      cy.visit("/dataset/new");
+      cy.getByTestId("connect-db-btn").click();
+
+      cy.getByTestId("input-classify").find("input").should("be.checked");
+      cy.getByTestId("input-classify").click();
+      cy.getByTestId("input-classify").find("input").should("not.be.checked");
+    });
+  });
+});

--- a/clients/ctl/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/ctl/admin-ui/src/features/common/form/inputs.tsx
@@ -11,6 +11,7 @@ import {
   Radio,
   RadioGroup,
   Stack,
+  Switch,
   Textarea,
   TextareaProps,
 } from "@fidesui/react";
@@ -462,6 +463,41 @@ export const CustomRadioGroup = ({
           {meta.error}
         </FormErrorMessage>
       ) : null}
+    </FormControl>
+  );
+};
+
+interface CustomSwitchProps {
+  label: string;
+  tooltip?: string;
+}
+export const CustomSwitch = ({
+  label,
+  tooltip,
+  ...props
+}: CustomSwitchProps & FieldHookConfig<boolean>) => {
+  const [field, meta] = useField({ ...props, type: "checkbox" });
+  const isInvalid = !!(meta.touched && meta.error);
+
+  return (
+    <FormControl isInvalid={isInvalid}>
+      <Grid templateColumns="1fr 3fr" justifyContent="center">
+        <FormLabel htmlFor={props.id || props.name} my={0}>
+          {label}
+        </FormLabel>
+        <Box display="flex" alignItems="center">
+          <Switch
+            name={field.name}
+            isChecked={field.checked}
+            onChange={field.onChange}
+            onBlur={field.onBlur}
+            colorScheme="secondary"
+            mr={2}
+            data-testid={`input-${field.name}`}
+          />
+          {tooltip ? <QuestionTooltip label={tooltip} /> : null}
+        </Box>
+      </Grid>
     </FormControl>
   );
 };

--- a/clients/ctl/admin-ui/src/features/dataset/DatabaseConnectForm.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatabaseConnectForm.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Spinner, Text, useToast } from "@fidesui/react";
+import { Box, Button, Text, useToast, VStack } from "@fidesui/react";
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import { Form, Formik, FormikHelpers } from "formik";
@@ -34,6 +34,8 @@ const DatabaseConnectForm = () => {
   const organizationKey = "default_organization";
   const [generate, { isLoading: isGenerating }] = useGenerateDatasetMutation();
   const [createDataset, { isLoading: isCreating }] = useCreateDatasetMutation();
+  const isLoading = isGenerating || isCreating;
+
   const toast = useToast();
   const router = useRouter();
 
@@ -91,27 +93,28 @@ const DatabaseConnectForm = () => {
     >
       {({ isSubmitting }) => (
         <Form>
-          <Text size="sm" color="gray.700" mb={8}>
-            Connect to one of your databases using a connection URL. You may
-            have received this URL from a colleague or your Ethyca developer
-            support engineer.
-          </Text>
-          <Box mb={8}>
-            <CustomTextInput name="url" label="Database URL" />
-          </Box>
-          <Box display="flex" alignItems="center">
-            <Button
-              size="sm"
-              colorScheme="primary"
-              type="submit"
-              disabled={isSubmitting}
-              mr="2"
-              data-testid="create-dataset-btn"
-            >
-              Create dataset
-            </Button>
-            {isGenerating || isCreating ? <Spinner /> : null}
-          </Box>
+          <VStack spacing={8} align="left">
+            <Text size="sm" color="gray.700">
+              Connect to one of your databases using a connection URL. You may
+              have received this URL from a colleague or your Ethyca developer
+              support engineer.
+            </Text>
+            <Box>
+              <CustomTextInput name="url" label="Database URL" />
+            </Box>
+            <Box>
+              <Button
+                size="sm"
+                colorScheme="primary"
+                type="submit"
+                isLoading={isSubmitting || isLoading}
+                isDisabled={isSubmitting || isLoading}
+                data-testid="create-dataset-btn"
+              >
+                Generate dataset
+              </Button>
+            </Box>
+          </VStack>
         </Form>
       )}
     </Formik>


### PR DESCRIPTION
Closes #1055

[Epic overview](https://github.com/ethyca/fides/issues/1041)

### Code Changes

* New CustomSwitch component to wrap Chakra's Switch.
* New `classify` field on the generate form which is available in Plus only.

### Steps to Confirm

* [ ] fidesctl - The toggle should not be visible on the generate form.
* [ ] fidesctl-plus - The toggle should be editable and default to On.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

In fidesctl:
![switch-no-plus](https://user-images.githubusercontent.com/2236777/189240758-6b1e9bb0-a296-4f0c-85c1-545b6a34c3e0.png)

With the fidectl-plus backend
![switched-on](https://user-images.githubusercontent.com/2236777/189240765-6a240271-430a-4eed-b435-1bb6771c996c.png)

For the tooltip I adapted some language from [our docs](https://ethyca.github.io/fidescls/0.9.2/)
![switch-tooltip](https://user-images.githubusercontent.com/2236777/189240764-12cd37e9-bd2b-4506-9398-976f556a28f9.png)


