### PR TITLE
Set up cypress component testing

### DIFF
--- a/.github/workflows/frontend_pr_checks.yml
+++ b/.github/workflows/frontend_pr_checks.yml
@@ -58,7 +58,7 @@ jobs:
           cd clients/ctl/admin-ui
           npm install
 
-      - name: Cypress run
+      - name: Cypress E2E tests
         uses: cypress-io/github-action@v4
         with:
           working-directory: clients/ctl/admin-ui
@@ -66,3 +66,13 @@ jobs:
           start: npm run cy:start
           wait-on: "http://localhost:3000"
           wait-on-timeout: 120
+
+      - name: Cypress component tests
+        uses: cypress-io/github-action@v4
+        with:
+          working-directory: clients/ctl/admin-ui
+          install: false
+          start: npm run cy:start
+          wait-on: "http://localhost:3000"
+          wait-on-timeout: 120
+          component: true

--- a/.github/workflows/frontend_pr_checks.yml
+++ b/.github/workflows/frontend_pr_checks.yml
@@ -72,7 +72,4 @@ jobs:
         with:
           working-directory: clients/ctl/admin-ui
           install: false
-          start: npm run cy:start
-          wait-on: "http://localhost:3000"
-          wait-on-timeout: 120
           component: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The types of changes are:
   * Refactor config wizard system forms to be reused for system management [#1072](https://github.com/ethyca/fides/pull/1072)
   * Add additional optional fields to system management forms [#1082](https://github.com/ethyca/fides/pull/1082)
   * Delete a system through the UI [#1085](https://github.com/ethyca/fides/pull/1085)
+* Cypress component testing [#1106](https://github.com/ethyca/fides/pull/1106)
 
 ### Changed
 

--- a/clients/ctl/admin-ui/cypress.config.ts
+++ b/clients/ctl/admin-ui/cypress.config.ts
@@ -5,9 +5,18 @@ export default defineConfig({
   e2e: {
     baseUrl: "http://localhost:3000",
   },
+
   defaultCommandTimeout: 5000,
+
   retries: {
     runMode: 3,
     openMode: 0,
+  },
+
+  component: {
+    devServer: {
+      framework: "next",
+      bundler: "webpack",
+    },
   },
 });

--- a/clients/ctl/admin-ui/cypress/components/DataCategoryInput.cy.tsx
+++ b/clients/ctl/admin-ui/cypress/components/DataCategoryInput.cy.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+
+import DataCategoryInput from "~/features/dataset/DataCategoryInput";
+import { MOCK_DATA_CATEGORIES } from "~/mocks/data";
+import { DataCategory } from "~/types/api";
+
+describe("DataCategoryInput", () => {
+  it("can check a category", () => {
+    const onCheckedSpy = cy.spy().as("onCheckedSpy");
+    cy.mount(
+      <DataCategoryInput
+        dataCategories={MOCK_DATA_CATEGORIES as DataCategory[]}
+        checked={["user"]}
+        onChecked={onCheckedSpy}
+      />
+    );
+
+    cy.getByTestId("selected-categories").should("contain", "user");
+    cy.getByTestId("data-category-dropdown").click();
+    cy.getByTestId("expand-System Data").click();
+    cy.getByTestId("checkbox-Authentication Data").click();
+
+    cy.get("@onCheckedSpy").should("have.been.calledWith", [
+      "user",
+      "system.authentication",
+    ]);
+  });
+});

--- a/clients/ctl/admin-ui/cypress/support/component-index.html
+++ b/clients/ctl/admin-ui/cypress/support/component-index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Components App</title>
+    <!-- Used by Next.js to inject CSS. -->
+    <div id="__next_css__DO_NOT_USE__"></div>
+  </head>
+  <body>
+    <div data-cy-root></div>
+  </body>
+</html>

--- a/clients/ctl/admin-ui/cypress/support/component.ts
+++ b/clients/ctl/admin-ui/cypress/support/component.ts
@@ -1,0 +1,48 @@
+// ***********************************************************
+// This example support/component.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import "./commands";
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/500.css";
+import "@fontsource/inter/700.css";
+
+import { ChakraProvider } from "@chakra-ui/react";
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { mount } from "cypress/react";
+import * as React from "react";
+
+import theme from "../../src/theme";
+
+// Augment the Cypress namespace to include type definitions for
+// your custom command.
+// Alternatively, can be defined in cypress/support/component.d.ts
+// with a <reference path="./component" /> at the top of your spec.
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount;
+    }
+  }
+}
+
+Cypress.Commands.add("mount", (jsx, options) =>
+  mount(React.createElement(ChakraProvider, { theme }, jsx), options)
+);
+
+// Example use:
+// cy.mount(<MyComponent />)

--- a/clients/ctl/admin-ui/cypress/tsconfig.json
+++ b/clients/ctl/admin-ui/cypress/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "compilerOptions": {
+    "jsx": "react",
     "target": "es5",
     "lib": ["es5", "dom"],
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node"],
+    "baseUrl": "..",
+    "paths": {
+      "~/*": ["src/*"]
+    }
   },
-  "include": ["**/*.ts", "../cypress.config.ts"]
+  "include": ["**/*.ts", "**/*.tsx", "../cypress.config.ts"]
 }

--- a/clients/ctl/admin-ui/jest.config.js
+++ b/clients/ctl/admin-ui/jest.config.js
@@ -38,4 +38,5 @@ module.exports = {
     "/node_modules/",
     "^.+\\.module\\.(css|sass|scss)$",
   ],
+  watchPathIgnorePatterns: ["node_modules"],
 };

--- a/clients/ctl/admin-ui/tsconfig.json
+++ b/clients/ctl/admin-ui/tsconfig.json
@@ -20,5 +20,10 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
-  "exclude": ["node_modules", "cypress/**/*.ts", "cypress.config.ts"]
+  "exclude": [
+    "node_modules",
+    "cypress/**/*.ts",
+    "cypress/**/*.tsx",
+    "cypress.config.ts"
+  ]
 }


### PR DESCRIPTION
Cypress introduced [component testing](https://docs.cypress.io/guides/component-testing/writing-your-first-component-test) a few versions ago. While thinking about the classify features which don't have endpoints to test with yet, I thought it would be useful to explore component testing. They're easier to build out in isolation, and are much faster than e2e tests

Component testing is kind of like a mix of storybook and jest tests: like storybook, it renders your component in a browser, but like jest, you can actually test things (although you can use cypress commands, which we already know and love). It looks like storybook now also has [interaction testing](https://storybook.js.org/docs/react/writing-tests/interaction-testing) which might be the same thing except for within storybook. However, since we're already using cypress, it was easier to set this up.

### Code Changes

* [x] Configure cypress to be able to use component testing (including tsconfigs and making it use chakra for theming)
* [x] Add a stanza to GHA to run component tests
* [x] Add a small test for `DataCategoryInput`

### Steps to Confirm

* [ ] Run `npm run cy:open`. This will let you choose between E2E testing and component testing. Choose component testing, then watch it do its thing
* [ ] [CI passes](https://github.com/ethyca/fides/actions/runs/3100405570/jobs/5020650252#step:6:84)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Traditionally this sort of test should live next to the component. We don't have a habit of putting our components in their own folders though, so it would make our folder structure kind of messy. We may want to consider putting our components in lil folders for purposes like this (maybe storybook files would also go here, css modules [not that we really have any], unit tests...). I put them in `cypress/components` (the default installation path) for now, but we can always move them if people feel strongly about it.
