### PR TITLE
Remove description column from classify systems table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The types of changes are:
 
 ### Changed
 * The organization info form step is now skipped if the server already has organization info. [#1840](https://github.com/ethyca/fides/pull/1840)
+* Removed the description column from the classify systems page. [#1867](https://github.com/ethyca/fides/pull/1867)
 
 ### Fixed
 

--- a/clients/admin-ui/src/features/system/ClassifySystemsTable.tsx
+++ b/clients/admin-ui/src/features/system/ClassifySystemsTable.tsx
@@ -29,8 +29,7 @@ const ClassifySystemsTable = ({ systems }: { systems: System[] }) => {
         <Thead>
           <Tr>
             <Th>System Name</Th>
-            <Th>Description</Th>
-            <Th>Classification Status</Th>
+            <Th maxWidth="100px">Classification Status</Th>
           </Tr>
         </Thead>
         <Tbody>
@@ -46,9 +45,6 @@ const ClassifySystemsTable = ({ systems }: { systems: System[] }) => {
               >
                 <Td>
                   <SystemTableCell system={system} attribute="name" />
-                </Td>
-                <Td>
-                  <SystemTableCell system={system} attribute="description" />
                 </Td>
                 <Td data-testid={`status-${system.fides_key}`}>
                   <ClassificationStatusBadge


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/342

### Code Changes

* [x] Removes the description column 
* [x] Some styling updates now that there are only two columns

### Steps to Confirm

* [ ] Remove protected routes from `_app.tsx` and go to `/classify-systems`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/24641006/204375833-0641a116-fb6e-440f-bd4b-6cc6253a7e9b.png">

