### PR TITLE
Remove warning when env vars default to blank strings in docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The types of changes are:
 * Nav bug: clicking on Privacy Request breadcrumb takes me to Home instead of /privacy-requests [#497](https://github.com/ethyca/fides/pull/2141)
 * Side nav disappears when viewing request details [#2129](https://github.com/ethyca/fides/pull/2155)
 * Improve readability for exceptions raised from custom request overrides [#2157](https://github.com/ethyca/fides/pull/2157)
+* Remove warning when env vars default to blank strings in docker-compose [#2188](https://github.com/ethyca/fides/pull/2188)
 
 ### Removed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,16 +20,16 @@ services:
       - .env
     environment:
       FIDES__CONFIG_PATH: ${FIDES__CONFIG_PATH:-/fides/.fides/fides.toml}
-      FIDES__CLI__ANALYTICS_ID: ${FIDES__CLI__ANALYTICS_ID:-}
+      FIDES__CLI__ANALYTICS_ID: ${FIDES__CLI__ANALYTICS_ID-}
       FIDES__CLI__SERVER_HOST: "fides"
       FIDES__CLI__SERVER_PORT: "8080"
       FIDES__DATABASE__SERVER: "fides-db"
       FIDES__DEV_MODE: "True"
       FIDES__REDIS__ENABLED: "True"
       FIDES__USER__ANALYTICS_OPT_OUT: "True"
-      VAULT_ADDR: ${VAULT_ADDR:-}
-      VAULT_NAMESPACE: ${VAULT_NAMESPACE:-}
-      VAULT_TOKEN: ${VAULT_TOKEN:-}
+      VAULT_ADDR: ${VAULT_ADDR-}
+      VAULT_NAMESPACE: ${VAULT_NAMESPACE-}
+      VAULT_TOKEN: ${VAULT_TOKEN-}
     volumes:
       - type: bind
         source: .
@@ -100,7 +100,7 @@ services:
       - "8000:8000"
     environment:
       FIDES__DEV_MODE: True
-      FIDES__CLI__ANALYTICS_ID: ${FIDES__CLI__ANALYTICS_ID:-}
+      FIDES__CLI__ANALYTICS_ID: ${FIDES__CLI__ANALYTICS_ID-}
 
       # Required security env vars
       FIDES__SECURITY__APP_ENCRYPTION_KEY: OLMkv91j8DHiDAULnK5Lxx3kSCov30b3


### PR DESCRIPTION
Closes #1434

### Code Changes

* Changed `:-` to `-` when defaulting to an empty string.

### Steps to Confirm

* [ ] Run `nox -s dev`
* [ ] Verify the following warnings are not present

```console
WARN[0000] The "VAULT_ADDR" variable is not set. Defaulting to a blank string.                                                                                                                                                                                                            
WARN[0000] The "VAULT_TOKEN" variable is not set. Defaulting to a blank string. 
WARN[0000] The "FIDES__CLI__ANALYTICS_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "VAULT_NAMESPACE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "FIDES__CLI__ANALYTICS_ID" variable is not set. Defaulting to a blank string. 
```

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
