### PR TITLE
pc/consent: Restructure consent src dir to make modle/browser distinction clearer

### DIFF
--- a/clients/privacy-center/.gitignore
+++ b/clients/privacy-center/.gitignore
@@ -82,6 +82,9 @@ typings/
 # The consent script is a build artifact.
 public/fides-consent.js
 
+# Fix conflict with root .gitignore Python rule.
+!lib
+
 # Nuxt.js build / generate output
 .nuxt
 dist

--- a/clients/privacy-center/packages/fides-consent/README.md
+++ b/clients/privacy-center/packages/fides-consent/README.md
@@ -27,7 +27,7 @@ In this example, `data_sharing` is a cookie key that has been [configured in the
 
 ## fides-consent.mjs & fides-consent.d.ts
 
-This package also exports its cookie utilities (`cookie.ts`) as a module the Privacy Center can import. This ensures the Privacy Center uses the exact same logic for reading & writing cookie data. This module is only used locally for convenience and is not published.
+This package also exports its library (`src/lib`) as a module the Privacy Center can import. This ensures the Privacy Center uses the exact same logic for reading & writing cookie data. This module is only used locally for convenience and is not published.
 
 Note that this module does _not_ define the `Fides.consent` global, as that is unnecessary when using modules.
 

--- a/clients/privacy-center/packages/fides-consent/package.json
+++ b/clients/privacy-center/packages/fides-consent/package.json
@@ -2,7 +2,7 @@
   "name": "fides-consent",
   "version": "0.0.1",
   "description": "Fides consent script",
-  "source": "src/index.ts",
+  "source": "src/lib/index.ts",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/clients/privacy-center/packages/fides-consent/rollup.config.js
+++ b/clients/privacy-center/packages/fides-consent/rollup.config.js
@@ -7,11 +7,11 @@ const name = require("./package.json").name;
 
 export default [
   {
-    input: `src/index.ts`,
+    input: `src/${name}.ts`,
     plugins: [
       nodeResolve(),
       esbuild({
-        minify: process.env.NODE_ENV === "development",
+        minify: process.env.NODE_ENV !== "development",
       }),
       copy({
         // Automatically add the built script to the privacy center's static files for testing:
@@ -31,7 +31,7 @@ export default [
     ],
   },
   {
-    input: `src/cookie.ts`,
+    input: `src/lib/index.ts`,
     plugins: [nodeResolve(), esbuild()],
     output: [
       {
@@ -43,7 +43,7 @@ export default [
     ],
   },
   {
-    input: `src/cookie.ts`,
+    input: `src/lib/index.ts`,
     plugins: [dts()],
     output: [
       {

--- a/clients/privacy-center/packages/fides-consent/src/fides-consent.ts
+++ b/clients/privacy-center/packages/fides-consent/src/fides-consent.ts
@@ -1,0 +1,12 @@
+/**
+ * This script defines the browser script entrypoint for Fides consent logic. It is distributed
+ * as `fides-consent.js` and is accessed from the `Fides` global variable.
+ */
+
+import { getConsentCookie } from "./lib/cookie";
+
+const Fides = {
+  consent: getConsentCookie(),
+};
+
+export default Fides;

--- a/clients/privacy-center/packages/fides-consent/src/index.ts
+++ b/clients/privacy-center/packages/fides-consent/src/index.ts
@@ -1,7 +1,0 @@
-import { getConsentCookie } from "./cookie";
-
-const Fides = {
-  consent: getConsentCookie(),
-};
-
-export default Fides;

--- a/clients/privacy-center/packages/fides-consent/src/lib/cookie.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/cookie.ts
@@ -1,4 +1,3 @@
-// import config from "config/config.json";
 import { getCookie, setCookie, Types } from "typescript-cookie";
 
 /**

--- a/clients/privacy-center/packages/fides-consent/src/lib/index.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/index.ts
@@ -1,0 +1,6 @@
+/**
+ * This module defines the library of features are exported as a module. This library
+ * is then bundled into `fides-consent.js` and imported by Privacy Center app, so that
+ * both can share the same consent logic.
+ */
+export * from "./cookie";


### PR DESCRIPTION
Start of #1801 

### Code Changes

* Move `src/index.ts` to `src/fides-consent.ts` to make it clearer it becomes `dist/fides-consent.js`
* Move `src/cookie.ts` to `src/lib/cookie.ts`
* Add `src/lib/index.ts` and use it as the root of the module build, so that if we want to add other code that isn't specifically for cookies (like a Shopify helper) we can have multiple files.

### Steps to Confirm

* Nothing should change 🙂 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
