### PR TITLE
Add Non Nullable DatasetConfig.ctl_dataset_id Field

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -1025,6 +1025,9 @@ dataset:
     - name: connection_config_id
       data_categories: [system.operations]
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: ctl_dataset_id
+      data_categories: [ system.operations ]
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
     - name: created_at
       data_categories: [system.operations]
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 ### Added
 
 * Common Subscriptions for app-wide data and feature checks. [#2030](https://github.com/ethyca/fides/pull/2030)
+* New datasetconfig.ctl_dataset_id field to unify fides dataset resources [#2046](https://github.com/ethyca/fides/pull/2046)
 
 ### Added
 * Send email alerts on privacy request failures once the specified threshold is reached. [#1793](https://github.com/ethyca/fides/pull/1793)

--- a/src/fides/api/ctl/migrations/versions/216cdc7944f1_add_datasetconfig_ctl_datasets_fk.py
+++ b/src/fides/api/ctl/migrations/versions/216cdc7944f1_add_datasetconfig_ctl_datasets_fk.py
@@ -1,0 +1,125 @@
+"""add datasetconfig.ctl_dataset_id fk
+
+Adding a FK to datasetconfig pointing to the ctl_datasets table.
+Also try to automigrate datasetconfig.datasets to the ctl_datasets row
+
+Revision ID: 216cdc7944f1
+Revises: 2fb48b0e268b
+Create Date: 2022-12-09 22:03:51.097585
+
+"""
+import json
+import uuid
+from typing import Any, Dict
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.elements import TextClause
+
+revision = "216cdc7944f1"
+down_revision = "2fb48b0e268b"
+branch_labels = None
+depends_on = None
+
+AUTO_MIGRATED_STRING = "auto-migrated from datasetconfig.dataset"
+
+
+def upgrade():
+    # Schema migration
+    op.add_column(
+        "datasetconfig", sa.Column("ctl_dataset_id", sa.String(), nullable=True)
+    )
+    op.create_index(
+        op.f("ix_datasetconfig_ctl_dataset_id"),
+        "datasetconfig",
+        ["ctl_dataset_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "datasetconfig_ctl_dataset_id_fkey",
+        "datasetconfig",
+        "ctl_datasets",
+        ["ctl_dataset_id"],
+        ["id"],
+    )
+
+    # Data migration - automatically trying to port datasetconfig.dataset -> ctl_datasets if possible.
+    bind = op.get_bind()
+    existing_datasetconfigs = bind.execute(
+        text("select id, created_at, updated_at, dataset from datasetconfig;")
+    )
+    for row in existing_datasetconfigs:
+        dataset: Dict[str, Any] = row["dataset"]
+        fides_key: str = dataset["fides_key"]
+
+        insert_into_ctl_datasets_query: TextClause = text(
+            "INSERT INTO ctl_datasets (id, fides_key, organization_fides_key, name, description, meta, data_categories, "
+            "collections, data_qualifier, created_at, updated_at, joint_controller, retention, fides_meta, third_country_transfers, tags) "
+            "VALUES (:id, :fides_key, :organization_fides_key, :name, :description, :meta, :data_categories, :collections, "
+            ":data_qualifier, :created_at, :updated_at, :joint_controller, :retention, :fides_meta, :third_country_transfers, :tags)"
+        )
+
+        new_ctl_dataset_id: str = "ctl_" + str(uuid.uuid4())
+        # Stashing extra text into the "meta" column so we can use this to downgrade if needed
+        appended_meta: Dict = dataset["meta"] or {}
+        appended_meta["fides_source"] = AUTO_MIGRATED_STRING
+
+        try:
+            bind.execute(
+                insert_into_ctl_datasets_query,
+                {
+                    "id": new_ctl_dataset_id,
+                    "fides_key": fides_key,
+                    "organization_fides_key": dataset["organization_fides_key"],
+                    "name": dataset["name"],
+                    "description": dataset["description"],
+                    "meta": json.dumps(appended_meta),
+                    "data_categories": dataset["data_categories"],
+                    "collections": json.dumps(dataset["collections"]),
+                    "data_qualifier": dataset["data_qualifier"],
+                    "created_at": row["created_at"],
+                    "updated_at": row["updated_at"],
+                    "joint_controller": dataset["joint_controller"],
+                    "retention": dataset["retention"],
+                    "fides_meta": dataset.get("fides_meta")
+                    or dataset.get("fidesops_meta"),
+                    "third_country_transfers": dataset["third_country_transfers"],
+                    "tags": dataset["tags"],
+                },
+            )
+        except IntegrityError as exc:
+            raise Exception(
+                f"Attempted to copy datasetconfig.datasets into their own ctl_datasets rows but got error: {exc}. "
+                f"Adjust fides_keys in ctl_datasets table to not conflict."
+            )
+
+        update_dataset_config_query: TextClause = text(
+            "UPDATE datasetconfig set ctl_dataset_id= :new_ctl_dataset_id WHERE id= :datasetconfig_id"
+        )
+
+        bind.execute(
+            update_dataset_config_query,
+            {"new_ctl_dataset_id": new_ctl_dataset_id, "datasetconfig_id": row["id"]},
+        )
+
+
+def downgrade():
+    op.drop_constraint(
+        "datasetconfig_ctl_dataset_id_fkey", "datasetconfig", type_="foreignkey"
+    )
+    op.drop_index(op.f("ix_datasetconfig_ctl_dataset_id"), table_name="datasetconfig")
+    op.drop_column("datasetconfig", "ctl_dataset_id")
+
+    # Data migration - remove ctl_datasets that were automatically created by the forward migration
+    bind = op.get_bind()
+    remove_automigrated_ctl_datasets_query: TextClause = text(
+        "delete from ctl_datasets where meta->>'source'= :automigration_string"
+    )
+    bind.execute(
+        remove_automigrated_ctl_datasets_query,
+        {"automigration_string": AUTO_MIGRATED_STRING},
+    )

--- a/src/fides/api/ctl/migrations/versions/9c6f62e4c9da_make_datasetconfig_ctl_datasets_non_nullable.py
+++ b/src/fides/api/ctl/migrations/versions/9c6f62e4c9da_make_datasetconfig_ctl_datasets_non_nullable.py
@@ -5,9 +5,8 @@ Revises: 216cdc7944f1
 Create Date: 2022-12-09 23:56:13.022119
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "9c6f62e4c9da"

--- a/src/fides/api/ctl/migrations/versions/9c6f62e4c9da_make_datasetconfig_ctl_datasets_non_nullable.py
+++ b/src/fides/api/ctl/migrations/versions/9c6f62e4c9da_make_datasetconfig_ctl_datasets_non_nullable.py
@@ -1,0 +1,29 @@
+"""make datasetconfig.ctl_datasets non-nullable
+
+Revision ID: 9c6f62e4c9da
+Revises: 216cdc7944f1
+Create Date: 2022-12-09 23:56:13.022119
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "9c6f62e4c9da"
+down_revision = "216cdc7944f1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Followup migration to make datasetconfig.ctl_dataset_id non nullable"""
+    op.alter_column(
+        "datasetconfig", "ctl_dataset_id", existing_type=sa.VARCHAR(), nullable=False
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "datasetconfig", "ctl_dataset_id", existing_type=sa.VARCHAR(), nullable=True
+    )

--- a/src/fides/api/ctl/sql_models.py
+++ b/src/fides/api/ctl/sql_models.py
@@ -6,6 +6,7 @@ Contains all of the SqlAlchemy models for the Fides resources.
 
 from typing import Dict
 
+from fideslang.models import Dataset as FideslangDataset
 from sqlalchemy import (
     ARRAY,
     BOOLEAN,
@@ -19,6 +20,7 @@ from sqlalchemy import (
     type_coerce,
 )
 from sqlalchemy.dialects.postgresql import BYTEA
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 from sqlalchemy.sql.sqltypes import DateTime
 
@@ -199,6 +201,16 @@ class Dataset(Base, FidesBase):
     joint_controller = Column(PGEncryptedString, nullable=True)
     retention = Column(String)
     third_country_transfers = Column(ARRAY(String))
+
+    @classmethod
+    def create_from_dataset_dict(cls, db: Session, dataset: dict) -> "Dataset":
+        """Add a method to create directly using a synchronous session"""
+        validated_dataset: FideslangDataset = FideslangDataset(**dataset)
+        ctl_dataset = cls(**validated_dataset.dict())
+        db.add(ctl_dataset)
+        db.commit()
+        db.refresh(ctl_dataset)
+        return ctl_dataset
 
 
 # Evaluation

--- a/src/fides/api/ops/api/v1/endpoints/dataset_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/dataset_endpoints.py
@@ -182,13 +182,12 @@ def patch_dataset_configs(
     """
     created_or_updated: List[Dataset] = []
     failed: List[BulkUpdateFailed] = []
-    logger.info("Starting bulk upsert for %s Dataset Configs", len(dataset_pairs))
+    logger.info("Starting bulk upsert for {} Dataset Configs", len(dataset_pairs))
 
     for dataset_pair in dataset_pairs:
         logger.info(
-            "Finding ctl_dataset with key '%s'", dataset_pair.ctl_dataset_fides_key
+            "Finding ctl_dataset with key '{}'", dataset_pair.ctl_dataset_fides_key
         )
-
         ctl_dataset: CtlDataset = (
             db.query(CtlDataset)
             .filter_by(fides_key=dataset_pair.ctl_dataset_fides_key)
@@ -199,7 +198,7 @@ def patch_dataset_configs(
         data = {
             "connection_config_id": connection_config.id,
             "fides_key": dataset_pair.fides_key,
-            "dataset": fetched_dataset.dict(),  # TODO Unified Fides Resources: Remove writing to this field.
+            "dataset": fetched_dataset.dict(),
             "ctl_dataset_id": ctl_dataset.id,
         }
 
@@ -266,7 +265,7 @@ def patch_datasets(
             dataset,
             db,
             failed,
-            DatasetConfig.create_or_update_with_ctl_dataset,
+            DatasetConfig.upsert_with_ctl_dataset,
         )
     return BulkPutDataset(
         succeeded=created_or_updated,
@@ -320,7 +319,7 @@ async def patch_yaml_datasets(
                 Dataset(**dataset),
                 db,
                 failed,
-                DatasetConfig.create_or_update_with_ctl_dataset,
+                DatasetConfig.upsert_with_ctl_dataset,
             )
     return BulkPutDataset(
         succeeded=created_or_updated,
@@ -342,7 +341,7 @@ def create_or_update_dataset(
             _validate_saas_dataset(connection_config, dataset)  # type: ignore
         # Try to find an existing DatasetConfig matching the given connection & key
         dataset_config = create_method(db, data=data)
-        created_or_updated.append(dataset_config.dataset)
+        created_or_updated.append(dataset_config.ctl_dataset)
     except (
         SaaSConfigNotFoundException,
         ValidationError,

--- a/src/fides/api/ops/api/v1/endpoints/dataset_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/dataset_endpoints.py
@@ -338,6 +338,8 @@ def create_or_update_dataset(
 ) -> None:
     try:
         if connection_config.connection_type == ConnectionType.saas:
+            # Validating here instead of on ctl_dataset creation because this only applies
+            # when a ctl_dataset is being linked to a Saas Connector.
             _validate_saas_dataset(connection_config, dataset)  # type: ignore
         # Try to find an existing DatasetConfig matching the given connection & key
         dataset_config = create_method(db, data=data)

--- a/src/fides/api/ops/api/v1/endpoints/saas_config_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/saas_config_endpoints.py
@@ -334,6 +334,7 @@ def instantiate_connection_from_template(
         template_values.instance_key,
         saas_connector_type,
     )
+
     return SaasConnectionTemplateResponse(
-        connection=connection_config, dataset=dataset_config.dataset
+        connection=connection_config, dataset=dataset_config.ctl_dataset
     )

--- a/src/fides/api/ops/api/v1/urn_registry.py
+++ b/src/fides/api/ops/api/v1/urn_registry.py
@@ -109,11 +109,12 @@ ACCESS_MANUAL_WEBHOOK = CONNECTION_BY_KEY + "/access_manual_webhook"
 
 # Collection URLs
 DATASET_VALIDATE = CONNECTION_BY_KEY + "/validate_dataset"
-DATASETS = CONNECTION_BY_KEY + "/dataset"
+DATASETS = CONNECTION_BY_KEY + "/dataset"  # TODO Unified Fides Resources DEPRECATE
+DATASET_CONFIGS = CONNECTION_BY_KEY + "/datasetconfig"
 DATASET_BY_KEY = CONNECTION_BY_KEY + "/dataset/{fides_key}"
 
 # YAML Collection URLs
-YAML_DATASETS = YAML + DATASETS
+YAML_DATASETS = YAML + DATASETS  # TODO Unified Fides Resources DEPRECATE
 
 # SaaS Config URLs
 SAAS_CONFIG_VALIDATE = CONNECTION_BY_KEY + "/validate_saas_config"

--- a/src/fides/api/ops/api/v1/urn_registry.py
+++ b/src/fides/api/ops/api/v1/urn_registry.py
@@ -109,12 +109,12 @@ ACCESS_MANUAL_WEBHOOK = CONNECTION_BY_KEY + "/access_manual_webhook"
 
 # Collection URLs
 DATASET_VALIDATE = CONNECTION_BY_KEY + "/validate_dataset"
-DATASETS = CONNECTION_BY_KEY + "/dataset"  # TODO Unified Fides Resources DEPRECATE
+DATASETS = CONNECTION_BY_KEY + "/dataset"
 DATASET_CONFIGS = CONNECTION_BY_KEY + "/datasetconfig"
 DATASET_BY_KEY = CONNECTION_BY_KEY + "/dataset/{fides_key}"
 
 # YAML Collection URLs
-YAML_DATASETS = YAML + DATASETS  # TODO Unified Fides Resources DEPRECATE
+YAML_DATASETS = YAML + DATASETS
 
 # SaaS Config URLs
 SAAS_CONFIG_VALIDATE = CONNECTION_BY_KEY + "/validate_saas_config"

--- a/src/fides/api/ops/models/datasetconfig.py
+++ b/src/fides/api/ops/models/datasetconfig.py
@@ -108,7 +108,9 @@ class DatasetConfig(Base):
         else:
             fetched_ctl_dataset = (
                 db.query(CtlDataset)
-                .filter(CtlDataset.fides_key == data["fides_key"])
+                .filter(
+                    CtlDataset.fides_key == data.get("dataset", {}).get("fides_key")
+                )
                 .first()
             )
             ctl_dataset = upsert_ctl_dataset(

--- a/src/fides/api/ops/models/datasetconfig.py
+++ b/src/fides/api/ops/models/datasetconfig.py
@@ -8,6 +8,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Session, relationship
 
+from fides.api.ctl.sql_models import Dataset
 from fides.api.ops.common_exceptions import ValidationError
 from fides.api.ops.graph.config import (
     Collection,
@@ -40,6 +41,7 @@ class DatasetConfig(Base):
     dataset = Column(
         MutableDict.as_mutable(JSONB), index=False, unique=False, nullable=False
     )
+    ctl_dataset_id = Column(String, ForeignKey(Dataset.id), index=True, nullable=False)
 
     connection_config = relationship(
         ConnectionConfig,

--- a/src/fides/api/ops/schemas/dataset.py
+++ b/src/fides/api/ops/schemas/dataset.py
@@ -99,6 +99,11 @@ class ValidateDatasetResponse(BaseSchema):
     traversal_details: DatasetTraversalDetails
 
 
+class DatasetConfigCtlDataset(BaseSchema):
+    fides_key: FidesKey  # The fides_key for the DatasetConfig
+    ctl_dataset_fides_key: FidesKey  # The fides_key for the ctl_datasets record
+
+
 class BulkPutDataset(BulkResponse):
     """Schema with mixed success/failure responses for Bulk Create/Update of Datasets."""
 

--- a/src/fides/api/ops/service/connectors/email_connector.py
+++ b/src/fides/api/ops/service/connectors/email_connector.py
@@ -177,7 +177,7 @@ def email_connector_erasure_send(db: Session, privacy_request: PrivacyRequest) -
         template_values: List[
             CheckpointActionRequired
         ] = privacy_request.get_email_connector_template_contents_by_dataset(
-            CurrentStep.erasure, ds.dataset.get("fides_key")
+            CurrentStep.erasure, ds.ctl_dataset.fides_key
         )
 
         if not template_values:

--- a/src/fides/api/ops/service/connectors/saas/connector_registry_service.py
+++ b/src/fides/api/ops/service/connectors/saas/connector_registry_service.py
@@ -131,7 +131,7 @@ def upsert_dataset_config_from_template(
         "fides_key": template_values.instance_key,
         "dataset": dataset_from_template,
     }
-    dataset_config = DatasetConfig.create_or_update_with_ctl_dataset(db, data=data)
+    dataset_config = DatasetConfig.upsert_with_ctl_dataset(db, data=data)
     return dataset_config
 
 

--- a/src/fides/api/ops/service/connectors/saas/connector_registry_service.py
+++ b/src/fides/api/ops/service/connectors/saas/connector_registry_service.py
@@ -131,7 +131,7 @@ def upsert_dataset_config_from_template(
         "fides_key": template_values.instance_key,
         "dataset": dataset_from_template,
     }
-    dataset_config = DatasetConfig.create_or_update(db, data=data)
+    dataset_config = DatasetConfig.create_or_update_with_ctl_dataset(db, data=data)
     return dataset_config
 
 

--- a/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
@@ -592,9 +592,7 @@ class TestPutDatasetConfigs:
         updated = dataset_config.updated_at
 
         db.expunge(ctl_dataset)
-        make_transient(
-            ctl_dataset
-        )  # http://docs.sqlalchemy.org/en/rel_1_1/orm/session_api.html#sqlalchemy.orm.session.make_transient
+        make_transient(ctl_dataset)
 
         ctl_dataset.id = str(uuid.uuid4())
         ctl_dataset.fides_key = "new_ctl_dataset"

--- a/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from typing import Dict, List, Optional
 from unittest import mock
 from unittest.mock import Mock
@@ -7,8 +8,10 @@ import pydash
 import pytest
 from fastapi import HTTPException
 from fastapi_pagination import Params
+from fideslang import Dataset
 from pydash import filter_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, make_transient
+from sqlalchemy.orm.attributes import flag_modified
 from starlette.testclient import TestClient
 
 from fides.api.ops.api.v1.scope_registry import (
@@ -18,6 +21,7 @@ from fides.api.ops.api.v1.scope_registry import (
 )
 from fides.api.ops.api.v1.urn_registry import (
     DATASET_BY_KEY,
+    DATASET_CONFIGS,
     DATASET_VALIDATE,
     DATASETS,
     V1_URL_PREFIX,
@@ -412,6 +416,413 @@ class TestValidateDataset:
         assert response_body["traversal_details"]["msg"] is None
 
 
+@pytest.mark.asyncio
+class TestPutDatasetConfigs:
+    @pytest.fixture
+    def datasets_url(self, connection_config) -> str:
+        path = V1_URL_PREFIX + DATASET_CONFIGS
+        path_params = {"connection_key": connection_config.key}
+        return path.format(**path_params)
+
+    @pytest.fixture
+    def request_body(self, ctl_dataset):
+        return [
+            {
+                "fides_key": "test_fides_key",
+                "ctl_dataset_fides_key": ctl_dataset.fides_key,
+            }
+        ]
+
+    def test_patch_datasets_not_authenticated(
+        self, datasets_url, api_client, request_body
+    ) -> None:
+        response = api_client.patch(datasets_url, headers={}, json=request_body)
+        assert response.status_code == 401
+
+    def test_patch_datasets_wrong_scope(
+        self,
+        request_body,
+        datasets_url,
+        api_client: TestClient,
+        generate_auth_header,
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[DATASET_READ])
+        response = api_client.patch(
+            datasets_url, headers=auth_header, json=request_body
+        )
+        assert response.status_code == 403
+
+    def test_patch_create_datasets_by_ctl_dataset_key(
+        self,
+        ctl_dataset,
+        generate_auth_header,
+        api_client,
+        datasets_url,
+        db,
+        request_body,
+    ):
+        auth_header = generate_auth_header(scopes=[DATASET_CREATE_OR_UPDATE])
+        response = api_client.patch(
+            datasets_url,
+            headers=auth_header,
+            json=request_body,
+        )
+        assert response.status_code == 200
+        dataset_config = DatasetConfig.get_by(
+            db=db, field="fides_key", value="test_fides_key"
+        )
+        assert dataset_config.ctl_dataset_id == ctl_dataset.id
+        assert (
+            dataset_config.ctl_dataset.fides_key == ctl_dataset.fides_key
+        ), "Differs from datasetconfig.fides_key in this case"
+        assert (
+            dataset_config.dataset["fides_key"] == ctl_dataset.fides_key
+        ), "Differs from datasetconfig.fides_key in this case"
+
+        succeeded = response.json()["succeeded"][0]
+        assert (
+            succeeded["fides_key"] == "postgres_example_subscriptions_dataset"
+        ), "Returns the fides_key of the ctl_dataset not the DatasetConfig"
+        assert succeeded["collections"] == Dataset.from_orm(ctl_dataset).collections
+
+        dataset_config.delete(db)
+
+    def test_patch_datasets_invalid_connection_key(
+        self, request_body, api_client: TestClient, generate_auth_header
+    ) -> None:
+        path = V1_URL_PREFIX + DATASETS
+        path_params = {"connection_key": "nonexistent_key"}
+        datasets_url = path.format(**path_params)
+
+        auth_header = generate_auth_header(scopes=[DATASET_CREATE_OR_UPDATE])
+        response = api_client.patch(
+            datasets_url, headers=auth_header, json=request_body
+        )
+        assert response.status_code == 404
+
+    def test_patch_datasets_bulk_create_limit_exceeded(
+        self, api_client: TestClient, request_body, generate_auth_header, datasets_url
+    ):
+        payload = []
+        for i in range(0, 51):
+            payload.append(request_body[0])
+
+        auth_header = generate_auth_header(scopes=[DATASET_CREATE_OR_UPDATE])
+        response = api_client.patch(datasets_url, headers=auth_header, json=payload)
+
+        assert 422 == response.status_code
+        assert (
+            json.loads(response.text)["detail"][0]["msg"]
+            == "ensure this value has at most 50 items"
+        )
+
+    def test_patch_create_datasets_bulk_create(
+        self,
+        ctl_dataset,
+        generate_auth_header,
+        api_client,
+        datasets_url,
+        db,
+        request_body,
+    ):
+        request_body.append(
+            {
+                "fides_key": "second_dataset_config",
+                "ctl_dataset_fides_key": ctl_dataset.fides_key,
+            }
+        )
+
+        auth_header = generate_auth_header(scopes=[DATASET_CREATE_OR_UPDATE])
+        response = api_client.patch(
+            datasets_url,
+            headers=auth_header,
+            json=request_body,
+        )
+
+        assert response.status_code == 200
+        response_body = json.loads(response.text)
+        assert len(response_body["succeeded"]) == 2
+        assert len(response_body["failed"]) == 0
+
+        first_dataset_config = DatasetConfig.get_by(
+            db=db, field="fides_key", value="test_fides_key"
+        )
+        assert first_dataset_config.ctl_dataset == ctl_dataset
+        assert (
+            response_body["succeeded"][0]["collections"]
+            == first_dataset_config.dataset["collections"]
+        )
+        assert response_body["succeeded"][0]["fides_key"] == ctl_dataset.fides_key
+        assert (
+            first_dataset_config.dataset["collections"]
+            == Dataset.from_orm(ctl_dataset).collections
+        )
+        assert len(first_dataset_config.dataset["collections"]) == 1
+
+        second_dataset_config = DatasetConfig.get_by(
+            db=db, field="fides_key", value="second_dataset_config"
+        )
+        assert (
+            response_body["succeeded"][1]["collections"]
+            == first_dataset_config.dataset["collections"]
+        )
+        assert response_body["succeeded"][1]["fides_key"] == ctl_dataset.fides_key
+        assert second_dataset_config.ctl_dataset == ctl_dataset
+        assert (
+            second_dataset_config.dataset["collections"]
+            == Dataset.from_orm(ctl_dataset).collections
+        )
+
+        first_dataset_config.delete(db)
+        second_dataset_config.delete(db)
+
+    def test_patch_update_dataset_configs(
+        self,
+        ctl_dataset,
+        generate_auth_header,
+        api_client,
+        datasets_url,
+        db,
+        request_body,
+        dataset_config,
+    ):
+
+        old_ctl_dataset_id = dataset_config.ctl_dataset.id
+        assert dataset_config.ctl_dataset == ctl_dataset
+        updated = dataset_config.updated_at
+
+        db.expunge(ctl_dataset)
+        make_transient(
+            ctl_dataset
+        )  # http://docs.sqlalchemy.org/en/rel_1_1/orm/session_api.html#sqlalchemy.orm.session.make_transient
+
+        ctl_dataset.id = str(uuid.uuid4())
+        ctl_dataset.fides_key = "new_ctl_dataset"
+        ctl_dataset.description = "updated description"
+        db.add(ctl_dataset)
+        db.commit()
+        db.refresh(ctl_dataset)
+
+        auth_header = generate_auth_header(scopes=[DATASET_CREATE_OR_UPDATE])
+        response = api_client.patch(
+            datasets_url,
+            headers=auth_header,
+            json=[
+                {
+                    "fides_key": dataset_config.fides_key,
+                    "ctl_dataset_fides_key": "new_ctl_dataset",
+                }
+            ],
+        )
+
+        assert response.status_code == 200
+        response_body = json.loads(response.text)
+        assert len(response_body["succeeded"]) == 1
+        assert len(response_body["failed"]) == 0
+
+        db.refresh(dataset_config)
+        assert dataset_config.ctl_dataset_id != old_ctl_dataset_id
+        assert dataset_config.updated_at != updated
+        assert response_body["succeeded"][0]["fides_key"] == "new_ctl_dataset"
+        assert response_body["succeeded"][0]["description"] == "updated description"
+        assert dataset_config.dataset["description"] == "updated description"
+        assert len(dataset_config.dataset["collections"]) == 1
+
+    @pytest.mark.unit_saas
+    def test_patch_datasets_missing_saas_config(
+        self,
+        saas_example_connection_config_without_saas_config,
+        saas_ctl_dataset,
+        api_client: TestClient,
+        generate_auth_header,
+    ):
+        path = V1_URL_PREFIX + DATASET_CONFIGS
+        path_params = {
+            "connection_key": saas_example_connection_config_without_saas_config.key
+        }
+        datasets_url = path.format(**path_params)
+
+        auth_header = generate_auth_header(scopes=[DATASET_CREATE_OR_UPDATE])
+        response = api_client.patch(
+            datasets_url,
+            headers=auth_header,
+            json=[
+                {
+                    "fides_key": saas_ctl_dataset.fides_key,
+                    "ctl_dataset_fides_key": saas_ctl_dataset.fides_key,
+                }
+            ],
+        )
+        assert response.status_code == 200
+
+        response_body = json.loads(response.text)
+        assert len(response_body["succeeded"]) == 0
+        assert len(response_body["failed"]) == 1
+        assert (
+            response_body["failed"][0]["message"]
+            == f"Connection config '{saas_example_connection_config_without_saas_config.key}' "
+            "must have a SaaS config before validating or adding a dataset"
+        )
+
+    @pytest.mark.unit_saas
+    def test_patch_datasets_extra_reference(
+        self,
+        saas_example_connection_config,
+        saas_ctl_dataset,
+        api_client: TestClient,
+        db: Session,
+        generate_auth_header,
+    ):
+        path = V1_URL_PREFIX + DATASET_CONFIGS
+        path_params = {"connection_key": saas_example_connection_config.key}
+        datasets_url = path.format(**path_params)
+
+        saas_ctl_dataset.collections[0]["fields"][0]["fides_meta"]["references"] = [
+            {
+                "dataset": "postgres_example_test_dataset",
+                "field": "another.field",
+                "direction": "from",
+            },
+        ]
+        flag_modified(saas_ctl_dataset, "collections")
+        db.add(saas_ctl_dataset)
+        db.commit()
+
+        auth_header = generate_auth_header(scopes=[DATASET_CREATE_OR_UPDATE])
+        response = api_client.patch(
+            datasets_url,
+            headers=auth_header,
+            json=[
+                {
+                    "fides_key": saas_example_connection_config.saas_config[
+                        "fides_key"
+                    ],
+                    "ctl_dataset_fides_key": saas_ctl_dataset.fides_key,
+                }
+            ],
+        )
+        assert response.status_code == 200
+
+        response_body = json.loads(response.text)
+        assert len(response_body["succeeded"]) == 0
+        assert len(response_body["failed"]) == 1
+        assert (
+            response_body["failed"][0]["message"]
+            == "A dataset for a ConnectionConfig type of 'saas' is not allowed to have "
+            "references or identities. Please add them to the SaaS config."
+        )
+
+    @pytest.mark.unit_saas
+    def test_patch_datasets_extra_identity(
+        self,
+        saas_example_connection_config,
+        saas_ctl_dataset,
+        api_client: TestClient,
+        db: Session,
+        generate_auth_header,
+    ):
+        path = V1_URL_PREFIX + DATASET_CONFIGS
+        path_params = {"connection_key": saas_example_connection_config.key}
+        datasets_url = path.format(**path_params)
+
+        saas_ctl_dataset.collections[0]["fields"][0]["fides_meta"]["identity"] = "email"
+        flag_modified(saas_ctl_dataset, "collections")
+        db.add(saas_ctl_dataset)
+        db.commit()
+
+        auth_header = generate_auth_header(scopes=[DATASET_CREATE_OR_UPDATE])
+        response = api_client.patch(
+            datasets_url,
+            headers=auth_header,
+            json=[
+                {
+                    "fides_key": saas_example_connection_config.saas_config[
+                        "fides_key"
+                    ],
+                    "ctl_dataset_fides_key": saas_ctl_dataset.fides_key,
+                }
+            ],
+        )
+        assert response.status_code == 200
+
+        response_body = json.loads(response.text)
+        assert len(response_body["succeeded"]) == 0
+        assert len(response_body["failed"]) == 1
+        assert (
+            response_body["failed"][0]["message"]
+            == "A dataset for a ConnectionConfig type of 'saas' is not allowed to have "
+            "references or identities. Please add them to the SaaS config."
+        ), "Validation is done when attaching dataset to Saas Config"
+
+    @pytest.mark.unit_saas
+    def test_patch_datasets_fides_key_mismatch(
+        self,
+        saas_example_connection_config,
+        saas_ctl_dataset,
+        api_client: TestClient,
+        db: Session,
+        generate_auth_header,
+    ):
+        path = V1_URL_PREFIX + DATASET_CONFIGS
+        path_params = {"connection_key": saas_example_connection_config.key}
+        datasets_url = path.format(**path_params)
+
+        saas_ctl_dataset.fides_key = "different_key"
+        db.add(saas_ctl_dataset)
+        db.commit()
+
+        auth_header = generate_auth_header(scopes=[DATASET_CREATE_OR_UPDATE])
+        response = api_client.patch(
+            datasets_url,
+            headers=auth_header,
+            json=[
+                {
+                    "fides_key": saas_example_connection_config.saas_config[
+                        "fides_key"
+                    ],
+                    "ctl_dataset_fides_key": saas_ctl_dataset.fides_key,
+                }
+            ],
+        )
+
+        assert response.status_code == 200
+
+        response_body = json.loads(response.text)
+        assert len(response_body["succeeded"]) == 0
+        assert len(response_body["failed"]) == 1
+        assert (
+            response_body["failed"][0]["message"]
+            == "The fides_key 'different_key' of the dataset does not match the fides_key "
+            "'saas_connector_example' of the connection config"
+        )
+
+    @mock.patch("fides.api.ops.models.datasetconfig.DatasetConfig.create_or_update")
+    def test_patch_datasets_failed_response(
+        self,
+        mock_create: Mock,
+        request_body,
+        datasets_url,
+        api_client: TestClient,
+        generate_auth_header,
+    ) -> None:
+        mock_create.side_effect = HTTPException(mock.Mock(status=400), "Test error")
+        auth_header = generate_auth_header(scopes=[DATASET_CREATE_OR_UPDATE])
+        response = api_client.patch(
+            datasets_url, headers=auth_header, json=request_body
+        )
+        assert response.status_code == 200  # Returns 200 regardless
+        response_body = json.loads(response.text)
+        assert len(response_body["succeeded"]) == 0
+        assert len(response_body["failed"]) == 1
+
+        for failed_response in response_body["failed"]:
+            assert "Dataset create/update failed" in failed_response["message"]
+            assert set(failed_response.keys()) == {"message", "data"}
+
+        for index, failed in enumerate(response_body["failed"]):
+            assert failed["data"]["fides_key"] == request_body[0]["fides_key"]
+
+
 class TestPutDatasets:
     @pytest.fixture
     def datasets_url(self, connection_config) -> str:
@@ -480,7 +891,6 @@ class TestPutDatasets:
         response = api_client.patch(
             datasets_url, headers=auth_header, json=example_datasets
         )
-
         assert response.status_code == 200
         response_body = json.loads(response.text)
         assert len(response_body["succeeded"]) == 11
@@ -492,10 +902,13 @@ class TestPutDatasets:
             db=db, field="fides_key", value="postgres_example_test_dataset"
         )
         assert postgres_config is not None
+        postgres_ctl_dataset = postgres_config.ctl_dataset
+        assert postgres_ctl_dataset is not None
         assert postgres_dataset["fides_key"] == "postgres_example_test_dataset"
         assert postgres_dataset["name"] == "Postgres Example Test Dataset"
         assert "Example of a Postgres dataset" in postgres_dataset["description"]
         assert len(postgres_dataset["collections"]) == 11
+        assert len(postgres_ctl_dataset.collections) == 11
 
         # Check the mongo dataset was created as well
         mongo_dataset = response_body["succeeded"][1]
@@ -503,10 +916,13 @@ class TestPutDatasets:
             db=db, field="fides_key", value="mongo_test"
         )
         assert mongo_config is not None
+        mongo_ctl_dataset = mongo_config.ctl_dataset
+        assert mongo_ctl_dataset is not None
         assert mongo_dataset["fides_key"] == "mongo_test"
         assert mongo_dataset["name"] == "Mongo Example Test Dataset"
         assert "Example of a Mongo dataset" in mongo_dataset["description"]
         assert len(mongo_dataset["collections"]) == 9
+        assert len(mongo_ctl_dataset.collections) == 9
 
         # Check the mssql dataset
         mssql_dataset = response_body["succeeded"][4]
@@ -514,12 +930,15 @@ class TestPutDatasets:
             db=db, field="fides_key", value="mssql_example_test_dataset"
         )
         assert mssql_config is not None
+        mssql_ctl_dataset = mssql_config.ctl_dataset
+        assert mssql_ctl_dataset is not None
         assert mssql_dataset["fides_key"] == "mssql_example_test_dataset"
         assert mssql_dataset["name"] == "Microsoft SQLServer Example Test Dataset"
         assert (
             "Example of a Microsoft SQLServer dataset" in mssql_dataset["description"]
         )
         assert len(mssql_dataset["collections"]) == 11
+        assert len(mssql_ctl_dataset.collections) == 11
 
         # check the mysql dataset
         mysql_dataset = response_body["succeeded"][5]
@@ -527,10 +946,13 @@ class TestPutDatasets:
             db=db, field="fides_key", value="mysql_example_test_dataset"
         )
         assert mysql_config is not None
+        mysql_ctl_dataset = mysql_config.ctl_dataset
+        assert mysql_ctl_dataset is not None
         assert mysql_dataset["fides_key"] == "mysql_example_test_dataset"
         assert mysql_dataset["name"] == "MySQL Example Test Dataset"
         assert "Example of a MySQL dataset" in mysql_dataset["description"]
         assert len(mysql_dataset["collections"]) == 11
+        assert len(mssql_ctl_dataset.collections) == 11
 
         # check the mariadb dataset
         mariadb_dataset = response_body["succeeded"][6]
@@ -538,16 +960,28 @@ class TestPutDatasets:
             db=db, field="fides_key", value="mariadb_example_test_dataset"
         )
         assert mariadb_config is not None
+        mariadb_ctl_dataset = mariadb_config.ctl_dataset
+        assert mariadb_ctl_dataset is not None
         assert mariadb_dataset["fides_key"] == "mariadb_example_test_dataset"
         assert mariadb_dataset["name"] == "MariaDB Example Test Dataset"
         assert "Example of a MariaDB dataset" in mariadb_dataset["description"]
         assert len(mariadb_dataset["collections"]) == 11
+        assert len(mssql_ctl_dataset.collections) == 11
 
         postgres_config.delete(db)
+        postgres_ctl_dataset.delete(db)
+
         mongo_config.delete(db)
+        mongo_ctl_dataset.delete(db)
+
         mssql_config.delete(db)
+        mssql_ctl_dataset.delete(db)
+
         mysql_config.delete(db)
+        mysql_ctl_dataset.delete(db)
+
         mariadb_config.delete(db)
+        mariadb_ctl_dataset.delete(db)
 
     def test_patch_datasets_bulk_update(
         self,
@@ -616,6 +1050,9 @@ class TestPutDatasets:
         )
         assert postgres_config is not None
         assert postgres_config.updated_at is not None
+        postgres_ctl_dataset = postgres_config.ctl_dataset
+        assert postgres_ctl_dataset is not None
+        assert len(postgres_ctl_dataset.collections) == 1
 
         # test mongo
         mongo_dataset = response_body["succeeded"][1]
@@ -628,6 +1065,11 @@ class TestPutDatasets:
         )
         assert mongo_config is not None
         assert mongo_config.updated_at is not None
+        mongo_ctl_dataset = mongo_config.ctl_dataset
+        assert mongo_ctl_dataset is not None
+        assert "birthday" not in [
+            f["name"] for f in mongo_ctl_dataset.collections[0]["fields"]
+        ]  # "birthday field should be removed
 
         # test snowflake
         snowflake_dataset = response_body["succeeded"][2]
@@ -640,6 +1082,10 @@ class TestPutDatasets:
         )
         assert snowflake_config is not None
         assert snowflake_config.updated_at is not None
+        snowflake_ctl_dataset = snowflake_config.ctl_dataset
+        assert "city" not in [
+            f["name"] for f in snowflake_ctl_dataset.collections[0]["fields"]
+        ]
 
         # test mssql
         mssql_dataset = response_body["succeeded"][4]
@@ -652,6 +1098,11 @@ class TestPutDatasets:
         )
         assert mssql_config is not None
         assert mssql_config.updated_at is not None
+        mssql_ctl_dataset = mssql_config.ctl_dataset
+        assert mssql_ctl_dataset is not None
+        assert "city" not in [
+            f["name"] for f in mssql_ctl_dataset.collections[0]["fields"]
+        ]
 
         # test bigquery
         bigquery_dataset = response_body["succeeded"][7]
@@ -664,12 +1115,25 @@ class TestPutDatasets:
         )
         assert bigquery_config is not None
         assert bigquery_config.updated_at is not None
+        bigquery_ctl_dataset = bigquery_config.ctl_dataset
+        assert "city" not in [
+            f["name"] for f in bigquery_ctl_dataset.collections[0]["fields"]
+        ]
 
         postgres_config.delete(db)
+        postgres_ctl_dataset.delete(db)
+
         mongo_config.delete(db)
+        mongo_ctl_dataset.delete(db)
+
         snowflake_config.delete(db)
+        snowflake_ctl_dataset.delete(db)
+
         mssql_config.delete(db)
+        mssql_ctl_dataset.delete(db)
+
         bigquery_config.delete(db)
+        bigquery_ctl_dataset.delete(db)
 
     @pytest.mark.unit_saas
     def test_patch_datasets_missing_saas_config(
@@ -804,7 +1268,9 @@ class TestPutDatasets:
             "'saas_connector_example' of the connection config"
         )
 
-    @mock.patch("fides.api.ops.models.datasetconfig.DatasetConfig.create_or_update")
+    @mock.patch(
+        "fides.api.ops.models.datasetconfig.DatasetConfig.create_or_update_with_ctl_dataset"
+    )
     def test_patch_datasets_failed_response(
         self,
         mock_create: Mock,
@@ -898,7 +1364,9 @@ class TestPutYamlDatasets:
         )
         assert response.status_code == 400
 
-    @mock.patch("fides.api.ops.models.datasetconfig.DatasetConfig.create_or_update")
+    @mock.patch(
+        "fides.api.ops.models.datasetconfig.DatasetConfig.create_or_update_with_ctl_dataset"
+    )
     def test_patch_datasets_failed_response(
         self,
         mock_create: Mock,
@@ -1147,6 +1615,7 @@ class TestDeleteDataset:
         connection_config,
         api_client: TestClient,
         generate_auth_header,
+        ctl_dataset,
     ) -> None:
         # Create a new dataset config so we don't run into issues trying to clean up an
         # already deleted fixture
@@ -1155,24 +1624,10 @@ class TestDeleteDataset:
             data={
                 "connection_config_id": connection_config.id,
                 "fides_key": "postgres_example_subscriptions",
-                "dataset": {
-                    "fides_key": "postgres_example_subscriptions",
-                    "name": "Postgres Example Subscribers Dataset",
-                    "description": "Example Postgres dataset created in test fixtures",
-                    "dataset_type": "PostgreSQL",
-                    "location": "postgres_example.test",
-                    "collections": [
-                        {
-                            "name": "subscriptions",
-                            "fields": [
-                                {
-                                    "name": "id",
-                                    "data_categories": ["system.operations"],
-                                },
-                            ],
-                        },
-                    ],
-                },
+                "dataset": Dataset.from_orm(
+                    ctl_dataset
+                ).dict(),  # Temporary, soon remove writing to this field.
+                "ctl_dataset_id": ctl_dataset.id,
             },
         )
 

--- a/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
@@ -1269,7 +1269,7 @@ class TestPutDatasets:
         )
 
     @mock.patch(
-        "fides.api.ops.models.datasetconfig.DatasetConfig.create_or_update_with_ctl_dataset"
+        "fides.api.ops.models.datasetconfig.DatasetConfig.upsert_with_ctl_dataset"
     )
     def test_patch_datasets_failed_response(
         self,
@@ -1365,7 +1365,7 @@ class TestPutYamlDatasets:
         assert response.status_code == 400
 
     @mock.patch(
-        "fides.api.ops.models.datasetconfig.DatasetConfig.create_or_update_with_ctl_dataset"
+        "fides.api.ops.models.datasetconfig.DatasetConfig.upsert_with_ctl_dataset"
     )
     def test_patch_datasets_failed_response(
         self,

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -54,13 +54,7 @@ from fides.api.ops.graph.config import CollectionAddress
 from fides.api.ops.graph.graph import DatasetGraph
 from fides.api.ops.models.connectionconfig import ConnectionConfig
 from fides.api.ops.models.datasetconfig import DatasetConfig
-from fides.api.ops.models.policy import (
-    ActionType,
-    CurrentStep,
-    Policy,
-    Rule,
-    RuleTarget,
-)
+from fides.api.ops.models.policy import ActionType, CurrentStep, Policy
 from fides.api.ops.models.privacy_request import (
     ExecutionLog,
     ExecutionLogStatus,

--- a/tests/ops/fixtures/application_fixtures.py
+++ b/tests/ops/fixtures/application_fixtures.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import ObjectDeletedError
 from toml import load as load_toml
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.api.v1.scope_registry import PRIVACY_REQUEST_READ, SCOPE_REGISTRY
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
@@ -1214,8 +1215,43 @@ def failed_privacy_request(db: Session, policy: Policy) -> PrivacyRequest:
 
 
 @pytest.fixture(scope="function")
+def ctl_dataset(db: Session, example_datasets):
+    dataset = CtlDataset(
+        fides_key="postgres_example_subscriptions_dataset",
+        organization_fides_key="default_organization",
+        name="Postgres Example Subscribers Dataset",
+        description="Example Postgres dataset created in test fixtures",
+        data_qualifier="aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
+        retention="No retention or erasure policy",
+        collections=[
+            {
+                "name": "subscriptions",
+                "fields": [
+                    {
+                        "name": "id",
+                        "data_categories": ["system.operations"],
+                    },
+                    {
+                        "name": "email",
+                        "data_categories": ["user.contact.email"],
+                        "fidesops_meta": {
+                            "identity": "email",
+                        },
+                    },
+                ],
+            },
+        ],
+    )
+    db.add(dataset)
+    db.commit()
+    yield dataset
+    dataset.delete(db)
+
+
+@pytest.fixture(scope="function")
 def dataset_config(
     connection_config: ConnectionConfig,
+    ctl_dataset,
     db: Session,
 ) -> Generator:
     dataset_config = DatasetConfig.create(
@@ -1223,6 +1259,7 @@ def dataset_config(
         data={
             "connection_config_id": connection_config.id,
             "fides_key": "postgres_example_subscriptions_dataset",
+            "ctl_dataset_id": ctl_dataset.id,
             "dataset": {
                 "fides_key": "postgres_example_subscriptions_dataset",
                 "name": "Postgres Example Subscribers Dataset",
@@ -1256,13 +1293,17 @@ def dataset_config(
 
 @pytest.fixture(scope="function")
 def dataset_config_preview(
-    connection_config: ConnectionConfig, db: Session
+    connection_config: ConnectionConfig, db: Session, ctl_dataset
 ) -> Generator:
+    ctl_dataset.fides_key = "postgres"
+    db.add(ctl_dataset)
+    db.commit()
     dataset_config = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": connection_config.id,
             "fides_key": "postgres",
+            "ctl_dataset_id": ctl_dataset.id,
             "dataset": {
                 "fides_key": "postgres",
                 "name": "Postgres Example Subscribers Dataset",

--- a/tests/ops/fixtures/bigquery_fixtures.py
+++ b/tests/ops/fixtures/bigquery_fixtures.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -74,16 +75,21 @@ def bigquery_example_test_dataset_config(
     bigquery_connection_config.name = fides_key
     bigquery_connection_config.key = fides_key
     bigquery_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, bigquery_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": bigquery_connection_config.id,
             "fides_key": fides_key,
             "dataset": bigquery_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/email_fixtures.py
+++ b/tests/ops/fixtures/email_fixtures.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -40,13 +41,18 @@ def email_dataset_config(
     email_connection_config.name = fides_key
     email_connection_config.key = fides_key
     email_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, email_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": email_connection_config.id,
             "fides_key": fides_key,
             "dataset": email_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)

--- a/tests/ops/fixtures/fides_connector_example_fixtures.py
+++ b/tests/ops/fixtures/fides_connector_example_fixtures.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -78,13 +79,18 @@ def fides_connector_example_test_dataset_config(
     fides_connector_connection_config.name = fides_key
     fides_connector_connection_config.key = fides_key
     fides_connector_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, fides_connector_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": fides_connector_connection_config.id,
             "fides_key": fides_key,
             "dataset": fides_connector_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)

--- a/tests/ops/fixtures/manual_fixtures.py
+++ b/tests/ops/fixtures/manual_fixtures.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -38,13 +39,18 @@ def manual_dataset_config(
     integration_manual_config.name = fides_key
     integration_manual_config.key = fides_key
     integration_manual_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, manual_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": integration_manual_config.id,
             "fides_key": fides_key,
             "dataset": manual_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)

--- a/tests/ops/fixtures/mariadb_fixtures.py
+++ b/tests/ops/fixtures/mariadb_fixtures.py
@@ -6,6 +6,7 @@ import pytest
 import sqlalchemy
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -71,12 +72,16 @@ def mariadb_example_test_dataset_config(
     connection_config_mariadb.name = fides_key
     connection_config_mariadb.key = fides_key
     connection_config_mariadb.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, mariadb_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": connection_config_mariadb.id,
             "fides_key": fides_key,
             "dataset": mariadb_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset

--- a/tests/ops/fixtures/mssql_fixtures.py
+++ b/tests/ops/fixtures/mssql_fixtures.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -32,12 +33,16 @@ def mssql_example_test_dataset_config(
     connection_config_mssql.name = fides_key
     connection_config_mssql.key = fides_key
     connection_config_mssql.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, mssql_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": connection_config_mssql.id,
             "fides_key": fides_key,
             "dataset": mssql_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset

--- a/tests/ops/fixtures/mysql_fixtures.py
+++ b/tests/ops/fixtures/mysql_fixtures.py
@@ -89,7 +89,7 @@ def mysql_example_test_dataset_config(
             "connection_config_id": connection_config_mysql.id,
             "fides_key": fides_key,
             "dataset": mysql_dataset,
-            "ctl_dataset_id": ctl_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset

--- a/tests/ops/fixtures/mysql_fixtures.py
+++ b/tests/ops/fixtures/mysql_fixtures.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -26,40 +27,45 @@ def dataset_config_mysql(
     connection_config: ConnectionConfig,
     db: Session,
 ) -> Generator:
+    dataset = {
+        "fides_key": "mysql_example_subscriptions_dataset",
+        "name": "Mysql Example Subscribers Dataset",
+        "description": "Example Mysql dataset created in test fixtures",
+        "dataset_type": "MySQL",
+        "location": "mysql_example.test",
+        "collections": [
+            {
+                "name": "subscriptions",
+                "fields": [
+                    {
+                        "name": "id",
+                        "data_categories": ["system.operations"],
+                    },
+                    {
+                        "name": "email",
+                        "data_categories": ["user.contact.email"],
+                        "fidesops_meta": {
+                            "identity": "email",
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, dataset)
+
     dataset_config = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": connection_config.id,
             "fides_key": "mysql_example_subscriptions_dataset",
-            "dataset": {
-                "fides_key": "mysql_example_subscriptions_dataset",
-                "name": "Mysql Example Subscribers Dataset",
-                "description": "Example Mysql dataset created in test fixtures",
-                "dataset_type": "MySQL",
-                "location": "mysql_example.test",
-                "collections": [
-                    {
-                        "name": "subscriptions",
-                        "fields": [
-                            {
-                                "name": "id",
-                                "data_categories": ["system.operations"],
-                            },
-                            {
-                                "name": "email",
-                                "data_categories": ["user.contact.email"],
-                                "fidesops_meta": {
-                                    "identity": "email",
-                                },
-                            },
-                        ],
-                    },
-                ],
-            },
+            "dataset": dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset_config
     dataset_config.delete(db)
+    ctl_dataset.delete(db)
 
 
 # TODO: Consolidate these
@@ -74,16 +80,21 @@ def mysql_example_test_dataset_config(
     connection_config_mysql.name = fides_key
     connection_config_mysql.key = fides_key
     connection_config_mysql.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, mysql_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": connection_config_mysql.id,
             "fides_key": fides_key,
             "dataset": mysql_dataset,
+            "ctl_dataset_id": ctl_dataset,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/postgres_fixtures.py
+++ b/tests/ops/fixtures/postgres_fixtures.py
@@ -49,7 +49,7 @@ def postgres_example_test_dataset_config(
         data={
             "connection_config_id": connection_config.id,
             "fides_key": fides_key,
-            "dataset": postgres_dataset,  # TODO Unified Fides Resources - Stop writing to this field
+            "dataset": postgres_dataset,
             "ctl_dataset_id": ctl_dataset.id,
         },
     )

--- a/tests/ops/fixtures/postgres_fixtures.py
+++ b/tests/ops/fixtures/postgres_fixtures.py
@@ -66,16 +66,21 @@ def postgres_example_test_dataset_config_read_access(
 ) -> Generator:
     postgres_dataset = example_datasets[0]
     fides_key = postgres_dataset["fides_key"]
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, postgres_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": read_connection_config.id,
             "fides_key": fides_key,
             "dataset": postgres_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/postgres_fixtures.py
+++ b/tests/ops/fixtures/postgres_fixtures.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy.orm import Session
 from sqlalchemy_utils.functions import drop_database
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -40,16 +41,21 @@ def postgres_example_test_dataset_config(
     connection_config.name = fides_key
     connection_config.key = fides_key
     connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, postgres_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": connection_config.id,
             "fides_key": fides_key,
-            "dataset": postgres_dataset,
+            "dataset": postgres_dataset,  # TODO Unified Fides Resources - Stop writing to this field
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture

--- a/tests/ops/fixtures/redshift_fixtures.py
+++ b/tests/ops/fixtures/redshift_fixtures.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -52,13 +53,18 @@ def redshift_example_test_dataset_config(
 ) -> Generator:
     dataset = example_datasets[3]
     fides_key = dataset["fides_key"]
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, dataset)
+
     dataset_config = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": redshift_connection_config.id,
             "fides_key": fides_key,
             "dataset": dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset_config
     dataset_config.delete(db=db)
+    ctl_dataset.delete(db=db)

--- a/tests/ops/fixtures/saas/adobe_campaign_fixtures.py
+++ b/tests/ops/fixtures/saas/adobe_campaign_fixtures.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -106,16 +107,21 @@ def adobe_campaign_dataset_config(
     adobe_campaign_connection_config.name = fides_key
     adobe_campaign_connection_config.key = fides_key
     adobe_campaign_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, adobe_campaign_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": adobe_campaign_connection_config.id,
             "fides_key": fides_key,
             "dataset": adobe_campaign_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/auth0_fixtures.py
+++ b/tests/ops/fixtures/saas/auth0_fixtures.py
@@ -6,6 +6,7 @@ import requests
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_204_NO_CONTENT
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -85,16 +86,21 @@ def auth0_dataset_config(
     auth0_connection_config.name = fides_key
     auth0_connection_config.key = fides_key
     auth0_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, auth0_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": auth0_connection_config.id,
             "fides_key": fides_key,
             "dataset": auth0_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/braze_fixtures.py
+++ b/tests/ops/fixtures/saas/braze_fixtures.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -98,16 +99,21 @@ def braze_dataset_config(
     braze_connection_config.name = fides_key
     braze_connection_config.key = fides_key
     braze_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, braze_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": braze_connection_config.id,
             "fides_key": fides_key,
             "dataset": braze_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/datadog_fixtures.py
+++ b/tests/ops/fixtures/saas/datadog_fixtures.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -95,12 +96,16 @@ def datadog_dataset_config(
     datadog_connection_config.name = fides_key
     datadog_connection_config.key = fides_key
     datadog_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, datadog_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": datadog_connection_config.id,
             "fides_key": fides_key,
             "dataset": datadog_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset

--- a/tests/ops/fixtures/saas/domo_fixtures.py
+++ b/tests/ops/fixtures/saas/domo_fixtures.py
@@ -8,6 +8,7 @@ from requests import Response
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_204_NO_CONTENT
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -107,16 +108,21 @@ def domo_dataset_config(
     domo_connection_config.name = fides_key
     domo_connection_config.key = fides_key
     domo_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, domo_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": domo_connection_config.id,
             "fides_key": fides_key,
             "dataset": domo_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 class DomoTestClient:

--- a/tests/ops/fixtures/saas/doordash_fixtures.py
+++ b/tests/ops/fixtures/saas/doordash_fixtures.py
@@ -154,16 +154,21 @@ def doordash_postgres_dataset_config(
     connection_config.name = fides_key
     connection_config.key = fides_key
     connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, doordash_postgres_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": connection_config.id,
             "fides_key": fides_key,
             "dataset": doordash_postgres_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/doordash_fixtures.py
+++ b/tests/ops/fixtures/saas/doordash_fixtures.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy.orm import Session
 from sqlalchemy_utils.functions import drop_database
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -102,16 +103,20 @@ def doordash_dataset_config(
     doordash_connection_config.name = fides_key
     doordash_connection_config.key = fides_key
     doordash_connection_config.save(db=db)
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, doordash_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": doordash_connection_config.id,
             "fides_key": fides_key,
             "dataset": doordash_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture()

--- a/tests/ops/fixtures/saas/fullstory_fixtures.py
+++ b/tests/ops/fixtures/saas/fullstory_fixtures.py
@@ -160,16 +160,21 @@ def fullstory_postgres_dataset_config(
     connection_config.name = fides_key
     connection_config.key = fides_key
     connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, fullstory_postgres_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": connection_config.id,
             "fides_key": fides_key,
             "dataset": fullstory_postgres_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/fullstory_fixtures.py
+++ b/tests/ops/fixtures/saas/fullstory_fixtures.py
@@ -6,6 +6,7 @@ import requests
 from sqlalchemy.orm import Session
 from sqlalchemy_utils.functions import create_database, database_exists, drop_database
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -107,16 +108,21 @@ def fullstory_dataset_config(
     fullstory_connection_config.name = fides_key
     fullstory_connection_config.key = fides_key
     fullstory_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, fullstory_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": fullstory_connection_config.id,
             "fides_key": fides_key,
             "dataset": fullstory_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture()

--- a/tests/ops/fixtures/saas/hubspot_fixtures.py
+++ b/tests/ops/fixtures/saas/hubspot_fixtures.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -94,16 +95,21 @@ def dataset_config_hubspot(
     connection_config_hubspot.name = fides_key
     connection_config_hubspot.key = fides_key
     connection_config_hubspot.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, hubspot_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": connection_config_hubspot.id,
             "fides_key": fides_key,
             "dataset": hubspot_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 class HubspotTestClient:

--- a/tests/ops/fixtures/saas/mailchimp_fixtures.py
+++ b/tests/ops/fixtures/saas/mailchimp_fixtures.py
@@ -5,6 +5,7 @@ import pydash
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -89,16 +90,21 @@ def mailchimp_dataset_config(
     mailchimp_connection_config.name = fides_key
     mailchimp_connection_config.key = fides_key
     mailchimp_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, mailchimp_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": mailchimp_connection_config.id,
             "fides_key": fides_key,
             "dataset": mailchimp_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/outreach_fixtures.py
+++ b/tests/ops/fixtures/saas/outreach_fixtures.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -99,16 +100,21 @@ def outreach_dataset_config(
     outreach_connection_config.name = fides_key
     outreach_connection_config.key = fides_key
     outreach_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, outreach_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": outreach_connection_config.id,
             "fides_key": fides_key,
             "dataset": outreach_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/request_override/firebase_auth_fixtures.py
+++ b/tests/ops/fixtures/saas/request_override/firebase_auth_fixtures.py
@@ -25,6 +25,7 @@ from fides.lib.db import session
 from tests.ops.test_helpers.vault_client import get_secrets
 
 secrets = get_secrets("firebase_auth")
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 
 
 @pytest.fixture
@@ -159,13 +160,17 @@ def firebase_auth_dataset_config(
     firebase_auth_connection_config.name = fides_key
     firebase_auth_connection_config.key = fides_key
     firebase_auth_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, firebase_auth_dataset)
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": firebase_auth_connection_config.id,
             "fides_key": fides_key,
             "dataset": firebase_auth_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)

--- a/tests/ops/fixtures/saas/request_override/mailchimp_override_fixtures.py
+++ b/tests/ops/fixtures/saas/request_override/mailchimp_override_fixtures.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Generator
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -62,16 +63,21 @@ def mailchimp_override_dataset_config(
     mailchimp_override_connection_config.name = fides_key
     mailchimp_override_connection_config.key = fides_key
     mailchimp_override_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, mailchimp_override_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": mailchimp_override_connection_config.id,
             "fides_key": fides_key,
             "dataset": mailchimp_override_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/rollbar_fixtures.py
+++ b/tests/ops/fixtures/saas/rollbar_fixtures.py
@@ -7,6 +7,7 @@ import requests
 from requests import Response
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -99,16 +100,21 @@ def rollbar_dataset_config(
     rollbar_connection_config.name = fides_key
     rollbar_connection_config.key = fides_key
     rollbar_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, rollbar_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": rollbar_connection_config.id,
             "fides_key": fides_key,
             "dataset": rollbar_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 class RollbarTestClient:

--- a/tests/ops/fixtures/saas/salesforce_fixtures.py
+++ b/tests/ops/fixtures/saas/salesforce_fixtures.py
@@ -6,6 +6,7 @@ import requests
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -111,16 +112,21 @@ def salesforce_dataset_config(
     salesforce_connection_config.name = fides_key
     salesforce_connection_config.key = fides_key
     salesforce_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, salesforce_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": salesforce_connection_config.id,
             "fides_key": fides_key,
             "dataset": salesforce_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/segment_fixtures.py
+++ b/tests/ops/fixtures/saas/segment_fixtures.py
@@ -8,6 +8,7 @@ import requests
 from faker import Faker
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -101,16 +102,21 @@ def segment_dataset_config(
     segment_connection_config.name = fides_key
     segment_connection_config.key = fides_key
     segment_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, segment_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": segment_connection_config.id,
             "fides_key": fides_key,
             "dataset": segment_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="session")

--- a/tests/ops/fixtures/saas/sendgrid_fixtures.py
+++ b/tests/ops/fixtures/saas/sendgrid_fixtures.py
@@ -6,6 +6,7 @@ import requests
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_202_ACCEPTED
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -94,16 +95,21 @@ def sendgrid_dataset_config(
     sendgrid_connection_config.name = fides_key
     sendgrid_connection_config.key = fides_key
     sendgrid_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, sendgrid_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": sendgrid_connection_config.id,
             "fides_key": fides_key,
             "dataset": sendgrid_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/sentry_fixtures.py
+++ b/tests/ops/fixtures/saas/sentry_fixtures.py
@@ -4,6 +4,7 @@ import pydash
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -86,13 +87,18 @@ def sentry_dataset_config(
     sentry_connection_config.name = fides_key
     sentry_connection_config.key = fides_key
     sentry_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, sentry_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": sentry_connection_config.id,
             "fides_key": fides_key,
             "dataset": sentry_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)

--- a/tests/ops/fixtures/saas/shopify_fixtures.py
+++ b/tests/ops/fixtures/saas/shopify_fixtures.py
@@ -8,6 +8,7 @@ from faker import Faker
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_204_NO_CONTENT
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -95,16 +96,21 @@ def shopify_dataset_config(
     shopify_connection_config.name = fides_key
     shopify_connection_config.key = fides_key
     shopify_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, shopify_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": shopify_connection_config.id,
             "fides_key": fides_key,
             "dataset": shopify_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/slack_enterprise_fixtures.py
+++ b/tests/ops/fixtures/saas/slack_enterprise_fixtures.py
@@ -6,6 +6,7 @@ import requests
 from requests import Response
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -89,16 +90,21 @@ def slack_enterprise_dataset_config(
     slack_enterprise_connection_config.name = fides_key
     slack_enterprise_connection_config.key = fides_key
     slack_enterprise_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, slack_enterprise_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": slack_enterprise_connection_config.id,
             "fides_key": fides_key,
             "dataset": slack_enterprise_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 class SlackTestClient:

--- a/tests/ops/fixtures/saas/square_fixtures.py
+++ b/tests/ops/fixtures/saas/square_fixtures.py
@@ -11,6 +11,7 @@ from requests import Response
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_204_NO_CONTENT
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -104,16 +105,21 @@ def square_dataset_config(
     square_connection_config.name = fides_key
     square_connection_config.key = fides_key
     square_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, square_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": square_connection_config.id,
             "fides_key": fides_key,
             "dataset": square_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 def square_idempotency_key():

--- a/tests/ops/fixtures/saas/stripe_fixtures.py
+++ b/tests/ops/fixtures/saas/stripe_fixtures.py
@@ -6,6 +6,7 @@ import requests
 from multidimensional_urlencode import urlencode as multidimensional_urlencode
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -97,16 +98,21 @@ def stripe_dataset_config(
     stripe_connection_config.name = fides_key
     stripe_connection_config.key = fides_key
     stripe_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, stripe_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": stripe_connection_config.id,
             "fides_key": fides_key,
             "dataset": stripe_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/twilio_conversations_fixtures.py
+++ b/tests/ops/fixtures/saas/twilio_conversations_fixtures.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy_utils.functions import create_database, database_exists, drop_database
 from starlette.status import HTTP_204_NO_CONTENT
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -108,16 +109,21 @@ def twilio_conversations_dataset_config(
     twilio_conversations_connection_config.name = fides_key
     twilio_conversations_connection_config.key = fides_key
     twilio_conversations_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, twilio_conversations_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": twilio_conversations_connection_config.id,
             "fides_key": fides_key,
             "dataset": twilio_conversations_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture()

--- a/tests/ops/fixtures/saas/twilio_conversations_fixtures.py
+++ b/tests/ops/fixtures/saas/twilio_conversations_fixtures.py
@@ -161,15 +161,20 @@ def twilio_postgres_dataset_config(
     connection_config.name = fides_key
     connection_config.key = fides_key
     connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, twilio_postgres_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": connection_config.id,
             "fides_key": fides_key,
             "dataset": twilio_postgres_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
+    dataset.delete(db=db)
     dataset.delete(db=db)
 
 

--- a/tests/ops/fixtures/saas/zendesk_fixtures.py
+++ b/tests/ops/fixtures/saas/zendesk_fixtures.py
@@ -6,6 +6,7 @@ import pytest
 import requests
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -93,16 +94,21 @@ def zendesk_dataset_config(
     zendesk_connection_config.name = fides_key
     zendesk_connection_config.key = fides_key
     zendesk_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, zendesk_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": zendesk_connection_config.id,
             "fides_key": fides_key,
             "dataset": zendesk_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas_example_fixtures.py
+++ b/tests/ops/fixtures/saas_example_fixtures.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy.orm import Session
 from toml import load as load_toml
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -51,6 +52,14 @@ def saas_external_example_config() -> Dict:
 @pytest.fixture
 def saas_example_dataset() -> Dict:
     return load_dataset("data/saas/dataset/saas_example_dataset.yml")[0]
+
+
+@pytest.fixture
+def saas_ctl_dataset(db: Session) -> Dict:
+    dataset = load_dataset("data/saas/dataset/saas_example_dataset.yml")[0]
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, dataset)
+    yield ctl_dataset
+    ctl_dataset.delete(db)
 
 
 @pytest.fixture
@@ -112,16 +121,21 @@ def saas_example_dataset_config(
     saas_example_connection_config.name = fides_key
     saas_example_connection_config.key = fides_key
     saas_example_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, saas_example_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": saas_example_connection_config.id,
             "fides_key": fides_key,
             "dataset": saas_example_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db)
 
 
 @pytest.fixture
@@ -134,16 +148,21 @@ def saas_external_example_dataset_config(
     saas_external_example_connection_config.name = fides_key
     saas_external_example_connection_config.key = fides_key
     saas_external_example_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, saas_external_example_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": saas_external_example_connection_config.id,
             "fides_key": fides_key,
             "dataset": saas_external_example_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/snowflake_fixtures.py
+++ b/tests/ops/fixtures/snowflake_fixtures.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -66,13 +67,18 @@ def snowflake_example_test_dataset_config(
 ) -> Generator:
     dataset = example_datasets[2]
     fides_key = dataset["fides_key"]
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, dataset)
+
     dataset_config = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": snowflake_connection_config.id,
             "fides_key": fides_key,
             "dataset": dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset_config
     dataset_config.delete(db=db)
+    ctl_dataset.delete(db=db)

--- a/tests/ops/fixtures/timescale_fixtures.py
+++ b/tests/ops/fixtures/timescale_fixtures.py
@@ -6,6 +6,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,

--- a/tests/ops/fixtures/timescale_fixtures.py
+++ b/tests/ops/fixtures/timescale_fixtures.py
@@ -2,11 +2,9 @@ from typing import Generator
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import text
 from sqlalchemy.orm import Session
-from sqlalchemy_utils import create_database, database_exists, drop_database
+from sqlalchemy_utils import drop_database
 
-from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,

--- a/tests/ops/models/test_datasetconfig.py
+++ b/tests/ops/models/test_datasetconfig.py
@@ -243,3 +243,176 @@ def test_validate_dataset_reference_invalid(db: Session, dataset_config: Dataset
     with pytest.raises(ValidationError) as e:
         validate_dataset_reference(db, dsr)
     assert "must include at least two dot-separated components" in e.value.message
+
+
+class TestUpsertWithCtlDataset:
+    def test_no_existing_dataset_config_or_ctl_dataset(
+        self, db, example_datasets, connection_config
+    ):
+        """Ctl Dataset is created"""
+        postgres_dataset = example_datasets[0]
+
+        dataset_config = DatasetConfig.upsert_with_ctl_dataset(
+            db=db,
+            data={
+                "connection_config_id": connection_config.id,
+                "fides_key": "brand_new_fides_key",
+                "dataset": postgres_dataset,
+            },
+        )
+        assert dataset_config.fides_key == "brand_new_fides_key"
+        assert dataset_config.ctl_dataset_id is not None
+
+        ctl_dataset = dataset_config.ctl_dataset
+
+        assert (
+            ctl_dataset.fides_key == "postgres_example_test_dataset"
+        ), "New ctl dataset record created"
+        assert ctl_dataset.description == postgres_dataset["description"]
+        assert ctl_dataset.organization_fides_key == "default_organization"
+        assert ctl_dataset.data_categories == postgres_dataset.get("data_categories")
+        assert ctl_dataset.collections is not None
+
+        dataset = dataset_config.dataset
+        assert dataset["description"] == postgres_dataset["description"]
+        assert (
+            dataset.get("organization_fides_key") is None
+        ), "Existing behavior, DatasetConfig.dataset not validated by Fideslang Dataset first"
+        assert dataset["collections"] is not None
+
+        dataset_config.delete(db)
+        ctl_dataset.delete(db)
+
+    def test_no_existing_dataset_config_but_ctl_dataset_exists(
+        self, db, ctl_dataset, connection_config
+    ):
+        """Ctl Dataset is created"""
+
+        assert (
+            ctl_dataset.description
+            == "Example Postgres dataset created in test fixtures"
+        )
+        assert ctl_dataset.name == "Postgres Example Subscribers Dataset"
+        current_ctl_dataset_id = ctl_dataset.id
+
+        dataset_config = DatasetConfig.upsert_with_ctl_dataset(
+            db=db,
+            data={
+                "connection_config_id": connection_config.id,
+                "fides_key": "brand_new_fides_key",
+                "dataset": {
+                    "fides_key": "postgres_example_subscriptions_dataset",
+                    "name": "New Dataset Name",
+                    "description": "New Dataset Description",
+                    "dataset_type": "PostgreSQL",
+                    "location": "postgres_example.test",
+                    "collections": [
+                        {
+                            "name": "subscriptions",
+                            "fields": [
+                                {
+                                    "name": "id",
+                                    "data_categories": ["system.operations"],
+                                },
+                                {
+                                    "name": "email",
+                                    "data_categories": ["user.contact.email"],
+                                    "fidesops_meta": {
+                                        "identity": "email",
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        )
+        assert dataset_config.fides_key == "brand_new_fides_key"
+        assert (
+            dataset_config.ctl_dataset_id == current_ctl_dataset_id
+        ), "Dataset config linked to existing ctl dataset"
+
+        ctl_dataset = dataset_config.ctl_dataset
+
+        assert (
+            ctl_dataset.fides_key == "postgres_example_subscriptions_dataset"
+        ), "Existing ctl dataset fides key"
+        assert (
+            ctl_dataset.description == "New Dataset Description"
+        ), "Updated description"
+        assert ctl_dataset.name == "New Dataset Name", "Updated name"
+
+        assert ctl_dataset.organization_fides_key == "default_organization"
+        assert ctl_dataset.data_categories is None
+        assert ctl_dataset.collections is not None
+
+        dataset = dataset_config.dataset
+        assert dataset["description"] == "New Dataset Description"
+        assert (
+            dataset.get("organization_fides_key") is None
+        ), "Existing behavior, DatasetConfig.dataset not validated by Fideslang Dataset first"
+        assert dataset["collections"] is not None
+
+        dataset_config.delete(db)
+        ctl_dataset.delete(db)
+
+    def test_existing_dataset_config_and_ctl_dataset(self, dataset_config, db):
+        existing_dataset_config_id = dataset_config.id
+        existing_ctl_dataset_id = dataset_config.ctl_dataset_id
+        existing_ctl_dataset_fides_key = dataset_config.ctl_dataset.fides_key
+
+        updated_dataset_config = DatasetConfig.upsert_with_ctl_dataset(
+            db=db,
+            data={
+                "connection_config_id": dataset_config.connection_config_id,
+                "fides_key": dataset_config.fides_key,
+                "dataset": {
+                    "fides_key": "brand_new_fides_key",
+                    "name": "New Dataset Name",
+                    "description": "New Dataset Description",
+                    "dataset_type": "PostgreSQL",
+                    "location": "postgres_example.test",
+                    "collections": [
+                        {
+                            "name": "subscriptions",
+                            "fields": [
+                                {
+                                    "name": "id",
+                                    "data_categories": ["system.operations"],
+                                },
+                                {
+                                    "name": "email",
+                                    "data_categories": ["user.contact.email"],
+                                    "fidesops_meta": {
+                                        "identity": "email",
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        )
+
+        assert updated_dataset_config.id == existing_dataset_config_id
+        assert updated_dataset_config.ctl_dataset_id == existing_ctl_dataset_id
+        updated_ctl_dataset = updated_dataset_config.ctl_dataset
+
+        assert (
+            updated_ctl_dataset.fides_key != existing_ctl_dataset_fides_key
+        ), "Because we updated based on the ctl_dataset.id, the fides key got changed"
+
+        assert (
+            updated_ctl_dataset.description == "New Dataset Description"
+        ), "Updated description"
+        assert updated_ctl_dataset.name == "New Dataset Name", "Updated name"
+
+        assert updated_ctl_dataset.collections is not None
+
+        dataset = updated_dataset_config.dataset
+
+        assert dataset["description"] == "New Dataset Description"
+        assert (
+            dataset.get("organization_fides_key") is None
+        ), "Existing behavior, DatasetConfig.dataset not validated by Fideslang Dataset first"
+        assert dataset["collections"] is not None

--- a/tests/ops/models/test_datasetconfig.py
+++ b/tests/ops/models/test_datasetconfig.py
@@ -22,14 +22,13 @@ def test_create_dataset(
         data={
             "connection_config_id": connection_config.id,
             "fides_key": postgres_dataset["fides_key"],
-            "dataset": postgres_dataset,  # TODO remove dataset as an argument
+            "dataset": postgres_dataset,
             "ctl_dataset_id": ctl_dataset.id,
         },
     )
     assert dataset_config.id is not None
     assert dataset_config.ctl_dataset_id is not None
-    linked_ctl_dataset = dataset_config.ctl_dataset
-    assert linked_ctl_dataset == ctl_dataset
+    assert dataset_config.ctl_dataset == ctl_dataset
 
     assert dataset_config.connection_config_id == connection_config.id
     assert dataset_config.fides_key == postgres_dataset["fides_key"]

--- a/tests/ops/service/connectors/test_connector_registry_service.py
+++ b/tests/ops/service/connectors/test_connector_registry_service.py
@@ -175,7 +175,7 @@ def update_config(
         secondary_mailchimp_dataset,
     ) = secondary_mailchimp_instance
     secondary_mailchimp_saas_config = secondary_mailchimp_config.saas_config
-    secondary_mailchimp_dataset.dataset["description"] = mailchimp_template_dataset[
+    secondary_mailchimp_dataset.ctl_dataset.description = mailchimp_template_dataset[
         "description"
     ]
     assert secondary_mailchimp_saas_config["version"] == mailchimp_version
@@ -189,7 +189,7 @@ def update_config(
         tertiary_mailchimp_dataset,
     ) = tertiary_mailchimp_instance
     tertiary_mailchimp_saas_config = tertiary_mailchimp_config.saas_config
-    tertiary_mailchimp_dataset.dataset["description"] = mailchimp_template_dataset[
+    tertiary_mailchimp_dataset.ctl_dataset.description = mailchimp_template_dataset[
         "description"
     ]
     tertiary_mailchimp_saas_config = (
@@ -206,7 +206,7 @@ def update_config(
         secondary_sendgrid_dataset,
     ) = secondary_sendgrid_instance
     secondary_sendgrid_saas_config = secondary_sendgrid_config.saas_config
-    secondary_sendgrid_dataset.dataset["description"] = sendgrid_template_dataset[
+    secondary_sendgrid_dataset.ctl_dataset.description = sendgrid_template_dataset[
         "description"
     ]
     assert secondary_sendgrid_saas_config["version"] == sendgrid_version
@@ -349,13 +349,13 @@ def validate_updated_instances_additions(
     fides_key: str,
 ):
     # check for dataset additions to template
-    assert updated_dataset_config.dataset["description"] == NEW_DATASET_DESCRIPTION
+    assert updated_dataset_config.ctl_dataset.description == NEW_DATASET_DESCRIPTION
     assert (
-        len(updated_dataset_config.dataset["collections"])
+        len(updated_dataset_config.ctl_dataset.collections)
         == len(original_template_dataset["collections"]) + 1
     )
-    assert NEW_COLLECTION in updated_dataset_config.dataset["collections"]
-    assert NEW_FIELD in updated_dataset_config.dataset["collections"][0]["fields"]
+    assert NEW_COLLECTION in updated_dataset_config.ctl_dataset.collections
+    assert NEW_FIELD in updated_dataset_config.ctl_dataset.collections[0]["fields"]
 
     # check for config additions to template
     updated_saas_config = updated_dataset_config.connection_config.saas_config
@@ -448,7 +448,7 @@ def validate_updated_instances_removals(
 ):
     # check for dataset removals to template
     assert (
-        len(updated_dataset_config.dataset["collections"])
+        len(updated_dataset_config.ctl_dataset.collections)
         == len(original_template_dataset["collections"]) - 1
     )
 

--- a/tests/ops/service/connectors/test_saas_queryconfig.py
+++ b/tests/ops/service/connectors/test_saas_queryconfig.py
@@ -47,7 +47,7 @@ class TestSaaSQueryConfig:
         assert (
             CollectionAddress(
                 saas_external_example_dataset_config.fides_key,
-                saas_external_example_dataset_config.dataset["collections"][0]["name"],
+                saas_external_example_dataset_config.ctl_dataset.collections[0]["name"],
             )
             in customer.parents.keys()
         )

--- a/tests/ops/test_helpers/dataset_utils.py
+++ b/tests/ops/test_helpers/dataset_utils.py
@@ -31,7 +31,7 @@ def update_dataset(
     """
 
     generated_dataset = generate_dataset(
-        dataset_config.dataset,
+        Dataset.from_orm(dataset_config.ctl_dataset).dict(),
         api_data,
         [endpoint["name"] for endpoint in connection_config.saas_config["endpoints"]],
     )


### PR DESCRIPTION
❗ Contains multiple migrations (schema and data)
👉  Note this PR is against a feature branch

Closes #1762, https://github.com/ethyca/fides/issues/1764

### Code Changes

* [ ] Added a non-nullable `datasetconfig.ctl_dataset_id` column
* [ ] Added a schema and data migration.  This is an attempt to also resolve https://github.com/ethyca/fides/issues/1764
    * [ ] First, create a `datasetconfig.ctl_dataset_id` column that is nullable
    * [ ] Then, attempt to copy the contents of DatasetConfig.dataset into new `ctl_dataset` records, and then link that `ctl_dataset` as the DatasetConfig.ctl_dataset_id.  If there's a conflict with an existing `ctl_datasets.fides_key`, I error instead of attempting to upsert.  The user should manually resolve.
    * [ ] Adds a follow-up schema migration to then make the `datasetconfig.ctl_dataset_id` field non-nullable
* [ ] Added a new API endpoint `PATCH {{host}}/connection/{{connection_key}}/datasetconfig` that takes in a `fides_key` (for the DatasetConfig) and an existing `ctl_dataset_fides_key`. It upserts a DatasetConfig, links to the existing CTLDataset, then copies the CTLDataset contents back to the DatasetConfig.dataset.  Soon, the DatasetConfig.dataset field is going away.
* [ ] Updated existing PATCH dataset config JSON and YAML variants to temporarily still work. A raw dataset passed in will attempt to upsert both the DatasetConfig and CTLDataset object.  I didn't want the UI to be broken on this feature branch.
    * [ ]  Creating a saas connector from a template still works. The dataset in the template currently upserts the DatasetConfig and CTL Dataset record.
* [ ] In the locations where we retrieve a DatasetConfig.dataset (such as building a graph), return the ctl_dataset record instead of DatasetConfig.dataset. 
* [ ] Lots of test fixtures needed to be changed to create a ctl_dataset before creating a datasetconfig and then linking the two.

### Steps to Confirm

Migration verification
* [ ] Checkout main.  Create a `datasetconfig` in your application database and then switch to this branch without dropping that database.  If you switch and bring up the shell, migrations should run.  Verify that the existing `datasetconfig` table has a `ctl_dataset_id` row.  Verify that this row is non-nullable and populated.  Locate the corresponding `ctl_datasets` record. Compare each column and match to what was in `datasetconfig.dataset`.  `DatasetConfig.dataset` itself should be untouched for now.  Any `fidesops_meta` fields are likely converted to `fides_meta` fields.'

Run a privacy request
* [ ] Run `nox -s test_env`
* [ ] Go to the privacy center, run a privacy request
* [ ] Return to admin UI, approve
* [ ] Verify json file in `fides_uploads` folder and contents are roughly correct.

Existing endpoint parity (will soon be deprecated, but the UI still works here)
* [ ] Run `nox -s test_env`
* [ ] Go to http://localhost:3000, login, then http://localhost:3000/datastore-connection. 
* [ ] Click on the three horizontal dots of the Postgres connector > Configure. Jump to Dataset configuration tab. Edit the description of the dataset. Verify API request is successful (`PATCH http://0.0.0.0:8080/api/v1/connection/postgres_connector/dataset`)
* [ ] Locate the updated datasetconfig.dataset field in the db. Verify the description has changed. Similarly note that the ctl_dataset.description column has changed (`select description from ctl_datasets where id = 'xxxxxx';`)

Test creating saas connectors from a template
* [ ] - http://localhost:3000/datastore-connection > Create new connection
* [ ] Select mailchimp. Enter in connector parameters - because we're not going to use this, your secrets can be fake
* [ ] On Dataset configuration tab click > Save Yaml System.
* [ ] Verify successful API requests
* [ ] Verify that new `datasetconfig` and `ctl_datasets` records and the DatasetConfig has a ctl_dataset_id FK. The dataset should exist in both places.
 
New endpoint
* [ ] In Postman or similar, create a new connection config resource `PATCH {{host}}/connection/`
* [ ] In Postman or similar, add a dataset config with the new endpoint: `PATCH {{host}}/connection/{{existing connection key}}/datasetconfig`.  Create a new fides_key (this will be the identifier for the DatasetConfig, but select an existing ctl_dataset fides_key.
```json
[{
    "fides_key": "new_dataset_config",
    "ctl_dataset_fides_key": "postgres_example_test_dataset"
}]
```
* [ ] Verify a new DatasetConfig was created and the contents of the existing ctl_dataset were ported back into the new DatasetConfig.dataset .
* [ ] Visit this new connector and dataset in the UI

Existing CTL datasets tab
* [ ] Go to http://localhost:3000/dataset. Our newly created datasets (mailchimp) and the postgres one created directly in the API should be there.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation Updated:
  * [ ] documentation complete, or draft/outline provided (tag docs-team to complete/review on this branch)
  * [ ] documentation issue created (tag docs-team to complete issue separately)
* [ ] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

We are trying to move to storing the bulk of the contents of a Dataset solely on the `ctl_datasets` table. Right now, similar concepts exist in both the `ctl_datasets` table and the `DatasetConfig.dataset` column.  

The idea with this increment is to add a _non-nullable_ `DatasetConfig.ctl_dataset_id` field. DSR's can't run without an associated dataset so I think we should keep this a constraint from the beginning.  I take the contents of existing `DatasetConfig.datasets` and attempt to create new `ctl_dataset` records and then link them to existing DatasetConfig. 

The next step is to keep writing to both places - `DatasetConfig.dataset` AND making the same changes to the `ctl_dataset` record.   This work also starts _reading_ from the `DatasetConfig.ctl_dataset` record instead of `DatasetConfig.dataset`.  

Follow-up work will deprecate some existing endpoints and stop writing to the DatasetConfig.dataset column.



