### PR TITLE
Release 2.3.1

### DIFF
--- a/src/fides/lib/oauth/api/routes/user_endpoints.py
+++ b/src/fides/lib/oauth/api/routes/user_endpoints.py
@@ -17,12 +17,13 @@ from starlette.status import (
     HTTP_404_NOT_FOUND,
 )
 
+from fides.api.ops.util.oauth_util import verify_oauth_client
 from fides.ctl.core.config import FidesConfig, get_config
 from fides.lib.models.client import ADMIN_UI_ROOT, ClientDetail
 from fides.lib.models.fides_user import FidesUser
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
 from fides.lib.oauth.api import urn_registry as urls
-from fides.lib.oauth.api.deps import get_db, verify_oauth_client
+from fides.lib.oauth.api.deps import get_db
 from fides.lib.oauth.schemas.oauth import AccessToken
 from fides.lib.oauth.schemas.user import (
     UserCreate,

--- a/tests/lib/conftest.py
+++ b/tests/lib/conftest.py
@@ -42,6 +42,12 @@ def config():
 @pytest.fixture
 def db(config):
     """Yield a connection to the test DB."""
+    # Included so that `AccessManualWebhook` can be located when
+    # `ConnectionConfig` is instantiated.
+    from fides.api.ops.models.manual_webhook import (  # pylint: disable=unused-import
+        AccessManualWebhook,
+    )
+
     # Create the test DB engine
     assert config.is_test_mode
     engine = get_db_engine(

--- a/tests/lib/test_fides_user_permissions.py
+++ b/tests/lib/test_fides_user_permissions.py
@@ -2,6 +2,11 @@
 
 from unittest.mock import MagicMock
 
+# Included so that `AccessManualWebhook` can be located when
+# `ConnectionConfig` is instantiated.
+from fides.api.ops.models.manual_webhook import (  # pylint: disable=unused-import
+    AccessManualWebhook,
+)
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
 from fides.lib.oauth.scopes import (
     PRIVACY_REQUEST_READ,
@@ -13,6 +18,7 @@ from fides.lib.oauth.scopes import (
 
 def test_create_user_permissions():
     permissions: FidesUserPermissions = FidesUserPermissions.create(  # type: ignore
+        # Not using the `db` here allows us to omit PK and FK data
         db=MagicMock(),
         data={"user_id": "test", "scopes": [PRIVACY_REQUEST_READ]},
     )
@@ -24,6 +30,7 @@ def test_create_user_permissions():
 
 def test_associated_privileges():
     permissions: FidesUserPermissions = FidesUserPermissions.create(  # type: ignore
+        # Not using the `db` here allows us to omit PK and FK data
         db=MagicMock(),
         data={
             "user_id": "test",

--- a/tests/ops/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_endpoints.py
@@ -160,6 +160,25 @@ class TestCreateUser:
         assert user.permissions is not None
         user.delete(db)
 
+    def test_create_user_as_root(
+        self,
+        db,
+        api_client,
+        root_auth_header,
+        url,
+    ) -> None:
+        auth_header = root_auth_header
+        body = {"username": "test_user", "password": str_to_b64_str("TestP@ssword9")}
+
+        response = api_client.post(url, headers=auth_header, json=body)
+
+        user = FidesUser.get_by(db, field="username", value=body["username"])
+        response_body = json.loads(response.text)
+        assert HTTP_201_CREATED == response.status_code
+        assert response_body == {"id": user.id}
+        assert user.permissions is not None
+        user.delete(db)
+
     def test_create_user_with_name(
         self,
         db,


### PR DESCRIPTION
# Release Checklist

The release checklist is a manual set of checks done before each release to ensure functionality of the most critical components of the application. Some of these steps are redundant with automated tests, while others are _only_ tested here as part of this check.

This checklist should be copy/pasted into the final pre-release PR, and checked off as you complete each step.

## Pre-Release Steps

### General

- [ ] Quickstart verified working and up-to-date
- [ ] New tables/columns added to [database diagram](https://github.com/ethyca/fides/blob/5a485387d8af247ec6479e4115088cbbb8394d77/docs/fides/docs/development/update_erd_diagram.md)
- [ ] `nox -s test_env` works (verify the admin UI, privacy center, CLI and webserver)
- [ ] `nox -s "build(sample)"` works on the release branch, creating the sample images (this is also prereq for `fides deploy up`)
- [ ] `fides deploy up --no-pull` works using the images built in previous step (verify the admin UI, privacy center, CLI and webserver)
```
mkdir ~/fides-2-1-0-test
cd ~/fides-2-1-0-test
python3 -m venv venv
source venv/bin/activate
pip install git+https://github.com/ethyca/fides.git@<branch>
fides deploy up --no-pull
fides status
fides deploy down
rm -rf ~/fides-2-1-0-test
exit 
```

### API

- [ ] Verify that the generated API docs are correct
- [ ] Verify that the Postman collection has been updated

### CLI

- [ ] Run a `fides push`
- [ ] Run a `fides pull`
- [ ] Run a `fides evaluate`
- [ ] Generate a dataset with `fides generate dataset db`
- [ ] Scan a database with `fides scan dataset db`

### Admin UI

- [ ] Every navigation button works
- [ ] DSR approval succeeds
- [ ] DSR execution succeeds

### Privacy Center

- [ ] Every navigation button works
- [ ] DSR submission succeeds
- [ ] Consent request submission succeeds

### Documentation

- [ ] Verify that the CHANGELOG is formatted correctly and clean up verbiage where needed
- [ ] Verify that the CHANGELOG is representative of the actual changes

## Post-Release Steps

- [ ] Verify the ethyca-fides release is published to PyPi: https://pypi.org/project/ethyca-fides/#history
- [ ] Verify the fides release is published to DockerHub: https://hub.docker.com/r/ethyca/fides
- [ ] Verify the fides-privacy-center release is published to DockerHub: https://hub.docker.com/r/ethyca/fides-privacy-center
- [ ] Verify the fides-sample-app release is published to DockerHub: https://hub.docker.com/r/ethyca/fides-sample-app
- [ ] Smoke test the PyPi & DockerHub releases with a clean `pip install ethyca-fides` and `fides deploy up`