### PR TITLE
Remove ui-build after building wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,3 +118,6 @@ COPY --from=built_frontend /fides/clients/admin-ui/out/ /fides/src/fides/ui-buil
 # Install without a symlink
 RUN python setup.py sdist
 RUN pip install dist/ethyca-fides-*.tar.gz
+
+# Remove this directory to prevent issues with catch all
+RUN rm -r /fides/src/fides/ui-build


### PR DESCRIPTION
Closes #2491

### Code Changes

* Removes the `ui-build` directory after the wheel build is completed

### Steps to Confirm

* [ ] Run `nox -s "fides_env(test)"`
* [ ] Navigate to `http://localhost:8080` and log in
* [ ] Navigate to any page that has a route after the `/`, such as `http://localhost:8080/add-systems`
* [ ] Refresh the browser and verify the page loads with no error.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
