### PR TITLE
use verification ttl property when setting in cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The types of changes are:
 ### Fixed
 
 * Store `fides_consent` cookie on the root domain of the Privacy Center [#2071](https://github.com/ethyca/fides/pull/2071)
+* Properly set the expire-time for verification codes [#2105](https://github.com/ethyca/fides/pull/2105)
 
 ## [2.3.1](https://github.com/ethyca/fides/compare/2.3.0...2.3.1)
 

--- a/src/fides/api/ops/util/identity_verification.py
+++ b/src/fides/api/ops/util/identity_verification.py
@@ -34,10 +34,12 @@ class IdentityVerificationMixin:
         cache.set_with_autoexpire(
             key=self._get_identity_verification_cache_key(),
             value=value,
+            expire_time=CONFIG.redis.identity_verification_code_ttl_seconds,
         )
         cache.set_with_autoexpire(
             key=self._get_identity_verification_attempt_count_cache_key(),
             value=0,
+            expire_time=CONFIG.redis.identity_verification_code_ttl_seconds,
         )
 
     def _increment_verification_code_attempt_count(self) -> None:
@@ -47,6 +49,7 @@ class IdentityVerificationMixin:
         cache.set_with_autoexpire(
             key=self._get_identity_verification_attempt_count_cache_key(),
             value=attempt_count + 1,
+            expire_time=CONFIG.redis.identity_verification_code_ttl_seconds,
         )
 
     def get_cached_verification_code(self) -> Optional[str]:

--- a/tests/ops/models/test_privacy_request.py
+++ b/tests/ops/models/test_privacy_request.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from time import sleep
 from typing import List
 from uuid import uuid4
 
@@ -30,8 +31,11 @@ from fides.api.ops.schemas.redis_cache import Identity
 from fides.api.ops.service.connectors.manual_connector import ManualAction
 from fides.api.ops.util.cache import FidesopsRedis, get_identity_cache_key
 from fides.api.ops.util.constants import API_DATE_FORMAT
+from fides.core.config import get_config
 
 paused_location = CollectionAddress("test_dataset", "test_collection")
+
+CONFIG = get_config()
 
 
 def test_privacy_request(
@@ -526,12 +530,33 @@ class TestPrivacyRequestCacheFailedStep:
 
 
 class TestCacheIdentityVerificationCode:
+    @pytest.fixture(scope="function")
+    def set_verification_code_ttl_to_1(self):
+        """sets the `redis.identity_verification_code_ttl_seconds` property to `1`"""
+        original_value = CONFIG.redis.identity_verification_code_ttl_seconds
+        CONFIG.redis.identity_verification_code_ttl_seconds = 1
+        yield
+        CONFIG.redis.identity_verification_code_ttl_seconds = original_value
+
     def test_cache_code(self, privacy_request):
         assert not privacy_request.get_cached_verification_code()
 
         privacy_request.cache_identity_verification_code("123456")
 
         assert privacy_request.get_cached_verification_code() == "123456"
+
+    @pytest.mark.usefixtures(
+        "set_verification_code_ttl_to_1",
+    )
+    def test_verification_code_expires(self, privacy_request):
+        """
+        Ensure the verification code expires correctly based on appropriate app config
+        """
+
+        privacy_request.cache_identity_verification_code("123456")
+        assert privacy_request.get_cached_verification_code() == "123456"
+        sleep(1.1)  # sleep a bit more than 1 just to give some breathing room
+        assert privacy_request.get_cached_verification_code() is None
 
 
 class TestCacheEmailConnectorTemplateContents:


### PR DESCRIPTION
Closes #2104 

### Code Changes

* use `redis.identity_verification_code_ttl_seconds` config property when setting the verification code in the cache
* provide some test coverage

### Steps to Confirm

look at issue description

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
