### PR TITLE
update email communication guide to use PUT for secret update

### DIFF
--- a/docs/fides/docs/guides/email_communications.md
+++ b/docs/fides/docs/guides/email_communications.md
@@ -47,7 +47,7 @@ Fides currently supports Mailgun for email integrations. Ensure you register or 
 
 ### Add the messaging configuration secrets 
 
-```json title="<code>POST api/v1/messaging/config/{{messaging_config_key}}/secret"
+```json title="<code>PUT api/v1/messaging/config/{{messaging_config_key}}/secret"
 {
     "mailgun_api_key": "nc123849ycnpq98fnu"
 }


### PR DESCRIPTION
Closes #1847 

### Code Changes

* update email guide in our docs

### Steps to Confirm

* `nox -s docs_serve`
* navigate to http://0.0.0.0:8000/fides/guides/email_communications/#add-the-messaging-configuration-secrets

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Found while going through steps in an implementation guide (cc @NevilleS)