### PR TITLE
Add a `plus_system_scans` table to the database

### DIFF
--- a/.fides/dataset.yml
+++ b/.fides/dataset.yml
@@ -1307,3 +1307,48 @@ dataset:
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
       retention: null
       fields: null
+  - name: plus_system_scans
+    description: 'Fides Generated Description for Table: plus_system_scans'
+    data_categories: null
+    data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    fields:
+    - name: created_at
+      description: 'Fides Generated Description for Column: created_at'
+      data_categories:
+      - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: error
+      description: 'Fides Generated Description for Column: error'
+      data_categories:
+      - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: id
+      description: 'Fides Generated Description for Column: id'
+      data_categories:
+      - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: is_classified
+      description: 'Fides Generated Description for Column: is_classified'
+      data_categories:
+      - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: result
+      description: 'Fides Generated Description for Column: result'
+      data_categories:
+      - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: status
+      description: 'Fides Generated Description for Column: status'
+      data_categories:
+      - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: system_count
+      description: 'Fides Generated Description for Column: system_count'
+      data_categories:
+      - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: updated_at
+      description: 'Fides Generated Description for Column: updated_at'
+      data_categories:
+      - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,7 +245,7 @@ The types of changes are:
 * Add datasets via database connection (UI only) [#834](https://github.com/ethyca/fides/pull/834)
 * Add Okta support to the `/generate` endpoint [#842](https://github.com/ethyca/fides/pull/842)
 * Add db support to `/generate` endpoint [849](https://github.com/ethyca/fides/pull/849)
-* Added OpenAPI TypeScript client generation for the UI app. See the [README](/clients/admin-ui/src/types/api/README.md) for more details.
+* Added OpenAPI TypeScript client generation for the UI app. See the [README](/clients/ctl/admin-ui/src/types/api/README.md) for more details.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,19 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
-## [1.9.4](https://github.com/ethyca/fides/compare/1.9.4...main)
+## [Unreleased](https://github.com/ethyca/fides/compare/1.9.4...main)
+
+### Added
+
+* The database includes a `plus_system_scans` relation, to track the status and results of System Scanner executions in fidesctl-plus [#1554](https://github.com/ethyca/fides/pull/1554)
+
+## [1.9.4](https://github.com/ethyca/fides/compare/1.9.4...1.9.2)
 
 ### Fixed
 
 * After editing a dataset, the table will stay on the previously selected collection instead of resetting to the first one. [#1511](https://github.com/ethyca/fides/pull/1511)
 
-## [1.9.2](https://github.com/ethyca/fides/compare/1.9.2...main)
+## [1.9.2](https://github.com/ethyca/fides/compare/1.9.2...1.9.1)
 
 ### Deprecated
 

--- a/src/fidesctl/api/ctl/migrations/versions/6b9885e68cbb_add_plus_system_scans_table.py
+++ b/src/fidesctl/api/ctl/migrations/versions/6b9885e68cbb_add_plus_system_scans_table.py
@@ -1,0 +1,33 @@
+"""Add plus_system_scans table
+
+Revision ID: 6b9885e68cbb
+Revises: 3d9c476d7cea
+Create Date: 2022-10-24 23:36:51.166480
+
+"""
+from alembic.op import create_table, drop_table
+from sqlalchemy import JSON, Boolean, Column, DateTime, Integer, String, text
+
+# revision identifiers, used by Alembic.
+revision = "6b9885e68cbb"
+down_revision = "3d9c476d7cea"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    create_table(
+        "plus_system_scans",
+        Column("id", Integer(), primary_key=True),
+        Column("created_at", DateTime(timezone=True), server_default=text("now()")),
+        Column("error", String(), nullable=True),
+        Column("is_classified", Boolean(), default=False, nullable=False),
+        Column("result", JSON(), nullable=True),
+        Column("status", String(), nullable=False),
+        Column("system_count", Integer(), autoincrement=False, nullable=True),
+        Column("updated_at", DateTime(timezone=True), server_default=text("now()")),
+    )
+
+
+def downgrade() -> None:
+    drop_table("plus_system_scans")

--- a/src/fidesctl/api/ctl/sql_models.py
+++ b/src/fidesctl/api/ctl/sql_models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     BOOLEAN,
     JSON,
     Column,
+    Integer,
     String,
     Text,
     TypeDecorator,
@@ -267,6 +268,23 @@ class System(Base, FidesBase):
     data_protection_impact_assessment = Column(JSON)
     egress = Column(JSON)
     ingress = Column(JSON)
+
+
+class SystemScans(Base):
+    """
+    The SQL model for System Scan instances.
+    """
+
+    __tablename__ = "plus_system_scans"
+
+    id = Column(Integer, primary_key=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    error = Column(String, nullable=True)
+    is_classified = Column(BOOLEAN, default=False, nullable=False)
+    result = Column(JSON, nullable=True)
+    status = Column(String, nullable=False)
+    system_count = Column(Integer, autoincrement=False, nullable=True)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now())
 
 
 sql_model_map: Dict = {

--- a/src/fidesctl/ctl/core/utils.py
+++ b/src/fidesctl/ctl/core/utils.py
@@ -4,8 +4,8 @@ import logging
 import re
 from functools import partial
 from json.decoder import JSONDecodeError
-from typing import Dict, Iterator, List
 from os.path import isfile
+from typing import Dict, Iterator, List
 
 import click
 import jwt


### PR DESCRIPTION
Closes #1396

### Code Changes

* [x] Add a new `plus_system_scans` table to the database
* [x] Add a corresponding `SystemScans` SQL model
* [x] Annotate the new database table

### Steps to Confirm

* [ ] Start fides
* [ ] List the relations in the databse
* [ ] Observe that `plus_system_scans` is included

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

### Description Of Changes

Adds the `plus_system_scans` relation to the fides database, and a corresponding `SystemScans` model. Any associated APIs will be added in fidesctl-plus, as a part of ethyca/fidesctl-plus#195.