### PR TITLE
ui: Common Subscriptions for app-wide data and feature checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The types of changes are:
 * `Security` in case of vulnerabilities.
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.2.2...main)
+### Added
+
+* Common Subscriptions for app-wide data and feature checks. [#2030](https://github.com/ethyca/fides/pull/2030)
 
 ### Fixed
 

--- a/clients/admin-ui/cypress/e2e/auth.cy.ts
+++ b/clients/admin-ui/cypress/e2e/auth.cy.ts
@@ -1,5 +1,3 @@
-import { stubHomePage } from "cypress/support/stubs";
-
 import { USER_PRIVILEGES } from "~/constants";
 
 describe("User Authentication", () => {
@@ -21,7 +19,6 @@ describe("User Authentication", () => {
       cy.visit("/login");
       cy.getByTestId("Login");
 
-      stubHomePage();
       cy.intercept("GET", "/api/v1/system", { body: [] });
       cy.fixture("login.json").then((body) => {
         cy.intercept("POST", "/api/v1/login", body).as("postLogin");
@@ -44,7 +41,6 @@ describe("User Authentication", () => {
   describe("when the user is logged in", () => {
     beforeEach(() => {
       cy.login();
-      stubHomePage();
     });
 
     it("lets them navigate to protected routes", () => {

--- a/clients/admin-ui/cypress/e2e/datasets-classify.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets-classify.cy.ts
@@ -1,7 +1,6 @@
 import {
   CONNECTION_STRING,
   stubDatasetCrud,
-  stubHomePage,
   stubPlus,
 } from "cypress/support/stubs";
 
@@ -37,7 +36,6 @@ describe("Datasets with Fides Classify", () => {
     });
 
     it("Can render the 'Status' column and classification status badges in the dataset table when plus features are enabled", () => {
-      stubHomePage();
       cy.visit("/");
       cy.getByTestId("nav-link-Datasets").click();
       cy.wait("@getDatasets");

--- a/clients/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets.cy.ts
@@ -1,7 +1,6 @@
 import {
   CONNECTION_STRING,
   stubDatasetCrud,
-  stubHomePage,
   stubPlus,
 } from "cypress/support/stubs";
 
@@ -15,7 +14,6 @@ describe("Dataset", () => {
 
   describe("List of datasets view", () => {
     it("Can navigate to the datasets list view", () => {
-      stubHomePage();
       cy.visit("/");
       cy.getByTestId("nav-link-Datasets").click();
       cy.wait("@getDatasets");

--- a/clients/admin-ui/cypress/e2e/nav-bar.cy.ts
+++ b/clients/admin-ui/cypress/e2e/nav-bar.cy.ts
@@ -1,12 +1,9 @@
-import { stubHomePage } from "cypress/support/stubs";
-
 describe("Nav Bar", () => {
   beforeEach(() => {
     cy.login();
   });
 
   it("Renders all page links", () => {
-    stubHomePage();
     cy.visit("/");
 
     cy.getByTestId("nav-link-Privacy Requests");

--- a/clients/admin-ui/cypress/e2e/systems-classify.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-classify.cy.ts
@@ -1,8 +1,4 @@
-import {
-  stubHomePage,
-  stubPlus,
-  stubTaxonomyEntities,
-} from "cypress/support/stubs";
+import { stubPlus, stubTaxonomyEntities } from "cypress/support/stubs";
 
 describe("Classify systems page", () => {
   beforeEach(() => {
@@ -13,7 +9,6 @@ describe("Classify systems page", () => {
   });
 
   it("Should reroute if not in plus", () => {
-    stubHomePage();
     stubPlus(false);
     cy.visit("/classify-systems");
     cy.url().should("eql", `${Cypress.config().baseUrl}/`);

--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -1,8 +1,4 @@
-import {
-  stubHomePage,
-  stubSystemCrud,
-  stubTaxonomyEntities,
-} from "cypress/support/stubs";
+import { stubSystemCrud, stubTaxonomyEntities } from "cypress/support/stubs";
 
 describe("System management page", () => {
   beforeEach(() => {
@@ -13,7 +9,6 @@ describe("System management page", () => {
   });
 
   it("Can navigate to the system management page", () => {
-    stubHomePage();
     cy.visit("/");
     cy.getByTestId("nav-link-Systems").click();
     cy.wait("@getSystems");

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -1,5 +1,3 @@
-import { stubHomePage } from "cypress/support/stubs";
-
 describe("Taxonomy management page", () => {
   beforeEach(() => {
     cy.login();
@@ -18,7 +16,6 @@ describe("Taxonomy management page", () => {
   });
 
   it("Can navigate to the taxonomy page", () => {
-    stubHomePage();
     cy.visit("/");
     cy.getByTestId("nav-link-Taxonomy").click();
     cy.getByTestId("taxonomy-tabs");

--- a/clients/admin-ui/cypress/support/e2e.ts
+++ b/clients/admin-ui/cypress/support/e2e.ts
@@ -14,7 +14,17 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import "./commands";
+
+import { stubHomePage, stubPlus, stubSystemCrud } from "./stubs";
+
+// Stub global subscriptions because they are required for every page. These just default
+// responses -- interceptions defined later will override them.
+beforeEach(() => {
+  stubHomePage();
+  stubSystemCrud();
+  stubPlus(false);
+});
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/clients/admin-ui/src/features/auth/ProtectedRoute.tsx
+++ b/clients/admin-ui/src/features/auth/ProtectedRoute.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import { ReactNode } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { LOGIN_ROUTE, VERIFY_AUTH_INTERVAL } from "~/constants";
@@ -29,23 +30,19 @@ const useProtectedRoute = (redirectUrl: string) => {
 };
 
 interface ProtectedRouteProps {
-  redirectUrl: string;
-  authenticatedBlock: JSX.Element;
-  children: JSX.Element;
+  children: ReactNode;
+  redirectUrl?: string;
 }
 
 const ProtectedRoute = ({
   children,
-  redirectUrl,
-  authenticatedBlock,
+  redirectUrl = LOGIN_ROUTE,
 }: ProtectedRouteProps) => {
   const authenticated = useProtectedRoute(redirectUrl);
-  return authenticated ? children : authenticatedBlock;
-};
 
-ProtectedRoute.defaultProps = {
-  authenticatedBlock: null,
-  redirectUrl: LOGIN_ROUTE,
+  // Silly type error: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return authenticated ? <>{children}</> : null;
 };
 
 export default ProtectedRoute;

--- a/clients/admin-ui/src/features/common/CommonSubscriptions.tsx
+++ b/clients/admin-ui/src/features/common/CommonSubscriptions.tsx
@@ -1,0 +1,28 @@
+import {
+  INITIAL_CONNECTIONS_FILTERS,
+  useGetAllDatastoreConnectionsQuery,
+} from "~/features/datastore-connections/datastore-connection.slice";
+import { useGetHealthQuery } from "~/features/plus/plus.slice";
+import { useGetAllSystemsQuery } from "~/features/system/system.slice";
+
+const useCommonSubscriptions = () => {
+  useGetHealthQuery();
+  useGetAllSystemsQuery();
+  useGetAllDatastoreConnectionsQuery(INITIAL_CONNECTIONS_FILTERS);
+};
+
+/**
+ * This component exists only to subscribe RTK Queries whose data should be available on _every
+ * page_. To add a global subscription, update the `useCommonSubscriptions` hook.
+ *
+ * To access the data from these queries, select the data from query's cache. More info on this
+ * pattern:
+ * https://redux.js.org/tutorials/essentials/part-8-rtk-query-advanced#selecting-users-data
+ */
+const CommonSubscriptions = () => {
+  useCommonSubscriptions();
+
+  return null;
+};
+
+export default CommonSubscriptions;

--- a/clients/admin-ui/src/features/common/features.slice.ts
+++ b/clients/admin-ui/src/features/common/features.slice.ts
@@ -1,5 +1,7 @@
 import { useAppSelector } from "~/app/hooks";
-import { selectHealth, useHasPlus } from "~/features/plus/plus.slice";
+import { selectInitialConnections } from "~/features/datastore-connections";
+import { selectHealth } from "~/features/plus/plus.slice";
+import { selectAllSystems } from "~/features/system";
 
 /**
  * Features are currently stateless and only use the Plus API. However, this a ".slice" file because
@@ -8,16 +10,26 @@ import { selectHealth, useHasPlus } from "~/features/plus/plus.slice";
 export interface Features {
   plus: boolean;
   dataFlowScanning: boolean;
+  systemsCount: number;
+  connectionsCount: number;
 }
 
 export const useFeatures = (): Features => {
-  const hasPlus = useHasPlus();
   const health = useAppSelector(selectHealth);
+  const allSystems = useAppSelector(selectAllSystems);
+  const initialConnections = useAppSelector(selectInitialConnections);
 
+  const plus = health !== undefined;
   const dataFlowScanning = health ? !!health.system_scanner.enabled : false;
 
+  const systemsCount = allSystems?.length ?? 0;
+
+  const connectionsCount = initialConnections?.total ?? 0;
+
   return {
-    plus: hasPlus,
+    plus,
     dataFlowScanning,
+    systemsCount,
+    connectionsCount,
   };
 };

--- a/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
+++ b/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { addCommonHeaders } from "common/CommonHeaders";
 
@@ -341,3 +341,23 @@ export const {
   usePatchDatastoreConnectionsMutation,
   useUpdateDatastoreConnectionSecretsMutation,
 } = datastoreConnectionApi;
+
+/**
+ * This constant is used for a `getAllDatastoreConnections` query that is run as a global
+ * subscription just to check whether the user has any connections at all.
+ */
+export const INITIAL_CONNECTIONS_FILTERS: DatastoreConnectionParams = {
+  search: "",
+  page: 1,
+  size: 5,
+};
+
+/**
+ * Returns the globally cached datastore connections response.
+ */
+export const selectInitialConnections = createSelector(
+  datastoreConnectionApi.endpoints.getAllDatastoreConnections.select(
+    INITIAL_CONNECTIONS_FILTERS
+  ),
+  ({ data }) => data
+);

--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -160,11 +160,6 @@ export const {
   useLazyGetLatestScanDiffQuery,
 } = plusApi;
 
-export const useHasPlus = () => {
-  const { isSuccess: hasPlus } = useGetHealthQuery();
-  return hasPlus;
-};
-
 export const selectHealth: (state: RootState) => HealthCheck | undefined =
   createSelector(plusApi.endpoints.getHealth.select(), ({ data }) => data);
 

--- a/clients/admin-ui/src/features/system/ClassifySystemsTable.tsx
+++ b/clients/admin-ui/src/features/system/ClassifySystemsTable.tsx
@@ -10,14 +10,12 @@ import EditClassifySystemDrawer from "./EditClassifySystemDrawer";
 import {
   selectActiveClassifySystem,
   setActiveClassifySystemFidesKey,
-  useGetAllSystemsQuery,
 } from "./system.slice";
 
 const ClassifySystemsTable = ({ systems }: { systems: System[] }) => {
   const dispatch = useAppDispatch();
   const classifyInstanceMap = useAppSelector(selectSystemClassifyInstanceMap);
   const activeSystem = useAppSelector(selectActiveClassifySystem);
-  useGetAllSystemsQuery();
 
   const handleClick = (system: System) => {
     dispatch(setActiveClassifySystemFidesKey(system.fides_key));

--- a/clients/admin-ui/src/features/system/DescribeSystemStep.tsx
+++ b/clients/admin-ui/src/features/system/DescribeSystemStep.tsx
@@ -5,7 +5,7 @@ import { Form, Formik } from "formik";
 import { useMemo, useState } from "react";
 import * as Yup from "yup";
 
-import { useAppDispatch } from "~/app/hooks";
+import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import {
   CustomCreatableMultiSelect,
   CustomMultiSelect,
@@ -21,8 +21,8 @@ import {
   transformSystemToFormValues,
 } from "~/features/system/form";
 import {
+  selectAllSystems,
   useCreateSystemMutation,
-  useGetAllSystemsQuery,
   useUpdateSystemMutation,
 } from "~/features/system/system.slice";
 import { System } from "~/types/api";
@@ -67,7 +67,7 @@ const DescribeSystemStep = ({
   const [updateSystem] = useUpdateSystemMutation();
   const [isLoading, setIsLoading] = useState(false);
   const dispatch = useAppDispatch();
-  const { data: systems } = useGetAllSystemsQuery();
+  const systems = useAppSelector(selectAllSystems);
   const systemOptions = systems
     ? systems.map((s) => ({ label: s.name ?? s.fides_key, value: s.fides_key }))
     : [];

--- a/clients/admin-ui/src/features/system/SystemRegisterSuccess.tsx
+++ b/clients/admin-ui/src/features/system/SystemRegisterSuccess.tsx
@@ -16,11 +16,11 @@ import {
 } from "@fidesui/react";
 import { useRouter } from "next/router";
 
-import { useAppDispatch } from "~/app/hooks";
+import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { StepperCircleCheckmarkIcon } from "~/features/common/Icon";
 import {
+  selectAllSystems,
   setActiveSystem,
-  useGetAllSystemsQuery,
 } from "~/features/system/system.slice";
 import { System } from "~/types/api";
 
@@ -29,7 +29,7 @@ interface Props {
   onAddNextSystem: () => void;
 }
 const SystemRegisterSuccess = ({ system, onAddNextSystem }: Props) => {
-  const { data: allRegisteredSystems } = useGetAllSystemsQuery();
+  const allRegisteredSystems = useAppSelector(selectAllSystems);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const otherSystems = allRegisteredSystems

--- a/clients/admin-ui/src/features/system/system.slice.ts
+++ b/clients/admin-ui/src/features/system/system.slice.ts
@@ -156,14 +156,19 @@ export const selectActiveClassifySystemFidesKey = createSelector(
   selectSystem,
   (state) => state.activeClassifySystemFidesKey
 );
+
+export const selectAllSystems = createSelector(
+  systemApi.endpoints.getAllSystems.select(),
+  ({ data }) => data
+);
+
 export const selectActiveClassifySystem = createSelector(
-  [(RootState) => RootState, selectActiveClassifySystemFidesKey],
-  (RootState, fidesKey) => {
+  [selectAllSystems, selectActiveClassifySystemFidesKey],
+  (allSystems, fidesKey) => {
     if (fidesKey === undefined) {
       return undefined;
     }
-    const allSystems: System[] | undefined =
-      systemApi.endpoints.getAllSystems.select()(RootState).data;
+
     const system = allSystems?.find((s) => s.fides_key === fidesKey);
     return system;
   }

--- a/clients/admin-ui/src/pages/_app.tsx
+++ b/clients/admin-ui/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 
 import ProtectedRoute from "~/features/auth/ProtectedRoute";
+import CommonSubscriptions from "~/features/common/CommonSubscriptions";
 
 import store, { persistor } from "../app/store";
 import flags from "../flags.json";
@@ -43,6 +44,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => (
               <Component {...pageProps} />
             ) : (
               <ProtectedRoute>
+                <CommonSubscriptions />
                 <Component {...pageProps} />
               </ProtectedRoute>
             )}


### PR DESCRIPTION
Necessary for https://github.com/ethyca/fides/issues/1909 and https://github.com/ethyca/fides/issues/1864


### Code Changes

- New component loaded at _app level: CommonSubscriptions
    - `useGetHealthQuery`
    -  `useGetAllSystemsQuery` 
    -  `useGetAllDatastoreConnectionsQuery` - Requests an un-filtered handful of connections just to see if there are any.
- Replace calls to `useGetAllSystemsQuery` with selection from global cache (where possible)
- `useFeatures` hook  uses global cache
    -  `systemsCount`
    - `connectionsCount`

### Steps to Confirm

* [ ] No regressions on the systems page
* [ ] No regressions in datastore connections
* [ ] No regressions in detecting that fidesplus is available

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This change introduces the CommonSubscriptions component which subscribes to the redux store a few queries for every page. These queries are used to detect which "features" are enabled, such as whether the server is Fidesplus or if the user has populated their system with key resources.

These subscriptions can also later load time for some data. For example, navigating away from the "Systems" tab will no longer unload the systems data (after an RTK-configured delay). We might even be able to add these subscriptions to the persist state, though that would require more testing.

