### PR TITLE
Pass GA cookie from privacy center

### DIFF
--- a/clients/privacy-center/__tests__/common/browser-identities.ts
+++ b/clients/privacy-center/__tests__/common/browser-identities.ts
@@ -1,0 +1,35 @@
+import { inspectForBrowserIdentities } from "~/common/browser-identities";
+
+const mockCookie = (value: str) => {
+  Object.defineProperty(window.document, "cookie", {
+    writable: true,
+    value,
+  });
+};
+
+const clientId = "968159977.1674053816";
+const gaCookie = `_ga=GA1.1.${clientId}`;
+
+describe("browser identities", () => {
+  it("can inspect for a google analytics cookie when it is the only cookie", () => {
+    mockCookie(`${gaCookie};`);
+    const identity = inspectForBrowserIdentities();
+    expect(identity).toEqual(clientId);
+  });
+
+  it("can inspect for a google analytics cookie when it is one of many cookies", () => {
+    mockCookie(`cookie1=value1; ${gaCookie}; cookie2=value2;`);
+    const identity = inspectForBrowserIdentities();
+    expect(identity).toEqual(clientId);
+  });
+
+  it("returns undefined if no ga cookie exists", () => {
+    // wrong key
+    mockCookie(`_gaFake=GA1.1.${clientId}`);
+    expect(inspectForBrowserIdentities()).toBe(undefined);
+
+    // malformed cookie
+    mockCookie(`_ga=GA1.1.`);
+    expect(inspectForBrowserIdentities()).toBe(undefined);
+  });
+});

--- a/clients/privacy-center/__tests__/common/browser-identities.ts
+++ b/clients/privacy-center/__tests__/common/browser-identities.ts
@@ -1,26 +1,26 @@
 import { inspectForBrowserIdentities } from "~/common/browser-identities";
 
