### PR TITLE
Masking Strategies: Handle Null Values and Non-Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The types of changes are:
 * Home screen header scaling and responsiveness issues [#2200](https://github.com/ethyca/fides/pull/2277)
 * Added a feature flag for the recent dataset classification UX changes [#2335](https://github.com/ethyca/fides/pull/2335)
 * Privacy Center identity inputs validate even when they are optional. [#2308](https://github.com/ethyca/fides/pull/2308)
+* Patch masking strategies to better handle null and non-string inputs [#2307](https://github.com/ethyca/fides/pull/2377)
 
 ### Security
 

--- a/src/fides/api/ops/service/masking/strategy/masking_strategy_aes_encrypt.py
+++ b/src/fides/api/ops/service/masking/strategy/masking_strategy_aes_encrypt.py
@@ -40,6 +40,7 @@ class AesEncryptionMaskingStrategy(MaskingStrategy):
     ) -> Optional[List[str]]:
         if values is None:
             return None
+
         if self.mode == AesEncryptionMaskingConfiguration.Mode.GCM:
             masking_meta: Dict[
                 SecretType, MaskingSecretMeta
@@ -59,10 +60,14 @@ class AesEncryptionMaskingStrategy(MaskingStrategy):
 
             masked_values: List[str] = []
             for value in values:
+                if value is None:
+                    masked_values.append(None)
+                    continue
+
                 nonce: bytes | None = self._generate_nonce(
-                    value, key_hmac, request_id, masking_meta  # type: ignore
+                    str(value), key_hmac, request_id, masking_meta  # type: ignore
                 )
-                masked: str = encrypt(value, key, nonce)  # type: ignore
+                masked: str = encrypt(str(value), key, nonce)  # type: ignore
                 if self.format_preservation is not None:
                     formatter = FormatPreservation(self.format_preservation)
                     masked = formatter.format(masked)

--- a/src/fides/api/ops/service/masking/strategy/masking_strategy_aes_encrypt.py
+++ b/src/fides/api/ops/service/masking/strategy/masking_strategy_aes_encrypt.py
@@ -37,7 +37,7 @@ class AesEncryptionMaskingStrategy(MaskingStrategy):
 
     def mask(
         self, values: Optional[List[str]], request_id: Optional[str]
-    ) -> Optional[List[str]]:
+    ) -> Optional[List[Optional[str]]]:
         if values is None:
             return None
 
@@ -58,7 +58,7 @@ class AesEncryptionMaskingStrategy(MaskingStrategy):
             # and therefore the same masked val through the aes strategy. This is called convergent encryption, with this
             # implementation loosely based on https://www.vaultproject.io/docs/secrets/transit#convergent-encryption
 
-            masked_values: List[str] = []
+            masked_values: List[Optional[str]] = []
             for value in values:
                 if value is None:
                     masked_values.append(None)

--- a/src/fides/api/ops/service/masking/strategy/masking_strategy_hash.py
+++ b/src/fides/api/ops/service/masking/strategy/masking_strategy_hash.py
@@ -47,6 +47,7 @@ class HashMaskingStrategy(MaskingStrategy):
         is None"""
         if values is None:
             return None
+
         masking_meta: Dict[
             SecretType, MaskingSecretMeta
         ] = self._build_masking_secret_meta()
@@ -58,7 +59,11 @@ class HashMaskingStrategy(MaskingStrategy):
 
         masked_values: List[str] = []
         for value in values:
-            masked: str = self.algorithm_function(value, salt)  # type: ignore
+            if value is None:
+                masked_values.append(None)
+                continue
+
+            masked: str = self.algorithm_function(str(value), salt)  # type: ignore
             if self.format_preservation is not None:
                 formatter = FormatPreservation(self.format_preservation)
                 masked = formatter.format(masked)

--- a/src/fides/api/ops/service/masking/strategy/masking_strategy_hash.py
+++ b/src/fides/api/ops/service/masking/strategy/masking_strategy_hash.py
@@ -42,7 +42,7 @@ class HashMaskingStrategy(MaskingStrategy):
 
     def mask(
         self, values: Optional[List[str]], request_id: Optional[str]
-    ) -> Optional[List[str]]:
+    ) -> Optional[List[Optional[str]]]:
         """Returns the hashed version of the provided values. Returns None if the provided value
         is None"""
         if values is None:
@@ -57,7 +57,7 @@ class HashMaskingStrategy(MaskingStrategy):
             masking_meta[SecretType.salt],
         )
 
-        masked_values: List[str] = []
+        masked_values: List[Optional[str]] = []
         for value in values:
             if value is None:
                 masked_values.append(None)

--- a/src/fides/api/ops/service/masking/strategy/masking_strategy_hmac.py
+++ b/src/fides/api/ops/service/masking/strategy/masking_strategy_hmac.py
@@ -37,7 +37,7 @@ class HmacMaskingStrategy(MaskingStrategy):
 
     def mask(
         self, values: Optional[List[str]], request_id: Optional[str]
-    ) -> Optional[List[str]]:
+    ) -> Optional[List[Optional[str]]]:
         """
         Returns a hash using the hmac algorithm, generating a hash of each of the supplied value and the secret hmac_key.
         Returns None if the provided value is None.
@@ -55,7 +55,7 @@ class HmacMaskingStrategy(MaskingStrategy):
             request_id, SecretType.salt, masking_meta[SecretType.salt]
         )
 
-        masked_values: List[str] = []
+        masked_values: List[Optional[str]] = []
         for value in values:
             if value is None:
                 masked_values.append(None)

--- a/src/fides/api/ops/service/masking/strategy/masking_strategy_hmac.py
+++ b/src/fides/api/ops/service/masking/strategy/masking_strategy_hmac.py
@@ -44,6 +44,7 @@ class HmacMaskingStrategy(MaskingStrategy):
         """
         if values is None:
             return None
+
         masking_meta: Dict[
             SecretType, MaskingSecretMeta
         ] = self._build_masking_secret_meta()
@@ -56,7 +57,10 @@ class HmacMaskingStrategy(MaskingStrategy):
 
         masked_values: List[str] = []
         for value in values:
-            masked: str = hmac_encrypt_return_str(value, key, salt, self.algorithm)  # type: ignore
+            if value is None:
+                masked_values.append(None)
+                continue
+            masked: str = hmac_encrypt_return_str(str(value), key, salt, self.algorithm)  # type: ignore
             if self.format_preservation is not None:
                 formatter = FormatPreservation(self.format_preservation)
                 masked = formatter.format(masked)

--- a/src/fides/api/ops/service/masking/strategy/masking_strategy_random_string_rewrite.py
+++ b/src/fides/api/ops/service/masking/strategy/masking_strategy_random_string_rewrite.py
@@ -34,6 +34,7 @@ class RandomStringRewriteMaskingStrategy(MaskingStrategy):
         """Replaces the value with a random lowercase string of the configured length"""
         if values is None:
             return None
+
         masked_values: List[str] = []
         for _ in range(len(values)):
             masked: str = "".join(

--- a/tests/ops/service/masking/strategy/test_masking_strategy_hash.py
+++ b/tests/ops/service/masking/strategy/test_masking_strategy_hash.py
@@ -118,7 +118,7 @@ def test_mask_arguments_null_in_list():
 def test_mask_datetime():
     configuration = HashMaskingConfiguration()
     masker = HashMaskingStrategy(configuration)
-    expected = ["Sb9RzoQls/Nymd23qY4ZXoy/HBDrZAxeRgKNYv5LwwxlsPE="]
+    expected = ["a6597d576d8fb7ff58047db31f6c526bf984db454fa2460cdf7cf4f9d72a6d09"]
 
     secret = MaskingSecretCache[str](
         secret="adobo",

--- a/tests/ops/service/masking/strategy/test_masking_strategy_hash.py
+++ b/tests/ops/service/masking/strategy/test_masking_strategy_hash.py
@@ -1,8 +1,7 @@
+from datetime import datetime
+
 from fides.api.ops.schemas.masking.masking_configuration import HashMaskingConfiguration
 from fides.api.ops.schemas.masking.masking_secrets import MaskingSecretCache, SecretType
-from fides.api.ops.service.masking.strategy.masking_strategy_aes_encrypt import (
-    AesEncryptionMaskingStrategy,
-)
 from fides.api.ops.service.masking.strategy.masking_strategy_hash import (
     HashMaskingStrategy,
 )
@@ -95,5 +94,39 @@ def test_mask_arguments_null():
     cache_secret(secret, request_id)
 
     masked = masker.mask(None, request_id)
+    assert expected == masked
+    clear_cache_secrets(request_id)
+
+
+def test_mask_arguments_null_in_list():
+    configuration = HashMaskingConfiguration()
+    masker = HashMaskingStrategy(configuration)
+    expected = [None]
+
+    secret = MaskingSecretCache[str](
+        secret="adobo",
+        masking_strategy=HashMaskingStrategy.name,
+        secret_type=SecretType.salt,
+    )
+    cache_secret(secret, request_id)
+
+    masked = masker.mask([None], request_id)
+    assert expected == masked
+    clear_cache_secrets(request_id)
+
+
+def test_mask_datetime():
+    configuration = HashMaskingConfiguration()
+    masker = HashMaskingStrategy(configuration)
+    expected = ["Sb9RzoQls/Nymd23qY4ZXoy/HBDrZAxeRgKNYv5LwwxlsPE="]
+
+    secret = MaskingSecretCache[str](
+        secret="adobo",
+        masking_strategy=HashMaskingStrategy.name,
+        secret_type=SecretType.salt,
+    )
+    cache_secret(secret, request_id)
+
+    masked = masker.mask([datetime(2000, 1, 1)], request_id)
     assert expected == masked
     clear_cache_secrets(request_id)

--- a/tests/ops/service/masking/strategy/test_masking_strategy_hmac.py
+++ b/tests/ops/service/masking/strategy/test_masking_strategy_hmac.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fides.api.ops.schemas.masking.masking_configuration import HmacMaskingConfiguration
 from fides.api.ops.schemas.masking.masking_secrets import MaskingSecretCache, SecretType
 from fides.api.ops.service.masking.strategy.masking_strategy_hmac import (
@@ -122,5 +124,51 @@ def test_mask_arguments_null():
     cache_secret(secret_salt, request_id)
 
     masked = masker.mask(None, request_id)
+    assert expected == masked
+    clear_cache_secrets(request_id)
+
+
+def test_mask_arguments_null_list():
+    configuration = HmacMaskingConfiguration()
+    masker = HmacMaskingStrategy(configuration)
+    expected = [None]
+
+    secret_key = MaskingSecretCache[str](
+        secret="test_key",
+        masking_strategy=HmacMaskingStrategy.name,
+        secret_type=SecretType.key,
+    )
+    cache_secret(secret_key, request_id)
+    secret_salt = MaskingSecretCache[str](
+        secret="test_salt",
+        masking_strategy=HmacMaskingStrategy.name,
+        secret_type=SecretType.salt,
+    )
+    cache_secret(secret_salt, request_id)
+
+    masked = masker.mask([None], request_id)
+    assert expected == masked
+    clear_cache_secrets(request_id)
+
+
+def test_mask_arguments_date():
+    configuration = HmacMaskingConfiguration()
+    masker = HmacMaskingStrategy(configuration)
+    expected = ["68cecd9f5bf6c4788da1513d64867b83eca1f7a260be104cb7a437dc863fc917"]
+
+    secret_key = MaskingSecretCache[str](
+        secret="test_key",
+        masking_strategy=HmacMaskingStrategy.name,
+        secret_type=SecretType.key,
+    )
+    cache_secret(secret_key, request_id)
+    secret_salt = MaskingSecretCache[str](
+        secret="test_salt",
+        masking_strategy=HmacMaskingStrategy.name,
+        secret_type=SecretType.salt,
+    )
+    cache_secret(secret_salt, request_id)
+
+    masked = masker.mask([datetime(2000, 1, 1)], request_id)
     assert expected == masked
     clear_cache_secrets(request_id)


### PR DESCRIPTION
Closes: #2391

### Code Changes

* [ ] Hash, Hmac, and AES Encrypt masking strategies adjusted to better handle null values and non-strings (here we try to coerce to a string instead of failing)

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Several of our masking strategies are set up to expect values to be strings.  There are some early exits if the input value is None, but since most inputs are now a list of values, even a list of one value, so that's not likely to be True.


If an array of values are passed in, if the original index is None, do nothing to that index.  Also try to coerce the original value to a string.