### PR TITLE
Migration Fix: Dataset.meta key not guaranteed to exist

### DIFF
--- a/src/fides/api/ctl/migrations/versions/216cdc7944f1_add_datasetconfig_ctl_datasets_fk.py
+++ b/src/fides/api/ctl/migrations/versions/216cdc7944f1_add_datasetconfig_ctl_datasets_fk.py
@@ -66,7 +66,7 @@ def upgrade():
 
         new_ctl_dataset_id: str = "ctl_" + str(uuid.uuid4())
         # Stashing extra text into the "meta" column so we can use this to downgrade if needed
-        appended_meta: Dict = dataset["meta"] or {}
+        appended_meta: Dict = {}
         appended_meta["fides_source"] = AUTO_MIGRATED_STRING
 
         validated_dataset: Dict = Dataset(

--- a/src/fides/api/ctl/migrations/versions/216cdc7944f1_add_datasetconfig_ctl_datasets_fk.py
+++ b/src/fides/api/ctl/migrations/versions/216cdc7944f1_add_datasetconfig_ctl_datasets_fk.py
@@ -66,7 +66,7 @@ def upgrade():
 
         new_ctl_dataset_id: str = "ctl_" + str(uuid.uuid4())
         # Stashing extra text into the "meta" column so we can use this to downgrade if needed
-        appended_meta: Dict = {}
+        appended_meta: Dict = dataset.get("meta", {})
         appended_meta["fides_source"] = AUTO_MIGRATED_STRING
 
         validated_dataset: Dict = Dataset(


### PR DESCRIPTION
Closes [#2509](https://github.com/ethyca/fides/issues/2509)

### Code Changes

* [ ] Remove an addressed field in the dataset migration

### Steps to Confirm

* [ ] Run `nox -s test_env`
* [ ] `docker exec -it <fides> bin/bash/`
* [ ] Cycle through the migrations
