### PR TITLE
Add helper function to debug required config vars

### DIFF
--- a/src/fides/__init__.py
+++ b/src/fides/__init__.py
@@ -1,6 +1,9 @@
 """Fides CLI"""
 
 from fides.ctl.core.config import get_config
+from fides.ctl.core.config.utils import check_if_required_config_vars_are_configured
+
+check_if_required_config_vars_are_configured()
 
 from ._version import get_versions
 

--- a/src/fides/__init__.py
+++ b/src/fides/__init__.py
@@ -1,11 +1,11 @@
 """Fides CLI"""
-
 from fides.ctl.core.config import get_config
 from fides.ctl.core.config.utils import check_if_required_config_vars_are_configured
 
+from ._version import get_versions
+
 check_if_required_config_vars_are_configured()
 
-from ._version import get_versions
 
 # Load the config here as a work around to the timing issue with environment variables
 get_config()

--- a/src/fides/ctl/core/config/utils.py
+++ b/src/fides/ctl/core/config/utils.py
@@ -92,8 +92,10 @@ def check_if_required_config_vars_are_configured() -> None:
         for missing_var in missing_required_config_vars:
             print(f"fides.toml: {missing_var[0]} or ENV VAR: {missing_var[1]}")
 
-        print("\nVisit the Fides deployment documentation for more information: "
-              "https://ethyca.github.io/fides/deployment/")
+        print(
+            "\nVisit the Fides deployment documentation for more information: "
+            "https://ethyca.github.io/fides/deployment/"
+        )
         sys.exit(1)
 
 

--- a/src/fides/ctl/core/config/utils.py
+++ b/src/fides/ctl/core/config/utils.py
@@ -52,13 +52,18 @@ def check_if_required_config_vars_are_configured() -> None:
         "FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET"
     )
     try:
-        app_encryption_key = get_config_from_file("", "security", "app_encryption_key")
-        oauth_root_client_id = get_config_from_file(
-            "", "security", "oauth_root_client_id"
-        )
-        oauth_root_client_secret = get_config_from_file(
-            "", "security", "oauth_root_client_secret"
-        )
+        if not app_encryption_key:
+            app_encryption_key = get_config_from_file(
+                "", "security", "app_encryption_key"
+            )
+        if not oauth_root_client_id:
+            oauth_root_client_id = get_config_from_file(
+                "", "security", "oauth_root_client_id"
+            )
+        if not oauth_root_client_secret:
+            oauth_root_client_secret = get_config_from_file(
+                "", "security", "oauth_root_client_secret"
+            )
     except FileNotFoundError:
         pass
 

