### PR TITLE
pc/fides-consent: ConsentValue with ConsentContext to support GPC

### DIFF
--- a/.github/workflows/frontend_checks.yml
+++ b/.github/workflows/frontend_checks.yml
@@ -105,11 +105,11 @@ jobs:
       - name: Format
         run: npm run format:ci
 
-      - name: Jest test
-        run: npm run test:ci
-
       - name: Build
         run: npm run build
+
+      - name: Jest test
+        run: npm run test:ci
 
   Privacy-Center-Cypress:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,20 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.6.3...main)
 
-* Update Admin UI to show all action types (access, erasure, consent, update) [#2523](https://github.com/ethyca/fides/pull/2523) 
-* Fixed bug for SMS completion notification not being sent [#2526](https://github.com/ethyca/fides/issues/2526)
+### Added
+
+* Privacy Center
+  * The consent config default value can depend on whether Global Privacy Control is enabled. [#2341](https://github.com/ethyca/fides/pull/2341)
 
 ### Changed
+
+* Update Admin UI to show all action types (access, erasure, consent, update) [#2523](https://github.com/ethyca/fides/pull/2523) 
 * Updated the UI for adding systems to a new design [#2490](https://github.com/ethyca/fides/pull/2490)
+
 ### Fixed
 
 * Fixed bug where refreshing a page in the UI would result in a 404 [#2502](https://github.com/ethyca/fides/pull/2502)
+* Fixed bug for SMS completion notification not being sent [#2526](https://github.com/ethyca/fides/issues/2526)
 
 ## [2.6.3](https://github.com/ethyca/fides/compare/2.6.2...2.6.3)
 

--- a/clients/privacy-center/README.md
+++ b/clients/privacy-center/README.md
@@ -23,7 +23,9 @@ You may configure the appearance of this web application at build time by modify
   - Which consent management options are present, and each option's:
     - The Fides Data Use that the user may consent to
     - Descriptive information for the type of consent
-    - The default consent state (opt in/out)
+    - The default consent state (opt in/out):
+      - This can be a single boolean which will apply when the user has not modified their consent.
+      - Or this can be an object with consent values that depend on the user's consent context, such as whether they are using Global Privacy Control. See [fides-consent](./packages/fides-consent/README.md#consent-context) for details.
     - The cookie keys that will be available to
       [fides-consent.js](./packages/fides-consent/README.md), which can be used to access a user's consent choices on outside of the Privacy Center.
     - Whether the user's consent choice should be propagated to any configured third party services (executable). Note that currently, only one option may be marked `executable` at a time.

--- a/clients/privacy-center/config/config.json
+++ b/clients/privacy-center/config/config.json
@@ -44,7 +44,10 @@
         "name": "Data Sales or Sharing",
         "description": "We may use some of your personal information for behavioral advertising purposes, which may be interpreted as 'Data Sales' or 'Data Sharing' under regulations such as CCPA, CPRA, VCDPA, etc.",
         "url": "https://example.com/privacy#data-sales",
-        "default": true,
+        "default": {
+          "value": true,
+          "globalPrivacyControl": false
+        },
         "highlight": false,
         "cookieKeys": ["data_sales"],
         "executable": false
@@ -54,7 +57,10 @@
         "name": "Email Marketing",
         "description": "We may use some of your personal information to contact you about our products & services.",
         "url": "https://example.com/privacy#email-marketing",
-        "default": true,
+        "default": {
+          "value": true,
+          "globalPrivacyControl": false
+        },
         "highlight": false,
         "cookieKeys": ["tracking"],
         "executable": false

--- a/clients/privacy-center/cypress/e2e/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent.cy.ts
@@ -233,5 +233,18 @@ describe("Consent settings", () => {
           ]);
       });
     });
+
+    describe("when globalPrivacyControl is enabled", () => {
+      it("uses the globalPrivacyControl default", () => {
+        cy.visit("/fides-consent-demo.html?globalPrivacyControl=true");
+        cy.get("#consent-json");
+        cy.window().then((win) => {
+          expect(win).to.have.nested.property("Fides.consent").that.eql({
+            data_sales: false,
+            tracking: false,
+          });
+        });
+      });
+    });
   });
 });

