### PR TITLE
Include base64 encoded icon image data in connection_type response

### DIFF
--- a/src/fides/api/ops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/connection_type_endpoints.py
@@ -29,7 +29,7 @@ from fides.api.ops.service.connectors.saas.connector_registry_service import (
     registry_file,
 )
 from fides.api.ops.util.oauth_util import verify_oauth_client
-from fides.api.ops.util.saas_util import load_config
+from fides.api.ops.util.saas_util import encode_file_contents, load_config
 
 router = APIRouter(tags=["Connection Types"], prefix=V1_URL_PREFIX)
 
@@ -81,17 +81,17 @@ def get_connection_types(
         )
 
         for item in saas_types:
-            human_readable_name: str = item
             if registry.get_connector_template(item) is not None:
-                human_readable_name = registry.get_connector_template(  # type: ignore[union-attr]
+                connector_template = registry.get_connector_template(  # type: ignore[union-attr]
                     item
-                ).human_readable
+                )
 
             connection_system_types.append(
                 ConnectionSystemTypeMap(
                     identifier=item,
                     type=SystemType.saas,
-                    human_readable=human_readable_name,
+                    human_readable=connector_template.human_readable,
+                    icon=encode_file_contents(connector_template.icon),
                 )
             )
 

--- a/src/fides/api/ops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/connection_type_endpoints.py
@@ -91,7 +91,7 @@ def get_connection_types(
                     identifier=item,
                     type=SystemType.saas,
                     human_readable=connector_template.human_readable,
-                    icon=encode_file_contents(connector_template.icon),
+                    encoded_icon=encode_file_contents(connector_template.icon),
                 )
             )
 

--- a/src/fides/api/ops/schemas/connection_configuration/connection_config.py
+++ b/src/fides/api/ops/schemas/connection_configuration/connection_config.py
@@ -63,7 +63,7 @@ class ConnectionSystemTypeMap(BaseModel):
     identifier: Union[ConnectionType, str]
     type: SystemType
     human_readable: str
-    icon: Optional[str]
+    encoded_icon: Optional[str]
 
     class Config:
         """Use enum values and set orm mode"""

--- a/src/fides/api/ops/schemas/connection_configuration/connection_config.py
+++ b/src/fides/api/ops/schemas/connection_configuration/connection_config.py
@@ -63,6 +63,7 @@ class ConnectionSystemTypeMap(BaseModel):
     identifier: Union[ConnectionType, str]
     type: SystemType
     human_readable: str
+    icon: Optional[str]
 
     class Config:
         """Use enum values and set orm mode"""

--- a/src/fides/api/ops/util/saas_util.py
+++ b/src/fides/api/ops/util/saas_util.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 import yaml
 from fideslib.core.config import load_file
+from fideslib.cryptography.cryptographic_util import bytes_to_b64_str
 from multidimensional_urlencode import urlencode as multidimensional_urlencode
 
 from fides.api.ops.common_exceptions import FidesopsException
@@ -289,3 +290,12 @@ def map_param_values(
         query_params=query_params,
         body=formatted_body,
     )
+
+
+def encode_file_contents(file_path: str) -> str:
+    """
+    Read file binary and b64 encode it.
+    """
+    file_path = load_file([file_path])
+    with open(file_path, "rb") as file:
+        return bytes_to_b64_str(file.read())

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -70,7 +70,7 @@ class TestGetConnections:
             "identifier": ConnectionType.postgres.value,
             "type": SystemType.database.value,
             "human_readable": "PostgreSQL",
-            "icon": None,
+            "encoded_icon": None,
         } in data
         first_saas_type = saas_template_registry.connector_types().pop()
         first_saas_template = saas_template_registry.get_connector_template(
@@ -80,7 +80,7 @@ class TestGetConnections:
             "identifier": first_saas_type,
             "type": SystemType.saas.value,
             "human_readable": first_saas_template.human_readable,
-            "icon": encode_file_contents(first_saas_template.icon),
+            "encoded_icon": encode_file_contents(first_saas_template.icon),
         } in data
 
         assert "saas" not in [item["identifier"] for item in data]
@@ -111,7 +111,7 @@ class TestGetConnections:
                 "identifier": saas_template[0],
                 "type": SystemType.saas.value,
                 "human_readable": saas_template[1].human_readable,
-                "icon": encode_file_contents(saas_template[1].icon),
+                "encoded_icon": encode_file_contents(saas_template[1].icon),
             }
             for saas_template in expected_saas_templates
         ]
@@ -137,7 +137,7 @@ class TestGetConnections:
                 "identifier": saas_template[0],
                 "type": SystemType.saas.value,
                 "human_readable": saas_template[1].human_readable,
