### PR TITLE
Retrieve child results during fides connector execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,12 @@ The types of changes are:
 * Add Fides connector to support parent-child Fides deployments [#1861](https://github.com/ethyca/fides/pull/1861)
 * Classification UI now polls for updates to classifications [#1908](https://github.com/ethyca/fides/pull/1908)
 
+
 ### Changed
 
 * The organization info form step is now skipped if the server already has organization info. [#1840](https://github.com/ethyca/fides/pull/1840)
 * Removed the description column from the classify systems page. [#1867](https://github.com/ethyca/fides/pull/1867)
+* Retrieve child results during fides connector execution [#1967](https://github.com/ethyca/fides/pull/1967)
 
 ### Fixed
 

--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -1351,7 +1351,7 @@ def privacy_request_data_transfer(
         dataset_graph.data_category_field_mapping,
     )
 
-    if not filtered_results:
+    if filtered_results is None:
         raise HTTPException(
             status_code=404,
             detail=f"No results found for privacy request {privacy_request_id}",

--- a/src/fides/api/ops/service/connectors/fides_connector.py
+++ b/src/fides/api/ops/service/connectors/fides_connector.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set
 
 from loguru import logger as log
 
@@ -9,12 +9,11 @@ from fides.api.ops.models.connectionconfig import (
     ConnectionTestStatus,
     ConnectionType,
 )
-from fides.api.ops.models.policy import Policy
+from fides.api.ops.models.policy import ActionType, Policy
 from fides.api.ops.models.privacy_request import PrivacyRequest
 from fides.api.ops.schemas.connection_configuration.connection_secrets_fides import (
     FidesConnectorSchema,
 )
-from fides.api.ops.schemas.privacy_request import PrivacyRequestResponse
 from fides.api.ops.schemas.redis_cache import Identity
 from fides.api.ops.service.connectors.base_connector import BaseConnector
 from fides.api.ops.service.connectors.fides.fides_client import FidesClient
@@ -79,7 +78,7 @@ class FidesConnector(BaseConnector[FidesClient]):
         privacy_request: PrivacyRequest,
         input_data: Dict[str, List[Any]],
     ) -> List[Row]:
-        """Execute access request and handle response on remote Fides"""
+        """Execute access request and fetch access data from remote Fides"""
         identity_data = privacy_request.get_cached_identity_data()
         if not identity_data:
             raise FidesError(
@@ -88,20 +87,30 @@ class FidesConnector(BaseConnector[FidesClient]):
 
         client: FidesClient = self.client()
 
+        # initiate privacy request execution on child
         pr_id: str = client.create_privacy_request(
             external_id=privacy_request.external_id or privacy_request.id,
             identity=Identity(**identity_data),
             policy_key=policy.key,
         )
-        privacy_request_response: PrivacyRequestResponse = (
-            client.poll_for_request_completion(
-                privacy_request_id=pr_id,
-                timeout=self.polling_timeout or None,
-                interval=self.polling_interval or None,
-            )
+
+        # block till privacy request completes on child
+        client.poll_for_request_completion(
+            privacy_request_id=pr_id,
+            timeout=self.polling_timeout or None,
+            interval=self.polling_interval or None,
         )
 
-        return [privacy_request_response.__dict__]
+        # for each rule, get appropriate results from the child
+        # store in a dict keyed by rule.key, to be unpacked later by request framework
+        results: Dict[str, Dict[str, List[Row]]] = {
+            rule.key: client.retrieve_request_results(
+                privacy_request_id=pr_id, rule_key=rule.key
+            )
+            for rule in policy.get_rules_for_action(action_type=ActionType.access)
+        }
+
+        return [results]
 
     def mask_data(
         self,
@@ -142,7 +151,7 @@ class FidesConnector(BaseConnector[FidesClient]):
 
 def filter_fides_connector_datasets(
     connector_configs: List[ConnectionConfig],
-) -> List[Tuple[str, ConnectionConfig]]:
+) -> Set[str]:
     """
     Helper function to retrieve the `fides_key`s of any `Dataset`s associated
     with any Fides connectors in the provided `List` of `ConnectionConfig`s.
@@ -150,9 +159,9 @@ def filter_fides_connector_datasets(
     Returns a `List` of `Tuple`s whose first element is the `fides_key`
     of the `Dataset`, and whose second element is the `ConnectionConfig` itself
     """
-    return [
-        (dataset.fides_key, connector_config)
+    return {
+        dataset.fides_key
         for connector_config in connector_configs
         for dataset in connector_config.datasets
         if connector_config.connection_type == ConnectionType.fides
-    ]
+    }

--- a/src/fides/api/ops/service/connectors/fides_connector.py
+++ b/src/fides/api/ops/service/connectors/fides_connector.py
@@ -156,8 +156,8 @@ def filter_fides_connector_datasets(
     Helper function to retrieve the `fides_key`s of any `Dataset`s associated
     with any Fides connectors in the provided `List` of `ConnectionConfig`s.
 
-    Returns a `List` of `Tuple`s whose first element is the `fides_key`
-    of the `Dataset`, and whose second element is the `ConnectionConfig` itself
+    Returns a `Set` of `str`s containing the `fides_key`
+    of the `Dataset`
     """
     return {
         dataset.fides_key

--- a/src/fides/api/ops/task/filter_results.py
+++ b/src/fides/api/ops/task/filter_results.py
@@ -15,7 +15,7 @@ def filter_data_categories(
     target_categories: Set[str],
     data_category_fields: Dict[CollectionAddress, Dict[FidesOpsKey, List[FieldPath]]],
     rule_key: str = "",
-    fides_connector_datasets: Set[str] = None,
+    fides_connector_datasets: Optional[Set[str]] = None,
 ) -> Dict[str, List[Dict[str, Optional[Any]]]]:
     """Filter access request results to only return fields associated with the target data categories
     and subcategories.


### PR DESCRIPTION
Closes #1966 

### Code Changes

* Reach out to child's privacy_request_data_transfer endpoint immediately after polling in the FidesConnector's main retrieve_data method
* Make one retrieval per rule in the provided policy, and store each result as an entry in a dict keyed by the rule.key
* Unpack this dict with some special-cased post-processing for Fides connectors at the framework level, depending on the rule whose results we are processing/persisting to storage
* Update tests as needed

### Steps to Confirm

* Ran thru privacy request execution with a child, manually (steps in https://github.com/ethyca/fides/pull/1861)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
