### PR TITLE
Store fides_consent cookie on the root domain of the Privacy Center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The types of changes are:
 
 * Nav redesign with sidebar groups. Feature flagged to only be visible in dev mode until release. [#2030](https://github.com/ethyca/fides/pull/2047)
 
+### Fixed
+
+* Store `fides_consent` cookie on the root domain of the Privacy Center [#2071](https://github.com/ethyca/fides/pull/2071)
+
 ## [2.3.0](https://github.com/ethyca/fides/compare/2.2.2...2.3.0)
 
 ### Added

--- a/clients/privacy-center/packages/fides-consent/src/lib/cookie.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/cookie.ts
@@ -49,12 +49,21 @@ export const setConsentCookie = (cookieKeyConsent: CookieKeyConsent) => {
     return;
   }
 
+  // Calculate the root domain by taking (up to) the last two parts of the domain:
+  //   privacy.example.com -> example.com
+  //   example.com -> example.com
+  //   localhost -> localhost
+  //
+  // TODO: This won't second-level domains like co.uk:
+  //   privacy.example.co.uk -> co.uk # ERROR
+  const rootDomain = window.location.hostname.split(".").slice(-2).join(".")
+
   setCookie(
     CONSENT_COOKIE_NAME,
     JSON.stringify(cookieKeyConsent),
     {
       // An explicit domain allows subdomains to access the cookie.
-      domain: window.location.hostname,
+      domain: rootDomain,
       expires: CONSENT_COOKIE_MAX_AGE_DAYS,
     },
     CODEC


### PR DESCRIPTION
Closes #2070

### Code Changes

* [X] Calculate the root domain (based on `window.location`)
* [X] Save the cookie using the root domain

### Steps to Confirm

* [X] Ran `nox -s test_env` and confirmed cookie still writes out unchanged
* [ ] Deploy privacy center to a subdomain and test

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, PR opened in [fidesdocs](https://github.com/ethyca/fidesdocs)
  * [x] documentation issue created in [fidesdocs](https://github.com/ethyca/fidesdocs)
* [x] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created: https://github.com/ethyca/fides/issues/2072
* [x] Update `CHANGELOG.md`

### Description Of Changes

This has one major issue, which is that it'll only work for "normal" TLDs like ".com", ".co", etc., but will calculate the root domain incorrectly for sites that use second-level domains like "example.co.uk" or "example.co.jp", etc.
