### PR TITLE
remove the need for package level imports in db setup scripts

### DIFF
--- a/tests/ops/integration_tests/setup_scripts/postgres_setup.py
+++ b/tests/ops/integration_tests/setup_scripts/postgres_setup.py
@@ -3,6 +3,9 @@ from uuid import uuid4
 import pydash
 from fideslib.core.config import load_toml
 from fideslib.db.session import get_db_engine, get_db_session
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
@@ -11,10 +14,34 @@ from fides.api.ops.models.connectionconfig import (
 )
 from fides.api.ops.service.connectors.sql_connector import PostgreSQLConnector
 from fides.ctl.core.config import get_config
-from tests.ops.test_helpers.db_utils import seed_postgres_data
 
 CONFIG = get_config()
 integration_config = load_toml(["tests/ops/integration_test_config.toml"])
+
+
+def seed_postgres_data(db: Session, query_file_path: str) -> Session:
+    """
+    :param db: SQLAlchemy session for the Postgres DB
+    :param query_file_path: file path pointing to the `.sql` file
+     that contains the query to seed the data in the DB. e.g.,
+     `./docker/sample_data/postgres_example.sql`
+
+    Using the provided sesion, creates the database, dropping it if it
+    already existed. Seeds the created database using the query found
+    in the  relative path provided. Some processing is done on the query
+    text so that it can be executed properly.
+    """
+    if database_exists(db.bind.url):
+        # Postgres cannot drop databases from within a transaction block, so
+        # we should drop the DB this way instead
+        drop_database(db.bind.url)
+    create_database(db.bind.url)
+    with open(query_file_path, "r") as query_file:
+        lines = query_file.read().splitlines()
+        filtered = [line for line in lines if not line.startswith("--")]
+        queries = " ".join(filtered).split(";")
+        [db.execute(f"{text(query.strip())};") for query in queries if query]
+    return db
 
 
 def setup():
@@ -52,7 +79,7 @@ def setup():
     )
     session = SessionLocal()
 
-    seed_postgres_data(session.bind.url, "./docker/sample_data/postgres_example.sql")
+    seed_postgres_data(session, "./docker/sample_data/postgres_example.sql")
 
 
 if __name__ == "__main__":

--- a/tests/ops/integration_tests/setup_scripts/timescale_setup.py
+++ b/tests/ops/integration_tests/setup_scripts/timescale_setup.py
@@ -3,6 +3,9 @@ from uuid import uuid4
 import pydash
 from fideslib.core.config import load_toml
 from fideslib.db.session import get_db_engine, get_db_session
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
@@ -11,10 +14,34 @@ from fides.api.ops.models.connectionconfig import (
 )
 from fides.api.ops.service.connectors import TimescaleConnector
 from fides.ctl.core.config import get_config
-from tests.ops.test_helpers.db_utils import seed_postgres_data
 
 CONFIG = get_config()
 integration_config = load_toml(["tests/ops/integration_test_config.toml"])
+
+
+def seed_postgres_data(db: Session, query_file_path: str) -> Session:
+    """
+    :param db: SQLAlchemy session for the Postgres DB
+    :param query_file_path: file path pointing to the `.sql` file
+     that contains the query to seed the data in the DB. e.g.,
+     `./docker/sample_data/postgres_example.sql`
+
+    Using the provided sesion, creates the database, dropping it if it
+    already existed. Seeds the created database using the query found
+    in the  relative path provided. Some processing is done on the query
+    text so that it can be executed properly.
+    """
+    if database_exists(db.bind.url):
+        # Postgres cannot drop databases from within a transaction block, so
+        # we should drop the DB this way instead
+        drop_database(db.bind.url)
+    create_database(db.bind.url)
+    with open(query_file_path, "r") as query_file:
+        lines = query_file.read().splitlines()
+        filtered = [line for line in lines if not line.startswith("--")]
+        queries = " ".join(filtered).split(";")
+        [db.execute(f"{text(query.strip())};") for query in queries if query]
+    return db
 
 
 def setup():
@@ -54,7 +81,7 @@ def setup():
     )
     session = SessionLocal()
 
-    seed_postgres_data(session.bind.url, "./docker/sample_data/timescale_example.sql")
+    seed_postgres_data(session, "./docker/sample_data/timescale_example.sql")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1577 

### Code Changes

* [x] Update `setup_postgres` and `setup_timescale` scripts to use local DB functions rather than the imported

### Steps to Confirm

* [ ] run `docker compose -f docker-compose.yml -f docker/docker-compose.integration-postgres.yml up`
* [ ] once succeeded, open another tab in the terminal
* [ ] run `docker compose -f docker-compose.yml -f docker/docker-compose.integration-postgres.yml run fides python tests/ops/integration_tests/setup_scripts/postgres_setup.py`
* [ ] confirm the script runs without error
* [ ] inspect the `postgres_example` Postgres DB, confirm the test data exists

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

More info here: https://ethyca.slack.com/archives/CBKK8TS74/p1666815665895189?thread_ts=1666814870.893109&cid=CBKK8TS74

Please note: this approach is not DRY, and not ideal for the long term. Local integration tests are effectively blocked until this is solved so it makes sense to ship this first.
