### PR TITLE
Fix Cookie House purchase modal flashing 'Error' in title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The types of changes are:
 * Improve readability for exceptions raised from custom request overrides [#2157](https://github.com/ethyca/fides/pull/2157)
 * Importing custom request overrides on server startup [#2186](https://github.com/ethyca/fides/pull/2186)
 * Remove warning when env vars default to blank strings in docker-compose [#2188](https://github.com/ethyca/fides/pull/2188)
+* Fix Cookie House purchase modal flashing 'Error' in title [#2274](https://github.com/ethyca/fides/pull/2274)
 
 ### Removed
 

--- a/src/fides/data/sample_project/cookie_house/src/components/PurchaseModal/index.tsx
+++ b/src/fides/data/sample_project/cookie_house/src/components/PurchaseModal/index.tsx
@@ -55,7 +55,7 @@ const Modal = ({
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onSubmit={handleSubmit(onSubmit)}
       >
-       <h2>{product?.name ?? 'Error'}</h2>
+       <h2>Submit Your Order</h2>
        <p>All fields required</p>
        <div>
         <input type="text" placeholder='Name*' {...register('name', { required: true })} />


### PR DESCRIPTION
Closes #2138 

### Code Changes

* [X] Replace the dynamic `product.name` from title with static "Submit Your Order" text instead

### Steps to Confirm

* [X] Run `nox -s "build(sample)"` to rebuild project
* [X] Run `fides deploy up --no-pull` to run sample project
* [X] Purchase a cookie!

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [X] Update `CHANGELOG.md`

### Description Of Changes

This is a subtle one - but technically the `product` prop is only valid for this modal until the purchase is made, so when the modal is fading out the "Error" text would display. Rather than fight with some additional state here, the safest change is to just not render a dynamic title on the modal.

See quick video here: 
https://www.loom.com/share/a050cfa7cce14d42b7f01d1086481ff1

...and updated screenshot:
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/1834295/213309045-0da7409d-ffa0-4ac4-bd9e-0e359b33034a.png">
