### PR TITLE
Poll for classification updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The types of changes are:
 * Add function to poll privacy request for completion [#1860](https://github.com/ethyca/fides/pull/1860)
 * Added rescan flow for the data flow scanner [#1844](https://github.com/ethyca/fides/pull/1844)
 * Add Fides connector to support parent-child Fides deployments [#1861](https://github.com/ethyca/fides/pull/1861)
+* Classification UI now polls for updates to classifications [#1908](https://github.com/ethyca/fides/pull/1908)
 
 ### Changed
 

--- a/clients/admin-ui/src/pages/classify-systems/index.tsx
+++ b/clients/admin-ui/src/pages/classify-systems/index.tsx
@@ -20,6 +20,8 @@ import {
 import ClassifySystemsTable from "~/features/system/ClassifySystemsTable";
 import { ClassificationStatus, GenerateTypes } from "~/types/api";
 
+const POLL_INTERVAL_SECONDS = 5;
+
 const ClassifySystemsLayout = ({ children }: { children: ReactNode }) => (
   <Layout title="Classify Systems">
     <Stack spacing={4}>
@@ -64,7 +66,10 @@ const ClassifySystems: NextPage = () => {
         resource_type: GenerateTypes.SYSTEMS,
         fides_keys: systems?.map((s) => s.fides_key),
       },
-      { skip: !hasPlus, pollingInterval: shouldPoll ? 20 * 1000 : undefined }
+      {
+        skip: !hasPlus,
+        pollingInterval: shouldPoll ? POLL_INTERVAL_SECONDS * 1000 : undefined,
+      }
     );
 
   useEffect(() => {

--- a/clients/admin-ui/src/pages/classify-systems/index.tsx
+++ b/clients/admin-ui/src/pages/classify-systems/index.tsx
@@ -2,7 +2,7 @@ import { Button, Heading, HStack, Spinner, Stack, Text } from "@fidesui/react";
 import type { NextPage } from "next";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 
 import { useAppSelector } from "~/app/hooks";
@@ -56,13 +56,15 @@ const ClassifySystems: NextPage = () => {
     }
   }, [dispatch, allSystems]);
 
+  // Poll for updates to classification until all classifications are finished
+  const [shouldPoll, setShouldPoll] = useState(true);
   const { isLoading: isLoadingClassifications, data: classifications } =
     useGetAllClassifyInstancesQuery(
       {
         resource_type: GenerateTypes.SYSTEMS,
         fides_keys: systems?.map((s) => s.fides_key),
       },
-      { skip: !hasPlus }
+      { skip: !hasPlus, pollingInterval: shouldPoll ? 20 * 1000 : undefined }
     );
 
   useEffect(() => {
@@ -81,6 +83,12 @@ const ClassifySystems: NextPage = () => {
           c.status === ClassificationStatus.REVIEWED
       )
     : false;
+
+  useEffect(() => {
+    if (isClassificationFinished) {
+      setShouldPoll(false);
+    }
+  }, [isClassificationFinished]);
 
   if (isLoading) {
     return (

--- a/clients/admin-ui/src/pages/classify-systems/index.tsx
+++ b/clients/admin-ui/src/pages/classify-systems/index.tsx
@@ -20,7 +20,7 @@ import {
 import ClassifySystemsTable from "~/features/system/ClassifySystemsTable";
 import { ClassificationStatus, GenerateTypes } from "~/types/api";
 
-const POLL_INTERVAL_SECONDS = 5;
+const POLL_INTERVAL_SECONDS = 3;
 
 const ClassifySystemsLayout = ({ children }: { children: ReactNode }) => (
   <Layout title="Classify Systems">


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/368

Turns out this was pretty easy, thanks to some [built in RTK polling functionality](https://redux-toolkit.js.org/rtk-query/usage/polling) 🎉 

### Code Changes

* [x] Pass a polling interval to `useGetAllClassifyInstancesQuery` which stops once all classifications are done. I set it to 20 seconds, though it's easy to change if we want.

I couldn't think of a good way to cypress test this one since it depends on waiting quite a while for the next poll to happen.

### Steps to Confirm

* [ ] Go through the `/add-systems` flow and use the data flow scanner. Continue until you end up at the classifications page, which should show all entries as "Processing"
* [ ] Open up the network tab (or your fides plus server). Every 20 seconds, you should see it requery `/api/v1/plus/classify`
* [ ] Eventually, all entries will change to `Awaiting Review`. At this point, you should no longer see requeries for `/api/v1/plus/classify`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
