### PR TITLE
Make identity_inputs optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The types of changes are:
 * Improve readability for exceptions raised from custom request overrides [#2157](https://github.com/ethyca/fides/pull/2157)
 * Importing custom request overrides on server startup [#2186](https://github.com/ethyca/fides/pull/2186)
 * Remove warning when env vars default to blank strings in docker-compose [#2188](https://github.com/ethyca/fides/pull/2188)
+* Privacy center config no longer requires `identity_inputs` and will use `email` as a default [#2263](https://github.com/ethyca/fides/pull/2263)
 
 ### Removed
 

--- a/clients/privacy-center/README.md
+++ b/clients/privacy-center/README.md
@@ -25,7 +25,7 @@ You may configure the appearance of this web application at build time by modify
     - Descriptive information for the type of consent
     - The default consent state (opt in/out)
     - The cookie keys that will be available to
-      [fides-consent.js](./packages/fides-consent/README.md), which can be used to access a user's consent choices on outside of the Privacy Center.
+      [fides-consent.js](./packages/fides-consent/README.md), which can be used to access a user's consent choices outside of the Privacy Center.
 
 You can also add any CSS you'd like to the page by adding it to the `config.css` file inside the `config` directory.
 

--- a/clients/privacy-center/README.md
+++ b/clients/privacy-center/README.md
@@ -13,14 +13,19 @@ You may configure the appearance of this web application at build time by modify
   - Title
   - Description
   - Icon
+  - Policy key
 - Whether consent management is enabled
-- Consent management options:
-  - The Fides Data Use that the user may consent to
-  - Descriptive information for the type of consent
-  - The default consent state (opt in/out)
-  - The cookie keys that will be available to
-    [fides-consent.js](./packages/fides-consent/README.md), which can be used to access a user's
-    consent choices on outside of the Privacy Center. 
+- Consent options:
+  - Personally Identifying Information a user must submit
+  - Title
+  - Description
+  - Icon
+  - Which consent management options are present, and each option's:
+    - The Fides Data Use that the user may consent to
+    - Descriptive information for the type of consent
+    - The default consent state (opt in/out)
+    - The cookie keys that will be available to
+      [fides-consent.js](./packages/fides-consent/README.md), which can be used to access a user's consent choices on outside of the Privacy Center.
 
 You can also add any CSS you'd like to the page by adding it to the `config.css` file inside the `config` directory.
 

--- a/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
+++ b/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
@@ -21,7 +21,7 @@ import { ErrorToastOptions } from "~/common/toast-options";
 import { Headers } from "headers-polyfill";
 import { addCommonHeaders } from "~/common/CommonHeaders";
 
-import { config, hostUrl } from "~/constants";
+import { config, defaultIdentityInput, hostUrl } from "~/constants";
 import dynamic from "next/dynamic";
 import * as Yup from "yup";
 import { ModalViews, VerificationType } from "../types";
@@ -43,10 +43,8 @@ const useConsentRequestForm = ({
   isVerificationRequired: boolean;
   successHandler: () => void;
 }) => {
-  // If no identity inputs are configured, use an optional email field
-  const identityInputs = config.consent?.identity_inputs ?? {
-    email: "optional",
-  };
+  const identityInputs =
+    config.consent?.identity_inputs ?? defaultIdentityInput;
   const [isLoading, setIsLoading] = useState(false);
   const toast = useToast();
   const formik = useFormik({

--- a/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
+++ b/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
@@ -188,7 +188,7 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
             </Text>
           ) : null}
           <Stack spacing={3}>
-            {config.consent?.identity_inputs.email ? (
+            {config.consent?.identity_inputs?.email ? (
               <FormControl
                 id="email"
                 isInvalid={touched.email && Boolean(errors.email)}
@@ -212,7 +212,7 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
                 <FormErrorMessage>{errors.email}</FormErrorMessage>
               </FormControl>
             ) : null}
-            {config.consent?.identity_inputs.phone ? (
+            {config.consent?.identity_inputs?.phone ? (
               <FormControl
                 id="phone"
                 isInvalid={touched.phone && Boolean(errors.phone)}

--- a/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
+++ b/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
@@ -43,6 +43,10 @@ const useConsentRequestForm = ({
   isVerificationRequired: boolean;
   successHandler: () => void;
 }) => {
+  // If no identity inputs are configured, use an optional email field
+  const identityInputs = config.consent?.identity_inputs ?? {
+    email: "optional",
+  };
   const [isLoading, setIsLoading] = useState(false);
   const toast = useToast();
   const formik = useFormik({
@@ -114,7 +118,7 @@ const useConsentRequestForm = ({
     validationSchema: Yup.object().shape({
       email: (() => {
         let validation = Yup.string();
-        if (config.consent?.identity_inputs?.email === "required") {
+        if (identityInputs.email === "required") {
           validation = validation
             .email("Email is invalid")
             .required("Email is required");
@@ -123,7 +127,7 @@ const useConsentRequestForm = ({
       })(),
       phone: (() => {
         let validation = Yup.string();
-        if (config.consent?.identity_inputs?.phone === "required") {
+        if (identityInputs?.phone === "required") {
           validation = validation
             .required("Phone is required")
             // E.164 international standard format
@@ -134,7 +138,7 @@ const useConsentRequestForm = ({
     }),
   });
 
-  return { ...formik, isLoading };
+  return { ...formik, isLoading, identityInputs };
 };
 
 type ConsentRequestFormProps = {
@@ -165,6 +169,7 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
     dirty,
     setFieldValue,
     resetForm,
+    identityInputs,
   } = useConsentRequestForm({
     onClose,
     setCurrentView,
@@ -188,15 +193,13 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
             </Text>
           ) : null}
           <Stack spacing={3}>
-            {config.consent?.identity_inputs?.email ? (
+            {identityInputs.email ? (
               <FormControl
                 id="email"
                 isInvalid={touched.email && Boolean(errors.email)}
               >
                 <FormLabel>
-                  {config.consent?.identity_inputs.email === "required"
-                    ? "Email*"
-                    : "Email"}
+                  {identityInputs.email === "required" ? "Email*" : "Email"}
                 </FormLabel>
                 <Input
                   id="email"
@@ -212,15 +215,13 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
                 <FormErrorMessage>{errors.email}</FormErrorMessage>
               </FormControl>
             ) : null}
-            {config.consent?.identity_inputs?.phone ? (
+            {identityInputs?.phone ? (
               <FormControl
                 id="phone"
                 isInvalid={touched.phone && Boolean(errors.phone)}
               >
                 <FormLabel>
-                  {config.consent?.identity_inputs.phone === "required"
-                    ? "Phone*"
-                    : "Phone"}
+                  {identityInputs.phone === "required" ? "Phone*" : "Phone"}
                 </FormLabel>
                 <Input
                   as={PhoneInput}

--- a/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
@@ -47,6 +47,10 @@ const usePrivacyRequestForm = ({
   setPrivacyRequestId: (id: string) => void;
   isVerificationRequired: boolean;
 }) => {
+  // If no identity inputs are configured, use an optional email field
+  const identityInputs = action?.identity_inputs ?? {
+    email: "optional",
+  };
   const [isLoading, setIsLoading] = useState(false);
   const toast = useToast();
   const formik = useFormik({
@@ -142,14 +146,14 @@ const usePrivacyRequestForm = ({
     validationSchema: Yup.object().shape({
       name: (() => {
         let validation = Yup.string();
-        if (action?.identity_inputs?.name === "required") {
+        if (identityInputs.name === "required") {
           validation = validation.required("Name is required");
         }
         return validation;
       })(),
       email: (() => {
         let validation = Yup.string();
-        if (action?.identity_inputs?.email === "required") {
+        if (identityInputs.email === "required") {
           validation = validation
             .email("Email is invalid")
             .required("Email is required");
@@ -158,7 +162,7 @@ const usePrivacyRequestForm = ({
       })(),
       phone: (() => {
         let validation = Yup.string();
-        if (action?.identity_inputs?.phone === "required") {
+        if (identityInputs.phone === "required") {
           validation = validation
             .required("Phone is required")
             // E.164 international standard format
@@ -169,7 +173,7 @@ const usePrivacyRequestForm = ({
     }),
   });
 
-  return { ...formik, isLoading };
+  return { ...formik, isLoading, identityInputs };
 };
 
 type PrivacyRequestFormProps = {
@@ -204,6 +208,7 @@ const PrivacyRequestForm: React.FC<PrivacyRequestFormProps> = ({
     isValid,
     dirty,
     resetForm,
+    identityInputs,
   } = usePrivacyRequestForm({
     onClose,
     action,
@@ -229,15 +234,13 @@ const PrivacyRequestForm: React.FC<PrivacyRequestFormProps> = ({
             {action.description}
           </Text>
           <Stack spacing={3}>
-            {action.identity_inputs?.name ? (
+            {identityInputs.name ? (
               <FormControl
                 id="name"
                 isInvalid={touched.name && Boolean(errors.name)}
               >
                 <FormLabel>
-                  {action.identity_inputs.name === "required"
-                    ? "Name*"
-                    : "Name"}
+                  {identityInputs.name === "required" ? "Name*" : "Name"}
                 </FormLabel>
                 <Input
                   id="name"
@@ -251,15 +254,13 @@ const PrivacyRequestForm: React.FC<PrivacyRequestFormProps> = ({
                 <FormErrorMessage>{errors.name}</FormErrorMessage>
               </FormControl>
             ) : null}
-            {action.identity_inputs?.email ? (
+            {identityInputs.email ? (
               <FormControl
                 id="email"
                 isInvalid={touched.email && Boolean(errors.email)}
               >
                 <FormLabel>
-                  {action.identity_inputs.email === "required"
-                    ? "Email*"
-                    : "Email"}
+                  {identityInputs.email === "required" ? "Email*" : "Email"}
                 </FormLabel>
                 <Input
                   id="email"
@@ -274,15 +275,13 @@ const PrivacyRequestForm: React.FC<PrivacyRequestFormProps> = ({
                 <FormErrorMessage>{errors.email}</FormErrorMessage>
               </FormControl>
             ) : null}
-            {action.identity_inputs?.phone ? (
+            {identityInputs.phone ? (
               <FormControl
                 id="phone"
                 isInvalid={touched.phone && Boolean(errors.phone)}
               >
                 <FormLabel>
-                  {action.identity_inputs.phone === "required"
-                    ? "Phone*"
-                    : "Phone"}
+                  {identityInputs.phone === "required" ? "Phone*" : "Phone"}
                 </FormLabel>
                 <Input
                   as={PhoneInput}

--- a/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
@@ -229,7 +229,7 @@ const PrivacyRequestForm: React.FC<PrivacyRequestFormProps> = ({
             {action.description}
           </Text>
           <Stack spacing={3}>
-            {action.identity_inputs.name ? (
+            {action.identity_inputs?.name ? (
               <FormControl
                 id="name"
                 isInvalid={touched.name && Boolean(errors.name)}
@@ -251,7 +251,7 @@ const PrivacyRequestForm: React.FC<PrivacyRequestFormProps> = ({
                 <FormErrorMessage>{errors.name}</FormErrorMessage>
               </FormControl>
             ) : null}
-            {action.identity_inputs.email ? (
+            {action.identity_inputs?.email ? (
               <FormControl
                 id="email"
                 isInvalid={touched.email && Boolean(errors.email)}
@@ -274,7 +274,7 @@ const PrivacyRequestForm: React.FC<PrivacyRequestFormProps> = ({
                 <FormErrorMessage>{errors.email}</FormErrorMessage>
               </FormControl>
             ) : null}
-            {action.identity_inputs.phone ? (
+            {action.identity_inputs?.phone ? (
               <FormControl
                 id="phone"
                 isInvalid={touched.phone && Boolean(errors.phone)}

--- a/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
@@ -22,7 +22,7 @@ import { ErrorToastOptions, SuccessToastOptions } from "~/common/toast-options";
 import { PrivacyRequestStatus } from "~/types";
 
 import { PrivacyRequestOption } from "~/types/config";
-import { hostUrl, config } from "~/constants";
+import { hostUrl, config, defaultIdentityInput } from "~/constants";
 
 import dynamic from "next/dynamic";
 import * as Yup from "yup";
@@ -47,10 +47,7 @@ const usePrivacyRequestForm = ({
   setPrivacyRequestId: (id: string) => void;
   isVerificationRequired: boolean;
 }) => {
-  // If no identity inputs are configured, use an optional email field
-  const identityInputs = action?.identity_inputs ?? {
-    email: "optional",
-  };
+  const identityInputs = action?.identity_inputs ?? defaultIdentityInput;
   const [isLoading, setIsLoading] = useState(false);
   const toast = useToast();
   const formik = useFormik({

--- a/clients/privacy-center/constants/index.ts
+++ b/clients/privacy-center/constants/index.ts
@@ -12,3 +12,5 @@ export const hostUrl =
   process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
     ? config.server_url_development || (config as any).fidesops_host_development
     : config.server_url_production || (config as any).fidesops_host_production;
+
+export const defaultIdentityInput = { email: "optional" };

--- a/clients/privacy-center/types/config.ts
+++ b/clients/privacy-center/types/config.ts
@@ -10,7 +10,7 @@ export type Config = {
     icon_path: string;
     title: string;
     description: string;
-    identity_inputs: Record<string, string>;
+    identity_inputs?: Record<string, string>;
     consentOptions: ConfigConsentOption[];
   };
 };
@@ -20,7 +20,7 @@ export type PrivacyRequestOption = {
   icon_path: string;
   title: string;
   description: string;
-  identity_inputs: Record<string, string>;
+  identity_inputs?: Record<string, string>;
 };
 
 export type ConfigConsentOption = {


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2259

### Code Changes

* [x] Makes identity inputs optional in typescript
* [x] Uses `email` as a default when no identity inputs are provided

### Steps to Confirm

* [ ] Start up `nox -s test_env`. The privacy center should come up without problem, despite the test env's config not having identity inputs. Clicking on "manage your consent" should show only an email field.
* [ ] Editing the `identity_inputs` field on either actions or consent options should show the fields as you set them (note the test env's privacy center will not hot reload though—it's easiest to test this just with `npm run dev`, or to `nox -s "build(privacy-center)"` and then `docker-compose up fides-pc --no-deps fides-pc`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
