### PR TITLE
[DRAFT] Mandrill consent connector

### DIFF
--- a/data/saas/config/mandrill_config.yml
+++ b/data/saas/config/mandrill_config.yml
@@ -1,0 +1,44 @@
+saas_config:
+  fides_key: <instance_fides_key>
+  name: Mandril SaaS Config
+  type: mandrill
+  description: A sample schema representing the Mandril connector for Fided
+  version: 0.0.1
+
+  connector_params:
+    - name: domain
+    - name: api_key
+
+  client_config:
+    protocol: https
+    host: <domain>
+
+  consent_requests:
+    opt_in:
+      - method: POST
+        path: /allowlists/add
+        body: |
+          {
+            "key": "<api_key>",
+            "email": "<email>"
+          }
+        data_uses: [advertising.first_party]
+    opt_out:
+      - method: POST
+        path: /allowlists/delete
+        body: |
+          {
+            "key": "<api_key>",
+            "email": "<email>"
+          }
+        data_uses: [ advertising.first_party]
+
+  test_request:
+    method: GET
+    path: /users/ping
+    body: |
+      {
+        "key": "<api_key>",
+      }
+
+  endpoints: []

--- a/data/saas/dataset/mandrill_dataset.yml
+++ b/data/saas/dataset/mandrill_dataset.yml
@@ -1,0 +1,5 @@
+dataset:
+  - fides_key: <instance_fides_key>
+    name: Mandril Dataset
+    description: A sample dataset representing the Mandril connector for Fides
+    collections: []

--- a/data/saas/saas_connector_registry.toml
+++ b/data/saas/saas_connector_registry.toml
@@ -52,6 +52,12 @@ dataset = "data/saas/dataset/mailchimp_dataset.yml"
 icon = "data/saas/icon/mailchimp.svg"
 human_readable = "Mailchimp"
 
+[mandrill]
+config = "data/saas/config/mandrill_config.yml"
+dataset = "data/saas/dataset/mandrill_dataset.yml"
+icon = "data/saas/icon/default.svg"
+human_readable = "Mandrill"
+
 [outreach]
 config = "data/saas/config/outreach_config.yml"
 dataset = "data/saas/dataset/outreach_dataset.yml"

--- a/src/fides/api/ops/schemas/saas/saas_config.py
+++ b/src/fides/api/ops/schemas/saas/saas_config.py
@@ -104,6 +104,7 @@ class SaaSRequest(BaseModel):
     grouped_inputs: Optional[List[str]] = []
     ignore_errors: Optional[bool] = False
     rate_limit_config: Optional[RateLimitConfig]
+    data_uses: Optional[List[str]] = []
 
     class Config:
         """Populate models with the raw value of enum fields, rather than the enum itself"""
@@ -209,6 +210,13 @@ class SaaSRequestMap(BaseModel):
     read: Union[SaaSRequest, List[SaaSRequest]] = []
     update: Optional[SaaSRequest]
     delete: Optional[SaaSRequest]
+
+
+class ConsentRequestMap(BaseModel):
+    """A map of actions to SaaS requests"""
+
+    opt_in: List[SaaSRequest] = []
+    opt_out: List[SaaSRequest] = []
 
 
 class Endpoint(BaseModel):
@@ -337,6 +345,7 @@ class SaaSConfig(SaaSConfigBase):
     test_request: SaaSRequest
     data_protection_request: Optional[SaaSRequest] = None  # GDPR Delete
     rate_limit_config: Optional[RateLimitConfig]
+    consent_requests: Optional[ConsentRequestMap]
 
     @property
     def top_level_endpoint_dict(self) -> Dict[str, Endpoint]:


### PR DESCRIPTION


Closes #2150
### Code Changes

- Made this a type of saas connector
- Experimental format explored in mandrill saas config, mandrill dataset is mostly empty
- SaasConnector.run_consent_request has special casing just for mandrill.  Any other consent requests for other saas connector types are skipped.

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Exploring Mandrill consent connector
