### PR TITLE
update required python version in readme, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In order to get started quickly with Fides, a sample project is bundled within t
 #### Minimum requirements
 
 * [Docker](https://www.docker.com/products/docker-desktop) (version 20.10.11 or later)
-* [Python](https://www.python.org/downloads/) (version 3.8 or later)
+* [Python](https://www.python.org/downloads/) (version 3.8 through 3.10)
 
 #### Download and install Fides
 

--- a/docs/fides/docs/dsr_quickstart/basic_setup.md
+++ b/docs/fides/docs/dsr_quickstart/basic_setup.md
@@ -10,7 +10,7 @@ The instance you use for running Fides should simulate a "typical" developer mac
 ### Instance requirements
 Your instance must: 
 
-* Have [Docker](https://www.docker.com/products/docker-desktop) (version 20.10.11 or later) or [Python](https://www.python.org/downloads/) (version 3.9 or later) installed
+* Have [Docker](https://www.docker.com/products/docker-desktop) (version 20.10.11 or later) or [Python](https://www.python.org/downloads/) (version 3.8, 3.9, or 3.10) installed
 * Have a hard drive to persist database volumes, YAML resource files, etc.
 * Be accessible for interactive shell commands (e.g. SSH)
 * Be accessible via HTTP for web browser commands

--- a/docs/fides/docs/getting-started/sample_project.md
+++ b/docs/fides/docs/getting-started/sample_project.md
@@ -9,7 +9,7 @@ To Fides in your own infrastructure, see the provided [DSR Automation](../dsr_qu
 ### Minimum requirements 
 
 *  [Docker](https://www.docker.com/products/docker-desktop) (version 20.10.11 or later)
-*  [Python](https://www.python.org/downloads/) (version 3.9 or later) 
+*  [Python](https://www.python.org/downloads/) (version 3.8 through 3.10) 
 ### Download and install Fides
 You can easily download and install the Fides demo using `pip`. Run the following command to get started:
 


### PR DESCRIPTION
Closes #1727 

### Code Changes

* updated the required version of python in the readme and docs to specify any version between 3.8 and 3.10 (so excluding 3.11)

### Steps to Confirm

* build the docs and view!

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`