### PR TITLE
Connector dataset dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.4.0...main)
 
+### Added
+
+* Unified Fides Resources: Added a dataset dropdown selector when configuring a connector to link an existing dataset to the connector configuration. [#2162](https://github.com/ethyca/fides/pull/2162)
+
 ### Fixed
 
 * Remove next-auth from privacy center to fix JS console error [#2090](https://github.com/ethyca/fides/pull/2090)

--- a/clients/admin-ui/cypress/e2e/connectors.cy.ts
+++ b/clients/admin-ui/cypress/e2e/connectors.cy.ts
@@ -85,13 +85,13 @@ describe("Connectors", () => {
       // Unset the linked dataset, which should switch the save button enable-ness
       cy.getByTestId("dataset-selector").select("Select");
       cy.getByTestId("save-dataset-link-btn").should("be.disabled");
+      // The monaco yaml editor takes a bit to load
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(1000);
       cy.getByTestId("save-yaml-btn").click();
 
       // Click past the confirmation modal
       cy.getByTestId("confirmation-modal");
-      // The monaco yaml editor takes a bit to load
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(500);
       cy.getByTestId("continue-btn").click();
 
       cy.wait("@upsertDataset").then((interception) => {

--- a/clients/admin-ui/cypress/e2e/connectors.cy.ts
+++ b/clients/admin-ui/cypress/e2e/connectors.cy.ts
@@ -109,5 +109,23 @@ describe("Connectors", () => {
         ]);
       });
     });
+
+    it("Should not show the dataset selector if no datasets exist", () => {
+      cy.intercept("GET", "/api/v1/dataset", { body: [] }).as("getDatasets");
+      cy.intercept(
+        "GET",
+        "/api/v1/connection/postgres_connector/datasetconfig",
+        {
+          body: {
+            items: [],
+          },
+        }
+      ).as("getEmptyPostgresConnectorDatasetconfig");
+
+      cy.visit("/datastore-connection/postgres_connector");
+      cy.getByTestId("tab-Dataset configuration").click();
+      cy.wait("@getEmptyPostgresConnectorDatasetconfig");
+      cy.getByTestId("dataset-selector-section").should("not.exist");
+    });
   });
 });

