### PR TITLE
Fix CI git permissions

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -172,10 +172,10 @@ jobs:
 
       - name: Install Nox
         run: pip install nox>=2022
-        
+
       # This is a required workaround due to: https://github.com/ethyca/fides/issues/2440
       - name: Fix git directory permissions
-      - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run test suite
         run: nox -s "pytest(${{ matrix.test_selection }})"

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -172,6 +172,10 @@ jobs:
 
       - name: Install Nox
         run: pip install nox>=2022
+        
+      # This is a required workaround due to: https://github.com/ethyca/fides/issues/2440
+      - name: Fix git directory permissions
+      - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run test suite
         run: nox -s "pytest(${{ matrix.test_selection }})"

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -173,10 +173,6 @@ jobs:
       - name: Install Nox
         run: pip install nox>=2022
 
-      # This is a required workaround due to: https://github.com/ethyca/fides/issues/2440
-      - name: Fix git directory permissions
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
       - name: Run test suite
         run: nox -s "pytest(${{ matrix.test_selection }})"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.5.0...main)
 
-
 ### Added
 
 * Unified Fides Resources: Added a dataset dropdown selector when configuring a connector to link an existing dataset to the connector configuration. [#2162](https://github.com/ethyca/fides/pull/2162)
@@ -43,7 +42,8 @@ The types of changes are:
 
 * Home screen header scaling and responsiveness issues [#2200](https://github.com/ethyca/fides/pull/2277)
 * Added a feature flag for the recent dataset classification UX changes [#2335](https://github.com/ethyca/fides/pull/2335)
-* Privacy Center 
+* Fixed a CI bug caused by git security upgrades [#2441](https://github.com/ethyca/fides/pull/2441)
+* Privacy Center
   * Identity inputs validate even when they are optional. [#2308](https://github.com/ethyca/fides/pull/2308)
   * Submit buttons show loading state and disable while submitting. [#2401](https://github.com/ethyca/fides/pull/2401)
   * Phone inputs no longer request country SVGs from external domain. [#2378](https://github.com/ethyca/fides/pull/2378)
@@ -119,7 +119,6 @@ The types of changes are:
 ### Removed
 
 * Remove "Create New System" button when viewing systems. All systems can now be created via the "Add systems" button on the home page. [#2132](https://github.com/ethyca/fides/pull/2132)
-
 
 ## [2.4.0](https://github.com/ethyca/fides/compare/2.3.1...2.4.0)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,9 @@ ENV PYTHONUNBUFFERED=TRUE
 # Reset the busted git cache
 RUN git rm --cached -r .
 
+# This is a required workaround due to: https://github.com/ethyca/fides/issues/2440
+RUN git config --global --add safe.directory /fides
+
 # Enable detection of running within Docker
 ENV RUNNING_IN_DOCKER=true
 


### PR DESCRIPTION
Closes #2440 

### Code Changes

* [x] Add a line to the CI workflow that sets git directory permissions

### Steps to Confirm

* [x] `pytest(ctl-not-external)` checks pass

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

[GitHub Actions Issue](https://github.com/actions/runner-images/issues/6775)