### PR TITLE
Removes unused object_name field on s3 storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The types of changes are:
 
 * Added endpoints to retrieve DSR `Rule`s and `Rule Target`s [#2116](https://github.com/ethyca/fides/pull/2116)
 
+### Removed
+
+* Removed unused object_name field on s3 storage config [#2133](https://github.com/ethyca/fides/pull/2133)
+
 ### Fixed
 
 * Remove next-auth from privacy center to fix JS console error [#2090](https://github.com/ethyca/fides/pull/2090)

--- a/docs/fides/docs/development/postman/Fides.postman_collection.json
+++ b/docs/fides/docs/development/postman/Fides.postman_collection.json
@@ -1394,7 +1394,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n  {\n    \"name\": \"My Access Request Upload Bucket\",\n    \"key\": \"{{S3_BUCKET_KEY}}\",\n    \"type\": \"s3\",\n    \"format\": \"csv\",\n    \"details\": {\n      \"bucket\": \"test_bucket\",\n      \"object_name\": \"test_name\"\n    }\n  }\n]",
+							"raw": "[\n  {\n    \"name\": \"My Access Request Upload Bucket\",\n    \"key\": \"{{S3_BUCKET_KEY}}\",\n    \"type\": \"s3\",\n    \"format\": \"csv\",\n    \"details\": {\n      \"bucket\": \"test_bucket\"\n    }\n  }\n]",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/docs/fides/docs/getting-started/storage.md
+++ b/docs/fides/docs/getting-started/storage.md
@@ -72,8 +72,7 @@ On success, the response from the above endpoint will include a `storage_key` fo
             "details": {
                 "auth_method": "secret_keys",
                 "bucket": "my-bucket",
-                "naming": "request_id",
-                "object_name": "requests"
+                "naming": "request_id"
             },
             "key": "s3_storage_2"
         }

--- a/scripts/setup/s3_storage.py
+++ b/scripts/setup/s3_storage.py
@@ -30,7 +30,6 @@ def create_s3_storage(
                 "details": {
                     "auth_method": "secret_keys",
                     "bucket": bucket,
-                    "object_name": "requests",
                     "naming": "request_id",
                 },
             },

--- a/src/fides/api/ops/schemas/storage/storage.py
+++ b/src/fides/api/ops/schemas/storage/storage.py
@@ -26,7 +26,6 @@ class StorageDetails(Enum):
 
     # s3-specific
     BUCKET = "bucket"
-    OBJECT_NAME = "object_name"
     NAMING = "naming"
     MAX_RETRIES = "max_retries"
     AUTH_METHOD = "auth_method"
@@ -58,7 +57,6 @@ class StorageDetailsS3(FileBasedStorageDetails):
 
     auth_method: S3AuthMethod
     bucket: str
-    object_name: str
     max_retries: Optional[int] = 0
 
     class Config:

--- a/src/fides/api/ops/tasks/storage.py
+++ b/src/fides/api/ops/tasks/storage.py
@@ -95,18 +95,18 @@ def write_to_in_memory_buffer(
 
 
 def create_presigned_url_for_s3(
-    s3_client: Session, bucket_name: str, object_name: str
+    s3_client: Session, bucket_name: str, file_key: str
 ) -> str:
     """ "Generate a presigned URL to share an S3 object
 
     :param s3_client: s3 base client
     :param bucket_name: string
-    :param object_name: string
+    :param file_key: string
     :return: Presigned URL as string.
     """
     response = s3_client.generate_presigned_url(
         "get_object",
-        Params={"Bucket": bucket_name, "Key": object_name},
+        Params={"Bucket": bucket_name, "Key": file_key},
         ExpiresIn=CONFIG.security.subject_request_download_link_ttl_seconds,
     )
 

--- a/tests/ops/api/v1/endpoints/test_storage_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_storage_endpoints.py
@@ -112,7 +112,6 @@ class TestPatchStorageConfig:
                 "details": {
                     "auth_method": S3AuthMethod.SECRET_KEYS.value,
                     "bucket": "some-bucket",
-                    "object_name": "requests",
                     "naming": "some-filename-convention-enum",
                     "max_retries": 10,
                 },
@@ -202,7 +201,6 @@ class TestPatchStorageConfig:
                         "bucket": "some-bucket",
                         "naming": "some-filename-convention-enum",
                         "max_retries": 10,
-                        "object_name": "requests",
                     },
                     "key": "my_s3_bucket",
                     "format": "csv",
@@ -252,7 +250,6 @@ class TestPatchStorageConfig:
                 "details": {
                     "auth_method": S3AuthMethod.SECRET_KEYS.value,
                     "bucket": "some-bucket",
-                    "object_name": "requests",
                     "naming": "some-filename-convention-enum",
                     "max_retries": 10,
                 },
@@ -298,7 +295,6 @@ class TestPatchStorageConfig:
                     "details": {
                         # "bucket": "removed-from-payload",
                         "auth_method": S3AuthMethod.SECRET_KEYS.value,
-                        "object_name": "some-object",
                         "naming": "request_id",
                         "max_retries": 10,
                     },

--- a/tests/ops/models/test_base.py
+++ b/tests/ops/models/test_base.py
@@ -44,7 +44,6 @@ def test_create_key(db: Session):
             "type": StorageType.s3.value,
             "details": {
                 "bucket": "some-bucket",
-                "object_name": "requests",
                 "naming": "some-filename-convention-enum",
                 "max_retries": 10,
             },

--- a/tests/ops/models/test_storage.py
+++ b/tests/ops/models/test_storage.py
@@ -21,7 +21,6 @@ class TestStorageConfigModel:
         return {
             StorageDetails.BUCKET.value: "some bucket",
             StorageDetails.NAMING.value: "some naming",
-            StorageDetails.OBJECT_NAME.value: "some object name",
             StorageDetails.MAX_RETRIES.value: 0,
             StorageDetails.AUTH_METHOD.value: S3AuthMethod.SECRET_KEYS.value,
         }

--- a/tests/ops/service/storage_uploader_service_test.py
+++ b/tests/ops/service/storage_uploader_service_test.py
@@ -52,7 +52,6 @@ def test_uploader_s3_success_secrets_auth(
             "bucket": "some-bucket",
             "naming": FileNaming.request_id.value,
             "max_retries": 10,
-            "object_name": "something",
         },
         "secrets": {
             StorageSecrets.AWS_ACCESS_KEY_ID.value: "1345234524",
@@ -101,7 +100,6 @@ def test_uploader_s3_success_automatic_auth(
             "bucket": "some-bucket",
             "naming": FileNaming.request_id.value,
             "max_retries": 10,
-            "object_name": "something",
         },
     }
     storage_config = StorageConfig.create(db, data=mock_config)
@@ -143,7 +141,6 @@ def test_uploader_s3_invalid_file_naming(mock_upload_to_s3: Mock, db: Session) -
             "bucket": "some-bucket",
             "naming": "something invalid",
             "max_retries": 10,
-            "object_name": "something",
         },
         "secrets": {
             StorageSecrets.AWS_ACCESS_KEY_ID.value: "1345234524",


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/1458

### Code Changes

* [ ] Removes unused `object_name` field on s3 storage config

### Steps to Confirm

* [ ] Add storage config secrets for s3, don't use `object_name` field. Confirm it's successful.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
