### PR TITLE
497- Nav bug: clicking on Privacy Request breadcrumb takes me to Home instead of /privacy-requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The types of changes are:
 ### Fixed
 
 * Remove next-auth from privacy center to fix JS console error [#2090](https://github.com/ethyca/fides/pull/2090)
+* Nav bug: clicking on Privacy Request breadcrumb takes me to Home instead of /privacy-requests [#497](https://github.com/ethyca/fides/pull/2141)
 
 ## [2.4.0](https://github.com/ethyca/fides/compare/2.3.1...2.4.0)
 

--- a/clients/admin-ui/src/pages/subject-request/[id].tsx
+++ b/clients/admin-ui/src/pages/subject-request/[id].tsx
@@ -14,9 +14,10 @@ import { useRouter } from "next/router";
 import { useGetAllPrivacyRequestsQuery } from "privacy-requests/index";
 import SubjectRequest from "subject-request/SubjectRequest";
 
+import { useFeatures } from "~/features/common/features";
 import Layout from "~/features/common/Layout";
 
-import { INDEX_ROUTE } from "../../constants";
+import { INDEX_ROUTE, PRIVACY_REQUESTS_ROUTE } from "../../constants";
 
 const useSubjectRequestDetails = () => {
   const router = useRouter();
@@ -35,6 +36,9 @@ const useSubjectRequestDetails = () => {
 };
 
 const SubjectRequestDetails: NextPage = () => {
+  const {
+    flags: { navV2 },
+  } = useFeatures();
   const { data, isLoading, isUninitialized } = useSubjectRequestDetails();
   let body =
     !data || data?.items.length === 0 ? (
@@ -58,7 +62,10 @@ const SubjectRequestDetails: NextPage = () => {
         <Box mt={2} mb={9}>
           <Breadcrumb fontWeight="medium" fontSize="sm">
             <BreadcrumbItem>
-              <BreadcrumbLink as={NextLink} href={INDEX_ROUTE}>
+              <BreadcrumbLink
+                as={NextLink}
+                href={navV2 ? PRIVACY_REQUESTS_ROUTE : INDEX_ROUTE}
+              >
                 Privacy Requests
               </BreadcrumbLink>
             </BreadcrumbItem>


### PR DESCRIPTION
Closes #[497](https://github.com/ethyca/fidesplus/issues/497)

### Code Changes

* Updated the **SubjectRequestDetails** component

### Steps to Confirm

1. Click the **View Details** menu option for a given DSR record
2. Click the `Privacy Requests` breadcrumb hyperlink which should navigate the user to http://localhost:3000/privacy-requests

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

- Updated the `Privacy Requests` breadcrumb hyperlink

![Screen Shot 2023-01-05 at 11 53 37 AM](https://user-images.githubusercontent.com/68459950/210836346-70ff96cb-d64f-4ed4-aa72-74e983a238af.png)

