### PR TITLE
Add auth to all slices

### DIFF
--- a/clients/admin-ui/src/features/common/health.slice.ts
+++ b/clients/admin-ui/src/features/common/health.slice.ts
@@ -2,12 +2,19 @@ import { createSelector } from "@reduxjs/toolkit";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import type { RootState } from "~/app/store";
+import { selectToken } from "~/features/auth";
+import { addCommonHeaders } from "~/features/common/CommonHeaders";
 import { CoreHealthCheck } from "~/types/api";
 
 export const healthApi = createApi({
   reducerPath: "healthApi",
   baseQuery: fetchBaseQuery({
     baseUrl: `/`,
+    prepareHeaders: (headers, { getState }) => {
+      const token: string | null = selectToken(getState() as RootState);
+      addCommonHeaders(headers, token);
+      return headers;
+    },
   }),
   tagTypes: ["Health"],
   endpoints: (build) => ({

--- a/clients/admin-ui/src/features/config-wizard/scanner.slice.ts
+++ b/clients/admin-ui/src/features/config-wizard/scanner.slice.ts
@@ -1,11 +1,19 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
+import type { RootState } from "~/app/store";
+import { selectToken } from "~/features/auth";
+import { addCommonHeaders } from "~/features/common/CommonHeaders";
 import { GenerateRequestPayload, GenerateResponse } from "~/types/api";
 
 export const scannerApi = createApi({
   reducerPath: "scannerApi",
   baseQuery: fetchBaseQuery({
     baseUrl: process.env.NEXT_PUBLIC_FIDESCTL_API,
+    prepareHeaders: (headers, { getState }) => {
+      const token: string | null = selectToken(getState() as RootState);
+      addCommonHeaders(headers, token);
+      return headers;
+    },
   }),
   endpoints: (build) => ({
     generate: build.mutation<GenerateResponse, GenerateRequestPayload>({

--- a/clients/admin-ui/src/features/data-qualifier/data-qualifier.slice.ts
+++ b/clients/admin-ui/src/features/data-qualifier/data-qualifier.slice.ts
@@ -2,12 +2,19 @@ import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import type { RootState } from "~/app/store";
+import { selectToken } from "~/features/auth";
+import { addCommonHeaders } from "~/features/common/CommonHeaders";
 import { DataQualifier } from "~/types/api";
 
 export const dataQualifierApi = createApi({
   reducerPath: "dataQualifierApi",
   baseQuery: fetchBaseQuery({
     baseUrl: process.env.NEXT_PUBLIC_FIDESCTL_API,
+    prepareHeaders: (headers, { getState }) => {
+      const token: string | null = selectToken(getState() as RootState);
+      addCommonHeaders(headers, token);
+      return headers;
+    },
   }),
   tagTypes: ["Data Qualifiers"],
   endpoints: (build) => ({

--- a/clients/admin-ui/src/features/data-subjects/data-subject.slice.ts
+++ b/clients/admin-ui/src/features/data-subjects/data-subject.slice.ts
@@ -2,12 +2,19 @@ import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import type { RootState } from "~/app/store";
+import { selectToken } from "~/features/auth";
+import { addCommonHeaders } from "~/features/common/CommonHeaders";
 import { DataSubject } from "~/types/api";
 
 export const dataSubjectsApi = createApi({
   reducerPath: "dataSubjectsApi",
   baseQuery: fetchBaseQuery({
     baseUrl: process.env.NEXT_PUBLIC_FIDESCTL_API,
+    prepareHeaders: (headers, { getState }) => {
+      const token: string | null = selectToken(getState() as RootState);
+      addCommonHeaders(headers, token);
+      return headers;
+    },
   }),
   tagTypes: ["Data Subjects"],
   endpoints: (build) => ({

--- a/clients/admin-ui/src/features/data-use/data-use.slice.ts
+++ b/clients/admin-ui/src/features/data-use/data-use.slice.ts
@@ -2,12 +2,19 @@ import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import type { RootState } from "~/app/store";
+import { selectToken } from "~/features/auth";
+import { addCommonHeaders } from "~/features/common/CommonHeaders";
 import { DataUse } from "~/types/api";
 
 export const dataUseApi = createApi({
   reducerPath: "dataUseApi",
   baseQuery: fetchBaseQuery({
     baseUrl: process.env.NEXT_PUBLIC_FIDESCTL_API,
+    prepareHeaders: (headers, { getState }) => {
+      const token: string | null = selectToken(getState() as RootState);
+      addCommonHeaders(headers, token);
+      return headers;
+    },
   }),
   tagTypes: ["Data Uses"],
   endpoints: (build) => ({

--- a/clients/admin-ui/src/features/organization/organization.slice.ts
+++ b/clients/admin-ui/src/features/organization/organization.slice.ts
@@ -1,6 +1,9 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
+import type { RootState } from "~/app/store";
+import { selectToken } from "~/features/auth";
+import { addCommonHeaders } from "~/features/common/CommonHeaders";
 import { Organization } from "~/types/api";
 
 // Organization API
@@ -8,7 +11,11 @@ export const organizationApi = createApi({
   reducerPath: "organizationApi",
   baseQuery: fetchBaseQuery({
     baseUrl: process.env.NEXT_PUBLIC_FIDESCTL_API,
-    prepareHeaders: (headers) => headers,
+    prepareHeaders: (headers, { getState }) => {
+      const token: string | null = selectToken(getState() as RootState);
+      addCommonHeaders(headers, token);
+      return headers;
+    },
   }),
   tagTypes: ["Organization"],
   endpoints: (build) => ({

--- a/clients/admin-ui/src/features/system/system.slice.ts
+++ b/clients/admin-ui/src/features/system/system.slice.ts
@@ -2,6 +2,8 @@ import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import type { RootState } from "~/app/store";
+import { selectToken } from "~/features/auth";
+import { addCommonHeaders } from "~/features/common/CommonHeaders";
 import { System } from "~/types/api";
 
 interface SystemDeleteResponse {
@@ -19,6 +21,11 @@ export const systemApi = createApi({
   reducerPath: "systemApi",
   baseQuery: fetchBaseQuery({
     baseUrl: process.env.NEXT_PUBLIC_FIDESCTL_API,
+    prepareHeaders: (headers, { getState }) => {
+      const token: string | null = selectToken(getState() as RootState);
+      addCommonHeaders(headers, token);
+      return headers;
+    },
   }),
   tagTypes: ["System"],
   endpoints: (build) => ({

--- a/clients/admin-ui/src/features/taxonomy/taxonomy.slice.ts
+++ b/clients/admin-ui/src/features/taxonomy/taxonomy.slice.ts
@@ -2,12 +2,19 @@ import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import type { RootState } from "~/app/store";
+import { selectToken } from "~/features/auth";
+import { addCommonHeaders } from "~/features/common/CommonHeaders";
 import { DataCategory } from "~/types/api";
 
 export const taxonomyApi = createApi({
   reducerPath: "taxonomyApi",
   baseQuery: fetchBaseQuery({
     baseUrl: process.env.NEXT_PUBLIC_FIDESCTL_API,
+    prepareHeaders: (headers, { getState }) => {
+      const token: string | null = selectToken(getState() as RootState);
+      addCommonHeaders(headers, token);
+      return headers;
+    },
   }),
   tagTypes: ["Data Categories"],
   endpoints: (build) => ({


### PR DESCRIPTION
https://github.com/ethyca/fides/pull/2588 enforces auth on all routes. previously many of our old ctl routes didn't include auth headers. this makes them include them.

### Code Changes

* [x] copy pasta auth headers everywhere

### Steps to Confirm

* [ ] Click through the UI and make sure everything is still accessible

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

This is a lot of inelegant copy/pasta-ing, but I can live with it considering we've got this ticket in the pipeline https://github.com/ethyca/fides/issues/1386

(once that ticket is in, we'd only need the one `prepareHeader`
