### PR TITLE
Skip Missing Param Values

### DIFF
--- a/data/saas/config/google_analytics_config.yml
+++ b/data/saas/config/google_analytics_config.yml
@@ -92,6 +92,7 @@ saas_config:
     opt_out:
       method: POST
       path: /analytics/v3/userDeletion/userDeletionRequests:upsert
+      skip_missing_param_values: true
       param_values:
         - name: ga_client_id
           identity: ga_client_id

--- a/src/fides/api/ops/schemas/saas/saas_config.py
+++ b/src/fides/api/ops/schemas/saas/saas_config.py
@@ -104,7 +104,9 @@ class SaaSRequest(BaseModel):
     grouped_inputs: Optional[List[str]] = []
     ignore_errors: Optional[bool] = False
     rate_limit_config: Optional[RateLimitConfig]
-    skip_missing_param_values: Optional[bool] = False
+    skip_missing_param_values: Optional[
+        bool
+    ] = False  # Skip instead of raising an exception if placeholders can't be populated in body
 
     class Config:
         """Populate models with the raw value of enum fields, rather than the enum itself"""

--- a/src/fides/api/ops/schemas/saas/saas_config.py
+++ b/src/fides/api/ops/schemas/saas/saas_config.py
@@ -104,6 +104,7 @@ class SaaSRequest(BaseModel):
     grouped_inputs: Optional[List[str]] = []
     ignore_errors: Optional[bool] = False
     rate_limit_config: Optional[RateLimitConfig]
+    skip_missing_param_values: Optional[bool] = False
 
     class Config:
         """Populate models with the raw value of enum fields, rather than the enum itself"""

--- a/src/fides/api/ops/service/connectors/saas_connector.py
+++ b/src/fides/api/ops/service/connectors/saas_connector.py
@@ -399,15 +399,25 @@ class SaaSConnector(BaseConnector[AuthenticatedClient]):
             cast(Optional[List[PostProcessorStrategy]], masking_request.postprocessors),
         )
 
-        prepared_requests = [
-            query_config.generate_update_stmt(row, policy, privacy_request)
-            for row in rows
-        ]
         rows_updated = 0
         client = self.create_client()
-        for prepared_request in prepared_requests:
+        for row in rows:
+            try:
+                prepared_request = query_config.generate_update_stmt(
+                    row, policy, privacy_request
+                )
+            except ValueError as exc:
+                if masking_request.skip_missing_param_values:
+                    logger.info(
+                        "Skipping optional masking request on node {}: {}",
+                        node.address.value,
+                        exc,
+                    )
+                    continue
+                raise exc
             client.send(prepared_request, masking_request.ignore_errors)
             rows_updated += 1
+
         self.unset_connector_state()
         return rows_updated
 

--- a/src/fides/api/ops/service/connectors/saas_query_config.py
+++ b/src/fides/api/ops/service/connectors/saas_query_config.py
@@ -187,12 +187,22 @@ class SaaSQueryConfig(QueryConfig[SaaSRequestParams]):
                 input_data, filtered_secrets, grouped_inputs
             )
             for param_value_map in param_value_maps:
-                request_params.append(
-                    self.generate_query(
-                        {name: [value] for name, value in param_value_map.items()},
-                        policy,
+                try:
+                    request_params.append(
+                        self.generate_query(
+                            {name: [value] for name, value in param_value_map.items()},
+                            policy,
+                        )
                     )
-                )
+                except ValueError as exc:
+                    if read_request.skip_missing_param_values:
+                        logger.info(
+                            "Skipping optional read request on node {}: {}",
+                            self.node.address.value,
+                            exc,
+                        )
+                        continue
+                    raise exc
 
         return request_params
 

--- a/tests/ops/integration_tests/saas/test_mailchimp_transactional_task.py
+++ b/tests/ops/integration_tests/saas/test_mailchimp_transactional_task.py
@@ -1,5 +1,4 @@
 import json
-import random
 from unittest import mock
 from uuid import uuid4
 

--- a/tests/ops/service/connectors/test_saas_connector.py
+++ b/tests/ops/service/connectors/test_saas_connector.py
@@ -282,6 +282,79 @@ class TestSaasConnector:
             == []
         )
 
+    @mock.patch(
+        "fides.api.ops.service.connectors.saas_connector.AuthenticatedClient.send"
+    )
+    def test_skip_missing_param_values_masking(
+        self, mock_send: Mock, saas_example_config, saas_example_connection_config
+    ):
+        """
+        Verifies skip_missing_param_values behavior for Connector.mask_data.
+
+        If skip_missing_param_values=True and we couldn't populate the placeholders in the body,
+        we just skip the request instead of raising an exception
+        """
+        # mock the json response from calling the data_management request
+        mock_send().json.return_value = 1
+
+        saas_config = SaaSConfig(**saas_example_config)
+        graph = saas_config.get_graph(saas_example_connection_config.secrets)
+        node = Node(
+            graph,
+            next(
+                collection
+                for collection in graph.collections
+                if collection.name == "data_management"
+            ),
+        )
+
+        traversal_node = TraversalNode(node)
+        connector: SaaSConnector = get_connector(saas_example_connection_config)
+
+        # Base case - we can populate all placeholders in request body
+        assert (
+            connector.mask_data(
+                traversal_node,
+                Policy(),
+                PrivacyRequest(id="123"),
+                {"customer_id": 1},
+                {"phone_number": "555-555-5555"},
+            )
+            == 1
+        )
+
+        #  Mock adding a new placeholder to the request body for which we don't have a value
+        connector.endpoints[
+            "data_management"
+        ].requests.update.body = (
+            '{\n  "unique_id": "<privacy_request_id>", "email": "<placeholder>"\n}\n'
+        )
+
+        # Should raise ValueError because we don't have email value for request body
+        with pytest.raises(ValueError):
+            connector.mask_data(
+                traversal_node,
+                Policy(),
+                PrivacyRequest(id="123"),
+                {"customer_id": 1},
+                {"phone_number": "555-555-5555"},
+            )
+
+        # Set skip_missing_param_values to True, so the missing placeholder just causes the request to be skipped
+        connector.endpoints[
+            "data_management"
+        ].requests.update.skip_missing_param_values = True
+        assert (
+            connector.mask_data(
+                traversal_node,
+                Policy(),
+                PrivacyRequest(id="123"),
+                {"customer_id": 1},
+                {"phone_number": "555-555-5555"},
+            )
+            == 0
+        )
+
 
 @pytest.mark.integration_saas
 @pytest.mark.integration_segment

