### PR TITLE
Merge `celery` subsection to `fides.toml`

### DIFF
--- a/.fides/celery.toml
+++ b/.fides/celery.toml
@@ -1,3 +1,5 @@
+# Remove this
+
 event_queue_prefix = "fides_worker"
 task_default_queue = "fides"
 task_always_eager = true

--- a/.fides/celery.toml
+++ b/.fides/celery.toml
@@ -1,5 +1,0 @@
-# Remove this
-
-event_queue_prefix = "fides_worker"
-task_default_queue = "fides"
-task_always_eager = true

--- a/.fides/fides.toml
+++ b/.fides/fides.toml
@@ -49,3 +49,8 @@ task_retry_delay = 1
 
 [admin_ui]
 enabled = true
+
+[celery]
+event_queue_prefix = "fides_worker"
+task_default_queue = "fides"
+task_always_eager = true

--- a/data/config/celery.override.toml
+++ b/data/config/celery.override.toml
@@ -1,2 +1,0 @@
-event_queue_prefix = "overridden_fides_worker"
-task_default_queue = "overridden_fides"

--- a/src/fides/api/ops/tasks/__init__.py
+++ b/src/fides/api/ops/tasks/__init__.py
@@ -5,7 +5,7 @@ from loguru import logger
 from sqlalchemy.orm import Session
 from toml import load as load_toml
 
-from fides.ctl.core.config import get_config
+from fides.ctl.core.config import get_config, FidesConfig
 from fides.lib.db.session import get_db_session
 
 CONFIG = get_config()
@@ -25,7 +25,7 @@ class DatabaseTask(Task):  # pylint: disable=W0223
         return self._session
 
 
-def _create_celery(config_path: str = CONFIG.execution.celery_config_path) -> Celery:
+def _create_celery(config: FidesConfig = get_config()) -> Celery:
     """
     Returns a configured version of the Celery application
     """
@@ -34,21 +34,16 @@ def _create_celery(config_path: str = CONFIG.execution.celery_config_path) -> Ce
 
     celery_config: Dict[str, Any] = {
         # Defaults for the celery config
-        "broker_url": CONFIG.redis.connection_url,
-        "result_backend": CONFIG.redis.connection_url,
+        "broker_url": config.redis.connection_url,
+        "result_backend": config.redis.connection_url,
         "event_queue_prefix": "fides_worker",
         "task_always_eager": True,
-        # Fidesops requires this to route emails to separate queues
+        # Ops requires this to route emails to separate queues
         "task_create_missing_queues": True,
         "task_default_queue": "fides",
     }
 
-    try:
-        celery_config_overrides: MutableMapping[str, Any] = load_toml(config_path)
-    except FileNotFoundError as e:
-        logger.warning(f"{config_path} could not be loaded: %s", e)
-    else:
-        celery_config.update(celery_config_overrides)
+    celery_config.update(config.celery)
 
     app.conf.update(celery_config)
 

--- a/src/fides/ctl/core/config/__init__.py
+++ b/src/fides/ctl/core/config/__init__.py
@@ -51,7 +51,8 @@ class FidesConfig(FidesSettings):
     # These should match the `settings_map` in `build_config`
     admin_ui: AdminUISettings
     cli: CLISettings
-    credentials: Dict[str, Dict]
+    celery: Dict
+    credentials: Dict
     database: DatabaseSettings
     execution: ExecutionSettings
     logging: LoggingSettings
@@ -136,12 +137,15 @@ def build_config(config_dict: Dict[str, Any]) -> FidesConfig:
     for key, value in settings_map.items():
         settings_map[key] = value.parse_obj(config_dict.get(key, {}))
 
-    # logic for populating the user-defined credentials sub-settings.
+    # Logic for populating the user-defined credentials sub-settings.
     # this is done to allow overrides without typed pydantic models
     config_environment_dict = config_dict.get("credentials", {})
     settings_map["credentials"] = merge_credentials_environment(
         credentials_dict=config_environment_dict
     )
+
+    # The Celery subsection is uniquely simple
+    settings_map["celery"] = config_dict.get("celery", {})
 
     fides_config = FidesConfig(**settings_map)
     return fides_config

--- a/src/fides/ctl/core/config/execution_settings.py
+++ b/src/fides/ctl/core/config/execution_settings.py
@@ -13,7 +13,6 @@ class ExecutionSettings(FidesSettings):
     subject_identity_verification_required: bool = False
     require_manual_request_approval: bool = False
     masking_strict: bool = True
-    celery_config_path: str = ".fides/celery.toml"
 
     class Config:
         env_prefix = ENV_PREFIX

--- a/tests/ops/tasks/test_celery.py
+++ b/tests/ops/tasks/test_celery.py
@@ -25,6 +25,10 @@ def test_celery_default_config() -> None:
 
 
 def test_celery_config_override() -> None:
-    celery_app = _create_celery(config_path="data/config/celery.override.toml")
+    config = get_config()
+    config.celery["event_queue_prefix"] = "overridden_fides_worker"
+    config.celery["task_default_queue"] = "overridden_fides"
+
+    celery_app = _create_celery(config=config)
     assert celery_app.conf["event_queue_prefix"] == "overridden_fides_worker"
     assert celery_app.conf["task_default_queue"] == "overridden_fides"


### PR DESCRIPTION
Closes #1591 

### Code Changes

* [x] remove the `celery.toml`
* [x] add a `celery` subsection to `fides.toml`
* [x] update references to `celery.toml` in the code

### Steps to Confirm

* [ ] use `fides view config celery` to confirm that the correct values are there
* [ ] update the `fides.toml` and observe the changes

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Quick change that adds the celery configuration values as part of the `fides.toml` instead of placing them in a separate file

This change does _not_ enable users to configure the celery values via env vars via the fides configuration logic, as I'm assuming Celery will handle that itself. If this assumption is incorrect I can make that change

__NOTE:__ branchception