### PR TITLE
Include `latest` tag on privacy-center and sample-app images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The types of changes are:
 * Added a feature flag for the recent dataset classification UX changes [#2335](https://github.com/ethyca/fides/pull/2335)
 * Privacy Center identity inputs validate even when they are optional. [#2308](https://github.com/ethyca/fides/pull/2308)
 * Patch masking strategies to better handle null and non-string inputs [#2307](https://github.com/ethyca/fides/pull/2377)
+* Renamed prod pushes tag to be `latest` for privacy center and sample app [#2401](https://github.com/ethyca/fides/pull/2407)
 
 ### Security
 

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -212,8 +212,8 @@ def push(session: nox.Session, tag: str) -> None:
         #   - ethyca/fides-privacy-center:latest
         #   - ethyca/fides-sample-app:2.0.0
         #   - ethyca/fides-sample-app:latest
-        privacy_center_latest = f"{PRIVACY_CENTER_IMAGE}:dev"
-        sample_app_latest = f"{SAMPLE_APP_IMAGE}:dev"
+        privacy_center_latest = f"{PRIVACY_CENTER_IMAGE}:latest"
+        sample_app_latest = f"{SAMPLE_APP_IMAGE}:latest"
         session.run(
             "docker", "tag", privacy_center_prod, privacy_center_latest, external=True
         )


### PR DESCRIPTION
Closes #2301

### Code Changes

* [x] Update `dev` to `latest` on `nox -s "push(prod)"`

### Steps to Confirm

* [x] validated manually, ci checks can be tricky sometimes

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

`nox -s "push(dev)"` runs on every push to `main` and releases meaning we were just duplicating the `dev` tags!
