### PR TITLE
Admin reset password frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The types of changes are:
 * Unified Fides Resources: Added new datasetconfig.ctl_dataset_id field to unify fides dataset resources [#2046](https://github.com/ethyca/fides/pull/2046)
 * Add new connection config routes that couple them with systems [#2249](https://github.com/ethyca/fides/pull/2249)
 * Endpoints to allow a user with the `user:password-reset` scope to reset users' passwords. In addition, users no longer require a scope to edit their own passwords. [#2373](https://github.com/ethyca/fides/pull/2373)
+* New form to reset a user's password without knowing an old password [#2390](https://github.com/ethyca/fides/pull/2390)
 
 ### Changed
 

--- a/clients/admin-ui/cypress/e2e/user-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/user-management.cy.ts
@@ -1,0 +1,135 @@
+import { utf8ToB64 } from "~/features/common/utils";
+
+const CYPRESS_USER_ID = "123";
+const USER_1_ID = "fid_ee8f54ce-19f7-4640-b311-1cc1e77e7166";
+
+describe("User management", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.intercept("/api/v1/user?*", {
+      fixture: "user-management/users.json",
+    }).as("getAllUsers");
+    cy.intercept("/api/v1/user/*", { fixture: "user-management/user.json" }).as(
+      "getUser"
+    );
+    cy.intercept("/api/v1/user/*/permission", {
+      fixture: "user-management/permissions.json",
+    }).as("getPermissions");
+  });
+
+  describe("View users", () => {
+    it("can view all users", () => {
+      cy.visit("/user-management");
+      cy.wait("@getAllUsers");
+      const numUsers = 4;
+      cy.getByTestId("user-management-table")
+        .find("tbody > tr")
+        .then((rows) => {
+          expect(rows.length).to.eql(numUsers);
+        });
+    });
+  });
+
+  describe("Password management", () => {
+    it("can update their own password", () => {
+      cy.intercept("POST", "/api/v1/user/*/reset-password", {
+        fixture: "user-management/user.json",
+      }).as("postResetPassword");
+
+      const oldPassword = "g00dPassword!";
+      const newPassword = "b3tt3rPassword!";
+      cy.visit(`/user-management/profile/${CYPRESS_USER_ID}`);
+      cy.wait("@getUser");
+      cy.wait("@getPermissions");
+      cy.getByTestId("update-password-btn").click();
+      cy.getByTestId("input-oldPassword").type(oldPassword);
+      cy.getByTestId("input-newPassword").type(newPassword);
+      cy.getByTestId("submit-btn").click();
+
+      cy.wait("@postResetPassword").then((interception) => {
+        const { body, url } = interception.request;
+        expect(url).to.contain(CYPRESS_USER_ID);
+        expect(body).to.eql({
+          old_password: utf8ToB64(oldPassword),
+          new_password: utf8ToB64(newPassword),
+        });
+      });
+    });
+
+    it("cannot update another user's password", () => {
+      cy.intercept("/api/v1/user/*", {
+        body: {
+          id: USER_1_ID,
+          username: "user_1",
+          created_at: "2023-01-26T16:16:49.575653+00:00",
+          first_name: "User",
+          last_name: "One",
+        },
+      }).as("getOtherUser");
+      cy.visit(`/user-management/profile/${USER_1_ID}`);
+      cy.wait("@getOtherUser");
+      cy.wait("@getPermissions");
+      cy.getByTestId("update-password-btn").should("not.exist");
+    });
+
+    it("can reset another user's password", () => {
+      const newPassword = "b3tt3rPassword!";
+      cy.intercept("/api/v1/user/*", {
+        body: {
+          id: USER_1_ID,
+          username: "user_1",
+          created_at: "2023-01-26T16:16:49.575653+00:00",
+          first_name: "User",
+          last_name: "One",
+        },
+      }).as("getOtherUser");
+      cy.intercept("POST", "/api/v1/user/*/force-reset-password", {
+        fixture: "user-management/user.json",
+      }).as("postForceResetPassword");
+
+      cy.visit(`/user-management/profile/${USER_1_ID}`);
+      cy.wait("@getOtherUser");
+      cy.wait("@getPermissions");
+      cy.getByTestId("reset-password-btn").click();
+      cy.getByTestId("input-password").type(newPassword);
+      cy.getByTestId("input-passwordConfirmation").type(newPassword);
+      cy.getByTestId("submit-btn").click();
+
+      cy.wait("@postForceResetPassword").then((interception) => {
+        const { body, url } = interception.request;
+        expect(url).to.contain(USER_1_ID);
+        expect(body).to.eql({
+          new_password: utf8ToB64(newPassword),
+        });
+      });
+    });
+
+    it("only show reset button if user has the scope for it", () => {
+      cy.fixture("user-management/permissions.json").then((permissions) => {
+        cy.intercept(`/api/v1/user/${CYPRESS_USER_ID}/permission`, {
+          body: {
+            ...permissions,
+            scopes: permissions.scopes.filter(
+              (scope) => scope !== "user:password-reset"
+            ),
+          },
+        }).as("getUserPermissionWithoutPasswordReset");
+      });
+      cy.intercept("/api/v1/user/*", {
+        body: {
+          id: USER_1_ID,
+          username: "user_1",
+          created_at: "2023-01-26T16:16:49.575653+00:00",
+          first_name: "User",
+          last_name: "One",
+        },
+      }).as("getOtherUser");
+
+      cy.visit(`/user-management/profile/${USER_1_ID}`);
+      cy.wait("@getOtherUser");
+      cy.wait("@getUserPermissionWithoutPasswordReset");
+      cy.wait("@getPermissions");
+      cy.getByTestId("reset-password-btn").should("not.exist");
+    });
+  });
+});