-const mockCookie = (value: str) => {
+const mockCookie = (value: string) => {
   Object.defineProperty(window.document, "cookie", {
     writable: true,
     value,
   });
 };
 
-const clientId = "968159977.1674053816";
+const clientId = "999999999.8888888888";
 const gaCookie = `_ga=GA1.1.${clientId}`;
 
 describe("browser identities", () => {
   it("can inspect for a google analytics cookie when it is the only cookie", () => {
     mockCookie(`${gaCookie};`);
     const identity = inspectForBrowserIdentities();
-    expect(identity).toEqual(clientId);
+    expect(identity?.gaClientId).toEqual(clientId);
   });
 
   it("can inspect for a google analytics cookie when it is one of many cookies", () => {
     mockCookie(`cookie1=value1; ${gaCookie}; cookie2=value2;`);
     const identity = inspectForBrowserIdentities();
-    expect(identity).toEqual(clientId);
+    expect(identity?.gaClientId).toEqual(clientId);
   });
 
   it("returns undefined if no ga cookie exists", () => {
@@ -30,6 +30,6 @@ describe("browser identities", () => {
 
     // malformed cookie
     mockCookie(`_ga=GA1.1.`);
-    expect(inspectForBrowserIdentities()).toBe(undefined);
+    expect(inspectForBrowserIdentities()?.gaClientId).toBe(undefined);
   });
 });

--- a/clients/privacy-center/common/browser-identities.ts
+++ b/clients/privacy-center/common/browser-identities.ts
@@ -1,0 +1,28 @@
+/**
+ * With some consent requests, we also want to send information that only
+ * the browser would know about, for example, the value of a Google Analytics
+ * cookie.
+ *
+ * Inspects the cookies on this site and returns a relevant user ID.
+ *
+ * Currently hard coded to Google Analytics until we have evidence of other
+ * identities we may want to leverage.
+ */
+const GA_COOKIE_KEY = "_ga";
+// The GA cookie only uses the last two sections as the clientId
+const GA_COOKIE_REGEX = /=\w+\.\w+\.(\w+\.\w+)/;
+
+export const inspectForBrowserIdentities = () => {
+  // Returns a string of all cookies on the page separated by semicolons
+  // For example, 'cookie1=value1; cookie2=value2'
+  const { cookie } = document;
+
+  const gaCookie = cookie
+    .split("; ")
+    .filter((c) => c.startsWith(`${GA_COOKIE_KEY}=`))[0];
+  if (!gaCookie) {
+    return undefined;
+  }
+  const match = gaCookie.match(GA_COOKIE_REGEX);
+  return match ? match[1] : undefined;
+};

--- a/clients/privacy-center/common/browser-identities.ts
+++ b/clients/privacy-center/common/browser-identities.ts
@@ -1,3 +1,7 @@
+interface BrowserIdentities {
+  gaClientId?: string;
+}
+
 /**
  * With some consent requests, we also want to send information that only
  * the browser would know about, for example, the value of a Google Analytics
@@ -12,7 +16,9 @@ const GA_COOKIE_KEY = "_ga";
 // The GA cookie only uses the last two sections as the clientId
 const GA_COOKIE_REGEX = /=\w+\.\w+\.(\w+\.\w+)/;
 
-export const inspectForBrowserIdentities = () => {
+export const inspectForBrowserIdentities = ():
+  | BrowserIdentities
+  | undefined => {
   if (typeof window === "undefined") {
     return undefined;
   }
@@ -28,5 +34,6 @@ export const inspectForBrowserIdentities = () => {
     return undefined;
   }
   const match = gaCookie.match(GA_COOKIE_REGEX);
-  return match ? match[1] : undefined;
+  const gaClientId = match ? match[1] : undefined;
+  return { gaClientId };
 };

--- a/clients/privacy-center/common/browser-identities.ts
+++ b/clients/privacy-center/common/browser-identities.ts
@@ -13,9 +13,13 @@ const GA_COOKIE_KEY = "_ga";
 const GA_COOKIE_REGEX = /=\w+\.\w+\.(\w+\.\w+)/;
 
 export const inspectForBrowserIdentities = () => {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
   // Returns a string of all cookies on the page separated by semicolons
   // For example, 'cookie1=value1; cookie2=value2'
-  const { cookie } = document;
+  const { cookie } = window.document;
 
   const gaCookie = cookie
     .split("; ")

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -144,7 +144,7 @@ const Consent: NextPage = () => {
         executable: d.executable ?? false,
       })),
       browser_identity: browserIdentity
-        ? { user_id: browserIdentity }
+        ? { ga_client_id: browserIdentity.gaClientId }
         : undefined,
     };
 

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -32,6 +32,7 @@ import { useLocalStorage } from "~/common/hooks";
 import { useAppSelector } from "~/app/hooks";
 import { selectConfigConsentOptions } from "~/features/common/config.slice";
 import ConsentItemCard from "~/components/ConsentItemCard";
+import { inspectForBrowserIdentities } from "~/common/browser-identities";
 
 const Consent: NextPage = () => {
   const content: any = [];
@@ -128,6 +129,7 @@ const Consent: NextPage = () => {
   const saveUserConsentOptions = useCallback(async () => {
     const headers: Headers = new Headers();
     addCommonHeaders(headers, null);
+    const browserIdentity = inspectForBrowserIdentities();
 
     const body = {
       code: verificationCode,
@@ -141,6 +143,9 @@ const Consent: NextPage = () => {
         data_use: d.fidesDataUseKey,
         executable: d.executable ?? false,
       })),
+      browser_identity: browserIdentity
+        ? { user_id: browserIdentity }
+        : undefined,
     };
 
     const response = await fetch(


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/519

### Code Changes

* [x] Adds a function `inspectForBrowserIdentities` which looks through cookies on the page and pulls out relevant values
  * This is meant to be extended and potentially refactored once there are other services we'd like to integrate with besides GA. For now, it is hard coded to look for GA cookie values, but it could be extended to look through `config.json` for more cookie values/regexes
* [x] Adds jest test for this function
* [x] Calls this function before sending a consent request PATCH
* [x] Adds cypress test which tests that we are indeed sending the cookie via this PATCH

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
