### PR TITLE
Bump fideslog to v1.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/1.9.6...main)
 
+### Fixed
+
+* Exceptions are no longer raised when sending analytics on Windows [#1666](https://github.com/ethyca/fides/pull/1666)
+
+## [2.0.0](https://github.com/ethyca/fides/compare/1.9.6...2.0.0)
+
 ### Added
 
 * Allow delete-only SaaS connector endpoints [#1200](https://github.com/ethyca/fides/pull/1200)
@@ -31,6 +37,7 @@ The types of changes are:
 * Added a column selector to the scan results page of the config wizard [#1590](https://github.com/ethyca/fides/pull/1590)
 
 ### Changed
+
 * Updated mypy to version 0.981 and Python to version 3.10.7 [#1448](https://github.com/ethyca/fides/pull/1448)
 
 ### Developer Experience
@@ -68,7 +75,7 @@ The types of changes are:
 * Update privacy center docs to include consent information [#1537](https://github.com/ethyca/fides/pull/1537)
 * Update UI docs to include DSR countdown information and additional descriptions/filtering [#1545](https://github.com/ethyca/fides/pull/1545)
 
-### Changed 
+### Changed
 
 * Allow multiple masking strategies to be specified when using fides as a masking engine [#1647](https://github.com/ethyca/fides/pull/1647)
 
@@ -335,7 +342,7 @@ The types of changes are:
 * Add datasets via database connection (UI only) [#834](https://github.com/ethyca/fides/pull/834)
 * Add Okta support to the `/generate` endpoint [#842](https://github.com/ethyca/fides/pull/842)
 * Add db support to `/generate` endpoint [849](https://github.com/ethyca/fides/pull/849)
-* Added OpenAPI TypeScript client generation for the UI app. See the [README](/clients/ctl/admin-ui/src/types/api/README.md) for more details.
+* Added OpenAPI TypeScript client generation for the UI app. See the [README](/clients/admin-ui/src/types/api/README.md) for more details.
 
 ### Changed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ fastapi-pagination[sqlalchemy]~= 0.10.0
 fastapi[all]==0.82.0
 fideslang==1.3.0
 fideslib==3.1.5
-fideslog==1.2.9
+fideslog==1.2.10
 firebase-admin==5.3.0
 GitPython==3.1.27
 hvac==0.11.2


### PR DESCRIPTION
Closes #1660

### Code Changes

* [x] Bump fideslog to v1.2.10

### Steps to Confirm

1. Buy a Windows machine
1. Using the Windows machine, start fides
1. Observe that errors are no longer thrown when sending analytics events **synchronously**

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`