### PR TITLE
[1637] api/permissions: Allow the root user to query their own permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The types of changes are:
 * Fixed wording on identity verification modal in the Privacy Center [#1674](https://github.com/ethyca/fides/pull/1674)
 * Update system fides_key tooltip text [#1533](https://github.com/ethyca/fides/pull/1685)
 * Removed local storage parsing that is redundant with redux-persist. [#1678](https://github.com/ethyca/fides/pull/1678)
+* Allow users to query their own permissions, including root user. [#1698](https://github.com/ethyca/fides/pull/1698)
 
 ### Security
 

--- a/src/fides/api/ops/util/oauth_util.py
+++ b/src/fides/api/ops/util/oauth_util.py
@@ -44,12 +44,20 @@ async def get_current_user(
     authorization: str = Security(oauth2_scheme),
     db: Session = Depends(get_db),
 ) -> FidesUser:
-    """A wrapper around verify_oauth_client that returns that client's user if one exsits."""
+    """A wrapper around verify_oauth_client that returns that client's user if one exists."""
     client = await verify_oauth_client(
         security_scopes=security_scopes,
         authorization=authorization,
         db=db,
     )
+
+    if client.id == CONFIG.security.oauth_root_client_id:
+        return FidesUser(
+            id=CONFIG.security.oauth_root_client_id,
+            username=CONFIG.security.root_username,
+            created_at=datetime.utcnow(),
+        )
+
     return client.user
 
 


### PR DESCRIPTION
Closes #1637

### Code Changes

- Allow the root user to query their own permissions.
- Test fixtures root user!

### Steps to Confirm

* [ ] Log in as `root_user`
* [ ] The root user doesn't show up in user management (it's not a record)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

The special-casing of `root_user` goes all the way into [fideslib](https://github.com/ethyca/fideslib/blob/4b1fd0c50dcf07a7244152f3bedf12f39ecdfef7/fideslib/models/client.py#L97). This solves our login problem, and my change to `get_current_user` may prove helpful, but this will probably continue to be weird.

https://user-images.githubusercontent.com/2236777/200084386-4413e2a4-d4b5-4220-9286-0a684faaa8b1.mp4



