### PR TITLE
ui/config-wizard: Show & review scanner result systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
     * The format is generic. A reasonable set of defaults will be added later: (#1444)[https://github.com/ethyca/fides/issues/1444]
     * The cookie name defaults to `fides_consent` but can be configured under `config.json > consent > cookieName`.
     * Each consent option can provide an array of `cookieKeys`.
+* Config Wizard: AWS scan results populate in system review forms. [#1454](https://github.com/ethyca/fides/pull/1454)
 
 ### Changed
 * Updated mypy to version 0.981 and Python to version 3.10.7 [#1448](https://github.com/ethyca/fides/pull/1448)

--- a/clients/admin-ui/cypress/fixtures/generate/system_to_review.json
+++ b/clients/admin-ui/cypress/fixtures/generate/system_to_review.json
@@ -1,0 +1,25 @@
+{
+  "fides_key": "example-postgres-cluster",
+  "organization_fides_key": "default_organization",
+  "name": "example-postgres-cluster",
+  "description": "Fides Generated Description for RDS Cluster: example-postgres-cluster",
+  "registry_id": null,
+  "meta": null,
+  "fidesctl_meta": {
+    "resource_id": "arn:aws:rds:us-east-2:123456789012:cluster:example-postgres-cluster",
+    "endpoint_address": "example-postgres-cluster.cluster-123456789012.us-east-2.rds.amazonaws.com",
+    "endpoint_port": "5432"
+  },
+  "system_type": "rds_cluster",
+  "data_responsibility_title": "Controller",
+  "privacy_declarations": [],
+  "system_dependencies": null,
+  "joint_controller": null,
+  "third_country_transfers": null,
+  "administrating_department": "Not defined",
+  "data_protection_impact_assessment": {
+    "is_required": false,
+    "progress": null,
+    "link": null
+  }
+}

--- a/clients/admin-ui/src/features/config-wizard/ConfigWizardWalkthrough.tsx
+++ b/clients/admin-ui/src/features/config-wizard/ConfigWizardWalkthrough.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, Divider, Stack } from "@fidesui/react";
 import HorizontalStepper from "common/HorizontalStepper";
 import Stepper from "common/Stepper";
-import { useRouter } from "next/router";
 import React from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
@@ -17,6 +16,7 @@ import AuthenticateScanner from "./AuthenticateScanner";
 import {
   changeReviewStep,
   changeStep,
+  reset,
   selectReviewStep,
   selectStep,
   selectSystemToCreate,
@@ -28,15 +28,13 @@ import ScanResultsForm from "./ScanResultsForm";
 import ViewYourDataMapPage from "./ViewYourDataMapPage";
 
 const ConfigWizardWalkthrough = () => {
-  const router = useRouter();
-
   const step = useAppSelector(selectStep);
   const reviewStep = useAppSelector(selectReviewStep);
   const dispatch = useAppDispatch();
   const system = useAppSelector(selectSystemToCreate);
 
   const handleCancelSetup = () => {
-    router.push("/");
+    dispatch(reset());
   };
 
   const handleSuccess = (values: System) => {

--- a/clients/admin-ui/src/features/config-wizard/ConfigWizardWalkthrough.tsx
+++ b/clients/admin-ui/src/features/config-wizard/ConfigWizardWalkthrough.tsx
@@ -8,7 +8,6 @@ import { CloseSolidIcon } from "~/features/common/Icon";
 import DescribeSystemStep from "~/features/system/DescribeSystemStep";
 import PrivacyDeclarationStep from "~/features/system/PrivacyDeclarationStep";
 import ReviewSystemStep from "~/features/system/ReviewSystemStep";
-import SystemRegisterSuccess from "~/features/system/SystemRegisterSuccess";
 import { System } from "~/types/api";
 
 import AddSystemForm from "./AddSystemForm";
@@ -16,29 +15,34 @@ import AuthenticateScanner from "./AuthenticateScanner";
 import {
   changeReviewStep,
   changeStep,
+  continueReview,
   reset,
+  reviewManualSystem,
   selectReviewStep,
   selectStep,
-  selectSystemToCreate,
-  setSystemToCreate,
+  selectSystemInReview,
+  selectSystemsForReview,
+  setSystemInReview,
 } from "./config-wizard.slice";
 import { HORIZONTAL_STEPS, STEPS } from "./constants";
 import OrganizationInfoForm from "./OrganizationInfoForm";
 import ScanResultsForm from "./ScanResultsForm";
+import SuccessPage from "./SuccessPage";
 import ViewYourDataMapPage from "./ViewYourDataMapPage";
 
 const ConfigWizardWalkthrough = () => {
   const step = useAppSelector(selectStep);
   const reviewStep = useAppSelector(selectReviewStep);
   const dispatch = useAppDispatch();
-  const system = useAppSelector(selectSystemToCreate);
+  const system = useAppSelector(selectSystemInReview);
+  const systemsForReview = useAppSelector(selectSystemsForReview);
 
   const handleCancelSetup = () => {
     dispatch(reset());
   };
 
   const handleSuccess = (values: System) => {
-    dispatch(setSystemToCreate(values));
+    dispatch(setSystemInReview(values));
     dispatch(changeReviewStep());
   };
 
@@ -80,6 +84,7 @@ const ConfigWizardWalkthrough = () => {
                 ) : null}
                 {reviewStep === 1 && (
                   <DescribeSystemStep
+                    system={system}
                     onCancel={handleCancelSetup}
                     onSuccess={handleSuccess}
                     abridged
@@ -102,13 +107,15 @@ const ConfigWizardWalkthrough = () => {
                   />
                 )}
                 {reviewStep === 4 && system && (
-                  <SystemRegisterSuccess
-                    system={system}
+                  <SuccessPage
+                    systemInReview={system}
+                    systemsForReview={systemsForReview}
                     onAddNextSystem={() => {
-                      dispatch(changeStep(5));
-                      dispatch(changeReviewStep(1));
+                      dispatch(reviewManualSystem());
                     }}
-                    onContinue={() => dispatch(changeStep())}
+                    onContinue={() => {
+                      dispatch(continueReview());
+                    }}
                   />
                 )}
               </Stack>

--- a/clients/admin-ui/src/features/config-wizard/ScanResultsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/ScanResultsForm.tsx
@@ -123,7 +123,10 @@ const ScanResultsForm = () => {
                     </Thead>
                     <Tbody>
                       {systems.map((system) => (
-                        <Tr key={system.fides_key}>
+                        <Tr
+                          key={system.fides_key}
+                          data-testid={`scan-result-row-${system.fides_key}`}
+                        >
                           <Td>
                             <Field
                               type="checkbox"
@@ -134,6 +137,7 @@ const ScanResultsForm = () => {
                                 <Checkbox
                                   {...field}
                                   isChecked={field.checked}
+                                  data-testid="checkbox"
                                 />
                               )}
                             </Field>
@@ -170,7 +174,12 @@ const ScanResultsForm = () => {
                   <Button variant="outline" onClick={handleCancel}>
                     Cancel
                   </Button>
-                  <Button type="submit" variant="primary" isDisabled={!isValid}>
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    isDisabled={!isValid}
+                    data-testid="register-btn"
+                  >
                     Register selected systems
                   </Button>
                 </HStack>

--- a/clients/admin-ui/src/features/config-wizard/SuccessPage.tsx
+++ b/clients/admin-ui/src/features/config-wizard/SuccessPage.tsx
@@ -80,9 +80,15 @@ const SuccessPage = ({
                   </Td>
                   <Td>
                     {i <= systemInReviewIndex ? (
-                      <StepperCircleCheckmarkIcon boxSize={5} />
+                      <StepperCircleCheckmarkIcon
+                        boxSize={5}
+                        data-testid="system-reviewed"
+                      />
                     ) : (
-                      <StepperCircleIcon boxSize={5} />
+                      <StepperCircleIcon
+                        boxSize={5}
+                        data-testid="system-needs-review"
+                      />
                     )}
                   </Td>
                 </Tr>

--- a/clients/admin-ui/src/features/config-wizard/SuccessPage.tsx
+++ b/clients/admin-ui/src/features/config-wizard/SuccessPage.tsx
@@ -16,28 +16,31 @@ import {
 } from "@fidesui/react";
 import React from "react";
 
-import { StepperCircleCheckmarkIcon } from "~/features/common/Icon";
-import { useGetAllSystemsQuery } from "~/features/system/system.slice";
+import {
+  StepperCircleCheckmarkIcon,
+  StepperCircleIcon,
+} from "~/features/common/Icon";
 import { System } from "~/types/api";
 
 interface Props {
-  system: System;
+  systemInReview: System;
+  systemsForReview: System[];
   onContinue: () => void;
   onAddNextSystem: () => void;
 }
-const SystemRegisterSuccess = ({
-  system,
+const SuccessPage = ({
+  systemInReview,
+  systemsForReview,
   onAddNextSystem,
   onContinue,
 }: Props) => {
-  const { data: allRegisteredSystems } = useGetAllSystemsQuery();
-  const otherSystems = allRegisteredSystems
-    ? allRegisteredSystems.filter(
-        (registeredSystem) => registeredSystem.name !== system.name
-      )
-    : [];
+  const systemName = systemInReview.name ?? systemInReview.fides_key;
 
-  const systemName = system.name ?? system.fides_key;
+  // Systems are reviewed in order, so a lower index means that system has been reviewed
+  // and a higher index means they'll reviewed after hitting "next".
+  const systemInReviewIndex = systemsForReview.findIndex(
+    (s) => s.fides_key === systemInReview.fides_key
+  );
 
   return (
     <chakra.form w="100%">
@@ -68,23 +71,26 @@ const SystemRegisterSuccess = ({
               </Tr>
             </Thead>
             <Tbody>
-              <Tr>
-                <Td color="green.500">{systemName}</Td>
-                <Td>
-                  <StepperCircleCheckmarkIcon boxSize={5} />
-                </Td>
-              </Tr>
-              {otherSystems.map((s) => (
+              {systemsForReview.map((s, i) => (
                 <Tr key={`${s.fides_key}-tr`}>
-                  <Td>{s.name}</Td>
+                  <Td
+                    color={i === systemInReviewIndex ? "green.500" : undefined}
+                  >
+                    {s.name}
+                  </Td>
                   <Td>
-                    <StepperCircleCheckmarkIcon boxSize={5} />
+                    {i <= systemInReviewIndex ? (
+                      <StepperCircleCheckmarkIcon boxSize={5} />
+                    ) : (
+                      <StepperCircleIcon boxSize={5} />
+                    )}
                   </Td>
                 </Tr>
               ))}
             </Tbody>
           </Table>
         </TableContainer>
+
         <Text>You can continue to add more systems now or finish.</Text>
 
         <Box>
@@ -95,8 +101,9 @@ const SystemRegisterSuccess = ({
             variant="outline"
             data-testid="add-next-system-btn"
           >
-            Add next system
+            Add system manually
           </Button>
+
           <Button
             onClick={onContinue}
             colorScheme="primary"
@@ -110,4 +117,4 @@ const SystemRegisterSuccess = ({
     </chakra.form>
   );
 };
-export default SystemRegisterSuccess;
+export default SuccessPage;

--- a/clients/admin-ui/src/features/config-wizard/config-wizard.slice.ts
+++ b/clients/admin-ui/src/features/config-wizard/config-wizard.slice.ts
@@ -22,7 +22,7 @@ export interface State {
 }
 
 const initialState: State = {
-  step: 1,
+  step: 0,
   reviewStep: 1,
   systemToCreate: null,
 };
@@ -89,6 +89,14 @@ export const slice = createSlice({
         (system) => fidesKeySet.has(system.fides_key)
       );
     },
+    /**
+     * Reset the wizard to its initial state, except for the organization which will probably
+     * be the same if the user comes back.
+     */
+    reset: (draftState) => ({
+      ...initialState,
+      organization: draftState.organization,
+    }),
   },
 });
 
@@ -96,6 +104,7 @@ export const {
   changeStep,
   changeReviewStep,
   setSystemToCreate,
+  reset,
   setOrganization,
   setSystemsForReview,
   chooseSystemsForReview,

--- a/clients/admin-ui/src/features/config-wizard/config-wizard.slice.ts
+++ b/clients/admin-ui/src/features/config-wizard/config-wizard.slice.ts
@@ -11,20 +11,21 @@ export interface State {
   reviewStep: number;
   organization?: Organization;
   /**
-   * The system that the user is currently manually creating.
-   */
-  systemToCreate: System | null;
-  /**
    * The systems that were returned by a system scan, some of which the user will select for review.
    * These are persisted to the backend after the "Describe" step.
    */
   systemsForReview?: System[];
+  /**
+   * The system that is currently being put through the review steps. It is persisted
+   * on the "Describe" step and then updated with additional info. Once it's registered,
+   * the next `systemForReview` is swapped in, if any.
+   */
+  systemInReview?: System;
 }
 
 const initialState: State = {
   step: 0,
   reviewStep: 1,
-  systemToCreate: null,
 };
 
 export const slice = createSlice({
@@ -74,11 +75,61 @@ export const slice = createSlice({
         draftState.reviewStep = REVIEW_STEPS - 1;
       }
     },
+    reviewManualSystem: (draftState) => {
+      draftState.systemInReview = undefined;
+      draftState.reviewStep = 1;
+    },
+    /**
+     * Move to the next system that needs review, if any.
+     */
+    continueReview: (draftState) => {
+      const { systemInReview, systemsForReview } = draftState;
+      if (!(systemInReview && systemsForReview)) {
+        throw new Error(
+          "Can't finish system review when there is no review in progress."
+        );
+      }
+
+      const reviewIndex = systemsForReview.findIndex(
+        (s) => s.fides_key === systemInReview.fides_key
+      );
+      if (reviewIndex < 0) {
+        throw new Error("The system in review couldn't be found by fides key.");
+      }
+
+      const nextIndex = reviewIndex + 1;
+      if (nextIndex < systemsForReview.length) {
+        // If there is another system to review, swap it in.
+        draftState.systemInReview = systemsForReview[nextIndex];
+      } else {
+        // Otherwise move to the next wizard step.
+        draftState.systemInReview = undefined;
+        draftState.step += 1;
+      }
+
+      // Always reset the review step
+      draftState.reviewStep = 1;
+    },
     setOrganization: (draftState, action: PayloadAction<Organization>) => {
       draftState.organization = action.payload;
     },
-    setSystemToCreate: (draftState, action: PayloadAction<System>) => {
-      draftState.systemToCreate = action.payload;
+    setSystemInReview: (draftState, action: PayloadAction<System>) => {
+      const systemInReview = action.payload;
+      const { systemsForReview = [] } = draftState;
+
+      // Whenever the in-progress system is updated, ensure the object in the array
+      // is updated in tandem.
+      const reviewIndex = systemsForReview.findIndex(
+        (s) => s.fides_key === systemInReview.fides_key
+      );
+      if (reviewIndex < 0) {
+        systemsForReview.push(systemInReview);
+      } else {
+        systemsForReview[reviewIndex] = systemInReview;
+      }
+
+      draftState.systemInReview = systemInReview;
+      draftState.systemsForReview = systemsForReview;
     },
     setSystemsForReview: (draftState, action: PayloadAction<System[]>) => {
       draftState.systemsForReview = action.payload;
@@ -88,6 +139,9 @@ export const slice = createSlice({
       draftState.systemsForReview = (draftState.systemsForReview ?? []).filter(
         (system) => fidesKeySet.has(system.fides_key)
       );
+      // Start reviewing the first system. (ESLint false positive.)
+      // eslint-disable-next-line prefer-destructuring
+      draftState.systemInReview = draftState.systemsForReview[0];
     },
     /**
      * Reset the wizard to its initial state, except for the organization which will probably
@@ -103,8 +157,10 @@ export const slice = createSlice({
 export const {
   changeStep,
   changeReviewStep,
-  setSystemToCreate,
+  continueReview,
   reset,
+  reviewManualSystem,
+  setSystemInReview,
   setOrganization,
   setSystemsForReview,
   chooseSystemsForReview,
@@ -129,9 +185,9 @@ export const selectOrganizationFidesKey = createSelector(
   (state) => state.organization?.fides_key ?? DEFAULT_ORGANIZATION_FIDES_KEY
 );
 
-export const selectSystemToCreate = createSelector(
+export const selectSystemInReview = createSelector(
   selectConfigWizard,
-  (state) => state.systemToCreate
+  (state) => state.systemInReview
 );
 
 export const selectSystemsForReview = createSelector(

--- a/clients/admin-ui/src/features/config-wizard/setup.tsx
+++ b/clients/admin-ui/src/features/config-wizard/setup.tsx
@@ -1,12 +1,14 @@
 import { Button, Container, Heading, Image, Stack } from "@fidesui/react";
 import { useRouter } from "next/router";
 
-interface Props {
-  wizardStep: Function;
-}
+import { useAppDispatch } from "~/app/hooks";
 
-const Setup = ({ wizardStep }: Props) => {
+import { changeStep } from "./config-wizard.slice";
+
+const Setup = () => {
   const router = useRouter();
+  const dispatch = useAppDispatch();
+
   return (
     <Stack>
       <Container
@@ -48,7 +50,7 @@ const Setup = ({ wizardStep }: Props) => {
           <Stack direction={["column", "row"]} spacing="24px">
             <Button
               variant="primary"
-              onClick={() => wizardStep(true)}
+              onClick={() => dispatch(changeStep())}
               data-testid="guided-setup-btn"
             >
               Guided Setup (Recommended)
@@ -57,7 +59,7 @@ const Setup = ({ wizardStep }: Props) => {
               variant="ghost"
               mr={4}
               colorScheme="complimentary"
-              onClick={() => router.push("/")}
+              onClick={() => router.push("/system")}
             >
               Skip (Power User)
             </Button>

--- a/clients/admin-ui/src/features/system/DescribeSystemStep.tsx
+++ b/clients/admin-ui/src/features/system/DescribeSystemStep.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Heading, Stack, useToast } from "@fidesui/react";
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
 import { Form, Formik } from "formik";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import * as Yup from "yup";
 
 import {
@@ -16,6 +16,7 @@ import {
   defaultInitialValues,
   FormValues,
   transformFormValuesToSystem,
+  transformSystemToFormValues,
 } from "~/features/system/form";
 import {
   useCreateSystemMutation,
@@ -33,17 +34,23 @@ interface Props {
   onCancel: () => void;
   onSuccess: (system: System) => void;
   abridged?: boolean;
-  initialValues?: FormValues;
+  system?: System;
 }
 
 const DescribeSystemStep = ({
   onCancel,
   onSuccess,
   abridged,
-  initialValues: passedInInitialValues,
+  system: passedInSystem,
 }: Props) => {
-  const isEditing = !!passedInInitialValues;
-  const initialValues = passedInInitialValues ?? defaultInitialValues;
+  const isEditing = !!passedInSystem;
+  const initialValues = useMemo(
+    () =>
+      passedInSystem
+        ? transformSystemToFormValues(passedInSystem)
+        : defaultInitialValues,
+    [passedInSystem]
+  );
   const [createSystem] = useCreateSystemMutation();
   const [updateSystem] = useUpdateSystemMutation();
   const [isLoading, setIsLoading] = useState(false);

--- a/clients/admin-ui/src/features/system/ManualSystemFlow.tsx
+++ b/clients/admin-ui/src/features/system/ManualSystemFlow.tsx
@@ -51,7 +51,7 @@ const ManualSystemFlow = () => {
 
   const goBack = () => {
     router.back();
-    dispatch(setActiveSystem(null));
+    dispatch(setActiveSystem(undefined));
   };
 
   const handleSuccess = (system: System) => {
@@ -61,7 +61,7 @@ const ManualSystemFlow = () => {
 
   const goToIndex = () => {
     router.push("/system");
-    dispatch(setActiveSystem(null));
+    dispatch(setActiveSystem(undefined));
   };
 
   return (

--- a/clients/admin-ui/src/features/system/ManualSystemFlow.tsx
+++ b/clients/admin-ui/src/features/system/ManualSystemFlow.tsx
@@ -6,7 +6,6 @@ import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { System } from "~/types/api";
 
 import DescribeSystemStep from "./DescribeSystemStep";
-import { transformSystemToFormValues } from "./form";
 import PrivacyDeclarationStep from "./PrivacyDeclarationStep";
 import ReviewSystemStep from "./ReviewSystemStep";
 import { selectActiveSystem, setActiveSystem } from "./system.slice";
@@ -82,11 +81,7 @@ const ManualSystemFlow = () => {
           <DescribeSystemStep
             onSuccess={handleSuccess}
             onCancel={goBack}
-            initialValues={
-              activeSystem
-                ? transformSystemToFormValues(activeSystem)
-                : undefined
-            }
+            system={activeSystem}
           />
         ) : null}
         {currentStepIndex === 1 && activeSystem ? (

--- a/clients/admin-ui/src/features/system/system.slice.ts
+++ b/clients/admin-ui/src/features/system/system.slice.ts
@@ -91,17 +91,18 @@ export const {
 } = systemApi;
 
 export interface State {
-  activeSystem: System | null;
+  activeSystem?: System;
 }
-const initialState: State = {
-  activeSystem: null,
-};
+const initialState: State = {};
 
 export const systemSlice = createSlice({
   name: "system",
   initialState,
   reducers: {
-    setActiveSystem: (draftState, action: PayloadAction<System | null>) => {
+    setActiveSystem: (
+      draftState,
+      action: PayloadAction<System | undefined>
+    ) => {
       draftState.activeSystem = action.payload;
     },
   },

--- a/clients/admin-ui/src/pages/config-wizard/index.tsx
+++ b/clients/admin-ui/src/pages/config-wizard/index.tsx
@@ -1,42 +1,35 @@
 import type { NextPage } from "next";
-import { useState } from "react";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { Flags } from "react-feature-flags";
 
+import { useAppSelector } from "~/app/hooks";
 import Header from "~/features/common/Header";
 import Layout from "~/features/common/Layout";
+import { selectStep } from "~/features/config-wizard/config-wizard.slice";
 import ConfigWizardWalkthrough from "~/features/config-wizard/ConfigWizardWalkthrough";
 
 import Setup from "../../features/config-wizard/setup";
 import Custom404 from "../404";
 
 const ConfigWizard: NextPage = () => {
-  const [configWizardStep, setConfigWizardStep] = useState(false);
+  const step = useAppSelector(selectStep);
 
-  const handleWizardStep = (step: boolean) => {
-    setConfigWizardStep(step);
-  };
-
-  return !configWizardStep ? (
+  return (
     <Flags
       authorizedFlags={["configWizardFlag"]}
-      renderOn={() => (
-        <Layout title="Config Wizard" noPadding>
-          <Setup wizardStep={handleWizardStep} />
-        </Layout>
-      )}
-      renderOff={() => <Custom404 />}
-    />
-  ) : (
-    <Flags
-      authorizedFlags={["configWizardFlag"]}
-      renderOn={() => (
-        <>
-          <Header />
-          <ConfigWizardWalkthrough />
-        </>
-      )}
+      renderOn={() =>
+        step === 0 ? (
+          <Layout title="Config Wizard" noPadding>
+            <Setup />
+          </Layout>
+        ) : (
+          <>
+            <Header />
+            <ConfigWizardWalkthrough />
+          </>
+        )
+      }
       renderOff={() => <Custom404 />}
     />
   );

--- a/clients/admin-ui/src/pages/system/new/index.tsx
+++ b/clients/admin-ui/src/pages/system/new/index.tsx
@@ -9,13 +9,20 @@ import {
 } from "@fidesui/react";
 import type { NextPage } from "next";
 import NextLink from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { useAppDispatch } from "~/app/hooks";
 import Layout from "~/features/common/Layout";
+import { setActiveSystem } from "~/features/system/system.slice";
 import SystemYamlForm from "~/features/system/SystemYamlForm";
 
 const NewSystem: NextPage = () => {
+  const dispatch = useAppDispatch();
   const [showYamlForm, setShowYamlForm] = useState(false);
+
+  useEffect(() => {
+    dispatch(setActiveSystem(null));
+  }, [dispatch]);
 
   return (
     <Layout title="Systems">

--- a/clients/admin-ui/src/pages/system/new/index.tsx
+++ b/clients/admin-ui/src/pages/system/new/index.tsx
@@ -21,7 +21,7 @@ const NewSystem: NextPage = () => {
   const [showYamlForm, setShowYamlForm] = useState(false);
 
   useEffect(() => {
-    dispatch(setActiveSystem(null));
+    dispatch(setActiveSystem(undefined));
   }, [dispatch]);
 
   return (


### PR DESCRIPTION
Closes #904 

### Code Changes

- Show & review scanner result systems
- Reset wizard state instead of relying on routing
- Improved checking of system create vs editing
  - DescribeSystemStep was already querying the existing systems. This info can be used to check if the system that was passed in (if any) already exists (by fides key). This also disable the fides key field so that the user can't accidentally switch to _creating_ a new system by modifying that field.
- Describe step accepts system object
- ui/system: Reset active system when navigating from the "new" page


### Steps to Confirm

* [ ] Reviewing AWS systems
  1. Go through the wizard flow through the AWS scanner (fidesctl-integration-test credentials)
  2. Select multiple systems from the scan results table
  3. Fill out the system review forms
  4. The success page should show which have been reviewed and the ones remaining
  5. Hitting "Continue" should move onto more systems until there are none left.
* [ ] Manually adding systems
  * After going through manual steps, the success page should show the custom system
  * The "Add manual system" button should work.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
  * The end state issues are separate: https://github.com/orgs/ethyca/projects/17/views/3?filterQuery=is%3Aissue+is%3Aopen+wizard+end+state
* [x] Update `CHANGELOG.md`

### Description Of Changes

Showing the review status
<img width="925" alt="complet-not-complet" src="https://user-images.githubusercontent.com/2236777/195933841-8740669d-4c4e-4f2e-815f-0fd0415257c8.png">

The whole review flow

https://user-images.githubusercontent.com/2236777/195933867-f2d2886b-1f8c-432a-b51e-75e291b4cdf3.mp4

Manual flow

https://user-images.githubusercontent.com/2236777/195933951-b32d2191-1c2e-4aee-a250-f783ae3fdc44.mp4



