### PR TITLE
Fix cypress tests

### DIFF
--- a/clients/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets.cy.ts
@@ -1,6 +1,7 @@
 import {
   CONNECTION_STRING,
   stubDatasetCrud,
+  stubHomePage,
   stubPlus,
 } from "cypress/support/stubs";
 
@@ -17,6 +18,7 @@ describe("Dataset", () => {
 
   describe("List of datasets view", () => {
     it("Can navigate to the datasets list view", () => {
+      stubHomePage();
       cy.visit("/");
       cy.getByTestId("nav-link-Datasets").click();
       cy.wait("@getDatasets");

--- a/clients/admin-ui/cypress/e2e/nav-bar.cy.ts
+++ b/clients/admin-ui/cypress/e2e/nav-bar.cy.ts
@@ -1,9 +1,12 @@
+import { stubHomePage } from "cypress/support/stubs";
+
 describe("Nav Bar", () => {
   before(() => {
     cy.login();
   });
 
   it("Renders all page links", () => {
+    stubHomePage();
     cy.visit("/");
 
     cy.getByTestId("nav-link-Subject Requests");

--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -1,4 +1,8 @@
-import { stubSystemCrud, stubTaxonomyEntities } from "../support/stubs";
+import {
+  stubHomePage,
+  stubSystemCrud,
+  stubTaxonomyEntities,
+} from "cypress/support/stubs";
 
 describe("System management page", () => {
   before(() => {
@@ -11,6 +15,7 @@ describe("System management page", () => {
   });
 
   it("Can navigate to the system management page", () => {
+    stubHomePage();
     cy.visit("/");
     cy.getByTestId("nav-link-Systems").click();
     cy.wait("@getSystems");

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -1,3 +1,5 @@
+import { stubHomePage } from "cypress/support/stubs";
+
 describe("Taxonomy management page", () => {
   before(() => {
     cy.login();
@@ -19,6 +21,7 @@ describe("Taxonomy management page", () => {
   });
 
   it("Can navigate to the taxonomy page", () => {
+    stubHomePage();
     cy.visit("/");
     cy.getByTestId("nav-link-Taxonomy").click();
     cy.getByTestId("taxonomy-tabs");

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -85,3 +85,10 @@ export const stubPlus = (available: boolean) => {
     }).as("getPlusHealth");
   }
 };
+
+export const stubHomePage = () => {
+  cy.intercept("GET", "/api/v1/privacy-request*", {
+    statusCode: 200,
+    body: { items: [], total: 0, page: 1, size: 25 },
+  }).as("getPrivacyRequests");
+};


### PR DESCRIPTION
Cypress tests were failing on main. This seems to be because we were trying to call `/privacy-request`, whose result, if it failed, was not caught. This adds an intercept to cypress tests that call the home page to return empty privacy request data so that the home page can still load ok

### Code Changes

* [x] Add a function which stubs the home page
* [x] Call the function where needed

### Steps to Confirm

* [ ] Run the cypress tests

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
