### PR TITLE
1853 id verification consent sms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The types of changes are:
 * Nav 2.0 - Replace form flow side navs with top tabs [#2037](https://github.com/ethyca/fides/pull/2050)
 * Adds new erasure policy for complete user data masking [#1839](https://github.com/ethyca/fides/pull/1839)
 * Added ability to use Mailgun templates when sending emails. [#2039](https://github.com/ethyca/fides/pull/2039)
+* Adds SMS id verification for consent [#2094](https://github.com/ethyca/fides/pull/2094)
 
 ## [2.3.1](https://github.com/ethyca/fides/compare/2.3.0...2.3.1)
 

--- a/clients/privacy-center/__tests__/RequestModal.test.tsx
+++ b/clients/privacy-center/__tests__/RequestModal.test.tsx
@@ -66,7 +66,7 @@ describe("RequestModal", () => {
     expect(
       screen.getByPlaceholderText("test-email@example.com")
     ).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("+1 000 000 0000")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("000 000 0000")).toBeInTheDocument();
 
     unmount();
 
@@ -81,7 +81,7 @@ describe("RequestModal", () => {
     expect(
       screen.getByPlaceholderText("test-email@example.com")
     ).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText("+1 000 000 0000")).toBeNull();
+    expect(screen.queryByPlaceholderText("000 000 0000")).toBeNull();
 
     unmount();
 
@@ -94,7 +94,7 @@ describe("RequestModal", () => {
 
     expect(screen.queryByPlaceholderText("Michael Brown")).toBeNull();
     expect(screen.queryByPlaceholderText("test-email@example.com")).toBeNull();
-    expect(screen.getByPlaceholderText("+1 000 000 0000")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("000 000 0000")).toBeInTheDocument();
 
     unmount();
   });

--- a/clients/privacy-center/__tests__/RequestModal.test.tsx
+++ b/clients/privacy-center/__tests__/RequestModal.test.tsx
@@ -116,7 +116,7 @@ describe("RequestModal", () => {
         target: { value: "testing@ethyca.com" },
       });
 
-      fireEvent.change(screen.getByPlaceholderText("+1 000 000 0000"), {
+      fireEvent.change(screen.getByPlaceholderText("000 000 0000"), {
         target: { value: "0000000000" },
       });
     });
@@ -151,7 +151,7 @@ describe("RequestModal", () => {
         target: { value: "testing@ethyca.com" },
       });
 
-      fireEvent.change(screen.getByPlaceholderText("+1 000 000 0000"), {
+      fireEvent.change(screen.getByPlaceholderText("000 000 0000"), {
         target: { value: "0000000000" },
       });
     });
@@ -189,7 +189,7 @@ describe("RequestModal", () => {
         target: { value: "testing@ethyca.com" },
       });
 
-      fireEvent.change(screen.getByPlaceholderText("+1 000 000 0000"), {
+      fireEvent.change(screen.getByPlaceholderText("000 000 0000"), {
         target: { value: "0000000000" },
       });
     });

--- a/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
+++ b/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
@@ -22,8 +22,8 @@ import { addCommonHeaders } from "~/common/CommonHeaders";
 
 import {config, hostUrl} from "~/constants";
 import dynamic from "next/dynamic";
-import { ModalViews, VerificationType } from "../types";
 import * as Yup from "yup";
+import { ModalViews, VerificationType } from "../types";
 
 const PhoneInput = dynamic(() => import("react-phone-number-input"), {
   ssr: false,
@@ -202,8 +202,7 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
                       name="email"
                       type="email"
                       focusBorderColor="primary.500"
-                      placeholder="Email*"
-                      isRequired
+                      placeholder="test-email@example.com"
                       onChange={handleChange}
                       onBlur={handleBlur}
                       value={values.email}
@@ -228,7 +227,7 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
                       name="phone"
                       type="tel"
                       focusBorderColor="primary.500"
-                      placeholder="+1 000 000 0000"
+                      placeholder="000 000 0000"
                       defaultCountry="US"
                       onChange={(value) => {
                         setFieldValue("phone", value, true);

--- a/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
+++ b/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
@@ -3,7 +3,8 @@ import {
   Button,
   chakra,
   FormControl,
-  FormErrorMessage, FormLabel,
+  FormErrorMessage,
+  FormLabel,
   Input,
   ModalBody,
   ModalFooter,
@@ -20,7 +21,7 @@ import { ErrorToastOptions } from "~/common/toast-options";
 import { Headers } from "headers-polyfill";
 import { addCommonHeaders } from "~/common/CommonHeaders";
 
-import {config, hostUrl} from "~/constants";
+import { config, hostUrl } from "~/constants";
 import dynamic from "next/dynamic";
 import * as Yup from "yup";
 import { ModalViews, VerificationType } from "../types";
@@ -115,8 +116,8 @@ const useConsentRequestForm = ({
         let validation = Yup.string();
         if (config.consent?.identity_inputs?.email === "required") {
           validation = validation
-              .email("Email is invalid")
-              .required("Email is required");
+            .email("Email is invalid")
+            .required("Email is required");
         }
         return validation;
       })(),
@@ -124,9 +125,9 @@ const useConsentRequestForm = ({
         let validation = Yup.string();
         if (config.consent?.identity_inputs?.phone === "required") {
           validation = validation
-              .required("Phone is required")
-              // E.164 international standard format
-              .matches(/^\+[1-9]\d{1,14}$/, "Phone is invalid");
+            .required("Phone is required")
+            // E.164 international standard format
+            .matches(/^\+[1-9]\d{1,14}$/, "Phone is invalid");
         }
         return validation;
       })(),
@@ -188,55 +189,55 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
           ) : null}
           <Stack spacing={3}>
             {config.consent?.identity_inputs.email ? (
-                <FormControl
-                    id="email"
-                    isInvalid={touched.email && Boolean(errors.email)}
-                >
-                  <FormLabel>
-                    {config.consent?.identity_inputs.email === "required"
-                        ? "Email*"
-                        : "Email"}
-                  </FormLabel>
-                  <Input
-                      id="email"
-                      name="email"
-                      type="email"
-                      focusBorderColor="primary.500"
-                      placeholder="test-email@example.com"
-                      onChange={handleChange}
-                      onBlur={handleBlur}
-                      value={values.email}
-                      isInvalid={touched.email && Boolean(errors.email)}
-                  />
-                  <FormErrorMessage>{errors.email}</FormErrorMessage>
-                </FormControl>
+              <FormControl
+                id="email"
+                isInvalid={touched.email && Boolean(errors.email)}
+              >
+                <FormLabel>
+                  {config.consent?.identity_inputs.email === "required"
+                    ? "Email*"
+                    : "Email"}
+                </FormLabel>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  focusBorderColor="primary.500"
+                  placeholder="test-email@example.com"
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  value={values.email}
+                  isInvalid={touched.email && Boolean(errors.email)}
+                />
+                <FormErrorMessage>{errors.email}</FormErrorMessage>
+              </FormControl>
             ) : null}
             {config.consent?.identity_inputs.phone ? (
-                <FormControl
-                    id="phone"
-                    isInvalid={touched.phone && Boolean(errors.phone)}
-                >
-                  <FormLabel>
-                    {config.consent?.identity_inputs.phone === "required"
-                        ? "Phone*"
-                        : "Phone"}
-                  </FormLabel>
-                  <Input
-                      as={PhoneInput}
-                      id="phone"
-                      name="phone"
-                      type="tel"
-                      focusBorderColor="primary.500"
-                      placeholder="000 000 0000"
-                      defaultCountry="US"
-                      onChange={(value) => {
-                        setFieldValue("phone", value, true);
-                      }}
-                      onBlur={handleBlur}
-                      value={values.phone}
-                  />
-                  <FormErrorMessage>{errors.phone}</FormErrorMessage>
-                </FormControl>
+              <FormControl
+                id="phone"
+                isInvalid={touched.phone && Boolean(errors.phone)}
+              >
+                <FormLabel>
+                  {config.consent?.identity_inputs.phone === "required"
+                    ? "Phone*"
+                    : "Phone"}
+                </FormLabel>
+                <Input
+                  as={PhoneInput}
+                  id="phone"
+                  name="phone"
+                  type="tel"
+                  focusBorderColor="primary.500"
+                  placeholder="000 000 0000"
+                  defaultCountry="US"
+                  onChange={(value) => {
+                    setFieldValue("phone", value, true);
+                  }}
+                  onBlur={handleBlur}
+                  value={values.phone}
+                />
+                <FormErrorMessage>{errors.phone}</FormErrorMessage>
+              </FormControl>
             ) : null}
           </Stack>
         </ModalBody>

--- a/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
@@ -290,7 +290,7 @@ const PrivacyRequestForm: React.FC<PrivacyRequestFormProps> = ({
                   name="phone"
                   type="tel"
                   focusBorderColor="primary.500"
-                  placeholder="+1 000 000 0000"
+                  placeholder="000 000 0000"
                   defaultCountry="US"
                   onChange={(value) => {
                     setFieldValue("phone", value, true);

--- a/clients/privacy-center/config/config.json
+++ b/clients/privacy-center/config/config.json
@@ -33,6 +33,10 @@
     "icon_path": "/consent.svg",
     "title": "Manage your consent",
     "description": "Manage your consent preferences, including the option to select 'Do Not Sell My Personal Information'.",
+    "identity_inputs": {
+      "email": "required",
+      "phone": "optional"
+    },
     "consentOptions": [
       {
         "fidesDataUseKey": "advertising",

--- a/clients/privacy-center/types/config.ts
+++ b/clients/privacy-center/types/config.ts
@@ -10,6 +10,7 @@ export type Config = {
     icon_path: string;
     title: string;
     description: string;
+    identity_inputs: Record<string, string>;
     consentOptions: ConfigConsentOption[];
   };
 };

--- a/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
@@ -11,8 +11,8 @@ from starlette.status import (
     HTTP_400_BAD_REQUEST,
     HTTP_403_FORBIDDEN,
     HTTP_404_NOT_FOUND,
-    HTTP_500_INTERNAL_SERVER_ERROR,
     HTTP_422_UNPROCESSABLE_ENTITY,
+    HTTP_500_INTERNAL_SERVER_ERROR,
 )
 
 from fides.api.ops.api.deps import get_db

--- a/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
@@ -330,7 +330,9 @@ def infer_target_identity_type(
 ) -> str:
     """
     Consent requests, unlike privacy requests, only accept 1 identity type- email or phone.
-    If both identity types are provided, use identity type if defined in CONFIG.notifications.notification_service_type, else default to email
+    These identity types are configurable as optional/required within the privacy center config.json.
+    If both identity types are provided, we'll use identity type if defined in
+    CONFIG.notifications.notification_service_type, else default to email.
     """
     if identity_data.email and identity_data.phone_number:
         messaging_method = get_messaging_method(

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -160,6 +160,8 @@ def dispatch_message(
             f"Notification service type is not valid: {CONFIG.notifications.notification_service_type}"
         )
     messaging_service: MessagingServiceType = messaging_config.service_type  # type: ignore
+    # fixme: do we want to support multiple message service types i.e. either email or phone number identities are accepted
+    # or both are accepted, using one message service type as default?
     logger.info(
         "Retrieving appropriate dispatcher for email service: {}", messaging_service
     )

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -160,8 +160,6 @@ def dispatch_message(
             f"Notification service type is not valid: {CONFIG.notifications.notification_service_type}"
         )
     messaging_service: MessagingServiceType = messaging_config.service_type  # type: ignore
-    # fixme: do we want to support multiple message service types i.e. either email or phone number identities are accepted
-    # or both are accepted, using one message service type as default?
     logger.info(
         "Retrieving appropriate dispatcher for email service: {}", messaging_service
     )
@@ -202,9 +200,9 @@ def _build_sms(  # pylint: disable=too-many-return-statements
         )
     if action_type == MessagingActionType.CONSENT_REQUEST:
         return (
-            "Your consent request verification code is {{code}}. "
+            f"Your consent request verification code is {body_params.verification_code}. "
             "Please return to the consent request page and enter the code to continue. "
-            "This code will expire in {{minutes}} minutes"
+            f"This code will expire in {body_params.get_verification_code_ttl_minutes()} minutes"
         )
     if action_type == MessagingActionType.PRIVACY_REQUEST_RECEIPT:
         if len(body_params.request_types) > 1:

--- a/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
@@ -18,10 +18,9 @@ from fides.api.ops.models.privacy_request import (
     Consent,
     ConsentRequest,
     ProvidedIdentity,
-    ProvidedIdentityType,
 )
-from fides.core.config import get_config
 from fides.api.ops.schemas.messaging.messaging import MessagingServiceType
+from fides.core.config import get_config
 
 CONFIG = get_config()
 


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/1853

### Code Changes

* [ ] Adjust back-end to support both email and SMS id verification for consent
* [ ] Adds SMS input field to privacy center
* [ ] Adds unit tests

### Steps to Confirm

* [ ] In `fides.toml` set `subject_identity_verification_required = true` and `notification_service_type = "twilio_text"`
* [ ] `nox -s dev`
* [ ] Add twilio sms config/secret using postman (follow https://docs.ethyca.com/fides/dsr_quickstart/dsr_support/messaging#twilio to set up your twilio acct)
* [ ] Ensure your phone number has been added to the twilio account's verified phone numbers (https://console.twilio.com/us1/develop/phone-numbers/manage/verified)
* [ ] In a new terminal, `cd` into `clients/privacy-center`, run `npm install`, `npm run build`, then `npm run dev`
* [ ] Submit consent request, enter verification code sent to phone
* [ ] Please also regression test email id verification for consent

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
