### PR TITLE
Specify python 3.10 for docs build in GitHub actions

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -20,6 +20,8 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       - name: Echo the Release Tag
         run: echo ${{ env.TAG }}


### PR DESCRIPTION
This is an attempt to fix #1968

### Code Changes

* Specify Python 3.10 for the docs build action.

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
