### PR TITLE
[1220] privacy-center: Set cookie with mapping of data use to consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The types of changes are:
 
 ### Added
 * Allow delete-only SaaS connector endpoints [#1200](https://github.com/ethyca/fides/pull/1200)
+* Privacy center consent choices store a browser cookie. [#1364](https://github.com/ethyca/fides/pull/1364)
+    * The format is generic. A reasonable set of defaults will be added later: (#1444)[https://github.com/ethyca/fides/issues/1444]
+    * The cookie name defaults to `fides_consent` but can be configured under `config.json > consent > cookieName`.
+    * Each consent option can provide an array of `cookieKeys`.
 
 ### Developer Experience
 

--- a/clients/privacy-center/__tests__/features/consent/helpers.test.ts
+++ b/clients/privacy-center/__tests__/features/consent/helpers.test.ts
@@ -1,0 +1,107 @@
+import { makeConsentItems } from "~/features/consent/helpers";
+import { ApiUserConsents } from "~/features/consent/types";
+
+describe("makeConsentItems", () => {
+  const consentOptions = [
+    {
+      description: "Data shared with third parties",
+      fidesDataUseKey: "third_party_sharing",
+      highlight: true,
+      name: "Third Party Sharing",
+      url: "https://example.com/privacy#data-sales",
+    },
+    {
+      description: "Configured description",
+      fidesDataUseKey: "custom.use",
+      highlight: true,
+      name: "Custom",
+      url: "https://example.com/privacy#custom",
+    },
+    {
+      default: true,
+      description: "Default opted in",
+      fidesDataUseKey: "provide.service",
+      highlight: false,
+      name: "Provide a service",
+      url: "https://example.com/privacy#provide-service",
+    },
+  ];
+
+  it("Matches config options with API response data", () => {
+    const data: ApiUserConsents = {
+      consent: [
+        {
+          data_use: "third_party_sharing",
+          opt_in: false,
+        },
+        {
+          data_use: "custom.use",
+          data_use_description: "Custom API description",
+          opt_in: true,
+        },
+      ],
+    };
+
+    const items = makeConsentItems(data, consentOptions);
+
+    expect(items).toEqual([
+      {
+        consentValue: false,
+        defaultValue: false,
+        description: "Data shared with third parties",
+        fidesDataUseKey: "third_party_sharing",
+        highlight: true,
+        name: "Third Party Sharing",
+        url: "https://example.com/privacy#data-sales",
+      },
+      {
+        consentValue: true,
+        defaultValue: false,
+        description: "Custom API description",
+        fidesDataUseKey: "custom.use",
+        highlight: true,
+        name: "Custom",
+        url: "https://example.com/privacy#custom",
+      },
+      {
+        defaultValue: true,
+        description: "Default opted in",
+        fidesDataUseKey: "provide.service",
+        highlight: false,
+        name: "Provide a service",
+        url: "https://example.com/privacy#provide-service",
+      },
+    ]);
+  });
+
+  it("Creates default items when there is no API response data", () => {
+    const items = makeConsentItems({}, consentOptions);
+
+    expect(items).toEqual([
+      {
+        defaultValue: false,
+        description: "Data shared with third parties",
+        fidesDataUseKey: "third_party_sharing",
+        highlight: true,
+        name: "Third Party Sharing",
+        url: "https://example.com/privacy#data-sales",
+      },
+      {
+        defaultValue: false,
+        description: "Configured description",
+        fidesDataUseKey: "custom.use",
+        highlight: true,
+        name: "Custom",
+        url: "https://example.com/privacy#custom",
+      },
+      {
+        defaultValue: true,
+        description: "Default opted in",
+        fidesDataUseKey: "provide.service",
+        highlight: false,
+        name: "Provide a service",
+        url: "https://example.com/privacy#provide-service",
+      },
+    ]);
+  });
+});

--- a/clients/privacy-center/__tests__/features/consent/helpers.test.ts
+++ b/clients/privacy-center/__tests__/features/consent/helpers.test.ts
@@ -1,5 +1,8 @@
-import { makeConsentItems } from "~/features/consent/helpers";
-import { ApiUserConsents } from "~/features/consent/types";
+import {
+  makeConsentItems,
+  makeDataUseConsent,
+} from "~/features/consent/helpers";
+import { ApiUserConsents, ConsentItem } from "~/features/consent/types";
 
 describe("makeConsentItems", () => {
   const consentOptions = [
@@ -103,5 +106,48 @@ describe("makeConsentItems", () => {
         url: "https://example.com/privacy#provide-service",
       },
     ]);
+  });
+});
+
+describe("makeDataUseConsent", () => {
+  const irrelevantProps = {
+    description: "",
+    highlight: false,
+    name: "",
+    url: "https://example.com/privacy#data-sales",
+  };
+  const consentItems: ConsentItem[] = [
+    {
+      consentValue: false,
+      defaultValue: false,
+      fidesDataUseKey: "third_party_sharing",
+      ...irrelevantProps,
+    },
+    {
+      consentValue: true,
+      defaultValue: false,
+      fidesDataUseKey: "custom.use",
+      ...irrelevantProps,
+    },
+    {
+      consentValue: false,
+      defaultValue: true,
+      fidesDataUseKey: "not.default",
+      ...irrelevantProps,
+    },
+    {
+      defaultValue: true,
+      fidesDataUseKey: "provide.service",
+      ...irrelevantProps,
+    },
+  ];
+
+  it("Merges the items into a map from Data Use to consent boolean", () => {
+    expect(makeDataUseConsent(consentItems)).toEqual({
+      third_party_sharing: false,
+      "custom.use": true,
+      "not.default": false,
+      "provide.service": true,
+    });
   });
 });

--- a/clients/privacy-center/config/config.json
+++ b/clients/privacy-center/config/config.json
@@ -30,7 +30,7 @@
   ],
   "includeConsent": true,
   "consent": {
-    "cookieName": "ethyca_consent",
+    "cookieName": "fides_consent",
     "consentOptions": [
       {
         "fidesDataUseKey": "advertising",
@@ -38,7 +38,8 @@
         "description": "We may use some of your personal information for advertising performance analysis and audience modeling for ongoing advertising which may be interpreted as 'Data Sharing' under some regulations.",
         "url": "https://example.com/privacy#advertising",
         "default": true,
-        "highlight": false
+        "highlight": false,
+        "cookieKeys": ["data_sales"]
       },
       {
         "fidesDataUseKey": "improve",
@@ -46,7 +47,32 @@
         "description": "We may use some of your personal information to collect analytics about how you use our products & services, in order to improve our service.",
         "url": "https://example.com/privacy#data-sales",
         "default": true,
-        "highlight": false
+        "highlight": false,
+        "cookieKeys": ["data_sales"]
+      },
+      {
+        "name": "Analytics",
+        "fidesDataUseKey": "third_party_sharing",
+        "description": "...",
+        "url": "https://example.com/privacy#analytics",
+        "cookieKeys": ["data_sharing"]
+      },
+      {
+        "name": "Personalize",
+        "fidesDataUseKey": "personalize",
+        "default": true,
+        "url": "https://example.com/privacy#personalize",
+        "description": "...",
+        "cookieKeys": ["functional"]
+      },
+      {
+        "name": "Essential",
+        "fidesDataUseKey": "provide.service",
+        "default": true,
+        "url": "https://example.com/privacy#essential",
+        "highlight": true,
+        "description": "...",
+        "cookieKeys": ["essential"]
       }
     ]
   }

