### PR TITLE
pc/consent: Show GPC banner and how it affects individual consent choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ The types of changes are:
     * Bulk edit custom field values [#2612](https://github.com/ethyca/fides/issues/2612)
 * Privacy Center
   * The consent config default value can depend on whether Global Privacy Control is enabled. [#2341](https://github.com/ethyca/fides/pull/2341)
-  * `inspectForBrowserIdentities` now also looks for `ljt_readerID`
+  * When GPC is enabled, the UI indicates which data uses are opted out by default. [#2596](https://github.com/ethyca/fides/pull/2596)
+  * `inspectForBrowserIdentities` now also looks for `ljt_readerID`. [#2543](https://github.com/ethyca/fides/pull/2543)
 
 ### Added
   * Added new Wunderkind Consent Saas Connector [#2600](https://github.com/ethyca/fides/pull/2600)

--- a/clients/privacy-center/__tests__/features/consent/helpers.test.ts
+++ b/clients/privacy-center/__tests__/features/consent/helpers.test.ts
@@ -1,205 +1,144 @@
-import {
-  makeConsentItems,
-  makeCookieKeyConsent,
-} from "~/features/consent/helpers";
-import { ApiUserConsents, ConsentItem } from "~/features/consent/types";
+import { ConsentContext } from "fides-consent";
+
+import { makeCookieKeyConsent } from "~/features/consent/helpers";
 import { ConfigConsentOption } from "~/types/config";
 
-describe("makeConsentItems", () => {
-  const consentOptions: ConfigConsentOption[] = [
-    {
-      cookieKeys: ["data_sharing"],
-      default: false,
-      description: "Data shared with third parties",
-      fidesDataUseKey: "third_party_sharing",
-      highlight: true,
-      name: "Third Party Sharing",
-      url: "https://example.com/privacy#data-sales",
-      executable: true,
-    },
-    {
-      cookieKeys: ["custom_key"],
-      default: false,
-      description: "Configured description",
-      fidesDataUseKey: "custom.use",
-      highlight: true,
-      name: "Custom",
-      url: "https://example.com/privacy#custom",
-      executable: false,
-    },
-    {
-      cookieKeys: [],
-      default: true,
-      description: "Default opted in",
-      fidesDataUseKey: "provide.service",
-      name: "Provide a service",
-      url: "https://example.com/privacy#provide-service",
-      executable: false,
-    },
-  ];
-
-  it("Matches config options with API response data", () => {
-    const data: ApiUserConsents = {
-      consent: [
-        {
-          data_use: "third_party_sharing",
-          opt_in: false,
-        },
-        {
-          data_use: "custom.use",
-          data_use_description: "Custom API description",
-          opt_in: true,
-        },
-      ],
-    };
-
-    const items = makeConsentItems(data, consentOptions);
-
-    expect(items).toEqual([
-      {
-        cookieKeys: ["data_sharing"],
-        consentValue: false,
-        defaultValue: false,
-        description: "Data shared with third parties",
-        fidesDataUseKey: "third_party_sharing",
-        highlight: true,
-        name: "Third Party Sharing",
-        url: "https://example.com/privacy#data-sales",
-        executable: true,
-      },
-      {
-        cookieKeys: ["custom_key"],
-        consentValue: true,
-        defaultValue: false,
-        description: "Custom API description",
-        fidesDataUseKey: "custom.use",
-        highlight: true,
-        name: "Custom",
-        url: "https://example.com/privacy#custom",
-        executable: false,
-      },
-      {
-        cookieKeys: [],
-        defaultValue: true,
-        description: "Default opted in",
-        fidesDataUseKey: "provide.service",
-        highlight: false,
-        name: "Provide a service",
-        url: "https://example.com/privacy#provide-service",
-        executable: false,
-      },
-    ]);
-  });
-
-  it("Creates default items when there is no API response data", () => {
-    const items = makeConsentItems({}, consentOptions);
-
-    expect(items).toEqual([
-      {
-        cookieKeys: ["data_sharing"],
-        defaultValue: false,
-        description: "Data shared with third parties",
-        fidesDataUseKey: "third_party_sharing",
-        highlight: true,
-        name: "Third Party Sharing",
-        url: "https://example.com/privacy#data-sales",
-        executable: true,
-      },
-      {
-        cookieKeys: ["custom_key"],
-        defaultValue: false,
-        description: "Configured description",
-        fidesDataUseKey: "custom.use",
-        highlight: true,
-        name: "Custom",
-        url: "https://example.com/privacy#custom",
-        executable: false,
-      },
-      {
-        cookieKeys: [],
-        defaultValue: true,
-        description: "Default opted in",
-        fidesDataUseKey: "provide.service",
-        highlight: false,
-        name: "Provide a service",
-        url: "https://example.com/privacy#provide-service",
-        executable: false,
-      },
-    ]);
-  });
-});
-
 describe("makeCookieKeyConsent", () => {
-  // Only the consent booleans and cookieKeys matter for resolving the cookie mapping.
+  // Some display options don't matter for these tests.
   const irrelevantProps = {
     description: "",
     highlight: false,
     name: "",
-    fidesDataUseKey: "",
     url: "https://example.com/privacy#data-sales",
   };
 
-  const dataSalesWithConsent: ConsentItem = {
-    cookieKeys: ["data_sales"],
-    consentValue: true,
-    defaultValue: false,
-    ...irrelevantProps,
-  };
-  const dataSalesWithoutConsent: ConsentItem = {
-    cookieKeys: ["data_sales", "google_ads"],
-    consentValue: false,
-    defaultValue: false,
-    ...irrelevantProps,
-  };
-  const dataSharingWithConsent: ConsentItem = {
-    cookieKeys: ["data_sharing", "google_analytics"],
-    consentValue: true,
-    defaultValue: false,
-    ...irrelevantProps,
-  };
-  const dataSharingWithDefaultConsent: ConsentItem = {
-    cookieKeys: ["data_sharing", "google_analytics"],
-    defaultValue: true,
-    ...irrelevantProps,
-  };
-  const analyticsWithoutConsent: ConsentItem = {
-    cookieKeys: ["google_analytics"],
-    consentValue: false,
-    defaultValue: true,
-    ...irrelevantProps,
-  };
+  describe("With blank consent context", () => {
+    const consentContext: ConsentContext = {};
 
-  it("Applies default consent", () => {
-    expect(makeCookieKeyConsent([dataSharingWithDefaultConsent])).toEqual({
-      data_sharing: true,
-      google_analytics: true,
+    const dataUseSales: ConfigConsentOption = {
+      fidesDataUseKey: "data_use.sales",
+      cookieKeys: ["data_sales"],
+      default: false,
+      ...irrelevantProps,
+    };
+    const dataUseSalesGads: ConfigConsentOption = {
+      fidesDataUseKey: "data_use.sales.gads",
+      cookieKeys: ["data_sales", "google_ads"],
+      default: false,
+      ...irrelevantProps,
+    };
+    const dataUseSharingGanDefault: ConfigConsentOption = {
+      fidesDataUseKey: "data_use.sharing.gan.default",
+      cookieKeys: ["data_sharing", "google_analytics"],
+      default: true,
+      ...irrelevantProps,
+    };
+    const dataUseGanDefault: ConfigConsentOption = {
+      cookieKeys: ["google_analytics"],
+      fidesDataUseKey: "data_use.gan.default",
+      default: true,
+      ...irrelevantProps,
+    };
+
+    it("applies default consent", () => {
+      expect(
+        makeCookieKeyConsent({
+          consentOptions: [dataUseSharingGanDefault],
+          fidesKeyToConsent: {},
+          consentContext,
+        })
+      ).toEqual({
+        data_sharing: true,
+        google_analytics: true,
+      });
+    });
+
+    it("allows overriding default consent", () => {
+      expect(
+        makeCookieKeyConsent({
+          consentOptions: [dataUseGanDefault],
+          fidesKeyToConsent: {
+            [dataUseGanDefault.fidesDataUseKey]: false,
+          },
+          consentContext,
+        })
+      ).toEqual({
+        google_analytics: false,
+      });
+    });
+
+    it("removes consent if some matching keys don't have consent", () => {
+      expect(
+        makeCookieKeyConsent({
+          consentOptions: [dataUseSales, dataUseSalesGads],
+          fidesKeyToConsent: {
+            [dataUseSales.fidesDataUseKey]: false,
+            [dataUseSalesGads.fidesDataUseKey]: true,
+          },
+          consentContext,
+        })
+      ).toEqual({
+        data_sales: false,
+        google_ads: true,
+      });
+    });
+
+    it("applies consent if all matching keys have consent", () => {
+      expect(
+        makeCookieKeyConsent({
+          consentOptions: [dataUseSales, dataUseSalesGads],
+          fidesKeyToConsent: {
+            [dataUseSales.fidesDataUseKey]: true,
+            [dataUseSalesGads.fidesDataUseKey]: true,
+          },
+          consentContext,
+        })
+      ).toEqual({
+        data_sales: true,
+        google_ads: true,
+      });
     });
   });
 
-  it("Allows overriding default consent", () => {
-    expect(makeCookieKeyConsent([analyticsWithoutConsent])).toEqual({
-      google_analytics: false,
-    });
-  });
+  describe("With GPC enabled in the consent context", () => {
+    const consentContext: ConsentContext = {
+      globalPrivacyControl: true,
+    };
 
-  it("Removes consent if some matching keys don't have consent", () => {
-    expect(
-      makeCookieKeyConsent([dataSalesWithConsent, dataSalesWithoutConsent])
-    ).toEqual({
-      data_sales: false,
-      google_ads: false,
-    });
-  });
+    const dataUseSalesDefaultNoGpc: ConfigConsentOption = {
+      fidesDataUseKey: "data_use.sales",
+      cookieKeys: ["data_sales"],
+      default: {
+        value: true,
+        globalPrivacyControl: false,
+      },
+      ...irrelevantProps,
+    };
 
-  it("Applies consent if all matching keys have consent", () => {
-    expect(
-      makeCookieKeyConsent([
-        dataSharingWithConsent,
-        dataSharingWithDefaultConsent,
-      ])
-    ).toEqual({
-      data_sharing: true,
-      google_analytics: true,
+    it("applies the GPC default consent", () => {
+      expect(
+        makeCookieKeyConsent({
+          consentOptions: [dataUseSalesDefaultNoGpc],
+          fidesKeyToConsent: {},
+          consentContext,
+        })
+      ).toEqual({
+        data_sales: false,
+      });
+    });
+
+    it("allows overriding the GPC default consent", () => {
+      expect(
+        makeCookieKeyConsent({
+          consentOptions: [dataUseSalesDefaultNoGpc],
+          fidesKeyToConsent: {
+            [dataUseSalesDefaultNoGpc.fidesDataUseKey]: true,
+          },
+          consentContext,
+        })
+      ).toEqual({
+        data_sales: true,
+      });
     });
   });
 });

--- a/clients/privacy-center/app/store.ts
+++ b/clients/privacy-center/app/store.ts
@@ -18,6 +18,7 @@ import createWebStorage from "redux-persist/lib/storage/createWebStorage";
 
 import { baseApi } from "~/features/common/api.slice";
 import { reducer as configReducer } from "~/features/common/config.slice";
+import { reducer as consentReducer } from "~/features/consent/consent.slice";
 
 /**
  * To prevent the "redux-persist failed to create sync storage. falling back to noop storage"
@@ -44,6 +45,7 @@ const storage =
 const reducer = {
   [baseApi.reducerPath]: baseApi.reducer,
   config: configReducer,
+  consent: consentReducer,
 };
 
 export type RootState = StateFromReducersMapObject<typeof reducer>;

--- a/clients/privacy-center/components/ConsentItemCard.tsx
+++ b/clients/privacy-center/components/ConsentItemCard.tsx
@@ -1,103 +1,97 @@
-import React, { useMemo } from "react";
+import React from "react";
 import {
-  Flex,
   Box,
-  Text,
+  Flex,
+  HStack,
   Link,
   Radio,
   RadioGroup,
+  Spacer,
   Stack,
-  HStack,
+  Text,
+  ExternalLinkIcon,
 } from "@fidesui/react";
-import { ExternalLinkIcon } from "@chakra-ui/icons";
-import { getConsentContext, resolveConsentValue } from "fides-consent";
 
 import { ConfigConsentOption } from "~/types/config";
-import { useAppDispatch, useAppSelector } from "~/app/hooks";
-import {
-  changeConsent,
-  selectFidesKeyToConsent,
-} from "~/features/consent/consent.slice";
+import { useAppDispatch } from "~/app/hooks";
+import { changeConsent } from "~/features/consent/consent.slice";
+import { GpcStatus } from "~/features/consent/types";
+import { GpcBadge, GpcInfo } from "~/features/consent/GpcMessages";
 
 type ConsentItemProps = {
   option: ConfigConsentOption;
+  value: boolean;
+  gpcStatus: GpcStatus;
 };
 
-const ConsentItemCard = ({ option }: ConsentItemProps) => {
+const ConsentItemCard = ({ option, value, gpcStatus }: ConsentItemProps) => {
   const { name, description, highlight, url, fidesDataUseKey } = option;
 
-  const defaultValue = useMemo(
-    () => resolveConsentValue(option.default, getConsentContext()),
-    [option]
-  );
-
   const dispatch = useAppDispatch();
-  const fidesKeyToConsent = useAppSelector(selectFidesKeyToConsent);
-
-  const value = fidesKeyToConsent[option.fidesDataUseKey] ?? defaultValue;
 
   const handleRadioChange = (radioValue: string) => {
     dispatch(changeConsent({ option, value: radioValue === "true" }));
   };
 
   return (
-    <Flex
-      flexDirection="row"
-      width="720px"
+    <Box
       backgroundColor={highlight ? "gray.100" : undefined}
-      justifyContent="center"
+      borderRadius="md"
       data-testid={`consent-item-card-${fidesDataUseKey}`}
+      paddingX={12}
+      paddingY={3}
+      width="full"
+      lineHeight={5}
     >
-      <Flex mb="24px" mt="24px" mr="35px" ml="35px" width="100%">
-        <Box width="100%" pr="60px">
-          <Text
-            fontSize="lg"
-            fontWeight="bold"
-            lineHeight="7"
-            color="gray.600"
-            mb="4px"
-          >
+      <Stack>
+        <Flex direction="row">
+          <Text fontSize="lg" fontWeight="bold" color="gray.600" mb="4px">
             {name}
           </Text>
-          <Text
-            fontSize="sm"
-            fontWeight="medium"
-            lineHeight="5"
-            color="gray.600"
-            mb="2px"
-          >
-            {description}
-          </Text>
-          <Link href={url} isExternal>
-            <HStack>
-              <Text
-                fontSize="sm"
-                fontWeight="medium"
-                lineHeight="5"
-                color="complimentary.500"
-              >
-                {" "}
-                Find out more about this consent{" "}
-              </Text>
-              <ExternalLinkIcon mx="2px" color="complimentary.500" />
-            </HStack>
-          </Link>
-        </Box>
-        <RadioGroup
-          value={value ? "true" : "false"}
-          onChange={handleRadioChange}
-        >
-          <Stack direction="row">
-            <Radio value="true" colorScheme="whatsapp">
-              Yes
-            </Radio>
-            <Radio value="false" colorScheme="whatsapp">
-              No
-            </Radio>
+          <Spacer />
+          <GpcBadge status={gpcStatus} />
+        </Flex>
+
+        <GpcInfo status={gpcStatus} />
+
+        <HStack spacing={10}>
+          <Stack>
+            <Text fontSize="sm" fontWeight="medium" color="gray.600" mb="2px">
+              {description}
+            </Text>
+
+            <Link href={url} isExternal>
+              <HStack>
+                <Text
+                  fontSize="sm"
+                  fontWeight="medium"
+                  color="complimentary.500"
+                >
+                  Find out more about this consent
+                </Text>
+                <ExternalLinkIcon mx="2px" color="complimentary.500" />
+              </HStack>
+            </Link>
           </Stack>
-        </RadioGroup>
-      </Flex>
-    </Flex>
+
+          <Box>
+            <RadioGroup
+              value={value ? "true" : "false"}
+              onChange={handleRadioChange}
+            >
+              <Stack direction="row">
+                <Radio value="true" colorScheme="whatsapp">
+                  Yes
+                </Radio>
+                <Radio value="false" colorScheme="whatsapp">
+                  No
+                </Radio>
+              </Stack>
+            </RadioGroup>
+          </Box>
+        </HStack>
+      </Stack>
+    </Box>
   );
 };
 

--- a/clients/privacy-center/features/common/config.slice.ts
+++ b/clients/privacy-center/features/common/config.slice.ts
@@ -3,6 +3,7 @@ import { produce } from "immer";
 
 import type { RootState } from "~/app/store";
 import { config as initialConfig } from "~/constants";
+import { Consent, ConsentPreferences } from "~/types/api";
 import { ConfigConsentOption } from "~/types/config";
 
 type State = {
@@ -25,10 +26,37 @@ export const configSlice = createSlice({
       }
       draftState.consent.consentOptions = payload;
     },
+
+    /**
+     * When consent preferences are returned from the API, they include the up-to-date description
+     * of the related data use. This overrides the statically configured data use info.
+     */
+    updateConsentOptionsFromApi(
+      draftState,
+      { payload }: PayloadAction<ConsentPreferences>
+    ) {
+      const consentPreferencesMap = new Map<string, Consent>(
+        (payload.consent ?? []).map((consent) => [consent.data_use, consent])
+      );
+
+      draftState.consent?.consentOptions?.forEach((draftOption) => {
+        const apiConsent = consentPreferencesMap.get(
+          draftOption.fidesDataUseKey
+        );
+        if (!apiConsent) {
+          return;
+        }
+
+        if (apiConsent.data_use_description) {
+          draftOption.description = apiConsent.data_use_description;
+        }
+      });
+    },
   },
 });
 
 export const { reducer } = configSlice;
+export const { updateConsentOptionsFromApi } = configSlice.actions;
 
 /**
  * The stored config state, which is the subset of configs options that can be modified at runtime.

--- a/clients/privacy-center/features/consent/GpcMessages.tsx
+++ b/clients/privacy-center/features/consent/GpcMessages.tsx
@@ -17,15 +17,11 @@ const BADGE_COLORS = {
 
 export const GpcBadge = ({ status }: { status: GpcStatus }) =>
   status === GpcStatus.NONE ? null : (
-    <HStack>
+    <HStack data-testid="gpc-badge">
       <Text color="gray.600" fontWeight="semibold" fontSize="xs">
         Global Privacy Control
       </Text>
-      <Badge
-        variant="solid"
-        colorScheme={BADGE_COLORS[status]}
-        data-testid="gpc-badge"
-      >
+      <Badge variant="solid" colorScheme={BADGE_COLORS[status]}>
         {status}
       </Badge>
     </HStack>
@@ -78,6 +74,7 @@ export const GpcBanner = () => (
     padding={4}
     spacing={1}
     lineHeight={5}
+    data-testid="gpc-banner"
   >
     <Stack direction="row">
       <WarningTwoIcon color="blue.400" />

--- a/clients/privacy-center/features/consent/GpcMessages.tsx
+++ b/clients/privacy-center/features/consent/GpcMessages.tsx
@@ -1,0 +1,104 @@
+import {
+  Badge,
+  Box,
+  Link,
+  Stack,
+  Text,
+  HStack,
+  WarningTwoIcon,
+} from "@fidesui/react";
+import { GpcStatus } from "./types";
+
+const BADGE_COLORS = {
+  [GpcStatus.NONE]: undefined,
+  [GpcStatus.APPLIED]: "green",
+  [GpcStatus.OVERRIDDEN]: "red",
+};
+
+export const GpcBadge = ({ status }: { status: GpcStatus }) =>
+  status === GpcStatus.NONE ? null : (
+    <HStack>
+      <Text color="gray.600" fontWeight="semibold" fontSize="xs">
+        Global Privacy Control
+      </Text>
+      <Badge
+        variant="solid"
+        colorScheme={BADGE_COLORS[status]}
+        data-testid="gpc-badge"
+      >
+        {status}
+      </Badge>
+    </HStack>
+  );
+
+const InfoText: typeof Text = (props) => (
+  <Box
+    background="gray.100"
+    border="1px solid"
+    borderColor="blue.50"
+    borderRadius="md"
+    fontSize="xs"
+    paddingX={2}
+    paddingY={3}
+  >
+    <Text {...props} />
+  </Box>
+);
+
+const GpcApplied = () => (
+  <InfoText>
+    You were opted out of this use case because of Global Privacy Controls.
+  </InfoText>
+);
+
+const GpcOverridden = () => (
+  <InfoText>
+    The default Global Privacy Control for this use case has been overridden.
+  </InfoText>
+);
+
+export const GpcInfo = ({ status }: { status: GpcStatus }) => {
+  if (status === GpcStatus.APPLIED) {
+    return <GpcApplied />;
+  }
+
+  if (status === GpcStatus.OVERRIDDEN) {
+    return <GpcOverridden />;
+  }
+
+  return null;
+};
+
+export const GpcBanner = () => (
+  <Stack
+    border="1px solid"
+    borderColor="blue.400"
+    borderRadius="lg"
+    background="gray.100"
+    padding={4}
+    spacing={1}
+    lineHeight={5}
+  >
+    <Stack direction="row">
+      <WarningTwoIcon color="blue.400" />
+      <Text fontSize="sm" fontWeight="bold">
+        Global Privacy Control detected
+      </Text>
+    </Stack>
+
+    <Box paddingLeft={6}>
+      <Text fontSize="sm">
+        We recognized that you have enabled your browser&apos;s{" "}
+        <Link
+          href="https://globalprivacycontrol.org"
+          isExternal
+          color="complimentary.500"
+        >
+          Global Privacy Control
+        </Link>
+        . You have been opted out of data sales and sharing use cases as a
+        result.
+      </Text>
+    </Box>
+  </Stack>
+);

--- a/clients/privacy-center/features/consent/consent.slice.ts
+++ b/clients/privacy-center/features/consent/consent.slice.ts
@@ -1,9 +1,15 @@
+import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+import type { RootState } from "~/app/store";
 import { VerificationType } from "~/components/modals/types";
 import { baseApi } from "~/features/common/api.slice";
 import {
   ConsentPreferences,
   ConsentPreferencesWithVerificationCode,
 } from "~/types/api";
+import { ConfigConsentOption } from "~/types/config";
+
+import { FidesKeyToConsent } from "./types";
 
 export const consentApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
@@ -49,3 +55,65 @@ export const {
   useLazyGetConsentRequestPreferencesQuery,
   useUpdateConsentRequestPreferencesMutation,
 } = consentApi;
+
+type State = {
+  /** The consent choices currently shown in the UI */
+  fidesKeyToConsent: FidesKeyToConsent;
+  /** The consent choices stored on the server (returned by the most recent API call). */
+  persistedFidesKeyToConsent: FidesKeyToConsent;
+};
+
+const initialState: State = {
+  fidesKeyToConsent: {},
+  persistedFidesKeyToConsent: {},
+};
+
+export const consentSlice = createSlice({
+  name: "consent",
+  initialState,
+  reducers: {
+    changeConsent(
+      draftState,
+      {
+        payload: { option, value },
+      }: PayloadAction<{ option: ConfigConsentOption; value: boolean }>
+    ) {
+      draftState.fidesKeyToConsent[option.fidesDataUseKey] = value;
+    },
+
+    /**
+     * Update the stored consent preferences with the data returned by the API. These values take
+     * precedence over the locally-stored opt in/out booleans to ensure the UI matches the server.
+     *
+     * Note: we have to store a copy of the API results instead of selecting from the API's cache
+     * directly because there are 3 different endpoints that may return this info. If we simplify
+     * how that fetching works with/without verification, this would also become simpler.
+     */
+    updateConsentFromApi(
+      draftState,
+      { payload }: PayloadAction<ConsentPreferences>
+    ) {
+      const consentPreferences = payload.consent ?? [];
+      consentPreferences.forEach((consent) => {
+        draftState.fidesKeyToConsent[consent.data_use] = consent.opt_in;
+        draftState.persistedFidesKeyToConsent[consent.data_use] =
+          consent.opt_in;
+      });
+    },
+  },
+});
+
+export const { reducer } = consentSlice;
+export const { changeConsent, updateConsentFromApi } = consentSlice.actions;
+
+export const selectConsentState = (state: RootState) => state.consent;
+
+export const selectFidesKeyToConsent = createSelector(
+  selectConsentState,
+  (state) => state.fidesKeyToConsent
+);
+
+export const selectPersistedFidesKeyToConsent = createSelector(
+  selectConsentState,
+  (state) => state.persistedFidesKeyToConsent
+);

--- a/clients/privacy-center/features/consent/helpers.ts
+++ b/clients/privacy-center/features/consent/helpers.ts
@@ -5,7 +5,7 @@ import {
 } from "fides-consent";
 
 import { ConfigConsentOption } from "~/types/config";
-import { FidesKeyToConsent } from "./types";
+import { FidesKeyToConsent, GpcStatus } from "./types";
 
 export const makeCookieKeyConsent = ({
   consentOptions,
@@ -30,4 +30,29 @@ export const makeCookieKeyConsent = ({
     });
   });
   return cookieKeyConsent;
+};
+
+export const getGpcStatus = ({
+  value,
+  consentOption,
+  consentContext,
+}: {
+  value: boolean;
+  consentOption: ConfigConsentOption;
+  consentContext: ConsentContext;
+}): GpcStatus => {
+  // If GPC is not enabled, it won't be applied at all.
+  if (!consentContext.globalPrivacyControl) {
+    return GpcStatus.NONE;
+  }
+  // Options that are plain booleans apply without considering GPC.
+  if (typeof consentOption.default !== "object") {
+    return GpcStatus.NONE;
+  }
+
+  if (value === consentOption.default.globalPrivacyControl) {
+    return GpcStatus.APPLIED;
+  }
+
+  return GpcStatus.OVERRIDDEN;
 };

--- a/clients/privacy-center/features/consent/helpers.ts
+++ b/clients/privacy-center/features/consent/helpers.ts
@@ -1,85 +1,32 @@
 import {
+  ConsentContext,
   CookieKeyConsent,
-  getConsentContext,
   resolveConsentValue,
 } from "fides-consent";
+
 import { ConfigConsentOption } from "~/types/config";
+import { FidesKeyToConsent } from "./types";
 
-import { ConsentItem, ApiUserConsents, ApiUserConsent } from "./types";
-
-export const makeConsentItems = (
-  data: ApiUserConsents,
-  consentOptions: ConfigConsentOption[]
-): ConsentItem[] => {
-  const consentContext = getConsentContext();
-
-  if (data.consent) {
-    const newConsentItems: ConsentItem[] = [];
-    const userConsentMap: { [key: string]: ApiUserConsent } = {};
-    data.consent.forEach((option) => {
-      const key = option.data_use;
-      userConsentMap[key] = option;
-    });
-    consentOptions.forEach((d) => {
-      const defaultValue = resolveConsentValue(d.default, consentContext);
-
-      if (d.fidesDataUseKey in userConsentMap) {
-        const currentConsent = userConsentMap[d.fidesDataUseKey];
-
-        newConsentItems.push({
-          defaultValue,
-          consentValue: currentConsent.opt_in,
-          description: currentConsent.data_use_description
-            ? currentConsent.data_use_description
-            : d.description,
-          fidesDataUseKey: currentConsent.data_use,
-          highlight: d.highlight ?? false,
-          name: d.name,
-          url: d.url,
-          cookieKeys: d.cookieKeys ?? [],
-          executable: d.executable ?? false,
-        });
-      } else {
-        newConsentItems.push({
-          defaultValue,
-          fidesDataUseKey: d.fidesDataUseKey,
-          name: d.name,
-          description: d.description,
-          highlight: d.highlight ?? false,
-          url: d.url,
-          cookieKeys: d.cookieKeys ?? [],
-          executable: d.executable ?? false,
-        });
-      }
-    });
-
-    return newConsentItems;
-  }
-
-  return consentOptions.map((option) => ({
-    fidesDataUseKey: option.fidesDataUseKey,
-    name: option.name,
-    description: option.description,
-    highlight: option.highlight ?? false,
-    url: option.url,
-    defaultValue: resolveConsentValue(option.default, consentContext),
-    cookieKeys: option.cookieKeys ?? [],
-    executable: option.executable ?? false,
-  }));
-};
-
-export const makeCookieKeyConsent = (
-  consentItems: ConsentItem[]
-): CookieKeyConsent => {
+export const makeCookieKeyConsent = ({
+  consentOptions,
+  fidesKeyToConsent,
+  consentContext,
+}: {
+  consentOptions: ConfigConsentOption[];
+  fidesKeyToConsent: FidesKeyToConsent;
+  consentContext: ConsentContext;
+}): CookieKeyConsent => {
   const cookieKeyConsent: CookieKeyConsent = {};
-  consentItems.forEach((item) => {
-    const consent =
-      item.consentValue === undefined ? item.defaultValue : item.consentValue;
+  consentOptions.forEach((option) => {
+    const defaultValue = resolveConsentValue(option.default, consentContext);
+    const value = fidesKeyToConsent[option.fidesDataUseKey] ?? defaultValue;
 
-    item.cookieKeys?.forEach((cookieKey) => {
+    option.cookieKeys?.forEach((cookieKey) => {
       const previousConsent = cookieKeyConsent[cookieKey];
+      // For a cookie key to have consent, _all_ data uses that target that cookie key
+      // must have consent.
       cookieKeyConsent[cookieKey] =
-        previousConsent === undefined ? consent : previousConsent && consent;
+        previousConsent === undefined ? value : previousConsent && value;
     });
   });
   return cookieKeyConsent;

--- a/clients/privacy-center/features/consent/types.ts
+++ b/clients/privacy-center/features/consent/types.ts
@@ -1,3 +1,12 @@
 export type FidesKeyToConsent = {
   [fidesKey: string]: boolean | undefined;
 };
+
+export enum GpcStatus {
+  /** GPC is not relevant for the consent option. */
+  NONE = "none",
+  /** GPC is enabled and consent matches the configured default. */
+  APPLIED = "applied",
+  /** GPC is enabled but consent has been set to override the configured default. */
+  OVERRIDDEN = "overridden",
+}

--- a/clients/privacy-center/features/consent/types.ts
+++ b/clients/privacy-center/features/consent/types.ts
@@ -1,21 +1,3 @@
-export type ConsentItem = {
-  fidesDataUseKey: string;
-  name: string;
-  description: string;
-  highlight: boolean;
-  url: string;
-  defaultValue: boolean;
-  consentValue?: boolean;
-  cookieKeys?: string[];
-  executable?: boolean;
-};
-
-export type ApiUserConsent = {
-  data_use: string;
-  data_use_description?: string;
-  opt_in: boolean;
-};
-
-export type ApiUserConsents = {
-  consent?: ApiUserConsent[];
+export type FidesKeyToConsent = {
+  [fidesKey: string]: boolean | undefined;
 };

--- a/clients/privacy-center/package-lock.json
+++ b/clients/privacy-center/package-lock.json
@@ -9,12 +9,10 @@
         "packages/fides-consent"
       ],
       "dependencies": {
-        "@chakra-ui/icons": "^1.1.7",
-        "@chakra-ui/react": "^1.7.4",
-        "@chakra-ui/system": "^1.12.1",
-        "@emotion/react": "^11",
-        "@emotion/styled": "^11",
-        "@fidesui/react": "^0.0.9",
+        "@chakra-ui/react": "^1.8.9",
+        "@emotion/react": "^11.10.5",
+        "@emotion/styled": "^11.10.5",
+        "@fidesui/react": "^0.0.21",
         "@fontsource/inter": "^4.5.4",
         "@reduxjs/toolkit": "^1.9.1",
         "fides-consent": "./packages/fides-consent",
@@ -1540,37 +1538,37 @@
       }
     },
     "node_modules/@emotion/babel-plugin": {
-      "version": "11.10.2",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz",
-      "integrity": "sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz",
+      "integrity": "sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/plugin-syntax-jsx": "^7.17.12",
         "@babel/runtime": "^7.18.3",
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/serialize": "^1.1.1",
         "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
-        "stylis": "4.0.13"
+        "stylis": "4.1.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@emotion/cache": {
-      "version": "11.10.3",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
-      "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+      "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
       "dependencies": {
         "@emotion/memoize": "^0.8.0",
-        "@emotion/sheet": "^1.2.0",
+        "@emotion/sheet": "^1.2.1",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
-        "stylis": "4.0.13"
+        "stylis": "4.1.3"
       }
     },
     "node_modules/@emotion/hash": {
@@ -1592,14 +1590,14 @@
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
     "node_modules/@emotion/react": {
-      "version": "11.10.4",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.4.tgz",
-      "integrity": "sha512-j0AkMpr6BL8gldJZ6XQsQ8DnS9TxEQu1R+OGmDZiWjBAJtCcbt0tS3I/YffoqHXxH6MjgI7KdMbYKw3MEiU9eA==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.5.tgz",
+      "integrity": "sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.0",
-        "@emotion/cache": "^11.10.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/babel-plugin": "^11.10.5",
+        "@emotion/cache": "^11.10.5",
+        "@emotion/serialize": "^1.1.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
@@ -1619,9 +1617,9 @@
       }
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
-      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
@@ -1631,19 +1629,19 @@
       }
     },
     "node_modules/@emotion/sheet": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
-      "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
     },
     "node_modules/@emotion/styled": {
-      "version": "11.10.4",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.4.tgz",
-      "integrity": "sha512-pRl4R8Ez3UXvOPfc2bzIoV8u9P97UedgHS4FPX594ntwEuAMA114wlaHvOK24HB48uqfXiGlYIZYCxVJ1R1ttQ==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.5.tgz",
+      "integrity": "sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.0",
+        "@emotion/babel-plugin": "^11.10.5",
         "@emotion/is-prop-valid": "^1.2.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/serialize": "^1.1.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
         "@emotion/utils": "^1.2.0"
       },
@@ -1806,59 +1804,61 @@
       }
     },
     "node_modules/@fidesui/react": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@fidesui/react/-/react-0.0.9.tgz",
-      "integrity": "sha512-7hQHRjj7w8FILwIYc520KzkNqG3iT2ah4T7Qfeai1oXA+2NZue1emL29vLwvUx5RI6UiTQgDwebQMgzDuioFew==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@fidesui/react/-/react-0.0.21.tgz",
+      "integrity": "sha512-Xfvh8tqoQL5p9lV4ZfN9kZxFKVfySAnugr4yUwrhQncUDfWB9nJho6Uc7XFl8oge88q6NnPlBb359cQ5ztM5aA==",
       "dependencies": {
-        "@chakra-ui/accordion": "1.4.6",
-        "@chakra-ui/alert": "1.3.5",
-        "@chakra-ui/avatar": "1.3.6",
-        "@chakra-ui/breadcrumb": "1.3.4",
-        "@chakra-ui/checkbox": "1.6.5",
-        "@chakra-ui/close-button": "1.2.5",
-        "@chakra-ui/control-box": "1.1.4",
-        "@chakra-ui/counter": "1.2.5",
-        "@chakra-ui/css-reset": "1.1.2",
-        "@chakra-ui/editable": "1.3.5",
-        "@chakra-ui/form-control": "1.5.6",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/icon": "2.0.3",
-        "@chakra-ui/image": "1.1.5",
-        "@chakra-ui/input": "1.4.1",
-        "@chakra-ui/layout": "1.7.4",
-        "@chakra-ui/live-region": "1.1.4",
-        "@chakra-ui/media-query": "2.0.1",
-        "@chakra-ui/menu": "1.8.6",
-        "@chakra-ui/modal": "1.10.7",
-        "@chakra-ui/number-input": "1.4.2",
-        "@chakra-ui/pin-input": "1.7.5",
-        "@chakra-ui/popover": "1.11.4",
-        "@chakra-ui/popper": "2.4.2",
-        "@chakra-ui/portal": "1.3.5",
-        "@chakra-ui/progress": "1.2.4",
-        "@chakra-ui/provider": "1.7.9",
-        "@chakra-ui/radio": "1.4.7",
-        "@chakra-ui/react-env": "1.1.4",
-        "@chakra-ui/select": "1.2.6",
-        "@chakra-ui/skeleton": "1.2.9",
-        "@chakra-ui/slider": "1.5.6",
-        "@chakra-ui/spinner": "1.2.4",
-        "@chakra-ui/stat": "1.2.5",
-        "@chakra-ui/switch": "1.3.5",
-        "@chakra-ui/system": "1.10.3",
-        "@chakra-ui/table": "1.3.4",
-        "@chakra-ui/tabs": "1.6.5",
-        "@chakra-ui/tag": "1.2.5",
-        "@chakra-ui/textarea": "1.2.6",
-        "@chakra-ui/theme": "1.13.2",
-        "@chakra-ui/toast": "1.5.4",
-        "@chakra-ui/tooltip": "1.4.6",
-        "@chakra-ui/transition": "1.4.5",
-        "@chakra-ui/utils": "1.10.2",
-        "@chakra-ui/visually-hidden": "1.1.4",
-        "@fidesui/react-button": "^0.0.6",
-        "@fidesui/react-provider": "^0.0.7",
-        "@fidesui/react-theme": "^0.0.7"
+        "@chakra-ui/accordion": "^1.4.6",
+        "@chakra-ui/alert": "^1.3.5",
+        "@chakra-ui/avatar": "^1.3.6",
+        "@chakra-ui/breadcrumb": "^1.3.4",
+        "@chakra-ui/checkbox": "^1.6.5",
+        "@chakra-ui/close-button": "^1.2.5",
+        "@chakra-ui/control-box": "^1.1.4",
+        "@chakra-ui/counter": "^1.2.5",
+        "@chakra-ui/css-reset": "^1.1.2",
+        "@chakra-ui/editable": "^1.3.5",
+        "@chakra-ui/form-control": "^1.5.6",
+        "@chakra-ui/hooks": "^1.8.2",
+        "@chakra-ui/icon": "^2.0.3",
+        "@chakra-ui/icons": "^1.1.5",
+        "@chakra-ui/image": "^1.1.5",
+        "@chakra-ui/input": "^1.4.1",
+        "@chakra-ui/layout": "^1.7.4",
+        "@chakra-ui/live-region": "^1.1.4",
+        "@chakra-ui/media-query": "^2.0.1",
+        "@chakra-ui/menu": "^1.8.6",
+        "@chakra-ui/modal": "^1.10.7",
+        "@chakra-ui/number-input": "^1.4.2",
+        "@chakra-ui/pin-input": "^1.7.5",
+        "@chakra-ui/popover": "^1.11.4",
+        "@chakra-ui/popper": "^2.4.2",
+        "@chakra-ui/portal": "^1.3.5",
+        "@chakra-ui/progress": "^1.2.4",
+        "@chakra-ui/provider": "^1.7.9",
+        "@chakra-ui/radio": "^1.4.7",
+        "@chakra-ui/react-env": "^1.1.4",
+        "@chakra-ui/select": "^1.2.6",
+        "@chakra-ui/skeleton": "^1.2.9",
+        "@chakra-ui/slider": "^1.5.6",
+        "@chakra-ui/spinner": "^1.2.4",
+        "@chakra-ui/stat": "^1.2.5",
+        "@chakra-ui/switch": "^1.3.5",
+        "@chakra-ui/system": "^1.10.3",
+        "@chakra-ui/table": "^1.3.4",
+        "@chakra-ui/tabs": "^1.6.5",
+        "@chakra-ui/tag": "^1.2.5",
+        "@chakra-ui/textarea": "^1.2.6",
+        "@chakra-ui/theme": "^1.13.2",
+        "@chakra-ui/toast": "^1.5.4",
+        "@chakra-ui/tooltip": "^1.4.6",
+        "@chakra-ui/transition": "^1.4.5",
+        "@chakra-ui/utils": "^1.10.2",
+        "@chakra-ui/visually-hidden": "^1.1.4",
+        "@fidesui/react-button": "^0.0.7",
+        "@fidesui/react-icon": "^0.1.1",
+        "@fidesui/react-provider": "^0.0.19",
+        "@fidesui/react-theme": "^0.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": "^1.10.3",
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/@fidesui/react-button": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@fidesui/react-button/-/react-button-0.0.6.tgz",
-      "integrity": "sha512-DKONQljVdUMs34ZhIlm9/rXzCYAW6IJ+QmqC+HkZHpZ9ILbn5svu1KwSmt3DZsylSzhzc8HhQY1s5NdC0XlxKw==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@fidesui/react-button/-/react-button-0.0.7.tgz",
+      "integrity": "sha512-8nB2lk6tT4YhuXlGnec9hjAl7fSSilMEspbk1NC49Fh7S98y2BYjh7wY1Kk+SmpB5x8Clhqc/A6bkMMy49V/Kg==",
       "dependencies": {
         "@chakra-ui/button": "^1.5.3"
       },
@@ -1879,13 +1879,27 @@
         "react-dom": "^17.0.2"
       }
     },
+    "node_modules/@fidesui/react-icon": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fidesui/react-icon/-/react-icon-0.1.1.tgz",
+      "integrity": "sha512-uBMM6Kv902fcO1XfVV1CbSsJXC/OoC/vdT56TvPu34S0Xg++34aFuQmomRNE2SDVfyPcMajeWQqID1vTJDNdaw==",
+      "dependencies": {
+        "@chakra-ui/icon": "^2.0.3",
+        "@chakra-ui/icons": "^1.1.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": "^1.10.3",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      }
+    },
     "node_modules/@fidesui/react-provider": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@fidesui/react-provider/-/react-provider-0.0.7.tgz",
-      "integrity": "sha512-CBHJASepiyJ4XiVuWZ3+gkWPDnYheoew5v3F4Uu18NLN67NTfLoWgGWDyn4yRHe1/EINDtbI9r4E5bkMWL8YKA==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@fidesui/react-provider/-/react-provider-0.0.19.tgz",
+      "integrity": "sha512-nsZqTOoVKConOsNVma+YuyxlJs/MfOAmzazBfN0XsXZKQSW2NIq8czA6mOwwMlqrkLds/dD6eudPtO0/eb4aIw==",
       "dependencies": {
         "@chakra-ui/provider": "^1.7.7",
-        "@fidesui/react-theme": "^0.0.7"
+        "@fidesui/react-theme": "^0.1.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": "^1.10.3",
@@ -1894,9 +1908,9 @@
       }
     },
     "node_modules/@fidesui/react-theme": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@fidesui/react-theme/-/react-theme-0.0.7.tgz",
-      "integrity": "sha512-eQ+BnhJpRiBuFOo1sHjTq6p+Ap44ctxNSaMEKQpgruPA7YDARzxjMcDotFk0g/6SysEcqnYVy6rKkbx0XMkSxA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@fidesui/react-theme/-/react-theme-0.1.0.tgz",
+      "integrity": "sha512-ZsJpdUQcJr64iEO7l/gP0G0ViexwyYeDT+3Yu8i+pXpCYJtKg0QVxCMGqX57Ga7DkYw1q9IRm5nHU/yAyG2K9A==",
       "dependencies": {
         "@chakra-ui/react": "^1.8.0",
         "@chakra-ui/utils": "^1.10.2"
@@ -1905,24 +1919,6 @@
         "@chakra-ui/system": "^1.10.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/accordion": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.4.6.tgz",
-      "integrity": "sha512-dmHMMDM/TAdFb8LretCzk72QtjtTFkrk1BP8NvinSPsqF90UDsFUlzp9URgJfW1kdfgpwyEo9pry9U9uYX0PLg==",
-      "dependencies": {
-        "@chakra-ui/descendant": "2.1.2",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/icon": "2.0.3",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/transition": "1.4.5",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@fidesui/react/node_modules/@chakra-ui/alert": {
@@ -1950,33 +1946,6 @@
         "@chakra-ui/system": ">=1.0.0"
       }
     },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/avatar": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.3.6.tgz",
-      "integrity": "sha512-gyULR3Wfi0ARSw7UCgVCSl5aWdCNFK2lqMuBaDc628t71NXrBK8+PUtrn1jp0JXBg3++aX2A0CuUHXIESEC9Ew==",
-      "dependencies": {
-        "@chakra-ui/image": "1.1.5",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/breadcrumb": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.3.4.tgz",
-      "integrity": "sha512-qk71qvf9s/DRBbUCVUg1weFnrXrdCe7pa9hE8++5UDQv6V5DU3TPN7jxp9yzkARI/mGFWpioIvQHxE1MDCTGAg==",
-      "dependencies": {
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
     "node_modules/@fidesui/react/node_modules/@chakra-ui/checkbox": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.6.5.tgz",
@@ -1990,18 +1959,6 @@
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
         "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/clickable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.2.4.tgz",
-      "integrity": "sha512-TYXKrJxeN1AXTRxgNViEw3uEJ4NlO7CptjoXqakrHCLNU2cf4ETTCd4C4OGDZiVwE1UTu155ffHGM+tiXgcGSA==",
-      "dependencies": {
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
         "react": ">=16.8.6"
       }
     },
@@ -2031,18 +1988,6 @@
         "react": ">=16.8.6"
       }
     },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/control-box": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.1.4.tgz",
-      "integrity": "sha512-uV/A6UIlu1/kEktY1YZCi1HOmX/ZaLTCsflJpmf5RLnZa5F7VMdT9E/lr6/PfMQiQKXIj4fpMQI56T6LuAp2Aw==",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
     "node_modules/@fidesui/react/node_modules/@chakra-ui/counter": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.2.5.tgz",
@@ -2050,52 +1995,6 @@
       "dependencies": {
         "@chakra-ui/hooks": "1.8.2",
         "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/css-reset": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-1.1.2.tgz",
-      "integrity": "sha512-7BQxaBtUQlAZsjl2gNnPtTK0p7MALb7f6/hn5C2tQR9OOy7o9tR1RQQIYd4+DsS/SGtBVdiWCix98eLdlwY/iQ==",
-      "peerDependencies": {
-        "@emotion/react": ">=10.0.35",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/descendant": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-2.1.2.tgz",
-      "integrity": "sha512-o3WrYD0zGBdRB7aM9bENci7BWrFYBCMTcix/0iQQfsvIPeFKZOKOx/zUHXVby6nvmC7rIPep5yCn9UNNB+REkg==",
-      "dependencies": {
-        "@chakra-ui/react-utils": "^1.2.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/editable": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.3.5.tgz",
-      "integrity": "sha512-6JQ5fMf8KsHJpzHZ6rt/5frz7VNmXUC4Phi5CbEsN1KcKPeIxjjdMh9MADvcrDMWkhj7Nx2Zcvii9Oeaa8kF2g==",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/focus-lock": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.2.4.tgz",
-      "integrity": "sha512-irMhZLH02Ue88MM/36/cziD+VNRqZbtGTrnERB3/j5PdGZT6vF/9bv+TZDCKo3gNe2Z8pEJFfFsQ++f53xKyeg==",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.2",
-        "react-focus-lock": "2.5.2"
       },
       "peerDependencies": {
         "react": ">=16.8.6"
@@ -2142,58 +2041,6 @@
         "react": ">=16.8.6"
       }
     },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/image": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.1.5.tgz",
-      "integrity": "sha512-xzCS7OFZeHUYkYz67J5nuIfVjCF0KyZ6lj1PuWZbQIzH2ZKkDq7eTYpWkAkCRyZ4Z6Cz+s/WtBL53FqCYQ6nwg==",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/input": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.4.1.tgz",
-      "integrity": "sha512-CLFX8KCvoSdALxWsJrwIDTCFwok1f/YRRei8n/UDedPzzmOxaWX95wA2kL716PWzcnOhQdii7U6xqyZNPXgOXQ==",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.5.6",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/layout": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.7.4.tgz",
-      "integrity": "sha512-WtjmyyxV5Cp4o99idFFzcZdR29Jdq/I3QL9daVbj1crD1byLytagDRQzEknh0mwNMOVBymMw2fDWT1ZCavW2VQ==",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.3",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/live-region": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.1.4.tgz",
-      "integrity": "sha512-OQq6ruL7503gdfyQkxyZLhl/wpDr1CZwMoKJM/KGcfr91ctAdUQ8gmgL47py/cRKzF1RKMd1dfn6E0ULIzQSqA==",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
     "node_modules/@fidesui/react/node_modules/@chakra-ui/media-query": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-2.0.1.tgz",
@@ -2205,96 +2052,6 @@
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0",
         "@chakra-ui/theme": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/menu": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.8.6.tgz",
-      "integrity": "sha512-b5KcXZFQRsgu7XXHz/3yyNB0K4NFvIYVSDTfMmRQKKExEjQ7az7mtVNAUFDQIYXXoj4QhLXPfWISw1Ijgw1LHA==",
-      "dependencies": {
-        "@chakra-ui/clickable": "1.2.4",
-        "@chakra-ui/descendant": "2.1.2",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/popper": "2.4.2",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/transition": "1.4.5",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/modal": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.10.7.tgz",
-      "integrity": "sha512-4Ao9tIHZxOe1zUgmScw5SFeZgUAPjjvhAnqqt4Hp+OfFC7ML35GwYbU+yYGiYasvLXnqDwcrdZ4ggmDTMqUGdw==",
-      "dependencies": {
-        "@chakra-ui/close-button": "1.2.5",
-        "@chakra-ui/focus-lock": "1.2.4",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/portal": "1.3.5",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/transition": "1.4.5",
-        "@chakra-ui/utils": "1.10.2",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.4.1"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/number-input": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.4.2.tgz",
-      "integrity": "sha512-+OOQRWDYQd8OL+zIafRN7hii6tssXuQ5hcmNUBmrcNMdwKvRPQW0hvzSuhc09NSA/rDV/TvsAFyqpo4lY7gGng==",
-      "dependencies": {
-        "@chakra-ui/counter": "1.2.5",
-        "@chakra-ui/form-control": "1.5.6",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/icon": "2.0.3",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/pin-input": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.7.5.tgz",
-      "integrity": "sha512-1MwBRPpPy6HSr/f+c0jVUes/plNVUnm5uiUDgsI9IeV2SMj0pxz3+5RkMjX+ygsVuXqY4CaWGNtPkyQXivfy/w==",
-      "dependencies": {
-        "@chakra-ui/descendant": "2.1.2",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/popover": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.11.4.tgz",
-      "integrity": "sha512-133NJABbmFD77HCJ2pAOF+JuXbYs3dkX6Oq0hGI5LtfTxCddIIHbwmVQ44IP8vpj5KRKLSy/DurgPngJ70aE/Q==",
-      "dependencies": {
-        "@chakra-ui/close-button": "1.2.5",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/popper": "2.4.2",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
         "react": ">=16.8.6"
       }
     },
@@ -2324,54 +2081,6 @@
         "react-dom": ">=16.8.6"
       }
     },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/progress": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.2.4.tgz",
-      "integrity": "sha512-ukPf4G/nphfsx0ZPRnDPElFzWVrJSHG5PT7uLuT+hUmxmotSCI3qtHryySVfCXqaU2SKQDF1fy1XhRANO0AEMA==",
-      "dependencies": {
-        "@chakra-ui/theme-tools": "1.3.4",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/provider": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-1.7.9.tgz",
-      "integrity": "sha512-VQ8l1FzNlMyQZas0jEXuWNoMZfyMcv8CidIUboQtdkh+MXli7Q19O2MtOKeLGbQmzQ5ZZnMlQZTnWjkTWDpqCw==",
-      "dependencies": {
-        "@chakra-ui/css-reset": "1.1.2",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/portal": "1.3.5",
-        "@chakra-ui/react-env": "1.1.4",
-        "@chakra-ui/system": "1.10.3",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/radio": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.4.7.tgz",
-      "integrity": "sha512-skf03KkqhEsI4fAPvhjTr3A0MBhsHElEuZcZVZ+Q4j9SA3VmBH5neMy5zeJrVFHQTy8JuPi649jECE54BFkLTw==",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.5.6",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2",
-        "@chakra-ui/visually-hidden": "1.1.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
     "node_modules/@fidesui/react/node_modules/@chakra-ui/react-env": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-1.1.4.tgz",
@@ -2394,77 +2103,6 @@
         "react": ">=16.8.6"
       }
     },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/select": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.2.6.tgz",
-      "integrity": "sha512-nn3cTSvze1PBpel9+pIkxAhXRnhhbuUVkSkwpMAYSKqdh5vd/6NhwArADvnjctY/7FYTxIwA0JCmUL4oDtF9AQ==",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.5.6",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/skeleton": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.2.9.tgz",
-      "integrity": "sha512-kMzVLJQVy+wyuE/uE2CZoG40qulS0YKZw36bkp23ANrkNVH0LhdcsxFTaIhcuA2PWy+P+GCY84zK+F3kHQmxHA==",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/media-query": "2.0.1",
-        "@chakra-ui/system": "1.10.3",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/theme": ">=1.0.0",
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/slider": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.5.6.tgz",
-      "integrity": "sha512-2LDbPeZI1kSTmRm0iQteRuezdheh9fM8b0rDyuIgts4KEEJmyyGzqrpWGzDb+cWl6b+S1QF/s1mthf0B05FMSA==",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/spinner": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.2.4.tgz",
-      "integrity": "sha512-TDK9s3USnaMvrtfBZFUbo6KxJKBFEqxhnoPH3cuqZwXfkA0djmiN9tm4kFNsc7ETIE9raMOZ1OLgU76AJEW6mQ==",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.2",
-        "@chakra-ui/visually-hidden": "1.1.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/stat": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.2.5.tgz",
-      "integrity": "sha512-uZY1nrpGBxXI23HQj6gDI2mhDbRJ+BmeAu1bWYoHiiRX3qMjhubJyAGHA/DOGNSAtdqR1EIvwTOJ6zxvwlVp3w==",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.3",
-        "@chakra-ui/utils": "1.10.2",
-        "@chakra-ui/visually-hidden": "1.1.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
     "node_modules/@fidesui/react/node_modules/@chakra-ui/styled-system": {
       "version": "1.17.2",
       "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.17.2.tgz",
@@ -2472,20 +2110,6 @@
       "dependencies": {
         "@chakra-ui/utils": "1.10.2",
         "csstype": "^3.0.9"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/switch": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.3.5.tgz",
-      "integrity": "sha512-m1q5zVvy4fI902YjRkr+1BSRKpAEW0CtvWcHO2CK/TL//enGbo/STX6yMo/smtSynqUlldrQ3U1/H8pJZ5k1NQ==",
-      "dependencies": {
-        "@chakra-ui/checkbox": "1.6.5",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@fidesui/react/node_modules/@chakra-ui/system": {
@@ -2502,60 +2126,6 @@
       "peerDependencies": {
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/table": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.3.4.tgz",
-      "integrity": "sha512-o0a+EPLEi4wWCFxnb3HYlUf4NXlzQUlUtB2Y3eGrBbZK5ClDFZFdNL8t6v8X3zMrGRcfHDBgQyxPhT7E1c4Gqw==",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/tabs": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.6.5.tgz",
-      "integrity": "sha512-GKQI289qvjPHsURdu9JjLRZdfDweN7qRk9xLt4vPHAml5bRkhej1l+Fn20SVWUU5Sjn4PoP2xJmutvIqal48qw==",
-      "dependencies": {
-        "@chakra-ui/clickable": "1.2.4",
-        "@chakra-ui/descendant": "2.1.2",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/tag": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.2.5.tgz",
-      "integrity": "sha512-aZTAJ4HxGFDIIgURd35jvB8InFMmx4DX510ytWN9zy3Ec4jPPXgnGFKCETFNL2kGMnZDv2SOcxOHUIsWpmBSnQ==",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.3",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/textarea": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.2.6.tgz",
-      "integrity": "sha512-D8ZWA3mbYtYoj32NprHMO0yD/MRaj8LPVuCwZLr8+IUku9RDtnS4MUtvoUU7j9BDSuEjWtHvYXmQgal2q2X/1w==",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.5.6",
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
         "react": ">=16.8.6"
       }
     },
@@ -2582,57 +2152,6 @@
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=1.0.0"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/toast": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.5.4.tgz",
-      "integrity": "sha512-Vz3YV5hlE95qdXAAjy+eV+uM6idvKG2EwJU2AqDUIHgIDhOeNTTEGScSiS6xnLu/IYUD9XtQGdXe3pKg4jEDZQ==",
-      "dependencies": {
-        "@chakra-ui/alert": "1.3.5",
-        "@chakra-ui/close-button": "1.2.5",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/theme": "1.13.2",
-        "@chakra-ui/transition": "1.4.5",
-        "@chakra-ui/utils": "1.10.2",
-        "@reach/alert": "0.13.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/tooltip": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.4.6.tgz",
-      "integrity": "sha512-rZs/q/E7H37rV63hTEXJw6GOwHgxYOOY9GdDA2AxzeOfQfSFazxACh3a+PEP02aNXAqnFZrLAAowHp4EqxtrGw==",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/popper": "2.4.2",
-        "@chakra-ui/portal": "1.3.5",
-        "@chakra-ui/react-utils": "1.2.2",
-        "@chakra-ui/utils": "1.10.2",
-        "@chakra-ui/visually-hidden": "1.1.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@fidesui/react/node_modules/@chakra-ui/transition": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.4.5.tgz",
-      "integrity": "sha512-DGRURmiWOdHJEh30ZKgM6az+Zae1ZpMjxhfbBHcNPyuU+GLzCSMOzmC8XieJGHe/yZ3+X93LdYAMX+yDF16rqQ==",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.2"
-      },
-      "peerDependencies": {
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
       }
     },
     "node_modules/@fidesui/react/node_modules/@chakra-ui/utils": {
@@ -6060,9 +5579,9 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -15108,9 +14627,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
-      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -17203,34 +16722,34 @@
       }
     },
     "@emotion/babel-plugin": {
-      "version": "11.10.2",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz",
-      "integrity": "sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz",
+      "integrity": "sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==",
       "requires": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/plugin-syntax-jsx": "^7.17.12",
         "@babel/runtime": "^7.18.3",
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/serialize": "^1.1.1",
         "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
-        "stylis": "4.0.13"
+        "stylis": "4.1.3"
       }
     },
     "@emotion/cache": {
-      "version": "11.10.3",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
-      "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+      "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
       "requires": {
         "@emotion/memoize": "^0.8.0",
-        "@emotion/sheet": "^1.2.0",
+        "@emotion/sheet": "^1.2.1",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
-        "stylis": "4.0.13"
+        "stylis": "4.1.3"
       }
     },
     "@emotion/hash": {
@@ -17252,14 +16771,14 @@
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
     "@emotion/react": {
-      "version": "11.10.4",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.4.tgz",
-      "integrity": "sha512-j0AkMpr6BL8gldJZ6XQsQ8DnS9TxEQu1R+OGmDZiWjBAJtCcbt0tS3I/YffoqHXxH6MjgI7KdMbYKw3MEiU9eA==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.5.tgz",
+      "integrity": "sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==",
       "requires": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.0",
-        "@emotion/cache": "^11.10.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/babel-plugin": "^11.10.5",
+        "@emotion/cache": "^11.10.5",
+        "@emotion/serialize": "^1.1.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
@@ -17267,9 +16786,9 @@
       }
     },
     "@emotion/serialize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
-      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
       "requires": {
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
@@ -17279,19 +16798,19 @@
       }
     },
     "@emotion/sheet": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
-      "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
     },
     "@emotion/styled": {
-      "version": "11.10.4",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.4.tgz",
-      "integrity": "sha512-pRl4R8Ez3UXvOPfc2bzIoV8u9P97UedgHS4FPX594ntwEuAMA114wlaHvOK24HB48uqfXiGlYIZYCxVJ1R1ttQ==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.5.tgz",
+      "integrity": "sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==",
       "requires": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.0",
+        "@emotion/babel-plugin": "^11.10.5",
         "@emotion/is-prop-valid": "^1.2.0",
-        "@emotion/serialize": "^1.1.0",
+        "@emotion/serialize": "^1.1.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
         "@emotion/utils": "^1.2.0"
       }
@@ -17390,74 +16909,63 @@
       "requires": {}
     },
     "@fidesui/react": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@fidesui/react/-/react-0.0.9.tgz",
-      "integrity": "sha512-7hQHRjj7w8FILwIYc520KzkNqG3iT2ah4T7Qfeai1oXA+2NZue1emL29vLwvUx5RI6UiTQgDwebQMgzDuioFew==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@fidesui/react/-/react-0.0.21.tgz",
+      "integrity": "sha512-Xfvh8tqoQL5p9lV4ZfN9kZxFKVfySAnugr4yUwrhQncUDfWB9nJho6Uc7XFl8oge88q6NnPlBb359cQ5ztM5aA==",
       "requires": {
-        "@chakra-ui/accordion": "1.4.6",
-        "@chakra-ui/alert": "1.3.5",
-        "@chakra-ui/avatar": "1.3.6",
-        "@chakra-ui/breadcrumb": "1.3.4",
-        "@chakra-ui/checkbox": "1.6.5",
-        "@chakra-ui/close-button": "1.2.5",
-        "@chakra-ui/control-box": "1.1.4",
-        "@chakra-ui/counter": "1.2.5",
-        "@chakra-ui/css-reset": "1.1.2",
-        "@chakra-ui/editable": "1.3.5",
-        "@chakra-ui/form-control": "1.5.6",
-        "@chakra-ui/hooks": "1.8.2",
-        "@chakra-ui/icon": "2.0.3",
-        "@chakra-ui/image": "1.1.5",
-        "@chakra-ui/input": "1.4.1",
-        "@chakra-ui/layout": "1.7.4",
-        "@chakra-ui/live-region": "1.1.4",
-        "@chakra-ui/media-query": "2.0.1",
-        "@chakra-ui/menu": "1.8.6",
-        "@chakra-ui/modal": "1.10.7",
-        "@chakra-ui/number-input": "1.4.2",
-        "@chakra-ui/pin-input": "1.7.5",
-        "@chakra-ui/popover": "1.11.4",
-        "@chakra-ui/popper": "2.4.2",
-        "@chakra-ui/portal": "1.3.5",
-        "@chakra-ui/progress": "1.2.4",
-        "@chakra-ui/provider": "1.7.9",
-        "@chakra-ui/radio": "1.4.7",
-        "@chakra-ui/react-env": "1.1.4",
-        "@chakra-ui/select": "1.2.6",
-        "@chakra-ui/skeleton": "1.2.9",
-        "@chakra-ui/slider": "1.5.6",
-        "@chakra-ui/spinner": "1.2.4",
-        "@chakra-ui/stat": "1.2.5",
-        "@chakra-ui/switch": "1.3.5",
-        "@chakra-ui/system": "1.10.3",
-        "@chakra-ui/table": "1.3.4",
-        "@chakra-ui/tabs": "1.6.5",
-        "@chakra-ui/tag": "1.2.5",
-        "@chakra-ui/textarea": "1.2.6",
-        "@chakra-ui/theme": "1.13.2",
-        "@chakra-ui/toast": "1.5.4",
-        "@chakra-ui/tooltip": "1.4.6",
-        "@chakra-ui/transition": "1.4.5",
-        "@chakra-ui/utils": "1.10.2",
-        "@chakra-ui/visually-hidden": "1.1.4",
-        "@fidesui/react-button": "^0.0.6",
-        "@fidesui/react-provider": "^0.0.7",
-        "@fidesui/react-theme": "^0.0.7"
+        "@chakra-ui/accordion": "^1.4.6",
+        "@chakra-ui/alert": "^1.3.5",
+        "@chakra-ui/avatar": "^1.3.6",
+        "@chakra-ui/breadcrumb": "^1.3.4",
+        "@chakra-ui/checkbox": "^1.6.5",
+        "@chakra-ui/close-button": "^1.2.5",
+        "@chakra-ui/control-box": "^1.1.4",
+        "@chakra-ui/counter": "^1.2.5",
+        "@chakra-ui/css-reset": "^1.1.2",
+        "@chakra-ui/editable": "^1.3.5",
+        "@chakra-ui/form-control": "^1.5.6",
+        "@chakra-ui/hooks": "^1.8.2",
+        "@chakra-ui/icon": "^2.0.3",
+        "@chakra-ui/icons": "^1.1.5",
+        "@chakra-ui/image": "^1.1.5",
+        "@chakra-ui/input": "^1.4.1",
+        "@chakra-ui/layout": "^1.7.4",
+        "@chakra-ui/live-region": "^1.1.4",
+        "@chakra-ui/media-query": "^2.0.1",
+        "@chakra-ui/menu": "^1.8.6",
+        "@chakra-ui/modal": "^1.10.7",
+        "@chakra-ui/number-input": "^1.4.2",
+        "@chakra-ui/pin-input": "^1.7.5",
+        "@chakra-ui/popover": "^1.11.4",
+        "@chakra-ui/popper": "^2.4.2",
+        "@chakra-ui/portal": "^1.3.5",
+        "@chakra-ui/progress": "^1.2.4",
+        "@chakra-ui/provider": "^1.7.9",
+        "@chakra-ui/radio": "^1.4.7",
+        "@chakra-ui/react-env": "^1.1.4",
+        "@chakra-ui/select": "^1.2.6",
+        "@chakra-ui/skeleton": "^1.2.9",
+        "@chakra-ui/slider": "^1.5.6",
+        "@chakra-ui/spinner": "^1.2.4",
+        "@chakra-ui/stat": "^1.2.5",
+        "@chakra-ui/switch": "^1.3.5",
+        "@chakra-ui/system": "^1.10.3",
+        "@chakra-ui/table": "^1.3.4",
+        "@chakra-ui/tabs": "^1.6.5",
+        "@chakra-ui/tag": "^1.2.5",
+        "@chakra-ui/textarea": "^1.2.6",
+        "@chakra-ui/theme": "^1.13.2",
+        "@chakra-ui/toast": "^1.5.4",
+        "@chakra-ui/tooltip": "^1.4.6",
+        "@chakra-ui/transition": "^1.4.5",
+        "@chakra-ui/utils": "^1.10.2",
+        "@chakra-ui/visually-hidden": "^1.1.4",
+        "@fidesui/react-button": "^0.0.7",
+        "@fidesui/react-icon": "^0.1.1",
+        "@fidesui/react-provider": "^0.0.19",
+        "@fidesui/react-theme": "^0.1.0"
       },
       "dependencies": {
-        "@chakra-ui/accordion": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.4.6.tgz",
-          "integrity": "sha512-dmHMMDM/TAdFb8LretCzk72QtjtTFkrk1BP8NvinSPsqF90UDsFUlzp9URgJfW1kdfgpwyEo9pry9U9uYX0PLg==",
-          "requires": {
-            "@chakra-ui/descendant": "2.1.2",
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/icon": "2.0.3",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/transition": "1.4.5",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
         "@chakra-ui/alert": {
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-1.3.5.tgz",
@@ -17476,25 +16984,6 @@
             "@chakra-ui/theme-tools": "^1.3.4"
           }
         },
-        "@chakra-ui/avatar": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.3.6.tgz",
-          "integrity": "sha512-gyULR3Wfi0ARSw7UCgVCSl5aWdCNFK2lqMuBaDc628t71NXrBK8+PUtrn1jp0JXBg3++aX2A0CuUHXIESEC9Ew==",
-          "requires": {
-            "@chakra-ui/image": "1.1.5",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/breadcrumb": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.3.4.tgz",
-          "integrity": "sha512-qk71qvf9s/DRBbUCVUg1weFnrXrdCe7pa9hE8++5UDQv6V5DU3TPN7jxp9yzkARI/mGFWpioIvQHxE1MDCTGAg==",
-          "requires": {
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
         "@chakra-ui/checkbox": {
           "version": "1.6.5",
           "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.6.5.tgz",
@@ -17504,15 +16993,6 @@
             "@chakra-ui/react-utils": "1.2.2",
             "@chakra-ui/utils": "1.10.2",
             "@chakra-ui/visually-hidden": "1.1.4"
-          }
-        },
-        "@chakra-ui/clickable": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.2.4.tgz",
-          "integrity": "sha512-TYXKrJxeN1AXTRxgNViEw3uEJ4NlO7CptjoXqakrHCLNU2cf4ETTCd4C4OGDZiVwE1UTu155ffHGM+tiXgcGSA==",
-          "requires": {
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2"
           }
         },
         "@chakra-ui/close-button": {
@@ -17534,14 +17014,6 @@
             "@chakra-ui/utils": "1.10.2"
           }
         },
-        "@chakra-ui/control-box": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.1.4.tgz",
-          "integrity": "sha512-uV/A6UIlu1/kEktY1YZCi1HOmX/ZaLTCsflJpmf5RLnZa5F7VMdT9E/lr6/PfMQiQKXIj4fpMQI56T6LuAp2Aw==",
-          "requires": {
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
         "@chakra-ui/counter": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.2.5.tgz",
@@ -17549,39 +17021,6 @@
           "requires": {
             "@chakra-ui/hooks": "1.8.2",
             "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/css-reset": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-1.1.2.tgz",
-          "integrity": "sha512-7BQxaBtUQlAZsjl2gNnPtTK0p7MALb7f6/hn5C2tQR9OOy7o9tR1RQQIYd4+DsS/SGtBVdiWCix98eLdlwY/iQ==",
-          "requires": {}
-        },
-        "@chakra-ui/descendant": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-2.1.2.tgz",
-          "integrity": "sha512-o3WrYD0zGBdRB7aM9bENci7BWrFYBCMTcix/0iQQfsvIPeFKZOKOx/zUHXVby6nvmC7rIPep5yCn9UNNB+REkg==",
-          "requires": {
-            "@chakra-ui/react-utils": "^1.2.2"
-          }
-        },
-        "@chakra-ui/editable": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.3.5.tgz",
-          "integrity": "sha512-6JQ5fMf8KsHJpzHZ6rt/5frz7VNmXUC4Phi5CbEsN1KcKPeIxjjdMh9MADvcrDMWkhj7Nx2Zcvii9Oeaa8kF2g==",
-          "requires": {
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/focus-lock": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.2.4.tgz",
-          "integrity": "sha512-irMhZLH02Ue88MM/36/cziD+VNRqZbtGTrnERB3/j5PdGZT6vF/9bv+TZDCKo3gNe2Z8pEJFfFsQ++f53xKyeg==",
-          "requires": {
-            "@chakra-ui/utils": "1.10.2",
-            "react-focus-lock": "2.5.2"
           }
         },
         "@chakra-ui/form-control": {
@@ -17614,115 +17053,12 @@
             "@chakra-ui/utils": "1.10.2"
           }
         },
-        "@chakra-ui/image": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.1.5.tgz",
-          "integrity": "sha512-xzCS7OFZeHUYkYz67J5nuIfVjCF0KyZ6lj1PuWZbQIzH2ZKkDq7eTYpWkAkCRyZ4Z6Cz+s/WtBL53FqCYQ6nwg==",
-          "requires": {
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/input": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.4.1.tgz",
-          "integrity": "sha512-CLFX8KCvoSdALxWsJrwIDTCFwok1f/YRRei8n/UDedPzzmOxaWX95wA2kL716PWzcnOhQdii7U6xqyZNPXgOXQ==",
-          "requires": {
-            "@chakra-ui/form-control": "1.5.6",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/layout": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.7.4.tgz",
-          "integrity": "sha512-WtjmyyxV5Cp4o99idFFzcZdR29Jdq/I3QL9daVbj1crD1byLytagDRQzEknh0mwNMOVBymMw2fDWT1ZCavW2VQ==",
-          "requires": {
-            "@chakra-ui/icon": "2.0.3",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/live-region": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.1.4.tgz",
-          "integrity": "sha512-OQq6ruL7503gdfyQkxyZLhl/wpDr1CZwMoKJM/KGcfr91ctAdUQ8gmgL47py/cRKzF1RKMd1dfn6E0ULIzQSqA==",
-          "requires": {
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
         "@chakra-ui/media-query": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-2.0.1.tgz",
           "integrity": "sha512-sUaTCThH2mqnX0HuXgrQdXFFXEO70tu0HDTRaPDufiK9DY8lqoMCNCFMt20Tr6XLIDHoMM/YfWmY4Qaz1QjE6w==",
           "requires": {
             "@chakra-ui/react-env": "1.1.4",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/menu": {
-          "version": "1.8.6",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.8.6.tgz",
-          "integrity": "sha512-b5KcXZFQRsgu7XXHz/3yyNB0K4NFvIYVSDTfMmRQKKExEjQ7az7mtVNAUFDQIYXXoj4QhLXPfWISw1Ijgw1LHA==",
-          "requires": {
-            "@chakra-ui/clickable": "1.2.4",
-            "@chakra-ui/descendant": "2.1.2",
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/popper": "2.4.2",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/transition": "1.4.5",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/modal": {
-          "version": "1.10.7",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.10.7.tgz",
-          "integrity": "sha512-4Ao9tIHZxOe1zUgmScw5SFeZgUAPjjvhAnqqt4Hp+OfFC7ML35GwYbU+yYGiYasvLXnqDwcrdZ4ggmDTMqUGdw==",
-          "requires": {
-            "@chakra-ui/close-button": "1.2.5",
-            "@chakra-ui/focus-lock": "1.2.4",
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/portal": "1.3.5",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/transition": "1.4.5",
-            "@chakra-ui/utils": "1.10.2",
-            "aria-hidden": "^1.1.1",
-            "react-remove-scroll": "2.4.1"
-          }
-        },
-        "@chakra-ui/number-input": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.4.2.tgz",
-          "integrity": "sha512-+OOQRWDYQd8OL+zIafRN7hii6tssXuQ5hcmNUBmrcNMdwKvRPQW0hvzSuhc09NSA/rDV/TvsAFyqpo4lY7gGng==",
-          "requires": {
-            "@chakra-ui/counter": "1.2.5",
-            "@chakra-ui/form-control": "1.5.6",
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/icon": "2.0.3",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/pin-input": {
-          "version": "1.7.5",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.7.5.tgz",
-          "integrity": "sha512-1MwBRPpPy6HSr/f+c0jVUes/plNVUnm5uiUDgsI9IeV2SMj0pxz3+5RkMjX+ygsVuXqY4CaWGNtPkyQXivfy/w==",
-          "requires": {
-            "@chakra-ui/descendant": "2.1.2",
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/popover": {
-          "version": "1.11.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.11.4.tgz",
-          "integrity": "sha512-133NJABbmFD77HCJ2pAOF+JuXbYs3dkX6Oq0hGI5LtfTxCddIIHbwmVQ44IP8vpj5KRKLSy/DurgPngJ70aE/Q==",
-          "requires": {
-            "@chakra-ui/close-button": "1.2.5",
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/popper": "2.4.2",
-            "@chakra-ui/react-utils": "1.2.2",
             "@chakra-ui/utils": "1.10.2"
           }
         },
@@ -17745,40 +17081,6 @@
             "@chakra-ui/utils": "1.10.2"
           }
         },
-        "@chakra-ui/progress": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.2.4.tgz",
-          "integrity": "sha512-ukPf4G/nphfsx0ZPRnDPElFzWVrJSHG5PT7uLuT+hUmxmotSCI3qtHryySVfCXqaU2SKQDF1fy1XhRANO0AEMA==",
-          "requires": {
-            "@chakra-ui/theme-tools": "1.3.4",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/provider": {
-          "version": "1.7.9",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-1.7.9.tgz",
-          "integrity": "sha512-VQ8l1FzNlMyQZas0jEXuWNoMZfyMcv8CidIUboQtdkh+MXli7Q19O2MtOKeLGbQmzQ5ZZnMlQZTnWjkTWDpqCw==",
-          "requires": {
-            "@chakra-ui/css-reset": "1.1.2",
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/portal": "1.3.5",
-            "@chakra-ui/react-env": "1.1.4",
-            "@chakra-ui/system": "1.10.3",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/radio": {
-          "version": "1.4.7",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.4.7.tgz",
-          "integrity": "sha512-skf03KkqhEsI4fAPvhjTr3A0MBhsHElEuZcZVZ+Q4j9SA3VmBH5neMy5zeJrVFHQTy8JuPi649jECE54BFkLTw==",
-          "requires": {
-            "@chakra-ui/form-control": "1.5.6",
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2",
-            "@chakra-ui/visually-hidden": "1.1.4"
-          }
-        },
         "@chakra-ui/react-env": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-1.1.4.tgz",
@@ -17795,55 +17097,6 @@
             "@chakra-ui/utils": "^1.10.2"
           }
         },
-        "@chakra-ui/select": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.2.6.tgz",
-          "integrity": "sha512-nn3cTSvze1PBpel9+pIkxAhXRnhhbuUVkSkwpMAYSKqdh5vd/6NhwArADvnjctY/7FYTxIwA0JCmUL4oDtF9AQ==",
-          "requires": {
-            "@chakra-ui/form-control": "1.5.6",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/skeleton": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.2.9.tgz",
-          "integrity": "sha512-kMzVLJQVy+wyuE/uE2CZoG40qulS0YKZw36bkp23ANrkNVH0LhdcsxFTaIhcuA2PWy+P+GCY84zK+F3kHQmxHA==",
-          "requires": {
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/media-query": "2.0.1",
-            "@chakra-ui/system": "1.10.3",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/slider": {
-          "version": "1.5.6",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.5.6.tgz",
-          "integrity": "sha512-2LDbPeZI1kSTmRm0iQteRuezdheh9fM8b0rDyuIgts4KEEJmyyGzqrpWGzDb+cWl6b+S1QF/s1mthf0B05FMSA==",
-          "requires": {
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/spinner": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.2.4.tgz",
-          "integrity": "sha512-TDK9s3USnaMvrtfBZFUbo6KxJKBFEqxhnoPH3cuqZwXfkA0djmiN9tm4kFNsc7ETIE9raMOZ1OLgU76AJEW6mQ==",
-          "requires": {
-            "@chakra-ui/utils": "1.10.2",
-            "@chakra-ui/visually-hidden": "1.1.4"
-          }
-        },
-        "@chakra-ui/stat": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.2.5.tgz",
-          "integrity": "sha512-uZY1nrpGBxXI23HQj6gDI2mhDbRJ+BmeAu1bWYoHiiRX3qMjhubJyAGHA/DOGNSAtdqR1EIvwTOJ6zxvwlVp3w==",
-          "requires": {
-            "@chakra-ui/icon": "2.0.3",
-            "@chakra-ui/utils": "1.10.2",
-            "@chakra-ui/visually-hidden": "1.1.4"
-          }
-        },
         "@chakra-ui/styled-system": {
           "version": "1.17.2",
           "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.17.2.tgz",
@@ -17851,15 +17104,6 @@
           "requires": {
             "@chakra-ui/utils": "1.10.2",
             "csstype": "^3.0.9"
-          }
-        },
-        "@chakra-ui/switch": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.3.5.tgz",
-          "integrity": "sha512-m1q5zVvy4fI902YjRkr+1BSRKpAEW0CtvWcHO2CK/TL//enGbo/STX6yMo/smtSynqUlldrQ3U1/H8pJZ5k1NQ==",
-          "requires": {
-            "@chakra-ui/checkbox": "1.6.5",
-            "@chakra-ui/utils": "1.10.2"
           }
         },
         "@chakra-ui/system": {
@@ -17872,44 +17116,6 @@
             "@chakra-ui/styled-system": "1.17.2",
             "@chakra-ui/utils": "1.10.2",
             "react-fast-compare": "3.2.0"
-          }
-        },
-        "@chakra-ui/table": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.3.4.tgz",
-          "integrity": "sha512-o0a+EPLEi4wWCFxnb3HYlUf4NXlzQUlUtB2Y3eGrBbZK5ClDFZFdNL8t6v8X3zMrGRcfHDBgQyxPhT7E1c4Gqw==",
-          "requires": {
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/tabs": {
-          "version": "1.6.5",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.6.5.tgz",
-          "integrity": "sha512-GKQI289qvjPHsURdu9JjLRZdfDweN7qRk9xLt4vPHAml5bRkhej1l+Fn20SVWUU5Sjn4PoP2xJmutvIqal48qw==",
-          "requires": {
-            "@chakra-ui/clickable": "1.2.4",
-            "@chakra-ui/descendant": "2.1.2",
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/tag": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.2.5.tgz",
-          "integrity": "sha512-aZTAJ4HxGFDIIgURd35jvB8InFMmx4DX510ytWN9zy3Ec4jPPXgnGFKCETFNL2kGMnZDv2SOcxOHUIsWpmBSnQ==",
-          "requires": {
-            "@chakra-ui/icon": "2.0.3",
-            "@chakra-ui/utils": "1.10.2"
-          }
-        },
-        "@chakra-ui/textarea": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.2.6.tgz",
-          "integrity": "sha512-D8ZWA3mbYtYoj32NprHMO0yD/MRaj8LPVuCwZLr8+IUku9RDtnS4MUtvoUU7j9BDSuEjWtHvYXmQgal2q2X/1w==",
-          "requires": {
-            "@chakra-ui/form-control": "1.5.6",
-            "@chakra-ui/utils": "1.10.2"
           }
         },
         "@chakra-ui/theme": {
@@ -17929,41 +17135,6 @@
           "requires": {
             "@chakra-ui/utils": "1.10.2",
             "@ctrl/tinycolor": "^3.4.0"
-          }
-        },
-        "@chakra-ui/toast": {
-          "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.5.4.tgz",
-          "integrity": "sha512-Vz3YV5hlE95qdXAAjy+eV+uM6idvKG2EwJU2AqDUIHgIDhOeNTTEGScSiS6xnLu/IYUD9XtQGdXe3pKg4jEDZQ==",
-          "requires": {
-            "@chakra-ui/alert": "1.3.5",
-            "@chakra-ui/close-button": "1.2.5",
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/theme": "1.13.2",
-            "@chakra-ui/transition": "1.4.5",
-            "@chakra-ui/utils": "1.10.2",
-            "@reach/alert": "0.13.2"
-          }
-        },
-        "@chakra-ui/tooltip": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.4.6.tgz",
-          "integrity": "sha512-rZs/q/E7H37rV63hTEXJw6GOwHgxYOOY9GdDA2AxzeOfQfSFazxACh3a+PEP02aNXAqnFZrLAAowHp4EqxtrGw==",
-          "requires": {
-            "@chakra-ui/hooks": "1.8.2",
-            "@chakra-ui/popper": "2.4.2",
-            "@chakra-ui/portal": "1.3.5",
-            "@chakra-ui/react-utils": "1.2.2",
-            "@chakra-ui/utils": "1.10.2",
-            "@chakra-ui/visually-hidden": "1.1.4"
-          }
-        },
-        "@chakra-ui/transition": {
-          "version": "1.4.5",
-          "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.4.5.tgz",
-          "integrity": "sha512-DGRURmiWOdHJEh30ZKgM6az+Zae1ZpMjxhfbBHcNPyuU+GLzCSMOzmC8XieJGHe/yZ3+X93LdYAMX+yDF16rqQ==",
-          "requires": {
-            "@chakra-ui/utils": "1.10.2"
           }
         },
         "@chakra-ui/utils": {
@@ -17988,26 +17159,35 @@
       }
     },
     "@fidesui/react-button": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@fidesui/react-button/-/react-button-0.0.6.tgz",
-      "integrity": "sha512-DKONQljVdUMs34ZhIlm9/rXzCYAW6IJ+QmqC+HkZHpZ9ILbn5svu1KwSmt3DZsylSzhzc8HhQY1s5NdC0XlxKw==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@fidesui/react-button/-/react-button-0.0.7.tgz",
+      "integrity": "sha512-8nB2lk6tT4YhuXlGnec9hjAl7fSSilMEspbk1NC49Fh7S98y2BYjh7wY1Kk+SmpB5x8Clhqc/A6bkMMy49V/Kg==",
       "requires": {
         "@chakra-ui/button": "^1.5.3"
       }
     },
+    "@fidesui/react-icon": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fidesui/react-icon/-/react-icon-0.1.1.tgz",
+      "integrity": "sha512-uBMM6Kv902fcO1XfVV1CbSsJXC/OoC/vdT56TvPu34S0Xg++34aFuQmomRNE2SDVfyPcMajeWQqID1vTJDNdaw==",
+      "requires": {
+        "@chakra-ui/icon": "^2.0.3",
+        "@chakra-ui/icons": "^1.1.5"
+      }
+    },
     "@fidesui/react-provider": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@fidesui/react-provider/-/react-provider-0.0.7.tgz",
-      "integrity": "sha512-CBHJASepiyJ4XiVuWZ3+gkWPDnYheoew5v3F4Uu18NLN67NTfLoWgGWDyn4yRHe1/EINDtbI9r4E5bkMWL8YKA==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@fidesui/react-provider/-/react-provider-0.0.19.tgz",
+      "integrity": "sha512-nsZqTOoVKConOsNVma+YuyxlJs/MfOAmzazBfN0XsXZKQSW2NIq8czA6mOwwMlqrkLds/dD6eudPtO0/eb4aIw==",
       "requires": {
         "@chakra-ui/provider": "^1.7.7",
-        "@fidesui/react-theme": "^0.0.7"
+        "@fidesui/react-theme": "^0.1.0"
       }
     },
     "@fidesui/react-theme": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@fidesui/react-theme/-/react-theme-0.0.7.tgz",
-      "integrity": "sha512-eQ+BnhJpRiBuFOo1sHjTq6p+Ap44ctxNSaMEKQpgruPA7YDARzxjMcDotFk0g/6SysEcqnYVy6rKkbx0XMkSxA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@fidesui/react-theme/-/react-theme-0.1.0.tgz",
+      "integrity": "sha512-ZsJpdUQcJr64iEO7l/gP0G0ViexwyYeDT+3Yu8i+pXpCYJtKg0QVxCMGqX57Ga7DkYw1q9IRm5nHU/yAyG2K9A==",
       "requires": {
         "@chakra-ui/react": "^1.8.0",
         "@chakra-ui/utils": "^1.10.2"
@@ -20498,9 +19678,9 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "requires": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -27093,9 +26273,9 @@
       "requires": {}
     },
     "stylis": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
-      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/clients/privacy-center/package.json
+++ b/clients/privacy-center/package.json
@@ -26,12 +26,10 @@
     "packages/fides-consent"
   ],
   "dependencies": {
-    "@chakra-ui/icons": "^1.1.7",
-    "@chakra-ui/react": "^1.7.4",
-    "@chakra-ui/system": "^1.12.1",
-    "@emotion/react": "^11",
-    "@emotion/styled": "^11",
-    "@fidesui/react": "^0.0.9",
+    "@chakra-ui/react": "^1.8.9",
+    "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
+    "@fidesui/react": "^0.0.21",
     "@fontsource/inter": "^4.5.4",
     "@reduxjs/toolkit": "^1.9.1",
     "fides-consent": "./packages/fides-consent",

--- a/clients/privacy-center/packages/fides-consent/src/lib/consent-context.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/consent-context.ts
@@ -4,16 +4,45 @@ declare global {
   }
 }
 
+/**
+ * Returns `window.navigator.globalPrivacyControl` as defined by the spec.
+ *
+ * If the GPC value is undefined, then current page URL is checked for a `globalPrivacyControl`
+ * query parameter. For example: `privacy-center.example.com/consent?globalPrivacyControl=true`.
+ * This allows fides-consent.js to function as if GPC is enabled while testing or demoing without
+ * having to modify the browser before the script runs.
+ */
+const getGlobalPrivacyControl = (): boolean | undefined => {
+  if (typeof window.navigator?.globalPrivacyControl === "boolean") {
+    return window.navigator.globalPrivacyControl;
+  }
+
+  const url = new URL(window.location.href);
+  const gpcParam = url.searchParams.get("globalPrivacyControl");
+  if (gpcParam === "true") {
+    return true;
+  }
+  if (gpcParam === "false") {
+    return false;
+  }
+
+  return undefined;
+};
+
 export type ConsentContext = {
   globalPrivacyControl?: boolean;
 };
 
+/**
+ * Returns the context in which consent should be evaluated. This includes information from the
+ * browser/document, such as whether GPC is enabled.
+ */
 export const getConsentContext = (): ConsentContext => {
   if (typeof window === "undefined") {
     return {};
   }
 
   return {
-    globalPrivacyControl: window.navigator.globalPrivacyControl,
+    globalPrivacyControl: getGlobalPrivacyControl(),
   };
 };

--- a/clients/privacy-center/public/fides-consent-demo.html
+++ b/clients/privacy-center/public/fides-consent-demo.html
@@ -3,21 +3,6 @@
   <head>
     <title>fides-consent script demo page</title>
 
-    <script>
-      // Allow override of `globalPrivacyControl` via a query parameter, which allows Cypress to
-      // test that behavior.
-      (() => {
-        if (window.navigator.globalPrivacyControl !== undefined) {
-          return;
-        }
-
-        const url = new URL(window.location);
-        window.navigator.globalPrivacyControl = JSON.parse(
-          url.searchParams.get("globalPrivacyControl")
-        );
-      })();
-    </script>
-
     <script src="/fides-consent.js"></script>
 
     <style>


### PR DESCRIPTION
Closes #2230

### Code Changes

- pc/fides-consent: support globalPrivacyControl query param directly
  - Take a look at the screenshots below
- pc/consent: Refactor consent local state into RTK store
- pc/consent: helpers now only needs makeCookieKeyConsent
- pc/package.json: Update fidesui dependencies to match admin-ui
  - The icons were out of date
- pc/consent: Show GPC banner and how it affects individual consent choices
- pc/consent: Cypress tests for GPC defaults and overrides in consent UI


### Steps to Confirm

* [ ] You can enable GPC in [Firefox](https://blog.mozilla.org/netpolicy/2021/10/28/implementing-global-privacy-control/) or fake it by navigating to the demo page with the query parameter set: http://localhost:3000/fides-consent-demo.html?globalPrivacyControl=true.
* [ ] With GPC disabled, the UI should function as before
* [ ] With GPC enabled, the the UI should note it's been detected and which have been applied/overridden.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
    * I extracted the confirmation modal to a ticket: https://github.com/ethyca/fides/issues/2597
* [x] Update `CHANGELOG.md`

### Description Of Changes
(These are a bit zoomed out so I could capture the URL and the whole page)

GPC enabled:
<img width="953" alt="gpc-true" src="https://user-images.githubusercontent.com/2236777/218907444-0e116ee5-d75c-481f-ba58-d2d746a1d730.png">

GPC disabled:
<img width="957" alt="gpc-false" src="https://user-images.githubusercontent.com/2236777/218907442-a9ec49e3-7e6e-42de-858e-87d7059a07d8.png">
