### PR TITLE
Do not always create a `fides.toml` by default

### DIFF
--- a/src/fides/cli/__init__.py
+++ b/src/fides/cli/__init__.py
@@ -96,6 +96,7 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
         check_server(VERSION, str(config.cli.server_url), quiet=True)
 
     ctx.obj["CONFIG"] = config
+    # This should only get called by `fides init`
     create_config_file(ctx)
 
     # init also handles this workflow

--- a/src/fides/cli/__init__.py
+++ b/src/fides/cli/__init__.py
@@ -9,7 +9,6 @@ import fides
 from fides.cli.utils import (
     check_and_update_analytics_config,
     check_server,
-    create_config_file,
 )
 from fides.ctl.core.config import get_config
 
@@ -45,7 +44,6 @@ ALL_COMMANDS = API_COMMANDS + LOCAL_COMMANDS
 SERVER_CHECK_COMMAND_NAMES = [
     command.name for command in API_COMMANDS if command.name not in ["status", "worker"]
 ]
-WITHOUT_ANALYTICS_COMMANDS = ["init", "deploy", "webserver"]
 VERSION = fides.__version__
 APP = fides.__name__
 PACKAGE = "ethyca-fides"
@@ -96,22 +94,17 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
         check_server(VERSION, str(config.cli.server_url), quiet=True)
 
     ctx.obj["CONFIG"] = config
-    # This should only get called by `fides init`
-    create_config_file(ctx)
 
-    # init also handles this workflow
-    if ctx.invoked_subcommand not in WITHOUT_ANALYTICS_COMMANDS:
-        check_and_update_analytics_config(ctx, config_path)
-
-        # Analytics requires explicit opt-in
-        if config.user.analytics_opt_out is False:
-            ctx.meta["ANALYTICS_CLIENT"] = AnalyticsClient(
-                client_id=config.cli.analytics_id,
-                developer_mode=config.test_mode,
-                os=system(),
-                product_name=APP + "-cli",
-                production_version=version(PACKAGE),
-            )
+    # Analytics requires explicit opt-in
+    no_analytics = config.user.analytics_opt_out
+    if not no_analytics:
+        ctx.meta["ANALYTICS_CLIENT"] = AnalyticsClient(
+            client_id=config.cli.analytics_id,
+            developer_mode=config.test_mode,
+            os=system(),
+            product_name=APP + "-cli",
+            production_version=version(PACKAGE),
+        )
 
 
 # Add all commands here before dynamically checking them in the CLI

--- a/src/fides/cli/commands/util.py
+++ b/src/fides/cli/commands/util.py
@@ -42,7 +42,6 @@ def init(ctx: click.Context, fides_directory_location: str) -> None:
 
     click.echo(FIDES_ASCII_ART)
     click.echo("Initializing fides...")