--- a/clients/privacy-center/config/config.json
+++ b/clients/privacy-center/config/config.json
@@ -30,6 +30,7 @@
   ],
   "includeConsent": true,
   "consent": {
+    "cookieName": "ethyca_consent",
     "consentOptions": [
       {
         "fidesDataUseKey": "advertising",

--- a/clients/privacy-center/config/types.ts
+++ b/clients/privacy-center/config/types.ts
@@ -1,4 +1,13 @@
 import config from "./config.json";
 
 export type Config = typeof config;
-export type ConfigConsentOption = Config["consent"]["consentOptions"][number];
+
+export type ConfigConsentOption = {
+  cookieKeys: string[];
+  default?: boolean;
+  description: string;
+  fidesDataUseKey: string;
+  highlight?: boolean;
+  name: string;
+  url: string;
+};

--- a/clients/privacy-center/config/types.ts
+++ b/clients/privacy-center/config/types.ts
@@ -1,0 +1,4 @@
+import config from "./config.json";
+
+export type Config = typeof config;
+export type ConfigConsentOption = Config["consent"]["consentOptions"][number];

--- a/clients/privacy-center/features/consent/cookie.ts
+++ b/clients/privacy-center/features/consent/cookie.ts
@@ -1,20 +1,34 @@
-import { getCookie, setCookie } from "typescript-cookie";
+import { getCookie, setCookie, Types } from "typescript-cookie";
 
 import config from "~/config/config.json";
 
-import { DataUseConsent } from "./types";
+import { CookieKeyConsent } from "./types";
 
 export const CONSENT_COOKIE_NAME =
-  config.consent?.cookieName ?? "ethyca_consent";
+  config.consent?.cookieName ?? "fides_consent";
 
 export const CONSENT_COOKIE_MAX_AGE_DAYS = 365;
 
-export const getConsentCookie = (): DataUseConsent => {
+/**
+ * The typescript-cookie default codec has a more conservative strategy in order to
+ * comply with the exact requirements of RFC 6265. For ease of use in external pages,
+ * we instead use encode/decodeURIComponent which are available in every browser.
+ *
+ * See: https://github.com/carhartl/typescript-cookie#encoding
+ */
+const CODEC: Types.CookieCodecConfig<string, string> = {
+  decodeName: decodeURIComponent,
+  decodeValue: decodeURIComponent,
+  encodeName: encodeURIComponent,
+  encodeValue: encodeURIComponent,
+};
+
+export const getConsentCookie = (): CookieKeyConsent => {
   if (typeof document === "undefined") {
     return {};
   }
 
-  const cookie = getCookie(CONSENT_COOKIE_NAME);
+  const cookie = getCookie(CONSENT_COOKIE_NAME, CODEC);
   if (!cookie) {
     return {};
   }
@@ -28,14 +42,19 @@ export const getConsentCookie = (): DataUseConsent => {
   }
 };
 
-export const setConsentCookie = (dataUseConsent: DataUseConsent) => {
+export const setConsentCookie = (cookieKeyConsent: CookieKeyConsent) => {
   if (typeof document === "undefined") {
     return;
   }
 
-  setCookie(CONSENT_COOKIE_NAME, JSON.stringify(dataUseConsent), {
-    // An explicit domain allows subdomains to access the cookie.
-    domain: window.location.hostname,
-    expires: CONSENT_COOKIE_MAX_AGE_DAYS,
-  });
+  setCookie(
+    CONSENT_COOKIE_NAME,
+    JSON.stringify(cookieKeyConsent),
+    {
+      // An explicit domain allows subdomains to access the cookie.
+      domain: window.location.hostname,
+      expires: CONSENT_COOKIE_MAX_AGE_DAYS,
+    },
+    CODEC
+  );
 };

--- a/clients/privacy-center/features/consent/cookie.ts
+++ b/clients/privacy-center/features/consent/cookie.ts
@@ -1,0 +1,41 @@
+import { getCookie, setCookie } from "typescript-cookie";
+
+import config from "~/config/config.json";
+
+import { DataUseConsent } from "./types";
+
+export const CONSENT_COOKIE_NAME =
+  config.consent?.cookieName ?? "ethyca_consent";
+
+export const CONSENT_COOKIE_MAX_AGE_DAYS = 365;
+
+export const getConsentCookie = (): DataUseConsent => {
+  if (typeof document === "undefined") {
+    return {};
+  }
+
+  const cookie = getCookie(CONSENT_COOKIE_NAME);
+  if (!cookie) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(cookie);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("Unable to read consent cookie: invalid JSON.", err);
+    return {};
+  }
+};
+
+export const setConsentCookie = (dataUseConsent: DataUseConsent) => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  setCookie(CONSENT_COOKIE_NAME, JSON.stringify(dataUseConsent), {
+    // An explicit domain allows subdomains to access the cookie.
+    domain: window.location.hostname,
+    expires: CONSENT_COOKIE_MAX_AGE_DAYS,
+  });
+};

--- a/clients/privacy-center/features/consent/helpers.ts
+++ b/clients/privacy-center/features/consent/helpers.ts
@@ -1,6 +1,11 @@
 import { ConfigConsentOption } from "~/config/types";
 
-import { ConsentItem, ApiUserConsents, ApiUserConsent } from "./types";
+import {
+  ConsentItem,
+  ApiUserConsents,
+  ApiUserConsent,
+  DataUseConsent,
+} from "./types";
 
 export const makeConsentItems = (
   data: ApiUserConsents,
@@ -52,4 +57,15 @@ export const makeConsentItems = (
     defaultValue: option.default ? option.default : false,
   }));
   return temp;
+};
+
+export const makeDataUseConsent = (
+  consentItems: ConsentItem[]
+): DataUseConsent => {
+  const dataUseConsent: DataUseConsent = {};
+  consentItems.forEach((item) => {
+    dataUseConsent[item.fidesDataUseKey] =
+      item.consentValue ?? item.defaultValue;
+  });
+  return dataUseConsent;
 };

--- a/clients/privacy-center/features/consent/helpers.ts
+++ b/clients/privacy-center/features/consent/helpers.ts
@@ -4,13 +4,13 @@ import {
   ConsentItem,
   ApiUserConsents,
   ApiUserConsent,
-  DataUseConsent,
+  CookieKeyConsent,
 } from "./types";
 
 export const makeConsentItems = (
   data: ApiUserConsents,
   consentOptions: ConfigConsentOption[]
-) => {
+): ConsentItem[] => {
   if (data.consent) {
     const newConsentItems: ConsentItem[] = [];
     const userConsentMap: { [key: string]: ApiUserConsent } = {};
@@ -29,18 +29,20 @@ export const makeConsentItems = (
             ? currentConsent.data_use_description
             : d.description,
           fidesDataUseKey: currentConsent.data_use,
-          highlight: d.highlight,
+          highlight: d.highlight ?? false,
           name: d.name,
           url: d.url,
+          cookieKeys: d.cookieKeys ?? [],
         });
       } else {
         newConsentItems.push({
           fidesDataUseKey: d.fidesDataUseKey,
           name: d.name,
           description: d.description,
-          highlight: d.highlight,
+          highlight: d.highlight ?? false,
           url: d.url,
           defaultValue: d.default ? d.default : false,
+          cookieKeys: d.cookieKeys ?? [],
         });
       }
     });
