### PR TITLE
pc/api: Add common headers to base query

### DIFF
--- a/clients/privacy-center/common/CommonHeaders.ts
+++ b/clients/privacy-center/common/CommonHeaders.ts
@@ -1,11 +1,9 @@
-/* eslint-disable import/prefer-default-export */
-
 /**
- * Adds common headers to all api calls to fidesops
+ * Adds common headers to all api calls to fides
  */
-export function addCommonHeaders(headers: Headers, token: string | null) {
+export function addCommonHeaders(headers: Headers, token?: string | null) {
   headers.set("Access-Control-Allow-Origin", "*");
-  headers.set("X-Fides-Source", "fidesops-privacy-center");
+  headers.set("X-Fides-Source", "fides-privacy-center");
   headers.set("Accept", "application/json");
   headers.set("Content-Type", "application/json");
   if (token) {
@@ -13,5 +11,3 @@ export function addCommonHeaders(headers: Headers, token: string | null) {
   }
   return headers;
 }
-
-

--- a/clients/privacy-center/features/common/api.slice.ts
+++ b/clients/privacy-center/features/common/api.slice.ts
@@ -1,4 +1,5 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { addCommonHeaders } from "~/common/CommonHeaders";
 import { hostUrl } from "~/constants";
 
 /**
@@ -11,9 +12,7 @@ export const baseApi = createApi({
   reducerPath: "baseApi",
   baseQuery: fetchBaseQuery({
     baseUrl: hostUrl,
-    headers: {
-      "X-Fides-Source": "fides-privacy-center",
-    },
+    prepareHeaders: (headers) => addCommonHeaders(headers),
   }),
   tagTypes: [],
   endpoints: () => ({}),

--- a/clients/privacy-center/pages/index.tsx
+++ b/clients/privacy-center/pages/index.tsx
@@ -51,7 +51,7 @@ const Home: NextPage = () => {
       // TODO(#2299): Use error utils from shared package.
       const errorData = (getIdVerificationConfigQuery.error as any)?.data;
       toast({
-        description: errorData.detail,
+        description: errorData?.detail,
         ...ConfigErrorToastOptions,
       });
       return;


### PR DESCRIPTION
### Description Of Changes

The request done by the index page [wasn't](https://github.com/ethyca/fides/pull/2300/files#diff-8a8754ffd864b1b78f7740b3bab4da785a47767ec93102493ff4feef95283544L53) adding common headers, so when I used it as my first example for RTK queries I also left out that part. The most important header is probably the one that allows cross-origin requests, which probably too liberal but is necessary with Fides on a different domain.