### PR TITLE
Only check for required variables when the webserver is run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The types of changes are:
 * Allow users to query their own permissions, including root user. [#1698](https://github.com/ethyca/fides/pull/1698)
 * Single-select taxonomy fields legal basis and special category can be cleared. [#1712](https://github.com/ethyca/fides/pull/1712)
 * Fixes the issue where the security config is not properly loading from environment variables. [#1718](https://github.com/ethyca/fides/pull/1718)
+* Fixes the issue where the CLI can't run without the config values required by the webserver. [#1811](https://github.com/ethyca/fides/pull/1811)
 * Correctly handle response from adobe jwt auth endpoint as milliseconds, rather than seconds. [#1754](https://github.com/ethyca/fides/pull/1754)
 
 ### Security

--- a/src/fides/__init__.py
+++ b/src/fides/__init__.py
@@ -1,11 +1,7 @@
 """Fides CLI"""
 from fides.ctl.core.config import get_config
-from fides.ctl.core.config.utils import check_if_required_config_vars_are_configured
 
 from ._version import get_versions
-
-check_if_required_config_vars_are_configured()
-
 
 # Load the config here as a work around to the timing issue with environment variables
 get_config()

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -322,5 +322,6 @@ def read_other_paths(request: Request) -> Response:
 
 def start_webserver() -> None:
     "Run the webserver."
+    # Check for required variables here
     server = Server(Config(app, host="0.0.0.0", port=8080, log_level=WARNING))
     server.run()

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -62,6 +62,7 @@ from fides.api.ops.util.logger import Pii, get_fides_log_record_factory
 from fides.api.ops.util.oauth_util import verify_oauth_client
 from fides.ctl.core.config import FidesConfig
 from fides.ctl.core.config import get_config as get_ctl_config
+from fides.ctl.core.config.utils import check_required_webserver_config_values
 
 CONFIG: FidesConfig = get_ctl_config()
 
@@ -196,6 +197,7 @@ for handler in ExceptionHandlers.get_handlers():
 @app.on_event("startup")
 async def setup_server() -> None:
     "Run all of the required setup steps for the webserver."
+
     log.warning(
         f"Startup configuration: reloading = {CONFIG.hot_reloading}, dev_mode = {CONFIG.dev_mode}",
     )
@@ -322,6 +324,6 @@ def read_other_paths(request: Request) -> Response:
 
 def start_webserver() -> None:
     "Run the webserver."
-    # Check for required variables here
+    check_required_webserver_config_values()
     server = Server(Config(app, host="0.0.0.0", port=8080, log_level=WARNING))
     server.run()

--- a/src/fides/ctl/core/config/security_settings.py
+++ b/src/fides/ctl/core/config/security_settings.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional, Tuple, Union
 import validators
 from fideslib.core.config import FidesSettings
 from fideslib.cryptography.cryptographic_util import generate_salt, hash_with_salt
-from fideslib.exceptions import MissingConfig
 from pydantic import validator
 from slowapi.wrappers import parse_many  # type: ignore
 

--- a/src/fides/ctl/core/config/security_settings.py
+++ b/src/fides/ctl/core/config/security_settings.py
@@ -45,6 +45,11 @@ class SecuritySettings(FidesSettings):
         cls, v: Optional[str], values: Dict[str, str]
     ) -> Optional[str]:
         """Validate the encryption key is exactly 32 characters"""
+
+        # If the value is the default value, return immediately to prevent unwanted errors
+        if v == "":
+            return v
+
         if v is None or len(v.encode(values.get("encoding", "UTF-8"))) != 32:
             raise ValueError(
                 "APP_ENCRYPTION_KEY value must be exactly 32 characters long"
@@ -77,17 +82,16 @@ class SecuritySettings(FidesSettings):
     @classmethod
     def assemble_root_access_token(
         cls, v: Optional[str], values: Dict[str, str]
-    ) -> Tuple:
+    ) -> Optional[Tuple]:
         """
         Sets a hashed value of the root access key.
         This is hashed as it is not wise to return a plaintext for of the
         root credential anywhere in the system.
         """
-        value = values.get("oauth_root_client_secret")
+        value = values.get("oauth_root_client_secret", "")
+
         if not value:
-            raise MissingConfig(
-                "oauth_root_client_secret is required", SecuritySettings
-            )
+            return None
 
         encoding = values.get("encoding", "UTF-8")
 

--- a/src/fides/ctl/core/config/security_settings.py
+++ b/src/fides/ctl/core/config/security_settings.py
@@ -24,7 +24,7 @@ class SecuritySettings(FidesSettings):
     rate_limit_prefix: str = "fides-"
     aes_encryption_key_length: int = 16
     aes_gcm_nonce_length: int = 12
-    app_encryption_key: str
+    app_encryption_key: str = ""
     drp_jwt_secret: Optional[str] = None
     root_username: Optional[str] = None
     root_password: Optional[str] = None
@@ -32,8 +32,8 @@ class SecuritySettings(FidesSettings):
     encoding: str = "UTF-8"
 
     cors_origins: List[str] = []
-    oauth_root_client_id: str
-    oauth_root_client_secret: str
+    oauth_root_client_id: str = ""
+    oauth_root_client_secret: str = ""
     oauth_root_client_secret_hash: Optional[Tuple]
     oauth_access_token_expire_minutes: int = 60 * 24 * 8
     oauth_client_id_length_bytes = 16

--- a/src/fides/ctl/core/config/utils.py
+++ b/src/fides/ctl/core/config/utils.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Union
 from click import echo
 from fideslib.core.config import load_file
 from toml import dump, load
+
 from fides.ctl.core.utils import echo_red
 
 DEFAULT_CONFIG_PATH = ".fides/fides.toml"
@@ -59,13 +60,11 @@ def check_required_webserver_config_values() -> None:
     }
 
     missing_required_config_vars = []
-    for key in required_config_dict:
+    for key, value in required_config_dict.items():
         try:
-            config_value = getenv(
-                required_config_dict[key]["env_var"]
-            ) or get_config_from_file(
+            config_value = getenv(value["env_var"]) or get_config_from_file(
                 "",
-                required_config_dict[key]["config_subsection"],
+                value["config_subsection"],
                 key,
             )
         except FileNotFoundError:
@@ -74,7 +73,7 @@ def check_required_webserver_config_values() -> None:
         if not config_value:
             missing_required_config_vars.append(key)
 
-    if len(missing_required_config_vars):
+    if missing_required_config_vars:
         echo_red(
             "\nThere are missing required configuration variables. Please add the following config variables to either the "
             "`fides.toml` file or your environment variables to start Fides: \n"

--- a/src/fides/data/sample_project/docker-compose.yml
+++ b/src/fides/data/sample_project/docker-compose.yml
@@ -17,6 +17,11 @@ services:
         condition: service_started
     environment:
       FIDES__CONFIG_PATH: "/fides/src/fides/data/sample_project/fides.toml"
+      # These need to be defined here instead of the config file
+      # due to the `check_required_webserver_config_values` function
+      FIDES__SECURITY__APP_ENCRYPTION_KEY: "examplevalidprojectencryptionkey"
+      FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID: "fidesadmin"
+      FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET: "fidesadminsecret"
     # Mount a local volume so the user can see their privacy requests
     volumes:
       - type: bind

--- a/src/fides/data/sample_project/fides.toml
+++ b/src/fides/data/sample_project/fides.toml
@@ -13,10 +13,7 @@ port = 6379
 db_index = 0
 
 [security]
-app_encryption_key = "examplevalidprojectencryptionkey"
 cors_origins = [ "http://localhost:8080", "http://localhost:3001",]
-oauth_root_client_id = "fidesadmin"
-oauth_root_client_secret = "fidesadminsecret"
 
 [execution]
 require_manual_request_approval = true

--- a/tests/ops/api/test_ratelimit.py
+++ b/tests/ops/api/test_ratelimit.py
@@ -1,6 +1,6 @@
-import pytest
 from typing import Generator
 
+import pytest
 from fastapi.testclient import TestClient
 from slowapi.extension import Limiter
 from slowapi.util import get_remote_address


### PR DESCRIPTION
Closes #1810 

### Code Changes

* [x] make the "required" vars optional
* [x] add a check before the webserver starts
* [x] refactor the config var check a bit

### Steps to Confirm

* [ ] in a blank directory, run `fides webserver` and confirm you get the error
* [ ] run `nox -s "build(sample)"`, and then in a black directory `fides deploy up --no-pull --no-init` and confirm you get no errors
* [ ] in the `fides` project dir, running `fides webserver` works (but fails if no db is up)
* [ ] `docker run -it ethyca/fides:local /bin/bash`, set some env vars manually and verify the error (we want to make sure its loading env vars correctly)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Quick fix to make the CLI usable without the "required" webserver variables

Note that this will only fail only `fides webserver`, our compose setup that runs the app directly will not throw this error

Note that this also doesn't have tests, so let's be diligent in our manual review 🙂 

---

#### Error message when running `fides webserver` without the required variables:

```
test> fides webserver
Loading config from: .fides/fides.toml
Directory './.fides' already exists.
Configuration file already exists: ./.fides/fides.toml
To learn more about configuring fides, see:
        https://ethyca.github.io/fides/installation/configuration/
C:\Users\tlapiana\anaconda3\lib\site-packages\snowflake\connector\options.py:96: UserWarning: You have an incompatible version of 'pyarrow' installed (6.0.1), please install a version that adheres to: 'pyarrow<8.1.0,>=8.0.0; extra == "pandas"'
  warn_incompatible_dep(
INFO:fideslib.core.config:Loading file .fides/fides.toml from .
INFO:fideslib.core.config:Loading file .fides/fides.toml from .
INFO:fideslib.core.config:Loading file .fides/fides.toml from .  

There are missing required configuration variables. Please add the following config variables to either the `fides.toml` file or your environment variables to start Fides:

- app_encryption_key
- oauth_root_client_id
- oauth_root_client_secret

Visit the Fides deployment documentation for more information: https://ethyca.github.io/fides/deployment/
```