### PR TITLE
ui/custom-metadata: Refactor taxonomy to use a single form submission flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,17 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.6.6...main)
 
-* Access and erasure support for Braintree [#2223](https://github.com/ethyca/fides/pull/2223)
-* Added route to send a test message [#2585](https://github.com/ethyca/fides/pull/2585)
-* Added new Wunderkind Consent Saas Connector [#2600](https://github.com/ethyca/fides/pull/2600)
-
+* Fides API
+  * Access and erasure support for Braintree [#2223](https://github.com/ethyca/fides/pull/2223)
+  * Added route to send a test message [#2585](https://github.com/ethyca/fides/pull/2585)
+  * Added new Wunderkind Consent Saas Connector [#2600](https://github.com/ethyca/fides/pull/2600)
 * Admin UI
-  * Create custom fields from a resource screen - Button to Trigger modal [#524](https://github.com/ethyca/fides/pull/2536)
-  * Create Custom Lists [#525](https://github.com/ethyca/fides/pull/2536)
-  * Create Custom Field Definition [#526](https://github.com/ethyca/fides/pull/2536)
-  * Provide a custom field value in a resource [#528](https://github.com/ethyca/fides/pull/2536)
-
+  * Custom Metadata [#2536](https://github.com/ethyca/fides/pull/2536)
+    * Create Custom Lists
+    * Create Custom Field Definition
+    * Create custom fields from a the taxonomy editor
+    * Provide a custom field value in a resource
+    * Bulk edit custom field values [#2612](https://github.com/ethyca/fides/issues/2612)
 * Privacy Center
   * The consent config default value can depend on whether Global Privacy Control is enabled. [#2341](https://github.com/ethyca/fides/pull/2341)
 

--- a/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/allow-list/create.json
+++ b/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/allow-list/create.json
@@ -2,5 +2,5 @@
   "name": "Created list",
   "description": null,
   "allowed_values": ["allowed", "values"],
-  "id": "plu_5401a766-b83a-44c5-8a21-f7a46c02ee40"
+  "id": "id-allow-list-created"
 }

--- a/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/allow-list/list.json
+++ b/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/allow-list/list.json
@@ -2,13 +2,19 @@
   {
     "name": "Pokemon",
     "description": "There's like a thousand of these now",
-    "allowed_values": ["Bulbasaur", "Charmander", "Squirtle"],
-    "id": "plu_e868c7a7-fc87-48cf-8219-192c7770d2b6"
+    "allowed_values": [
+      "Bulbasaur",
+      "Charmander",
+      "Squirtle",
+      "Eevee",
+      "Snorlax"
+    ],
+    "id": "id-allow-list-pokemon"
   },
   {
     "name": "Prime numbers",
     "description": "Seems to be a pattern",
     "allowed_values": ["2", "3", "5", "7"],
-    "id": "plu_93c3ea8a-e1f9-4e0c-955f-8025aa7c049a"
+    "id": "id-allow-list-prime-numbers"
   }
 ]

--- a/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/custom-field-definition/create.json
+++ b/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/custom-field-definition/create.json
@@ -1,10 +1,10 @@
 {
-  "name": "11111111111111",
+  "name": "Created custom field",
   "description": null,
   "field_type": "string",
-  "allow_list_id": "plu_e868c7a7-fc87-48cf-8219-192c7770d2b6",
+  "allow_list_id": "id-allow-list-pokemon",
   "resource_type": "data category",
   "field_definition": null,
   "active": true,
-  "id": "plu_27bc6001-3125-44b0-b9eb-90ecb9a58802"
+  "id": "id-custom-field-definition-created"
 }

--- a/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/custom-field-definition/list.json
+++ b/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/custom-field-definition/list.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "Starter pokemon",
+    "description": null,
+    "field_type": "string",
+    "allow_list_id": "id-allow-list-pokemon",
+    "resource_type": "data category",
+    "field_definition": null,
+    "active": true,
+    "id": "id-custom-field-definition-starter-pokemon"
+  },
+  {
+    "name": "Pokemon party",
+    "description": null,
+    "field_type": "string[]",
+    "allow_list_id": "id-allow-list-pokemon",
+    "resource_type": "data category",
+    "field_definition": null,
+    "active": true,
+    "id": "id-custom-field-definition-pokemon-party"
+  },
+  {
+    "name": "Prime number",
+    "description": null,
+    "field_type": "string",
+    "allow_list_id": "id-allow-list-prime-numbers",
+    "resource_type": "data category",
+    "field_definition": null,
+    "active": true,
+    "id": "id-custom-field-definition-prime-number"
+  }
+]

--- a/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/custom-field/list.json
+++ b/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/custom-field/list.json
@@ -1,0 +1,14 @@
+[
+  {
+    "resource_id": "user.biometric",
+    "custom_field_definition_id": "id-custom-field-definition-starter-pokemon",
+    "value": "Squirtle",
+    "id": "id-custom-field-starter-pokemon"
+  },
+  {
+    "resource_id": "user.biometric",
+    "custom_field_definition_id": "id-custom-field-definition-pokemon-party",
+    "value": ["Charmander", "Eevee", "Snorlax"],
+    "id": "id-custom-field-pokemon-party"
+  }
+]

--- a/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/custom-field/update-party.json
+++ b/clients/admin-ui/cypress/fixtures/taxonomy/custom-metadata/custom-field/update-party.json
@@ -1,0 +1,6 @@
+{
+  "resource_id": "user.biometric",
+  "custom_field_definition_id": "id-custom-field-definition-pokemon-party",
+  "value": ["Charmander", "Eevee"],
+  "id": "id-custom-field-pokemon-party"
+}

--- a/clients/admin-ui/src/features/common/custom-fields/CustomFieldSelector.tsx
+++ b/clients/admin-ui/src/features/common/custom-fields/CustomFieldSelector.tsx
@@ -1,0 +1,65 @@
+import { useField } from "formik";
+import { useEffect } from "react";
+
+import { CustomSelect } from "~/features/common/form/inputs";
+import { AllowedTypes } from "~/types/api";
+
+import {
+  AllowListWithOptions,
+  CustomFieldDefinitionExisting,
+  CustomFieldExisting,
+} from "./types";
+
+type Props = {
+  allowList: AllowListWithOptions;
+  customField?: CustomFieldExisting;
+  customFieldDefinition: CustomFieldDefinitionExisting;
+};
+
+export const CustomFieldSelector = ({
+  allowList,
+  customField,
+  customFieldDefinition,
+}: Props) => {
+  const name = `definitionIdToCustomFieldValue.${customFieldDefinition.id}`;
+  const label = customFieldDefinition.name;
+  const tooltip = customFieldDefinition.description;
+  const { options } = allowList;
+
+  const [, meta, helpers] = useField({ name });
+
+  // This is a bit of a hack to set the initial value of the selector based on the CustomField
+  // returned by the API (if any). The "correct" way to do this would be to have the `initialValues`
+  // passed to `Formik` include the API values mapped by definition ID. However, because custom
+  // fields are so dynamic and depend on multiple API calls, mixing that logic into the (already
+  // complex) taxonomy form initialization isn't feasible for now. Those values are created by:
+  // src/features/taxonomy/hooks.tsx.
+  useEffect(
+    () => {
+      if (!customField?.value) {
+        return;
+      }
+
+      if (meta.touched) {
+        return;
+      }
+
+      helpers.setValue(customField.value, false);
+    },
+    // This should only ever run once, on first render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  return (
+    <CustomSelect
+      isClearable
+      isMulti={customFieldDefinition.field_type !== AllowedTypes.STRING}
+      label={label}
+      name={name}
+      options={options}
+      tooltip={tooltip}
+      defaultValue={customField?.value ?? ""}
+    />
+  );
+};

--- a/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
+++ b/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
@@ -1,169 +1,41 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Center, Divider, Flex, Spinner, Text } from "@fidesui/react";
-import { FieldArray, useFormikContext } from "formik";
-import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { CustomSelect } from "~/features/common/form/inputs";
-import { useAlert } from "~/features/common/hooks";
-import {
-  useGetAllAllowListQuery,
-  useGetCustomFieldDefinitionsByResourceTypeQuery,
-  useGetCustomFieldsForResourceQuery,
-  useUpsertCustomFieldMutation,
-} from "~/features/plus/plus.slice";
-import { AllowedTypes, ResourceTypes } from "~/types/api";
+import { ResourceTypes } from "~/types/api";
 
-import { useFeatures } from "../features";
+import { CustomFieldSelector } from "./CustomFieldSelector";
 import { CustomFieldsModal } from "./CustomFieldsModal";
-import { CustomFieldWithIdExtended } from "./types";
-
-const initialValues = {
-  customFields: [] as CustomFieldWithIdExtended[],
-};
-
-type FormValues = typeof initialValues;
+import { useCustomFields } from "./hooks";
 
 type CustomFieldsListProps = {
-  resourceId: string;
+  resourceFidesKey?: string;
   resourceType: ResourceTypes;
 };
 
-const CustomFieldsList = ({
-  resourceId,
+export const CustomFieldsList = ({
+  resourceFidesKey,
   resourceType,
 }: CustomFieldsListProps) => {
-  const { errorAlert, successAlert } = useAlert();
-
-  const { flags, plus } = useFeatures();
-  const skip = !(flags.customFields && plus);
-  const [isLoading, setIsLoading] = useState(!skip);
-
-  const { data: allAllowList } = useGetAllAllowListQuery(true, { skip });
-  const { data: customFieldDefinitions } =
-    useGetCustomFieldDefinitionsByResourceTypeQuery(resourceType, { skip });
-  const { data: customFields } = useGetCustomFieldsForResourceQuery(
-    resourceId,
-    { skip }
-  );
-  const [upsertCustomField] = useUpsertCustomFieldMutation();
-
-  // Reference parent Formik context
   const {
-    isSubmitting,
-    setSubmitting,
-    values: formValues,
-  } = useFormikContext();
-
-  const editCustomFieldList = useMemo(() => {
-    let withIds: CustomFieldWithIdExtended[] =
-      customFields?.filter((item) =>
-        customFieldDefinitions?.some(
-          (cfd) => cfd.id === item.custom_field_definition_id && cfd.active
-        )
-      ) || [];
-    withIds = withIds.map((item) => ({
-      ...item,
-      allow_list_id: customFieldDefinitions!.find(
-        (cfd) => cfd.id === item.custom_field_definition_id
-      )!.allow_list_id,
-    }));
-
-    const unassigned =
-      customFieldDefinitions?.filter(
-        (item) =>
-          !withIds.some(
-            (existing) => existing.custom_field_definition_id === item.id
-          )
-      ) || [];
-
-    const withNoIds: CustomFieldWithIdExtended[] = [];
-    unassigned.forEach((item) => {
-      withNoIds.push({
-        allow_list_id: item.allow_list_id,
-        custom_field_definition_id: item.id as string,
-        resource_id: resourceId,
-        value: item.field_type === AllowedTypes.STRING ? "" : [],
-      });
-    });
-
-    return [...withIds, ...withNoIds];
-  }, [customFieldDefinitions, customFields, resourceId]);
-
-  const getCustomFieldDefinition = useCallback(
-    (item: CustomFieldWithIdExtended) =>
-      customFieldDefinitions!.find(
-        (cfd) => cfd.id === item.custom_field_definition_id
-      ),
-    [customFieldDefinitions]
-  );
-
-  const getListOptions = useCallback(
-    (allow_list_id: string) => {
-      const value = allAllowList?.find((item) => item.id === allow_list_id);
-      const list = value?.allowed_values!.map((item) => ({
-        value: item,
-        label: item,
-      }));
-      return list;
-    },
-    [allAllowList]
-  );
-
-  const handleSubmit = useCallback(
-    (values: FormValues) => {
-      try {
-        let hasError = false;
-        values.customFields.forEach(async (customField) => {
-          if (!customField.id && customField.value.length === 0) {
-            return;
-          }
-          const clone = { ...customField };
-          delete clone.allow_list_id;
-          const result = await upsertCustomField(clone);
-          if ("error" in result) {
-            hasError = true;
-          }
-        });
-        if (hasError) {
-          errorAlert(
-            `One or more custom field(s) has failed to save, please try again`
-          );
-        } else {
-          successAlert(
-            `Custom field(s) successfully saved and added to this ${resourceType} form`
-          );
-        }
-      } finally {
-        setSubmitting(false);
-      }
-    },
-    [errorAlert, resourceType, setSubmitting, successAlert, upsertCustomField]
-  );
-
-  useEffect(() => {
-    if ((isLoading && customFieldDefinitions) || customFields) {
-      // Update the initial parent customFields
-      (formValues as any).customFields = [...editCustomFieldList];
-      setIsLoading(false);
-    }
-  }, [
-    customFieldDefinitions,
-    customFields,
-    editCustomFieldList,
-    formValues,
+    definitionIdToCustomField,
+    idToAllowListWithOptions,
+    idToCustomFieldDefinition,
+    isEnabled,
     isLoading,
-  ]);
+    sortedCustomFieldDefinitionIds,
+  } = useCustomFields({
+    resourceFidesKey,
+    resourceType,
+  });
 
-  useEffect(() => {
-    if (isSubmitting && (formValues as any).customFields) {
-      handleSubmit(formValues as FormValues);
-    }
-  }, [formValues, handleSubmit, isSubmitting]);
+  if (!isEnabled) {
+    return null;
+  }
 
-  return flags.customFields && plus ? (
+  return (
     <Flex
       flexDir="column"
       mt={resourceType === ResourceTypes.SYSTEM ? "28px" : ""}
+      data-testid="custom-fields-list"
     >
       <Flex flexDir="column" gap="24px">
         <Divider color="gray.200" />
@@ -178,47 +50,44 @@ const CustomFieldsList = ({
           </Text>
         </Flex>
         <CustomFieldsModal resourceType={resourceType} />
-        {isLoading && (
+        {isLoading ? (
           <Center>
             <Spinner />
           </Center>
-        )}
-        {!isLoading && (
-          <FieldArray
-            name="customFields"
-            render={() => {
-              const { customFields: list } = formValues as any;
-              return (
-                <Flex flexDirection="column" gap="12px" paddingBottom="24px">
-                  {list?.map((item: CustomFieldWithIdExtended, index: number) =>
-                    Array.isArray(item.value) ? (
-                      <CustomSelect
-                        label={getCustomFieldDefinition(item)!.name}
-                        key={JSON.stringify(item)}
-                        name={`customFields[${index}].value`}
-                        options={getListOptions(item.allow_list_id!) || []}
-                        tooltip={getCustomFieldDefinition(item)!.description}
-                        isMulti
-                      />
-                    ) : (
-                      <CustomSelect
-                        isClearable
-                        label={getCustomFieldDefinition(item)!.name}
-                        key={JSON.stringify(item)}
-                        name={`customFields[${index}].value`}
-                        options={getListOptions(item.allow_list_id!) || []}
-                        tooltip={getCustomFieldDefinition(item)!.description}
-                      />
-                    )
-                  )}
-                </Flex>
+        ) : (
+          <Flex flexDirection="column" gap="12px" paddingBottom="24px">
+            {sortedCustomFieldDefinitionIds.map((definitionId) => {
+              const customFieldDefinition =
+                idToCustomFieldDefinition.get(definitionId);
+              if (!customFieldDefinition) {
+                // This should never happen.
+                return null;
+              }
+
+              const allowList = idToAllowListWithOptions.get(
+                customFieldDefinition.allow_list_id!
               );
-            }}
-          />
+              if (!allowList) {
+                // This would only happen if the field definitions load before
+                // the allow list data.
+                return null;
+              }
+
+              // This will be undefined when no value has been saved for this field.
+              const customField = definitionIdToCustomField.get(definitionId);
+
+              return (
+                <CustomFieldSelector
+                  allowList={allowList}
+                  customField={customField}
+                  customFieldDefinition={customFieldDefinition}
+                  key={`${definitionId}-${customField?.id}`}
+                />
+              );
+            })}
+          </Flex>
         )}
       </Flex>
     </Flex>
-  ) : null;
+  );
 };
-
-export { CustomFieldsList };

--- a/clients/admin-ui/src/features/common/custom-fields/helpers.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/helpers.ts
@@ -1,8 +1,6 @@
-import { ResourceTypes } from "~/types/api";
+import { narrow } from "narrow-minded";
 
-import { RESOURCE_TYPE_OPTIONS } from "./constants";
+export const hasId = <I>(item: I): item is I & { id: string } =>
+  narrow({ id: "string" }, item);
 
-export const getResourceType = (valueOrLabel: string) =>
-  RESOURCE_TYPE_OPTIONS.find(
-    (option) => option.value === valueOrLabel || option.label === valueOrLabel
-  )?.value ?? ResourceTypes.SYSTEM;
+export const filterWithId = <I>(items?: I[]) => (items ?? []).filter(hasId);

--- a/clients/admin-ui/src/features/common/custom-fields/hooks.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/hooks.ts
@@ -1,0 +1,193 @@
+import { useCallback, useMemo } from "react";
+
+import { useFeatures } from "~/features/common/features";
+import { useAlert } from "~/features/common/hooks";
+import {
+  useDeleteCustomFieldMutation,
+  useGetAllAllowListQuery,
+  useGetCustomFieldDefinitionsByResourceTypeQuery,
+  useGetCustomFieldsForResourceQuery,
+  useUpsertCustomFieldMutation,
+} from "~/features/plus/plus.slice";
+import { ResourceTypes } from "~/types/api";
+
+import { filterWithId } from "./helpers";
+import { CustomFieldsFormValues } from "./types";
+
+type UseCustomFieldsOptions = {
+  resourceFidesKey?: string;
+  resourceType: ResourceTypes;
+};
+
+export const useCustomFields = ({
+  resourceFidesKey,
+  resourceType,
+}: UseCustomFieldsOptions) => {
+  const { errorAlert, successAlert } = useAlert();
+  const { flags, plus } = useFeatures();
+  const isEnabled = flags.customFields && plus;
+
+  // This keeps track of the fides key that was initially passed in. If that key started out blank,
+  // then we know the API call will just 404.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const queryFidesKey = useMemo(() => resourceFidesKey ?? "", []);
+
+  const allAllowListQuery = useGetAllAllowListQuery(true, {
+    skip: !isEnabled,
+  });
+  const customFieldDefinitionsQuery =
+    useGetCustomFieldDefinitionsByResourceTypeQuery(resourceType, {
+      skip: !isEnabled,
+    });
+  const customFieldsQuery = useGetCustomFieldsForResourceQuery(
+    resourceFidesKey ?? "",
+    {
+      skip: queryFidesKey !== "" && !(isEnabled && queryFidesKey),
+    }
+  );
+
+  // The `fixedCacheKey` options will ensure that components referencing the same resource will
+  // share mutation info. That won't be too useful, though, because `upsertCustomField` can issue
+  // multiple requests: one for each field associated with the resource.
+  const [upsertCustomFieldMutationTrigger, upsertCustomFieldMutationResult] =
+    useUpsertCustomFieldMutation({ fixedCacheKey: resourceFidesKey });
+  const [deleteCustomFieldMutationTrigger, deleteCustomFieldMutationResult] =
+    useDeleteCustomFieldMutation({ fixedCacheKey: resourceFidesKey });
+
+  const isLoading =
+    allAllowListQuery.isLoading ||
+    customFieldDefinitionsQuery.isLoading ||
+    customFieldsQuery.isLoading ||
+    upsertCustomFieldMutationResult.isLoading ||
+    deleteCustomFieldMutationResult.isLoading;
+
+  const idToAllowListWithOptions = useMemo(
+    () =>
+      new Map(
+        filterWithId(allAllowListQuery.data).map((allowList) => [
+          allowList.id,
+          {
+            ...allowList,
+            options: (allowList.allowed_values ?? []).map((value) => ({
+              value,
+              label: value,
+            })),
+          },
+        ])
+      ),
+    [allAllowListQuery.data]
+  );
+
+  const idToCustomFieldDefinition = useMemo(
+    () =>
+      new Map(
+        filterWithId(customFieldDefinitionsQuery.data).map((cfd) => [
+          cfd.id,
+          cfd,
+        ])
+      ),
+    [customFieldDefinitionsQuery]
+  );
+
+  const definitionIdToCustomField = useMemo(
+    () =>
+      new Map(
+        filterWithId(customFieldsQuery.data).map((fd) => [
+          fd.custom_field_definition_id,
+          fd,
+        ])
+      ),
+    [customFieldsQuery]
+  );
+
+  const sortedCustomFieldDefinitionIds = useMemo(() => {
+    const ids = [...idToCustomFieldDefinition.keys()];
+    ids.sort();
+    return ids;
+  }, [idToCustomFieldDefinition]);
+
+  /**
+   * Issue a batch of upsert and delete requests that will sync the form selections to the
+   * backend.
+   */
+  const upsertCustomFields = useCallback(
+    async (formValues: CustomFieldsFormValues) => {
+      // When creating an resource, the fides key may have initially been blank. But by the time the
+      // form is submitted it must not be blank (not undefined, not an empty string).
+      const fidesKey = formValues.fides_key || resourceFidesKey;
+      if (!fidesKey) {
+        return;
+      }
+
+      const { definitionIdToCustomFieldValue } = formValues;
+
+      // This will be undefined if the form never rendered a `CustomFieldList` that would assign
+      // form values.
+      if (!definitionIdToCustomFieldValue) {
+        return;
+      }
+
+      try {
+        // This would be a lot simpler (and more efficient) if the API had an endpoint for updating
+        // all the metadata associated with a field, including deleting options that weren't passed.
+        await Promise.allSettled(
+          sortedCustomFieldDefinitionIds.map((definitionId) => {
+            const customField = definitionIdToCustomField.get(definitionId);
+            const value = definitionIdToCustomFieldValue[definitionId];
+
+            if (
+              value === undefined ||
+              value === "" ||
+              (Array.isArray(value) && value.length === 0)
+            ) {
+              if (!customField?.id) {
+                return undefined;
+              }
+
+              return deleteCustomFieldMutationTrigger(customField);
+            }
+
+            const body = {
+              custom_field_definition_id: definitionId,
+              resource_id: fidesKey,
+              id: customField?.id,
+              value,
+            };
+
+            return upsertCustomFieldMutationTrigger(body);
+          })
+        );
+
+        successAlert(
+          `Custom field(s) successfully saved and added to this ${resourceType} form.`
+        );
+      } catch (e) {
+        errorAlert(
+          `One or more custom fields have failed to save, please try again.`
+        );
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
+    },
+    [
+      definitionIdToCustomField,
+      deleteCustomFieldMutationTrigger,
+      errorAlert,
+      resourceFidesKey,
+      resourceType,
+      sortedCustomFieldDefinitionIds,
+      successAlert,
+      upsertCustomFieldMutationTrigger,
+    ]
+  );
+
+  return {
+    definitionIdToCustomField,
+    idToAllowListWithOptions,
+    idToCustomFieldDefinition,
+    isEnabled,
+    isLoading,
+    sortedCustomFieldDefinitionIds,
+    upsertCustomFields,
+  };
+};

--- a/clients/admin-ui/src/features/common/custom-fields/index.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/index.ts
@@ -6,5 +6,6 @@ export * from "./CustomFieldsButton";
 export * from "./CustomFieldsList";
 export * from "./CustomFieldsModal";
 export * from "./helpers";
+export * from "./hooks";
 export * from "./Layout";
 export * from "./types";

--- a/clients/admin-ui/src/features/common/custom-fields/types.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/types.ts
@@ -1,4 +1,9 @@
-import { CustomFieldWithId } from "~/types/api";
+import { Option } from "~/features/common/form/inputs";
+import {
+  AllowList,
+  CustomFieldDefinitionWithId,
+  CustomFieldWithId,
+} from "~/types/api";
 
 import { TabData } from "../DataTabs";
 
@@ -8,4 +13,34 @@ export interface CustomFieldWithIdExtended extends CustomFieldWithId {
 
 export interface Tab extends TabData {
   submitButtonText: string;
+}
+
+export interface CustomFieldDefinitionExisting
+  extends CustomFieldDefinitionWithId {
+  id: string;
+}
+
+export interface CustomFieldExisting extends CustomFieldWithId {
+  id: string;
+}
+
+export interface AllowListWithOptions extends AllowList {
+  options: Option[];
+}
+
+/**
+ * The custom metadata fields are very dynamic and may not be rendered at all. If they are used,
+ * their values are stored as a mapping from the field definition's ID to the value, which may be a
+ * string or array depending on the definition's type.
+ */
+export interface CustomFieldsFormValues {
+  fides_key: string;
+  /**
+   * This is camel-cased because it is only used in UI code and must be handled specially when
+   * submitting the form. It does not correspond with a snake-cased API field.
+   */
+  definitionIdToCustomFieldValue?: Record<
+    string,
+    string | string[] | undefined
+  >;
 }

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -169,6 +169,7 @@ const SelectInput = ({
       name={fieldName}
       value={selected}
       size={size}
+      classNamePrefix="custom-select"
       chakraStyles={{
         container: (provided) => ({ ...provided, mr: 2, flexGrow: 1 }),
         dropdownIndicator: (provided) => ({

--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -192,6 +192,13 @@ export const plusApi = createApi({
       }),
       invalidatesTags: ["CustomFields"],
     }),
+    deleteCustomField: build.mutation<void, { id: string }>({
+      query: ({ id }) => ({
+        url: `custom-metadata/custom-field/${id}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["CustomFields"],
+    }),
 
     // Custom Metadata Custom Field Definition
     addCustomFieldDefinition: build.mutation<
@@ -221,6 +228,7 @@ export const plusApi = createApi({
 
 export const {
   useUpsertCustomFieldMutation,
+  useDeleteCustomFieldMutation,
   useUpsertAllowListMutation,
   useUpdateScanMutation,
   useUpdateClassifyInstanceMutation,

--- a/clients/admin-ui/src/features/system/DescribeSystemStep.tsx
+++ b/clients/admin-ui/src/features/system/DescribeSystemStep.tsx
@@ -2,10 +2,14 @@ import { Box, Button, Heading, Stack, useToast } from "@fidesui/react";
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
 import { Form, Formik } from "formik";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import * as Yup from "yup";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
+import {
+  CustomFieldsList,
+  useCustomFields,
+} from "~/features/common/custom-fields";
 import {
   CustomCreatableMultiSelect,
   CustomSelect,
@@ -26,8 +30,6 @@ import {
   useUpdateSystemMutation,
 } from "~/features/system/system.slice";
 import { ResourceTypes, System } from "~/types/api";
-
-import { CustomFieldsList } from "../common/custom-fields";
 
 const ValidationSchema = Yup.object().shape({
   fides_key: Yup.string().required().label("System key"),
@@ -65,9 +67,10 @@ const DescribeSystemStep = ({
         : defaultInitialValues,
     [passedInSystem]
   );
-  const [createSystem] = useCreateSystemMutation();
-  const [updateSystem] = useUpdateSystemMutation();
-  const [isLoading, setIsLoading] = useState(false);
+  const [createSystemMutationTrigger, createSystemMutationResult] =
+    useCreateSystemMutation();
+  const [updateSystemMutationTrigger, updateSystemMutationResult] =
+    useUpdateSystemMutation();
   const dispatch = useAppDispatch();
   const systems = useAppSelector(selectAllSystems);
   const systemOptions = systems
@@ -83,6 +86,11 @@ const DescribeSystemStep = ({
   );
 
   const toast = useToast();
+
+  const customFields = useCustomFields({
+    resourceType: ResourceTypes.SYSTEM,
+    resourceFidesKey: passedInSystem?.fides_key,
+  });
 
   const handleBack = () => {
     dispatch(changeStep(2));
@@ -110,18 +118,22 @@ const DescribeSystemStep = ({
       }
     };
 
-    setIsLoading(true);
-
     let result;
     if (isEditing) {
-      result = await updateSystem(systemBody);
+      result = await updateSystemMutationTrigger(systemBody);
     } else {
-      result = await createSystem(systemBody);
+      result = await createSystemMutationTrigger(systemBody);
     }
-    handleResult(result);
 
-    setIsLoading(false);
+    await customFields.upsertCustomFields(values);
+
+    handleResult(result);
   };
+
+  const isLoading =
+    updateSystemMutationResult.isLoading ||
+    createSystemMutationResult.isLoading ||
+    customFields.isLoading;
 
   return (
     <Formik
@@ -192,7 +204,7 @@ const DescribeSystemStep = ({
               ) : null}
               {isEditing && (
                 <CustomFieldsList
-                  resourceId={passedInSystem!.fides_key}
+                  resourceFidesKey={passedInSystem?.fides_key}
                   resourceType={ResourceTypes.SYSTEM}
                 />
               )}

--- a/clients/admin-ui/src/features/system/form.ts
+++ b/clients/admin-ui/src/features/system/form.ts
@@ -1,8 +1,10 @@
+import { CustomFieldsFormValues } from "~/features/common/custom-fields";
 import { DEFAULT_ORGANIZATION_FIDES_KEY } from "~/features/organization";
 import { DataProtectionImpactAssessment, System } from "~/types/api";
 
 export interface FormValues
-  extends Omit<System, "data_protection_impact_assessment"> {
+  extends Omit<System, "data_protection_impact_assessment">,
+    CustomFieldsFormValues {
   data_protection_impact_assessment?: {
     is_required: "true" | "false";
     progress?: DataProtectionImpactAssessment["progress"];
@@ -58,9 +60,23 @@ export const transformFormValuesToSystem = (formValues: FormValues): System => {
   const jointController = hasJointController
     ? formValues.joint_controller
     : undefined;
+
   return {
-    ...formValues,
-    organization_fides_key: DEFAULT_ORGANIZATION_FIDES_KEY,
+    // Fields that are preserved by the form:
+    data_responsibility_title: formValues.data_responsibility_title,
+    description: formValues.description,
+    egress: formValues.egress,
+    fides_key: formValues.fides_key,
+    ingress: formValues.ingress,
+    name: formValues.name,
+    organization_fides_key: formValues.organization_fides_key,
+    privacy_declarations: formValues.privacy_declarations,
+    system_dependencies: formValues.system_dependencies,
+    system_type: formValues.system_type,
+    tags: formValues.tags,
+    third_country_transfers: formValues.third_country_transfers,
+
+    // Fields that need transformation:
     data_protection_impact_assessment: impactAssessment,
     joint_controller: jointController,
     administrating_department:

--- a/clients/admin-ui/src/features/taxonomy/TaxonomyFormBase.tsx
+++ b/clients/admin-ui/src/features/taxonomy/TaxonomyFormBase.tsx
@@ -14,10 +14,6 @@ import { Form, Formik } from "formik";
 import { ReactNode, useState } from "react";
 import * as Yup from "yup";
 
-import {
-  CustomFieldsList,
-  getResourceType,
-} from "~/features/common/custom-fields";
 import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
 import { isErrorResult, parseError } from "~/features/common/helpers";
 import { successToastParams } from "~/features/common/toast";
@@ -26,15 +22,15 @@ import { RTKErrorResult } from "~/types/errors";
 
 import { parentKeyFromFidesKey } from "./helpers";
 import TaxonomyEntityTag from "./TaxonomyEntityTag";
-import { Labels, TaxonomyEntity } from "./types";
-
-export type FormValues = Partial<TaxonomyEntity> &
-  Pick<TaxonomyEntity, "fides_key">;
+import { FormValues, Labels, TaxonomyEntity } from "./types";
 
 interface Props {
   labels: Labels;
   onCancel: () => void;
-  onSubmit: (entity: TaxonomyEntity) => RTKResult<TaxonomyEntity>;
+  onSubmit: (
+    initialValues: FormValues,
+    newValues: FormValues
+  ) => RTKResult<TaxonomyEntity>;
   renderExtraFormFields?: (entity: FormValues) => ReactNode;
   initialValues: FormValues;
 }
@@ -59,27 +55,9 @@ const TaxonomyFormBase = ({
 
   const handleSubmit = async (newValues: FormValues) => {
     setFormError(null);
-    // parent_key and fides_keys are immutable
-    // parent_key also needs to be undefined, not an empty string, if there is no parent element
-    let payload: TaxonomyEntity;
-    if (isCreate) {
-      const parentKey = parentKeyFromFidesKey(newValues.fides_key);
-      payload = {
-        ...newValues,
-        parent_key: parentKey === "" ? undefined : parentKey,
-      };
-    } else {
-      payload = {
-        ...newValues,
-        parent_key:
-          initialValues.parent_key === ""
-            ? undefined
-            : initialValues.parent_key,
-        fides_key: initialValues.fides_key,
-      };
-    }
 
-    const result = await onSubmit(payload);
+    const result = await onSubmit(initialValues, newValues);
+
     if (isErrorResult(result)) {
       handleError(result.error);
     } else {
@@ -146,14 +124,6 @@ const TaxonomyFormBase = ({
                   />
                 ))}
               {renderExtraFormFields ? renderExtraFormFields(values) : null}
-              {["data category", "data use", "data subject"].includes(
-                labels.fides_key.toLowerCase()
-              ) && (
-                <CustomFieldsList
-                  resourceId={initialValues.fides_key}
-                  resourceType={getResourceType(labels.fides_key)}
-                />
-              )}
             </Stack>
 
             {formError ? (

--- a/clients/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
+++ b/clients/admin-ui/src/features/taxonomy/TaxonomyTabContent.tsx
@@ -56,6 +56,8 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
     isLoading,
     data,
     labels,
+    entityToEdit,
+    setEntityToEdit,
     handleCreate: createEntity,
     handleEdit,
     handleDelete: deleteEntity,
@@ -69,7 +71,6 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
     return null;
   }, [data]);
 
-  const [entityToEdit, setEntityToEdit] = useState<TaxonomyEntity | null>(null);
   const [nodeToDelete, setNodeToDelete] = useState<TaxonomyEntityNode | null>(
     null
   );
@@ -81,7 +82,7 @@ const TaxonomyTabContent = ({ useTaxonomy }: Props) => {
     if (isAdding) {
       setEntityToEdit(null);
     }
-  }, [isAdding]);
+  }, [isAdding, setEntityToEdit]);
 
   const closeAddForm = () => {
     dispatch(setIsAddFormOpen(false));

--- a/clients/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/admin-ui/src/features/taxonomy/hooks.tsx
@@ -1,5 +1,7 @@
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 
+import { CustomFieldsList } from "~/features/common/custom-fields";
+import { useCustomFields } from "~/features/common/custom-fields/hooks";
 import { RTKResult } from "~/features/common/types";
 import {
   DataCategory,
@@ -9,6 +11,7 @@ import {
   DataUse,
   IncludeExcludeEnum,
   LegalBasisEnum,
+  ResourceTypes,
   SpecialCategoriesEnum,
 } from "~/types/api";
 
@@ -38,21 +41,30 @@ import {
   useGetAllDataUsesQuery,
   useUpdateDataUseMutation,
 } from "../data-use/data-use.slice";
+import { parentKeyFromFidesKey } from "./helpers";
 import {
   useCreateDataCategoryMutation,
   useDeleteDataCategoryMutation,
   useGetAllDataCategoriesQuery,
   useUpdateDataCategoryMutation,
 } from "./taxonomy.slice";
-import type { FormValues } from "./TaxonomyFormBase";
-import { Labels, TaxonomyEntity } from "./types";
+import { FormValues, Labels, TaxonomyEntity } from "./types";
 
 export interface TaxonomyHookData<T extends TaxonomyEntity> {
   data?: TaxonomyEntity[];
   isLoading: boolean;
   labels: Labels;
-  handleCreate: (entity: T) => RTKResult<TaxonomyEntity>;
-  handleEdit: (entity: T) => RTKResult<TaxonomyEntity>;
+  resourceType?: ResourceTypes;
+  entityToEdit: T | null;
+  setEntityToEdit: (entity: T | null) => void;
+  handleCreate: (
+    initialValues: FormValues,
+    newValues: FormValues
+  ) => RTKResult<TaxonomyEntity>;
+  handleEdit: (
+    initialValues: FormValues,
+    newValues: FormValues
+  ) => RTKResult<TaxonomyEntity>;
   handleDelete: (key: string) => RTKResult<string>;
   renderExtraFormFields?: (entity: T) => ReactNode;
   transformEntityToInitialValues: (entity: T) => FormValues;
@@ -66,7 +78,33 @@ const transformTaxonomyBaseToInitialValues = (t: TaxonomyEntity) => ({
   is_default: t.is_default ?? false,
 });
 
+const transformBaseFormValuesToEntity = (
+  initialValues: FormValues,
+  newValues: FormValues
+) => {
+  const isCreate = initialValues.fides_key === "";
+
+  // parent_key and fides_keys are immutable
+  // parent_key also needs to be undefined, not an empty string, if there is no parent element
+  const entity = { ...newValues };
+  if (isCreate) {
+    const parentKey = parentKeyFromFidesKey(newValues.fides_key);
+    entity.parent_key = parentKey === "" ? undefined : parentKey;
+  } else {
+    entity.parent_key =
+      initialValues.parent_key === "" ? undefined : initialValues.parent_key;
+    entity.fides_key = initialValues.fides_key;
+  }
+
+  delete entity.definitionIdToCustomFieldValue;
+
+  return entity;
+};
+
 export const useDataCategory = (): TaxonomyHookData<DataCategory> => {
+  const resourceType = ResourceTypes.DATA_CATEGORY;
+  const [entityToEdit, setEntityToEdit] = useState<DataCategory | null>(null);
+
   const { data, isLoading } = useGetAllDataCategoriesQuery();
 
   const labels = {
@@ -76,22 +114,71 @@ export const useDataCategory = (): TaxonomyHookData<DataCategory> => {
     parent_key: "Parent category",
   };
 
-  const [handleEdit] = useUpdateDataCategoryMutation();
-  const [handleDelete] = useDeleteDataCategoryMutation();
-  const [handleCreate] = useCreateDataCategoryMutation();
+  const [createDataCategoryMutationTrigger] = useCreateDataCategoryMutation();
+  const [updateDataCategoryMutationTrigger] = useUpdateDataCategoryMutation();
+  const [deleteDataCategoryMutationTrigger] = useDeleteDataCategoryMutation();
+
+  const customFields = useCustomFields({
+    resourceFidesKey: entityToEdit?.fides_key,
+    resourceType,
+  });
+
+  const handleCreate = async (
+    initialValues: FormValues,
+    newValues: FormValues
+  ) => {
+    const payload = transformBaseFormValuesToEntity(initialValues, newValues);
+    const result = await createDataCategoryMutationTrigger(payload);
+
+    if (customFields.isEnabled) {
+      await customFields.upsertCustomFields(newValues);
+    }
+
+    return result;
+  };
+
+  const handleEdit = async (
+    initialValues: FormValues,
+    newValues: FormValues
+  ) => {
+    const payload = transformBaseFormValuesToEntity(initialValues, newValues);
+    const result = updateDataCategoryMutationTrigger(payload);
+
+    if (customFields.isEnabled) {
+      await customFields.upsertCustomFields(newValues);
+    }
+
+    return result;
+  };
+
+  const handleDelete = deleteDataCategoryMutationTrigger;
+
+  const renderExtraFormFields = (formValues: FormValues) => (
+    <CustomFieldsList
+      resourceFidesKey={formValues.fides_key}
+      resourceType={resourceType}
+    />
+  );
 
   return {
     data,
     isLoading,
     labels,
+    resourceType,
+    entityToEdit,
+    setEntityToEdit,
     handleCreate,
     handleEdit,
     handleDelete,
+    renderExtraFormFields,
     transformEntityToInitialValues: transformTaxonomyBaseToInitialValues,
   };
 };
 
 export const useDataUse = (): TaxonomyHookData<DataUse> => {
+  const resourceType = ResourceTypes.DATA_USE;
+  const [entityToEdit, setEntityToEdit] = useState<DataUse | null>(null);
+
   const { data, isLoading } = useGetAllDataUsesQuery();
 
   const labels = {
@@ -107,8 +194,9 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
       "Legitimate interest impact assessment",
   };
 
-  const [edit] = useUpdateDataUseMutation();
-  const [create] = useCreateDataUseMutation();
+  const [createDataUseMutationTrigger] = useCreateDataUseMutation();
+  const [updateDataUseMutationTrigger] = useUpdateDataUseMutation();
+  const [deleteDataUseMutationTrigger] = useDeleteDataUseMutation();
 
   const transformFormValuesToEntity = (formValues: DataUse) => ({
     ...formValues,
@@ -131,12 +219,44 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
         : formValues.special_category,
   });
 
-  const [handleDelete] = useDeleteDataUseMutation();
-  const handleEdit = (entity: DataUse) =>
-    edit(transformFormValuesToEntity(entity));
+  const customFields = useCustomFields({
+    resourceFidesKey: entityToEdit?.fides_key,
+    resourceType,
+  });
 
-  const handleCreate = (entity: DataUse) =>
-    create(transformFormValuesToEntity(entity));
+  const handleCreate = async (
+    initialValues: FormValues,
+    newValues: FormValues
+  ) => {
+    const payload = transformFormValuesToEntity(
+      transformBaseFormValuesToEntity(initialValues, newValues)
+    );
+    const result = await createDataUseMutationTrigger(payload);
+
+    if (customFields.isEnabled) {
+      await customFields.upsertCustomFields(newValues);
+    }
+
+    return result;
+  };
+
+  const handleEdit = async (
+    initialValues: FormValues,
+    newValues: FormValues
+  ) => {
+    const payload = transformFormValuesToEntity(
+      transformBaseFormValuesToEntity(initialValues, newValues)
+    );
+    const result = updateDataUseMutationTrigger(payload);
+
+    if (customFields.isEnabled) {
+      await customFields.upsertCustomFields(newValues);
+    }
+
+    return result;
+  };
+
+  const handleDelete = deleteDataUseMutationTrigger;
 
   const transformEntityToInitialValues = (du: DataUse) => {
     const base = transformTaxonomyBaseToInitialValues(du);
@@ -188,6 +308,10 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
           label={labels.legitimate_interest_impact_assessment}
         />
       ) : null}
+      <CustomFieldsList
+        resourceFidesKey={formValues.fides_key}
+        resourceType={resourceType}
+      />
     </>
   );
 
@@ -195,6 +319,9 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
     data,
     isLoading,
     labels,
+    resourceType,
+    entityToEdit,
+    setEntityToEdit,
     handleCreate,
     handleEdit,
     handleDelete,
@@ -204,6 +331,9 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
 };
 
 export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
+  const resourceType = ResourceTypes.DATA_SUBJECT;
+  const [entityToEdit, setEntityToEdit] = useState<DataSubject | null>(null);
+
   const { data, isLoading } = useGetAllDataSubjectsQuery();
 
   const labels = {
@@ -215,9 +345,9 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     automatic_decisions: "Automatic decisions or profiling",
   };
 
-  const [edit] = useUpdateDataSubjectMutation();
-  const [create] = useCreateDataSubjectMutation();
-  const [handleDelete] = useDeleteDataSubjectMutation();
+  const [createDataSubjectMutationTrigger] = useCreateDataSubjectMutation();
+  const [updateDataSubjectMutationTrigger] = useUpdateDataSubjectMutation();
+  const [deleteDataSubjectMutationTrigger] = useDeleteDataSubjectMutation();
 
   const transformFormValuesToEntity = (entity: DataSubject) => {
     const transformedEntity: DataSubject = {
@@ -242,11 +372,44 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     return transformedEntity;
   };
 
-  const handleEdit = (entity: DataSubject) =>
-    edit(transformFormValuesToEntity(entity));
+  const customFields = useCustomFields({
+    resourceFidesKey: entityToEdit?.fides_key,
+    resourceType,
+  });
 
-  const handleCreate = (entity: DataSubject) =>
-    create(transformFormValuesToEntity(entity));
+  const handleCreate = async (
+    initialValues: FormValues,
+    newValues: FormValues
+  ) => {
+    const payload = transformFormValuesToEntity(
+      transformBaseFormValuesToEntity(initialValues, newValues)
+    );
+    const result = await createDataSubjectMutationTrigger(payload);
+
+    if (customFields.isEnabled) {
+      await customFields.upsertCustomFields(newValues);
+    }
+
+    return result;
+  };
+
+  const handleEdit = async (
+    initialValues: FormValues,
+    newValues: FormValues
+  ) => {
+    const payload = transformFormValuesToEntity(
+      transformBaseFormValuesToEntity(initialValues, newValues)
+    );
+    const result = updateDataSubjectMutationTrigger(payload);
+
+    if (customFields.isEnabled) {
+      await customFields.upsertCustomFields(newValues);
+    }
+
+    return result;
+  };
+
+  const handleDelete = deleteDataSubjectMutationTrigger;
 
   const transformEntityToInitialValues = (ds: DataSubject) => {
     const base = transformTaxonomyBaseToInitialValues(ds);
@@ -282,6 +445,10 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
         label={labels.automatic_decisions}
         options={YesNoOptions}
       />
+      <CustomFieldsList
+        resourceFidesKey={entity.fides_key}
+        resourceType={resourceType}
+      />
     </>
   );
 
@@ -289,6 +456,9 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
     data,
     isLoading,
     labels,
+    resourceType,
+    entityToEdit,
+    setEntityToEdit,
     handleCreate,
     handleEdit,
     handleDelete,
@@ -299,6 +469,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
 
 export const useDataQualifier = (): TaxonomyHookData<DataQualifier> => {
   const { data, isLoading } = useGetAllDataQualifiersQuery();
+  const [entityToEdit, setEntityToEdit] = useState<DataQualifier | null>(null);
 
   const labels = {
     fides_key: "Data qualifier",
@@ -307,14 +478,28 @@ export const useDataQualifier = (): TaxonomyHookData<DataQualifier> => {
     parent_key: "Parent data qualifier",
   };
 
-  const [handleCreate] = useCreateDataQualifierMutation();
-  const [handleEdit] = useUpdateDataQualifierMutation();
-  const [handleDelete] = useDeleteDataQualifierMutation();
+  const [createDataQualifierMutationTrigger] = useCreateDataQualifierMutation();
+  const [updateDataQualifierMutationTrigger] = useUpdateDataQualifierMutation();
+  const [deleteDataQualifierMutationTrigger] = useDeleteDataQualifierMutation();
+
+  const handleCreate = (initialValues: FormValues, newValues: FormValues) =>
+    createDataQualifierMutationTrigger(
+      transformBaseFormValuesToEntity(initialValues, newValues)
+    );
+
+  const handleEdit = (initialValues: FormValues, newValues: FormValues) =>
+    updateDataQualifierMutationTrigger(
+      transformBaseFormValuesToEntity(initialValues, newValues)
+    );
+
+  const handleDelete = deleteDataQualifierMutationTrigger;
 
   return {
     data,
     isLoading,
     labels,
+    entityToEdit,
+    setEntityToEdit,
     handleCreate,
     handleEdit,
     handleDelete,

--- a/clients/admin-ui/src/features/taxonomy/types.ts
+++ b/clients/admin-ui/src/features/taxonomy/types.ts
@@ -1,4 +1,5 @@
-import { TreeNode } from "../common/types";
+import { CustomFieldsFormValues } from "~/features/common/custom-fields";
+import { TreeNode } from "~/features/common/types";
 
 export interface TaxonomyEntityNode extends TreeNode {
   description?: string;
@@ -20,3 +21,7 @@ export interface Labels {
   description: string;
   parent_key?: string;
 }
+
+export type FormValues = Partial<TaxonomyEntity> &
+  Pick<TaxonomyEntity, "fides_key"> &
+  CustomFieldsFormValues;


### PR DESCRIPTION
Closes #2545

### Code Changes

* This is a large refactor to get taxonomy and custom fields working together. See description below and my line comments.

### Steps to Confirm

* [ ] Cypress tests!
* [ ] From various taxonomy tabs
    * [ ] Assign custom fields
    * [ ] Single-select
        * [ ] Initial selection
        * [ ] Change selection
        * [ ] Clear selection
        * [ ] See value on reload
    * [ ] Multi-select
        * [ ] Initial selection
        * [ ] Change selection
        * [ ] Clear selection
        * [ ] See value on reload
* [ ] Those steps, but from the "Describe system" tab

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
    - Might be spun out: https://github.com/ethyca/fides/issues/2545#issuecomment-1429021292
    - https://github.com/ethyca/fides/issues/2612
* [ ] Update `CHANGELOG.md`

### Description Of Changes

* [x] I'm tired. When I finish my self-review I'll check this box.
