### PR TITLE
[2290] Request details Approve & Deny button group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The types of changes are:
 * Add new select/deselect all permissions buttons [#2437](https://github.com/ethyca/fides/pull/2437)
 * Endpoints to allow a user with the `user:password-reset` scope to reset users' passwords. In addition, users no longer require a scope to edit their own passwords. [#2373](https://github.com/ethyca/fides/pull/2373)
 * New form to reset a user's password without knowing an old password [#2390](https://github.com/ethyca/fides/pull/2390)
+* Approve & deny buttons on the "Request details" page. [#2473](https://github.com/ethyca/fides/pull/2473)
 * Consent Propagation
   * Add the ability to execute Consent Requests via the Privacy Request Execution layer [#2125](https://github.com/ethyca/fides/pull/2125)
   * Add a Mailchimp Transactional Consent Connector [#2194](https://github.com/ethyca/fides/pull/2194)

--- a/clients/admin-ui/cypress/e2e/datasets-classify.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets-classify.cy.ts
@@ -89,7 +89,6 @@ describe("Datasets with Fides Classify", () => {
 
       cy.url().should("match", /dataset$/);
 
-
       // The combination of Next routing and a toast message makes Cypress get weird
       // when re-running this test case. Introducing a delay fixes it.
       // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/clients/admin-ui/cypress/e2e/datasets-classify.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets-classify.cy.ts
@@ -142,8 +142,7 @@ describe("Datasets with Fides Classify", () => {
     }) => {
       cy.getByTestId(`field-row-${name}`).within(() => {
         taxonomyEntities.forEach((te) => {
-          // Right now this displays the whole taxonomy path, but this might be abbreviated later.
-          cy.get(`[data-testid^=taxonomy-entity-]`).contains(te);
+          cy.getByTestIdPrefix("taxonomy-entity").contains(te);
         });
       });
     };

--- a/clients/admin-ui/cypress/e2e/privacy-requests.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-requests.cy.ts
@@ -101,5 +101,27 @@ describe("Privacy Requests", () => {
         cy.getByTestId("request-status-badge").contains("New");
       });
     });
+
+    it("allows approving a new request", () => {
+      cy.getByTestId("privacy-request-approve-btn").click();
+      cy.getByTestId("continue-btn").click();
+
+      cy.wait("@approvePrivacyRequest")
+        .its("request.body.request_ids")
+        .should("have.length", 1);
+    });
+
+    it("allows denying a new request", () => {
+      cy.getByTestId("privacy-request-deny-btn").click();
+
+      cy.getByTestId("deny-privacy-request-modal").within(() => {
+        cy.getByTestId("input-denialReason").type("test denial");
+        cy.getByTestId("deny-privacy-request-modal-btn").click();
+      });
+
+      cy.wait("@denyPrivacyRequest")
+        .its("request.body.request_ids")
+        .should("have.length", 1);
+    });
   });
 });

--- a/clients/admin-ui/cypress/e2e/privacy-requests.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-requests.cy.ts
@@ -1,0 +1,70 @@
+import { stubPrivacyRequests } from "cypress/support/stubs";
+
+import { PrivacyRequestEntity } from "~/features/privacy-requests/types";
+
+describe("Privacy Requests", () => {
+  beforeEach(() => {
+    cy.login();
+    stubPrivacyRequests();
+  });
+
+  describe("The requests table", () => {
+    beforeEach(() => {
+      cy.visit("/privacy-requests");
+      cy.wait("@getPrivacyRequests");
+
+      cy.getByTestIdPrefix("privacy-request-row").as("rows");
+
+      // Annoyingly fancy, I know, but this selects the containing rows that have a badge with the
+      // matching status text -- as opposed to just filtering by status which would yield the badge
+      // element itself.
+      const selectByStatus = (status: string) =>
+        cy
+          .get("@rows")
+          .getByTestId("request-status-badge")
+          .filter(`:contains('${status}')`)
+          .closest("[data-testid^='privacy-request-row']");
+
+      selectByStatus("New").as("rowsNew");
+      selectByStatus("Completed").as("rowsCompleted");
+      selectByStatus("Error").as("rowsError");
+    });
+
+    // TODO: add multi-page stubs to test the pagination controls.
+    it("shows the first page of results", () => {
+      cy.get("@rowsNew").should("have.length", 4);
+      cy.get("@rowsCompleted").should("have.length", 3);
+      cy.get("@rowsError").should("have.length", 1);
+    });
+
+    it("allows navigation to the details of request", () => {
+      cy.get("@rowsNew")
+        .first()
+        .within(() => {
+          cy.getByTestId("privacy-request-more-btn").click();
+        });
+
+      cy.getByTestId("privacy-request-more-menu")
+        .contains("View Details")
+        .click();
+
+      cy.location("pathname").should("match", /^\/privacy-requests\/pri.+/);
+    });
+  });
+
+  describe("The request details page", () => {
+    beforeEach(() => {
+      cy.get<PrivacyRequestEntity>("@privacyRequest").then((privacyRequest) => {
+        cy.visit(`/privacy-requests/${privacyRequest.id}`);
+      });
+      cy.wait("@getPrivacyRequest");
+    });
+
+    it("shows the request details", () => {
+      cy.getByTestId("privacy-request-details").within(() => {
+        cy.contains("Request ID").parent().contains(/pri_/);
+        cy.getByTestId("request-status-badge").contains("New");
+      });
+    });
+  });
+});

--- a/clients/admin-ui/cypress/e2e/privacy-requests.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-requests.cy.ts
@@ -50,6 +50,41 @@ describe("Privacy Requests", () => {
 
       cy.location("pathname").should("match", /^\/privacy-requests\/pri.+/);
     });
