### PR TITLE
Update sample project resources for `fides evaluate` usage in `fides deploy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The types of changes are:
 * Made privacy declarations optional when adding systems manually - [#2173](https://github.com/ethyca/fides/pull/2173)
 * Dynamic imports of custom overrides and SaaS test fixtures [#2169](https://github.com/ethyca/fides/pull/2169)
 * Added `AuthenticatedClient` to custom request override interface [#2171](https://github.com/ethyca/fides/pull/2171)
+* Update sample project resources for `fides evaluate` usage in `fides deploy` [#2253](https://github.com/ethyca/fides/pull/2253)
 
 ### Removed
 

--- a/src/fides/data/sample_project/sample_resources/sample_systems.yml
+++ b/src/fides/data/sample_project/sample_resources/sample_systems.yml
@@ -21,19 +21,17 @@ system:
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-        dataset_references:
-          - demo_users_dataset
 
   - fides_key: cookie_house_postgres
     name: Cookie House PostgreSQL Database
-    description: Store data about our users for orders.
-    system_type: Application
+    description: Primary database for Cookie House orders.
+    system_type: Database
     administrating_department: Engineering
     data_responsibility_title: Processor
     system_dependencies:
     - cookie_house
     privacy_declarations:
-      - name: Collect data for marketing
+      - name: Store data about customer orders
         data_categories:
           - user.contact
           - user.financial
@@ -46,8 +44,8 @@ system:
 
   - fides_key: cookie_house_mongo
     name: Cookie House Customer Database
-    description: Store detailed data about our users for additional customer marketing.
-    system_type: Application
+    description: Additional database to store detailed data about users.
+    system_type: Database
     administrating_department: Engineering
     data_responsibility_title: Processor
     system_dependencies:
@@ -56,7 +54,7 @@ system:
       - name: Collect detailed data for marketing
         data_categories:
           - user.contact
-        data_use: advertising
+        data_use: advertising.first_party
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
@@ -65,7 +63,7 @@ system:
 
   - fides_key: cookie_house_marketing
     name: Cookie House Marketing System
-    description: Collect data about our users for marketing.
+    description: Marketing application for audience analysis.
     system_type: Application
     administrating_department: Marketing
     data_responsibility_title: Processor
@@ -75,7 +73,7 @@ system:
       - name: Collect data for marketing
         data_categories:
           - user.device.cookie_id
-        data_use: advertising
+        data_use: advertising.first_party
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified


### PR DESCRIPTION
### Code Changes

* [X] Fix reference to non-existent dataset `demo_users_dataset` 
* [X] Update Postgres & Mongo systems to be specified as Databases
* [X] Update Postgres & Mongo system declarations to be more realistic uses 😄 

### Steps to Confirm

* [x] Run `nox -s "build(sample)"` to build sample project files
* [x] Run `pip install ~/git/fides && fides deploy up --no-pull` in a venv to install locally
* [x] Try `fides pull -a .fides/sample_resources.yml` to pull all resources
* [x] Try `fides evaluate --dry` to see if policy evaluation passes by default
* [x] Modify the `cookie_house_mongo` declaration to be used for `advertising.third_party` and see if policy evaluation fails

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This modifies the Cookie House YAML declarations to be more accurate and consistent, removes the reference to the missing demo_users_dataset, and makes it easier to quickly experiment with Fides policies!

Goal here is just to have a built-in demo of the CI policies baked into the Cookie House sample project too - we're close, but since the declarations aren't quite internally consistent it doesn't serve as a useful demo of those features yet.
