### PR TITLE
Updating Firebase Auth to delete user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The types of changes are:
 * Updated the UI for adding systems to a new design [#2490](https://github.com/ethyca/fides/pull/2490)
 * Various form components now take a `stacked` or `inline` variant [#2542](https://github.com/ethyca/fides/pull/2542)
 * UX fixes for user management [#2537](https://github.com/ethyca/fides/pull/2537)
+* Updating Firebase Auth connector to mask the user with a delete instead of an update [#2602](https://github.com/ethyca/fides/pull/2602)
 
 ### Fixed
 

--- a/data/saas/config/firebase_auth_config.yml
+++ b/data/saas/config/firebase_auth_config.yml
@@ -3,7 +3,7 @@ saas_config:
   name: Firebase Auth SaaS Config
   type: firebase_auth
   description: A sample schema representing the Firebase Auth connector for Fidesops
-  version: 0.0.2
+  version: 0.0.3
 
   connector_params:
     - name: domain
@@ -37,14 +37,14 @@ saas_config:
         read:
           - request_override: firebase_auth_user_access
             param_values:
-            - name: email
-              identity: email
+              - name: email
+                identity: email
           - request_override: firebase_auth_user_access
             param_values:
-            - name: phone_number
-              identity: phone_number
-        update:
-          request_override: firebase_auth_user_update
+              - name: phone_number
+                identity: phone_number
+        delete:
+          request_override: firebase_auth_user_delete
           param_values:
             - name: email
               identity: email

--- a/tests/ops/integration_tests/saas/request_override/test_firebase_auth_task.py
+++ b/tests/ops/integration_tests/saas/request_override/test_firebase_auth_task.py
@@ -221,6 +221,9 @@ async def test_firebase_auth_access_request_phone_number_identity(
     assert "photo_url" not in provider_data[1].keys()
 
 
+@pytest.mark.skip(
+    "Re-enable this test if the general config needs to test the user update functionality"
+)
 @pytest.mark.integration_saas
 @pytest.mark.integration_firebase_auth
 @pytest.mark.asyncio
@@ -308,6 +311,9 @@ async def test_firebase_auth_update_request(
     )
 
 
+@pytest.mark.skip(
+    "Re-enable this test if the general config needs to test the user update functionality"
+)
 @pytest.mark.integration_saas
 @pytest.mark.integration_firebase_auth
 @pytest.mark.asyncio
@@ -410,8 +416,8 @@ async def test_firebase_auth_delete_request(
     """
     Tests delete functionality by explicitly invoking the delete override function
 
-    We can't have an'end-to-end' privacy request test, as preferred, because
-    our delete function is not configured by default (the udpate function is).
+    We can't have an 'end-to-end' privacy request test, as preferred, because
+    our delete function is not configured by default (the update function is).
     But this at least gives us some test coverage of the delete function directly.
     """
     privacy_request = PrivacyRequest(id=f"test_firebase_delete_request_task_{uuid4()}")
@@ -455,7 +461,7 @@ async def test_firebase_auth_delete_request_phone_number_identity(
     Tests delete functionality by explicitly invoking the delete override function
 
     We can't have an'end-to-end' privacy request test, as preferred, because
-    our delete function is not configured by default (the udpate function is).
+    our delete function is not configured by default (the update function is).
     But this at least gives us some test coverage of the delete function directly.
     """
     privacy_request = PrivacyRequest(id=f"test_firebase_delete_request_task_{uuid4()}")

--- a/tests/ops/integration_tests/saas/request_override/test_firebase_auth_task.py
+++ b/tests/ops/integration_tests/saas/request_override/test_firebase_auth_task.py
@@ -560,13 +560,7 @@ async def test_firebase_auth_user_delete_function(
     erasure_policy_string_rewrite,
     firebase_auth_secrets,
 ) -> None:
-    """
-    Tests delete functionality by explicitly invoking the delete override function
-
-    We can't have an 'end-to-end' privacy request test, as preferred, because
-    our delete function is not configured by default (the update function is).
-    But this at least gives us some test coverage of the delete function directly.
-    """
+    """Tests delete functionality by explicitly invoking the delete override function"""
     privacy_request = PrivacyRequest(id=f"test_firebase_delete_request_task_{uuid4()}")
     identity = Identity(**{"email": firebase_auth_user.email})
     privacy_request.cache_identity(identity)
@@ -604,13 +598,7 @@ async def test_firebase_auth_user_delete_function_with_phone_number_identity(
     erasure_policy_string_rewrite,
     firebase_auth_secrets,
 ) -> None:
-    """
-    Tests delete functionality by explicitly invoking the delete override function
-
-    We can't have an 'end-to-end' privacy request test, as preferred, because
-    our delete function is not configured by default (the update function is).
-    But this at least gives us some test coverage of the delete function directly.
-    """
+    """Tests delete functionality by explicitly invoking the delete override function"""
     privacy_request = PrivacyRequest(id=f"test_firebase_delete_request_task_{uuid4()}")
     identity = Identity(**{"phone_number": firebase_auth_user.phone_number})
     privacy_request.cache_identity(identity)


### PR DESCRIPTION
Closes #2601 

### Code Changes

* [x] Updating config to use `firebase_auth_user_delete` instead of `firebase_auth_user_update`

### Steps to Confirm

* [x] Ran integration tests

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
