### PR TITLE
ui/dataset: Only reset collection index on actual dataset update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ The types of changes are:
 
 * Add unlinked docs and fix any remaining broken links [#1266](https://github.com/ethyca/fides/pull/1266)
 
+### Fixed
+
+* After editing a dataset, the table will stay on the previously selected collection instead of resetting to the first one. [#1511](https://github.com/ethyca/fides/pull/1511)
+
 ## [1.9.2](https://github.com/ethyca/fides/compare/1.9.1...1.9.2)
 
 ### Deprecated

--- a/clients/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -71,7 +71,6 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
   useEffect(() => {
     if (dataset) {
       dispatch(setActiveDatasetFidesKey(dataset.fides_key));
-      dispatch(setActiveCollectionIndex(0));
     }
   }, [dispatch, dataset]);
 

--- a/clients/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/admin-ui/src/features/dataset/dataset.slice.ts
@@ -100,7 +100,7 @@ export const datasetSlice = createSlice({
 
       // Clear out the related fields when the dataset is changed.
       draftState.activeDatasetFidesKey = action.payload;
-      draftState.activeCollectionIndex = undefined;
+      draftState.activeCollectionIndex = 0;
       draftState.activeFieldIndex = undefined;
     },
     setActiveCollectionIndex: (


### PR DESCRIPTION
Closes #1436 

### Code Changes

* Test that replicates the collection switch.
* Easy fix! 

### Steps to Confirm

1. Edit a dataset with multiple collections
2. Select a collection other than first.
3. Edit and save any field.
4. Result: The same collection should be shown, which shows the updated field.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This is a case where multiple action dispatch is more error prone than having a single reducer that understands how the state should be updated.
