### PR TITLE
treat  response from adobe jwt appropriately, as milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The types of changes are:
 * Show a helpful error message if Docker daemon is not running during "fides deploy" [#1694](https://github.com/ethyca/fides/pull/1694)
 * Allow users to query their own permissions, including root user. [#1698](https://github.com/ethyca/fides/pull/1698)
 * Single-select taxonomy fields legal basis and special category can be cleared. [#1712](https://github.com/ethyca/fides/pull/1712)
+* Correctly handle response from adobe jwt auth endpoint as milliseconds, rather than seconds. [#1754](https://github.com/ethyca/fides/pull/1754)
 
 ### Security
 

--- a/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_adobe_campaign.py
+++ b/src/fides/api/ops/service/saas_request/override_implementations/authentication_strategy_adobe_campaign.py
@@ -84,6 +84,7 @@ class AdobeAuthenticationStrategy(AuthenticationStrategy):
             if response.ok:
                 json_response = response.json()
                 access_token = json_response.get("access_token")
+                # note: `expires_in` is expressed in ms
                 expires_in = json_response.get("expires_in")
 
                 # merge the new values into the existing connection_config secrets
@@ -92,7 +93,9 @@ class AdobeAuthenticationStrategy(AuthenticationStrategy):
                     **secrets,
                     **{
                         "access_token": access_token,
-                        "expires_at": int(datetime.utcnow().timestamp()) + expires_in,
+                        "expires_at": (
+                            datetime.utcnow() + timedelta(milliseconds=expires_in)
+                        ).timestamp(),
                     },
                 }
                 connection_config.update(db, data={"secrets": updated_secrets})


### PR DESCRIPTION
Closes #1753 

### Code Changes

correct treatment of `expires_in` in adobe JWT response as milliseconds value, not seconds.

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
