### PR TITLE
Expire OTP tokens after a configurable threshold for DSRs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ output-format="colorized"
 
 [tool.pylint.format]
 max-line-length="88"
-max-module-lines="1500"
 
 [tool.pylint.basic]
 good-names="_,i,setUp,tearDown,maxDiff,default_app_config"

--- a/src/fides/api/ops/models/privacy_request.py
+++ b/src/fides/api/ops/models/privacy_request.py
@@ -56,6 +56,7 @@ from fides.api.ops.schemas.external_https import (
 from fides.api.ops.schemas.masking.masking_secrets import MaskingSecretCache
 from fides.api.ops.schemas.redis_cache import Identity
 from fides.api.ops.tasks import celery_app
+from fides.api.ops.util.identity_verification import IdentityVerificationMixin
 from fides.api.ops.util.cache import (
     FidesopsRedis,
     get_all_cache_keys_for_privacy_request,
@@ -836,7 +837,7 @@ class Consent(Base):
     UniqueConstraint(provided_identity_id, data_use, name="uix_identity_data_use")
 
 
-class ConsentRequest(Base):
+class ConsentRequest(IdentityVerificationMixin, Base):
     """Tracks consent requests."""
 
     provided_identity_id = Column(
@@ -848,85 +849,12 @@ class ConsentRequest(Base):
         back_populates="consent_request",
     )
 
-    def _get_identity_verification_cache_key(self) -> str:
-        return f"IDENTITY_VERIFICATION_CODE__{self.id}"
-
-    def _get_identity_verification_attempt_count_cache_key(self) -> str:
-        return self._get_identity_verification_cache_key() + "__attempt_count"
-
-    def cache_identity_verification_code(self, value: str) -> None:
-        """Cache the generated identity verification code for later comparison."""
-        cache: FidesopsRedis = get_cache()
-        cache.set_with_autoexpire(
-            key=self._get_identity_verification_cache_key(),
-            value=value,
-        )
-        cache.set_with_autoexpire(
-            key=self._get_identity_verification_attempt_count_cache_key(),
-            value=0,
-        )
-
-    def _increment_verification_code_attempt_count(self) -> None:
-        """Cache the generated identity verification code for later comparison."""
-        cache: FidesopsRedis = get_cache()
-        attempt_count: int = self._get_cached_verification_code_attempt_count()
-        cache.set_with_autoexpire(
-            key=self._get_identity_verification_attempt_count_cache_key(),
-            value=attempt_count + 1,
-        )
-
     def get_cached_identity_data(self) -> Dict[str, Any]:
         """Retrieves any identity data pertaining to this request from the cache."""
         prefix = f"id-{self.id}-identity-*"
         cache: FidesopsRedis = get_cache()
         keys = cache.keys(prefix)
         return {key.split("-")[-1]: cache.get(key) for key in keys}
-
-    def get_cached_verification_code(self) -> Optional[str]:
-        """Retrieve the generated identity verification code if it exists"""
-        cache = get_cache()
-        values = cache.get_values([self._get_identity_verification_cache_key()]) or {}
-        if not values:
-            return None
-
-        return values.get(self._get_identity_verification_cache_key(), None)
-
-    def _get_cached_verification_code_attempt_count(self) -> int:
-        """Retrieve the generated identity verification code if it exists"""
-        cache = get_cache()
-        attempts = cache.get(self._get_identity_verification_attempt_count_cache_key())
-        if not attempts:
-            attempts = "0"
-        return int(attempts)
-
-    def purge_verification_code(self) -> None:
-        """Removes any verification codes from the cache so they can no longer be used."""
-        cache = get_cache()
-        cache.delete(self._get_identity_verification_cache_key())
-        cache.delete(self._get_identity_verification_attempt_count_cache_key())
-
-    def verify_identity(self, provided_code: str) -> ConsentRequest:
-        """Verify the identification code supplied by the user."""
-        code: Optional[str] = self.get_cached_verification_code()
-        if not code:
-            raise IdentityVerificationException(
-                f"Identification code expired for {self.id}."
-            )
-
-        attempt_count: int = self._get_cached_verification_code_attempt_count()
-        if attempt_count >= CONFIG.security.identity_verification_attempt_limit:
-            # When the attempt_count we can remove the verification code entirely
-            # from the cache to ensure it can never be used again.
-            self.purge_verification_code()
-            raise PermissionError(f"Attempt limit hit for '{self.id}'")
-
-        self._increment_verification_code_attempt_count()
-        if code != provided_code:
-            raise PermissionError(f"Incorrect identification code for '{self.id}'")
-
-        # This code should only be successfully used once, so purge here now that's happened.
-        self.purge_verification_code()
-        return self
 
 
 # Unique text to separate a step from a collection address, so we can store two values in one.

--- a/src/fides/api/ops/models/privacy_request.py
+++ b/src/fides/api/ops/models/privacy_request.py
@@ -829,6 +829,13 @@ class ConsentRequest(IdentityVerificationMixin, Base):
         keys = cache.keys(prefix)
         return {key.split("-")[-1]: cache.get(key) for key in keys}
 
+    def verify_identity(self, provided_code: str) -> object:
+        """
+        A method to call the internal identity verification method provided by the
+        `IdentityVerificationMixin`.
+        """
+        return self._verify_identity(provided_code=provided_code)
+
 
 # Unique text to separate a step from a collection address, so we can store two values in one.
 PAUSED_SEPARATOR = "__fidesops_paused_sep__"

--- a/src/fides/api/ops/models/privacy_request.py
+++ b/src/fides/api/ops/models/privacy_request.py
@@ -829,12 +829,12 @@ class ConsentRequest(IdentityVerificationMixin, Base):
         keys = cache.keys(prefix)
         return {key.split("-")[-1]: cache.get(key) for key in keys}
 
-    def verify_identity(self, provided_code: str) -> object:
+    def verify_identity(self, provided_code: str) -> None:
         """
         A method to call the internal identity verification method provided by the
         `IdentityVerificationMixin`.
         """
-        return self._verify_identity(provided_code=provided_code)
+        self._verify_identity(provided_code=provided_code)
 
 
 # Unique text to separate a step from a collection address, so we can store two values in one.

--- a/src/fides/api/ops/util/identity_verification.py
+++ b/src/fides/api/ops/util/identity_verification.py
@@ -100,10 +100,8 @@ class IdentityVerificationMixin:
             self.purge_verification_code()
             raise PermissionError(f"Attempt limit hit for '{self.id}'")
 
-        self._increment_verification_code_attempt_count()
         if code != provided_code:
+            self._increment_verification_code_attempt_count()
             raise PermissionError(f"Incorrect identification code for '{self.id}'")
 
-        # This code should only be successfully used once, so purge here now that's happened.
-        self.purge_verification_code()
         return self

--- a/src/fides/api/ops/util/identity_verification.py
+++ b/src/fides/api/ops/util/identity_verification.py
@@ -74,8 +74,8 @@ class IdentityVerificationMixin:
     def purge_verification_code(self) -> None:
         """Removes any verification codes from the cache so they can no longer be used."""
         logger.debug(
-            "Removing cached identity verification code for record with ID: %s"
-            % self.id
+            "Removing cached identity verification code for record with ID: %s",
+            self.id,
         )
         cache = get_cache()
         cache.delete(self._get_identity_verification_cache_key())
@@ -92,8 +92,8 @@ class IdentityVerificationMixin:
         attempt_count: int = self._get_cached_verification_code_attempt_count()
         if attempt_count >= CONFIG.security.identity_verification_attempt_limit:
             logger.debug(
-                "Failed identity verification attempt limit exceeded for record with ID: %s"
-                % self.id
+                "Failed identity verification attempt limit exceeded for record with ID: %s",
+                self.id,
             )
             # When the attempt_count we can remove the verification code entirely
             # from the cache to ensure it can never be used again.
@@ -107,9 +107,3 @@ class IdentityVerificationMixin:
         # This code should only be successfully used once, so purge here now that's happened.
         self.purge_verification_code()
         return self
-
-    def verify_identity(self, provided_code: str) -> object:
-        """
-        A default method for verifying identities that can be overloaded with other actions.
-        """
-        return self._verify_identity(provided_code=provided_code)

--- a/src/fides/api/ops/util/identity_verification.py
+++ b/src/fides/api/ops/util/identity_verification.py
@@ -81,7 +81,7 @@ class IdentityVerificationMixin:
         cache.delete(self._get_identity_verification_cache_key())
         cache.delete(self._get_identity_verification_attempt_count_cache_key())
 
-    def _verify_identity(self, provided_code: str) -> object:
+    def _verify_identity(self, provided_code: str) -> None:
         """Verify the identification code supplied by the user."""
         code: Optional[str] = self.get_cached_verification_code()
         if not code:
@@ -103,5 +103,3 @@ class IdentityVerificationMixin:
         if code != provided_code:
             self._increment_verification_code_attempt_count()
             raise PermissionError(f"Incorrect identification code for '{self.id}'")
-
-        return self

--- a/src/fides/api/ops/util/identity_verification.py
+++ b/src/fides/api/ops/util/identity_verification.py
@@ -21,11 +21,16 @@ class IdentityVerificationMixin:
     """
 
     def _get_identity_verification_cache_key(self) -> str:
-        """ """
+        """
+        Returns the cache key at which the identity verification code is stored.
+        """
         return f"IDENTITY_VERIFICATION_CODE__{self.id}"
 
     def _get_identity_verification_attempt_count_cache_key(self) -> str:
-        """ """
+        """
+        Returns the cache key at which the attempt count for this request's identity
+        verification is stored.
+        """
         return self._get_identity_verification_cache_key() + "__attempt_count"
 
     def cache_identity_verification_code(self, value: str) -> None:

--- a/src/fides/api/ops/util/identity_verification.py
+++ b/src/fides/api/ops/util/identity_verification.py
@@ -24,7 +24,7 @@ class IdentityVerificationMixin:
         """
         Returns the cache key at which the identity verification code is stored.
         """
-        return f"IDENTITY_VERIFICATION_CODE__{self.id}"
+        return f"IDENTITY_VERIFICATION_CODE__{self.id}"  # type: ignore
 
     def _get_identity_verification_attempt_count_cache_key(self) -> str:
         """
@@ -75,7 +75,7 @@ class IdentityVerificationMixin:
         """Removes any verification codes from the cache so they can no longer be used."""
         logger.debug(
             "Removing cached identity verification code for record with ID: %s",
-            self.id,
+            self.id,  # type: ignore
         )
         cache = get_cache()
         cache.delete(self._get_identity_verification_cache_key())
@@ -86,20 +86,20 @@ class IdentityVerificationMixin:
         code: Optional[str] = self.get_cached_verification_code()
         if not code:
             raise IdentityVerificationException(
-                f"Identification code expired for {self.id}."
+                f"Identification code expired for {self.id}."  # type: ignore
             )
 
         attempt_count: int = self._get_cached_verification_code_attempt_count()
         if attempt_count >= CONFIG.security.identity_verification_attempt_limit:
             logger.debug(
                 "Failed identity verification attempt limit exceeded for record with ID: %s",
-                self.id,
+                self.id,  # type: ignore
             )
             # When the attempt_count we can remove the verification code entirely
             # from the cache to ensure it can never be used again.
             self.purge_verification_code()
-            raise PermissionError(f"Attempt limit hit for '{self.id}'")
+            raise PermissionError(f"Attempt limit hit for '{self.id}'")  # type: ignore
 
         if code != provided_code:
             self._increment_verification_code_attempt_count()
-            raise PermissionError(f"Incorrect identification code for '{self.id}'")
+            raise PermissionError(f"Incorrect identification code for '{self.id}'")  # type: ignore

--- a/src/fides/api/ops/util/identity_verification.py
+++ b/src/fides/api/ops/util/identity_verification.py
@@ -72,7 +72,7 @@ class IdentityVerificationMixin:
         cache.delete(self._get_identity_verification_cache_key())
         cache.delete(self._get_identity_verification_attempt_count_cache_key())
 
-    def verify_identity(self, provided_code: str) -> object:
+    def _verify_identity(self, provided_code: str) -> object:
         """Verify the identification code supplied by the user."""
         code: Optional[str] = self.get_cached_verification_code()
         if not code:
@@ -94,3 +94,9 @@ class IdentityVerificationMixin:
         # This code should only be successfully used once, so purge here now that's happened.
         self.purge_verification_code()
         return self
+
+    def verify_identity(self, provided_code: str) -> object:
+        """
+        A default method for verifying identities that can be overloaded with other actions.
+        """
+        return self._verify_identity(provided_code=provided_code)

--- a/src/fides/api/ops/util/identity_verification.py
+++ b/src/fides/api/ops/util/identity_verification.py
@@ -1,0 +1,96 @@
+import logging
+from typing import Optional
+
+from fides.api.ops.common_exceptions import IdentityVerificationException
+from fides.api.ops.util.cache import (
+    FidesopsRedis,
+    get_cache,
+)
+
+from fides.ctl.core.config import get_config
+
+
+logger = logging.getLogger(__name__)
+CONFIG = get_config()
+
+
+class IdentityVerificationMixin:
+    """
+    A class housing common identity verification logic for use as a mixin with
+    any sqlalchemy model with an ID.
+    """
+
+    def _get_identity_verification_cache_key(self) -> str:
+        """ """
+        return f"IDENTITY_VERIFICATION_CODE__{self.id}"
+
+    def _get_identity_verification_attempt_count_cache_key(self) -> str:
+        """ """
+        return self._get_identity_verification_cache_key() + "__attempt_count"
+
+    def cache_identity_verification_code(self, value: str) -> None:
+        """Cache the generated identity verification code for later comparison."""
+        cache: FidesopsRedis = get_cache()
+        cache.set_with_autoexpire(
+            key=self._get_identity_verification_cache_key(),
+            value=value,
+        )
+        cache.set_with_autoexpire(
+            key=self._get_identity_verification_attempt_count_cache_key(),
+            value=0,
+        )
+
+    def _increment_verification_code_attempt_count(self) -> None:
+        """Cache the generated identity verification code for later comparison."""
+        cache: FidesopsRedis = get_cache()
+        attempt_count: int = self._get_cached_verification_code_attempt_count()
+        cache.set_with_autoexpire(
+            key=self._get_identity_verification_attempt_count_cache_key(),
+            value=attempt_count + 1,
+        )
+
+    def get_cached_verification_code(self) -> Optional[str]:
+        """Retrieve the generated identity verification code if it exists"""
+        cache = get_cache()
+        values = cache.get_values([self._get_identity_verification_cache_key()]) or {}
+        if not values:
+            return None
+
+        return values.get(self._get_identity_verification_cache_key(), None)
+
+    def _get_cached_verification_code_attempt_count(self) -> int:
+        """Retrieve the generated identity verification code if it exists"""
+        cache = get_cache()
+        attempts = cache.get(self._get_identity_verification_attempt_count_cache_key())
+        if not attempts:
+            attempts = "0"
+        return int(attempts)
+
+    def purge_verification_code(self) -> None:
+        """Removes any verification codes from the cache so they can no longer be used."""
+        cache = get_cache()
+        cache.delete(self._get_identity_verification_cache_key())
+        cache.delete(self._get_identity_verification_attempt_count_cache_key())
+
+    def verify_identity(self, provided_code: str) -> object:
+        """Verify the identification code supplied by the user."""
+        code: Optional[str] = self.get_cached_verification_code()
+        if not code:
+            raise IdentityVerificationException(
+                f"Identification code expired for {self.id}."
+            )
+
+        attempt_count: int = self._get_cached_verification_code_attempt_count()
+        if attempt_count >= CONFIG.security.identity_verification_attempt_limit:
+            # When the attempt_count we can remove the verification code entirely
+            # from the cache to ensure it can never be used again.
+            self.purge_verification_code()
+            raise PermissionError(f"Attempt limit hit for '{self.id}'")
+
+        self._increment_verification_code_attempt_count()
+        if code != provided_code:
+            raise PermissionError(f"Incorrect identification code for '{self.id}'")
+
+        # This code should only be successfully used once, so purge here now that's happened.
+        self.purge_verification_code()
+        return self

--- a/src/fides/api/ops/util/identity_verification.py
+++ b/src/fides/api/ops/util/identity_verification.py
@@ -73,6 +73,10 @@ class IdentityVerificationMixin:
 
     def purge_verification_code(self) -> None:
         """Removes any verification codes from the cache so they can no longer be used."""
+        logger.debug(
+            "Removing cached identity verification code for record with ID: %s"
+            % self.id
+        )
         cache = get_cache()
         cache.delete(self._get_identity_verification_cache_key())
         cache.delete(self._get_identity_verification_attempt_count_cache_key())
@@ -87,6 +91,10 @@ class IdentityVerificationMixin:
 
         attempt_count: int = self._get_cached_verification_code_attempt_count()
         if attempt_count >= CONFIG.security.identity_verification_attempt_limit:
+            logger.debug(
+                "Failed identity verification attempt limit exceeded for record with ID: %s"
+                % self.id
+            )
             # When the attempt_count we can remove the verification code entirely
             # from the cache to ensure it can never be used again.
             self.purge_verification_code()

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -2952,6 +2952,11 @@ class TestVerifyIdentity:
             )
             assert not mock_dispatch_message.called
 
+        assert (
+            privacy_request._get_cached_verification_code_attempt_count()
+            == CONFIG.security.identity_verification_attempt_limit
+        )
+
         request_body = {"code": VERIFICATION_CODE}
         resp = api_client.post(url, headers={}, json=request_body)
         assert resp.status_code == 403

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -2926,6 +2926,41 @@ class TestVerifyIdentity:
         assert not mock_dispatch_message.called
 
     @mock.patch(
+        "fides.api.ops.api.v1.endpoints.privacy_request_endpoints.dispatch_message_task.apply_async"
+    )
+    def test_too_many_attempts(
+        self,
+        mock_dispatch_message,
+        db,
+        api_client,
+        url,
+        privacy_request,
+        privacy_request_receipt_notification_enabled,
+    ):
+        VERIFICATION_CODE = "999999"
+        privacy_request.status = PrivacyRequestStatus.identity_unverified
+        privacy_request.save(db)
+        privacy_request.cache_identity_verification_code(VERIFICATION_CODE)
+
+        request_body = {"code": self.code}
+        for _ in range(0, CONFIG.security.identity_verification_attempt_limit):
+            resp = api_client.post(url, headers={}, json=request_body)
+            assert resp.status_code == 403
+            assert (
+                resp.json()["detail"]
+                == f"Incorrect identification code for '{privacy_request.id}'"
+            )
+            assert not mock_dispatch_message.called
+
+        request_body = {"code": VERIFICATION_CODE}
+        resp = api_client.post(url, headers={}, json=request_body)
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == f"Attempt limit hit for '{privacy_request.id}'"
+        assert not mock_dispatch_message.called
+        assert privacy_request.get_cached_verification_code() is None
+        assert privacy_request._get_cached_verification_code_attempt_count() == 0
+
+    @mock.patch(
         "fides.api.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
     @mock.patch(


### PR DESCRIPTION
This PR is branched off from https://github.com/ethyca/fides/pull/1734

### Code Changes

* [x] Adds a new `IdentityVerificationMixin` that can be used in combination with any class with an ID
* [x] Adds mixin to `PrivacyRequest` and `ConsentRequest` to be sure they both use the same logic

### Steps to Confirm

* [ ] Run `nox -s test_env` with `subject_identity_verification_required = true`
* [ ] Submit a DSR through the privacy centre
* [ ] Submit an invalid verification code three times to `/api/v1/privacy-request/{id}/verify` with data `{"code": "..."}`
* [ ] Submit an invalid verification code a fourth time to `/api/v1/privacy-request/{id}/verify` with data `{"code": "..."}`
* [ ] Assert the response suggest the attempt limit was hit for the DSR ID

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`