### PR TITLE
Display policy key on request details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The types of changes are:
 * Unified Fides Resources: Updated test env setup and quickstart to use new endpoints [#2225](https://github.com/ethyca/fides/pull/2225)
 * Update fideslang to 1.3.3 [#2343](https://github.com/ethyca/fides/pull/2343)
 * Display the request type instead of the policy name on the request table [#2382](https://github.com/ethyca/fides/pull/2382)
+* Display the policy key on the request details page [#2395](https://github.com/ethyca/fides/pull/2395)
 
 ### Fixed
 

--- a/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Flex, Heading, HStack, Text, Tag} from "@fidesui/react";
+import { Box, Divider, Flex, Heading, HStack, Tag,Text } from "@fidesui/react";
 import DaysLeftTag from "common/DaysLeftTag";
 import { PrivacyRequestEntity } from "privacy-requests/types";
 
@@ -51,7 +51,11 @@ const RequestDetails = ({ subjectRequest }: RequestDetailsProps) => {
         <Text mb={4} mr={2} fontSize="sm" color="gray.900" fontWeight="500">
           Policy key:
         </Text>
-        <Tag color="white" bg="primary.400" fontWeight="medium" fontSize="sm">{subjectRequest.policy.key}</Tag>
+        <Box>
+          <Tag color="white" bg="primary.400" fontWeight="medium" fontSize="sm">
+            {subjectRequest.policy.key}
+          </Tag>
+        </Box>
       </Flex>
       <Flex alignItems="flex-start">
         <Text mb={4} mr={2} fontSize="sm" color="gray.900" fontWeight="500">

--- a/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Flex, Heading, HStack, Tag,Text } from "@fidesui/react";
+import { Box, Divider, Flex, Heading, HStack, Tag, Text } from "@fidesui/react";
 import DaysLeftTag from "common/DaysLeftTag";
 import { PrivacyRequestEntity } from "privacy-requests/types";
 

--- a/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Flex, Heading, HStack, Text } from "@fidesui/react";
+import { Box, Divider, Flex, Heading, HStack, Text, Tag} from "@fidesui/react";
 import DaysLeftTag from "common/DaysLeftTag";
 import { PrivacyRequestEntity } from "privacy-requests/types";
 
@@ -46,6 +46,12 @@ const RequestDetails = ({ subjectRequest }: RequestDetailsProps) => {
         <Box mr={1} mb={4}>
           <RequestType rules={policy.rules} />
         </Box>
+      </Flex>
+      <Flex>
+        <Text mb={4} mr={2} fontSize="sm" color="gray.900" fontWeight="500">
+          Policy key:
+        </Text>
+        <Tag color="white" bg="primary.400" fontWeight="medium" fontSize="sm">{subjectRequest.policy.key}</Tag>
       </Flex>
       <Flex alignItems="flex-start">
         <Text mb={4} mr={2} fontSize="sm" color="gray.900" fontWeight="500">


### PR DESCRIPTION
Closes #2288 

### Code Changes

* [ ] Display policy key on request details page

### Steps to Confirm

* [ ] Run fides and navigate to a request details page
* [ ] ensure the policy key is displayed

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Simple change to display the policy key on the request details page.

<img width="610" alt="Screenshot 2023-01-26 at 15 00 32" src="https://user-images.githubusercontent.com/17103888/214938427-15245705-0e5c-4602-a589-0dfd73fbd8cf.png">

