### PR TITLE
1405/1406/Okta system scanning and results

### DIFF
--- a/clients/admin-ui/cypress/e2e/config-wizard.cy.ts
+++ b/clients/admin-ui/cypress/e2e/config-wizard.cy.ts
@@ -130,4 +130,76 @@ describe.skip("Config Wizard", () => {
         });
     });
   });
+  describe("Okta scan steps", () => {
+    beforeEach(() => {
+      stubSystemCrud();
+      stubTaxonomyEntities();
+
+      // Move past organization step.
+      cy.getByTestId("organization-info-form");
+      cy.getByTestId("submit-btn").click();
+      // Select Okta to move to form step.
+      cy.getByTestId("add-system-form");
+      cy.getByTestId("okta-btn").click();
+      // Fill form
+      cy.getByTestId("authenticate-okta-form");
+      cy.getByTestId("input-orgUrl").type("fakeOrgUrl");
+      cy.getByTestId("input-token").type("fakeToken");
+    });
+
+    it("Allows submitting the form and reviewing the results", () => {
+      cy.intercept("POST", "/api/v1/generate", {
+        fixture: "generate/system.json",
+      }).as("postGenerate");
+
+      cy.getByTestId("submit-btn").click();
+      cy.wait("@postGenerate");
+
+      cy.getByTestId("scan-results");
+      cy.getByTestId(`checkbox-example-system-1`).click();
+      cy.getByTestId("register-btn").click();
+
+      // The request while editing the form should match the generated system's body.
+      cy.intercept("POST", "/api/v1/system", {
+        fixture: "generate/system_to_review.json",
+      }).as("postSystem");
+      cy.intercept("PUT", "/api/v1/system*", {
+        fixture: "generate/system_to_review.json",
+      }).as("putSystem");
+
+      // assert that the systems do POST
+      cy.intercept("POST", "/api/v1/system/upsert", []).as("upsertSystems");
+
+      cy.getByTestId("warning-modal-confirm-btn").click();
+
+      cy.wait("@upsertSystems").then((interception) => {
+        assert.isNotNull(interception.response.body, "Upsert call has data");
+      });
+    });
+
+    it("Displays API errors and allows resubmission", () => {
+      cy.intercept("POST", "/api/v1/generate", {
+        statusCode: 403,
+        body: {
+          detail: "The security token included in the request is invalid.",
+        },
+      }).as("postGenerate403");
+      cy.getByTestId("submit-btn").click();
+      cy.wait("@postGenerate403");
+      // Expect the custom message for this specific error.
+      cy.getByTestId("scanner-error");
+      cy.getByTestId("permission-msg");
+
+      cy.intercept("POST", "/api/v1/generate", {
+        statusCode: 500,
+        body: "Internal Server Error",
+      }).as("postGenerate500");
+      cy.getByTestId("submit-btn").click();
+      cy.wait("@postGenerate500");
+      // Expect the generic message with a log.
+      cy.getByTestId("scanner-error");
+      cy.getByTestId("generic-msg");
+      cy.getByTestId("error-log").contains("Internal Server Error");
+    });
+  });
 });

--- a/clients/admin-ui/src/features/config-wizard/AddSystemForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AddSystemForm.tsx
@@ -18,6 +18,7 @@ import { useFeatures } from "~/features/common/features.slice";
 import {
   AWSLogoIcon,
   ManualSetupIcon,
+  OktaLogoIcon,
   QuestionIcon,
   RuntimeScannerLogo,
 } from "~/features/common/Icon";
