### PR TITLE
avoid error if access results key is not found for erasures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The types of changes are:
 ### Fixed
 
 * Timing issues with bulk DSR reprocessing, specifically when analytics are enabled [#2015](https://github.com/ethyca/fides/pull/2015)
+* Error caused by running erasure requests with disabled connectors [#2045](https://github.com/ethyca/fides/pull/2045)
 
 ## [2.2.2](https://github.com/ethyca/fides/compare/2.2.1...2.2.2)
 

--- a/src/fides/api/ops/task/graph_task.py
+++ b/src/fides/api/ops/task/graph_task.py
@@ -724,13 +724,13 @@ async def run_erasure(  # pylint: disable = too-many-arguments
         dsk: Dict[CollectionAddress, Any] = {
             k: (
                 t.erasure_request,
-                access_request_data[
-                    str(k)
-                ],  # Pass in the results of the access request for this collection
+                access_request_data.get(
+                    str(k), []
+                ),  # Pass in the results of the access request for this collection
                 *[
-                    access_request_data[
-                        str(upstream_key)
-                    ]  # Additionally pass in the original input data we used for the access request. It's helpful in
+                    access_request_data.get(
+                        str(upstream_key), []
+                    )  # Additionally pass in the original input data we used for the access request. It's helpful in
                     # cases like the EmailConnector where the access request doesn't actually retrieve data.
                     for upstream_key in t.input_keys
                 ],


### PR DESCRIPTION
Closes #2048 

### Code Changes

* default to an empty list `[]` if, in the beginning of erasure request execution, no access result cache entry is found for the given collection

### Steps to Confirm

* See issue description steps to reproduce, and ensure that requests no longer error in this scenario, but instead go to `COMPLETE`
* Also can confirm that the `Event Details` for the step associated with the disabled connector show all of its events with `skipped` status

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Passing in the empty list is effectively a no-op here, just a way to prevent an error. This is because the list doesn't actually get used, as the erasure request execution will not proceed because the connector is disabled.
