### PR TITLE
specifically handle and report decryption errors on server bootup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The types of changes are:
 ### Added
 
 * Nav redesign with sidebar groups. Feature flagged to only be visible in dev mode until release. [#2030](https://github.com/ethyca/fides/pull/2047)
+* Improved error handling for incorrect app encryption key [#2089](https://github.com/ethyca/fides/pull/2089)
 
 ### Fixed
 

--- a/src/fides/api/ctl/database/database.py
+++ b/src/fides/api/ctl/database/database.py
@@ -9,6 +9,7 @@ from alembic.runtime import migration
 from loguru import logger as log
 from sqlalchemy.orm import Session
 from sqlalchemy_utils.functions import create_database, database_exists
+from sqlalchemy_utils.types.encrypted.encrypted_type import InvalidCiphertextError
 
 from fides.api.ctl.utils.errors import get_full_exception_name
 from fides.ctl.core.config import get_config
@@ -99,6 +100,13 @@ async def configure_db(database_url: str) -> None:
     try:
         create_db_if_not_exists(database_url)
         await init_db(database_url)
+    except InvalidCiphertextError as cipher_error:
+        log.error(
+            "Unable to configure database due to a decryption error! Check to ensure your `app_encryption_key` has not changed."
+        )
+        log.opt(exception=True).error(cipher_error)
+
     except Exception as error:  # pylint: disable=broad-except
         error_type = get_full_exception_name(error)
         log.error("Unable to configure database: {}: {}", error_type, error)
+        log.opt(exception=True).error(error)


### PR DESCRIPTION
Closes #2088 

### Code Changes

* Better handle decryption errors on server bootup to prevent people from getting too far with a bad encryption key

### Steps to Confirm

* run `nox -s dev `
* update your `fides.toml` to change a character in the `app_encryption_key` property
* trigger a restart of your server by trivially changing a source code file, by re-running `nox -s dev`, etc.
* look for the new logging around the decryption problems on startup

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, PR opened in [fidesdocs](https://github.com/ethyca/fidesdocs)
  * [ ] documentation issue created in [fidesdocs](https://github.com/ethyca/fidesdocs)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

See the issue for some ideas around _further_ guardrails/handling of this. I'm a bit unsure about how far we should go, and how important it is. But this change here seems like some trivial low hanging fruit that will hopefully make things a bit smoother if this happens to come up in the wild.
