### PR TITLE
Reenable most cypress tests

### DIFF
--- a/clients/admin-ui/cypress/e2e/auth.cy.ts
+++ b/clients/admin-ui/cypress/e2e/auth.cy.ts
@@ -1,7 +1,6 @@
 import { USER_PRIVILEGES } from "~/constants";
 
-// TODO: Update Cypress test to reflect the nav bar 2.0
-describe.skip("User Authentication", () => {
+describe("User Authentication", () => {
   describe("when the user not logged in", () => {
     it("redirects them to the login page", () => {
       cy.visit("/");
@@ -35,7 +34,7 @@ describe.skip("User Authentication", () => {
       cy.get("#email").type("cypress-user@ethyca.com");
       cy.get("#password").type("FakePassword123!{Enter}");
 
-      cy.getByTestId("nav-bar");
+      cy.getByTestId("Home");
     });
   });
 
@@ -46,7 +45,7 @@ describe.skip("User Authentication", () => {
 
     it("lets them navigate to protected routes", () => {
       cy.visit("/");
-      cy.getByTestId("Privacy Requests");
+      cy.getByTestId("Home");
 
       cy.visit("/user-management");
       cy.getByTestId("User Management");
@@ -70,13 +69,15 @@ describe.skip("User Authentication", () => {
       cy.getByTestId("Login");
     });
 
-    it("/login redirects to the onboarding flow if the user has no systems", () => {
+    // TODO: Update Cypress test to reflect the nav bar 2.0
+    it.skip("/login redirects to the onboarding flow if the user has no systems", () => {
       cy.intercept("GET", "/api/v1/system", { body: [] });
       cy.visit("/login");
       cy.getByTestId("setup");
     });
 
-    it("/login redirects to the systems page if the user has systems", () => {
+    // TODO: Update Cypress test to reflect the nav bar 2.0
+    it.skip("/login redirects to the systems page if the user has systems", () => {
       cy.intercept("GET", "/api/v1/system", { fixture: "systems.json" }).as(
         "getSystems"
       );

--- a/clients/admin-ui/cypress/e2e/config-wizard-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/config-wizard-plus.cy.ts
@@ -9,8 +9,6 @@ import { ClusterHealth } from "~/types/api";
 const goToDataFlowScanner = () => {
   // Go through the initial config wizard steps
   cy.visit("/add-systems");
-  cy.getByTestId("guided-setup-btn").click();
-  cy.wait("@getOrganization");
 
   // Select Runtime scanner to move to scan step.
   cy.getByTestId("add-system-form");
@@ -21,8 +19,7 @@ const goToDataFlowScanner = () => {
  * This test suite is a parallel of config-wizard.cy.ts for testing the config wizard flow
  * when the user has access to the Fides+.
  */
-// TODO: Update Cypress test to reflect the nav bar 2.0
-describe.skip("Config wizard with plus settings", () => {
+describe("Config wizard with plus settings", () => {
   beforeEach(() => {
     cy.login();
     cy.intercept("GET", "/api/v1/organization/*", {
@@ -37,9 +34,8 @@ describe.skip("Config wizard with plus settings", () => {
   describe("Data flow scanner health", () => {
     it("Disables data flow scanner button if it is not enabled", () => {
       stubPlus(true, {
-        core_fidesctl_version: "1.9.6",
-        fidesctl_plus_server: "healthy",
-        fidescls_version: "1.0.3",
+        core_fides_version: "1.9.6",
+        fidesplus_server: "healthy",
         system_scanner: {
           enabled: false,
           cluster_health: null,
@@ -47,7 +43,6 @@ describe.skip("Config wizard with plus settings", () => {
         },
       });
       cy.visit("/add-systems");
-      cy.getByTestId("guided-setup-btn").click();
       cy.getByTestId("add-system-form");
 
       cy.wait("@getPlusHealth");
@@ -58,9 +53,8 @@ describe.skip("Config wizard with plus settings", () => {
 
     it("Can show the scanner as unhealthy", () => {
       stubPlus(true, {
-        core_fidesctl_version: "1.9.6",
-        fidesctl_plus_server: "healthy",
-        fidescls_version: "1.0.3",
+        core_fides_version: "1.9.6",
+        fidesplus_server: "healthy",
         system_scanner: {
           enabled: true,
           cluster_health: ClusterHealth.UNHEALTHY,
@@ -68,7 +62,6 @@ describe.skip("Config wizard with plus settings", () => {
         },
       });
       cy.visit("/add-systems");
-      cy.getByTestId("guided-setup-btn").click();
       cy.getByTestId("add-system-form");
 
       cy.wait("@getPlusHealth");
@@ -82,7 +75,6 @@ describe.skip("Config wizard with plus settings", () => {
     it("Can show the scanner as enabled and healthy", () => {
       stubPlus(true);
       cy.visit("/add-systems");
-      cy.getByTestId("guided-setup-btn").click();
       cy.getByTestId("add-system-form");
 
       cy.wait("@getPlusHealth");
@@ -241,7 +233,8 @@ describe.skip("Config wizard with plus settings", () => {
       cy.getByTestId("add-system-form");
     });
 
-    it("Resets the flow when it is completed", () => {
+    // TODO: Update Cypress test to reflect the nav bar 2.0
+    it.skip("Resets the flow when it is completed", () => {
       goToDataFlowScanner();
       cy.wait("@putScanResults");
       cy.getByTestId("scan-results");

--- a/clients/admin-ui/cypress/e2e/config-wizard.cy.ts
+++ b/clients/admin-ui/cypress/e2e/config-wizard.cy.ts
@@ -1,7 +1,6 @@
 import { stubSystemCrud, stubTaxonomyEntities } from "cypress/support/stubs";
 
-// TODO: Update Cypress test to reflect the nav bar 2.0
-describe.skip("Config Wizard", () => {
+describe("Config Wizard", () => {
   beforeEach(() => {
     cy.login();
     cy.intercept("GET", "/api/v1/organization/*", {
@@ -9,7 +8,8 @@ describe.skip("Config Wizard", () => {
     }).as("getOrganization");
   });
 
-  describe("Organization setup", () => {
+  // TODO: Update Cypress test to reflect the nav bar 2.0
+  describe.skip("Organization setup", () => {
     beforeEach(() => {
       cy.intercept("PUT", "/api/v1/organization**", {
         fixture: "organization.json",
@@ -53,10 +53,7 @@ describe.skip("Config Wizard", () => {
       stubSystemCrud();
       stubTaxonomyEntities();
 
-      // Move past organization step.
       cy.visit("/add-systems");
-      cy.getByTestId("guided-setup-btn").click();
-      cy.wait("@getOrganization");
       // Select AWS to move to form step.
       cy.getByTestId("add-system-form");
       cy.getByTestId("aws-btn").click();
@@ -148,10 +145,7 @@ describe.skip("Config Wizard", () => {
       stubSystemCrud();
       stubTaxonomyEntities();
 
-      // Move past organization step.
       cy.visit("/add-systems");
-      cy.getByTestId("guided-setup-btn").click();
-      cy.wait("@getOrganization");
       // Select Okta to move to form step.
       cy.getByTestId("add-system-form");
       cy.getByTestId("okta-btn").click();

--- a/clients/admin-ui/cypress/e2e/datasets-classify.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets-classify.cy.ts
@@ -11,8 +11,8 @@ import { ClassificationResponse, ClassificationStatus } from "~/types/api";
  * access to the  Fidescls API. This suite should cover the behavior that is different when a
  * dataset is classified.
  */
-// TODO: Update Cypress test to reflect the nav bar 2.0
-describe.skip("Datasets with Fides Classify", () => {
+
+describe("Datasets with Fides Classify", () => {
   beforeEach(() => {
     cy.login();
   });
@@ -36,7 +36,8 @@ describe.skip("Datasets with Fides Classify", () => {
       cy.getByTestId("input-classify").find("input").should("not.be.checked");
     });
 
-    it("Can render the 'Status' column and classification status badges in the dataset table when plus features are enabled", () => {
+    // TODO: Update Cypress test to reflect the nav bar 2.0
+    it.skip("Can render the 'Status' column and classification status badges in the dataset table when plus features are enabled", () => {
       cy.visit("/");
       cy.getByTestId("nav-link-Datasets").click();
       cy.wait("@getDatasets");

--- a/clients/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets.cy.ts
@@ -4,8 +4,7 @@ import {
   stubPlus,
 } from "cypress/support/stubs";
 
-// TODO: Update Cypress test to reflect the nav bar 2.0
-describe.skip("Dataset", () => {
+describe("Dataset", () => {
   beforeEach(() => {
     cy.login();
     stubDatasetCrud();
@@ -14,7 +13,8 @@ describe.skip("Dataset", () => {
   });
 
   describe("List of datasets view", () => {
-    it("Can navigate to the datasets list view", () => {
+    // TODO: Update Cypress test to reflect the nav bar 2.0
+    it.skip("Can navigate to the datasets list view", () => {
       cy.visit("/");
       cy.getByTestId("nav-link-Datasets").click();
       cy.wait("@getDatasets");

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -1,5 +1,4 @@
-// TODO: Update Cypress test to reflect the nav bar 2.0
-describe.skip("Taxonomy management page", () => {
+describe("Taxonomy management page", () => {
   beforeEach(() => {
     cy.login();
     cy.intercept("GET", "/api/v1/data_category", {
@@ -16,7 +15,8 @@ describe.skip("Taxonomy management page", () => {
     }).as("getDataQualifiers");
   });
 
-  it("Can navigate to the taxonomy page", () => {
+  // TODO: Update Cypress test to reflect the nav bar 2.0
+  it.skip("Can navigate to the taxonomy page", () => {
     cy.visit("/");
     cy.getByTestId("nav-link-Taxonomy").click();
     cy.getByTestId("taxonomy-tabs");


### PR DESCRIPTION
Closes #<issue>

### Code Changes

* [x] Un-skips most of the cypress tests
* [x] Left a few skipped that are nav bar dependent, which should be fixed separately
* [x] Had to fix a few small things with the config wizard. It seems like that work got redone significantly recently, and I'm not quite sure if they're directly linked to the new nav bar or not. We can re-skip them if we prefer.

### Steps to Confirm

* [ ] Watch the cypress tests run and pass ☺️ 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