+
+    it("allows approving a new request", () => {
+      cy.get("@rowsNew")
+        .first()
+        .within(() => {
+          // The approve button shows up on hover, but there isn't a good way to simulate that in
+          // tests. Instead we click on the menu button to make all the controls appear.
+          cy.getByTestId("privacy-request-more-btn").click();
+          cy.getByTestId("privacy-request-approve-btn").click();
+        });
+
+      cy.getByTestId("continue-btn").click();
+
+      cy.wait("@approvePrivacyRequest")
+        .its("request.body.request_ids")
+        .should("have.length", 1);
+    });
+
+    it("allows denying a new request", () => {
+      cy.get("@rowsNew")
+        .first()
+        .within(() => {
+          cy.getByTestId("privacy-request-more-btn").click();
+          cy.getByTestId("privacy-request-deny-btn").click();
+        });
+
+      cy.getByTestId("deny-privacy-request-modal").within(() => {
+        cy.getByTestId("input-denialReason").type("test denial");
+        cy.getByTestId("deny-privacy-request-modal-btn").click();
+      });
+
+      cy.wait("@denyPrivacyRequest")
+        .its("request.body.request_ids")
+        .should("have.length", 1);
+    });
   });
 
   describe("The request details page", () => {

--- a/clients/admin-ui/cypress/fixtures/privacy-requests/approve.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-requests/approve.json
@@ -1,0 +1,48 @@
+{
+  "failed": [],
+  "succeeded": [
+    {
+      "id": "pri_c3f64359-1656-4f82-a016-98a26b479f36",
+      "created_at": "2023-01-27T00:57:09.027484+00:00",
+      "started_processing_at": null,
+      "reviewed_at": "2023-01-31T21:51:57.317223+00:00",
+      "reviewed_by": null,
+      "reviewer": null,
+      "finished_processing_at": null,
+      "identity_verified_at": null,
+      "paused_at": null,
+      "status": "approved",
+      "external_id": null,
+      "identity": { "phone_number": null, "email": "cypress-user@ethyca.com" },
+      "policy": {
+        "name": "default_access_policy",
+        "key": "default_access_policy",
+        "drp_action": null,
+        "execution_timeframe": 45,
+        "rules": [
+          {
+            "name": "Example access Rule",
+            "key": "default_access_policy_rule",
+            "action_type": "access",
+            "storage_destination": {
+              "name": "s3_storage",
+              "type": "s3",
+              "details": {
+                "bucket": "fides-test-privacy-requests",
+                "naming": "request_id",
+                "auth_method": "secret_keys",
+                "max_retries": 0
+              },
+              "key": "s3_storage",
+              "format": "json"
+            },
+            "masking_strategy": null
+          }
+        ]
+      },
+      "action_required_details": null,
+      "resume_endpoint": null,
+      "days_left": 45
+    }
+  ]
+}

--- a/clients/admin-ui/cypress/fixtures/privacy-requests/deny.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-requests/deny.json
@@ -1,0 +1,48 @@
+{
+  "failed": [],
+  "succeeded": [
+    {
+      "id": "pri_c3f64359-1656-4f82-a016-98a26b479f36",
+      "created_at": "2023-01-27T00:57:09.027484+00:00",
+      "started_processing_at": null,
+      "reviewed_at": "2023-01-31T22:19:47.384387+00:00",
+      "reviewed_by": null,
+      "reviewer": null,
+      "finished_processing_at": null,
+      "identity_verified_at": null,
+      "paused_at": null,
+      "status": "denied",
+      "external_id": null,
+      "identity": { "phone_number": null, "email": "cypress-user@ethyca.com" },
+      "policy": {
+        "name": "default_access_policy",
+        "key": "default_access_policy",
+        "drp_action": null,
+        "execution_timeframe": 45,
+        "rules": [
+          {
+            "name": "Example access Rule",
+            "key": "default_access_policy_rule",
+            "action_type": "access",
+            "storage_destination": {
+              "name": "s3_storage",
+              "type": "s3",
+              "details": {
+                "bucket": "fides-test-privacy-requests",
+                "naming": "request_id",
+                "auth_method": "secret_keys",
+                "max_retries": 0
+              },
+              "key": "s3_storage",
+              "format": "json"
+            },
+            "masking_strategy": null
+          }
+        ]
+      },
+      "action_required_details": null,
+      "resume_endpoint": null,
+      "days_left": 45
+    }
+  ]
+}

--- a/clients/admin-ui/cypress/fixtures/privacy-requests/list.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-requests/list.json
@@ -1,0 +1,358 @@
+{
+  "items": [
+    {
+      "id": "pri_c3f64359-1656-4f82-a016-98a26b479f36",
+      "created_at": "2023-01-27T00:57:09.027484+00:00",
+      "started_processing_at": null,
+      "reviewed_at": null,
+      "reviewed_by": null,
+      "reviewer": null,
+      "finished_processing_at": null,
+      "identity_verified_at": null,
+      "paused_at": null,
+      "status": "pending",
+      "external_id": null,
+      "identity": { "phone_number": null, "email": "cypress-user@ethyca.com" },
+      "policy": {
+        "name": "default_access_policy",
+        "key": "default_access_policy",
+        "drp_action": null,
+        "execution_timeframe": 45,
+        "rules": [
+          {
+            "name": "Example access Rule",
+            "key": "default_access_policy_rule",
+            "action_type": "access",
+            "storage_destination": {
+              "name": "s3_storage",
+              "type": "s3",
+              "details": {
+                "bucket": "fides-test-privacy-requests",
+                "naming": "request_id",
+                "auth_method": "secret_keys",
+                "max_retries": 0
+              },
+              "key": "s3_storage",
+              "format": "json"
+            },
+            "masking_strategy": null
+          }
+        ]
+      },
+      "action_required_details": null,
+      "resume_endpoint": null,
+      "days_left": 45
+    },
+    {
+      "id": "pri_6411a2ea-72d2-4111-aad3-9170ba5e5934",
+      "created_at": "2023-01-27T00:56:59.960623+00:00",
+      "started_processing_at": null,
+      "reviewed_at": null,
+      "reviewed_by": null,
+      "reviewer": null,
+      "finished_processing_at": null,
+      "identity_verified_at": null,
+      "paused_at": null,
+      "status": "pending",
+      "external_id": null,
+      "identity": { "phone_number": null, "email": "cypress-user@ethyca.com" },
+      "policy": {
+        "name": "default_access_policy",
+        "key": "default_access_policy",
+        "drp_action": null,
+        "execution_timeframe": 45,
+        "rules": [
+          {
+            "name": "Example access Rule",
+            "key": "default_access_policy_rule",
+            "action_type": "access",
+            "storage_destination": {
+              "name": "s3_storage",
+              "type": "s3",
+              "details": {
+                "bucket": "fides-test-privacy-requests",
+                "naming": "request_id",
+                "auth_method": "secret_keys",
+                "max_retries": 0
+              },
+              "key": "s3_storage",
+              "format": "json"
+            },
+            "masking_strategy": null
+          }
+        ]
+      },
+      "action_required_details": null,
+      "resume_endpoint": null,
+      "days_left": 45
+    },
+    {
+      "id": "pri_34650722-960c-4abd-b6a6-6dba4461dfbe",
+      "created_at": "2023-01-27T00:56:43.654355+00:00",
+      "started_processing_at": null,
+      "reviewed_at": null,
+      "reviewed_by": null,
+      "reviewer": null,
+      "finished_processing_at": null,
+      "identity_verified_at": null,
+      "paused_at": null,
+      "status": "pending",
+      "external_id": null,
+      "identity": { "phone_number": null, "email": "horse@example.com" },
+      "policy": {
+        "name": "default_access_policy",
+        "key": "default_access_policy",
+        "drp_action": null,
+        "execution_timeframe": 45,
+        "rules": [
+          {
+            "name": "Example access Rule",
+            "key": "default_access_policy_rule",
+            "action_type": "access",
+            "storage_destination": {
+              "name": "s3_storage",
+              "type": "s3",
+              "details": {
+                "bucket": "fides-test-privacy-requests",
+                "naming": "request_id",
+                "auth_method": "secret_keys",
+                "max_retries": 0
+              },
+              "key": "s3_storage",
+              "format": "json"
+            },
+            "masking_strategy": null
+          }
+        ]
+      },
+      "action_required_details": null,
+      "resume_endpoint": null,
+      "days_left": 45
+    },
+    {
+      "id": "pri_8750c782-3fad-4ae6-bbcf-219f70f537ee",
+      "created_at": "2023-01-27T00:55:26.133348+00:00",
+      "started_processing_at": null,
+      "reviewed_at": null,
+      "reviewed_by": null,
+      "reviewer": null,
+      "finished_processing_at": null,
+      "identity_verified_at": null,
+      "paused_at": null,
+      "status": "pending",
+      "external_id": null,
+      "identity": { "phone_number": null, "email": "cypress-user@ethyca.com" },
+      "policy": {
+        "name": "default_access_policy",
+        "key": "default_access_policy",
+        "drp_action": null,
+        "execution_timeframe": 45,
+        "rules": [
+          {
+            "name": "Example access Rule",
+            "key": "default_access_policy_rule",
+            "action_type": "access",
+            "storage_destination": {
+              "name": "s3_storage",
+              "type": "s3",
+              "details": {
+                "bucket": "fides-test-privacy-requests",
+                "naming": "request_id",
+                "auth_method": "secret_keys",
+                "max_retries": 0
+              },
+              "key": "s3_storage",
+              "format": "json"
+            },
+            "masking_strategy": null
+          }
+        ]
+      },
+      "action_required_details": null,
+      "resume_endpoint": null,
+      "days_left": 45
+    },
+    {
+      "id": "pri_8f719d4a-848d-42b9-8aaa-e7ac442ebba0",
+      "created_at": "2023-01-27T00:30:38.676759+00:00",
+      "started_processing_at": "2023-01-27T00:31:15.978689+00:00",
+      "reviewed_at": null,
+      "reviewed_by": null,
+      "reviewer": null,
+      "finished_processing_at": "2023-01-27T00:31:19.237969+00:00",
+      "identity_verified_at": "2023-01-27T00:31:15.958049+00:00",
+      "paused_at": null,
+      "status": "complete",
+      "external_id": null,
+      "identity": { "phone_number": null, "email": "cypress-user@ethyca.com" },
+      "policy": {
+        "name": "default_access_policy",
+        "key": "default_access_policy",
+        "drp_action": null,
+        "execution_timeframe": 45,
+        "rules": [
+          {
+            "name": "Example access Rule",
+            "key": "default_access_policy_rule",
+            "action_type": "access",
+            "storage_destination": {
+              "name": "s3_storage",
+              "type": "s3",
+              "details": {
+                "bucket": "fides-test-privacy-requests",
+                "naming": "request_id",
+                "auth_method": "secret_keys",
+                "max_retries": 0
+              },
+              "key": "s3_storage",
+              "format": "json"
+            },
+            "masking_strategy": null
+          }
+        ]
+      },
+      "action_required_details": null,
+      "resume_endpoint": null,
+      "days_left": 45
+    },
+    {
+      "id": "pri_a0fe994d-f1ee-40d9-bbcb-dedb76a08efe",
+      "created_at": "2023-01-27T00:18:30.573987+00:00",
+      "started_processing_at": "2023-01-27T00:19:23.237680+00:00",
+      "reviewed_at": null,
+      "reviewed_by": null,
+      "reviewer": null,
+      "finished_processing_at": "2023-01-27T00:19:25.764529+00:00",
+      "identity_verified_at": "2023-01-27T00:19:23.226101+00:00",
+      "paused_at": null,
+      "status": "complete",
+      "external_id": null,
+      "identity": { "phone_number": null, "email": "cypress-user@ethyca.com" },
+      "policy": {
+        "name": "default_access_policy",
+        "key": "default_access_policy",
+        "drp_action": null,
+        "execution_timeframe": 45,
+        "rules": [
+          {
+            "name": "Example access Rule",
+            "key": "default_access_policy_rule",
+            "action_type": "access",
+            "storage_destination": {
+              "name": "s3_storage",
+              "type": "s3",
+              "details": {
+                "bucket": "fides-test-privacy-requests",
+                "naming": "request_id",
+                "auth_method": "secret_keys",
+                "max_retries": 0
+              },
+              "key": "s3_storage",
+              "format": "json"
+            },
+            "masking_strategy": null
+          }
+        ]
+      },
+      "action_required_details": null,
+      "resume_endpoint": null,
+      "days_left": 45
+    },
+    {
+      "id": "pri_741784e9-1d75-4a6c-bdf7-66c9c814f1c1",
+      "created_at": "2023-01-27T00:17:27.604890+00:00",
+      "started_processing_at": "2023-01-27T00:17:42.956488+00:00",
+      "reviewed_at": null,
+      "reviewed_by": null,
+      "reviewer": null,
+      "finished_processing_at": "2023-01-27T00:17:46.143286+00:00",
+      "identity_verified_at": "2023-01-27T00:17:42.943415+00:00",
+      "paused_at": null,
+      "status": "complete",
+      "external_id": null,
+      "identity": { "phone_number": null, "email": "cypress-user@ethyca.com" },
+      "policy": {
+        "name": "default_access_policy",
+        "key": "default_access_policy",
+        "drp_action": null,
+        "execution_timeframe": 45,
+        "rules": [
+          {
+            "name": "Example access Rule",
+            "key": "default_access_policy_rule",
+            "action_type": "access",
+            "storage_destination": {
+              "name": "s3_storage",
+              "type": "s3",
+              "details": {
+                "bucket": "fides-test-privacy-requests",
+                "naming": "request_id",
+                "auth_method": "secret_keys",
+                "max_retries": 0
+              },
+              "key": "s3_storage",
+              "format": "json"
+            },
+            "masking_strategy": null
+          }
+        ]
+      },
+      "action_required_details": null,
+      "resume_endpoint": null,
+      "days_left": 45
+    },
+    {
+      "id": "pri_4f87b8b0-f97e-45e7-8561-300a6a932d04",
+      "created_at": "2023-01-27T00:11:32.826199+00:00",
+      "started_processing_at": "2023-01-27T00:11:59.565780+00:00",
+      "reviewed_at": null,
+      "reviewed_by": null,
+      "reviewer": null,
+      "finished_processing_at": "2023-01-27T00:12:00.964637+00:00",
+      "identity_verified_at": "2023-01-27T00:11:59.385923+00:00",
+      "paused_at": null,
+      "status": "error",
+      "external_id": null,
+      "identity": {
+        "phone_number": "+14155551234",
+        "email": "cypress-user@ethyca.com"
+      },
+      "policy": {
+        "name": "default_access_policy",
+        "key": "default_access_policy",
+        "drp_action": null,
+        "execution_timeframe": 45,
+        "rules": [
+          {
+            "name": "Example access Rule",
+            "key": "default_access_policy_rule",
+            "action_type": "access",
+            "storage_destination": {
+              "name": "s3_storage",
+              "type": "s3",
+              "details": {
+                "bucket": "fides-test-privacy-requests",
+                "naming": "request_id",
+                "auth_method": "secret_keys",
+                "max_retries": 0
+              },
+              "key": "s3_storage",
+              "format": "json"
+            },
+            "masking_strategy": null
+          }
+        ]
+      },
+      "action_required_details": {
+        "step": "access",
+        "collection": "mailchimp_instance_mailchimp:conversations",
+        "action_needed": null
+      },
+      "resume_endpoint": "/privacy-request/pri_4f87b8b0-f97e-45e7-8561-300a6a932d04/retry",
+      "days_left": 45
+    }
+  ],
+  "total": 8,
+  "page": 1,
+  "size": 25
+}

--- a/clients/admin-ui/cypress/support/commands.ts
+++ b/clients/admin-ui/cypress/support/commands.ts
@@ -2,8 +2,12 @@
 
 import { STORAGE_ROOT_KEY, USER_PRIVILEGES } from "~/constants";
 
-Cypress.Commands.add("getByTestId", (selector, ...args) =>
-  cy.get(`[data-testid='${selector}']`, ...args)
+Cypress.Commands.add("getByTestId", (selector, options) =>
+  cy.get(`[data-testid='${selector}']`, options)
+);
+
+Cypress.Commands.add("getByTestIdPrefix", (prefix, options) =>
+  cy.get(`[data-testid^='${prefix}']`, options)
 );
 
 Cypress.Commands.add("login", () => {
@@ -34,20 +38,34 @@ Cypress.Commands.add("login", () => {
 
 declare global {
   namespace Cypress {
+    type GetBy = (
+      selector: string,
+      options?: Partial<
+        Cypress.Loggable &
+          Cypress.Timeoutable &
+          Cypress.Withinable &
+          Cypress.Shadow
+      >
+    ) => Chainable<JQuery<HTMLElement>>;
+
     interface Chainable {
       /**
-       * Custom command to select DOM element by data-testid attribute
+       * Custom command to select DOM element by data-testid attribute.
        * @example cy.getByTestId('clear-btn')
        */
-      getByTestId(
-        selector: string,
-        options?: Partial<
-          Cypress.Loggable &
-            Cypress.Timeoutable &
-            Cypress.Withinable &
-            Cypress.Shadow
-        >
-      ): Chainable<JQuery<HTMLElement>>;
+      getByTestId: GetBy;
+      /**
+       * Custom command to select DOM element by the prefix of a data-testid attribute. Useful for
+       * elements that get rendered in a list where each item has its own unique id.
+       *
+       * @example
+       * cy.getByTestIdPrefix('row')
+       * // => [ tr#01, tr#02, ..., tr#20]
+       * // Versus:
+       * cy.getByTestId('row-13')
+       * // => tr#13
+       */
+      getByTestIdPrefix: GetBy;
       /**
        * Programmatically login with a mock user
        */

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -139,4 +139,24 @@ export const stubPrivacyRequests = () => {
       ).as("getPrivacyRequest");
     }
   );
+
+  cy.intercept(
+    {
+      method: "PATCH",
+      pathname: "/api/v1/privacy-request/administrate/approve",
+    },
+    {
+      fixture: "privacy-requests/approve.json",
+    }
+  ).as("approvePrivacyRequest");
+
+  cy.intercept(
+    {
+      method: "PATCH",
+      pathname: "/api/v1/privacy-request/administrate/deny",
+    },
+    {
+      fixture: "privacy-requests/deny.json",
+    }
+  ).as("denyPrivacyRequest");
 };

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -1,3 +1,4 @@
+import { PrivacyRequestResponse } from "~/features/privacy-requests/types";
 import { HealthCheck } from "~/types/api";
 
 export const stubTaxonomyEntities = () => {
@@ -91,5 +92,51 @@ export const stubHomePage = () => {
   cy.intercept("GET", "/api/v1/privacy-request*", {
     statusCode: 200,
     body: { items: [], total: 0, page: 1, size: 25 },
-  }).as("getPrivacyRequests");
+  }).as("getHomePagePrivacyRequests");
+};
+
+export const stubPrivacyRequests = () => {
+  cy.intercept(
+    {
+      method: "GET",
+      pathname: "/api/v1/privacy-request",
+      /**
+       * Query parameters could also match fixtures more specifically:
+       * https://docs.cypress.io/api/commands/intercept#Icon-nameangle-right--routeMatcher-RouteMatcher
+       */
+      query: {
+        include_identities: "true",
+        page: "*",
+        size: "*",
+      },
+    },
+    { fixture: "privacy-requests/list.json" }
+  ).as("getPrivacyRequests");
+
+  cy.fixture("privacy-requests/list.json").then(
+    (privacyRequests: PrivacyRequestResponse) => {
+      const privacyRequest = privacyRequests.items[0];
+
+      // This lets us use `cy.get("@privacyRequest")` as a shorthand for getting the singular
+      // privacy request object.
+      cy.wrap(privacyRequest).as("privacyRequest");
+
+      cy.intercept(
+        {
+          method: "GET",
+          pathname: "/api/v1/privacy-request",
+          query: {
+            include_identities: "true",
+            request_id: privacyRequest.id,
+          },
+        },
+        {
+          body: {
+            items: [privacyRequest],
+            total: 1,
+          },
+        }
+      ).as("getPrivacyRequest");
+    }
+  );
 };

--- a/clients/admin-ui/src/features/common/ConfirmationModal.tsx
+++ b/clients/admin-ui/src/features/common/ConfirmationModal.tsx
@@ -44,7 +44,7 @@ const ConfirmationModal = ({
     isOpen={isOpen}
     onClose={onClose}
     size="lg"
-    returnFocusOnClose={returnFocusOnClose || true}
+    returnFocusOnClose={returnFocusOnClose ?? true}
     isCentered={isCentered}
   >
     <ModalOverlay />

--- a/clients/admin-ui/src/features/common/RequestStatusBadge.tsx
+++ b/clients/admin-ui/src/features/common/RequestStatusBadge.tsx
@@ -58,6 +58,7 @@ const RequestStatusBadge: React.FC<RequestBadgeProps> = ({ status }) => (
     width={107}
     lineHeight="18px"
     textAlign="center"
+    data-testid="request-status-badge"
   >
     {statusPropMap[status].label}
   </Badge>

--- a/clients/admin-ui/src/features/privacy-requests/ApprovePrivacyRequestModal.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/ApprovePrivacyRequestModal.tsx
@@ -3,26 +3,26 @@ import React, { useCallback } from "react";
 
 type ApproveModalProps = {
   isOpen: boolean;
-  handleMenuClose: () => void;
-  handleApproveRequest: () => Promise<any>;
+  onClose: () => void;
+  onApproveRequest: () => Promise<any>;
   isLoading: boolean;
 };
 
 const ApprovePrivacyRequestModal = ({
   isOpen,
-  handleMenuClose,
-  handleApproveRequest,
+  onClose,
+  onApproveRequest,
   isLoading,
 }: ApproveModalProps) => {
   const handleSubmit = useCallback(() => {
-    handleApproveRequest().then(() => {
-      handleMenuClose();
+    onApproveRequest().then(() => {
+      onClose();
     });
-  }, [handleApproveRequest, handleMenuClose]);
+  }, [onApproveRequest, onClose]);
   return (
     <ConfirmationModal
       isOpen={isOpen}
-      onClose={handleMenuClose}
+      onClose={onClose}
       onConfirm={handleSubmit}
       message="Are you sure you want to approve this privacy request?"
       continueButtonText="Confirm"

--- a/clients/admin-ui/src/features/privacy-requests/DenyPrivacyRequestModal.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/DenyPrivacyRequestModal.tsx
@@ -43,7 +43,11 @@ const DenyPrivacyRequestModal = ({
       returnFocusOnClose={false}
     >
       <ModalOverlay />
-      <ModalContent width="100%" maxWidth="456px">
+      <ModalContent
+        width="100%"
+        maxWidth="456px"
+        data-testid="deny-privacy-request-modal"
+      >
         <Formik
           initialValues={initialValues}
           validationSchema={Yup.object({
@@ -88,6 +92,7 @@ const DenyPrivacyRequestModal = ({
                   variant="solid"
                   disabled={!dirty || !isValid}
                   isLoading={isSubmitting}
+                  data-testid="deny-privacy-request-modal-btn"
                 >
                   Confirm
                 </Button>

--- a/clients/admin-ui/src/features/privacy-requests/DenyPrivacyRequestModal.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/DenyPrivacyRequestModal.tsx
@@ -14,31 +14,31 @@ import * as Yup from "yup";
 
 type DenyModalProps = {
   isOpen: boolean;
-  handleMenuClose: () => void;
-  handleDenyRequest: (reason: string) => Promise<any>;
+  onClose: () => void;
+  onDenyRequest: (reason: string) => Promise<any>;
 };
 
 const initialValues = { denialReason: "" };
 type FormValues = typeof initialValues;
 const DenyPrivacyRequestModal = ({
   isOpen,
-  handleMenuClose,
-  handleDenyRequest,
+  onClose,
+  onDenyRequest,
 }: DenyModalProps) => {
   const handleSubmit = useCallback(
     (values: FormValues, formikHelpers: FormikHelpers<FormValues>) => {
       const { setSubmitting } = formikHelpers;
-      handleDenyRequest(values.denialReason).then(() => {
+      onDenyRequest(values.denialReason).then(() => {
         setSubmitting(false);
-        handleMenuClose();
+        onClose();
       });
     },
-    [handleDenyRequest, handleMenuClose]
+    [onDenyRequest, onClose]
   );
   return (
     <Modal
       isOpen={isOpen}
-      onClose={handleMenuClose}
+      onClose={onClose}
       isCentered
       returnFocusOnClose={false}
     >
@@ -79,7 +79,7 @@ const DenyPrivacyRequestModal = ({
                   colorScheme="gray.200"
                   mr={3}
                   disabled={isSubmitting}
-                  onClick={handleMenuClose}
+                  onClick={onClose}
                 >
                   Close
                 </Button>

--- a/clients/admin-ui/src/features/privacy-requests/PrivacyRequest.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/PrivacyRequest.tsx
@@ -14,7 +14,7 @@ const PrivacyRequest: React.FC<PrivacyRequestProps> = ({
   data: subjectRequest,
 }) => (
   <VStack align="stretch" display="flex-start" spacing={6}>
-    <Box>
+    <Box data-testid="privacy-request-details">
       <RequestDetails subjectRequest={subjectRequest} />
     </Box>
     <Box>

--- a/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestDetails.tsx
@@ -1,12 +1,23 @@
-import { Box, Divider, Flex, Heading, HStack, Tag, Text } from "@fidesui/react";
-import DaysLeftTag from "common/DaysLeftTag";
-import { PrivacyRequestEntity } from "privacy-requests/types";
+import {
+  Box,
+  ButtonGroup,
+  Divider,
+  Flex,
+  Heading,
+  HStack,
+  Tag,
+  Text,
+} from "@fidesui/react";
 
+import ClipboardButton from "~/features/common/ClipboardButton";
+import DaysLeftTag from "~/features/common/DaysLeftTag";
+import RequestStatusBadge from "~/features/common/RequestStatusBadge";
+import RequestType from "~/features/common/RequestType";
+import { PrivacyRequestEntity } from "~/features/privacy-requests/types";
 import { PrivacyRequestStatus as ApiPrivacyRequestStatus } from "~/types/api/models/PrivacyRequestStatus";
 
-import ClipboardButton from "../common/ClipboardButton";
-import RequestStatusBadge from "../common/RequestStatusBadge";
-import RequestType from "../common/RequestType";
+import ApproveButton from "./buttons/ApproveButton";
+import DenyButton from "./buttons/DenyButton";
 import ReprocessButton from "./buttons/ReprocessButton";
 
 type RequestDetailsProps = {
@@ -63,12 +74,23 @@ const RequestDetails = ({ subjectRequest }: RequestDetailsProps) => {
         </Text>
         <HStack spacing="16px">
           <RequestStatusBadge status={status} />
-          {status === "error" && (
-            <ReprocessButton
-              buttonProps={{ size: "xs" }}
-              subjectRequest={subjectRequest}
-            />
-          )}
+          <ButtonGroup isAttached variant="outline" borderRadius="md">
+            {status === "error" && (
+              <ReprocessButton
+                buttonProps={{ size: "xs" }}
+                subjectRequest={subjectRequest}
+              />
+            )}
+
+            {status === "pending" && (
+              <>
+                <ApproveButton subjectRequest={subjectRequest}>
+                  Approve
+                </ApproveButton>
+                <DenyButton subjectRequest={subjectRequest}>Deny</DenyButton>
+              </>
+            )}
+          </ButtonGroup>
 
           <DaysLeftTag
             daysLeft={subjectRequest.days_left}

--- a/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
@@ -282,6 +282,7 @@ const RequestRow = ({
                   bg: "gray.100",
                 }}
                 ref={hoverButtonRef}
+                data-testid="privacy-request-approve-btn"
               >
                 Approve
               </Button>
@@ -296,6 +297,7 @@ const RequestRow = ({
                 _hover={{
                   bg: "gray.100",
                 }}
+                data-testid="privacy-request-deny-btn"
               >
                 Deny
               </Button>

--- a/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
@@ -181,6 +181,7 @@ const RequestRow = ({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       height="36px"
+      data-testid={`privacy-request-row-${request.id}`}
     >
       <Td px={0}>
         <Checkbox
@@ -238,6 +239,7 @@ const RequestRow = ({
           mr={2.5}
           onFocus={shiftFocusToHoverMenu}
           tabIndex={showMenu ? -1 : 0}
+          data-testid="privacy-request-more-btn"
         >
           <MoreIcon color="gray.700" w={18} h={18} />
         </Button>
@@ -320,7 +322,7 @@ const RequestRow = ({
               <MoreIcon color="gray.700" w={18} h={18} />
             </MenuButton>
             <Portal>
-              <MenuList shadow="xl">
+              <MenuList shadow="xl" data-testid="privacy-request-more-menu">
                 <MenuItem
                   _focus={{ color: "complimentary.500", bg: "gray.100" }}
                   onClick={handleIdCopy}

--- a/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestRow.tsx
@@ -16,24 +16,20 @@ import {
   useClipboard,
   useToast,
 } from "@fidesui/react";
-import DaysLeftTag from "common/DaysLeftTag";
-import RequestType from "common/RequestType";
-import { formatDate } from "common/utils";
 import { useRouter } from "next/router";
-import ApprovePrivacyRequestModal from "privacy-requests/ApprovePrivacyRequestModal";
 import React, { useRef, useState } from "react";
 
+import DaysLeftTag from "~/features/common/DaysLeftTag";
 import { useFeatures } from "~/features/common/features";
+import PII from "~/features/common/PII";
+import RequestStatusBadge from "~/features/common/RequestStatusBadge";
+import RequestType from "~/features/common/RequestType";
+import { formatDate } from "~/features/common/utils";
 import { PrivacyRequestStatus as ApiPrivacyRequestStatus } from "~/types/api/models/PrivacyRequestStatus";
 
-import PII from "../common/PII";
-import RequestStatusBadge from "../common/RequestStatusBadge";
+import ApproveButton from "./buttons/ApproveButton";
+import DenyButton from "./buttons/DenyButton";
 import ReprocessButton from "./buttons/ReprocessButton";
-import DenyPrivacyRequestModal from "./DenyPrivacyRequestModal";
-import {
-  useApproveRequestMutation,
-  useDenyRequestMutation,
-} from "./privacy-requests.slice";
 import { PrivacyRequestEntity } from "./types";
 
 const useRequestRow = (request: PrivacyRequestEntity) => {
@@ -45,10 +41,6 @@ const useRequestRow = (request: PrivacyRequestEntity) => {
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  const [denyModalOpen, setDenyModalOpen] = useState(false);
-  const [approveModalOpen, setApproveModalOpen] = useState(false);
-  const [approveRequest, approveRequestResult] = useApproveRequestMutation();
-  const [denyRequest, denyRequestResult] = useDenyRequestMutation();
   const handleMenuOpen = () => setMenuOpen(true);
   const handleMenuClose = () => setMenuOpen(false);
   const handleMouseEnter = () => setHovered(true);
@@ -60,26 +52,11 @@ const useRequestRow = (request: PrivacyRequestEntity) => {
   };
   const handleFocus = () => setFocused(true);
   const handleBlur = () => setFocused(false);
-  const handleApproveRequest = () => approveRequest(request);
-
-  const handleDenyRequest = (reason: string) =>
-    denyRequest({ id: request.id, reason });
   const { onCopy } = useClipboard(request.id);
-  const handleDenyModalOpen = () => setDenyModalOpen(true);
-  const handleApproveModalOpen = () => setApproveModalOpen(true);
   const resetSharedModalStates = () => {
     setFocused(false);
     setHovered(false);
     setMenuOpen(false);
-  };
-  const handleDenyModalClose = () => {
-    setDenyModalOpen(false);
-    resetSharedModalStates();
-  };
-
-  const handleApproveModalClose = () => {
-    setApproveModalOpen(false);
-    resetSharedModalStates();
   };
   const handleIdCopy = () => {
     onCopy();
@@ -107,17 +84,10 @@ const useRequestRow = (request: PrivacyRequestEntity) => {
     router.push(url);
   };
   return {
-    approveRequestResult,
-    denyRequestResult,
     hovered,
     focused,
     menuOpen,
-    denyModalOpen,
-    approveModalOpen,
-    handleDenyModalOpen,
-    handleDenyModalClose,
-    handleApproveModalOpen,
-    handleApproveModalClose,
+    resetSharedModalStates,
     handleMenuClose,
     handleMenuOpen,
     handleMouseEnter,
@@ -125,8 +95,6 @@ const useRequestRow = (request: PrivacyRequestEntity) => {
     handleFocus,
     handleBlur,
     handleIdCopy,
-    handleApproveRequest,
-    handleDenyRequest,
     hoverButtonRef,
     shiftFocusToHoverMenu,
     handleViewDetails,
@@ -152,22 +120,13 @@ const RequestRow = ({
     handleMenuClose,
     handleMouseEnter,
     handleMouseLeave,
-    handleApproveRequest,
-    handleDenyRequest,
     handleIdCopy,
     menuOpen,
-    approveRequestResult,
-    denyRequestResult,
     hoverButtonRef,
-    denyModalOpen,
-    handleDenyModalClose,
-    handleDenyModalOpen,
-    approveModalOpen,
-    handleApproveModalClose,
-    handleApproveModalOpen,
     shiftFocusToHoverMenu,
     handleFocus,
     handleBlur,
+    resetSharedModalStates,
     focused,
     handleViewDetails,
   } = useRequestRow(request);
@@ -267,51 +226,19 @@ const RequestRow = ({
           )}
           {request.status === "pending" && (
             <>
-              <Button
-                size="xs"
-                mr="-px"
-                bg="white"
-                onClick={() => {
-                  handleApproveModalOpen();
-                  handleBlur();
-                }}
-                isDisabled={
-                  approveRequestResult.isLoading || denyRequestResult.isLoading
-                }
-                _hover={{
-                  bg: "gray.100",
-                }}
+              <ApproveButton
+                subjectRequest={request}
+                onClose={resetSharedModalStates}
                 ref={hoverButtonRef}
-                data-testid="privacy-request-approve-btn"
               >
                 Approve
-              </Button>
-              <Button
-                size="xs"
-                mr="-px"
-                bg="white"
-                onClick={handleDenyModalOpen}
-                isDisabled={
-                  approveRequestResult.isLoading || denyRequestResult.isLoading
-                }
-                _hover={{
-                  bg: "gray.100",
-                }}
-                data-testid="privacy-request-deny-btn"
+              </ApproveButton>
+              <DenyButton
+                subjectRequest={request}
+                onClose={resetSharedModalStates}
               >
                 Deny
-              </Button>
-              <DenyPrivacyRequestModal
-                isOpen={denyModalOpen}
-                handleMenuClose={handleDenyModalClose}
-                handleDenyRequest={handleDenyRequest}
-              />
-              <ApprovePrivacyRequestModal
-                isOpen={approveModalOpen}
-                handleMenuClose={handleApproveModalClose}
-                handleApproveRequest={handleApproveRequest}
-                isLoading={approveRequestResult.isLoading}
-              />
+              </DenyButton>
             </>
           )}
           <Menu onOpen={handleMenuOpen} onClose={handleMenuClose}>

--- a/clients/admin-ui/src/features/privacy-requests/RequestTable.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestTable.tsx
@@ -72,7 +72,7 @@ const RequestTable = ({ revealPII }: RequestTableProps) => {
 
   return (
     <>
-      <Table size="sm">
+      <Table size="sm" data-testid="privacy-request-table">
         <Thead>
           <Tr>
             <Th px={0}>

--- a/clients/admin-ui/src/features/privacy-requests/buttons/ApproveButton.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/buttons/ApproveButton.tsx
@@ -1,0 +1,53 @@
+import { ButtonProps, forwardRef, useDisclosure } from "@fidesui/react";
+import { ReactNode } from "react";
+
+import ApprovePrivacyRequestModal from "~/features/privacy-requests/ApprovePrivacyRequestModal";
+import { useMutations } from "~/features/privacy-requests/hooks/useMutations";
+import { PrivacyRequestEntity } from "~/features/privacy-requests/types";
+
+import { StyledButton } from "./StyledButton";
+
+type ApproveButtonProps = {
+  buttonProps?: ButtonProps;
+  children?: ReactNode;
+  onClose?: () => void;
+  subjectRequest: PrivacyRequestEntity;
+};
+
+const ApproveButton = forwardRef<ApproveButtonProps, "button">(
+  ({ buttonProps, children, onClose, subjectRequest }, ref) => {
+    const { handleApproveRequest, isLoading } = useMutations({
+      subjectRequest,
+    });
+
+    const modal = useDisclosure();
+    const handleClose = () => {
+      modal.onClose();
+      onClose?.();
+    };
+
+    return (
+      <>
+        <StyledButton
+          ref={ref}
+          onClick={modal.onOpen}
+          isLoading={isLoading}
+          isDisabled={isLoading}
+          {...buttonProps}
+          data-testid="privacy-request-approve-btn"
+        >
+          {children}
+        </StyledButton>
+
+        <ApprovePrivacyRequestModal
+          isOpen={modal.isOpen}
+          isLoading={isLoading}
+          onClose={handleClose}
+          onApproveRequest={handleApproveRequest}
+        />
+      </>
+    );
+  }
+);
+
+export default ApproveButton;

--- a/clients/admin-ui/src/features/privacy-requests/buttons/DenyButton.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/buttons/DenyButton.tsx
@@ -1,0 +1,50 @@
+import { ButtonProps, forwardRef, useDisclosure } from "@fidesui/react";
+import { ReactNode } from "react";
+
+import DenyPrivacyRequestModal from "~/features/privacy-requests/DenyPrivacyRequestModal";
+import { useMutations } from "~/features/privacy-requests/hooks/useMutations";
+import { PrivacyRequestEntity } from "~/features/privacy-requests/types";
+
+import { StyledButton } from "./StyledButton";
+
+type DenyButtonProps = {
+  buttonProps?: ButtonProps;
+  children?: ReactNode;
+  onClose?: () => void;
+  subjectRequest: PrivacyRequestEntity;
+};
+
+const DenyButton = forwardRef<DenyButtonProps, "button">(
+  ({ buttonProps, children, onClose, subjectRequest }, ref) => {
+    const { handleDenyRequest, isLoading } = useMutations({ subjectRequest });
+
+    const modal = useDisclosure();
+    const handleClose = () => {
+      modal.onClose();
+      onClose?.();
+    };
+
+    return (
+      <>
+        <StyledButton
+          ref={ref}
+          onClick={modal.onOpen}
+          isLoading={isLoading}
+          isDisabled={isLoading}
+          {...buttonProps}
+          data-testid="privacy-request-deny-btn"
+        >
+          {children}
+        </StyledButton>
+
+        <DenyPrivacyRequestModal
+          isOpen={modal.isOpen}
+          onClose={handleClose}
+          onDenyRequest={handleDenyRequest}
+        />
+      </>
+    );
+  }
+);
+
+export default DenyButton;

--- a/clients/admin-ui/src/features/privacy-requests/buttons/StyledButton.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/buttons/StyledButton.tsx
@@ -1,0 +1,22 @@
+import { Button, forwardRef } from "@fidesui/react";
+
+/**
+ * Provides the default styling props for buttons used by Privacy Request actions.
+ */
+export const StyledButton: typeof Button = forwardRef((props, ref) => (
+  <Button
+    ref={ref}
+    size="xs"
+    bg="white"
+    _loading={{
+      opacity: 1,
+      div: { opacity: 0.4 },
+    }}
+    _hover={{
+      bg: "gray.100",
+    }}
+    {...props}
+  />
+));
+
+export default StyledButton;

--- a/clients/admin-ui/src/features/privacy-requests/hooks/useMutations.ts
+++ b/clients/admin-ui/src/features/privacy-requests/hooks/useMutations.ts
@@ -1,0 +1,37 @@
+import {
+  useApproveRequestMutation,
+  useDenyRequestMutation,
+} from "~/features/privacy-requests/privacy-requests.slice";
+import { PrivacyRequestEntity } from "~/features/privacy-requests/types";
+
+export const useMutations = ({
+  subjectRequest,
+}: {
+  subjectRequest: PrivacyRequestEntity;
+}) => {
+  // The `fixedCacheKey` options allows multiple components to reference the same mutation state for
+  // a subject request.
+  const [approveRequest, approveRequestResult] = useApproveRequestMutation({
+    fixedCacheKey: subjectRequest.id,
+  });
+  const [denyRequest, denyRequestResult] = useDenyRequestMutation({
+    fixedCacheKey: subjectRequest.id,
+  });
+
+  const handleApproveRequest = () => approveRequest(subjectRequest);
+  const handleDenyRequest = (reason: string) =>
+    denyRequest({ id: subjectRequest.id, reason });
+
+  const isLoading =
+    denyRequestResult.isLoading || approveRequestResult.isLoading;
+
+  return {
+    approveRequest,
+    approveRequestResult,
+    denyRequest,
+    denyRequestResult,
+    handleApproveRequest,
+    handleDenyRequest,
+    isLoading,
+  };
+};


### PR DESCRIPTION
Closes #2290

### Code Changes

- Request details Approve & Deny button group
  - ApproveButton component
  - DenyButton component
  - Tests for approve & deny buttons

- General improvements:
  - StyledButton for shared button styles
  - Use "on" for props and "handle" for handler functions
  - Fix `returnFocusOnClose`
  - Initial tests for requests table and details pages
  - getByTestIdPrefix Cypress command

### Steps to Confirm

* [ ] Details page buttons
  * Approve a request
  * Deny a request with reason modal
* [ ] Table menu buttons
  * Should be verified as well because the components were refactored
  * Approve a request
  * Deny a request with reason modal

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Updated video_ after resolving https://github.com/ethyca/fides/pull/2443 merge conflicts:
<video src="https://user-images.githubusercontent.com/2236777/216207332-394757b4-500d-4f8a-b0d7-5512edbb0a94.mp4" />

With the buttons refactored out, they can be dropped right into the page:
<img width="479" alt="details-button" src="https://user-images.githubusercontent.com/2236777/216171488-8f11c699-19d7-4a0a-adbf-e2a16fb73e1d.png">

Video of using Deny button & modal:
<video src="https://user-images.githubusercontent.com/2236777/216171028-cdbc5fb4-4b6d-457c-b0d4-5907301f2070.mp4" />


