### PR TITLE
Fides Consent Banner (POC)

### DIFF
--- a/clients/privacy-center/README.md
+++ b/clients/privacy-center/README.md
@@ -94,6 +94,14 @@ To run the interactive test interface, run:
 npm run test
 ```
 
+For a fully-loaded development & test setup of both the Privacy Center and the
+Fides Consent library, run the following commands in three separate terminals:
+```bash
+npm run dev
+cd packages/fides-consent && npm run watch
+npm run cy:open
+```
+
 ## Deployment
 
 To deploy this site, fork this repository. Then, configure a smart hosting service such as Vercel or Netlify to deploy it, specifying the root directory for the client application as the `clients/privacy-center` directory (relative to the root of the repository).

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -1,0 +1,102 @@
+import { ConsentBannerOptions } from "fides-consent";
+
+// The fides-consent-demo.html page is wired up to inject the
+// `fidesConsentBannerOptions` into the Fides.banner(...) function
+declare global {
+  interface Window {
+    fidesConsentBannerOptions?: ConsentBannerOptions;
+  }
+}
+
+describe("Consent banner", () => {
+    // Default options to use for all tests
+    const testBannerOptions: ConsentBannerOptions = {
+        debug: true, // enable debug logging
+        labels: {
+            bannerDescription: "This test website is overriding the banner description label. It is very long, so it'll force a wrap.",
+            primaryButton: "Accept Test Cookies",
+            secondaryButton: "Reject Test Cookies",
+            tertiaryButton: "Manage Test Cookies",
+        }
+    };
+
+    describe("when disabled", () => {
+        beforeEach(() =>{
+            cy.visit("/fides-consent-demo.html", {
+                onBeforeLoad: (win) => {
+                    win.fidesConsentBannerOptions = {
+                        ...testBannerOptions,
+                        ...{
+                            isEnabled: false,
+                        }
+                    }
+                },
+            });
+        });
+
+        it("does not render", () => {
+            cy.get("div#fides-consent-banner").should("not.exist");
+            cy.contains("button", "Accept Test Cookies").should("not.exist");
+        });
+    })
+
+    describe("when enabled", () => {
+        beforeEach(() =>{
+            cy.visit("/fides-consent-demo.html", {
+                onBeforeLoad: (win) => {
+                    win.fidesConsentBannerOptions = {
+                        ...testBannerOptions,
+                        ...{
+                            isEnabled: true,
+                        }
+                    }
+                },
+            });
+        });
+
+        it("should render the expected HTML banner", () => {
+            // Consider me paranoid, but the various DOM APIs that consent-banner.ts uses
+            // (like createElement) are very easy to mess up. This test is (almost) a DOM
+            // snapshot test that asserts that the rendered banner HTML is similar to this:
+            //
+            // <div id='fides-consent-banner' class='fides-consent-banner'>
+            //   <div id='fides-consent-banner-description' class='fides-consent-banner-description'>
+            //     {labels.bannerDescription}
+            //   </div>
+            //   <div id='fides-consent-banner-buttons' class='fides-consent-banner-buttons'>
+            //     <button id='fides-consent-banner-tertiary-button' class='fides-consent-banner-button fides-consent-banner-primary-button'>
+            //       {labels.tertiaryButton}
+            //     </button>
+            //     <button id='fides-consent-banner-secondary-button' class='fides-consent-banner-button fides-consent-banner-secondary-button'>
+            //       {labels.secondaryButton}
+            //     </button>
+            //     <button id='fides-consent-banner-primary-button' class='fides-consent-banner-button fides-consent-banner-primary-button'>
+            //       {labels.primaryButton}
+            //     </button>
+            //   </div>
+            // </div>
+            cy.get("div#fides-consent-banner.fides-consent-banner").within(banner => {
+                cy.get("div#fides-consent-banner-description.fides-consent-banner-description")
+                  .contains("This test website is overriding the banner description label.");
+                cy.get("div#fides-consent-banner-buttons.fides-consent-banner-buttons").within(buttonsDiv => {
+                    cy.get("button#fides-consent-banner-button-tertiary.fides-consent-banner-button.fides-consent-banner-button-tertiary")
+                      .contains("Manage Test Cookies");
+                    cy.get("button#fides-consent-banner-button-secondary.fides-consent-banner-button.fides-consent-banner-button-secondary")
+                      .contains("Reject Test Cookies");
+                    cy.get("button#fides-consent-banner-button-primary.fides-consent-banner-button.fides-consent-banner-button-primary")
+                      .contains("Accept Test Cookies");
+
+                    // Order matters - it should always be tertiary, then secondary, then primary!
+                    cy.get("button").within(buttons => {
+                        const buttonIds = buttons.map((_, elem) => elem.id).get();
+                        cy.wrap(buttonIds).should("have.ordered.members", [
+                            "fides-consent-banner-button-tertiary",
+                            "fides-consent-banner-button-secondary",
+                            "fides-consent-banner-button-primary",
+                        ]);
+                    });
+                })
+            });
+        });
+    })
+});

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -1,4 +1,4 @@
-import { ConsentBannerOptions } from "fides-consent";
+import { CONSENT_COOKIE_NAME, ConsentBannerOptions, CookieKeyConsent } from "fides-consent";
 
 // The fides-consent-demo.html page is wired up to inject the
 // `fidesConsentBannerOptions` into the Fides.banner(...) function
@@ -8,95 +8,225 @@ declare global {
   }
 }
 
+// We define a custom Cypress command 
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      visitConsentDemo(bannerOptions?: ConsentBannerOptions): Chainable<any>;
+    }
+  }
+}
+
+
 describe("Consent banner", () => {
-    // Default options to use for all tests
-    const testBannerOptions: ConsentBannerOptions = {
-        debug: true, // enable debug logging
-        labels: {
-            bannerDescription: "This test website is overriding the banner description label. It is very long, so it'll force a wrap.",
-            primaryButton: "Accept Test Cookies",
-            secondaryButton: "Reject Test Cookies",
-            tertiaryButton: "Manage Test Cookies",
+  // Default options to use for all tests
+  const testBannerOptions: ConsentBannerOptions = {
+    debug: true, // enable debug logging
+    labels: {
+      bannerDescription: "This test website is overriding the banner description label.",
+      primaryButton: "Accept Test",
+      secondaryButton: "Reject Test",
+      tertiaryButton: "Customize Test",
+    }
+  };
+
+  const testCookieValue: CookieKeyConsent = {
+    data_sales: true,
+    tracking: false,
+  }
+
+  Cypress.Commands.add("visitConsentDemo", (bannerOptions?: ConsentBannerOptions) => {
+    cy.visit("/fides-consent-demo.html", {
+      onBeforeLoad: (win) => {
+        win.fidesConsentBannerOptions = {
+          ...testBannerOptions,
+          ...bannerOptions,
         }
-    };
+      },
+    });
+  })
 
-    describe("when disabled", () => {
-        beforeEach(() =>{
-            cy.visit("/fides-consent-demo.html", {
-                onBeforeLoad: (win) => {
-                    win.fidesConsentBannerOptions = {
-                        ...testBannerOptions,
-                        ...{
-                            isEnabled: false,
-                        }
-                    }
-                },
+  describe("when disabled", () => {
+    beforeEach(() => {
+      cy.visitConsentDemo({ isDisabled: true });
+    });
+
+    it("does not render", () => {
+      cy.get("div#fides-consent-banner").should("not.exist");
+      cy.contains("button", "Accept Test").should("not.exist");
+    });
+  })
+
+  describe("when user has a saved consent cookie", () => {
+    beforeEach(() => {
+      cy.setCookie(CONSENT_COOKIE_NAME, JSON.stringify(testCookieValue));
+    });
+
+    describe("when banner is not disabled", () => {
+      beforeEach(() => {
+        cy.visitConsentDemo({ isDisabled: false })
+      });
+
+      it("does not render", () => {
+        cy.get("div#fides-consent-banner").should("not.exist");
+        cy.contains("button", "Accept Test").should("not.exist");
+      });
+    });
+  });
+
+  describe("when user has no saved consent cookie", () => {
+    beforeEach(() => {
+      cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
+    });
+
+    describe("when banner is not disabled", () => {
+      beforeEach(() => {
+        cy.visitConsentDemo({
+          isDisabled: false,
+          isGeolocationEnabled: false,
+        });
+      });
+
+      it("should render the expected HTML banner", () => {
+        // Consider me paranoid, but the various DOM APIs that consent-banner.ts uses
+        // (like createElement) are very easy to mess up. This test is (almost) a DOM
+        // snapshot test that asserts that the rendered banner HTML is similar to this:
+        //
+        // <div id='fides-consent-banner' class='fides-consent-banner'>
+        //   <div id='fides-consent-banner-description' class='fides-consent-banner-description'>
+        //     {labels.bannerDescription}
+        //   </div>
+        //   <div id='fides-consent-banner-buttons' class='fides-consent-banner-buttons'>
+        //     <button id='fides-consent-banner-tertiary-button' class='fides-consent-banner-button fides-consent-banner-primary-button'>
+        //       {labels.tertiaryButton}
+        //     </button>
+        //     <button id='fides-consent-banner-secondary-button' class='fides-consent-banner-button fides-consent-banner-secondary-button'>
+        //       {labels.secondaryButton}
+        //     </button>
+        //     <button id='fides-consent-banner-primary-button' class='fides-consent-banner-button fides-consent-banner-primary-button'>
+        //       {labels.primaryButton}
+        //     </button>
+        //   </div>
+        // </div>
+        cy.get("div#fides-consent-banner.fides-consent-banner").within(banner => {
+          cy.get("div#fides-consent-banner-description.fides-consent-banner-description")
+            .contains("This test website is overriding the banner description label.");
+          cy.get("div#fides-consent-banner-buttons.fides-consent-banner-buttons").within(buttonsDiv => {
+            cy.get("button#fides-consent-banner-button-tertiary.fides-consent-banner-button.fides-consent-banner-button-tertiary")
+              .contains("Customize Test");
+            cy.get("button#fides-consent-banner-button-secondary.fides-consent-banner-button.fides-consent-banner-button-secondary")
+              .contains("Reject Test");
+            cy.get("button#fides-consent-banner-button-primary.fides-consent-banner-button.fides-consent-banner-button-primary")
+              .contains("Accept Test");
+
+            // Order matters - it should always be tertiary, then secondary, then primary!
+            cy.get("button").within(buttons => {
+              const buttonIds = buttons.map((_, elem) => elem.id).get();
+              cy.wrap(buttonIds).should("have.ordered.members", [
+                "fides-consent-banner-button-tertiary",
+                "fides-consent-banner-button-secondary",
+                "fides-consent-banner-button-primary",
+              ]);
             });
+          })
         });
+      });
 
-        it("does not render", () => {
-            cy.get("div#fides-consent-banner").should("not.exist");
-            cy.contains("button", "Accept Test Cookies").should("not.exist");
+      it("should allow accepting all", () => {
+        cy.contains("button", "Accept Test").should("be.visible").click();
+        // TODO: consent.cy.ts uses cy.waitUntil to wait longer for the cookie to save in CI - will this be needed?
+        cy.getCookie(CONSENT_COOKIE_NAME).should("exist").then((cookie) => {
+          const cookieKeyConsent = JSON.parse(
+            decodeURIComponent(cookie!.value)
+          );
+          expect(cookieKeyConsent).property("data_sales").is.true;
+          expect(cookieKeyConsent).property("tracking").is.true;
+        })
+        cy.contains("button", "Accept Test").should("not.be.visible");
+      });
+
+      it("should support rejecting all consent options", () => {
+        cy.contains("button", "Reject Test").should("be.visible").click();
+        // TODO: consent.cy.ts uses cy.waitUntil to wait longer for the cookie to save in CI - will this be needed?
+        cy.getCookie(CONSENT_COOKIE_NAME).should("exist").then((cookie) => {
+          const cookieKeyConsent = JSON.parse(
+            decodeURIComponent(cookie!.value)
+          );
+          expect(cookieKeyConsent).property("data_sales").is.false;
+          expect(cookieKeyConsent).property("tracking").is.false;
+        })
+      });
+
+      it("should navigate to Privacy Center to manage consent options", () => {
+        cy.contains("button", "Customize Test").should("be.visible").click();
+        cy.url().should("equal", "http://localhost:3000/");
+      });
+
+      it.skip("should save the consent request to the Fides API", () => {
+        // TODO: add tests for saving to API (ie PATCH /api/v1/consent-request/{id}/preferences...)
+        expect(false).to.be.true
+      });
+
+      it.skip("should support option to display at top or bottom of page", () => {
+        // TODO: add tests for top/bottom
+        expect(false).to.be.true
+      });
+
+      it.skip("should support styling with CSS variables", () => {
+        // TODO: add tests for CSS
+        expect(false).to.be.true
+      });
+    });
+
+    describe("when banner geolocation is enabled", () => {
+      it("should show the banner when geolocation country is in EU", () => {
+        const locationData = {
+          country: "FR",
+          region: "IDF",
+          location: "FR-IDF",
+        }
+        cy.intercept("GET", "https://example-api.com/location", { body: locationData });
+        cy.visitConsentDemo({
+          geolocationApiUrl: "https://example-api.com/location",
+          isDisabled: false,
+          isGeolocationEnabled: true,
         });
-    })
+        cy.get("div#fides-consent-banner").should("exist");
+        cy.contains("button", "Accept Test").should("exist");
+      });
 
-    describe("when enabled", () => {
-        beforeEach(() =>{
-            cy.visit("/fides-consent-demo.html", {
-                onBeforeLoad: (win) => {
-                    win.fidesConsentBannerOptions = {
-                        ...testBannerOptions,
-                        ...{
-                            isEnabled: true,
-                        }
-                    }
-                },
-            });
+      it("should hide the banner when geolocation country is not in EU", () => {
+        const locationData = {
+          country: "US",
+          region: "NY",
+          location: "US-NY",
+        }
+        cy.intercept("GET", "https://example-api.com/location", { body: locationData });
+        cy.visitConsentDemo({
+          geolocationApiUrl: "https://example-api.com/location",
+          isDisabled: false,
+          isGeolocationEnabled: true,
         });
+        cy.get("div#fides-consent-banner").should("not.exist");
+        cy.contains("button", "Accept Test").should("not.exist");
+      });
 
-        it("should render the expected HTML banner", () => {
-            // Consider me paranoid, but the various DOM APIs that consent-banner.ts uses
-            // (like createElement) are very easy to mess up. This test is (almost) a DOM
-            // snapshot test that asserts that the rendered banner HTML is similar to this:
-            //
-            // <div id='fides-consent-banner' class='fides-consent-banner'>
-            //   <div id='fides-consent-banner-description' class='fides-consent-banner-description'>
-            //     {labels.bannerDescription}
-            //   </div>
-            //   <div id='fides-consent-banner-buttons' class='fides-consent-banner-buttons'>
-            //     <button id='fides-consent-banner-tertiary-button' class='fides-consent-banner-button fides-consent-banner-primary-button'>
-            //       {labels.tertiaryButton}
-            //     </button>
-            //     <button id='fides-consent-banner-secondary-button' class='fides-consent-banner-button fides-consent-banner-secondary-button'>
-            //       {labels.secondaryButton}
-            //     </button>
-            //     <button id='fides-consent-banner-primary-button' class='fides-consent-banner-button fides-consent-banner-primary-button'>
-            //       {labels.primaryButton}
-            //     </button>
-            //   </div>
-            // </div>
-            cy.get("div#fides-consent-banner.fides-consent-banner").within(banner => {
-                cy.get("div#fides-consent-banner-description.fides-consent-banner-description")
-                  .contains("This test website is overriding the banner description label.");
-                cy.get("div#fides-consent-banner-buttons.fides-consent-banner-buttons").within(buttonsDiv => {
-                    cy.get("button#fides-consent-banner-button-tertiary.fides-consent-banner-button.fides-consent-banner-button-tertiary")
-                      .contains("Manage Test Cookies");
-                    cy.get("button#fides-consent-banner-button-secondary.fides-consent-banner-button.fides-consent-banner-button-secondary")
-                      .contains("Reject Test Cookies");
-                    cy.get("button#fides-consent-banner-button-primary.fides-consent-banner-button.fides-consent-banner-button-primary")
-                      .contains("Accept Test Cookies");
-
-                    // Order matters - it should always be tertiary, then secondary, then primary!
-                    cy.get("button").within(buttons => {
-                        const buttonIds = buttons.map((_, elem) => elem.id).get();
-                        cy.wrap(buttonIds).should("have.ordered.members", [
-                            "fides-consent-banner-button-tertiary",
-                            "fides-consent-banner-button-secondary",
-                            "fides-consent-banner-button-primary",
-                        ]);
-                    });
-                })
-            });
+      it("should show the banner when geolocation country is included in custom isEnabledCountries", () => {
+        const locationData = {
+          country: "US",
+          region: "NY",
+          location: "US-NY",
+        }
+        cy.intercept("GET", "https://example-api.com/location", { body: locationData });
+        cy.visitConsentDemo({
+          geolocationApiUrl: "https://example-api.com/location",
+          isDisabled: false,
+          isGeolocationEnabled: true,
+          isEnabledCountries: ["US", "CA"],
         });
-    })
+        cy.get("div#fides-consent-banner").should("exist");
+        cy.contains("button", "Accept Test").should("exist");
+      });
+    });
+  });
 });

--- a/clients/privacy-center/packages/fides-consent/src/fides-consent.ts
+++ b/clients/privacy-center/packages/fides-consent/src/fides-consent.ts
@@ -9,7 +9,7 @@ import consentConfig from "./consent-config.json";
 import { gtm } from "./integrations/gtm";
 import { meta } from "./integrations/meta";
 import { shopify } from "./integrations/shopify";
-import { banner, getBannerOptions } from "./lib/consent-banner";
+import { ConsentBannerOptions, getBannerOptions, initBanner } from "./lib/consent-banner";
 import { ConsentConfig } from "./lib/consent-config";
 import { getConsentContext } from "./lib/consent-context";
 import { getConsentCookie, makeDefaults } from "./lib/cookie";
@@ -25,6 +25,14 @@ const defaults = makeDefaults({
  * Immediately load the stored consent settings from the browser cookie.
  */
 const consent = getConsentCookie(defaults);
+
+/**
+ * Create a wrapped `banner` function that injects the default consent settings
+ * as an argument, so it can be used as Fides.banner()
+ */
+const banner = async (extraOptions?: ConsentBannerOptions): Promise<void> => {
+  return initBanner.call(undefined, defaults, extraOptions);
+}
 
 const Fides = {
   consent,

--- a/clients/privacy-center/packages/fides-consent/src/fides-consent.ts
+++ b/clients/privacy-center/packages/fides-consent/src/fides-consent.ts
@@ -9,6 +9,7 @@ import consentConfig from "./consent-config.json";
 import { gtm } from "./integrations/gtm";
 import { meta } from "./integrations/meta";
 import { shopify } from "./integrations/shopify";
+import { banner, getBannerOptions } from "./lib/consent-banner";
 import { ConsentConfig } from "./lib/consent-config";
 import { getConsentContext } from "./lib/consent-context";
 import { getConsentCookie, makeDefaults } from "./lib/cookie";
@@ -28,6 +29,8 @@ const consent = getConsentCookie(defaults);
 const Fides = {
   consent,
 
+  banner,
+  getBannerOptions,
   gtm,
   meta,
   shopify,

--- a/clients/privacy-center/packages/fides-consent/src/lib/consent-banner.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/consent-banner.ts
@@ -1,0 +1,300 @@
+export type ConsentBannerOptions = {
+  // Whether or not debug log statements should be enabled
+  debug?: boolean
+
+  // Whether or not the banner should be displayed
+  isEnabled?: boolean 
+
+  // Display labels used for the banner text
+  labels?: {
+    bannerDescription?: string
+    primaryButton?: string
+    secondaryButton?: string
+    tertiaryButton?: string
+  }
+};
+
+/**
+ * Get the configured options for the consent banner 
+ */
+export const getBannerOptions = (): ConsentBannerOptions => {
+  return _globalBannerOptions;
+};
+
+/**
+ * Initialize the Fides Consent Banner, with optional extraOptions to override defaults.
+ * 
+ * (see the type definition of ConsentBannerOptions for what options are available)
+ */
+export const banner = (extraOptions?: ConsentBannerOptions): void => {
+  // If the user provides any extra options, override the defaults
+  if (extraOptions !== undefined) {
+    if (typeof extraOptions !== "object") {
+      console.error("Invalid 'extraOptions' arg for Fides.banner(), ignoring", extraOptions);
+    } else {
+      setBannerOptions({ ...getBannerOptions(), ...extraOptions });
+    }
+  }
+
+  const options: ConsentBannerOptions = getBannerOptions();
+  debugLog("Initializing Fides consent banner...", options);
+
+  if (options.isEnabled) {
+    // TODO: wrap into displayBanner() and call after a getLocation() call first
+    debugLog("Building Fides consent banner...");
+    const banner: Node = buildBanner();
+
+    debugLog("Building Fides consent banner styles...");
+    const styles: Node = buildStyles();
+
+    debugLog("Adding Fides consent banner CSS & HTML into the DOM...");
+    document.head.appendChild(styles);
+    document.body.appendChild(banner);
+  }
+
+  debugLog("Fides consent banner initialization complete!");
+};
+
+/**
+ * Configuration options used for the consent banner. The default values (below)
+ * will be mutated by the banner() function to override with any user-provided
+ * options at runtime.
+ * 
+ * This is effectively a global variable, but we provide getter/setter functions
+ * to make it seem safer and only export the getBannerOptions() one outside this
+ * module.
+ */
+let _globalBannerOptions: ConsentBannerOptions = {
+  debug: false,
+  isEnabled: false,
+  labels: {
+    bannerDescription: "This website processes your data respectfully, so we require your consent to use cookies.",
+    primaryButton: "Accept All",
+    secondaryButton: "Reject All",
+    tertiaryButton: "Manage Preferences",
+  }
+};
+
+/**
+ * Change the consent banner options.
+ * 
+ * WARNING: If called after `banner()` has already ran, many of these options
+ * will no longer take effect!
+ */
+const setBannerOptions = (options: ConsentBannerOptions): void => {
+  _globalBannerOptions = options;
+};
+
+/**
+ * Wrapper around 'console.log' that only logs output when the 'debug' banner
+ * option is truthy
+ */
+type ConsoleLogParameters = Parameters<typeof console.log>
+const debugLog = (...args: ConsoleLogParameters): void => {
+  if (getBannerOptions().debug) {
+    console.log(...args) // TODO: use console.debug instead?
+  }
+};
+
+/**
+ * Builds the DOM elements for the consent banner (container, buttons, etc.) and
+ * return a single div that can be added to the body. The expected HTML is:
+ * 
+ * <div>
+ *   <div></div>
+ *   <div>
+ *     <button></button>
+ *     <button></button>
+ *     <button></button>
+ *   </div>
+ * </div>
+ * 
+ * To ease CSS customization, we also add descriptive classes to every element
+ */
+const buildBanner = (): Node => {
+  const options: ConsentBannerOptions = getBannerOptions();
+
+  // Create the overall banner container
+  const banner = document.createElement("div");
+  banner.id = "fides-consent-banner";
+  banner.classList.add("fides-consent-banner");
+
+  // Add the banner description
+  const bannerDescription = document.createElement("div");
+  bannerDescription.id = "fides-consent-banner-description";
+  bannerDescription.classList.add("fides-consent-banner-description");
+  bannerDescription.innerText = options.labels?.bannerDescription || "";
+  banner.appendChild(bannerDescription);
+
+  // Create the button container
+  const buttonContainer = document.createElement("div");
+  buttonContainer.id = "fides-consent-banner-buttons";
+  buttonContainer.classList.add("fides-consent-banner-buttons");
+
+  // Create the banner buttons
+  const tertiaryButton = buildButton(
+    "fides-consent-banner-button-tertiary",
+    "fides-consent-banner-button-tertiary",
+    options.labels?.tertiaryButton,
+  );
+  buttonContainer.appendChild(tertiaryButton);
+  const secondaryButton = buildButton(
+    "fides-consent-banner-button-secondary",
+    "fides-consent-banner-button-secondary",
+    options.labels?.secondaryButton,
+  );
+  buttonContainer.appendChild(secondaryButton);
+  const primaryButton = buildButton(
+    "fides-consent-banner-button-primary",
+    "fides-consent-banner-button-primary",
+    options.labels?.primaryButton,
+  );
+  buttonContainer.appendChild(primaryButton);
+
+  // Add the button container to the banner
+  banner.appendChild(buttonContainer);
+
+  return banner;
+};
+
+/**
+ * Builds a button DOM element with the given id, class name, and text label
+ */
+const buildButton = (id: string, className: string, label?: string): Node => {
+  const options: ConsentBannerOptions = getBannerOptions();
+  const button = document.createElement("button");
+  button.id = id;
+  button.innerHTML = label || "";
+  button.classList.add("fides-consent-banner-button");
+  button.classList.add(className);
+  button.addEventListener("click", () => {
+    debugLog(`Fides consent banner button clicked with id='${id}'`);
+    // TODO: callback
+  });
+  return button;
+};
+
+/**
+ * Default CSS styles for the banner
+ */
+const _defaultBannerStyle = `
+:root {
+  --fides-consent-banner-font-family: inherit;
+  --fides-consent-banner-font-size: 16px;
+  --fides-consent-banner-background: #fff;
+  --fides-consent-banner-text-color: #24292f;
+  --fides-consent-banner-padding: 0.75em 2em 1em;
+
+  --fides-consent-banner-button-background: #eee;
+  --fides-consent-banner-button-text-color: #24292f;
+  --fides-consent-banner-button-hover-background: #ccc;
+  --fides-consent-banner-button-border-radius: 4px;
+  --fides-consent-banner-button-padding: 1em 1.5em;
+
+  --fides-consent-banner-button-primary-background: #464b83;
+  --fides-consent-banner-button-primary-text-color: #fff;
+  --fides-consent-banner-button-primary-hover-background: #3f4375;
+
+  --fides-consent-banner-button-secondary-background: var(--fides-consent-banner-button-background);
+  --fides-consent-banner-button-secondary-text-color: var(--fides-consent-banner-button-text-color);
+  --fides-consent-banner-button-secondary-hover-background: var(--fides-consent-banner-button-hover-background);
+
+  --fides-consent-banner-button-tertiary-background: var(--fides-consent-banner-button-background);
+  --fides-consent-banner-button-tertiary-text-color: var(--fides-consent-banner-button-text-color);
+  --fides-consent-banner-button-tertiary-hover-background: var(--fides-consent-banner-button-hover-background);
+}
+
+div#fides-consent-banner {
+  font-family: var(--fides-consent-banner-font-family);
+  font-size: var(--fides-consent-banner-font-size);
+  background: var(--fides-consent-banner-background);
+  color: var(--fides-consent-banner-text-color);
+
+  position: fixed;
+  z-index: 1;
+  width: 100%;
+  bottom: 0;
+  left: 0;
+  box-sizing: border-box;
+  padding: var(--fides-consent-banner-padding);
+
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+}
+
+div#fides-consent-banner-description {
+  margin-top: 0.5em;
+  margin-right: 2em;
+  min-width: 40%;
+  flex: 1;
+}
+
+div#fides-consent-banner-buttons {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+button.fides-consent-banner-button {
+  display: inline-block;
+  flex: auto;
+  cursor: pointer;
+  text-align: center;
+  margin: 0;
+  margin-top: 0.25em;
+  margin-right: 0.25em;
+  padding: var(--fides-consent-banner-button-padding);
+  background: var(--fides-consent-banner-button-background);
+  color: var(--fides-consent-banner-button-text-color);
+  border: none;
+  border-radius: var(--fides-consent-banner-button-border-radius);
+
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  text-decoration: none;
+}
+
+button.fides-consent-banner-button:hover {
+  background: var(--fides-consent-banner-button-hover-background);
+}
+
+button.fides-consent-banner-button.fides-consent-banner-button-primary {
+  background: var(--fides-consent-banner-button-primary-background);
+  color: var(--fides-consent-banner-button-primary-text-color);
+}
+
+button.fides-consent-banner-button.fides-consent-banner-button-primary:hover {
+  background: var(--fides-consent-banner-button-primary-hover-background);
+}
+
+button.fides-consent-banner-button.fides-consent-banner-button-secondary {
+  background: var(--fides-consent-banner-button-secondary-background);
+  color: var(--fides-consent-banner-button-secondary-text-color);
+}
+
+button.fides-consent-banner-button.fides-consent-banner-button-secondary:hover {
+  background: var(--fides-consent-banner-button-secondary-hover-background);
+}
+
+button.fides-consent-banner-button.fides-consent-banner-button-tertiary {
+  background: var(--fides-consent-banner-button-tertiary-background);
+  color: var(--fides-consent-banner-button-tertiary-text-color);
+}
+
+button.fides-consent-banner-button.fides-consent-banner-button-tertiary:hover {
+  background: var(--fides-consent-banner-button-tertiary-hover-background);
+}
+`
+
+/**
+ * Builds a 'style' element containing the CSS styles for the consent banner
+ */
+const buildStyles = (): Node => {
+  const style = document.createElement("style");
+  style.innerHTML = _defaultBannerStyle;
+  return style;
+};

--- a/clients/privacy-center/packages/fides-consent/src/lib/cookie.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/cookie.ts
@@ -57,6 +57,11 @@ export const makeDefaults = ({
   return defaults;
 };
 
+export const hasSavedConsentCookie = (): boolean => {
+  const cookie = getCookie(CONSENT_COOKIE_NAME, CODEC);
+  return !!cookie;
+}
+
 export const getConsentCookie = (
   defaults: CookieKeyConsent
 ): CookieKeyConsent => {
@@ -106,4 +111,30 @@ export const setConsentCookie = (cookieKeyConsent: CookieKeyConsent) => {
     },
     CODEC
   );
+};
+
+export const setConsentCookieAcceptAll = (defaults: CookieKeyConsent): void => {
+  if (defaults === undefined) {
+    // eslint-disable-next-line no-console
+    console.error("Unable to set consent cookie to accept all: invalid defaults.");
+    return;
+  }
+
+  // Override all consent values to true and save the cookie
+  const entries: [string, boolean][] = Object.keys(defaults).map((key) => [key, true]);
+  const cookieKeyConsent = Object.fromEntries(entries);
+  setConsentCookie(cookieKeyConsent);
+};
+
+export const setConsentCookieRejectAll = (defaults: CookieKeyConsent): void => {
+  if (defaults === undefined) {
+    // eslint-disable-next-line no-console
+    console.error("Unable to set consent cookie to reject all: invalid defaults.");
+    return;
+  }
+
+  // Override all consent values to false and save the cookie
+  const entries: [string, boolean][] = Object.keys(defaults).map((key) => [key, false]);
+  const cookieKeyConsent = Object.fromEntries(entries);
+  setConsentCookie(cookieKeyConsent);
 };

--- a/clients/privacy-center/packages/fides-consent/src/lib/index.ts
+++ b/clients/privacy-center/packages/fides-consent/src/lib/index.ts
@@ -3,6 +3,7 @@
  * is then bundled into `fides-consent.js` and imported by Privacy Center app, so that
  * both can share the same consent logic.
  */
+export * from "./consent-banner";
 export * from "./consent-config";
 export * from "./consent-context";
 export * from "./consent-value";

--- a/clients/privacy-center/public/fides-consent-demo.html
+++ b/clients/privacy-center/public/fides-consent-demo.html
@@ -1,62 +1,75 @@
 <!DOCTYPE html>
 <html>
-  <head>
+
+<head>
     <title>fides-consent script demo page</title>
 
     <script src="/fides-consent.js"></script>
 
     <style>
-      body {
-        max-width: 800px;
-        margin: 16px;
-      }
-      pre {
-        background-color: #eee;
-        padding: 16px;
-      }
+        body {
+            max-width: 800px;
+            margin: 16px;
+        }
+        
+        pre {
+            background-color: #eee;
+            padding: 16px;
+        }
     </style>
-  </head>
+</head>
 
-  <body>
+<body>
     <main>
-      <h1>fides-consent.js demo page</h1>
-      <p>
-        This page exists to demonstrate and debug the fides-consent.js script.
-        It is used by the Privacy Center's test suite to ensure the a users's
-        consent choices can be accessed by pages that live outside of the
-        Privacy Center.
-      </p>
+        <h1>fides-consent.js demo page</h1>
+        <p>
+            This page exists to demonstrate and debug the fides-consent.js script. It is used by the Privacy Center's test suite to ensure the a users's consent choices can be accessed by pages that live outside of the Privacy Center.
+        </p>
 
-      <h2>Was the fides global defined?</h2>
-      <pre id="has-fides"></pre>
+        <h2>Was the fides global defined?</h2>
+        <pre id="has-fides"></pre>
 
-      <h2>Consent JSON</h2>
-      <pre id="consent-json"></pre>
+        <h2>Consent JSON</h2>
+        <pre id="consent-json"></pre>
+
+        <h2>Consent Banner Options</h2>
+        <pre id="consent-banner-options"></pre>
     </main>
-  </body>
+</body>
 
-  <script>
+<script>
     (() => {
-      const hasFides = typeof Fides === "object";
-      document.getElementById("has-fides").textContent = String(hasFides);
+        const hasFides = typeof Fides === "object";
+        document.getElementById("has-fides").textContent = String(hasFides);
 
-      if (!hasFides) {
-        return;
-      }
+        if (!hasFides) {
+            return;
+        }
 
-      // Pretty-print the fides consent object and add it to the page.
-      document.getElementById("consent-json").textContent = JSON.stringify(
-        Fides.consent,
-        null,
-        2
-      );
+        // Initialize the banner, providing any test options (if injected by test code)
+        Fides.banner(window.fidesConsentBannerOptions);
 
-      // Test behavior of integrations that can be configured without/before their platform scripts.
-      Fides.gtm();
-      Fides.meta({
-        consent: Fides.consent.tracking,
-        dataUse: Fides.consent.data_sales,
-      });
+        // Pretty-print the fides consent object and add it to the page.
+        document.getElementById("consent-json").textContent = JSON.stringify(
+            Fides.consent,
+            null,
+            2
+        );
+
+        // Pretty-print the fides consent banner options object and add it to the page.
+        document.getElementById("consent-banner-options").textContent = JSON.stringify(
+            Fides.getBannerOptions(),
+            null,
+            2
+        );
+
+        // Test behavior of integrations that can be configured without/before their platform scripts.
+        Fides.gtm();
+        Fides.meta({
+            consent: Fides.consent.tracking,
+            dataUse: Fides.consent.data_sales,
+        });
     })();
-  </script>
+</script>
+
 </html>


### PR DESCRIPTION
### Code Changes

* [X] Render a basic consent banner via `Fides.banner()`
* [X] Add support for banner options via `Fides.banner(options)`
* [X] Add basic styles for banner that support customization with CSS
* [X] Skip banner initialization when `fides_consent` cookie exists on device
* [X] Support accept all / reject all choices and save the `fides_consent` cookie
* [ ] Save consent preferences to Fides API when a banner choice is made
* [X] Support using a geolocation API to only enable banner in certain countries
* [X] Add Cypress tests for all functionality

### Steps to Confirm

* [X] Run all Privacy Center Cypress tests with `npm run cy:run`
* [X] Run `npm run dev` and load http://localhost:3000/fides-consent-demo.html to try it out

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

In the coming months we'd like to extend the Fides Privacy Center outward by supporting a consent banner that users can add to their website to prompt users for consent. This is particularly important for "opt-in" consent options, like tracking cookies for the ePrivacy Directive or GDPR!

This banner is a basic proof-of-concept to see how we might extend `fides-consent.js` with this functionality. Here's a quick Loom showing it in action:

