### PR TITLE
Fix docker compose version check on older versions

### DIFF
--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -113,9 +113,7 @@ def check_docker_compose_version(session: nox.Session) -> bool:
         docker_compose_version = parsed.split("version ")[-1].split(",")[0]
         split_docker_compose = convert_semver_to_list(docker_compose_version)
 
-    try:
-        assert len(split_docker_compose) == 3
-    except AssertionError:
+    if len(split_docker_compose) != 3:
         session.error(
             "Docker Compose version format is invalid, expecting semver format. Please upgrade to a more recent version and try again"
         )
@@ -144,9 +142,7 @@ def check_docker_version(session: nox.Session) -> bool:
     split_docker_version = [int(x) for x in docker_version.split(".")]
     split_required_docker_version = convert_semver_to_list(REQUIRED_DOCKER_VERSION)
 
-    try:
-        assert len(split_docker_version) == 3
-    except AssertionError:
+    if len(split_docker_version) != 3:
         session.error(
             "Docker version format is invalid, expecting semver format. Please upgrade to a more recent version and try again"
         )

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -64,10 +64,20 @@ def check_docker_compose_version(session: nox.Session) -> bool:
     """Verify the Docker Compose version."""
     raw = run("docker-compose --version", stdout=PIPE, check=True, shell=True)
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
-    docker_compose_version = parsed.split("v")[-1]
+    try:
+        docker_compose_version = parsed.split("v")[-1]
+        split_docker_compose = [int(x) for x in docker_compose_version.split(".")]
+    except ValueError:
+        docker_compose_version = parsed.split("version ")[-1].split(",")[0]
+        split_docker_compose = [int(x) for x in docker_compose_version.split(".")]
     print(parsed)
-    version_is_valid = int(docker_compose_version.replace(".", "")) >= int(
-        REQUIRED_DOCKER_COMPOSE_VERSION.replace(".", "")
+    split_required_docker_compose_version = [
+        int(x) for x in REQUIRED_DOCKER_COMPOSE_VERSION.split(".")
+    ]
+    version_is_valid = (
+        split_docker_compose[0] >= split_required_docker_compose_version[0]
+        and split_docker_compose[1] >= split_required_docker_compose_version[1]
+        and split_docker_compose[2] >= split_required_docker_compose_version[2]
     )
     if not version_is_valid:
         session.error(
@@ -82,9 +92,15 @@ def check_docker_version(session: nox.Session) -> bool:
     raw = run("docker --version", stdout=PIPE, check=True, shell=True)
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
     docker_version = parsed.split("version ")[-1].split(",")[0]
+    split_docker_version = [
+        int(x) for x in docker_version.split(".")
+    ]
     print(parsed)
-    version_is_valid = int(docker_version.replace(".", "")) >= int(
-        REQUIRED_DOCKER_VERSION.replace(".", "")
+    split_required_docker_version = [int(x) for x in REQUIRED_DOCKER_VERSION.split(".")]
+    version_is_valid = (
+        split_docker_version[0] >= split_required_docker_version[0]
+        and split_docker_version[1] >= split_required_docker_version[1]
+        and split_docker_version[2] >= split_required_docker_version[2]
     )
     if not version_is_valid:
         session.error(

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -92,9 +92,7 @@ def check_docker_version(session: nox.Session) -> bool:
     raw = run("docker --version", stdout=PIPE, check=True, shell=True)
     parsed = raw.stdout.decode("utf-8").rstrip("\n")
     docker_version = parsed.split("version ")[-1].split(",")[0]
-    split_docker_version = [
-        int(x) for x in docker_version.split(".")
-    ]
+    split_docker_version = [int(x) for x in docker_version.split(".")]
     print(parsed)
     split_required_docker_version = [int(x) for x in REQUIRED_DOCKER_VERSION.split(".")]
     version_is_valid = (


### PR DESCRIPTION
Closes #1437

### Code Changes

* [x] Parse the subprocess output differently for older versions of docker-compose
* [x] Changed how versions are validated.

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Older versions of docker-compose follow a different versioning format, and therefore were breaking the version check function.

Additionally, version checking was flawed and is now fixed to handle semver comparisons properly.
