### PR TITLE
Remove optional-requirements.txt from manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@ include LICENSE
 include README.md
 include requirements.txt
 include dev-requirements.txt
-include optional-requirements.txt
 include dangerous-requirements.txt
 include versioneer.py
 include src/fides/api/ctl/alembic.ini


### PR DESCRIPTION
Closes #2616

### Code Changes

* Removed `optional-requriments.txt` from the `MANIFEST.in` file

### Steps to Confirm

* [ ] Run `nox -s "build(sample)"`
* [ ] Verify there is no warning about a missing `optional-requirements.txt` file

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
