### PR TITLE
Increase Default Pool Size and Max Overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The types of changes are:
 
 ### Added
 
+* Added config properties to override database Engine parameters [#2511](https://github.com/ethyca/fides/pull/2511)
+* Increased default pool_size and max_overflow to 50 [#2560](https://github.com/ethyca/fides/pull/2560)
+
 * Admin UI
   * Create custom fields from a resource screen - Button to Trigger modal [#524](https://github.com/ethyca/fides/pull/2536)
   * Create Custom Lists [#525](https://github.com/ethyca/fides/pull/2536)
@@ -58,8 +61,6 @@ The types of changes are:
 ### Added
 * Add default storage configuration functionality and associated APIs [#2438](https://github.com/ethyca/fides/pull/2438)
 
-### Added
-* Added config properties to override database Engine parameters [#2511](https://github.com/ethyca/fides/pull/2511)
 
 ## [2.6.1](https://github.com/ethyca/fides/compare/2.6.0...2.6.1)
 

--- a/src/fides/core/config/database_settings.py
+++ b/src/fides/core/config/database_settings.py
@@ -23,10 +23,10 @@ class DatabaseSettings(FidesSettings):
     db: str = "default_db"
     test_db: str = "default_test_db"
 
-    api_engine_pool_size: int = 5
-    api_engine_max_overflow: int = 10
-    task_engine_pool_size: int = 5
-    task_engine_max_overflow: int = 10
+    api_engine_pool_size: int = 50
+    api_engine_max_overflow: int = 50
+    task_engine_pool_size: int = 50
+    task_engine_max_overflow: int = 50
 
     sqlalchemy_database_uri: Optional[str] = None
     sqlalchemy_test_database_uri: Optional[str] = None

--- a/src/fides/lib/db/session.py
+++ b/src/fides/lib/db/session.py
@@ -14,8 +14,8 @@ def get_db_engine(
     *,
     config: FidesConfig | None = None,
     database_uri: str | URL | None = None,
-    pool_size: int = 5,
-    max_overflow: int = 10,
+    pool_size: int = 50,
+    max_overflow: int = 50,
 ) -> Engine:
     """Return a database engine.
 


### PR DESCRIPTION
Closes Issue: N/A

### Code Changes

* [ ] Updates default values for task and api engine pool size and max overflow values

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Quick follow-up to https://github.com/ethyca/fides/pull/2511. Bump pool_size and max_overflow to 50 each as defaults to start.