### PR TITLE
Add `execution.require_manual_request_approval` to supported config API

### DIFF
--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -1676,7 +1676,7 @@ def create_privacy_request_func(
                     privacy_request_data.identity,
                     config_proxy.notifications.notification_service_type,
                 )
-            if not CONFIG.execution.require_manual_request_approval:
+            if not config_proxy.execution.require_manual_request_approval:
                 AuditLog.create(
                     db=db,
                     data={

--- a/src/fides/api/ops/schemas/application_config.py
+++ b/src/fides/api/ops/schemas/application_config.py
@@ -41,6 +41,9 @@ class NotificationApplicationConfig(BaseSchema):
     send_request_review_notification: Optional[bool]
     notification_service_type: Optional[str]
 
+    class Config:
+        extra = Extra.forbid
+
     @validator("notification_service_type", pre=True)
     @classmethod
     def validate_notification_service_type(cls, value: str) -> Optional[str]:

--- a/src/fides/api/ops/schemas/application_config.py
+++ b/src/fides/api/ops/schemas/application_config.py
@@ -57,7 +57,8 @@ class NotificationApplicationConfig(BaseSchema):
 
 
 class ExecutionApplicationConfig(BaseSchema):
-    subject_identity_verification_required: bool
+    subject_identity_verification_required: Optional[bool]
+    require_manual_request_approval: Optional[bool]
 
     class Config:
         extra = Extra.forbid

--- a/src/fides/core/config/config_proxy.py
+++ b/src/fides/core/config/config_proxy.py
@@ -51,6 +51,7 @@ class ExecutionSettingsProxy(ConfigProxyBase):
     prefix = "execution"
 
     subject_identity_verification_required: bool
+    require_manual_request_approval: bool
 
 
 class StorageSettingsProxy(ConfigProxyBase):

--- a/src/fides/core/config/utils.py
+++ b/src/fides/core/config/utils.py
@@ -52,6 +52,7 @@ CONFIG_KEY_ALLOWLIST = {
         "task_retry_delay",
         "task_retry_backoff",
         "require_manual_request_approval",
+        "subject_identity_verification_required",
     ],
     "storage": [
         "active_default_storage_type",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -566,12 +566,14 @@ def analytics_opt_out():
 
 
 @pytest.fixture
-def require_manual_request_approval():
+def require_manual_request_approval(db):
     """Require manual request approval"""
     original_value = CONFIG.execution.require_manual_request_approval
     CONFIG.execution.require_manual_request_approval = True
+    ApplicationConfig.update_config_set(db, CONFIG)
     yield
     CONFIG.execution.require_manual_request_approval = original_value
+    ApplicationConfig.update_config_set(db, CONFIG)
 
 
 @pytest.fixture

--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -27,7 +27,10 @@ class TestPatchApplicationConfig:
                 "send_request_receipt_notification": True,
                 "send_request_review_notification": True,
             },
-            "execution": {"subject_identity_verification_required": True},
+            "execution": {
+                "subject_identity_verification_required": True,
+                "require_manual_request_approval": True,
+            },
         }
 
     def test_patch_application_config_unauthenticated(
@@ -383,7 +386,10 @@ class TestDeleteApplicationConfig:
                 "send_request_receipt_notification": True,
                 "send_request_review_notification": True,
             },
-            "execution": {"subject_identity_verification_required": True},
+            "execution": {
+                "subject_identity_verification_required": True,
+                "require_manual_request_approval": True,
+            },
         }
 
     def test_reset_application_config(


### PR DESCRIPTION
In initial config API implementation, I forgot about the "manual request approval" setting and that we should support that through the API, in order to allow the UI-based system config to turn this on by default, when a messaging provider is configured.

This PR adds in support for setting this property via the config API.

### Code Changes

* allow/support `execution.require_manual_request_approval` setting via config API
* update our code references to this property to use the `config_proxy` rather than the basic `CONFIG` object, so that API changes are picked up by the app during privacy request execution
* some small fixes/cleanup in related areas of config API

