### PR TITLE
Don't parse an empty dir

### DIFF
--- a/src/fides/ctl/core/parse.py
+++ b/src/fides/ctl/core/parse.py
@@ -3,7 +3,7 @@ from fideslang import Taxonomy
 from fideslang.manifests import ingest_manifests
 from fideslang.parse import load_manifests_into_taxonomy
 
-from fides.ctl.core.utils import echo_green
+from fides.ctl.core.utils import echo_green, get_manifest_list
 
 
 def parse(manifests_dir: str) -> Taxonomy:
@@ -13,6 +13,9 @@ def parse(manifests_dir: str) -> Taxonomy:
 
     # Check if any manifests exist before trying to parse them
     print(f"Loading resource manifests from: {manifests_dir}")
+    if not get_manifest_list(manifests_dir):
+        print("No manifests found to parse, skipping...")
+        return Taxonomy()
     ingested_manifests = ingest_manifests(manifests_dir)
     taxonomy = load_manifests_into_taxonomy(ingested_manifests)
     echo_green("Taxonomy successfully created.")

--- a/src/fides/ctl/core/parse.py
+++ b/src/fides/ctl/core/parse.py
@@ -11,6 +11,7 @@ def parse(manifests_dir: str) -> Taxonomy:
     Parse local manifest file(s) into a Taxonomy.
     """
 
+    # Check if any manifests exist before trying to parse them
     print(f"Loading resource manifests from: {manifests_dir}")
     ingested_manifests = ingest_manifests(manifests_dir)
     taxonomy = load_manifests_into_taxonomy(ingested_manifests)

--- a/src/fides/ctl/core/utils.py
+++ b/src/fides/ctl/core/utils.py
@@ -13,6 +13,7 @@ import sqlalchemy
 from fideslang.models import DatasetField, FidesModel
 from fideslang.validation import FidesValidationError
 from git.repo import Repo
+from git.repo.fun import is_git_dir
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -138,6 +139,12 @@ def git_is_dirty(dir_to_check: str = ".") -> bool:
     Checks to see if the local repo has unstaged changes.
     Can also specify a directory to check.
     """
+    if not is_git_dir(".git"):
+        echo_red(
+            "This command must be run at the top-level of a git repo. Please try again."
+        )
+        raise SystemExit(1)
+
     repo = Repo()
     git_session = repo.git()
 

--- a/src/fides/ctl/core/utils.py
+++ b/src/fides/ctl/core/utils.py
@@ -146,12 +146,12 @@ def git_is_dirty(dir_to_check: str = ".") -> bool:
         from git.repo import Repo
         from git.repo.fun import is_git_dir
     except ImportError:
-        print("Git executable not detected, skipping git checks...")
+        print("Git executable not detected, skipping git check...")
         return False
 
     git_dir_path = ".git/"
     if not is_git_dir(git_dir_path):
-        print(f"No git repo detected at '{git_dir_path}', skipping checks...")
+        print(f"No git repo detected at '{git_dir_path}', skipping git check...")
         return False
 
     repo = Repo()

--- a/src/fides/ctl/core/utils.py
+++ b/src/fides/ctl/core/utils.py
@@ -13,8 +13,6 @@ import requests
 import sqlalchemy
 from fideslang.models import DatasetField, FidesModel
 from fideslang.validation import FidesValidationError
-from git.repo import Repo
-from git.repo.fun import is_git_dir
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -143,11 +141,18 @@ def git_is_dirty(dir_to_check: str = ".") -> bool:
     Checks to see if the local repo has unstaged changes.
     Can also specify a directory to check.
     """
-    if not is_git_dir(".git"):
-        echo_red(
-            "This command must be run at the top-level of a git repo. Please try again."
-        )
-        raise SystemExit(1)
+
+    try:
+        from git.repo import Repo
+        from git.repo.fun import is_git_dir
+    except ImportError:
+        print("Git executable not detected, skipping git checks...")
+        return False
+
+    git_dir_path = ".git/"
+    if not is_git_dir(git_dir_path):
+        print(f"No git repo detected at '{git_dir_path}', skipping checks...")
+        return False
 
     repo = Repo()
     git_session = repo.git()

--- a/src/fides/ctl/core/utils.py
+++ b/src/fides/ctl/core/utils.py
@@ -5,6 +5,7 @@ import re
 from functools import partial
 from json.decoder import JSONDecodeError
 from typing import Dict, Iterator, List
+from os.path import isfile
 
 import click
 import jwt
@@ -103,8 +104,11 @@ def get_all_level_fields(fields: list) -> Iterator[DatasetField]:
 
 def get_manifest_list(manifests_dir: str) -> List[str]:
     """Get a list of manifest files from the manifest directory."""
-
     yml_endings = ["yml", "yaml"]
+
+    if isfile(manifests_dir) and manifests_dir.split(".")[-1] in yml_endings:
+        return [manifests_dir]
+
     manifest_list = []
     for yml_ending in yml_endings:
         manifest_list += glob.glob(f"{manifests_dir}/**/*.{yml_ending}", recursive=True)


### PR DESCRIPTION
Closes #1485 
Closes #1484 

### Code Changes

* [x] check for multiple possible scenarios when checking git status (no git, not a git repo, repo is dirty/clean)
* [x] check that the manifest dir isn't empty before trying to parse, and also accepts individual files

### Steps to Confirm

* [ ] run the `git_is_dirty` function without being at the top level of a git repo and see the message
* [ ] run the function from within a container that doesn't have git and see the message (hard to test)
* [ ] remove all of the manifest files from `.fides`, stage (but don't commit!) the changes and then run `fides pull`, `fides push` and whatever else. This test the new `parse` logic that handles when there are no manifest files in the target dir
* [ ] remove all but a single manifest file and test parsing

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

@nicolas-ethyca found a bug in the `parse` logic that fails if no manifest exist. This is not the expected behavior, as `fides pull` was specifically designed to fill an empty repo. We should also be more lenient in regards to running with git available/in a git repo