--- a/tests/ops/service/connectors/test_saas_queryconfig.py
+++ b/tests/ops/service/connectors/test_saas_queryconfig.py
@@ -7,7 +7,7 @@ import pytest
 
 from fides.api.ops.graph.config import CollectionAddress
 from fides.api.ops.graph.graph import DatasetGraph
-from fides.api.ops.graph.traversal import Traversal
+from fides.api.ops.graph.traversal import Traversal, TraversalNode
 from fides.api.ops.models.connectionconfig import ConnectionConfig
 from fides.api.ops.models.datasetconfig import DatasetConfig
 from fides.api.ops.models.privacy_request import PrivacyRequest
@@ -15,6 +15,7 @@ from fides.api.ops.schemas.saas.saas_config import ParamValue, SaaSConfig, SaaSR
 from fides.api.ops.schemas.saas.shared_schemas import HTTPMethod, SaaSRequestParams
 from fides.api.ops.service.connectors.saas_query_config import SaaSQueryConfig
 from fides.core.config import get_config
+from tests.ops.graph.graph_test_util import generate_node
 
 CONFIG = get_config()
 privacy_request = PrivacyRequest(id="234544")
@@ -558,6 +559,54 @@ class TestSaaSQueryConfig:
             endpoints["mailing_lists"].requests.read,
         )
         assert len(prepared_requests) == 3
+
+    def test_skip_missing_param_values_read_request(self, policy):
+        """Test read requests with missing param values in body skipped instead of erroring if
+        skip_missing_param_values is set"""
+
+        config = SaaSQueryConfig(
+            generate_node("test_dataset", "test_collection", "test_field"),
+            {},
+            {},
+        )
+
+        read_request = SaaSRequest(  # Contrived request - we often don't have request bodies for read requests.
+            method="GET",
+            path="/api/0/user/",
+            body='{"email": "<email>"}',
+            param_values=[{"name": "email", "identity": "email"}],
+        )
+
+        # Base sanity check - one prepared request created, with email placeholder added to body
+        prepared_requests: List[SaaSRequestParams] = config.generate_requests(
+            {
+                "email": ["customer-1example.com"],
+            },
+            policy,
+            read_request,
+        )
+        assert len(prepared_requests) == 1
+
+        # Verify generate_requests errors because we don't have email placeholder to add to body
+        with pytest.raises(ValueError):
+            config.generate_requests(
+                {
+                    "phone_number": ["111-111-1111"],
+                },
+                policy,
+                read_request,
+            )
+
+        # Verify with skip_missing_param_values, we skip building a prepared request instead of erroring
+        read_request.skip_missing_param_values = True
+        prepared_requests: List[SaaSRequestParams] = config.generate_requests(
+            {
+                "phone_number": ["111-111-1111"],
+            },
+            policy,
+            read_request,
+        )
+        assert len(prepared_requests) == 0
 
 
 class TestGenerateProductList:


### PR DESCRIPTION
Closes #2375 

### Code Changes

* [ ] Add a new `SaaSRequest.skip_missing_param_values` attribute with a default value of False 
* [ ] Set the google analytics opt out request to have skip_missing_param_values=true
* [ ] Update SaaSConnector.run_consent_request to skip sending a request if we can't replace all the placeholder values in the request rather than fail, provided skip_missing_param_values=true

### Steps to Confirm

* [ ] Update privacy center test env config.json to have advertising.first_party be executable=true
* [ ] Run `nox -s test_env`
* [ ] Set up the GA consent connector locally
* [ ] Go to the privacy center, delete your ga cookie `_ga="GA1.1.XXXXXXXXX.XXXXXXXXX"`from the browser
* [ ]  In the privacy center, update your consent preferences: Specifically opt out of Email Marketing
* [ ] Go to admin app, approve the privacy request
* [ ] Verify privacy request completes instead of errors
* [ ] Verify in docker container that no request was made to GA, instead you see a log: `Skipping optional consent request on node google_analytics:google_analytics: Unable to replace placeholders in body for the 'opt_out' request of google_analytics`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Add a new SaasRequest.skip_missing_param_values to indicate whether we should skip an http request when we can't map all the param values in the request body rather than fail.  

For example, we pull the google analytics client id from the browser for the google analytics consent connector but it isn't always guaranteed to exist.  Rather than having that request fail, we should just skip it.

Functionality added for retrieve_data, mask_data, and run_consent_request, although this is unlikely to be needed for read requests.  (It affects when we can't place param values in the body only)