--- a/clients/admin-ui/cypress/fixtures/user-management/permissions.json
+++ b/clients/admin-ui/cypress/fixtures/user-management/permissions.json
@@ -1,0 +1,33 @@
+{
+  "scopes": [
+    "privacy-request:read",
+    "privacy-request:review",
+    "privacy-request:resume",
+    "connection:read",
+    "connection:create_or_update",
+    "connection:instantiate",
+    "connection_type:read",
+    "connection:delete",
+    "consent:read",
+    "dataset:read",
+    "dataset:create_or_update",
+    "dataset:delete",
+    "policy:read",
+    "policy:create_or_update",
+    "user:read",
+    "user:create",
+    "user:update",
+    "user:delete",
+    "user:password-reset",
+    "user-permission:create",
+    "user-permission:update",
+    "user-permission:read",
+    "privacy-request:upload_data",
+    "privacy-request:view_data",
+    "webhook:create_or_update",
+    "webhook:read",
+    "webhook:delete"
+  ],
+  "id": "123",
+  "user_id": "123"
+}

--- a/clients/admin-ui/cypress/fixtures/user-management/user.json
+++ b/clients/admin-ui/cypress/fixtures/user-management/user.json
@@ -1,0 +1,7 @@
+{
+  "id": "123",
+  "username": "cypress-user@ethyca.com",
+  "created_at": "2022-09-28T16:15:30.994Z",
+  "first_name": "Cypress",
+  "last_name": "User"
+}

--- a/clients/admin-ui/cypress/fixtures/user-management/users.json
+++ b/clients/admin-ui/cypress/fixtures/user-management/users.json
@@ -1,0 +1,35 @@
+{
+  "items": [
+    {
+      "id": "fid_bad38cda-476b-4d25-9883-798ba1415f40",
+      "username": "user_3",
+      "created_at": "2023-01-26T16:24:50.718476+00:00",
+      "first_name": "User",
+      "last_name": "Three"
+    },
+    {
+      "id": "fid_560cceb5-f567-4d76-a905-1e16ada1c143",
+      "username": "user_2",
+      "created_at": "2023-01-26T16:23:56.023966+00:00",
+      "first_name": "User",
+      "last_name": "Two"
+    },
+    {
+      "id": "fid_ee8f54ce-19f7-4640-b311-1cc1e77e7166",
+      "username": "user_1",
+      "created_at": "2023-01-26T16:16:49.575653+00:00",
+      "first_name": "User",
+      "last_name": "One"
+    },
+    {
+      "id": "123",
+      "username": "cypress-user@ethyca.com",
+      "created_at": "2022-09-28T16:15:30.994Z",
+      "first_name": "Cypress",
+      "last_name": "User"
+    }
+  ],
+  "total": 4,
+  "page": 1,
+  "size": 25
+}

