### PR TITLE
1710 dsr bulk reprocess not working with 20 demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.2.2...main)
 
+### Fixed
+
+* Timing issues with bulk DSR reprocessing, specifically when analytics are enabled [#2015](https://github.com/ethyca/fides/pull/2015)
+
 ## [2.2.2](https://github.com/ethyca/fides/compare/2.2.1...2.2.2)
 
 ### Docs

--- a/data/dataset/remote_fides_example_test_dataset.yml
+++ b/data/dataset/remote_fides_example_test_dataset.yml
@@ -3,9 +3,8 @@ dataset:
     name: Fides Child Example Test Dataset
     description: Example of a Remote Fides Child Dataset
     collections:
-      - name: privacy_request
+      - name: placeholder
         fields:
           - name: placeholder
-            data_categories: [system.operations]
             fidesops_meta:
               identity: email

--- a/docker-compose.child-env.yml
+++ b/docker-compose.child-env.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "8081:8080"
     depends_on:
-      fides-child-db:
+      fides-db:
         condition: service_healthy
       redis-child:
         condition: service_started
@@ -23,8 +23,9 @@ services:
       FIDES__CLI__ANALYTICS_ID: ${FIDES__CLI__ANALYTICS_ID:-}
       FIDES__CLI__SERVER_HOST: "fides-child"
       FIDES__CLI__SERVER_PORT: "8080"
-      FIDES__DATABASE__SERVER: "fides-child-db"
-      FIDES__DATABASE__DB: "fides-child"
+      FIDES__DATABASE__SERVER: "fides-db"
+      FIDES__DATABASE__DB: "child_test_db"
+      FIDES__DATABASE__TEST_DB: "child_test_db"
       FIDES__DEV_MODE: "True"
       FIDES__REDIS__ENABLED: "True"
       FIDES__REDIS__HOST: "redis-child"
@@ -41,7 +42,7 @@ services:
         target: /fides
         read_only: False
 
-  fides-child-db:
+  fides-db:
     image: postgres:12
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
@@ -53,7 +54,7 @@ services:
     expose:
       - 5432
     ports:
-      - "5433:5432"
+      - "5432:5432"
     environment:
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "fides"

--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -1708,6 +1708,4 @@ def _process_privacy_request_restart(
         from_step=failed_step.value,
     )
 
-    privacy_request.cache_failed_checkpoint_details()  # Reset failed step and collection to None
-
     return privacy_request

--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -178,7 +178,7 @@ def get_privacy_request_or_error(
     status_code=HTTP_200_OK,
     response_model=BulkPostPrivacyRequests,
 )
-async def create_privacy_request(
+def create_privacy_request(
     *,
     db: Session = Depends(deps.get_db),
     data: conlist(PrivacyRequestCreate, max_items=50) = Body(...),  # type: ignore
@@ -197,7 +197,7 @@ async def create_privacy_request(
     dependencies=[Security(verify_oauth_client, scopes=[PRIVACY_REQUEST_CREATE])],
     response_model=BulkPostPrivacyRequests,
 )
-async def create_privacy_request_authenticated(
+def create_privacy_request_authenticated(
     *,
     db: Session = Depends(deps.get_db),
     data: conlist(PrivacyRequestCreate, max_items=50) = Body(...),  # type: ignore
@@ -794,7 +794,7 @@ def get_request_preview_queries(
     status_code=HTTP_200_OK,
     response_model=PrivacyRequestResponse,
 )
-async def resume_privacy_request(
+def resume_privacy_request(
     privacy_request_id: str,
     *,
     db: Session = Depends(deps.get_db),
@@ -851,7 +851,7 @@ def validate_manual_input(
                 )
 
 
-async def resume_privacy_request_with_manual_input(
+def resume_privacy_request_with_manual_input(
     privacy_request_id: str,
     db: Session,
     expected_paused_step: CurrentStep,
@@ -951,7 +951,7 @@ async def resume_privacy_request_with_manual_input(
         Security(verify_oauth_client, scopes=[PRIVACY_REQUEST_CALLBACK_RESUME])
     ],
 )
-async def resume_with_manual_input(
+def resume_with_manual_input(
     privacy_request_id: str,
     *,
     db: Session = Depends(deps.get_db),
@@ -961,7 +961,7 @@ async def resume_with_manual_input(
 
     If there's no manual data to submit, pass in an empty list to resume the privacy request.
     """
-    return await resume_privacy_request_with_manual_input(
+    return resume_privacy_request_with_manual_input(
         privacy_request_id=privacy_request_id,
         db=db,
         expected_paused_step=CurrentStep.access,
@@ -977,7 +977,7 @@ async def resume_with_manual_input(
         Security(verify_oauth_client, scopes=[PRIVACY_REQUEST_CALLBACK_RESUME])
     ],
 )
-async def resume_with_erasure_confirmation(
+def resume_with_erasure_confirmation(
     privacy_request_id: str,
     *,
     db: Session = Depends(deps.get_db),
@@ -988,7 +988,7 @@ async def resume_with_erasure_confirmation(
 
     If no rows were masked, pass in a 0 to resume the privacy request.
     """
-    return await resume_privacy_request_with_manual_input(
+    return resume_privacy_request_with_manual_input(
         privacy_request_id=privacy_request_id,
         db=db,
         expected_paused_step=CurrentStep.erasure,
@@ -1004,7 +1004,7 @@ async def resume_with_erasure_confirmation(
         Security(verify_oauth_client, scopes=[PRIVACY_REQUEST_CALLBACK_RESUME])
     ],
 )
-async def bulk_restart_privacy_request_from_failure(
+def bulk_restart_privacy_request_from_failure(
     privacy_request_ids: List[str],
     *,
     db: Session = Depends(deps.get_db),
@@ -1066,7 +1066,7 @@ async def bulk_restart_privacy_request_from_failure(
         Security(verify_oauth_client, scopes=[PRIVACY_REQUEST_CALLBACK_RESUME])
     ],
 )
-async def restart_privacy_request_from_failure(
+def restart_privacy_request_from_failure(
     privacy_request_id: str,
     *,
     db: Session = Depends(deps.get_db),
@@ -1180,7 +1180,7 @@ def _send_privacy_request_review_message_to_user(
     status_code=HTTP_200_OK,
     response_model=PrivacyRequestResponse,
 )
-async def verify_identification_code(
+def verify_identification_code(
     privacy_request_id: str,
     *,
     db: Session = Depends(deps.get_db),
@@ -1506,7 +1506,7 @@ def view_uploaded_manual_webhook_data(
         Security(verify_oauth_client, scopes=[PRIVACY_REQUEST_CALLBACK_RESUME])
     ],
 )
-async def resume_privacy_request_from_requires_input(
+def resume_privacy_request_from_requires_input(
     privacy_request_id: str,
     *,
     db: Session = Depends(deps.get_db),

--- a/src/fides/api/ops/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/ops/service/privacy_request/request_runner_service.py
@@ -294,6 +294,9 @@ async def run_privacy_request(
 
     with self.session as session:
         privacy_request = PrivacyRequest.get(db=session, object_id=privacy_request_id)
+
+        privacy_request.cache_failed_checkpoint_details()  # Reset failed step and collection to None
+
         if privacy_request.status == PrivacyRequestStatus.canceled:
             logging.info(
                 "Terminating privacy request %s: request canceled.", privacy_request.id

--- a/src/fides/api/ops/tasks/__init__.py
+++ b/src/fides/api/ops/tasks/__init__.py
@@ -58,6 +58,7 @@ def _create_celery(config_path: str = CONFIG.execution.celery_config_path) -> Ce
             "fides.api.ops.tasks",
             "fides.api.ops.tasks.scheduled",
             "fides.api.ops.service.privacy_request",
+            "fides.api.ops.service.privacy_request.request_runner_service",
         ]
     )
     return app


### PR DESCRIPTION
Closes #1710 

### Code Changes

* remove `async` keyword from privacy request endpoints, as it is one contributing reason that reprocessed privacy requests are being executed concurrently when running without a worker, which is _not_ a state we expect/handle
* update the order in which a reprocessed privacy request cache entry is cleared, to prevent requests that encounter another error on re-processing from getting into an unrecoverable state
* make a small tweak to celery app instantiation to ensure worker properly picks up privacy requests

### Steps to Confirm

The steps in the issue describe how to reproduce the problem while using `fides deploy up`. But we won't have the fix available in that workflow until we merge this PR, since it requires an update `ethyca-fides` package on pypi - so we're in a bit of a catch 22 there. That being said, I was able to reproduce the problem on all of my local testing environments (e.g. `nox -s dev` and `nox -s test_env` if I just updated my local `fides.toml` to have `analytics_opt_out = false`. So to confirm, you could

* update `fides.toml` to have `analytics_opt_out = false`
* run `nox -s dev -- ui`
* run through the steps to repro listed in the issue

In general, the comments I left on the issue provide some context for different testing I did and my findings - they may be useful to read while evaluating this fix.

I'll also attach the latest version of the little test script ([test_fides_1710.py.txt](https://github.com/ethyca/fides/files/10219427/test_fides_1710.py.txt)) I had that helped to reproduce the problem and verify the fix - the script uses `fides` dependencies so it needs to run in a python env with `ethyca-fides` installed. it's also not the most beautiful script - but it gets the job done :)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

* Removing the `async` keyword from the endpoint function doesn't get super close to the "root cause" of the problems seen in DSR reprocessing. If someone comes along and writes a new `async` endpoint function that queues privacy requests, the underlying infrastructure will still allow us to get into a state where we've got multiple concurrent DSR executions occurring when not using a worker, which is not something that will be handled well. That being said, this was by far the simplest and least intrusive fix I could think of, and it's effective - our current routes do not put us in a bad state, whether using a worker or not, with manual approval or not, when submitted or reprocessing, etc.
    * This change also comes with the added benefit of making these endpoints _not_ clog up the whole server until they finish executing. This is a bit counterintuitive, because we're removing the `async` keyword. But because of the way that fastAPI works, when the endpoint functions were `async`, they were being executed on the app's main event loop; if the underlying work it was doing was not effectively leveraging `async`/`await` functionality - and most of it is not - then all of that work would clog up the _entire web server_. This did not impact manually approved privacy requests (since they were using a `sync` endpoint), and it didn't impact execution with a worker (since that work was successfully pushed off onto another process); but when running without a worker, and when bulk re-processing requests, or when creating a privacy request without manual approval required (both `async` endpoints), the whole server would lock up until the privacy requests finished execution! With this change, they no longer do that since the `sync` endpoints do _all_ of their work on a separate thread/event loop than the one used by the main webserver
    * Note that we introduced some of these `async` endpoints in https://github.com/ethyca/fidesops/pull/1174 while generally adding `async` functionality to the ops codebase to avoid errors with the `fideslog` client calls. The changes in this PR don't impact this, since what was needed there was for the celery task function to be `async`; we can call the `async` celery task from `sync` endpoints, as we do in this PR, due to the `@sync` wrapper we have.
* The other change, that switches when the cache is cleared during privacy request re-execution, was not a direct fix for this ticket's bug, but it came up in some testing. Before this fix, privacy requests could effectively only be re-executed _once_, since their cached "failed checkpoint details" state was getting cleared _after_ their re-execution ended. With this change, privacy requests should be able to be re-executed as many times as needed.