### PR TITLE
[1076] ui/plus: Approve dataset classification button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The types of changes are:
   * Initial implementation of API request to kick off classify, with confirmation modal. [#1069](https://github.com/ethyca/fides/pull/1069)
   * Initial Classification & Review status for generated datasets. [#1074](https://github.com/ethyca/fides/pull/1074)
   * The dataset fields table shows data categories from the classifier (if available). [#1088](https://github.com/ethyca/fides/pull/1088)
+  * The "Approve" button can be used to update the dataset with the classifier's suggestions. [#1129](https://github.com/ethyca/fides/pull/1129)
 * System management UI:
   * New page to add a system via yaml [#1062](https://github.com/ethyca/fides/pull/1062)
   * Skeleton of page to add a system manually [#1068](https://github.com/ethyca/fides/pull/1068)

--- a/clients/ctl/admin-ui/cypress/e2e/datasets-classify.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/datasets-classify.cy.ts
@@ -1,3 +1,5 @@
+import { stubDatasetCrud, stubPlus } from "cypress/support/stubs";
+
 import {
   ClassifyInstance,
   ClassifyStatusEnum,
@@ -10,13 +12,8 @@ import {
  */
 describe("Datasets with Fides Classify", () => {
   beforeEach(() => {
-    cy.intercept("GET", "/api/v1/plus/health", {
-      statusCode: 200,
-      body: {
-        status: "healthy",
-        core_fidesctl_version: "1.8",
-      },
-    }).as("getPlusHealth");
+    stubDatasetCrud();
+    stubPlus(true);
     cy.intercept("GET", "/api/v1/plus/classify", {
       fixture: "classify/list.json",
     }).as("getClassifyList");
@@ -48,15 +45,9 @@ describe("Datasets with Fides Classify", () => {
       cy.intercept("POST", "/api/v1/generate", {
         fixture: "generate/dataset.json",
       }).as("postGenerate");
-      cy.intercept("POST", "/api/v1/dataset", { fixture: "dataset.json" }).as(
-        "postDataset"
-      );
       cy.intercept("POST", "/api/v1/plus/classify", {
         fixture: "classify/create.json",
       }).as("postClassify");
-      cy.intercept("GET", "/api/v1/dataset", { fixture: "datasets.json" }).as(
-        "getDatasets"
-      );
 
       // Confirm the request.
       cy.getByTestId("confirmation-modal").getByTestId("continue-btn").click();
@@ -77,12 +68,6 @@ describe("Datasets with Fides Classify", () => {
   });
 
   describe("List of datasets with classifications", () => {
-    beforeEach(() => {
-      cy.intercept("GET", "/api/v1/dataset", { fixture: "datasets.json" }).as(
-        "getDatasets"
-      );
-    });
-
     it("Shows the each dataset's classify status", () => {
       cy.visit("/dataset");
       cy.wait("@getDatasets");
@@ -106,9 +91,6 @@ describe("Datasets with Fides Classify", () => {
       cy.intercept("GET", "/api/v1/dataset/*", {
         fixture: "classify/dataset-in-review.json",
       }).as("getDataset");
-      cy.intercept("GET", "/api/v1/data_category", {
-        fixture: "data_categories.json",
-      }).as("getDataCategory");
     });
 
     /**
@@ -166,9 +148,6 @@ describe("Datasets with Fides Classify", () => {
       cy.intercept("GET", "/api/v1/dataset/*", {
         fixture: "classify/dataset-in-review.json",
       }).as("getDataset");
-      cy.intercept("GET", "/api/v1/data_category", {
-        fixture: "data_categories.json",
-      }).as("getDataCategory");
 
       cy.intercept("PUT", "/api/v1/dataset/*", {
         fixture: "classify/dataset-in-review.json",

--- a/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
@@ -1,20 +1,10 @@
+import { stubDatasetCrud, stubPlus } from "cypress/support/stubs";
+
 describe("Dataset", () => {
   beforeEach(() => {
-    cy.intercept("GET", "/api/v1/dataset", { fixture: "datasets.json" }).as(
-      "getDatasets"
-    );
-    cy.intercept("GET", "/api/v1/dataset/*", { fixture: "dataset.json" }).as(
-      "getDataset"
-    );
-    cy.intercept("GET", "/api/v1/data_category", {
-      fixture: "data_categories.json",
-    }).as("getDataCategory");
-
+    stubDatasetCrud();
     // Ensure these tests all run with Plus features disabled.
-    cy.intercept("GET", "/api/v1/plus/health", {
-      statusCode: 400,
-      body: {},
-    }).as("getPlusHealth");
+    stubPlus(false);
   });
 
   describe("List of datasets view", () => {
@@ -159,11 +149,6 @@ describe("Dataset", () => {
   });
 
   describe("Can edit datasets", () => {
-    beforeEach(() => {
-      cy.intercept("PUT", "/api/v1/dataset/*", { fixture: "dataset.json" }).as(
-        "putDataset"
-      );
-    });
     it("Can edit dataset fields", () => {
       const newDescription = "new description";
       cy.visit("/dataset/demo_users_dataset");
@@ -211,18 +196,6 @@ describe("Dataset", () => {
   });
 
   describe("Deleting datasets", () => {
-    beforeEach(() => {
-      cy.intercept("PUT", "/api/v1/dataset/*").as("putDataset");
-      cy.fixture("dataset.json").then((dataset) => {
-        cy.intercept("DELETE", "/api/v1/dataset/*", {
-          body: {
-            message: "resource deleted",
-            resource: dataset,
-          },
-        }).as("deleteDataset");
-      });
-    });
-
     it("Can delete a field from a dataset", () => {
       const fieldName = "uuid";
       cy.visit("/dataset/demo_users_dataset");
@@ -282,9 +255,6 @@ describe("Dataset", () => {
     });
 
     it("Can create a dataset via yaml", () => {
-      cy.intercept("POST", "/api/v1/dataset", { fixture: "dataset.json" }).as(
-        "postDataset"
-      );
       cy.visit("/dataset/new");
       cy.getByTestId("upload-yaml-btn").click();
       cy.fixture("dataset.json").then((dataset) => {
@@ -350,9 +320,7 @@ describe("Dataset", () => {
       cy.intercept("POST", "/api/v1/generate", {
         fixture: "generate/dataset.json",
       }).as("postGenerate");
-      cy.intercept("POST", "/api/v1/dataset", { fixture: "dataset.json" }).as(
-        "postDataset"
-      );
+
       cy.visit("/dataset/new");
       cy.getByTestId("connect-db-btn").click();
       cy.getByTestId("input-url").type(connectionString);
@@ -385,9 +353,6 @@ describe("Dataset", () => {
             },
           }).as("postGenerate");
         }
-      );
-      cy.intercept("POST", "/api/v1/dataset", { fixture: "dataset.json" }).as(
-        "postDataset"
       );
 
       cy.visit("/dataset/new");
@@ -424,9 +389,7 @@ describe("Dataset", () => {
           error: "SyntaxError: Unexpected token I in JSON at position 0",
         },
       }).as("postGenerate");
-      cy.intercept("POST", "/api/v1/dataset", { fixture: "dataset.json" }).as(
-        "postDataset"
-      );
+
       cy.visit("/dataset/new");
       cy.getByTestId("connect-db-btn").click();
 
@@ -470,12 +433,6 @@ describe("Dataset", () => {
   });
 
   describe("Data category checkbox tree", () => {
-    beforeEach(() => {
-      cy.intercept("PUT", "/api/v1/dataset/*", { fixture: "dataset.json" }).as(
-        "putDataset"
-      );
-    });
-
     it("Can render chosen data categories", () => {
       cy.visit("/dataset/demo_users_dataset");
       cy.getByTestId("field-row-uuid").click();

--- a/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
@@ -9,6 +9,12 @@ describe("Dataset", () => {
     cy.intercept("GET", "/api/v1/data_category", {
       fixture: "data_categories.json",
     }).as("getDataCategory");
+
+    // Ensure these tests all run with Plus features disabled.
+    cy.intercept("GET", "/api/v1/plus/health", {
+      statusCode: 400,
+      body: {},
+    }).as("getPlusHealth");
   });
 
   describe("List of datasets view", () => {
@@ -19,6 +25,9 @@ describe("Dataset", () => {
       cy.getByTestId("dataset-table");
       cy.getByTestId("dataset-row-demo_users_dataset_4");
       cy.url().should("contain", "/dataset");
+
+      // The classifier toggle should not be available.
+      cy.get("input-classify").should("not.exist");
     });
 
     it("Can navigate to the datasets view via URL", () => {

--- a/clients/ctl/admin-ui/cypress/fixtures/classify/create.json
+++ b/clients/ctl/admin-ui/cypress/fixtures/classify/create.json
@@ -1,8 +1,10 @@
 {
   "id": "classification-response",
-  "status": "In Work",
-  "datasets": {
-    "fides_key": "demo_users_dataset",
-    "collections": []
-  }
+  "datasets": [
+    {
+      "fides_key": "demo_users_dataset",
+      "status": "In Work",
+      "collections": []
+    }
+  ]
 }

--- a/clients/ctl/admin-ui/cypress/fixtures/classify/list.json
+++ b/clients/ctl/admin-ui/cypress/fixtures/classify/list.json
@@ -1,20 +1,20 @@
 [
   {
     "id": "2",
-    "status": "In Work",
     "datasets": [
       {
         "fides_key": "demo_users_dataset_2",
+        "status": "In Work",
         "collections": []
       }
     ]
   },
   {
     "id": "3",
-    "status": "Complete",
     "datasets": [
       {
         "fides_key": "demo_users_dataset_3",
+        "status": "Complete",
         "collections": [
           {
             "name": "users",
@@ -38,10 +38,10 @@
   },
   {
     "id": "4",
-    "status": "Reviewed",
     "datasets": [
       {
         "fides_key": "demo_users_dataset_4",
+        "status": "Reviewed",
         "collections": [
           {
             "name": "users",
@@ -65,10 +65,10 @@
   },
   {
     "id": "classification_in_review",
-    "status": "Complete",
     "datasets": [
       {
         "fides_key": "dataset_in_review",
+        "status": "Complete",
         "collections": [
           {
             "name": "users",

--- a/clients/ctl/admin-ui/cypress/fixtures/classify/update.json
+++ b/clients/ctl/admin-ui/cypress/fixtures/classify/update.json
@@ -1,0 +1,8 @@
+{
+  "id": "classification-response",
+  "status": "In Work",
+  "datasets": {
+    "fides_key": "demo_users_dataset",
+    "collections": []
+  }
+}

--- a/clients/ctl/admin-ui/cypress/support/stubs.ts
+++ b/clients/ctl/admin-ui/cypress/support/stubs.ts
@@ -32,3 +32,53 @@ export const stubSystemCrud = () => {
     }).as("deleteSystem");
   });
 };
+
+export const stubDatasetCrud = () => {
+  // Dataset editing references taxonomy info, like data categories.
+  stubTaxonomyEntities();
+
+  // Create
+  cy.intercept("POST", "/api/v1/dataset", { fixture: "dataset.json" }).as(
+    "postDataset"
+  );
+
+  // Read
+  cy.intercept("GET", "/api/v1/dataset", { fixture: "datasets.json" }).as(
+    "getDatasets"
+  );
+  cy.intercept("GET", "/api/v1/dataset/*", { fixture: "dataset.json" }).as(
+    "getDataset"
+  );
+
+  // Update
+  cy.intercept("PUT", "/api/v1/dataset/*", { fixture: "dataset.json" }).as(
+    "putDataset"
+  );
+
+  // Delete
+  cy.fixture("dataset.json").then((dataset) => {
+    cy.intercept("DELETE", "/api/v1/dataset/*", {
+      body: {
+        message: "resource deleted",
+        resource: dataset,
+      },
+    }).as("deleteDataset");
+  });
+};
+
+export const stubPlus = (available: boolean) => {
+  if (available) {
+    cy.intercept("GET", "/api/v1/plus/health", {
+      statusCode: 200,
+      body: {
+        status: "healthy",
+        core_fidesctl_version: "1.8",
+      },
+    }).as("getPlusHealth");
+  } else {
+    cy.intercept("GET", "/api/v1/plus/health", {
+      statusCode: 400,
+      body: {},
+    }).as("getPlusHealth");
+  }
+};

--- a/clients/ctl/admin-ui/package-lock.json
+++ b/clients/ctl/admin-ui/package-lock.json
@@ -21,6 +21,7 @@
         "formik": "^2.2.9",
         "framer-motion": "^5",
         "i18n-iso-countries": "^7.4.0",
+        "immer": "^9.0.15",
         "js-yaml": "^4.1.0",
         "lodash.debounce": "^4.0.8",
         "msw": "^0.43.0",
@@ -7213,8 +7214,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.12",
-      "license": "MIT",
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -16386,7 +16388,9 @@
       "version": "5.2.0"
     },
     "immer": {
-      "version": "9.0.12"
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
     },
     "import-fresh": {
       "version": "3.3.0",

--- a/clients/ctl/admin-ui/package.json
+++ b/clients/ctl/admin-ui/package.json
@@ -37,6 +37,7 @@
     "formik": "^2.2.9",
     "framer-motion": "^5",
     "i18n-iso-countries": "^7.4.0",
+    "immer": "^9.0.15",
     "js-yaml": "^4.1.0",
     "lodash.debounce": "^4.0.8",
     "msw": "^0.43.0",

--- a/clients/ctl/admin-ui/src/features/common/plus.slice.ts
+++ b/clients/ctl/admin-ui/src/features/common/plus.slice.ts
@@ -104,7 +104,6 @@ export const useHasPlus = () => {
 const emptyClassifyDatasetMap: Map<string, ClassifyDataset> = new Map();
 export const selectClassifyDatasetMap = createSelector(
   plusApi.endpoints.getAllClassifyInstances.select(),
-
   ({ data: instances }) => {
     if (!instances) {
       return emptyClassifyDatasetMap;
@@ -126,29 +125,17 @@ export const selectClassifyDatasetMap = createSelector(
  * cached getAllClassifyInstances response state, as well as the "active" dataset according
  * to the dataset feature's state.
  */
-export const selectActiveClassifyDataset = createSelector(
-  [
-    plusApi.endpoints.getAllClassifyInstances.select(),
-    selectActiveDatasetFidesKey,
-  ],
-  ({ data: instances }, fidesKey) => {
-    let classifyDataset: ClassifyDataset | undefined;
-    instances?.find((ci) =>
-      ci.datasets?.find((ds) => {
-        if (ds.fides_key === fidesKey) {
-          classifyDataset = ds;
-          return true;
-        }
-        return false;
-      })
-    );
-    return classifyDataset;
-  }
+export const selectClassifyInstanceDataset = createSelector(
+  [selectClassifyDatasetMap, selectActiveDatasetFidesKey],
+  (classifyDatasetMap, fidesKey) =>
+    classifyDatasetMap && fidesKey
+      ? classifyDatasetMap.get(fidesKey)
+      : undefined
 );
 
 const emptyCollectionMap: Map<string, ClassifyCollection> = new Map();
 export const selectClassifyInstanceCollectionMap = createSelector(
-  selectActiveClassifyDataset,
+  selectClassifyInstanceDataset,
   (classifyInstance) =>
     classifyInstance?.collections
       ? new Map(classifyInstance.collections.map((c) => [c.name, c]))

--- a/clients/ctl/admin-ui/src/features/dataset/ApproveClassification.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/ApproveClassification.tsx
@@ -1,0 +1,58 @@
+import { Button, chakra, HStack } from "@fidesui/react";
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+
+import {
+  ClassifyStatusEnum,
+  selectActiveClassifyDataset,
+  selectClassifyInstanceCollection,
+} from "~/features/common/plus.slice";
+
+const ApproveClassification = () => {
+  const classifyDataset = useSelector(selectActiveClassifyDataset);
+  const classifyCollection = useSelector(selectClassifyInstanceCollection);
+
+  const fieldCount = useMemo(
+    () =>
+      classifyCollection?.fields?.reduce(
+        (acc, field) => (field.classifications.length > 0 ? acc + 1 : acc),
+        0
+      ) ?? 0,
+    [classifyCollection]
+  );
+
+  const handleApprove = () => {};
+
+  // This component is only visible if the classifier has run on this dataset and has not been reviewed yet.
+  if (
+    !(
+      classifyDataset &&
+      classifyCollection &&
+      classifyDataset.status === ClassifyStatusEnum.COMPLETE
+    )
+  ) {
+    return null;
+  }
+
+  return (
+    <HStack>
+      <chakra.p fontSize="sm" color="gray.600">
+        <chakra.span fontWeight="bold">{fieldCount}</chakra.span>{" "}
+        {fieldCount === 1 ? "field has" : "fields have"} been identified within
+        this{" "}
+        <chakra.span fontWeight="bold">{classifyCollection.name}</chakra.span>{" "}
+        table that are likely to contain personal data.
+      </chakra.p>
+      <Button
+        size="sm"
+        variant="primary"
+        flexShrink={0}
+        onClick={handleApprove}
+      >
+        Approve dataset classification
+      </Button>
+    </HStack>
+  );
+};
+
+export default ApproveClassification;

--- a/clients/ctl/admin-ui/src/features/dataset/DatabaseConnectForm.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatabaseConnectForm.tsx
@@ -8,7 +8,10 @@ import ConfirmationModal from "~/features/common/ConfirmationModal";
 import { useFeatures } from "~/features/common/features.slice";
 import { CustomSwitch, CustomTextInput } from "~/features/common/form/inputs";
 import { getErrorMessage } from "~/features/common/helpers";
-import { useCreateClassifyInstanceMutation } from "~/features/common/plus.slice";
+import {
+  ClassifyInstance,
+  useCreateClassifyInstanceMutation,
+} from "~/features/common/plus.slice";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
 import { DEFAULT_ORGANIZATION_FIDES_KEY } from "~/features/organization";
 import { Dataset, GenerateTypes, System, ValidTargets } from "~/types/api";
@@ -133,7 +136,7 @@ const DatabaseConnectForm = () => {
         error: string;
       }
     | {
-        status: string;
+        classifyInstance: ClassifyInstance;
       }
   > => {
     const result = await classifyMutation({
@@ -153,7 +156,7 @@ const DatabaseConnectForm = () => {
     }
 
     return {
-      status: result.data.status,
+      classifyInstance: result.data,
     };
   };
 

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -1,4 +1,4 @@
-import { Box, Select, Spinner } from "@fidesui/react";
+import { Box, HStack, Select, Spinner } from "@fidesui/react";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -6,6 +6,7 @@ import { useFeatures } from "~/features/common/features.slice";
 import { useGetAllClassifyInstancesQuery } from "~/features/common/plus.slice";
 import { useGetAllDataCategoriesQuery } from "~/features/taxonomy/taxonomy.slice";
 
+import ApproveClassification from "./ApproveClassification";
 import ColumnDropdown from "./ColumnDropdown";
 import {
   selectActiveCollection,
@@ -94,7 +95,7 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
     <Box>
       <DatasetHeading />
 
-      <Box mb={4} display="flex" justifyContent="space-between">
+      <HStack mb={4} justifyContent="space-between">
         <Select
           onChange={handleChangeCollection}
           mr={2}
@@ -107,8 +108,9 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
             </option>
           ))}
         </Select>
-        <Box display="flex">
-          <Box mr={2}>
+        <ApproveClassification />
+        <HStack>
+          <Box>
             <ColumnDropdown
               allColumns={ALL_COLUMNS}
               selectedColumns={columns}
@@ -123,8 +125,8 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
               dispatch(setActiveEditor(EditableType.DATASET))
             }
           />
-        </Box>
-      </Box>
+        </HStack>
+      </HStack>
 
       <DatasetFieldsTable columns={columns} />
 

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -1,4 +1,4 @@
-import { Box, Select, Spinner } from "@fidesui/react";
+import { Box, Heading, Select, Spinner } from "@fidesui/react";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -91,6 +91,10 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
 
   return (
     <Box>
+      <Heading mb={6} fontSize="2xl" fontWeight="semibold">
+        Dataset
+      </Heading>
+
       <Box mb={4} display="flex" justifyContent="space-between">
         <Select
           onChange={handleChangeCollection}

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, Select, Spinner } from "@fidesui/react";
+import { Box, Select, Spinner } from "@fidesui/react";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -17,6 +17,7 @@ import {
   useGetDatasetByKeyQuery,
 } from "./dataset.slice";
 import DatasetFieldsTable from "./DatasetFieldsTable";
+import DatasetHeading from "./DatasetHeading";
 import EditCollectionDrawer from "./EditCollectionDrawer";
 import EditDatasetDrawer from "./EditDatasetDrawer";
 import MoreActionsMenu from "./MoreActionsMenu";
@@ -91,9 +92,7 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
 
   return (
     <Box>
-      <Heading mb={6} fontSize="2xl" fontWeight="semibold">
-        Dataset
-      </Heading>
+      <DatasetHeading />
 
       <Box mb={4} display="flex" justifyContent="space-between">
         <Select

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetHeading.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetHeading.tsx
@@ -1,0 +1,64 @@
+import { Heading, HStack, Text, VStack } from "@fidesui/react";
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+
+import { StepperCircleCheckmarkIcon } from "~/features/common/Icon";
+import {
+  ClassifyStatusEnum,
+  selectClassifyInstanceDataset,
+} from "~/features/common/plus.slice";
+
+const DatasetHeading = () => {
+  const classifyDataset = useSelector(selectClassifyInstanceDataset);
+  const status = classifyDataset?.status ?? ClassifyStatusEnum.REVIEWED;
+
+  const fieldCount = useMemo(
+    () =>
+      classifyDataset?.collections?.reduce(
+        // Count across all collections...
+        (acc, collection) =>
+          acc +
+          collection.fields.reduce(
+            // Count the fields that have at least one classification.
+            (fieldAcc, field) =>
+              field.classifications.length > 0 ? fieldAcc + 1 : fieldAcc,
+            0
+          ),
+        0
+      ) ?? 0,
+    [classifyDataset]
+  );
+
+  /* eslint-disable no-nested-ternary */
+  const fieldCountMessage =
+    fieldCount === 0
+      ? "Fides did not identify any fields that are likely to contain personal data, but there may be some."
+      : fieldCount === 1
+      ? "Fides identified a field that is likely to contain personal data."
+      : `Fides identified ${fieldCount} fields that are likely to contain personal data.`;
+
+  return (
+    <VStack align="left" mb={6}>
+      {status === ClassifyStatusEnum.COMPLETE ? (
+        <>
+          <HStack>
+            <Heading fontSize="2xl">
+              Dataset classification ready for review
+            </Heading>
+            <StepperCircleCheckmarkIcon fontSize="2xl" />
+          </HStack>
+          <Text fontSize="sm" color="gray.600" maxW="720px">
+            {fieldCountMessage} Please confirm all dataset fields to finish
+            annotating this system. For each table, please review the
+            recommended data categories. You can accept the automated
+            suggestions, or update any field as appropriate before approving.
+          </Text>
+        </>
+      ) : (
+        <Heading fontSize="2xl">Dataset</Heading>
+      )}
+    </VStack>
+  );
+};
+
+export default DatasetHeading;

--- a/clients/ctl/admin-ui/src/features/dataset/DatasetTable.tsx
+++ b/clients/ctl/admin-ui/src/features/dataset/DatasetTable.tsx
@@ -10,7 +10,11 @@ import {
 } from "@fidesui/react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { useClassifyInstancesMap } from "~/features/common/plus.slice";
+import { useFeatures } from "~/features/common/features.slice";
+import {
+  selectClassifyDatasetMap,
+  useGetAllClassifyInstancesQuery,
+} from "~/features/common/plus.slice";
 import { Dataset } from "~/types/api";
 
 import { STATUS_DISPLAY } from "./constants";
@@ -25,7 +29,11 @@ const DatasetsTable = () => {
   const activeDatasetFidesKey = useSelector(selectActiveDatasetFidesKey);
 
   const { data: datasets } = useGetAllDatasetsQuery();
-  const classifyInstancesMap = useClassifyInstancesMap();
+  const features = useFeatures();
+  useGetAllClassifyInstancesQuery(undefined, {
+    skip: !features.plus,
+  });
+  const classifyDatasetMap = useSelector(selectClassifyDatasetMap);
 
   const handleRowClick = (dataset: Dataset) => {
     // toggle the active dataset
@@ -55,9 +63,9 @@ const DatasetsTable = () => {
             activeDatasetFidesKey &&
             activeDatasetFidesKey === dataset.fides_key;
 
-          const classifyInstance = classifyInstancesMap.get(dataset.fides_key);
+          const classifyDataset = classifyDatasetMap.get(dataset.fides_key);
           const statusDisplay =
-            STATUS_DISPLAY[classifyInstance?.status ?? "unknown"];
+            STATUS_DISPLAY[classifyDataset?.status ?? "unknown"];
 
           return (
             <Tr

--- a/clients/ctl/admin-ui/src/features/dataset/helpers.ts
+++ b/clients/ctl/admin-ui/src/features/dataset/helpers.ts
@@ -1,3 +1,8 @@
+import produce from "immer";
+
+import { ClassifyDataset } from "~/features/common/plus.slice";
+import { Dataset, DatasetCollection, DatasetField } from "~/types/api";
+
 /**
  * Because there is only one /dataset endpoint which handles dataset, collection,
  * and field modifications, and always takes a whole dataset object, it is convenient
@@ -8,8 +13,6 @@
  * so we have to use their index in the array. If they ever get a unique ID, we should
  * use that instead.
  */
-
-import { Dataset, DatasetCollection, DatasetField } from "~/types/api";
 
 export const getUpdatedDatasetFromCollection = (
   dataset: Dataset,
@@ -57,6 +60,54 @@ export const getUpdatedDatasetFromField = (
     collectionIndex
   );
 };
+
+/**
+ * Returns a new dataset object with the top-scoring classification results filling in data
+ * categories that were left blank on the dataset. Uses immer to efficiently modify a draft object.
+ */
+export const getUpdatedDatasetFromClassifyDataset = (
+  dataset: Dataset,
+  classifyDataset: ClassifyDataset
+): Dataset =>
+  produce(dataset, (draftDataset) => {
+    const classifyCollectionMap = new Map(
+      classifyDataset.collections.map((c) => [c.name, c])
+    );
+
+    draftDataset.collections.forEach((draftCollection) => {
+      const classifyCollection = classifyCollectionMap.get(
+        draftCollection.name
+      );
+      const classifyFieldMap = new Map(
+        classifyCollection?.fields?.map((f) => [f.name, f])
+      );
+
+      draftCollection.fields.forEach((draftField) => {
+        if (
+          draftField.data_categories &&
+          draftField.data_categories.length > 0
+        ) {
+          return;
+        }
+
+        const classifyField = classifyFieldMap.get(draftField.name);
+        if (!(classifyField && classifyField.classifications.length > 0)) {
+          return;
+        }
+
+        const topClassification = classifyField.classifications.reduce(
+          (maxClassification, next) => {
+            if (maxClassification.score < next.score) {
+              return next;
+            }
+            return maxClassification;
+          }
+        );
+
+        draftField.data_categories = [topClassification.label];
+      });
+    });
+  });
 
 export const removeFieldFromDataset = (
   dataset: Dataset,

--- a/clients/ctl/admin-ui/src/mocks/data.ts
+++ b/clients/ctl/admin-ui/src/mocks/data.ts
@@ -1,4 +1,11 @@
 import {
+  Classification,
+  ClassifyCollection,
+  ClassifyDataset,
+  ClassifyField,
+  ClassifyStatusEnum,
+} from "~/features/common/plus.slice";
+import {
   DataResponsibilityTitle,
   Dataset,
   DatasetCollection,
@@ -210,4 +217,47 @@ export const mockDataset = (partialDataset?: Partial<Dataset>): Dataset => {
     collections: [mockDatasetCollection()],
   };
   return Object.assign(dataset, partialDataset);
+};
+
+export const mockClassification = (
+  partial?: Partial<Classification>
+): Classification => {
+  const initial: Classification = {
+    label: "system.operations",
+    score: 1,
+    aggregated_score: 1,
+    classification_paradigm: "",
+  };
+  return Object.assign(initial, partial);
+};
+
+export const mockClassifyField = (
+  partial?: Partial<ClassifyField>
+): ClassifyField => {
+  const initial: ClassifyField = {
+    name: "created_at",
+    classifications: [mockClassification()],
+  };
+  return Object.assign(initial, partial);
+};
+
+export const mockClassifyCollection = (
+  partial?: Partial<ClassifyCollection>
+): ClassifyCollection => {
+  const initial: ClassifyCollection = {
+    name: "created_at",
+    fields: [mockClassifyField()],
+  };
+  return Object.assign(initial, partial);
+};
+
+export const mockClassifyDataset = (
+  partial?: Partial<ClassifyDataset>
+): ClassifyDataset => {
+  const initial: ClassifyDataset = {
+    fides_key: "sample_dataset",
+    status: ClassifyStatusEnum.COMPLETE,
+    collections: [mockClassifyCollection()],
+  };
+  return Object.assign(initial, partial);
 };

--- a/clients/ctl/admin-ui/src/pages/dataset/[id].tsx
+++ b/clients/ctl/admin-ui/src/pages/dataset/[id].tsx
@@ -1,4 +1,4 @@
-import { Box, Breadcrumb, BreadcrumbItem, Heading } from "@fidesui/react";
+import { Box, Breadcrumb, BreadcrumbItem } from "@fidesui/react";
 import type { NextPage } from "next";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
@@ -18,10 +18,7 @@ const DatasetDetail: NextPage = () => {
 
   return (
     <Layout title={`Dataset - ${id}`}>
-      <Heading mb={2} fontSize="2xl" fontWeight="semibold">
-        Dataset
-      </Heading>
-      <Box mb={8}>
+      <Box mb={6}>
         <Breadcrumb fontWeight="medium" fontSize="sm" color="gray.600">
           <BreadcrumbItem>
             <NextLink href="/dataset">Datasets</NextLink>


### PR DESCRIPTION
Closes #1076 

### Code Changes

- "Approve classification" button for datasets that need review
    - This makes two API calls: the normal dataset update call and then a new endpoint for tracking this status.
    - There is a unit-tested function for creating the dataset update body. This uses immer as an explicit dependency,
      but it was already pulled in by RTK.
- Move classify status field to be per-dataset
    - Discussion: https://github.com/ethyca/fidesctl-plus/pull/106#discussion_r980343600
    - This required some selector restructuring. It's kind of nice we usually only need the
      ClassifyDataset instead of the instance itself.


### Steps to Confirm

- [ ] The classify logic still must be run within cypress.
- [ ] The dataset viewing and editing should still work when Plus/Cls is unavailable.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
    - https://github.com/ethyca/fides/issues/1120
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Before click:
![1-approval-button](https://user-images.githubusercontent.com/2236777/192667674-5dc3a785-5d7b-49a5-941b-ca6b07f847b8.png)

While loading:
![2-loading](https://user-images.githubusercontent.com/2236777/192669088-3c3e1bea-b8b2-4435-97e7-b56ea233ef52.png)

Success:
![3-success](https://user-images.githubusercontent.com/2236777/192667670-4ddf5629-286a-4763-8301-439dfa5f31ee.png)

