### PR TITLE
Disable analytics middleware on non-API routes, enable in testing

### DIFF
--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -79,11 +79,18 @@ ROUTERS = crud.routers + [  # type: ignore[attr-defined]
 @app.middleware("http")
 async def dispatch_log_request(request: Request, call_next: Callable) -> Response:
     """
-    HTTP Middleware that logs analytics events for each call to Fidesops endpoints.
-    :param request: Request to fidesops api
+    HTTP Middleware that logs analytics events for each call to Fides endpoints.
+    :param request: Request to Fides api
     :param call_next: Callable api endpoint
     :return: Response
     """
+
+    # Only log analytics events for requests that are for API endpoints (i.e. /api/...)
+    path = request.url.path
+    if (not path.startswith(API_PREFIX)) or (path.endswith("/health")):
+        return await call_next(request)
+
+
     fides_source: Optional[str] = request.headers.get("X-Fides-Source")
     now: datetime = datetime.now(tz=timezone.utc)
     endpoint = f"{request.method}: {request.url}"

--- a/src/fides/data/sample_project/fides.toml
+++ b/src/fides/data/sample_project/fides.toml
@@ -31,4 +31,4 @@ server_host = "fides"
 server_port = 8080
 
 [user]
-analytics_opt_out = true
+analytics_opt_out = false

--- a/src/fides/data/test_env/fides.test_env.toml
+++ b/src/fides/data/test_env/fides.test_env.toml
@@ -40,4 +40,4 @@ server_host = "localhost"
 server_port = 8080
 
 [user]
-analytics_opt_out = true
+analytics_opt_out = false


### PR DESCRIPTION
### Code Changes

* [X] Update analytics middleware to only run on `/api/v1/...` routes
* [X] Re-enable analytics in test environment, sample project, etc.

### Steps to Confirm

* [X] Ran `nox -s test_env` with some temporary debug logs to confirm analytics middleware was running (and then removed these)
* [X] Ran `fides deploy up` with analytics enabled on `main` and confirmed very poor performance on UI pages
* [X] Ran `fides deploy up` with analytics enabled on this branch and confirmed good performance on UI pages

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [X] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [X] documentation issue created (tag docs-team to complete issue separately)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [X] Update `CHANGELOG.md`

### Description Of Changes

Our analytics middleware is too expansive - it runs on all routes, which in turn means it generates events for every GET. This is OK in most cases, but in a production deployment we also serve up all the UI assets from the server, which means every GET for JS files, image files, CSS snippets, etc. are all generating analytics events. These are uninteresting noise in our analytics, but they also bog down the Python event loop, and since we've not enabled much concurrency in our server yet, it leads to noticeable sluggishness in the Admin UI when running a release image.

This is a pretty simple performance improvement: only run analytics on the API routes, ignoring everything else. I also included `/health` in here explicitly, since that is a common "ping" API that isn't interesting for analytics either.
