### PR TITLE
Switch off dynamic top nav

### DIFF
--- a/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
@@ -25,7 +25,7 @@ export const NAV_CONFIG: NavConfigGroup[] = [
   },
   {
     title: "Privacy requests",
-    requiresConnections: true,
+    requiresConnections: false,
     routes: [
       { title: "Request manager", path: "/privacy-requests" },
       { title: "Connection manager", path: "/datastore-connection" },
@@ -33,7 +33,7 @@ export const NAV_CONFIG: NavConfigGroup[] = [
   },
   {
     title: "Data map",
-    requiresSystems: true,
+    requiresSystems: false,
     routes: [
       { title: "View map", path: "/datamap", requiresPlus: true },
       { title: "View systems", path: "/system" },


### PR DESCRIPTION
This PR switches off requirements for privacy requests to require connections, and datamap to require systems.