### PR TITLE
1672/Hide dataset table status column outside of plus environment

### DIFF
--- a/clients/admin-ui/cypress/e2e/datasets-classify.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets-classify.cy.ts
@@ -1,6 +1,7 @@
 import {
   CONNECTION_STRING,
   stubDatasetCrud,
+  stubHomePage,
   stubPlus,
 } from "cypress/support/stubs";
 
@@ -33,6 +34,22 @@ describe("Datasets with Fides Classify", () => {
       cy.getByTestId("input-classify").find("input").should("be.checked");
       cy.getByTestId("input-classify").click();
       cy.getByTestId("input-classify").find("input").should("not.be.checked");
+    });
+
+    it("Can render the 'Status' column and classification status badges in the dataset table when plus features are enabled", () => {
+      stubHomePage();
+      cy.visit("/");
+      cy.getByTestId("nav-link-Datasets").click();
+      cy.wait("@getDatasets");
+      cy.getByTestId("dataset-table");
+      cy.getByTestId("dataset-row-demo_users_dataset_4");
+      cy.url().should("contain", "/dataset");
+
+      cy.getByTestId("dataset-table__status-table-header").should(
+        "have.text",
+        "Status"
+      );
+      cy.getByTestId("classification-status-badge").should("exist");
     });
 
     it("Classifies the dataset after generating it", () => {

--- a/clients/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets.cy.ts
@@ -587,28 +587,3 @@ describe("Dataset", () => {
     });
   });
 });
-
-describe("Dataset Plus Enabled", () => {
-  beforeEach(() => {
-    cy.login();
-    stubDatasetCrud();
-    // Ensure these tests all run with Plus features enabled.
-    stubPlus(true);
-  });
-
-  it("Can render the 'Status' column and classification status badges in the dataset table when plus features are enabled", () => {
-    stubHomePage();
-    cy.visit("/");
-    cy.getByTestId("nav-link-Datasets").click();
-    cy.wait("@getDatasets");
-    cy.getByTestId("dataset-table");
-    cy.getByTestId("dataset-row-demo_users_dataset_4");
-    cy.url().should("contain", "/dataset");
-
-    cy.getByTestId("dataset-table__status-table-header").should(
-      "have.text",
-      "Status"
-    );
-    cy.getByTestId("classification-status-badge").should("exist");
-  });
-});

--- a/clients/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets.cy.ts
@@ -25,6 +25,9 @@ describe("Dataset", () => {
 
       // The classifier toggle should not be available.
       cy.get("input-classify").should("not.exist");
+
+      cy.getByTestId("dataset-table__status-table-header").should("not.exist");
+      cy.getByTestId("classification-status-badge").should("not.exist");
     });
 
     it("Can navigate to the datasets view via URL", () => {
@@ -582,5 +585,30 @@ describe("Dataset", () => {
         "user.unique_id"
       );
     });
+  });
+});
+
+describe("Dataset Plus Enabled", () => {
+  beforeEach(() => {
+    cy.login();
+    stubDatasetCrud();
+    // Ensure these tests all run with Plus features enabled.
+    stubPlus(true);
+  });
+
+  it("Can render the 'Status' column and classification status badges in the dataset table when plus features are enabled", () => {
+    stubHomePage();
+    cy.visit("/");
+    cy.getByTestId("nav-link-Datasets").click();
+    cy.wait("@getDatasets");
+    cy.getByTestId("dataset-table");
+    cy.getByTestId("dataset-row-demo_users_dataset_4");
+    cy.url().should("contain", "/dataset");
+
+    cy.getByTestId("dataset-table__status-table-header").should(
+      "have.text",
+      "Status"
+    );
+    cy.getByTestId("classification-status-badge").should("exist");
   });
 });

--- a/clients/admin-ui/src/features/dataset/DatasetTable.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetTable.tsx
@@ -77,12 +77,14 @@ const DatasetsTable = () => {
               <Td pl={1}>{dataset.name}</Td>
               <Td pl={1}>{dataset.fides_key}</Td>
               <Td pl={1}>{dataset.description}</Td>
-              <Td pl={1} data-testid={`dataset-status-${dataset.fides_key}`}>
-                <ClassificationStatusBadge
-                  resource={GenerateTypes.DATASETS}
-                  status={classifyDataset?.status}
-                />
-              </Td>
+              {features.plus ? (
+                <Td pl={1} data-testid={`dataset-status-${dataset.fides_key}`}>
+                  <ClassificationStatusBadge
+                    resource={GenerateTypes.DATASETS}
+                    status={classifyDataset?.status}
+                  />
+                </Td>
+              ) : null}
             </Tr>
           );
         })}

--- a/clients/admin-ui/src/features/dataset/DatasetTable.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetTable.tsx
@@ -49,7 +49,11 @@ const DatasetsTable = () => {
           <Th pl={1}>Name</Th>
           <Th pl={1}>Fides Key</Th>
           <Th pl={1}>Description</Th>
-          {features.plus ? <Th pl={1}>Status</Th> : null}
+          {features.plus ? (
+            <Th data-testid="dataset-table__status-table-header" pl={1}>
+              Status
+            </Th>
+          ) : null}
         </Tr>
       </Thead>
       <Tbody>

--- a/clients/admin-ui/src/features/dataset/DatasetTable.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetTable.tsx
@@ -41,6 +41,7 @@ const DatasetsTable = () => {
   if (!datasets) {
     return <div>Empty state</div>;
   }
+
   return (
     <Table size="sm" data-testid="dataset-table">
       <Thead>
@@ -48,7 +49,7 @@ const DatasetsTable = () => {
           <Th pl={1}>Name</Th>
           <Th pl={1}>Fides Key</Th>
           <Th pl={1}>Description</Th>
-          <Th pl={1}>Status</Th>
+          {features.plus ? <Th pl={1}>Status</Th> : null}
         </Tr>
       </Thead>
       <Tbody>

--- a/clients/admin-ui/src/features/plus/ClassificationStatusBadge.tsx
+++ b/clients/admin-ui/src/features/plus/ClassificationStatusBadge.tsx
@@ -53,7 +53,10 @@ const ClassificationStatusBadge = ({
 } & BadgeProps) => {
   const statusDisplay = classificationStatuses(resource)[status ?? "unknown"];
   return (
-    <Tooltip label={statusDisplay.tooltip}>
+    <Tooltip
+      data-testid="classification-status-badge"
+      label={statusDisplay.tooltip}
+    >
       <Badge
         variant="solid"
         colorScheme={statusDisplay.color}


### PR DESCRIPTION
Closes #1672 
<img width="1423" alt="Screen Shot 2022-11-28 at 7 53 15 PM" src="https://user-images.githubusercontent.com/99051851/204419039-74776713-4860-410d-af1d-49d852ce28d6.png">

<img width="1440" alt="Screen Shot 2022-11-28 at 7 53 10 PM" src="https://user-images.githubusercontent.com/99051851/204419044-ea19acfb-026b-4191-8068-208d00feda7b.png">


### Code Changes

* [ ] Wrap status column in dataset table around plus feature flag

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
