### PR TITLE
pc/dev: Automatically build fides-consent after npm install

### DIFF
--- a/clients/privacy-center/package-lock.json
+++ b/clients/privacy-center/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "fidesops-privacy-center",
+      "hasInstallScript": true,
       "workspaces": [
         "packages/fides-consent"
       ],

--- a/clients/privacy-center/package.json
+++ b/clients/privacy-center/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "prebuild": "npm run build:fides-consent",
+    "postinstall": "npm run build:fides-consent",
     "build": "next build",
     "build:fides-consent": "npm run --workspace=fides-consent build",
     "start": "next start",


### PR DESCRIPTION
Removes this stumbling block: https://ethyca.slack.com/archives/C043URV1KLL/p1671548316676079

### Description Of Changes

The fides-consent package automatically builds when the Privacy Center builds. However, from a clean clone of the repo running `npm run dev` does not _build_ the PC, it just kicks of the Next watcher. By also building the subpackage after install we ensure `dev` works from scratch.
