### PR TITLE
Show systems without privacy declarations on data map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The types of changes are:
 
 * Handle malformed tokens [#1523](https://github.com/ethyca/fides/pull/1523)
 * Remove thrown exception from getAllPrivacyRequests method [#1592](https://github.com/ethyca/fides/pull/1593)
+* Include systems without a privacy declaration on data map [#1603](https://github.com/ethyca/fides/pull/1603)
 
 
 ### Docs

--- a/src/fides/ctl/core/export.py
+++ b/src/fides/ctl/core/export.py
@@ -231,11 +231,15 @@ def generate_system_records(
                 data_protection_impact_assessment["progress"],
                 data_protection_impact_assessment["link"],
             ]
-            length_to_na = 12
-            start_position = 6
-            for i in range(length_to_na):
-                system_row.insert(i + start_position, EMPTY_COLUMN_PLACEHOLDER)
+            num_privacy_declaration_fields = 12
+            privacy_declaration_start_index = 6
+            for i in range(num_privacy_declaration_fields):
+                system_row.insert(
+                    i + privacy_declaration_start_index, EMPTY_COLUMN_PLACEHOLDER
+                )
             system_row.append(EMPTY_COLUMN_PLACEHOLDER)
+
+            # also add n/a for the dataset reference
             output_list += [tuple(system_row)]
 
     return output_list

--- a/tests/ctl/core/test_export.py
+++ b/tests/ctl/core/test_export.py
@@ -114,7 +114,7 @@ def test_system_records_to_export_sans_privacy_declaration(
     test_sample_system_taxonomy: Generator, test_config: FidesConfig
 ) -> None:
     """
-    Asserts that unique records for systems without a privacy declaratopm
+    Asserts that unique records for systems without a privacy declaration
     are returned properly (including the header row)
     """
     test_sample_system_taxonomy["system"][0].privacy_declarations = []

--- a/tests/ctl/core/test_export.py
+++ b/tests/ctl/core/test_export.py
@@ -110,6 +110,20 @@ def test_system_records_to_export(
 
 
 @pytest.mark.unit
+def test_system_records_to_export_sans_privacy_declaration(
+    test_sample_system_taxonomy: Generator, test_config: FidesConfig
+) -> None:
+    """
+    Asserts that unique records for systems without a privacy declaratopm
+    are returned properly (including the header row)
+    """
+    test_sample_system_taxonomy["system"][0].privacy_declarations = []
+    output_list = export.generate_system_records(test_sample_system_taxonomy)
+    print(output_list)
+    assert len(output_list) == 2
+
+
+@pytest.mark.unit
 def test_dataset_records_to_export(test_sample_dataset_taxonomy: Generator) -> None:
     """
     Asserts that unique records are returned properly (including


### PR DESCRIPTION
Closes #1414

### Code Changes

* [x] Add a failing test for systems without privacy declarations
* [x] Add a path to handle systems without a privacy declaration

### Steps to Confirm

* [x] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Originally discovered as part of a plus feature where systems are generated without privacy declarations.
