### PR TITLE
include feature flag check in helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,17 @@ The types of changes are:
 
 * Add warning to 'fides deploy' when installed outside of a virtual environment [#2641](https://github.com/ethyca/fides/pull/2641)
 
+### Fixed
+
+* Fix error with the classify dataset feature flag not writing the dataset to the server [#2675](https://github.com/ethyca/fides/pull/2675)
+
 ## [2.7.0](https://github.com/ethyca/fides/compare/2.6.6...2.7.0)
 
 * Fides API
   * Access and erasure support for Braintree [#2223](https://github.com/ethyca/fides/pull/2223)
   * Added route to send a test message [#2585](https://github.com/ethyca/fides/pull/2585)
   * Add default storage configuration functionality and associated APIs [#2438](https://github.com/ethyca/fides/pull/2438)
-  
+
 * Admin UI
   * Custom Metadata [#2536](https://github.com/ethyca/fides/pull/2536)
     * Create Custom Lists
@@ -141,7 +145,7 @@ The types of changes are:
   * Add a "skip_param_values option" to optionally skip when we are missing param values in the body [#2384](https://github.com/ethyca/fides/pull/2384)
   * Adds a new Universal Analytics Connector that works with the UA Tracking Id
 * Adds intake and storage of Global Privacy Control Signal props for Consent [#2599](https://github.com/ethyca/fides/pull/2599)
-  
+
 ### Changed
 
 * Unified Fides Resources
@@ -162,7 +166,7 @@ The types of changes are:
 
 ### Developer Experience
 
-* `nox -s test_env` has been replaced with `nox -s "fides_env(dev)"` 
+* `nox -s test_env` has been replaced with `nox -s "fides_env(dev)"`
 * New command `nox -s "fides_env(test)"` creates a complete test environment with seed data (similar to `fides_env(dev)`) but with the production fides image so the built UI can be accessed at `localhost:8080` [#2399](https://github.com/ethyca/fides/pull/2399)
 * Change from code climate to codecov for coverage reporting [#2402](https://github.com/ethyca/fides/pull/2402)
 

--- a/clients/admin-ui/src/features/dataset/helpers.ts
+++ b/clients/admin-ui/src/features/dataset/helpers.ts
@@ -98,8 +98,10 @@ export const getUpdatedDatasetFromClassifyDataset = (
         draftCollection.name
       );
 
-      if (classifyCollection?.name !== activeCollection) {
-        return;
+      if (activeCollection) {
+        if (classifyCollection?.name !== activeCollection) {
+          return;
+        }
       }
 
       const classifyFieldMap = new Map(

--- a/clients/admin-ui/src/features/dataset/helpers.ts
+++ b/clients/admin-ui/src/features/dataset/helpers.ts
@@ -98,10 +98,9 @@ export const getUpdatedDatasetFromClassifyDataset = (
         draftCollection.name
       );
 
-      if (activeCollection) {
-        if (classifyCollection?.name !== activeCollection) {
-          return;
-        }
+      if (activeCollection && classifyCollection?.name !== activeCollection) {
+        return;
+      }
       }
 
       const classifyFieldMap = new Map(

--- a/clients/admin-ui/src/features/dataset/helpers.ts
+++ b/clients/admin-ui/src/features/dataset/helpers.ts
@@ -101,7 +101,6 @@ export const getUpdatedDatasetFromClassifyDataset = (
       if (activeCollection && classifyCollection?.name !== activeCollection) {
         return;
       }
-      }
 
       const classifyFieldMap = new Map(
         classifyCollection?.fields?.map((f) => [f.name, f])


### PR DESCRIPTION
Closes [fidesplus#619](https://github.com/ethyca/fidesplus/issues/619)

### Code Changes

* [x] Include feature flag in helper function

### Steps to Confirm

* [x] Tested that the classification details are visible on the data map after approval for both feature flag scenarios
    * [x] Add a new system and privacy declaration
    * [x] Validate the one line on the data map
    * [x] Classify and approve a dataset (I used `postgresql+psycopg2://postgres:fides@fidesplus-db:5432/fides`)
    * [x] Reference dataset in privacy declaration
    * [x] View details on data map!
    * [x] Delete and do it again with the feature flag flipped

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

If the feature flag was enabled, the data would be visible on the data map. Adding the feature flag and not accounting for it in all areas is the root cause of the issue here
