### PR TITLE
Update Admin UI to show all action types (access, erasure, consent, update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.6.2...main)
 
+### Fixed
+
+* Update Admin UI to show all action types (access, erasure, consent, update) [#2523](https://github.com/ethyca/fides/pull/2523) 
+
 
 ## [2.6.2](https://github.com/ethyca/fides/compare/2.6.1...2.6.2)
 

--- a/clients/admin-ui/src/features/privacy-requests/types.ts
+++ b/clients/admin-ui/src/features/privacy-requests/types.ts
@@ -13,6 +13,8 @@ export type PrivacyRequestStatus =
 export enum ActionType {
   ACCESS = "access",
   ERASURE = "erasure",
+  CONSENT = "consent",
+  UPDATE = "update",
 }
 
 export interface DenyPrivacyRequest {


### PR DESCRIPTION
### Code Changes

* [X] Update frontend `ActionType` to include all potential action type values

### Steps to Confirm

* [X] Edit `src/fides/data/test_env/privacy_center_config/config.json`: change `executable: true` for the `Data Sales or Sharing` consent option
* [X] Run `nox -s fides_env(test)`
* [X] Submit access, erasure, and consent requests from the privacy center (for consent, ensure you opt-out of the `Data Sales or Sharing` option as it is the executable one)
* [X] Confirm that the different Privacy Requests show each type: Access, Erasure, Consent:
<img width="1643" alt="image" src="https://user-images.githubusercontent.com/1834295/217068462-0739944f-2a68-440c-912b-e95a463bfd39.png">
(screenshot showing this in action using `fides_env(test)` locally)

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

The frontend type for `ActionType` has lagged behind the valid values from the Python model - this updates the Admin UI to support the "consent" and "update" types.

See the Python enum that defines these: https://github.com/ethyca/fides/blob/main/src/fides/api/ops/models/policy.py#L40
