### PR TITLE
docs: fix typo in Postgres, remove connection string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.1.0...main)
 
+### Docs
+
+* Remove documentation about no-longer used connection string override [#1824](https://github.com/ethyca/fides/pull/1824)
+* Fix typo in headings [#1824](https://github.com/ethyca/fides/pull/1824)
+
 ...
 
 ## [2.1.0](https://github.com/ethyca/fides/compare/2.0.0...2.1.0)

--- a/docs/fides/docs/installation/configuration.md
+++ b/docs/fides/docs/installation/configuration.md
@@ -158,7 +158,7 @@ enabled = true
 
 The `fides.toml` file should specify the following variables:
 
-#### Posgtres database
+#### Postgres database
 
 | Name | Type | Default | Description |
 | :---- | :---- | :------- | :----------- |
@@ -282,7 +282,6 @@ The following environment variables are not included in the default `fides.toml`
 | `FIDES__HOT_RELOAD` | `False` | If `True`, the Fides server will reload code changes without needing to restart the server. This variable should always be set to `False` in production systems.|
 | `FIDES__DEV_MODE` | `False` | If `True`, the Fides server will log error tracebacks, and log details of third party requests. This variable should always be set to `False` in production systems.|
 | `FIDES_CONFIG_PATH` | None | If this is set to a path, that path will be used to load `.toml` files first. Any .toml files on this path will override any installed .toml files. |
-| `FIDES__DATABASE__SQLALCHEMY_DATABASE_URI` | None | An optional override for the URI used for the database connection, in the form of `postgresql://<user>:<password>@<hostname>:<port>/<database>`. |
 
 ## Celery configuration
 


### PR DESCRIPTION
since the SQL Alchemy Connection String URI no longer works as an override, we can remove it from the docs.


### Code Changes

* Typo -- postgres
* Remove documentation about the connection string override

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
