### PR TITLE
Adds support for twilio email (sendgrid) dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The types of changes are:
 * Privacy Center `fides-consent.js`:
   * `Fides.shopify` integration function. [#2152](https://github.com/ethyca/fides/pull/2152)
   * Dedicated folder for integrations.
+* Adds support for Twilio email service (Sendgrid) [#2154](https://github.com/ethyca/fides/pull/2154)
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ module = [
   "plotly.*",
   "pydash.*",
   "pymongo.*",
+  "sendgrid.*",
   "snowflake.*",
   "sqlalchemy.ext.*",
   "sqlalchemy.future.*",

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ PyMySQL==1.0.2
 python-jose[cryptography]==3.3.0
 pyyaml>=5,<6
 redis==3.5.3
+sendgrid==6.9.7
 slowapi==0.1.5
 snowflake-sqlalchemy==1.4.3
 sqlalchemy[asyncio]==1.4.27

--- a/src/fides/api/ops/schemas/messaging/messaging.py
+++ b/src/fides/api/ops/schemas/messaging/messaging.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from re import compile as regex
-from typing import Any, Dict, List, Optional, Tuple, Union, Type
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from pydantic import BaseModel, Extra, root_validator
 

--- a/src/fides/api/ops/schemas/messaging/messaging.py
+++ b/src/fides/api/ops/schemas/messaging/messaging.py
@@ -118,6 +118,9 @@ class MessagingServiceDetails(Enum):
     API_VERSION = "api_version"
     DOMAIN = "domain"
 
+    # Twilio Email
+    TWILIO_EMAIL_FROM = "twilio_email_from"
+
 
 class MessagingServiceDetailsMailgun(BaseModel):
     """The details required to represent a Mailgun email configuration."""
@@ -125,6 +128,17 @@ class MessagingServiceDetailsMailgun(BaseModel):
     is_eu_domain: Optional[bool] = False
     api_version: Optional[str] = "v3"
     domain: str
+
+    class Config:
+        """Restrict adding other fields through this schema."""
+
+        extra = Extra.forbid
+
+
+class MessagingServiceDetailsTwilioEmail(BaseModel):
+    """The details required to represent a Twilio email configuration."""
+
+    twilio_email_from: str
 
     class Config:
         """Restrict adding other fields through this schema."""
@@ -205,7 +219,9 @@ class MessagingConfigRequest(BaseModel):
     name: str
     key: Optional[FidesOpsKey]
     service_type: MessagingServiceType
-    details: Optional[MessagingServiceDetailsMailgun]
+    details: Optional[
+        Union[MessagingServiceDetailsMailgun, MessagingServiceDetailsTwilioEmail]
+    ]
 
     class Config:
         use_enum_values = False

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -448,10 +448,12 @@ def _twilio_email_dispatcher(
         response = sg.client.mail.send.post(request_body=mail.get())
         if response.status_code >= 400:
             logger.error(
-                "Email failed to send with status code: %s", response.status_code
+                "Email failed to send: %s: %s",
+                response.status_code,
+                Pii(str(response.body)),
             )
             raise MessageDispatchException(
-                f"Email failed to send with status code {response.status_code}"
+                f"Email failed to send: {response.status_code}, {Pii(str(response.body))}"
             )
     except Exception as e:
         logger.error("Email failed to send: {}", Pii(str(e)))

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -5,8 +5,8 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 import requests
 import sendgrid
-from sendgrid.helpers.mail import Email, To, Content, Mail
 from loguru import logger
+from sendgrid.helpers.mail import Content, Email, Mail, To
 from sqlalchemy.orm import Session
 from twilio.base.exceptions import TwilioRestException
 from twilio.rest import Client

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -4,6 +4,8 @@ import json
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import requests
+import sendgrid
+from sendgrid.helpers.mail import Email, To, Content, Mail
 from loguru import logger
 from sqlalchemy.orm import Session
 from twilio.base.exceptions import TwilioRestException
@@ -323,6 +325,8 @@ def _get_dispatcher_from_config_type(
         return _mailgun_dispatcher
     if message_service_type == MessagingServiceType.TWILIO_TEXT:
         return _twilio_sms_dispatcher
+    if message_service_type == MessagingServiceType.TWILIO_EMAIL:
+        return _twilio_email_dispatcher
     return None
 
 
@@ -406,6 +410,49 @@ def _mailgun_dispatcher(
                 raise MessageDispatchException(
                     f"Email failed to send with status code {response.status_code}"
                 )
+    except Exception as e:
+        logger.error("Email failed to send: {}", Pii(str(e)))
+        raise MessageDispatchException(f"Email failed to send due to: {Pii(e)}")
+
+
+def _twilio_email_dispatcher(
+    messaging_config: MessagingConfig,
+    message: EmailForActionType,
+    to: Optional[str],
+) -> None:
+    """Dispatches email using twilio sendgrid"""
+    if not to:
+        logger.error("Message failed to send. No email identity supplied.")
+        raise MessageDispatchException("No email identity supplied.")
+    if not messaging_config.details or not messaging_config.secrets:
+        logger.error(
+            "Message failed to send. No twilio email config details or secrets supplied."
+        )
+        raise MessageDispatchException(
+            "No twilio email config details or secrets supplied."
+        )
+
+    try:
+        sg = sendgrid.SendGridAPIClient(
+            api_key=messaging_config.secrets[
+                MessagingServiceSecrets.TWILIO_API_KEY.value
+            ]
+        )
+        from_email = Email(
+            messaging_config.details[MessagingServiceDetails.TWILIO_EMAIL_FROM.value]
+        )
+        to_email = To(to.strip())
+        subject = message.subject
+        content = Content("text/html", message.body)
+        mail = Mail(from_email, to_email, subject, content)
+        response = sg.client.mail.send.post(request_body=mail.get())
+        if response.status_code >= 400:
+            logger.error(
+                "Email failed to send with status code: %s", response.status_code
+            )
+            raise MessageDispatchException(
+                f"Email failed to send with status code {response.status_code}"
+            )
     except Exception as e:
         logger.error("Email failed to send: {}", Pii(str(e)))
         raise MessageDispatchException(f"Email failed to send due to: {Pii(e)}")

--- a/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
@@ -44,7 +44,9 @@ class TestPostMessagingConfig:
         return {
             "name": "twilio_email",
             "service_type": MessagingServiceType.TWILIO_EMAIL.value,
-            "details": {MessagingServiceDetails.TWILIO_EMAIL_FROM: "test@email.com"}
+            "details": {
+                MessagingServiceDetails.TWILIO_EMAIL_FROM.value: "test@email.com"
+            },
         }
 
     @pytest.fixture(scope="function")
@@ -190,7 +192,7 @@ class TestPostMessagingConfig:
         )
         assert response.status_code == 422
         errors = response.json()["detail"]
-        assert errors[0]["msg"] == "Mailgun messaging config must include details"
+        assert errors[0]["msg"] == "Messaging config must include details"
 
     def test_post_email_config_service_already_exists(
         self,
@@ -238,7 +240,9 @@ class TestPostMessagingConfig:
             "key": "my_twilio_email_config",
             "name": "twilio_email",
             "service_type": MessagingServiceType.TWILIO_EMAIL.value,
-            "details": {MessagingServiceDetails.TWILIO_EMAIL_FROM.value: "test@email.com"},
+            "details": {
+                MessagingServiceDetails.TWILIO_EMAIL_FROM.value: "test@email.com"
+            },
         }
         assert expected_response == response_body
         email_config.delete(db)

--- a/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
@@ -44,6 +44,7 @@ class TestPostMessagingConfig:
         return {
             "name": "twilio_email",
             "service_type": MessagingServiceType.TWILIO_EMAIL.value,
+            "details": {MessagingServiceDetails.TWILIO_EMAIL_FROM: "test@email.com"}
         }
 
     @pytest.fixture(scope="function")
@@ -237,7 +238,7 @@ class TestPostMessagingConfig:
             "key": "my_twilio_email_config",
             "name": "twilio_email",
             "service_type": MessagingServiceType.TWILIO_EMAIL.value,
-            "details": None,
+            "details": {MessagingServiceDetails.TWILIO_EMAIL_FROM.value: "test@email.com"},
         }
         assert expected_response == response_body
         email_config.delete(db)


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/1975

### Code Changes

* [ ] Adds dispatcher for Twilio Email
* [ ] Adds `sendgrid` client to requirements
* [ ] Updates model for Twilio Email to include additional details needed in config

**Note**-  this ticket does not include support for fides templates through sendgrid.

### Steps to Confirm

* [ ] In config:
```
FIDES__EXECUTION__SUBJECT_IDENTITY_VERIFICATION_REQUIRED=true
FIDES__NOTIFICATIONS__NOTIFICATION_SERVICE_TYPE="twilio_email"
FIDES__NOTIFICATIONS__SEND_REQUEST_COMPLETION_NOTIFICATION=true
FIDES__NOTIFICATIONS__SEND_REQUEST_RECEIPT_NOTIFICATION=true
FIDES__NOTIFICATIONS__SEND_REQUEST_REVIEW_NOTIFICATION=true
```
* [ ] Set up a Sendgrid test acct
* [ ] Use postman to add a new Twilio Email config:
```
{
    "key": "twilio_email_key",
    "name": "twilio_email",
    "service_type": "twilio_email",
    "details": {
    "twilio_email_from": "your_sender_email_in_sendgrid@email.com"
    }
}
```
* [ ] Use postman to add Twilio Email secrets:
```
{
    "twilio_api_key": "your-api-key"
}
```
* [ ] Submit privacy request and confirm emails are sent

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