@@ -48,24 +50,30 @@ export const makeConsentItems = (
     return newConsentItems;
   }
 
-  const temp = consentOptions.map((option) => ({
+  return consentOptions.map((option) => ({
     fidesDataUseKey: option.fidesDataUseKey,
     name: option.name,
     description: option.description,
-    highlight: option.highlight,
+    highlight: option.highlight ?? false,
     url: option.url,
     defaultValue: option.default ? option.default : false,
+    cookieKeys: option.cookieKeys ?? [],
   }));
-  return temp;
 };
 
-export const makeDataUseConsent = (
+export const makeCookieKeyConsent = (
   consentItems: ConsentItem[]
-): DataUseConsent => {
-  const dataUseConsent: DataUseConsent = {};
+): CookieKeyConsent => {
+  const cookieKeyConsent: CookieKeyConsent = {};
   consentItems.forEach((item) => {
-    dataUseConsent[item.fidesDataUseKey] =
-      item.consentValue ?? item.defaultValue;
+    const consent =
+      item.consentValue === undefined ? item.defaultValue : item.consentValue;
+
+    item.cookieKeys.forEach((cookieKey) => {
+      const previousConsent = cookieKeyConsent[cookieKey];
+      cookieKeyConsent[cookieKey] =
+        previousConsent === undefined ? consent : previousConsent && consent;
+    });
   });
-  return dataUseConsent;
+  return cookieKeyConsent;
 };

--- a/clients/privacy-center/features/consent/helpers.ts
+++ b/clients/privacy-center/features/consent/helpers.ts
@@ -1,0 +1,55 @@
+import { ConfigConsentOption } from "~/config/types";
+
+import { ConsentItem, ApiUserConsents, ApiUserConsent } from "./types";
+
+export const makeConsentItems = (
+  data: ApiUserConsents,
+  consentOptions: ConfigConsentOption[]
+) => {
+  if (data.consent) {
+    const newConsentItems: ConsentItem[] = [];
+    const userConsentMap: { [key: string]: ApiUserConsent } = {};
+    data.consent.forEach((option) => {
+      const key = option.data_use;
+      userConsentMap[key] = option;
+    });
+    consentOptions.forEach((d) => {
+      if (d.fidesDataUseKey in userConsentMap) {
+        const currentConsent = userConsentMap[d.fidesDataUseKey];
+
+        newConsentItems.push({
+          consentValue: currentConsent.opt_in,
+          defaultValue: d.default ? d.default : false,
+          description: currentConsent.data_use_description
+            ? currentConsent.data_use_description
+            : d.description,
+          fidesDataUseKey: currentConsent.data_use,
+          highlight: d.highlight,
+          name: d.name,
+          url: d.url,
+        });
+      } else {
+        newConsentItems.push({
+          fidesDataUseKey: d.fidesDataUseKey,
+          name: d.name,
+          description: d.description,
+          highlight: d.highlight,
+          url: d.url,
+          defaultValue: d.default ? d.default : false,
+        });
+      }
+    });
+
+    return newConsentItems;
+  }
+
+  const temp = consentOptions.map((option) => ({
+    fidesDataUseKey: option.fidesDataUseKey,
+    name: option.name,
+    description: option.description,
+    highlight: option.highlight,
+    url: option.url,
+    defaultValue: option.default ? option.default : false,
+  }));
+  return temp;
+};

--- a/clients/privacy-center/features/consent/types.ts
+++ b/clients/privacy-center/features/consent/types.ts
@@ -6,6 +6,7 @@ export type ConsentItem = {
   url: string;
   defaultValue: boolean;
   consentValue?: boolean;
+  cookieKeys: string[];
 };
 
 export type ApiUserConsent = {
@@ -18,6 +19,9 @@ export type ApiUserConsents = {
   consent?: ApiUserConsent[];
 };
 
-export type DataUseConsent = {
-  [dataUse: string]: boolean | undefined;
+/**
+ * A mapping from the cookie keys (defined in config.json) to the resolved consent value.
+ */
+export type CookieKeyConsent = {
+  [cookieKey: string]: boolean | undefined;
 };

--- a/clients/privacy-center/features/consent/types.ts
+++ b/clients/privacy-center/features/consent/types.ts
@@ -1,0 +1,19 @@
+export type ConsentItem = {
+  fidesDataUseKey: string;
+  name: string;
+  description: string;
+  highlight: boolean;
+  url: string;
+  defaultValue: boolean;
+  consentValue?: boolean;
+};
+
+export type ApiUserConsent = {
+  data_use: string;
+  data_use_description?: string;
+  opt_in: boolean;
+};
+
+export type ApiUserConsents = {
+  consent?: ApiUserConsent[];
+};

--- a/clients/privacy-center/features/consent/types.ts
+++ b/clients/privacy-center/features/consent/types.ts
@@ -17,3 +17,7 @@ export type ApiUserConsent = {
 export type ApiUserConsents = {
   consent?: ApiUserConsent[];
 };
+
+export type DataUseConsent = {
+  [dataUse: string]: boolean | undefined;
+};

--- a/clients/privacy-center/jest.config.js
+++ b/clients/privacy-center/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
 
     // Handle module aliases
     '^@/components/(.*)$': '<rootDir>/components/$1',
+    "^~/(.*)$": "<rootDir>/$1",
   },
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/__tests__/jest.setup.ts'],

--- a/clients/privacy-center/package-lock.json
+++ b/clients/privacy-center/package-lock.json
@@ -19,7 +19,8 @@
         "next": "12.2.5",
         "next-auth": "^4.10.3",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "typescript-cookie": "^1.0.4"
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^12.0.10",
@@ -12774,6 +12775,14 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typescript-cookie": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typescript-cookie/-/typescript-cookie-1.0.4.tgz",
+      "integrity": "sha512-vZo252VmoEleD/dbE9Wb2lMK63V3M/8aqFbp2Pdb4Oxq8YqqADJ7iMh8THZenFXN+uZJPE8RXkztEaHkOptH4w==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -22701,6 +22710,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
+    },
+    "typescript-cookie": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typescript-cookie/-/typescript-cookie-1.0.4.tgz",
+      "integrity": "sha512-vZo252VmoEleD/dbE9Wb2lMK63V3M/8aqFbp2Pdb4Oxq8YqqADJ7iMh8THZenFXN+uZJPE8RXkztEaHkOptH4w=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/clients/privacy-center/package.json
+++ b/clients/privacy-center/package.json
@@ -30,7 +30,8 @@
     "next": "12.2.5",
     "next-auth": "^4.10.3",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "typescript-cookie": "^1.0.4"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^12.0.10",

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -5,6 +5,7 @@ import { Flex, Heading, Text, Stack, Image, Button } from "@fidesui/react";
 import { useRouter } from "next/router";
 
 import { Headers } from "headers-polyfill";
+import { makeConsentItems } from "~/features/consent/helpers";
 import { ApiUserConsents, ConsentItem } from "~/features/consent/types";
 import ConsentItemCard from "../components/ConsentItemCard";
 
@@ -45,52 +46,7 @@ const Consent: NextPage = () => {
       if (!response.ok) {
         router.push("/");
       }
-      if (data.consent) {
-        const newConsentItems: ConsentItem[] = [];
-        const userConsentMap: { [key: string]: ApiUserConsent } = {};
-        data.consent.forEach((option) => {
-          const key = option.data_use as string;
-          userConsentMap[key] = option;
-        });
-        config.consent.consentOptions.forEach((d) => {
-          if (d.fidesDataUseKey in userConsentMap) {
-            const currentConsent = userConsentMap[d.fidesDataUseKey];
-
-            newConsentItems.push({
-              consentValue: currentConsent.opt_in,
-              defaultValue: d.default ? d.default : false,
-              description: currentConsent.data_use_description
-                ? currentConsent.data_use_description
-                : "",
-              fidesDataUseKey: currentConsent.data_use,
-              highlight: d.highlight,
-              name: d.name,
-              url: d.url,
-            });
-          } else {
-            newConsentItems.push({
-              fidesDataUseKey: d.fidesDataUseKey,
-              name: d.name,
-              description: d.description,
-              highlight: d.highlight,
-              url: d.url,
-              defaultValue: d.default ? d.default : false,
-            });
-          }
-        });
-
-        setConsentItems(newConsentItems);
-      } else {
-        const temp = config.consent.consentOptions.map((option) => ({
-          fidesDataUseKey: option.fidesDataUseKey,
-          name: option.name,
-          description: option.description,
-          highlight: option.highlight,
-          url: option.url,
-          defaultValue: option.default ? option.default : false,
-        }));
-        setConsentItems(temp);
-      }
+      setConsentItems(makeConsentItems(data, config.consent.consentOptions));
     };
     getUserConsents();
   }, [router, consentRequestId, verificationCode]);

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/router";
 import { Headers } from "headers-polyfill";
 import {
   makeConsentItems,
-  makeDataUseConsent,
+  makeCookieKeyConsent,
 } from "~/features/consent/helpers";
 import { setConsentCookie } from "~/features/consent/cookie";
 import { ApiUserConsents, ConsentItem } from "~/features/consent/types";
@@ -56,7 +56,7 @@ const Consent: NextPage = () => {
         config.consent.consentOptions
       );
       setConsentItems(updatedConsentItems);
-      setConsentCookie(makeDataUseConsent(updatedConsentItems));
+      setConsentCookie(makeCookieKeyConsent(updatedConsentItems));
     };
     getUserConsents();
   }, [router, consentRequestId, verificationCode]);
