### PR TITLE
ui/auth: Remove lingering local storage parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 * Exceptions are no longer raised when sending analytics on Windows [#1666](https://github.com/ethyca/fides/pull/1666)
 * Fixed wording on identity verification modal in the Privacy Center [#1674](https://github.com/ethyca/fides/pull/1674)
 * Update system fides_key tooltip text [#1533](https://github.com/ethyca/fides/pull/1685)
+* Removed local storage parsing that is redundant with redux-persist. [#1678](https://github.com/ethyca/fides/pull/1678)
 
 ### Security
 

--- a/clients/admin-ui/src/app/store.ts
+++ b/clients/admin-ui/src/app/store.ts
@@ -57,7 +57,7 @@ import {
 import { reducer as systemReducer, systemApi } from "~/features/system";
 import { reducer as taxonomyReducer, taxonomyApi } from "~/features/taxonomy";
 
-import { authApi, AuthState, reducer as authReducer } from "../features/auth";
+import { authApi, reducer as authReducer } from "../features/auth";
 
 /**
  * To prevent the "redux-perist failed to create sync storage. falling back to noop storage"
@@ -111,10 +111,12 @@ const reducer = {
   userManagement: userManagementReducer,
 };
 
+export type RootState = StateFromReducersMapObject<typeof reducer>;
+
 const allReducers = combineReducers(reducer);
 
-const rootReducer = (state: any, action: AnyAction) => {
-  let newState = { ...state };
+const rootReducer = (state: RootState | undefined, action: AnyAction) => {
+  let newState = state;
   if (action.type === "auth/logout") {
     storage.removeItem(STORAGE_ROOT_KEY);
     newState = undefined;
@@ -151,8 +153,6 @@ const persistConfig = {
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);
 
-export type RootState = StateFromReducersMapObject<typeof reducer>;
-
 export const makeStore = (preloadedState?: Partial<RootState>) =>
   configureStore({
     reducer: persistedReducer,
@@ -181,23 +181,7 @@ export const makeStore = (preloadedState?: Partial<RootState>) =>
     preloadedState,
   });
 
-let storedAuthState: AuthState | undefined;
-if (typeof window !== "undefined" && "localStorage" in window) {
-  const storedAuthStateString = localStorage.getItem(STORAGE_ROOT_KEY);
-  if (storedAuthStateString) {
-    try {
-      storedAuthState = JSON.parse(storedAuthStateString);
-    } catch (error) {
-      // TODO: build in formal error logging system
-      // eslint-disable-next-line no-console
-      console.error(error);
-    }
-  }
-}
-
-const store = makeStore({
-  auth: storedAuthState,
-});
+const store = makeStore();
 
 type AppStore = ReturnType<typeof makeStore>;
 export type AppDispatch = AppStore["dispatch"];


### PR DESCRIPTION
### Description Of Changes

I was wondering why we need to manually open up localStorage when we have redux-persist configured to do that for us now. Removed this and the log in/out still works as expected. So I think this was just a lingering from changeover.

Similar to this block that was left over from the fidesops merge: https://github.com/ethyca/fides/pull/1569/files#diff-3071c1012e5bece4441d5b7643c083188c22fbfe96caea78da1f09fdeeeb1599L59

