### PR TITLE
Generated dataset fides_keys are unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Added
 * Include `ingress` and `egress` fields on system export and `datamap/` endpoint [#1740](https://github.com/ethyca/fides/pull/1740)
+* Repeatable unique identifier for dataset fides_keys and metadata [#1786](https://github.com/ethyca/fides/pull/1786)
 * Adds SMS support for identity verification notifications [#1726](https://github.com/ethyca/fides/pull/1726)
 * Added phone number validation in back-end and react phone number form in Privacy Center [#1745](https://github.com/ethyca/fides/pull/1745)
 * Adds SMS message template for all subject notifications [#1743](https://github.com/ethyca/fides/pull/1743)

--- a/src/fides/ctl/core/dataset.py
+++ b/src/fides/ctl/core/dataset.py
@@ -123,20 +123,19 @@ def create_db_dataset(schema_name: str, db_tables: Dict[str, List[str]]) -> Data
     return dataset
 
 
-def make_dataset_fides_key_unique(
-    datasets: List[Dataset], database_host: str, database_name: str
-) -> List[Dataset]:
+def make_dataset_key_unique(
+    dataset: Dataset, database_host: str, database_name: str
+) -> Dataset:
     """
-    Ensure each generated dataset has a repeatable unique ID appended to the end
+    Ensure the dataset has a repeatable unique ID appended to the end
     to avoid naming collisions.
     """
 
-    for dataset in datasets:
-        dataset.fides_key = generate_unique_fides_key(
-            dataset.fides_key, database_host, database_name
-        )
-        dataset.meta = {"database_host": database_host, "database_name": database_name}
-    return datasets
+    dataset.fides_key = generate_unique_fides_key(
+        dataset.fides_key, database_host, database_name
+    )
+    dataset.meta = {"database_host": database_host, "database_name": database_name}
+    return dataset
 
 
 def find_uncategorized_dataset_fields(
@@ -301,9 +300,10 @@ def generate_db_datasets(connection_string: str) -> List[Dataset]:
     db_engine = get_db_engine(connection_string)
     db_schemas = get_db_schemas(engine=db_engine)
     db_datasets = create_db_datasets(db_schemas=db_schemas)
-    unique_db_datasets = make_dataset_fides_key_unique(
-        db_datasets, db_engine.url.host, db_engine.url.database
-    )
+    unique_db_datasets = [
+        make_dataset_key_unique(dataset, db_engine.url.host, db_engine.url.database)
+        for dataset in db_datasets
+    ]
     return unique_db_datasets
 
 
@@ -344,7 +344,10 @@ def generate_bigquery_datasets(bigquery_config: BigQueryConfig) -> List[Dataset]
     bigquery_engine = get_bigquery_engine(bigquery_config)
     bigquery_schemas = get_db_schemas(engine=bigquery_engine)
     bigquery_datasets = create_db_datasets(db_schemas=bigquery_schemas)
-    unique_bigquery_datasets = make_dataset_fides_key_unique(
-        bigquery_datasets, bigquery_engine.url.host, bigquery_engine.url.database
-    )
+    unique_bigquery_datasets = [
+        make_dataset_key_unique(
+            dataset, bigquery_engine.url.host, bigquery_engine.url.database
+        )
+        for dataset in bigquery_datasets
+    ]
     return unique_bigquery_datasets

--- a/src/fides/ctl/core/dataset.py
+++ b/src/fides/ctl/core/dataset.py
@@ -12,7 +12,13 @@ from fides.ctl.connectors.models import BigQueryConfig
 from fides.ctl.core.api_helpers import list_server_resources
 from fides.ctl.core.parse import parse
 
-from .utils import check_fides_key, echo_green, echo_red, get_db_engine
+from .utils import (
+    check_fides_key,
+    echo_green,
+    echo_red,
+    generate_unique_fides_key,
+    get_db_engine,
+)
 
 SCHEMA_EXCLUSION = {
     "postgresql": ["information_schema"],
@@ -115,6 +121,22 @@ def create_db_dataset(schema_name: str, db_tables: Dict[str, List[str]]) -> Data
         ],
     )
     return dataset
+
+
+def make_dataset_fides_key_unique(
+    datasets: List[Dataset], database_host: str, database_name: str
+) -> List[Dataset]:
+    """
+    Ensure each generated dataset has a repeatable unique ID appended to the end
+    to avoid naming collisions.
+    """
+
+    for dataset in datasets:
+        dataset.fides_key = generate_unique_fides_key(
+            dataset.fides_key, database_host, database_name
+        )
+        dataset.meta = {"database_host": database_host, "database_name": database_name}
+    return datasets
 
 
 def find_uncategorized_dataset_fields(
@@ -279,7 +301,10 @@ def generate_db_datasets(connection_string: str) -> List[Dataset]:
     db_engine = get_db_engine(connection_string)
     db_schemas = get_db_schemas(engine=db_engine)
     db_datasets = create_db_datasets(db_schemas=db_schemas)
-    return db_datasets
+    unique_db_datasets = make_dataset_fides_key_unique(
+        db_datasets, db_engine.url.host, db_engine.url.database
+    )
+    return unique_db_datasets
 
 
 def write_dataset_manifest(
@@ -319,4 +344,7 @@ def generate_bigquery_datasets(bigquery_config: BigQueryConfig) -> List[Dataset]
     bigquery_engine = get_bigquery_engine(bigquery_config)
     bigquery_schemas = get_db_schemas(engine=bigquery_engine)
     bigquery_datasets = create_db_datasets(db_schemas=bigquery_schemas)
-    return bigquery_datasets
+    unique_bigquery_datasets = make_dataset_fides_key_unique(
+        bigquery_datasets, bigquery_engine.url.host, bigquery_engine.url.database
+    )
+    return unique_bigquery_datasets

--- a/src/fides/ctl/core/utils.py
+++ b/src/fides/ctl/core/utils.py
@@ -3,6 +3,7 @@ import glob
 import logging
 import re
 from functools import partial
+from hashlib import sha1
 from json.decoder import JSONDecodeError
 from os.path import isfile
 from typing import Dict, Iterator, List
@@ -134,6 +135,19 @@ def sanitize_fides_key(proposed_fides_key: str) -> str:
     """
     sanitized_fides_key = re.sub(r"[^a-zA-Z0-9_.-]", "_", proposed_fides_key)
     return sanitized_fides_key
+
+
+def generate_unique_fides_key(
+    proposed_fides_key: str, database_host: str, database_name: str
+) -> str:
+    """
+    Uses host and name to generates a UUID to be
+    appended to the fides_key of a dataset
+    """
+    fides_key_uuid = sha1(
+        "-".join([database_host, database_name, proposed_fides_key]).encode()
+    )
+    return f"{proposed_fides_key}_{fides_key_uuid.hexdigest()[:10]}"
 
 
 def git_is_dirty(dir_to_check: str = ".") -> bool:

--- a/src/fides/ctl/core/utils.py
+++ b/src/fides/ctl/core/utils.py
@@ -141,7 +141,7 @@ def generate_unique_fides_key(
     proposed_fides_key: str, database_host: str, database_name: str
 ) -> str:
     """
-    Uses host and name to generates a UUID to be
+    Uses host and name to generate a UUID to be
     appended to the fides_key of a dataset
     """
     fides_key_uuid = sha1(

--- a/tests/ctl/core/test_utils.py
+++ b/tests/ctl/core/test_utils.py
@@ -113,3 +113,12 @@ class TestGitIsDirty:
             file.write("test file")
         assert utils.git_is_dirty()
         os.remove(test_file)
+
+
+@pytest.mark.unit
+def test_repeatable_unique_key() -> None:
+    expected_unique_fides_key = "test_dataset_87ccd73621"
+    unique_fides_key = utils.generate_unique_fides_key(
+        "test_dataset", "test_host", "test_name"
+    )
+    assert unique_fides_key == expected_unique_fides_key


### PR DESCRIPTION
Closes [fidesplus-licensing#62](https://github.com/ethyca/fidesplus-licensing/issues/62)

### Code Changes

* [x] Added function to create repeatable hash
* [x] Update generated datasets to have a repeatable uuid as suffix of fides_key. Also include hash components in `meta`

### Steps to Confirm

* [x] Generated datasets both through the API and CLI successfully
* [x] Validate the args passed to classify are updated to reflect new fides_key values as well

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [x] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Currently this is geared heavily towards datasets but could be more agnostic to allow for uniqueness in other resources (i.e. Systems) as well
