### PR TITLE
Restrict startsWith comparisons in CheckboxTree more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The types of changes are:
 ### Fixed
 
 * Fixed the "help" link in the UI header [#1078](https://github.com/ethyca/fides/pull/1078)
+* Fixed a bug in Data Category Dropdowns where checking i.e. `user.biometric` would also check `user.biometric_health` [#1126](https://github.com/ethyca/fides/pull/1126)
 
 ### Security
 

--- a/clients/ctl/admin-ui/__tests__/checkbox-tree.test.tsx
+++ b/clients/ctl/admin-ui/__tests__/checkbox-tree.test.tsx
@@ -28,6 +28,11 @@ const MOCK_NODES = [
         value: "grandparent.aunt",
         children: [],
       },
+      {
+        label: "aunt_second",
+        value: "grandparent.aunt_second",
+        children: [],
+      },
     ],
   },
   {
@@ -236,6 +241,7 @@ describe("Checkbox tree", () => {
           "grandparent.parent.child",
           "grandparent.parent.sibling",
           "grandparent.aunt",
+          "grandparent.aunt_second",
         ].sort()
       );
       expect(
@@ -254,6 +260,13 @@ describe("Checkbox tree", () => {
           (d) => d.value
         )
       ).toEqual(["grandparent.parent.child"]);
+
+      // make sure aunt_second does not sneak in
+      expect(
+        getDescendantsAndCurrent(MOCK_NODES, "grandparent.aunt").map(
+          (d) => d.value
+        )
+      ).toEqual(["grandparent.aunt"]);
     });
 
     it("can determine if an ancestor is selected", () => {

--- a/clients/ctl/admin-ui/src/features/common/CheckboxTree.tsx
+++ b/clients/ctl/admin-ui/src/features/common/CheckboxTree.tsx
@@ -36,6 +36,16 @@ export const ancestorIsSelected = (selected: string[], nodeName: string) => {
   return intersection.length > 0;
 };
 
+const matchNodeOrDescendant = (value: string, match: string) => {
+  if (value === match) {
+    return true;
+  }
+  if (value.startsWith(`${match}.`)) {
+    return true;
+  }
+  return false;
+};
+
 export const getDescendantsAndCurrent = (
   nodes: TreeNode[],
   nodeName: string,
@@ -46,7 +56,7 @@ export const getDescendantsAndCurrent = (
     if (node.children) {
       getDescendantsAndCurrent(node.children, nodeName, descendants);
     }
-    if (node.value.startsWith(nodeName)) {
+    if (matchNodeOrDescendant(node.value, nodeName)) {
       descendants.push(node);
     }
   });
@@ -151,8 +161,10 @@ const CheckboxTree = ({ nodes, selected, onSelected }: CheckboxTreeProps) => {
     let newSelected: string[] = [];
     if (checked.indexOf(node.value) >= 0) {
       // take advantage of dot notation here for unchecking children
-      newChecked = checked.filter((s) => !s.startsWith(node.value));
-      newSelected = selected.filter((s) => !s.startsWith(node.value));
+      newChecked = checked.filter((s) => !matchNodeOrDescendant(s, node.value));
+      newSelected = selected.filter(
+        (s) => !matchNodeOrDescendant(s, node.value)
+      );
     } else {
       // we need to mark all descendants as checked, though these are not
       // technically 'selected'
@@ -169,7 +181,9 @@ const CheckboxTree = ({ nodes, selected, onSelected }: CheckboxTreeProps) => {
   const handleExpanded = (node: TreeNode) => {
     if (expanded.indexOf(node.value) >= 0) {
       // take advantage of dot notation here for unexpanding children
-      setExpanded(expanded.filter((c) => !c.startsWith(node.value)));
+      setExpanded(
+        expanded.filter((c) => !matchNodeOrDescendant(c, node.value))
+      );
     } else {
       setExpanded([...expanded, node.value]);
     }
@@ -186,7 +200,7 @@ const CheckboxTree = ({ nodes, selected, onSelected }: CheckboxTreeProps) => {
       const isIndeterminate =
         isChecked &&
         node.children.length > 0 &&
-        checked.filter((s) => s.startsWith(node.value)).length !==
+        checked.filter((s) => s.startsWith(`${node.value}.`)).length + 1 !==
           thisDescendants.length;
       const isDisabled = ancestorIsSelected(selected, node.value);
 


### PR DESCRIPTION
While working on taxonomy dropdowns, I found a small 🐛 where checking `user.biometric` would also check `user.biometric_health` even though they are siblings to each other. This was because of some scrappy `startsWith` comparisons we were doing. This PR firms up that comparison so it is a little more sophisticated. 

### Code Changes

* [x] Compare against the value with a period instead of just the value
* [x] Update tests with a new case that shows this


### Steps to Confirm

* [ ] Visit the data category selector in a dataset and click "User > Biometric Data". It should no longer also check "User > Biometric Health Data"

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Before:


https://user-images.githubusercontent.com/24641006/192631885-fe800c06-2cc0-4311-89bb-d803ade0b0c3.mov


After:

https://user-images.githubusercontent.com/24641006/192631683-c4dc2271-e995-4986-a2ad-dcdde2b28d2e.mov



