### PR TITLE
Improve test environment reliability

### DIFF
--- a/clients/privacy-center/config/config.json
+++ b/clients/privacy-center/config/config.json
@@ -1,77 +1,79 @@
 {
-    "title": "Take control of your data",
-    "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
-    "server_url_development": "http://localhost:8080/api/v1",
-    "server_url_production": "http://localhost:8080/api/v1",
-    "logo_path": "/logo.svg",
-    "actions": [{
-            "policy_key": "default_access_policy",
-            "icon_path": "/download.svg",
-            "title": "Access your data",
-            "description": "We will email you a report of the data related to your account.",
-            "identity_inputs": {
-                "name": "optional",
-                "email": "required",
-                "phone": "optional"
-            }
-        },
-        {
-            "policy_key": "default_erasure_policy",
-            "icon_path": "/delete.svg",
-            "title": "Erase your data",
-            "description": "We will delete all of your account data. This action cannot be undone.",
-            "identity_inputs": {
-                "name": "optional",
-                "email": "required",
-                "phone": "optional"
-            }
-        }
-    ],
-    "includeConsent": false,
-    "consent": {
-        "cookieName": "fides_consent",
-        "consentOptions": [{
-                "fidesDataUseKey": "advertising",
-                "name": "Advertising / Data Sharing",
-                "description": "We may use some of your personal information for advertising performance analysis and audience modeling for ongoing advertising which may be interpreted as 'Data Sharing' under some regulations.",
-                "url": "https://example.com/privacy#advertising",
-                "default": true,
-                "highlight": false,
-                "cookieKeys": ["data_sales"]
-            },
-            {
-                "fidesDataUseKey": "improve",
-                "name": "Product Analytics",
-                "description": "We may use some of your personal information to collect analytics about how you use our products & services, in order to improve our service.",
-                "url": "https://example.com/privacy#data-sales",
-                "default": true,
-                "highlight": false,
-                "cookieKeys": ["data_sales"]
-            },
-            {
-                "name": "Analytics",
-                "fidesDataUseKey": "third_party_sharing",
-                "description": "...",
-                "url": "https://example.com/privacy#analytics",
-                "cookieKeys": ["data_sharing"]
-            },
-            {
-                "name": "Personalize",
-                "fidesDataUseKey": "personalize",
-                "default": true,
-                "url": "https://example.com/privacy#personalize",
-                "description": "...",
-                "cookieKeys": ["functional"]
-            },
-            {
-                "name": "Essential",
-                "fidesDataUseKey": "provide.service",
-                "default": true,
-                "url": "https://example.com/privacy#essential",
-                "highlight": true,
-                "description": "...",
-                "cookieKeys": ["essential"]
-            }
-        ]
+  "title": "Take control of your data",
+  "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
+  "server_url_development": "http://localhost:8080/api/v1",
+  "server_url_production": "http://localhost:8080/api/v1",
+  "logo_path": "/logo.svg",
+  "actions": [
+    {
+      "policy_key": "default_access_policy",
+      "icon_path": "/download.svg",
+      "title": "Access your data",
+      "description": "We will email you a report of the data related to your account.",
+      "identity_inputs": {
+        "name": "optional",
+        "email": "required",
+        "phone": "optional"
+      }
+    },
+    {
+      "policy_key": "default_erasure_policy",
+      "icon_path": "/delete.svg",
+      "title": "Erase your data",
+      "description": "We will delete all of your account data. This action cannot be undone.",
+      "identity_inputs": {
+        "name": "optional",
+        "email": "required",
+        "phone": "optional"
+      }
     }
+  ],
+  "includeConsent": false,
+  "consent": {
+    "cookieName": "fides_consent",
+    "consentOptions": [
+      {
+        "fidesDataUseKey": "advertising",
+        "name": "Advertising / Data Sharing",
+        "description": "We may use some of your personal information for advertising performance analysis and audience modeling for ongoing advertising which may be interpreted as 'Data Sharing' under some regulations.",
+        "url": "https://example.com/privacy#advertising",
+        "default": true,
+        "highlight": false,
+        "cookieKeys": ["data_sales"]
+      },
+      {
+        "fidesDataUseKey": "improve",
+        "name": "Product Analytics",
+        "description": "We may use some of your personal information to collect analytics about how you use our products & services, in order to improve our service.",
+        "url": "https://example.com/privacy#data-sales",
+        "default": true,
+        "highlight": false,
+        "cookieKeys": ["data_sales"]
+      },
+      {
+        "name": "Analytics",
+        "fidesDataUseKey": "third_party_sharing",
+        "description": "...",
+        "url": "https://example.com/privacy#analytics",
+        "cookieKeys": ["data_sharing"]
+      },
+      {
+        "name": "Personalize",
+        "fidesDataUseKey": "personalize",
+        "default": true,
+        "url": "https://example.com/privacy#personalize",
+        "description": "...",
+        "cookieKeys": ["functional"]
+      },
+      {
+        "name": "Essential",
+        "fidesDataUseKey": "provide.service",
+        "default": true,
+        "url": "https://example.com/privacy#essential",
+        "highlight": true,
+        "description": "...",
+        "cookieKeys": ["essential"]
+      }
+    ]
+  }
 }

--- a/clients/privacy-center/config/config.json
+++ b/clients/privacy-center/config/config.json
@@ -1,79 +1,77 @@
 {
-  "title": "Take control of your data",
-  "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
-  "server_url_development": "http://localhost:8080/api/v1",
-  "server_url_production": "http://localhost:8080/api/v1",
-  "logo_path": "/logo.svg",
-  "actions": [
-    {
-      "policy_key": "default_access_policy",
-      "icon_path": "/download.svg",
-      "title": "Access your data",
-      "description": "We will email you a report of the data related to your account.",
-      "identity_inputs": {
-        "name": "optional",
-        "email": "required",
-        "phone": "optional"
-      }
-    },
-    {
-      "policy_key": "default_erasure_policy",
-      "icon_path": "/delete.svg",
-      "title": "Erase your data",
-      "description": "We will delete all of your account data. This action cannot be undone.",
-      "identity_inputs": {
-        "name": "optional",
-        "email": "required",
-        "phone": "optional"
-      }
+    "title": "Take control of your data",
+    "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
+    "server_url_development": "http://localhost:8080/api/v1",
+    "server_url_production": "http://localhost:8080/api/v1",
+    "logo_path": "/logo.svg",
+    "actions": [{
+            "policy_key": "default_access_policy",
+            "icon_path": "/download.svg",
+            "title": "Access your data",
+            "description": "We will email you a report of the data related to your account.",
+            "identity_inputs": {
+                "name": "optional",
+                "email": "required",
+                "phone": "optional"
+            }
+        },
+        {
+            "policy_key": "default_erasure_policy",
+            "icon_path": "/delete.svg",
+            "title": "Erase your data",
+            "description": "We will delete all of your account data. This action cannot be undone.",
+            "identity_inputs": {
+                "name": "optional",
+                "email": "required",
+                "phone": "optional"
+            }
+        }
+    ],
+    "includeConsent": false,
+    "consent": {
+        "cookieName": "fides_consent",
+        "consentOptions": [{
+                "fidesDataUseKey": "advertising",
+                "name": "Advertising / Data Sharing",
+                "description": "We may use some of your personal information for advertising performance analysis and audience modeling for ongoing advertising which may be interpreted as 'Data Sharing' under some regulations.",
+                "url": "https://example.com/privacy#advertising",
+                "default": true,
+                "highlight": false,
+                "cookieKeys": ["data_sales"]
+            },
+            {
+                "fidesDataUseKey": "improve",
+                "name": "Product Analytics",
+                "description": "We may use some of your personal information to collect analytics about how you use our products & services, in order to improve our service.",
+                "url": "https://example.com/privacy#data-sales",
+                "default": true,
+                "highlight": false,
+                "cookieKeys": ["data_sales"]
+            },
+            {
+                "name": "Analytics",
+                "fidesDataUseKey": "third_party_sharing",
+                "description": "...",
+                "url": "https://example.com/privacy#analytics",
+                "cookieKeys": ["data_sharing"]
+            },
+            {
+                "name": "Personalize",
+                "fidesDataUseKey": "personalize",
+                "default": true,
+                "url": "https://example.com/privacy#personalize",
+                "description": "...",
+                "cookieKeys": ["functional"]
+            },
+            {
+                "name": "Essential",
+                "fidesDataUseKey": "provide.service",
+                "default": true,
+                "url": "https://example.com/privacy#essential",
+                "highlight": true,
+                "description": "...",
+                "cookieKeys": ["essential"]
+            }
+        ]
     }
-  ],
-  "includeConsent": true,
-  "consent": {
-    "cookieName": "fides_consent",
-    "consentOptions": [
-      {
-        "fidesDataUseKey": "advertising",
-        "name": "Advertising / Data Sharing",
-        "description": "We may use some of your personal information for advertising performance analysis and audience modeling for ongoing advertising which may be interpreted as 'Data Sharing' under some regulations.",
-        "url": "https://example.com/privacy#advertising",
-        "default": true,
-        "highlight": false,
-        "cookieKeys": ["data_sales"]
-      },
-      {
-        "fidesDataUseKey": "improve",
-        "name": "Product Analytics",
-        "description": "We may use some of your personal information to collect analytics about how you use our products & services, in order to improve our service.",
-        "url": "https://example.com/privacy#data-sales",
-        "default": true,
-        "highlight": false,
-        "cookieKeys": ["data_sales"]
-      },
-      {
-        "name": "Analytics",
-        "fidesDataUseKey": "third_party_sharing",
-        "description": "...",
-        "url": "https://example.com/privacy#analytics",
-        "cookieKeys": ["data_sharing"]
-      },
-      {
-        "name": "Personalize",
-        "fidesDataUseKey": "personalize",
-        "default": true,
-        "url": "https://example.com/privacy#personalize",
-        "description": "...",
-        "cookieKeys": ["functional"]
-      },
-      {
-        "name": "Essential",
-        "fidesDataUseKey": "provide.service",
-        "default": true,
-        "url": "https://example.com/privacy#essential",
-        "highlight": true,
-        "description": "...",
-        "cookieKeys": ["essential"]
-      }
-    ]
-  }
 }

--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -55,7 +55,7 @@ def test_env(session: nox.Session) -> None:
     )
     try:
         session.run(*COMPOSE_DOWN_VOLUMES, external=True)
-    except:
+    except nox.command.CommandFailed:
         session.error(
             "Failed to cleanly teardown existing containers & volumes. Please exit out of all other nox sessions and try again"
         )

--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -50,18 +50,15 @@ def dev(session: nox.Session) -> None:
 def test_env(session: nox.Session) -> None:
     """Spins up a comprehensive test environment seeded with data."""
 
-    session.warn(
+    session.log(
         "Tearing down existing containers & volumes to prepare test environment..."
     )
     try:
         session.run(*COMPOSE_DOWN_VOLUMES, external=True)
     except:
-        # Often, you'll unexpectedly be running a separate session (like `nox -s dev`) which has it's own teardown
-        session.warn(
-            "Failed to cleanly teardown existing containers & volumes. Were you running a separate nox session?"
+        session.error(
+            "Failed to cleanly teardown existing containers & volumes. Please exit out of all other nox sessions and try again"
         )
-        session.warn("Please try again!")
-        raise
     session.notify("teardown", posargs=["volumes"])
 
     session.log("Building images...")

--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -9,6 +9,7 @@ from constants_nox import (
     START_APP_EXTERNAL,
 )
 from docker_nox import build
+from utils_nox import COMPOSE_DOWN_VOLUMES
 from run_infrastructure import ALL_DATASTORES, run_infrastructure
 
 
@@ -48,6 +49,19 @@ def dev(session: nox.Session) -> None:
 @nox.session()
 def test_env(session: nox.Session) -> None:
     """Spins up a comprehensive test environment seeded with data."""
+
+    session.warn(
+        "Tearing down existing containers & volumes to prepare test environment..."
+    )
+    try:
+        session.run(*COMPOSE_DOWN_VOLUMES, external=True)
+    except:
+        # Often, you'll unexpectedly be running a separate session (like `nox -s dev`) which has it's own teardown
+        session.warn(
+            "Failed to cleanly teardown existing containers & volumes. Were you running a separate nox session?"
+        )
+        session.warn("Please try again!")
+        raise
     session.notify("teardown", posargs=["volumes"])
 
     session.log("Building images...")
@@ -55,11 +69,14 @@ def test_env(session: nox.Session) -> None:
     build(session, "admin_ui")
     build(session, "privacy_center")
 
-    session.log("Starting the application with example databases...")
-    # NOTE: Example databases must exist in docker-compose.integration-tests.yml
+    session.log(
+        "Starting the application with example databases defined in docker-compose.integration-tests.yml..."
+    )
     session.run(*START_APP_EXTERNAL, "fides-ui", "fides-pc", external=True)
 
-    session.log("Seeding example data for DSR Automation tests...")
+    session.log(
+        "Running example setup scripts for DSR Automation tests... (scripts/load_examples.py)"
+    )
     session.run(
         *RUN_NO_DEPS,
         "python",
@@ -67,7 +84,9 @@ def test_env(session: nox.Session) -> None:
         external=True,
     )
 
-    session.log("Seeding example data for Data Mapping tests...")
+    session.log(
+        "Pushing example resources for Data Mapping tests... (demo_resources/*)"
+    )
     session.run(*RUN_NO_DEPS, "fides", "push", "demo_resources/", external=True)
 
     session.log("****************************************")
@@ -78,8 +97,8 @@ def test_env(session: nox.Session) -> None:
     session.log("")
     session.log("Fides Admin UI running at http://localhost:3000")
     session.log("Fides Privacy Center running at http://localhost:3001")
-    session.log("Example Postgres Database running at postgres://localhost:6432")
-    session.log("Example Mongo Database running at postgres://localhost:27017")
+    session.log("Example Postgres Database running at localhost:6432")
+    session.log("Example Mongo Database running at localhost:27017")
     session.log("Username: 'fidestest', Password: 'Apassword1!")
     session.log("Opening Fides CLI shell...")
     session.run(*RUN_NO_DEPS, "/bin/bash", external=True)


### PR DESCRIPTION
### Code Changes

* [X] Teardown Docker containers and volumes before starting build
* [X] Disable consent option in privacy center by default 

### Steps to Confirm

* [X] Run `nox -s test_env` and confirm existing docker volumes are removed
* [X] Confirm privacy center only shows default download and access options 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

In some local testing I found it was possible for initial setup scripts to fail and conflict if the local dev database was already populated or in an unexpected state. This forces the test environment to clear out existing volumes before starting.

While doing this testing, I also noticed that, by default, the privacy center won't work without some optional configuration (identity verification). So I disabled consent in the privacy center defaults to ensure the default image is stable.