### PR TITLE
Rename `user_id` --> `ga_client_id`

### DIFF
--- a/src/fides/api/ctl/migrations/versions/392992c7733a_add_user_id_as_a_provided_identity_type.py
+++ b/src/fides/api/ctl/migrations/versions/392992c7733a_add_user_id_as_a_provided_identity_type.py
@@ -1,4 +1,4 @@
-"""Add user_id as a provided identity type
+"""Add ga_client_id as a provided identity type
 
 Revision ID: 392992c7733a
 Revises: de456534dbda
@@ -16,7 +16,7 @@ depends_on = None
 
 
 def upgrade():
-    op.execute("ALTER TYPE providedidentitytype ADD VALUE 'user_id'")
+    op.execute("ALTER TYPE providedidentitytype ADD VALUE 'ga_client_id'")
 
 
 def downgrade():

--- a/src/fides/api/ops/models/privacy_request.py
+++ b/src/fides/api/ops/models/privacy_request.py
@@ -767,7 +767,7 @@ class ProvidedIdentityType(EnumType):
 
     email = "email"
     phone_number = "phone_number"
-    user_id = "user_id"
+    ga_client_id = "ga_client_id"
 
 
 class ProvidedIdentity(Base):  # pylint: disable=R0904

--- a/src/fides/api/ops/schemas/redis_cache.py
+++ b/src/fides/api/ops/schemas/redis_cache.py
@@ -11,7 +11,7 @@ class Identity(BaseSchema):
 
     phone_number: Optional[str] = None
     email: Optional[str] = None
-    user_id: Optional[str] = None
+    ga_client_id: Optional[str] = None
 
     @validator("phone_number")
     @classmethod
@@ -25,6 +25,6 @@ class Identity(BaseSchema):
         return value
 
     class Config:
-        """Only allow phone_number, email, and user ID to be supplied"""
+        """Only allow phone_number, email, and GA client id to be supplied"""
 
         extra = Extra.forbid

--- a/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
@@ -715,7 +715,7 @@ class TestSaveConsent:
                 {"data_use": "advertising", "executable": True},
                 {"data_use": "improve", "executable": False},
             ],
-            "browser_identity": {"user_id": "test_user_id"},
+            "browser_identity": {"ga_client_id": "test_ga_client_id"},
         }
         response = api_client.patch(
             f"{V1_URL_PREFIX}{CONSENT_REQUEST_PREFERENCES_WITH_ID.format(consent_request_id=consent_request.id)}",
@@ -737,7 +737,7 @@ class TestSaveConsent:
             "create a Privacy Request provided identity "
         )
         assert identity.phone_number is None
-        assert identity.user_id == "test_user_id", (
+        assert identity.ga_client_id == "test_ga_client_id", (
             "Browser identity pulled from Consent Provided Identity and persisted "
             "to a Privacy Request provided identity"
         )

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -1284,7 +1284,7 @@ class TestGetPrivacyRequests:
         assert ast.literal_eval(first_row["Subject identity"]) == {
             "email": TEST_EMAIL,
             "phone_number": TEST_PHONE,
-            "user_id": None,
+            "ga_client_id": None,
         }
         assert first_row["Policy key"] == "example_access_request_policy"
         assert first_row["Request status"] == "approved"

--- a/tests/ops/models/test_consent_request.py
+++ b/tests/ops/models/test_consent_request.py
@@ -204,7 +204,7 @@ class TestQueuePrivacyRequestToPropagateConsentHelper:
             "encrypted_value": {"value": "test@email.com"},
         }
         provided_identity = ProvidedIdentity.create(db, data=provided_identity_data)
-        browser_identity = Identity(user_id="user_id_from_browser")
+        browser_identity = Identity(ga_client_id="user_id_from_browser")
 
         consent_preferences = ConsentPreferences(
             consent=[{"data_use": "advertising", "opt_in": False}]
@@ -225,6 +225,6 @@ class TestQueuePrivacyRequestToPropagateConsentHelper:
         call_kwargs = mock_create_privacy_request.call_args[1]
         identity_of_privacy_request = call_kwargs["data"][0].identity
         assert identity_of_privacy_request.email == "test@email.com"
-        assert identity_of_privacy_request.user_id == browser_identity.user_id
+        assert identity_of_privacy_request.ga_client_id == browser_identity.ga_client_id
 
         provided_identity.delete(db)


### PR DESCRIPTION
Patches up https://github.com/ethyca/fides/pull/2304 after some more conversation with @pattisdr 

### Code Changes

* [x] Rename all references of `user_id` to `ga_client_id`. Since this was merged to a feature branch, should be safe to make these changes directly instead of making another alembic migration

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Will also need to update https://github.com/ethyca/fides/pull/2337
