### PR TITLE
1276 update get connections API to support specifying saas types

### DIFF
--- a/src/fides/api/ops/api/v1/endpoints/connection_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/connection_endpoints.py
@@ -110,7 +110,8 @@ def get_connections(
 
     Connection_type supports "or" filtering:
     ?connection_type=postgres&connection_type=mongo will be translated
-    into an "or" query.
+    into an "or" query. This parameter can also be used to filter by specific
+    SaaS connector types.
     """
     logger.info(
         "Finding connection configurations with pagination params %s and search query: '%s'.",

--- a/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
@@ -798,7 +798,40 @@ class TestGetConnections:
         assert ordered[0].key == items[0]["key"]
         assert ordered[1].key == items[1]["key"]
 
+        auth_header = generate_auth_header(scopes=[CONNECTION_READ])
+        resp = api_client.get(url + "?connection_type=POSTGRES", headers=auth_header)
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 2
+
+        ordered = (
+            db.query(ConnectionConfig)
+            .filter(
+                ConnectionConfig.key.in_(
+                    [read_connection_config.key, connection_config.key]
+                )
+            )
+            .order_by(ConnectionConfig.name.asc())
+            .all()
+        )
+        assert len(ordered) == 2
+        assert ordered[0].key == items[0]["key"]
+        assert ordered[1].key == items[1]["key"]
+
         resp = api_client.get(url + "?connection_type=custom", headers=auth_header)
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 1
+        ordered = (
+            db.query(ConnectionConfig)
+            .filter(ConnectionConfig.key == saas_example_connection_config.key)
+            .order_by(ConnectionConfig.name.asc())
+            .all()
+        )
+        assert len(ordered) == 1
+        assert ordered[0].key == items[0]["key"]
+
+        resp = api_client.get(url + "?connection_type=CUSTOM", headers=auth_header)
         assert resp.status_code == 200
         items = resp.json()["items"]
         assert len(items) == 1

--- a/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
@@ -767,6 +767,7 @@ class TestGetConnections:
         assert ordered[0].key == items[0]["key"]
         assert ordered[1].key == items[1]["key"]
 
+    @pytest.mark.unit_saas
     def test_filter_connection_type(
         self,
         db,
@@ -774,7 +775,7 @@ class TestGetConnections:
         read_connection_config,
         api_client,
         generate_auth_header,
-        stripe_connection_config,
+        saas_example_connection_config,
         url,
     ):
         auth_header = generate_auth_header(scopes=[CONNECTION_READ])
@@ -797,13 +798,13 @@ class TestGetConnections:
         assert ordered[0].key == items[0]["key"]
         assert ordered[1].key == items[1]["key"]
 
-        resp = api_client.get(url + "?connection_type=stripe", headers=auth_header)
+        resp = api_client.get(url + "?connection_type=custom", headers=auth_header)
         assert resp.status_code == 200
         items = resp.json()["items"]
         assert len(items) == 1
         ordered = (
             db.query(ConnectionConfig)
-            .filter(ConnectionConfig.key == stripe_connection_config.key)
+            .filter(ConnectionConfig.key == saas_example_connection_config.key)
             .order_by(ConnectionConfig.name.asc())
             .all()
         )
@@ -811,7 +812,7 @@ class TestGetConnections:
         assert ordered[0].key == items[0]["key"]
 
         resp = api_client.get(
-            url + "?connection_type=stripe&connection_type=postgres",
+            url + "?connection_type=custom&connection_type=postgres",
             headers=auth_header,
         )
         assert resp.status_code == 200
@@ -824,7 +825,7 @@ class TestGetConnections:
                     [
                         read_connection_config.key,
                         connection_config.key,
-                        stripe_connection_config.key,
+                        saas_example_connection_config.key,
                     ]
                 )
             )


### PR DESCRIPTION
Closes #1276 

### Code Changes

- accept basic `str` inputs as well as `ConnectionType` enum for `connection_type` query param
- perform filter on `ConnectionConfig.saas_config.type` field for values that are not `ConnectionType`s

### Steps to Confirm

* automated tests cover new functionality
* or, to test manually, spin up `fides` on this branch, make a new connector of type `sentry` (for exmaple) using the UI, then the following request should give you filtered results, i.e. only the one connector you've created: `/api/v1/connection?connection_type=sentry`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
