### PR TITLE
Fix parent user creation bug

### DIFF
--- a/src/fides/api/ctl/database/seed.py
+++ b/src/fides/api/ctl/database/seed.py
@@ -79,6 +79,9 @@ def create_or_update_parent_user() -> None:
                 user.update_password(db_session, CONFIG.security.parent_server_password)
                 return
 
+            # User already exists and the password hasn't changed to nothing to do.
+            return
+
         log.info("Creating parent user")
         user = FidesUser.create(
             db=db_session,


### PR DESCRIPTION
Closes #1832

### Code Changes

* [ ] Checks if the user exists with no changes to the password and exits gracefully if so

### Steps to Confirm

* [ ] Add a `parent_server_username` and `parent_server_password` to the fides.toml
* [ ] Run `nox -s dev`
* [ ] Stop the server
* [ ] Run `nox -s dev` again. The servers should not freeze and report healthy.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
