### PR TITLE
[#2319] Don't allow db resets unless `config.dev_mode` is `True`

### DIFF
--- a/src/fides/api/ctl/routes/admin.py
+++ b/src/fides/api/ctl/routes/admin.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from fides.api.ctl.database import database
 from fides.api.ctl.routes.util import API_PREFIX
+from fides.api.ctl.utils import errors
 from fides.api.ctl.utils.api_router import APIRouter
 from fides.core.config import FidesConfig, get_config
 
@@ -24,6 +25,11 @@ async def db_action(action: DBActions) -> Dict:
 
     action_text = "initialized"
     if action == DBActions.reset:
+        if not CONFIG.dev_mode:
+            raise errors.FunctionalityNotConfigured(
+                "unable to reset fides database outside of dev_mode."
+            )
+
         database.reset_db(CONFIG.database.sync_database_uri)
         action_text = DBActions.reset
     await database.configure_db(CONFIG.database.sync_database_uri)

--- a/tests/ctl/api/test_admin.py
+++ b/tests/ctl/api/test_admin.py
@@ -22,7 +22,7 @@ def test_db_reset_dev_mode_enabled(
 
 def test_db_reset_dev_mode_disabled(
     test_config: FidesConfig,
-    test_config_dev_mode_disabled: FidesConfig,
+    test_config_dev_mode_disabled: FidesConfig,  # temporarily switches off config.dev_mode
     test_client: TestClient,
 ) -> None:
     with pytest.raises(

--- a/tests/ctl/api/test_admin.py
+++ b/tests/ctl/api/test_admin.py
@@ -1,0 +1,35 @@
+# pylint: disable=missing-docstring, redefined-outer-name
+import pytest
+from starlette.testclient import TestClient
+
+from fides.api.ctl.routes.util import API_PREFIX
+from fides.api.ctl.utils import errors
+from fides.core.config import FidesConfig
+
+
+def test_db_reset_dev_mode_enabled(
+    test_config: FidesConfig,
+    test_client: TestClient,
+) -> None:
+    assert test_config.dev_mode
+    response = test_client.post(
+        test_config.cli.server_url + API_PREFIX + "/admin/db/reset/",
+        headers=test_config.user.request_headers,
+    )
+    assert response.status_code == 200
+    assert response.json() == {"data": {"message": "fides database reset"}}
+
+
+def test_db_reset_dev_mode_disabled(
+    test_config: FidesConfig,
+    test_config_dev_mode_disabled: FidesConfig,
+    test_client: TestClient,
+) -> None:
+    with pytest.raises(
+        errors.FunctionalityNotConfigured,
+        match="unable to reset fides database outside of dev_mode.",
+    ):
+        test_client.post(
+            test_config.cli.server_url + API_PREFIX + "/admin/db/reset/",
+            headers=test_config.user.request_headers,
+        )

--- a/tests/ctl/conftest.py
+++ b/tests/ctl/conftest.py
@@ -94,6 +94,14 @@ def test_config(test_config_path: str) -> Generator:
     yield get_config(test_config_path)
 
 
+@pytest.fixture(scope="function")
+def test_config_dev_mode_disabled() -> Generator:
+    original_value = CONFIG.dev_mode
+    CONFIG.dev_mode = False
+    yield CONFIG
+    CONFIG.dev_mode = original_value
+
+
 @pytest.fixture(scope="session")
 def test_client() -> Generator:
     """Starlette test client fixture. Easier to use mocks with when testing out API calls"""


### PR DESCRIPTION
Closes #2319 

### Code Changes

* [ ] Raise a `FunctionalityNotConfigured` exception if a DB reset is called via the API against a server running outside of `dev_mode`

### Steps to Confirm

* [ ] Run `nox -s test_env`
* [ ] Send a `POST` request to `/admin/db/reset`
* [ ] Assert that the request fails

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

I opted to use `dev_mode` here instead of adding a new configuration variable to work against config. bloat, but I'm happy to change if anyone has a compelling reason to.
