### PR TITLE
pc/cy: Use waitUntil to check for cookie consent updates

### DIFF
--- a/clients/privacy-center/cypress/e2e/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent.cy.ts
@@ -149,11 +149,18 @@ describe("Consent settings", () => {
         expect(interception.request.body.browser_identity).to.eql(undefined);
       });
 
-      // The cookie should also have been updated.
-      cy.getCookie(CONSENT_COOKIE_NAME).should((cookie) => {
-        const cookieKeyConsent = JSON.parse(decodeURIComponent(cookie!.value));
-        expect(cookieKeyConsent.data_sales).to.eq(true);
-      });
+      // The cookie should also have been updated. This may take a moment in CI,
+      // so we `waitUntil` the value becomes what we expect.
+      // https://github.com/cypress-io/cypress/issues/4802#issuecomment-941891554
+      cy.waitUntil(() =>
+        cy.getCookie(CONSENT_COOKIE_NAME).then((cookie) => {
+          const cookieKeyConsent = JSON.parse(
+            decodeURIComponent(cookie!.value)
+          );
+          // `waitUntil` retries until we return a truthy value.
+          return cookieKeyConsent.data_sales === true;
+        })
+      );
     });
 
     it("can grab cookies and send to a consent request", () => {

--- a/clients/privacy-center/cypress/support/commands.ts
+++ b/clients/privacy-center/cypress/support/commands.ts
@@ -1,4 +1,6 @@
 /// <reference types="cypress" />
+// eslint-disable-next-line import/no-extraneous-dependencies
+import "cypress-wait-until";
 
 import type { AppDispatch } from "~/app/store";
 

--- a/clients/privacy-center/cypress/tsconfig.json
+++ b/clients/privacy-center/cypress/tsconfig.json
@@ -4,7 +4,7 @@
     "jsx": "react",
     "target": "es5",
     "lib": ["es5", "dom"],
-    "types": ["cypress", "node"]
+    "types": ["cypress", "cypress-wait-until", "node"]
   },
   "include": ["**/*.ts", "**/*.tsx", "../cypress.config.ts"],
   "exclude": []

--- a/clients/privacy-center/package-lock.json
+++ b/clients/privacy-center/package-lock.json
@@ -40,6 +40,7 @@
         "babel-jest": "^27.5.1",
         "cross-env": "^7.0.3",
         "cypress": "^10.10.0",
+        "cypress-wait-until": "^1.7.2",
         "eslint": "^8.23.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-airbnb-typescript": "^16.1.0",
@@ -5729,6 +5730,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/cypress-wait-until": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
+      "dev": true
     },
     "node_modules/cypress/node_modules/@types/node": {
       "version": "14.18.32",
@@ -19929,6 +19936,12 @@
           }
         }
       }
+    },
+    "cypress-wait-until": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
+      "dev": true
     },
     "damerau-levenshtein": {
       "version": "1.0.8",

--- a/clients/privacy-center/package.json
+++ b/clients/privacy-center/package.json
@@ -57,6 +57,7 @@
     "babel-jest": "^27.5.1",
     "cross-env": "^7.0.3",
     "cypress": "^10.10.0",
+    "cypress-wait-until": "^1.7.2",
     "eslint": "^8.23.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^16.1.0",


### PR DESCRIPTION
✅ Trying to resolve a build flake  ♻️

I was able to reproduce by enabling network throttling my Cypress browser. Then I was able to get `waitUntil` to resolve the issue.