@@ -87,6 +88,25 @@ const AddSystemForm = () => {
                 label="Infrastructure scanning allows you to connect to your cloud infrastructure and automatically identify systems that should be on your data map."
                 placement="right"
               >
+                <QuestionIcon boxSize={5} color="gray.400" />
+              </Tooltip>
+            </Stack>
+            <Stack direction="row" display="flex" alignItems="center">
+              <IconButton
+                aria-label="Okta"
+                boxSize={iconButtonSize}
+                minW={iconButtonSize}
+                boxShadow="base"
+                variant="ghost"
+                icon={<OktaLogoIcon boxSize="full" />}
+                onClick={() => {
+                  dispatch(setAddSystemsMethod(ValidTargets.OKTA));
+                  dispatch(changeStep());
+                }}
+                data-testid="okta-btn"
+              />
+              <Text>System Scan (Okta)</Text>
+              <Tooltip fontSize="md" label="Need text" placement="right">
                 <QuestionIcon boxSize={5} color="gray.400" />
               </Tooltip>
             </Stack>

--- a/clients/admin-ui/src/features/config-wizard/AddSystemForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AddSystemForm.tsx
@@ -106,9 +106,6 @@ const AddSystemForm = () => {
                 data-testid="okta-btn"
               />
               <Text>System Scan (Okta)</Text>
-              <Tooltip fontSize="md" label="Need text" placement="right">
-                <QuestionIcon boxSize={5} color="gray.400" />
-              </Tooltip>
             </Stack>
             {plus ? (
               <Stack direction="row" display="flex" alignItems="center">

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
@@ -21,7 +21,6 @@ import {
 } from "~/features/common/helpers";
 import { useAlert } from "~/features/common/hooks";
 import {
-  Dataset,
   GenerateResponse,
   GenerateTypes,
   System,
@@ -40,11 +39,10 @@ import {
   DOCS_URL_AWS_PERMISSIONS,
   DOCS_URL_IAM_POLICY,
 } from "./constants";
+import { isSystem } from "./helpers";
 import { useGenerateMutation } from "./scanner.slice";
 import ScannerError from "./ScannerError";
 import ScannerLoading from "./ScannerLoading";
-
-const isSystem = (sd: System | Dataset): sd is System => "system_type" in sd;
 
 const initialValues = {
   aws_access_key_id: "",
@@ -134,7 +132,7 @@ const AuthenticateAwsForm = () => {
             ) : null}
 
             {scannerError ? (
-              <ScannerError error={scannerError} isAWSScan />
+              <ScannerError error={scannerError} scanType="aws" />
             ) : null}
             {!isSubmitting && !scannerError ? (
               <>

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
@@ -133,7 +133,9 @@ const AuthenticateAwsForm = () => {
               />
             ) : null}
 
-            {scannerError ? <ScannerError error={scannerError} /> : null}
+            {scannerError ? (
+              <ScannerError error={scannerError} isAWSScan />
+            ) : null}
             {!isSubmitting && !scannerError ? (
               <>
                 <Heading size="lg">Authenticate Scanner</Heading>

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
@@ -24,7 +24,6 @@ import {
 } from "~/features/common/helpers";
 import { useAlert } from "~/features/common/hooks";
 import {
-  Dataset,
   GenerateResponse,
   GenerateTypes,
   System,
@@ -38,11 +37,10 @@ import {
   setSystemsForReview,
 } from "./config-wizard.slice";
 import { DOCS_URL_OKTA_TOKEN } from "./constants";
+import { isSystem } from "./helpers";
 import { useGenerateMutation } from "./scanner.slice";
 import ScannerError from "./ScannerError";
 import ScannerLoading from "./ScannerLoading";
-
-const isSystem = (sd: System | Dataset): sd is System => "system_type" in sd;
 
 const initialValues = {
   orgUrl: "",
@@ -52,11 +50,7 @@ const initialValues = {
 type FormValues = typeof initialValues;
 
 const ValidationSchema = Yup.object().shape({
-  orgUrl: Yup.string()
-    .required()
-    .trim()
-    .matches(/^[^\s]+$/, "Cannot contain spaces")
-    .label("URL"),
+  orgUrl: Yup.string().required().trim().url().label("URL"),
   token: Yup.string()
     .required()
     .trim()
@@ -174,15 +168,10 @@ const AuthenticateOktaForm = () => {
                 </Text>
                 panel.
                 <Stack>
-                  <CustomTextInput
-                    name="orgUrl"
-                    label="Org URL:"
-                    tooltip="Need text"
-                  />
+                  <CustomTextInput name="orgUrl" label="Org URL:" />
                   <CustomTextInput
                     name="token"
                     label="Okta token:"
-                    tooltip="Need text"
                     type="password"
                   />
                 </Stack>

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
@@ -37,11 +37,7 @@ import {
   selectOrganizationFidesKey,
   setSystemsForReview,
 } from "./config-wizard.slice";
-//   import {
-//     OKTA_REGION_OPTIONS,
-//     DOCS_URL_OKTA_PERMISSIONS,
-//     DOCS_URL_IAM_POLICY,
-//   } from "./constants";
+import { DOCS_URL_OKTA_TOKEN } from "./constants";
 import { useGenerateMutation } from "./scanner.slice";
 import ScannerError from "./ScannerError";
 import ScannerLoading from "./ScannerLoading";
@@ -170,7 +166,7 @@ const AuthenticateOktaForm = () => {
                 <Text m="0px !important">
                   In order to run the scanner, please provide your Okta token.
                   You can find{" "}
-                  <DocsLink href="https://help.okta.com/oie/en-us/Content/Topics/Security/API.htm">
+                  <DocsLink href={DOCS_URL_OKTA_TOKEN}>
                     instructions here{" "}
                   </DocsLink>{" "}
                   on how to retrieve a suitable token from your Okta
@@ -179,12 +175,12 @@ const AuthenticateOktaForm = () => {
                 panel.
                 <Stack>
                   <CustomTextInput
-                    name="okta_org_url"
+                    name="orgUrl"
                     label="Org URL:"
                     tooltip="Need text"
                   />
                   <CustomTextInput
-                    name="okta_token"
+                    name="token"
                     label="Okta token:"
                     tooltip="Need text"
                   />

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
@@ -2,16 +2,20 @@ import {
   Accordion,
   AccordionButton,
   AccordionItem,
+  AccordionPanel,
   Button,
+  Divider,
   Heading,
   HStack,
   Stack,
+  Text,
 } from "@fidesui/react";
 import { Form, Formik } from "formik";
 import { useState } from "react";
 import * as Yup from "yup";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
+import DocsLink from "~/features/common/DocsLink";
 import { CustomTextInput } from "~/features/common/form/inputs";
 import {
   isErrorResult,
@@ -141,7 +145,7 @@ const AuthenticateOktaForm = () => {
                           The scanner can be connected to your sign-on provider
                           to automatically scan and create a list of all systems
                           that your team are using that may contain personal
-                          data. (show more)
+                          data.
                           <AccordionButton
                             display="inline"
                             padding="0px"
@@ -152,26 +156,36 @@ const AuthenticateOktaForm = () => {
                             {isExpanded ? `(show less)` : `(show more)`}
                           </AccordionButton>
                         </h2>
-                        Currently the scanner supports certain Okta. We will be
-                        adding support for other sign-on providers (e.g.
-                        Auth0,Microsoft, Google) shortly, please let us know if
-                        you have specific requests. (show less)
+                        <AccordionPanel padding="0px" mt="20px">
+                          Currently the scanner supports certain Okta. We will
+                          be adding support for other sign-on providers (e.g.
+                          Auth0,Microsoft, Google) shortly, please let us know
+                          if you have specific requests.
+                        </AccordionPanel>
                       </>
                     )}
                   </AccordionItem>
                 </Accordion>
-                In order to run the scanner, please provide your Okta token. You
-                can find instructions here on how to retrieve a suitable token
-                from your Okta administration panel.
+                <Divider m="20px 0px !important" />
+                <Text m="0px !important">
+                  In order to run the scanner, please provide your Okta token.
+                  You can find{" "}
+                  <DocsLink href="https://help.okta.com/oie/en-us/Content/Topics/Security/API.htm">
+                    instructions here{" "}
+                  </DocsLink>{" "}
+                  on how to retrieve a suitable token from your Okta
+                  administration
+                </Text>
+                panel.
                 <Stack>
                   <CustomTextInput
                     name="okta_org_url"
-                    label="URL"
+                    label="Org URL:"
                     tooltip="Need text"
                   />
                   <CustomTextInput
                     name="okta_token"
-                    label="Token"
+                    label="Okta token:"
                     tooltip="Need text"
                   />
                 </Stack>

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
@@ -183,6 +183,7 @@ const AuthenticateOktaForm = () => {
                     name="token"
                     label="Okta token:"
                     tooltip="Need text"
+                    type="password"
                   />
                 </Stack>
               </>

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
@@ -1,0 +1,203 @@
+import {
+  Accordion,
+  AccordionButton,
+  AccordionItem,
+  Button,
+  Heading,
+  HStack,
+  Stack,
+} from "@fidesui/react";
+import { Form, Formik } from "formik";
+import { useState } from "react";
+import * as Yup from "yup";
+
+import { useAppDispatch, useAppSelector } from "~/app/hooks";
+import { CustomTextInput } from "~/features/common/form/inputs";
+import {
+  isErrorResult,
+  ParsedError,
+  parseError,
+} from "~/features/common/helpers";
+import { useAlert } from "~/features/common/hooks";
+import {
+  Dataset,
+  GenerateResponse,
+  GenerateTypes,
+  System,
+  ValidTargets,
+} from "~/types/api";
+import { RTKErrorResult } from "~/types/errors";
+
+import {
+  changeStep,
+  selectOrganizationFidesKey,
+  setSystemsForReview,
+} from "./config-wizard.slice";
+//   import {
+//     OKTA_REGION_OPTIONS,
+//     DOCS_URL_OKTA_PERMISSIONS,
+//     DOCS_URL_IAM_POLICY,
+//   } from "./constants";
+import { useGenerateMutation } from "./scanner.slice";
+import ScannerError from "./ScannerError";
+import ScannerLoading from "./ScannerLoading";
+
+const isSystem = (sd: System | Dataset): sd is System => "system_type" in sd;
+
+const initialValues = {
+  orgUrl: "",
+  token: "",
+};
+
+type FormValues = typeof initialValues;
+
+const ValidationSchema = Yup.object().shape({
+  orgUrl: Yup.string()
+    .required()
+    .trim()
+    .matches(/^[^\s]+$/, "Cannot contain spaces")
+    .label("URL"),
+  token: Yup.string()
+    .required()
+    .trim()
+    .matches(/^[^\s]+$/, "Cannot contain spaces")
+    .label("Token"),
+});
+
+const AuthenticateOktaForm = () => {
+  const organizationKey = useAppSelector(selectOrganizationFidesKey);
+  const dispatch = useAppDispatch();
+  const { successAlert } = useAlert();
+
+  const [scannerError, setScannerError] = useState<ParsedError>();
+
+  const handleResults = (results: GenerateResponse["generate_results"]) => {
+    const systems: System[] = (results ?? []).filter(isSystem);
+    dispatch(setSystemsForReview(systems));
+    dispatch(changeStep());
+    successAlert(
+      `Your scan was successfully completed, with ${systems.length} new systems detected!`,
+      `Scan Successfully Completed`,
+      { isClosable: true }
+    );
+  };
+  const handleError = (error: RTKErrorResult["error"]) => {
+    const parsedError = parseError(error, {
+      status: 500,
+      message: "Our system encountered a problem while connecting to Okta.",
+    });
+    setScannerError(parsedError);
+  };
+  const handleCancel = () => {
+    dispatch(changeStep(2));
+  };
+
+  const [generate, { isLoading }] = useGenerateMutation();
+
+  const handleSubmit = async (values: FormValues) => {
+    setScannerError(undefined);
+
+    const result = await generate({
+      organization_key: organizationKey,
+      generate: {
+        config: values,
+        target: ValidTargets.OKTA,
+        type: GenerateTypes.SYSTEMS,
+      },
+    });
+
+    if (isErrorResult(result)) {
+      handleError(result.error);
+    } else {
+      handleResults(result.data.generate_results);
+    }
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={ValidationSchema}
+      onSubmit={handleSubmit}
+    >
+      {({ isValid, isSubmitting, dirty }) => (
+        <Form data-testid="authenticate-okta-form">
+          <Stack spacing={10}>
+            {isSubmitting ? (
+              <ScannerLoading
+                title="System scanning in progress"
+                onClose={handleCancel}
+              />
+            ) : null}
+
+            {scannerError ? <ScannerError error={scannerError} /> : null}
+            {!isSubmitting && !scannerError ? (
+              <>
+                <Heading size="lg">Authenticate Scanner</Heading>
+                <Accordion allowToggle border="transparent">
+                  <AccordionItem>
+                    {({ isExpanded }) => (
+                      <>
+                        <h2>
+                          The scanner can be connected to your sign-on provider
+                          to automatically scan and create a list of all systems
+                          that your team are using that may contain personal
+                          data. (show more)
+                          <AccordionButton
+                            display="inline"
+                            padding="0px"
+                            ml="5px"
+                            width="auto"
+                            color="complimentary.500"
+                          >
+                            {isExpanded ? `(show less)` : `(show more)`}
+                          </AccordionButton>
+                        </h2>
+                        Currently the scanner supports certain Okta. We will be
+                        adding support for other sign-on providers (e.g.
+                        Auth0,Microsoft, Google) shortly, please let us know if
+                        you have specific requests. (show less)
+                      </>
+                    )}
+                  </AccordionItem>
+                </Accordion>
+                In order to run the scanner, please provide your Okta token. You
+                can find instructions here on how to retrieve a suitable token
+                from your Okta administration panel.
+                <Stack>
+                  <CustomTextInput
+                    name="okta_org_url"
+                    label="URL"
+                    tooltip="Need text"
+                  />
+                  <CustomTextInput
+                    name="okta_token"
+                    label="Token"
+                    tooltip="Need text"
+                  />
+                </Stack>
+              </>
+            ) : null}
+            {!isSubmitting ? (
+              <HStack>
+                <Button variant="outline" onClick={handleCancel}>
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  variant="primary"
+                  isDisabled={!dirty || !isValid}
+                  isLoading={isLoading}
+                  data-testid="submit-btn"
+                >
+                  Save and Continue
+                </Button>
+              </HStack>
+            ) : null}
+          </Stack>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default AuthenticateOktaForm;

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateScanner.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateScanner.tsx
@@ -1,15 +1,11 @@
-import React from "react";
-
 import { useAppSelector } from "~/app/hooks";
 import { ValidTargets } from "~/types/api";
 
 import AuthenticateAwsForm from "./AuthenticateAwsForm";
+import AuthenticateOktaForm from "./AuthenticateOktaForm";
 import { selectAddSystemsMethod } from "./config-wizard.slice";
 import LoadRuntimeScanner from "./LoadRuntimeScanner";
 import { SystemMethods } from "./types";
-
-// TODO(#577)
-const AuthenticateOktaForm = () => null;
 
 const AuthenticateScanner = () => {
   const infrastructure = useAppSelector(selectAddSystemsMethod);

--- a/clients/admin-ui/src/features/config-wizard/ScannerError.tsx
+++ b/clients/admin-ui/src/features/config-wizard/ScannerError.tsx
@@ -25,7 +25,13 @@ const ErrorLog = ({ message }: { message: string }) => (
   </>
 );
 
-const ScannerError = ({ error }: { error: ParsedError }) => (
+const ScannerError = ({
+  error,
+  isAWSScan,
+}: {
+  error: ParsedError;
+  isAWSScan?: boolean;
+}) => (
   <Stack data-testid="scanner-error" spacing="4">
     <HStack>
       <Badge color="white" bg="red.500" py="2">
@@ -36,7 +42,7 @@ const ScannerError = ({ error }: { error: ParsedError }) => (
       </Heading>
     </HStack>
 
-    {error.status === 403 ? (
+    {error.status === 403 && isAWSScan ? (
       <>
         <Text data-testid="permission-msg">
           Fides was unable to scan AWS. It appears that the credentials were

--- a/clients/admin-ui/src/features/config-wizard/ScannerError.tsx
+++ b/clients/admin-ui/src/features/config-wizard/ScannerError.tsx
@@ -10,6 +10,7 @@ import {
 
 import DocsLink from "~/features/common/DocsLink";
 import { ParsedError } from "~/features/common/helpers";
+import { ValidTargets } from "~/types/api";
 
 import { DOCS_URL_AWS_PERMISSIONS, DOCS_URL_ISSUES } from "./constants";
 
@@ -27,10 +28,10 @@ const ErrorLog = ({ message }: { message: string }) => (
 
 const ScannerError = ({
   error,
-  isAWSScan,
+  scanType = "",
 }: {
   error: ParsedError;
-  isAWSScan?: boolean;
+  scanType?: string;
 }) => (
   <Stack data-testid="scanner-error" spacing="4">
     <HStack>
@@ -42,7 +43,7 @@ const ScannerError = ({
       </Heading>
     </HStack>
 
-    {error.status === 403 && isAWSScan ? (
+    {error.status === 403 && scanType === ValidTargets.AWS ? (
       <>
         <Text data-testid="permission-msg">
           Fides was unable to scan AWS. It appears that the credentials were

--- a/clients/admin-ui/src/features/config-wizard/constants.tsx
+++ b/clients/admin-ui/src/features/config-wizard/constants.tsx
@@ -50,6 +50,8 @@ export const DOCS_URL_AWS_PERMISSIONS =
 export const DOCS_URL_IAM_POLICY =
   "https://ethyca.github.io/fides/guides/generate_resources/#sample-iam-policy";
 export const DOCS_URL_ISSUES = "https://github.com/ethyca/fides/issues";
+export const DOCS_URL_OKTA_TOKEN =
+  "https://help.okta.com/oie/en-us/Content/Topics/Security/API.htm";
 
 // Source: https://docs.aws.amazon.com/general/latest/gr/rande.html
 export const AWS_REGION_OPTIONS = [

--- a/clients/admin-ui/src/features/config-wizard/constants.tsx
+++ b/clients/admin-ui/src/features/config-wizard/constants.tsx
@@ -46,9 +46,13 @@ export const iconButtonSize = 107;
 
 // When more links like these are introduced we should move them to a single file.
 export const DOCS_URL_AWS_PERMISSIONS =
-  "https://ethyca.github.io/fides/guides/generate_resources/#required-permissions";
+  "https://ethyca.github.io/fides/2.0.0/getting-started/generate_resources/#required-permissions";
+export const DOCS_URL_OKTA_CREDENTIALS =
+  "https://ethyca.github.io/fides/2.0.0/getting-started/generate_resources/#providing-credentials_2";
 export const DOCS_URL_IAM_POLICY =
-  "https://ethyca.github.io/fides/guides/generate_resources/#sample-iam-policy";
+  "https://ethyca.github.io/fides/2.0.0/getting-started/generate_resources/#sample-iam-policy";
+export const DOCS_URL_ACCESS_MANAGEMENT =
+  "https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_access-management.html";
 export const DOCS_URL_ISSUES = "https://github.com/ethyca/fides/issues";
 export const DOCS_URL_OKTA_TOKEN =
   "https://help.okta.com/oie/en-us/Content/Topics/Security/API.htm";

--- a/clients/admin-ui/src/features/config-wizard/helpers.tsx
+++ b/clients/admin-ui/src/features/config-wizard/helpers.tsx
@@ -1,0 +1,4 @@
+import { Dataset, System } from "~/types/api";
+
+export const isSystem = (sd: System | Dataset): sd is System =>
+  "system_type" in sd;


### PR DESCRIPTION
Closes #1405 and #1406

https://user-images.githubusercontent.com/99051851/201859219-16cd8f62-53a1-4fc1-bd0a-bee15af816db.mov

Note:
The designs don't contain an org url field, but I think this field is required?
Also, the designs include a tooltip next to the fields, but the text isn't given yet. I have notified @mfbrown [here](https://github.com/ethyca/fides/issues/1405#issuecomment-1314839371) about these pending questions.

TODO:
Tooltip text (once supplied)

### Code Changes

* [ ] Add authenticate okta scan form
* [ ] Add okta system scan button to system pick page

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
