### PR TITLE
Add function to poll privacy_request for completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The types of changes are:
 * Add authenticated privacy request route. [#1819](https://github.com/ethyca/fides/pull/1819)
 * Enabled the onboarding flow [#1836](https://github.com/ethyca/fides/pull/1836)
 * Access and erasure support for Fullstory API [#1821](https://github.com/ethyca/fides/pull/1821)
+* Add function to poll privacy request for completion [#1860](https://github.com/ethyca/fides/pull/1860)
 
 ### Changed
 * The organization info form step is now skipped if the server already has organization info. [#1840](https://github.com/ethyca/fides/pull/1840)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ fideslib==3.1.5
 fideslog==1.2.10
 firebase-admin==5.3.0
 GitPython==3.1.27
+httpx==0.23.1
 hvac==0.11.2
 Jinja2==3.1.2
 loguru>=0.5,<0.6

--- a/src/fides/api/ops/common_exceptions.py
+++ b/src/fides/api/ops/common_exceptions.py
@@ -183,7 +183,3 @@ class NoSuchSaaSRequestOverrideException(ValueError):
 
 class IdentityVerificationException(FidesopsException):
     """Custom exceptions for when we cannot verify the identity of a subjct"""
-
-
-class TimeoutError(Exception):
-    """The operation has timed out."""

--- a/src/fides/api/ops/common_exceptions.py
+++ b/src/fides/api/ops/common_exceptions.py
@@ -183,3 +183,7 @@ class NoSuchSaaSRequestOverrideException(ValueError):
 
 class IdentityVerificationException(FidesopsException):
     """Custom exceptions for when we cannot verify the identity of a subjct"""
+
+
+class TimeoutError(Exception):
+    """The operation has timed out."""

--- a/src/fides/api/ops/service/privacy_request/request_service.py
+++ b/src/fides/api/ops/service/privacy_request/request_service.py
@@ -101,7 +101,7 @@ async def poll_server_for_completion(
         else:
             async with AsyncClient() as async_client:
                 response = await async_client.get(
-                    url, headers={"Authorizetion": f"Bearer {token}"}
+                    url, headers={"Authorization": f"Bearer {token}"}
                 )
         response.raise_for_status()
 

--- a/src/fides/api/ops/service/privacy_request/request_service.py
+++ b/src/fides/api/ops/service/privacy_request/request_service.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, Set
 from httpx import AsyncClient
 
 from fides.api.ops.api.v1.urn_registry import V1_URL_PREFIX
-from fides.api.ops.common_exceptions import TimeoutError
 from fides.api.ops.models.policy import ActionType, Policy
 from fides.api.ops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
 from fides.api.ops.schemas.drp_privacy_request import DrpPrivacyRequestCreate

--- a/src/fides/api/ops/service/privacy_request/request_service.py
+++ b/src/fides/api/ops/service/privacy_request/request_service.py
@@ -109,10 +109,10 @@ async def poll_server_for_completion(
         # privacy reqeust there should only be one value present in items.
         status = PrivacyRequestResponse(**response.json()["items"][0])
         if status.status and status.status in (
-            "denied",
-            "complete",
-            "canceled",
-            "error",
+            PrivacyRequestStatus.complete,
+            PrivacyRequestStatus.canceled,
+            PrivacyRequestStatus.error,
+            PrivacyRequestStatus.denied,
         ):
             return status
 

--- a/src/fides/api/ops/service/privacy_request/request_service.py
+++ b/src/fides/api/ops/service/privacy_request/request_service.py
@@ -1,11 +1,19 @@
+from __future__ import annotations
+
 import logging
+from asyncio import sleep
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Set
 
+from httpx import AsyncClient
+
+from fides.api.ops.api.v1.urn_registry import V1_URL_PREFIX
+from fides.api.ops.common_exceptions import TimeoutError
 from fides.api.ops.models.policy import ActionType, Policy
 from fides.api.ops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
 from fides.api.ops.schemas.drp_privacy_request import DrpPrivacyRequestCreate
 from fides.api.ops.schemas.masking.masking_secrets import MaskingSecretCache
+from fides.api.ops.schemas.privacy_request import PrivacyRequestResponse
 from fides.api.ops.schemas.redis_cache import Identity
 from fides.api.ops.service.masking.strategy.masking_strategy import MaskingStrategy
 from fides.ctl.core.config import get_config
@@ -66,3 +74,52 @@ def cache_data(
                 privacy_request.cache_masking_secret(masking_secret)
     if drp_request_body:
         privacy_request.cache_drp_request_body(drp_request_body)
+
+
+async def poll_server_for_completion(
+    privacy_request_id: str,
+    server_url: str,
+    token: str,
+    *,
+    poll_interval_seconds: int = 30,
+    timeout_seconds: int = 1800,  # 30 minutes
+    client: AsyncClient | None = None,
+) -> PrivacyRequestResponse:
+    """Poll a server for privacy request completion.
+
+    Requests will report complete with if they have a status of canceled, complete,
+    denied, or error. By default the polling will time out if not completed in 30
+    minutes, time can be overridden by setting the timeout_seconds.
+    """
+    url = f"{server_url}{V1_URL_PREFIX}/privacy-request?request_id={privacy_request_id}"
+    start_time = datetime.now()
+    elapsed_time = 0.0
+    while elapsed_time < timeout_seconds:
+        if client:
+            response = await client.get(
+                url, headers={"Authorization": f"Bearer {token}"}
+            )
+        else:
+            async with AsyncClient() as async_client:
+                response = await async_client.get(
+                    url, headers={"Authorizetion": f"Bearer {token}"}
+                )
+        response.raise_for_status()
+
+        # Privacy requests are returned pagined. Since this is searching for a specific
+        # privacy reqeust there should only be one value present in items.
+        status = PrivacyRequestResponse(**response.json()["items"][0])
+        if status.status and status.status in (
+            "denied",
+            "complete",
+            "canceled",
+            "error",
+        ):
+            return status
+
+        await sleep(poll_interval_seconds)
+        time_delta = datetime.now() - start_time
+        elapsed_time = time_delta.seconds
+    raise TimeoutError(
+        f"Timeout of {timeout_seconds} minutes has been exceeded while waiting for privacy request {privacy_request_id}"
+    )

--- a/src/fides/api/ops/service/privacy_request/request_service.py
+++ b/src/fides/api/ops/service/privacy_request/request_service.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from httpx import AsyncClient
 
-from fides.api.ops.api.v1.urn_registry import V1_URL_PREFIX
+from fides.api.ops.api.v1.urn_registry import PRIVACY_REQUESTS, V1_URL_PREFIX
 from fides.api.ops.models.policy import ActionType, Policy
 from fides.api.ops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
 from fides.api.ops.schemas.drp_privacy_request import DrpPrivacyRequestCreate
@@ -90,7 +90,9 @@ async def poll_server_for_completion(
     denied, or error. By default the polling will time out if not completed in 30
     minutes, time can be overridden by setting the timeout_seconds.
     """
-    url = f"{server_url}{V1_URL_PREFIX}/privacy-request?request_id={privacy_request_id}"
+    url = (
+        f"{server_url}{V1_URL_PREFIX}{PRIVACY_REQUESTS}?request_id={privacy_request_id}"
+    )
     start_time = datetime.now()
     elapsed_time = 0.0
     while elapsed_time < timeout_seconds:
@@ -120,5 +122,5 @@ async def poll_server_for_completion(
         time_delta = datetime.now() - start_time
         elapsed_time = time_delta.seconds
     raise TimeoutError(
-        f"Timeout of {timeout_seconds} minutes has been exceeded while waiting for privacy request {privacy_request_id}"
+        f"Timeout of {timeout_seconds} seconds has been exceeded while waiting for privacy request {privacy_request_id}"
     )

--- a/tests/ops/service/privacy_request/test_request_service.py
+++ b/tests/ops/service/privacy_request/test_request_service.py
@@ -4,7 +4,6 @@ from httpx import HTTPStatusError
 
 from fides.api.ctl.database.seed import create_or_update_parent_user
 from fides.api.ops.api.v1.urn_registry import LOGIN, V1_URL_PREFIX
-from fides.api.ops.common_exceptions import TimeoutError
 from fides.api.ops.models.privacy_request import PrivacyRequest
 from fides.api.ops.service.privacy_request.request_service import (
     poll_server_for_completion,

--- a/tests/ops/service/privacy_request/test_request_service.py
+++ b/tests/ops/service/privacy_request/test_request_service.py
@@ -1,0 +1,113 @@
+import pytest
+from fideslib.cryptography.cryptographic_util import str_to_b64_str
+from httpx import HTTPStatusError
+
+from fides.api.ctl.database.seed import create_or_update_parent_user
+from fides.api.ops.api.v1.urn_registry import LOGIN, V1_URL_PREFIX
+from fides.api.ops.common_exceptions import TimeoutError
+from fides.api.ops.models.privacy_request import PrivacyRequest
+from fides.api.ops.service.privacy_request.request_service import (
+    poll_server_for_completion,
+)
+from fides.ctl.core.config import get_config
+
+CONFIG = get_config()
+
+
+@pytest.fixture
+def parent_user_config():
+    original_user = CONFIG.security.parent_server_username
+    original_password = CONFIG.security.parent_server_password
+    CONFIG.security.parent_server_username = "parent_user"
+    CONFIG.security.parent_server_password = "Apassword1!"
+    yield
+    CONFIG.security.parent_server_username = original_user
+    CONFIG.security.parent_server_password = original_password
+
+
+@pytest.mark.parametrize("status", ["complete", "denied", "canceled", "error"])
+@pytest.mark.usefixtures("parent_user_config")
+async def test_poll_server_for_completion(status, async_api_client, db, policy):
+    create_or_update_parent_user()
+
+    pr = PrivacyRequest.create(
+        db=db,
+        data={
+            "requested_at": None,
+            "policy_id": policy.id,
+            "status": status,
+        },
+    )
+
+    login_url = f"{V1_URL_PREFIX}{LOGIN}"
+    body = {
+        "username": CONFIG.security.parent_server_username,
+        "password": str_to_b64_str(CONFIG.security.parent_server_password),
+    }
+
+    login_response = await async_api_client.post(login_url, json=body)
+
+    response = await poll_server_for_completion(
+        privacy_request_id=pr.id,
+        server_url="http://0.0.0.0:8080",
+        token=login_response.json()["token_data"]["access_token"],
+        client=async_api_client,
+        poll_interval_seconds=1,
+    )
+
+    assert response.status == status
+
+
+@pytest.mark.usefixtures("parent_user_config")
+async def test_poll_server_for_completion_timeout(async_api_client, db, policy):
+    create_or_update_parent_user()
+
+    pr = PrivacyRequest.create(
+        db=db,
+        data={
+            "requested_at": None,
+            "policy_id": policy.id,
+            "status": "pending",
+        },
+    )
+
+    login_url = f"{V1_URL_PREFIX}{LOGIN}"
+    body = {
+        "username": CONFIG.security.parent_server_username,
+        "password": str_to_b64_str(CONFIG.security.parent_server_password),
+    }
+
+    login_response = await async_api_client.post(login_url, json=body)
+
+    with pytest.raises(TimeoutError):
+        await poll_server_for_completion(
+            privacy_request_id=pr.id,
+            server_url="http://0.0.0.0:8080",
+            token=login_response.json()["token_data"]["access_token"],
+            client=async_api_client,
+            poll_interval_seconds=1,
+            timeout_seconds=2,
+        )
+
+
+@pytest.mark.usefixtures("parent_user_config")
+async def test_poll_server_for_completion_non_200(async_api_client, db, policy):
+    create_or_update_parent_user()
+
+    pr = PrivacyRequest.create(
+        db=db,
+        data={
+            "requested_at": None,
+            "policy_id": policy.id,
+            "status": "complete",
+        },
+    )
+
+    with pytest.raises(HTTPStatusError):
+        await poll_server_for_completion(
+            privacy_request_id=pr.id,
+            server_url="http://0.0.0.0:8080",
+            token="somebadtoken",
+            client=async_api_client,
+            poll_interval_seconds=1,
+        )


### PR DESCRIPTION
Closes #1749

### Code Changes

* Added httpx as a dependency in order to preform async requests.
* Added a `poll_server_for_completion` function to poll for completion.

### Steps to Confirm

* [ ] Verify that the function return with the correct status on privacy requests. More through testing will be possible once the connector for child servers is in place.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