-                "icon": encode_file_contents(saas_template[1].icon),
+                "encoded_icon": encode_file_contents(saas_template[1].icon),
             }
             for saas_template in expected_saas_templates
         ]
@@ -153,13 +153,13 @@ class TestGetConnections:
             "identifier": ConnectionType.postgres.value,
             "type": SystemType.database.value,
             "human_readable": "PostgreSQL",
-            "icon": None,
+            "encoded_icon": None,
         } in data
         assert {
             "identifier": ConnectionType.redshift.value,
             "type": SystemType.database.value,
             "human_readable": "Amazon Redshift",
-            "icon": None,
+            "encoded_icon": None,
         } in data
         for expected_data in expected_saas_data:
             assert expected_data in data
@@ -187,7 +187,7 @@ class TestGetConnections:
                 "identifier": saas_template[0],
                 "type": SystemType.saas.value,
                 "human_readable": saas_template[1].human_readable,
-                "icon": encode_file_contents(saas_template[1].icon),
+                "encoded_icon": encode_file_contents(saas_template[1].icon),
             }
             for saas_template in expected_saas_types
         ]
@@ -202,7 +202,7 @@ class TestGetConnections:
             "identifier": ConnectionType.postgres.value,
             "type": SystemType.database.value,
             "human_readable": "PostgreSQL",
-            "icon": None,
+            "encoded_icon": None,
         } in data
 
         for expected_data in expected_saas_data:
@@ -222,7 +222,7 @@ class TestGetConnections:
                 "identifier": saas_template[0],
                 "type": SystemType.saas.value,
                 "human_readable": saas_template[1].human_readable,
-                "icon": encode_file_contents(saas_template[1].icon),
+                "encoded_icon": encode_file_contents(saas_template[1].icon),
             }
             for saas_template in expected_saas_types
         ]
@@ -236,13 +236,13 @@ class TestGetConnections:
             "identifier": ConnectionType.postgres.value,
             "type": SystemType.database.value,
             "human_readable": "PostgreSQL",
-            "icon": None,
+            "encoded_icon": None,
         } in data
         assert {
             "identifier": ConnectionType.redshift.value,
             "type": SystemType.database.value,
             "human_readable": "Amazon Redshift",
-            "icon": None,
+            "encoded_icon": None,
         } in data
 
         for expected_data in expected_saas_data:
@@ -311,7 +311,7 @@ class TestGetConnections:
                 "identifier": "manual_webhook",
                 "type": "manual",
                 "human_readable": "Manual Webhook",
-                "icon": None,
+                "encoded_icon": None,
             }
         ]
 

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -27,6 +27,7 @@ from fides.api.ops.service.connectors.saas.connector_registry_service import (
     load_registry,
     registry_file,
 )
+from fides.api.ops.util.saas_util import encode_file_contents
 
 
 class TestGetConnections:
@@ -69,14 +70,17 @@ class TestGetConnections:
             "identifier": ConnectionType.postgres.value,
             "type": SystemType.database.value,
             "human_readable": "PostgreSQL",
+            "icon": None,
         } in data
         first_saas_type = saas_template_registry.connector_types().pop()
+        first_saas_template = saas_template_registry.get_connector_template(
+            first_saas_type
+        )
         assert {
             "identifier": first_saas_type,
             "type": SystemType.saas.value,
-            "human_readable": saas_template_registry.get_connector_template(
-                first_saas_type
-            ).human_readable,
+            "human_readable": first_saas_template.human_readable,
+            "icon": encode_file_contents(first_saas_template.icon),
         } in data
 
         assert "saas" not in [item["identifier"] for item in data]
@@ -94,44 +98,48 @@ class TestGetConnections:
         auth_header = generate_auth_header(scopes=[CONNECTION_TYPE_READ])
 
         search = "str"
