### PR TITLE
1629 custom auth strategy adobe campaign

### DIFF
--- a/data/saas/config/adobe_campaign_config.yml
+++ b/data/saas/config/adobe_campaign_config.yml
@@ -15,15 +15,21 @@ saas_config:
     - name: regulation
       description: The regulation to follow for data protection requests
     - name: client_id
-    - name: access_token
+    - name: technical_account_id
+    - name: private_key
+    - name: client_secret
 
   client_config:
     protocol: https
     host: <domain>/<organization_id>
     authentication:
-      strategy: bearer
+      strategy: adobe
       configuration:
-        token: <access_token>
+        organization_id: <organization_id>
+        technical_account_id: <technical_account_id>
+        client_id: <client_id>
+        private_key: <private_key>
+        client_secret: <client_secret>
 
   test_request:
     method: GET

--- a/data/saas/config/adobe_campaign_config.yml
+++ b/data/saas/config/adobe_campaign_config.yml
@@ -29,7 +29,7 @@ saas_config:
     protocol: https
     host: <domain>/<organization>
     authentication:
-      strategy: adobe
+      strategy: adobe_campaign
       configuration:
         organization_id: <organization_id>
         technical_account_id: <technical_account_id>

--- a/data/saas/config/adobe_campaign_config.yml
+++ b/data/saas/config/adobe_campaign_config.yml
@@ -3,33 +3,39 @@ saas_config:
   name: Adobe Campaign SaaS Config
   type: adobe_campaign
   description: A schema representing the Adobe Campaign connector for Fidesops
-  version: 0.0.1
+  version: 0.0.2
 
   connector_params:
     - name: domain
       default_value: mc.adobe.io
+    - name: organization
+      description: e.g. ORGANIZATION for production or ORGANIZATION-mkt-stage for staging
     - name: organization_id
+      description: e.g. ***@AdobeOrg
+    - name: client_id
+    - name: client_secret
+    - name: technical_account_id
+      description: e.g. ***@techacct.adobe.com
+    - name: private_key
+      description: PEM formatted
     - name: namespace
       default_value: defaultNamespace1
       description: The namespace to use for data protections requests
     - name: regulation
+      options: [CCPA, GDPR]
       description: The regulation to follow for data protection requests
-    - name: client_id
-    - name: technical_account_id
-    - name: private_key
-    - name: client_secret
 
   client_config:
     protocol: https
-    host: <domain>/<organization_id>
+    host: <domain>/<organization>
     authentication:
       strategy: adobe
       configuration:
         organization_id: <organization_id>
         technical_account_id: <technical_account_id>
         client_id: <client_id>
-        private_key: <private_key>
         client_secret: <client_secret>
+        private_key: <private_key>
 
   test_request:
     method: GET