--- a/clients/privacy-center/features/consent/helpers.ts
+++ b/clients/privacy-center/features/consent/helpers.ts
@@ -1,4 +1,8 @@
-import { CookieKeyConsent } from "fides-consent";
+import {
+  CookieKeyConsent,
+  getConsentContext,
+  resolveConsentValue,
+} from "fides-consent";
 import { ConfigConsentOption } from "~/types/config";
 
 import { ConsentItem, ApiUserConsents, ApiUserConsent } from "./types";
@@ -7,6 +11,8 @@ export const makeConsentItems = (
   data: ApiUserConsents,
   consentOptions: ConfigConsentOption[]
 ): ConsentItem[] => {
+  const consentContext = getConsentContext();
+
   if (data.consent) {
     const newConsentItems: ConsentItem[] = [];
     const userConsentMap: { [key: string]: ApiUserConsent } = {};
@@ -15,12 +21,14 @@ export const makeConsentItems = (
       userConsentMap[key] = option;
     });
     consentOptions.forEach((d) => {
+      const defaultValue = resolveConsentValue(d.default, consentContext);
+
       if (d.fidesDataUseKey in userConsentMap) {
         const currentConsent = userConsentMap[d.fidesDataUseKey];
 
         newConsentItems.push({
+          defaultValue,
           consentValue: currentConsent.opt_in,
-          defaultValue: d.default ? d.default : false,
           description: currentConsent.data_use_description
             ? currentConsent.data_use_description
             : d.description,
@@ -33,12 +41,12 @@ export const makeConsentItems = (
         });
       } else {
         newConsentItems.push({
+          defaultValue,
           fidesDataUseKey: d.fidesDataUseKey,
           name: d.name,
           description: d.description,
           highlight: d.highlight ?? false,
           url: d.url,
-          defaultValue: d.default ? d.default : false,
           cookieKeys: d.cookieKeys ?? [],
           executable: d.executable ?? false,
         });
@@ -54,7 +62,7 @@ export const makeConsentItems = (
     description: option.description,
     highlight: option.highlight ?? false,
     url: option.url,
-    defaultValue: option.default ? option.default : false,
+    defaultValue: resolveConsentValue(option.default, consentContext),
     cookieKeys: option.cookieKeys ?? [],
     executable: option.executable ?? false,
   }));

--- a/clients/privacy-center/jest.config.js
+++ b/clients/privacy-center/jest.config.js
@@ -21,6 +21,10 @@ module.exports = {
     // Handle module aliases
     "^@/components/(.*)$": "<rootDir>/components/$1",
     "^~/(.*)$": "<rootDir>/$1",
+
+    // Handle symlink installed package.
+    "^fides-consent$":
+      "<rootDir>/packages/fides-consent/dist/fides-consent.mjs",
   },
   // Add more setup options before each test is run
   setupFilesAfterEnv: ["<rootDir>/__tests__/jest.setup.ts"],
@@ -33,7 +37,7 @@ module.exports = {
   transform: {
     // Use babel-jest to transpile tests with the next/babel preset
     // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object
-    "^.+\\.(js|jsx|ts|tsx)$": ["babel-jest", { presets: ["next/babel"] }],
+    "^.+\\.(js|mjs|jsx|ts|tsx)$": ["babel-jest", { presets: ["next/babel"] }],
   },
   transformIgnorePatterns: [
     "/node_modules/",

--- a/clients/privacy-center/packages/fides-consent/README.md
+++ b/clients/privacy-center/packages/fides-consent/README.md
@@ -82,6 +82,53 @@ for the cookie key to be true. For example, with the default configuration:
 By default, `Fides.consent.tracking` will be set to `true`. If the user removes their consent for 
 `advertising.first_party`, `improve`, or both, then `Fides.consent.tracking` will be set to `false`.
 
+### Consent Context
+
+The `default` specified in a consent option is applied when a user has not made any consent choices
+(for example, if they have not visited the Privacy Center). This default value can be:
+
+- `true`: Behave as if the user has granted consent.
+- `false`: Behave as if the user has revoked their consent.
+
+However, this choice may need to be different based on information provided by the user's browser:
+their _Consent Context_.
+
+Currently, the only context that can be used is whether the user has enabled [Global Privacy Control](https://globalprivacycontrol.org/#about). To configure a default value which depends on this context, pass an object with
+the following properties: 
+
+- `value`: The consent boolean that applies when there is no relevant consent context.
+- `globalPrivacyControl`. The consent boolean that applies the user has enabled GPC.
+
+For example, with this configuration:
+
+```json
+{
+  "consent": {
+    "consentOptions": [
+      {
+        "fidesDataUseKey": "advertising.first_party",
+        "name": "Email Marketing",
+        "default": {
+          "value": true,
+          "globalPrivacyControl": false
+        },
+        "cookieKeys": ["data_sales"]
+      },
+      {
+        "fidesDataUseKey": "provide.service",
+        "name": "Core functionality",
+        "default": true,
+        "cookieKeys": ["functional"]
+      }
+    ]
+  }
+}
+```
+
+The `data_sales` cookie key will default to `true` (grant consent) **unless the user has enabled GPC** in which case consent will be revoked without the user having to go through the Privacy Center.
+
+On the other hand, the `functional` cookie key will always default to `true` and the user must go through the Privacy Center to revoke consent.
+
 ## Integrations
 
 ### Google Tag Manager

--- a/clients/privacy-center/packages/fides-consent/rollup.config.js
+++ b/clients/privacy-center/packages/fides-consent/rollup.config.js
@@ -23,40 +23,26 @@ const generateConsentConfig = () => {
    * @type {import('../../types/config').Config}
    */
   const privacyCenterConfig = require("../../config/config.json");
-  const consentOptions = privacyCenterConfig.consent?.consentOptions ?? [];
+  const privacyCenterOptions =
+    privacyCenterConfig.consent?.consentOptions ?? [];
 
-  if (consentOptions.length === 0) {
+  if (privacyCenterOptions.length === 0) {
     console.warn(
       "Privacy Center config.json has no consent options configured."
     );
   }
 
+  const options = privacyCenterOptions.map((pcOption) => ({
+    fidesDataUseKey: pcOption.fidesDataUseKey,
+    default: pcOption.default,
+    cookieKeys: pcOption.cookieKeys,
+  }));
+
   /**
-   * @type {import('./src/lib/cookie').CookieKeyConsent}
+   * @type {import('./src/lib/consent-config').ConsentConfig}
    */
-  const defaults = {};
-  consentOptions.forEach(({ cookieKeys, default: current }) => {
-    if (current === undefined) {
-      return;
-    }
-
-    cookieKeys.forEach((cookieKey) => {
-      const previous = defaults[cookieKey];
-      if (previous === undefined) {
-        defaults[cookieKey] = current;
-        return;
-      }
-
-      if (current !== previous) {
-        console.warn(`Conflicting configuration for cookieKey "${cookieKey}".`);
-      }
-
-      defaults[cookieKey] = previous && current;
-    });
-  });
-
   const consentConfig = {
-    defaults: defaults,
+    options,
   };
 
   fs.writeFileSync(

--- a/clients/privacy-center/packages/fides-consent/src/fides-consent.ts
+++ b/clients/privacy-center/packages/fides-consent/src/fides-consent.ts
@@ -9,13 +9,24 @@ import consentConfig from "./consent-config.json";
 import { gtm } from "./integrations/gtm";
 import { meta } from "./integrations/meta";
 import { shopify } from "./integrations/shopify";
-import { getConsentCookie } from "./lib/cookie";
+import { ConsentConfig } from "./lib/consent-config";
+import { getConsentContext } from "./lib/consent-context";
+import { getConsentCookie, makeDefaults } from "./lib/cookie";
+
+const config: ConsentConfig = consentConfig;
+const context = getConsentContext();
+const defaults = makeDefaults({
+  config,
+  context,
+});
+
+/**
+ * Immediately load the stored consent settings from the browser cookie.
+ */
+const consent = getConsentCookie(defaults);
 
 const Fides = {
-  /**
-   * Immediately load the stored consent settings from the browser cookie.
-   */
-  consent: getConsentCookie(consentConfig.defaults),
+  consent,
 
   gtm,
   meta,

--- a/clients/privacy-center/packages/fides-consent/src/lib/consent-config.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/consent-config.ts
@@ -1,0 +1,11 @@
+import { ConsentValue } from "./consent-value";
+
+export type ConsentOption = {
+  cookieKeys: string[];
+  default?: ConsentValue;
+  fidesDataUseKey: string;
+};
+
+export type ConsentConfig = {
+  options: ConsentOption[];
+};

--- a/clients/privacy-center/packages/fides-consent/src/lib/consent-context.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/consent-context.ts
@@ -1,0 +1,19 @@
+declare global {
+  interface Navigator {
+    globalPrivacyControl?: boolean;
+  }
+}
+
+export type ConsentContext = {
+  globalPrivacyControl?: boolean;
+};
+
+export const getConsentContext = (): ConsentContext => {
+  if (typeof window === "undefined") {
+    return {};
+  }
+
+  return {
+    globalPrivacyControl: window.navigator.globalPrivacyControl,
+  };
+};

--- a/clients/privacy-center/packages/fides-consent/src/lib/consent-value.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/consent-value.ts
@@ -1,0 +1,43 @@
+import { ConsentContext } from "./consent-context";
+
+export type ConditionalValue = {
+  value: boolean;
+  globalPrivacyControl: boolean;
+};
+
+/**
+ * A consent value can be a boolean:
+ *  - `true`: consent/opt-in
+ *  - `false`: revoke/opt-out
+ *
+ * A consent value can also be context-dependent, which means it will be decided based on
+ * information about the user's environment (browser). The `ConditionalValue` object maps the
+ * context conditions to the value that should be used:
+ *  - `value`: The default value if no context applies.
+ *  - `globalPrivacyControl`: The value to use if the user's browser has Global Privacy Control
+ *    enabled.
+ */
+export type ConsentValue = boolean | ConditionalValue;
+
+export type ConsentTypeToValue = {
+  [consentType: string]: ConsentValue;
+};
+
+export const resolveConsentValue = (
+  value: ConsentValue | undefined,
+  context: ConsentContext
+): boolean => {
+  if (value === undefined) {
+    return false;
+  }
+
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (context.globalPrivacyControl === true) {
+    return value.globalPrivacyControl;
+  }
+
+  return value.value;
+};

--- a/clients/privacy-center/packages/fides-consent/src/lib/index.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/index.ts
@@ -3,4 +3,7 @@
  * is then bundled into `fides-consent.js` and imported by Privacy Center app, so that
  * both can share the same consent logic.
  */
+export * from "./consent-config";
+export * from "./consent-context";
+export * from "./consent-value";
 export * from "./cookie";

--- a/clients/privacy-center/public/fides-consent-demo.html
+++ b/clients/privacy-center/public/fides-consent-demo.html
@@ -2,6 +2,22 @@
 <html>
   <head>
     <title>fides-consent script demo page</title>
+
+    <script>
+      // Allow override of `globalPrivacyControl` via a query parameter, which allows Cypress to
+      // test that behavior.
+      (() => {
+        if (window.navigator.globalPrivacyControl !== undefined) {
+          return;
+        }
+
+        const url = new URL(window.location);
+        window.navigator.globalPrivacyControl = JSON.parse(
+          url.searchParams.get("globalPrivacyControl")
+        );
+      })();
+    </script>
+
     <script src="/fides-consent.js"></script>
 
     <style>

--- a/clients/privacy-center/types/config.ts
+++ b/clients/privacy-center/types/config.ts
@@ -1,3 +1,5 @@
+import { ConsentValue } from "fides-consent";
+
 export type Config = {
   title: string;
   description: string;
@@ -26,7 +28,7 @@ export type PrivacyRequestOption = {
 
 export type ConfigConsentOption = {
   cookieKeys: string[];
-  default?: boolean;
+  default?: ConsentValue;
   description: string;
   fidesDataUseKey: string;
   highlight?: boolean;


### PR DESCRIPTION
Closes #2227 
This might cover #2228 but I'll need to run through the AC more before closing it.

### Code Changes

- pc/fides-consent: ConsentValue with ConsentContext to support GPC
- pc/consent: Resolve ConsentValue with ConsentContext.
- pc/config: Default data_sales consent to false for GPC


### Steps to Confirm

* [ ] You can enable GPC in [Firefox](https://blog.mozilla.org/netpolicy/2021/10/28/implementing-global-privacy-control/) or fake it by navigating to the demo page with the query parameter set: http://localhost:3000/fides-consent-demo.html?globalPrivacyControl=true. Also make sure you don't have consent saved (this PR only covers the default behavior).
* [ ] With GPC enabled, the demo page should show `"data_sales": false`
* [ ] With GPC disabled, the demo page should show `"data_sales": true`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

I'm going to comment on some relevant sections of the refactor.
