### PR TITLE
Bypass the organization form if organization name and description are already filled out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The types of changes are:
 * Enabled the onboarding flow [#1836](https://github.com/ethyca/fides/pull/1836)
 * Access and erasure support for Fullstory API [#1821](https://github.com/ethyca/fides/pull/1821)
 
+### Changed
+* The organization info form step is now skipped if the server already has organization info. [#1840](https://github.com/ethyca/fides/pull/1840)
+
 ### Fixed
 
 * Fix error in parent user creation seeding. [#1832](https://github.com/ethyca/fides/issues/1832)

--- a/clients/admin-ui/cypress/e2e/config-wizard-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/config-wizard-plus.cy.ts
@@ -5,11 +5,7 @@ import { stubPlus } from "cypress/support/stubs";
  * This could be put in a beforeEach, but then you can't overwrite intercepts
  */
 const goToDataFlowScanner = () => {
-  // Move past organization step.
-  cy.getByTestId("organization-info-form");
-  cy.getByTestId("submit-btn").click();
-
-  // Select data flow scanner to move to scan step.
+  // Select Runtime scanner to move to scan step.
   cy.getByTestId("add-system-form");
   cy.getByTestId("data-flow-scan-btn").click();
 };

--- a/clients/admin-ui/cypress/e2e/config-wizard.cy.ts
+++ b/clients/admin-ui/cypress/e2e/config-wizard.cy.ts
@@ -6,22 +6,27 @@ describe("Config Wizard", () => {
     cy.intercept("GET", "/api/v1/organization/*", {
       fixture: "organization.json",
     }).as("getOrganization");
-
-    cy.intercept("PUT", "/api/v1/organization**", {
-      fixture: "organization.json",
-    }).as("updateOrganization");
-  });
-
-  beforeEach(() => {
-    cy.visit("/add-systems");
-    cy.getByTestId("guided-setup-btn").click();
-    cy.wait("@getOrganization");
   });
 
   describe("Organization setup", () => {
-    it("Fills in the default organization", () => {
+    beforeEach(() => {
+      cy.intercept("PUT", "/api/v1/organization**", {
+        fixture: "organization.json",
+      }).as("updateOrganization");
+    });
+
+    it("Can fill in an organization", () => {
+      cy.fixture("organization.json").then((org) => {
+        cy.intercept("GET", "/api/v1/organization/*", {
+          body: { org, name: null, description: null },
+        }).as("getEmptyOrganization");
+      });
+      cy.visit("/add-systems");
+      cy.getByTestId("guided-setup-btn").click();
+      cy.wait("@getEmptyOrganization");
+
       cy.getByTestId("organization-info-form");
-      cy.getByTestId("input-name").should("have.value", "Demo Organization");
+      cy.getByTestId("input-name").type("Updated name");
       cy.getByTestId("input-description")
         .clear()
         .type("Updated description")
@@ -32,6 +37,13 @@ describe("Config Wizard", () => {
         expect(body.fides_key).to.eq("default_organization");
         expect(body.description).to.eq("Updated description");
       });
+      cy.getByTestId("add-system-form");
+    });
+
+    it("Can skip the org flow if an organization already exists", () => {
+      cy.visit("/add-systems");
+      cy.getByTestId("guided-setup-btn").click();
+      cy.getByTestId("add-system-form");
     });
   });
 
@@ -41,8 +53,9 @@ describe("Config Wizard", () => {
       stubTaxonomyEntities();
 
       // Move past organization step.
-      cy.getByTestId("organization-info-form");
-      cy.getByTestId("submit-btn").click();
+      cy.visit("/add-systems");
+      cy.getByTestId("guided-setup-btn").click();
+      cy.wait("@getOrganization");
       // Select AWS to move to form step.
       cy.getByTestId("add-system-form");
       cy.getByTestId("aws-btn").click();
@@ -135,8 +148,9 @@ describe("Config Wizard", () => {
       stubTaxonomyEntities();
 
       // Move past organization step.
-      cy.getByTestId("organization-info-form");
-      cy.getByTestId("submit-btn").click();
+      cy.visit("/add-systems");
+      cy.getByTestId("guided-setup-btn").click();
+      cy.wait("@getOrganization");
       // Select Okta to move to form step.
       cy.getByTestId("add-system-form");
       cy.getByTestId("okta-btn").click();

--- a/clients/admin-ui/src/features/config-wizard/OrganizationInfoForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/OrganizationInfoForm.tsx
@@ -10,7 +10,7 @@ import {
   useToast,
 } from "@fidesui/react";
 import { useFormik } from "formik";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useAppDispatch } from "~/app/hooks";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
@@ -34,10 +34,21 @@ const useOrganizationInfoForm = () => {
 
   const [createOrganization] = useCreateOrganizationMutation();
   const [updateOrganization] = useUpdateOrganizationMutation();
-  const { data: existingOrg } = useGetOrganizationByFidesKeyQuery(
-    DEFAULT_ORGANIZATION_FIDES_KEY
-  );
-  const [isLoading, setIsLoading] = useState(false);
+  const { data: existingOrg, isLoading: isLoadingOrganization } =
+    useGetOrganizationByFidesKeyQuery(DEFAULT_ORGANIZATION_FIDES_KEY);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+
+  useEffect(() => {
+    // Only consider a redirect when data has loaded but before a user has submitted anything
+    if (isLoadingOrganization || hasSubmitted) {
+      return;
+    }
+    // If the organization name and description already exist, we bypass this step
+    if (existingOrg?.name && existingOrg?.description) {
+      dispatch(changeStep());
+    }
+  }, [isLoadingOrganization, existingOrg, dispatch, hasSubmitted]);
+
   const toast = useToast();
   const formik = useFormik({
     initialValues: {
@@ -45,14 +56,13 @@ const useOrganizationInfoForm = () => {
       description: existingOrg?.description ?? "",
     },
     onSubmit: async (values) => {
+      setHasSubmitted(true);
       const organizationBody = {
         name: values.name ?? existingOrg?.name,
         description: values.description ?? existingOrg?.description,
         fides_key: existingOrg?.fides_key ?? DEFAULT_ORGANIZATION_FIDES_KEY,
         organization_fides_key: DEFAULT_ORGANIZATION_FIDES_KEY,
       };
-
-      setIsLoading(true);
 
       if (!existingOrg) {
         const createOrganizationResult = await createOrganization(
@@ -87,8 +97,6 @@ const useOrganizationInfoForm = () => {
         toast.closeAll();
         handleSuccess(organizationBody);
       }
-
-      setIsLoading(false);
     },
     enableReinitialize: true,
     validate: (values) => {
@@ -109,7 +117,7 @@ const useOrganizationInfoForm = () => {
     },
   });
 
-  return { ...formik, isLoading };
+  return formik;
 };
 
 const OrganizationInfoForm = () => {
@@ -118,9 +126,9 @@ const OrganizationInfoForm = () => {
     handleBlur,
     handleChange,
     handleSubmit,
-    isLoading,
     touched,
     values,
+    isSubmitting,
   } = useOrganizationInfoForm();
 
   return (
@@ -192,7 +200,7 @@ const OrganizationInfoForm = () => {
           type="submit"
           variant="primary"
           isDisabled={!values.name || !values.description}
-          isLoading={isLoading}
+          isLoading={isSubmitting}
           data-testid="submit-btn"
         >
           Save and Continue


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/1826

### Code Changes

* [x] Add a `useEffect` in `OrganizationInfoForm.tsx` to advance to the next step if the org name and description are already filled out
  * [x] Sneaky removal of a manual `useState` to keep track of submitting. We can just use formik's built-in `isSubmitting` prop for the same effect
* [x] Update cypress tests (had to mess around with the `beforeEach`'s since before the org form would always show up and so all the tests clicked through them. but now it only sometimes shows up depending on the org payload)

### Steps to Confirm

* [ ] Clear our your organization's name and description. I use:
```
UPDATE ctl_organizations SET name = null, description = null where fides_key='default_organization';
```
* [ ] Go through the config wizard flow and set up an org
* [ ] Go through the flow again. This time, the org form will be skipped


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes



https://user-images.githubusercontent.com/24641006/203392719-892cd444-b31f-4893-a32f-b6a5e9ef52ab.mov