@@ -108,7 +108,7 @@ const Consent: NextPage = () => {
       data,
       config.consent.consentOptions
     );
-    setConsentCookie(makeDataUseConsent(updatedConsentItems));
+    setConsentCookie(makeCookieKeyConsent(updatedConsentItems));
 
     router.push("/");
     // TODO: display alert on successful patch

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -5,6 +5,7 @@ import { Flex, Heading, Text, Stack, Image, Button } from "@fidesui/react";
 import { useRouter } from "next/router";
 
 import { Headers } from "headers-polyfill";
+import { ApiUserConsents, ConsentItem } from "~/features/consent/types";
 import ConsentItemCard from "../components/ConsentItemCard";
 
 import config from "../config/config.json";
@@ -12,17 +13,6 @@ import { hostUrl } from "../constants";
 import { addCommonHeaders } from "../common/CommonHeaders";
 import { VerificationType } from "../components/modals/types";
 import { useLocalStorage } from "../common/hooks";
-import { ConsentItem } from "../types";
-
-type ApiUserConsent = {
-  data_use: string;
-  data_use_description?: string;
-  opt_in: boolean;
-};
-
-type ApiUserConcents = {
-  consent: ApiUserConsent[];
-};
 
 const Consent: NextPage = () => {
   const content: any = [];
@@ -51,7 +41,7 @@ const Consent: NextPage = () => {
           body: JSON.stringify({ code: verificationCode }),
         }
       );
