### PR TITLE
Add pre-commit & pre-push Gitleaks secrets detection hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 minimum_pre_commit_version: "2"
 
 # To use this pre-commit hooks on the pre-commit stage only, run
-# pre-commit install
+# pre-commit install --hook-type pre-commit
 
 repos:
   - repo: local
@@ -10,7 +10,7 @@ repos:
         name: gitleaks-pre-commit
         description: Detect hardcoded secrets pre-commit using Gitleaks
         entry: gitleaks protect --verbose --no-banner --redact --staged
-        language: golang
+        language: system
         stages: [commit]
 
       - id: gitleaks-pre-push
@@ -19,5 +19,5 @@ repos:
         name: gitleaks-pre-push
         description: Detect hardcoded secrets pre-push using Gitleaks
         entry: gitleaks detect --verbose --no-banner --redact --log-opts "origin..HEAD"
-        language: golang
+        language: system
         stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 minimum_pre_commit_version: "2"
 
-# To use this pre-commit hooks on the pre-commit stage only, run
+# To use hooks on the pre-commit stage only, run
 # pre-commit install --hook-type pre-commit
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,23 @@
 minimum_pre_commit_version: "2"
 
+# To use this pre-commit hooks on the pre-commit stage only, run
+# pre-commit install
+
 repos:
   - repo: local
     hooks:
-      - id: docker
-        name: docker
-        entry: make build-local
-        files: "^fides/"
-        types_or: [file, python]
-        language: system
+      - id: gitleaks-pre-commit
+        name: gitleaks-pre-commit
+        description: Detect hardcoded secrets pre-commit using Gitleaks
+        entry: gitleaks protect --verbose --no-banner --redact --staged
+        language: golang
+        stages: [commit]
 
-      - id: black
-        name: black
-        entry: make black
-        files: "^fides/"
-        types_or: [file, python]
-        language: system
-
-      - id: mypy
-        name: mypy
-        entry: make mypy
-        files: "^fides/"
-        types_or: [file, python]
-        language: system
-
-      - id: xenon
-        name: xenon
-        entry: make xenon
-        files: "^fides/"
-        types_or: [file, python]
-        language: system
-
-      - id: pylint
-        name: pylint
-        entry: make pylint
-        files: "^fides/"
-        types_or: [file, python]
-        language: system
+      - id: gitleaks-pre-push
+        # To use this pre-push hook, run
+        # pre-commit install --hook-type pre-push
+        name: gitleaks-pre-push
+        description: Detect hardcoded secrets pre-push using Gitleaks
+        entry: gitleaks detect --verbose --no-banner --redact --log-opts "origin..HEAD"
+        language: golang
+        stages: [push]


### PR DESCRIPTION
Closes #1497 

### Code Changes

* [ ] Add a pre-commit hook for Gitleaks secrets detection
* [ ] Add a pre-push hook for Gitleaks secrets detection

### Steps to Confirm

* [ ] [Install pre-commit locally](https://pre-commit.com/#install)
* [ ] [Install gitleaks locally](https://github.com/zricethezav/gitleaks/blob/master/README.md#getting-started)
* [ ] In the root of the fides repo, run
   * [ ] `pre-commit install --hook-type pre-commit` if you want to use the pre-commit hook
   * [ ] `pre-commit install --hook-type pre-push` if you want to use the pre-push hook
* [ ] Create any file with a fake secret e.g. `discord_client_secret = '8dyfuiRyq=vVc3RRr_edRk-fK__JItpZ'` that will be detected by Gitleaks
* [ ] Try to commit or push, as applicable. The commit/push should fail.


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

The purpose of these changes is to enable devs to detect hardcoded secrets before accidentally publishing them. It leverages [the pre-commit framework](https://pre-commit.com/) and [Gitleaks](https://github.com/zricethezav/gitleaks).