### PR TITLE
Fix tsconfigs so cypress types do not override jest types

### DIFF
--- a/clients/privacy-center/cypress/tsconfig.json
+++ b/clients/privacy-center/cypress/tsconfig.json
@@ -1,13 +1,11 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
     "target": "es5",
     "lib": ["es5", "dom"],
-    "types": ["cypress", "node"],
-    "baseUrl": "..",
-    "paths": {
-      "~/*": ["./*"]
-    }
+    "types": ["cypress", "node"]
   },
-  "include": ["**/*.ts", "**/*.tsx", "../cypress.config.ts"]
+  "include": ["**/*.ts", "**/*.tsx", "../cypress.config.ts"],
+  "exclude": []
 }

--- a/clients/privacy-center/cypress/tsconfig.json
+++ b/clients/privacy-center/cypress/tsconfig.json
@@ -1,10 +1,13 @@
 {
-  "extends": "../tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
     "target": "es5",
     "lib": ["es5", "dom"],
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node"],
+    "baseUrl": "..",
+    "paths": {
+      "~/*": ["./*"]
+    }
   },
   "include": ["**/*.ts", "**/*.tsx", "../cypress.config.ts"]
 }

--- a/clients/privacy-center/tsconfig.json
+++ b/clients/privacy-center/tsconfig.json
@@ -20,5 +20,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "cypress/**/*.ts", "cypress.config.ts"]
 }


### PR DESCRIPTION
I was getting a bunch of red underlines in vs code when opening jest tests. I remember having to do this before for admin-ui, it's a careful tsconfig dance https://stackoverflow.com/questions/58999086/cypress-causing-type-errors-in-jest-assertions

<img width="734" alt="image" src="https://user-images.githubusercontent.com/24641006/213790290-558a11bb-0bf9-4550-80a0-84d4258ffa89.png">


### Code Changes

* [x] Make the tsconfigs cooperate

### Steps to Confirm

* [ ] Try to write both jest or cypress tests. Your intellisense should not complain anymore

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
