### PR TITLE
Custom metadata UI updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The types of changes are:
     * Create custom fields from a the taxonomy editor
     * Provide a custom field value in a resource
     * Bulk edit custom field values [#2612](https://github.com/ethyca/fides/issues/2612)
+    * Custom metadata UI Polish [#2624](https://github.com/ethyca/fides/pull/2625)
 * Privacy Center
   * The consent config default value can depend on whether Global Privacy Control is enabled. [#2341](https://github.com/ethyca/fides/pull/2341)
 

--- a/clients/admin-ui/src/features/common/custom-fields/CreateCustomFields.tsx
+++ b/clients/admin-ui/src/features/common/custom-fields/CreateCustomFields.tsx
@@ -147,6 +147,7 @@ const CreateCustomFields = forwardRef(
                   options={FIELD_TYPE_OPTIONS}
                 />
                 <CustomSelect
+                  isRequired
                   label="Select custom list"
                   labelProps={CUSTOM_LABEL_STYLES}
                   name="allow_list_id"

--- a/clients/admin-ui/src/features/common/custom-fields/CreateCustomFields.tsx
+++ b/clients/admin-ui/src/features/common/custom-fields/CreateCustomFields.tsx
@@ -150,6 +150,7 @@ const CreateCustomFields = forwardRef(
                   isRequired
                   label="Select custom list"
                   labelProps={CUSTOM_LABEL_STYLES}
+                  menuPosition="fixed"
                   name="allow_list_id"
                   options={allowListOptions}
                 />

--- a/clients/admin-ui/src/features/common/custom-fields/CustomFieldSelector.tsx
+++ b/clients/admin-ui/src/features/common/custom-fields/CustomFieldSelector.tsx
@@ -44,7 +44,12 @@ export const CustomFieldSelector = ({
         return;
       }
 
-      helpers.setValue(customField.value, false);
+      helpers.setValue(
+        customFieldDefinition.field_type !== AllowedTypes.STRING
+          ? customField.value
+          : customField.value.toString(),
+        false
+      );
     },
     // This should only ever run once, on first render.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -43,6 +43,7 @@ interface CustomInputProps {
   label: string;
   tooltip?: string;
   variant?: Variant;
+  isRequired?: boolean;
 }
 
 // We allow `undefined` here and leave it up to each component that uses this field
@@ -125,6 +126,7 @@ const SelectInput = ({
   isSearchable,
   isClearable,
   isMulti = false,
+  isDisabled = false,
 }: { fieldName: string; isMulti?: boolean } & Omit<SelectProps, "label">) => {
   const [initialField] = useField(fieldName);
   const field = { ...initialField, value: initialField.value ?? [] };
@@ -193,6 +195,7 @@ const SelectInput = ({
       isClearable={isClearable}
       instanceId={`select-${field.name}`}
       isMulti={isMulti}
+      isDisabled={isDisabled}
     />
   );
 };
@@ -202,6 +205,7 @@ export const CustomTextInput = ({
   tooltip,
   disabled,
   variant = "inline",
+  isRequired = false,
   ...props
 }: CustomInputProps & StringField) => {
   const [initialField, meta] = useField(props);
@@ -213,7 +217,7 @@ export const CustomTextInput = ({
 
   if (variant === "inline") {
     return (
-      <FormControl isInvalid={isInvalid}>
+      <FormControl isInvalid={isInvalid} isRequired={isRequired}>
         <Grid templateColumns="1fr 3fr">
           <Label htmlFor={props.id || props.name}>{label}</Label>
           <Box display="flex" alignItems="center">
@@ -271,6 +275,7 @@ interface SelectProps {
   tooltip?: string;
   options: Option[];
   isDisabled?: boolean;
+  isRequired?: boolean;
   isSearchable?: boolean;
   isClearable?: boolean;
   size?: Size;
@@ -282,6 +287,7 @@ export const CustomSelect = ({
   tooltip,
   options,
   isDisabled,
+  isRequired,
   isSearchable,
   isClearable,
   size = "sm",
@@ -293,7 +299,7 @@ export const CustomSelect = ({
   const isInvalid = !!(meta.touched && meta.error);
   if (variant === "inline") {
     return (
-      <FormControl isInvalid={isInvalid}>
+      <FormControl isInvalid={isInvalid} isRequired={isRequired}>
         <Grid templateColumns="1fr 3fr">
           <Label htmlFor={props.id || props.name} {...labelProps}>
             {label}
@@ -310,6 +316,7 @@ export const CustomSelect = ({
               isSearchable={isSearchable === undefined ? isMulti : isSearchable}
               isClearable={isClearable}
               isMulti={isMulti}
+              isDisabled={isDisabled}
             />
             {tooltip ? <QuestionTooltip label={tooltip} /> : null}
           </Box>
@@ -323,7 +330,7 @@ export const CustomSelect = ({
     );
   }
   return (
-    <FormControl isInvalid={isInvalid} isDisabled={isDisabled}>
+    <FormControl isInvalid={isInvalid} isRequired={isRequired}>
       <VStack alignItems="start">
         <Flex alignItems="center">
           <Label htmlFor={props.id || props.name} my={0} {...labelProps}>
@@ -339,6 +346,7 @@ export const CustomSelect = ({
             isSearchable={isSearchable === undefined ? isMulti : isSearchable}
             isClearable={isClearable}
             isMulti={isMulti}
+            isDisabled={isDisabled}
           />
         </Box>
         <ErrorMessage

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -196,6 +196,7 @@ const SelectInput = ({
       instanceId={`select-${field.name}`}
       isMulti={isMulti}
       isDisabled={isDisabled}
+      menuPosition="fixed"
     />
   );
 };

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -26,6 +26,7 @@ import {
 } from "@fidesui/react";
 import {
   CreatableSelect,
+  MenuPosition,
   MultiValue,
   Select,
   SingleValue,
@@ -127,6 +128,7 @@ const SelectInput = ({
   isClearable,
   isMulti = false,
   isDisabled = false,
+  menuPosition = "absolute",
 }: { fieldName: string; isMulti?: boolean } & Omit<SelectProps, "label">) => {
   const [initialField] = useField(fieldName);
   const field = { ...initialField, value: initialField.value ?? [] };
@@ -196,7 +198,7 @@ const SelectInput = ({
       instanceId={`select-${field.name}`}
       isMulti={isMulti}
       isDisabled={isDisabled}
-      menuPosition="fixed"
+      menuPosition={menuPosition}
     />
   );
 };
@@ -281,6 +283,7 @@ interface SelectProps {
   isClearable?: boolean;
   size?: Size;
   isMulti?: boolean;
+  menuPosition?: MenuPosition;
 }
 export const CustomSelect = ({
   label,
@@ -318,6 +321,7 @@ export const CustomSelect = ({
               isClearable={isClearable}
               isMulti={isMulti}
               isDisabled={isDisabled}
+              menuPosition={props.menuPosition}
             />
             {tooltip ? <QuestionTooltip label={tooltip} /> : null}
           </Box>
@@ -348,6 +352,7 @@ export const CustomSelect = ({
             isClearable={isClearable}
             isMulti={isMulti}
             isDisabled={isDisabled}
+            menuPosition={props.menuPosition}
           />
         </Box>
         <ErrorMessage

--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -163,7 +163,7 @@ export const plusApi = createApi({
       }),
       providesTags: ["AllowList"],
       transformResponse: (allowList: AllowList[]) =>
-        allowList.sort((a, b) => a.name!.localeCompare(b.name!)),
+        allowList.sort((a, b) => (a.name ?? "").localeCompare(b.name ?? "")),
     }),
     upsertAllowList: build.mutation<AllowList, AllowListUpdate>({
       query: (params: AllowListUpdate) => ({

--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -162,6 +162,8 @@ export const plusApi = createApi({
         params: { show_values },
       }),
       providesTags: ["AllowList"],
+      transformResponse: (allowList: AllowList[]) =>
+        allowList.sort((a, b) => a.name!.localeCompare(b.name!)),
     }),
     upsertAllowList: build.mutation<AllowList, AllowListUpdate>({
       query: (params: AllowListUpdate) => ({

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -14,7 +14,7 @@
     "description": "Custom fields can be added to many forms throughout Fides. You can create, show, and hide custom fields that you add to Fides at any time.",
     "development": true,
     "test": true,
-    "production": false
+    "production": true
   },
   "navV2": {
     "description": "The updated navigation experience with links to related features in the sidebar.",

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -14,7 +14,7 @@
     "description": "Custom fields can be added to many forms throughout Fides. You can create, show, and hide custom fields that you add to Fides at any time.",
     "development": true,
     "test": true,
-    "production": true
+    "production": false
   },
   "navV2": {
     "description": "The updated navigation experience with links to related features in the sidebar.",


### PR DESCRIPTION
Closes #2624 

### Code Changes

* Added **isRequired** attribute to `CustomSelect` component. When value is true, a red asterisk is displayed to the right of the html label indicating that this input is required.
* Added **isDisabled** attribute to Chakra `Select` component nested in `CustomSelect` parent component
* Updated the `CustomFieldSelector` component to set the **Formik** field value accordingly if the custom field value is a string or an array.
* Added optional **menuPosition** attribute to `CustomSelect` component

### Steps to Confirm

**FidesPlus**
1. Execute `make server` command from Terminal prompt

**Fides Admin UI**

1. Execute `npm i` command from **clients > admin-ui** Terminal prompt
2. Execute `npm run dev` command from same Terminal prompt
3. Open browser tab and navigate to http://localhost:3000
4. Login as `root_user`
5. Click the **Management** top level menu item
6. Within **Taxonomy Management**, click either the Data Categories, Data Subjects, or Data Uses tab
7. Select a given record and click the **Edit** button
8. Click the **Add a custom field** button 
9. For Systems, you can navigate back to the **Home** landing page and click the **Add systems** or  **Manage systems** card

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
