### PR TITLE
2237/Add button to test messaging config

### DIFF
--- a/clients/admin-ui/src/features/privacy-requests/configuration/MailgunEmailConfiguration.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/MailgunEmailConfiguration.tsx
@@ -8,6 +8,7 @@ import { useAlert, useAPIHelper } from "~/features/common/hooks";
 import {
   useCreateMessagingConfigurationMutation,
   useCreateMessagingConfigurationSecretsMutation,
+  useCreateTestConnectionMessageMutation,
   useGetMessagingConfigurationDetailsQuery,
 } from "~/features/privacy-requests/privacy-requests.slice";
 
@@ -25,6 +26,8 @@ const MailgunEmailConfiguration = () => {
     useCreateMessagingConfigurationMutation();
   const [createMessagingConfigurationSecrets] =
     useCreateMessagingConfigurationSecretsMutation();
+  const [createTestConnectionMessage] =
+    useCreateTestConnectionMessageMutation();
 
   const handleMailgunConfiguration = async (value: { domain: string }) => {
     const result = await createMessagingConfiguration({
@@ -56,7 +59,22 @@ const MailgunEmailConfiguration = () => {
       handleError(result.error);
     } else {
       successAlert(`Mailgun security key successfully updated.`);
+      setConfigurationStep("testConnection");
     }
+  };
+
+  const handleTestConnection = async () => {
+    const result = await createTestConnectionMessage({
+      // test
+    });
+
+    if (isErrorResult(result)) {
+      handleError(result.error);
+    } else {
+      successAlert(`Test message successfully sent.`);
+    }
+    // I can enter a test identifier (Email or SMS) based on the messaging service type.
+    // I can click on test the configuration to send a test message.
   };
 
   const initialValues = {
@@ -65,6 +83,10 @@ const MailgunEmailConfiguration = () => {
 
   const initialAPIKeyValue = {
     api_key: messagingDetails?.key ?? "",
+  };
+
+  const initialEmailValue = {
+    email: messagingDetails?.email ?? "",
   };
 
   return (
@@ -109,8 +131,8 @@ const MailgunEmailConfiguration = () => {
           )}
         </Formik>
       </Stack>
-      {configurationStep === "apiKey" ? (
-        // TODO: configurationStep === "testConnection" will be set after https://github.com/ethyca/fides/issues/2237
+      {configurationStep === "apiKey" ||
+      configurationStep === "testConnection" ? (
         <>
           <Divider />
           <Heading fontSize="md" fontWeight="semibold" mt={10}>
@@ -128,6 +150,47 @@ const MailgunEmailConfiguration = () => {
                     label="API key"
                     placeholder="Optional"
                     type="password"
+                  />
+                  <Button
+                    onClick={() => resetForm()}
+                    mr={2}
+                    size="sm"
+                    variant="outline"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    isDisabled={isSubmitting}
+                    type="submit"
+                    colorScheme="primary"
+                    size="sm"
+                    data-testid="save-btn"
+                  >
+                    Save
+                  </Button>
+                </Form>
+              )}
+            </Formik>
+          </Stack>
+        </>
+      ) : null}
+      {configurationStep === "testConnection" ? (
+        <>
+          <Divider />
+          <Heading fontSize="md" fontWeight="semibold" mt={10}>
+            Test connection
+          </Heading>
+          <Stack>
+            <Formik
+              initialValues={initialEmailValue}
+              onSubmit={handleTestConnection}
+            >
+              {({ isSubmitting, resetForm }) => (
+                <Form>
+                  <CustomTextInput
+                    name="email"
+                    label="Email"
+                    placeholder="youremail@domain.com"
                   />
                   <Button
                     onClick={() => resetForm()}

--- a/clients/admin-ui/src/features/privacy-requests/configuration/MailgunEmailConfiguration.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/MailgunEmailConfiguration.tsx
@@ -8,9 +8,10 @@ import { useAlert, useAPIHelper } from "~/features/common/hooks";
 import {
   useCreateMessagingConfigurationMutation,
   useCreateMessagingConfigurationSecretsMutation,
-  useCreateTestConnectionMessageMutation,
   useGetMessagingConfigurationDetailsQuery,
 } from "~/features/privacy-requests/privacy-requests.slice";
+
+import TestMessagingProviderConnectionButton from "./TestMessagingProviderConnectionButton";
 
 type ConnectionStep = "" | "apiKey" | "testConnection";
 
@@ -26,8 +27,6 @@ const MailgunEmailConfiguration = () => {
     useCreateMessagingConfigurationMutation();
   const [createMessagingConfigurationSecrets] =
     useCreateMessagingConfigurationSecretsMutation();
-  const [createTestConnectionMessage] =
-    useCreateTestConnectionMessageMutation();
 
   const handleMailgunConfiguration = async (value: { domain: string }) => {
     const result = await createMessagingConfiguration({
@@ -63,30 +62,12 @@ const MailgunEmailConfiguration = () => {
     }
   };
 
-  const handleTestConnection = async () => {
-    const result = await createTestConnectionMessage({
-      // test
-    });
-
-    if (isErrorResult(result)) {
-      handleError(result.error);
-    } else {
-      successAlert(`Test message successfully sent.`);
-    }
-    // I can enter a test identifier (Email or SMS) based on the messaging service type.
-    // I can click on test the configuration to send a test message.
-  };
-
   const initialValues = {
     domain: messagingDetails?.details.domain ?? "",
   };
 
   const initialAPIKeyValue = {
     api_key: messagingDetails?.key ?? "",
-  };
-
-  const initialEmailValue = {
-    email: messagingDetails?.email ?? "",
   };
 
   return (
@@ -175,45 +156,9 @@ const MailgunEmailConfiguration = () => {
         </>
       ) : null}
       {configurationStep === "testConnection" ? (
-        <>
-          <Divider />
-          <Heading fontSize="md" fontWeight="semibold" mt={10}>
-            Test connection
-          </Heading>
-          <Stack>
-            <Formik
-              initialValues={initialEmailValue}
-              onSubmit={handleTestConnection}
-            >
-              {({ isSubmitting, resetForm }) => (
-                <Form>
-                  <CustomTextInput
-                    name="email"
-                    label="Email"
-                    placeholder="youremail@domain.com"
-                  />
-                  <Button
-                    onClick={() => resetForm()}
-                    mr={2}
-                    size="sm"
-                    variant="outline"
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    isDisabled={isSubmitting}
-                    type="submit"
-                    colorScheme="primary"
-                    size="sm"
-                    data-testid="save-btn"
-                  >
-                    Save
-                  </Button>
-                </Form>
-              )}
-            </Formik>
-          </Stack>
-        </>
+        <TestMessagingProviderConnectionButton
+          messagingDetails={messagingDetails}
+        />
       ) : null}
     </Box>
   );

--- a/clients/admin-ui/src/features/privacy-requests/configuration/TestMessagingProviderConnectionButton.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/TestMessagingProviderConnectionButton.tsx
@@ -1,0 +1,77 @@
+import { Button, Divider, Heading, Stack } from "@fidesui/react";
+import { Form,Formik } from "formik";
+
+import { CustomTextInput } from "~/features/common/form/inputs";
+import { isErrorResult } from "~/features/common/helpers";
+import { useAlert, useAPIHelper } from "~/features/common/hooks";
+import { useCreateTestConnectionMessageMutation } from "~/features/privacy-requests/privacy-requests.slice";
+
+const TestMessagingProviderConnectionButton = (messagingDetails: any) => {
+  const { successAlert } = useAlert();
+  const { handleError } = useAPIHelper();
+  const [createTestConnectionMessage] =
+    useCreateTestConnectionMessageMutation();
+
+  const initialEmailValue = {
+    email: messagingDetails?.email ?? "",
+  };
+
+  const handleTestConnection = async () => {
+    const result = await createTestConnectionMessage({
+      // test
+    });
+
+    if (isErrorResult(result)) {
+      handleError(result.error);
+    } else {
+      successAlert(`Test message successfully sent.`);
+    }
+    // I can enter a test identifier (Email or SMS) based on the messaging service type.
+    // I can click on test the configuration to send a test message.
+  };
+
+  return (
+    <>
+      <Divider />
+      <Heading fontSize="md" fontWeight="semibold" mt={10}>
+        Test connection
+      </Heading>
+      <Stack>
+        <Formik
+          initialValues={initialEmailValue}
+          onSubmit={handleTestConnection}
+        >
+          {({ isSubmitting, resetForm }) => (
+            <Form>
+              {/* Should this input be phone number if coming from SMS path or is it always an email? */}
+              <CustomTextInput
+                name="email"
+                label="Email"
+                placeholder="youremail@domain.com"
+              />
+              <Button
+                onClick={() => resetForm()}
+                mr={2}
+                size="sm"
+                variant="outline"
+              >
+                Cancel
+              </Button>
+              <Button
+                isDisabled={isSubmitting}
+                type="submit"
+                colorScheme="primary"
+                size="sm"
+                data-testid="save-btn"
+              >
+                Save
+              </Button>
+            </Form>
+          )}
+        </Formik>
+      </Stack>
+    </>
+  );
+};
+
+export default TestMessagingProviderConnectionButton;

--- a/clients/admin-ui/src/features/privacy-requests/configuration/TwilioEmailConfiguration.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/TwilioEmailConfiguration.tsx
@@ -11,6 +11,8 @@ import {
   useGetMessagingConfigurationDetailsQuery,
 } from "~/features/privacy-requests/privacy-requests.slice";
 
+import TestMessagingProviderConnectionButton from "./TestMessagingProviderConnectionButton";
+
 const TwilioEmailConfiguration = () => {
   const [configurationStep, setConfigurationStep] = useState("");
   const { successAlert } = useAlert();
@@ -52,7 +54,7 @@ const TwilioEmailConfiguration = () => {
       handleError(result.error);
     } else {
       successAlert(`Twilio email secrets successfully updated.`);
-      setConfigurationStep("configureTwilioEmailSecrets");
+      setConfigurationStep("testConnection");
     }
   };
 
@@ -148,6 +150,11 @@ const TwilioEmailConfiguration = () => {
             </Formik>
           </Stack>
         </>
+      ) : null}
+      {configurationStep === "testConnection" ? (
+        <TestMessagingProviderConnectionButton
+          messagingDetails={messagingDetails}
+        />
       ) : null}
     </Box>
   );

--- a/clients/admin-ui/src/features/privacy-requests/configuration/TwilioSMS.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/TwilioSMS.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Heading, Stack } from "@fidesui/react";
 import { Form, Formik } from "formik";
+import { useState } from "react";
 
 import { CustomTextInput } from "~/features/common/form/inputs";
 import { isErrorResult } from "~/features/common/helpers";
@@ -9,7 +10,10 @@ import {
   useGetMessagingConfigurationDetailsQuery,
 } from "~/features/privacy-requests/privacy-requests.slice";
 
+import TestMessagingProviderConnectionButton from "./TestMessagingProviderConnectionButton";
+
 const TwilioSMSConfiguration = () => {
+  const [configurationStep, setConfigurationStep] = useState("");
   const { successAlert } = useAlert();
   const { handleError } = useAPIHelper();
   const { data: messagingDetails } = useGetMessagingConfigurationDetailsQuery({
@@ -35,6 +39,7 @@ const TwilioSMSConfiguration = () => {
       handleError(result.error);
     } else {
       successAlert(`Twilio text secrets successfully updated.`);
+      setConfigurationStep("testConnection");
     }
   };
 
@@ -103,6 +108,11 @@ const TwilioSMSConfiguration = () => {
           )}
         </Formik>
       </Stack>
+      {configurationStep === "testConnection" ? (
+        <TestMessagingProviderConnectionButton
+          messagingDetails={messagingDetails}
+        />
+      ) : null}
     </Box>
   );
 };

--- a/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -416,6 +416,13 @@ export const privacyRequestApi = createApi({
         body: params,
       }),
     }),
+    createTestConnectionMessage: build.mutation<any, any>({
+      query: (params) => ({
+        url: `messaging/config/test`,
+        method: "PUT",
+        body: params,
+      }),
+    }),
     uploadManualWebhookData: build.mutation<
       any,
       PatchUploadManualWebhookDataRequest
@@ -449,4 +456,5 @@ export const {
   useGetActiveStorageQuery,
   useCreateMessagingConfigurationMutation,
   useCreateMessagingConfigurationSecretsMutation,
+  useCreateTestConnectionMessageMutation,
 } = privacyRequestApi;


### PR DESCRIPTION
Closes #2237 

TODO:
* Test connection on both SMS and email
*  Cypress test for connection

### Code Changes

* [ ] Add test messaging connection to client file
* [ ] Add test connection button to mailgun SMS and email
* [ ] Test connection through Cypress

### Steps to Confirm

* [ ] ...

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
