### PR TITLE
Classification flow redirect

### DIFF
--- a/clients/admin-ui/src/features/common/hooks/useInterzoneNav.ts
+++ b/clients/admin-ui/src/features/common/hooks/useInterzoneNav.ts
@@ -1,0 +1,19 @@
+import { useFeatures } from "~/features/common/features.slice";
+import { resolveLink } from "~/features/common/nav/zone-config";
+
+export const useInterzoneNav = () => {
+  const features = useFeatures();
+
+  const datamapRoute = resolveLink({
+    href: "/datamap",
+    basePath: "/",
+  });
+
+  /**
+   * Often we need to either go to the systems page or the datamap page
+   * depending on if this is an open source or plus instance
+   */
+  const systemOrDatamapRoute = features.plus ? datamapRoute.href : "/system";
+
+  return { systemOrDatamapRoute };
+};

--- a/clients/admin-ui/src/features/config-wizard/ScanResults.tsx
+++ b/clients/admin-ui/src/features/config-wizard/ScanResults.tsx
@@ -15,10 +15,9 @@ import {
   ColumnDropdown,
   ColumnMetadata,
 } from "~/features/common/ColumnDropdown";
-import { useFeatures } from "~/features/common/features.slice";
 import { isErrorResult } from "~/features/common/helpers";
 import { useAPIHelper } from "~/features/common/hooks";
-import { resolveLink } from "~/features/common/nav/zone-config";
+import { useInterzoneNav } from "~/features/common/hooks/useInterzoneNav";
 import { SystemsCheckboxTable } from "~/features/common/SystemsCheckboxTable";
 import WarningModal from "~/features/common/WarningModal";
 import {
@@ -45,6 +44,7 @@ const ScanResults = () => {
   const systems = useAppSelector(selectSystemsForReview);
   const dispatch = useAppDispatch();
   const router = useRouter();
+  const { systemOrDatamapRoute } = useInterzoneNav();
 
   const {
     isOpen: isWarningOpen,
@@ -53,7 +53,6 @@ const ScanResults = () => {
   } = useDisclosure();
   const [upsertSystems] = useUpsertSystemsMutation();
   const [selectedSystems, setSelectedSystems] = useState<System[]>(systems);
-  const features = useFeatures();
   const [selectedColumns, setSelectedColumns] =
     useState<ColumnMetadata[]>(ALL_COLUMNS);
   const method = useAppSelector(selectAddSystemsMethod);
@@ -87,14 +86,7 @@ const ScanResults = () => {
       return navigateAndReset("/classify-systems");
     }
 
-    const datamapRoute = resolveLink({
-      href: "/datamap",
-      basePath: "/",
-    });
-
-    return features.plus
-      ? navigateAndReset(datamapRoute.href)
-      : navigateAndReset("/system");
+    return navigateAndReset(systemOrDatamapRoute);
   };
 
   const handleSubmit = () => {

--- a/clients/admin-ui/src/features/config-wizard/SuccessPage.tsx
+++ b/clients/admin-ui/src/features/config-wizard/SuccessPage.tsx
@@ -17,12 +17,11 @@ import {
 import { useRouter } from "next/router";
 
 import { useAppDispatch } from "~/app/hooks";
-import { useFeatures } from "~/features/common/features.slice";
+import { useInterzoneNav } from "~/features/common/hooks/useInterzoneNav";
 import {
   StepperCircleCheckmarkIcon,
   StepperCircleIcon,
 } from "~/features/common/Icon";
-import { resolveLink } from "~/features/common/nav/zone-config";
 import { System } from "~/types/api";
 
 import { setActiveSystem } from "../system";
@@ -39,8 +38,8 @@ const SuccessPage = ({
 }: Props) => {
   const systemName = systemInReview.name ?? systemInReview.fides_key;
   const dispatch = useAppDispatch();
-  const features = useFeatures();
   const router = useRouter();
+  const { systemOrDatamapRoute } = useInterzoneNav();
 
   // Systems are reviewed in order, so a lower index means that system has been reviewed
   // and a higher index means they'll reviewed after hitting "next".
@@ -50,15 +49,7 @@ const SuccessPage = ({
 
   const onFinish = () => {
     dispatch(setActiveSystem(undefined));
-
-    const datamapRoute = resolveLink({
-      href: "/datamap",
-      basePath: "/",
-    });
-
-    return features.plus
-      ? router.push(datamapRoute.href)
-      : router.push("/system");
+    router.push(systemOrDatamapRoute);
   };
 
   return (

--- a/clients/admin-ui/src/pages/classify-systems/index.tsx
+++ b/clients/admin-ui/src/pages/classify-systems/index.tsx
@@ -1,10 +1,12 @@
-import { Heading, Spinner, Stack, Text } from "@fidesui/react";
+import { Button, Heading, HStack, Spinner, Stack, Text } from "@fidesui/react";
 import type { NextPage } from "next";
+import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { ReactNode, useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 import { useAppSelector } from "~/app/hooks";
+import { useInterzoneNav } from "~/features/common/hooks/useInterzoneNav";
 import Layout from "~/features/common/Layout";
 import {
   useGetAllClassifyInstancesQuery,
@@ -32,6 +34,7 @@ const ClassifySystemsLayout = ({ children }: { children: ReactNode }) => (
 const ClassifySystems: NextPage = () => {
   const router = useRouter();
   const dispatch = useDispatch();
+  const { systemOrDatamapRoute } = useInterzoneNav();
   const { isSuccess: hasPlus, isLoading: isLoadingPlus } = useGetHealthQuery();
   /**
    * TODO: fides#1744
@@ -109,6 +112,13 @@ const ClassifySystems: NextPage = () => {
       ) : (
         "No systems with classifications found"
       )}
+      <HStack>
+        <NextLink href={systemOrDatamapRoute} passHref>
+          <Button variant="primary" size="sm">
+            Finish
+          </Button>
+        </NextLink>
+      </HStack>
     </ClassifySystemsLayout>
   );
 };


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/1854

### Code Changes

* [x] Add a custom hook `useInterzoneNav` which figures out if we should route to the systems page or the datamap page. This functionality has come up a few times now, so figured it'd be useful in a hook
* [x] Replace existing instances of going to /system or /datamap with the new hook
* [x] Add a button to the classify systems page which will go to either /system or /datamap. In retrospect, this will always go to /datamap since this page is only viewable in plus!

### Steps to Confirm

* [ ] Run the datamap UI via `npm run dev` 
* [ ] Add a system manually and make sure you are redirected to either /system or /datamap depending on which backend you are running
* [ ] Same as ^ but for adding a system via i.e. the AWS scanner
* [ ] Go to /classify-systems and clicking "finish" should take you to the datamap page

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

![image](https://user-images.githubusercontent.com/24641006/204617568-60a4746a-5506-40cb-b0a3-c47ec1a22b7e.png)

