### PR TITLE
Fix user creation as root

### DIFF
--- a/src/fides/lib/oauth/api/routes/user_endpoints.py
+++ b/src/fides/lib/oauth/api/routes/user_endpoints.py
@@ -17,12 +17,12 @@ from starlette.status import (
     HTTP_404_NOT_FOUND,
 )
 
+from fides.api.ops.util.oauth_util import verify_oauth_client
 from fides.ctl.core.config import FidesConfig, get_config
 from fides.lib.models.client import ADMIN_UI_ROOT, ClientDetail
 from fides.lib.models.fides_user import FidesUser
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
 from fides.lib.oauth.api import urn_registry as urls
-
 from fides.lib.oauth.api.deps import get_db
 from fides.lib.oauth.schemas.oauth import AccessToken
 from fides.lib.oauth.schemas.user import (
@@ -38,7 +38,6 @@ from fides.lib.oauth.scopes import (
     USER_DELETE,
     USER_READ,
 )
-from fides.api.ops.util.oauth_util import verify_oauth_client
 
 router = APIRouter()
 

--- a/src/fides/lib/oauth/api/routes/user_endpoints.py
+++ b/src/fides/lib/oauth/api/routes/user_endpoints.py
@@ -22,7 +22,8 @@ from fides.lib.models.client import ADMIN_UI_ROOT, ClientDetail
 from fides.lib.models.fides_user import FidesUser
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
 from fides.lib.oauth.api import urn_registry as urls
-from fides.lib.oauth.api.deps import get_db, verify_oauth_client
+
+from fides.lib.oauth.api.deps import get_db
 from fides.lib.oauth.schemas.oauth import AccessToken
 from fides.lib.oauth.schemas.user import (
     UserCreate,
@@ -37,6 +38,7 @@ from fides.lib.oauth.scopes import (
     USER_DELETE,
     USER_READ,
 )
+from fides.api.ops.util.oauth_util import verify_oauth_client
 
 router = APIRouter()
 

--- a/tests/lib/conftest.py
+++ b/tests/lib/conftest.py
@@ -44,9 +44,9 @@ def db(config):
     """Yield a connection to the test DB."""
     # Included so that `AccessManualWebhook` can be located when
     # `ConnectionConfig` is instantiated.
-    from fides.api.ops.models.manual_webhook import (
+    from fides.api.ops.models.manual_webhook import (  # pylint: disable=unused-import
         AccessManualWebhook,
-    )  # pylint: disable=unused-import
+    )
 
     # Create the test DB engine
     assert config.is_test_mode

--- a/tests/lib/conftest.py
+++ b/tests/lib/conftest.py
@@ -42,6 +42,12 @@ def config():
 @pytest.fixture
 def db(config):
     """Yield a connection to the test DB."""
+    # Included so that `AccessManualWebhook` can be located when
+    # `ConnectionConfig` is instantiated.
+    from fides.api.ops.models.manual_webhook import (
+        AccessManualWebhook,
+    )  # pylint: disable=unused-import
+
     # Create the test DB engine
     assert config.is_test_mode
     engine = get_db_engine(

--- a/tests/lib/test_client_model.py
+++ b/tests/lib/test_client_model.py
@@ -4,6 +4,12 @@ from copy import deepcopy
 
 import pytest
 
+# Included so that `AccessManualWebhook` can be located when
+# `ConnectionConfig` is instantiated.
+from fides.api.ops.models.manual_webhook import (
+    AccessManualWebhook,
+)  # pylint: disable=unused-import
+
 from fides.lib.cryptography.cryptographic_util import hash_with_salt
 from fides.lib.models.client import ClientDetail, _get_root_client_detail
 from fides.lib.oauth.scopes import SCOPES

--- a/tests/lib/test_client_model.py
+++ b/tests/lib/test_client_model.py
@@ -4,12 +4,6 @@ from copy import deepcopy
 
 import pytest
 
-# Included so that `AccessManualWebhook` can be located when
-# `ConnectionConfig` is instantiated.
-from fides.api.ops.models.manual_webhook import (
-    AccessManualWebhook,
-)  # pylint: disable=unused-import
-
 from fides.lib.cryptography.cryptographic_util import hash_with_salt
 from fides.lib.models.client import ClientDetail, _get_root_client_detail
 from fides.lib.oauth.scopes import SCOPES

--- a/tests/lib/test_fides_user_permissions.py
+++ b/tests/lib/test_fides_user_permissions.py
@@ -12,6 +12,10 @@ from fides.lib.oauth.scopes import (
 
 
 def test_create_user_permissions():
+    from fides.api.ops.models.manual_webhook import (
+        AccessManualWebhook,
+    )  # pylint: disable=unused-import
+
     permissions: FidesUserPermissions = FidesUserPermissions.create(  # type: ignore
         db=MagicMock(),
         data={"user_id": "test", "scopes": [PRIVACY_REQUEST_READ]},
@@ -23,6 +27,10 @@ def test_create_user_permissions():
 
 
 def test_associated_privileges():
+    from fides.api.ops.models.manual_webhook import (
+        AccessManualWebhook,
+    )  # pylint: disable=unused-import
+
     permissions: FidesUserPermissions = FidesUserPermissions.create(  # type: ignore
         db=MagicMock(),
         data={

--- a/tests/lib/test_fides_user_permissions.py
+++ b/tests/lib/test_fides_user_permissions.py
@@ -2,6 +2,12 @@
 
 from unittest.mock import MagicMock
 
+# Included so that `AccessManualWebhook` can be located when
+# `ConnectionConfig` is instantiated.
+from fides.api.ops.models.manual_webhook import (
+    AccessManualWebhook,
+)  # pylint: disable=unused-import
+
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
 from fides.lib.oauth.scopes import (
     PRIVACY_REQUEST_READ,
@@ -12,10 +18,6 @@ from fides.lib.oauth.scopes import (
 
 
 def test_create_user_permissions():
-    from fides.api.ops.models.manual_webhook import (
-        AccessManualWebhook,
-    )  # pylint: disable=unused-import
-
     permissions: FidesUserPermissions = FidesUserPermissions.create(  # type: ignore
         db=MagicMock(),
         data={"user_id": "test", "scopes": [PRIVACY_REQUEST_READ]},
@@ -27,10 +29,6 @@ def test_create_user_permissions():
 
 
 def test_associated_privileges():
-    from fides.api.ops.models.manual_webhook import (
-        AccessManualWebhook,
-    )  # pylint: disable=unused-import
-
     permissions: FidesUserPermissions = FidesUserPermissions.create(  # type: ignore
         db=MagicMock(),
         data={

--- a/tests/lib/test_fides_user_permissions.py
+++ b/tests/lib/test_fides_user_permissions.py
@@ -19,6 +19,7 @@ from fides.lib.oauth.scopes import (
 
 def test_create_user_permissions():
     permissions: FidesUserPermissions = FidesUserPermissions.create(  # type: ignore
+        # Not using the `db` here allows us to omit PK and FK data
         db=MagicMock(),
         data={"user_id": "test", "scopes": [PRIVACY_REQUEST_READ]},
     )
@@ -30,6 +31,7 @@ def test_create_user_permissions():
 
 def test_associated_privileges():
     permissions: FidesUserPermissions = FidesUserPermissions.create(  # type: ignore
+        # Not using the `db` here allows us to omit PK and FK data
         db=MagicMock(),
         data={
             "user_id": "test",

--- a/tests/lib/test_fides_user_permissions.py
+++ b/tests/lib/test_fides_user_permissions.py
@@ -4,10 +4,9 @@ from unittest.mock import MagicMock
 
 # Included so that `AccessManualWebhook` can be located when
 # `ConnectionConfig` is instantiated.
-from fides.api.ops.models.manual_webhook import (
+from fides.api.ops.models.manual_webhook import (  # pylint: disable=unused-import
     AccessManualWebhook,
-)  # pylint: disable=unused-import
-
+)
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
 from fides.lib.oauth.scopes import (
     PRIVACY_REQUEST_READ,

--- a/tests/ops/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_endpoints.py
@@ -159,7 +159,7 @@ class TestCreateUser:
         assert response_body == {"id": user.id}
         assert user.permissions is not None
         user.delete(db)
-        
+
     def test_create_user_as_root(
         self,
         db,

--- a/tests/ops/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_endpoints.py
@@ -159,6 +159,25 @@ class TestCreateUser:
         assert response_body == {"id": user.id}
         assert user.permissions is not None
         user.delete(db)
+        
+    def test_create_user_as_root(
+        self,
+        db,
+        api_client,
+        root_auth_header,
+        url,
+    ) -> None:
+        auth_header = root_auth_header
+        body = {"username": "test_user", "password": str_to_b64_str("TestP@ssword9")}
+
+        response = api_client.post(url, headers=auth_header, json=body)
+
+        user = FidesUser.get_by(db, field="username", value=body["username"])
+        response_body = json.loads(response.text)
+        assert HTTP_201_CREATED == response.status_code
+        assert response_body == {"id": user.id}
+        assert user.permissions is not None
+        user.delete(db)
 
     def test_create_user_with_name(
         self,


### PR DESCRIPTION
Closes #2077 

### Code Changes

* [x] add a test to catch the 403 caused by creating a user as root
* [x] add the fix

### Steps to Confirm

* [ ] Run `nox -s dev`
* [ ] Login as the root user
* [ ] Create a user, assert the user is created
* [ ] Edit a user, assert the user's data is updated
* [ ] Login as the created user, assert that the user is able to act in some way

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, PR opened in [fidesdocs](https://github.com/ethyca/fidesdocs)
  * [ ] documentation issue created in [fidesdocs](https://github.com/ethyca/fidesdocs)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

This regression was caused by the removal of the `fideslib` references from our codebase. `fideslib` was designed to have a common override pattern (with safe backstop) for the `verify_oauth_client` API dependency — which is not being overridden correctly now that the code is in the main codebase. This PR switches out the version of that method designed to be overloaded with the current method in use by the rest of the codebase.