### PR TITLE
Add docker version checks to Nox

### DIFF
--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -1,11 +1,10 @@
 """Contains the nox sessions for running development environments."""
-from tabnanny import check
 import nox
 
 from constants_nox import COMPOSE_SERVICE_NAME, RUN, START_APP
 from docker_nox import build
-from utils_nox import check_docker_compose_version, check_docker_version
 from run_infrastructure import ALL_DATASTORES, run_infrastructure
+from utils_nox import check_docker_compose_version, check_docker_version
 
 
 @nox.session()

--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -1,14 +1,19 @@
 """Contains the nox sessions for running development environments."""
+from tabnanny import check
 import nox
 
 from constants_nox import COMPOSE_SERVICE_NAME, RUN, START_APP
 from docker_nox import build
+from utils_nox import check_docker_compose_version, check_docker_version
 from run_infrastructure import ALL_DATASTORES, run_infrastructure
 
 
 @nox.session()
 def dev(session: nox.Session) -> None:
     """Spin up the application. Uses positional arguments for additional features."""
+    check_docker_compose_version(session)
+    check_docker_version(session)
+
     build(session, "dev")
     session.notify("teardown")
 

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -1,4 +1,5 @@
 """Contains various utility-related nox sessions."""
+from subprocess import run, PIPE
 import nox
 
 from constants_nox import COMPOSE_FILE, INTEGRATION_COMPOSE_FILE
@@ -53,32 +54,35 @@ def teardown(session: nox.Session) -> None:
     else:
         session.run(*COMPOSE_DOWN, external=True)
     print("Teardown complete")
-    
-def docker_compose_version_is_valid() -> bool:
+
+
+@nox.session()
+def check_docker_compose_version(session: nox.Session) -> bool:
     """Verify the Docker Compose version."""
-    required_docker_compose_version = "1.29.10"
+    required_docker_compose_version = "2.10.2"
     raw = run("docker-compose --version", stdout=PIPE)
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
     docker_compose_version = parsed.split("v")[-1]
-    click.echo(parsed)
-    version_is_valid = docker_compose_version > required_docker_compose_version
+    print(parsed)
+    version_is_valid = docker_compose_version >= required_docker_compose_version
     if not version_is_valid:
-        echo_red(
+        session.error(
             f"Docker Compose version is not compatible, please update to at least version {required_docker_compose_version}!"
         )
     return version_is_valid
 
 
-def docker_version_is_valid() -> bool:
+@nox.session()
+def check_docker_version(session: nox.Session) -> bool:
     """Verify the Docker version."""
-    required_docker_version = "20.10.8"
+    required_docker_version = "20.10.17"
     raw = run("docker --version", stdout=PIPE)
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
     docker_version = parsed.split("v")[-1]
-    click.echo(parsed)
-    version_is_valid = docker_version > required_docker_version
+    print(parsed)
+    version_is_valid = docker_version >= required_docker_version
     if not version_is_valid:
-        echo_red(
+        session.error(
             f"Docker version is not compatible, please update to at least version {required_docker_version}!"
         )
     return version_is_valid

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -62,7 +62,7 @@ def teardown(session: nox.Session) -> None:
 @nox.session()
 def check_docker_compose_version(session: nox.Session) -> bool:
     """Verify the Docker Compose version."""
-    raw = run("docker-compose --version", stdout=PIPE, check=True)
+    raw = run("docker-compose --version", stdout=PIPE, check=True, shell=True)
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
     docker_compose_version = parsed.split("v")[-1]
     print(parsed)
@@ -79,7 +79,7 @@ def check_docker_compose_version(session: nox.Session) -> bool:
 @nox.session()
 def check_docker_version(session: nox.Session) -> bool:
     """Verify the Docker version."""
-    raw = run("docker --version", stdout=PIPE, check=True)
+    raw = run("docker --version", stdout=PIPE, check=True, shell=True)
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
     docker_version = parsed.split("version ")[-1].split(",")[0]
     print(parsed)

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -1,5 +1,6 @@
 """Contains various utility-related nox sessions."""
-from subprocess import run, PIPE
+from subprocess import PIPE, run
+
 import nox
 
 from constants_nox import COMPOSE_FILE, INTEGRATION_COMPOSE_FILE
@@ -26,6 +27,8 @@ COMPOSE_DOWN = (
     "--remove-orphans",
 )
 COMPOSE_DOWN_VOLUMES = COMPOSE_DOWN + ("--volumes",)
+REQUIRED_DOCKER_VERSION = "20.10.17"
+REQUIRED_DOCKER_COMPOSE_VERSION = "2.10.2"
 
 
 @nox.session()
@@ -59,15 +62,14 @@ def teardown(session: nox.Session) -> None:
 @nox.session()
 def check_docker_compose_version(session: nox.Session) -> bool:
     """Verify the Docker Compose version."""
-    required_docker_compose_version = "2.10.2"
-    raw = run("docker-compose --version", stdout=PIPE)
+    raw = run("docker-compose --version", stdout=PIPE, check=True)
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
     docker_compose_version = parsed.split("v")[-1]
     print(parsed)
-    version_is_valid = docker_compose_version >= required_docker_compose_version
+    version_is_valid = docker_compose_version >= REQUIRED_DOCKER_COMPOSE_VERSION
     if not version_is_valid:
         session.error(
-            f"Docker Compose version is not compatible, please update to at least version {required_docker_compose_version}!"
+            f"Docker Compose version is not compatible, please update to at least version {REQUIRED_DOCKER_COMPOSE_VERSION}!"
         )
     return version_is_valid
 
@@ -75,15 +77,14 @@ def check_docker_compose_version(session: nox.Session) -> bool:
 @nox.session()
 def check_docker_version(session: nox.Session) -> bool:
     """Verify the Docker version."""
-    required_docker_version = "20.10.17"
-    raw = run("docker --version", stdout=PIPE)
+    raw = run("docker --version", stdout=PIPE, check=True)
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
     docker_version = parsed.split("v")[-1]
     print(parsed)
-    version_is_valid = docker_version >= required_docker_version
+    version_is_valid = docker_version >= REQUIRED_DOCKER_VERSION
     if not version_is_valid:
         session.error(
-            f"Docker version is not compatible, please update to at least version {required_docker_version}!"
+            f"Docker version is not compatible, please update to at least version {REQUIRED_DOCKER_VERSION}!"
         )
     return version_is_valid
 

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -66,10 +66,12 @@ def check_docker_compose_version(session: nox.Session) -> bool:
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
     docker_compose_version = parsed.split("v")[-1]
     print(parsed)
-    version_is_valid = docker_compose_version >= REQUIRED_DOCKER_COMPOSE_VERSION
+    version_is_valid = int(docker_compose_version.replace(".", "")) >= int(
+        REQUIRED_DOCKER_COMPOSE_VERSION.replace(".", "")
+    )
     if not version_is_valid:
         session.error(
-            f"Docker Compose version is not compatible, please update to at least version {REQUIRED_DOCKER_COMPOSE_VERSION}!"
+            f"Your Docker Compose version (v{docker_compose_version})is not compatible, please update to at least version {REQUIRED_DOCKER_COMPOSE_VERSION}!"
         )
     return version_is_valid
 
@@ -79,12 +81,14 @@ def check_docker_version(session: nox.Session) -> bool:
     """Verify the Docker version."""
     raw = run("docker --version", stdout=PIPE, check=True)
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
-    docker_version = parsed.split("v")[-1]
+    docker_version = parsed.split("version ")[-1].split(",")[0]
     print(parsed)
-    version_is_valid = docker_version >= REQUIRED_DOCKER_VERSION
+    version_is_valid = int(docker_version.replace(".", "")) >= int(
+        REQUIRED_DOCKER_VERSION.replace(".", "")
+    )
     if not version_is_valid:
         session.error(
-            f"Docker version is not compatible, please update to at least version {REQUIRED_DOCKER_VERSION}!"
+            f"Your Docker version (v{docker_version}) is not compatible, please update to at least version {REQUIRED_DOCKER_VERSION}!"
         )
     return version_is_valid
 

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -53,6 +53,35 @@ def teardown(session: nox.Session) -> None:
     else:
         session.run(*COMPOSE_DOWN, external=True)
     print("Teardown complete")
+    
+def docker_compose_version_is_valid() -> bool:
+    """Verify the Docker Compose version."""
+    required_docker_compose_version = "1.29.10"
+    raw = run("docker-compose --version", stdout=PIPE)
+    parsed = raw.stdout.decode("utf-8").rstrip("\n")
+    docker_compose_version = parsed.split("v")[-1]
+    click.echo(parsed)
+    version_is_valid = docker_compose_version > required_docker_compose_version
+    if not version_is_valid:
+        echo_red(
+            f"Docker Compose version is not compatible, please update to at least version {required_docker_compose_version}!"
+        )
+    return version_is_valid
+
+
+def docker_version_is_valid() -> bool:
+    """Verify the Docker version."""
+    required_docker_version = "20.10.8"
+    raw = run("docker --version", stdout=PIPE)
+    parsed = raw.stdout.decode("utf-8").rstrip("\n")
+    docker_version = parsed.split("v")[-1]
+    click.echo(parsed)
+    version_is_valid = docker_version > required_docker_version
+    if not version_is_valid:
+        echo_red(
+            f"Docker version is not compatible, please update to at least version {required_docker_version}!"
+        )
+    return version_is_valid
 
 
 def install_requirements(session: nox.Session) -> None:


### PR DESCRIPTION
Closes #1428 

### Code Changes

* [x] add a session to verify docker version
* [x] add a session to verify docker compose version
* [x] call version check sessions from the `dev` session

### Steps to Confirm

* [ ] `nox -s dev` works (or doesn't) and shows the version numbers
* [ ] hardcoding in an older version immediately errors out of the `dev` session
* [ ] calling the sessions individually also works `nox -s check_docker_version` / `nox -s check_docker_compose_version`
* [ ] someone with an M1 mac confirms that these versions are available for that platform

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

These version checks are a better way to let users know if their Docker versions are out of date.

__Warning__: Because I'm not sure when certain features got introduced, I've biased to making these versions _very_ recent. This will most likely force anyone who is not continually updating their Docker to immediately update
