### PR TITLE
Re-add SaaS template update script to startup hook

### DIFF
--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -210,9 +210,8 @@ async def setup_server() -> None:
 
     logger.info("Validating SaaS connector templates...")
     registry = load_registry(registry_file)
-    db = get_api_session()
-    update_saas_configs(registry, db)
-    db.close()
+    with get_api_session() as db:
+        update_saas_configs(registry, db)
 
     logger.info("Running Redis connection test...")
     try:

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -47,6 +47,7 @@ from fides.api.ops.analytics import (
     in_docker_container,
     send_analytics_event,
 )
+from fides.api.ops.api.deps import get_api_session
 from fides.api.ops.api.v1.api import api_router
 from fides.api.ops.api.v1.exception_handlers import ExceptionHandlers
 from fides.api.ops.common_exceptions import (
@@ -57,6 +58,7 @@ from fides.api.ops.schemas.analytics import Event, ExtraData
 from fides.api.ops.service.connectors.saas.connector_registry_service import (
     load_registry,
     registry_file,
+    update_saas_configs,
 )
 from fides.api.ops.tasks.scheduled.scheduler import scheduler
 from fides.api.ops.tasks.scheduled.tasks import initiate_scheduled_request_intake
@@ -207,7 +209,10 @@ async def setup_server() -> None:
     await configure_db(CONFIG.database.sync_database_uri)
 
     logger.info("Validating SaaS connector templates...")
-    load_registry(registry_file)
+    registry = load_registry(registry_file)
+    db = get_api_session()
+    update_saas_configs(registry, db)
+    db.close()
 
     logger.info("Running Redis connection test...")
     try:

--- a/src/fides/api/ops/api/deps.py
+++ b/src/fides/api/ops/api/deps.py
@@ -20,7 +20,7 @@ def get_config() -> FidesConfig:
 def get_db() -> Generator:
     """Return our database session"""
     try:
-        db = _get_session()
+        db = get_api_session()
         yield db
     finally:
         db.close()
@@ -29,14 +29,14 @@ def get_db() -> Generator:
 def get_db_for_health_check() -> Generator:
     """Gets a database session regardless of whether the application db is disabled, for a health check."""
     try:
-        db = _get_session()
+        db = get_api_session()
         yield db
     finally:
         db.close()
 
 
-def _get_session() -> Session:
-    """Gets a database session"""
+def get_api_session() -> Session:
+    """Gets the shared database session to use for API functionality"""
     global _engine  # pylint: disable=W0603
     if not _engine:
         _engine = get_db_engine(config=CONFIG)


### PR DESCRIPTION
Re-add SaaS template update script on startup that had been removed accidentally in merging over to unified Fides.

Closes #1195 

### Code Changes

* execute update script in startup hook
* include a new session getter dependency function to allow a session to be retrieved directly, as is needed for the update script execution

### Steps to Confirm

* create a sample connector instance from template (i chose hubspot as an example)
* update the template config or dataset for your given connector, and increment the version number in the saas config template
* restart the fides app (don't clear your db), allow it to fully boot-up
* make an API call (e.g. `{{host}}/connection/[instance_key]/dataset` or `{{host}}/connection/[instance_key]/saas_config`) to retrieve the config/dataset of your sample connector instance and confirm that it has the updates you applied to the template

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  - [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  - [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Context:
In fidesops, on webserver bootup we [ran](https://github.com/ethyca/fidesops/blob/main/src/fidesops/main.py#L248) an update "script" for saas configs to pick up any updates coming from a new version of their corresponding templates. See https://github.com/ethyca/fidesops/pull/1307 and associated issue https://github.com/ethyca/fidesops/issues/1098 for more context.
