### PR TITLE
Make local docker UI better

### DIFF
--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev-docker": "test -d node_modules || npm install && npm run dev",
     "dev:mock": "echo '🚨 Running with mock API'; NEXT_PUBLIC_MOCK_API=true next dev",
     "build": "next build",
     "start": "next start",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       test: [ "CMD", "curl", "-f", "http://0.0.0.0:8080/health" ]
       interval: 20s
       timeout: 5s
-      retries: 5
+      retries: 10
     ports:
       - "8080:8080"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   fides-ui:
     image: ethyca/fides:local-ui
-    command: npm run dev-docker
+    command: npm run dev
     expose:
       - 3000
     ports:
@@ -45,6 +45,8 @@ services:
         source: .
         target: /fides
         read_only: False
+      # do not volume mount over the node_modules
+      - /fides/clients/admin-ui/node_modules
     environment:
       - NEXT_PUBLIC_FIDESCTL_API_SERVER=http://fides:8080
 


### PR DESCRIPTION
Lots of people were getting a problem when spinning up `nox -s dev -- ui` where `node_modules` might be halfway filled out, so the `test -d node_modules` would succeed, but it wouldn't actually work since not everything was installed properly. This might have happened from the docker-compose timing out while bringing the services up (a few of us had to up the `retries` count to let the healthcheck be happy).

Instead of making `test -d node_modules` more sophisticated, we can just tell docker-compose not to override `node_modules` (since the docker container [already installs everything](https://github.com/ethyca/fides/blob/aking-make-docker-ui-better/Dockerfile/#L11-L14). it's just this will happen when the user doesn't have node modules on their local machine)

### Code Changes

* [x] Increase `retries` to 10 🥲 
* [x] Instead of testing for existence of node_modules, let's just not overwrite them! 

### Steps to Confirm

* [ ] Delete local `clients/admin-ui/node_modules` folder 
* [ ] Run `docker-compose up fides-ui`
* [ ] You should be able to visit localhost:3000 much faster!

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
