### PR TITLE
[Unified Fides] Wrong Config Resource Passed into Email Create/Update [#1139]

### DIFF
--- a/src/fides/api/ops/service/email/email_crud_service.py
+++ b/src/fides/api/ops/service/email/email_crud_service.py
@@ -9,9 +9,7 @@ from fides.api.ops.common_exceptions import (
 )
 from fides.api.ops.models.email import EmailConfig
 from fides.api.ops.schemas.email.email import EmailConfigRequest, EmailConfigResponse
-from fides.ctl.core.config import get_config
 
-CONFIG = get_config()
 logger = logging.getLogger(__name__)
 
 
@@ -21,7 +19,7 @@ def create_email_config(db: Session, config: EmailConfigRequest) -> EmailConfigR
         raise EmailConfigAlreadyExistsException(
             f"Only one email config is supported at a time. Config with key {config.key} is already configured."
         )
-    return _create_or_update_email_config(db=db, config=CONFIG)
+    return _create_or_update_email_config(db=db, config=config)
 
 
 def update_email_config(
@@ -32,7 +30,7 @@ def update_email_config(
     )
     if not existing_config_with_key:
         raise EmailConfigNotFoundException(f"No email config found with key {key}")
-    return _create_or_update_email_config(db=db, config=CONFIG)
+    return _create_or_update_email_config(db=db, config=config)
 
 
 def _create_or_update_email_config(


### PR DESCRIPTION
Closes #1139 

### Code Changes

* [x] Removed passing in the incorrect FidesConfig resource instead of the EmailConfigRequest object

### Steps to Confirm

* [x] A POST or a PATCH to update an EmailConfig in Postman now succeeds.  This addresses a few of the previously failing email-related unit tests.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
