### PR TITLE
use `loguru` to stop logs being swallowed in Celery instantiation

### DIFF
--- a/src/fides/api/ops/tasks/__init__.py
+++ b/src/fides/api/ops/tasks/__init__.py
@@ -1,7 +1,6 @@
 from typing import Any, ContextManager, Dict, List, MutableMapping, Optional, Union
 
 from celery import Celery, Task
-from celery.utils.log import get_task_logger
 from fideslib.core.config import load_toml
 from fideslib.db.session import get_db_session
 from loguru import logger

--- a/src/fides/api/ops/tasks/__init__.py
+++ b/src/fides/api/ops/tasks/__init__.py
@@ -4,11 +4,11 @@ from celery import Celery, Task
 from celery.utils.log import get_task_logger
 from fideslib.core.config import load_toml
 from fideslib.db.session import get_db_session
+from loguru import logger
 from sqlalchemy.orm import Session
 
 from fides.ctl.core.config import get_config
 
-logger = get_task_logger(__name__)
 
 CONFIG = get_config()
 MESSAGING_QUEUE_NAME = "fidesops.messaging"


### PR DESCRIPTION
### Description Of Changes

This PR expedites part of our fix for https://github.com/ethyca/fides/issues/1842 to aid @RobertKeyser in some debugging.