-      const data = (await response.json()) as ApiUserConcents;
+      const data = (await response.json()) as ApiUserConsents;
       if (!response.ok) {
         router.push("/");
       }
@@ -145,7 +135,7 @@ const Consent: NextPage = () => {
         body: JSON.stringify(body),
       }
     );
-    (await response.json()) as ApiUserConcents;
+    (await response.json()) as ApiUserConsents;
     router.push("/");
     // TODO: display alert on successful patch
     // TODO: display error alert on failed patch

--- a/clients/privacy-center/tsconfig.json
+++ b/clients/privacy-center/tsconfig.json
@@ -13,7 +13,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
   "exclude": ["node_modules"]

--- a/clients/privacy-center/types/index.ts
+++ b/clients/privacy-center/types/index.ts
@@ -12,14 +12,3 @@ export enum PrivacyRequestStatus {
   IDENTITY_UNVERIFIED = "identity_unverified",
   REQUIRES_INPUT = "requires_input",
 }
-
-export type ConsentItem = {
-  fidesDataUseKey: string;
-  name: string;
-  description: string;
-  highlight: boolean;
-  url: string;
-  defaultValue: boolean;
-  // eslint-disable-next-line react/require-default-props
-  consentValue?: boolean;
-};


### PR DESCRIPTION
Closes #1220 

