### PR TITLE
Support exporting _all_ resources via `fides pull`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Closes <issue>
+Closes #<issue>
 
 ### Code Changes
 
@@ -6,14 +6,14 @@ Closes <issue>
 
 ### Steps to Confirm
 
-* [ ] _list any manual steps taken to confirm the changes_
+* [ ] _list any manual steps for reviewers to confirm the changes_
 
 ### Pre-Merge Checklist
 
 * [ ] All CI Pipelines Succeeded
 * Documentation:
-  * [ ] documentation complete, PR opened in [fidesdocs](https://github.com/ethyca/fidesdocs)
-  * [ ] documentation issue created in [fidesdocs](https://github.com/ethyca/fidesdocs)
+  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
+  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
 * [ ] Issue Requirements are Met
 * [ ] Relevant Follow-Up Issues Created
 * [ ] Update `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The types of changes are:
 * Do not always create a `fides.toml` by default [#2023](https://github.com/ethyca/fides/pull/2023)
 * The `fideslib` module has been merged into `fides`, code redundancies have been removed [#1859](https://github.com/ethyca/fides/pull/1859)
 * Replace 'ingress' and 'egress' with 'sources' and 'destinations' across UI [#2044](https://github.com/ethyca/fides/pull/2044)
+* Update the functionality of `fides pull -a <filename>` to include _all_ resource types. [#2083](https://github.com/ethyca/fides/pull/2083)
 
 ### Fixed
 

--- a/src/fides/cli/commands/core.py
+++ b/src/fides/cli/commands/core.py
@@ -170,5 +170,5 @@ def pull(ctx: click.Context, manifests_dir: str, all_resources: Optional[str]) -
         url=config.cli.server_url,
         manifests_dir=manifests_dir,
         headers=config.user.request_headers,
-        all_resources=all_resources,
+        all_resources_file=all_resources,
     )

--- a/src/fides/cli/commands/core.py
+++ b/src/fides/cli/commands/core.py
@@ -157,6 +157,7 @@ def pull(ctx: click.Context, manifests_dir: str, all_resources: Optional[str]) -
     The pull is aborted if there are unstaged or untracked files in the manifests dir.
     """
 
+    # Make the resources that are pulled configurable
     config = ctx.obj["CONFIG"]
     # Do this to validate the manifests since they won't get parsed during the pull process
     _parse.parse(manifests_dir)

--- a/src/fides/ctl/core/pull.py
+++ b/src/fides/ctl/core/pull.py
@@ -3,10 +3,13 @@ from typing import Dict, List, Optional
 
 import yaml
 from fideslang.manifests import load_yaml_into_dict
+from fideslang import model_list
 
 from fides.cli.utils import print_divider
 from fides.ctl.core.api_helpers import get_server_resource, list_server_resources
 from fides.ctl.core.utils import echo_green, get_manifest_list
+
+MODEL_LIST = model_list
 
 
 def write_manifest_file(manifest_path: str, manifest: Dict) -> None:
@@ -63,7 +66,10 @@ def pull_existing_resources(
 
 
 def pull_missing_resources(
-    manifest_path: str, url: str, headers: Dict[str, str], existing_keys: List[str]
+    manifest_path: str,
+    url: str,
+    headers: Dict[str, str],
+    existing_keys: List[str],
 ) -> bool:
     """
     Writes all "system", "dataset" and "policy" resources out locally
@@ -71,7 +77,6 @@ def pull_missing_resources(
     """
 
     print(f"Writing out new resources to file: '{manifest_path}'...")
-    resources_to_pull = ["system", "dataset", "policy"]
     resource_manifest = {
         resource: list_server_resources(
             url=url,
@@ -80,7 +85,7 @@ def pull_missing_resources(
             exclude_keys=existing_keys,
             raw=True,
         )
-        for resource in resources_to_pull
+        for resource in MODEL_LIST
     }
 
     # Write out the resources in a file
@@ -93,20 +98,22 @@ def pull(
     manifests_dir: str,
     url: str,
     headers: Dict[str, str],
-    all_resources: Optional[str],
+    all_resources_file: Optional[str],
 ) -> None:
     """
     If a resource in a local file has a matching resource on the server,
     write the server version into the local file.
 
-    If the 'all' flag is passed, additionally pull all other server resources
-    into local files as well.
+    If the 'all_resources_file' option is present, pull all other server resources
+    into local a file.
     """
-    existing_keys = pull_existing_resources(manifests_dir, url, headers)
+    existing_keys = pull_existing_resources(
+        manifests_dir=manifests_dir, url=url, headers=headers
+    )
 
-    if all_resources:
+    if all_resources_file:
         pull_missing_resources(
-            manifest_path=all_resources,
+            manifest_path=all_resources_file,
             url=url,
             headers=headers,
             existing_keys=existing_keys,

--- a/src/fides/ctl/core/pull.py
+++ b/src/fides/ctl/core/pull.py
@@ -2,8 +2,8 @@
 from typing import Dict, List, Optional
 
 import yaml
-from fideslang.manifests import load_yaml_into_dict
 from fideslang import model_list
+from fideslang.manifests import load_yaml_into_dict
 
 from fides.cli.utils import print_divider
 from fides.ctl.core.api_helpers import get_server_resource, list_server_resources

--- a/src/fides/ctl/core/pull.py
+++ b/src/fides/ctl/core/pull.py
@@ -109,7 +109,7 @@ def pull(
     write the server version into the local file.
 
     If the 'all_resources_file' option is present, pull all other server resources
-    into local a file.
+    into a local file.
     """
     existing_keys = pull_existing_resources(
         manifests_dir=manifests_dir, url=url, headers=headers

--- a/src/fides/ctl/core/pull.py
+++ b/src/fides/ctl/core/pull.py
@@ -88,6 +88,10 @@ def pull_missing_resources(
         for resource in MODEL_LIST
     }
 
+    resource_manifest = {
+        key: value for key, value in resource_manifest.items() if value
+    }
+
     # Write out the resources in a file
     write_manifest_file(manifest_path, resource_manifest)
     print_divider()


### PR DESCRIPTION
Closes #1988 

### Code Changes

* [x] update the `--all-resources` flag to actually include all resources
* [x] updated the PR checklist to make it easier to open docs issues

### Steps to Confirm

* [ ] run `fides push` and confirm everything gets uploaded as expected
* [ ] run `fides pull` and confirm that local objects have been updated (they should now show the `null` fields, but functionally remain unchanged)
* [ ] run `git reset --hard` to undo the changes to the manifest files (required for a later step)
* [ ] run `fides evaluate` and confirm that it passes
* [ ] run `fides pull -a test.yml` and confirm that _everything_ gets exported from the database, including the taxonomy as well as the successful evaluation. Note though that any resources that already exist in other manifest files _will not_ be duplicated into the new file (i.e. there should be no datasets)
* [ ] run `fides push test.yml` and confirm that it succeeds

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, PR opened in [fidesdocs](https://github.com/ethyca/fidesdocs)
  * [ ] documentation issue created in [fidesdocs](https://github.com/ethyca/fidesdocs)
* [x] Issue Requirements are Met
* [ ] ~~Relevant Follow-Up Issues Created~~
* [x] Update `CHANGELOG.md`

### Description Of Changes

`fides pull` was hardcoded to only export systems, datasets, and policies, but we have users for whom this is not sufficient. Some users have also modified their default taxonomies, stored evaluations, and more. This PR will update `fides pull` to be able to export _all_ `ctl` resources from the database,  not only making it good for keeping local objects in-sync, but also adding the "grey market" use-case of being able to fully "backup" a `ctl` instance as a set of files.
