### PR TITLE
Make CLI startup logging cleaner

### DIFF
--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -5,6 +5,7 @@ import logging
 import subprocess
 from datetime import datetime, timezone
 from logging import WARNING
+from os import getenv
 from typing import Callable, Optional
 
 from fastapi import FastAPI, HTTPException, Request, Response, status
@@ -181,6 +182,16 @@ for handler in ExceptionHandlers.get_handlers():
 @app.on_event("startup")
 async def setup_server() -> None:
     "Run all of the required setup steps for the webserver."
+    logger.warning(
+        "Startup configuration: reloading = %s, dev_mode = %s",
+        CONFIG.hot_reloading,
+        CONFIG.dev_mode,
+    )
+    logger.warning(
+        "Startup configuration: pii logging = %s",
+        getenv("FIDES__LOG_PII", "").lower() == "true",
+    )
+
     if logger.getEffectiveLevel() == logging.DEBUG:
         logger.warning(
             "WARNING: log level is DEBUG, so sensitive or personal data may be logged. "

--- a/src/fides/cli/__init__.py
+++ b/src/fides/cli/__init__.py
@@ -72,7 +72,7 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
     """
 
     ctx.ensure_object(dict)
-    config = get_config(config_path)
+    config = get_config(config_path, verbose=True)
 
     # Dyanmically add commands to the CLI
     cli.commands = LOCAL_COMMAND_DICT

--- a/src/fides/ctl/core/config/__init__.py
+++ b/src/fides/ctl/core/config/__init__.py
@@ -51,14 +51,6 @@ class FidesConfig(BaseModel):
     class Config:  # pylint: disable=C0115
         case_sensitive = True
 
-    logger.warning(
-        "Startup configuration: reloading = %s, dev_mode = %s", hot_reloading, dev_mode
-    )
-    logger.warning(
-        "Startup configuration: pii logging = %s",
-        getenv("FIDES__LOG_PII", "").lower() == "true",
-    )
-
     def log_all_config_values(self) -> None:
         """Output DEBUG logs of all the config values."""
         for settings in [
@@ -171,7 +163,7 @@ def censor_config(config: FidesConfig) -> Dict[str, Any]:
 
 
 @lru_cache(maxsize=1)
-def get_config(config_path_override: str = "") -> FidesConfig:
+def get_config(config_path_override: str = "", verbose: bool = False) -> FidesConfig:
     """
     Attempt to load user-defined configuration.
 
@@ -181,9 +173,9 @@ def get_config(config_path_override: str = "") -> FidesConfig:
     """
 
     env_config_path = getenv("FIDES__CONFIG_PATH")
-    config_path = config_path_override or env_config_path or DEFAULT_CONFIG_PATHv
-    # Update this to be less noisy
-    print(f"Loading config from: {config_path}")
+    config_path = config_path_override or env_config_path or DEFAULT_CONFIG_PATH
+    if verbose:
+        print(f"Loading config from: {config_path}")
     try:
         settings = (
             toml.load(config_path)

--- a/src/fides/ctl/core/config/__init__.py
+++ b/src/fides/ctl/core/config/__init__.py
@@ -181,7 +181,8 @@ def get_config(config_path_override: str = "") -> FidesConfig:
     """
 
     env_config_path = getenv("FIDES__CONFIG_PATH")
-    config_path = config_path_override or env_config_path or DEFAULT_CONFIG_PATH
+    config_path = config_path_override or env_config_path or DEFAULT_CONFIG_PATHv
+    # Update this to be less noisy
     print(f"Loading config from: {config_path}")
     try:
         settings = (


### PR DESCRIPTION
Closes #1065 

### Code Changes

* [x] add a `verbose` flag to `get_config` to control when messages get printed out
* [x] move server-related config logging to `main.py` from the config build

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

This PR makes the standard CLI logging less verbose, removes duplicate logging messages, etc.

#### Old
```
fides> fides
Startup configuration: reloading = False, dev_mode = False
Startup configuration: pii logging = False
Loading config from: .fides/fides.toml
Loading config from: .fides/fides.toml
Usage: fides [OPTIONS] COMMAND [ARGS]...

  The parent group for the Fides CLI.
```

#### New
```
fides> fides    
Loading config from: .fides/fides.toml
Usage: fides [OPTIONS] COMMAND [ARGS]...

  The parent group for the Fides CLI.
```