### PR TITLE
Handle case where legacy dataset has meta: null

### DIFF
--- a/src/fides/api/ctl/migrations/versions/216cdc7944f1_add_datasetconfig_ctl_datasets_fk.py
+++ b/src/fides/api/ctl/migrations/versions/216cdc7944f1_add_datasetconfig_ctl_datasets_fk.py
@@ -66,7 +66,7 @@ def upgrade():
 
         new_ctl_dataset_id: str = "ctl_" + str(uuid.uuid4())
         # Stashing extra text into the "meta" column so we can use this to downgrade if needed
-        appended_meta: Dict = dataset.get("meta", {})
+        appended_meta: Dict = dataset.get("meta") or {}
         appended_meta["fides_source"] = AUTO_MIGRATED_STRING
 
         validated_dataset: Dict = Dataset(


### PR DESCRIPTION
Closes #2509

### Code Changes

* [X] Update migration upgrade script

### Steps to Confirm

n/a

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

The fix in https://github.com/ethyca/fides/pull/2510 isn't quite right - it's also possible for `dataset.get("meta", {})` to return `None` if someone defines a Dataset with a `meta` key but keeps it `null`. This can be hard to do locally but happens in practice.