### PR TITLE
Remove unclear config warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The types of changes are:
   * No longer use `react-feature-flags` library.
   * Can have descriptions. [#2243](https://github.com/ethyca/fides/pull/2243)
 * Made privacy declarations optional when adding systems manually - [#2173](https://github.com/ethyca/fides/pull/2173)
+* Removed an unclear logging message. [#2266](https://github.com/ethyca/fides/pull/2266)
 * Dynamic imports of custom overrides and SaaS test fixtures [#2169](https://github.com/ethyca/fides/pull/2169)
 * Added `AuthenticatedClient` to custom request override interface [#2171](https://github.com/ethyca/fides/pull/2171)
 

--- a/src/fides/core/config/__init__.py
+++ b/src/fides/core/config/__init__.py
@@ -179,7 +179,8 @@ def get_config(config_path_override: str = "", verbose: bool = False) -> FidesCo
         config = build_config(config_dict=settings)
         return config
     except FileNotFoundError:
-        print("No config file found.")
+        if verbose:
+            print("No config file found.")
     except IOError:
         echo_red(f"Error reading config file: {config_path}")
 

--- a/src/fides/core/config/__init__.py
+++ b/src/fides/core/config/__init__.py
@@ -171,16 +171,14 @@ def get_config(config_path_override: str = "", verbose: bool = False) -> FidesCo
 
     env_config_path = getenv(DEFAULT_CONFIG_PATH_ENV_VAR)
     config_path = config_path_override or env_config_path or DEFAULT_CONFIG_PATH
-    if verbose:
-        print(f"Loading config from: {config_path}")
 
     try:
         settings = toml.load(config_path)
         config = build_config(config_dict=settings)
+        print(f"Loaded config from: {config_path}")
         return config
     except FileNotFoundError:
-        if verbose:
-            print("No config file found.")
+        pass
     except IOError:
         echo_red(f"Error reading config file: {config_path}")
 


### PR DESCRIPTION
Closes #2164 

### Code Changes

* [x] remove the unclear message
* [x] move the `config_path` logging message to within the `try` block

### Steps to Confirm

* [ ] move into a directory without a `.fides/fides.toml`
* [ ] run `fides view config`
* [ ] note that the logs show `Using default configuration values.`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This is a quick PR to make one of the config-related logging messages less scary/confusing.

#### Old

```
test> fides view config
No config file found.
Using default configuration values.
```

#### New

```
test> fides view config
Using default configuration values.
```