### PR TITLE
Update sample project landing page copy to be version-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.2.0...main)
 
+### Changed
+
+* Update sample project landing page copy to be version-agnostic [#1958](https://github.com/ethyca/fides/pull/1958)
+
 ## [2.2.0](https://github.com/ethyca/fides/compare/2.1.0...2.2.0)
 
 ### Added

--- a/src/fides/data/sample_project/cookie_house/src/components/Landing/index.tsx
+++ b/src/fides/data/sample_project/cookie_house/src/components/Landing/index.tsx
@@ -11,8 +11,8 @@ const Landing = () => (
         <div className={css.content}>
             <div className={css.headingContent}>
                 <Image src={landingImage} width={1860} alt="" className={css.box} />
-                <h1>Welcome to Fides 2.0</h1>
-                <p className={css.subhead}>Let's run our first privacy request in under 5 minutes!</p>
+                <h1>Welcome to Fides!</h1>
+                <p className={css.subhead}>Let's run our first privacy request in under 5 minutes</p>
             </div>
             <main>
                 <h2>What's in the box?</h2>

--- a/src/fides/data/sample_project/cookie_house/src/pages/landing.tsx
+++ b/src/fides/data/sample_project/cookie_house/src/pages/landing.tsx
@@ -6,7 +6,7 @@ const LandingPage = () => {
   return (
     <>
       <Head>
-        <title>Welcome to Fides 2.0</title>
+        <title>Welcome to Fides</title>
         <meta name="description" content="Sample Project used within Fides (github.com/ethyca/fides)" />
         <link rel="icon" href="/favicon.ico" />
         <meta charSet="utf-8" />


### PR DESCRIPTION
### Code Changes

* [X] Update sample project landing pages to remove specific version number

### Steps to Confirm

* [X] Run `fides deploy` locally

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation Updated:
  * [X] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [X] documentation issue created (tag docs-team to complete issue separately)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Now that we're living in a post-2.0 world, the version number in the heading is a bit misleading 👍

Here's the updated version:
<img width="1374" alt="image" src="https://user-images.githubusercontent.com/1834295/205130023-af12c509-7eb8-4d37-945c-558dab28b8ed.png">

