### PR TITLE
Privacy request approval modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The types of changes are:
 * Display the request type instead of the policy name on the request table [#2382](https://github.com/ethyca/fides/pull/2382)
 * Make denial reasons required [#2400](https://github.com/ethyca/fides/pull/2400)
 * Display the policy key on the request details page [#2395](https://github.com/ethyca/fides/pull/2395)
+* Privacy Request approval now uses a modal [#2443](https://github.com/ethyca/fides/pull/2443)
 
 ### Developer Experience
 

--- a/clients/admin-ui/src/features/common/ConfirmationModal.tsx
+++ b/clients/admin-ui/src/features/common/ConfirmationModal.tsx
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { ThemingProps } from "@chakra-ui/system";
 import {
   Button,
   Modal,
@@ -14,8 +16,15 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
-  title: string;
-  message: ReactNode;
+  title?: string;
+  message?: ReactNode;
+  cancelButtonText?: string;
+  cancelButtonThemingProps?: ThemingProps<"Button">;
+  continueButtonText?: string;
+  continueButtonThemingProps?: ThemingProps<"Button">;
+  isLoading?: boolean;
+  returnFocusOnClose?: boolean;
+  isCentered?: boolean;
 }
 const ConfirmationModal = ({
   isOpen,
@@ -23,12 +32,25 @@ const ConfirmationModal = ({
   onConfirm,
   title,
   message,
+  cancelButtonText,
+  cancelButtonThemingProps,
+  continueButtonText,
+  continueButtonThemingProps,
+  isLoading,
+  returnFocusOnClose,
+  isCentered,
 }: Props) => (
-  <Modal isOpen={isOpen} onClose={onClose} size="lg">
+  <Modal
+    isOpen={isOpen}
+    onClose={onClose}
+    size="lg"
+    returnFocusOnClose={returnFocusOnClose || true}
+    isCentered={isCentered}
+  >
     <ModalOverlay />
     <ModalContent textAlign="center" p={2} data-testid="confirmation-modal">
-      <ModalHeader fontWeight="medium">{title}</ModalHeader>
-      <ModalBody>{message}</ModalBody>
+      {title ? <ModalHeader fontWeight="medium">{title}</ModalHeader> : null}
+      {message ? <ModalBody>{message}</ModalBody> : null}
       <ModalFooter>
         <SimpleGrid columns={2} width="100%">
           <Button
@@ -36,15 +58,19 @@ const ConfirmationModal = ({
             mr={3}
             onClick={onClose}
             data-testid="cancel-btn"
+            isDisabled={isLoading}
+            {...cancelButtonThemingProps}
           >
-            Cancel
+            {cancelButtonText || "Cancel"}
           </Button>
           <Button
             colorScheme="primary"
             onClick={onConfirm}
             data-testid="continue-btn"
+            isLoading={isLoading}
+            {...continueButtonThemingProps}
           >
-            Continue
+            {continueButtonText || "Continue"}
           </Button>
         </SimpleGrid>
       </ModalFooter>

--- a/clients/admin-ui/src/features/privacy-requests/ApprovePrivacyRequestModal.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/ApprovePrivacyRequestModal.tsx
@@ -1,0 +1,39 @@
+import ConfirmationModal from "common/ConfirmationModal";
+import React, { useCallback } from "react";
+
+type ApproveModalProps = {
+  isOpen: boolean;
+  handleMenuClose: () => void;
+  handleApproveRequest: () => Promise<any>;
+  isLoading: boolean;
+};
+
+const ApprovePrivacyRequestModal = ({
+  isOpen,
+  handleMenuClose,
+  handleApproveRequest,
+  isLoading,
+}: ApproveModalProps) => {
+  const handleSubmit = useCallback(() => {
+    handleApproveRequest().then(() => {
+      handleMenuClose();
+    });
+  }, [handleApproveRequest, handleMenuClose]);
+  return (
+    <ConfirmationModal
+      isOpen={isOpen}
+      onClose={handleMenuClose}
+      onConfirm={handleSubmit}
+      message="Are you sure you want to approve this privacy request?"
+      continueButtonText="Confirm"
+      continueButtonThemingProps={{
+        variant: "solid",
+      }}
+      isLoading={isLoading}
+      returnFocusOnClose={false}
+      isCentered
+    />
+  );
+};
+
+export default ApprovePrivacyRequestModal;

--- a/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
@@ -20,6 +20,7 @@ import DaysLeftTag from "common/DaysLeftTag";
 import RequestType from "common/RequestType";
 import { formatDate } from "common/utils";
 import { useRouter } from "next/router";
+import ApprovePrivacyRequestModal from "privacy-requests/ApprovePrivacyRequestModal";
 import React, { useRef, useState } from "react";
 
 import { useFeatures } from "~/features/common/features";
@@ -44,9 +45,10 @@ const useRequestRow = (request: PrivacyRequestEntity) => {
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  const [modalOpen, setModalOpen] = useState(false);
+  const [denyModalOpen, setDenyModalOpen] = useState(false);
+  const [approveModalOpen, setApproveModalOpen] = useState(false);
   const [approveRequest, approveRequestResult] = useApproveRequestMutation();
-  const [denyRequest] = useDenyRequestMutation();
+  const [denyRequest, denyRequestResult] = useDenyRequestMutation();
   const handleMenuOpen = () => setMenuOpen(true);
   const handleMenuClose = () => setMenuOpen(false);
   const handleMouseEnter = () => setHovered(true);
@@ -59,15 +61,25 @@ const useRequestRow = (request: PrivacyRequestEntity) => {
   const handleFocus = () => setFocused(true);
   const handleBlur = () => setFocused(false);
   const handleApproveRequest = () => approveRequest(request);
+
   const handleDenyRequest = (reason: string) =>
     denyRequest({ id: request.id, reason });
   const { onCopy } = useClipboard(request.id);
-  const handleModalOpen = () => setModalOpen(true);
-  const handleModalClose = () => {
-    setModalOpen(false);
+  const handleDenyModalOpen = () => setDenyModalOpen(true);
+  const handleApproveModalOpen = () => setApproveModalOpen(true);
+  const resetSharedModalStates = () => {
     setFocused(false);
     setHovered(false);
     setMenuOpen(false);
+  };
+  const handleDenyModalClose = () => {
+    setDenyModalOpen(false);
+    resetSharedModalStates();
+  };
+
+  const handleApproveModalClose = () => {
+    setApproveModalOpen(false);
+    resetSharedModalStates();
   };
   const handleIdCopy = () => {
     onCopy();
@@ -96,12 +108,16 @@ const useRequestRow = (request: PrivacyRequestEntity) => {
   };
   return {
     approveRequestResult,
+    denyRequestResult,
     hovered,
     focused,
     menuOpen,
-    modalOpen,
-    handleModalOpen,
-    handleModalClose,
+    denyModalOpen,
+    approveModalOpen,
+    handleDenyModalOpen,
+    handleDenyModalClose,
+    handleApproveModalOpen,
+    handleApproveModalClose,
     handleMenuClose,
     handleMenuOpen,
     handleMouseEnter,
@@ -133,10 +149,14 @@ const RequestRow: React.FC<{
     handleIdCopy,
     menuOpen,
     approveRequestResult,
+    denyRequestResult,
     hoverButtonRef,
-    modalOpen,
-    handleModalClose,
-    handleModalOpen,
+    denyModalOpen,
+    handleDenyModalClose,
+    handleDenyModalOpen,
+    approveModalOpen,
+    handleApproveModalClose,
+    handleApproveModalOpen,
     shiftFocusToHoverMenu,
     handleFocus,
     handleBlur,
@@ -222,6 +242,7 @@ const RequestRow: React.FC<{
           onBlur={handleBlur}
           shadow="base"
           borderRadius="md"
+          backgroundColor="white"
         >
           {request.status === "error" && (
             <ReprocessButton
@@ -237,14 +258,12 @@ const RequestRow: React.FC<{
                 mr="-px"
                 bg="white"
                 onClick={() => {
-                  handleApproveRequest();
+                  handleApproveModalOpen();
                   handleBlur();
                 }}
-                isLoading={approveRequestResult.isLoading}
-                _loading={{
-                  opacity: 1,
-                  div: { opacity: 0.4 },
-                }}
+                isDisabled={
+                  approveRequestResult.isLoading || denyRequestResult.isLoading
+                }
                 _hover={{
                   bg: "gray.100",
                 }}
@@ -256,11 +275,10 @@ const RequestRow: React.FC<{
                 size="xs"
                 mr="-px"
                 bg="white"
-                onClick={handleModalOpen}
-                _loading={{
-                  opacity: 1,
-                  div: { opacity: 0.4 },
-                }}
+                onClick={handleDenyModalOpen}
+                isDisabled={
+                  approveRequestResult.isLoading || denyRequestResult.isLoading
+                }
                 _hover={{
                   bg: "gray.100",
                 }}
@@ -268,9 +286,15 @@ const RequestRow: React.FC<{
                 Deny
               </Button>
               <DenyPrivacyRequestModal
-                isOpen={modalOpen}
-                handleMenuClose={handleModalClose}
+                isOpen={denyModalOpen}
+                handleMenuClose={handleDenyModalClose}
                 handleDenyRequest={handleDenyRequest}
+              />
+              <ApprovePrivacyRequestModal
+                isOpen={approveModalOpen}
+                handleMenuClose={handleApproveModalClose}
+                handleApproveRequest={handleApproveRequest}
+                isLoading={approveRequestResult.isLoading}
               />
             </>
           )}


### PR DESCRIPTION
Closes #2289 Closes #2291 


### Code Changes

* [ ] Update `ConfirmationModal` so it's able to be reused as the approval modal.
* [ ] Add `ApprovePrivacyRequestModal` component
* [ ] Update `RequestRow` to handle new `ApprovePrivacyRequestModal` component

### Steps to Confirm

* [x] Run fides and create some privacy requests.
* [x] Approve them and observe the new modal
* [x] Try throttling network activity to slow 3G. This will make it easier to test the loading spinners and the disabled approve/deny buttons in the background

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Adds new approval modal and disables the approve/deny buttons in the background while a request is happening.


https://user-images.githubusercontent.com/17103888/215832468-64313a70-2811-44e7-a8b1-1dc645ee0bf8.mov


