### PR TITLE
Add messaging test route

### DIFF
--- a/.fides/fides.toml
+++ b/.fides/fides.toml
@@ -58,4 +58,4 @@ task_default_queue = "fides"
 task_always_eager = true
 
 [notifications]
-notification_service_type = "mailgun"
+notification_service_type = "twilio_text"

--- a/.fides/fides.toml
+++ b/.fides/fides.toml
@@ -58,4 +58,4 @@ task_default_queue = "fides"
 task_always_eager = true
 
 [notifications]
-notification_service_type = "twilio_text"
+notification_service_type = "mailgun"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The types of changes are:
 * Added config properties to override database Engine parameters [#2511](https://github.com/ethyca/fides/pull/2511)
 * Increased default pool_size and max_overflow to 50 [#2560](https://github.com/ethyca/fides/pull/2560)
 * Access and erasure support for Braintree [#2223](https://github.com/ethyca/fides/pull/2223)
+* Added route to send a test message [#2585](https://github.com/ethyca/fides/pull/2585)
 
 * Admin UI
   * Create custom fields from a resource screen - Button to Trigger modal [#524](https://github.com/ethyca/fides/pull/2536)

--- a/docs/fides/docs/development/postman/Fides.postman_collection.json
+++ b/docs/fides/docs/development/postman/Fides.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cbd35879-b646-4c71-9c80-92cff0dfab77",
+		"_postman_id": "03d28ae1-a240-42f8-839e-92a4d43132ed",
 		"name": "Fidesops",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -4450,6 +4450,29 @@
 								"config",
 								"{{mailgun_config_key}}",
 								"secret"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Test Message",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"email\": {{test_email}}\n}"
+						},
+						"url": {
+							"raw": "{{host}}/messaging/config/test",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"messaging",
+								"config",
+								"test"
 							]
 						}
 					},

--- a/src/fides/api/ops/api/v1/endpoints/messaging_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/messaging_endpoints.py
@@ -39,12 +39,12 @@ from fides.api.ops.schemas.messaging.messaging import (
     MessagingActionType,
     MessagingConfigRequest,
     MessagingConfigResponse,
-    TestMessage,
     TestMessagingStatusMessage,
 )
 from fides.api.ops.schemas.messaging.messaging_secrets_docs_only import (
     possible_messaging_secrets,
 )
+from fides.api.ops.schemas.redis_cache import Identity
 from fides.api.ops.service.messaging.message_dispatch_service import dispatch_message
 from fides.api.ops.service.messaging.messaging_crud_service import (
     create_or_update_messaging_config,
@@ -269,7 +269,7 @@ def delete_config_by_key(
     },
 )
 def send_test_message(
-    message_info: TestMessage, db: Session = Depends(deps.get_db)
+    message_info: Identity, db: Session = Depends(deps.get_db)
 ) -> Dict[str, str]:
     """Sends a test message."""
     try:
@@ -283,5 +283,4 @@ def send_test_message(
         raise HTTPException(
             status_code=400, detail=f"There was an error sending the test message: {e}"
         )
-
     return {"details": "Test message successfully sent"}

--- a/src/fides/api/ops/api/v1/endpoints/messaging_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/messaging_endpoints.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from fastapi import Depends, Security
 from fastapi_pagination import Page, Params
@@ -27,18 +27,25 @@ from fides.api.ops.api.v1.urn_registry import (
     MESSAGING_BY_KEY,
     MESSAGING_CONFIG,
     MESSAGING_SECRETS,
+    MESSAGING_TEST,
     V1_URL_PREFIX,
 )
-from fides.api.ops.common_exceptions import MessagingConfigNotFoundException
+from fides.api.ops.common_exceptions import (
+    MessageDispatchException,
+    MessagingConfigNotFoundException,
+)
 from fides.api.ops.models.messaging import MessagingConfig, get_schema_for_secrets
 from fides.api.ops.schemas.messaging.messaging import (
+    MessagingActionType,
     MessagingConfigRequest,
     MessagingConfigResponse,
+    TestMessage,
     TestMessagingStatusMessage,
 )
 from fides.api.ops.schemas.messaging.messaging_secrets_docs_only import (
     possible_messaging_secrets,
 )
+from fides.api.ops.service.messaging.message_dispatch_service import dispatch_message
 from fides.api.ops.service.messaging.messaging_crud_service import (
     create_or_update_messaging_config,
     delete_messaging_config,
@@ -48,8 +55,11 @@ from fides.api.ops.service.messaging.messaging_crud_service import (
 from fides.api.ops.util.api_router import APIRouter
 from fides.api.ops.util.logger import Pii
 from fides.api.ops.util.oauth_util import verify_oauth_client
+from fides.core.config import get_config
 
 router = APIRouter(tags=["messaging"], prefix=V1_URL_PREFIX)
+
+CONFIG = get_config()
 
 
 @router.post(
@@ -239,3 +249,39 @@ def delete_config_by_key(
             status_code=HTTP_404_NOT_FOUND,
             detail=e.message,
         )
+
+
+@router.post(
+    MESSAGING_TEST,
+    status_code=HTTP_200_OK,
+    dependencies=[Security(verify_oauth_client, scopes=[MESSAGING_CREATE_OR_UPDATE])],
+    response_model=Dict[str, str],
+    responses={
+        HTTP_200_OK: {
+            "content": {
+                "application/json": {
+                    "example": {
+                        "details": "Test message successfully sent",
+                    }
+                }
+            }
+        }
+    },
+)
+def send_test_message(
+    message_info: TestMessage, db: Session = Depends(deps.get_db)
+) -> Dict[str, str]:
+    """Sends a test message."""
+    try:
+        dispatch_message(
+            db,
+            action_type=MessagingActionType.TEST_MESSAGE,
+            to_identity=message_info,
+            service_type=CONFIG.notifications.notification_service_type,
+        )
+    except MessageDispatchException as e:
+        raise HTTPException(
+            status_code=400, detail=f"There was an error sending the test message: {e}"
+        )
+
+    return {"details": "Test message successfully sent"}

--- a/src/fides/api/ops/api/v1/urn_registry.py
+++ b/src/fides/api/ops/api/v1/urn_registry.py
@@ -45,6 +45,7 @@ STORAGE_ACTIVE_DEFAULT = "/storage/active/default"
 MESSAGING_CONFIG = "/messaging/config"
 MESSAGING_SECRETS = "/messaging/config/{config_key}/secret"
 MESSAGING_BY_KEY = "/messaging/config/{config_key}"
+MESSAGING_TEST = "/messaging/config/test"
 
 # Policy URLs
 POLICY_LIST = "/dsr/policy"

--- a/src/fides/api/ops/email_templates/get_email_template.py
+++ b/src/fides/api/ops/email_templates/get_email_template.py
@@ -14,6 +14,7 @@ from fides.api.ops.email_templates.template_names import (
     PRIVACY_REQUEST_REVIEW_APPROVE_TEMPLATE,
     PRIVACY_REQUEST_REVIEW_DENY_TEMPLATE,
     SUBJECT_IDENTITY_VERIFICATION_TEMPLATE,
+    TEST_MESSAGE_TEMPLATE,
 )
 from fides.api.ops.schemas.messaging.messaging import MessagingActionType
 
@@ -47,6 +48,8 @@ def get_email_template(  # pylint: disable=too-many-return-statements
         return template_env.get_template(PRIVACY_REQUEST_REVIEW_DENY_TEMPLATE)
     if action_type == MessagingActionType.PRIVACY_REQUEST_REVIEW_APPROVE:
         return template_env.get_template(PRIVACY_REQUEST_REVIEW_APPROVE_TEMPLATE)
+    if action_type == MessagingActionType.TEST_MESSAGE:
+        return template_env.get_template(TEST_MESSAGE_TEMPLATE)
 
     logger.error("No corresponding template linked to the {}", action_type)
     raise EmailTemplateUnhandledActionType(

--- a/src/fides/api/ops/email_templates/template_names.py
+++ b/src/fides/api/ops/email_templates/template_names.py
@@ -7,3 +7,4 @@ PRIVACY_REQUEST_COMPLETE_ACCESS_TEMPLATE = "privacy_request_complete_access.html
 PRIVACY_REQUEST_ERROR_NOTIFICATION_TEMPLATE = "privacy_request_error_notification.html"
 PRIVACY_REQUEST_REVIEW_DENY_TEMPLATE = "privacy_request_review_deny.html"
 PRIVACY_REQUEST_REVIEW_APPROVE_TEMPLATE = "privacy_request_review_approve.html"
+TEST_MESSAGE_TEMPLATE = "test_message.html"

--- a/src/fides/api/ops/email_templates/templates/test_message.html
+++ b/src/fides/api/ops/email_templates/templates/test_message.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/src/fides/api/ops/email_templates/templates/test_message.html
+++ b/src/fides/api/ops/email_templates/templates/test_message.html
@@ -1,0 +1,11 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Fides Test message</title>
+  </head>
+  <body>
+    <main>
+      <p>This is a test message from Fides.</p>
+    </main>
+  </body>
+</html>

--- a/src/fides/api/ops/schemas/messaging/messaging.py
+++ b/src/fides/api/ops/schemas/messaging/messaging.py
@@ -291,18 +291,3 @@ class TestMessagingStatusMessage(Msg):
 
     test_status: Optional[MessagingConnectionTestStatus] = None
     failure_reason: Optional[str] = None
-
-
-class TestMessage(BaseModel):
-    phone_number: Optional[str] = None
-    email: Optional[str] = None
-
-    @root_validator
-    def validate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if not values.get("phone_number") and not values.get("email"):
-            raise ValueError("Either a phone number or an email address is required")
-        if values.get("phone_number") and values.get("email"):
-            raise ValueError(
-                "Only a phone number or email address can be provided, not both"
-            )
-        return values

--- a/src/fides/api/ops/schemas/messaging/messaging.py
+++ b/src/fides/api/ops/schemas/messaging/messaging.py
@@ -45,6 +45,7 @@ class MessagingActionType(str, Enum):
     PRIVACY_REQUEST_COMPLETE_DELETION = "privacy_request_complete_deletion"
     PRIVACY_REQUEST_REVIEW_DENY = "privacy_request_review_deny"
     PRIVACY_REQUEST_REVIEW_APPROVE = "privacy_request_review_approve"
+    TEST_MESSAGE = "test_message"
 
 
 class ErrorNotificaitonBodyParams(BaseModel):
@@ -290,3 +291,18 @@ class TestMessagingStatusMessage(Msg):
 
     test_status: Optional[MessagingConnectionTestStatus] = None
     failure_reason: Optional[str] = None
+
+
+class TestMessage(BaseModel):
+    phone_number: Optional[str] = None
+    email: Optional[str] = None
+
+    @root_validator
+    def validate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if not values.get("phone_number") and not values.get("email"):
+            raise ValueError("Either a phone number or an email address is required")
+        if values.get("phone_number") and values.get("email"):
+            raise ValueError(
+                "Only a phone number or email address can be provided, not both"
+            )
+        return values

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -154,7 +154,9 @@ def dispatch_message(
             action_type=action_type,
             body_params=message_body_params,
         )
-    else:
+    else:  # pragma: no cover
+        # This is here as a fail safe, but it should be impossible to reach because
+        # is controlled by a datbase enum field.
         logger.error(
             "Notification service type is not valid: {}",
             CONFIG.notifications.notification_service_type,

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -36,7 +36,6 @@ from fides.api.ops.schemas.messaging.messaging import (
     RequestReceiptBodyParams,
     RequestReviewDenyBodyParams,
     SubjectIdentityVerificationBodyParams,
-    TestMessage,
 )
 from fides.api.ops.schemas.redis_cache import Identity
 from fides.api.ops.tasks import MESSAGING_QUEUE_NAME, DatabaseTask, celery_app
@@ -113,7 +112,7 @@ def dispatch_message_task(
 def dispatch_message(
     db: Session,
     action_type: MessagingActionType,
-    to_identity: Optional[Union[Identity, TestMessage]],
+    to_identity: Optional[Identity],
     service_type: Optional[str],
     message_body_params: Optional[
         Union[

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -488,12 +488,12 @@ def _twilio_sms_dispatcher(
     auth_token = messaging_config.secrets[
         MessagingServiceSecrets.TWILIO_AUTH_TOKEN.value
     ]
-    messaging_service_id = messaging_config.secrets[
+    messaging_service_id = messaging_config.secrets.get(
         MessagingServiceSecrets.TWILIO_MESSAGING_SERVICE_SID.value
-    ]
-    sender_phone_number = messaging_config.secrets[
+    )
+    sender_phone_number = messaging_config.secrets.get(
         MessagingServiceSecrets.TWILIO_SENDER_PHONE_NUMBER.value
-    ]
+    )
 
     client = Client(account_sid, auth_token)
     try:

--- a/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
@@ -18,6 +18,7 @@ from fides.api.ops.api.v1.urn_registry import (
     MESSAGING_TEST,
     V1_URL_PREFIX,
 )
+from fides.api.ops.common_exceptions import MessageDispatchException
 from fides.api.ops.models.messaging import MessagingConfig
 from fides.api.ops.schemas.messaging.messaging import (
     MessagingServiceDetails,
@@ -798,3 +799,17 @@ class TestTestMesage:
             headers=auth_header,
         )
         assert response.status_code == 422
+
+    @patch(
+        "fides.api.ops.api.v1.endpoints.messaging_endpoints.dispatch_message",
+        side_effect=MessageDispatchException("No service"),
+    )
+    def test_test_message_dispatch_error(
+        self, mock_dispatch_message, generate_auth_header, url, api_client
+    ):
+        auth_header = generate_auth_header(scopes=[MESSAGING_CREATE_OR_UPDATE])
+        response = api_client.post(
+            url, json={"phone_number": "+19198675309"}, headers=auth_header
+        )
+        assert response.status_code == 400
+        assert mock_dispatch_message.called

--- a/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
@@ -798,7 +798,7 @@ class TestTestMesage:
             json=info,
             headers=auth_header,
         )
-        assert response.status_code == 422
+        assert response.status_code == 400
 
     @patch(
         "fides.api.ops.api.v1.endpoints.messaging_endpoints.dispatch_message",

--- a/tests/ops/service/messaging/message_dispatch_service_test.py
+++ b/tests/ops/service/messaging/message_dispatch_service_test.py
@@ -18,7 +18,6 @@ from fides.api.ops.schemas.messaging.messaging import (
     MessagingServiceSecrets,
     MessagingServiceType,
     SubjectIdentityVerificationBodyParams,
-    TestMessage,
 )
 from fides.api.ops.schemas.redis_cache import Identity
 from fides.api.ops.service.messaging.message_dispatch_service import (
@@ -160,7 +159,7 @@ class TestMessageDispatchService:
         dispatch_message(
             db=db,
             action_type=MessagingActionType.TEST_MESSAGE,
-            to_identity=TestMessage(email="test@email.com"),
+            to_identity=Identity(email="test@email.com"),
             service_type=MessagingServiceType.MAILGUN.value,
         )
         body = '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <title>Fides Test message</title>\n  </head>\n  <body>\n    <main>\n      <p>This is a test message from Fides.</p>\n    </main>\n  </body>\n</html>'
@@ -182,7 +181,7 @@ class TestMessageDispatchService:
         dispatch_message(
             db=db,
             action_type=MessagingActionType.TEST_MESSAGE,
-            to_identity=TestMessage(email="test@email.com"),
+            to_identity=Identity(email="test@email.com"),
             service_type=MessagingServiceType.TWILIO_EMAIL.value,
         )
         body = '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <title>Fides Test message</title>\n  </head>\n  <body>\n    <main>\n      <p>This is a test message from Fides.</p>\n    </main>\n  </body>\n</html>'
@@ -204,7 +203,7 @@ class TestMessageDispatchService:
         dispatch_message(
             db=db,
             action_type=MessagingActionType.TEST_MESSAGE,
-            to_identity=TestMessage(phone_number="+19198675309"),
+            to_identity=Identity(phone_number="+19198675309"),
             service_type=MessagingServiceType.TWILIO_TEXT.value,
         )
         body = '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <title>Fides Test message</title>\n  </head>\n  <body>\n    <main>\n      <p>This is a test message from Fides.</p>\n    </main>\n  </body>\n</html>'

--- a/tests/ops/service/messaging/message_dispatch_service_test.py
+++ b/tests/ops/service/messaging/message_dispatch_service_test.py
@@ -20,7 +20,10 @@ from fides.api.ops.schemas.messaging.messaging import (
     TestMessage,
 )
 from fides.api.ops.schemas.redis_cache import Identity
-from fides.api.ops.service.messaging.message_dispatch_service import dispatch_message
+from fides.api.ops.service.messaging.message_dispatch_service import (
+    _get_dispatcher_from_config_type,
+    dispatch_message,
+)
 from fides.core.config import get_config
 
 CONFIG = get_config()
@@ -396,3 +399,10 @@ class TestMessageDispatchService:
         assert "No notification service type configured" in exc.value.args[0]
 
         mock_mailgun_dispatcher.assert_not_called()
+
+    def test_dispatch_invalid_action_type(self, db):
+        with pytest.raises(MessageDispatchException):
+            dispatch_message(db, "bad", None, None)
+
+    def test_dispatcher_from_config_type_unknown(self):
+        assert _get_dispatcher_from_config_type("bad") is None


### PR DESCRIPTION
Closes #2457

### Code Changes

* Added a route to all sending a test message.

### Steps to Confirm

* Configure a messaging service
* Go to http://localhost:8080/docs#/messaging/send_test_message_api_v1_messaging_config_test_post
* Enter either a phone number or email address, matching the type of message service setup
* Verify the message was received

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
