### PR TITLE
Show request type instead of policy name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The types of changes are:
 * Unified Fides Resources: Validate request body on crud endpoints on upsert. Validate dataset data categories before save. [#2134](https://github.com/ethyca/fides/pull/2134/)
 * Unified Fides Resources: Updated test env setup and quickstart to use new endpoints [#2225](https://github.com/ethyca/fides/pull/2225)
 * Update fideslang to 1.3.3 [#2343](https://github.com/ethyca/fides/pull/2343)
+* Display the request type instead of the policy name on the request table [#2382](https://github.com/ethyca/fides/pull/2382)
 
 ### Fixed
 

--- a/clients/admin-ui/src/features/common/RequestType.tsx
+++ b/clients/admin-ui/src/features/common/RequestType.tsx
@@ -23,8 +23,6 @@ const RequestType = ({ rules }: RequestTypeProps) => {
       bg="primary.400"
       fontWeight="medium"
       fontSize="sm"
-      mr={1}
-      mb={4}
     >
       {action_type}
     </Tag>

--- a/clients/admin-ui/src/features/common/RequestType.tsx
+++ b/clients/admin-ui/src/features/common/RequestType.tsx
@@ -2,6 +2,8 @@ import { Box, Tag } from "@fidesui/react";
 import { ActionType, Rule } from "privacy-requests/types";
 import React from "react";
 
+import { capitalize } from "~/features/common/utils";
+
 type RequestTypeProps = {
   rules: Rule[];
 };
@@ -11,9 +13,7 @@ const RequestType = ({ rules }: RequestTypeProps) => {
     new Set(
       rules
         .filter((d) => Object.values(ActionType).includes(d.action_type))
-        .map((d) =>
-          d.action_type === ActionType.ACCESS ? "Download" : "Delete"
-        )
+        .map((d) => capitalize(d.action_type))
     )
   );
   const tags = actions.map((action_type) => (

--- a/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
@@ -1,4 +1,4 @@
-import { Divider, Flex, Heading, HStack, Text, Box } from "@fidesui/react";
+import { Box,Divider, Flex, Heading, HStack, Text } from "@fidesui/react";
 import DaysLeftTag from "common/DaysLeftTag";
 import { PrivacyRequestEntity } from "privacy-requests/types";
 
@@ -44,8 +44,7 @@ const RequestDetails = ({ subjectRequest }: RequestDetailsProps) => {
           Request Type:
         </Text>
         <Box mr={1} mb={4}>
-
-          <RequestType rules={policy.rules}  />
+          <RequestType rules={policy.rules} />
         </Box>
       </Flex>
       <Flex alignItems="flex-start">

--- a/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
@@ -1,4 +1,4 @@
-import { Box,Divider, Flex, Heading, HStack, Text } from "@fidesui/react";
+import { Box, Divider, Flex, Heading, HStack, Text } from "@fidesui/react";
 import DaysLeftTag from "common/DaysLeftTag";
 import { PrivacyRequestEntity } from "privacy-requests/types";
 

--- a/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
@@ -1,4 +1,4 @@
-import { Divider, Flex, Heading, HStack, Text } from "@fidesui/react";
+import { Divider, Flex, Heading, HStack, Text, Box } from "@fidesui/react";
 import DaysLeftTag from "common/DaysLeftTag";
 import { PrivacyRequestEntity } from "privacy-requests/types";
 
@@ -43,7 +43,10 @@ const RequestDetails = ({ subjectRequest }: RequestDetailsProps) => {
         <Text mb={4} mr={2} fontSize="sm" color="gray.900" fontWeight="500">
           Request Type:
         </Text>
-        <RequestType rules={policy.rules} />
+        <Box mr={1} mb={4}>
+
+          <RequestType rules={policy.rules}  />
+        </Box>
       </Flex>
       <Flex alignItems="flex-start">
         <Text mb={4} mr={2} fontSize="sm" color="gray.900" fontWeight="500">

--- a/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
@@ -10,7 +10,6 @@ import {
   MenuList,
   MoreIcon,
   Portal,
-  Tag,
   Td,
   Text,
   Tr,
@@ -34,6 +33,7 @@ import {
   useDenyRequestMutation,
 } from "./privacy-requests.slice";
 import { PrivacyRequestEntity } from "./types";
+import RequestType from "common/RequestType";
 
 const useRequestRow = (request: PrivacyRequestEntity) => {
   const {
@@ -183,16 +183,7 @@ const RequestRow: React.FC<{
         />
       </Td>
       <Td py={1}>
-        <Tag
-          color="white"
-          bg="primary.400"
-          px={2}
-          py={0.5}
-          size="sm"
-          fontWeight="medium"
-        >
-          {request.policy.name}
-        </Tag>
+        <RequestType rules={request.policy.rules}/>
       </Td>
       <Td py={1}>
         <Text fontSize="xs">

--- a/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
@@ -17,6 +17,7 @@ import {
   useToast,
 } from "@fidesui/react";
 import DaysLeftTag from "common/DaysLeftTag";
+import RequestType from "common/RequestType";
 import { formatDate } from "common/utils";
 import { useRouter } from "next/router";
 import React, { useRef, useState } from "react";
@@ -33,7 +34,6 @@ import {
   useDenyRequestMutation,
 } from "./privacy-requests.slice";
 import { PrivacyRequestEntity } from "./types";
-import RequestType from "common/RequestType";
 
 const useRequestRow = (request: PrivacyRequestEntity) => {
   const {
@@ -183,7 +183,7 @@ const RequestRow: React.FC<{
         />
       </Td>
       <Td py={1}>
-        <RequestType rules={request.policy.rules}/>
+        <RequestType rules={request.policy.rules} />
       </Td>
       <Td py={1}>
         <Text fontSize="xs">


### PR DESCRIPTION
Closes #2282 

### Code Changes

* [ ] Display request type on privacy request table
* [ ] Remove margin from the `RequestType` component and add it to a wrapper div instead

### Steps to Confirm

* [ ] Run `nox -s dev`, the admin ui, and the privacy center
* [ ] Create access and erasure requests
* [ ] See the updated display in the requests table

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Quick change to display the request type in the privacy requests table

<img width="807" alt="Screenshot 2023-01-26 at 11 50 54" src="https://user-images.githubusercontent.com/17103888/214898088-03bf2d03-0095-4dcb-9945-37d9ea707e75.png">


The request details page still looks correct because the margin was moved.

<img width="582" alt="Screenshot 2023-01-26 at 11 51 23" src="https://user-images.githubusercontent.com/17103888/214898137-db63fdb3-08a2-4f1b-b524-222e4ec08b3b.png">


