### PR TITLE
ui/datasets: Refactor selectors

### DIFF
--- a/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
@@ -424,8 +424,9 @@ describe("Dataset", () => {
         "putDataset"
       );
     });
+
     it("Can render chosen data categories", () => {
-      cy.visit("/dataset/demo_users");
+      cy.visit("/dataset/demo_users_dataset");
       cy.getByTestId("field-row-uuid").click();
       cy.getByTestId("data-category-dropdown").click();
       cy.get("[data-testid='checkbox-Unique ID'] > span").should(
@@ -440,7 +441,7 @@ describe("Dataset", () => {
     });
 
     it("Can deselect data categories", () => {
-      cy.visit("/dataset/demo_users");
+      cy.visit("/dataset/demo_users_dataset");
       cy.getByTestId("field-row-uuid").click();
       cy.getByTestId("data-category-dropdown").click();
       cy.getByTestId("checkbox-Unique ID").click();
@@ -463,7 +464,7 @@ describe("Dataset", () => {
     });
 
     it("Can select more data categories", () => {
-      cy.visit("/dataset/demo_users");
+      cy.visit("/dataset/demo_users_dataset");
       cy.getByTestId("field-row-uuid").click();
       cy.getByTestId("data-category-dropdown").click();
       cy.getByTestId("checkbox-Telemetry Data").click();
@@ -484,7 +485,7 @@ describe("Dataset", () => {
     });
 
     it("Can interact with the checkbox tree properly", () => {
-      cy.visit("/dataset/demo_users");
+      cy.visit("/dataset/demo_users_dataset");
       cy.getByTestId("field-row-uuid").click();
       cy.getByTestId("data-category-dropdown").click();
       // expand system data
@@ -529,7 +530,7 @@ describe("Dataset", () => {
     });
 
     it("Should be able to clear selected", () => {
-      cy.visit("/dataset/demo_users");
+      cy.visit("/dataset/demo_users_dataset");
       cy.getByTestId("field-row-uuid").click();
       cy.getByTestId("data-category-dropdown").click();
       cy.getByTestId("checkbox-System Data").click();

--- a/clients/ctl/admin-ui/src/features/dataset/DatabaseConnectForm.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatabaseConnectForm.tsx
@@ -14,7 +14,7 @@ import { DEFAULT_ORGANIZATION_FIDES_KEY } from "~/features/organization";
 import { Dataset, GenerateTypes, System, ValidTargets } from "~/types/api";
 
 import {
-  setActiveDataset,
+  setActiveDatasetFidesKey,
   useCreateDatasetMutation,
   useGenerateDatasetMutation,
 } from "./dataset.slice";
@@ -175,7 +175,7 @@ const DatabaseConnectForm = () => {
     }
 
     toast(successToastParams(`Generate and classify are now in progress`));
-    dispatch(setActiveDataset(createResult.dataset));
+    dispatch(setActiveDatasetFidesKey(createResult.dataset.fides_key));
     router.push(`/dataset`);
   };
 

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -2,21 +2,22 @@ import { Box, Select, Spinner } from "@fidesui/react";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { useClassificationsMap } from "~/features/common/plus.slice";
 import { useGetAllDataCategoriesQuery } from "~/features/taxonomy/taxonomy.slice";
 
 import ColumnDropdown from "./ColumnDropdown";
 import {
   selectActiveCollectionIndex,
+  selectActiveEditor,
   setActiveCollectionIndex,
   setActiveDatasetFidesKey,
+  setActiveEditor,
   useGetDatasetByKeyQuery,
 } from "./dataset.slice";
 import DatasetFieldsTable from "./DatasetFieldsTable";
 import EditCollectionDrawer from "./EditCollectionDrawer";
 import EditDatasetDrawer from "./EditDatasetDrawer";
 import MoreActionsMenu from "./MoreActionsMenu";
-import { ColumnMetadata } from "./types";
+import { ColumnMetadata, EditableType } from "./types";
 
 const ALL_COLUMNS: ColumnMetadata[] = [
   { name: "Field Name", attribute: "name" },
@@ -42,9 +43,9 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
   const dispatch = useDispatch();
   const { dataset, isLoading } = useDataset(fidesKey);
   const activeCollectionIndex = useSelector(selectActiveCollectionIndex);
+  const activeEditor = useSelector(selectActiveEditor);
+
   const [columns, setColumns] = useState<ColumnMetadata[]>(ALL_COLUMNS);
-  const [isModifyingCollection, setIsModifyingCollection] = useState(false);
-  const [isModifyingDataset, setIsModifyingDataset] = useState(false);
 
   // Query subscriptions:
   useGetAllDataCategoriesQuery();
@@ -105,8 +106,12 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
             />
           </Box>
           <MoreActionsMenu
-            onModifyCollection={() => setIsModifyingCollection(true)}
-            onModifyDataset={() => setIsModifyingDataset(true)}
+            onModifyCollection={() =>
+              dispatch(setActiveEditor(EditableType.COLLECTION))
+            }
+            onModifyDataset={() =>
+              dispatch(setActiveEditor(EditableType.DATASET))
+            }
           />
         </Box>
       </Box>
@@ -118,16 +123,16 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
           />
           <EditCollectionDrawer
             collection={activeCollection}
-            isOpen={isModifyingCollection}
-            onClose={() => setIsModifyingCollection(false)}
+            isOpen={activeEditor === EditableType.COLLECTION}
+            onClose={() => dispatch(setActiveEditor(undefined))}
           />
         </>
       ) : null}
       {dataset ? (
         <EditDatasetDrawer
           dataset={dataset}
-          isOpen={isModifyingDataset}
-          onClose={() => setIsModifyingDataset(false)}
+          isOpen={activeEditor === EditableType.DATASET}
+          onClose={() => dispatch(setActiveEditor(undefined))}
         />
       ) : null}
     </Box>

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -6,7 +6,8 @@ import { useGetAllDataCategoriesQuery } from "~/features/taxonomy/taxonomy.slice
 
 import ColumnDropdown from "./ColumnDropdown";
 import {
-  selectActiveCollectionIndex,
+  selectActiveCollection,
+  selectActiveCollections,
   selectActiveEditor,
   setActiveCollectionIndex,
   setActiveDatasetFidesKey,
@@ -42,7 +43,8 @@ interface Props {
 const DatasetCollectionView = ({ fidesKey }: Props) => {
   const dispatch = useDispatch();
   const { dataset, isLoading } = useDataset(fidesKey);
-  const activeCollectionIndex = useSelector(selectActiveCollectionIndex);
+  const activeCollections = useSelector(selectActiveCollections);
+  const activeCollection = useSelector(selectActiveCollection);
   const activeEditor = useSelector(selectActiveEditor);
 
   const [columns, setColumns] = useState<ColumnMetadata[]>(ALL_COLUMNS);
@@ -66,6 +68,10 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
     []
   );
 
+  const handleChangeCollection = (event: ChangeEvent<HTMLSelectElement>) => {
+    dispatch(setActiveCollectionIndex(event.target.selectedIndex));
+  };
+
   if (isLoading) {
     return <Spinner />;
   }
@@ -73,14 +79,6 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
   if (!dataset) {
     return <div>Dataset not found</div>;
   }
-
-  const { collections } = dataset;
-  const activeCollection =
-    activeCollectionIndex != null ? collections[activeCollectionIndex] : null;
-
-  const handleChangeCollection = (event: ChangeEvent<HTMLSelectElement>) => {
-    dispatch(setActiveCollectionIndex(event.target.selectedIndex));
-  };
 
   return (
     <Box>
@@ -91,7 +89,7 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
           width="auto"
           data-testid="collection-select"
         >
-          {collections.map((collection) => (
+          {(activeCollections ?? []).map((collection) => (
             <option key={collection.name} value={collection.name}>
               {collection.name}
             </option>

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -2,13 +2,14 @@ import { Box, Select, Spinner } from "@fidesui/react";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import { useClassificationsMap } from "~/features/common/plus.slice";
 import { useGetAllDataCategoriesQuery } from "~/features/taxonomy/taxonomy.slice";
 
 import ColumnDropdown from "./ColumnDropdown";
 import {
   selectActiveCollectionIndex,
   setActiveCollectionIndex,
-  setActiveDataset,
+  setActiveDatasetFidesKey,
   useGetDatasetByKeyQuery,
 } from "./dataset.slice";
 import DatasetFieldsTable from "./DatasetFieldsTable";
@@ -50,17 +51,14 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
 
   useEffect(() => {
     if (dataset) {
-      dispatch(setActiveDataset(dataset));
+      dispatch(setActiveDatasetFidesKey(dataset.fides_key));
+      dispatch(setActiveCollectionIndex(0));
     }
   }, [dispatch, dataset]);
 
-  useEffect(() => {
-    dispatch(setActiveCollectionIndex(0));
-  }, [dispatch]);
-
   useEffect(
     () => () => {
-      dispatch(setActiveDataset(null));
+      dispatch(setActiveDatasetFidesKey(undefined));
     },
     // This hook only runs on component un-mount to clear the active dataset.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -113,18 +113,15 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
           />
         </Box>
       </Box>
+
+      <DatasetFieldsTable columns={columns} />
+
       {activeCollection ? (
-        <>
-          <DatasetFieldsTable
-            fields={activeCollection.fields}
-            columns={columns}
-          />
-          <EditCollectionDrawer
-            collection={activeCollection}
-            isOpen={activeEditor === EditableType.COLLECTION}
-            onClose={() => dispatch(setActiveEditor(undefined))}
-          />
-        </>
+        <EditCollectionDrawer
+          collection={activeCollection}
+          isOpen={activeEditor === EditableType.COLLECTION}
+          onClose={() => dispatch(setActiveEditor(undefined))}
+        />
       ) : null}
       {dataset ? (
         <EditDatasetDrawer

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
@@ -22,7 +22,7 @@ const DatasetFieldsTable = ({ fields, columns }: Props) => {
 
   const handleClose = () => {
     setEditDrawerIsOpen(false);
-    dispatch(setActiveFieldIndex(null));
+    dispatch(setActiveFieldIndex(undefined));
   };
 
   const handleClick = (index: number) => {
@@ -31,7 +31,7 @@ const DatasetFieldsTable = ({ fields, columns }: Props) => {
   };
 
   const activeField =
-    activeFieldIndex != null ? fields[activeFieldIndex] : null;
+    activeFieldIndex !== undefined ? fields[activeFieldIndex] : undefined;
 
   return (
     <Box>

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
@@ -1,14 +1,18 @@
 import { Box, Table, Tbody, Td, Th, Thead, Tr } from "@fidesui/react";
-import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { DatasetField } from "~/types/api";
 
 import IdentifiabilityTag from "../taxonomy/IdentifiabilityTag";
 import TaxonomyEntityTag from "../taxonomy/TaxonomyEntityTag";
-import { selectActiveFieldIndex, setActiveFieldIndex } from "./dataset.slice";
+import {
+  selectActiveEditor,
+  selectActiveFieldIndex,
+  setActiveEditor,
+  setActiveFieldIndex,
+} from "./dataset.slice";
 import EditFieldDrawer from "./EditFieldDrawer";
-import { ColumnMetadata } from "./types";
+import { ColumnMetadata, EditableType } from "./types";
 
 interface Props {
   fields: DatasetField[];
@@ -17,17 +21,17 @@ interface Props {
 
 const DatasetFieldsTable = ({ fields, columns }: Props) => {
   const dispatch = useDispatch();
-  const [editDrawerIsOpen, setEditDrawerIsOpen] = useState(false);
   const activeFieldIndex = useSelector(selectActiveFieldIndex);
+  const activeEditor = useSelector(selectActiveEditor);
 
   const handleClose = () => {
-    setEditDrawerIsOpen(false);
     dispatch(setActiveFieldIndex(undefined));
+    dispatch(setActiveEditor(undefined));
   };
 
   const handleClick = (index: number) => {
     dispatch(setActiveFieldIndex(index));
-    setEditDrawerIsOpen(true);
+    dispatch(setActiveEditor(EditableType.FIELD));
   };
 
   const activeField =
@@ -87,7 +91,7 @@ const DatasetFieldsTable = ({ fields, columns }: Props) => {
       </Table>
       {activeField ? (
         <EditFieldDrawer
-          isOpen={editDrawerIsOpen}
+          isOpen={activeEditor === EditableType.FIELD}
           onClose={handleClose}
           field={activeField}
         />

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
@@ -1,6 +1,8 @@
 import { Box, Table, Tbody, Td, Th, Thead, Tr } from "@fidesui/react";
 import { useDispatch, useSelector } from "react-redux";
 
+import { DatasetField } from "~/types/api";
+
 import IdentifiabilityTag from "../taxonomy/IdentifiabilityTag";
 import TaxonomyEntityTag from "../taxonomy/TaxonomyEntityTag";
 import {
@@ -12,6 +14,42 @@ import {
 } from "./dataset.slice";
 import EditFieldDrawer from "./EditFieldDrawer";
 import { ColumnMetadata, EditableType } from "./types";
+
+// Chakra wants a JSX.Element, so all returns need to be wrapped in a fragment.
+/* eslint-disable react/jsx-no-useless-fragment */
+const Cell = ({
+  attribute,
+  field,
+}: {
+  attribute: keyof DatasetField;
+  field: DatasetField;
+}): JSX.Element => {
+  if (attribute === "data_qualifier") {
+    const dataQualifierName = field[attribute];
+    return (
+      <>
+        {dataQualifierName ? (
+          <IdentifiabilityTag dataQualifierName={dataQualifierName} />
+        ) : null}
+      </>
+    );
+  }
+
+  if (attribute === "data_categories") {
+    return (
+      <>
+        {(field[attribute] ?? []).map((dc) => (
+          <Box key={`${field.name}-${dc}`} mr={2} mb={2}>
+            <TaxonomyEntityTag name={dc} />
+          </Box>
+        ))}
+      </>
+    );
+  }
+
+  return <>{field[attribute]}</>;
+};
+/* eslint-disable react/jsx-no-useless-fragment */
 
 interface Props {
   columns: ColumnMetadata[];
@@ -62,23 +100,7 @@ const DatasetFieldsTable = ({ columns }: Props) => {
             >
               {columns.map((c) => (
                 <Td key={`${c.name}-${field.name}`} pl={0}>
-                  {(() => {
-                    if (c.attribute === "data_qualifier") {
-                      return (
-                        <IdentifiabilityTag
-                          dataQualifierName={field[c.attribute] ?? ""}
-                        />
-                      );
-                    }
-                    if (c.attribute === "data_categories") {
-                      return field[c.attribute]?.map((dc) => (
-                        <Box key={`${field.name}-${dc}`} mr={2} mb={2}>
-                          <TaxonomyEntityTag name={dc} />
-                        </Box>
-                      ));
-                    }
-                    return field[c.attribute];
-                  })()}
+                  <Cell field={field} attribute={c.attribute} />
                 </Td>
               ))}
             </Tr>

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetFieldsTable.tsx
@@ -1,13 +1,12 @@
 import { Box, Table, Tbody, Td, Th, Thead, Tr } from "@fidesui/react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { DatasetField } from "~/types/api";
-
 import IdentifiabilityTag from "../taxonomy/IdentifiabilityTag";
 import TaxonomyEntityTag from "../taxonomy/TaxonomyEntityTag";
 import {
   selectActiveEditor,
-  selectActiveFieldIndex,
+  selectActiveField,
+  selectActiveFields,
   setActiveEditor,
   setActiveFieldIndex,
 } from "./dataset.slice";
@@ -15,13 +14,13 @@ import EditFieldDrawer from "./EditFieldDrawer";
 import { ColumnMetadata, EditableType } from "./types";
 
 interface Props {
-  fields: DatasetField[];
   columns: ColumnMetadata[];
 }
 
-const DatasetFieldsTable = ({ fields, columns }: Props) => {
+const DatasetFieldsTable = ({ columns }: Props) => {
   const dispatch = useDispatch();
-  const activeFieldIndex = useSelector(selectActiveFieldIndex);
+  const activeFields = useSelector(selectActiveFields);
+  const activeField = useSelector(selectActiveField);
   const activeEditor = useSelector(selectActiveEditor);
 
   const handleClose = () => {
@@ -33,9 +32,6 @@ const DatasetFieldsTable = ({ fields, columns }: Props) => {
     dispatch(setActiveFieldIndex(index));
     dispatch(setActiveEditor(EditableType.FIELD));
   };
-
-  const activeField =
-    activeFieldIndex !== undefined ? fields[activeFieldIndex] : undefined;
 
   return (
     <Box>
@@ -50,7 +46,7 @@ const DatasetFieldsTable = ({ fields, columns }: Props) => {
           </Tr>
         </Thead>
         <Tbody>
-          {fields.map((field, idx) => (
+          {(activeFields ?? []).map((field, idx) => (
             <Tr
               key={field.name}
               _hover={{ bg: "gray.50" }}

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetTable.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetTable.tsx
@@ -15,24 +15,24 @@ import { Dataset } from "~/types/api";
 
 import { STATUS_DISPLAY } from "./constants";
 import {
-  selectActiveDataset,
-  setActiveDataset,
+  selectActiveDatasetFidesKey,
+  setActiveDatasetFidesKey,
   useGetAllDatasetsQuery,
 } from "./dataset.slice";
 
 const DatasetsTable = () => {
   const dispatch = useDispatch();
-  const activeDataset = useSelector(selectActiveDataset);
+  const activeDatasetFidesKey = useSelector(selectActiveDatasetFidesKey);
 
   const { data: datasets } = useGetAllDatasetsQuery();
   const classificationsMap = useClassificationsMap();
 
   const handleRowClick = (dataset: Dataset) => {
     // toggle the active dataset
-    if (dataset.fides_key === activeDataset?.fides_key) {
-      dispatch(setActiveDataset(null));
+    if (dataset.fides_key === activeDatasetFidesKey) {
+      dispatch(setActiveDatasetFidesKey(undefined));
     } else {
-      dispatch(setActiveDataset(dataset));
+      dispatch(setActiveDatasetFidesKey(dataset.fides_key));
     }
   };
 
@@ -52,7 +52,8 @@ const DatasetsTable = () => {
       <Tbody>
         {datasets.map((dataset) => {
           const isActive =
-            activeDataset && activeDataset.fides_key === dataset.fides_key;
+            activeDatasetFidesKey &&
+            activeDatasetFidesKey === dataset.fides_key;
 
           const classification = classificationsMap.get(dataset.fides_key);
           const statusDisplay =

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetYamlForm.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetYamlForm.tsx
@@ -5,7 +5,10 @@ import { Dataset } from "~/types/api";
 
 import { successToastParams } from "../common/toast";
 import YamlForm from "../YamlForm";
-import { setActiveDataset, useCreateDatasetMutation } from "./dataset.slice";
+import {
+  setActiveDatasetFidesKey,
+  useCreateDatasetMutation,
+} from "./dataset.slice";
 
 // handle the common case where everything is nested under a `dataset` key
 interface NestedDataset {
@@ -41,7 +44,7 @@ const DatasetYamlForm = () => {
 
   const handleSuccess = (newDataset: Dataset) => {
     toast(successToastParams("Successfully loaded new dataset YAML"));
-    setActiveDataset(newDataset);
+    setActiveDatasetFidesKey(newDataset.fides_key);
     router.push(`/dataset/${newDataset.fides_key}`);
   };
 

--- a/clients/ctl/admin-ui/src/features/dataset/EditCollectionDrawer.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/EditCollectionDrawer.tsx
@@ -36,7 +36,7 @@ const EditCollectionDrawer = ({ collection, isOpen, onClose }: Props) => {
       "description" | "data_qualifier" | "data_categories"
     >
   ) => {
-    if (dataset && collectionIndex != null) {
+    if (dataset && collectionIndex !== undefined) {
       const updatedCollection = { ...collection, ...values };
       const updatedDataset = getUpdatedDatasetFromCollection(
         dataset,
@@ -54,7 +54,7 @@ const EditCollectionDrawer = ({ collection, isOpen, onClose }: Props) => {
   };
 
   const handleDelete = async () => {
-    if (dataset && collectionIndex != null) {
+    if (dataset && collectionIndex !== undefined) {
       const updatedDataset = removeCollectionFromDataset(
         dataset,
         collectionIndex
@@ -63,7 +63,7 @@ const EditCollectionDrawer = ({ collection, isOpen, onClose }: Props) => {
         await updateDataset(updatedDataset);
         toast(successToastParams("Successfully deleted collection"));
         const newActiveCollectionIndex =
-          dataset.collections.length > 0 ? 0 : null;
+          dataset.collections.length > 0 ? 0 : undefined;
         setActiveCollectionIndex(newActiveCollectionIndex);
       } catch (error) {
         toast(errorToastParams(error as string));

--- a/clients/ctl/admin-ui/src/features/dataset/EditDatasetDrawer.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/EditDatasetDrawer.tsx
@@ -6,7 +6,7 @@ import { errorToastParams, successToastParams } from "~/features/common/toast";
 import { Dataset } from "~/types/api";
 
 import {
-  setActiveDataset,
+  setActiveDatasetFidesKey,
   useDeleteDatasetMutation,
   useUpdateDatasetMutation,
 } from "./dataset.slice";
@@ -50,7 +50,7 @@ const EditDatasetDrawer = ({ dataset, isOpen, onClose }: Props) => {
     } else {
       toast(successToastParams("Successfully deleted dataset"));
     }
-    setActiveDataset(null);
+    setActiveDatasetFidesKey(undefined);
     router.push("/dataset");
     onClose();
   };

--- a/clients/ctl/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -35,7 +35,7 @@ const EditFieldDrawer = ({ field, isOpen, onClose }: Props) => {
     >
   ) => {
     // merge the updated fields with the original dataset
-    if (dataset && collectionIndex != null && fieldIndex != null) {
+    if (dataset && collectionIndex !== undefined && fieldIndex !== undefined) {
       const updatedField = { ...field, ...values };
       const updatedDataset = getUpdatedDatasetFromField(
         dataset,
@@ -49,7 +49,7 @@ const EditFieldDrawer = ({ field, isOpen, onClose }: Props) => {
   };
 
   const handleDelete = () => {
-    if (dataset && collectionIndex != null && fieldIndex != null) {
+    if (dataset && collectionIndex !== undefined && fieldIndex !== undefined) {
       const updatedDataset = removeFieldFromDataset(
         dataset,
         collectionIndex,

--- a/clients/ctl/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/ctl/admin-ui/src/features/dataset/dataset.slice.ts
@@ -4,11 +4,15 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import type { AppState } from "~/app/store";
 import { Dataset, GenerateRequestPayload, GenerateResponse } from "~/types/api";
 
+import { EditableType } from "./types";
+
 export interface State {
   activeDatasetFidesKey?: string;
   // collections and fields don't have unique IDs, so we have to use their index
   activeCollectionIndex?: number;
   activeFieldIndex?: number;
+  // Controls whether the edit drawer is open and what is being edited.
+  activeEditor?: EditableType;
 }
 
 const initialState: State = {};
@@ -117,6 +121,12 @@ export const datasetSlice = createSlice({
     ) => {
       draftState.activeFieldIndex = action.payload;
     },
+    setActiveEditor: (
+      draftState,
+      action: PayloadAction<EditableType | undefined>
+    ) => {
+      draftState.activeEditor = action.payload;
+    },
   },
 });
 
@@ -124,7 +134,10 @@ export const {
   setActiveDatasetFidesKey,
   setActiveCollectionIndex,
   setActiveFieldIndex,
+  setActiveEditor,
 } = datasetSlice.actions;
+
+export const { reducer } = datasetSlice;
 
 const selectDataset = (state: AppState) => state.dataset;
 
@@ -149,4 +162,7 @@ export const selectActiveFieldIndex = createSelector(
   (state) => state.activeFieldIndex
 );
 
-export const { reducer } = datasetSlice;
+export const selectActiveEditor = createSelector(
+  selectDataset,
+  (state) => state.activeEditor
+);

--- a/clients/ctl/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/ctl/admin-ui/src/features/dataset/dataset.slice.ts
@@ -167,9 +167,17 @@ export const selectActiveCollection = createSelector(
     index !== undefined && collections ? collections[index] : undefined
 );
 
+export const selectActiveFields = createSelector(
+  [selectActiveCollection],
+  (collection) => collection?.fields
+);
 export const selectActiveFieldIndex = createSelector(
   selectDataset,
   (state) => state.activeFieldIndex
+);
+export const selectActiveField = createSelector(
+  [selectActiveFieldIndex, selectActiveFields],
+  (index, fields) => (index !== undefined && fields ? fields[index] : undefined)
 );
 
 export const selectActiveEditor = createSelector(

--- a/clients/ctl/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/ctl/admin-ui/src/features/dataset/dataset.slice.ts
@@ -148,13 +148,23 @@ export const selectActiveDatasetFidesKey = createSelector(
 export const selectActiveDataset = createSelector(
   [(appState) => appState, selectActiveDatasetFidesKey],
   (appState, fidesKey) =>
-    fidesKey &&
-    datasetApi.endpoints.getDatasetByKey.select(fidesKey)(appState)?.data
+    fidesKey !== undefined
+      ? datasetApi.endpoints.getDatasetByKey.select(fidesKey)(appState)?.data
+      : undefined
 );
 
+export const selectActiveCollections = createSelector(
+  selectActiveDataset,
+  (dataset) => dataset?.collections
+);
 export const selectActiveCollectionIndex = createSelector(
   selectDataset,
   (state) => state.activeCollectionIndex
+);
+export const selectActiveCollection = createSelector(
+  [selectActiveCollectionIndex, selectActiveCollections],
+  (index, collections) =>
+    index !== undefined && collections ? collections[index] : undefined
 );
 
 export const selectActiveFieldIndex = createSelector(

--- a/clients/ctl/admin-ui/src/features/dataset/types.ts
+++ b/clients/ctl/admin-ui/src/features/dataset/types.ts
@@ -4,3 +4,9 @@ export interface ColumnMetadata {
   name: string;
   attribute: keyof DatasetField;
 }
+
+export enum EditableType {
+  DATASET = "dataset",
+  COLLECTION = "collection",
+  FIELD = "field",
+}

--- a/clients/ctl/admin-ui/src/pages/dataset/index.tsx
+++ b/clients/ctl/admin-ui/src/pages/dataset/index.tsx
@@ -15,20 +15,20 @@ import { useSelector } from "react-redux";
 import Layout from "~/features/common/Layout";
 import { successToastParams } from "~/features/common/toast";
 import {
-  selectActiveDataset,
+  selectActiveDatasetFidesKey,
   useGetAllDatasetsQuery,
 } from "~/features/dataset/dataset.slice";
 import DatasetsTable from "~/features/dataset/DatasetTable";
 
 const DataSets: NextPage = () => {
   const { isLoading } = useGetAllDatasetsQuery();
-  const activeDataset = useSelector(selectActiveDataset);
+  const activeDatasetFidesKey = useSelector(selectActiveDatasetFidesKey);
   const router = useRouter();
   const toast = useToast();
 
   const handleLoadDataset = () => {
-    if (activeDataset) {
-      router.push(`/dataset/${activeDataset.fides_key}`);
+    if (activeDatasetFidesKey) {
+      router.push(`/dataset/${activeDatasetFidesKey}`);
       toast(successToastParams("Successfully loaded dataset"));
     }
   };
@@ -61,7 +61,7 @@ const DataSets: NextPage = () => {
         <Button
           size="sm"
           colorScheme="primary"
-          disabled={!activeDataset}
+          disabled={!activeDatasetFidesKey}
           onClick={handleLoadDataset}
           data-testid="load-dataset-btn"
         >


### PR DESCRIPTION
### Code Changes

- Track dataset by fides key instead of object copy and nulls
  - Previously we've stored a copy of the dataset returned by the get-by-key query,
  but only every use its key property. With this change we only store the key and
  use the object from the query directly.
  - As part of this, I also converted a lot of `null` to `undefined`. There different
  opinions on this, but undefined is generally more useful in a TS codebase because:

    1. It plays nicely with optional function arguments.
    2. It can be represented by a single question mark in interfaces. (See the State
       changes in this commit.)
    3. It doesn't have null's `typeof null === "object"` confusion.

- Single state for edit drawer
  - This resolves some naming inconsistencies and also makes it explicit that only one drawer can ever be open.
- Extract collection lookups to selector
- Extract field lookups to selector
- Extract field types into Cell component


### Steps to Confirm

* [ ] The dataset editing experience should be unchanged.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

These changes set me up for #1075. Layering in classification information means a lot of nested lookups with fallbacks. Well-organized selectors are going to make this possible.