### PR TITLE
Use logo from config on privacy center's 404 page

### DIFF
--- a/clients/privacy-center/pages/404.tsx
+++ b/clients/privacy-center/pages/404.tsx
@@ -2,6 +2,8 @@ import Head from "next/head";
 import NextLink from "next/link";
 import { Stack, Heading, Box, Text, Button, Link, Image } from "@fidesui/react";
 
+import { config } from "~/constants";
+
 const Custom404 = () => (
   <div>
     <Head>
@@ -53,8 +55,8 @@ const Custom404 = () => (
             </Stack>
             <Box display={[null, null, "none"]}>
               <Image
-                src="/logo.svg"
-                alt="FidesOps logo"
+                src={config.logo_path}
+                alt="Logo"
                 width="124px"
                 height="38px"
               />
@@ -66,8 +68,8 @@ const Custom404 = () => (
             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
             <Link>
               <Image
-                src="/logo.svg"
-                alt="FidesOps logo"
+                src={config.logo_path}
+                alt="Logo"
                 width="124px"
                 height="38px"
               />


### PR DESCRIPTION
### Code Changes

* Changes 404 page on privacy center to use the configured logo image rather than the default "Acme Logo" one

### Steps to Confirm

* [ ] Run locally with a custom logo and verify it is shown on both homepage and 404 page

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

(I'm assuming that the default logo wasn't left in intentionally; I noticed the alt text was "FidesOps Logo" but assuming that's a holdover and wasn't meant to e.g. brand it with fides)
