### PR TITLE
Run all checks on merges to `main`

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -267,7 +267,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     continue-on-error: true
-    if: contains(github.event.pull_request.labels.*.name, 'run unsafe ci checks')
+    if: contains(github.event.pull_request.labels.*.name, 'run unsafe ci checks') || github.event_name == 'push'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -1,10 +1,12 @@
 name: Backend Code Checks
 
-# Run this on main as well
 on:
   pull_request:
     paths-ignore:
       - "**.md"
+  push:
+    branches:
+      - "main"
 
 env:
   IMAGE: ethyca/fides:local

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -1,5 +1,6 @@
 name: Backend Code Checks
 
+# Run this on main as well
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -198,7 +198,8 @@ jobs:
         python_version: ["3.8.14", "3.9.14", "3.10.7"]
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: contains(github.event.pull_request.labels.*.name, 'run unsafe ci checks')
+    # In PRs run with the "unsafe" label, or run on a "push" event to main
+    if: contains(github.event.pull_request.labels.*.name, 'run unsafe ci checks') || github.event_name == 'push'
     continue-on-error: true
     steps:
       - name: Download container
@@ -235,7 +236,8 @@ jobs:
         python_version: ["3.8.14", "3.9.14", "3.10.7"]
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: contains(github.event.pull_request.labels.*.name, 'run unsafe ci checks')
+    # In PRs run with the "unsafe" label, or run on a "push" event to main
+    if: contains(github.event.pull_request.labels.*.name, 'run unsafe ci checks') || github.event_name == 'push'
     continue-on-error: true
     steps:
       - name: Download container
@@ -267,6 +269,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     continue-on-error: true
+    # In PRs run with the "unsafe" label, or run on a "push" event to main
     if: contains(github.event.pull_request.labels.*.name, 'run unsafe ci checks') || github.event_name == 'push'
     permissions:
       contents: read

--- a/.github/workflows/cli_checks.yml
+++ b/.github/workflows/cli_checks.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
+  push:
+    branches:
+      - "main"
+
 
 env:
   DEFAULT_PYTHON_VERSION: "3.10.7"

--- a/.github/workflows/cli_checks.yml
+++ b/.github/workflows/cli_checks.yml
@@ -32,7 +32,7 @@ jobs:
 
   Fides-Deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/frontend_checks.yml
+++ b/.github/workflows/frontend_checks.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "clients/**"
       - ".github/workflows/frontend_pr_checks.yml"
+  push:
+    branches:
+      - "main"
 
 env:
   CI: true

--- a/.github/workflows/static_code_checks.yml
+++ b/.github/workflows/static_code_checks.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
+  push:
+    branches:
+      - "main"
 
 env:
   IMAGE: ethyca/fides:local


### PR DESCRIPTION
Closes #1662 

### Code Changes

* [x] update backend checks
* [x] update frontend checks
* [x] update static checks
* [x] update CLI checks
* [x] update the "dangerous" checks to make sure they'll run on `main` without the label

### Steps to Confirm

* [ ] check documentation to confirm this should probably work

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

This PR updates code checks to run on pushes to `main` in addition to their runs during PRs. This helps us keep a more clear picture of the stability of `main` as well as more easily tracking down what merges potentially broke which things
