### PR TITLE
api/permissions: Allow user to GET their own permissions

### DIFF
--- a/tests/ops/api/v1/endpoints/test_user_permission_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_permission_endpoints.py
@@ -22,6 +22,7 @@ from fides.api.ops.api.v1.scope_registry import (
 )
 from fides.api.ops.api.v1.urn_registry import USER_PERMISSIONS, V1_URL_PREFIX
 from fides.ctl.core.config import get_config
+from tests.ops.conftest import generate_auth_header_for_user
 
 CONFIG = get_config()
 
@@ -89,7 +90,7 @@ class TestCreateUserPermissions:
             f"{V1_URL_PREFIX}/user/{user.id}/permission", headers=auth_header, json=body
         )
         permissions = FidesUserPermissions.get_by(db, field="user_id", value=user.id)
-        response_body = json.loads(response.text)
+        response_body = response.json()
         assert HTTP_201_CREATED == response.status_code
         assert response_body["id"] == permissions.id
         assert permissions.scopes == [PRIVACY_REQUEST_READ]
@@ -176,7 +177,7 @@ class TestEditUserPermissions:
         response = api_client.put(
             f"{V1_URL_PREFIX}/user/{user.id}/permission", headers=auth_header, json=body
         )
-        response_body = json.loads(response.text)
+        response_body = response.json()
         client: ClientDetail = ClientDetail.get_by(db, field="user_id", value=user.id)
         assert HTTP_200_OK == response.status_code
         assert response_body["id"] == permissions.id
@@ -188,62 +189,116 @@ class TestEditUserPermissions:
 
 class TestGetUserPermissions:
     @pytest.fixture(scope="function")