--- a/clients/admin-ui/src/constants.ts
+++ b/clients/admin-ui/src/constants.ts
@@ -85,6 +85,10 @@ export const USER_PRIVILEGES: UserPrivileges[] = [
     scope: "user:delete",
   },
   {
+    privilege: "Reset another user's password",
+    scope: "user:password-reset",
+  },
+  {
     privilege: "Assign user permissions",
     scope: "user-permission:create",
   },

--- a/clients/admin-ui/src/features/common/form/validation.ts
+++ b/clients/admin-ui/src/features/common/form/validation.ts
@@ -1,0 +1,9 @@
+import * as Yup from "yup";
+
+export const passwordValidation = Yup.string()
+  .required()
+  .min(8, "Password must have at least eight characters.")
+  .matches(/[0-9]/, "Password must have at least one number.")
+  .matches(/[A-Z]/, "Password must have at least one capital letter.")
+  .matches(/[a-z]/, "Password must have at least one lowercase letter.")
+  .matches(/[\W]/, "Password must have at least one symbol.");

--- a/clients/admin-ui/src/features/user-management/EditUserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/EditUserForm.tsx
@@ -41,16 +41,12 @@ const useUserForm = (profile: User, permissions: UserPermissions) => {
       ? userPermissions.scopes.includes("user:update")
       : false;
   }
-  const canForceResetPassword = userPermissions
-    ? userPermissions.scopes.includes("user:password-reset")
-    : false;
 
   return {
     handleSubmit,
     isOwnProfile,
     canUpdateUser,
     initialValues,
-    canForceResetPassword,
   };
 };
 