-        expected_saas_types = [
-            connector_type
+        expected_saas_templates = [
+            (
+                connector_type,
+                saas_template_registry.get_connector_template(connector_type),
+            )
             for connector_type in saas_template_registry.connector_types()
             if search.lower() in connector_type.lower()
         ]
         expected_saas_data = [
             {
-                "identifier": saas_type,
+                "identifier": saas_template[0],
                 "type": SystemType.saas.value,
-                "human_readable": saas_template_registry.get_connector_template(
-                    saas_type
-                ).human_readable,
+                "human_readable": saas_template[1].human_readable,
+                "icon": encode_file_contents(saas_template[1].icon),
             }
-            for saas_type in expected_saas_types
+            for saas_template in expected_saas_templates
         ]
 
         resp = api_client.get(url + f"?search={search}", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()["items"]
 
-        assert len(data) == len(expected_saas_types)
+        assert len(data) == len(expected_saas_templates)
         assert data[0] in expected_saas_data
 
         search = "re"
-        expected_saas_types = [
-            connector_type
+        expected_saas_templates = [
+            (
+                connector_type,
+                saas_template_registry.get_connector_template(connector_type),
+            )
             for connector_type in saas_template_registry.connector_types()
             if search.lower() in connector_type.lower()
         ]
         expected_saas_data = [
             {
-                "identifier": saas_type,
+                "identifier": saas_template[0],
                 "type": SystemType.saas.value,
-                "human_readable": saas_template_registry.get_connector_template(
-                    saas_type
-                ).human_readable,
+                "human_readable": saas_template[1].human_readable,
+                "icon": encode_file_contents(saas_template[1].icon),
             }
-            for saas_type in expected_saas_types
+            for saas_template in expected_saas_templates
         ]
 
         resp = api_client.get(url + f"?search={search}", headers=auth_header)
@@ -139,17 +147,19 @@ class TestGetConnections:
         data = resp.json()["items"]
 
         # 2 constant non-saas connection types match the search string
-        assert len(data) == len(expected_saas_types) + 2
+        assert len(data) == len(expected_saas_templates) + 2
 
         assert {
             "identifier": ConnectionType.postgres.value,
             "type": SystemType.database.value,
             "human_readable": "PostgreSQL",
+            "icon": None,
         } in data
         assert {
             "identifier": ConnectionType.redshift.value,
             "type": SystemType.database.value,
             "human_readable": "Amazon Redshift",
+            "icon": None,
         } in data
         for expected_data in expected_saas_data:
             assert expected_data in data
@@ -165,19 +175,21 @@ class TestGetConnections:
 
         search = "St"
         expected_saas_types = [
-            connector_type
+            (
+                connector_type,
+                saas_template_registry.get_connector_template(connector_type),
+            )
             for connector_type in saas_template_registry.connector_types()
             if search.lower() in connector_type.lower()
         ]
         expected_saas_data = [
             {
-                "identifier": saas_type,
+                "identifier": saas_template[0],
                 "type": SystemType.saas.value,
-                "human_readable": saas_template_registry.get_connector_template(
-                    saas_type
-                ).human_readable,
+                "human_readable": saas_template[1].human_readable,
+                "icon": encode_file_contents(saas_template[1].icon),
             }
-            for saas_type in expected_saas_types
+            for saas_template in expected_saas_types
         ]
 
         resp = api_client.get(url + f"?search={search}", headers=auth_header)
@@ -190,6 +202,7 @@ class TestGetConnections:
             "identifier": ConnectionType.postgres.value,
             "type": SystemType.database.value,
             "human_readable": "PostgreSQL",
+            "icon": None,
         } in data
 
         for expected_data in expected_saas_data:
@@ -197,19 +210,21 @@ class TestGetConnections:
 
         search = "Re"
         expected_saas_types = [
-            connector_type
+            (
+                connector_type,
+                saas_template_registry.get_connector_template(connector_type),
+            )
             for connector_type in saas_template_registry.connector_types()
             if search.lower() in connector_type.lower()
         ]
         expected_saas_data = [
             {
-                "identifier": saas_type,
+                "identifier": saas_template[0],
                 "type": SystemType.saas.value,
-                "human_readable": saas_template_registry.get_connector_template(
-                    saas_type
-                ).human_readable,
+                "human_readable": saas_template[1].human_readable,
+                "icon": encode_file_contents(saas_template[1].icon),
             }
-            for saas_type in expected_saas_types
+            for saas_template in expected_saas_types
         ]
 
         resp = api_client.get(url + f"?search={search}", headers=auth_header)
@@ -221,11 +236,13 @@ class TestGetConnections:
             "identifier": ConnectionType.postgres.value,
             "type": SystemType.database.value,
             "human_readable": "PostgreSQL",
+            "icon": None,
         } in data
         assert {
             "identifier": ConnectionType.redshift.value,
             "type": SystemType.database.value,
             "human_readable": "Amazon Redshift",
+            "icon": None,
         } in data
 
         for expected_data in expected_saas_data:
@@ -294,6 +311,7 @@ class TestGetConnections:
                 "identifier": "manual_webhook",
                 "type": "manual",
                 "human_readable": "Manual Webhook",
+                "icon": None,
             }
         ]
 


### PR DESCRIPTION
Closes #1231 

Follow up ticket for front-end work is: https://github.com/ethyca/fides/issues/1413

### Code Changes

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

* Adds `encoded_image` field to the response body schema of `api/v1/connection_types`, and the field includes a base64 encoded image binary for the connector's icon image. 
* The field is currently only populated for SaaS connectors; other connectors have `None` for the field.
* Sample response payload: [sample_response_encoded_icon_base64.json.txt](https://github.com/ethyca/fides/files/9766824/sample_response_encoded_icon_base64.json.txt) (github doesn't seem to allow `.json` uploads...)

