### PR TITLE
2233/Configuration notification banner

### DIFF
--- a/clients/admin-ui/src/constants.ts
+++ b/clients/admin-ui/src/constants.ts
@@ -141,4 +141,6 @@ export const CONFIG_WIZARD_ROUTE = "/add-systems";
 export const DATAMAP_ROUTE = "/datamap";
 export const DATASTORE_CONNECTION_ROUTE = "/datastore-connection";
 export const PRIVACY_REQUESTS_ROUTE = "/privacy-requests";
+export const PRIVACY_REQUESTS_CONFIGURATION_ROUTE =
+  "/privacy-requests/configure";
 export const SYSTEM_ROUTE = "/system";

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex } from "@fidesui/react";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import React from "react";
 
 import { useFeatures } from "~/features/common/features";
@@ -7,6 +8,12 @@ import Header from "~/features/common/Header";
 import NavBar from "~/features/common/nav/NavBar";
 import { NavSideBar } from "~/features/common/nav/v2/NavSideBar";
 import { NavTopBar } from "~/features/common/nav/v2/NavTopBar";
+
+import ConfigurationNotificationBanner from "../privacy-requests/configuration/ConfigurationNotificationBanner";
+// import {
+//   useGetActiveMessagingProviderQuery,
+//   useGetActiveStorageQuery,
+// } from "~/features/privacy-requests/privacy-requests.slice";
 
 const Layout = ({
   children,
@@ -16,6 +23,15 @@ const Layout = ({
   title: string;
 }) => {
   const features = useFeatures();
+  const router = useRouter();
+  //   const { data: activeMessagingProvider } =
+  //     useGetActiveMessagingProviderQuery();
+  //   const { data: activeStorage } = useGetActiveStorageQuery();
+  const showConfigurationNotificationBanner =
+    // if the above returns empty in either GET &&
+    features.flags.privacyRequestsConfiguration &&
+    (router.pathname === "/privacy-requests" ||
+      router.pathname === "/datastore-connection");
 
   return (
     <div data-testid={title}>
@@ -34,6 +50,9 @@ const Layout = ({
               <NavSideBar />
             </Box>
             <Flex direction="column" flex={1} minWidth={0}>
+              {showConfigurationNotificationBanner ? (
+                <ConfigurationNotificationBanner />
+              ) : null}
               {children}
             </Flex>
           </Flex>

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -8,12 +8,12 @@ import Header from "~/features/common/Header";
 import NavBar from "~/features/common/nav/NavBar";
 import { NavSideBar } from "~/features/common/nav/v2/NavSideBar";
 import { NavTopBar } from "~/features/common/nav/v2/NavTopBar";
+import {
+  useGetActiveMessagingProviderQuery,
+  useGetActiveStorageQuery,
+} from "~/features/privacy-requests/privacy-requests.slice";
 
 import ConfigurationNotificationBanner from "../privacy-requests/configuration/ConfigurationNotificationBanner";
-// import {
-//   useGetActiveMessagingProviderQuery,
-//   useGetActiveStorageQuery,
-// } from "~/features/privacy-requests/privacy-requests.slice";
 
 const Layout = ({
   children,
@@ -24,11 +24,11 @@ const Layout = ({
 }) => {
   const features = useFeatures();
   const router = useRouter();
-  //   const { data: activeMessagingProvider } =
-  //     useGetActiveMessagingProviderQuery();
-  //   const { data: activeStorage } = useGetActiveStorageQuery();
+  const { data: activeMessagingProvider } =
+    useGetActiveMessagingProviderQuery();
+  const { data: activeStorage } = useGetActiveStorageQuery();
   const showConfigurationNotificationBanner =
-    // if the above returns empty in either GET &&
+    (!activeStorage || !activeMessagingProvider) &&
     features.flags.privacyRequestsConfiguration &&
     (router.pathname === "/privacy-requests" ||
       router.pathname === "/datastore-connection");

--- a/clients/admin-ui/src/features/privacy-requests/configuration/ConfigurationNotificationBanner.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/ConfigurationNotificationBanner.tsx
@@ -1,39 +1,43 @@
 import { Box, Button, Stack, Text } from "@fidesui/react";
+import { useRouter } from "next/router";
 
-const ConfigurationNotificationBanner = () => (
-  <Box
-    bg="gray.50"
-    border="1px solid"
-    borderColor="blue.400"
-    borderRadius="md"
-    justifyContent="space-between"
-    p={5}
-    mb={5}
-    mt={5}
-  >
-    <Box>
-      <Stack
-        direction={{ base: "column", sm: "row" }}
-        justifyContent="space-between"
-      >
-        <Text fontWeight="semibold">
-          {/* ICON */}
-          Configure your storage and messaging provider
-        </Text>
-        <Button
-          size="sm"
-          variant="outline"
-          // onClick route to cofiguration page
+const ConfigurationNotificationBanner = () => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/privacy-requests/configure");
+  };
+
+  return (
+    <Box
+      bg="gray.50"
+      border="1px solid"
+      borderColor="blue.400"
+      borderRadius="md"
+      justifyContent="space-between"
+      p={5}
+      mb={5}
+      mt={5}
+    >
+      <Box>
+        <Stack
+          direction={{ base: "column", sm: "row" }}
+          justifyContent="space-between"
         >
-          Configure
-        </Button>
-      </Stack>
+          <Text fontWeight="semibold">
+            Configure your storage and messaging provider
+          </Text>
+          <Button size="sm" variant="outline" onClick={handleClick}>
+            Configure
+          </Button>
+        </Stack>
 
-      <Text color="muted">
-        Before Fides can process your privacy requests we need two simple steps
-        to configure your storage and email client.{" "}
-      </Text>
+        <Text>
+          Before Fides can process your privacy requests we need two simple
+          steps to configure your storage and email client.{" "}
+        </Text>
+      </Box>
     </Box>
-  </Box>
-);
+  );
+};
 export default ConfigurationNotificationBanner;

--- a/clients/admin-ui/src/features/privacy-requests/configuration/ConfigurationNotificationBanner.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/ConfigurationNotificationBanner.tsx
@@ -1,0 +1,39 @@
+import { Box, Button, Stack, Text } from "@fidesui/react";
+
+const ConfigurationNotificationBanner = () => (
+  <Box
+    bg="gray.50"
+    border="1px solid"
+    borderColor="blue.400"
+    borderRadius="md"
+    justifyContent="space-between"
+    p={5}
+    mb={5}
+    mt={5}
+  >
+    <Box>
+      <Stack
+        direction={{ base: "column", sm: "row" }}
+        justifyContent="space-between"
+      >
+        <Text fontWeight="semibold">
+          {/* ICON */}
+          Configure your storage and messaging provider
+        </Text>
+        <Button
+          size="sm"
+          variant="outline"
+          // onClick route to cofiguration page
+        >
+          Configure
+        </Button>
+      </Stack>
+
+      <Text color="muted">
+        Before Fides can process your privacy requests we need two simple steps
+        to configure your storage and email client.{" "}
+      </Text>
+    </Box>
+  </Box>
+);
+export default ConfigurationNotificationBanner;

--- a/clients/admin-ui/src/features/privacy-requests/configuration/ConfigurationNotificationBanner.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/ConfigurationNotificationBanner.tsx
@@ -1,11 +1,13 @@
 import { Box, Button, Stack, Text } from "@fidesui/react";
 import { useRouter } from "next/router";
 
+import { PRIVACY_REQUESTS_CONFIGURATION_ROUTE } from "~/constants";
+
 const ConfigurationNotificationBanner = () => {
   const router = useRouter();
 
   const handleClick = () => {
-    router.push("/privacy-requests/configure");
+    router.push(PRIVACY_REQUESTS_CONFIGURATION_ROUTE);
   };
 
   return (

--- a/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -359,6 +359,11 @@ export const privacyRequestApi = createApi({
         body: params,
       }),
     }),
+    getActiveStorage: build.query<any, void>({
+      query: () => ({
+        url: `storage/default/active`,
+      }),
+    }),
     getStorageDetails: build.query<any, ConfigStorageDetailsRequest>({
       query: (params) => ({
         url: `storage/default/${params.type}`,
@@ -379,6 +384,11 @@ export const privacyRequestApi = createApi({
         url: `storage/default/${params.type}/secret`,
         method: "PUT",
         body: params,
+      }),
+    }),
+    getActiveMessagingProvider: build.query<any, void>({
+      query: () => ({
+        url: `messaging/default/active`,
       }),
     }),
     getMessagingConfigurationDetails: build.query<any, ConfigMessagingRequest>({
@@ -435,6 +445,8 @@ export const {
   useCreateStorageSecretsMutation,
   useCreateConfigurationSettingsMutation,
   useGetMessagingConfigurationDetailsQuery,
+  useGetActiveMessagingProviderQuery,
+  useGetActiveStorageQuery,
   useCreateMessagingConfigurationMutation,
   useCreateMessagingConfigurationSecretsMutation,
 } = privacyRequestApi;


### PR DESCRIPTION
Closes #2233

<img width="1172" alt="Screen Shot 2023-02-13 at 11 48 39 PM" src="https://user-images.githubusercontent.com/99051851/218651154-6e9e54d0-01c7-40ec-9a6a-755d3e539506.png">

### Code Changes

* [ ] Add active storage endpoint and active messaging provider endpoint to client
* [ ] Create configuration notification banner for privacy requests component
* [ ] Hook to the Layout to show on both privacy requests pages

### Steps to Confirm

* [ ] Have inactive storage or messaging provider configuration
* [ ] Go to Privacy requests and datastore connectors route
* [ ] Configuration notification should appear
* [ ] Clicking on Configure button takes you to page to pick configuration type
* [ ] Banner disappears if both types have been configured

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
