### PR TITLE
Remove superfluous `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
-# Set the fidesctl core team as the default codeowners
-* @ethyca/automation-team @ethyca/experience-team
-
 # Set the product/tech writing team as owners for the docs
 docs/ @ethyca/docs-authors

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Set the product/tech writing team as owners for the docs
-docs/ @ethyca/docs-authors
+/docs/ @ethyca/docs-authors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fides/compare/1.9.2...main)
 
 ### Added
+
 * Allow delete-only SaaS connector endpoints [#1200](https://github.com/ethyca/fides/pull/1200)
 
 ### Developer Experience
 
 * Repository dispatch events are sent to fidesctl-plus and fidesops-plus [#1263](https://github.com/ethyca/fides/pull/1263)
+* Only the `docs-authors` team members are specified as `CODEOWNERS` [#1446](https://github.com/ethyca/fides/pull/1446)
 
 ### Docs
 


### PR DESCRIPTION
Closes #1445

### Code Changes

* [x] Remove automations and experience teams from `CODEOWNERS`
* [x] Specify that the docs-authors team owns the `docs/` directory only at the repo root

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`