### PR TITLE
Fix value for Twilio SMS-type messaging config

### DIFF
--- a/docs/fides/docs/guides/messaging.md
+++ b/docs/fides/docs/guides/messaging.md
@@ -43,7 +43,7 @@ FIDES__NOTIFICATIONS__SEND_REQUEST_REVIEW_NOTIFICATION=true
 For the `FIDES__NOTIFICATIONS__NOTIFICATION_SERVICE_TYPE` variable, we currently support the following service types:
 
 - `mailgun`
-- `twilio_sms`
+- `twilio_text`
 - `twilio_email`
 
 These service types must correspond to the `service_type` in one of your messaging configs in the database.
@@ -78,7 +78,7 @@ These service types must correspond to the `service_type` in one of your messagi
 |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `key`          | *Optional.* A unique key used to manage your messaging config. This is auto-generated from `name` if left blank. Accepted values are alphanumeric, `_`, and `.`. |
 | `name`         | A unique user-friendly name for your messaging config.                                                                                                           |
-| `service_type` | The email service to configure. Currently, Fides supports `mailgun`, `twilio_email`, and `twilio_sms`.                                                           |
+| `service_type` | The email service to configure. Currently, Fides supports `mailgun`, `twilio_email`, and `twilio_text`.                                                           |
 | `details`      | A dict of key/val config vars specific to the messaging service.                                                                                                 |
 | `domain`       | Your unique Mailgun domain.                                                                                                                                      |
 | `is_eu_domain` | *Optional.* A boolean that denotes whether your Mailgun domain was created in the EU region. Defaults to `False`.                                                |


### PR DESCRIPTION
### Code Changes

* Replaced references to `twilio_sms` with `twilio_text` (the former is not actually a supported value) in the messaging config docs

### Steps to Confirm

n/a

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

The docs seemed to have both `twilio_sms` and `twilio_text` in a couple of different places, so I wasn't sure which was accurate; when attempting to set `FIDES__NOTIFICATIONS__NOTIFICATION_SERVICE_TYPE=twilio_sms`, however, the validator complained that the proper value is `twilio_text`, so I went ahead and replaced references to `twilio_sms` with `twilio_text`.