### PR TITLE
Making offset limit optional

### DIFF
--- a/docs/fides/docs/saas_connectors/saas_pagination.md
+++ b/docs/fides/docs/saas_connectors/saas_pagination.md
@@ -13,7 +13,7 @@ This strategy can be used to iterate through pages, or to define the offset for 
 #### Configuration details
 - `incremental_param` (_str_): The query param to increment the value for.
 - `increment_by` (_int_): The value to increment the `incremental_param` after each set of results.
-- `limit` (_str_): The max value the `incremental_param` can reach.
+- `limit` (optional _str_): The max value the `incremental_param` can reach.
 
 #### Example
 This example would take the `page` query param and increment it by 1 until the limit of 10 is reached or no more results are returned (whichever comes first).

--- a/src/fides/api/ops/schemas/saas/strategy_configuration.py
+++ b/src/fides/api/ops/schemas/saas/strategy_configuration.py
@@ -37,7 +37,7 @@ class OffsetPaginationConfiguration(StrategyConfiguration):
 
     incremental_param: str
     increment_by: int
-    limit: Union[int, ConnectorParamRef]
+    limit: Optional[Union[int, ConnectorParamRef]]
 
     @validator("increment_by")
     def check_increment_by(cls, increment_by: int) -> int:

--- a/src/fides/api/ops/service/pagination/pagination_strategy_offset.py
+++ b/src/fides/api/ops/service/pagination/pagination_strategy_offset.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Dict, Optional, Union
 
 import pydash
@@ -12,6 +13,8 @@ from fides.api.ops.schemas.saas.strategy_configuration import (
     OffsetPaginationConfiguration,
 )
 from fides.api.ops.service.pagination.pagination_strategy import PaginationStrategy
+
+logger = logging.getLogger(__name__)
 
 
 class OffsetPaginationStrategy(PaginationStrategy):
@@ -62,7 +65,8 @@ class OffsetPaginationStrategy(PaginationStrategy):
                     f"The value '{limit}' of the '{self.limit.connector_param}' connector_param could not be cast to an int"
                 )
         param_value += self.increment_by
-        if param_value > limit:
+        if limit and param_value > limit:
+            logger.info("Pagination limit has been reached")
             return None
 
         # update query param and return updated request_param tuple

--- a/tests/ops/service/pagination/test_pagination_strategy_offset.py
+++ b/tests/ops/service/pagination/test_pagination_strategy_offset.py
@@ -45,6 +45,24 @@ def test_offset(response_with_body):
     )
 
 
+def test_offset_with_no_limit(response_with_body):
+    config = OffsetPaginationConfiguration(incremental_param="page", increment_by=1)
+    request_params: SaaSRequestParams = SaaSRequestParams(
+        method=HTTPMethod.GET,
+        path="/conversations",
+        query_params={"page": 1},
+    )
+    paginator = OffsetPaginationStrategy(config)
+    next_request: Optional[SaaSRequestParams] = paginator.get_next_request(
+        request_params, {}, response_with_body, "conversations"
+    )
+    assert next_request == SaaSRequestParams(
+        method=HTTPMethod.GET,
+        path="/conversations",
+        query_params={"page": 2},
+    )
+
+
 def test_offset_with_connector_param_reference(response_with_body):
     config = OffsetPaginationConfiguration(
         incremental_param="page",


### PR DESCRIPTION
Closes #1482 

### Code Changes

* [x] Making `limit` optional for `offset` pagination strategy
* [x] Added unit test
* [x] Updated documentation

### Steps to Confirm

* [ ] Ran rest of the offset pagination unit tests

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
* [ ] Issue Requirements are Met