### PR TITLE
Add sovrn cookie to privacy center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The types of changes are:
 
 * Privacy Center
   * The consent config default value can depend on whether Global Privacy Control is enabled. [#2341](https://github.com/ethyca/fides/pull/2341)
+  * `inspectForBrowserIdentities` now also looks for `ljt_readerID`
 
 ### Changed
 

--- a/clients/privacy-center/__tests__/common/browser-identities.ts
+++ b/clients/privacy-center/__tests__/common/browser-identities.ts
@@ -7,20 +7,24 @@ const mockCookie = (value: string) => {
   });
 };
 
+// google
 const clientId = "999999999.8888888888";
 const gaCookie = `_ga=GA1.1.${clientId}`;
+
+// sovrn
+const sovrnCookie = "ljt_readerID=test";
 
 describe("browser identities", () => {
   it("can inspect for a google analytics cookie when it is the only cookie", () => {
     mockCookie(`${gaCookie};`);
     const identity = inspectForBrowserIdentities();
-    expect(identity?.gaClientId).toEqual(clientId);
+    expect(identity?.ga_client_id).toEqual(clientId);
   });
 
   it("can inspect for a google analytics cookie when it is one of many cookies", () => {
     mockCookie(`cookie1=value1; ${gaCookie}; cookie2=value2;`);
     const identity = inspectForBrowserIdentities();
-    expect(identity?.gaClientId).toEqual(clientId);
+    expect(identity?.ga_client_id).toEqual(clientId);
   });
 
   it("returns undefined if no ga cookie exists", () => {
@@ -30,6 +34,18 @@ describe("browser identities", () => {
 
     // malformed cookie
     mockCookie(`_ga=GA1.1.`);
-    expect(inspectForBrowserIdentities()?.gaClientId).toBe(undefined);
+    expect(inspectForBrowserIdentities()?.ga_client_id).toBe(undefined);
+  });
+
+  it("can inspect for a sovrn cookie", () => {
+    mockCookie(`${sovrnCookie};`);
+    const identity = inspectForBrowserIdentities();
+    expect(identity?.ljt_readerID).toEqual("test");
+  });
+
+  it("can inspect for both ga and sovrn", () => {
+    mockCookie(`${sovrnCookie}; ${gaCookie}`);
+    const identity = inspectForBrowserIdentities();
+    expect(identity).toEqual({ ga_client_id: clientId, ljt_readerID: "test" });
   });
 });

--- a/clients/privacy-center/common/browser-identities.ts
+++ b/clients/privacy-center/common/browser-identities.ts
@@ -51,15 +51,8 @@ export const inspectForBrowserIdentities = ():
       .filter((c) => c.startsWith(`${cookieConfig.cookieKey}=`))[0];
 
     if (thisCookie) {
-      // if (cookieConfig.regex) {
       const match = thisCookie.match(cookieConfig.regex ?? DEFAULT_REGEX);
       browserIdentities[cookieConfig.key] = match ? match[1] : undefined;
-      // } else {
-      //   // eslint-disable-next-line prefer-destructuring
-      //   browserIdentities[cookieConfig.key] = thisCookie.split(
-      //     `${cookieConfig.cookieKey}=`
-      //   )[1];
-      // }
     }
   });
 

--- a/clients/privacy-center/common/browser-identities.ts
+++ b/clients/privacy-center/common/browser-identities.ts
@@ -1,6 +1,26 @@
 interface BrowserIdentities {
-  gaClientId?: string;
+  ga_client_id?: string;
+  ljt_readerID?: string;
 }
+
+interface CookieConfig {
+  key: keyof BrowserIdentities;
+  cookieKey: string;
+  regex?: RegExp;
+}
+
+const DEFAULT_REGEX = /=(\w+)/;
+
+const GA_COOKIE_KEY = "_ga";
+// The GA cookie only uses the last two sections as the clientId
+const GA_COOKIE_REGEX = /=\w+\.\w+\.(\w+\.\w+)/;
+
+const SOVRN_COOKIE_KEY = "ljt_readerID";
+
+const COOKIES: CookieConfig[] = [
+  { key: "ga_client_id", cookieKey: GA_COOKIE_KEY, regex: GA_COOKIE_REGEX },
+  { key: SOVRN_COOKIE_KEY, cookieKey: SOVRN_COOKIE_KEY },
+];
 
 /**
  * With some consent requests, we also want to send information that only
@@ -9,13 +29,9 @@ interface BrowserIdentities {
  *
  * Inspects the cookies on this site and returns a relevant user ID.
  *
- * Currently hard coded to Google Analytics until we have evidence of other
+ * Currently hard coded to Google Analytics + Sovrn until we have evidence of other
  * identities we may want to leverage.
  */