--- a/src/fides/api/ops/service/saas_request/__init__.py
+++ b/src/fides/api/ops/service/saas_request/__init__.py
@@ -1,5 +1,5 @@
 from fides.api.ops.service.saas_request.override_implementations import (
-    authentication_strategy_adobe,
+    authentication_strategy_adobe_campaign,
     authentication_strategy_doordash,
     domo_request_overrides,
     mailchimp_request_overrides,

--- a/src/fides/api/ops/service/saas_request/__init__.py
+++ b/src/fides/api/ops/service/saas_request/__init__.py
@@ -1,4 +1,5 @@
 from fides.api.ops.service.saas_request.override_implementations import (
+    authentication_strategy_adobe,
     authentication_strategy_doordash,
     domo_request_overrides,
     mailchimp_request_overrides,

--- a/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_adobe.py
+++ b/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_adobe.py
@@ -1,0 +1,68 @@
+import math
+import time
+from typing import Any, Dict, Optional
+
+import jwt.utils
+from jwt import encode
+from requests import PreparedRequest
+
+from fides.api.ops.models.connectionconfig import ConnectionConfig
+from fides.api.ops.schemas.saas.strategy_configuration import StrategyConfiguration
+from fides.api.ops.service.authentication.authentication_strategy import (
+    AuthenticationStrategy,
+)
+from fides.api.ops.util.saas_util import assign_placeholders
+
+
+class AdobeAuthenticationConfiguration(StrategyConfiguration):
+    """
+    Parameters to generate an Adobe JWT token
+    """
+
+    organization_id: str
+    technical_account_id: str
+    client_id: str
+    private_key: str
+    client_secret: str
+
+
+class AdobeAuthenticationStrategy(AuthenticationStrategy):
+    """
+    Adds an Adobe JWT as bearer auth to the request
+    """
+
+    name = "adobe"
+    configuration_model = AdobeAuthenticationConfiguration
+
+    def __init__(self, configuration: AdobeAuthenticationConfiguration):
+        self.organization_id = configuration.organization_id
+        self.technical_account_id = configuration.technical_account_id
+        self.client_id = configuration.client_id
+        self.private_key = configuration.private_key
+        self.client_secrent = configuration.client_secret
+
+    def add_authentication(
+        self, request: PreparedRequest, connection_config: ConnectionConfig
+    ) -> PreparedRequest:
+        """
+        Generate an Adobe JWT and add it as bearer auth
+        """
+
+        secrets: Optional[Dict[str, Any]] = connection_config.secrets
+
+        token = encode(
+            {
+                "exp": str(math.floor(time.time() + 60)),
+                "iss": f"{assign_placeholders(self.organization_id, secrets)}@AdobeOrg",
+                "sub": f"{assign_placeholders(self.technical_account_id, secrets)}@techacct.adobe.com",
+                "https://ims-na1.adobelogin.com/s/meta_scope": True,
+                "aud": f"https://ims-na1.adobelogin.com/c/{assign_placeholders(self.client_id, secrets)}",
+            },
+            jwt.utils.base64url_decode(
+                assign_placeholders(self.private_key, secrets)  # type: ignore
+            ),
+            algorithm="RS256",
+        )
+
+        request.headers["Authorization"] = f"Bearer {token}"
+        return request

--- a/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_adobe.py
+++ b/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_adobe.py
@@ -86,14 +86,15 @@ class AdobeAuthenticationStrategy(AuthenticationStrategy):
                 access_token = json_response.get("access_token")
                 expires_in = json_response.get("expires_in")
 
-                data = {
-                    "access_token": access_token,
-                    "expires_at": int(datetime.utcnow().timestamp()) + expires_in,
-                }
-
-                # save values to the connection_config secrets
+                # merge the new values into the existing connection_config secrets
                 db = Session.object_session(connection_config)
-                updated_secrets = {**secrets, **data}
+                updated_secrets = {
+                    **secrets,
+                    **{
+                        "access_token": access_token,
+                        "expires_at": int(datetime.utcnow().timestamp()) + expires_in,
+                    },
+                }
                 connection_config.update(db, data={"secrets": updated_secrets})
                 logger.info(
                     "Successfully updated the access token for %s",

--- a/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_adobe_campaign.py
+++ b/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_adobe_campaign.py
@@ -2,7 +2,7 @@ import logging
 import math
 import time
 from datetime import datetime, timedelta
-from typing import Dict, cast
+from typing import Dict, Optional, cast
 
 from jwt import encode
 from requests import PreparedRequest, post
@@ -54,8 +54,8 @@ class AdobeAuthenticationStrategy(AuthenticationStrategy):
         """
 
         secrets = cast(Dict, connection_config.secrets)
-        access_token = secrets.get("access_token")
-        expires_at = secrets.get("expires_at")
+        access_token: Optional[str] = secrets.get("access_token")
+        expires_at: Optional[int] = secrets.get("expires_at")
 
         if not access_token or self._close_to_expiration(expires_at, connection_config):
             # generate a JWT token and sign it with the private key
@@ -67,7 +67,7 @@ class AdobeAuthenticationStrategy(AuthenticationStrategy):
                     "https://ims-na1.adobelogin.com/s/ent_campaign_sdk": True,
                     "aud": f"https://ims-na1.adobelogin.com/c/{assign_placeholders(self.client_id, secrets)}",
                 },
-                assign_placeholders(self.private_key, secrets),
+                str(assign_placeholders(self.private_key, secrets)),
                 algorithm="RS256",
             )
 
@@ -108,7 +108,7 @@ class AdobeAuthenticationStrategy(AuthenticationStrategy):
 
     @staticmethod
     def _close_to_expiration(
-        expires_at: int, connection_config: ConnectionConfig
+        expires_at: Optional[int], connection_config: ConnectionConfig
     ) -> bool:
         """Check if the access_token will expire in the next 10 minutes."""
 

--- a/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_adobe_campaign.py
+++ b/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_adobe_campaign.py
@@ -19,7 +19,7 @@ from fides.api.ops.util.saas_util import assign_placeholders
 logger = logging.getLogger(__name__)
 
 
-class AdobeAuthenticationConfiguration(StrategyConfiguration):
+class AdobeCampaignAuthenticationConfiguration(StrategyConfiguration):
     """
     Parameters to generate an Adobe JWT token
     """
@@ -36,10 +36,10 @@ class AdobeAuthenticationStrategy(AuthenticationStrategy):
     Adds an Adobe JWT as bearer auth to the request
     """
 
-    name = "adobe"
-    configuration_model = AdobeAuthenticationConfiguration
+    name = "adobe_campaign"
+    configuration_model = AdobeCampaignAuthenticationConfiguration
 
-    def __init__(self, configuration: AdobeAuthenticationConfiguration):
+    def __init__(self, configuration: AdobeCampaignAuthenticationConfiguration):
         self.organization_id = configuration.organization_id
         self.technical_account_id = configuration.technical_account_id
         self.client_id = configuration.client_id

--- a/tests/ops/fixtures/saas/adobe_campaign_fixtures.py
+++ b/tests/ops/fixtures/saas/adobe_campaign_fixtures.py
@@ -25,16 +25,24 @@ secrets = get_secrets("adobe_campaign")
 def adobe_campaign_secrets(saas_config):
     return {
         "domain": pydash.get(saas_config, "adobe_campaign.domain") or secrets["domain"],
+        "organization": pydash.get(saas_config, "adobe_campaign.organization")
+        or secrets["organization"],
         "organization_id": pydash.get(saas_config, "adobe_campaign.organization_id")
         or secrets["organization_id"],
+        "client_id": pydash.get(saas_config, "adobe_campaign.client_id")
+        or secrets["client_id"],
+        "client_secret": pydash.get(saas_config, "adobe_campaign.client_secret")
+        or secrets["client_secret"],
+        "technical_account_id": pydash.get(
+            saas_config, "adobe_campaign.technical_account_id"
+        )
+        or secrets["technical_account_id"],
+        "private_key": pydash.get(saas_config, "adobe_campaign.private_key")
+        or secrets["private_key"],
         "namespace": pydash.get(saas_config, "adobe_campaign.namespace")
         or secrets["namespace"],
         "regulation": pydash.get(saas_config, "adobe_campaign.regulation")
         or secrets["regulation"],
-        "client_id": pydash.get(saas_config, "adobe_campaign.client_id")
-        or secrets["client_id"],
-        "access_token": pydash.get(saas_config, "adobe_campaign.access_token")
-        or secrets["access_token"],
     }
 
 


### PR DESCRIPTION
Closes #1629 

### Code Changes

* [x] Added new `adobe_campaign` authentication strategy that does the following
  * [x] Generates and signs a short-lived JWT
  * [x] Exchanges the JWT for an access token with a 24 hour TTL
  * [x] Refreshes the token after 24 hours have elapsed
* [x] Updates the adobe_campaign_config.yml with the new required connector params
  * [x] Adding descriptions to help with configuration

### Steps to Confirm

* [x] Re-ran the connection test successfully

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