@@ -59,13 +55,8 @@ interface Props {
   permissions: UserPermissions;
 }
 const EditUserForm = ({ user, permissions }: Props) => {
-  const {
-    isOwnProfile,
-    handleSubmit,
-    canUpdateUser,
-    initialValues,
-    canForceResetPassword,
-  } = useUserForm(user, permissions);
+  const { isOwnProfile, handleSubmit, canUpdateUser, initialValues } =
+    useUserForm(user, permissions);
 
   return (
     <div>
@@ -79,7 +70,6 @@ const EditUserForm = ({ user, permissions }: Props) => {
           initialValues={initialValues}
           canEditNames={canUpdateUser}
           canChangePassword={isOwnProfile}
-          canForceResetPassword={canForceResetPassword}
         />
       </main>
     </div>

--- a/clients/admin-ui/src/features/user-management/EditUserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/EditUserForm.tsx
@@ -41,12 +41,16 @@ const useUserForm = (profile: User, permissions: UserPermissions) => {
       ? userPermissions.scopes.includes("user:update")
       : false;
   }
+  const canForceResetPassword = userPermissions
+    ? userPermissions.scopes.includes("user:password-reset")
+    : false;
 
   return {
     handleSubmit,
     isOwnProfile,
     canUpdateUser,
     initialValues,
+    canForceResetPassword,
   };
 };
 
@@ -55,8 +59,13 @@ interface Props {
   permissions: UserPermissions;
 }
 const EditUserForm = ({ user, permissions }: Props) => {
-  const { isOwnProfile, handleSubmit, canUpdateUser, initialValues } =
-    useUserForm(user, permissions);
+  const {
+    isOwnProfile,
+    handleSubmit,
+    canUpdateUser,
+    initialValues,
+    canForceResetPassword,
+  } = useUserForm(user, permissions);
 
   return (
     <div>
@@ -70,6 +79,7 @@ const EditUserForm = ({ user, permissions }: Props) => {
           initialValues={initialValues}
           canEditNames={canUpdateUser}
           canChangePassword={isOwnProfile}
+          canForceResetPassword={canForceResetPassword}
         />
       </main>
     </div>

--- a/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
@@ -28,7 +28,7 @@ const ValidationSchema = Yup.object().shape({
   password: passwordValidation.label("Password"),
   passwordConfirmation: Yup.string()
     .required()
-    .oneOf([Yup.ref("password"), null], "Passwords must match")
+    .oneOf([Yup.ref("password")], "Passwords must match")
     .label("Password confirmation"),
 });
 const initialValues = { password: "", passwordConfirmation: "" };
@@ -44,7 +44,6 @@ const useNewPasswordModal = (id: string) => {
       id,
       new_password: values.password,
     });
-    // TODO error handling and whatnot
     if (isErrorResult(result)) {
       toast(errorToastParams(getErrorMessage(result.error)));
     } else {

--- a/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
@@ -73,15 +73,7 @@ const NewPasswordModal = ({ id }: Props) => {
 
   return (
     <>
-      <Button
-        bg="primary.800"
-        _hover={{ bg: "primary.400" }}
-        _active={{ bg: "primary.500" }}
-        colorScheme="primary"
-        maxWidth="40%"
-        size="sm"
-        onClick={onOpen}
-      >
+      <Button colorScheme="primary" size="sm" onClick={onOpen}>
         Reset password
       </Button>
       <Modal isCentered isOpen={isOpen} onClose={onClose}>

--- a/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
@@ -73,7 +73,12 @@ const NewPasswordModal = ({ id }: Props) => {
 
   return (
     <>
-      <Button colorScheme="primary" size="sm" onClick={onOpen}>
+      <Button
+        colorScheme="primary"
+        size="sm"
+        onClick={onOpen}
+        data-testid="reset-password-btn"
+      >
         Reset password
       </Button>
       <Modal isCentered isOpen={isOpen} onClose={onClose}>
@@ -119,6 +124,7 @@ const NewPasswordModal = ({ id }: Props) => {
                       isLoading={isSubmitting}
                       type="submit"
                       width="50%"
+                      data-testid="submit-btn"
                     >
                       Change Password
                     </Button>

--- a/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
@@ -1,0 +1,144 @@
+import {
+  Button,
+  ButtonGroup,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text,
+  useDisclosure,
+  useToast,
+} from "@fidesui/react";
+import { Form, Formik } from "formik";
+import * as Yup from "yup";
+
+import { CustomTextInput } from "~/features/common/form/inputs";
+import { passwordValidation } from "~/features/common/form/validation";
+import { getErrorMessage } from "~/features/common/helpers";
+import { errorToastParams, successToastParams } from "~/features/common/toast";
+import { isErrorResult } from "~/types/errors";
+
+import { useForceResetUserPasswordMutation } from "./user-management.slice";
+
+const ValidationSchema = Yup.object().shape({
+  password: passwordValidation.label("Password"),
+  passwordConfirmation: Yup.string()
+    .required()
+    .oneOf([Yup.ref("password"), null], "Passwords must match")
+    .label("Password confirmation"),
+});
+const initialValues = { password: "", passwordConfirmation: "" };
+type FormValues = typeof initialValues;
+
+const useNewPasswordModal = (id: string) => {
+  const modal = useDisclosure();
+  const toast = useToast();
+  const [resetPassword] = useForceResetUserPasswordMutation();
+
+  const handleResetPassword = async (values: FormValues) => {
+    const result = await resetPassword({
+      id,
+      new_password: values.password,
+    });
+    // TODO error handling and whatnot
+    if (isErrorResult(result)) {
+      toast(errorToastParams(getErrorMessage(result.error)));
+    } else {
+      toast(
+        successToastParams(
+          "Successfully reset user's password. Please inform the user of their new password."
+        )
+      );
+      modal.onClose();
+    }
+  };
+
+  return {
+    ...modal,
+    handleResetPassword,
+  };
+};
+
+interface Props {
+  id: string;
+}
+
+const NewPasswordModal = ({ id }: Props) => {
+  const { handleResetPassword, isOpen, onClose, onOpen } =
+    useNewPasswordModal(id);
+
+  return (
+    <>
+      <Button
+        bg="primary.800"
+        _hover={{ bg: "primary.400" }}
+        _active={{ bg: "primary.500" }}
+        colorScheme="primary"
+        maxWidth="40%"
+        size="sm"
+        onClick={onOpen}
+      >
+        Reset password
+      </Button>
+      <Modal isCentered isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <Formik
+            initialValues={initialValues}
+            validationSchema={ValidationSchema}
+            onSubmit={handleResetPassword}
+          >
+            {({ isSubmitting, dirty, isValid }) => (
+              <Form>
+                <ModalHeader>Reset Password</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>
+                  <Stack direction="column" spacing={4}>
+                    <Text mb={2}>Choose a new password for this user.</Text>
+                    <CustomTextInput
+                      name="password"
+                      label="Password"
+                      placeholder="********"
+                      type="password"
+                      tooltip="Password must contain at least 8 characters, 1 number, 1 capital letter, 1 lowercase letter, and at least 1 symbol."
+                    />
+                    <CustomTextInput
+                      name="passwordConfirmation"
+                      label="Confirm Password"
+                      placeholder="********"
+                      type="password"
+                      tooltip="Must match above password."
+                    />
+                  </Stack>
+                </ModalBody>
+
+                <ModalFooter>
+                  <ButtonGroup size="sm" spacing="2" width="100%">
+                    <Button onClick={onClose} variant="outline" width="50%">
+                      Cancel
+                    </Button>
+                    <Button
+                      colorScheme="primary"
+                      disabled={!dirty || !isValid}
+                      isLoading={isSubmitting}
+                      type="submit"
+                      width="50%"
+                    >
+                      Change Password
+                    </Button>
+                  </ButtonGroup>
+                </ModalFooter>
+              </Form>
+            )}
+          </Formik>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default NewPasswordModal;

--- a/clients/admin-ui/src/features/user-management/PasswordManagement.tsx
+++ b/clients/admin-ui/src/features/user-management/PasswordManagement.tsx
@@ -1,0 +1,54 @@
+import { HStack } from "@fidesui/react";
+
+import { useAppSelector } from "~/app/hooks";
+import { selectUser } from "~/features/auth";
+import { CustomTextInput } from "~/features/common/form/inputs";
+
+import NewPasswordModal from "./NewPasswordModal";
+import UpdatePasswordModal from "./UpdatePasswordModal";
+import { useGetUserPermissionsQuery } from "./user-management.slice";
+
+interface Props {
+  profileId?: string;
+}
+const PasswordManagement = ({ profileId }: Props) => {
+  const isNewUser = profileId == null;
+  const currentUser = useAppSelector(selectUser);
+  const { data: userPermissions } = useGetUserPermissionsQuery(
+    currentUser?.id ?? ""
+  );
+
+  const isOwnProfile = currentUser ? currentUser.id === profileId : false;
+  const canForceResetPassword = userPermissions
+    ? userPermissions.scopes.includes("user:password-reset")
+    : false;
+
+  if (isNewUser) {
+    return (
+      <CustomTextInput
+        name="password"
+        label="Password"
+        placeholder="********"
+        type="password"
+        tooltip="Password must contain at least 8 characters, 1 number, 1 capital letter, 1 lowercase letter, and at least 1 symbol."
+      />
+    );
+  }
+
+  if (!profileId) {
+    return null;
+  }
+
+  if (!isOwnProfile && !canForceResetPassword) {
+    return null;
+  }
+
+  return (
+    <HStack>
+      {isOwnProfile ? <UpdatePasswordModal id={profileId} /> : null}
+      {canForceResetPassword ? <NewPasswordModal id={profileId} /> : null}
+    </HStack>
+  );
+};
+
+export default PasswordManagement;

--- a/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
@@ -78,7 +78,12 @@ const UpdatePasswordModal: React.FC<UpdatePasswordModalProps> = ({ id }) => {
 
   return (
     <>
-      <Button colorScheme="primary" size="sm" onClick={onOpen}>
+      <Button
+        colorScheme="primary"
+        size="sm"
+        onClick={onOpen}
+        data-testid="update-password-btn"
+      >
         Update Password
       </Button>
       <Modal isCentered isOpen={isOpen} onClose={onClose}>
@@ -96,6 +101,7 @@ const UpdatePasswordModal: React.FC<UpdatePasswordModalProps> = ({ id }) => {
                   placeholder="Old Password"
                   type="password"
                   value={oldPasswordValue}
+                  data-testid="input-oldPassword"
                 />
               </FormControl>
               <FormControl>
@@ -106,6 +112,7 @@ const UpdatePasswordModal: React.FC<UpdatePasswordModalProps> = ({ id }) => {
                   placeholder="New Password"
                   type="password"
                   value={newPasswordValue}
+                  data-testid="input-newPassword"
                 />
               </FormControl>
             </Stack>
@@ -133,6 +140,7 @@ const UpdatePasswordModal: React.FC<UpdatePasswordModalProps> = ({ id }) => {
               type="submit"
               variant="solid"
               width="50%"
+              data-testid="submit-btn"
             >
               Change Password
             </Button>

--- a/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
@@ -78,15 +78,7 @@ const UpdatePasswordModal: React.FC<UpdatePasswordModalProps> = ({ id }) => {
 
   return (
     <>
-      <Button
-        bg="primary.800"
-        _hover={{ bg: "primary.400" }}
-        _active={{ bg: "primary.500" }}
-        colorScheme="primary"
-        maxWidth="40%"
-        size="sm"
-        onClick={onOpen}
-      >
+      <Button colorScheme="primary" size="sm" onClick={onOpen}>
         Update Password
       </Button>
       <Modal isCentered isOpen={isOpen} onClose={onClose}>

--- a/clients/admin-ui/src/features/user-management/UserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/UserForm.tsx
@@ -18,6 +18,8 @@ import * as Yup from "yup";
 import { CustomTextInput } from "~/features/common/form/inputs";
 
 import { USER_MANAGEMENT_ROUTE, USER_PRIVILEGES } from "../../constants";
+import { passwordValidation } from "../common/form/validation";
+import NewPasswordModal from "./NewPasswordModal";
 import { User, UserCreateResponse } from "./types";
 import UpdatePasswordModal from "./UpdatePasswordModal";
 import { useUpdateUserPermissionsMutation } from "./user-management.slice";
@@ -36,14 +38,7 @@ const ValidationSchema = Yup.object().shape({
   username: Yup.string().required().label("Username"),
   first_name: Yup.string().label("First name"),
   last_name: Yup.string().label("Last name"),
-  password: Yup.string()
-    .required()
-    .min(8, "Password must have at least eight characters.")
-    .matches(/[0-9]/, "Password must have at least one number.")
-    .matches(/[A-Z]/, "Password must have at least one capital letter.")
-    .matches(/[a-z]/, "Password must have at least one lowercase letter.")
-    .matches(/[\W]/, "Password must have at least one symbol.")
-    .label("Password"),
+  password: passwordValidation.label("Password"),
   scopes: Yup.array().of(Yup.string()),
 });
 
@@ -59,6 +54,7 @@ interface Props {
   initialValues?: FormValues;
   canEditNames?: boolean;
   canChangePassword?: boolean;
+  canForceResetPassword?: boolean;
 }
 
 const UserForm = ({
@@ -66,6 +62,7 @@ const UserForm = ({
   initialValues,
   canEditNames,
   canChangePassword,
+  canForceResetPassword,
 }: Props) => {
   const router = useRouter();
   const { handleError } = useAPIHelper();
@@ -138,8 +135,14 @@ const UserForm = ({
                     tooltip="Password must contain at least 8 characters, 1 number, 1 capital letter, 1 lowercase letter, and at least 1 symbol."
                   />
                 ) : (
-                  canChangePassword &&
-                  profileId != null && <UpdatePasswordModal id={profileId} />
+                  <>
+                    {canChangePassword && profileId != null && (
+                      <UpdatePasswordModal id={profileId} />
+                    )}
+                    {canForceResetPassword && profileId != null && (
+                      <NewPasswordModal id={profileId} />
+                    )}
+                  </>
                 )}
               </Stack>
               <Divider mb={7} mt={7} />

--- a/clients/admin-ui/src/features/user-management/UserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/UserForm.tsx
@@ -4,7 +4,6 @@ import {
   Checkbox,
   Divider,
   Heading,
-  HStack,
   Stack,
   Text,
 } from "@fidesui/react";
@@ -16,13 +15,12 @@ import NextLink from "next/link";
 import { useRouter } from "next/router";
 import * as Yup from "yup";
 
+import { USER_MANAGEMENT_ROUTE, USER_PRIVILEGES } from "~/constants";
 import { CustomTextInput } from "~/features/common/form/inputs";
+import { passwordValidation } from "~/features/common/form/validation";
 
-import { USER_MANAGEMENT_ROUTE, USER_PRIVILEGES } from "../../constants";
-import { passwordValidation } from "../common/form/validation";
-import NewPasswordModal from "./NewPasswordModal";
+import PasswordManagement from "./PasswordManagement";
 import { User, UserCreateResponse } from "./types";
-import UpdatePasswordModal from "./UpdatePasswordModal";
 import { useUpdateUserPermissionsMutation } from "./user-management.slice";
 
 const defaultInitialValues = {
@@ -55,7 +53,6 @@ interface Props {
   initialValues?: FormValues;
   canEditNames?: boolean;
   canChangePassword?: boolean;
-  canForceResetPassword?: boolean;
 }
 
 const UserForm = ({
@@ -63,7 +60,6 @@ const UserForm = ({
   initialValues,
   canEditNames,
   canChangePassword,
-  canForceResetPassword,
 }: Props) => {
   const router = useRouter();
   const { handleError } = useAPIHelper();
@@ -127,24 +123,7 @@ const UserForm = ({
                   placeholder="Enter last name of user"
                   disabled={nameDisabled}
                 />
-                {isNewUser ? (
-                  <CustomTextInput
-                    name="password"
-                    label="Password"
-                    placeholder="********"
-                    type="password"
-                    tooltip="Password must contain at least 8 characters, 1 number, 1 capital letter, 1 lowercase letter, and at least 1 symbol."
-                  />
-                ) : (
-                  <HStack>
-                    {canChangePassword && profileId != null && (
-                      <UpdatePasswordModal id={profileId} />
-                    )}
-                    {canForceResetPassword && profileId != null && (
-                      <NewPasswordModal id={profileId} />
-                    )}
-                  </HStack>
-                )}
+                <PasswordManagement profileId={profileId} />
               </Stack>
               <Divider mb={7} mt={7} />
               <Heading fontSize="xl" colorScheme="primary">

--- a/clients/admin-ui/src/features/user-management/UserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/UserForm.tsx
@@ -4,6 +4,7 @@ import {
   Checkbox,
   Divider,
   Heading,
+  HStack,
   Stack,
   Text,
 } from "@fidesui/react";
@@ -135,14 +136,14 @@ const UserForm = ({
                     tooltip="Password must contain at least 8 characters, 1 number, 1 capital letter, 1 lowercase letter, and at least 1 symbol."
                   />
                 ) : (
-                  <>
+                  <HStack>
                     {canChangePassword && profileId != null && (
                       <UpdatePasswordModal id={profileId} />
                     )}
                     {canForceResetPassword && profileId != null && (
                       <NewPasswordModal id={profileId} />
                     )}
-                  </>
+                  </HStack>
                 )}
               </Stack>
               <Divider mb={7} mt={7} />

--- a/clients/admin-ui/src/features/user-management/UserManagementTable.tsx
+++ b/clients/admin-ui/src/features/user-management/UserManagementTable.tsx
@@ -56,7 +56,7 @@ const UserManagementTable: React.FC<UsersTableProps> = () => {
 
   return (
     <>
-      <Table size="sm">
+      <Table size="sm" data-testid="user-management-table">
         <Thead>
           <Tr>
             <Th pl={0}>Username</Th>

--- a/clients/admin-ui/src/features/user-management/user-management.slice.ts
+++ b/clients/admin-ui/src/features/user-management/user-management.slice.ts
@@ -5,6 +5,7 @@ import { utf8ToB64 } from "common/utils";
 
 import type { RootState } from "~/app/store";
 import { BASE_URL } from "~/constants";
+import { UserForcePasswordReset } from "~/types/api";
 
 import { selectToken } from "../auth";
 import {
@@ -151,6 +152,19 @@ export const userApi = createApi({
       }),
       invalidatesTags: ["User"],
     }),
+    forceResetUserPassword: build.mutation<
+      UserResponse,
+      { id: string } & UserForcePasswordReset
+    >({
+      query: ({ id, new_password }) => ({
+        url: `user/${id}/force-reset-password`,
+        method: "POST",
+        body: {
+          new_password: utf8ToB64(new_password),
+        },
+      }),
+      invalidatesTags: ["User"],
+    }),
     updateUserPermissions: build.mutation<
       UserPermissions,
       UserPermissionsEditParams
@@ -182,4 +196,5 @@ export const {
   useUpdateUserPasswordMutation,
   useUpdateUserPermissionsMutation,
   useGetUserPermissionsQuery,
+  useForceResetUserPasswordMutation,
 } = userApi;

--- a/clients/admin-ui/src/types/api/index.ts
+++ b/clients/admin-ui/src/types/api/index.ts
@@ -104,6 +104,7 @@ export type { SystemsDiff } from "./models/SystemsDiff";
 export { SystemType } from "./models/SystemType";
 export type { UserCreate } from "./models/UserCreate";
 export type { UserCreateResponse } from "./models/UserCreateResponse";
+export type { UserForcePasswordReset } from "./models/UserForcePasswordReset";
 export type { UserLogin } from "./models/UserLogin";
 export type { UserLoginResponse } from "./models/UserLoginResponse";
 export type { UserPasswordReset } from "./models/UserPasswordReset";

--- a/clients/admin-ui/src/types/api/models/UserForcePasswordReset.ts
+++ b/clients/admin-ui/src/types/api/models/UserForcePasswordReset.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Only a new password, for the case where the user does not remember their password
+ */
+export type UserForcePasswordReset = {
+  new_password: string;
+};


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2208

### Code Changes

* [x] Add new typescript types based off the work done in https://github.com/ethyca/fides/pull/2373
* [x] Add a new modal `NewPasswordModal`. This visually looks a lot like `UpdatePasswordModal` but the code is actually quite different. `UpdatePasswordModal` is a bit out of date in terms of form validation, UX, and using shared components. There's already a separate [tech debt ticket](https://github.com/ethyca/fides/issues/2296) to refactor various parts of user management though
* [x] Refactors all of the password related logic to be in the same component
* [x] Adds cypress tests (there were none for user management 🙀)

### Steps to Confirm

1. `nox -s dev` and `npm run dev` to start up the admin ui
2. Log in as `root_user`
3. Click "Management" > "Users" and create a new user. You should see a new scope "Reset another user's password" which can be assigned
4. Create a new user with this reset another user's password scope, as well as view/create/read/update users, assign/update/read permissions. Give the user a password you'll remember ;) 
![image](https://user-images.githubusercontent.com/24641006/214918926-13c12a36-8592-4cc0-99c2-b8d650d458be.png)
5. Create another user with the same perms as above, but without the reset password perm
6. Log out and sign in as the user you made in step 4. You should be able to edit the user made in step 5's password by clicking on the new Reset password button. remember this new password!

https://user-images.githubusercontent.com/24641006/214920218-ecee9f51-a365-4325-8755-17d9bd2385a7.mov

8. Log out and sign in as the user you made in step 5 whose password you just changed. Log in with your new password. it should work!
9. Go to the user management page and edit the user made in step 4. You should not see the Reset password button because this user does not have that perm
10. But if you go to the step 5 user's page, you should see "Update Password" which lets you update this user's password (because it's their own account)


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

In addition to the video above, there's also some form validation:

https://user-images.githubusercontent.com/24641006/214921319-57f8a603-db74-4499-9988-4ace4bf57c17.mov



