### PR TITLE
Doordash (Access)

### DIFF
--- a/data/saas/config/doordash_config.yml
+++ b/data/saas/config/doordash_config.yml
@@ -1,0 +1,44 @@
+saas_config:
+  fides_key: <instance_fides_key>
+  name: Doordash SaaS Config
+  type: doordash
+  description: A sample schema representing the Doordash connector for Fidesops
+  version: 0.0.1
+
+  connector_params:
+    - name: domain
+      default_value: openapi.doordash.com
+    - name: developer_id
+      label: Developer ID
+    - name: key_id
+      label: Key ID
+    - name: signing_secret
+
+  external_references:
+    - name: doordash_delivery_id
+      label: Doordash Delivery ID
+
+  client_config:
+    protocol: https
+    host: <domain>
+    authentication:
+      strategy: doordash
+      configuration:
+        developer_id: <developer_id>
+        key_id: <key_id>
+        signing_secret: <signing_secret>
+
+  test_request:
+    method: GET
+    path: /developer/v1/businesses
+
+  endpoints:
+    - name: deliveries
+      requests:
+        read:
+          method: GET
+          path: /drive/v2/deliveries/<delivery_id>
+          param_values:
+            - name: delivery_id
+              references:
+                - doordash_delivery_id

--- a/data/saas/dataset/doordash_dataset.yml
+++ b/data/saas/dataset/doordash_dataset.yml
@@ -1,0 +1,115 @@
+dataset:
+  - fides_key: <instance_fides_key>
+    name: Doordash Dataset
+    description: A sample dataset representing the Doordash connector for Fidesops
+    collections:
+      - name: deliveries
+        fields:
+          - name: external_delivery_id
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: currency
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: delivery_status
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: fee
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: integer
+          - name: pickup_address
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: pickup_phone_number
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: pickup_instructions
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: pickup_reference_tag
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: dropoff_address
+            data_categories: [user.contact.address]
+            fidesops_meta:
+              data_type: string
+          - name: dropoff_business_name
+            data_categories: [user]
+            fidesops_meta:
+              data_type: string
+          - name: dropoff_phone_number
+            data_categories: [user.contact.phone_number]
+            fidesops_meta:
+              data_type: string
+          - name: dropoff_instructions
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: dropoff_contact_given_name
+            data_categories: [user.name]
+            fidesops_meta:
+              data_type: string
+          - name: dropoff_contact_family_name
+            data_categories: [user.name]
+            fidesops_meta:
+              data_type: string
+          - name: dropoff_contact_send_notifications
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: boolean
+          - name: order_value
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: integer
+          - name: cancellation_reason
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: updated_at
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: pickup_time_estimated
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: dropoff_time_estimated
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: support_reference
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: tracking_url
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: contactless_dropoff
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: boolean
+          - name: action_if_undeliverable
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: string
+          - name: tip
+            data_categories: [system.operations]
+            fidesops_meta:
+              data_type: integer
+          - name: order_contains
+            fidesops_meta:
+              data_type: object
+            fields:
+              - name: alcohol
+                data_categories: [system.operations]
+                fidesops_meta:
+                  data_type: boolean

--- a/data/saas/saas_connector_registry.toml
+++ b/data/saas/saas_connector_registry.toml
@@ -16,6 +16,12 @@ dataset = "data/saas/dataset/datadog_dataset.yml"
 icon = "data/saas/icon/default.svg"
 human_readable = "Datadog"
 
+[doordash]
+config = "data/saas/config/doordash_config.yml"
+dataset = "data/saas/dataset/doordash_dataset.yml"
+icon = "data/saas/icon/default.svg"
+human_readable = "Doordash"
+
 [firebase_auth]
 config = "data/saas/config/firebase_auth_config.yml"
 dataset = "data/saas/dataset/firebase_auth_dataset.yml"

--- a/noxfiles/ci_nox.py
+++ b/noxfiles/ci_nox.py
@@ -243,16 +243,14 @@ def pytest_ops(session: nox.Session, mark: str) -> None:
         )
         session.run(*run_command, external=True)
     elif mark == "saas":
