### PR TITLE
ui/package: restore copy-export command

### DIFF
--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -16,6 +16,7 @@
     "analyze:server": "cross-env BUNDLE_ANALYZE=server next build",
     "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build",
     "export": "next build && next export",
+    "copy-export": "mkdir -p ../../src/fides/ui-build/static/admin/ && rsync -a --delete out/ ../../src/fides/ui-build/static/admin/",
     "chrome:debug": "BROWSER='google chrome' BROWSER_ARGS='--remote-debugging-port=9222' npm run dev",
     "cy:open": "cypress open",
     "cy:run": "cypress run",


### PR DESCRIPTION
### Description Of Changes

The `copy-export` command is helpful when you want to test that the static build assets are correctly served by the [catchall route](https://github.com/ethyca/fides/blob/a2cc9b0d4402531b3e58ef4bc9c1abeff36f9a68/src/fides/api/main.py#L283). Otherwise you have to [rebuild the prod image](https://github.com/ethyca/fides/blob/b2cacbfe58e0a4f6c1be8984d9afd432b9233c44/Dockerfile#L99-L100) and run it.
