### PR TITLE
1467 twilio sms identity verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/1.9.6...main)
 
+### Added
+
+* Adds SMS support for identity verification notifications [#1726](https://github.com/ethyca/fides/pull/1726)
+
 ### Changed
 
 * Optional dependencies are no longer used for 3rd-party connectivity. Instead they are used to isolate dangerous dependencies. [#1679](https://github.com/ethyca/fides/pull/1679)

--- a/docs/fides/docs/development/postman/Fides.postman_collection.json
+++ b/docs/fides/docs/development/postman/Fides.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "652de86a-b40e-4711-b488-4b26252683ab",
+		"_postman_id": "1329eef2-2d7e-462d-b8f0-f185557f144c",
 		"name": "Fidesops",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "13396647"
@@ -2423,7 +2423,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n    {\"name\": \"Email ConnectionConfig\",\n    \"key\": \"{{email_connection_config_key}}\",\n    \"connection_type\": \"email\",\n    \"access\": \"read\",\n    \"email_service_type\": \"mailgun\"\n}]",
+							"raw": "[\n    {\"name\": \"Email ConnectionConfig\",\n    \"key\": \"{{email_connection_config_key}}\",\n    \"connection_type\": \"email\",\n    \"access\": \"read\"\n}]",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -75,7 +75,6 @@ from fides.api.ops.graph.traversal import Traversal
 from fides.api.ops.models.connectionconfig import ConnectionConfig
 from fides.api.ops.models.datasetconfig import DatasetConfig
 from fides.api.ops.models.manual_webhook import AccessManualWebhook
-from fides.api.ops.models.messaging import get_messaging_method
 from fides.api.ops.models.policy import (
     ActionType,
     CurrentStep,
@@ -281,7 +280,7 @@ async def create_privacy_request(
         except Exception as exc:
             logger.error("Exception: %s", Pii(str(exc)))
             failure = {
-                "message": "This record could not be added",
+                "message": f"This record could not be added: {exc}",
                 "data": kwargs,
             }
             failed.append(failure)
@@ -323,9 +322,7 @@ def _send_privacy_request_receipt_message_to_user(
                 action_type=MessagingActionType.PRIVACY_REQUEST_RECEIPT,
                 body_params=RequestReceiptBodyParams(request_types=request_types),
             ).dict(),
-            "messaging_method": get_messaging_method(
-                CONFIG.notifications.notification_service_type
-            ),
+            "service_type": CONFIG.notifications.notification_service_type,
             "to_identity": to_identity,
         },
     )
@@ -1177,9 +1174,7 @@ def _send_privacy_request_review_message_to_user(
                 if action_type is MessagingActionType.PRIVACY_REQUEST_REVIEW_DENY
                 else None,
             ).dict(),
-            "messaging_method": get_messaging_method(
-                CONFIG.notifications.notification_service_type
-            ),
+            "service_type": CONFIG.notifications.notification_service_type,
             "to_identity": to_identity,
         },
     )

--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -264,9 +264,9 @@ async def create_privacy_request(
                 queue_privacy_request(privacy_request.id)
         except MessageDispatchException as exc:
             kwargs["privacy_request_id"] = privacy_request.id
-            logger.error("EmailDispatchException: %s", exc)
+            logger.error("MessageDispatchException: %s", exc)
             failure = {
-                "message": "Verification email could not be sent.",
+                "message": "Verification message could not be sent.",
                 "data": kwargs,
             }
             failed.append(failure)

--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -280,7 +280,7 @@ async def create_privacy_request(
         except Exception as exc:
             logger.error("Exception: %s", Pii(str(exc)))
             failure = {
-                "message": f"This record could not be added",
+                "message": "This record could not be added",
                 "data": kwargs,
             }
             failed.append(failure)

--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -280,7 +280,7 @@ async def create_privacy_request(
         except Exception as exc:
             logger.error("Exception: %s", Pii(str(exc)))
             failure = {
-                "message": f"This record could not be added: {exc}",
+                "message": f"This record could not be added",
                 "data": kwargs,
             }
             failed.append(failure)

--- a/src/fides/api/ops/models/messaging.py
+++ b/src/fides/api/ops/models/messaging.py
@@ -95,14 +95,18 @@ class MessagingConfig(Base):
     )  # Type bytea in the db
 
     @classmethod
-    def get_configuration(cls, db: Session) -> Base:
+    def get_configuration(cls, db: Session, service_type: str) -> Base:
         """
-        Fetches the first configured MessagingConfig record. Once fetched this function validates that
+        Fetches the configured MessagingConfig record by service type. Once fetched this function validates that
         the MessagingConfig is configured with secrets.
         """
-        instance: Optional[Base] = cls.query(db=db).first()
+        instance: Optional[Base] = cls.get_by(
+            db=db, field="service_type", value=service_type
+        )
         if not instance:
-            raise MessageDispatchException("No messaging config found.")
+            raise MessageDispatchException(
+                f"No messaging config found for service_type {service_type}."
+            )
         if not instance.secrets:
             logger.warning(
                 "Messaging secrets not found for config with key: %s", instance.key

--- a/src/fides/api/ops/schemas/messaging/messaging.py
+++ b/src/fides/api/ops/schemas/messaging/messaging.py
@@ -206,12 +206,12 @@ class MessagingConfigRequest(BaseModel):
         use_enum_values = False
         orm_mode = True
 
-    @root_validator
+    @root_validator(pre=True)
     def validate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         # uppercase to match enums in database
         values["service_type"] = values.get("service_type").upper()  # type: ignore
         service_type: MessagingServiceType = values.get("service_type")  # type: ignore
-        if service_type == MessagingServiceType.MAILGUN:
+        if service_type == MessagingServiceType.MAILGUN.value:
             if not values.get("details"):
                 raise ValueError("Mailgun messaging config must include details")
         return values

--- a/src/fides/api/ops/schemas/messaging/messaging.py
+++ b/src/fides/api/ops/schemas/messaging/messaging.py
@@ -17,19 +17,21 @@ class MessagingMethod(Enum):
 
 
 class MessagingServiceType(Enum):
-    """Enum for messaging service type"""
+    """Enum for messaging service type. Upper-cased in the database"""
 
-    MAILGUN = "mailgun"
+    MAILGUN = "MAILGUN"
 
-    TWILIO_TEXT = "twilio_text"
-    TWILIO_EMAIL = "twilio_email"
+    TWILIO_TEXT = "TWILIO_TEXT"
+    TWILIO_EMAIL = "TWILIO_EMAIL"
 
 
 EMAIL_MESSAGING_SERVICES: Tuple[str, ...] = (
     MessagingServiceType.MAILGUN.value,
     MessagingServiceType.TWILIO_EMAIL.value,
 )
-SMS_MESSAGING_SERVICES: Tuple[str, ...] = tuple(MessagingServiceType.TWILIO_TEXT.value)
+SMS_MESSAGING_SERVICES: Tuple[str, ...] = tuple(
+    [MessagingServiceType.TWILIO_TEXT.value]
+)
 
 
 class MessagingActionType(str, Enum):
@@ -170,7 +172,7 @@ class MessagingServiceSecretsTwilioSMS(BaseModel):
         sender_phone = values.get("twilio_sender_phone_number")
         if not values.get("twilio_messaging_service_sid") and not sender_phone:
             raise ValueError(
-                "Either the twilio_messaging_service_id or the twilio_sender_phone_number should be supplied."
+                "Either the twilio_messaging_service_sid or the twilio_sender_phone_number should be supplied."
             )
         if sender_phone:
             pattern = regex(r"^\+\d+$")
@@ -206,6 +208,8 @@ class MessagingConfigRequest(BaseModel):
 
     @root_validator
     def validate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        # uppercase to match enums in database
+        values["service_type"] = values.get("service_type").upper()  # type: ignore
         service_type: MessagingServiceType = values.get("service_type")  # type: ignore
         if service_type == MessagingServiceType.MAILGUN:
             if not values.get("details"):

--- a/src/fides/api/ops/schemas/messaging/messaging.py
+++ b/src/fides/api/ops/schemas/messaging/messaging.py
@@ -29,9 +29,7 @@ EMAIL_MESSAGING_SERVICES: Tuple[str, ...] = (
     MessagingServiceType.MAILGUN.value,
     MessagingServiceType.TWILIO_EMAIL.value,
 )
-SMS_MESSAGING_SERVICES: Tuple[str, ...] = tuple(
-    [MessagingServiceType.TWILIO_TEXT.value]
-)
+SMS_MESSAGING_SERVICES: Tuple[str, ...] = (MessagingServiceType.TWILIO_TEXT.value,)
 
 
 class MessagingActionType(str, Enum):
@@ -208,12 +206,14 @@ class MessagingConfigRequest(BaseModel):
 
     @root_validator(pre=True)
     def validate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        # uppercase to match enums in database
-        values["service_type"] = values.get("service_type").upper()  # type: ignore
-        service_type: MessagingServiceType = values.get("service_type")  # type: ignore
-        if service_type == MessagingServiceType.MAILGUN.value:
-            if not values.get("details"):
-                raise ValueError("Mailgun messaging config must include details")
+        service_type_pre = values.get("service_type")
+        if service_type_pre:
+            # uppercase to match enums in database
+            values["service_type"] = service_type_pre.upper()
+            service_type: MessagingServiceType = values["service_type"]
+            if service_type == MessagingServiceType.MAILGUN.value:
+                if not values.get("details"):
+                    raise ValueError("Mailgun messaging config must include details")
         return values
 
 

--- a/src/fides/api/ops/service/_verification.py
+++ b/src/fides/api/ops/service/_verification.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
-from fides.api.ops.models.messaging import MessagingConfig, get_messaging_method
 from fides.api.ops.models.privacy_request import ConsentRequest, PrivacyRequest
 from fides.api.ops.schemas.messaging.messaging import (
     MessagingActionType,
@@ -22,9 +21,6 @@ def send_verification_code_to_user(
     db: Session, request: ConsentRequest | PrivacyRequest, to_identity: Identity | None
 ) -> str:
     """Generate and cache a verification code, and then message the user"""
-    MessagingConfig.get_configuration(
-        db=db
-    )  # Validates Fidesops is currently configured to send messages
     verification_code = generate_id_verification_code()
     request.cache_identity_verification_code(verification_code)
     messaging_action_type = (
@@ -36,9 +32,7 @@ def send_verification_code_to_user(
         db,
         action_type=messaging_action_type,
         to_identity=to_identity,
-        messaging_method=get_messaging_method(
-            CONFIG.notifications.notification_service_type
-        ),
+        service_type=CONFIG.notifications.notification_service_type,
         message_body_params=SubjectIdentityVerificationBodyParams(
             verification_code=verification_code,
             verification_code_ttl_seconds=CONFIG.redis.identity_verification_code_ttl_seconds,

--- a/src/fides/api/ops/service/connectors/email_connector.py
+++ b/src/fides/api/ops/service/connectors/email_connector.py
@@ -239,10 +239,25 @@ def _get_email_messaging_config_service_type(db: Session) -> Optional[str]:
     if not messaging_configs:
         # let messaging dispatch service handle non-existent service
         return None
-    for messaging_config in messaging_configs:
-        if messaging_config.service_type == MessagingServiceType.TWILIO_EMAIL:
-            return MessagingServiceType.TWILIO_EMAIL.value
-        if messaging_config.service_type == MessagingServiceType.MAILGUN:
-            return MessagingServiceType.MAILGUN.value
-        return None
+    twilio_email_config = next(
+        (
+            config
+            for config in messaging_configs
+            if config.service_type == MessagingServiceType.TWILIO_EMAIL
+        ),
+        None,
+    )
+    mailgun_config = next(
+        (
+            config
+            for config in messaging_configs
+            if config.service_type == MessagingServiceType.MAILGUN
+        ),
+        None,
+    )
+    if twilio_email_config:
+        # we prefer twilio over mailgun
+        return MessagingServiceType.TWILIO_EMAIL.value
+    if mailgun_config:
+        return MessagingServiceType.MAILGUN.value
     return None

--- a/src/fides/api/ops/service/connectors/email_connector.py
+++ b/src/fides/api/ops/service/connectors/email_connector.py
@@ -25,7 +25,6 @@ from fides.api.ops.models.privacy_request import (
 )
 from fides.api.ops.schemas.connection_configuration import EmailSchema
 from fides.api.ops.schemas.messaging.messaging import (
-    EMAIL_MESSAGING_SERVICES,
     MessagingActionType,
     MessagingServiceType,
 )
@@ -234,7 +233,9 @@ def _get_email_messaging_config_service_type(db: Session) -> Optional[str]:
     Email connectors require that an email messaging service has been configured.
     Prefers Twilio if both Twilio email AND Mailgun has been configured.
     """
-    messaging_configs: Optional[List[MessagingConfig]] = MessagingConfig.query(db=db).all()
+    messaging_configs: Optional[List[MessagingConfig]] = MessagingConfig.query(
+        db=db
+    ).all()
     if not messaging_configs:
         # let messaging dispatch service handle non-existent service
         return None

--- a/src/fides/api/ops/service/connectors/email_connector.py
+++ b/src/fides/api/ops/service/connectors/email_connector.py
@@ -234,9 +234,7 @@ def _get_email_messaging_config_service_type(db: Session) -> Optional[str]:
     Email connectors require that an email messaging service has been configured.
     Prefers Twilio if both Twilio email AND Mailgun has been configured.
     """
-    messaging_configs: Optional[List[MessagingConfig]] = MessagingConfig.filter(
-        db=db, conditions=MessagingConfig.service_type in EMAIL_MESSAGING_SERVICES
-    ).all()
+    messaging_configs: Optional[List[MessagingConfig]] = MessagingConfig.query(db=db).all()
     if not messaging_configs:
         # let messaging dispatch service handle non-existent service
         return None
@@ -245,9 +243,5 @@ def _get_email_messaging_config_service_type(db: Session) -> Optional[str]:
             return MessagingServiceType.TWILIO_EMAIL.value
         if messaging_config.service_type == MessagingServiceType.MAILGUN:
             return MessagingServiceType.MAILGUN.value
-        logger.info(
-            "New email service type %s needs to be implemented in email connector",
-            messaging_config.service_type,
-        )
-        return messaging_config.service_type
+        return None
     return None

--- a/src/fides/api/ops/service/connectors/email_connector.py
+++ b/src/fides/api/ops/service/connectors/email_connector.py
@@ -245,6 +245,9 @@ def _get_email_messaging_config_service_type(db: Session) -> Optional[str]:
             return MessagingServiceType.TWILIO_EMAIL.value
         if messaging_config.service_type == MessagingServiceType.MAILGUN:
             return MessagingServiceType.MAILGUN.value
-        logger.info("New email service type %s needs to be implemented in email connector", messaging_config.service_type)
+        logger.info(
+            "New email service type %s needs to be implemented in email connector",
+            messaging_config.service_type,
+        )
         return messaging_config.service_type
     return None

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -10,7 +10,7 @@ from twilio.rest import Client
 
 from fides.api.ops.common_exceptions import MessageDispatchException
 from fides.api.ops.email_templates import get_email_template
-from fides.api.ops.models.messaging import MessagingConfig
+from fides.api.ops.models.messaging import MessagingConfig, get_messaging_method
 from fides.api.ops.models.privacy_request import CheckpointActionRequired
 from fides.api.ops.schemas.messaging.messaging import (
     AccessRequestCompleteBodyParams,
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 def dispatch_message_task(
     self: DatabaseTask,
     message_meta: Dict[str, Any],
-    messaging_method: Optional[MessagingMethod],
+    service_type: Optional[str],
     to_identity: Identity,
 ) -> None:
     """
@@ -51,7 +51,7 @@ def dispatch_message_task(
             db,
             schema.action_type,
             to_identity,
-            messaging_method,
+            service_type,
             schema.body_params,
         )
 
@@ -60,7 +60,7 @@ def dispatch_message(
     db: Session,
     action_type: MessagingActionType,
     to_identity: Optional[Identity],
-    messaging_method: Optional[MessagingMethod],
+    service_type: Optional[str],
     message_body_params: Optional[
         Union[
             AccessRequestCompleteBodyParams,
@@ -77,12 +77,18 @@ def dispatch_message(
     if not to_identity:
         logger.error("Message failed to send. No identity supplied.")
         raise MessageDispatchException("No identity supplied.")
+    if not service_type:
+        logger.error("Message failed to send. No notification service type configured.")
+        raise MessageDispatchException(" No notification service type configured.")
 
     logger.info("Retrieving message config")
-    messaging_config: MessagingConfig = MessagingConfig.get_configuration(db=db)
+    messaging_config: MessagingConfig = MessagingConfig.get_configuration(
+        db=db, service_type=service_type
+    )
     logger.info(
         "Building appropriate message template for action type: %s", action_type
     )
+    messaging_method = get_messaging_method(service_type)
     message: Optional[Union[EmailForActionType, str]] = None
     if messaging_method == MessagingMethod.EMAIL:
         message = _build_email(
@@ -134,8 +140,12 @@ def _build_sms(
     action_type: MessagingActionType,
     body_params: Any,
 ) -> str:
-    if action_type == MessagingActionType.CONSENT_REQUEST:
-        return "Hello, this message was sent from Fides!"
+    if action_type == MessagingActionType.SUBJECT_IDENTITY_VERIFICATION:
+        return (
+            f"Your privacy request verification code is {body_params.verification_code}. "
+            f"Please return to the Privacy Center and enter the code to continue. "
+            f"This code will expire in {body_params.get_verification_code_ttl_minutes()} minutes"
+        )
     logger.error("Message action type %s is not implemented", action_type)
     raise MessageDispatchException(
         f"Message action type {action_type} is not implemented"
@@ -305,10 +315,12 @@ def _twilio_sms_dispatcher(
     try:
         if messaging_service_id:
             client.messages.create(
-                to=to, messaging_service_sid=messaging_service_id, body=message
+                to=to.strip(), messaging_service_sid=messaging_service_id, body=message
             )
         elif sender_phone_number:
-            client.messages.create(to=to, from_=sender_phone_number, body=message)
+            client.messages.create(
+                to=to.strip(), from_=sender_phone_number, body=message
+            )
         else:
             logger.error(
                 "Message failed to send. Either sender phone number or messaging service sid must be provided."

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -79,7 +79,7 @@ def dispatch_message(
         raise MessageDispatchException("No identity supplied.")
     if not service_type:
         logger.error("Message failed to send. No notification service type configured.")
-        raise MessageDispatchException(" No notification service type configured.")
+        raise MessageDispatchException("No notification service type configured.")
 
     logger.info("Retrieving message config")
     messaging_config: MessagingConfig = MessagingConfig.get_configuration(
@@ -315,12 +315,10 @@ def _twilio_sms_dispatcher(
     try:
         if messaging_service_id:
             client.messages.create(
-                to=to.strip(), messaging_service_sid=messaging_service_id, body=message
+                to=to, messaging_service_sid=messaging_service_id, body=message
             )
         elif sender_phone_number:
-            client.messages.create(
-                to=to.strip(), from_=sender_phone_number, body=message
-            )
+            client.messages.create(to=to, from_=sender_phone_number, body=message)
         else:
             logger.error(
                 "Message failed to send. Either sender phone number or messaging service sid must be provided."

--- a/src/fides/api/ops/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/ops/service/privacy_request/request_runner_service.py
@@ -28,7 +28,6 @@ from fides.api.ops.graph.graph import DatasetGraph
 from fides.api.ops.models.connectionconfig import ConnectionConfig
 from fides.api.ops.models.datasetconfig import DatasetConfig
 from fides.api.ops.models.manual_webhook import AccessManualWebhook
-from fides.api.ops.models.messaging import get_messaging_method
 from fides.api.ops.models.policy import (
     ActionType,
     CurrentStep,
@@ -456,9 +455,7 @@ def initiate_privacy_request_completion_email(
             db=session,
             action_type=MessagingActionType.PRIVACY_REQUEST_COMPLETE_ACCESS,
             to_identity=to_identity,
-            messaging_method=get_messaging_method(
-                CONFIG.notifications.notification_service_type
-            ),
+            service_type=CONFIG.notifications.notification_service_type,
             message_body_params=AccessRequestCompleteBodyParams(
                 download_links=access_result_urls
             ),
@@ -468,9 +465,7 @@ def initiate_privacy_request_completion_email(
             db=session,
             action_type=MessagingActionType.PRIVACY_REQUEST_COMPLETE_DELETION,
             to_identity=to_identity,
-            messaging_method=get_messaging_method(
-                CONFIG.notifications.notification_service_type
-            ),
+            service_type=CONFIG.notifications.notification_service_type,
             message_body_params=None,
         )
 

--- a/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
@@ -602,7 +602,7 @@ class TestPutMessagingConfigSecretTwilioSms:
         response = api_client.put(url, headers=auth_header, json=payload)
         assert response.status_code == 400
         assert (
-            f"Either the twilio_messaging_service_id or the twilio_sender_phone_number should be supplied. ('__root__',)"
+            f"Either the twilio_messaging_service_sid or the twilio_sender_phone_number should be supplied. ('__root__',)"
             in response.json()["detail"]
         )
 

--- a/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
@@ -101,7 +101,7 @@ class TestPostMessagingConfig:
         assert 422 == response.status_code
         assert (
             json.loads(response.text)["detail"][0]["msg"]
-            == "value is not a valid enumeration member; permitted: 'mailgun', 'twilio_text', 'twilio_email'"
+            == "value is not a valid enumeration member; permitted: 'MAILGUN', 'TWILIO_TEXT', 'TWILIO_EMAIL'"
         )
 
     def test_post_email_config_with_no_key(

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -66,6 +66,7 @@ from fides.api.ops.schemas.masking.masking_secrets import SecretType
 from fides.api.ops.schemas.messaging.messaging import (
     MessagingActionType,
     MessagingMethod,
+    MessagingServiceType,
     RequestReceiptBodyParams,
     RequestReviewDenyBodyParams,
     SubjectIdentityVerificationBodyParams,
@@ -1893,7 +1894,7 @@ class TestApprovePrivacyRequest:
         call_args = mock_dispatch_message.call_args[1]
         task_kwargs = call_args["kwargs"]
         assert task_kwargs["to_identity"] == Identity(email="test@example.com")
-        assert task_kwargs["messaging_method"] == MessagingMethod.EMAIL
+        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -2023,7 +2024,7 @@ class TestDenyPrivacyRequest:
         call_args = mock_dispatch_message.call_args[1]
         task_kwargs = call_args["kwargs"]
         assert task_kwargs["to_identity"] == Identity(email="test@example.com")
-        assert task_kwargs["messaging_method"] == MessagingMethod.EMAIL
+        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -2094,7 +2095,7 @@ class TestDenyPrivacyRequest:
         call_args = mock_dispatch_message.call_args[1]
         task_kwargs = call_args["kwargs"]
         assert task_kwargs["to_identity"] == Identity(email="test@example.com")
-        assert task_kwargs["messaging_method"] == MessagingMethod.EMAIL
+        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -2976,7 +2977,7 @@ class TestVerifyIdentity:
         assert task_kwargs["to_identity"] == Identity(
             phone_number="+1 234 567 8910", email="test@example.com"
         )
-        assert task_kwargs["messaging_method"] == MessagingMethod.EMAIL
+        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -3084,7 +3085,7 @@ class TestVerifyIdentity:
         assert task_kwargs["to_identity"] == Identity(
             phone_number="+1 234 567 8910", email="test@example.com"
         )
-        assert task_kwargs["messaging_method"] == MessagingMethod.EMAIL
+        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -3184,7 +3185,7 @@ class TestCreatePrivacyRequestEmailVerificationRequired:
             kwargs["action_type"] == MessagingActionType.SUBJECT_IDENTITY_VERIFICATION
         )
         assert kwargs["to_identity"] == Identity(email="test@example.com")
-        assert kwargs["messaging_method"] == MessagingMethod.EMAIL
+        assert kwargs["service_type"] == MessagingServiceType.MAILGUN.value
         assert kwargs["message_body_params"] == SubjectIdentityVerificationBodyParams(
             verification_code=pr.get_cached_verification_code(),
             verification_code_ttl_seconds=CONFIG.redis.identity_verification_code_ttl_seconds,
@@ -3701,7 +3702,7 @@ class TestCreatePrivacyRequestEmailReceiptNotification:
         call_args = mock_dispatch_message.call_args[1]
         task_kwargs = call_args["kwargs"]
         assert task_kwargs["to_identity"] == Identity(email="test@example.com")
-        assert task_kwargs["messaging_method"] == MessagingMethod.EMAIL
+        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -3752,7 +3753,7 @@ class TestCreatePrivacyRequestEmailReceiptNotification:
         call_args = mock_dispatch_message.call_args[1]
         task_kwargs = call_args["kwargs"]
         assert task_kwargs["to_identity"] == Identity(email="test@example.com")
-        assert task_kwargs["messaging_method"] == MessagingMethod.EMAIL
+        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
 
         message_meta = task_kwargs["message_meta"]
         assert (

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -3130,7 +3130,7 @@ class TestCreatePrivacyRequestEmailVerificationRequired:
         assert resp.status_code == 200
         response_data = resp.json()["failed"]
         assert len(response_data) == 1
-        assert response_data[0]["message"] == "Verification email could not be sent."
+        assert response_data[0]["message"] == "Verification message could not be sent."
         assert (
             response_data[0]["data"]["status"]
             == PrivacyRequestStatus.identity_unverified.value

--- a/tests/ops/integration_tests/test_integration_email.py
+++ b/tests/ops/integration_tests/test_integration_email.py
@@ -16,7 +16,7 @@ from fides.api.ops.models.privacy_request import (
 from fides.api.ops.schemas.dataset import FidesopsDataset
 from fides.api.ops.schemas.messaging.messaging import (
     MessagingActionType,
-    MessagingMethod,
+    MessagingServiceType,
 )
 from fides.api.ops.schemas.redis_cache import Identity
 from fides.api.ops.service.connectors.email_connector import (
@@ -187,7 +187,7 @@ async def test_email_connector_cache_and_delayed_send(
         == MessagingActionType.MESSAGE_ERASURE_REQUEST_FULFILLMENT
     )
     assert call_args["to_identity"] == Identity(email="test@example.com")
-    assert call_args["messaging_method"] == MessagingMethod.EMAIL
+    assert call_args["service_type"] == MessagingServiceType.MAILGUN.value
     assert call_args["message_body_params"] == raw_email_template_values
 
     created_email_audit_log = (

--- a/tests/ops/service/messaging/message_dispatch_service_test.py
+++ b/tests/ops/service/messaging/message_dispatch_service_test.py
@@ -193,7 +193,7 @@ def test_sms_dispatch_twilio_success(
         f"Your privacy request verification code is 2348. "
         + f"Please return to the Privacy Center and enter the code to continue. "
         + f"This code will expire in 10 minutes",
-        "test@email.com",
+        "+12312341231",
     )
 
 
@@ -214,7 +214,7 @@ def test_sms_dispatch_twilio_config_not_found(
                 verification_code="2348", verification_code_ttl_seconds=600
             ),
         )
-    assert exc.value.args[0] == "No messaging config found."
+    assert exc.value.args[0] == "No messaging config found for service_type TWILIO_TEXT."
 
     mock_twilio_dispatcher.assert_not_called()
 
@@ -247,7 +247,7 @@ def test_sms_dispatch_twilio_config_no_secrets(
         )
     assert (
         exc.value.args[0]
-        == "Messaging secrets not found for config with key: my_mailgun_messaging_config"
+        == "Messaging secrets not found for config with key: my_twilio_sms_config"
     )
 
     mock_mailgun_dispatcher.assert_not_called()

--- a/tests/ops/service/messaging/message_dispatch_service_test.py
+++ b/tests/ops/service/messaging/message_dispatch_service_test.py
@@ -214,7 +214,9 @@ def test_sms_dispatch_twilio_config_not_found(
                 verification_code="2348", verification_code_ttl_seconds=600
             ),
         )
-    assert exc.value.args[0] == "No messaging config found for service_type TWILIO_TEXT."
+    assert (
+        exc.value.args[0] == "No messaging config found for service_type TWILIO_TEXT."
+    )
 
     mock_twilio_dispatcher.assert_not_called()
 

--- a/tests/ops/service/messaging/message_dispatch_service_test.py
+++ b/tests/ops/service/messaging/message_dispatch_service_test.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from fides.api.ops.common_exceptions import MessageDispatchException
 from fides.api.ops.graph.config import CollectionAddress
-from fides.api.ops.models.messaging import MessagingConfig, get_messaging_method
+from fides.api.ops.models.messaging import MessagingConfig
 from fides.api.ops.models.policy import CurrentStep
 from fides.api.ops.models.privacy_request import CheckpointActionRequired, ManualAction
 from fides.api.ops.schemas.messaging.messaging import (
@@ -36,7 +36,7 @@ def test_email_dispatch_mailgun_success(
         db=db,
         action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
         to_identity=Identity(**{"email": "test@email.com"}),
-        messaging_method=get_messaging_method(MessagingServiceType.MAILGUN.value),
+        service_type=MessagingServiceType.MAILGUN.value,
         message_body_params=SubjectIdentityVerificationBodyParams(
             verification_code="2348", verification_code_ttl_seconds=600
         ),
@@ -64,7 +64,7 @@ def test_email_dispatch_mailgun_config_not_found(
             db=db,
             action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
             to_identity=Identity(**{"email": "test@email.com"}),
-            messaging_method=get_messaging_method(MessagingServiceType.MAILGUN.value),
+            service_type=MessagingServiceType.MAILGUN.value,
             message_body_params=SubjectIdentityVerificationBodyParams(
                 verification_code="2348", verification_code_ttl_seconds=600
             ),
@@ -98,7 +98,7 @@ def test_email_dispatch_mailgun_config_no_secrets(
             db=db,
             action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
             to_identity=Identity(**{"email": "test@email.com"}),
-            messaging_method=get_messaging_method(MessagingServiceType.MAILGUN.value),
+            service_type=MessagingServiceType.MAILGUN.value,
             message_body_params=SubjectIdentityVerificationBodyParams(
                 verification_code="2348", verification_code_ttl_seconds=600
             ),
@@ -128,9 +128,7 @@ def test_email_dispatch_mailgun_failed_email(db: Session, messaging_config) -> N
                 db=db,
                 action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
                 to_identity=Identity(**{"email": "test@email.com"}),
-                messaging_method=get_messaging_method(
-                    MessagingServiceType.MAILGUN.value
-                ),
+                service_type=MessagingServiceType.MAILGUN.value,
                 message_body_params=SubjectIdentityVerificationBodyParams(
                     verification_code="2348", verification_code_ttl_seconds=600
                 ),
@@ -172,3 +170,86 @@ def test_fidesops_email_parse_object():
             },
         }
     )
+
+
+@mock.patch(
+    "fides.api.ops.service.messaging.message_dispatch_service._twilio_sms_dispatcher"
+)
+def test_sms_dispatch_twilio_success(
+    mock_twilio_dispatcher: Mock, db: Session, messaging_config_twilio_sms
+) -> None:
+
+    dispatch_message(
+        db=db,
+        action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
+        to_identity=Identity(**{"phone": "+12312341231"}),
+        service_type=MessagingServiceType.TWILIO_TEXT.value,
+        message_body_params=SubjectIdentityVerificationBodyParams(
+            verification_code="2348", verification_code_ttl_seconds=600
+        ),
+    )
+    mock_twilio_dispatcher.assert_called_with(
+        messaging_config_twilio_sms,
+        f"Your privacy request verification code is 2348. "
+        + f"Please return to the Privacy Center and enter the code to continue. "
+        + f"This code will expire in 10 minutes",
+        "test@email.com",
+    )
+
+
+@mock.patch(
+    "fides.api.ops.service.messaging.message_dispatch_service._twilio_sms_dispatcher"
+)
+def test_sms_dispatch_twilio_config_not_found(
+    mock_twilio_dispatcher: Mock, db: Session
+) -> None:
+
+    with pytest.raises(MessageDispatchException) as exc:
+        dispatch_message(
+            db=db,
+            action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
+            to_identity=Identity(**{"phone": "+12312341231"}),
+            service_type=MessagingServiceType.TWILIO_TEXT.value,
+            message_body_params=SubjectIdentityVerificationBodyParams(
+                verification_code="2348", verification_code_ttl_seconds=600
+            ),
+        )
+    assert exc.value.args[0] == "No messaging config found."
+
+    mock_twilio_dispatcher.assert_not_called()
+
+
+@mock.patch(
+    "fides.api.ops.service.messaging.message_dispatch_service._twilio_sms_dispatcher"
+)
+def test_sms_dispatch_twilio_config_no_secrets(
+    mock_mailgun_dispatcher: Mock, db: Session
+) -> None:
+
+    messaging_config = MessagingConfig.create(
+        db=db,
+        data={
+            "name": "twilio sms config",
+            "key": "my_twilio_sms_config",
+            "service_type": MessagingServiceType.TWILIO_TEXT,
+        },
+    )
+
+    with pytest.raises(MessageDispatchException) as exc:
+        dispatch_message(
+            db=db,
+            action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
+            to_identity=Identity(**{"phone": "+12312341231"}),
+            service_type=MessagingServiceType.TWILIO_TEXT.value,
+            message_body_params=SubjectIdentityVerificationBodyParams(
+                verification_code="2348", verification_code_ttl_seconds=600
+            ),
+        )
+    assert (
+        exc.value.args[0]
+        == "Messaging secrets not found for config with key: my_mailgun_messaging_config"
+    )
+
+    mock_mailgun_dispatcher.assert_not_called()
+
+    messaging_config.delete(db)

--- a/tests/ops/service/messaging/message_dispatch_service_test.py
+++ b/tests/ops/service/messaging/message_dispatch_service_test.py
@@ -69,7 +69,7 @@ def test_email_dispatch_mailgun_config_not_found(
                 verification_code="2348", verification_code_ttl_seconds=600
             ),
         )
-    assert exc.value.args[0] == "No messaging config found."
+    assert exc.value.args[0] == "No messaging config found for service_type MAILGUN."
 
     mock_mailgun_dispatcher.assert_not_called()
 
@@ -182,7 +182,7 @@ def test_sms_dispatch_twilio_success(
     dispatch_message(
         db=db,
         action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
-        to_identity=Identity(**{"phone": "+12312341231"}),
+        to_identity=Identity(**{"phone_number": "+12312341231"}),
         service_type=MessagingServiceType.TWILIO_TEXT.value,
         message_body_params=SubjectIdentityVerificationBodyParams(
             verification_code="2348", verification_code_ttl_seconds=600
@@ -208,7 +208,7 @@ def test_sms_dispatch_twilio_config_not_found(
         dispatch_message(
             db=db,
             action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
-            to_identity=Identity(**{"phone": "+12312341231"}),
+            to_identity=Identity(**{"phone_number": "+12312341231"}),
             service_type=MessagingServiceType.TWILIO_TEXT.value,
             message_body_params=SubjectIdentityVerificationBodyParams(
                 verification_code="2348", verification_code_ttl_seconds=600
@@ -239,7 +239,7 @@ def test_sms_dispatch_twilio_config_no_secrets(
         dispatch_message(
             db=db,
             action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
-            to_identity=Identity(**{"phone": "+12312341231"}),
+            to_identity=Identity(**{"phone_number": "+12312341231"}),
             service_type=MessagingServiceType.TWILIO_TEXT.value,
             message_body_params=SubjectIdentityVerificationBodyParams(
                 verification_code="2348", verification_code_ttl_seconds=600

--- a/tests/ops/service/privacy_request/request_runner_service_test.py
+++ b/tests/ops/service/privacy_request/request_runner_service_test.py
@@ -36,7 +36,7 @@ from fides.api.ops.schemas.messaging.messaging import (
     AccessRequestCompleteBodyParams,
     EmailForActionType,
     MessagingActionType,
-    MessagingMethod,
+    MessagingServiceType,
 )
 from fides.api.ops.schemas.policy import Rule
 from fides.api.ops.schemas.redis_cache import Identity
@@ -1973,7 +1973,7 @@ class TestPrivacyRequestsEmailNotifications:
                     db=ANY,
                     action_type=MessagingActionType.PRIVACY_REQUEST_COMPLETE_ACCESS,
                     to_identity=identity,
-                    messaging_method=MessagingMethod.EMAIL,
+                    service_type=MessagingServiceType.MAILGUN.value,
                     message_body_params=AccessRequestCompleteBodyParams(
                         download_links=[upload_mock.return_value]
                     ),
@@ -1982,7 +1982,7 @@ class TestPrivacyRequestsEmailNotifications:
                     db=ANY,
                     action_type=MessagingActionType.PRIVACY_REQUEST_COMPLETE_DELETION,
                     to_identity=identity,
-                    messaging_method=MessagingMethod.EMAIL,
+                    service_type=MessagingServiceType.MAILGUN.value,
                     message_body_params=None,
                 ),
             ],

--- a/tests/ops/service/privacy_request/request_runner_service_test.py
+++ b/tests/ops/service/privacy_request/request_runner_service_test.py
@@ -2053,7 +2053,7 @@ class TestPrivacyRequestsEmailNotifications:
         data = {
             "requested_at": "2021-08-30T16:09:37.359Z",
             "policy_key": policy.key,
-            "identity": {"phone": "1231231233"},
+            "identity": {"phone_number": "1231231233"},
         }
 
         pr = get_privacy_request_results(

--- a/tests/ops/service/processors/post_processor_strategy/test_post_processor_strategy_filter.py
+++ b/tests/ops/service/processors/post_processor_strategy/test_post_processor_strategy_filter.py
@@ -135,7 +135,7 @@ def test_filter_nonexistent_field():
 
 
 def test_filter_by_nonexistent_identity_reference():
-    identity_data: Dict[str, Any] = {"phone": "123-1234-1235"}
+    identity_data: Dict[str, Any] = {"phone_number": "123-1234-1235"}
     config = FilterPostProcessorConfiguration(
         field="email_contact", value={"identity": "email"}
     )


### PR DESCRIPTION
Closes [1467](https://github.com/ethyca/fides/issues/1467)

### Code Changes

* [ ] Refactors message dispatch service to take service type instead of messaging method (email vs sms). This way we can accurately retrieve the given service in the DB.
* [ ] Implements service preference in email connector (Twilio is preferred, then mailgun)
* [ ] Implements id verification template for SMS services

### Steps to Confirm

* [ ] Added the following to `fides.toml`: `
```
[notifications]
notification_service_type = "twilio_text"
```
* [ ] Adjusted `subject_identity_verification_required ` to ` true` in `fides.toml`
* [ ] `nox -s dev`
* [ ] Used postman to add rules/policies needed for creating a privacy request
* [ ] Used postman to add Twilio SMS messaging config / secrets
* [ ] Used postman to create an access request using my phone number as identity input
* [ ] Confirmed text message received

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
