### PR TITLE
Release 2.4.0

### DIFF
--- a/docs/fides/docs/development/release_checklist.md
+++ b/docs/fides/docs/development/release_checklist.md
@@ -13,6 +13,7 @@ This checklist should be copy/pasted into the final pre-release PR, and checked 
 - [ ] `nox -s test_env` works (verify the admin UI, privacy center, CLI and webserver)
 - [ ] `nox -s "build(sample)"` works on the release branch, creating the sample images (this is also prereq for `fides deploy up`)
 - [ ] `fides deploy up --no-pull` works using the images built in previous step (verify the admin UI, privacy center, CLI and webserver)
+
 ```
 mkdir ~/fides-2-1-0-test
 cd ~/fides-2-1-0-test
@@ -33,11 +34,13 @@ exit
 
 ### CLI
 
+Run these from within `nox -s dev -- shell`
+
 - [ ] Run a `fides push`
 - [ ] Run a `fides pull`
 - [ ] Run a `fides evaluate`
-- [ ] Generate a dataset with `fides generate dataset db`
-- [ ] Scan a database with `fides scan dataset db`
+- [ ] Generate a dataset with `fides generate dataset db --credentials-id app_postgres test.yml`
+- [ ] Scan a database with `fides scan dataset db --credentials-id app_postgres`
 
 ### Admin UI
 
@@ -58,8 +61,8 @@ exit
 
 ## Post-Release Steps
 
-- [ ] Verify the ethyca-fides release is published to PyPi: https://pypi.org/project/ethyca-fides/#history
-- [ ] Verify the fides release is published to DockerHub: https://hub.docker.com/r/ethyca/fides
-- [ ] Verify the fides-privacy-center release is published to DockerHub: https://hub.docker.com/r/ethyca/fides-privacy-center
-- [ ] Verify the fides-sample-app release is published to DockerHub: https://hub.docker.com/r/ethyca/fides-sample-app
+- [ ] Verify the ethyca-fides release is published to PyPi: <https://pypi.org/project/ethyca-fides/#history>
+- [ ] Verify the fides release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides>
+- [ ] Verify the fides-privacy-center release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-privacy-center>
+- [ ] Verify the fides-sample-app release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-sample-app>
 - [ ] Smoke test the PyPi & DockerHub releases with a clean `pip install ethyca-fides` and `fides deploy up`

--- a/src/fides/__init__.py
+++ b/src/fides/__init__.py
@@ -1,4 +1,4 @@
-"""Fides CLI"""
+"""The root module for the Fides package."""
 from fides.core.config import get_config
 
 from ._version import get_versions


### PR DESCRIPTION
# Release Checklist

The release checklist is a manual set of checks done before each release to ensure functionality of the most critical components of the application. Some of these steps are redundant with automated tests, while others are _only_ tested here as part of this check.

This checklist should be copy/pasted into the final pre-release PR, and checked off as you complete each step.

## Pre-Release Steps

### General

- [x] Quickstart verified working and up-to-date
- [x] New tables/columns added to [database diagram](https://github.com/ethyca/fides/blob/5a485387d8af247ec6479e4115088cbbb8394d77/docs/fides/docs/development/update_erd_diagram.md)
- [x] `nox -s test_env` works (verify the admin UI, privacy center, CLI and webserver)
- [x] `nox -s "build(sample)"` works on the release branch, creating the sample images (this is also prereq for `fides deploy up`)
- [x] `fides deploy up --no-pull` works using the images built in previous step (verify the admin UI, privacy center, CLI and webserver)
```
mkdir ~/fides-2-1-0-test
cd ~/fides-2-1-0-test
python3 -m venv venv
source venv/bin/activate
pip install git+https://github.com/ethyca/fides.git@<branch>
fides deploy up --no-pull
fides status
fides deploy down
rm -rf ~/fides-2-1-0-test
exit 
```

### API

- [x] Verify that the generated API docs are correct
- [x] Verify that the Postman collection has been updated

### CLI

- [x] Run a `fides push`
- [x] Run a `fides pull`
- [x] Run a `fides evaluate`
- [x] Generate a dataset with `fides generate dataset db`
- [x] Scan a database with `fides scan dataset db`

### Admin UI

- [x] Every navigation button works
- [x] DSR approval succeeds
- [x] DSR execution succeeds

### Privacy Center

- [x] Every navigation button works
- [x] DSR submission succeeds
- [x] Consent request submission succeeds

### Documentation

- [x] Verify that the CHANGELOG is formatted correctly and clean up verbiage where needed
- [x] Verify that the CHANGELOG is representative of the actual changes

## Post-Release Steps

- [x] Verify the ethyca-fides release is published to PyPi: https://pypi.org/project/ethyca-fides/#history
- [x] Verify the fides release is published to DockerHub: https://hub.docker.com/r/ethyca/fides
- [x] Verify the fides-privacy-center release is published to DockerHub: https://hub.docker.com/r/ethyca/fides-privacy-center
- [x] Verify the fides-sample-app release is published to DockerHub: https://hub.docker.com/r/ethyca/fides-sample-app
- [x] Smoke test the PyPi & DockerHub releases with a clean `pip install ethyca-fides` and `fides deploy up`