### PR TITLE
pc/consent: Pass GPC status fields to consent update request

### DIFF
--- a/clients/privacy-center/cypress/e2e/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent.cy.ts
@@ -1,6 +1,7 @@
 import { hostUrl } from "~/constants";
 import { CONSENT_COOKIE_NAME } from "fides-consent";
 import { GpcStatus } from "~/features/consent/types";
+import { ConsentPreferencesWithVerificationCode } from "~/types/api";
 
 describe("Consent settings", () => {
   describe("when the user isn't verified", () => {
@@ -140,13 +141,23 @@ describe("Consent settings", () => {
       cy.getByTestId("save-btn").click();
 
       cy.wait("@patchConsentPreferences").then((interception) => {
-        const consent = interception.request.body.consent.find(
-          (c: any) => c.data_use === "advertising"
+        const body = interception.request
+          .body as ConsentPreferencesWithVerificationCode;
+
+        const advertisingConsent = body.consent.find(
+          (c) => c.data_use === "advertising"
         );
-        expect(consent?.opt_in).to.eq(true);
+        expect(advertisingConsent?.opt_in).to.eq(true);
+
+        const gpcConsent = body.consent.find(
+          (c) => c.data_use === "collect.gpc"
+        );
+        expect(gpcConsent?.opt_in).to.eq(true);
+        expect(gpcConsent?.has_gpc_flag).to.eq(false);
+        expect(gpcConsent?.conflicts_with_gpc).to.eq(false);
 
         // there should be no browser identity
-        expect(interception.request.body.browser_identity).to.eql(undefined);
+        expect(body.browser_identity).to.eql(undefined);
       });
 
       // The cookie should also have been updated. This may take a moment in CI,
@@ -176,9 +187,10 @@ describe("Consent settings", () => {
       cy.getByTestId("save-btn").click();
 
       cy.wait("@patchConsentPreferences").then((interception) => {
-        const { body } = interception.request;
-        expect(body.browser_identity.ga_client_id).to.eq(clientId);
-        expect(body.browser_identity.ljt_readerID).to.eq(sovrnCookieValue);
+        const body = interception.request
+          .body as ConsentPreferencesWithVerificationCode;
+        expect(body.browser_identity?.ga_client_id).to.eq(clientId);
+        expect(body.browser_identity?.ljt_readerID).to.eq(sovrnCookieValue);
       });
     });
 
@@ -229,7 +241,7 @@ describe("Consent settings", () => {
     });
 
     describe("when globalPrivacyControl is enabled", () => {
-      it("lets the user consent to override GPC", () => {
+      it("applies the GPC defaults", () => {
         cy.visit("/consent?globalPrivacyControl=true");
         cy.getByTestId("consent");
 
@@ -240,6 +252,48 @@ describe("Consent settings", () => {
           cy.getRadio().should("not.be.checked");
 
           cy.getByTestId("gpc-badge").should("contain", GpcStatus.APPLIED);
+        });
+
+        cy.getByTestId("save-btn").click();
+
+        cy.wait("@patchConsentPreferences").then((interception) => {
+          const body = interception.request
+            .body as ConsentPreferencesWithVerificationCode;
+
+          const gpcConsent = body.consent.find(
+            (c) => c.data_use === "collect.gpc"
+          );
+          expect(gpcConsent?.opt_in).to.eq(false);
+          expect(gpcConsent?.has_gpc_flag).to.eq(true);
+          expect(gpcConsent?.conflicts_with_gpc).to.eq(false);
+        });
+      });
+
+      it("lets the user consent to override GPC", () => {
+        cy.visit("/consent?globalPrivacyControl=true");
+        cy.getByTestId("consent");
+
+        cy.getByTestId("gpc-banner");
+
+        cy.getByTestId(`consent-item-card-collect.gpc`).within(() => {
+          cy.contains("GPC test");
+          cy.getRadio().should("not.be.checked").check({ force: true });
+
+          cy.getByTestId("gpc-badge").should("contain", GpcStatus.OVERRIDDEN);
+        });
+
+        cy.getByTestId("save-btn").click();
+
+        cy.wait("@patchConsentPreferences").then((interception) => {
+          const body = interception.request
+            .body as ConsentPreferencesWithVerificationCode;
+
+          const gpcConsent = body.consent.find(
+            (c) => c.data_use === "collect.gpc"
+          );
+          expect(gpcConsent?.opt_in).to.eq(true);
+          expect(gpcConsent?.has_gpc_flag).to.eq(true);
+          expect(gpcConsent?.conflicts_with_gpc).to.eq(true);
         });
       });
     });

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -40,6 +40,7 @@ import { getGpcStatus, makeCookieKeyConsent } from "~/features/consent/helpers";
 import { useGetIdVerificationConfigQuery } from "~/features/id-verification";
 import { ConsentPreferences } from "~/types/api";
 import { GpcBanner } from "~/features/consent/GpcMessages";
+import { GpcStatus } from "~/features/consent/types";
 
 const Consent: NextPage = () => {
   const [consentRequestId] = useLocalStorage("consentRequestId", "");
@@ -219,11 +220,18 @@ const Consent: NextPage = () => {
     const consent = consentOptions.map((option) => {
       const defaultValue = resolveConsentValue(option.default, consentContext);
       const value = fidesKeyToConsent[option.fidesDataUseKey] ?? defaultValue;
+      const gpcStatus = getGpcStatus({
+        value,
+        consentOption: option,
+        consentContext,
+      });
 
       return {
         data_use: option.fidesDataUseKey,
         data_use_description: option.description,
         opt_in: value,
+        has_gpc_flag: gpcStatus !== GpcStatus.NONE,
+        conflicts_with_gpc: gpcStatus === GpcStatus.OVERRIDDEN,
       };
     });
 

--- a/clients/privacy-center/types/api/models/Consent.ts
+++ b/clients/privacy-center/types/api/models/Consent.ts
@@ -9,4 +9,6 @@ export type Consent = {
   data_use: string;
   data_use_description?: string;
   opt_in: boolean;
+  has_gpc_flag?: boolean;
+  conflicts_with_gpc?: boolean;
 };

--- a/clients/privacy-center/types/api/models/Identity.ts
+++ b/clients/privacy-center/types/api/models/Identity.ts
@@ -9,4 +9,5 @@ export type Identity = {
   phone_number?: string;
   email?: string;
   ga_client_id?: string;
+  ljt_readerID?: string;
 };


### PR DESCRIPTION
Closes #2232 

### Code Changes

- pc/types: Update Consent API model
- pc/cy: Assert GPC fields passed to API
- pc/consent: Pass GPC status fields to consent update request

### Steps to Confirm

* [ ] Build latest fides so that new fields are in the API + DB
* [ ] Enable GPC in browser or using `?globalPrivacyControl=true` query parameter.
* [ ] Override an option that's highlighted for GPC and save -> The value choice should be reflected in the request & DB

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