--- a/src/fides/ctl/core/config/utils.py
+++ b/src/fides/ctl/core/config/utils.py
@@ -42,9 +42,15 @@ def get_config_from_file(
 
 
 def check_if_required_config_vars_are_configured() -> None:
-    app_encryption_key = getenv("FIDES__SECURITY__APP_ENCRYPTION_KEY")
-    oauth_root_client_id = getenv("FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID")
-    oauth_root_client_secret = getenv("FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET")
+    app_encryption_key: Union[str, int, None] = getenv(
+        "FIDES__SECURITY__APP_ENCRYPTION_KEY"
+    )
+    oauth_root_client_id: Union[str, int, None] = getenv(
+        "FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID"
+    )
+    oauth_root_client_secret: Union[str, int, None] = getenv(
+        "FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET"
+    )
     try:
         app_encryption_key = get_config_from_file("", "security", "app_encryption_key")
         oauth_root_client_id = get_config_from_file(

--- a/src/fides/ctl/core/config/utils.py
+++ b/src/fides/ctl/core/config/utils.py
@@ -86,7 +86,7 @@ def check_if_required_config_vars_are_configured() -> None:
 
     if len(missing_required_config_vars) > 0:
         print(
-            "There are missing required config variables. Please add the following to start Fides: "
+            "There are missing required config variables. Please add the following config variables to either the `fides.toml` file or your environment variable to start Fides: "
         )
         for missing_var in missing_required_config_vars:
             print(f"fides.toml: {missing_var[0]} or ENV VAR: {missing_var[1]}")

--- a/src/fides/ctl/core/config/utils.py
+++ b/src/fides/ctl/core/config/utils.py
@@ -86,10 +86,14 @@ def check_if_required_config_vars_are_configured() -> None:
 
     if len(missing_required_config_vars) > 0:
         print(
-            "There are missing required config variables. Please add the following config variables to either the `fides.toml` file or your environment variable to start Fides: "
+            "There are missing required config variables. Please add the following config variables to either the "
+            "`fides.toml` file or your environment variables to start Fides: \n"
         )
         for missing_var in missing_required_config_vars:
             print(f"fides.toml: {missing_var[0]} or ENV VAR: {missing_var[1]}")
+
+        print("\nVisit the Fides deployment documentation for more information: "
+              "https://ethyca.github.io/fides/deployment/")
         sys.exit(1)
 
 

--- a/src/fides/ctl/core/config/utils.py
+++ b/src/fides/ctl/core/config/utils.py
@@ -1,3 +1,4 @@
+import sys
 from os import getenv
 from typing import Any, Dict, Union
 
@@ -38,6 +39,47 @@ def get_config_from_file(
             return config_option
 
     return None
+
+
+def check_if_required_config_vars_are_configured() -> None:
+    app_encryption_key = getenv("FIDES__SECURITY__APP_ENCRYPTION_KEY")
+    oauth_root_client_id = getenv("FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID")
+    oauth_root_client_secret = getenv("FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET")
+    try:
+        app_encryption_key = get_config_from_file("", "security", "app_encryption_key")
+        oauth_root_client_id = get_config_from_file(
+            "", "security", "oauth_root_client_id"
+        )
+        oauth_root_client_secret = get_config_from_file(
+            "", "security", "oauth_root_client_secret"
+        )
+    except FileNotFoundError:
+        pass
+
+    missing_required_config_vars = []
+    if app_encryption_key is None:
+        missing_required_config_vars.append(
+            ("security.app_encryption_key", "FIDES__SECURITY__APP_ENCRYPTION_KEY")
+        )
+    if oauth_root_client_id is None:
+        missing_required_config_vars.append(
+            ("security.oauth_root_client_id", "FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID")
+        )
+    if oauth_root_client_secret is None:
+        missing_required_config_vars.append(
+            (
+                "security.oauth_root_client_secret",
+                "FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET",
+            )
+        )
+
+    if len(missing_required_config_vars) > 0:
+        print(
+            "There are missing required config variables. Please add the following to start Fides: "
+        )
+        for missing_var in missing_required_config_vars:
+            print(f"fides.toml: {missing_var[0]} or ENV VAR: {missing_var[1]}")
+        sys.exit(1)
 
 
 def update_config_file(  # type: ignore


### PR DESCRIPTION
Closes #1787 

### Code Changes

* [ ] Add helper function to `fides.ctl.core.config.utils` that checks if all the required config variables are configured

### Steps to Confirm

* [ ] Run `nox -s "build(dev)" && docker run -it ethyca/fides:local` and it should display the message and exit with error code 1

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

In the current draft state this PR serves as a starting point to get a conversation going. This solution is harder to maintain for developers but _hopefully_ offers a great user experience by immediately displaying all of the missing required configs vars. The output should look like this when no config is provided.

<img width="1157" alt="Screen Shot 2022-11-16 at 08 43 44" src="https://user-images.githubusercontent.com/17103888/202196606-bd4e84f5-1917-463e-8eea-965db1fefb20.png">

It works by running before the pydantic code tries to load everything in. It circumvents catching `MissingConfig` exceptions by manually checking for config vars. It also makes it very easy to display helpful error messages.

I'm open to a more automated solution but I want to minimize how much work is done for this increment when fides config is about to receive a big overhaul (#1760). I think this adds a good amount of value while being simple to implement. 

 


