### PR TITLE
Form to add a system via yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The types of changes are:
 ### Added
 
 * Initial system management page [#1054](https://github.com/ethyca/fides/pull/1054)
+  * New page to add a system via yaml [#1062](https://github.com/ethyca/fides/pull/1062)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,17 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/1.8.4...main)
 
+* Changed behavior of `load_default_taxonomy` to append instead of upsert [#1040](https://github.com/ethyca/fides/pull/1040)
+* New page to add a system via yaml [#1062](https://github.com/ethyca/fides/pull/1062)
 
 ## [1.8.4](https://github.com/ethyca/fides/compare/1.8.3...1.8.4) - 2022-09-09
 
 ### Added
 
 * Initial system management page [#1054](https://github.com/ethyca/fides/pull/1054)
-  * New page to add a system via yaml [#1062](https://github.com/ethyca/fides/pull/1062)
 
 ### Changed
 
-* Changed behavior of `load_default_taxonomy` to append instead of upsert [#1040](https://github.com/ethyca/fides/pull/1040)
 * Deleting a taxonomy field with children will now cascade delete all of its children as well. [#1042](https://github.com/ethyca/fides/pull/1042)
 
 ### Fixed

--- a/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
@@ -283,14 +283,14 @@ describe("Dataset", () => {
         const datasetAsString = JSON.stringify(dataset);
         // Cypress doesn't have a native "paste" command, so instead do change the value directly
         // (.type() is too slow, even with 0 delay)
-        cy.getByTestId("input-datasetYaml")
+        cy.getByTestId("input-yaml")
           .click()
           .invoke("val", datasetAsString)
           .trigger("change");
         // type just one space character to make sure the text field triggers Formik's handlers
-        cy.getByTestId("input-datasetYaml").type(" ");
+        cy.getByTestId("input-yaml").type(" ");
 
-        cy.getByTestId("create-dataset-btn").click();
+        cy.getByTestId("submit-yaml-btn").click();
         cy.wait("@postDataset").then((interception) => {
           const { body } = interception.request;
           expect(body).to.eql(dataset);
@@ -323,16 +323,16 @@ describe("Dataset", () => {
       cy.visit("/dataset/new");
       cy.getByTestId("upload-yaml-btn").click();
       // type something that isn't yaml
-      cy.getByTestId("input-datasetYaml").type("invalid: invalid: invalid");
-      cy.getByTestId("create-dataset-btn").click();
-      cy.getByTestId("error-datasetYaml").should("contain", "Could not parse");
+      cy.getByTestId("input-yaml").type("invalid: invalid: invalid");
+      cy.getByTestId("submit-yaml-btn").click();
+      cy.getByTestId("error-yaml").should("contain", "Could not parse");
 
       // type something that is valid yaml and let backend render an error
-      cy.getByTestId("input-datasetYaml")
+      cy.getByTestId("input-yaml")
         .clear()
         .type("valid yaml that is not a dataset");
-      cy.getByTestId("create-dataset-btn").click();
-      cy.getByTestId("error-datasetYaml").should("contain", "field required");
+      cy.getByTestId("submit-yaml-btn").click();
+      cy.getByTestId("error-yaml").should("contain", "field required");
     });
 
     it("Can create a dataset by connecting to a database", () => {

--- a/clients/ctl/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/systems.cy.ts
@@ -40,4 +40,64 @@ describe("System management page", () => {
       cy.getByTestId("system-demo_marketing_system");
     });
   });
+
+  describe("Can create a new system", () => {
+    it("Can create a system via yaml", () => {
+      cy.intercept("POST", "/api/v1/system", { fixture: "system.json" }).as(
+        "postSystem"
+      );
+      cy.visit("/system/new");
+      cy.getByTestId("upload-yaml-btn").click();
+      cy.fixture("system.json").then((system) => {
+        const systemAsString = JSON.stringify(system);
+        // Cypress doesn't have a native "paste" command, so instead do change the value directly
+        // (.type() is too slow, even with 0 delay)
+        cy.getByTestId("input-yaml")
+          .click()
+          .invoke("val", systemAsString)
+          .trigger("change");
+        // type just one space character to make sure the text field triggers Formik's handlers
+        cy.getByTestId("input-yaml").type(" ");
+
+        cy.getByTestId("submit-yaml-btn").click();
+        cy.wait("@postSystem").then((interception) => {
+          const { body } = interception.request;
+          expect(body).to.eql(system);
+        });
+
+        // should navigate to the created system
+        cy.getByTestId("toast-success-msg");
+        cy.url().should("contain", `system`);
+      });
+    });
+
+    it("Can render errors in yaml", () => {
+      cy.intercept("POST", "/api/v1/system", {
+        statusCode: 422,
+        body: {
+          detail: [
+            {
+              loc: ["body", "fides_key"],
+              msg: "field required",
+              type: "value_error.missing",
+            },
+            {
+              loc: ["body", "system_type"],
+              msg: "field required",
+              type: "value_error.missing",
+            },
+          ],
+        },
+      }).as("postSystem");
+      cy.visit("/system/new");
+      cy.getByTestId("upload-yaml-btn").click();
+
+      // invalid system with missing fields
+      cy.getByTestId("input-yaml")
+        .clear()
+        .type("valid yaml that is not a system");
+      cy.getByTestId("submit-yaml-btn").click();
+      cy.getByTestId("error-yaml").should("contain", "field required");
+    });
+  });
 });

--- a/clients/ctl/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/systems.cy.ts
@@ -18,11 +18,13 @@ describe("System management page", () => {
     });
 
     it("Can render system cards", () => {
-      cy.getByTestId("system-fidesctl_system").within(() => {
-        cy.getByTestId("more-btn").click();
-        cy.getByTestId("edit-btn");
-        cy.getByTestId("delete-btn");
-      });
+      cy.getByTestId("system-fidesctl_system");
+      // Uncomment when we enable the more actions button
+      // cy.getByTestId("system-fidesctl_system").within(() => {
+      //   cy.getByTestId("more-btn").click();
+      //   cy.getByTestId("edit-btn");
+      //   cy.getByTestId("delete-btn");
+      // });
       cy.getByTestId("system-demo_analytics_system");
       cy.getByTestId("system-demo_marketing_system");
     });

--- a/clients/ctl/admin-ui/cypress/fixtures/system.json
+++ b/clients/ctl/admin-ui/cypress/fixtures/system.json
@@ -1,0 +1,31 @@
+{
+  "fides_key": "demo_analytics_system",
+  "organization_fides_key": "default_organization",
+  "tags": null,
+  "name": "Demo Analytics System",
+  "description": "A system used for analyzing customer behaviour.",
+  "registry_id": null,
+  "meta": null,
+  "fidesctl_meta": null,
+  "system_type": "Service",
+  "data_responsibility_title": "Controller",
+  "privacy_declarations": [
+    {
+      "name": "Analyze customer behaviour for improvements.",
+      "data_categories": ["user.contact", "user.device.cookie_id"],
+      "data_use": "improve.system",
+      "data_qualifier": "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
+      "data_subjects": ["customer"],
+      "dataset_references": ["demo_users_dataset"]
+    }
+  ],
+  "system_dependencies": null,
+  "joint_controller": null,
+  "third_country_transfers": ["USA", "CAN"],
+  "administrating_department": "Engineering",
+  "data_protection_impact_assessment": {
+    "is_required": true,
+    "progress": "Complete",
+    "link": "https://example.org/analytics_system_data_protection_impact_assessment"
+  }
+}

--- a/clients/ctl/admin-ui/src/features/YamlForm.tsx
+++ b/clients/ctl/admin-ui/src/features/YamlForm.tsx
@@ -1,0 +1,101 @@
+import { Box, Button, Text } from "@fidesui/react";
+import { Form, Formik, FormikHelpers } from "formik";
+import yaml from "js-yaml";
+
+import { CustomTextArea } from "~/features/common/form/inputs";
+import { getErrorMessage, isYamlException } from "~/features/common/helpers";
+import { RTKResult } from "~/features/common/types";
+
+const initialValues = { yaml: "" };
+type FormValues = typeof initialValues;
+
+interface Props<T> {
+  description: string;
+  submitButtonText: string;
+  onCreate: (yaml: unknown) => RTKResult<T>;
+  onSuccess: (data: T) => void;
+}
+
+const YamlForm = <T extends unknown>({
+  description,
+  submitButtonText,
+  onCreate,
+  onSuccess,
+}: Props<T>) => {
+  const handleCreate = async (
+    newValues: FormValues,
+    formikHelpers: FormikHelpers<FormValues>
+  ) => {
+    const { setErrors } = formikHelpers;
+    const parsedYaml = yaml.load(newValues.yaml, { json: true });
+    const result = await onCreate(parsedYaml);
+
+    if ("error" in result) {
+      const errorMessage = getErrorMessage(result.error);
+      setErrors({ yaml: errorMessage });
+    } else if ("data" in result) {
+      onSuccess(result.data);
+    }
+  };
+
+  const validate = (newValues: FormValues) => {
+    try {
+      const parsedYaml = yaml.load(newValues.yaml, { json: true });
+      if (!parsedYaml) {
+        return { yaml: "Could not parse the supplied YAML" };
+      }
+    } catch (error) {
+      if (isYamlException(error)) {
+        return {
+          yaml: `Could not parse the supplied YAML: \n\n${error.message}`,
+        };
+      }
+      return { yaml: "Could not parse the supplied YAML" };
+    }
+    return {};
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validate={validate}
+      onSubmit={handleCreate}
+      validateOnChange={false}
+      validateOnBlur={false}
+    >
+      {({ isSubmitting }) => (
+        <Form>
+          <Text size="sm" color="gray.700" mb={4}>
+            {description}
+          </Text>
+          {/* note: the error is more helpful in a monospace font, so apply Menlo to the whole Box */}
+          <Box mb={4} whiteSpace="pre-line" fontFamily="Menlo">
+            <CustomTextArea
+              name="yaml"
+              textAreaProps={{
+                fontWeight: 400,
+                lineHeight: "150%",
+                color: "gray.800",
+                fontSize: "13px",
+                height: "50vh",
+                width: "100%",
+                mb: "2",
+              }}
+            />
+          </Box>
+          <Button
+            size="sm"
+            colorScheme="primary"
+            type="submit"
+            disabled={isSubmitting}
+            data-testid="submit-yaml-btn"
+          >
+            {submitButtonText}
+          </Button>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default YamlForm;

--- a/clients/ctl/admin-ui/src/features/common/types.tsx
+++ b/clients/ctl/admin-ui/src/features/common/types.tsx
@@ -1,5 +1,14 @@
+import { RTKErrorResult } from "~/types/errors";
+
 export interface TreeNode {
   label: string;
   value: string;
   children: TreeNode[];
 }
+
+export type RTKResult<T> = Promise<
+  | {
+      data: T;
+    }
+  | { error: RTKErrorResult["error"] }
+>;

--- a/clients/ctl/admin-ui/src/features/config-wizard/DescribeSystemsForm.tsx
+++ b/clients/ctl/admin-ui/src/features/config-wizard/DescribeSystemsForm.tsx
@@ -8,7 +8,6 @@ import { useAppDispatch } from "~/app/hooks";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { QuestionIcon } from "~/features/common/Icon";
 import { DEFAULT_ORGANIZATION_FIDES_KEY } from "~/features/organization";
-import { System } from "~/types/api";
 
 import {
   CustomCreatableMultiSelect,
@@ -18,7 +17,15 @@ import {
 import { useCreateSystemMutation } from "../system/system.slice";
 import { changeReviewStep, setSystemFidesKey } from "./config-wizard.slice";
 
-type FormValues = Partial<System>;
+const initialValues = {
+  description: "",
+  fides_key: "",
+  name: "",
+  organization_fides_key: DEFAULT_ORGANIZATION_FIDES_KEY,
+  tags: [],
+  system_type: "",
+};
+type FormValues = typeof initialValues;
 
 const DescribeSystemsForm = ({
   handleCancelSetup,
@@ -31,15 +38,6 @@ const DescribeSystemsForm = ({
   const [isLoading, setIsLoading] = useState(false);
 
   const toast = useToast();
-
-  const initialValues = {
-    description: "",
-    fides_key: "",
-    name: "",
-    organization_fides_key: DEFAULT_ORGANIZATION_FIDES_KEY,
-    tags: [],
-    system_type: "",
-  };
 
   const handleSubmit = async (values: FormValues) => {
     const systemBody = {

--- a/clients/ctl/admin-ui/src/features/system/SystemCard.tsx
+++ b/clients/ctl/admin-ui/src/features/system/SystemCard.tsx
@@ -17,6 +17,7 @@ interface SystemCardProps {
 }
 const SystemCard = ({ system }: SystemCardProps) => {
   // TODO fides#1035, fides#1036
+  const showMoreActions = false; // disable while feature is not implemented yet
   const handleEdit = () => {};
   const handleDelete = () => {};
 
@@ -30,24 +31,26 @@ const SystemCard = ({ system }: SystemCardProps) => {
           <Text>{system.description}</Text>
         </Box>
       </Box>
-      <Menu>
-        <MenuButton
-          as={IconButton}
-          icon={<MoreIcon />}
-          aria-label="more actions"
-          variant="unstyled"
-          size="sm"
-          data-testid="more-btn"
-        />
-        <MenuList>
-          <MenuItem onClick={handleEdit} data-testid="edit-btn">
-            Edit
-          </MenuItem>
-          <MenuItem onClick={handleDelete} data-testid="delete-btn">
-            Delete
-          </MenuItem>
-        </MenuList>
-      </Menu>
+      {showMoreActions ? (
+        <Menu>
+          <MenuButton
+            as={IconButton}
+            icon={<MoreIcon />}
+            aria-label="more actions"
+            variant="unstyled"
+            size="sm"
+            data-testid="more-btn"
+          />
+          <MenuList>
+            <MenuItem onClick={handleEdit} data-testid="edit-btn">
+              Edit
+            </MenuItem>
+            <MenuItem onClick={handleDelete} data-testid="delete-btn">
+              Delete
+            </MenuItem>
+          </MenuList>
+        </Menu>
+      ) : null}
     </Box>
   );
 };

--- a/clients/ctl/admin-ui/src/features/system/SystemYamlForm.tsx
+++ b/clients/ctl/admin-ui/src/features/system/SystemYamlForm.tsx
@@ -1,0 +1,57 @@
+import { useToast } from "@fidesui/react";
+import { useRouter } from "next/router";
+
+import { System } from "~/types/api";
+
+import { successToastParams } from "../common/toast";
+import YamlForm from "../YamlForm";
+import { useCreateSystemMutation } from "./system.slice";
+
+// handle the common case where everything is nested under a `system` key
+interface NestedSystem {
+  system: System[];
+}
+export function isSystemArray(value: unknown): value is NestedSystem {
+  return (
+    typeof value === "object" &&
+    value != null &&
+    "system" in value &&
+    Array.isArray((value as any).system)
+  );
+}
+
+const DESCRIPTION =
+  "Get started creating your system by pasting your system YAML below! You may have received this YAML from a colleague or your Ethyca developer support engineer.";
+
+const SystemYamlForm = () => {
+  const [createSystem] = useCreateSystemMutation();
+  const toast = useToast();
+  const router = useRouter();
+
+  const handleCreate = async (yaml: unknown) => {
+    let system;
+    if (isSystemArray(yaml)) {
+      [system] = yaml.system;
+    } else {
+      system = yaml;
+    }
+
+    return createSystem(system);
+  };
+
+  const handleSuccess = () => {
+    toast(successToastParams("Successfully loaded new system YAML"));
+    router.push(`/system`);
+  };
+
+  return (
+    <YamlForm<System>
+      description={DESCRIPTION}
+      submitButtonText="Create system"
+      onCreate={handleCreate}
+      onSuccess={handleSuccess}
+    />
+  );
+};
+
+export default SystemYamlForm;

--- a/clients/ctl/admin-ui/src/features/system/SystemsManagement.tsx
+++ b/clients/ctl/admin-ui/src/features/system/SystemsManagement.tsx
@@ -25,7 +25,7 @@ const SystemsManagement = ({ systems }: Props) => {
   }, [systems, searchFilter]);
 
   if (!systems || !systems.length) {
-    return <div data-testid="empty-state">Empty state</div>;
+    return <div data-testid="empty-state">No systems registered.</div>;
   }
 
   return (

--- a/clients/ctl/admin-ui/src/features/system/system.slice.ts
+++ b/clients/ctl/admin-ui/src/features/system/system.slice.ts
@@ -27,7 +27,9 @@ export const systemApi = createApi({
       query: (fides_key) => ({ url: `system/${fides_key}/` }),
       providesTags: ["System"],
     }),
-    createSystem: build.mutation<{}, Partial<System>>({
+    // we accept 'unknown' as well since the user can paste anything in, and we rely
+    // on the backend to do the validation for us
+    createSystem: build.mutation<System, System | unknown>({
       query: (body) => ({
         url: `system/`,
         method: "POST",

--- a/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyFormBase.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/TaxonomyFormBase.tsx
@@ -17,11 +17,12 @@ import * as Yup from "yup";
 import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
 import { isErrorResult, parseError } from "~/features/common/helpers";
 import { successToastParams } from "~/features/common/toast";
+import { RTKResult } from "~/features/common/types";
 import { RTKErrorResult } from "~/types/errors";
 
 import { parentKeyFromFidesKey } from "./helpers";
 import TaxonomyEntityTag from "./TaxonomyEntityTag";
-import { Labels, RTKResult, TaxonomyEntity } from "./types";
+import { Labels, TaxonomyEntity } from "./types";
 
 export type FormValues = Partial<TaxonomyEntity> &
   Pick<TaxonomyEntity, "fides_key">;

--- a/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/ctl/admin-ui/src/features/taxonomy/hooks.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 
+import { RTKResult } from "~/features/common/types";
 import {
   DataCategory,
   DataQualifier,
@@ -44,7 +45,7 @@ import {
   useUpdateDataCategoryMutation,
 } from "./taxonomy.slice";
 import type { FormValues } from "./TaxonomyFormBase";
-import { Labels, RTKResult, TaxonomyEntity } from "./types";
+import { Labels, TaxonomyEntity } from "./types";
 
 export interface TaxonomyHookData<T extends TaxonomyEntity> {
   data?: TaxonomyEntity[];

--- a/clients/ctl/admin-ui/src/features/taxonomy/types.ts
+++ b/clients/ctl/admin-ui/src/features/taxonomy/types.ts
@@ -1,5 +1,3 @@
-import { RTKErrorResult } from "~/types/errors";
-
 import { TreeNode } from "../common/types";
 
 export interface TaxonomyEntityNode extends TreeNode {
@@ -22,10 +20,3 @@ export interface Labels {
   description: string;
   parent_key?: string;
 }
-
-export type RTKResult<T> = Promise<
-  | {
-      data: T;
-    }
-  | { error: RTKErrorResult["error"] }
->;

--- a/clients/ctl/admin-ui/src/pages/system/index.tsx
+++ b/clients/ctl/admin-ui/src/pages/system/index.tsx
@@ -1,5 +1,6 @@
-import { Heading, Spinner } from "@fidesui/react";
+import { Box, Button, Heading, Spinner } from "@fidesui/react";
 import type { NextPage } from "next";
+import NextLink from "next/link";
 import React from "react";
 
 import Layout from "~/features/common/Layout";
@@ -20,9 +21,19 @@ const Systems: NextPage = () => {
 
   return (
     <Layout title="Systems">
-      <Heading mb={8} fontSize="2xl" fontWeight="semibold">
-        System Management
-      </Heading>
+      <Box display="flex" justifyContent="space-between">
+        <Heading mb={8} fontSize="2xl" fontWeight="semibold">
+          System Management
+        </Heading>
+        <Button
+          size="sm"
+          colorScheme="primary"
+          mr={2}
+          data-testid="create-system-btn"
+        >
+          <NextLink href="/system/new">Create New System</NextLink>
+        </Button>
+      </Box>
       {isLoading ? <Spinner /> : <SystemsManagement systems={systems} />}
     </Layout>
   );

--- a/clients/ctl/admin-ui/src/pages/system/new/index.tsx
+++ b/clients/ctl/admin-ui/src/pages/system/new/index.tsx
@@ -12,6 +12,7 @@ import NextLink from "next/link";
 import { useState } from "react";
 
 import Layout from "~/features/common/Layout";
+import SystemYamlForm from "~/features/system/SystemYamlForm";
 
 const NewSystem: NextPage = () => {
   const [generateMethod, setGenerateMethod] = useState<
@@ -55,7 +56,7 @@ const NewSystem: NextPage = () => {
           </Button>
         </Box>
         <Box w={{ base: "100%", lg: "50%" }}>
-          {generateMethod === "yaml" ? <div>yaml form</div> : null}
+          {generateMethod === "yaml" ? <SystemYamlForm /> : null}
         </Box>
       </Stack>
     </Layout>

--- a/clients/ctl/admin-ui/src/pages/system/new/index.tsx
+++ b/clients/ctl/admin-ui/src/pages/system/new/index.tsx
@@ -1,0 +1,65 @@
+import {
+  Box,
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  Heading,
+  Stack,
+  Text,
+} from "@fidesui/react";
+import type { NextPage } from "next";
+import NextLink from "next/link";
+import { useState } from "react";
+
+import Layout from "~/features/common/Layout";
+
+const NewSystem: NextPage = () => {
+  const [generateMethod, setGenerateMethod] = useState<
+    "yaml" | "manual" | null
+  >(null);
+  return (
+    <Layout title="Systems">
+      <Heading mb={2} fontSize="2xl" fontWeight="semibold">
+        Create a new system
+      </Heading>
+      <Box mb={8}>
+        <Breadcrumb fontWeight="medium" fontSize="sm" color="gray.600">
+          <BreadcrumbItem>
+            <NextLink href="/system">System Connections</NextLink>
+          </BreadcrumbItem>
+          <BreadcrumbItem>
+            <NextLink href="#">Create a new system</NextLink>
+          </BreadcrumbItem>
+        </Breadcrumb>
+      </Box>
+      <Stack spacing={8}>
+        <Box w={{ base: "100%", lg: "50%" }}>
+          <Text>
+            Choose whether to upload a new system YAML or manually generate a
+            system.
+          </Text>
+        </Box>
+        <Box>
+          <Button
+            size="sm"
+            mr={2}
+            variant="outline"
+            onClick={() => setGenerateMethod("yaml")}
+            isActive={generateMethod === "yaml"}
+            data-testid="upload-yaml-btn"
+          >
+            Upload a new system YAML
+          </Button>
+          <Button size="sm" variant="outline">
+            Manually generate a system
+          </Button>
+        </Box>
+        <Box w={{ base: "100%", lg: "50%" }}>
+          {generateMethod === "yaml" ? <div>yaml form</div> : null}
+        </Box>
+      </Stack>
+    </Layout>
+  );
+};
+
+export default NewSystem;


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/1032

### Code Changes

* [x] New page at `/system/new` to show options for creating a new system
* [x] Refactors `DatasetYamlForm` so that the core of it can be reused for a `SystemYamlForm`
* [x] Creates a `SystemYamlForm`
* [x] Adds Cypress tests

### Steps to Confirm

* [ ] Click the new "Create new system" button located at `/system` (or navigate directly to `/system/new`)
* [ ] Click "Upload a new system YAML"
* [ ] Copy and paste a system yaml into the input box
* [ ] Click "create system" and your new system should show up in the list of systems now

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes


https://user-images.githubusercontent.com/24641006/189423716-029d78df-bd5d-42d2-9a06-d6d593a62c08.mov

Because we're using the same yaml validators/forms as `DatasetYamlForm.tsx` did, the error rendering is exactly the same.
