### PR TITLE
Notify fidesctl-plus and fidesops-plus on new releases

### DIFF
--- a/.github/workflows/release_event.yml
+++ b/.github/workflows/release_event.yml
@@ -1,18 +1,28 @@
-name: Release Dispatch Event
+name: Notify Downstream Projects of Release
 
 on:
   release:
     types: [released]
 
 jobs:
-  Notify-of-New-Release:
+  fidesctl-plus:
     runs-on: ubuntu-latest
     steps:
-
-      - name: Repository Dispatch
+      - name: Send Repository Dispatch Event
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
-          repository: ethyca/fidesplus
-          event-type: new-fides-release
           client-payload: '{"tag": "${{ github.event.release.tag_name }}", "url": "${{ github.event.release.html_url }}"}'
+          event-type: new-fides-release
+          repository: ethyca/fidesctl-plus
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+
+  fidesops-plus:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Repository Dispatch Event
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          client-payload: '{"tag": "${{ github.event.release.tag_name }}", "url": "${{ github.event.release.html_url }}"}'
+          event-type: new-fides-release
+          repository: ethyca/fidesops-plus
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
+## [Unreleased](https://github.com/ethyca/fides/compare/1.9.2...main)
+
+### Developer Experience
+
+* Repository dispatch events are sent to fidesctl-plus and fidesops-plus [#1263](https://github.com/ethyca/fides/pull/1263)
+
 ## [1.9.2](https://github.com/ethyca/fides/compare/1.9.2...main)
 
 ### Deprecated


### PR DESCRIPTION
Closes #1242

### Code Changes

* [x] Notify fidesctl-plus and fidesops-plus on new releases
* [x] Remove notification to fidesplus

### Steps to Confirm

* [ ] Create a new release in this repository
* [ ] Observe that issues are automatically created in the fidesctl-plus and fidesops-plus repositories

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

### Description Of Changes

Once the -plus codebases have been merged into the fidesplus repo, most (but not all) of these changes can be reverted, such that only fidesplus is notified.