### PR TITLE
scripts/email: Use all-caps enum string for email service_type

### DIFF
--- a/scripts/setup/email.py
+++ b/scripts/setup/email.py
@@ -22,7 +22,7 @@ def create_email_integration(
         json={
             "name": "fides Emails",
             "key": key,
-            "service_type": "mailgun",
+            "service_type": "MAILGUN",
             "details": {
                 "is_eu_domain": False,
                 "api_version": "v3",


### PR DESCRIPTION
### Code Changes

* `mailgun` => `MAILGUN`

### Steps to Confirm

* [ ] Clear out your fides_env(dev) containers+volumes, then rebuild them from scratch.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Postgres and/or SQLAlchemy yelled at me when I setup the env from scratch. The enum values for the table [are supposed to be uppercase](https://github.com/ethyca/fides/blob/9a3a6d377d7c5178192b554ee1078c74ceacac97/src/fides/api/ctl/migrations/versions/179f2bb623ae_update_table_for_twilio.py#L42), but I don't know why this hadn't caused problems earlier (code is 3 months old). It's possible I ended up with a minor version update that started enforcing this for correctness.