-        """
-        This test runs an additional integration Postgres database.
-        Some connectors cannot be traversed with the standard email
-        identity and require another dataset to provide a starting value.
-
-                ┌────────┐                 ┌────────┐
-        email──►│postgres├──►delivery_id──►│doordash│
-                └────────┘                 └────────┘
-
-        """
+        # This test runs an additional integration Postgres database.
+        # Some connectors cannot be traversed with the standard email
+        # identity and require another dataset to provide a starting value.
+        #
+        #         ┌────────┐                 ┌────────┐
+        # email──►│postgres├──►delivery_id──►│doordash│
+        #         └────────┘                 └────────┘
+        #
         session.run(*START_APP_WITH_EXTERNAL_POSTGRES, external=True)
         run_command = (
             "docker-compose",

--- a/noxfiles/ci_nox.py
+++ b/noxfiles/ci_nox.py
@@ -243,6 +243,16 @@ def pytest_ops(session: nox.Session, mark: str) -> None:
         )
         session.run(*run_command, external=True)
     elif mark == "saas":
+        """
+        This test runs an additional integration Postgres database.
+        Some connectors cannot be traversed with the standard email
+        identity and require another dataset to provide a starting value.
+
+                ┌────────┐                 ┌────────┐
+        email──►│postgres├──►delivery_id──►│doordash│
+                └────────┘                 └────────┘
+
+        """
         session.run(*START_APP_WITH_EXTERNAL_POSTGRES, external=True)
         run_command = (
             "docker-compose",

--- a/noxfiles/ci_nox.py
+++ b/noxfiles/ci_nox.py
@@ -10,6 +10,7 @@ from constants_nox import (
     RUN,
     RUN_NO_DEPS,
     START_APP,
+    START_APP_WITH_EXTERNAL_POSTGRES,
     WITH_TEST_CONFIG,
 )
 from run_infrastructure import OPS_TEST_DIR, run_infrastructure
@@ -242,7 +243,7 @@ def pytest_ops(session: nox.Session, mark: str) -> None:
         )
         session.run(*run_command, external=True)
     elif mark == "saas":
