### PR TITLE
Switch mongo tests from randint to uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The types of changes are:
 * Added new Cypress E2E smoke tests [#2241](https://github.com/ethyca/fides/pull/2241)
 * New command `nox -s e2e_test` which will spin up the test environment and run true E2E Cypress tests against it [#2417](https://github.com/ethyca/fides/pull/2417)
 * Cypress E2E tests now run in CI and are reported to Cypress Cloud [#2417](https://github.com/ethyca/fides/pull/2417)
+* Change from `randomint` to `uuid` in mongodb tests to reduce flakiness. [#2591](https://github.com/ethyca/fides/pull/2591)
 
 ### Removed
 

--- a/tests/ops/integration_tests/test_mongo_task.py
+++ b/tests/ops/integration_tests/test_mongo_task.py
@@ -1,8 +1,8 @@
 import copy
-import random
 from datetime import datetime
 from unittest import mock
 from unittest.mock import Mock
+from uuid import uuid4
 
 import pytest
 from bson import ObjectId
@@ -53,9 +53,7 @@ async def test_combined_erasure_task(
     """Includes examples of mongo nested and array erasures"""
     policy = erasure_policy("A", "B")
     seed_email = postgres_inserts["customer"][0]["email"]
-    privacy_request = PrivacyRequest(
-        id=f"test_sql_erasure_task_{random.randint(0, 1000)}"
-    )
+    privacy_request = PrivacyRequest(id=f"test_sql_erasure_task_{uuid4()}")
     mongo_dataset, postgres_dataset = combined_mongo_postgresql_graph(
         integration_postgres_config, integration_mongodb_config
     )
@@ -146,9 +144,7 @@ async def test_combined_erasure_task(
         "mongo_test:rewards": 0,
     }
 
-    privacy_request = PrivacyRequest(
-        id=f"test_sql_erasure_task_{random.randint(0, 1000)}"
-    )
+    privacy_request = PrivacyRequest(id=f"test_sql_erasure_task_{uuid4()}")
     rerun_access = await graph_task.run_access_request(
         privacy_request,
         policy,
@@ -261,9 +257,7 @@ async def test_combined_erasure_task(
 async def test_mongo_erasure_task(db, mongo_inserts, integration_mongodb_config):
     policy = erasure_policy("A", "B")
     seed_email = mongo_inserts["customer"][0]["email"]
-    privacy_request = PrivacyRequest(
-        id=f"test_sql_erasure_task_{random.randint(0, 1000)}"
-    )
+    privacy_request = PrivacyRequest(id=f"test_sql_erasure_task_{uuid4()}")
 
     dataset, graph = integration_db_mongo_graph(
         "mongo_test", integration_mongodb_config.key
@@ -304,7 +298,7 @@ async def test_mongo_erasure_task(db, mongo_inserts, integration_mongodb_config)
 async def test_dask_mongo_task(
     db, integration_mongodb_config: ConnectionConfig
 ) -> None:
-    privacy_request = PrivacyRequest(id=f"test_mongo_task_{random.randint(0,1000)}")
+    privacy_request = PrivacyRequest(id=f"test_mongo_task_{uuid4()}")
 
     v = await graph_task.run_access_request(
         privacy_request,
@@ -343,7 +337,7 @@ async def test_composite_key_erasure(
     integration_mongodb_config: ConnectionConfig,
 ) -> None:
 
-    privacy_request = PrivacyRequest(id=f"test_mongo_task_{random.randint(0,1000)}")
+    privacy_request = PrivacyRequest(id=f"test_mongo_task_{uuid4()}")
     policy = erasure_policy("A")
     customer = Collection(
         name="customer",
@@ -419,7 +413,7 @@ async def test_composite_key_erasure(
 
     # re-run access request. Description has been
     # nullified here.
-    privacy_request = PrivacyRequest(id=f"test_mongo_task_{random.randint(0,1000)}")
+    privacy_request = PrivacyRequest(id=f"test_mongo_task_{uuid4()}")
     access_request_data = await graph_task.run_access_request(
         privacy_request,
         policy,
@@ -442,7 +436,7 @@ async def test_access_erasure_type_conversion(
     """Retrieve data from the type_link table. This requires retrieving data from
     the employee foreign_id field, which is an object_id stored as a string, and
     converting it into an object_id to query against the type_link_test._id field."""
-    privacy_request = PrivacyRequest(id=f"test_mongo_task_{random.randint(0,1000)}")
+    privacy_request = PrivacyRequest(id=f"test_mongo_task_{uuid4()}")
     policy = erasure_policy("A")
     employee = Collection(
         name="employee",
@@ -615,7 +609,7 @@ async def test_object_querying_mongo(
 async def test_get_cached_data_for_erasures(
     integration_postgres_config, integration_mongodb_config, policy, db
 ) -> None:
-    privacy_request = PrivacyRequest(id=f"test_mongo_task_{random.randint(0,1000)}")
+    privacy_request = PrivacyRequest(id=f"test_mongo_task_{uuid4()}")
 
     mongo_dataset, postgres_dataset = combined_mongo_postgresql_graph(
         integration_postgres_config, integration_mongodb_config
@@ -720,9 +714,7 @@ async def test_return_all_elements_config_erasure(
     """Includes examples of mongo nested and array erasures"""
     policy = erasure_policy("A", "B")
 
-    privacy_request = PrivacyRequest(
-        id=f"test_sql_erasure_task_{random.randint(0, 1000)}"
-    )
+    privacy_request = PrivacyRequest(id=f"test_sql_erasure_task_{uuid4()}")
     mongo_dataset, postgres_dataset = combined_mongo_postgresql_graph(
         integration_postgres_config, integration_mongodb_config
     )
@@ -1051,7 +1043,7 @@ async def test_array_querying_mongo(
     ]
 
     # Run again with different email
-    privacy_request = PrivacyRequest(id=f"test_mongo_task_{random.randint(0,1000)}")
+    privacy_request = PrivacyRequest(id=f"test_mongo_task_{uuid4()}")
     access_request_results = await graph_task.run_access_request(
         privacy_request,
         policy,


### PR DESCRIPTION
Relates to #2178

### Code Changes

* Switch from `randint` to `uuid` in mongo tests

### Steps to Confirm

* verify mongo tests pass

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

The random int used in mongo tests is random, but not unique. The mongo tests don't clear out records between tests so by chance it is possible to have a clash in ids. This PR changes the use of random ints to using uuids. This is one of the causes mongo tests are flaky in CI, but I suspect it isn't the only reason so there is probably more to do here.