### PR TITLE
1468 - Implements all subject notifications using SMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The types of changes are:
 ### Added
 * Include `ingress` and `egress` fields on system export and `datamap/` endpoint [#1740](https://github.com/ethyca/fides/pull/1740)
 * Adds SMS support for identity verification notifications [#1726](https://github.com/ethyca/fides/pull/1726)
+* Adds SMS message template for all subject notifications [#1743](https://github.com/ethyca/fides/pull/1743)
 
 ### Changed
 

--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -323,7 +323,7 @@ def _send_privacy_request_receipt_message_to_user(
                 body_params=RequestReceiptBodyParams(request_types=request_types),
             ).dict(),
             "service_type": CONFIG.notifications.notification_service_type,
-            "to_identity": to_identity,
+            "to_identity": to_identity.dict(),
         },
     )
 
@@ -1175,7 +1175,7 @@ def _send_privacy_request_review_message_to_user(
                 else None,
             ).dict(),
             "service_type": CONFIG.notifications.notification_service_type,
-            "to_identity": to_identity,
+            "to_identity": to_identity.dict(),
         },
     )
 

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -40,7 +40,7 @@ def dispatch_message_task(
     self: DatabaseTask,
     message_meta: Dict[str, Any],
     service_type: Optional[str],
-    to_identity: Identity,
+    to_identity: Dict[str, Any],
 ) -> None:
     """
     A wrapper function to dispatch a message task into the Celery queues
@@ -50,7 +50,7 @@ def dispatch_message_task(
         dispatch_message(
             db,
             schema.action_type,
-            to_identity,
+            Identity.parse_obj(to_identity),
             service_type,
             schema.body_params,
         )
@@ -154,11 +154,11 @@ def _build_sms(  # pylint: disable=too-many-return-statements
             "This code will expire in {{minutes}} minutes"
         )
     if action_type == MessagingActionType.PRIVACY_REQUEST_RECEIPT:
-        if body_params.request_types.length > 1:
+        if len(body_params.request_types) > 1:
             return f"The following requests have been received: {separator.join(body_params.request_types)}"
         return f"Your {body_params.request_types[0]} request has been received"
     if action_type == MessagingActionType.PRIVACY_REQUEST_COMPLETE_ACCESS:
-        if body_params.download_links.length > 1:
+        if len(body_params.download_links) > 1:
             return (
                 "Your data access has been completed and can be downloaded at the following links. "
                 "For security purposes, these secret links will expire in 24 hours: "

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -140,12 +140,36 @@ def _build_sms(
     action_type: MessagingActionType,
     body_params: Any,
 ) -> str:
+    separator = ","
     if action_type == MessagingActionType.SUBJECT_IDENTITY_VERIFICATION:
         return (
             f"Your privacy request verification code is {body_params.verification_code}. "
             f"Please return to the Privacy Center and enter the code to continue. "
             f"This code will expire in {body_params.get_verification_code_ttl_minutes()} minutes"
         )
+    if action_type == MessagingActionType.CONSENT_REQUEST:
+        return "Your consent request verification code is {{code}}. " \
+               "Please return to the consent request page and enter the code to continue. " \
+               "This code will expire in {{minutes}} minutes"
+    if action_type == MessagingActionType.PRIVACY_REQUEST_RECEIPT:
+        if body_params.request_types.length > 1:
+            return f"The following requests have been received: {separator.join(body_params.request_types)}"
+        return f"Your {body_params.request_types[0]} request has been received"
+    if action_type == MessagingActionType.PRIVACY_REQUEST_COMPLETE_ACCESS:
+        if body_params.download_links.length > 1:
+            return "Your data access has been completed and can be downloaded at the following links. " \
+                   "For security purposes, these secret links will expire in 24 hours: " \
+                   f"{separator.join(body_params.download_links)}"
+        return f"Your data access has been completed and can be downloaded at {body_params.download_links[0]}. " \
+               f"For security purposes, this secret link will expire in 24 hours."
+    if action_type == MessagingActionType.PRIVACY_REQUEST_COMPLETE_DELETION:
+        return "Your privacy request for deletion has been completed."
+    if action_type == MessagingActionType.PRIVACY_REQUEST_REVIEW_APPROVE:
+        return "Your privacy request has been approved and is currently processing."
+    if action_type == MessagingActionType.PRIVACY_REQUEST_REVIEW_DENY:
+        if body_params.rejection_reason:
+            return f"Your privacy request has been denied for the following reason: {body_params.rejection_reason}"
+        return "Your privacy request has been denied."
     logger.error("Message action type %s is not implemented", action_type)
     raise MessageDispatchException(
         f"Message action type {action_type} is not implemented"

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -136,7 +136,7 @@ def dispatch_message(
     )
 
 
-def _build_sms(
+def _build_sms(  # pylint: disable=too-many-return-statements
     action_type: MessagingActionType,
     body_params: Any,
 ) -> str:

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -148,20 +148,26 @@ def _build_sms(
             f"This code will expire in {body_params.get_verification_code_ttl_minutes()} minutes"
         )
     if action_type == MessagingActionType.CONSENT_REQUEST:
-        return "Your consent request verification code is {{code}}. " \
-               "Please return to the consent request page and enter the code to continue. " \
-               "This code will expire in {{minutes}} minutes"
+        return (
+            "Your consent request verification code is {{code}}. "
+            "Please return to the consent request page and enter the code to continue. "
+            "This code will expire in {{minutes}} minutes"
+        )
     if action_type == MessagingActionType.PRIVACY_REQUEST_RECEIPT:
         if body_params.request_types.length > 1:
             return f"The following requests have been received: {separator.join(body_params.request_types)}"
         return f"Your {body_params.request_types[0]} request has been received"
     if action_type == MessagingActionType.PRIVACY_REQUEST_COMPLETE_ACCESS:
         if body_params.download_links.length > 1:
-            return "Your data access has been completed and can be downloaded at the following links. " \
-                   "For security purposes, these secret links will expire in 24 hours: " \
-                   f"{separator.join(body_params.download_links)}"
-        return f"Your data access has been completed and can be downloaded at {body_params.download_links[0]}. " \
-               f"For security purposes, this secret link will expire in 24 hours."
+            return (
+                "Your data access has been completed and can be downloaded at the following links. "
+                "For security purposes, these secret links will expire in 24 hours: "
+                f"{separator.join(body_params.download_links)}"
+            )
+        return (
+            f"Your data access has been completed and can be downloaded at {body_params.download_links[0]}. "
+            f"For security purposes, this secret link will expire in 24 hours."
+        )
     if action_type == MessagingActionType.PRIVACY_REQUEST_COMPLETE_DELETION:
         return "Your privacy request for deletion has been completed."
     if action_type == MessagingActionType.PRIVACY_REQUEST_REVIEW_APPROVE:


### PR DESCRIPTION
Closes [1468](https://github.com/ethyca/fides/issues/1468)

### Code Changes

* [ ] Implements SMS body templates for all subject notifications

### Steps to Confirm

* [ ] Add the following to `fides.toml`: `
```
[notifications]
notification_service_type = "twilio_text"
send_request_receipt_notification = true
```
* [ ] `nox -s dev`
* [ ] Used postman to add rules/policies needed for creating a privacy request
* [ ] Used postman to add Twilio SMS messaging config / secrets
* [ ] Used postman to create an access request using my phone number as identity input
* [ ] Confirmed text message received

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