### Code Changes

- Main change: Set cookie with a configurable mapping cookie keys to consent value.
- Supporting commits:
  - TS and Jest config for absolute imports
  - Extract "Consent" types and fix spelling
  - Extract consent items logic to helper and unit test it
  - Initial implementation Data Use Fides Keys as the cookie keys.

### Steps to Confirm

* [ ] Run the privacy center on localhost
  - The cookie will only be tied to that domain
* [ ] Host the privacy center on a real domain
  - Other pages on that domain (and subdomains) should be able read the cookie as well.
  - You can find the cookie under the "Application" tab of the browser tools.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

This change assigns a browser cookie whenever the user updates their consent options. This cookie is highly configurable: 
- The cookie name defaults to `fides_consent` but can be configured under `config.json > consent > cookieName`.
- Each consent option (`config.json > consent > consentOptions`) can provide an array of `cookieKeys`:
  - The example config demonstrates several keys that might be useful when making use of this cookie.
  - Multiple Data Uses can reference the same Cookie Key. A user must consent to _all_ of those uses in order for that Cookie Key to be `true`.

The cookie is stored as a JSON-stringified, URI-encoded value. For example:

Encoded: `%7B%22data_sales%22%3Afalse%2C%22data_sharing%22%3Atrue%2C%22functional%22%3Atrue%2C%22essential%22%3Atrue%7D`
Decoded: `'{"data_sales":false,"data_sharing":true,"functional":true,"essential":true}'`
Decoded & Parsed:
```json
{
  "data_sales": false,
  "data_sharing": true,
  "functional": true,
  "essential": true
}
```

