### PR TITLE
Make celery.toml optional

### DIFF
--- a/src/fides/api/ops/tasks/__init__.py
+++ b/src/fides/api/ops/tasks/__init__.py
@@ -38,8 +38,11 @@ def _create_celery(config_path: str = CONFIG.execution.celery_config_path) -> Ce
         # Defaults for the celery config
         "broker_url": CONFIG.redis.connection_url,
         "result_backend": CONFIG.redis.connection_url,
+        "event_queue_prefix": "fides_worker",
+        "task_always_eager": True,
         # Fidesops requires this to route emails to separate queues
         "task_create_missing_queues": True,
+        "task_default_queue": "fides",
     }
 
     try:

--- a/src/fides/data/sample_project/celery.toml
+++ b/src/fides/data/sample_project/celery.toml
@@ -1,3 +1,0 @@
-event_queue_prefix = "fides_worker"
-task_default_queue = "fides"
-task_always_eager = true

--- a/src/fides/data/sample_project/fides.toml
+++ b/src/fides/data/sample_project/fides.toml
@@ -17,7 +17,6 @@ cors_origins = [ "http://localhost:8080", "http://localhost:3001",]
 
 [execution]
 require_manual_request_approval = true
-celery_config_path = "/fides/src/fides/data/sample_project/celery.toml"
 
 [cli]
 server_host = "fides"


### PR DESCRIPTION
This PR ensures to pass `task_always_eager` into the default Celery config to prevent the webserver hanging on startup when Redis is being used with SSL (without a worker).
