### PR TITLE
Don't display remaining days for terminal requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The types of changes are:
 * Fix Cookie House purchase modal flashing 'Error' in title [#2274](https://github.com/ethyca/fides/pull/2274)
 * Stop dependency from upgrading `packaging` to version with known issue [#2273](https://github.com/ethyca/fides/pull/2273)
 * Privacy center config no longer requires `identity_inputs` and will use `email` as a default [#2263](https://github.com/ethyca/fides/pull/2263)
+* No longer display remaining days for privacy requests in terminal states [#2292](https://github.com/ethyca/fides/pull/2292)
 
 ### Removed
 

--- a/clients/admin-ui/src/features/common/DaysLeftTag.tsx
+++ b/clients/admin-ui/src/features/common/DaysLeftTag.tsx
@@ -1,13 +1,22 @@
 import { Tag } from "@fidesui/react";
 import React from "react";
 
+import { PrivacyRequestStatus } from "~/types/api/models/PrivacyRequestStatus";
+
 type DaysLeftTagProps = {
   daysLeft?: number;
   includeText: boolean;
+  status: PrivacyRequestStatus;
 };
 
-const DaysLeftTag = ({ daysLeft, includeText }: DaysLeftTagProps) => {
-  if (!daysLeft) {
+const DaysLeftTag = ({ daysLeft, includeText, status }: DaysLeftTagProps) => {
+  if (
+    !daysLeft ||
+    status === PrivacyRequestStatus.COMPLETE ||
+    status === PrivacyRequestStatus.CANCELED ||
+    status === PrivacyRequestStatus.DENIED ||
+    status === PrivacyRequestStatus.IDENTITY_UNVERIFIED
+  ) {
     return null;
   }
 

--- a/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
@@ -2,6 +2,8 @@ import { Divider, Flex, Heading, HStack, Text } from "@fidesui/react";
 import DaysLeftTag from "common/DaysLeftTag";
 import { PrivacyRequestEntity } from "privacy-requests/types";
 
+import { PrivacyRequestStatus as ApiPrivacyRequestStatus } from "~/types/api/models/PrivacyRequestStatus";
+
 import ClipboardButton from "../common/ClipboardButton";
 import RequestStatusBadge from "../common/RequestStatusBadge";
 import RequestType from "../common/RequestType";
@@ -56,7 +58,11 @@ const RequestDetails = ({ subjectRequest }: RequestDetailsProps) => {
             />
           )}
 
-          <DaysLeftTag daysLeft={subjectRequest.days_left} includeText />
+          <DaysLeftTag
+            daysLeft={subjectRequest.days_left}
+            includeText
+            status={subjectRequest.status as ApiPrivacyRequestStatus}
+          />
         </HStack>
       </Flex>
     </>

--- a/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
@@ -23,6 +23,7 @@ import { useRouter } from "next/router";
 import React, { useRef, useState } from "react";
 
 import { useFeatures } from "~/features/common/features";
+import { PrivacyRequestStatus as ApiPrivacyRequestStatus } from "~/types/api/models/PrivacyRequestStatus";
 
 import PII from "../common/PII";
 import RequestStatusBadge from "../common/RequestStatusBadge";
@@ -175,7 +176,11 @@ const RequestRow: React.FC<{
         <RequestStatusBadge status={request.status} />
       </Td>
       <Td py={1}>
-        <DaysLeftTag daysLeft={request.days_left} includeText={false} />
+        <DaysLeftTag
+          daysLeft={request.days_left}
+          includeText={false}
+          status={request.status as ApiPrivacyRequestStatus}
+        />
       </Td>
       <Td py={1}>
         <Tag


### PR DESCRIPTION
Closes #2209

### Code Changes

* [ ] Updated the `DaysLeftTag` component to not display the remaining days for requests in terminal states

### Steps to Confirm

* [ ] Run `nox -s test_env`
* [ ] Go to the privacy center and create a four requests
* [ ] Approve and deny two of them. I got the other 2 states by manually updating the records in the database

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

<img width="1655" alt="Screenshot 2023-01-19 at 12 34 55" src="https://user-images.githubusercontent.com/17103888/213519800-8a1b846c-73f2-48fb-b8ba-b2882527684f.png">

<img width="784" alt="Screenshot 2023-01-19 at 12 36 39" src="https://user-images.githubusercontent.com/17103888/213519820-43e9ebd9-4b44-44fd-836e-39ab8913ef8e.png">


