### PR TITLE
Allow string dates to stay strings in cache decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The types of changes are:
 
 * Fix support for "redis.user" setting when authenticating to the Redis cache [#2666](https://github.com/ethyca/fides/pull/2666)
 * Fix error with the classify dataset feature flag not writing the dataset to the server [#2675](https://github.com/ethyca/fides/pull/2675)
+* Allow string dates to stay strings in cache decoding [#2695](https://github.com/ethyca/fides/pull/2695)
 * Admin UI
   * Remove Identifiability (Data Qualifier) from taxonomy editor [2684](https://github.com/ethyca/fides/pull/2684)
 

--- a/tests/ops/util/test_cache.py
+++ b/tests/ops/util/test_cache.py
@@ -10,6 +10,7 @@ from bson.objectid import ObjectId
 
 from fides.api.ops.util.cache import (
     ENCODED_BYTES_PREFIX,
+    ENCODED_DATE_PREFIX,
     ENCODED_MONGO_OBJECT_ID_PREFIX,
     FidesopsRedis,
 )
@@ -121,7 +122,15 @@ class TestCustomJSONEncoder:
             (b"some value", f'"{ENCODED_BYTES_PREFIX}some%20value"'),
             (
                 datetime(2023, 2, 14, 20, 58),
-                f'"{datetime(2023, 2, 14, 20, 58).isoformat()}"',
+                f'"{ENCODED_DATE_PREFIX}{datetime(2023, 2, 14, 20, 58).isoformat()}"',
+            ),
+            (
+                {"a": datetime(2023, 2, 14, 20, 58)},
+                f'{{"a": "{ENCODED_DATE_PREFIX}{datetime(2023, 2, 14, 20, 58).isoformat()}"}}',
+            ),
+            (
+                {"a": {"b": datetime(2023, 2, 14, 20, 58)}},
+                f'{{"a": {{"b": "{ENCODED_DATE_PREFIX}{datetime(2023, 2, 14, 20, 58).isoformat()}"}}}}',
             ),
             ({"a": "b"}, '{"a": "b"}'),
             ({"a": {"b": "c"}}, '{"a": {"b": "c"}}'),
@@ -152,16 +161,28 @@ class TestCustomDecoder:
         [
             (f'{{"a": "{ENCODED_BYTES_PREFIX}some%20value"}}', {"a": b"some value"}),
             (
-                f'{{"a": "{datetime(2023, 2, 17, 14, 5).isoformat()}"}}',
-                {"a": datetime(2023, 2, 17, 14, 5)},
-            ),
-            (
                 f'{{"a": "{ENCODED_MONGO_OBJECT_ID_PREFIX}507f191e810c19729de860ea"}}',
                 {"a": ObjectId("507f191e810c19729de860ea")},
             ),
+            (
+                f'{{"a": "{ENCODED_DATE_PREFIX}{datetime(2023, 2, 17, 14, 5).isoformat()}"}}',
+                {"a": datetime(2023, 2, 17, 14, 5)},
+            ),
+            (
+                f'{{"a": {{"b": {{"c": "{ENCODED_DATE_PREFIX}{datetime(2023, 2, 17, 14, 5).isoformat()}"}}}}}}',
+                {"a": {"b": {"c": datetime(2023, 2, 17, 14, 5)}}},
+            ),
+            (
+                '{"birthday": "2001-11-08"}',
+                {"birthday": "2001-11-08"},
+            ),
+            (
+                '{"a": {"b": {"birthday": "2001-11-08"}}}',
+                {"a": {"b": {"birthday": "2001-11-08"}}},
+            ),
         ],
     )
-    def test_decode_bytes(self, value, expected):
+    def test_cache_decode(self, value, expected):
         cache = FidesopsRedis()
         assert cache.decode_obj(value) == expected
 


### PR DESCRIPTION
Closes #2691

### Code Changes

* Prefix date objects when caching
* Look for date prefix before decoding back to a date object

### Steps to Confirm

* [ ] Send values to cache that are a date object
* [ ] Retrieve the values and verify they are returned as date objects
* [ ] Send date values to cache formatted as a string
* [ ] Retrieve the values and verify they are in string format

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