-    print_divider()
 
     # create the config file as needed
     config_path = create_config_file(
@@ -52,7 +51,6 @@ def init(ctx: click.Context, fides_directory_location: str) -> None:
 
     # request explicit consent for analytics collection
     check_and_update_analytics_config(ctx=ctx, config_path=config_path)
-    print_divider()
 
     send_init_analytics(config.user.analytics_opt_out, config_path, executed_at)
     echo_green("fides initialization complete.")

--- a/src/fides/cli/utils.py
+++ b/src/fides/cli/utils.py
@@ -59,16 +59,17 @@ FIDES_ASCII_ART = """
 """
 
 
-def check_server_health(server_url: str) -> requests.Response:
+def check_server_health(server_url: str, verbose: bool = True) -> requests.Response:
     """Hit the '/health' endpoint and verify the server is available."""
 
     healthcheck_url = server_url + "/health"
     try:
         health_response = check_response(_api.ping(healthcheck_url))
     except requests.exceptions.ConnectionError:
-        echo_red(
-            f"Connection failed, webserver is unreachable at URL:\n{healthcheck_url}."
-        )
+        if verbose:
+            echo_red(
+                f"Connection failed, webserver is unreachable at URL:\n{healthcheck_url}."
+            )
         raise SystemExit(1)
     return health_response
 
@@ -227,7 +228,7 @@ def check_and_update_analytics_config(ctx: click.Context, config_path: str) -> N
         if ctx.obj["CONFIG"].user.analytics_opt_out is False:
             server_url = ctx.obj["CONFIG"].cli.server_url
             try:
-                check_server_health(server_url)
+                check_server_health(server_url, verbose=False)
                 should_attempt_registration = not is_user_registered(ctx)
             except SystemExit:
                 should_attempt_registration = False

--- a/src/fides/cli/utils.py
+++ b/src/fides/cli/utils.py
@@ -28,7 +28,7 @@ from fideslog.sdk.python.utils import (
 )
 from requests import get, put
 
-from fides import __name__ as app_name
+import fides
 from fides.api.ops.api.v1.urn_registry import REGISTRATION, V1_URL_PREFIX
 from fides.ctl.connectors.models import (
     AWSConfig,
@@ -47,6 +47,8 @@ from fides.ctl.core.config.credentials_settings import (
 from fides.ctl.core.config.utils import get_config_from_file, update_config_file
 from fides.ctl.core.utils import check_response, echo_green, echo_red
 
+APP = fides.__name__
+PACKAGE = "ethyca-fides"
 FIDES_ASCII_ART = """
 ███████╗██╗██████╗ ███████╗███████╗
 ██╔════╝██║██╔══██╗██╔════╝██╔════╝
@@ -277,8 +279,8 @@ def send_init_analytics(opt_out: bool, config_path: str, executed_at: datetime) 
             client_id=analytics_id or generate_client_id(FIDESCTL_CLI),
             developer_mode=bool(getenv("FIDES_TEST_MODE") == "True"),
             os=system(),
-            product_name=app_name + "-cli",
-            production_version=version(app_name),
+            product_name=APP + "-cli",
+            production_version=version(PACKAGE),
         )
 
         event = AnalyticsEvent(

--- a/src/fides/cli/utils.py
+++ b/src/fides/cli/utils.py
@@ -197,18 +197,18 @@ def register_user(ctx: click.Context, email: str, organization: str) -> None:
 
 def check_and_update_analytics_config(ctx: click.Context, config_path: str) -> None:
     """
-    Ensure the analytics-related config is present. If not,
-    prompt the user to opt-in to analytics and/or update the
-    config file with their preferences.
+    Verify that the analytics opt-out value is populated. If not,
+    prompt the user to opt-in to analytics and update the config
+    file with their preferences if needed.
+
+    NOTE: This doesn't handle the case where we've collected consent for this
+    CLI instance, but are connected to a server for the first time that is
+    unregistered. This *should* be something we can detect and then
+    "re-prompt" the user for their email/org information, but right
+    now a lot of our test automation runs headless and this kind of
+    prompt can't be skipped otherwise.
     """
 
-    # Prompt for user prompt if we've not collected explicit opt-out or opt-in
-    #
-    # NOTE: this doesn't handle the case where we've collected consent for this CLI,
-    # but are connected to a server for the first time that is unregistered.
-    # This *should* be something we can detect and then "re-prompt" the user for
-    # their email/org information, but right now a lot of our test automation
-    # runs headless and this kind of prompt can't be skipped otherwsie
     config_updates: Dict[str, Dict] = {}
     if ctx.obj["CONFIG"].user.analytics_opt_out is None:
         click.echo(OPT_OUT_COPY)


### PR DESCRIPTION
Closes #1661

### Code Changes

* [x] remove the call to create the config from within the main CLI codepath
* [x] only run `check_and_update_analytics_config` when `fides init` is run

### Steps to Confirm

* [ ] head into a fresh directory and run `fides`, confirm no file was written and no `.fides` dir exists
* [ ] run `fides init` and confirm that the flow works, as well as prompting about user analytics

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

The side-effect of having the `fides.toml` _always_ be created whether it exists or not is a bit redundant and potentially error-prone (see the attached issue for more discussion). As such, the config file should only be created when a user specifically runs the `fides init` command

Due to this change though, we also needed to update how `analytics_opt_out` is handled, given that before we always expected the user to have a file-based configuration file to update. The behaviour is now that we assume analytics is false if there is no config file, but will prompt the user for it when they run `fides init`. This means we defaulting to `opt-out` and are no longer prompting the user every time they use the CLI to update this. I think this is no longer a major issue, as we should be relying more heavily on the `user registration` flow for valuable usage analytics.