### PR TITLE
Switch from pickle to json for cache

### DIFF
--- a/src/fides/api/ops/models/privacy_request.py
+++ b/src/fides/api/ops/models/privacy_request.py
@@ -142,7 +142,10 @@ def generate_request_callback_jwe(webhook: PolicyPreWebhook) -> str:
         scopes=[PRIVACY_REQUEST_CALLBACK_RESUME],
         iat=datetime.now().isoformat(),
     )
-    return generate_jwe(json.dumps(jwe.dict()), CONFIG.security.app_encryption_key)
+    return generate_jwe(
+        json.dumps(jwe.dict()),
+        CONFIG.security.app_encryption_key,
+    )
 
 
 class PrivacyRequest(IdentityVerificationMixin, Base):  # pylint: disable=R0904
@@ -440,7 +443,9 @@ class PrivacyRequest(IdentityVerificationMixin, Base):  # pylint: disable=R0904
         actions: List[CheckpointActionRequired] = []
         for email_content in email_contents.values():
             if email_content:
-                actions.append(CheckpointActionRequired.parse_obj(email_content))
+                actions.append(
+                    _parse_cache_to_checkpoint_action_required(email_content)
+                )
         return actions
 
     def cache_paused_collection_details(
@@ -927,12 +932,11 @@ def get_action_required_details(
     performed to complete the request.
     """
     cache: FidesopsRedis = get_cache()
-    cached_stopped: Optional[CheckpointActionRequired] = cache.get_encoded_by_key(
-        cached_key
-    )
-    return (
-        CheckpointActionRequired.parse_obj(cached_stopped) if cached_stopped else None
-    )
+    cached_stopped: Optional[dict[str, Any]] = cache.get_encoded_by_key(cached_key)
+    if cached_stopped:
+        return _parse_cache_to_checkpoint_action_required(cached_stopped)
+
+    return None
 
 
 class ExecutionLogStatus(EnumType):
@@ -994,3 +998,26 @@ def can_run_checkpoint(
     return EXECUTION_CHECKPOINTS.index(
         request_checkpoint
     ) >= EXECUTION_CHECKPOINTS.index(from_checkpoint)
+
+
+def _parse_cache_to_checkpoint_action_required(
+    cache: dict[str, Any]
+) -> CheckpointActionRequired:
+    collection = (
+        CollectionAddress(
+            cache["collection"]["dataset"],
+            cache["collection"]["collection"],
+        )
+        if cache.get("collection")
+        else None
+    )
+    action_needed = (
+        [ManualAction(**action) for action in cache["action_needed"]]
+        if cache.get("action_needed")
+        else None
+    )
+    return CheckpointActionRequired(
+        step=cache["step"],
+        collection=collection,
+        action_needed=action_needed,
+    )

--- a/src/fides/api/ops/util/cache.py
+++ b/src/fides/api/ops/util/cache.py
@@ -53,9 +53,7 @@ def _custom_decoder(json_dict: Dict[str, Any]) -> Dict[str, Any]:
             json_dict[k] = datetime.fromisoformat(v)
             continue
         except (TypeError, ValueError):
-            logger.info(
-                "Error decoding cache. If you are coming from a version of fides prior to 2.8 this could be an issue with cache format and the request needs to be reprocessed."
-            )
+            pass
 
         if isinstance(v, str):
             # The mongodb objectids couldn't be directly json encoded so they are converted
@@ -151,6 +149,10 @@ class FidesopsRedis(Redis):
                 # The cache used to be stored as a pickle. This decoder is unable
                 # to decode the pickle object (this is on purpose) so None is returned
                 # if a cache value is present in the old format rather the crashing.
+
+                logger.info(
+                    "Error decoding cache. If you are coming from a version of fides prior to 2.8 this could be an issue with cache format and the request needs to be reprocessed."
+                )
                 return None
             # Secrets are just a string and not dict so decode here.
             if isinstance(result, str) and result.startswith("quote_encoded"):

--- a/src/fides/api/ops/util/cache.py
+++ b/src/fides/api/ops/util/cache.py
@@ -1,7 +1,10 @@
-import base64
-import pickle
+import json
+from datetime import date, datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import quote, unquote_to_bytes
 
+from bson.objectid import ObjectId
 from loguru import logger
 from redis import Redis
 from redis.client import Script  # type: ignore
@@ -18,6 +21,51 @@ CONFIG = get_config()
 RedisValue = Union[bytes, float, int, str]
 
 _connection = None
+
+ENCODED_BYTES_PREFIX = "quote_encoded_"
+ENCODED_MONGO_OBJECT_ID_PREFIX = "encoded_object_id_"
+
+
+class CustomJSONEncoder(json.JSONEncoder):
+    def default(self, o: Any) -> Any:  # pylint: disable=too-many-return-statements
+        if isinstance(o, Enum):
+            return o.value
+        if isinstance(o, bytes):
+            return f"{ENCODED_BYTES_PREFIX}{quote(o)}"
+        if isinstance(o, (datetime, date)):
+            return o.isoformat()
+        if isinstance(o, ObjectId):
+            return f"{ENCODED_MONGO_OBJECT_ID_PREFIX}{str(o)}"
+        if isinstance(o, object):
+            if hasattr(o, "__dict__"):
+                return o.__dict__
+            if not isinstance(o, int) and not isinstance(o, float):
+                return str(o)
+
+        # It doesn't seem possible to make it here, but I'm leaving in as a fail safe
+        # just in case.
+        return super().default(o)  # pragma: no cover
+
+
+def _custom_decoder(json_dict: Dict[str, Any]) -> Dict[str, Any]:
+    for k, v in json_dict.items():
+        try:
+            json_dict[k] = datetime.fromisoformat(v)
+            continue
+        except (TypeError, ValueError):
+            pass
+
+        if isinstance(v, str):
+            # The mongodb objectids couldn't be directly json encoded so they are converted
+            # to strings and prefixed with encoded_object_id in order to find during decodeint.
+            if v.startswith(ENCODED_MONGO_OBJECT_ID_PREFIX):
+                json_dict[k] = ObjectId(v[18:])
+            # The bytes from secrets couldn't be directly json encoded so it is url
+            # encode and prefixed with quite_encoded in order to find during decodeint.
+            elif v.startswith(ENCODED_BYTES_PREFIX):
+                json_dict[k] = unquote_to_bytes(v)[14:]
+
+    return json_dict
 
 
 class FidesopsRedis(Redis):
@@ -85,17 +133,21 @@ class FidesopsRedis(Redis):
 
     @staticmethod
     def encode_obj(obj: Any) -> bytes:
-        """Encode an object to a base64 string that can be stored in Redis"""
-        return base64.b64encode(pickle.dumps(obj))
+        """Encode an object to a JSON string that can be stored in Redis"""
+        return json.dumps(obj, cls=CustomJSONEncoder)  # type: ignore
 
     @staticmethod
-    def decode_obj(bs: Optional[bytes]) -> Any:
-        """Decode an object from its base64 representation.
+    def decode_obj(bs: Optional[str]) -> Any:
+        """Decode an object from its JSON.
 
         Since Redis may not contain a value
         for a given key it's possible we may try to decode an empty object."""
         if bs:
-            return pickle.loads(base64.b64decode(bs))
+            result = json.loads(bs, object_hook=_custom_decoder)
+            # Secrets are just a string and not dict so decode here.
+            if isinstance(result, str) and result.startswith("quote_encoded"):
+                result = unquote_to_bytes(result)[14:]
+            return result
         return None
 
 

--- a/src/fides/api/ops/util/cache.py
+++ b/src/fides/api/ops/util/cache.py
@@ -56,7 +56,6 @@ def _custom_decoder(json_dict: Dict[str, Any]) -> Dict[str, Any]:
             logger.info(
                 "Error decoding cache. If you are coming from a version of fides prior to 2.8 this could be an issue with cache format and the request needs to be reprocessed."
             )
-            pass
 
         if isinstance(v, str):
             # The mongodb objectids couldn't be directly json encoded so they are converted

--- a/src/fides/api/ops/util/cache.py
+++ b/src/fides/api/ops/util/cache.py
@@ -53,6 +53,9 @@ def _custom_decoder(json_dict: Dict[str, Any]) -> Dict[str, Any]:
             json_dict[k] = datetime.fromisoformat(v)
             continue
         except (TypeError, ValueError):
+            logger.info(
+                "Error decoding cache. If you are coming from a version of fides prior to 2.8 this could be an issue with cache format and the request needs to be reprocessed."
+            )
             pass
 
         if isinstance(v, str):

--- a/tests/ops/util/test_cache.py
+++ b/tests/ops/util/test_cache.py
@@ -1,7 +1,19 @@
+import json
 import random
+from datetime import datetime
+from enum import Enum
 from typing import Any, List
 
-from fides.api.ops.util.cache import FidesopsRedis
+import pytest
+from bson.objectid import ObjectId
+
+from fides.api.ops.util.cache import (
+    ENCODED_BYTES_PREFIX,
+    ENCODED_MONGO_OBJECT_ID_PREFIX,
+    CustomJSONEncoder,
+    FidesopsRedis,
+    _custom_decoder,
+)
 from fides.core.config import get_config
 
 from ..fixtures.application_fixtures import faker
@@ -48,11 +60,15 @@ class CacheTestObject:
 
 
 def test_encode_decode() -> None:
-    for i in range(10):
+    for _ in range(10):
         test_obj = CacheTestObject(
             random.random(), random.randint(0, 1000), faker.name()
         )
-        assert FidesopsRedis.decode_obj(FidesopsRedis.encode_obj(test_obj)) == test_obj
+        result = FidesopsRedis.decode_obj(FidesopsRedis.encode_obj(test_obj))
+        assert CacheTestObject(*result["values"]) == test_obj
+
+
+def test_decode_none():
     assert FidesopsRedis.decode_obj(None) is None
 
 
@@ -73,3 +89,58 @@ def test_scan(cache: FidesopsRedis) -> List:
     cache.delete_keys_by_prefix(f"EN_{prefix}")
     keys = cache.get_keys_by_prefix(f"EN_{prefix}")
     assert len(keys) == 0
+
+
+class TestCustomJSONEncoder:
+    def test_encode_enum_string(self):
+        class TestEnum(Enum):
+            test = "test_value"
+
+        result = json.dumps({"key": TestEnum.test}, cls=CustomJSONEncoder)
+
+        assert result == '{"key": "test_value"}'
+
+    def test_encode_enum_dict(self):
+        class TestEnum(Enum):
+            test = {"key": "test_value"}
+
+        result = json.dumps({"key": TestEnum.test}, cls=CustomJSONEncoder)
+
+        assert result == '{"key": {"key": "test_value"}}'
+
+    def test_encode_object(self):
+        class SomeClass:
+            def __init__(self):
+                self.val = "some value"
+
+        assert json.dumps(SomeClass(), cls=CustomJSONEncoder) == '{"val": "some value"}'
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (b"some value", f'"{ENCODED_BYTES_PREFIX}some%20value"'),
+            (
+                datetime(2023, 2, 14, 20, 58),
+                f'"{datetime(2023, 2, 14, 20, 58).isoformat()}"',
+            ),
+            ({"a": "b"}, '{"a": "b"}'),
+            ({"a": {"b": "c"}}, '{"a": {"b": "c"}}'),
+            (
+                ObjectId("507f191e810c19729de860ea"),
+                f'"{ENCODED_MONGO_OBJECT_ID_PREFIX}507f191e810c19729de860ea"',
+            ),
+            ({"a": 1}, '{"a": 1}'),
+            ("some value", '"some value"'),
+            (1, "1"),
+        ],
+    )
+    def test_encode(self, value, expected):
+        assert json.dumps(value, cls=CustomJSONEncoder) == expected
+
+
+class TestCustomDecoder:
+    def test_decode_bytes(self):
+        encoded_bytes = f'"{ENCODED_BYTES_PREFIX}some%20value"'
+        assert json.loads(f'{{"a": {encoded_bytes}}}', object_hook=_custom_decoder) == {
+            "a": b"some value"
+        }


### PR DESCRIPTION
Closes #2633

### Code Changes

* Replaces pickle with json encoding for cache.
* Handles cases where old cache pickle values are still present.

### Steps to Confirm

* [ ] Create a privacy request
* [ ] Approve and run the privacy request
* [ ] Create a failed privacy request cached in the old pickle format, run a new privacy request and verify there are no 500 server errors.
* [ ] Test any other areas that caches data, the more you can think of the better here.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