--- a/clients/admin-ui/cypress/e2e/connectors.cy.ts
+++ b/clients/admin-ui/cypress/e2e/connectors.cy.ts
@@ -32,6 +32,9 @@ describe("Connectors", () => {
         "/api/v1/connection/postgres_connector/datasetconfig",
         { body: {} }
       ).as("patchDatasetconfig");
+      cy.intercept("GET", "/api/v1/dataset", { fixture: "datasets.json" }).as(
+        "getDatasets"
+      );
     });
 
     it("Should show data store connections and view configuration", () => {
@@ -46,15 +49,51 @@ describe("Connectors", () => {
       cy.getByTestId("input-name").should("have.value", "postgres_connector");
     });
 
-    it("Should allow saving a dataset configuration", () => {
+    it("Should allow saving a dataset configuration via dropdown", () => {
       cy.visit("/datastore-connection/postgres_connector");
       cy.getByTestId("tab-Dataset configuration").click();
       cy.wait("@getPostgresConnectorDatasetconfig");
-      // The monaco yaml editor takes a bit to load. Since this is likely going away,
-      // just wait for now and remove this once the yaml editor is no longer available
+
+      // The yaml editor will start off disabled
+      cy.getByTestId("save-yaml-btn").should("be.disabled");
+      // The dataset dropdown selector should have the value of the existing connected dataset
+      cy.getByTestId("save-dataset-link-btn").should("be.enabled");
+      cy.getByTestId("dataset-selector").should(
+        "have.value",
+        "postgres_example_test_dataset"
+      );
+
+      // Change the linked dataset
+      cy.getByTestId("dataset-selector").select("demo_users_dataset_2");
+      cy.getByTestId("save-dataset-link-btn").click();
+
+      cy.wait("@patchDatasetconfig").then((interception) => {
+        expect(interception.request.body).to.eql([
+          {
+            fides_key: "postgres_example_test_dataset",
+            ctl_dataset_fides_key: "demo_users_dataset_2",
+          },
+        ]);
+      });
+    });
+
+    it("Should allow saving a dataset configuration via yaml", () => {
+      cy.visit("/datastore-connection/postgres_connector");
+      cy.getByTestId("tab-Dataset configuration").click();
+      cy.wait("@getPostgresConnectorDatasetconfig");
+
+      // Unset the linked dataset, which should switch the save button enable-ness
+      cy.getByTestId("dataset-selector").select("Select");
+      cy.getByTestId("save-dataset-link-btn").should("be.disabled");
+      cy.getByTestId("save-yaml-btn").click();
+
+      // Click past the confirmation modal
+      cy.getByTestId("confirmation-modal");
+      // The monaco yaml editor takes a bit to load
       // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(1000);
-      cy.getByTestId("save-btn").click();
+      cy.wait(500);
+      cy.getByTestId("continue-btn").click();
+
       cy.wait("@upsertDataset").then((interception) => {
         expect(interception.request.body.length).to.eql(1);
         expect(interception.request.body[0].fides_key).to.eql(

--- a/clients/admin-ui/cypress/fixtures/datasets.json
+++ b/clients/admin-ui/cypress/fixtures/datasets.json
@@ -290,5 +290,20 @@
         ]
       }
     ]
+  },
+  {
+    "fides_key": "postgres_example_test_dataset",
+    "organization_fides_key": "default_organization",
+    "tags": null,
+    "name": "Postgres Example Test Dataset",
+    "description": "Example of a Postgres dataset containing a variety of related tables like customers, products, addresses, etc.",
+    "meta": null,
+    "data_categories": null,
+    "data_qualifier": "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
+    "fides_meta": null,
+    "joint_controller": null,
+    "retention": "No retention or erasure policy",
+    "third_country_transfers": null,
+    "collections": []
   }
 ]

--- a/clients/admin-ui/src/app/store.ts
+++ b/clients/admin-ui/src/app/store.ts
@@ -9,10 +9,7 @@ import {
   connectionTypeApi,
   reducer as connectionTypeReducer,
 } from "connection-type/index";
-import {
-  datastoreConnectionApi,
-  reducer as datastoreConnectionReducer,
-} from "datastore-connections/index";
+import { reducer as datastoreConnectionReducer } from "datastore-connections/index";
 import {
   privacyRequestApi,
   reducer as privacyRequestsReducer,
@@ -34,6 +31,7 @@ import {
 } from "user-management/index";
 
 import { STORAGE_ROOT_KEY } from "~/constants";
+import { baseApi } from "~/features/common/api.slice";
 import { reducer as configWizardReducer } from "~/features/config-wizard/config-wizard.slice";
 import { scannerApi } from "~/features/config-wizard/scanner.slice";
 import {
@@ -48,7 +46,7 @@ import {
   dataUseApi,
   reducer as dataUseReducer,
 } from "~/features/data-use/data-use.slice";
-import { datasetApi, reducer as datasetReducer } from "~/features/dataset";
+import { reducer as datasetReducer } from "~/features/dataset";
 import {
   organizationApi,
   reducer as organizationReducer,
@@ -83,12 +81,11 @@ const storage =
 
 const reducer = {
   [authApi.reducerPath]: authApi.reducer,
+  [baseApi.reducerPath]: baseApi.reducer,
   [connectionTypeApi.reducerPath]: connectionTypeApi.reducer,
   [dataQualifierApi.reducerPath]: dataQualifierApi.reducer,
   [dataSubjectsApi.reducerPath]: dataSubjectsApi.reducer,
   [dataUseApi.reducerPath]: dataUseApi.reducer,
-  [datasetApi.reducerPath]: datasetApi.reducer,
-  [datastoreConnectionApi.reducerPath]: datastoreConnectionApi.reducer,
   [organizationApi.reducerPath]: organizationApi.reducer,
   [plusApi.reducerPath]: plusApi.reducer,
   [privacyRequestApi.reducerPath]: privacyRequestApi.reducer,
@@ -135,12 +132,11 @@ const persistConfig = {
   */
   blacklist: [
     authApi.reducerPath,
+    baseApi.reducerPath,
     connectionTypeApi.reducerPath,
     dataQualifierApi.reducerPath,
     dataSubjectsApi.reducerPath,
     dataUseApi.reducerPath,
-    datasetApi.reducerPath,
-    datastoreConnectionApi.reducerPath,
     organizationApi.reducerPath,
     plusApi.reducerPath,
     privacyRequestApi.reducerPath,
@@ -163,12 +159,11 @@ export const makeStore = (preloadedState?: Partial<RootState>) =>
         },
       }).concat(
         authApi.middleware,
+        baseApi.middleware,
         connectionTypeApi.middleware,
         dataQualifierApi.middleware,
         dataSubjectsApi.middleware,
         dataUseApi.middleware,
-        datasetApi.middleware,
-        datastoreConnectionApi.middleware,
         organizationApi.middleware,
         plusApi.middleware,
         privacyRequestApi.middleware,

--- a/clients/admin-ui/src/features/common/api.slice.ts
+++ b/clients/admin-ui/src/features/common/api.slice.ts
@@ -1,0 +1,22 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+import type { RootState } from "~/app/store";
+import { selectToken } from "~/features/auth";
+
+import { addCommonHeaders } from "./CommonHeaders";
+
+// Uses the code splitting pattern. New endpoints should be injected into this base API
+// which itself has an empty endpoint object.
+export const baseApi = createApi({
+  reducerPath: "baseApi",
+  baseQuery: fetchBaseQuery({
+    baseUrl: process.env.NEXT_PUBLIC_FIDESCTL_API,
+    prepareHeaders: (headers, { getState }) => {
+      const token: string | null = selectToken(getState() as RootState);
+      addCommonHeaders(headers, token);
+      return headers;
+    },
+  }),
+  tagTypes: ["DatastoreConnection", "Dataset", "Datasets"],
+  endpoints: () => ({}),
+});

--- a/clients/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/admin-ui/src/features/dataset/dataset.slice.ts
@@ -1,7 +1,7 @@
 import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import type { RootState } from "~/app/store";
+import { baseApi } from "~/features/common/api.slice";
 import {
   BulkPutDataset,
   Dataset,
@@ -27,12 +27,7 @@ interface DatasetDeleteResponse {
   resource: Dataset;
 }
 
-export const datasetApi = createApi({
-  reducerPath: "datasetApi",
-  baseQuery: fetchBaseQuery({
-    baseUrl: process.env.NEXT_PUBLIC_FIDESCTL_API,
-  }),
-  tagTypes: ["Dataset", "Datasets"],
+const datasetApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getAllDatasets: build.query<Dataset[], void>({
       query: () => ({ url: `dataset/` }),

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
@@ -55,7 +55,7 @@ const DatasetConfiguration: React.FC = () => {
   >(undefined);
 
   useEffect(() => {
-    if (data) {
+    if (data && data.items.length) {
       setSelectedDatasetKey(data.items[0].ctl_dataset.fides_key);
     }
   }, [data]);

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
@@ -151,10 +151,12 @@ const DatasetConfiguration: React.FC = () => {
     );
   }
 
+  const datasetsExist = allDatasets && allDatasets.length;
+
   return (
     <VStack alignItems="left">
       <HStack spacing={8} mb={4}>
-        {allDatasets && allDatasets.length ? (
+        {datasetsExist ? (
           <>
             <VStack alignSelf="start" mr={4}>
               <Box data-testid="dataset-selector-section" mb={4}>
@@ -201,18 +203,22 @@ const DatasetConfiguration: React.FC = () => {
               isSubmitting={isSubmitting}
               onSubmit={handleSubmitYaml}
               disabled={datasetSelected}
+              // Only render the cancel button if the dataset dropdown view is unavailable
+              onCancel={!datasetsExist ? handleCancel : undefined}
             />
           ) : null}
         </Box>
       </HStack>
-      <Button
-        width="fit-content"
-        size="sm"
-        variant="outline"
-        onClick={handleCancel}
-      >
-        Cancel
-      </Button>
+      {datasetsExist ? (
+        <Button
+          width="fit-content"
+          size="sm"
+          variant="outline"
+          onClick={handleCancel}
+        >
+          Cancel
+        </Button>
+      ) : null}
     </VStack>
   );
 };

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
@@ -163,7 +163,7 @@ const DatasetConfiguration: React.FC = () => {
   return (
     <VStack alignItems="left">
       {loadAllDatasetsError ? (
-        <Copy mb={4}>
+        <Copy mb={4} color="red">
           There was a problem loading existing datasets, please try again.
         </Copy>
       ) : null}

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
@@ -149,10 +149,10 @@ const DatasetConfiguration: React.FC = () => {
 
   return (
     <VStack alignItems="left">
-      <HStack spacing={6}>
+      <HStack spacing={8}>
         {allDatasets && allDatasets.length ? (
           <>
-            <VStack alignSelf="start">
+            <VStack alignSelf="start" mr={4}>
               <Box data-testid="dataset-selector" mb={4}>
                 <Copy mb={4}>
                   Choose a dataset to associate with this connector.

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
@@ -1,12 +1,13 @@
 import {
   Box,
+  Button,
   Center,
-  Divider,
   HStack,
   Select,
   Spinner,
   Text,
   TextProps,
+  VStack,
 } from "@fidesui/react";
 import { useAlert, useAPIHelper } from "common/hooks";
 import { selectConnectionTypeState } from "connection-type/connection-type.slice";
@@ -16,7 +17,7 @@ import {
 } from "datastore-connections/datastore-connection.slice";
 import { PatchDatasetsConfigRequest } from "datastore-connections/types";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { ChangeEvent, useState } from "react";
 import { DATASTORE_CONNECTION_ROUTE } from "src/constants";
 
 import { useAppSelector } from "~/app/hooks";
@@ -49,7 +50,11 @@ const DatasetConfiguration: React.FC = () => {
   const { data: allDatasets, isLoading: isLoadingAllDatasets } =
     useGetAllDatasetsQuery();
 
-  const handleSubmit = async (value: unknown) => {
+  const [selectedDatasetKey, setSelectedDatasetKey] = useState<
+    string | undefined
+  >(undefined);
+
+  const handleSubmitYaml = async (value: unknown) => {
     try {
       setIsSubmitting(true);
       // First update the datasets
@@ -98,6 +103,13 @@ const DatasetConfiguration: React.FC = () => {
     }
   };
 
+  const handleSelectDataset = (event: ChangeEvent<HTMLSelectElement>) => {
+    setSelectedDatasetKey(event.target.value);
+  };
+
+  const datasetSelected =
+    selectedDatasetKey !== "" && selectedDatasetKey !== undefined;
+
   if (isFetching || isLoading || isLoadingAllDatasets) {
     return (
       <Center>
@@ -107,38 +119,56 @@ const DatasetConfiguration: React.FC = () => {
   }
 
   return (
-    <HStack spacing={6}>
-      {allDatasets && allDatasets.length ? (
-        <>
-          <Box data-testid="dataset-selector" mb={4} alignSelf="start">
-            <Copy mb={4}>
-              Choose a dataset to associate with this connector.
-            </Copy>
-            <Select size="sm" width="fit-content" placeholder="Select">
-              {allDatasets.map((ds) => (
-                <option key={ds.fides_key} value={ds.fides_key}>
-                  {ds.fides_key}
-                </option>
-              ))}
-            </Select>
-          </Box>
-          <Copy>or</Copy>
-        </>
-      ) : null}
-      <Box data-testid="yaml-editor">
-        <Copy mb={4}>
-          View your system yaml below! You can also modify the yaml if you need
-          to assign any references between datasets.
-        </Copy>
-        {isSuccess && data!?.items ? (
-          <YamlEditorForm
-            data={data.items.map((item) => item.ctl_dataset)}
-            isSubmitting={isSubmitting}
-            onSubmit={handleSubmit}
-          />
+    <VStack alignItems="left">
+      <HStack spacing={6}>
+        {allDatasets && allDatasets.length ? (
+          <>
+            <VStack alignSelf="start">
+              <Box data-testid="dataset-selector" mb={4}>
+                <Copy mb={4}>
+                  Choose a dataset to associate with this connector.
+                </Copy>
+                <Select
+                  size="sm"
+                  width="fit-content"
+                  placeholder="Select"
+                  onChange={handleSelectDataset}
+                >
+                  {allDatasets.map((ds) => (
+                    <option key={ds.fides_key} value={ds.fides_key}>
+                      {ds.fides_key}
+                    </option>
+                  ))}
+                </Select>
+              </Box>
+              <Button
+                size="sm"
+                colorScheme="primary"
+                alignSelf="start"
+                disabled={!datasetSelected}
+              >
+                Save
+              </Button>
+            </VStack>
+            <Copy>or</Copy>
+          </>
         ) : null}
-      </Box>
-    </HStack>
+        <Box data-testid="yaml-editor">
+          <Copy mb={4}>
+            View your system yaml below! You can also modify the yaml if you
+            need to assign any references between datasets.
+          </Copy>
+          {isSuccess && data!?.items ? (
+            <YamlEditorForm
+              data={data.items.map((item) => item.ctl_dataset)}
+              isSubmitting={isSubmitting}
+              onSubmit={handleSubmitYaml}
+              disabled={datasetSelected}
+            />
+          ) : null}
+        </Box>
+      </HStack>
+    </VStack>
   );
 };
 

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
@@ -60,6 +60,10 @@ const DatasetConfiguration: React.FC = () => {
     }
   }, [data]);
 
+  const handleCancel = () => {
+    router.push(DATASTORE_CONNECTION_ROUTE);
+  };
+
   const handlePatchDatasetConfig = async (
     datasetPairs: DatasetConfigCtlDataset[]
   ) => {
@@ -149,7 +153,7 @@ const DatasetConfiguration: React.FC = () => {
 
   return (
     <VStack alignItems="left">
-      <HStack spacing={8}>
+      <HStack spacing={8} mb={4}>
         {allDatasets && allDatasets.length ? (
           <>
             <VStack alignSelf="start" mr={4}>
@@ -199,6 +203,14 @@ const DatasetConfiguration: React.FC = () => {
           ) : null}
         </Box>
       </HStack>
+      <Button
+        width="fit-content"
+        size="sm"
+        variant="outline"
+        onClick={handleCancel}
+      >
+        Cancel
+      </Button>
     </VStack>
   );
 };

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
@@ -157,7 +157,7 @@ const DatasetConfiguration: React.FC = () => {
         {allDatasets && allDatasets.length ? (
           <>
             <VStack alignSelf="start" mr={4}>
-              <Box data-testid="dataset-selector" mb={4}>
+              <Box data-testid="dataset-selector-section" mb={4}>
                 <Copy mb={4}>
                   Choose a dataset to associate with this connector.
                 </Copy>
@@ -167,6 +167,7 @@ const DatasetConfiguration: React.FC = () => {
                   placeholder="Select"
                   onChange={handleSelectDataset}
                   value={selectedDatasetKey}
+                  data-testid="dataset-selector"
                 >
                   {allDatasets.map((ds) => (
                     <option key={ds.fides_key} value={ds.fides_key}>
@@ -181,6 +182,7 @@ const DatasetConfiguration: React.FC = () => {
                 alignSelf="start"
                 disabled={!datasetSelected}
                 onClick={handleLinkDataset}
+                data-testid="save-dataset-link-btn"
               >
                 Save
               </Button>
@@ -188,7 +190,7 @@ const DatasetConfiguration: React.FC = () => {
             <Copy>or</Copy>
           </>
         ) : null}
-        <Box data-testid="yaml-editor">
+        <Box data-testid="yaml-editor-section">
           <Copy mb={4}>
             View your system yaml below! You can also modify the yaml if you
             need to assign any references between datasets.

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
@@ -47,8 +47,11 @@ const DatasetConfiguration: React.FC = () => {
   );
   const [patchDatasetConfig] = usePatchDatasetConfigsMutation();
   const [upsertDatasets] = useUpsertDatasetsMutation();
-  const { data: allDatasets, isLoading: isLoadingAllDatasets } =
-    useGetAllDatasetsQuery();
+  const {
+    data: allDatasets,
+    isLoading: isLoadingAllDatasets,
+    error: loadAllDatasetsError,
+  } = useGetAllDatasetsQuery();
 
   const [selectedDatasetKey, setSelectedDatasetKey] = useState<
     string | undefined
@@ -143,7 +146,11 @@ const DatasetConfiguration: React.FC = () => {
   const datasetSelected =
     selectedDatasetKey !== "" && selectedDatasetKey !== undefined;
 
-  if (isFetching || isLoading || isLoadingAllDatasets) {
+  if (
+    isFetching ||
+    isLoading ||
+    (isLoadingAllDatasets && !loadAllDatasetsError)
+  ) {
     return (
       <Center>
         <Spinner />
@@ -155,6 +162,11 @@ const DatasetConfiguration: React.FC = () => {
 
   return (
     <VStack alignItems="left">
+      {loadAllDatasetsError ? (
+        <Copy mb={4}>
+          There was a problem loading existing datasets, please try again.
+        </Copy>
+      ) : null}
       <HStack spacing={8} mb={4}>
         {datasetsExist ? (
           <>

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
@@ -192,7 +192,7 @@ const DatasetConfiguration: React.FC = () => {
         ) : null}
         <Box data-testid="yaml-editor-section">
           <Copy mb={4}>
-            View your system yaml below! You can also modify the yaml if you
+            View your dataset YAML below! You can also modify the YAML if you
             need to assign any references between datasets.
           </Copy>
           {isSuccess && data!?.items ? (

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -120,7 +120,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
           colorScheme="primary"
           isDisabled={disabled || isEmptyState || !!yamlError || isSubmitting}
           isLoading={isSubmitting}
-          loadingText="Saving Yaml system"
+          loadingText="Saving"
           onClick={handleConfirmation}
           size="sm"
           type="submit"
@@ -166,7 +166,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
                       Error message:
                     </Heading>
                     <Text color="gray.700" fontSize="sm" fontWeight="400">
-                      Yaml system is required
+                      YAML dataset is required
                     </Text>
                   </Box>
                 )}

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -2,6 +2,7 @@ import { ConfirmationModal } from "@fidesui/components";
 import {
   Box,
   Button,
+  ButtonGroup,
   Divider,
   Flex,
   Heading,
@@ -35,6 +36,7 @@ type YamlEditorFormProps = {
   data: Dataset[];
   isSubmitting: boolean;
   onSubmit: (value: unknown) => void;
+  onCancel?: () => void;
   disabled?: boolean;
 };
 
@@ -42,6 +44,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
   data = [],
   isSubmitting = false,
   onSubmit,
+  onCancel,
   disabled,
 }) => {
   const monacoRef = useRef(null);
@@ -115,20 +118,21 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
           }}
           theme="light"
         />
-        <Button
-          mt="24px !important"
-          colorScheme="primary"
-          isDisabled={disabled || isEmptyState || !!yamlError || isSubmitting}
-          isLoading={isSubmitting}
-          loadingText="Saving"
-          onClick={handleConfirmation}
-          size="sm"
-          type="submit"
-          data-testid="save-yaml-btn"
-          width="fit-content"
-        >
-          Save
-        </Button>
+        <ButtonGroup size="sm">
+          {onCancel ? <Button onClick={onCancel}>Cancel</Button> : null}
+          <Button
+            colorScheme="primary"
+            isDisabled={disabled || isEmptyState || !!yamlError || isSubmitting}
+            isLoading={isSubmitting}
+            loadingText="Saving"
+            onClick={handleConfirmation}
+            type="submit"
+            data-testid="save-yaml-btn"
+            width="fit-content"
+          >
+            Save
+          </Button>
+        </ButtonGroup>
       </VStack>
       {isTouched && (isEmptyState || yamlError) && (
         <SlideFade in>

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -36,12 +36,14 @@ type YamlEditorFormProps = {
   data: Dataset[];
   isSubmitting: boolean;
   onSubmit: (value: unknown) => void;
+  disabled?: boolean;
 };
 
 const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
   data = [],
   isSubmitting = false,
   onSubmit,
+  disabled,
 }) => {
   const monacoRef = useRef(null);
   const router = useRouter();
@@ -92,7 +94,6 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
   return (
     <Flex gap="97px">
       <VStack align="stretch" w="918px">
-        <Divider color="gray.100" />
         <Editor
           defaultLanguage="yaml"
           defaultValue={yamlData}
@@ -105,10 +106,10 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
             minimap: {
               enabled: true,
             },
+            readOnly: disabled,
           }}
           theme="light"
         />
-        <Divider color="gray.100" />
         <ButtonGroup
           mt="24px !important"
           size="sm"

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -75,10 +75,6 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
     }
   };
 
-  const handleCancel = () => {
-    router.push(DATASTORE_CONNECTION_ROUTE);
-  };
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleMount = (editor: any, _monaco: any) => {
     monacoRef.current = editor;
@@ -110,33 +106,20 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
           }}
           theme="light"
         />
-        <ButtonGroup
+        <Button
           mt="24px !important"
+          colorScheme="primary"
+          isDisabled={disabled || isEmptyState || !!yamlError || isSubmitting}
+          isLoading={isSubmitting}
+          loadingText="Saving Yaml system"
+          onClick={handleSubmit}
           size="sm"
-          spacing="8px"
-          variant="outline"
+          type="submit"
+          data-testid="save-btn"
+          width="fit-content"
         >
-          <Button onClick={handleCancel} variant="outline">
-            Cancel
-          </Button>
-          <Button
-            bg="primary.800"
-            color="white"
-            isDisabled={isEmptyState || !!yamlError || isSubmitting}
-            isLoading={isSubmitting}
-            loadingText="Saving Yaml system"
-            onClick={handleSubmit}
-            size="sm"
-            variant="solid"
-            type="submit"
-            _active={{ bg: "primary.500" }}
-            _disabled={{ opacity: "inherit" }}
-            _hover={{ bg: "primary.400" }}
-            data-testid="save-btn"
-          >
-            Save Yaml system
-          </Button>
-        </ButtonGroup>
+          Save Yaml system
+        </Button>
       </VStack>
       {isTouched && (isEmptyState || yamlError) && (
         <SlideFade in>

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -1,3 +1,4 @@
+import { ConfirmationModal } from "@fidesui/components";
 import {
   Box,
   Button,
@@ -8,6 +9,7 @@ import {
   SlideFade,
   Tag,
   Text,
+  useDisclosure,
   VStack,
 } from "@fidesui/react";
 import { useAlert } from "common/hooks/useAlert";
@@ -51,6 +53,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
   const [isTouched, setIsTouched] = useState(false);
   const [isEmptyState, setIsEmptyState] = useState(!yamlData);
   const { navV2 } = useFeatures();
+  const warningDisclosure = useDisclosure();
 
   const validate = (value: string) => {
     yaml.load(value, { json: true });
@@ -83,6 +86,16 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
     onSubmit(yamlDoc);
   };
 
+  const handleConfirmation = () => {
+    // Only need the confirmation if we are overwriting, which only happens when
+    // there is already data
+    if (data.length) {
+      warningDisclosure.onOpen();
+    } else {
+      handleSubmit();
+    }
+  };
+
   return (
     <Flex gap="97px">
       <VStack align="stretch" w="800px">
@@ -108,7 +121,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
           isDisabled={disabled || isEmptyState || !!yamlError || isSubmitting}
           isLoading={isSubmitting}
           loadingText="Saving Yaml system"
-          onClick={handleSubmit}
+          onClick={handleConfirmation}
           size="sm"
           type="submit"
           data-testid="save-btn"
@@ -185,6 +198,31 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
           </Box>
         </SlideFade>
       )}
+      <ConfirmationModal
+        isOpen={warningDisclosure.isOpen}
+        onClose={warningDisclosure.onClose}
+        onConfirm={handleSubmit}
+        title="Overwrite dataset"
+        message={
+          <>
+            <Text>
+              You are about to overwrite the dataset{data.length > 1 ? "s" : ""}{" "}
+              {data.map((d, i) => {
+                const isLast = i === data.length - 1;
+                return (
+                  <>
+                    <Text color="complimentary.500" as="span" fontWeight="bold">
+                      {d.fides_key}
+                    </Text>
+                    {isLast ? "." : ", "}
+                  </>
+                );
+              })}
+            </Text>
+            <Text>Are you sure you would like to continue?</Text>
+          </>
+        }
+      />
     </Flex>
   );
 };

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -21,6 +21,7 @@ import dynamic from "next/dynamic";
 import React, { useRef, useState } from "react";
 
 import { useFeatures } from "~/features/common/features.slice";
+import { useGetAllDatasetsQuery } from "~/features/dataset";
 import { Dataset } from "~/types/api";
 
 const Editor = dynamic(
@@ -57,6 +58,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
   const [isEmptyState, setIsEmptyState] = useState(!yamlData);
   const { navV2 } = useFeatures();
   const warningDisclosure = useDisclosure();
+  const { data: allDatasets } = useGetAllDatasetsQuery();
 
   const validate = (value: string) => {
     yaml.load(value, { json: true });
@@ -91,17 +93,19 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
 
   const handleConfirmation = () => {
     // Only need the confirmation if we are overwriting, which only happens when
-    // there is already data
-    if (data.length) {
+    // there are already datasets
+    if (allDatasets && allDatasets.length) {
       const value: string = (monacoRef.current as any).getValue();
-      // Check if the fides key that is in the editor is the same as the one that already exists
+      // Check if the fides key that is in the editor is the same as one that already exists
       // If so, then it is an overwrite and we should open the confirmation modal
-      if (data.some((d) => value.includes(`fides_key: ${d.fides_key}\n`))) {
+      if (
+        allDatasets.some((d) => value.includes(`fides_key: ${d.fides_key}\n`))
+      ) {
         warningDisclosure.onOpen();
+        return;
       }
-    } else {
-      handleSubmit();
     }
+    handleSubmit();
   };
 
   return (

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -210,7 +210,10 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
       <ConfirmationModal
         isOpen={warningDisclosure.isOpen}
         onClose={warningDisclosure.onClose}
-        onConfirm={handleSubmit}
+        onConfirm={() => {
+          handleSubmit();
+          warningDisclosure.onClose();
+        }}
         title="Overwrite dataset"
         message={
           <>

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -59,6 +59,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
   const { navV2 } = useFeatures();
   const warningDisclosure = useDisclosure();
   const { data: allDatasets } = useGetAllDatasetsQuery();
+  const [overWrittenKeys, setOverWrittenKeys] = useState<string[]>([]);
 
   const validate = (value: string) => {
     yaml.load(value, { json: true });
@@ -89,6 +90,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
     const value = (monacoRef.current as any).getValue();
     const yamlDoc = yaml.load(value, { json: true });
     onSubmit(yamlDoc);
+    setOverWrittenKeys([]);
   };
 
   const handleConfirmation = () => {
@@ -98,9 +100,11 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
       const value: string = (monacoRef.current as any).getValue();
       // Check if the fides key that is in the editor is the same as one that already exists
       // If so, then it is an overwrite and we should open the confirmation modal
-      if (
-        allDatasets.some((d) => value.includes(`fides_key: ${d.fides_key}\n`))
-      ) {
+      const overlappingKeys = allDatasets
+        .filter((d) => value.includes(`fides_key: ${d.fides_key}\n`))
+        .map((d) => d.fides_key);
+      setOverWrittenKeys(overlappingKeys);
+      if (overlappingKeys.length) {
         warningDisclosure.onOpen();
         return;
       }
@@ -222,13 +226,14 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
         message={
           <>
             <Text>
-              You are about to overwrite the dataset{data.length > 1 ? "s" : ""}{" "}
-              {data.map((d, i) => {
-                const isLast = i === data.length - 1;
+              You are about to overwrite the dataset
+              {overWrittenKeys.length > 1 ? "s" : ""}{" "}
+              {overWrittenKeys.map((key, i) => {
+                const isLast = i === overWrittenKeys.length - 1;
                 return (
                   <>
                     <Text color="complimentary.500" as="span" fontWeight="bold">
-                      {d.fides_key}
+                      {key}
                     </Text>
                     {isLast ? "." : ", "}
                   </>

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -46,7 +46,6 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
   disabled,
 }) => {
   const monacoRef = useRef(null);
-  const router = useRouter();
   const { errorAlert } = useAlert();
   const yamlData = data.length > 0 ? yaml.dump(data) : undefined;
   const [yamlError, setYamlError] = useState(

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -93,7 +93,12 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
     // Only need the confirmation if we are overwriting, which only happens when
     // there is already data
     if (data.length) {
-      warningDisclosure.onOpen();
+      const value: string = (monacoRef.current as any).getValue();
+      // Check if the fides key that is in the editor is the same as the one that already exists
+      // If so, then it is an overwrite and we should open the confirmation modal
+      if (data.some((d) => value.includes(`fides_key: ${d.fides_key}\n`))) {
+        warningDisclosure.onOpen();
+      }
     } else {
       handleSubmit();
     }

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -127,7 +127,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
           data-testid="save-btn"
           width="fit-content"
         >
-          Save Yaml system
+          Save
         </Button>
       </VStack>
       {isTouched && (isEmptyState || yamlError) && (

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -124,7 +124,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
           onClick={handleConfirmation}
           size="sm"
           type="submit"
-          data-testid="save-btn"
+          data-testid="save-yaml-btn"
           width="fit-content"
         >
           Save

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  ButtonGroup,
   Divider,
   Flex,
   Heading,
@@ -16,9 +15,7 @@ import { ErrorWarningIcon } from "common/Icon";
 import yaml, { YAMLException } from "js-yaml";
 import { narrow } from "narrow-minded";
 import dynamic from "next/dynamic";
-import { useRouter } from "next/router";
 import React, { useRef, useState } from "react";
-import { DATASTORE_CONNECTION_ROUTE } from "src/constants";
 
 import { useFeatures } from "~/features/common/features.slice";
 import { Dataset } from "~/types/api";
@@ -88,7 +85,7 @@ const YamlEditorForm: React.FC<YamlEditorFormProps> = ({
 
   return (
     <Flex gap="97px">
-      <VStack align="stretch" w="918px">
+      <VStack align="stretch" w="800px">
         <Editor
           defaultLanguage="yaml"
           defaultValue={yamlData}

--- a/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
+++ b/clients/admin-ui/src/features/datastore-connections/datastore-connection.slice.ts
@@ -1,7 +1,6 @@
 import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { addCommonHeaders } from "common/CommonHeaders";
 
+import { baseApi } from "~/features/common/api.slice";
 import {
   BulkPutDataset,
   Page_DatasetConfigSchema_,
@@ -9,8 +8,7 @@ import {
 } from "~/types/api";
 
 import type { RootState } from "../../app/store";
-import { BASE_URL, CONNECTION_ROUTE } from "../../constants";
-import { selectToken } from "../auth";
+import { CONNECTION_ROUTE } from "../../constants";
 import { DisabledStatus, TestingStatus } from "./constants";
 import {
   CreateAccessManualWebhookRequest,
@@ -152,17 +150,7 @@ export const selectDatastoreConnectionFilters = (
 
 export const { reducer } = datastoreConnectionSlice;
 
-export const datastoreConnectionApi = createApi({
-  reducerPath: "datastoreConnectionApi",
-  baseQuery: fetchBaseQuery({
-    baseUrl: BASE_URL,
-    prepareHeaders: (headers, { getState }) => {
-      const token: string | null = selectToken(getState() as RootState);
-      addCommonHeaders(headers, token);
-      return headers;
-    },
-  }),
-  tagTypes: ["DatastoreConnection"],
+export const datastoreConnectionApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     createAccessManualWebhook: build.mutation<
       CreateAccessManualWebhookResponse,
@@ -184,7 +172,8 @@ export const datastoreConnectionApi = createApi({
         method: "POST",
         body: { ...params },
       }),
-      invalidatesTags: ["DatastoreConnection"],
+      // Creating a connection config also creates a dataset behind the scenes
+      invalidatesTags: ["DatastoreConnection", "Datasets"],
     }),
     deleteDatastoreConnection: build.mutation({
       query: (id) => ({


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2114

### Code Changes

* [x] Adds a dataset dropdown next to the existing yaml editor
* [x] Allows the dataset dropdown to link a dataset to a connector config
* [x] Additional confirmation button for overwriting datasets in the yaml editor
* [x] Fix copy (system yaml --> dataset YAML)
* [x] Cypress tests

### Steps to Confirm

* [ ] `nox -s test_env`
* [ ] Configure a connector dataset

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Using the dropdown

https://user-images.githubusercontent.com/24641006/211687577-d15544a6-4ed1-4fd8-b27b-91840857f52b.mov

Using the yaml editor

https://user-images.githubusercontent.com/24641006/211687670-72ddcd58-c9b9-4319-b864-659f38f8e692.mov