-const GA_COOKIE_KEY = "_ga";
-// The GA cookie only uses the last two sections as the clientId
-const GA_COOKIE_REGEX = /=\w+\.\w+\.(\w+\.\w+)/;
-
 export const inspectForBrowserIdentities = ():
   | BrowserIdentities
   | undefined => {
@@ -27,13 +43,28 @@ export const inspectForBrowserIdentities = ():
   // For example, 'cookie1=value1; cookie2=value2'
   const { cookie } = window.document;
 
-  const gaCookie = cookie
-    .split("; ")
-    .filter((c) => c.startsWith(`${GA_COOKIE_KEY}=`))[0];
-  if (!gaCookie) {
-    return undefined;
-  }
-  const match = gaCookie.match(GA_COOKIE_REGEX);
-  const gaClientId = match ? match[1] : undefined;
-  return { gaClientId };
+  const browserIdentities: BrowserIdentities = {};
+
+  COOKIES.forEach((cookieConfig) => {
+    const thisCookie = cookie
+      .split("; ")
+      .filter((c) => c.startsWith(`${cookieConfig.cookieKey}=`))[0];
+
+    if (thisCookie) {
+      // if (cookieConfig.regex) {
+      const match = thisCookie.match(cookieConfig.regex ?? DEFAULT_REGEX);
+      browserIdentities[cookieConfig.key] = match ? match[1] : undefined;
+      // } else {
+      //   // eslint-disable-next-line prefer-destructuring
+      //   browserIdentities[cookieConfig.key] = thisCookie.split(
+      //     `${cookieConfig.cookieKey}=`
+      //   )[1];
+      // }
+    }
+  });
+  console.log({ browserIdentities });
+
+  return Object.keys(browserIdentities).length > 0
+    ? browserIdentities
+    : undefined;
 };

--- a/clients/privacy-center/common/browser-identities.ts
+++ b/clients/privacy-center/common/browser-identities.ts
@@ -62,7 +62,6 @@ export const inspectForBrowserIdentities = ():
       // }
     }
   });
-  console.log({ browserIdentities });
 
   return Object.keys(browserIdentities).length > 0
     ? browserIdentities

--- a/clients/privacy-center/cypress/e2e/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent.cy.ts
@@ -139,10 +139,13 @@ describe("Consent settings", () => {
       });
     });
 
-    it("can grab the GA cookie and send to a consent request", () => {
+    it("can grab cookies and send to a consent request", () => {
       const clientId = "999999999.8888888888";
-      const cookieValue = `GA1.1.${clientId}`;
-      cy.setCookie("_ga", cookieValue);
+      const gaCookieValue = `GA1.1.${clientId}`;
+      const sovrnCookieValue = "test";
+
+      cy.setCookie("_ga", gaCookieValue);
+      cy.setCookie("ljt_readerID", sovrnCookieValue);
       cy.visit("/consent");
       cy.getByTestId("consent");
 
@@ -151,6 +154,7 @@ describe("Consent settings", () => {
       cy.wait("@patchConsentPreferences").then((interception) => {
         const { body } = interception.request;
         expect(body.browser_identity.ga_client_id).to.eq(clientId);
+        expect(body.browser_identity.ljt_readerID).to.eq(sovrnCookieValue);
       });
     });
 

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -217,9 +217,6 @@ const Consent: NextPage = () => {
     }));
 
     const browserIdentity = inspectForBrowserIdentities();
-    // const browserIdentityBody = browserIdentity
-    //   ? { ga_client_id: browserIdentity.gaClientId }
-    //   : undefined;
 
     updateConsentRequestPreferencesMutationTrigger({
       id: consentRequestId,

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -217,9 +217,9 @@ const Consent: NextPage = () => {
     }));
 
     const browserIdentity = inspectForBrowserIdentities();
-    const browserIdentityBody = browserIdentity
-      ? { ga_client_id: browserIdentity.gaClientId }
-      : undefined;
+    // const browserIdentityBody = browserIdentity
+    //   ? { ga_client_id: browserIdentity.gaClientId }
+    //   : undefined;
 
     updateConsentRequestPreferencesMutationTrigger({
       id: consentRequestId,
@@ -228,7 +228,7 @@ const Consent: NextPage = () => {
         policy_key: config.consent?.policy_key,
         consent,
         executable_options: executableOptions,
-        browser_identity: browserIdentityBody,
+        browser_identity: browserIdentity,
       },
     });
   }, [


### PR DESCRIPTION
Part of https://github.com/ethyca/fides/issues/2458

### Code Changes

* [x] Refactor `inspectForBrowserIdentities` to be able to handle more than one cookie value
* [x] Update tests

### Steps to Confirm

* [ ] Spin up the privacy center
* [ ] Add a cookie to your browser i.e. `document.cookie = "ljt_readerID=fides_test_reader_id;";`
* [ ] Change your consent preferences
* [ ] Inspect the network tab, and you should see `ljt_readerID` show up in the payload for PATCH preferences under `browser_identity`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
