### PR TITLE
Add Privacy Center to the default development build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@ src/ui-build/
 
 # Frontend
 **/node_modules
-**/.next
 
 
 # Ignore Python-Specific Files

--- a/clients/ops/privacy-center/Dockerfile
+++ b/clients/ops/privacy-center/Dockerfile
@@ -35,7 +35,7 @@ FROM node:16-alpine as runner
 
 WORKDIR /app
 
-ENV NODE_END production
+ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN addgroup --system --gid 1001 nodejs

--- a/clients/ops/privacy-center/Dockerfile
+++ b/clients/ops/privacy-center/Dockerfile
@@ -1,16 +1,22 @@
 # Based on vercel/next.js example https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
+##############################
+## Install the dependencies ##
+##############################
 FROM node:16-alpine as deps
 
 RUN apk add --no-cache libc6-compat
 
 WORKDIR /app
 
-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
 RUN npm clean-install
 
 
-from node:16-alpine as builder
+###########################
+## Build the application ##
+###########################
+FROM node:16-alpine as builder
 
 WORKDIR /app
 
@@ -22,6 +28,9 @@ ENV NEXT_TELEMETRY_DISABLED 1
 RUN npm run build
 
 
+##########################
+## Setup the prod image ##
+##########################
 FROM node:16-alpine as runner
 
 WORKDIR /app

