### PR TITLE
Change CLI Crud operations to use YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 ### Changed
 
 * Update sample project landing page copy to be version-agnostic [#1958](https://github.com/ethyca/fides/pull/1958)
+* `get` and `ls` CLI commands now return valid `fides` object YAML [#1991](https://github.com/ethyca/fides/pull/1991)
 
 ## [2.2.0](https://github.com/ethyca/fides/compare/2.1.0...2.2.0)
 
@@ -36,7 +37,6 @@ The types of changes are:
 * Add rescan flow for the data flow scanner [#1844](https://github.com/ethyca/fides/pull/1844)
 * Add Fides connector to support parent-child Fides deployments [#1861](https://github.com/ethyca/fides/pull/1861)
 * Classification UI now polls for updates to classifications [#1908](https://github.com/ethyca/fides/pull/1908)
-
 
 ### Changed
 

--- a/src/fides/cli/__init__.py
+++ b/src/fides/cli/__init__.py
@@ -15,7 +15,7 @@ from fides.ctl.core.config import get_config
 
 from .commands.annotate import annotate
 from .commands.core import evaluate, parse, pull, push
-from .commands.crud import delete, get, ls
+from .commands.crud import delete, get_resource, list_resources
 from .commands.db import database
 from .commands.export import export
 from .commands.generate import generate
@@ -33,8 +33,8 @@ API_COMMANDS = [
     database,
     delete,
     export,
-    get,
-    ls,
+    get_resource,
+    list_resources,
     status,
     pull,
     push,

--- a/src/fides/cli/commands/crud.py
+++ b/src/fides/cli/commands/crud.py
@@ -36,6 +36,8 @@ def get(ctx: click.Context, resource_type: str, fides_key: str) -> None:
     """
     View a resource from the server as a JSON object.
     """
+    
+    # Print it as TOML
     config = ctx.obj["CONFIG"]
     handle_cli_response(
         _api.get(

--- a/src/fides/cli/commands/crud.py
+++ b/src/fides/cli/commands/crud.py
@@ -1,10 +1,12 @@
 """Contains all of the CRUD-type CLI commands for fides."""
-
 import click
+import yaml
 
 from fides.cli.options import fides_key_argument, resource_type_argument
-from fides.cli.utils import handle_cli_response, with_analytics
+from fides.cli.utils import handle_cli_response, print_divider, with_analytics
 from fides.ctl.core import api as _api
+from fides.ctl.core.api_helpers import get_server_resource, list_server_resources
+from fides.ctl.core.utils import echo_green
 
 
 @click.command()
@@ -34,19 +36,18 @@ def delete(ctx: click.Context, resource_type: str, fides_key: str) -> None:
 @with_analytics
 def get(ctx: click.Context, resource_type: str, fides_key: str) -> None:
     """
-    View a resource from the server as a JSON object.
+    View a resource from the server as a YAML object.
     """
-    
-    # Print it as TOML
     config = ctx.obj["CONFIG"]
-    handle_cli_response(
-        _api.get(
-            url=config.cli.server_url,
-            resource_type=resource_type,
-            resource_id=fides_key,
-            headers=config.user.request_headers,
-        )
+    resource = get_server_resource(
+        url=config.cli.server_url,
+        resource_type=resource_type,
+        resource_key=fides_key,
+        headers=config.user.request_headers,
+        raw=True,
     )
+    print_divider()
+    echo_green(yaml.dump({resource_type: [resource]}))
 
 
 @click.command()
@@ -55,13 +56,15 @@ def get(ctx: click.Context, resource_type: str, fides_key: str) -> None:
 @with_analytics
 def ls(ctx: click.Context, resource_type: str) -> None:  # pylint: disable=invalid-name
     """
-    Get a list of all resources of this type from the server and display them as JSON.
+    Get a list of all resources of this type from the server and display them as YAML.
     """
     config = ctx.obj["CONFIG"]
-    handle_cli_response(
-        _api.ls(
-            url=config.cli.server_url,
-            resource_type=resource_type,
-            headers=config.user.request_headers,
-        )
+    resources = list_server_resources(
+        url=config.cli.server_url,
+        resource_type=resource_type,
+        headers=config.user.request_headers,
+        exclude_keys=[],
+        raw=True,
     )
+    print_divider()
+    echo_green(yaml.dump({resource_type: resources}))

--- a/src/fides/cli/commands/crud.py
+++ b/src/fides/cli/commands/crud.py
@@ -29,12 +29,12 @@ def delete(ctx: click.Context, resource_type: str, fides_key: str) -> None:
     )
 
 
-@click.command()
+@click.command(name="get")
 @click.pass_context
 @resource_type_argument
 @fides_key_argument
 @with_analytics
-def get(ctx: click.Context, resource_type: str, fides_key: str) -> None:
+def get_resource(ctx: click.Context, resource_type: str, fides_key: str) -> None:
     """
     View a resource from the server as a YAML object.
     """
@@ -50,11 +50,11 @@ def get(ctx: click.Context, resource_type: str, fides_key: str) -> None:
     echo_green(yaml.dump({resource_type: [resource]}))
 
 
-@click.command()
+@click.command(name="ls")
 @click.pass_context
 @resource_type_argument
 @with_analytics
-def ls(ctx: click.Context, resource_type: str) -> None:  # pylint: disable=invalid-name
+def list_resources(ctx: click.Context, resource_type: str) -> None:
     """
     Get a list of all resources of this type from the server and display them as YAML.
     """

--- a/src/fides/ctl/core/api_helpers.py
+++ b/src/fides/ctl/core/api_helpers.py
@@ -47,11 +47,11 @@ def get_server_resource(
     resource_key: str,
     headers: Dict[str, str],
     raw: bool = False,
-) -> Optional[Union[FidesModel, Dict]]:
+) -> Union[FidesModel, Dict]:
     """
     Attempt to get a given resource from the server.
 
-    Returns None if the object does not exist on the server.
+    Returns {} if the object does not exist on the server.
 
     As we don't always have a way to attribute fides_keys to the
     right resource, this function helps check what resource
@@ -74,7 +74,7 @@ def get_server_resource(
             from_server=True,
         )
 
-    return server_resource
+    return server_resource or {}
 
 
 def list_server_resources(

--- a/tests/ctl/core/test_api_helpers.py
+++ b/tests/ctl/core/test_api_helpers.py
@@ -87,7 +87,7 @@ class TestGetServerResource:
         """
         resource_type = created_resources[0]
         resource_key = created_resources[1][0]
-        result: FidesModel = _api_helpers.get_server_resource(
+        result = _api_helpers.get_server_resource(
             url=test_config.cli.server_url,
             resource_type=resource_type,
             resource_key=resource_key,
@@ -103,13 +103,13 @@ class TestGetServerResource:
         Tests that a missing resource returns None
         """
         resource_key = str(uuid.uuid4())
-        result: Optional[FidesModel] = _api_helpers.get_server_resource(
+        result = _api_helpers.get_server_resource(
             url=test_config.cli.server_url,
             resource_type=resource_type,
             resource_key=resource_key,
             headers=test_config.user.request_headers,
         )
-        assert result is None
+        assert not result
 
 
 @pytest.mark.integration
@@ -155,13 +155,13 @@ class TestGetServerResources:
 class TestListServerResources:
     def test_list_server_resources_passing(self, test_config: FidesConfig) -> None:
         resource_type = "data_category"
-        result: List[FidesModel] = _api_helpers.list_server_resources(
+        result = _api_helpers.list_server_resources(
             url=test_config.cli.server_url,
             resource_type=resource_type,
             headers=test_config.user.request_headers,
             exclude_keys=[],
         )
-        assert len(result) > 1
+        assert result
 
     def test_list_server_resources_none(self, test_config: FidesConfig) -> None:
         resource_type = "system"


### PR DESCRIPTION
Closes #1989 

### Code Changes

* [x] update the `get` command
* [x] update the `ls` command

### Steps to Confirm

* [ ] spin up the server using `nox -s dev`
* [ ] run `fides push` populate the database
* [ ] run `fides ls system` to confirm you get the list of systems
* [ ] run `fides get data_category user` to confirm you get a single user
* [ ] copy/pasta the `fides ls system` output into a yaml file and push it to confirm it is valid

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This change standardizes the output of CLI commands to use YAML when displaying `fides` resources, and furthermore are properly formatted to be used for a subsequent `fides push`