### PR TITLE
Do not rely on order for checking intercept results

### DIFF
--- a/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
@@ -391,12 +391,14 @@ describe("Dataset", () => {
         ).to.eql(connectionString);
       });
 
-      // Two requests should be intercepted. (Cypress waits in LIFO order.)
+      // Two requests should be intercepted.
       cy.wait("@postDataset").then((interception) => {
-        expect(interception.request.body.fides_key).to.eql("generated-2");
-      });
-      cy.wait("@postDataset").then((interception) => {
-        expect(interception.request.body.fides_key).to.eql("generated-1");
+        const generatedKeys = [];
+        generatedKeys.push(interception.request.body.fides_key);
+        cy.wait("@postDataset").then((interception2) => {
+          generatedKeys.push(interception2.request.body.fides_key);
+          expect(generatedKeys.sort()).to.eql(["generated-1", "generated-2"]);
+        });
       });
 
       // Should navigate to the first created dataset.

--- a/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/ctl/admin-ui/cypress/e2e/datasets.cy.ts
@@ -392,13 +392,11 @@ describe("Dataset", () => {
       });
 
       // Two requests should be intercepted.
-      cy.wait("@postDataset").then((interception) => {
-        const generatedKeys = [];
-        generatedKeys.push(interception.request.body.fides_key);
-        cy.wait("@postDataset").then((interception2) => {
-          generatedKeys.push(interception2.request.body.fides_key);
-          expect(generatedKeys.sort()).to.eql(["generated-1", "generated-2"]);
-        });
+      cy.wait(["@postDataset", "@postDataset"]).then((interceptions) => {
+        const generatedKeys = interceptions.map(
+          (i) => i.request.body.fides_key
+        );
+        expect(generatedKeys.sort()).to.eql(["generated-1", "generated-2"]);
       });
 
       // Should navigate to the first created dataset.


### PR DESCRIPTION
This test was failing in electron. It became more apparent on the branch off of unified-fides, for some reason. But I can reproduce reliably when making Cypress run via electron instead of chrome locally. 

It might be vaguely related to this? https://github.com/cypress-io/cypress/issues/8055

I figured the test doesn't really care about the order, just that both requests happen, so I made it collect both requests then sort and then compare to what we expect.

### Code Changes

* [x] Update test to not care so much about the order network requests come in

### Steps to Confirm

* [ ] Run cypress tests via electron and make sure they all pass

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
