### PR TITLE
update docs location

### DIFF
--- a/src/fides/core/deploy.py
+++ b/src/fides/core/deploy.py
@@ -239,7 +239,7 @@ def print_deploy_success() -> None:
     echo_green("    (user=mongo_test, password=mongo_pass, db=mongo_test)")
 
     # Documentation
-    echo_green("\n- Visit ethyca.github.io/fides for documentation.")
+    echo_green("\n- Visit docs.ethyca.com for documentation.")
     echo_green("\nRun `fides deploy down` to stop the application.")
 
     # Open the landing page and DSR directory


### PR DESCRIPTION
Closes #2073 

### Code Changes

* [x] Updates messaging in the `fides deploy up` script to correctly link the new docs site

### Steps to Confirm

* [ ] run `fides deploy up`
* [ ] assert the docs link at the bottom shows "docs.ethyca.com" — I've purposely omitted the `https://` as it was left out before

![Screenshot 2023-01-05 at 17 59 03](https://user-images.githubusercontent.com/1667340/210896283-e5efdc7f-6921-43b5-9e7d-122f1daefa36.png)