### PR TITLE
Revert "Remove dead "view" code from the backend"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,6 @@ The types of changes are:
 
 * Admin-UI-Cypress tests that fail in CI will now upload screen recordings for debugging. [#1728](https://github.com/ethyca/fides/pull/1728/files/c23e62fea284f7910028c8483feff893903068b8#r1019491323)
 
-### Removed
-
-* Removed the `view` endpoint for evaluations [#1703](https://github.com/ethyca/fides/pull/1703)
-
 ### Fixed
 
 * Exceptions are no longer raised when sending analytics on Windows [#1666](https://github.com/ethyca/fides/pull/1666)

--- a/src/fides/api/ctl/view.py
+++ b/src/fides/api/ctl/view.py
@@ -1,0 +1,54 @@
+"""
+Contains api endpoints for fides web pages
+"""
+from fastapi.responses import HTMLResponse
+
+from fides.api.ctl.routes.crud import list_resource  # type: ignore[attr-defined]
+from fides.api.ctl.sql_models import Evaluation  # type: ignore[attr-defined]
+from fides.api.ctl.utils.api_router import APIRouter
+
+router = APIRouter(
+    tags=["View"],
+    prefix="/view",
+)
+
+
+@router.get("/evaluations")
+async def evaluation_view() -> HTMLResponse:
+    "Returns an html document with a list of evaluations"
+
+    html = '<html lang="en">'
+    html += "<head>"
+    html += '<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">'
+    html += "<body>"
+    html += "<h2>Evaluations</h2>"
+    html += '<table class="table table-striped" style="text-align: left;">'
+    html += "<tr><th>Id</th><th>Status</th><th>Violations</th><th>Message</th></tr>"
+    for evaluation in await list_resource(Evaluation):
+        html += "<tr>"
+        html += f"<td>{evaluation.fides_key}</td>"
+        html += f"<td>{evaluation.status}</td>"
+
+        html += "<td>"
+        for index, violation in enumerate(evaluation.violations):
+            violating_attributes = violation.get("violating_attributes")
+            html += f"<b>Violation {index + 1}</b><br/>"
+            html += "<ul>"
+            html += f"<li>Data Categories: {violating_attributes.get('data_categories')}</li>"
+            html += (
+                f"<li>Data Subjects: {violating_attributes.get('data_subjects')}</li>"
+            )
+            html += f"<li>Data Uses: {violating_attributes.get('data_uses')}</li>"
+            html += (
+                f"<li>Data Qualifier: {violating_attributes.get('data_qualifier')}</li>"
+            )
+            html += f"<li>Detail: {violation.get('detail')}</li>"
+            html += "</ul>"
+        html += "</td>"
+
+        html += f"<td>{evaluation.message}</td>"
+        html += "</tr>"
+    html += "</table>"
+    html += "</head>"
+    html += "</html>"
+    return HTMLResponse(html)

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -20,6 +20,7 @@ from starlette.background import BackgroundTask
 from starlette.middleware.cors import CORSMiddleware
 from uvicorn import Config, Server
 
+from fides.api.ctl import view
 from fides.api.ctl.database.database import configure_db
 from fides.api.ctl.routes import admin, crud, datamap, generate, health, validate
 from fides.api.ctl.routes.util import API_PREFIX
@@ -71,6 +72,7 @@ ROUTERS = crud.routers + [  # type: ignore[attr-defined]
     generate.router,
     health.router,
     validate.router,
+    view.router,
 ]
 
 


### PR DESCRIPTION
Reverts ethyca/fides#1703

### Code Changes

* [x] Restores `view.py` and `/view/evaluations`

### Steps to Confirm

* [X] Run `nox -s test_env` and confirm `/view/evaluations` works

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Turns out this code wasn't actually dead, and we use the "view evaluations" page for some demos and testing!
