### PR TITLE
Make policy_key optional for consent

### DIFF
--- a/clients/privacy-center/types/config.ts
+++ b/clients/privacy-center/types/config.ts
@@ -11,7 +11,7 @@ export type Config = {
     title: string;
     description: string;
     identity_inputs?: Record<string, string>;
-    policy_key: string;
+    policy_key?: string;
     consentOptions: ConfigConsentOption[];
   };
 };

--- a/tests/ops/integration_tests/saas/request_override/test_firebase_auth_task.py
+++ b/tests/ops/integration_tests/saas/request_override/test_firebase_auth_task.py
@@ -92,6 +92,7 @@ async def test_firebase_auth_access_request(
     assert "photo_url" not in provider_data[1].keys()
 
 
+@pytest.mark.integration_saas
 @pytest.mark.integration_firebase_auth
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("firebase_auth_user")


### PR DESCRIPTION
Policy key can be optional in privacy center config.json

### Code Changes

* [x] Just a TS fix so there's no breaking change in the privacy center

### Steps to Confirm

* [ ] Remove the `policy_key` from the `consent` block of the config.json
* [ ] Run `npm run build`. it should build 👌 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
