### PR TITLE
Add warning to 'fides deploy' when installed outside of a virtual environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
+## [Unreleased](https://github.com/ethyca/fides/compare/2.7.0...main)
 
-## [Unreleased](https://github.com/ethyca/fides/compare/2.6.6...main)
+### Fixed
+
+* Add warning to 'fides deploy' when installed outside of a virtual environment [#2641](https://github.com/ethyca/fides/pull/2641)
+
+## [2.7.0](https://github.com/ethyca/fides/compare/2.6.6...2.7.0)
 
 * Fides API
   * Access and erasure support for Braintree [#2223](https://github.com/ethyca/fides/pull/2223)

--- a/src/fides/cli/commands/util.py
+++ b/src/fides/cli/commands/util.py
@@ -17,6 +17,7 @@ from fides.core.config.helpers import create_config_file
 from fides.core.deploy import (
     check_docker_version,
     check_fides_uploads_dir,
+    check_virtualenv,
     print_deploy_success,
     pull_specific_docker_image,
     seed_example_data,
@@ -128,6 +129,7 @@ def up(ctx: click.Context, no_pull: bool = False, no_init: bool = False) -> None
     Starts the sample project via docker compose.
     """
 
+    check_virtualenv()
     check_docker_version()
     config = ctx.obj["CONFIG"]
     echo_green("Docker version is compatible, starting deploy...")

--- a/src/fides/core/deploy.py
+++ b/src/fides/core/deploy.py
@@ -1,3 +1,4 @@
+import sys
 import webbrowser
 from functools import partial
 from os import environ, getcwd, makedirs
@@ -95,6 +96,39 @@ def check_docker_version() -> bool:
             f"Error: Your Docker version (v{docker_version}) is not compatible, please update to at least version {REQUIRED_DOCKER_VERSION}!"
         )
     return version_is_valid
+
+
+def check_virtualenv() -> bool:
+    """
+    Check to see if the deploy is running from a virtual environment, and log a
+    warning if not.
+
+    In many cases, running outside of a virtual environment will lead to
+    mysterious Docker or Python errors, so warning the user helps get ahead of
+    some of these problems.
+    """
+
+    # Adapted from https://stackoverflow.com/a/58026969/
+    # Detect a virtualenv by checking sys.prefix if the  "base" prefixes match
+    real_prefix = getattr(sys, "real_prefix", None)  # set by older virtualenv
+    base_prefix = getattr(sys, "base_prefix", sys.prefix)
+    running_in_virtualenv = (base_prefix or real_prefix) != sys.prefix
+    print(f"in check_virtualenv(), {sys.base_prefix}, {sys.prefix}")
+
+    if not running_in_virtualenv:
+        echo_red(
+            f"WARNING: Your 'fides' CLI is installed outside of a virtual environment at: {sys.prefix}"
+        )
+        echo_red(
+            "Docker may not have permission to access this path, so if you encounter issues with Docker mounts, "
+            "try reinstalling 'ethyca-fides' using a virtual environment (see https://docs.python.org/3/library/venv.html)."
+        )
+        echo_red(
+            "If you did install using a virtual environment, check your PATH. "
+            "You may have a global version of 'ethyca-fides' installed that is taking precedence!"
+        )
+        return False
+    return True
 
 
 def seed_example_data() -> None:

--- a/src/fides/core/deploy.py
+++ b/src/fides/core/deploy.py
@@ -113,7 +113,6 @@ def check_virtualenv() -> bool:
     real_prefix = getattr(sys, "real_prefix", None)  # set by older virtualenv
     base_prefix = getattr(sys, "base_prefix", sys.prefix)
     running_in_virtualenv = (base_prefix or real_prefix) != sys.prefix
-    print(f"in check_virtualenv(), {sys.base_prefix}, {sys.prefix}")
 
     if not running_in_virtualenv:
         echo_red(

--- a/tests/ctl/cli/test_deploy.py
+++ b/tests/ctl/cli/test_deploy.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest import mock
 
 from fides.core import deploy
 
@@ -23,3 +24,21 @@ class TestDeploy:
     )
     def test_compare_semvers(self, semver_1, semver_2, expected):
         assert deploy.compare_semvers(semver_1, semver_2) is expected
+
+    @mock.patch("fides.core.deploy.sys")
+    def test_check_virtualenv(self, mock_sys):
+        # Emulate non-virtual environment
+        mock_sys.prefix = (
+            "/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9"
+        )
+        mock_sys.base_prefix = (
+            "/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9"
+        )
+        assert deploy.check_virtualenv() == False
+
+        # Emulate virtual environment
+        mock_sys.prefix = "/Users/fidesuser/fides/venv"
+        mock_sys.base_prefix = (
+            "/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9"
+        )
+        assert deploy.check_virtualenv() == True


### PR DESCRIPTION
### Code Changes

* [X] Add check to `fides deploy` that logs a warning outside a virtual environment

### Steps to Confirm

* [X] Use `pip install <path/to/fides/repo/dir>` to install the local package and run `fides deploy` to confirm warning"

Example warning:
![image](https://user-images.githubusercontent.com/1834295/219694035-f6c03821-093d-4b1e-b381-64370fa8a897.png)
```
~/git/sandbox/fides-deploy-test% fides deploy up
Using default configuration values.
Using default configuration values.
in check_virtualenv(), /usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9, /usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9
WARNING: Your 'fides' CLI is installed outside of a virtual environment at: /usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9
Docker may not have permission to access this path, so if you encounter issues with Docker mounts, try reinstalling 'ethyca-fides' using a virtual environment (see https://docs.python.org/3/library/venv.html).
If you did install using a virtual environment, check your PATH. You may have a global version of 'ethyca-fides' installed that is taking precedence!
Docker version is compatible, starting deploy...
Pulling ethyca/fides image from DockerHub to match local fides version: 2.6.1.post0.dev70
```

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Users regularly run into mysterious Docker permissioning issues when using `fides deploy` because, on most operating systems, the globally installed Python libraries folder isn't accessible to use for a Docker mount. We rely on this to mount some config files for the docker-compose.yml inside `fides deploy` so this results in mysterious errors like:
```
Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /opt/homebrew/lib/python3.10/site-packages/fides/data/sample_project/privacy_center/config
```

This doesn't really _fix_ that issue - a real fix would likely be to not mount from the lib folder at all (and instead make a local copy of the necessary config files in the directory where `fides deploy` is invoked), but it at least triggers a warning that will let a savvy user notice the issue and recommend they use a `venv` instead.

Another common problem is  we _think_ we're calling the `fides` CLI from within a `venv`, but due to mysterious-reasons-I-cannot-justify it appears that the `venv/bin` folder is given a lower precedence in the `PATH` than globally installed Python packages... which means that when you install things in the `venv` thinking they'll be used, often you end up calling into a globally installed package instead! This warning will also trigger when that happens, so that you can fight with your local shell and do something like:
* uninstall the global `fides` CLI to avoid the footgun
* force the venv to be used like `./venv/bin/fides`
