### PR TITLE
Release 2.5.0

### DIFF
--- a/clients/admin-ui/cypress/README.md
+++ b/clients/admin-ui/cypress/README.md
@@ -12,7 +12,7 @@ npm run start
 npm run cy:open
 ```
 
-However, because we do some [inter-zone navigation](https://github.com/ethyca/fides/blob/main/clients/admin-ui/src/features/common/zones/config.ts/#L12-L24) which Cypress will not handle due to security risks, sometimes it is important to run the webapp with `NODE_ENV=test`. We have a command `cy:start` which captures that, and also makes the server a little faster via a production build.
+However, because we do some [inter-zone navigation](https://github.com/ethyca/fides/blob/main/clients/admin-ui/src/features/common/zones/config.ts/#L12-L24) which Cypress will not handle due to security risks, sometimes it is important to run the webapp with `NODE_ENV=test`. We have a command `cy:start` which captures that, and also makes the server a little faster via a production build. This will potentially cause issues if testing manually with `fidesplus`, however the Cypress tests will run properly.
 
 ```
 # Start the webapp in test mode

--- a/docs/fides/docs/development/release_checklist.md
+++ b/docs/fides/docs/development/release_checklist.md
@@ -10,9 +10,10 @@ This checklist should be copy/pasted into the final pre-release PR, and checked 
 
 - [ ] Quickstart verified working and up-to-date
 - [ ] Add any new tables/columns to the [database diagram](https://github.com/ethyca/fides/blob/5a485387d8af247ec6479e4115088cbbb8394d77/docs/fides/docs/development/update_erd_diagram.md) if they have not already been added
-    - To check for the new tables/columns that have been added in the release, look for new migration files in the `src/fides/api/ctl/migrations` directory and inspect their contents
-    - If found, look at the latest database diagram, and check whether it contains the tables/columns that were added in these migrations
-    - If the diagram is not up to date, follow the steps in the link above to generate a new database diagram with the up-to-date schema, ensuring that all tables and their relationships can be clearly seen
+  - To check for the new tables/columns that have been added in the release, look for new migration files in the `src/fides/api/ctl/migrations` directory and inspect their contents
+  - If found, look at the latest database diagram, and check whether it contains the tables/columns that were added in these migrations
+  - If the diagram is not up to date, follow the steps in the link above to generate a new database diagram with the up-to-date schema, ensuring that all tables and their relationships can be clearly seen
+  - Open up an issue on [fidesdocs](https://github.com/ethyca/fidesdocs/issues) to update the diagram on the new docs site
 - [ ] `nox -s test_env` works (verify the admin UI, privacy center, CLI and webserver)
 - [ ] `nox -s "build(sample)"` works on the release branch, creating the sample images (this is also prereq for `fides deploy up`)
 - [ ] `fides deploy up --no-pull` works using the images built in previous step (verify the admin UI, privacy center, CLI and webserver)
@@ -27,7 +28,7 @@ fides deploy up --no-pull
 fides status
 fides deploy down
 rm -rf ~/fides-2-1-0-test
-exit 
+exit
 ```
 
 Next, run the following checks against the environment you've spun up using `fides deploy up --no-pull`:

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -324,7 +324,7 @@ def create_dsr_policy(key: str):
     if response.ok:
         policies = (response.json())["succeeded"]
         if len(policies) > 0:
-            logger.info("Created fidesops policy with key=%s via {url}", key)
+            logger.info("Created fidesops policy with key={key} via {url}")
             return response.json()
 
     raise RuntimeError(


### PR DESCRIPTION
## Pre-Release Steps

### General

- [x] Quickstart verified working and up-to-date
- [x] Add any new tables/columns to the [database diagram](https://github.com/ethyca/fides/blob/5a485387d8af247ec6479e4115088cbbb8394d77/docs/fides/docs/development/update_erd_diagram.md) if they have not already been added
    - To check for the new tables/columns that have been added in the release, look for new migration files in the `src/fides/api/ctl/migrations` directory and inspect their contents
    - If found, look at the latest database diagram, and check whether it contains the tables/columns that were added in these migrations
    - If the diagram is not up to date, follow the steps in the link above to generate a new database diagram with the up-to-date schema, ensuring that all tables and their relationships can be clearly seen
- [x] `nox -s test_env` works (verify the admin UI, privacy center, CLI and webserver)
- [x] `nox -s "build(sample)"` works on the release branch, creating the sample images (this is also prereq for `fides deploy up`)
- [x] `fides deploy up --no-pull` works using the images built in previous step (verify the admin UI, privacy center, CLI and webserver)

```
mkdir ~/fides-2-1-0-test
cd ~/fides-2-1-0-test
python3 -m venv venv
source venv/bin/activate
pip install git+https://github.com/ethyca/fides.git@<branch>
fides deploy up --no-pull
fides status
fides deploy down
rm -rf ~/fides-2-1-0-test
exit 
```

Next, run the following checks against the environment you've spun up using `fides deploy up --no-pull`:

### API

- [x] Verify that the generated API docs are correct
- [x] Verify that the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### CLI

Run these from within `nox -s dev -- shell`

- [x] Run a `fides push`
- [x] Run a `fides pull`
- [x] Run a `fides evaluate`
- [x] Generate a dataset with `fides generate dataset db --credentials-id app_postgres test.yml`
- [x] Scan a database with `fides scan dataset db --credentials-id app_postgres`

### Admin UI

- [x] Every navigation button works
- [x] DSR approval succeeds
- [x] DSR execution succeeds

### Privacy Center

- [x] Every navigation button works
- [x] DSR submission succeeds
- [x] Consent request submission succeeds

### Documentation

- [x] Verify that the CHANGELOG is formatted correctly and clean up verbiage where needed
- [x] Verify that the CHANGELOG is representative of the actual changes

## Post-Release Steps

- [x] Verify the ethyca-fides release is published to PyPi: <https://pypi.org/project/ethyca-fides/#history>
- [x] Verify the fides release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides>
- [x] Verify the fides-privacy-center release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-privacy-center>
- [x] Verify the fides-sample-app release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-sample-app>
- [x] Smoke test the PyPi & DockerHub releases with a clean `pip install ethyca-fides` and `fides deploy up`