### PR TITLE
Populate Ingress/Egress on datamap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/1.9.6...main)
 
+### Added
+* Include `ingress` and `egress` fields on system export and `datamap/` endpoint [#1740](https://github.com/ethyca/fides/pull/1740)
+
 ### Changed
 
 * Optional dependencies are no longer used for 3rd-party connectivity. Instead they are used to isolate dangerous dependencies. [#1679](https://github.com/ethyca/fides/pull/1679)

--- a/demo_resources/demo_system.yml
+++ b/demo_resources/demo_system.yml
@@ -5,6 +5,9 @@ system:
     system_type: Service
     administrating_department: Engineering
     data_responsibility_title: Controller
+    ingress:
+    - fides_key: demo_marketing_system
+      type: system
     third_country_transfers:
     - USA
     - CAN
@@ -32,13 +35,8 @@ system:
     data_responsibility_title: Processor
     system_dependencies:
     - demo_analytics_system
-    ingress:
-    - fides_key: hubspot
-      type: system
-    - fides_key: marketing_website
-      type: system
     egress:
-    - fides_key: salesforce
+    - fides_key: demo_analytics_system
       type: system
     privacy_declarations:
       - name: Collect data for marketing

--- a/demo_resources/demo_system.yml
+++ b/demo_resources/demo_system.yml
@@ -32,6 +32,14 @@ system:
     data_responsibility_title: Processor
     system_dependencies:
     - demo_analytics_system
+    ingress:
+    - fides_key: hubspot
+      type: system
+    - fides_key: marketing_website
+      type: system
+    egress:
+    - fides_key: salesforce
+      type: system
     privacy_declarations:
       - name: Collect data for marketing
         data_categories:

--- a/src/fides/api/ctl/routes/datamap.py
+++ b/src/fides/api/ctl/routes/datamap.py
@@ -21,6 +21,8 @@ API_EXTRA_COLUMNS = {
     "dataset.fides_key": "Dataset Fides Key (if applicable)",
     "system.system_dependencies": "Related cross-system dependencies",
     "system.description": "Description of the System",
+    "system.ingress": "Related Systems which receive data to this System",
+    "system.egress": "Related Systems which send data to this System",
 }
 DATAMAP_COLUMNS_API = {**DATAMAP_COLUMNS, **API_EXTRA_COLUMNS}
 
@@ -64,6 +66,8 @@ router = APIRouter(tags=["Datamap"], prefix=f"{API_PREFIX}/datamap")
                             "dataset.fides_key": "",
                             "system.system_dependencies": "",
                             "system.description": "",
+                            "system.ingress": [],
+                            "system.egress": [],
                         },
                     ]
                 }

--- a/src/fides/ctl/core/export.py
+++ b/src/fides/ctl/core/export.py
@@ -149,6 +149,8 @@ def generate_system_records(
             "system.administrating_department",
             "system.third_country_transfers",
             "system.system_dependencies",
+            "system.ingress",
+            "system.egress",
             "system.privacy_declaration.name",
             "system.privacy_declaration.data_categories",
             "system.privacy_declaration.data_use.name",
@@ -171,6 +173,10 @@ def generate_system_records(
     for system in server_resources["system"]:
         third_country_list = ", ".join(system.third_country_transfers or [])
         system_dependencies = ", ".join(system.system_dependencies or [])
+        system_ingress = ", ".join(
+            [ingress.fides_key for ingress in system.ingress or []]
+        )
+        system_egress = ", ".join([egress.fides_key for egress in system.egress or []])
         data_protection_impact_assessment = (
             get_formatted_data_protection_impact_assessment(
                 system.data_protection_impact_assessment.dict()
@@ -196,6 +202,8 @@ def generate_system_records(
                         system.administrating_department,
                         third_country_list,
                         system_dependencies,
+                        system_ingress,
+                        system_egress,
                         declaration.name,
                         category,
                         data_use["name"],
@@ -227,12 +235,14 @@ def generate_system_records(
                 system.administrating_department,
                 third_country_list,
                 system_dependencies,
+                system_ingress,
+                system_egress,
                 data_protection_impact_assessment["is_required"],
                 data_protection_impact_assessment["progress"],
                 data_protection_impact_assessment["link"],
             ]
             num_privacy_declaration_fields = 12
-            privacy_declaration_start_index = 7
+            privacy_declaration_start_index = 9
             for i in range(num_privacy_declaration_fields):
                 system_row.insert(
                     i + privacy_declaration_start_index, EMPTY_COLUMN_PLACEHOLDER


### PR DESCRIPTION
Closes #1669

### Code Changes

* [x] Include `ingress`/`egress` in demo resources
* [x] Include values as part of exporting system
* [x] Include values as part of datamap from api

### Steps to Confirm

1. `fides push demo_resources`
1. `curl --location --request GET 'http://0.0.0.0:8080/api/v1/datamap/default_organization' \`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Need to confirm the new values are only required as part of the API and not exporting to a flat file