### PR TITLE
[Unified Fides Resources] Update Test Env Setup and Quickstart

### DIFF
--- a/.fides/fides.toml
+++ b/.fides/fides.toml
@@ -7,7 +7,7 @@ db = "fides"
 test_db = "fides_test"
 
 [credentials]
-app_postgres = {connection_string="postgresql+psycopg2://postgres:fides@fides-db:5432/fides_test"}
+app_postgres = {connection_string="postgresql+psycopg2://postgres:fides@fides-db:5432/fides"}
 
 [logging]
 level = "INFO"

--- a/data/saas/dataset/recharge_dataset.yml
+++ b/data/saas/dataset/recharge_dataset.yml
@@ -91,7 +91,6 @@ dataset:
             fidesops_meta:
               data_type: string
           - name: shopify_customer_id
-            data_categories: [system.operations]
             fidesops_meta:
               data_type: object
           - name: status

--- a/scripts/setup/dataset.py
+++ b/scripts/setup/dataset.py
@@ -17,13 +17,33 @@ def create_dataset(
     with open(yaml_path, "r") as file:
         dataset = yaml.safe_load(file).get("dataset", [])[0]
 
+    # Create ctl_dataset resource first
     dataset_create_data = [dataset]
-    dataset_path = urls.DATASETS.format(connection_key=connection_key)
+    dataset_path = "/dataset/upsert"
     url = f"{constants.BASE_URL}{dataset_path}"
-    response = requests.patch(
+    response = requests.post(
         url,
         headers=auth_header,
         json=dataset_create_data,
+    )
+
+    if response.ok:
+        json_data = response.json()
+        logger.info(json_data["message"])
+    else:
+        raise RuntimeError(
+            f"fides dataset creation failed! response.status_code={response.status_code}, response.json()={response.json()}"
+        )
+
+    # Now link that ctl_dataset to the DatasetConfig
+    dataset_config_path = urls.DATASET_CONFIGS.format(connection_key=connection_key)
+    url = f"{constants.BASE_URL}{dataset_config_path}"
+
+    fides_key = dataset["fides_key"]
+    response = requests.patch(
+        url,
+        headers=auth_header,
+        json=[{"fides_key": fides_key, "ctl_dataset_fides_key": fides_key}],
     )
 
     if response.ok:
@@ -33,5 +53,5 @@ def create_dataset(
             return response.json()
 
     raise RuntimeError(
-        f"fides dataset creation failed! response.status_code={response.status_code}, response.json()={response.json()}"
+        f"fides dataset config creation failed! response.status_code={response.status_code}, response.json()={response.json()}"
     )

--- a/tests/ops/fixtures/saas/friendbuy_nextgen_fixtures.py
+++ b/tests/ops/fixtures/saas/friendbuy_nextgen_fixtures.py
@@ -6,6 +6,7 @@ import requests
 from requests import post
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -100,16 +101,20 @@ def friendbuy_nextgen_dataset_config(
     friendbuy_nextgen_connection_config.name = fides_key
     friendbuy_nextgen_connection_config.key = fides_key
     friendbuy_nextgen_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, friendbuy_nextgen_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": friendbuy_nextgen_connection_config.id,
             "fides_key": fides_key,
-            "dataset": friendbuy_nextgen_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/fixtures/saas/recharge_fixtures.py
+++ b/tests/ops/fixtures/saas/recharge_fixtures.py
@@ -8,6 +8,7 @@ from faker import Faker
 from requests import Response
 from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import Dataset as CtlDataset
 from fides.api.ops.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
@@ -93,16 +94,20 @@ def recharge_dataset_config(
     recharge_connection_config.name = fides_key
     recharge_connection_config.key = fides_key
     recharge_connection_config.save(db=db)
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(db, recharge_dataset)
+
     dataset = DatasetConfig.create(
         db=db,
         data={
             "connection_config_id": recharge_connection_config.id,
             "fides_key": fides_key,
-            "dataset": recharge_dataset,
+            "ctl_dataset_id": ctl_dataset.id,
         },
     )
     yield dataset
     dataset.delete(db=db)
+    ctl_dataset.delete(db)
 
 
 class RechargeTestClient:


### PR DESCRIPTION
Closes N/A

### Code Changes

* [ ] Adjust test env setup and quickstart to call a different set of endpoints when creating datasetconfigs (upsert the ctl dataset first and then link to the datasetconfig) instead of the old endpoint (patch a datasetconfig)

### Steps to Confirm

* [ ] Run `nox -s test_env`
* [ ] Verify everything came up as expected
* [ ] `nox -s clean`
* [ ] Run `nox -s quickstart` - run quickstart through to the end

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Get tests passing on `unified-fides-resources` branch after update with main.

Also: Remove remaining uses of ops dataset endpoints in fides that we'd like to eventually deprecate (not a blocker for `unified-fides-resources`): deprecation will happen as a follow-up in the future: https://github.com/ethyca/fides/issues/2092.  These endpoints still work, but are riskier because a dataset is upserted in the background, and we don't want people to unintentionally override their datasets.

-  Instead of a patch to /connection/connection_key/dataset do a post to /dataset/upsert and then a patch to /connection/connection_key/datasetconfig in both the test env setup and the quickstart