### PR TITLE
pc/consent: Use RTK queries for consent verification and preferences

### DIFF
--- a/clients/privacy-center/components/ConsentItemCard.tsx
+++ b/clients/privacy-center/components/ConsentItemCard.tsx
@@ -12,32 +12,29 @@ import {
 import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { ConsentItem } from "~/features/consent/types";
 
-type SetConsentValueProp = {
-  setConsentValue: (x: boolean) => void;
+type ConsentItemProps = {
+  item: ConsentItem;
+  setConsentValue: (value: boolean) => void;
 };
 
-type ConsentItemProps = ConsentItem & SetConsentValueProp;
-
-const ConsentItemCard: React.FC<ConsentItemProps> = ({
-  name,
-  description,
-  highlight,
-  defaultValue,
-  consentValue,
-  url,
-  fidesDataUseKey,
-  setConsentValue,
-}) => {
-  const [value, setValue] = useState("false");
+const ConsentItemCard = ({ item, setConsentValue }: ConsentItemProps) => {
+  const {
+    name,
+    description,
+    highlight,
+    defaultValue,
+    consentValue,
+    url,
+    fidesDataUseKey,
+  } = item;
+  const [value, setValue] = useState(consentValue ?? defaultValue);
   const backgroundColor = highlight ? "gray.100" : "";
+
   useEffect(() => {
-    if (consentValue !== undefined) {
-      setValue(consentValue ? "true" : "false");
-    } else {
-      setValue(defaultValue ? "true" : "false");
-      setConsentValue(defaultValue);
+    if (consentValue !== value) {
+      setConsentValue(value);
     }
-  }, [consentValue, defaultValue, setValue, setConsentValue]);
+  }, [value, consentValue, setConsentValue]);
 
   return (
     <Flex
@@ -83,11 +80,10 @@ const ConsentItemCard: React.FC<ConsentItemProps> = ({
           </Link>
         </Box>
         <RadioGroup
+          value={value ? "true" : "false"}
           onChange={(e) => {
-            setValue(e);
-            setConsentValue(e === "true");
+            setValue(e === "true");
           }}
-          value={value}
         >
           <Stack direction="row">
             <Radio value="true" colorScheme="whatsapp">

--- a/clients/privacy-center/cypress/e2e/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent.cy.ts
@@ -62,7 +62,7 @@ describe("Consent settings", () => {
 
       cy.intercept(
         "PATCH",
-        `${hostUrl}/consent-request/consent-request-id/preferences/`,
+        `${hostUrl}/consent-request/consent-request-id/preferences`,
         (req) => {
           req.reply(req.body);
         }

--- a/clients/privacy-center/features/consent/consent.slice.ts
+++ b/clients/privacy-center/features/consent/consent.slice.ts
@@ -1,0 +1,51 @@
+import { VerificationType } from "~/components/modals/types";
+import { baseApi } from "~/features/common/api.slice";
+import {
+  ConsentPreferences,
+  ConsentPreferencesWithVerificationCode,
+} from "~/types/api";
+
+export const consentApi = baseApi.injectEndpoints({
+  endpoints: (build) => ({
+    postConsentRequestVerification: build.mutation<
+      ConsentPreferences,
+      {
+        id: string;
+        code: string;
+      }
+    >({
+      query: ({ id, code }) => ({
+        url: `${VerificationType.ConsentRequest}/${id}/verify`,
+        method: "POST",
+        body: {
+          code,
+        },
+      }),
+    }),
+    getConsentRequestPreferences: build.query<
+      ConsentPreferences,
+      {
+        id: string;
+      }
+    >({
+      query: ({ id }) => `${VerificationType.ConsentRequest}/${id}/preferences`,
+    }),
+    updateConsentRequestPreferences: build.mutation<
+      ConsentPreferences,
+      { id: string; body: ConsentPreferencesWithVerificationCode }
+    >({
+      query: ({ id, body }) => ({
+        url: `${VerificationType.ConsentRequest}/${id}/preferences`,
+        method: "PATCH",
+        body,
+        credentials: "include",
+      }),
+    }),
+  }),
+});
+
+export const {
+  usePostConsentRequestVerificationMutation,
+  useLazyGetConsentRequestPreferencesQuery,
+  useUpdateConsentRequestPreferencesMutation,
+} = consentApi;

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -1,38 +1,37 @@
-import React, { useEffect, useState, useCallback } from "react";
-import type { NextPage } from "next";
-import Head from "next/head";
 import {
+  Button,
   Flex,
   Heading,
-  Text,
-  Stack,
   Image,
-  Button,
+  Stack,
+  Text,
   useToast,
 } from "@fidesui/react";
-import { useRouter } from "next/router";
-import { ErrorToastOptions, SuccessToastOptions } from "~/common/toast-options";
 import produce from "immer";
+import type { NextPage } from "next";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import React, { useCallback, useEffect, useState } from "react";
 
-import {
-  makeConsentItems,
-  makeCookieKeyConsent,
-} from "~/features/consent/helpers";
 import { setConsentCookie } from "fides-consent";
-import { ApiUserConsents, ConsentItem } from "~/features/consent/types";
-
-import { config } from "~/constants";
-import { useLocalStorage } from "~/common/hooks";
 import { useAppSelector } from "~/app/hooks";
-import { useGetIdVerificationConfigQuery } from "~/features/id-verification";
-import { selectConfigConsentOptions } from "~/features/common/config.slice";
-import ConsentItemCard from "~/components/ConsentItemCard";
 import { inspectForBrowserIdentities } from "~/common/browser-identities";
+import { useLocalStorage } from "~/common/hooks";
+import { ErrorToastOptions, SuccessToastOptions } from "~/common/toast-options";
+import ConsentItemCard from "~/components/ConsentItemCard";
+import { config } from "~/constants";
+import { selectConfigConsentOptions } from "~/features/common/config.slice";
 import {
   useLazyGetConsentRequestPreferencesQuery,
   usePostConsentRequestVerificationMutation,
   useUpdateConsentRequestPreferencesMutation,
 } from "~/features/consent/consent.slice";
+import {
+  makeConsentItems,
+  makeCookieKeyConsent,
+} from "~/features/consent/helpers";
+import { ApiUserConsents, ConsentItem } from "~/features/consent/types";
+import { useGetIdVerificationConfigQuery } from "~/features/id-verification";
 
 const Consent: NextPage = () => {
   const [consentRequestId] = useLocalStorage("consentRequestId", "");

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -11,13 +11,8 @@ import {
   useToast,
 } from "@fidesui/react";
 import { useRouter } from "next/router";
-import {
-  ConfigErrorToastOptions,
-  ErrorToastOptions,
-  SuccessToastOptions,
-} from "~/common/toast-options";
+import { ErrorToastOptions, SuccessToastOptions } from "~/common/toast-options";
 
-import { Headers } from "headers-polyfill";
 import {
   makeConsentItems,
   makeCookieKeyConsent,
@@ -25,17 +20,20 @@ import {
 import { setConsentCookie } from "fides-consent";
 import { ApiUserConsents, ConsentItem } from "~/features/consent/types";
 
-import { hostUrl, config } from "~/constants";
-import { addCommonHeaders } from "~/common/CommonHeaders";
-import { VerificationType } from "~/components/modals/types";
+import { config } from "~/constants";
 import { useLocalStorage } from "~/common/hooks";
 import { useAppSelector } from "~/app/hooks";
+import { useGetIdVerificationConfigQuery } from "~/features/id-verification";
 import { selectConfigConsentOptions } from "~/features/common/config.slice";
 import ConsentItemCard from "~/components/ConsentItemCard";
 import { inspectForBrowserIdentities } from "~/common/browser-identities";
+import {
+  useLazyGetConsentRequestPreferencesQuery,
+  usePostConsentRequestVerificationMutation,
+  useUpdateConsentRequestPreferencesMutation,
+} from "~/features/consent/consent.slice";
 
 const Consent: NextPage = () => {
-  const content: any = [];
   const [consentRequestId] = useLocalStorage("consentRequestId", "");
   const [verificationCode] = useLocalStorage("verificationCode", "");
   const router = useRouter();
@@ -43,147 +41,208 @@ const Consent: NextPage = () => {
   const [consentItems, setConsentItems] = useState<ConsentItem[]>([]);
   const consentOptions = useAppSelector(selectConfigConsentOptions);
 
-  useEffect(() => {
-    const getUserConsents = async () => {
-      if (!consentRequestId) {
-        router.push("/");
-        return;
-      }
+  const getIdVerificationConfigQueryResult = useGetIdVerificationConfigQuery();
+  const [
+    postConsentRequestVerificationMutationTrigger,
+    postConsentRequestVerificationMutationResult,
+  ] = usePostConsentRequestVerificationMutation();
+  const [
+    getConsentRequestPreferencesQueryTrigger,
+    getConsentRequestPreferencesQueryResult,
+  ] = useLazyGetConsentRequestPreferencesQuery();
+  const [
+    updateConsentRequestPreferencesMutationTrigger,
+    updateConsentRequestPreferencesMutationResult,
+  ] = useUpdateConsentRequestPreferencesMutation();
 
-      const headers: Headers = new Headers();
-      addCommonHeaders(headers, null);
-
-      const configResponse = await fetch(`${hostUrl}/id-verification/config`, {
-        headers,
+  // TODO(#2299): Use error utils from shared package.
+  const toastError = useCallback(
+    ({
+      title = "An error occurred while retrieving user consent preferences.",
+      error,
+    }: {
+      title?: string;
+      error?: any;
+    }) => {
+      toast({
+        title,
+        description: error?.data?.detail,
+        ...ErrorToastOptions,
       });
-      const privacyCenterConfig = await configResponse.json();
-      if (!configResponse.ok) {
-        toast({
-          description: privacyCenterConfig.detail,
-          ...ConfigErrorToastOptions,
-        });
-        return;
-      }
+    },
+    [toast]
+  );
 
-      if (
-        privacyCenterConfig.identity_verification_required &&
-        !verificationCode
-      ) {
-        router.push("/");
-        return;
-      }
+  const redirectToIndex = useCallback(() => {
+    router.push("/");
+  }, [router]);
 
-      const verifyUrl = privacyCenterConfig.identity_verification_required
-        ? `${VerificationType.ConsentRequest}/${consentRequestId}/verify`
-        : `${VerificationType.ConsentRequest}/${consentRequestId}/preferences`;
-
-      const requestOptions: RequestInit = {
-        method: privacyCenterConfig.identity_verification_required
-          ? "POST"
-          : "GET",
-        headers,
-      };
-      if (privacyCenterConfig.identity_verification_required) {
-        requestOptions.body = JSON.stringify({ code: verificationCode });
-      }
-
-      const response = await fetch(`${hostUrl}/${verifyUrl}`, requestOptions);
-      const data = (await response.json()) as ApiUserConsents;
-      if (!response.ok) {
-        toast({
-          title: "An error occurred while retrieving user consent preferences",
-          description: (data as any).detail,
-          ...ErrorToastOptions,
-        });
-
-        router.push("/");
-        return;
-      }
-
+  const updateConsentItems = useCallback(
+    (data: ApiUserConsents) => {
       const updatedConsentItems = makeConsentItems(data, consentOptions);
       setConsentItems(updatedConsentItems);
       setConsentCookie(makeCookieKeyConsent(updatedConsentItems));
-    };
-    getUserConsents();
-  }, [router, consentRequestId, verificationCode, toast, consentOptions]);
+    },
+    [consentOptions]
+  );
 
-  consentItems.forEach((option) => {
-    content.push(
-      <ConsentItemCard
-        key={option.fidesDataUseKey}
-        fidesDataUseKey={option.fidesDataUseKey}
-        name={option.name}
-        description={option.description}
-        highlight={option.highlight}
-        url={option.url}
-        defaultValue={option.defaultValue}
-        consentValue={option.consentValue}
-        setConsentValue={(value) => {
-          /* eslint-disable-next-line no-param-reassign */
-          option.consentValue = value;
-        }}
-      />
-    );
-  });
-
-  const saveUserConsentOptions = useCallback(async () => {
-    const headers: Headers = new Headers();
-    addCommonHeaders(headers, null);
-    const browserIdentity = inspectForBrowserIdentities();
-
-    const body = {
-      code: verificationCode,
-      policy_key: config.consent?.policy_key,
-      consent: consentItems.map((d) => ({
-        data_use: d.fidesDataUseKey,
-        data_use_description: d.description,
-        opt_in: d.consentValue,
-      })),
-      executable_options: consentItems.map((d) => ({
-        data_use: d.fidesDataUseKey,
-        executable: d.executable ?? false,
-      })),
-      browser_identity: browserIdentity
-        ? { ga_client_id: browserIdentity.gaClientId }
-        : undefined,
-    };
-
-    const response = await fetch(
-      `${hostUrl}/${VerificationType.ConsentRequest}/${consentRequestId}/preferences/`,
-      {
-        method: "PATCH",
-        headers,
-        body: JSON.stringify(body),
-        credentials: "include",
-      }
-    );
-
-    const data = (await response.json()) as ApiUserConsents;
-    if (!response.ok) {
-      toast({
-        title: "An error occurred while saving user consent preferences",
-        description: (data as any).detail,
-        ...ErrorToastOptions,
-      });
-      router.push("/");
+  /**
+   * When the Id verification method is known, trigger the request that will
+   * return the consent choices saved on the backend.
+   */
+  useEffect(() => {
+    if (!consentRequestId) {
+      toastError({ title: "No consent request in progress." });
+      redirectToIndex();
+      return;
     }
-    const updatedConsentItems = makeConsentItems(data, consentOptions);
-    setConsentCookie(makeCookieKeyConsent(updatedConsentItems));
-    toast({
-      title: "Your consent preferences have been saved",
-      ...SuccessToastOptions,
-    });
 
-    router.push("/");
-    // TODO: display alert on successful patch
-    // TODO: display error alert on failed patch
+    if (getIdVerificationConfigQueryResult.isError) {
+      toastError({ error: getIdVerificationConfigQueryResult.error });
+      return;
+    }
+
+    if (!getIdVerificationConfigQueryResult.isSuccess) {
+      return;
+    }
+
+    const privacyCenterConfig = getIdVerificationConfigQueryResult.data;
+    if (
+      privacyCenterConfig.identity_verification_required &&
+      !verificationCode
+    ) {
+      toastError({ title: "Identity verification is required." });
+      redirectToIndex();
+      return;
+    }
+
+    if (privacyCenterConfig.identity_verification_required) {
+      postConsentRequestVerificationMutationTrigger({
+        id: consentRequestId,
+        code: verificationCode,
+      });
+    } else {
+      getConsentRequestPreferencesQueryTrigger({
+        id: consentRequestId,
+      });
+    }
   }, [
+    consentRequestId,
     verificationCode,
+    getIdVerificationConfigQueryResult,
+    postConsentRequestVerificationMutationTrigger,
+    getConsentRequestPreferencesQueryTrigger,
+    toastError,
+    redirectToIndex,
+  ]);
+
+  /**
+   * Initialize consent items from the request verification response.
+   */
+  useEffect(() => {
+    if (postConsentRequestVerificationMutationResult.isError) {
+      toastError({
+        error: postConsentRequestVerificationMutationResult.error,
+      });
+      redirectToIndex();
+      return;
+    }
+
+    if (postConsentRequestVerificationMutationResult.isSuccess) {
+      updateConsentItems(postConsentRequestVerificationMutationResult.data);
+    }
+  }, [
+    postConsentRequestVerificationMutationResult,
+    updateConsentItems,
+    toastError,
+    redirectToIndex,
+  ]);
+
+  /**
+   * Initialize consent items from the unverified preferences response.
+   */
+  useEffect(() => {
+    if (getConsentRequestPreferencesQueryResult.isError) {
+      toastError({
+        error: getConsentRequestPreferencesQueryResult.error,
+      });
+      redirectToIndex();
+      return;
+    }
+
+    if (getConsentRequestPreferencesQueryResult.isSuccess) {
+      updateConsentItems(getConsentRequestPreferencesQueryResult.data);
+    }
+  }, [
+    getConsentRequestPreferencesQueryResult,
+    updateConsentItems,
+    toastError,
+    redirectToIndex,
+  ]);
+
+  /**
+   * Update the consent choices on the backend.
+   */
+  const saveUserConsentOptions = useCallback(() => {
+    const consent = consentItems.map((d) => ({
+      data_use: d.fidesDataUseKey,
+      data_use_description: d.description,
+      opt_in: Boolean(d.consentValue),
+    }));
+
+    const executableOptions = consentItems.map((d) => ({
+      data_use: d.fidesDataUseKey,
+      executable: d.executable ?? false,
+    }));
+
+    const browserIdentity = inspectForBrowserIdentities();
+    const browserIdentityBody = browserIdentity
+      ? { ga_client_id: browserIdentity.gaClientId }
+      : undefined;
+
+    updateConsentRequestPreferencesMutationTrigger({
+      id: consentRequestId,
+      body: {
+        code: verificationCode,
+        policy_key: config.consent?.policy_key,
+        consent,
+        executable_options: executableOptions,
+        browser_identity: browserIdentityBody,
+      },
+    });
+  }, [
     consentItems,
     consentRequestId,
+    verificationCode,
+    updateConsentRequestPreferencesMutationTrigger,
+  ]);
+
+  /**
+   * Handle consent update result.
+   */
+  useEffect(() => {
+    if (updateConsentRequestPreferencesMutationResult.isError) {
+      toastError({
+        title: "An error occurred while saving user consent preferences",
+        error: updateConsentRequestPreferencesMutationResult.error,
+      });
+      return;
+    }
+
+    if (updateConsentRequestPreferencesMutationResult.isSuccess) {
+      updateConsentItems(updateConsentRequestPreferencesMutationResult.data);
+      toast({
+        title: "Your consent preferences have been saved",
+        ...SuccessToastOptions,
+      });
+      redirectToIndex();
+    }
+  }, [
+    updateConsentRequestPreferencesMutationResult,
+    updateConsentItems,
+    toastError,
     toast,
-    router,
-    consentOptions,
+    redirectToIndex,
   ]);
 
   return (
@@ -235,9 +294,26 @@ const Consent: NextPage = () => {
               hard to protect your information and put you in control.
             </Text>
           </Stack>
+
           <Flex m={-2} flexDirection="column">
-            {content}
+            {consentItems.map((option) => (
+              <ConsentItemCard
+                key={option.fidesDataUseKey}
+                fidesDataUseKey={option.fidesDataUseKey}
+                name={option.name}
+                description={option.description}
+                highlight={option.highlight}
+                url={option.url}
+                defaultValue={option.defaultValue}
+                consentValue={option.consentValue}
+                setConsentValue={(value) => {
+                  /* eslint-disable-next-line no-param-reassign */
+                  option.consentValue = value;
+                }}
+              />
+            ))}
           </Flex>
+
           <Stack direction="row" justifyContent="flex-start" width="720px">
             <Button
               size="sm"

--- a/clients/privacy-center/types/api/index.ts
+++ b/clients/privacy-center/types/api/index.ts
@@ -2,4 +2,9 @@
 /* tslint:disable */
 /* eslint-disable */
 
+export type { Consent } from "./models/Consent";
+export type { ConsentPreferences } from "./models/ConsentPreferences";
+export type { ConsentPreferencesWithVerificationCode } from "./models/ConsentPreferencesWithVerificationCode";
+export type { ConsentWithExecutableStatus } from "./models/ConsentWithExecutableStatus";
+export type { Identity } from "./models/Identity";
 export type { IdentityVerificationConfigResponse } from "./models/IdentityVerificationConfigResponse";

--- a/clients/privacy-center/types/api/models/Consent.ts
+++ b/clients/privacy-center/types/api/models/Consent.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Schema for consent.
+ */
+export type Consent = {
+  data_use: string;
+  data_use_description?: string;
+  opt_in: boolean;
+};

--- a/clients/privacy-center/types/api/models/ConsentPreferences.ts
+++ b/clients/privacy-center/types/api/models/ConsentPreferences.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { Consent } from './Consent';
+
+/**
+ * Schema for consent preferences.
+ */
+export type ConsentPreferences = {
+  consent?: Array<Consent>;
+};

--- a/clients/privacy-center/types/api/models/ConsentPreferencesWithVerificationCode.ts
+++ b/clients/privacy-center/types/api/models/ConsentPreferencesWithVerificationCode.ts
@@ -1,0 +1,18 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { Consent } from './Consent';
+import type { ConsentWithExecutableStatus } from './ConsentWithExecutableStatus';
+import type { Identity } from './Identity';
+
+/**
+ * Schema for consent preferences including the verification code.
+ */
+export type ConsentPreferencesWithVerificationCode = {
+  code?: string;
+  consent: Array<Consent>;
+  policy_key?: string;
+  executable_options?: Array<ConsentWithExecutableStatus>;
+  browser_identity?: Identity;
+};

--- a/clients/privacy-center/types/api/models/ConsentWithExecutableStatus.ts
+++ b/clients/privacy-center/types/api/models/ConsentWithExecutableStatus.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Schema for executable consents
+ */
+export type ConsentWithExecutableStatus = {
+  data_use: string;
+  executable: boolean;
+};

--- a/clients/privacy-center/types/api/models/Identity.ts
+++ b/clients/privacy-center/types/api/models/Identity.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Some PII grouping pertaining to a human
+ */
+export type Identity = {
+  phone_number?: string;
+  email?: string;
+  ga_client_id?: string;
+};


### PR DESCRIPTION
Spun out while working on #2230

### Code Changes

pc/types: API models for consent preferences
pc/consent: Use RTK queries for consent verification and preferences
pc/consent: Draft consent changes with consistent state management

### Steps to Confirm

* [ ] The UI form submission works as before
* [x] The body of the consent preferences submission has all fields:
  * [ ] `code` (If id verification is enabled)
  * [ ] `consent` For each data use
  * [ ] `executable_options` Relatively new additions
  * [ ] `policy_key` Ditto
  * [ ] `browser_identity` If using GTM?

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
  * https://github.com/ethyca/fides/issues/2299
* [ ] Update `CHANGELOG.md`

### Description Of Changes

For #2230 I need to toggle more UI elements based on whether a data use has been opted in/out (and the window's GPC flag). Testing this with `fetch` async functions is painful, so I'm continuing the spread of RTK into the PC. I split this into its own PR to keep things tidy.
