### PR TITLE
Add Increased CTL Dataset Validation [#2115]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The types of changes are:
 * Unified Fides Resources: New datasetconfig.ctl_dataset_id field to unify fides dataset resources [#2046](https://github.com/ethyca/fides/pull/2046)
 * Unified Fides Resources: Remove DatasetConfig.dataset field [#2096](https://github.com/ethyca/fides/pull/2096)
 * Unified Fides Resources: Update UI dataset config routes to use new unified routes [#2113](https://github.com/ethyca/fides/pull/2113)
+* Unified Fides Resources: Validate request body on crud endpoints on upsert. Validate dataset data categories before save. [#2134](https://github.com/ethyca/fides/pull/2134/)
 
 ## [2.4.0](https://github.com/ethyca/fides/compare/2.3.1...2.4.0)
 

--- a/src/fides/api/ctl/routes/crud.py
+++ b/src/fides/api/ctl/routes/crud.py
@@ -48,7 +48,9 @@ async def get_data_categories_from_db(async_session: AsyncSession) -> List[Fides
     return data_categories
 
 
-async def validate_data_categories(resource: FidesModel, async_session: AsyncSession):
+async def validate_data_categories(
+    resource: FidesModel, async_session: AsyncSession
+) -> None:
     """Validate data categories defined on Datasets against data categories in the db"""
     if not isinstance(resource, Dataset):
         return

--- a/src/fides/api/ctl/routes/crud.py
+++ b/src/fides/api/ctl/routes/crud.py
@@ -8,9 +8,12 @@ generated programmatically for each resource.
 
 from typing import Dict, List
 
-from fastapi import Depends, Response, status
-from fideslang import model_map
+from fastapi import Depends, HTTPException, Response, status
+from fideslang import Dataset, FidesModel, model_map
+from fideslang.validation import FidesKey
+from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
 from fides.api.ctl.database.crud import (
     create_resource,
@@ -28,9 +31,38 @@ from fides.api.ctl.routes.util import (
     forbid_if_editing_is_default,
     get_resource_type,
 )
-from fides.api.ctl.sql_models import models_with_default_field, sql_model_map
+from fides.api.ctl.sql_models import (
+    DataCategory,
+    models_with_default_field,
+    sql_model_map,
+)
 from fides.api.ctl.utils import errors
 from fides.api.ctl.utils.api_router import APIRouter
+from fides.api.ops.schemas.dataset import validate_data_categories_against_db
+
+
+async def get_data_categories_from_db(async_session: AsyncSession) -> List[FidesKey]:
+    """Similar method to one on the ops side except this uses an async session to retrieve data categories"""
+    resources = await list_resource(DataCategory, async_session)
+    data_categories = [res.fides_key for res in resources]
+    return data_categories
+
+
+async def validate_data_categories(resource: FidesModel, async_session: AsyncSession):
+    """Validate data categories defined on Datasets against data categories in the db"""
+    if not isinstance(resource, Dataset):
+        return
+
+    try:
+        defined_data_categories: List[FidesKey] = await get_data_categories_from_db(
+            async_session
+        )
+        validate_data_categories_against_db(resource, defined_data_categories)
+    except PydanticValidationError as e:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY, detail=e.errors()
+        )
+
 
 # CRUD Endpoints
 routers = []
@@ -73,6 +105,7 @@ for model_type, fides_model in model_map.items():
         will return a `403 Forbidden`.
         """
         sql_model = sql_model_map[resource_type]
+        await validate_data_categories(resource, db)
         if sql_model in models_with_default_field and resource.is_default:
             raise errors.ForbiddenError(resource_type, resource.fides_key)
         return await create_resource(sql_model, resource.dict(), db)
@@ -127,6 +160,7 @@ for model_type, fides_model in model_map.items():
         with a `403 Forbidden` if attempted.
         """
         sql_model = sql_model_map[resource_type]
+        await validate_data_categories(resource, db)
         await forbid_if_editing_is_default(sql_model, resource.fides_key, resource, db)
         return await update_resource(sql_model, resource.dict(), db)
 
@@ -171,7 +205,7 @@ for model_type, fides_model in model_map.items():
         },
     )
     async def upsert(
-        resources: List[Dict],
+        resources: List[fides_model],
         response: Response,
         resource_type: str = get_resource_type(router),
         db: AsyncSession = Depends(get_async_db),
@@ -188,8 +222,12 @@ for model_type, fides_model in model_map.items():
         """
 
         sql_model = sql_model_map[resource_type]
-        await forbid_if_editing_any_is_default(sql_model, resources, db)
-        result = await upsert_resources(sql_model, resources, db)
+        resource_dicts = [resource.dict() for resource in resources]
+        for resource in resources:
+            await validate_data_categories(resource, db)
+
+        await forbid_if_editing_any_is_default(sql_model, resource_dicts, db)
+        result = await upsert_resources(sql_model, resource_dicts, db)
         response.status_code = (
             status.HTTP_201_CREATED if result[0] > 0 else response.status_code
         )

--- a/src/fides/api/ops/api/v1/endpoints/dataset_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/dataset_endpoints.py
@@ -58,6 +58,7 @@ from fides.api.ops.schemas.dataset import (
     DatasetConfigSchema,
     DatasetTraversalDetails,
     ValidateDatasetResponse,
+    get_data_categories_from_db,
     validate_data_categories_against_db,
 )
 from fides.api.ops.util.api_router import APIRouter
@@ -90,7 +91,8 @@ def validate_data_categories(dataset: Dataset, db: Session) -> None:
     database instead of a static list.
     """
     try:
-        validate_data_categories_against_db(dataset, db)
+        defined_data_categories: List[FidesKey] = get_data_categories_from_db(db)
+        validate_data_categories_against_db(dataset, defined_data_categories)
     except PydanticValidationError as e:
         raise HTTPException(
             status_code=HTTP_422_UNPROCESSABLE_ENTITY, detail=e.errors()

--- a/src/fides/api/ops/schemas/dataset.py
+++ b/src/fides/api/ops/schemas/dataset.py
@@ -15,7 +15,14 @@ from fides.api.ops.util.data_category import (
 )
 
 
-def validate_data_categories_against_db(dataset: Dataset, db: Session) -> None:
+def get_data_categories_from_db(db: Session) -> List[FidesKey]:
+    """Query for existing data categories in the db using a synchronous session"""
+    return [cat[0] for cat in db.query(DataCategory.fides_key).all()]
+
+
+def validate_data_categories_against_db(
+    dataset: Dataset, defined_data_categories: List[FidesKey]
+) -> None:
     """
     Validate that data_categories defined on the Dataset, Collection, and Field levels exist
     in the database.  Doing this instead of a traditional validator function to have
@@ -23,9 +30,6 @@ def validate_data_categories_against_db(dataset: Dataset, db: Session) -> None:
 
     If no data categories in the database, default to using data categories from the default taxonomy.
     """
-    defined_data_categories: List[FidesKey] = [
-        cat[0] for cat in db.query(DataCategory.fides_key).all()
-    ]
     if not defined_data_categories:
         logger.info(
             "No data categories in the database: reverting to default data categories."

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -71,6 +71,25 @@ class TestCrud:
         print(result.text)
         assert result.status_code == 201
 
+    async def test_create_dataset_data_categories_validated(
+        self, test_config: FidesConfig, resources_dict: Dict
+    ):
+        endpoint = "dataset"
+        manifest: Dataset = resources_dict[endpoint]
+        manifest.collections[0].data_categories = ["bad_category"]
+
+        result = _api.create(
+            url=test_config.cli.server_url,
+            headers=test_config.user.request_headers,
+            json_resource=manifest.json(exclude_none=True),
+            resource_type=endpoint,
+        )
+        assert result.status_code == 422
+        assert (
+            result.json()["detail"][0]["msg"]
+            == "The data category bad_category is not supported."
+        )
+
     @pytest.mark.parametrize("endpoint", model_list)
     def test_api_ls(self, test_config: FidesConfig, endpoint: str) -> None:
         result = _api.ls(
@@ -131,6 +150,25 @@ class TestCrud:
         print(result.text)
         assert result.status_code == 200
 
+    async def test_update_dataset_data_categories_validated(
+        self, test_config: FidesConfig, resources_dict: Dict
+    ):
+        endpoint = "dataset"
+        manifest: Dataset = resources_dict[endpoint]
+        manifest.collections[0].data_categories = ["bad_category"]
+
+        result = _api.update(
+            url=test_config.cli.server_url,
+            headers=test_config.user.request_headers,
+            resource_type=endpoint,
+            json_resource=manifest.json(exclude_none=True),
+        )
+        assert result.status_code == 422
+        assert (
+            result.json()["detail"][0]["msg"]
+            == "The data category bad_category is not supported."
+        )
+
     @pytest.mark.parametrize("endpoint", model_list)
     def test_api_upsert(
         self, test_config: FidesConfig, resources_dict: Dict, endpoint: str
@@ -163,8 +201,8 @@ class TestCrud:
         resource = await get_resource(Dataset, manifest.fides_key, async_session)
         assert resource.organization_fides_key == "default_organization"
 
-    async def test_data_categories_validated_against_db(
-        self, test_config: FidesConfig, resources_dict: Dict, async_session
+    async def test_upsert_dataset_data_categories_validated(
+        self, test_config: FidesConfig, resources_dict: Dict
     ):
         endpoint = "dataset"
         manifest: Dataset = resources_dict[endpoint]
@@ -178,6 +216,10 @@ class TestCrud:
             resources=[dict_manifest],
         )
         assert result.status_code == 422
+        assert (
+            result.json()["detail"][0]["msg"]
+            == "The data category bad_category is not supported."
+        )
 
     @pytest.mark.parametrize("endpoint", model_list)
     def test_api_delete(

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -9,8 +9,10 @@ from fideslang import DEFAULT_TAXONOMY, model_list, parse
 from pytest import MonkeyPatch
 from starlette.testclient import TestClient
 
+from fides.api.ctl.database.crud import get_resource
 from fides.api.ctl.routes import health
 from fides.api.ctl.routes.util import API_PREFIX
+from fides.api.ctl.sql_models import Dataset
 from fides.core import api as _api
 from fides.core.config import FidesConfig
 
@@ -141,6 +143,41 @@ class TestCrud:
             resources=[loads(manifest.json())],
         )
         assert result.status_code == 200
+
+    async def test_upsert_validates_resources_against_pydantic_model(
+        self, test_config: FidesConfig, resources_dict: Dict, async_session
+    ):
+        endpoint = "dataset"
+        manifest: Dataset = resources_dict[endpoint]
+        dict_manifest = manifest.dict()
+        del dict_manifest["organization_fides_key"]
+
+        result = _api.upsert(
+            url=test_config.cli.server_url,
+            headers=test_config.user.request_headers,
+            resource_type=endpoint,
+            resources=[dict_manifest],
+        )
+        assert result.status_code == 200
+
+        resource = await get_resource(Dataset, manifest.fides_key, async_session)
+        assert resource.organization_fides_key == "default_organization"
+
+    async def test_data_categories_validated_against_db(
+        self, test_config: FidesConfig, resources_dict: Dict, async_session
+    ):
+        endpoint = "dataset"
+        manifest: Dataset = resources_dict[endpoint]
+        dict_manifest = manifest.dict()
+        dict_manifest["collections"][0]["data_categories"] = ["bad_category"]
+
+        result = _api.upsert(
+            url=test_config.cli.server_url,
+            headers=test_config.user.request_headers,
+            resource_type=endpoint,
+            resources=[dict_manifest],
+        )
+        assert result.status_code == 422
 
     @pytest.mark.parametrize("endpoint", model_list)
     def test_api_delete(


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2134
👉  Note branch is against `unified-fides-resources`

### Code Changes

- [ ] Fix crud upsert endpoints so they validate the request against the appropriate pydantic model.
- [ ] When creating, updating, or upserting Datasets, validate that the supplied data categories align with those currently in the db. (Note that this has to happen outside of typical Pydantic validation because we need access to a db session)

### Steps to Confirm

* [ ] Verify pasting a yaml dataset in the create connector workflow that is missing an `organization_fides_key` or `data_qualifier` throws an error when the `dataset` is upserted, not on the second request where the dataset is then linked to the DatasetConfig
* [ ] Verify that pasting a yaml dataset with a bad data category fails when you upsert a dataset in the create connector workflow

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

CTL Datasets could use some increased validation before they are saved to the database.  These are things I'm running into when testing `unified-fides-resources`

1) Upserting crud resources are not getting validated against the relevant pydantic model.  So when we upsert a CTL Dataset, it is very possible it is missing something, and this breaks later when we try to use it once it's linked to a DatasetConfig. 
2) On the ops side, we were validating data categories on the dataset before we saved to the db.  Now that datasets are no longer saved on DatasetConfigs, add this validation before saving a CTL Dataset.

