### PR TITLE
[1277] Flex dataset controls so that only the classify paragraph grows

### DIFF
--- a/clients/admin-ui/src/features/dataset/ApproveClassification.tsx
+++ b/clients/admin-ui/src/features/dataset/ApproveClassification.tsx
@@ -1,4 +1,4 @@
-import { Button, chakra, HStack, useToast } from "@fidesui/react";
+import { Button, chakra, Spacer, useToast } from "@fidesui/react";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
 
@@ -75,12 +75,12 @@ const ApproveClassification = () => {
       classifyDataset.status === ClassificationStatus.COMPLETE
     )
   ) {
-    return null;
+    return <Spacer />;
   }
 
   return (
-    <HStack>
-      <chakra.p fontSize="sm" color="gray.600">
+    <>
+      <chakra.p flexGrow={1} textAlign="center" fontSize="sm" color="gray.600">
         <chakra.span fontWeight="bold">{fieldCount}</chakra.span>{" "}
         {fieldCount === 1 ? "field has" : "fields have"} been identified within
         this{" "}
@@ -98,7 +98,7 @@ const ApproveClassification = () => {
       >
         Approve dataset classification
       </Button>
-    </HStack>
+    </>
   );
 };
 

--- a/clients/admin-ui/src/features/dataset/DatasetCollectionView.tsx
+++ b/clients/admin-ui/src/features/dataset/DatasetCollectionView.tsx
@@ -104,11 +104,11 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
     <Box>
       <DatasetHeading />
 
-      <HStack mb={4} justifyContent="space-between">
+      <HStack mb={4}>
         <Select
           onChange={handleChangeCollection}
-          mr={2}
-          width="auto"
+          width="fit-content"
+          flexShrink={0}
           data-testid="collection-select"
         >
           {(activeCollections ?? []).map((collection) => (
@@ -118,23 +118,21 @@ const DatasetCollectionView = ({ fidesKey }: Props) => {
           ))}
         </Select>
         <ApproveClassification />
-        <HStack>
-          <Box>
-            <ColumnDropdown
-              allColumns={ALL_COLUMNS}
-              selectedColumns={columns}
-              onChange={setColumns}
-            />
-          </Box>
-          <MoreActionsMenu
-            onModifyCollection={() =>
-              dispatch(setActiveEditor(EditableType.COLLECTION))
-            }
-            onModifyDataset={() =>
-              dispatch(setActiveEditor(EditableType.DATASET))
-            }
+        <Box>
+          <ColumnDropdown
+            allColumns={ALL_COLUMNS}
+            selectedColumns={columns}
+            onChange={setColumns}
           />
-        </HStack>
+        </Box>
+        <MoreActionsMenu
+          onModifyCollection={() =>
+            dispatch(setActiveEditor(EditableType.COLLECTION))
+          }
+          onModifyDataset={() =>
+            dispatch(setActiveEditor(EditableType.DATASET))
+          }
+        />
       </HStack>
 
       <DatasetFieldsTable columns={columns} />


### PR DESCRIPTION
Closes #1277 

### Code Changes

* Remove the space-between flex for the dataset controls
* Instead fill the space with the paragraph that can grow, or a [Spacer](https://chakra-ui.com/docs/components/flex#using-the-spacer) when that section isn't needed.

### Steps to Confirm

* [ ] `datasets-classify.cy.ts` demonstrates the various states of these buttons. `cy.viewport("macbook-16")` was handy for trying the wide res.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Wide res:
![wide-res](https://user-images.githubusercontent.com/2236777/204651585-461d8364-7d88-429b-918b-1bb293d5790c.png)

Narrow res still okay:
![narrow-res](https://user-images.githubusercontent.com/2236777/204651580-f27d543d-cffa-4789-a963-67bea466bae4.png)

Without classify section still okay:
![no-button](https://user-images.githubusercontent.com/2236777/204651573-4bfd15ae-472f-405c-ae06-e1b4f21b40c1.png)


