### PR TITLE
Fidesops -> Unified Fides final merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,16 +25,18 @@ The types of changes are:
 * Handle malformed tokens [#1523](https://github.com/ethyca/fides/pull/1523)
 * Remove thrown exception from getAllPrivacyRequests method [#1592](https://github.com/ethyca/fides/pull/1593)
 * Include systems without a privacy declaration on data map [#1603](https://github.com/ethyca/fides/pull/1603)
-
+* After editing a dataset, the table will stay on the previously selected collection instead of resetting to the first one. [#1511](https://github.com/ethyca/fides/pull/1511)
+* Fix redis `db_index` config issue [#1647](https://github.com/ethyca/fides/pull/1647)
 
 ### Docs
 
 * Add unlinked docs and fix any remaining broken links [#1266](https://github.com/ethyca/fides/pull/1266)
 * Update privacy center docs to include consent information [#1537](https://github.com/ethyca/fides/pull/1537)
 
-### Fixed
+### Changed 
 
-* After editing a dataset, the table will stay on the previously selected collection instead of resetting to the first one. [#1511](https://github.com/ethyca/fides/pull/1511)
+* Allow multiple masking strategies to be specified when using fides as a masking engine [#1647](https://github.com/ethyca/fides/pull/1647)
+
 
 ## [1.9.5](https://github.com/ethyca/fides/compare/1.9.4...1.9.5)
 

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -90,7 +90,6 @@ async def dispatch_log_request(request: Request, call_next: Callable) -> Respons
     if (not path.startswith(API_PREFIX)) or (path.endswith("/health")):
         return await call_next(request)
 
-
     fides_source: Optional[str] = request.headers.get("X-Fides-Source")
     now: datetime = datetime.now(tz=timezone.utc)
     endpoint = f"{request.method}: {request.url}"

--- a/src/fides/api/ops/schemas/masking/masking_api.py
+++ b/src/fides/api/ops/schemas/masking/masking_api.py
@@ -1,6 +1,6 @@
-from typing import Any, List
+from typing import Any, Dict, List, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 
 from fides.api.ops.schemas.policy import PolicyMaskingSpec
 
@@ -9,7 +9,25 @@ class MaskingAPIRequest(BaseModel):
     """The API Request for masking operations"""
 
     values: List[str]
-    masking_strategy: PolicyMaskingSpec
+    masking_strategy: Union[PolicyMaskingSpec, List[PolicyMaskingSpec]]
+    masking_strategies: List[PolicyMaskingSpec] = []
+
+    @root_validator(pre=False)
+    def build_masking_strategies(cls, values: Dict) -> Dict:
+        """
+        Update "masking_strategies" field by inspecting "masking_strategy".
+        The ability to specify one or more masking strategies was added in a
+        backwards-compatible way.  Pass in a single masking strategy, or a list
+        of masking_strategy objects under "masking_strategy", and we
+        set the "masking_strategies" value from there.
+        Masking_strategies should not be supplied directly.
+        """
+        strategy = values.get("masking_strategy")
+        values["masking_strategies"] = (
+            strategy if isinstance(strategy, list) else [strategy]
+        )
+
+        return values
 
 
 class MaskingAPIResponse(BaseModel):

--- a/src/fides/api/ops/schemas/policy.py
+++ b/src/fides/api/ops/schemas/policy.py
@@ -1,19 +1,18 @@
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from fides.api.ops.models.policy import ActionType, DrpAction
 from fides.api.ops.schemas.api import BulkResponse, BulkUpdateFailed
 from fides.api.ops.schemas.base_class import BaseSchema
-from fides.api.ops.schemas.masking.masking_configuration import FormatPreservationConfig
 from fides.api.ops.schemas.shared_schemas import FidesOpsKey
 from fides.api.ops.schemas.storage.storage import StorageDestinationResponse
 from fides.api.ops.util.data_category import DataCategory
 
 
 class PolicyMaskingSpec(BaseSchema):
-    """Models the masking strategy definition int the policy document"""
+    """Models the masking strategy definition"""
 
     strategy: str
-    configuration: Dict[str, Union[str, FormatPreservationConfig]]
+    configuration: Dict[str, Any]
 
 
 class PolicyMaskingSpecResponse(BaseSchema):

--- a/src/fides/cli/commands/util.py
+++ b/src/fides/cli/commands/util.py
@@ -148,7 +148,9 @@ def up(ctx: click.Context, no_pull: bool = False, no_init: bool = False) -> None
             config_path = create_config_file(ctx=ctx, fides_directory_location=".")
             check_and_update_analytics_config(ctx=ctx, config_path=config_path)
         else:
-            echo_green("Deployment successful! Skipping CLI initialization (run 'fides init' to initialize)")
+            echo_green(
+                "Deployment successful! Skipping CLI initialization (run 'fides init' to initialize)"
+            )
         print_divider()
 
         print_deploy_success()

--- a/src/fides/ctl/core/config/redis_settings.py
+++ b/src/fides/ctl/core/config/redis_settings.py
@@ -37,7 +37,8 @@ class RedisSettings(FidesSettings):
             # If the whole URL is provided via the config, preference that
             return v
 
-        return f"redis://{quote_plus(values.get('user', ''))}:{quote_plus(values['password'])}@{values['host']}:{values['port']}/{values.get('db_index', '')}"
+        db_index = values.get("db_index") if values.get("db_index") is not None else ""
+        return f"redis://{quote_plus(values.get('user', ''))}:{quote_plus(values.get('password', ''))}@{values.get('host', '')}:{values.get('port', '')}/{db_index}"
 
     class Config:
         env_prefix = ENV_PREFIX

--- a/tests/ops/api/v1/endpoints/test_masking_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_masking_endpoints.py
@@ -43,6 +43,27 @@ class TestGetMaskingStrategies:
 
 
 class TestMaskValues:
+    def test_no_strategies_specified(self, api_client: TestClient):
+        value = "my_email"
+        request = {
+            "values": [value],
+        }
+
+        response = api_client.put(f"{V1_URL_PREFIX}{MASKING}", json=request)
+        assert 422 == response.status_code
+
+    def test_mask_nothing(self, api_client: TestClient):
+        request = {
+            "values": None,
+            "masking_strategy": {
+                "strategy": StringRewriteMaskingStrategy.name,
+                "configuration": {"rewrite_value": "MASKED"},
+            },
+        }
+
+        response = api_client.put(f"{V1_URL_PREFIX}{MASKING}", json=request)
+        assert 422 == response.status_code
+
     def test_mask_value_string_rewrite(self, api_client: TestClient):
         value = "check"
         rewrite_val = "mate"
@@ -210,3 +231,62 @@ class TestMaskValues:
         json_response = json.loads(response.text)
         assert value == json_response["plain"][0]
         assert json_response["masked_values"][0] is None
+
+    def test_masking_values_multiple_strategies(self, api_client: TestClient):
+        value = "check"
+        rewrite_val = "mate"
+        request = {
+            "values": [value],
+            "masking_strategy": [
+                {
+                    "strategy": StringRewriteMaskingStrategy.name,
+                    "configuration": {"rewrite_value": rewrite_val},
+                },
+                {
+                    "strategy": HashMaskingStrategy.name,
+                    "configuration": {},
+                },
+            ],
+        }
+
+        response = api_client.put(f"{V1_URL_PREFIX}{MASKING}", json=request)
+        assert 200 == response.status_code
+        assert response.json()["plain"] == ["check"]
+        assert response.json()["masked_values"] != [
+            rewrite_val
+        ], "Final value is hashed, because that was the last strategy"
+
+        switch_order = {
+            "values": [value],
+            "masking_strategy": [
+                {
+                    "strategy": HashMaskingStrategy.name,
+                    "configuration": {},
+                },
+                {
+                    "strategy": StringRewriteMaskingStrategy.name,
+                    "configuration": {"rewrite_value": rewrite_val},
+                },
+            ],
+        }
+        response = api_client.put(f"{V1_URL_PREFIX}{MASKING}", json=switch_order)
+        assert 200 == response.status_code
+        assert response.json()["plain"] == ["check"]
+        assert response.json()["masked_values"] == [
+            rewrite_val
+        ], "Final value is rewrite value, because that was the last strategy specified"
+
+    def test_flexible_config(self, api_client: TestClient):
+        """Test that this request is allowed.  Allow the configuration to be
+        very flexible so different configuration requirements by many masking strategies are supported"""
+        value = "my_email"
+        request = {
+            "values": [value],
+            "masking_strategy": {
+                "strategy": NullMaskingStrategy.name,
+                "configuration": {"test_val": {"test": [["test"]]}},
+            },
+        }
+
+        response = api_client.put(f"{V1_URL_PREFIX}{MASKING}", json=request)
+        assert 200 == response.status_code


### PR DESCRIPTION
Closes 

### Code Changes

* [x] changes from: https://github.com/ethyca/fidesops/pull/1427
* [x] changes from: https://github.com/ethyca/fidesops/pull/1428

### Steps to Confirm

* [ ] For specifying multiple masking strategies, bring the server up `nox -s dev` and run a PUT request against the masking engine with one strategy (backwards compatible) and multiple strategies (a list of strategies) under "masking_strategy". Also test that there is a lot more flexibility in `configuration` format - in this example, I have a string mapped to a list of lists.

Note that specifying multiple masking strategies may feel contrived in core fides, but this work is to support combining multiple `plus` strategies.

**PUT masking/mask**
```json
{
  "values": [
    "111-111-1111",
    "customer-1@example.com"
  ],
  "masking_strategy": [
    {
      "strategy": "random_string_rewrite",
      "configuration": {
        "length": 20,
        "format_preservation": {
          "suffix": "@masked.com"
        }
      }
    },
    {
      "strategy": "hash",
      "configuration": {
        "a": [
          [
            "b"
          ]
        ]
      }
    }
  ]
}
```

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [X] Update `CHANGELOG.md`

### Description Of Changes

The old git merge strategy across repos isn't working anymore, so it's back to the hard way...

Luckily not much needs to get copy/pasted over, just those two PRs worth of changes. I've confirmed that everything before that was merged in the previously by manually checking the code changes against fides `main`
