### PR TITLE
Test multiple Python versions

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -6,7 +6,6 @@ on:
       - "**.md"
 
 env:
-  CONTAINER: fides-local
   IMAGE: ethyca/fides:local
 
 jobs:
@@ -37,8 +36,8 @@ jobs:
       - name: Upload container
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.CONTAINER }}
-          path: /tmp/${{ env.CONTAINER }}.tar
+          name: python-${{ matrix.python_version }}
+          path: /tmp/python-${{ matrix.python_version }}.tar
           retention-days: 1
 
 ###################
@@ -197,16 +196,19 @@ jobs:
 ###########
   Pytest-Ctl-Not-External:
     needs: Build
+    strategy:
+      matrix:
+        python_version: ["3.8.14", "3.9.14", "3.10.7"]
     runs-on: ubuntu-latest
     steps:
       - name: Download container
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.CONTAINER }}
+          name: python-${{ matrix.python_version }}
           path: /tmp/
 
       - name: Load image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
+        run: docker load --input /tmp/python-${{ matrix.python_version }}.tar
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   IMAGE: ethyca/fides:local
+  DEFAULT_PYTHON_VERSION: "3.10.7"
 
 jobs:
   Build:
@@ -50,10 +51,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
+      - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -68,7 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: set up python 3.10
+      - name: set up python
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
@@ -86,7 +87,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: set up python 3.10
+      - name: set up python
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
@@ -104,7 +105,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: set up python 3.10
+      - name: set up python
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
@@ -122,7 +123,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: set up python 3.10
+      - name: set up python
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
@@ -165,19 +166,19 @@ jobs:
       - name: Download container
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.CONTAINER }}
+          name: python-${{ env.DEFAULT_PYTHON_VERSION }}
           path: /tmp/
 
       - name: Load image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
+        run: docker load --input /tmp/python-${{ env.DEFAULT_PYTHON_VERSION }}.tar
 
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install Nox
         run: pip install nox>=2022

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -72,7 +72,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -90,7 +90,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -108,7 +108,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -126,7 +126,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -144,11 +144,11 @@ jobs:
       - name: Download container
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.CONTAINER }}
+          name: python-${{ env.DEFAULT_PYTHON_VERSION }}
           path: /tmp/
 
       - name: Load image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
+        run: docker load --input /tmp/python-${{ env.DEFAULT_PYTHON_VERSION }}.tar
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -227,11 +227,11 @@ jobs:
       - name: Download container
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.CONTAINER }}
+          name: python-${{ env.DEFAULT_PYTHON_VERSION }}
           path: /tmp/
 
       - name: Load image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
+        run: docker load --input /tmp/python-${{ env.DEFAULT_PYTHON_VERSION }}.tar
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -257,11 +257,11 @@ jobs:
       - name: Download container
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.CONTAINER }}
+          name: python-${{ env.DEFAULT_PYTHON_VERSION }}
           path: /tmp/
 
       - name: Load image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
+        run: docker load --input /tmp/python-${{ env.DEFAULT_PYTHON_VERSION }}.tar
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -279,11 +279,11 @@ jobs:
       - name: Download container
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.CONTAINER }}
+          name: python-${{ env.DEFAULT_PYTHON_VERSION }}
           path: /tmp/
 
       - name: Load image
-        run: docker load --input /tmp/${{ env.CONTAINER }}.tar
+        run: docker load --input /tmp/python-${{ env.DEFAULT_PYTHON_VERSION }}.tar
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -7,13 +7,13 @@ on:
 
 env:
   IMAGE: ethyca/fides:local
-  DEFAULT_PYTHON_VERSION: "3.10.7"
+  DEFAULT_PYTHON_VERSION: "3.10.6"
 
 jobs:
   Build:
     strategy:
       matrix:
-        python_version: ["3.8.14", "3.9.14", "3.10.7"]
+        python_version: ["3.8.14", "3.9.14", "3.10.6"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -199,7 +199,7 @@ jobs:
     needs: Build
     strategy:
       matrix:
-        python_version: ["3.8.14", "3.9.14", "3.10.7"]
+        python_version: ["3.8.14", "3.9.14", "3.10.6"]
     runs-on: ubuntu-latest
     steps:
       - name: Download container
@@ -222,16 +222,19 @@ jobs:
 
   Pytest-Ctl-External:
     needs: Build
+    strategy:
+      matrix:
+        python_version: ["3.8.14", "3.9.14", "3.10.6"]
     runs-on: ubuntu-latest
     steps:
       - name: Download container
         uses: actions/download-artifact@v3
         with:
-          name: python-${{ env.DEFAULT_PYTHON_VERSION }}
+          name: python-${{ matrix.python_version }}
           path: /tmp/
 
       - name: Load image
-        run: docker load --input /tmp/python-${{ env.DEFAULT_PYTHON_VERSION }}.tar
+        run: docker load --input /tmp/python-${{ matrix.python_version }}.tar
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -252,16 +255,19 @@ jobs:
 
   Pytest-Unit-Ops:
     needs: Build
+    strategy:
+      matrix:
+        python_version: ["3.8.14", "3.9.14", "3.10.6"]
     runs-on: ubuntu-latest
     steps:
       - name: Download container
         uses: actions/download-artifact@v3
         with:
-          name: python-${{ env.DEFAULT_PYTHON_VERSION }}
+          name: python-${{ matrix.python_version }}
           path: /tmp/
 
       - name: Load image
-        run: docker load --input /tmp/python-${{ env.DEFAULT_PYTHON_VERSION }}.tar
+        run: docker load --input /tmp/python-${{ matrix.python_version }}.tar
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -274,16 +280,19 @@ jobs:
 
   Pytest-Integration-Ops:
     needs: Build
+    strategy:
+      matrix:
+        python_version: ["3.8.14", "3.9.14", "3.10.6"]
     runs-on: ubuntu-latest
     steps:
       - name: Download container
         uses: actions/download-artifact@v3
         with:
-          name: python-${{ env.DEFAULT_PYTHON_VERSION }}
+          name: python-${{ matrix.python_version }}
           path: /tmp/
 
       - name: Load image
-        run: docker load --input /tmp/python-${{ env.DEFAULT_PYTHON_VERSION }}.tar
+        run: docker load --input /tmp/python-${{ matrix.python_version }}.tar
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -11,6 +11,9 @@ env:
 
 jobs:
   Build:
+    strategy:
+      matrix:
+        python_version: ["3.8.14", "3.9.14", "3.10.7"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,8 +28,9 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
+          build-args: PYTHON_VERSION=${{ matrix.python_version }}
           target: prod
-          outputs: type=docker,dest=/tmp/${{ env.CONTAINER }}.tar
+          outputs: type=docker,dest=/tmp/python-${{ matrix.python_version }}.tar
           push: false
           tags: ${{ env.IMAGE }}
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -69,10 +69,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
+      - name: set up python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -87,10 +87,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
+      - name: set up python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -105,10 +105,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
+      - name: set up python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -123,10 +123,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
+      - name: set up python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install Nox
         run: pip install nox>=2022

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,35 +85,29 @@ RUN git clone --depth=1 https://github.com/pyenv/pyenv.git .pyenv
 ENV PYENV_ROOT="$HOME/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
-ARG python37="3.7.14"
 ARG python38="3.8.14"
 ARG python39="3.9.14"
 ARG python310="3.10.7"
 
-RUN pyenv install ${python37}
 RUN pyenv install ${python38}
 RUN pyenv install ${python39}
 RUN pyenv install ${python310}
 
 COPY optional-requirements.txt .
-RUN pyenv global ${python37} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
 RUN pyenv global ${python38} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
 RUN pyenv global ${python39} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
 RUN pyenv global ${python310} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
 
 COPY dev-requirements.txt .
-RUN pyenv global ${python37} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
 RUN pyenv global ${python38} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
 RUN pyenv global ${python39} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
 RUN pyenv global ${python310} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
 
 COPY requirements.txt .
-RUN pyenv global ${python37} ; pip install -U pip --no-cache-dir install -r requirements.txt
 RUN pyenv global ${python38} ; pip install -U pip --no-cache-dir install -r requirements.txt
 RUN pyenv global ${python39} ; pip install -U pip --no-cache-dir install -r requirements.txt
 RUN pyenv global ${python310} ; pip install -U pip --no-cache-dir install -r requirements.txt
 
-RUN pyenv global ${python310}
 ###############################
 ## General Application Setup ##
 ###############################
@@ -138,7 +132,9 @@ CMD [ "fides", "webserver" ]
 #############################
 FROM backend as dev
 
-RUN pip install -e .
+RUN pyenv global ${38} ; pip install -e .
+RUN pyenv global ${39} ; pip install -e .
+RUN pyenv global ${310} ; pip install -e .
 
 #############################
 ## Production Application ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN npm run export
 #############
 ## Backend ##
 #############
-FROM --platform=linux/amd64 python:3.9.13-slim-bullseye as backend
+FROM --platform=linux/amd64 python:3.10.7-slim-bullseye as backend
 
 # Install auxiliary software
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN npm run export
 #############
 ## Backend ##
 #############
-FROM --platform=linux/amd64 python:3.10.7-slim-bullseye as backend
+FROM --platform=linux/amd64 python:3.9.13-slim-bullseye as backend
 
 # Install auxiliary software
 RUN apt-get update && \
@@ -53,60 +53,14 @@ RUN : \
 ## Python Dependencies ##
 #########################
 
-RUN : \
-    && apt-get update \
-    && apt-get install \
-    -y --no-install-recommends \
-    build-essential \
-    libssl-dev \
-    zlib1g-dev \
-    libbz2-dev \
-    libreadline-dev \
-    libsqlite3-dev \
-    wget \
-    curl \
-    llvm \
-    libncurses5-dev \
-    xz-utils \
-    tk-dev \
-    libxml2-dev \
-    libxmlsec1-dev \
-    libffi-dev \
-    liblzma-dev \
-    mecab-ipadic-utf8 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV HOME="/root"
-
-WORKDIR $HOME
-RUN apt-get install -y git
-RUN git clone --depth=1 https://github.com/pyenv/pyenv.git .pyenv
-ENV PYENV_ROOT="$HOME/.pyenv"
-ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-
-ARG python38="3.8.14"
-ARG python39="3.9.14"
-ARG python310="3.10.7"
-
-RUN pyenv install ${python38}
-RUN pyenv install ${python39}
-RUN pyenv install ${python310}
-
 COPY optional-requirements.txt .
-RUN pyenv global ${python38} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
-RUN pyenv global ${python39} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
-RUN pyenv global ${python310} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
+RUN pip install -U pip --no-cache-dir install -r optional-requirements.txt
 
 COPY dev-requirements.txt .
-RUN pyenv global ${python38} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
-RUN pyenv global ${python39} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
-RUN pyenv global ${python310} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
+RUN pip install -U pip --no-cache-dir install -r dev-requirements.txt
 
 COPY requirements.txt .
-RUN pyenv global ${python38} ; pip install -U pip --no-cache-dir install -r requirements.txt
-RUN pyenv global ${python39} ; pip install -U pip --no-cache-dir install -r requirements.txt
-RUN pyenv global ${python310} ; pip install -U pip --no-cache-dir install -r requirements.txt
+RUN pip install -U pip --no-cache-dir install -r requirements.txt
 
 ###############################
 ## General Application Setup ##
@@ -132,9 +86,7 @@ CMD [ "fides", "webserver" ]
 #############################
 FROM backend as dev
 
-RUN pyenv global ${38} ; pip install -e .
-RUN pyenv global ${39} ; pip install -e .
-RUN pyenv global ${310} ; pip install -e .
+RUN pip install -e .
 
 #############################
 ## Production Application ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,9 @@ RUN : \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-#####################
-## Python Versions ##
-#####################
+#########################
+## Python Dependencies ##
+#########################
 
 RUN : \
     && apt-get update \
@@ -85,25 +85,35 @@ RUN git clone --depth=1 https://github.com/pyenv/pyenv.git .pyenv
 ENV PYENV_ROOT="$HOME/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
-RUN pyenv install 3.7.14
-RUN pyenv install 3.8.14
-RUN pyenv install 3.9.14
-RUN pyenv install 3.10.7
+ARG python37="3.7.14"
+ARG python38="3.8.14"
+ARG python39="3.9.14"
+ARG python310="3.10.7"
 
-RUN pyenv global 3.10.7
-#########################
-## Python Dependencies ##
-#########################
+RUN pyenv install ${python37}
+RUN pyenv install ${python38}
+RUN pyenv install ${python39}
+RUN pyenv install ${python310}
 
 COPY optional-requirements.txt .
-RUN pip install -U pip --no-cache-dir install -r optional-requirements.txt
+RUN pyenv global ${python37} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
+RUN pyenv global ${python38} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
+RUN pyenv global ${python39} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
+RUN pyenv global ${python310} ; pip install -U pip --no-cache-dir install -r optional-requirements.txt
 
 COPY dev-requirements.txt .
-RUN pip install -U pip --no-cache-dir install -r dev-requirements.txt
+RUN pyenv global ${python37} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
+RUN pyenv global ${python38} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
+RUN pyenv global ${python39} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
+RUN pyenv global ${python310} ; pip install -U pip --no-cache-dir install -r dev-requirements.txt
 
 COPY requirements.txt .
-RUN pip install -U pip --no-cache-dir install -r requirements.txt
+RUN pyenv global ${python37} ; pip install -U pip --no-cache-dir install -r requirements.txt
+RUN pyenv global ${python38} ; pip install -U pip --no-cache-dir install -r requirements.txt
+RUN pyenv global ${python39} ; pip install -U pip --no-cache-dir install -r requirements.txt
+RUN pyenv global ${python310} ; pip install -U pip --no-cache-dir install -r requirements.txt
 
+RUN pyenv global ${python310}
 ###############################
 ## General Application Setup ##
 ###############################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+
 ##############
 ## Frontend ##
 ##############
@@ -18,7 +19,8 @@ RUN npm run export
 #############
 ## Backend ##
 #############
-FROM --platform=linux/amd64 python:3.9.13-slim-bullseye as backend
+ARG PYTHON_VERSION=3.10.7
+FROM --platform=linux/amd64 python:${PYTHON_VERSION}-slim-bullseye as backend
 
 # Install auxiliary software
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG PYTHON_VERSION=3.10.7
+# Pin to 3.10.6 to avoid a mypy error in 3.10.7
+ARG PYTHON_VERSION=3.10.6
 
 ##############
 ## Frontend ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,11 +49,51 @@ RUN : \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+#####################
+## Python Versions ##
+#####################
+
+RUN : \
+    && apt-get update \
+    && apt-get install \
+    -y --no-install-recommends \
+    build-essential \
+    libssl-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    wget \
+    curl \
+    llvm \
+    libncurses5-dev \
+    xz-utils \
+    tk-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libffi-dev \
+    liblzma-dev \
+    mecab-ipadic-utf8 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV HOME="/root"
+
+WORKDIR $HOME
+RUN apt-get install -y git
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git .pyenv
+ENV PYENV_ROOT="$HOME/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN pyenv install 3.7.14
+RUN pyenv install 3.8.14
+RUN pyenv install 3.9.14
+RUN pyenv install 3.10.7
+
+RUN pyenv global 3.10.7
 #########################
 ## Python Dependencies ##
 #########################
-
-# Install multiple Python versions
 
 COPY optional-requirements.txt .
 RUN pip install -U pip --no-cache-dir install -r optional-requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN : \
 ## Python Dependencies ##
 #########################
 
+# Install multiple Python versions
+
 COPY optional-requirements.txt .
 RUN pip install -U pip --no-cache-dir install -r optional-requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # Pin to 3.10.6 to avoid a mypy error in 3.10.7
+# If you update this, also update `DEFAULT_PYTHON_VERSION`
+# in the GitHub workflow files
 ARG PYTHON_VERSION=3.10.6
 
 ##############

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG PYTHON_VERSION=3.10.7
 
 ##############
 ## Frontend ##
@@ -19,7 +20,6 @@ RUN npm run export
 #############
 ## Backend ##
 #############
-ARG PYTHON_VERSION=3.10.7
 FROM --platform=linux/amd64 python:${PYTHON_VERSION}-slim-bullseye as backend
 
 # Install auxiliary software

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -26,4 +26,4 @@ fastapi-caching[redis]
 sqlalchemy-redshift==0.8.11
 
 # Snowflake
-snowflake-sqlalchemy==1.3.4
+snowflake-sqlalchemy==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ celery[pytest]==5.2.7
 click==8.1.3
 colorama>=0.4.3
 cryptography~=3.4.8
-dask==2022.8.0
+dask==2022.2.0
 deepdiff==5.8.0
 emails
 fastapi[all]==0.81.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ celery[pytest]==5.2.7
 click==8.1.3
 colorama>=0.4.3
 cryptography~=3.4.8
-dask==2022.2.0
+dask==2022.8.0
 deepdiff==5.8.0
 emails
 fastapi[all]==0.81.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ mysql = ["pymysql==1.0.2"]
 okta = ["okta==2.5.0"]
 redis = ["redis==3.5.3", "fastapi-caching[redis]"]
 redshift = ["sqlalchemy-redshift==0.8.11"]
-snowflake = ["snowflake-sqlalchemy==1.3.4"]
+snowflake = ["snowflake-sqlalchemy==1.4.1"]
 
 extras = {
     "aws": aws,

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/ethyca/fides",
     entry_points={"console_scripts": ["fides=fides.cli:cli"]},
-    python_requires=">=3.7, <4",
+    python_requires=">=3.8, <4",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     include_package_data=True,
@@ -68,7 +68,6 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/ethyca/fides",
     entry_points={"console_scripts": ["fides=fides.cli:cli"]},
-    python_requires=">=3.9, <4",
+    python_requires=">=3.7, <4",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     include_package_data=True,

--- a/src/fides/api/ops/util/collection_util.py
+++ b/src/fides/api/ops/util/collection_util.py
@@ -17,7 +17,7 @@ def merge_dicts(*dicts: Dict[T, U]) -> Dict[T, U]:
     =>  {'A': 2, 'B': 2, 'C': 4}
     """
     if dicts:
-        return reduce(lambda x, y: x | y, dicts) or {}
+        return reduce(lambda x, y: {**x, **y}, dicts) or {}
     return {}
 
 


### PR DESCRIPTION
Closes #1017 

### Code Changes

* [x] add a docker build arg to specify python version
* [x] update the docker build workflow to be a matrix of python versions
* [x] update code checks to also run from a matrix of python version containers
* [x] set a `default version` in CI (should match the default build arg)
* [x] update the `setup.py` file to change python restriction

### Steps to Confirm

* [x] tests pass!

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

We want to expand our official support for both newer and older versions of Python by formally testing multiple versions in CI.

Python `3.8`, `3.9` and `3.10` will be our officially supported versions, and we can add 3.11 so that list when it comes out and we can test it. `3.7` is unable to be included due to some important requirements being incompatible.

__Note__:
Working as intended! Found some bugs on different versions that I fixed here as well 