### PR TITLE
Exclude untestable code from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,3 +204,6 @@ markers = [
     "unit_saas"
 ]
 asyncio_mode = "auto"
+
+[tool.coverage.run]
+omit = ["src/fides/api/ctl/migrations/*"]

--- a/src/fides/api/ops/graph/data_type.py
+++ b/src/fides/api/ops/graph/data_type.py
@@ -265,7 +265,7 @@ def get_data_type(value: Any) -> Tuple[Optional[str], bool]:
     return data_type, is_array
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     v = DataType.no_op.value
     for x in v.__dict__:
         print(x)

--- a/src/fides/api/ops/tasks/__init__.py
+++ b/src/fides/api/ops/tasks/__init__.py
@@ -89,5 +89,5 @@ def start_worker() -> None:
     )
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     start_worker()


### PR DESCRIPTION
Closes #<issue>

### Code Changes

* Added `pragma: no cover` to `if __name__ == "__main__:"` code
* Excluded migrations from coverage 

### Steps to Confirm

* [ ] Run `pytest tests/ctl -m "unit"` and verify `migrations` and `if __name__ == "__main__:"` sections are not included in the `term-missing` section

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

In thinking about #2135 I am adding some exclusions from coverage here. The `migrations` are used by alembic and not by fides code directly, the only reason we have them in a directory under coverage is so plus can access them.

We could probably jump through some hoops and find a way to test the ``if __name__ == "__main__:"`` sections, but doing so would be for the sake of coverage and not meaningful.