### PR TITLE
Add a "usage" session to nox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
-
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.2.1...main)
 
 ### Fixed
@@ -24,12 +23,12 @@ The types of changes are:
 * Update connection test endpoint to be effectively non-blocking [#2000](https://github.com/ethyca/fides/pull/2000)
 * Update Fides connector to better handle children with no access results [#2012](https://github.com/ethyca/fides/pull/2012)
 
-
 ## [2.2.1](https://github.com/ethyca/fides/compare/2.2.0...2.2.1)
 
 ### Added
 
 * Add health check indicator for data flow scanning option [#1973](https://github.com/ethyca/fides/pull/1973)
+* Add a `usage` session to Nox to print full session docstrings. [#2022](https://github.com/ethyca/fides/pull/2022)
 
 ### Changed
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,20 @@ REQUIRED_DOCKER_VERSION = "20.10.17"
 nox.options.sessions = []
 nox.options.reuse_existing_virtualenvs = True
 
+@nox.session()
+def usage(session: nox.Session) -> None:
+    """
+    Get the docstring for a Nox Session.
+    """
+    if not session.posargs:
+        session.error("Please provide a session name")
+
+    command = session.posargs[0]
+
+    if not command in globals() and not hasattr(command, "python"):
+        session.error("Sorry, this isn't a valid nox session")
+
+    session.log(globals()[command].__doc__)
 
 def check_for_env_file() -> None:
     """Create a .env file if none exists."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,7 @@ nox.options.reuse_existing_virtualenvs = True
 
 @nox.session()
 def usage(session: nox.Session) -> None:
-    """Prints the full docstring of a nox session provided via a pos arg."""
+    """Prints the documentation for a nox session provided: `nox -s usage -- <session>`."""
 
     if not session.posargs:
         session.error("Please provide a session name")

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,12 +32,14 @@ def usage(session: nox.Session) -> None:
     """Prints the documentation for a nox session provided: `nox -s usage -- <session>`."""
 
     if not session.posargs:
-        session.error("Please provide a session name")
+        session.error("Please provide a session name, such as `clean`")
 
     command = session.posargs[0]
 
     if not command in globals():
-        session.error("Sorry, this isn't a valid nox session")
+        session.error(
+            "Sorry, this isn't a valid nox session.\nExamples: `clean`, `build`, `pytest_ctl`"
+        )
 
     session.log(globals()[command].__doc__)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,20 +26,21 @@ REQUIRED_DOCKER_VERSION = "20.10.17"
 nox.options.sessions = []
 nox.options.reuse_existing_virtualenvs = True
 
+
 @nox.session()
 def usage(session: nox.Session) -> None:
-    """
-    Get the docstring for a Nox Session.
-    """
+    """Prints the full docstring of a nox session provided via a pos arg."""
+
     if not session.posargs:
         session.error("Please provide a session name")
 
     command = session.posargs[0]
 
-    if not command in globals() and not hasattr(command, "python"):
+    if not command in globals():
         session.error("Sorry, this isn't a valid nox session")
 
     session.log(globals()[command].__doc__)
+
 
 def check_for_env_file() -> None:
     """Create a .env file if none exists."""


### PR DESCRIPTION
Closes #1618

### Code Changes

* [x] add a session for `nox` that prints the entire docstring for a given session

### Steps to Confirm

* [ ] follow the examples given below and confirm everything works

### Pre-Merge Checklist

* [x] ~~All CI Pipelines Succeeded~~ Nothing here should affect any CI jobs or code logic
* Documentation Updated:
  * [x] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Using the standard `nox` command to list out all available sessions is nice and all, but it only shows the first line and isn't practical for showing in-depth information. Many session should contain a lot of usage information due to the complexity of the command given and this new session will allow us to do just that.

#### Example

No posargs provided
```
fides> nox -s usage 
Docker version 20.10.21, build baeda1f
nox > Running session usage
nox > Re-using existing virtual environment at .nox\usage.
nox > Session usage aborted: Please provide a session name.
```

Invalid session name provided
```
fides> nox -s usage -- foo
Docker version 20.10.21, build baeda1f
nox > Running session usage
nox > Re-using existing virtual environment at .nox\usage.
nox > Session usage aborted: Sorry, this isn't a valid nox session.
```

Valid session provided
```
fides> nox -s usage -- clean
Docker version 20.10.21, build baeda1f
nox > Running session usage
nox > Re-using existing virtual environment at .nox\usage.
nox > 
    Clean up docker containers, remove orphans, remove volumes
    and prune images related to this project.
    
nox > Session usage was successful.
```
