### PR TITLE
Separate 'next' and 'add' logic in PrivacyDeclarationForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The types of changes are:
 ### Changed
 
 * Changed behavior of `load_default_taxonomy` to append instead of upsert [#1040](https://github.com/ethyca/fides/pull/1040)
+* Changed behavior of adding privacy declarations to decouple the actions of the "add" and "next" buttons [#1086](https://github.com/ethyca/fides/pull/1086)
 
 ### Fixed
 

--- a/clients/ctl/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/systems.cy.ts
@@ -179,7 +179,8 @@ describe("System management page", () => {
           cy.getByTestId("input-data_qualifier").within(() => {
             cy.contains(declaration.data_qualifier).click();
           });
-          cy.getByTestId("confirm-btn").click();
+          cy.getByTestId("add-btn").click();
+          cy.getByTestId("next-btn").click();
           cy.wait("@putSystem").then((interception) => {
             const { body } = interception.request;
             // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -257,7 +258,7 @@ describe("System management page", () => {
       cy.getByTestId("toast-success-msg");
     });
 
-    it.only("Can render an error on delete", () => {
+    it("Can render an error on delete", () => {
       cy.intercept("DELETE", "/api/v1/system/*", {
         statusCode: 404,
         body: {

--- a/clients/ctl/admin-ui/src/features/config-wizard/PrivacyDeclarationForm.tsx
+++ b/clients/ctl/admin-ui/src/features/config-wizard/PrivacyDeclarationForm.tsx
@@ -231,6 +231,7 @@ const PrivacyDeclarationForm = ({ system, onCancel, onSuccess }: Props) => {
                 variant="link"
                 disabled={!dirty}
                 isLoading={isLoading}
+                data-testid="add-btn"
               >
                 Add <AddIcon boxSize={10} />
               </Button>
@@ -250,7 +251,7 @@ const PrivacyDeclarationForm = ({ system, onCancel, onSuccess }: Props) => {
                 size="sm"
                 disabled={formDeclarations.length === 0}
                 isLoading={isLoading}
-                data-testid="confirm-btn"
+                data-testid="next-btn"
                 onClick={handleSubmit}
               >
                 Next


### PR DESCRIPTION
I thought the behavior of the privacy declaration form was odd, so tried to make it more intuitive and like other forms I've used. Consider this form:

![image](https://user-images.githubusercontent.com/24641006/191112590-831314a1-3f6d-4e92-a51b-4c782b6fe7b7.png)

Old behavior:
* Fill out the form
* Clicking 'Add another declaration' adds the filled out declaration as an accordion to the top area (where privacy declarations 'one' and 'asdf' are)
  * However, if instead of clicking 'Add another declaration', you click "Confirm and Continue", this _also_ adds the declaration in the next screen. In other words, it takes whatever is filled out in the form and considers it done and should be added
  * This makes things a little weird when, if you only have one declaration, you click 'Add another declaration', you're kind of stuck, since you can't "Confirm and Continue" with a blank declaration since it's invalid, and you can't really go back either.

New behavior:
* Fill out the form
* "Confirm and Continue" is now called "Next" (the designs appear to have always had this, so we probably missed it the first time around)
* "Add another declaration" is now called "Add"
* "Next" is disabled while there are no declarations
* Clicking 'Add' adds the filled out declaration as an accordion to the top area (where privacy declarations 'one' and 'asdf' are)
* Now "Next" is enabled, and clicking it will bring you to the next page.
* If you partially fill out another declaration and then click "Next", it won't be counted since it's not part of the "finished" declarations

It's a little hard to explain, so happy to show on a call if that's easier. Went over this with @mfbrown earlier and we settled on this new behavior, though would still be down to hear other suggestions since it might still be a strange interaction.

Doing it this way also simplifies the code quite a bit which is always nice 😄 

### Code Changes

* [x] Refactor `PrivacyDeclarationForm.tsx`
* [x] Update tests

### Steps to Confirm

* [ ] Try adding privacy declarations and see if it feels right

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description of Changes
New form (mostly looks the same, behavior is just a little different)

![image](https://user-images.githubusercontent.com/24641006/191116694-f7516a55-7ec5-4664-9814-cc58d55e73ed.png)

