### PR TITLE
Add graceful 404 override

### DIFF
--- a/docs/fides/mkdocs.yml
+++ b/docs/fides/mkdocs.yml
@@ -91,6 +91,10 @@ extra:
     provider: mike
     default: stable
 
+watch:
+  - docs
+  - overrides
+
 plugins:
   # The "Last Update" footer only shows in production
   - git-revision-date:

--- a/docs/fides/overrides/404.html
+++ b/docs/fides/overrides/404.html
@@ -1,1 +1,1023 @@
-Sorry Mario, Peach is in another Castle
+<!doctype html>
+<html lang="en" class="no-js">
+
+<head>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+
+
+
+    <link rel="icon" href="/fides/img/favicon.ico">
+    <meta name="generator" content="mkdocs-1.4.2, mkdocs-material-8.2.7">
+
+
+
+    <title>Fides</title>
+
+
+
+    <link rel="stylesheet" href="/fides/assets/stylesheets/main.9d5733d3.min.css">
+
+
+    <link rel="stylesheet" href="/fides/assets/stylesheets/palette.e6a45f82.min.css">
+
+
+
+
+
+
+
+
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,400,400i,700,700i%7CRoboto+Mono:400,400i,700,700i&display=fallback">
+    <style>
+        :root {
+            --md-text-font: "Source Sans Pro";
+            --md-code-font: "Roboto Mono"
+        }
+
+    </style>
+
+
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/styles/default.min.css">
+
+    <link rel="stylesheet" href="/fides/css/fides.css">
+
+    <link rel="stylesheet" href="/fides/css/api.css">
+
+    <link rel="stylesheet" href="/fides/css/cli.css">
+
+    <link rel="stylesheet" href="/fides/css/taxonomy.css">
+
+    <script>__md_scope = new URL("/fides/", location), __md_get = (e, _ = localStorage, t = __md_scope) => JSON.parse(_.getItem(t.pathname + "." + e)), __md_set = (e, _, t = localStorage, a = __md_scope) => { try { t.setItem(a.pathname + "." + e, JSON.stringify(_)) } catch (e) { } }</script>
+
+
+
+
+
+</head>
+
+
+
+
+
+
+
+
+
+<body dir="ltr" data-md-color-scheme="default" data-md-color-primary="" data-md-color-accent="">
+
+
+
+    <script>var palette = __md_get("__palette"); if (palette && "object" == typeof palette.color) for (var key of Object.keys(palette.color)) document.body.setAttribute("data-md-color-" + key, palette.color[key])</script>
+
+    <input class="md-toggle" data-md-toggle="drawer" type="checkbox" id="__drawer" autocomplete="off">
+    <input class="md-toggle" data-md-toggle="search" type="checkbox" id="__search" autocomplete="off">
+    <label class="md-overlay" for="__drawer"></label>
+    <div data-md-component="skip">
+
+    </div>
+    <div data-md-component="announce">
+
+    </div>
+
+    <div data-md-component="outdated" hidden>
+        <aside class="md-banner md-banner--warning">
+
+            <div class="md-banner__inner md-grid md-typeset">
+
+                You're not viewing the latest version.
+                <a href="..//fides/">
+                    <strong>Click here to go to the latest stable version.</strong>
+                </a>
+
+            </div>
+            <script>var el = document.querySelector("[data-md-component=outdated]"), outdated = __md_get("__outdated", sessionStorage); !0 === outdated && el && (el.hidden = !1)</script>
+
+        </aside>
+    </div>
+
+
+
+
+    <header class="md-header" data-md-component="header">
+        <nav class="md-header__inner md-grid" aria-label="Header">
+            <a href="/fides/." title="Fides" class="md-header__button md-logo" aria-label="Fides"
+                data-md-component="logo">
+
+                <img src="/fides/img/fides-logo.svg" alt="logo">
+
+            </a>
+            <label class="md-header__button md-icon" for="__drawer">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <path d="M3 6h18v2H3V6m0 5h18v2H3v-2m0 5h18v2H3v-2z" />
+                </svg>
+            </label>
+            <div class="md-header__title" data-md-component="header-title">
+                <div class="md-header__ellipsis">
+                    <div class="md-header__topic">
+                        <span class="md-ellipsis">
+                            Fides
+                        </span>
+                    </div>
+                    <div class="md-header__topic" data-md-component="header-topic">
+                        <span class="md-ellipsis">
+
+
+
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <form class="md-header__option" data-md-component="palette">
+
+
+
+                <input class="md-option" data-md-color-media="" data-md-color-scheme="default" data-md-color-primary=""
+                    data-md-color-accent="" aria-label="Switch to dark mode" type="radio" name="__palette"
+                    id="__palette_1">
+
+                <label class="md-header__button md-icon" title="Switch to dark mode" for="__palette_2" hidden>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path
+                            d="M17 6H7c-3.31 0-6 2.69-6 6s2.69 6 6 6h10c3.31 0 6-2.69 6-6s-2.69-6-6-6zm0 10H7c-2.21 0-4-1.79-4-4s1.79-4 4-4h10c2.21 0 4 1.79 4 4s-1.79 4-4 4zM7 9c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z" />
+                    </svg>
+                </label>
+
+
+
+
+                <input class="md-option" data-md-color-media="" data-md-color-scheme="slate" data-md-color-primary=""
+                    data-md-color-accent="" aria-label="Switch to light mode" type="radio" name="__palette"
+                    id="__palette_2">
+
+                <label class="md-header__button md-icon" title="Switch to light mode" for="__palette_1" hidden>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path
+                            d="M17 7H7a5 5 0 0 0-5 5 5 5 0 0 0 5 5h10a5 5 0 0 0 5-5 5 5 0 0 0-5-5m0 8a3 3 0 0 1-3-3 3 3 0 0 1 3-3 3 3 0 0 1 3 3 3 3 0 0 1-3 3z" />
+                    </svg>
+                </label>
+
+
+            </form>
+
+
+
+            <label class="md-header__button md-icon" for="__search">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <path
+                        d="M9.5 3A6.5 6.5 0 0 1 16 9.5c0 1.61-.59 3.09-1.56 4.23l.27.27h.79l5 5-1.5 1.5-5-5v-.79l-.27-.27A6.516 6.516 0 0 1 9.5 16 6.5 6.5 0 0 1 3 9.5 6.5 6.5 0 0 1 9.5 3m0 2C7 5 5 7 5 9.5S7 14 9.5 14 14 12 14 9.5 12 5 9.5 5z" />
+                </svg>
+            </label>
+            <div class="md-search" data-md-component="search" role="dialog">
+                <label class="md-search__overlay" for="__search"></label>
+                <div class="md-search__inner" role="search">
+                    <form class="md-search__form" name="search">
+                        <input type="text" class="md-search__input" name="query" aria-label="Search"
+                            placeholder="Search" autocapitalize="off" autocorrect="off" autocomplete="off"
+                            spellcheck="false" data-md-component="search-query" required>
+                        <label class="md-search__icon md-icon" for="__search">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                <path
+                                    d="M9.5 3A6.5 6.5 0 0 1 16 9.5c0 1.61-.59 3.09-1.56 4.23l.27.27h.79l5 5-1.5 1.5-5-5v-.79l-.27-.27A6.516 6.516 0 0 1 9.5 16 6.5 6.5 0 0 1 3 9.5 6.5 6.5 0 0 1 9.5 3m0 2C7 5 5 7 5 9.5S7 14 9.5 14 14 12 14 9.5 12 5 9.5 5z" />
+                            </svg>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                <path d="M20 11v2H8l5.5 5.5-1.42 1.42L4.16 12l7.92-7.92L13.5 5.5 8 11h12z" />
+                            </svg>
+                        </label>
+                        <nav class="md-search__options" aria-label="Search">
+
+                            <button type="reset" class="md-search__icon md-icon" aria-label="Clear" tabindex="-1">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                    <path
+                                        d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z" />
+                                </svg>
+                            </button>
+                        </nav>
+
+                    </form>
+                    <div class="md-search__output">
+                        <div class="md-search__scrollwrap" data-md-scrollfix>
+                            <div class="md-search-result" data-md-component="search-result">
+                                <div class="md-search-result__meta">
+                                    Initializing search
+                                </div>
+                                <ol class="md-search-result__list"></ol>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+
+            <div class="md-header__source">
+                <a href="https://github.com/ethyca/fides" title="Go to repository" class="md-source"
+                    data-md-component="source">
+                    <div class="md-source__icon md-icon">
+
+                        <svg xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 496 512"><!--! Font Awesome Free 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.-->
+                            <path
+                                d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" />
+                        </svg>
+                    </div>
+                    <div class="md-source__repository">
+                        GitHub
+                    </div>
+                </a>
+            </div>
+
+        </nav>
+
+    </header>
+
+    <div class="md-container" data-md-component="container">
+
+
+
+
+
+        <nav class="md-tabs" aria-label="Tabs" data-md-component="tabs">
+            <div class="md-tabs__inner md-grid">
+                <ul class="md-tabs__list">
+
+
+
+
+
+
+
+
+
+                    <li class="md-tabs__item">
+                        <a href="/fides/." class="md-tabs__link">
+                            Fides
+                        </a>
+                    </li>
+
+
+
+
+
+
+
+
+
+
+
+                    <li class="md-tabs__item">
+                        <a href="/fides/ethyca/" class="md-tabs__link">
+                            About Ethyca
+                        </a>
+                    </li>
+
+
+
+                </ul>
+            </div>
+        </nav>
+
+
+
+        <main class="md-main" data-md-component="main">
+            <div class="md-main__inner md-grid">
+
+
+
+                <div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation">
+                    <div class="md-sidebar__scrollwrap">
+                        <div class="md-sidebar__inner">
+
+
+
+
+
+                            <nav class="md-nav md-nav--primary md-nav--lifted" aria-label="Navigation"
+                                data-md-level="0">
+                                <label class="md-nav__title" for="__drawer">
+                                    <a href="/fides/." title="Fides" class="md-nav__button md-logo" aria-label="Fides"
+                                        data-md-component="logo">
+
+                                        <img src="/fides/img/fides-logo.svg" alt="logo">
+
+                                    </a>
+                                    Fides
+                                </label>
+
+                                <div class="md-nav__source">
+                                    <a href="https://github.com/ethyca/fides" title="Go to repository" class="md-source"
+                                        data-md-component="source">
+                                        <div class="md-source__icon md-icon">
+
+                                            <svg xmlns="http://www.w3.org/2000/svg"
+                                                viewBox="0 0 496 512"><!--! Font Awesome Free 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.-->
+                                                <path
+                                                    d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" />
+                                            </svg>
+                                        </div>
+                                        <div class="md-source__repository">
+                                            GitHub
+                                        </div>
+                                    </a>
+                                </div>
+
+                                <ul class="md-nav__list" data-md-scrollfix>
+
+
+
+
+
+
+
+
+
+                                    <li class="md-nav__item md-nav__item--nested">
+
+
+                                        <input class="md-nav__toggle md-toggle" data-md-toggle="__nav_1" type="checkbox"
+                                            id="__nav_1">
+
+
+
+
+                                        <label class="md-nav__link" for="__nav_1">
+                                            Fides
+                                            <span class="md-nav__icon md-icon"></span>
+                                        </label>
+
+                                        <nav class="md-nav" aria-label="Fides" data-md-level="1">
+                                            <label class="md-nav__title" for="__nav_1">
+                                                <span class="md-nav__icon md-icon"></span>
+                                                Fides
+                                            </label>
+                                            <ul class="md-nav__list" data-md-scrollfix>
+
+
+
+
+
+
+                                                <li class="md-nav__item">
+                                                    <a href="/fides/." class="md-nav__link">
+                                                        What is Fides?
+                                                    </a>
+                                                </li>
+
+
+
+
+
+
+
+
+
+                                                <li class="md-nav__item">
+                                                    <a href="/fides/api/" class="md-nav__link">
+                                                        API
+                                                    </a>
+                                                </li>
+
+
+
+
+
+
+
+
+
+                                                <li class="md-nav__item">
+                                                    <a href="/fides/cli/" class="md-nav__link">
+                                                        CLI
+                                                    </a>
+                                                </li>
+
+
+
+
+
+
+
+
+
+
+                                                <li class="md-nav__item md-nav__item--nested">
+
+
+                                                    <input class="md-nav__toggle md-toggle" data-md-toggle="__nav_1_4"
+                                                        type="checkbox" id="__nav_1_4">
+
+
+
+
+                                                    <label class="md-nav__link" for="__nav_1_4">
+                                                        Community
+                                                        <span class="md-nav__icon md-icon"></span>
+                                                    </label>
+
+                                                    <nav class="md-nav" aria-label="Community" data-md-level="2">
+                                                        <label class="md-nav__title" for="__nav_1_4">
+                                                            <span class="md-nav__icon md-icon"></span>
+                                                            Community
+                                                        </label>
+                                                        <ul class="md-nav__list" data-md-scrollfix>
+
+
+
+
+
+
+                                                            <li class="md-nav__item">
+                                                                <a href="/fides/community/overview/"
+                                                                    class="md-nav__link">
+                                                                    Github, Slack, and Discord
+                                                                </a>
+                                                            </li>
+
+
+
+
+
+
+
+
+
+                                                            <li class="md-nav__item">
+                                                                <a href="/fides/community/hints_tips/"
+                                                                    class="md-nav__link">
+                                                                    Community Hints and Tips
+                                                                </a>
+                                                            </li>
+
+
+
+
+
+
+
+
+
+                                                            <li class="md-nav__item">
+                                                                <a href="/fides/community/code_of_conduct/"
+                                                                    class="md-nav__link">
+                                                                    Code of Conduct
+                                                                </a>
+                                                            </li>
+
+
+
+
+
+
+
+
+
+
+                                                            <li class="md-nav__item md-nav__item--nested">
+
+
+                                                                <input class="md-nav__toggle md-toggle"
+                                                                    data-md-toggle="__nav_1_4_4" type="checkbox"
+                                                                    id="__nav_1_4_4">
+
+
+
+
+                                                                <label class="md-nav__link" for="__nav_1_4_4">
+                                                                    Contributing
+                                                                    <span class="md-nav__icon md-icon"></span>
+                                                                </label>
+
+                                                                <nav class="md-nav" aria-label="Contributing"
+                                                                    data-md-level="3">
+                                                                    <label class="md-nav__title" for="__nav_1_4_4">
+                                                                        <span class="md-nav__icon md-icon"></span>
+                                                                        Contributing
+                                                                    </label>
+                                                                    <ul class="md-nav__list" data-md-scrollfix>
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/overview/"
+                                                                                class="md-nav__link">
+                                                                                Overview
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/contributing_details/"
+                                                                                class="md-nav__link">
+                                                                                Contributing Details
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/code_style/"
+                                                                                class="md-nav__link">
+                                                                                Code Style
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/ui/"
+                                                                                class="md-nav__link">
+                                                                                UI Development
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/fideslog/"
+                                                                                class="md-nav__link">
+                                                                                Fideslog Analytics
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/database_migration/"
+                                                                                class="md-nav__link">
+                                                                                Database Migration
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/documentation/"
+                                                                                class="md-nav__link">
+                                                                                Documentation
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/testing/"
+                                                                                class="md-nav__link">
+                                                                                Writing Tests
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/testing_environment/"
+                                                                                class="md-nav__link">
+                                                                                Testing Environment
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/dev_deployment/"
+                                                                                class="md-nav__link">
+                                                                                Local Fides Deploy
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/pull_requests/"
+                                                                                class="md-nav__link">
+                                                                                Pull Requests
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/releases/"
+                                                                                class="md-nav__link">
+                                                                                Releases
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/release_checklist/"
+                                                                                class="md-nav__link">
+                                                                                Release Checklist
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/vscode_debugging/"
+                                                                                class="md-nav__link">
+                                                                                VSCode Debugging
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/jetbrains_debugging/"
+                                                                                class="md-nav__link">
+                                                                                Jetbrains Debugging
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/postman/using_postman/"
+                                                                                class="md-nav__link">
+                                                                                Using Postman
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+
+
+
+
+
+                                                                        <li class="md-nav__item">
+                                                                            <a href="/fides/development/update_erd_diagram/"
+                                                                                class="md-nav__link">
+                                                                                Updating the Database Diagram
+                                                                            </a>
+                                                                        </li>
+
+
+
+
+                                                                    </ul>
+                                                                </nav>
+                                                            </li>
+
+
+
+
+                                                        </ul>
+                                                    </nav>
+                                                </li>
+
+
+
+
+                                            </ul>
+                                        </nav>
+                                    </li>
+
+
+
+
+
+
+
+
+
+
+
+                                    <li class="md-nav__item md-nav__item--nested">
+
+
+                                        <input class="md-nav__toggle md-toggle" data-md-toggle="__nav_2" type="checkbox"
+                                            id="__nav_2">
+
+
+
+
+                                        <label class="md-nav__link" for="__nav_2">
+                                            About Ethyca
+                                            <span class="md-nav__icon md-icon"></span>
+                                        </label>
+
+                                        <nav class="md-nav" aria-label="About Ethyca" data-md-level="1">
+                                            <label class="md-nav__title" for="__nav_2">
+                                                <span class="md-nav__icon md-icon"></span>
+                                                About Ethyca
+                                            </label>
+                                            <ul class="md-nav__list" data-md-scrollfix>
+
+
+
+
+
+
+                                                <li class="md-nav__item">
+                                                    <a href="/fides/ethyca/" class="md-nav__link">
+                                                        About Ethyca
+                                                    </a>
+                                                </li>
+
+
+
+
+
+
+
+
+
+                                                <li class="md-nav__item">
+                                                    <a href="/fides/license/" class="md-nav__link">
+                                                        License
+                                                    </a>
+                                                </li>
+
+
+
+
+                                            </ul>
+                                        </nav>
+                                    </li>
+
+
+
+                                </ul>
+                            </nav>
+                        </div>
+                    </div>
+                </div>
+
+
+
+                <div class="md-content" data-md-component="content">
+                    <article class="md-content__inner md-typeset">
+
+                        <h1>
+                            Our docs site has moved, head to
+                            <a href="http://docs.ethyca.com">
+                                <strong>docs.ethyca.com</strong>
+                            </a>
+                            for more!
+                        </h1>
+
+                    </article>
+                </div>
+            </div>
+
+            <a href="#" class="md-top md-icon" data-md-component="top" data-md-state="hidden">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <path d="M13 20h-2V8l-5.5 5.5-1.42-1.42L12 4.16l7.92 7.92-1.42 1.42L13 8v12z" />
+                </svg>
+                Back to top
+            </a>
+
+        </main>
+
+        <!--
+  Copyright (c) 2016-2021 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+
+
+        <!-- Footer -->
+        <footer class="md-footer">
+
+            <!-- Link to previous and/or next page -->
+
+
+    </div>
+
+    <div class="fides-footer">
+        <div class="footer-row">
+            <!--[if lte IE 8]>  <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script> <![endif]-->
+            <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
+            <script>
+                hbspt.forms.create({
+                    region: "na1",
+                    portalId: "7252764",
+                    formId: "0d22c925-3a81-4f10-bfdc-69a5d67e93bc"
+                });
+            </script>
+        </div>
+        <div class="footer-row">
+            <div class="footer-col">
+                <a href="https://ethyca.com/">
+                    <div class="footer-logo"> <!--?xml version="1.0" encoding="UTF-8"?--> <svg width="102px"
+                            height="36px" viewBox="0 0 102 36" version="1.1" xmlns="http://www.w3.org/2000/svg"
+                            xmlns:xlink="http://www.w3.org/1999/xlink">
+                            <title>Data Privacy Software &amp; CCPA Compliance Software | Ethyca </title>
+                            <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                                <g id="Logo/Master" fill="#FFFFFF">
+                                    <path
+                                        d="M2.55599163,26.7391304 L2.58517228,26.8287673 C2.62291887,26.9450783 2.66396004,27.0635573 2.70678971,27.1807167 C2.76402144,27.3368978 2.8258656,27.4934559 2.89043956,27.6461495 C2.9543546,27.7972408 3.02354098,27.9504058 3.09621022,28.1013086 C3.16869119,28.2514573 3.24503155,28.4003807 3.32306626,28.5440259 C3.40147749,28.6883308 3.48468942,28.833107 3.57044288,28.97449 C3.65600809,29.1153075 3.74590332,29.2555594 3.83758705,29.3911928 C3.92992969,29.5280516 4.02631998,29.663685 4.1240281,29.7942287 C4.22135969,29.9245838 4.32405676,30.0553159 4.42920124,30.1828434 C4.53265136,30.3084858 4.64146695,30.4342224 4.7522593,30.556283 C4.86163968,30.6768356 4.97610314,30.7971054 5.09254336,30.913605 C5.20823052,31.0295391 5.32834185,31.1441536 5.44939449,31.2542438 C5.57044714,31.3645226 5.69582981,31.4732932 5.82205966,31.5776339 C5.94847778,31.6822573 6.07903766,31.7850899 6.21016234,31.8833039 C6.34100462,31.9813295 6.47645932,32.0777527 6.61266708,32.1701229 C6.74915722,32.2623989 6.88931848,32.352507 7.02910322,32.4376196 C7.1699234,32.5234862 7.3144147,32.6067136 7.45852947,32.6851341 C7.60443273,32.7646856 7.75315992,32.8410324 7.90075754,32.9121952 C8.04957887,32.9842063 8.20244783,33.0535782 8.35522267,33.1183316 C8.50809163,33.1832735 8.66463171,33.245105 8.82051288,33.3024123 C8.97714709,33.3600023 9.13735828,33.4143876 9.29681642,33.4641544 C9.45731001,33.514204 9.62072166,33.5606719 9.78262722,33.6025213 C9.94547408,33.6446534 10.1122745,33.6832038 10.2784159,33.7174185 C10.4439926,33.7514447 10.6138052,33.7818892 10.7828647,33.8078094 C10.952489,33.8338239 11.1249372,33.8558796 11.2954087,33.8732226 C11.4680452,33.8908483 11.6432233,33.9042326 11.816048,33.9130926 C12.1666865,33.9308126 12.5219374,33.9307183 12.8718228,33.9129983 C13.0443652,33.9042326 13.2194491,33.8908483 13.3922739,33.8732226 C13.562463,33.8558796 13.7348171,33.8339181 13.9048179,33.8078094 C14.0740657,33.7817949 14.2437842,33.7513504 14.4093608,33.7174185 C14.5754081,33.6832038 14.7421144,33.6446534 14.9049613,33.6025213 C15.0669609,33.5607661 15.2304667,33.5141098 15.3913368,33.4640602 C15.5507009,33.4141991 15.7107238,33.3598138 15.8670756,33.3024123 C16.022392,33.2453878 16.1790262,33.1833678 16.3327423,33.1183316 C16.4857054,33.0533897 16.6383861,32.984112 16.7865485,32.9123837 C16.9343344,32.8410324 17.0832499,32.7645913 17.2288707,32.6852283 C17.3731738,32.6067136 17.5176651,32.5234862 17.6585794,32.4376196 C17.7983641,32.352507 17.9385254,32.2623989 18.0752979,32.1699344 C18.2109409,32.0780355 18.3463956,31.981518 18.4779909,31.8830212 C18.6090215,31.7848071 18.739299,31.6820688 18.8655288,31.5777281 C18.9918528,31.4732932 19.1173296,31.3644283 19.2383822,31.2542438 C19.2670922,31.2281351 19.3248888,31.1745038 19.3248888,31.1745038 L19.3248888,31.1745038 L19.3937927,31.1105987 L20.8043478,32.6291464 L20.6320878,32.7880609 C20.4859022,32.9210552 20.3351041,33.0517873 20.1840236,33.1767699 C20.0323784,33.3021295 19.8758383,33.4254155 19.7186393,33.5432347 C19.5602166,33.6618079 19.397558,33.7777419 19.2350877,33.8877379 C19.0724291,33.9978281 18.9041226,34.1060333 18.7347807,34.2091486 C18.5653446,34.3124525 18.3914844,34.4125516 18.218189,34.5069012 C18.0434816,34.6020991 17.8644442,34.6939981 17.6863481,34.7800532 C17.5074989,34.8664853 17.3239432,34.949807 17.1405757,35.0275677 C16.9553257,35.1060824 16.7668751,35.1806384 16.5803072,35.249162 C16.3932687,35.3178741 16.2006763,35.3832873 16.0075193,35.4436107 C15.8141739,35.5039342 15.6171574,35.5600161 15.4220236,35.6104427 C15.2251954,35.6613406 15.0246019,35.7078085 14.8257028,35.748621 C14.6252035,35.7898106 14.420939,35.8263817 14.2186511,35.8574859 C14.0152338,35.8887787 13.8077687,35.9151702 13.6019981,35.9361891 C13.3948154,35.9573023 13.1845265,35.9733257 12.9768732,35.9838823 C12.7661136,35.9946274 12.553189,36 12.3438413,36 C12.1343995,36 11.921569,35.9946274 11.7109977,35.9838823 C11.5033444,35.9733257 11.2929613,35.9573023 11.0856845,35.9361891 C10.8799139,35.9151702 10.6724488,35.8887787 10.4690315,35.8574859 C10.2665554,35.8263817 10.062385,35.7898106 9.8620739,35.748621 C9.66298654,35.7078085 9.46239309,35.6612463 9.26556489,35.6104427 C9.07043104,35.5600161 8.87360284,35.5040284 8.68053988,35.443705 C8.48757105,35.3833816 8.29469635,35.3179684 8.10728126,35.249162 C7.92014856,35.1803556 7.73179215,35.1057996 7.54748339,35.0276619 C7.3643042,34.9499956 7.18027783,34.8665796 7.00095801,34.7798647 C6.8231443,34.6939981 6.64420101,34.6020991 6.46930535,34.506807 C6.29610406,34.4125516 6.12233799,34.3124525 5.95280781,34.2092429 C5.78440721,34.1065988 5.61619487,33.9984879 5.45278321,33.8879264 C5.28974809,33.7774592 5.12718361,33.6616194 4.96960809,33.5436117 C4.81231496,33.4256983 4.65549249,33.302318 4.50356484,33.1766757 C4.35163718,33.0510333 4.2011215,32.9204896 4.05625368,32.7886264 C3.91044455,32.6558207 3.76642391,32.5183021 3.62805114,32.379841 C3.48788988,32.2394006 3.35055255,32.0950957 3.2198044,31.9509793 C3.08745602,31.8052605 2.9570844,31.6545462 2.83217238,31.5030779 C2.70650732,31.350667 2.58328966,31.1937319 2.46590813,31.0367025 C2.34909139,30.8804271 2.23349836,30.7176482 2.12214122,30.5527956 C2.01125474,30.3887913 1.90328633,30.2201685 1.80096579,30.05164 C1.6973274,29.8811321 1.59745427,29.7073252 1.50388792,29.534838 C1.40966265,29.3615024 1.31788479,29.182323 1.23119002,29.0025781 C1.14477763,28.8233987 1.06156571,28.639318 0.983719261,28.4553316 C0.906343467,28.2726648 0.831979869,28.0840598 0.762699353,27.8950779 C0.711492015,27.7552972 0.6621673,27.6127831 0.616137174,27.4714944 L0.616137174,27.4714944 L0.586956522,27.3818576 L2.55599163,26.7391304 Z M20.9347826,13.173913 L20.9347826,23.6383986 C20.9347826,23.9302729 20.9198923,24.2246926 20.8903943,24.5134559 C20.8614618,24.7986367 20.8176389,25.085043 20.7601509,25.3647559 C20.703511,25.6413577 20.6321693,25.9181481 20.5482932,26.1873022 C20.4652654,26.4537223 20.3679127,26.7190112 20.2591566,26.9759096 C20.1513429,27.2306397 20.0295813,27.4830129 19.8974531,27.7259587 C19.7665499,27.9670189 19.6217931,28.2049681 19.4674236,28.4332071 C19.3142791,28.6598433 19.1482235,28.8819544 18.9737802,29.0933181 C18.7999024,29.3039277 18.6137731,29.5087865 18.420387,29.7022381 C18.2273779,29.8953125 18.0226828,30.081505 17.8117676,30.2556302 C17.6009466,30.4298498 17.379005,30.5959617 17.1519743,30.7495351 C16.9242839,30.9035799 16.6863211,31.0483857 16.444777,31.1798046 C16.2019135,31.3119776 15.94972,31.4337805 15.6948877,31.5417249 C15.4379821,31.6506121 15.1726888,31.7479036 14.9068301,31.830771 C14.637296,31.914864 14.3606936,31.9861356 14.0845625,32.0427004 C13.8054156,32.1001136 13.5191062,32.1439514 13.233645,32.1730822 C12.9449796,32.2024959 12.6505653,32.2173913 12.3586957,32.2173913 C12.0669202,32.2173913 11.7726002,32.2024959 11.4839348,32.1730822 C11.1982851,32.1439514 10.9117873,32.1001136 10.6326403,32.0427004 C10.3567919,31.9861356 10.0801896,31.914864 9.81074964,31.8308653 C9.54460822,31.7479036 9.27931498,31.6505179 9.02240934,31.5416307 C8.76767129,31.4337805 8.51538354,31.3119776 8.27242582,31.1797103 C8.03107023,31.0483857 7.79339011,30.9037684 7.56569971,30.7498179 C7.33829204,30.5958674 7.11625621,30.4296612 6.90571799,30.2557245 C6.6948028,30.0815992 6.49001338,29.8953125 6.29691006,29.7021438 C6.10361825,29.5086922 5.91748889,29.3039277 5.74379957,29.0934124 C5.56926206,28.8821429 5.40311216,28.6598433 5.24977926,28.4329242 C5.09559818,28.2048739 4.95084138,27.9669247 4.81974976,27.7256759 C4.68771572,27.4828244 4.56604838,27.2305454 4.45823471,26.9759096 C4.34947862,26.7190112 4.25203165,26.4536281 4.16909806,26.1872079 C4.08531629,25.9183366 4.01397456,25.6417348 3.95724044,25.3650387 C3.89975239,25.0849488 3.85592953,24.7984481 3.82699701,24.5134559 C3.79749904,24.2246926 3.7826087,23.9302729 3.7826087,23.6383986 L3.7826087,23.6383986 L3.7826087,19.7731382 L5.8559484,19.7731382 L5.8559484,23.6383986 C5.8559484,23.8598498 5.86725753,24.0835635 5.88959305,24.303412 C5.9115516,24.5187353 5.94472504,24.7357555 5.98817093,24.9482505 C6.03133409,25.1581059 6.08533516,25.3673013 6.14847778,25.5700861 C6.2109607,25.7707025 6.28456426,25.9714133 6.36721512,26.166656 C6.44882931,26.3592591 6.54099869,26.5504481 6.64127293,26.7348493 C6.74060475,26.9176479 6.85030327,27.0980895 6.96735272,27.2713663 C7.08393096,27.4438889 7.2102162,27.6125463 7.34243872,27.7728132 C7.47456701,27.9327972 7.61602532,28.0884447 7.76304396,28.2356074 C7.90940289,28.3820159 8.06499761,28.5235222 8.22577568,28.6563551 C8.38608254,28.788811 8.55477699,28.9150448 8.72705268,29.0316625 C8.89989381,29.1485631 9.08036861,29.2582988 9.26319947,29.3577585 C9.44744398,29.4580667 9.6385682,29.5502673 9.83110607,29.6319092 C10.0254345,29.7143052 10.2261715,29.7879337 10.4277567,29.8507206 C10.6312267,29.9141675 10.8404455,29.9680926 11.0494759,30.0110818 C11.2605796,30.0544481 11.4773378,30.0876328 11.694096,30.1097873 C12.1353404,30.1545678 12.5826163,30.1546621 13.0234838,30.1096931 C13.2399593,30.0876328 13.4566233,30.0544481 13.6677269,30.0110818 C13.8769458,29.9680926 14.0863531,29.9141675 14.2897289,29.8507206 C14.4911255,29.7879337 14.6918625,29.7143052 14.8860968,29.6319092 C15.0786346,29.5503616 15.2697588,29.458161 15.4540976,29.3578528 C15.6372112,29.2582045 15.8177802,29.1483745 15.9907156,29.031474 C16.1626143,28.915139 16.3311203,28.7889053 16.4917099,28.6563551 C16.6524879,28.5235222 16.8080827,28.3819217 16.9542531,28.2357017 C17.1012717,28.088539 17.2428243,27.9327972 17.3749526,27.7727189 C17.5072694,27.612452 17.6334603,27.4438889 17.7498501,27.2715549 C17.867088,27.0981838 17.9767866,26.9177421 18.0759299,26.7351322 C18.1762984,26.5506367 18.268562,26.3593534 18.3501762,26.166656 C18.432827,25.9714133 18.5063364,25.7707968 18.5689135,25.5701804 C18.6321504,25.3671128 18.6861515,25.1577288 18.7292204,24.9478734 C18.7726663,24.7358498 18.8058397,24.5189238 18.8277983,24.303412 C18.8501338,24.0835635 18.8614429,23.8598498 18.8614429,23.6383986 L18.8614429,23.6383986 L18.8614429,13.173913 L20.9347826,13.173913 Z M24.7173913,18.8478261 L24.7173913,23.6524636 C24.7173913,23.8629255 24.7119235,24.0760253 24.701365,24.2858278 C24.6906179,24.4955361 24.6744973,24.7062807 24.6534746,24.9121264 C24.6326404,25.1176896 24.6060555,25.3250426 24.5748513,25.5286274 C24.5437414,25.7316469 24.5071637,25.9361737 24.4659667,26.1362727 C24.4247696,26.3368428 24.378199,26.5376955 24.3277632,26.7333667 C24.2768561,26.9305452 24.2206697,27.1277238 24.1608067,27.3192498 C24.1008494,27.5117179 24.0354243,27.7045629 23.9664169,27.8924148 C23.8968438,28.0819625 23.8221801,28.2706622 23.7446881,28.4533327 C23.6667248,28.6371336 23.5834822,28.8209345 23.4970343,28.9997424 C23.410398,29.179304 23.3184823,29.3583003 23.2238328,29.5319267 C23.1303145,29.7039515 23.0302914,29.8777664 22.9263089,30.0485665 C22.8242118,30.216352 22.7160813,30.3848911 22.6046513,30.5494735 C22.4928441,30.7146212 22.3769833,30.8773194 22.2601797,31.0333288 L22.2601797,31.0333288 L22.2036162,31.1086957 L20.5434783,29.8665556 L20.5998532,29.7911887 C20.6974252,29.6608982 20.7939602,29.5254263 20.88663,29.388447 C20.9788285,29.2522214 21.0688587,29.1121333 21.1541752,28.9718567 C21.2399632,28.8307322 21.3233943,28.6859337 21.4021118,28.5415119 C21.4803579,28.3976554 21.5568129,28.2487116 21.6292142,28.0988258 C21.701144,27.9499762 21.77034,27.7971699 21.8351052,27.644552 C21.8997761,27.4918399 21.9619017,27.3349827 22.0195021,27.1782196 C22.0767255,27.0223986 22.1310264,26.862244 22.1808966,26.7022778 C22.2302011,26.5442901 22.2768659,26.3805555 22.3195714,26.2155963 C22.3618997,26.0515792 22.4004571,25.8847358 22.4343009,25.7196824 C22.4684276,25.5538753 22.4988776,25.383923 22.5248968,25.214536 C22.5510102,25.04383 22.5729757,24.8712399 22.5902276,24.7017587 C22.607668,24.5302049 22.6211489,24.3548827 22.6299163,24.1804084 C22.6388722,24.006311 22.6433972,23.8287278 22.6433972,23.6524636 L22.6433972,23.6524636 L22.6433972,18.8478261 L24.7173913,18.8478261 Z M69.8812714,11.8695652 L71.6476327,17.4229438 C72.0572744,18.6965948 72.4668216,20.4288318 72.4668216,20.4288318 L72.5181094,20.4288318 L75.0011784,11.8695652 L79.173913,11.8695652 L74.6427301,25.0905886 C73.5932654,28.147483 72.3388381,29.2173913 69.7020945,29.2173913 L66.083042,29.2173913 L66.9886552,25.9822103 L68.4221649,25.9822103 C69.650901,25.9822103 70.1373328,25.4982625 70.1373328,24.6066408 C70.1373328,24.0461363 69.8812714,23.2819835 69.3438351,21.9063197 L65.4782609,11.8695652 L69.8812714,11.8695652 Z M7.80846292,10.826087 L9.78337596,11.4397671 L9.755461,11.5296405 C9.72895588,11.6151849 9.70639834,11.7031762 9.68825831,11.7912615 C9.67011829,11.8801939 9.6562078,11.9712907 9.6469968,12.0620111 C9.63759783,12.1549901 9.63299233,12.2493807 9.63299233,12.3421715 L9.63299233,12.3421715 L9.63299233,23.63526 C9.63299233,23.7281449 9.63769182,23.8226296 9.64709079,23.9161732 C9.6562078,24.0062348 9.67011829,24.0971435 9.68825831,24.186264 C9.70639834,24.2742552 9.72895588,24.3622465 9.755461,24.4476968 C9.78140217,24.531265 9.81213683,24.6152096 9.84672506,24.6973661 C9.88103133,24.7783933 9.91956714,24.8584795 9.96129859,24.9351777 C10.0030301,25.0121583 10.0488971,25.0879155 10.0978657,25.160473 C10.1463645,25.2323717 10.1993747,25.3032353 10.2552986,25.3710873 C10.3105646,25.4381865 10.3696841,25.5033095 10.4311535,25.5648563 C10.4929047,25.6266854 10.5580396,25.6859737 10.6249604,25.7412152 C10.6919751,25.7967391 10.7626554,25.8497221 10.8352155,25.8987525 C10.9082455,25.9480652 10.9839073,25.9940842 11.060039,26.0354918 C11.1372986,26.0775582 11.2172839,26.1161426 11.2976451,26.1502098 C11.3791343,26.1846535 11.4632551,26.215521 11.5477519,26.2418713 C11.6329066,26.2684098 11.7205991,26.2909017 11.8083855,26.3088764 C11.8968299,26.3271334 11.987812,26.3409673 12.0788881,26.3501899 C12.2618862,26.3688234 12.4554111,26.3688234 12.6384092,26.3501899 C12.7293913,26.3409673 12.8205614,26.3270393 12.9092877,26.3088764 C12.9969802,26.2909017 13.0844847,26.2684098 13.1693574,26.2418713 C13.2539482,26.215521 13.3380691,26.1847476 13.4190882,26.1503981 C13.4998254,26.1162367 13.5799987,26.0775582 13.6572583,26.0354918 C13.733578,25.9940842 13.8090518,25.9481593 13.8817999,25.8989407 C13.954454,25.8498162 14.0250403,25.7969273 14.091585,25.7417799 C14.1591637,25.6860678 14.2243926,25.6266854 14.2857679,25.5651386 C14.3474252,25.5035918 14.4068267,25.4380924 14.4623747,25.3706168 C14.5181106,25.303047 14.5710269,25.2323717 14.6195256,25.1603789 C14.6683063,25.0880096 14.7141733,25.0123465 14.7558107,24.9355542 C14.7977302,24.8584795 14.83636,24.7782992 14.8705723,24.697272 C14.9051605,24.6152096 14.9359891,24.5310768 14.9620243,24.4471322 C14.9884354,24.3619642 15.010899,24.2741611 15.029039,24.1861699 C15.047179,24.0972376 15.0611835,24.0060466 15.0703005,23.9154204 C15.0796995,23.8223473 15.084399,23.7280508 15.084399,23.63526 L15.084399,23.63526 L15.084399,21.658986 L17.1521739,21.658986 L17.1521739,23.63526 C17.1521739,23.7981614 17.1439028,23.9626627 17.1275486,24.1240584 C17.1111944,24.2843248 17.086757,24.4449677 17.0547065,24.6015639 C17.0232199,24.7559015 16.9834623,24.9106155 16.9367494,25.061377 C16.8903184,25.2107268 16.8358983,25.359512 16.774993,25.5036859 C16.7150275,25.6457894 16.6470729,25.7871401 16.572915,25.9238794 C16.4996969,26.0587366 16.4189597,26.1918057 16.3328651,26.3194165 C16.2478043,26.4454275 16.1552244,26.5695564 16.0574751,26.6882269 C15.9595377,26.8068975 15.855491,26.9215214 15.7479668,27.0291812 C15.6404425,27.1369352 15.5259629,27.241019 15.4079118,27.3386093 C15.2903306,27.4358231 15.1663581,27.528708 15.0391899,27.6145348 C14.9119277,27.700738 14.7789322,27.7816711 14.6441509,27.8548873 C14.5078657,27.9290447 14.3666931,27.997085 14.2242986,28.0573143 C14.0813402,28.11792 13.9330243,28.1723146 13.7836746,28.2188041 C13.6332909,28.26567 13.4785838,28.3054778 13.3238766,28.3371923 C13.1669137,28.3692832 13.0067551,28.3937514 12.8477244,28.409938 C12.686156,28.426407 12.5216739,28.4347826 12.3586957,28.4347826 C12.1956234,28.4347826 12.0311413,28.426407 11.8696669,28.4100321 C11.7104482,28.3937514 11.5503836,28.3692832 11.3938907,28.3372864 C11.2389955,28.3055719 11.0841004,28.26567 10.9335288,28.2188041 C10.784273,28.1722205 10.6358632,28.1178259 10.4923408,28.0570319 C10.3504162,27.9969909 10.2094316,27.9290447 10.0731464,27.8548873 C9.93845908,27.7816711 9.80546355,27.700738 9.67773146,27.6143466 C9.55084527,27.5285198 9.42668478,27.4356349 9.30882161,27.3381387 C9.19124041,27.2409249 9.07694885,27.1369352 8.9689546,27.0288048 C8.86161829,26.9213331 8.75775959,26.8068975 8.6602922,26.6886975 C8.56226087,26.5697446 8.46949297,26.4454275 8.38433824,26.3193224 C8.29824361,26.1917116 8.21750639,26.0585484 8.14428836,25.9234089 C8.07031841,25.7871401 8.00236381,25.6458835 7.94230435,25.5035918 C7.88139898,25.359512 7.82707289,25.210915 7.78082992,25.0620357 C7.73392903,24.9108978 7.69417136,24.7559956 7.66259079,24.6015639 C7.63054028,24.4448736 7.60610294,24.2845131 7.58984271,24.1248113 C7.57348849,23.962945 7.56521739,23.7982555 7.56521739,23.63526 L7.56521739,23.63526 L7.56521739,12.3421715 C7.56521739,12.17927 7.5733945,12.0147687 7.58974872,11.8532789 C7.60610294,11.6930125 7.63054028,11.5324638 7.66259079,11.3758676 C7.69417136,11.22153 7.73392903,11.066816 7.78064194,10.9159604 L7.78064194,10.9159604 L7.80846292,10.826087 Z M49.1335952,7.63043478 L49.1335952,11.9288714 L51.5217391,11.9288714 L51.5217391,14.5753987 L49.1335952,14.5753987 L49.1335952,20.8028714 C49.1335952,21.8407993 49.6985172,22.1002812 50.5973298,22.1002812 C50.9568171,22.1002812 51.3676867,22.074333 51.5217391,22.074333 L51.5217391,25.162074 C51.1622519,25.2657724 50.3661094,25.3695652 49.2362654,25.3695652 C46.7967391,25.3695652 45.0504963,24.5652655 45.0504963,21.7110583 L45.0504963,14.5753987 L43.3043478,14.5753987 L43.3043478,11.9288714 L45.0504963,11.9288714 L45.0504963,7.63043478 L49.1335952,7.63043478 Z M37.4311523,11.4130435 C38.3966525,11.4130435 39.2398038,11.5820306 39.9600408,11.919156 C40.6799949,12.2566586 41.2772232,12.7181669 41.7513485,13.3041522 C42.2255681,13.8900432 42.5812092,14.5739127 42.8183662,15.3550065 C43.0554288,16.1364774 43.173913,16.9709454 43.173913,17.858599 C43.173913,18.2673931 43.1517621,18.6489342 43.1081199,19.0039768 C43.0640065,19.3593023 43.0245117,19.6165549 42.9895414,19.7763005 L35.4817714,19.7763005 C35.6924414,20.5754057 36.0699507,21.1305546 36.6143937,21.4410873 C37.1586481,21.7519028 37.7998956,21.9071219 38.5375705,21.9071219 C38.993975,21.9071219 39.4372775,21.8404512 39.867855,21.7072985 C40.2979611,21.57424 40.7503125,21.3744166 41.2245321,21.108111 L42.8896264,23.6640405 C42.1692952,24.1793002 41.1849431,24.726245 40.3156819,24.9834033 C39.4463264,25.2405617 38.6428584,25.3695652 37.9052777,25.3695652 C36.939212,25.3695652 36.0435581,25.2139689 35.2183161,24.9034363 C34.3926028,24.5929979 33.6771731,24.1402597 33.0712729,23.5452215 C32.4653728,22.9504662 31.9866287,22.2179374 31.6356063,21.3477294 C31.2840183,20.4780873 31.1086957,19.4925494 31.1086957,18.3913043 C31.1086957,17.308448 31.2885428,16.3363008 31.6488026,15.4748628 C32.0084969,14.613802 32.4826223,13.8813675 33.0712729,13.277465 C33.6595465,12.6740341 34.3312398,12.2120543 35.086447,11.8924689 C35.8414657,11.5728834 36.6230656,11.4130435 37.4311523,11.4130435 Z M85.4476594,11.4130435 C87.1286159,11.4130435 88.5637971,11.8629527 89.6086957,12.6663014 L87.6697174,15.5368184 C87.6697174,15.5368184 86.7526522,14.7422397 85.4435145,14.7197961 C83.6518696,14.6890541 82.5955725,15.996535 82.5955725,18.3913043 C82.5955725,20.7860737 83.6518696,22.0935546 85.4435145,22.0628126 C86.7526522,22.040369 87.6697174,21.2457902 87.6697174,21.2457902 L89.6086957,24.1163073 C88.5637971,24.919656 87.1286159,25.3695652 85.4476594,25.3695652 C81.3005652,25.3695652 78.5869565,22.3568425 78.5869565,18.3913043 C78.5869565,14.4257662 81.3005652,11.4130435 85.4476594,11.4130435 Z M96.0650336,11.4130435 C98.0342964,11.4130435 99.3641245,11.7755358 100.310443,12.5006149 C101.435682,13.3291419 102,14.6238922 102,16.2810405 L102,25.0330056 L97.9823943,25.0330056 L97.9823943,23.5571034 L97.9065227,23.5571034 C97.1392199,24.6705132 95.9883127,25.3695652 94.0190499,25.3695652 C91.410541,25.3695652 89.5434783,23.9455285 89.5434783,21.3301895 C89.5434783,18.4043179 91.8451981,17.5239254 94.5561902,17.1613387 C97.0113518,16.8506175 97.8808547,16.5917618 97.8808547,15.6855308 C97.8808547,14.8309768 97.2348142,14.4135071 96.0906072,14.4066231 C94.7860697,14.3987889 93.0572197,15.6246639 92.7989619,15.8133064 L92.7661314,15.8375438 L92.7661314,15.8375438 L90.9905109,13.2334266 C90.9905109,13.2334266 92.8439847,11.4130435 96.0650336,11.4130435 Z M12.5670354,0.00174903382 L12.9891935,0.0160050725 C13.197251,0.0265557971 13.408138,0.0425702899 13.6158183,0.0636717391 C13.8218952,0.0846789855 14.0298584,0.11115 14.2336718,0.142425362 C14.436542,0.173418116 14.6411099,0.210063043 14.8418109,0.251135507 C15.0411915,0.292019565 15.2422698,0.338461594 15.4394811,0.389236957 C15.6349948,0.439635507 15.8322062,0.495686232 16.025645,0.555881884 C16.2184236,0.615983333 16.4114852,0.681360145 16.5999253,0.750316667 C16.7872336,0.81899058 16.976051,0.893505072 17.1609072,0.971693478 C17.344443,1.04941087 17.5287333,1.13278043 17.7084022,1.2193529 C17.8866564,1.30526594 18.065948,1.39701957 18.2411841,1.4922587 L18.2411841,1.4922587 L18.3240865,1.53719348 L17.3325594,3.3578529 L17.2497514,3.31282391 C17.1037527,3.23350507 16.954736,3.15720072 16.8069454,3.08598333 C16.6578343,3.01410652 16.5046678,2.94477319 16.3515955,2.87996159 C16.1982403,2.8150558 16.0413955,2.75316449 15.8852109,2.69607754 C15.7285547,2.63861377 15.5680316,2.5842587 15.4081688,2.53442536 C15.2473627,2.48440362 15.0835387,2.43786739 14.9214122,2.39613551 C14.758154,2.35402681 14.5911233,2.31540362 14.4246584,2.28130217 C14.2586651,2.24729493 14.0886163,2.21686739 13.9192276,2.19086739 C13.7492731,2.16486739 13.5764892,2.14291812 13.4055915,2.12558478 C13.2327132,2.10796884 13.0571942,2.09449783 12.8839387,2.08573696 C12.5327119,2.06802681 12.1766751,2.06802681 11.8261086,2.08573696 C11.6532303,2.09449783 11.4778999,2.10796884 11.3047387,2.12549058 C11.1341239,2.14282391 10.9614343,2.16486739 10.7911969,2.19086739 C10.6216196,2.21686739 10.4514765,2.24729493 10.2855775,2.28130217 C10.1193012,2.31540362 9.95217612,2.35402681 9.78910656,2.3960413 C9.62679151,2.43786739 9.46296742,2.48440362 9.30178415,2.53451957 C9.14201559,2.5842587 8.98168114,2.63861377 8.82511926,2.69607754 C8.66950054,2.75307029 8.5125614,2.81496159 8.35854602,2.8800558 C8.20528515,2.94496159 8.05230722,3.01420072 7.90376207,3.08579493 C7.75568849,3.15710652 7.60657746,3.23350507 7.4605788,3.31282391 C7.31608916,3.39129493 7.17131659,3.47457029 7.03012796,3.56038913 C6.88997679,3.64545435 6.74954268,3.73551232 6.61259819,3.82792536 C6.47669117,3.91967899 6.34087846,4.01623696 6.20912127,4.11467899 C6.07783565,4.21283841 5.94721023,4.31551957 5.82082896,4.41980217 C5.69369318,4.5245558 5.56797211,4.63336014 5.4472497,4.74310652 C5.32577278,4.85322971 5.20552194,4.96778043 5.08970388,5.0835558 C4.97322562,5.19989638 4.85853933,5.32000507 4.74875739,5.44067899 C4.63784368,5.56257754 4.52891057,5.6880558 4.42525906,5.81362826 C4.31962696,5.94146159 4.21682428,6.07212101 4.11958615,6.20193261 C4.02187645,6.33221522 3.92529853,6.46777319 3.83239886,6.60483841 C3.74025371,6.7410558 3.65018348,6.88122971 3.56482896,7.02149783 C3.47871993,7.16289638 3.39534602,7.30759203 3.31678214,7.45172246 C3.23859552,7.59547609 3.16201224,7.74441087 3.0895788,7.89438188 C3.01686241,8.04482391 2.94754134,8.19771522 2.88359619,8.34862826 C2.81880221,8.50133116 2.75674334,8.65817899 2.69911726,8.81493261 C2.64177411,8.97083841 2.58744903,9.13088913 2.53765104,9.29084565 C2.48832462,9.44882391 2.44154468,9.61254855 2.39882027,9.77759203 C2.35656742,9.94150507 2.31799284,10.1083384 2.28403967,10.2733819 C2.24999217,10.439179 2.21952863,10.609121 2.19349786,10.778592 C2.16737278,10.9492877 2.14539753,11.1217732 2.12813799,11.2912442 C2.11068983,11.4627877 2.09720288,11.6381935 2.08833732,11.812563 C2.07947177,11.98665 2.07494468,12.1642225 2.07494468,12.3404761 L2.07494468,12.3404761 L2.07494468,23.6449181 C2.07494468,23.8209833 2.07947177,23.9987442 2.08833732,24.1733022 C2.09729719,24.3477659 2.11068983,24.5228891 2.12813799,24.6935848 C2.13860689,24.797208 2.15067913,24.8996065 2.16416609,25.0015341 L2.16416609,25.0015341 L2.17661559,25.0949833 L0.119430301,25.3660993 L0.107075117,25.27265 C0.0909473579,25.1502804 0.0764229431,25.0273457 0.0637848161,24.9038457 C0.0428470234,24.6982949 0.0268135786,24.4879399 0.0160617391,24.2787152 C0.00540421405,24.0684543 2.82943144e-05,23.8552732 2.82943144e-05,23.6449181 L2.82943144e-05,23.6449181 L2.82943144e-05,12.3404761 C2.82943144e-05,12.1300268 0.00540421405,11.9169399 0.0160617391,11.70715 C0.0268135786,11.4974543 0.0429413378,11.2868167 0.0638791304,11.0808891 C0.0848169231,10.8753384 0.111319264,10.6679978 0.142537324,10.4645196 C0.173755385,10.2614181 0.210349365,10.0569036 0.251564749,9.85681667 C0.292685819,9.6562587 0.339277124,9.45541812 0.389923946,9.2598529 C0.440759398,9.06259203 0.496876455,8.86542536 0.556860401,8.67391087 C0.616844348,8.48145435 0.682298528,8.28862101 0.751336656,8.10078043 C0.821129298,7.91096159 0.895731973,7.72227319 0.97316408,7.53989638 C1.05097344,7.35638913 1.13434736,7.17259928 1.22092796,6.99351957 C1.30760288,6.81415725 1.3995594,6.63507754 1.49415672,6.46136739 C1.5878109,6.2894471 1.68787846,6.11564275 1.79190722,5.9448529 C1.8940497,5.77698333 2.00222829,5.60845435 2.11370789,5.44388188 C2.22547043,5.27883841 2.34147712,5.1160558 2.45833264,4.96015 C2.5754711,4.80367899 2.69892863,4.64692536 2.82512127,4.49422246 C2.95027645,4.34283841 3.08090187,4.19220797 3.21341358,4.04666449 C3.34413331,3.90300507 3.48173799,3.75887464 3.62236074,3.61822971 C3.76090856,3.47984565 3.90520957,3.34240362 4.05139686,3.20957754 C4.19748983,3.07703406 4.34820421,2.94646884 4.49976742,2.8215558 C4.65170789,2.69636014 4.80855271,2.57314275 4.96605773,2.45529493 C5.12478883,2.33678768 5.28766977,2.22101232 5.4505507,2.11098333 C5.61428047,2.00038913 5.78291458,1.89233841 5.95173732,1.78975145 C6.12159753,1.68650507 6.29579619,1.58646159 6.46933465,1.49216449 C6.64447645,1.39701957 6.82376809,1.30517174 7.00230522,1.21916449 C7.18140823,1.13287464 7.36532127,1.04959928 7.54914,0.971787681 C7.73456207,0.89341087 7.92328515,0.818896377 8.11040488,0.750316667 C8.29884502,0.681360145 8.49200087,0.615983333 8.68440221,0.555976087 C8.87812395,0.495686232 9.07542963,0.439635507 9.27103766,0.389236957 C9.46815472,0.338461594 9.66913866,0.292019565 9.86851926,0.251135507 C10.0690316,0.210063043 10.2735995,0.173418116 10.4767527,0.142331159 C10.6809433,0.111055797 10.8888122,0.0846789855 11.0946062,0.0636717391 C11.3021922,0.0425702899 11.5128905,0.0265557971 11.7208537,0.0160050725 C12.1419674,-0.00537898551 12.5686457,-0.00537898551 12.9891935,0.0160050725 Z M56.8534964,6.7173913 L56.8534964,13.451887 L56.9300704,13.451887 C57.8738848,12.1939579 58.9961515,11.4494039 60.8073008,11.4494039 C63.6643316,11.4494039 65.3478261,13.5031869 65.3478261,16.4297266 L65.3478261,24.9782609 L61.1899818,24.9782609 L61.1899818,17.2768803 C61.1899818,15.8906544 60.5012881,14.9408068 59.1492995,14.9408068 C57.7718177,14.9408068 56.8534964,16.095948 56.8534964,17.7132586 L56.8534964,24.9782609 L52.6956522,24.9782609 L52.6956522,6.7173913 L56.8534964,6.7173913 Z M12.326087,11.2826087 C12.9014229,11.2826087 13.3695652,11.747154 13.3695652,12.3182792 L13.3695652,12.3182792 L13.3695652,23.6165034 C13.3695652,24.1875344 12.9014229,24.6521739 12.326087,24.6521739 C11.750751,24.6521739 11.2826087,24.1875344 11.2826087,23.6165034 L11.2826087,23.6165034 L11.2826087,12.3182792 C11.2826087,11.747154 11.750751,11.2826087 12.326087,11.2826087 Z M97.9831492,18.7150391 C97.4461033,18.9999219 96.6788948,19.2070065 95.834871,19.4140911 C94.2236388,19.7765834 93.5587248,20.1909412 93.5587248,21.2008088 C93.5587248,22.2624474 94.3259333,22.6767109 95.3489723,22.6767109 C96.9089629,22.6767109 97.9831492,21.7187089 97.9831492,20.2945778 L97.9831492,18.7150391 Z M11.8425041,7.52484222 C12.1687196,7.49171926 12.4994698,7.49171926 12.8254964,7.52484222 C12.9855337,7.54107342 13.1465159,7.56560894 13.3038135,7.59769386 C13.4594107,7.62959005 13.6151967,7.66950746 13.7665426,7.7165968 C13.9165658,7.7632143 14.0657388,7.81775866 14.2099047,7.87881438 C14.352559,7.93892642 14.4942686,8.00715405 14.6312546,8.08142121 C14.766729,8.15493342 14.9004084,8.23608939 15.0287028,8.32271867 C15.1563359,8.40868738 15.2810403,8.50192239 15.3995096,8.59968702 C15.5176954,8.69707419 15.6326691,8.80144455 15.7411242,8.90977833 C15.8491069,9.01764028 15.9534996,9.13229669 16.0514682,9.25082215 C16.1500036,9.37019693 16.2432485,9.49476191 16.3287467,9.62130861 C16.415284,9.74917645 16.4965308,9.8828007 16.5701253,10.0183123 C16.6444756,10.1548619 16.7127797,10.2965074 16.7730535,10.439191 C16.8343665,10.5837618 16.8889719,10.732768 16.9354527,10.8820572 C16.9825003,11.0336113 17.0225569,11.18894 17.0542998,11.3437026 C17.0865151,11.5008243 17.1109837,11.6617207 17.1273275,11.8217679 C17.1437658,11.9841742 17.1521739,12.1493172 17.1521739,12.3127615 L17.1521739,12.3127615 L17.1521739,19.9565217 L15.0737664,19.9565217 L15.0737664,12.3127615 C15.0737664,12.2196209 15.0689483,12.1247816 15.0595955,12.0309804 C15.0504316,11.9407652 15.0364496,11.8496063 15.0181218,11.7602403 C14.999983,11.6719124 14.9773094,11.5836789 14.9505735,11.4979933 C14.9245935,11.4142894 14.8937008,11.3301137 14.8589347,11.2477309 C14.8243575,11.1664806 14.7856236,11.0861739 14.743772,11.0092645 C14.701826,10.9320719 14.6556286,10.8560118 14.6065026,10.7833489 C14.5576601,10.7111578 14.5044717,10.6400992 14.4482603,10.5720603 C14.3927101,10.5048707 14.3331921,10.4394741 14.2715011,10.3778521 C14.2094323,10.3158527 14.143868,10.2563069 14.0766032,10.2009132 C14.0092439,10.1452365 13.9382002,10.092202 13.8653614,10.0430366 C13.7919559,9.99349367 13.715905,9.94734801 13.6392874,9.90582635 C13.5616305,9.86364412 13.4813284,9.82504784 13.4004595,9.79088684 C13.3186458,9.75634837 13.2339979,9.72539586 13.1491611,9.69897298 C13.0635685,9.67236137 12.9754251,9.6497132 12.8870928,9.63168902 C12.7981937,9.61347611 12.7067437,9.5996041 12.6152938,9.59026173 C12.4312603,9.57157698 12.2368347,9.57167135 12.0528012,9.59026173 C11.9614457,9.5996041 11.8698068,9.61347611 11.7806242,9.63168902 C11.6924809,9.64980756 11.604432,9.67236137 11.5192173,9.69887862 C11.4341915,9.72539586 11.3496381,9.756254 11.2682023,9.79060374 C11.1869555,9.82495348 11.1064644,9.86364412 11.0288076,9.90582635 C10.9520954,9.94744238 10.8761391,9.99349367 10.8031114,10.0427535 C10.7299893,10.0921076 10.6591345,10.1450477 10.5921531,10.200347 L10.5921531,10.200347 L10.5193143,10.2605534 L9.19565217,8.65979906 L9.26858538,8.59968702 C9.38714908,8.50192239 9.511948,8.40859302 9.63967559,8.32243557 C9.7676866,8.23599502 9.90136599,8.15493342 10.0368404,8.08142121 C10.1738263,8.00715405 10.3157249,7.93883205 10.4587571,7.87853127 C10.6025451,7.81766429 10.7516236,7.7632143 10.9017413,7.71650243 C11.0528037,7.66960183 11.2084009,7.62968441 11.3638091,7.59778823 C11.5215791,7.56560894 11.6825612,7.54107342 11.8425041,7.52484222 Z M11.4827519,3.8270325 C12.0630236,3.76784797 12.6515876,3.76775357 13.2322362,3.8270325 C13.3776339,3.84194663 13.5242567,3.86063649 13.6677698,3.88281889 L13.6677698,3.88281889 L13.7608696,3.89726105 L13.445103,5.94965249 L13.3520032,5.93521033 C13.2426016,5.91840834 13.131598,5.90415497 13.0220079,5.89292218 C12.5810089,5.84808541 12.1336965,5.8481798 11.692886,5.89301657 C11.4764385,5.91519897 11.2597082,5.94833099 11.048726,5.99175186 C10.83944,6.03479516 10.6302482,6.08878808 10.4267102,6.1523147 C10.2252453,6.21527497 10.0247227,6.28899606 9.8304193,6.37140133 C9.6379063,6.45305145 9.44690099,6.54536801 9.26258604,6.64580238 C9.07949609,6.74557599 8.89895037,6.85554408 8.72603732,6.97268604 C8.55425503,7.08907287 8.38567659,7.21537097 8.22501351,7.34827661 C8.06435043,7.48118224 7.9087758,7.62286644 7.76262422,7.76936469 C7.61562457,7.91671248 7.4740903,8.07265006 7.34197907,8.23292972 C7.20967939,8.39339817 7.08350469,8.56217322 6.96712996,8.73472399 C6.84990717,8.9083131 6.74012858,9.08898169 6.64109228,9.27182133 C6.54064252,9.45654883 6.44848504,9.64797825 6.36688139,9.84101235 C6.2842412,10.0365007 6.21064715,10.2374638 6.1481723,10.4382382 C6.08456668,10.6424107 6.03076104,10.8519636 5.98788614,11.0612333 C5.94444586,11.273618 5.91127671,11.4907224 5.88932099,11.7065996 C5.86698835,11.9267246 5.85568069,12.1507197 5.85568069,12.3724493 L5.85568069,12.3724493 L5.85568069,18.1304348 L3.7826087,18.1304348 L3.7826087,12.3724493 C3.7826087,12.0802079 3.79749712,11.785418 3.82689705,11.4962916 C3.85582583,11.2116017 3.89964303,10.9248351 3.95712366,10.6440153 C4.01385045,10.3669713 4.08518298,10.0898328 4.16895393,9.82034024 C4.25206527,9.55358504 4.34931119,9.28796256 4.45814747,9.03074108 C4.56594722,8.77569064 4.68769308,8.52300004 4.8198043,8.27965435 C4.95069053,8.03838532 5.09533442,7.80013688 5.24977828,7.57151653 C5.40271446,7.34487845 5.56884291,7.12248806 5.74326365,6.91066971 C5.91721323,6.69988968 6.10331856,6.49477325 6.29658541,6.300984 C6.48956956,6.10766672 6.69433254,5.92124014 6.90512626,5.74689589 C7.11601422,5.57255164 7.33792716,5.40613642 7.56483431,5.25236989 C7.79258954,5.0981314 8.03052166,4.95323783 8.27194032,4.8216537 C8.51477243,4.68922003 8.7670276,4.56735841 9.02173277,4.45927819 C9.27869946,4.35015964 9.54386422,4.25284025 9.80978281,4.16977423 C10.0792822,4.08566988 10.3558488,4.01421423 10.6318501,3.95757831 C10.9110552,3.90009284 11.1973276,3.8562 11.4827519,3.8270325 Z M20.1633519,2.73913043 L20.2358678,2.79916748 C20.3866296,2.92433904 20.5369218,3.05508009 20.6823294,3.18789788 C20.827831,3.32090447 20.9715478,3.45863095 21.1096287,3.59739581 C21.249964,3.73852062 21.3870116,3.88304375 21.5170143,4.0268117 C21.6490835,4.1727508 21.7791802,4.32369298 21.9038287,4.47539035 C22.0292287,4.62812609 22.1520925,4.78520414 22.2692264,4.94256538 C22.3858907,5.09898264 22.5012399,5.26200775 22.6123622,5.42720401 C22.7230147,5.5914563 22.8307554,5.76023968 22.9328601,5.92902306 C23.0363738,6.10026078 23.1361302,6.27442484 23.2293113,6.44660655 C23.3232439,6.62020422 23.4148282,6.79956016 23.501434,6.97967128 C23.5877581,7.15949922 23.6707945,7.34385824 23.7483828,7.52774528 C23.8254075,7.71040515 23.8997082,7.89920088 23.9689365,8.08884619 C24.037883,8.27745312 24.1030722,8.47096874 24.1630012,8.66410677 C24.2223666,8.85545124 24.2783504,9.05293157 24.3291679,9.2506951 C24.3794219,9.44675946 24.4258246,9.64801571 24.4668731,9.84898876 C24.5078277,10.0495842 24.5443675,10.2543332 24.5752713,10.457383 C24.6064569,10.6618488 24.6329459,10.8699961 24.653705,11.0760666 C24.674652,11.2816651 24.6907145,11.4924556 24.7014228,11.7026796 C24.7119432,11.9133757 24.7173913,12.126998 24.7173913,12.3377884 L24.7173913,12.3377884 L24.7173913,17.1521739 L22.6508745,17.1521739 L22.6508745,12.3377884 C22.6508745,12.1612644 22.6463657,11.9832301 22.6374422,11.8083108 C22.6286125,11.633486 22.6152741,11.4580004 22.5978026,11.286857 C22.5807069,11.1168465 22.5587266,10.9436264 22.5327073,10.7720111 C22.5068759,10.6027557 22.4764417,10.4326508 22.442532,10.2665105 C22.4088102,10.1010311 22.3703918,9.93385244 22.3281222,9.76950576 C22.2855707,9.6040263 22.239168,9.44005721 22.1902291,9.28231838 C22.1403509,9.12174762 22.0861518,8.96108245 22.0290408,8.80457079 C21.9717419,8.64796474 21.9101222,8.49107549 21.8456844,8.33805655 C21.7819042,8.18673677 21.7128638,8.03343464 21.6403478,7.88230366 C21.5680197,7.73192786 21.4918404,7.58268484 21.4139703,7.43891689 C21.3356305,7.29420497 21.2525941,7.14920985 21.1670215,7.00789625 C21.0820125,6.86724343 20.9923069,6.7268738 20.9005348,6.59056329 C20.8083869,6.45349759 20.7122,6.31765906 20.6146979,6.18682362 C20.5175717,6.05636578 20.4150912,5.92534154 20.3101685,5.79762123 C20.2068427,5.67178888 20.0983505,5.54595653 19.9877919,5.42361689 C19.8786422,5.30297642 19.7643263,5.18252475 19.6482256,5.06575459 C19.5327825,4.94964522 19.4129245,4.83495181 19.2921272,4.72460071 C19.1713299,4.61415521 19.0462117,4.50522007 18.9202481,4.40072164 L18.9202481,4.40072164 L18.8478261,4.3406846 L20.1633519,2.73913043 Z M37.5364402,14.8755811 C37.0268733,14.8755811 36.5835708,15.026651 36.2060615,15.3283193 C35.8281751,15.6304592 35.5693385,16.1187488 35.4289861,16.7932826 L39.327748,16.7932826 C39.327748,16.2784944 39.2002148,15.8302826 38.9459027,15.44827 C38.691025,15.0665402 38.2214241,14.8755811 37.5364402,14.8755811 Z M15.9427508,4.5 L16.0275584,4.54023413 C16.1782232,4.61144666 16.3286066,4.68823152 16.474956,4.768322 C16.7150252,4.89979128 16.9517172,5.04467193 17.1784649,5.19890278 C17.4047436,5.35313362 17.6257687,5.51964248 17.8354423,5.69399039 C18.0453036,5.86843274 18.2492546,6.05496423 18.4414789,6.24857919 C18.6338908,6.44228859 18.819079,6.64752045 18.9921653,6.85832463 C19.1659083,7.07016773 19.3312081,7.29277771 19.4837491,7.52001556 C19.6373222,7.74848121 19.7813262,7.98686372 19.9119149,8.22855186 C20.0432541,8.47184558 20.1643676,8.72458394 20.2717843,8.97968345 C20.3800453,9.23704967 20.4769549,9.50291607 20.5596047,9.76982137 C20.6430051,10.0391823 20.7139283,10.3162878 20.7704979,10.5934877 C20.803708,10.7567854 20.8325088,10.9229165 20.856056,11.0871587 L20.856056,11.0871587 L20.8695652,11.1806605 L18.8269594,11.4782609 L18.8136378,11.3848535 C18.7956256,11.2605621 18.7738608,11.1347596 18.7487188,11.0109405 C18.7060335,10.8018363 18.6523721,10.5921655 18.5891416,10.388067 C18.527037,10.1870852 18.4537685,9.986009 18.3714938,9.79041067 C18.2902512,9.59745683 18.1985014,9.4059197 18.0986836,9.22118269 C17.9998039,9.03805128 17.8906048,8.85728102 17.7740882,8.68368868 C17.6579468,8.51085191 17.5322364,8.34188744 17.4006158,8.1813287 C17.2691828,8.02105329 17.1283684,7.86512242 16.9819252,7.71769171 C16.8362325,7.57101657 16.6813461,7.42925264 16.5213937,7.29617778 C16.3615352,7.16338625 16.1936087,7.03682818 16.0223048,6.92018697 C15.8504381,6.80316798 15.6708787,6.69332691 15.4885986,6.59349715 C15.3772418,6.53248483 15.2633519,6.47449479 15.1501188,6.42094372 L15.1501188,6.42094372 L15.0652174,6.38080404 L15.9427508,4.5 Z"
+                                        id="Combined-Shape"></path>
+                                </g>
+                            </g>
+                        </svg> </div>
+                </a>
+            </div>
+            <div class="footer-col">
+                <div class="social-icons">
+                    <a href="https://www.linkedin.com/company/ethyca/" id="linkedin">
+                        <div>
+                            <?xml version="1.0" encoding="UTF-8"?> <svg width="25px" height="25px" viewBox="0 0 25 25"
+                                version="1.1" xmlns="http://www.w3.org/2000/svg"
+                                xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                                    <g id="367773" fill="#999999" fill-rule="nonzero">
+                                        <path
+                                            d="M23.0007147,0 L2.13596671,0 C0.996350325,0 0,0.820523797 0,1.947116 L0,22.8574486 C0,23.9905529 0.996350325,24.9999274 2.13596671,24.9999274 L22.9942026,24.9999274 C24.1403311,24.9999274 24.9999639,23.9840408 24.9999639,22.8574486 L24.9999639,1.947116 C25.0064395,0.820523797 24.1403311,0 23.0007147,0 Z M7.74939142,20.8386996 L4.16773992,20.8386996 L4.16773992,9.70301951 L7.74939142,9.70301951 L7.74939142,20.8386996 Z M6.08229545,8.00987517 L6.05624708,8.00987517 C4.9101186,8.00987517 4.16773992,7.1567909 4.16773992,6.08880754 C4.16773992,5.00128791 4.92965488,4.16773992 6.10183173,4.16773992 C7.27400859,4.16773992 7.99033888,4.99477581 8.01638726,6.08880754 C8.01638726,7.1567909 7.27400859,8.00987517 6.08229545,8.00987517 Z M20.8386996,20.8386996 L17.2570481,20.8386996 L17.2570481,14.7498921 C17.2570481,13.2911831 16.7360806,12.2948328 15.440174,12.2948328 C14.4503358,12.2948328 13.8642473,12.9655784 13.6037636,13.6167878 C13.5060822,13.8512232 13.4800338,14.1703157 13.4800338,14.4959204 L13.4800338,20.8386996 L9.89838232,20.8386996 L9.89838232,9.70301951 L13.4800338,9.70301951 L13.4800338,11.2528978 C14.0010013,10.5105191 14.815013,9.44253576 16.7100323,9.44253576 C19.0608981,9.44253576 20.8386996,10.992414 20.8386996,14.3331181 L20.8386996,20.8386996 L20.8386996,20.8386996 Z"
+                                            id="Shape"></path>
+                                    </g>
+                                </g>
+                            </svg>
+                        </div>
+                    </a>
+                    <a href="https://fid.es/join-slack/" id="slack">
+                        <div> <svg width="24px" height="24px" viewBox="0 0 24 24" fill="#999999" role="img"
+                                xmlns="http://www.w3.org/2000/svg">
+                                <title>Slack icon</title>
+                                <path
+                                    d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z" />
+                            </svg> </div>
+                    </a>
+                    <a href="https://github.com/ethyca/fides" id="github">
+                        <div>
+                            <?xml version="1.0" encoding="UTF-8"?> <svg width="25px" height="25px" viewBox="0 0 25 25"
+                                version="1.1" xmlns="http://www.w3.org/2000/svg"
+                                xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <title>Github icon</title>
+                                <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                                    <g id="Octicons-mark-github" fill="#999999">
+                                        <path
+                                            d="M12.5,0 C5.59375,0 0,5.59375 0,12.5 C0,18.03125 3.578125,22.703125 8.546875,24.359375 C9.171875,24.46875 9.40625,24.09375 9.40625,23.765625 C9.40625,23.46875 9.390625,22.484375 9.390625,21.4375 C6.25,22.015625 5.4375,20.671875 5.1875,19.96875 C5.046875,19.609375 4.4375,18.5 3.90625,18.203125 C3.46875,17.96875 2.84375,17.390625 3.890625,17.375 C4.875,17.359375 5.578125,18.28125 5.8125,18.65625 C6.9375,20.546875 8.734375,20.015625 9.453125,19.6875 C9.5625,18.875 9.890625,18.328125 10.25,18.015625 C7.46875,17.703125 4.5625,16.625 4.5625,11.84375 C4.5625,10.484375 5.046875,9.359375 5.84375,8.484375 C5.71875,8.171875 5.28125,6.890625 5.96875,5.171875 C5.96875,5.171875 7.015625,4.84375 9.40625,6.453125 C10.40625,6.171875 11.46875,6.03125 12.53125,6.03125 C13.59375,6.03125 14.65625,6.171875 15.65625,6.453125 C18.046875,4.828125 19.09375,5.171875 19.09375,5.171875 C19.78125,6.890625 19.34375,8.171875 19.21875,8.484375 C20.015625,9.359375 20.5,10.46875 20.5,11.84375 C20.5,16.640625 17.578125,17.703125 14.796875,18.015625 C15.25,18.40625 15.640625,19.15625 15.640625,20.328125 C15.640625,22 15.625,23.34375 15.625,23.765625 C15.625,24.09375 15.859375,24.484375 16.484375,24.359375 C21.421875,22.703125 25,18.015625 25,12.5 C25,5.59375 19.40625,0 12.5,0 Z"
+                                            id="Path"></path>
+                                    </g>
+                                </g>
+                            </svg>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="footer-row docs-links">
+            <div class="links-wrap">
+                <div class="footer-col">
+                    <ul>
+                        <li> <a href="/fides/"> Fides </a> </li>
+                        <li> <a href="/fides/dsr_quickstart/basic_setup/"> DSR Automation </a> </li>
+                        <li> <a href="/fides/ui/overview/"> Fides UI </a></li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <ul>
+                        <li> <a href="/fideslang/"> Fideslang </a> </li>
+                        <li> <a href="/fideslang/explorer/"> Privacy Taxonomy Explorer </a> </li>
+                        <li> <a href="/fideslang/syntax/"> Privacy Taxonomy Syntax </a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="footer-row ethyca-info">
+            <div class="footer-col">
+                <ul>
+                    <li> <a href="https://privacy.ethyca.com"> Do not sell my personal information </a></li>
+                    <li> <a href="https://privacy.ethyca.com"> Privacy Policy </a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    </footer>
+
+    </div>
+    <div class="md-dialog" data-md-component="dialog">
+        <div class="md-dialog__inner md-typeset"></div>
+    </div>
+    <script id="__config"
+        type="application/json">{"base": "/fides/", "features": ["navigation.top", "navigation.instant", "navigation.tabs"], "search": "/fides/assets/javascripts/workers/search.5e67fbfe.min.js", "translations": {"clipboard.copied": "Copied to clipboard", "clipboard.copy": "Copy to clipboard", "search.config.lang": "en", "search.config.pipeline": "trimmer, stopWordFilter", "search.config.separator": "[\\s\\-]+", "search.placeholder": "Search", "search.result.more.one": "1 more on this page", "search.result.more.other": "# more on this page", "search.result.none": "No matching documents", "search.result.one": "1 matching document", "search.result.other": "# matching documents", "search.result.placeholder": "Type to start searching", "search.result.term.missing": "Missing", "select.version.title": "Select version"}, "version": {"default": "stable", "provider": "mike"}}</script>
+
+
+    <script src="/fides/assets/javascripts/bundle.e87a5f81.min.js"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
+
+    <script src="/fides/js/matomo.js"></script>
+
+
+</body>
+
+</html>

--- a/docs/fides/overrides/404.html
+++ b/docs/fides/overrides/404.html
@@ -849,7 +849,7 @@
                     <article class="md-content__inner md-typeset">
 
                         <h1>
-                            Our docs site has moved, head to
+                            Our official documentation has moved, please visit
                             <a href="http://docs.ethyca.com">
                                 <strong>docs.ethyca.com</strong>
                             </a>

--- a/docs/fides/overrides/404.html
+++ b/docs/fides/overrides/404.html
@@ -1,0 +1,1 @@
+Sorry Mario, Peach is in another Castle


### PR DESCRIPTION
Closes #2275 

### Code Changes

* [x] add a `404.html` override

### Steps to Confirm

* [x] run `nox -s docs_serve`
* [x] navigate to `localhost:8000/fides/fake`
* [x] confirm the new 404 page

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

This is a quick PR to have a more helpful 404 message now that some of our marketing content will be pointing to pages that no longer exist.

It should be noted that I couldn't figure out how to only override that one part of the 404 page in a timely manner, so I've gone ahead and copy/pastad the whole built 404 page and directly updated the text as an override. This isn't a perfect solution, but given that these are no longer the primary docs I feel ok with this compromise for now.