### PR TITLE
Move `packaging` to requirements.txt to fix `check_install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The types of changes are:
 * Improve readability for exceptions raised from custom request overrides [#2157](https://github.com/ethyca/fides/pull/2157)
 * Importing custom request overrides on server startup [#2186](https://github.com/ethyca/fides/pull/2186)
 * Remove warning when env vars default to blank strings in docker-compose [#2188](https://github.com/ethyca/fides/pull/2188)
+* Stop dependency from upgrading `packaging` to version with known issue [#2273](https://github.com/ethyca/fides/pull/2273)
 
 ### Removed
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,6 @@ GitPython==3.1.27
 isort==5.10.1
 mypy==0.981
 nox==2022.8.7
-packaging==21.3
 pre-commit==2.20.0
 pylint==2.15.4
 pytest-asyncio==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ loguru>=0.5,<0.6
 multidimensional_urlencode==0.0.4
 okta==2.7.0
 openpyxl==3.0.9
+packaging==21.3
 pandas==1.4.3
 passlib[bcrypt]==1.7.4
 plotly==5.4


### PR DESCRIPTION
Closes #2272

### Code Changes

* [x] Move `packaging` to `requirements.txt`

### Steps to Confirm

* [ ] `pip install .`
* [ ] `pip list | grep packaging` returns the correct version

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Found in #2263 and #2226
