### PR TITLE
fidesplus 390: Dev user auth cross domain

### DIFF
--- a/clients/admin-ui/src/features/common/nav/NavLink.tsx
+++ b/clients/admin-ui/src/features/common/nav/NavLink.tsx
@@ -31,9 +31,13 @@ export const NavLink = ({
     basePath,
   });
 
-  const isActive = exact
-    ? router.pathname === zoneLink.href
-    : router.pathname.startsWith(zoneLink.href);
+  // To be active, a link has to be in the same zone (same base path) and its path on that zone must
+  // match the current path (either exactly or as as a prefix).
+  const isActive =
+    basePath === zoneLink.basePath &&
+    (exact
+      ? router.pathname === zoneLink.href
+      : router.pathname.startsWith(zoneLink.href));
 
   // Don't let Next's router wrap links that are disabled or link outside of the this app's zone.
   if (disabled || zoneLink.basePath !== basePath) {

--- a/clients/admin-ui/src/features/common/zones/config.ts
+++ b/clients/admin-ui/src/features/common/zones/config.ts
@@ -3,7 +3,9 @@ import { RootConfig } from "./types";
 /**
  * Create a configuration with the required types and defaults.
  */
-export const configureZones = (config: Partial<RootConfig>): RootConfig => ({
+export const configureZones = <C extends Partial<RootConfig>>(
+  config: C
+): C & RootConfig => ({
   zones: [],
   ...config,
   basePath: "/",


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/390
Used by: https://github.com/ethyca/fidesplus/pull/409

This technically works™️. This lets fidesplus load the login page as an iframe in development and receive a message from the page _on a different domain_ with the actual auth info. It's a bit complicated though!

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