--- a/clients/ops/privacy-center/__tests__/RequestModal.test.tsx
+++ b/clients/ops/privacy-center/__tests__/RequestModal.test.tsx
@@ -126,7 +126,7 @@ describe("RequestModal", () => {
     render(<IndexPage />);
     server.use(
       rest.post(
-        `${mockConfig.fidesops_host_production}/privacy-request`,
+        `${hostUrl}/privacy-request`,
         (req, res, ctx) =>
           res(
             ctx.json({
@@ -171,7 +171,7 @@ describe("RequestModal", () => {
     render(<IndexPage />);
     server.use(
       rest.post(
-        `${mockConfig.fidesops_host_production}/privacy-request`,
+        `${hostUrl}/privacy-request`,
         (req, res, ctx) =>
           res(
             ctx.json({

--- a/clients/ops/privacy-center/__tests__/RequestModal.test.tsx
+++ b/clients/ops/privacy-center/__tests__/RequestModal.test.tsx
@@ -125,15 +125,13 @@ describe("RequestModal", () => {
   it("handles form submission success with an appropriate alert", async () => {
     render(<IndexPage />);
     server.use(
-      rest.post(
-        `${hostUrl}/privacy-request`,
-        (req, res, ctx) =>
-          res(
-            ctx.json({
-              succeeded: [{}],
-              failed: [],
-            })
-          )
+      rest.post(`${hostUrl}/privacy-request`, (req, res, ctx) =>
+        res(
+          ctx.json({
+            succeeded: [{}],
+            failed: [],
+          })
+        )
       )
     );
 
@@ -170,15 +168,13 @@ describe("RequestModal", () => {
   it("handles form submission failure with an appropriate alert", async () => {
     render(<IndexPage />);
     server.use(
-      rest.post(
-        `${hostUrl}/privacy-request`,
-        (req, res, ctx) =>
-          res(
-            ctx.json({
-              succeeded: [],
-              failed: [{}],
-            })
-          )
+      rest.post(`${hostUrl}/privacy-request`, (req, res, ctx) =>
+        res(
+          ctx.json({
+            succeeded: [],
+            failed: [{}],
+          })
+        )
       )
     );
 

--- a/clients/ops/privacy-center/config/__mocks__/config.json
+++ b/clients/ops/privacy-center/config/__mocks__/config.json
@@ -1,8 +1,8 @@
 {
   "title": "Privacy center",
   "description": "Privacy center test configuration",
-  "fidesops_host_development": "http://localhost:8080/api/v1",
-  "fidesops_host_production": "http://localhost:8080/api/v1",
+  "server_url_development": "http://localhost:8080/api/v1",
+  "fidesops_host_production": "http://example.com/api/v1",
   "logo_path": "/logo.svg",
   "actions": [
     {

--- a/clients/ops/privacy-center/config/__mocks__/config.json
+++ b/clients/ops/privacy-center/config/__mocks__/config.json
@@ -2,7 +2,7 @@
   "title": "Privacy center",
   "description": "Privacy center test configuration",
   "server_url_development": "http://localhost:8080/api/v1",
-  "fidesops_host_production": "http://example.com/api/v1",
+  "server_url_production": "http://example.com/api/v1",
   "logo_path": "/logo.svg",
   "actions": [
     {

--- a/clients/ops/privacy-center/config/config.json
+++ b/clients/ops/privacy-center/config/config.json
@@ -1,8 +1,8 @@
 {
   "title": "Take control of your data",
   "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
-  "fidesops_host_development": "http://localhost:8080/api/v1",
-  "fidesops_host_production": "",
+  "server_url_development": "http://localhost:8080/api/v1",
+  "server_url_production": "http://localhost:8080/api/v1",
   "logo_path": "/logo.svg",
   "actions": [
     {

--- a/clients/ops/privacy-center/config/config.json
+++ b/clients/ops/privacy-center/config/config.json
@@ -1,49 +1,51 @@
 {
-    "title": "Take control of your data",
-    "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
-    "server_url_development": "http://localhost:8080/api/v1",
-    "server_url_production": "http://localhost:8080/api/v1",
-    "logo_path": "/logo.svg",
-    "actions": [{
-            "policy_key": "example_request_policy",
-            "icon_path": "/download.svg",
-            "title": "Access your data",
-            "description": "We will email you a report of the data related to your account.",
-            "identity_inputs": {
-                "name": "optional",
-                "email": "required",
-                "phone": "optional"
-            }
-        },
-        {
-            "policy_key": "example_erasure_policy",
-            "icon_path": "/delete.svg",
-            "title": "Erase your data",
-            "description": "We will delete all of your account data. This action cannot be undone.",
-            "identity_inputs": {
-                "name": "optional",
-                "email": "required",
-                "phone": "optional"
-            }
-        }
-    ],
-    "includeConsent": true,
-    "consent": {
-        "consentOptions": [{
-                "fidesDataUseKey": "third_party_sharing",
-                "name": "Do not sell my personal information",
-                "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit. Lorem ipsum dolor sit amet, consectetur.",
-                "highlight": true,
-                "url": "https://example.com/privacy#data-sales"
-            },
-            {
-                "default": true,
-                "fidesDataUseKey": "provide.service",
-                "name": "Provide a service",
-                "url": "https://example.com/privacy#provide-service",
-                "highlight": false,
-                "description": "Manage how we use your data, including Do Not Sell My Personal Information."
-            }
-        ]
+  "title": "Take control of your data",
+  "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
+  "server_url_development": "http://localhost:8080/api/v1",
+  "server_url_production": "http://localhost:8080/api/v1",
+  "logo_path": "/logo.svg",
+  "actions": [
+    {
+      "policy_key": "example_request_policy",
+      "icon_path": "/download.svg",
+      "title": "Access your data",
+      "description": "We will email you a report of the data related to your account.",
+      "identity_inputs": {
+        "name": "optional",
+        "email": "required",
+        "phone": "optional"
+      }
+    },
+    {
+      "policy_key": "example_erasure_policy",
+      "icon_path": "/delete.svg",
+      "title": "Erase your data",
+      "description": "We will delete all of your account data. This action cannot be undone.",
+      "identity_inputs": {
+        "name": "optional",
+        "email": "required",
+        "phone": "optional"
+      }
     }
+  ],
+  "includeConsent": true,
+  "consent": {
+    "consentOptions": [
+      {
+        "fidesDataUseKey": "third_party_sharing",
+        "name": "Do not sell my personal information",
+        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit. Lorem ipsum dolor sit amet, consectetur.",
+        "highlight": true,
+        "url": "https://example.com/privacy#data-sales"
+      },
+      {
+        "default": true,
+        "fidesDataUseKey": "provide.service",
+        "name": "Provide a service",
+        "url": "https://example.com/privacy#provide-service",
+        "highlight": false,
+        "description": "Manage how we use your data, including Do Not Sell My Personal Information."
+      }
+    ]
+  }
 }

--- a/clients/ops/privacy-center/config/config.json
+++ b/clients/ops/privacy-center/config/config.json
@@ -1,51 +1,49 @@
 {
-  "title": "Take control of your data",
-  "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
-  "server_url_development": "http://localhost:8080/api/v1",
-  "server_url_production": "http://localhost:8080/api/v1",
-  "logo_path": "/logo.svg",
-  "actions": [
-    {
-      "policy_key": "download",
-      "icon_path": "/download.svg",
-      "title": "Download your data",
-      "description": "We will email you a report of the data related to your account.",
-      "identity_inputs": {
-        "name": "optional",
-        "email": "required",
-        "phone": "optional"
-      }
-    },
-    {
-      "policy_key": "delete",
-      "icon_path": "/delete.svg",
-      "title": "Delete your data",
-      "description": "We will delete all of your account data. This action cannot be undone.",
-      "identity_inputs": {
-        "name": "optional",
-        "email": "required",
-        "phone": "optional"
-      }
+    "title": "Take control of your data",
+    "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
+    "server_url_development": "http://localhost:8080/api/v1",
+    "server_url_production": "http://localhost:8080/api/v1",
+    "logo_path": "/logo.svg",
+    "actions": [{
+            "policy_key": "example_request_policy",
+            "icon_path": "/download.svg",
+            "title": "Access your data",
+            "description": "We will email you a report of the data related to your account.",
+            "identity_inputs": {
+                "name": "optional",
+                "email": "required",
+                "phone": "optional"
+            }
+        },
+        {
+            "policy_key": "example_erasure_policy",
+            "icon_path": "/delete.svg",
+            "title": "Erase your data",
+            "description": "We will delete all of your account data. This action cannot be undone.",
+            "identity_inputs": {
+                "name": "optional",
+                "email": "required",
+                "phone": "optional"
+            }
+        }
+    ],
+    "includeConsent": true,
+    "consent": {
+        "consentOptions": [{
+                "fidesDataUseKey": "third_party_sharing",
+                "name": "Do not sell my personal information",
+                "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit. Lorem ipsum dolor sit amet, consectetur.",
+                "highlight": true,
+                "url": "https://example.com/privacy#data-sales"
+            },
+            {
+                "default": true,
+                "fidesDataUseKey": "provide.service",
+                "name": "Provide a service",
+                "url": "https://example.com/privacy#provide-service",
+                "highlight": false,
+                "description": "Manage how we use your data, including Do Not Sell My Personal Information."
+            }
+        ]
     }
-  ],
-  "includeConsent": true,
-  "consent": {
-    "consentOptions": [
-      {
-        "fidesDataUseKey": "third_party_sharing",
-        "name": "Do not sell my personal information",
-        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit. Lorem ipsum dolor sit amet, consectetur.",
-        "highlight": true,
-        "url": "https://example.com/privacy#data-sales"
-      },
-      {
-        "default": true,
-        "fidesDataUseKey": "provide.service",
-        "name": "Provide a service",
-        "url": "https://example.com/privacy#provide-service",
-        "highlight": false,
-        "description": "Manage how we use your data, including Do Not Sell My Personal Information."
-      }
-    ]
-  }
 }

--- a/clients/ops/privacy-center/constants/index.ts
+++ b/clients/ops/privacy-center/constants/index.ts
@@ -3,7 +3,9 @@
 
 import config from "../config/config.json";
 
+// Compute the host URL for the server, while being backwards compatible with
+// the previous "fidesops_host_***" configuration
 export const hostUrl =
   process.env.NODE_ENV === "development"
-    ? config.fidesops_host_development
-    : config.fidesops_host_production;
+    ? (config.server_url_development || (config as any).fidesops_host_development)
+    : (config.server_url_production || (config as any).fidesops_host_production);

--- a/clients/ops/privacy-center/constants/index.ts
+++ b/clients/ops/privacy-center/constants/index.ts
@@ -5,6 +5,7 @@ import config from "../config/config.json";
 
 // Compute the host URL for the server, while being backwards compatible with
 // the previous "fidesops_host_***" configuration
+// DEFER: remove backwards compatibility (see https://github.com/ethyca/fides/issues/1264)
 export const hostUrl =
   process.env.NODE_ENV === "development"
     ? (config.server_url_development || (config as any).fidesops_host_development)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,16 +57,9 @@ services:
     image: ethyca/fides-privacy-center:local
     command: npm run dev
     expose:
-      - 3000
+      - 3001
     ports:
-      - "3000:3000"
-    volumes:
-      - type: bind
-        source: .
-        target: /fides
-        read_only: False
-      # do not volume mount over the node_modules
-      - /fides/clients/ops/privacy-center/node_modules
+      - "3001:3001"
     environment:
       - NEXT_PUBLIC_FIDESCTL_API_SERVER=http://fides:8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,11 +55,10 @@ services:
 
   fides-pc:
     image: ethyca/fides-privacy-center:local
-    command: npm run dev
     expose:
       - 3000
     ports:
-      - "3000:3000"
+      - "3001:3000"
     environment:
       - NEXT_PUBLIC_FIDESCTL_API_SERVER=http://fides:8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,9 +57,9 @@ services:
     image: ethyca/fides-privacy-center:local
     command: npm run dev
     expose:
-      - 3001
+      - 3000
     ports:
-      - "3001:3001"
+      - "3000:3000"
     environment:
       - NEXT_PUBLIC_FIDESCTL_API_SERVER=http://fides:8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,23 @@ services:
     environment:
       - NEXT_PUBLIC_FIDESCTL_API_SERVER=http://fides:8080
 
+  fides-pc:
+    image: ethyca/fides-privacy-center:local
+    command: npm run dev
+    expose:
+      - 3000
+    ports:
+      - "3000:3000"
+    volumes:
+      - type: bind
+        source: .
+        target: /fides
+        read_only: False
+      # do not volume mount over the node_modules
+      - /fides/clients/ops/privacy-center/node_modules
+    environment:
+      - NEXT_PUBLIC_FIDESCTL_API_SERVER=http://fides:8080
+
   fides-db:
     image: postgres:12
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,8 +59,11 @@ services:
       - 3000
     ports:
       - "3001:3000"
-    environment:
-      - NEXT_PUBLIC_FIDESCTL_API_SERVER=http://fides:8080
+    volumes:
+      - type: bind
+        source: ./clients/ops/privacy-center/config
+        target: /app/config
+        read_only: False
 
   fides-db:
     image: postgres:12

--- a/docs/fides/docs/ui/privacy_center.md
+++ b/docs/fides/docs/ui/privacy_center.md
@@ -12,8 +12,8 @@ The fidesops Privacy Center's text and actions are managed by a `config.json` fi
 {
   "title": "Take control of your data",
   "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
-  "fidesops_host_development": "http://localhost:8080/api/v1",
-  "fidesops_host_production": "",
+  "server_url_development": "http://localhost:8080/api/v1",
+  "server_url_production": "https://<$YOUR_SERVER_URL>/api/v1",
   "logo_path": "/logo.svg",
   "actions": [
     {
@@ -45,8 +45,8 @@ The fidesops Privacy Center's text and actions are managed by a `config.json` fi
 | Key | Description |
 |----|----|
 | `title` and `dscription` | Text fields to override the default text of either the main portal, or the associated action. |
-| `fidesops_host_development` | The URL to use for development deployments. |
-| `fidesops_host_production` | The URL to use for production deployments. |
+| `server_url_development` | The Fides server URL to use for development deployments. |
+| `server_url_production` | The Fides server URL to use for production deployments. |
 | `logo_path` | The relative path to a brand or site logo to replace the default. |
 | `actions` | A list of [action objects](#actions), each of which represent a new tile available in the portal, and are associated to a single fidesops policy. |
 | `policy_key` | The key of the [policy](../guides/policies.md) to use for this action. |

--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -22,7 +22,7 @@ def dev(session: nox.Session) -> None:
 
     if "pc" in session.posargs:
         build(session, "pc")
-        session.run("docker", "compose", "up", "-d", "fides-ui", external=True)
+        session.run("docker", "compose", "up", "-d", "fides-pc", external=True)
 
     open_shell = "shell" in session.posargs
     if not datastores:

--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -20,6 +20,10 @@ def dev(session: nox.Session) -> None:
         build(session, "ui")
         session.run("docker", "compose", "up", "-d", "fides-ui", external=True)
 
+    if "pc" in session.posargs:
+        build(session, "pc")
+        session.run("docker", "compose", "up", "-d", "fides-ui", external=True)
+
     open_shell = "shell" in session.posargs
     if not datastores:
         if open_shell:

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -24,6 +24,7 @@ def get_current_image() -> str:
         nox.param("dev", id="dev"),
         nox.param("test", id="test"),
         nox.param("ui", id="ui"),
+        nox.param("pc", id="pc"),
     ],
 )
 def build(session: nox.Session, image: str) -> None:

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -38,17 +38,27 @@ def build(session: nox.Session, image: str) -> None:
         "test": {"tag": lambda: IMAGE_LOCAL, "target": "prod"},
         "ui": {"tag": lambda: IMAGE_LOCAL_UI, "target": "frontend"},
     }
-    target = build_matrix[image]["target"]
-    tag = build_matrix[image]["tag"]
-    session.run(
-        "docker",
-        "build",
-        f"--target={target}",
-        "--tag",
-        tag(),
-        ".",
-        external=True,
-    )
+    if image == "pc":
+        session.run(
+            "docker",
+            "build",
+            "clients/ops/privacy-center",
+            "--tag",
+            "ethyca/fides-privacy-center:local",
+            external=True,
+        )
+    else:
+        target = build_matrix[image]["target"]
+        tag = build_matrix[image]["tag"]
+        session.run(
+            "docker",
+            "build",
+            f"--target={target}",
+            "--tag",
+            tag(),
+            ".",
+            external=True,
+        )
 
 
 @nox.session()


### PR DESCRIPTION
Closes #1164 
Closes #1141

### Code Changes

* [X] Improve the privacy center Dockerfile
* [X] Add `pc` as an optional arg to `nox` commands: `nox -s dev -- pc`, `nox -s build -- pc`
* [X] Add new configuration options for the privacy center: `server_url_development` and `server_url_production`
* [X] Maintain backwards compatibility for previous config: `fidesops_host_development` and `fidesops_host_production`

Note that I ended up using `git cherry-pick` to grab commits from https://github.com/ethyca/fides/pull/1145, which this PR replaces.

### Steps to Confirm

* [X] Ran `nox -s dev -- pc` and confirmed that privacy center loaded at http://localhost:3001 (after a long build delay!)
* [X] Ran `nox -s quickstart` and confirmed that the privacy center can be used to submit a request for jane@example.com (once Step Three has completed)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

This makes the privacy center a "first-class" service in the build, whereas historically it's only been developed with using `npm` commands in the sub-directory. It's still a bit slow to build and could use additional TLC, but this is a big improvement.
