### PR TITLE
ui/header: Remove extra menu divider when ff off

### DIFF
--- a/clients/admin-ui/src/features/common/Header.tsx
+++ b/clients/admin-ui/src/features/common/Header.tsx
@@ -79,17 +79,20 @@ const Header: React.FC = () => {
                   </Text> */}
                 </Stack>
 
-                <MenuDivider />
                 {features.flags.featuresPanel ? (
-                  <MenuItem
-                    _focus={{ color: "complimentary.500", bg: "gray.100" }}
-                    onClick={() => featuresPanelDisclosure.onOpen()}
-                  >
-                    Features
-                    <Text as="i" ml={2}>
-                      Beta
-                    </Text>{" "}
-                  </MenuItem>
+                  <>
+                    <MenuDivider />
+
+                    <MenuItem
+                      _focus={{ color: "complimentary.500", bg: "gray.100" }}
+                      onClick={() => featuresPanelDisclosure.onOpen()}
+                    >
+                      Features
+                      <Text as="i" ml={2}>
+                        Beta
+                      </Text>{" "}
+                    </MenuItem>
+                  </>
                 ) : null}
 
                 <MenuDivider />


### PR DESCRIPTION
Removes this extra line:
![image](https://user-images.githubusercontent.com/2236777/211085279-d72e733e-6f33-4b8f-ae79-7b90473cda41.png)