### PR TITLE
Fix support for "redis.user" setting when authenticating to the Redis cache

### DIFF
--- a/.fides/fides.toml
+++ b/.fides/fides.toml
@@ -22,7 +22,7 @@ analytics_opt_out = false
 
 [redis]
 host = "redis"
-password = "testpassword"
+password = "redispassword"
 port = 6379
 charset = "utf8"
 default_ttl_seconds = 604800

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,17 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.7.0...main)
 
 ### Added
+
 * Add API support for messaging config properties [#2551](https://github.com/ethyca/fides/pull/2551)
 
 ### Changed
 
 * Add warning to 'fides deploy' when installed outside of a virtual environment [#2641](https://github.com/ethyca/fides/pull/2641)
+* Removed unexpected default Redis password [#2666](https://github.com/ethyca/fides/pull/2666)
+
+### Fixed
+
+* Fix support for "redis.user" setting when authenticating to the Redis cache [#2666](https://github.com/ethyca/fides/pull/2666)
 
 ## [2.7.0](https://github.com/ethyca/fides/compare/2.6.6...2.7.0)
 

--- a/docker-compose.child-env.yml
+++ b/docker-compose.child-env.yml
@@ -66,9 +66,7 @@ services:
 
   redis-child:
     image: "redis:6.2.5-alpine"
-    command: redis-server --requirepass testpassword
-    environment:
-      - REDIS_PASSWORD=testpassword
+    command: redis-server --requirepass redispassword
     expose:
       - 6379
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,13 +127,23 @@ services:
 
   redis:
     image: "redis:6.2.5-alpine"
-    command: redis-server --requirepass testpassword
-    environment:
-      - REDIS_PASSWORD=testpassword
+    # AUTH option #1: no authentication at all
+    # command: redis-server
+    # AUTH option #2: require password
+    command: redis-server --requirepass redispassword
+    # AUTH option #3: Redis ACL defined in redis.conf
+    # command: redis-server /usr/local/etc/redis/redis.conf
     expose:
       - 6379
     ports:
       - "0.0.0.0:6379:6379"
+    volumes:
+      # Mount a redis.conf file for configuration
+      # NOTE: Only used by "AUTH option #3" above!
+      - type: bind
+        source: ./docker/redis
+        target: /usr/local/etc/redis
+        read_only: False
 
 volumes:
   postgres: null

--- a/docker/docker-compose.minimal-config.yml
+++ b/docker/docker-compose.minimal-config.yml
@@ -22,6 +22,7 @@ services:
       FIDES__DATABASE__PASSWORD: "fides"
       FIDES__DATABASE__PORT: "5432"
       FIDES__DATABASE__DB: "fides"
+      FIDES__REDIS__PASSWORD: "redispassword"
       FIDES__USER__ANALYTICS_OPT_OUT: "True"
       FIDES__SECURITY__APP_ENCRYPTION_KEY: "OLMkv91j8DHiDAULnK5Lxx3kSCov30b3"
       FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID: "fidesadmin"
@@ -52,9 +53,7 @@ services:
 
   redis:
     image: "redis:6.2.5-alpine"
-    command: redis-server --requirepass testpassword
-    environment:
-      - REDIS_PASSWORD=testpassword
+    command: redis-server --requirepass redispassword
     expose:
       - 6379
     ports:

--- a/docker/redis/redis.conf
+++ b/docker/redis/redis.conf
@@ -1,0 +1,15 @@
+# Redis configuration file for local Fides development
+#
+# Note that this file is not loaded by default, and it is checked in here for
+# manual testing in the future. To use this redis.conf file, do the following:
+# 1) Check docker-compose.yml is mounting this to /usr/local/etc/redis
+# 2) Edit docker-compose.yml to swap in the `command` for "AUTH option #3",
+#    which should look like this:
+#    ```
+#    command: redis-server /usr/local/etc/redis/redis.conf
+#    ```
+# 3) Make any edits to this file and bring up redis with `nox -s dev` or similar
+
+# Enable an ACL that gives access to all keys and all commands, but requires
+# a login with user="redisadmin" and password="redispassword"
+user redisadmin on ~* +@all >redispassword

--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -21,7 +21,26 @@ from utils_nox import COMPOSE_DOWN_VOLUMES
 
 @nox_session()
 def dev(session: Session) -> None:
-    """Spin up the application. Uses positional arguments for additional features."""
+    """
+    Spin up the Fides webserver in development mode alongside it's Postgres
+    database and Redis cache. Use positional arguments to run other services
+    like privacy center, shell, admin UI, etc. (see usage for examples)
+
+    Usage:
+      'nox -s dev' - runs the Fides weserver, database, and cache
+      'nox -s dev -- shell' - also open a shell on the Fides webserver
+      'nox -s dev -- ui' - also build and run the Admin UI
+      'nox -s dev -- pc' - also build and run the Privacy Center
+      'nox -s dev -- remote_debug' - run with remote debugging enabled (see docker-compose.remote-debug.yml)
+      'nox -s dev -- worker' - also run a Fides worker
+      'nox -s dev -- child' - also run a Fides child node
+      'nox -s dev -- <datastore>' - also run a test datastore (e.g. 'mssql', 'mongodb')
+
+    Note that you can combine any of the above arguments together, for example:
+      'nox -s dev -- shell ui pc'
+
+    See noxfiles/dev_nox.py for more info
+    """
 
     build(session, "dev")
     session.notify("teardown")

--- a/src/fides/api/ops/util/cache.py
+++ b/src/fides/api/ops/util/cache.py
@@ -172,6 +172,7 @@ def get_cache() -> FidesopsRedis:
             host=CONFIG.redis.host,
             port=CONFIG.redis.port,
             db=CONFIG.redis.db_index,
+            username=CONFIG.redis.user,
             password=CONFIG.redis.password,
             ssl=CONFIG.redis.ssl,
             ssl_cert_reqs=CONFIG.redis.ssl_cert_reqs,

--- a/src/fides/core/config/redis_settings.py
+++ b/src/fides/core/config/redis_settings.py
@@ -14,7 +14,7 @@ class RedisSettings(FidesSettings):
     host: str = "redis"
     port: int = 6379
     user: Optional[str] = None
-    password: str = None
+    password: Optional[str] = None
     charset: str = "utf8"
     decode_responses: bool = True
     default_ttl_seconds: int = 604800

--- a/src/fides/core/config/redis_settings.py
+++ b/src/fides/core/config/redis_settings.py
@@ -13,7 +13,7 @@ class RedisSettings(FidesSettings):
 
     host: str = "redis"
     port: int = 6379
-    user: Optional[str] = ""
+    user: Optional[str] = None
     password: str = "testpassword"
     charset: str = "utf8"
     decode_responses: bool = True

--- a/src/fides/core/config/redis_settings.py
+++ b/src/fides/core/config/redis_settings.py
@@ -37,17 +37,18 @@ class RedisSettings(FidesSettings):
             # If the whole URL is provided via the config, preference that
             return v
 
-        db_index = values.get("db_index") if values.get("db_index") is not None else ""
+        db_index = values.get("db_index") or ""
         connection_protocol = "redis"
         params = ""
         use_tls = values.get("ssl", False)
+        user = values.get("user") or ""
         if use_tls:
             # If using TLS update the connection URL format
             connection_protocol = "rediss"
             cert_reqs = values.get("ssl_cert_reqs", "none")
             params = f"?ssl_cert_reqs={quote_plus(cert_reqs)}"
 
-        return f"{connection_protocol}://{quote_plus(values.get('user', ''))}:{quote_plus(values.get('password', ''))}@{values.get('host', '')}:{values.get('port', '')}/{db_index}{params}"
+        return f"{connection_protocol}://{quote_plus(user)}:{quote_plus(values.get('password', ''))}@{values.get('host', '')}:{values.get('port', '')}/{db_index}{params}"
 
     class Config:
         env_prefix = ENV_PREFIX

--- a/src/fides/core/config/redis_settings.py
+++ b/src/fides/core/config/redis_settings.py
@@ -37,12 +37,16 @@ class RedisSettings(FidesSettings):
             # If the whole URL is provided via the config, preference that
             return v
 
-        db_index = values.get("db_index") or ""
         connection_protocol = "redis"
         params = ""
         use_tls = values.get("ssl", False)
+
+        # These vars are intentionally fetched with `or ""` as the default to account
+        # for the edge case where `None` is explicitly set in `values` by Pydantic because
+        # it is not overridden by the config file or an env var
         user = values.get("user") or ""
         password = values.get("password") or ""
+        db_index = values.get("db_index") or ""
         if use_tls:
             # If using TLS update the connection URL format
             connection_protocol = "rediss"

--- a/src/fides/data/test_env/fides.test_env.toml
+++ b/src/fides/data/test_env/fides.test_env.toml
@@ -8,7 +8,7 @@ db = "fides"
 
 [redis]
 host = "redis"
-password = "testpassword"
+password = "redispassword"
 port = 6379
 db_index = 0
 


### PR DESCRIPTION
Closes #2665

### Code Changes

* [X] Update cache.py client with optional `username` arg
* [X] Fix unexpected default Redis password: `testpassword`
* [X] Fix support for unauthenticated Redis servers

### Steps to Confirm

I used my local Docker setup to test the following configs:
* [x] Redis server with no auth:
  * [x] Fides with no auth (neither `redis.password` nor `redis.user`) connects
  * [x] Fides with `redis.password` does not connect
  * [x] Fides with `redis.password` and `redis.user` does not connect
* [x] Redis server with just password auth (e.g. `redis-server --requirepass <password>`):
  * [x] Fides with correct `redis.password` and no `redis.user` connects
  * [X] Fides with correct `redis.password` and incorrect `redis.user` does not connect
  * [x] Fides with incorrect `redis.password` does not connect
  * [x] Fides with no auth (neither `redis.password` nor `redis.user`) does not connect
* [x] Redis server with an ACL (e.g. `redis-server <path/to/redis.conf>`):
  * [x] Fides with correct `redis.password` and `redis.user` connects
  * [x] Fides with no auth (neither `redis.password` nor `redis.user`) does not connect
  * [x] Fides with incorrect `redis.password` and `redis.user` does not connect

For testing the Redis server with an ACL, I created this file at `./docker/redis/redis.conf`:
```
user redisadmin on ~* +@all >redispassword
```

I then modified `docker-compose.yml` to configure the `redis` service as:
```
  redis:
    image: "redis:6.2.5-alpine"
    command: redis-server /usr/local/etc/redis/redis.conf
    expose:
      - 6379
    ports:
      - "0.0.0.0:6379:6379"
    volumes:
      - type: bind
        source: ./docker/redis
        target: /usr/local/etc/redis
        read_only: False
```

And updated the `.fides/fides.toml` settings like:
```
[redis]
host = "redis"
user = "redisadmin"
password = "redispassword"
port = 6379
charset = "utf8"
default_ttl_seconds = 604800
db_index = 0
ssl = false
ssl_cert_reqs = "required"
```

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
  * Added: https://github.com/ethyca/fides/issues/2673
* [X] Update `CHANGELOG.md`
