### PR TITLE
2011 distributed fides better handle children with no access results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The types of changes are:
 
 ### Changed
 
+* Update connection test endpoint to be effectively non-blocking [#2000](https://github.com/ethyca/fides/pull/2000)
 * Update Fides connector to better handle children with no access results [#2012](https://github.com/ethyca/fides/pull/2012)
 
 ## [2.2.1](https://github.com/ethyca/fides/compare/2.2.0...2.2.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.2.1...main)
 
+### Changed
+
+* Update Fides connector to better handle children with no access results [#2012](https://github.com/ethyca/fides/pull/2012)
 
 ## [2.2.1](https://github.com/ethyca/fides/compare/2.2.0...2.2.1)
 

--- a/src/fides/api/ops/service/connectors/fides/fides_client.py
+++ b/src/fides/api/ops/service/connectors/fides/fides_client.py
@@ -216,5 +216,6 @@ class FidesClient:
                 privacy_request_id,
                 response.json(),
             )
+            return {}
 
         return response.json()

--- a/src/fides/api/ops/service/connectors/fides/fides_client.py
+++ b/src/fides/api/ops/service/connectors/fides/fides_client.py
@@ -187,9 +187,15 @@ class FidesClient:
         """
         Return privacy request object that tracks its status
         """
-        log.info(
-            f"Retrieving request status for privacy request {privacy_request_id if privacy_request_id else ''} on remote fides {self.uri}..."
-        )
+        if privacy_request_id:
+            log.info(
+                f"Retrieving request status for privacy request {privacy_request_id if privacy_request_id else ''} on remote fides {self.uri}..."
+            )
+        else:
+            log.info(
+                f"Retrieving request status for all privacy requests on remote fides {self.uri}..."
+            )
+
         request: PreparedRequest = self.authenticated_request(
             method="GET",
             path=urls.V1_URL_PREFIX + urls.PRIVACY_REQUESTS,
@@ -204,9 +210,14 @@ class FidesClient:
             )
             response.raise_for_status()
 
-        log.info(
-            f"Retrieved request status for privacy request {privacy_request_id if privacy_request_id else ''} on remote fides {self.uri}"
-        )
+        if privacy_request_id:
+            log.info(
+                f"Retrieved request status for privacy request {privacy_request_id if privacy_request_id else ''} on remote fides {self.uri}"
+            )
+        else:
+            log.info(
+                f"Retrieved request status for all privacy requests on remote fides {self.uri}"
+            )
         return response.json()["items"]
 
     def retrieve_request_results(

--- a/src/fides/api/ops/service/connectors/fides_connector.py
+++ b/src/fides/api/ops/service/connectors/fides_connector.py
@@ -69,6 +69,7 @@ class FidesConnector(BaseConnector[FidesClient]):
             log.error(f"Error testing connection to remote Fides {str(e)}")
             return ConnectionTestStatus.failed
 
+        log.info(f"Successful connection test for {self.configuration.key}")
         return ConnectionTestStatus.succeeded
 
     def retrieve_data(
@@ -84,6 +85,9 @@ class FidesConnector(BaseConnector[FidesClient]):
             raise FidesError(
                 f"No identity data found for privacy request {privacy_request.id}, cannot execute Fides connector!"
             )
+        log.info(
+            f"{self.configuration.key} starting retrieve_data for privacy request {privacy_request.id}..."
+        )
 
         client: FidesClient = self.client()
 
@@ -110,6 +114,9 @@ class FidesConnector(BaseConnector[FidesClient]):
             for rule in policy.get_rules_for_action(action_type=ActionType.access)
         }
 
+        log.info(
+            f"{self.configuration.key} finished retrieve_data for privacy request {privacy_request.id}"
+        )
         return [results]
 
     def mask_data(
@@ -126,6 +133,9 @@ class FidesConnector(BaseConnector[FidesClient]):
             raise FidesError(
                 f"No identity data found for privacy request {privacy_request.id}, cannot execute Fides connector!"
             )
+        log.info(
+            f"{self.configuration.key} starting mask_data for privacy request {privacy_request.id}..."
+        )
 
         client: FidesClient = self.client()
         update_ct = 0
@@ -142,6 +152,9 @@ class FidesConnector(BaseConnector[FidesClient]):
             )
             update_ct += 1
 
+        log.info(
+            f"{self.configuration.key} finished mask_data for privacy request {privacy_request.id}"
+        )
         return update_ct
 
     def close(self) -> None:

--- a/tests/ops/service/connectors/fides/test_fides_client.py
+++ b/tests/ops/service/connectors/fides/test_fides_client.py
@@ -355,3 +355,20 @@ class TestFidesClientIntegration:
         # or environment-specific issues,
         # let's not assume anything about the status here.
         assert statuses[0]["status"] is not None
+
+    def test_retrieve_request_results_nonexistent_request(
+        self, authenticated_fides_client: FidesClient, policy
+    ):
+        """
+        Tests that retrieving requests results for a nonexistent request
+        properly returns an empty dict.
+
+        At this point, a nonexistent request behaves the same as a
+        legitimate request that does not output data. So we use this to
+        ensure that these requests are handled well by the client,
+        and simply return no data.
+        """
+        result = authenticated_fides_client.retrieve_request_results(
+            "some_nonexistent_request", "some_nonexistent_rule"
+        )
+        assert result == {}


### PR DESCRIPTION
Closes #2011 

### Code Changes

* return empty dict if we error on the transfer endpoint, so that we just do not add results to the aggregate data result
* put in a simple test case around this scenario
* improve some logging in fides connector and client

### Steps to Confirm

See issue

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

