### PR TITLE
Add a check on the catchall path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The types of changes are:
 
 * Home screen header scaling and responsiveness issues [#2200](https://github.com/ethyca/fides/pull/2277)
 
+### Security
+
+* Add a check to the catchall path to prevent returning paths outside of the UI directory [#2330](https://github.com/ethyca/fides/pull/2330)
+
 ## [2.5.0](https://github.com/ethyca/fides/compare/2.4.0...2.5.0)
 
 ### Docs

--- a/src/fides/api/ctl/ui.py
+++ b/src/fides/api/ctl/ui.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional, Union
 
 from fastapi import Response
 from fastapi.responses import FileResponse
+from loguru import logger
 
 FIDES_DIRECTORY = "src/fides"
 ADMIN_UI_DIRECTORY = "ui-build/static/admin/"
@@ -23,8 +24,12 @@ def get_package_path() -> Optional[Path]:
     return None
 
 
-def get_path_to_admin_ui_file(path: str) -> Optional[Path]:
-    """Return a path to a packaged admin UI file."""
+def get_path_to_admin_ui_file(path: str = "") -> Optional[Path]:
+    """
+    Return a path to a packaged admin UI file.
+
+    If no path is given, returns the path to the root of the UI directory
+    """
     package_path = get_package_path()
     if package_path is None:
         return None
@@ -125,6 +130,16 @@ def match_route(route_file_map: Dict[re.Pattern, Path], route: str) -> Optional[
 
     # If no static matches exist, fallback to the first match
     return sorted(matches)[0]
+
+
+def path_is_in_ui_directory(path: Path) -> bool:
+    """Checks if the path exists within the UI directory"""
+    ui_directory = get_path_to_admin_ui_file()
+    if not ui_directory:
+        logger.debug("Unable to locate UI directory")
+        return False
+
+    return ui_directory in path.parents
 
 
 def _is_dynamic_path(path: Path) -> bool:

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -37,6 +37,7 @@ from fides.api.ctl.ui import (
     get_package_file_map,
     get_path_to_admin_ui_file,
     match_route,
+    path_is_in_ui_directory,
 )
 from fides.api.ctl.utils.errors import FidesError
 from fides.api.ctl.utils.logger import setup as setup_logging
@@ -311,23 +312,14 @@ def read_other_paths(request: Request) -> Response:
     if not ui_file:
         ui_file = get_path_to_admin_ui_file(path)
 
-    if ui_file and ui_file.is_file():
-        # We've found a file, but first safety check that this file is really only from our UI directory
-        ui_directory = get_path_to_admin_ui_file("")
-        if not ui_directory:
-            logger.debug("Unable to locate UI directory")
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Item not found"
-            )
-
-        # Check that the UI directory is part of the requested file's file path
-        if ui_directory in ui_file.parents:
-            logger.debug(
-                "catchall request path '{}' matched static admin UI file: {}",
-                path,
-                ui_file,
-            )
-            return FileResponse(ui_file)
+    # Serve up the file as long as it is within the UI directory
+    if ui_file and ui_file.is_file() and path_is_in_ui_directory(ui_file):
+        logger.debug(
+            "catchall request path '{}' matched static admin UI file: {}",
+            path,
+            ui_file,
+        )
+        return FileResponse(ui_file)
 
     # raise 404 for anything that should be backend endpoint but we can't find it
     if path.startswith(API_PREFIX[1:]):

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -311,14 +311,23 @@ def read_other_paths(request: Request) -> Response:
     if not ui_file:
         ui_file = get_path_to_admin_ui_file(path)
 
-    # If any of those worked, serve the file.
     if ui_file and ui_file.is_file():
-        logger.debug(
-            "catchall request path '{}' matched static admin UI file: {}",
-            path,
-            ui_file,
-        )
-        return FileResponse(ui_file)
+        # We've found a file, but first safety check that this file is really only from our UI directory
+        ui_directory = get_path_to_admin_ui_file("")
+        if not ui_directory:
+            logger.debug("Unable to locate UI directory")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Item not found"
+            )
+
+        # Check that the UI directory is part of the requested file's file path
+        if ui_directory in ui_file.parents:
+            logger.debug(
+                "catchall request path '{}' matched static admin UI file: {}",
+                path,
+                ui_file,
+            )
+            return FileResponse(ui_file)
 
     # raise 404 for anything that should be backend endpoint but we can't find it
     if path.startswith(API_PREFIX[1:]):

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -313,7 +313,11 @@ def read_other_paths(request: Request) -> Response:
         ui_file = get_path_to_admin_ui_file(path)
 
     # Serve up the file as long as it is within the UI directory
-    if ui_file and ui_file.is_file() and path_is_in_ui_directory(ui_file):
+    if ui_file and ui_file.is_file():
+        if not path_is_in_ui_directory(ui_file):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Item not found"
+            )
         logger.debug(
             "catchall request path '{}' matched static admin UI file: {}",
             path,


### PR DESCRIPTION
The catchall path should only serve paths found nested inside the UI directory

Closes https://github.com/ethyca/security-issues/issues/9

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
