### PR TITLE
privacy-center/config: Use typed constant to ensure modifying the config is typesafe

### DIFF
--- a/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
@@ -21,8 +21,8 @@ import { addCommonHeaders } from "~/common/CommonHeaders";
 import { ErrorToastOptions, SuccessToastOptions } from "~/common/toast-options";
 import { PrivacyRequestStatus } from "~/types";
 
-import config from "~/config/config.json";
-import { hostUrl } from "~/constants";
+import { PrivacyRequestOption } from "~/types/config";
+import { hostUrl, config } from "~/constants";
 
 import dynamic from "next/dynamic";
 import * as Yup from "yup";
@@ -42,7 +42,7 @@ const usePrivacyRequestForm = ({
   isVerificationRequired,
 }: {
   onClose: () => void;
-  action: typeof config.actions[0] | null;
+  action: PrivacyRequestOption | null;
   setCurrentView: (view: ModalViews) => void;
   setPrivacyRequestId: (id: string) => void;
   isVerificationRequired: boolean;
@@ -142,14 +142,14 @@ const usePrivacyRequestForm = ({
     validationSchema: Yup.object().shape({
       name: (() => {
         let validation = Yup.string();
-        if (action?.identity_inputs.name === "required") {
+        if (action?.identity_inputs?.name === "required") {
           validation = validation.required("Name is required");
         }
         return validation;
       })(),
       email: (() => {
         let validation = Yup.string();
-        if (action?.identity_inputs.email === "required") {
+        if (action?.identity_inputs?.email === "required") {
           validation = validation
             .email("Email is invalid")
             .required("Email is required");
@@ -158,7 +158,7 @@ const usePrivacyRequestForm = ({
       })(),
       phone: (() => {
         let validation = Yup.string();
-        if (action?.identity_inputs.phone === "required") {
+        if (action?.identity_inputs?.phone === "required") {
           validation = validation
             .required("Phone is required")
             // E.164 international standard format

--- a/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestModal.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestModal.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useState } from "react";
+
+import { config } from "~/constants";
+
 import RequestModal from "../RequestModal";
-
-import config from "../../../config/config.json";
-
 import PrivacyRequestForm from "./PrivacyRequestForm";
 import VerificationForm from "../VerificationForm";
 import RequestSubmitted from "./RequestSubmitted";

--- a/clients/privacy-center/constants/index.ts
+++ b/clients/privacy-center/constants/index.ts
@@ -1,6 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 
-import config from "../config/config.json";
+import { Config } from "~/types/config";
+import configJson from "~/config/config.json";
+
+export const config: Config = configJson;
 
 // Compute the host URL for the server, while being backwards compatible with
 // the previous "fidesops_host_***" configuration

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -25,11 +25,10 @@ import {
 import { setConsentCookie } from "fides-consent";
 import { ApiUserConsents, ConsentItem } from "~/features/consent/types";
 
-import { hostUrl } from "~/constants";
+import { hostUrl, config } from "~/constants";
 import { addCommonHeaders } from "~/common/CommonHeaders";
 import { VerificationType } from "~/components/modals/types";
 import { useLocalStorage } from "~/common/hooks";
-import consentConfig from "../config/config.json";
 import ConsentItemCard from "../components/ConsentItemCard";
 
 const Consent: NextPage = () => {
@@ -99,7 +98,7 @@ const Consent: NextPage = () => {
 
       const updatedConsentItems = makeConsentItems(
         data,
-        consentConfig.consent.consentOptions
+        config.consent?.consentOptions ?? []
       );
       setConsentItems(updatedConsentItems);
       setConsentCookie(makeCookieKeyConsent(updatedConsentItems));
@@ -160,7 +159,7 @@ const Consent: NextPage = () => {
     }
     const updatedConsentItems = makeConsentItems(
       data,
-      consentConfig.consent.consentOptions
+      config.consent?.consentOptions ?? []
     );
     setConsentCookie(makeCookieKeyConsent(updatedConsentItems));
     toast({
@@ -191,7 +190,7 @@ const Consent: NextPage = () => {
           alignItems="center"
         >
           <Image
-            src={consentConfig.logo_path}
+            src={config.logo_path}
             height="56px"
             width="304px"
             alt="Logo"

--- a/clients/privacy-center/pages/index.tsx
+++ b/clients/privacy-center/pages/index.tsx
@@ -12,11 +12,9 @@ import {
   useConsentRequestModal,
   ConsentRequestModal,
 } from "~/components/modals/consent-request-modal/ConsentRequestModal";
-import { hostUrl } from "~/constants";
+import { hostUrl, config } from "~/constants";
 import PrivacyCard from "../components/PrivacyCard";
 import ConsentCard from "../components/ConsentCard";
-
-import config from "../config/config.json";
 
 const Home: NextPage = () => {
   const [isVerificationRequired, setIsVerificationRequired] =

--- a/clients/privacy-center/types/config.ts
+++ b/clients/privacy-center/types/config.ts
@@ -19,7 +19,7 @@ export type PrivacyRequestOption = {
   icon_path: string;
   title: string;
   description: string;
-  identity_inputs: object;
+  identity_inputs: Record<string, string>;
 };
 
 export type ConfigConsentOption = {


### PR DESCRIPTION
Fixes: [thread](https://ethyca.slack.com/archives/CBKK8TS74/p1670365926982779?thread_ts=1670364285.589289&cid=CBKK8TS74)

### Code Changes

* Instead of importing the JSOn config directly, app code imports the typed constant.
* A couple places didn't handle potentially-missing actions, just needed some empty checks.

### Steps to Confirm

* Set `config.son > "actions"`  to an empty array
* Run `npm run build` -> should build
* Serve the built privacy center (`npm run cy:start` for example)
* Only the "Manage your consent" section should show.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