-        session.run(*START_APP, external=True)
+        session.run(*START_APP_WITH_EXTERNAL_POSTGRES, external=True)
         run_command = (
             "docker-compose",
             "run",

--- a/noxfiles/constants_nox.py
+++ b/noxfiles/constants_nox.py
@@ -26,6 +26,7 @@ COMPOSE_SERVICE_NAME = "fides"
 # Files
 COMPOSE_FILE = "docker-compose.yml"
 INTEGRATION_COMPOSE_FILE = "docker-compose.integration-tests.yml"
+INTEGRATION_POSTGRES_COMPOSE_FILE = "docker/docker-compose.integration-postgres.yml"
 
 # Image Names & Tags
 REGISTRY = "ethyca"
@@ -79,4 +80,16 @@ START_APP_EXTERNAL = (
     "-d",
     IMAGE_NAME,
     COMPOSE_SERVICE_NAME,
+)
+START_APP_WITH_EXTERNAL_POSTGRES = (
+    "docker",
+    "compose",
+    "-f",
+    COMPOSE_FILE,
+    "-f",
+    INTEGRATION_POSTGRES_COMPOSE_FILE,
+    "up",
+    "--wait",
+    "fides",
+    "postgres_example",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,7 @@ markers = [
     "integration_stripe",
     "integration_hubspot",
     "integration_datadog",
+    "integration_doordash",
     "integration_segment",
     "integration_sendgrid",
     "integration_auth0",

--- a/src/fides/api/ops/service/saas_request/__init__.py
+++ b/src/fides/api/ops/service/saas_request/__init__.py
@@ -1,3 +1,4 @@
 from fides.api.ops.service.saas_request.override_implementations import (
+    authentication_strategy_doordash,
     mailchimp_request_overrides,
 )

--- a/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_doordash.py
+++ b/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_doordash.py
@@ -53,7 +53,7 @@ class DoordashAuthenticationStrategy(AuthenticationStrategy):
                 "iat": str(math.floor(time.time())),
             },
             jwt.utils.base64url_decode(
-                assign_placeholders(self.signing_secret, secrets)
+                assign_placeholders(self.signing_secret, secrets)  # type: ignore
             ),
             algorithm="HS256",
             headers={"dd-ver": "DD-JWT-V1"},

--- a/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_doordash.py
+++ b/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_doordash.py
@@ -1,0 +1,63 @@
+import math
+import time
+
+import jwt.utils
+from requests import PreparedRequest
+
+from fides.api.ops.models.connectionconfig import ConnectionConfig
+from fides.api.ops.schemas.saas.strategy_configuration import StrategyConfiguration
+from fides.api.ops.service.authentication.authentication_strategy import (
+    AuthenticationStrategy,
+)
+from fides.api.ops.util.saas_util import assign_placeholders
+
+
+class DoordashAuthenticationConfiguration(StrategyConfiguration):
+    """
+    Parameters to generate a Doordash JWT token
+    """
+
+    developer_id: str
+    key_id: str
+    signing_secret: str
+
+
+class DoordashAuthenticationStrategy(AuthenticationStrategy):
+    """
+    Adds a Doordash JWT as bearer auth to the request
+    """
+
+    name = "doordash"
+    configuration_model = DoordashAuthenticationConfiguration
+
+    def __init__(self, configuration: DoordashAuthenticationConfiguration):
+        self.developer_id = configuration.developer_id
+        self.key_id = configuration.key_id
+        self.signing_secret = configuration.signing_secret
+
+    def add_authentication(
+        self, request: PreparedRequest, connection_config: ConnectionConfig
+    ) -> PreparedRequest:
+        """
+        Generate a Doordash JWT and add it as bearer auth
+        """
+
+        secrets = connection_config.secrets
+
+        token = jwt.encode(
+            {
+                "aud": "doordash",
+                "iss": assign_placeholders(self.developer_id, secrets),
+                "kid": assign_placeholders(self.key_id, secrets),
+                "exp": str(math.floor(time.time() + 60)),
+                "iat": str(math.floor(time.time())),
+            },
+            jwt.utils.base64url_decode(
+                assign_placeholders(self.signing_secret, secrets)
+            ),
+            algorithm="HS256",
+            headers={"dd-ver": "DD-JWT-V1"},
+        )
+
+        request.headers["Authorization"] = f"Bearer {token}"
+        return request

--- a/tests/ops/conftest.py
+++ b/tests/ops/conftest.py
@@ -44,6 +44,7 @@ from .fixtures.saas.auth0_fixtures import *
 from .fixtures.saas.braze_fixtures import *
 from .fixtures.saas.connection_template_fixtures import *
 from .fixtures.saas.datadog_fixtures import *
+from .fixtures.saas.doordash_fixtures import *
 from .fixtures.saas.hubspot_fixtures import *
 from .fixtures.saas.mailchimp_fixtures import *
 from .fixtures.saas.outreach_fixtures import *

--- a/tests/ops/fixtures/saas/doordash_fixtures.py
+++ b/tests/ops/fixtures/saas/doordash_fixtures.py
@@ -1,0 +1,181 @@
+from typing import Any, Dict, Generator
+
+import pydash
+import pytest
+from fideslib.cryptography import cryptographic_util
+from fideslib.db import session
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
+from sqlalchemy_utils.functions import create_database, database_exists, drop_database
+
+from fides.api.ops.models.connectionconfig import (
+    AccessLevel,
+    ConnectionConfig,
+    ConnectionType,
+)
+from fides.api.ops.models.datasetconfig import DatasetConfig
+from fides.api.ops.util.saas_util import (
+    load_config_with_replacement,
+    load_dataset_with_replacement,
+)
+from tests.ops.test_helpers.vault_client import get_secrets
+
+from ..application_fixtures import load_dataset
+
+secrets = get_secrets("doordash")
+
+
+@pytest.fixture(scope="function")
+def doordash_secrets(saas_config):
+    return {
+        "domain": pydash.get(saas_config, "doordash.domain") or secrets["domain"],
+        "developer_id": pydash.get(saas_config, "doordash.developer_id")
+        or secrets["developer_id"],
+        "key_id": pydash.get(saas_config, "doordash.key_id") or secrets["key_id"],
+        "signing_secret": pydash.get(saas_config, "doordash.signing_secret")
+        or secrets["signing_secret"],
+        "doordash_delivery_id": {
+            "dataset": "doordash_postgres",
+            "field": "doordash_deliveries.delivery_id",
+            "direction": "from",
+        },
+    }
+
+
+@pytest.fixture(scope="function")
+def doordash_identity_email(saas_config):
+    return (
+        pydash.get(saas_config, "doordash.identity_email") or secrets["identity_email"]
+    )
+
+
+@pytest.fixture(scope="session")
+def doordash_erasure_identity_email():
+    return f"{cryptographic_util.generate_secure_random_string(13)}@email.com"
+
+
+@pytest.fixture
+def doordash_config() -> Dict[str, Any]:
+    return load_config_with_replacement(
+        "data/saas/config/doordash_config.yml",
+        "<instance_fides_key>",
+        "doordash_instance",
+    )
+
+
+@pytest.fixture
+def doordash_dataset() -> Dict[str, Any]:
+    return load_dataset_with_replacement(
+        "data/saas/dataset/doordash_dataset.yml",
+        "<instance_fides_key>",
+        "doordash_instance",
+    )[0]
+
+
+@pytest.fixture(scope="function")
+def doordash_connection_config(
+    db: session, doordash_config, doordash_secrets
+) -> Generator:
+    fides_key = doordash_config["fides_key"]
+    connection_config = ConnectionConfig.create(
+        db=db,
+        data={
+            "key": fides_key,
+            "name": fides_key,
+            "connection_type": ConnectionType.saas,
+            "access": AccessLevel.write,
+            "secrets": doordash_secrets,
+            "saas_config": doordash_config,
+        },
+    )
+    yield connection_config
+    connection_config.delete(db)
+
+
+@pytest.fixture
+def doordash_dataset_config(
+    db: Session,
+    doordash_connection_config: ConnectionConfig,
+    doordash_dataset: Dict[str, Any],
+) -> Generator:
+    fides_key = doordash_dataset["fides_key"]
+    doordash_connection_config.name = fides_key
+    doordash_connection_config.key = fides_key
+    doordash_connection_config.save(db=db)
+    dataset = DatasetConfig.create(
+        db=db,
+        data={
+            "connection_config_id": doordash_connection_config.id,
+            "fides_key": fides_key,
+            "dataset": doordash_dataset,
+        },
+    )
+    yield dataset
+    dataset.delete(db=db)
+
+
+@pytest.fixture()
+def doordash_postgres_dataset() -> Dict[str, Any]:
+    return {
+        "fides_key": "doordash_postgres",
+        "name": "Doordash Postgres",
+        "description": "Lookup for Doordash delivery IDs",
+        "collections": [
+            {
+                "name": "doordash_deliveries",
+                "fields": [
+                    {
+                        "name": "email",
+                        "data_categories": ["user.contact.email"],
+                        "fidesops_meta": {"data_type": "string", "identity": "email"},
+                    },
+                    {
+                        "name": "delivery_id",
+                        "fidesops_meta": {"data_type": "string"},
+                    },
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def doordash_postgres_dataset_config(
+    connection_config: ConnectionConfig,
+    doordash_postgres_dataset: Dict[str, Any],
+    db: Session,
+) -> Generator:
+    fides_key = doordash_postgres_dataset["fides_key"]
+    connection_config.name = fides_key
+    connection_config.key = fides_key
+    connection_config.save(db=db)
+    dataset = DatasetConfig.create(
+        db=db,
+        data={
+            "connection_config_id": connection_config.id,
+            "fides_key": fides_key,
+            "dataset": doordash_postgres_dataset,
+        },
+    )
+    yield dataset
+    dataset.delete(db=db)
+
+
+@pytest.fixture(scope="function")
+def doordash_postgres_db(postgres_integration_session):
+    if database_exists(postgres_integration_session.bind.url):
+        drop_database(postgres_integration_session.bind.url)
+    create_database(postgres_integration_session.bind.url)
+    with open(
+        "./tests/ops/fixtures/saas/external_datasets/doordash.sql", "r"
+    ) as query_file:
+        lines = query_file.read().splitlines()
+        filtered = [line for line in lines if not line.startswith("--")]
+        queries = " ".join(filtered).split(";")
+        [
+            postgres_integration_session.execute(f"{text(query.strip())};")
+            for query in queries
+            if query
+        ]
+    yield postgres_integration_session
+    drop_database(postgres_integration_session.bind.url)

--- a/tests/ops/fixtures/saas/external_datasets/doordash.sql
+++ b/tests/ops/fixtures/saas/external_datasets/doordash.sql
@@ -1,0 +1,7 @@
+CREATE TABLE public.doordash_deliveries (
+    email CHARACTER VARYING(100) PRIMARY KEY,
+    delivery_id CHARACTER VARYING(100)
+);
+
+INSERT INTO public.doordash_deliveries VALUES
+('test@example.com', 'D-12345')

--- a/tests/ops/integration_tests/saas/test_doordash_task.py
+++ b/tests/ops/integration_tests/saas/test_doordash_task.py
@@ -1,0 +1,90 @@
+import logging
+import random
+
+import pytest
+
+from fides.api.ops.graph.graph import DatasetGraph
+from fides.api.ops.models.privacy_request import PrivacyRequest
+from fides.api.ops.schemas.redis_cache import Identity
+from fides.api.ops.service.connectors import get_connector
+from fides.api.ops.task import graph_task
+from tests.ops.graph.graph_test_util import assert_rows_match
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.integration_saas
+@pytest.mark.integration_doordash
+def test_doordash_connection_test(doordash_connection_config) -> None:
+    get_connector(doordash_connection_config).test_connection()
+
+
+@pytest.mark.integration_saas
+@pytest.mark.integration_doordash
+@pytest.mark.asyncio
+async def test_doordash_access_request_task(
+    db,
+    policy,
+    doordash_connection_config,
+    doordash_dataset_config,
+    doordash_identity_email,
+    connection_config,
+    doordash_postgres_dataset_config,
+    doordash_postgres_db,
+) -> None:
+    """Full access request based on the Doordash SaaS config"""
+
+    privacy_request = PrivacyRequest(
+        id=f"test_doordash_access_request_task_{random.randint(0, 1000)}"
+    )
+    identity_attribute = "email"
+    identity_value = doordash_identity_email
+    identity_kwargs = {identity_attribute: identity_value}
+    identity = Identity(**identity_kwargs)
+    privacy_request.cache_identity(identity)
+
+    dataset_name = doordash_connection_config.get_saas_config().fides_key
+    merged_graph = doordash_dataset_config.get_graph()
+    graph = DatasetGraph(*[merged_graph, doordash_postgres_dataset_config.get_graph()])
+
+    v = await graph_task.run_access_request(
+        privacy_request,
+        policy,
+        graph,
+        [doordash_connection_config, connection_config],
+        {"email": doordash_identity_email},
+        db,
+    )
+
+    assert_rows_match(
+        v[f"{dataset_name}:deliveries"],
+        min_size=1,
+        keys=[
+            "external_delivery_id",
+            "currency",
+            "delivery_status",
+            "fee",
+            "pickup_address",
+            "pickup_phone_number",
+            "pickup_instructions",
+            "pickup_reference_tag",
+            "dropoff_address",
+            "dropoff_business_name",
+            "dropoff_phone_number",
+            "dropoff_instructions",
+            "dropoff_contact_given_name",
+            "dropoff_contact_family_name",
+            "dropoff_contact_send_notifications",
+            "order_value",
+            "cancellation_reason",
+            "updated_at",
+            "pickup_time_estimated",
+            "dropoff_time_estimated",
+            "support_reference",
+            "tracking_url",
+            "contactless_dropoff",
+            "action_if_undeliverable",
+            "tip",
+            "order_contains",
+        ],
+    )

--- a/tests/ops/integration_tests/setup_scripts/timescale_setup.py
+++ b/tests/ops/integration_tests/setup_scripts/timescale_setup.py
@@ -1,10 +1,8 @@
 from uuid import uuid4
 
 import pydash
-import sqlalchemy
 from fideslib.core.config import load_toml
 from fideslib.db.session import get_db_engine, get_db_session
-from sqlalchemy_utils.functions import create_database, database_exists, drop_database
 
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
@@ -13,6 +11,7 @@ from fides.api.ops.models.connectionconfig import (
 )
 from fides.api.ops.service.connectors import TimescaleConnector
 from fides.ctl.core.config import get_config
+from tests.ops.test_helpers.db_utils import seed_postgres_data
 
 CONFIG = get_config()
 integration_config = load_toml(["tests/ops/integration_test_config.toml"])
@@ -55,19 +54,7 @@ def setup():
     )
     session = SessionLocal()
 
-    if database_exists(session.bind.url):
-        drop_database(session.bind.url)
-    create_database(session.bind.url)
-
-    with open("./docker/sample_data/timescale_example.sql", "r") as query_file:
-        lines = query_file.read().splitlines()
-        filtered = [line for line in lines if not line.startswith("--")]
-        queries = " ".join(filtered).split(";")
-        [
-            session.execute(f"{sqlalchemy.text(query.strip())};")
-            for query in queries
-            if query
-        ]
+    seed_postgres_data(session.bind.url, "./docker/sample_data/timescale_example.sql")
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_helpers/db_utils.py
+++ b/tests/ops/test_helpers/db_utils.py
@@ -1,0 +1,28 @@
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+from sqlalchemy_utils import create_database, database_exists, drop_database
+
+
+def seed_postgres_data(db: Session, query_file_path: str) -> Session:
+    """
+    :param db: SQLAlchemy session for the Postgres DB
+    :param query_file_path: file path pointing to the `.sql` file
+     that contains the query to seed the data in the DB. e.g.,
+     `./docker/sample_data/postgres_example.sql`
+
+    Using the provided sesion, creates the database, dropping it if it
+    already existed. Seeds the created database using the query found
+    in the  relative path provided. Some processing is done on the query
+    text so that it can be executed properly.
+    """
+    if database_exists(db.bind.url):
+        # Postgres cannot drop databases from within a transaction block, so
+        # we should drop the DB this way instead
+        drop_database(db.bind.url)
+    create_database(db.bind.url)
+    with open(query_file_path, "r") as query_file:
+        lines = query_file.read().splitlines()
+        filtered = [line for line in lines if not line.startswith("--")]
+        queries = " ".join(filtered).split(";")
+        [db.execute(f"{text(query.strip())};") for query in queries if query]
+    return db


### PR DESCRIPTION
# Purpose
Adds an example config and dataset to configure a SaaS connection to the Doordash API.

- The `delivery` entities are retrieved by `delivery_id` which are provided to the Doordash connector via the `doordash_delivery_id` external dataset reference.

**Note:** The Doordash API does not support updates or erasures for completed deliveries. Erasures must be configured separately via a maildrop connector.

# Changes

### Doordash Connector
- Adds SaaS config and Dataset
- Adds tests to verify access requests return the expected number of results and fields

### Nox
- Updates the `pytest_ops(saas)` to include an external Postgres database to test the external dataset references.

# Checklist

- [x] Good unit test/integration test coverage
- [ ] The `Run Unsafe PR Checks` label has been applied, and checks have passed, if this PR touches any external services

# Ticket

Fixes #1301
 