-    def url(self, oauth_client: ClientDetail) -> str:
-        return V1_URL_PREFIX + USER_PERMISSIONS
-
-    def test_get_user_permissions_not_authenticated(self, url, api_client):
-        response = api_client.get(url, headers={}, json={})
-        assert HTTP_401_UNAUTHORIZED == response.status_code
-
-    def test_get_user_permissions_wrong_scope(
-        self, url, api_client, generate_auth_header
-    ):
-        auth_header = generate_auth_header([SAAS_CONFIG_READ])
-        response = api_client.get(url, headers=auth_header, json={})
-        assert HTTP_403_FORBIDDEN == response.status_code
-
-    def test_get_user_permissions_invalid_user_id(
-        self, db, api_client, generate_auth_header
-    ) -> None:
-        auth_header = generate_auth_header([USER_PERMISSION_READ])
-        invalid_user_id = "bogus_user_id"
-        user = FidesUser.create(
+    def user(self, db) -> FidesUser:
+        return FidesUser.create(
             db=db,
             data={"username": "user_1", "password": "test_password"},
         )
 
-        permissions = FidesUserPermissions.create(
+    @pytest.fixture(scope="function")
+    def auth_user(self, db) -> FidesUser:
+        return FidesUser.create(
+            db=db,
+            data={"username": "auth_user", "password": "test_password"},
+        )
+
+    @pytest.fixture(scope="function")
+    def permissions(self, db, user) -> FidesUserPermissions:
+        return FidesUserPermissions.create(
             db=db, data={"user_id": user.id, "scopes": [PRIVACY_REQUEST_READ]}
         )
-        body = {"id": permissions.id, "scopes": [PRIVACY_REQUEST_READ]}
+
+    def test_get_user_permissions_not_authenticated(self, api_client, user):
+        response = api_client.get(
+            f"{V1_URL_PREFIX}/user/{user.id}/permission",
+        )
+        assert HTTP_401_UNAUTHORIZED == response.status_code
+
+    def test_get_user_permissions_wrong_scope(self, db, api_client, user, auth_user):
+        scopes = [PRIVACY_REQUEST_READ]
+        ClientDetail.create_client_and_secret(
+            db,
+            CONFIG.security.oauth_client_id_length_bytes,
+            CONFIG.security.oauth_client_secret_length_bytes,
+            scopes=scopes,
+            user_id=auth_user.id,
+        )
+        auth_header = generate_auth_header_for_user(auth_user, scopes)
+
+        response = api_client.get(
+            f"{V1_URL_PREFIX}/user/{user.id}/permission",
+            headers=auth_header,
+        )
+        assert HTTP_403_FORBIDDEN == response.status_code
+
+    def test_get_user_permissions_invalid_user_id(
+        self, db, api_client, auth_user
+    ) -> None:
+        scopes = [USER_PERMISSION_READ]
+        ClientDetail.create_client_and_secret(
+            db,
+            CONFIG.security.oauth_client_id_length_bytes,
+            CONFIG.security.oauth_client_secret_length_bytes,
+            scopes=scopes,
+            user_id=auth_user.id,
+        )
+        auth_header = generate_auth_header_for_user(auth_user, scopes)
+        invalid_user_id = "bogus_user_id"
+
         response = api_client.get(
             f"{V1_URL_PREFIX}/user/{invalid_user_id}/permission",
             headers=auth_header,
-            json=body,
         )
         permissions = FidesUserPermissions.get_by(
             db, field="user_id", value=invalid_user_id
         )
         assert HTTP_404_NOT_FOUND == response.status_code
         assert permissions is None
-        user.delete(db)
 
-    def test_get_user_permissions(self, db, api_client, generate_auth_header) -> None:
-        auth_header = generate_auth_header([USER_PERMISSION_READ])
-        user = FidesUser.create(
-            db=db,
-            data={"username": "user_1", "password": "test_password"},
+    def test_get_user_permissions(
+        self, db, api_client, user, auth_user, permissions
+    ) -> None:
+        scopes = [USER_PERMISSION_READ]
+        ClientDetail.create_client_and_secret(
+            db,
+            CONFIG.security.oauth_client_id_length_bytes,
+            CONFIG.security.oauth_client_secret_length_bytes,
+            scopes=scopes,
+            user_id=auth_user.id,
         )
-        permissions = FidesUserPermissions.create(
-            db=db, data={"user_id": user.id, "scopes": [PRIVACY_REQUEST_READ]}
-        )
+        auth_header = generate_auth_header_for_user(auth_user, scopes)
 
         response = api_client.get(
-            f"{V1_URL_PREFIX}/user/{user.id}/permission", headers=auth_header
+            f"{V1_URL_PREFIX}/user/{user.id}/permission",
+            headers=auth_header,
         )
-        response_body = json.loads(response.text)
+        response_body = response.json()
         assert HTTP_200_OK == response.status_code
         assert response_body["id"] == permissions.id
         assert response_body["user_id"] == user.id
         assert response_body["scopes"] == [PRIVACY_REQUEST_READ]
-        user.delete(db)
+
+    def test_get_current_user_permissions(self, db, api_client, auth_user) -> None:
+        # Note: Does not include USER_PERMISSION_READ.
+        scopes = [PRIVACY_REQUEST_READ, SAAS_CONFIG_READ]
+        ClientDetail.create_client_and_secret(
+            db,
+            CONFIG.security.oauth_client_id_length_bytes,
+            CONFIG.security.oauth_client_secret_length_bytes,
+            scopes=scopes,
+            user_id=auth_user.id,
+        )
+        auth_header = generate_auth_header_for_user(auth_user, scopes)
+        permissions = FidesUserPermissions.create(
+            db=db, data={"user_id": auth_user.id, "scopes": scopes}
+        )
+
+        response = api_client.get(
+            f"{V1_URL_PREFIX}/user/{auth_user.id}/permission",
+            headers=auth_header,
+        )
+        response_body = response.json()
+        assert HTTP_200_OK == response.status_code
+        assert response_body["id"] == permissions.id
+        assert response_body["user_id"] == auth_user.id
+        assert response_body["scopes"] == scopes


### PR DESCRIPTION
Required for #1480 

### Code Changes

* This change updates the GET USER_PERMISSIONS endpoint to only require the USER_PERMISSION_READ scope when requesting the permissions for _another_ user. If the User Id of the client credentials matches the User Id of the request, the scope check is skipped.
* Cleaned up tests for the endpoint and added case for current-user case
    * The test functions were inconsistent about creating the user and permissions object that needed to be queried.
    * Some were using a `url` fixture that was an invalid string - it contained `{user_id}` instead of actually passing the id.

### Steps to Confirm

* [ ] `GET /api/v1/user/{user_id}/permission` when authenticated as the root user should return the users's permissions.
* [ ] When authenticated as a user with limited permissions, this should only succeed with the current user Id and raise a `403` for any other.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Issue #1480 highlights that we never re-validate the auth token saved in localStorage. Requests that require auth return `403` if the token gets invalidated on the backend, but this isn't enough information for the frontend to tell whether the _token was invalid_ or if it just doesn't have permission for that one scope.

The User Permission endpoint seems like a robust solution: if a user can't get their own permissions, then they must not have a valid token. We could also use this in the future to toggle features that only make sense if the user has, for example, `PRIVACY_REQUEST_DELETE` permissions.

<details>
<summary>Alternative solutions/implementations</summary>

1. Log out on any endpoint `403` (or `401`)
   - I thought through this option, but it just creates more problems. It's perfectly reasonable for a user to have access to _some_ endpoints block without kicking them out of the app.
   - Also, some endpoints authenticate accounts other than Fides itself. For example, AWS scanning returns 403 if the credentials failed. So a global handler wouldn't work, resulting in a piecemeal solution.
2. Use the Login endpoint - Nope, that's a POST with credentials.
3. Use the GET USER_DETAIL endpoint
   - This was a strong contender, and we might want to allow the user to query themselves anyway.
   - However, for auth checking, the user's permissions seem like the most important information.
   - Also, the USER_DETAIL endpoint is implemented in fideslib, so it's a bit more annoying to change.
</details>