Example decode, parse, and lookup script: 
```js
var cookie = `%7B%22data_sales%22%3Afalse%2C%22data_sharing%22%3Atrue%2C%22functional%22%3Atrue%2C%22essential%22%3Atrue%7D`
if (JSON.parse(decodeURIComponent(cookie)).data_sharing) {
  console.log("Share data")
} else {
  console.log("Do not share data")
}
```
(^- This does not include the step of extracting `fides_consent` in from `document.cookie`)

Example UI:
![consnet-ui](https://user-images.githubusercontent.com/2236777/195224067-1324a7b1-9ac9-4406-aac6-7700b4031c84.png)

Result in the browser tools:
![browser-tools](https://user-images.githubusercontent.com/2236777/195224060-67eb40b3-f577-4075-8397-384dcd13a3d6.png)

<details>
<summary>Initial implementation</summary>

This is a draft that sets a cookie with an encoded JSON object that maps Dat Use Fides Keys to a boolean: whether the user has consented.

Cookie named `ethyca_consent` encoded value: `{%22third_party_sharing%22:true%2C%22provide.service%22:false}`
Decodes & parses to:
```json
{
    "third_party_sharing": true,
    "provide.service": false
}
```

Video of using the privacy center:
https://user-images.githubusercontent.com/2236777/194977133-39945e2c-a65d-4856-9c9a-8ed62f38379b.mp4
(This includes some debugging hacks to show a non-localhost domain and print the parsed cookie.)

</details>
