### PR TITLE
pc/consent: Fides.meta integration function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The types of changes are:
 * Privacy Center `fides-consent.js`:
   * `Fides.shopify` integration function. [#2152](https://github.com/ethyca/fides/pull/2152)
   * Dedicated folder for integrations.
+  * `Fides.meta` integration function (fbq). [#2217](https://github.com/ethyca/fides/pull/2217)
 * Adds support for Twilio email service (Sendgrid) [#2154](https://github.com/ethyca/fides/pull/2154)
 * Access and erasure support for Recharge [#1709](https://github.com/ethyca/fides/pull/1709)
 * Access and erasure support for Friendbuy Nextgen [#2085](https://github.com/ethyca/fides/pull/2085)

--- a/clients/privacy-center/config/config.json
+++ b/clients/privacy-center/config/config.json
@@ -54,7 +54,7 @@
         "url": "https://example.com/privacy#email-marketing",
         "default": true,
         "highlight": false,
-        "cookieKeys": []
+        "cookieKeys": ["tracking"]
       },
       {
         "fidesDataUseKey": "improve",
@@ -63,7 +63,7 @@
         "url": "https://example.com/privacy#analytics",
         "default": true,
         "highlight": false,
-        "cookieKeys": []
+        "cookieKeys": ["tracking"]
       }
     ]
   }

--- a/clients/privacy-center/packages/fides-consent/README.md
+++ b/clients/privacy-center/packages/fides-consent/README.md
@@ -51,10 +51,36 @@ For example, the default configuration includes a consent option for advertising
 When a user visits a page that includes `fides-consent.js` with this configuration, the value of
 `Fides.consent.data_sales` will be set to `true` by default.
 
-If the user visits the Privacy Center and removes their consent for advertising, this choice is
+If the user visits the Privacy Center and removes their consent for `advertising`, this choice is
 saved in their browser. Subsequent visits to pages that include `fides-consent.js` will have 
 `Fides.consent.data_sales` set to `false`.
 
+Multiple data uses can refer to the same cookie key. A user must consent to _all_ of those data uses
+for the cookie key to be true. For example, with the default configuration:
+
+```json
+{
+  "consent": {
+    "consentOptions": [
+      {
+        "fidesDataUseKey": "advertising.first_party",
+        "name": "Email Marketing",
+        "default": true,
+        "cookieKeys": ["tracking"]
+      },
+      {
+        "fidesDataUseKey": "improve",
+        "name": "Product Analytics",
+        "default": true,
+        "cookieKeys": ["tracking"]
+      }
+    ]
+  }
+}
+```
+
+By default, `Fides.consent.tracking` will be set to `true`. If the user removes their consent for 
+`advertising.first_party`, `improve`, or both, then `Fides.consent.tracking` will be set to `false`.
 
 ## Integrations
 
@@ -85,12 +111,44 @@ if (Fides.consent.data_sales) {
 }
 ```
 
+### Meta Pixel
+
+
+To integrate with [Meta's tracking pixel](https://developers.facebook.com/docs/meta-pixel/get-started),
+call `Fides.meta(options)`, where options is an object with the following properties:
+
+- `consent`: boolean - Whether the user consents to [Meta's use of cookies](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr). 
+  If `true`, consent it granted. Otherwise, consent is revoked.
+- `dataUse`: boolean - Whether user's data can be [used by Meta](https://developers.facebook.com/docs/meta-pixel/implementation/ccpa).
+  If `true`, Meta may use the data. Otherwise, Meta's Limited Data Use (LDU) mode will be be applied
+  as if the user were in California.
+
+For example, with the default Privacy Center configuration:
+
+```html
+<head>
+  <script src="example.com/privacy-center/fides-consent.js"></script>
+  <script>
+    Fides.meta({ 
+      consent: Fides.consent.tracking,
+      dataUse: Fides.consent.data_sales
+    })
+  </script>
+  
+  <!-- Include Meta's pixel code below-->
+<head>
+```
+
+This example omits [Meta's pixel code](https://developers.facebook.com/docs/meta-pixel/get-started).
+`Fides.meta()` should be included before Meta's code, before your use of
+`fbq('init', '{your-pixel-id-goes-here}')`.
+
 ### Shopify
 
 To integrate with Shopify's [Consent Tracking API](https://shopify.dev/api/consent-tracking?shpxid=7e81a186-C696-4E23-F327-E7F38E5FF5EE#consent-collection),
-call `Fides.shopify(options)`, where options is an with the following properties:
+call `Fides.shopify(options)`, where options is an object with the following properties:
 
-- `tracking`: The only consent option Shopify currently supports. Refer to their [visitor tracking](https://shopify.dev/api/consent-tracking#visitor-tracking) documentation.
+- `tracking`: boolean - The only consent option Shopify currently supports. Refer to their [visitor tracking](https://shopify.dev/api/consent-tracking#visitor-tracking) documentation.
 
 For example, with the default Privacy Center configuration:
 
@@ -98,11 +156,11 @@ For example, with the default Privacy Center configuration:
 <head>
   <!-- The script can be loaded in the store's theme, or in a custom pixel. -->
   <script src="example.com/privacy-center/fides-consent.js"></script>
-  <script>Fides.shopify({ tracking: Fides.consent.data_sales })</script>
+  <script>Fides.shopify({ tracking: Fides.consent.tracking })</script>
 <head>
 ```
 
-Note that `data_sales` is just an example cookie key. You may configure other data uses that should
+Note that `Fides.consent.tracking` is just an example cookie key. You may configure other data uses that should
 be considered tracking, whose cookie key you would pass as the `tracking` option instead.
 
 ##  fides-consent.mjs & fides-consent.d.ts

--- a/clients/privacy-center/packages/fides-consent/src/fides-consent.ts
+++ b/clients/privacy-center/packages/fides-consent/src/fides-consent.ts
@@ -7,6 +7,7 @@
 import consentConfig from "./consent-config.json";
 
 import { gtm } from "./integrations/gtm";
+import { meta } from "./integrations/meta";
 import { shopify } from "./integrations/shopify";
 import { getConsentCookie } from "./lib/cookie";
 
@@ -17,6 +18,7 @@ const Fides = {
   consent: getConsentCookie(consentConfig.defaults),
 
   gtm,
+  meta,
   shopify,
 };
 

--- a/clients/privacy-center/packages/fides-consent/src/integrations/gtm.ts
+++ b/clients/privacy-center/packages/fides-consent/src/integrations/gtm.ts
@@ -10,6 +10,7 @@ declare global {
  */
 export const gtm = () => {
   const dataLayer = window.dataLayer ?? [];
+  window.dataLayer = dataLayer;
   dataLayer.push({
     Fides: {
       consent: window.Fides.consent,

--- a/clients/privacy-center/packages/fides-consent/src/integrations/meta.ts
+++ b/clients/privacy-center/packages/fides-consent/src/integrations/meta.ts
@@ -1,0 +1,103 @@
+declare global {
+  namespace Meta {
+    type DataProcessingOption = "LDU";
+
+    /**
+     * Facebook doesn't document the many types of arguments this function accepts,
+     * they just provides some examples, mainly of the 'track' action.
+     *
+     * Consent and Limited Data Use have their own examples:
+     *  - https://developers.facebook.com/docs/meta-pixel/implementation/gdpr
+     *  - https://developers.facebook.com/docs/meta-pixel/implementation/ccpa
+     *  - https://developers.facebook.com/docs/marketing-apis/data-processing-options/
+     */
+    type FBQMethod = {
+      (
+        method: "dataProcessingOptions",
+        options: Array<DataProcessingOption>,
+        country?: 0 | 1,
+        state?: 0 | 1000
+      ): void;
+      (method: "consent", consent: "revoke" | "grant"): void;
+      (method: "init", pixelId: string): void;
+      (method: string, ...args: any[]): void;
+    };
+
+    type FBQObj = {
+      loaded: boolean;
+      version: string;
+      queue: any[];
+
+      callMethod?: FBQMethod;
+      push: (...args: Parameters<FBQMethod>) => void;
+    };
+
+    type FBQ = FBQMethod & FBQObj;
+  }
+
+  interface Window {
+    fbq?: Meta.FBQ;
+    _fbq?: Meta.FBQ;
+  }
+}
+
+/**
+ * Facebook handles the possibility of the API script being loaded after attempts to call
+ * `fbq(args)` by shimming `window.fbq` with a function that just enqueues the args to be called
+ * later.
+ */
+const getFbq = (): Meta.FBQ => {
+  if (window.fbq) {
+    return window.fbq;
+  }
+
+  const shim: Meta.FBQObj = {
+    queue: [],
+    loaded: true,
+    version: "2.0",
+
+    push(...args) {
+      const fbq = window.fbq!;
+      if (fbq.callMethod) {
+        fbq.callMethod(...args);
+      } else {
+        fbq.queue.push(args);
+      }
+    },
+  };
+
+  window.fbq = Object.assign(shim.push, shim);
+
+  // eslint-disable-next-line no-underscore-dangle
+  window._fbq = window.fbq;
+
+  return window.fbq;
+};
+
+type MetaOptions = {
+  consent: boolean | undefined;
+  dataUse: boolean | undefined;
+};
+
+/**
+ * Call Fides.meta to configure Meta Pixel tracking.
+ *
+ * @example
+ * Fides.meta({
+ *   consent: Fides.consent.data_sales,
+ *   dataUse: Fides.consent.data_sales,
+ * })
+ */
+export const meta = (options: MetaOptions) => {
+  const fbq = getFbq();
+
+  fbq("consent", options.consent ? "grant" : "revoke");
+
+  if (options.dataUse) {
+    fbq("dataProcessingOptions", []);
+  } else {
+    // The integer arguments translate to "treat this user as if they are in California" which will
+    // limit the use of their data.
+    fbq("dataProcessingOptions", ["LDU"], 1, 1000);
+  }
+};

--- a/clients/privacy-center/public/fides-consent-demo.html
+++ b/clients/privacy-center/public/fides-consent-demo.html
@@ -49,6 +49,13 @@
         null,
         2
       );
+
+      // Test behavior of integrations that can be configured without/before their platform scripts.
+      Fides.gtm();
+      Fides.meta({
+        consent: Fides.consent.tracking,
+        dataUse: Fides.consent.data_sales,
+      });
     })();
   </script>
 </html>


### PR DESCRIPTION
Closes #2160
Doc: https://ethyca.atlassian.net/wiki/spaces/EN/pages/2583789680/Facebook+fides-consent.js

### Code Changes

- Reverse engineered the `fbq` shimming process that FB just wants you to [paste into pages](https://developers.facebook.com/docs/meta-pixel/get-started). Somehow worse than GTM.
- Added some basic global variable tests to the cypress demo page.

### Steps to Confirm

* [ ] Read all the the documentation links that I reference in the code/readme. Use this info to compile JS+TS in your head to see if my implementation of their API is reasonable.
* [ ] If you're a wizard, or have a facebook business account, try actually putting this on a page and seeing analytics changes. [I can't.](https://ethyca.slack.com/archives/C04774UV24D/p1673381527757319)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

It's been tough to integrate with Meta because:
- I'm unable to create a test account/business to see the API track/not-track end-to-end
- `fbq` doesn't have an API for _reading_ what its state is, so you just have to hope a lack of error messages means something happened
- Whack-a-mole documentation

That said, the options I've provided for this function cover the cases that _were_ documented, leaning towards privacy-by-default instead of give-away-everything by default.
