### PR TITLE
[2460]: Change "manual webhook" to "manual process"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The types of changes are:
   * Add flow for selecting system types when manually creating a system [#2530](https://github.com/ethyca/fides/pull/2530)
   * Updated forms for privacy declarations [#2648](https://github.com/ethyca/fides/pull/2648)
   * Delete flow for privacy declarations [#2664](https://github.com/ethyca/fides/pull/2664)
+  * "Manual Webhook" has been renamed to "Manual Process". [#2717](https://github.com/ethyca/fides/pull/2717)
 * Convert all config values to Pydantic `Field` objects [#2613](https://github.com/ethyca/fides/pull/2613)
 * Add warning to 'fides deploy' when installed outside of a virtual environment [#2641](https://github.com/ethyca/fides/pull/2641)
 * Change how config creation/import is handled across the application [#2622](https://github.com/ethyca/fides/pull/2622)

--- a/clients/admin-ui/cypress/fixtures/connectors/connection_types.json
+++ b/clients/admin-ui/cypress/fixtures/connectors/connection_types.json
@@ -57,7 +57,7 @@
     {
       "identifier": "manual_webhook",
       "type": "manual",
-      "human_readable": "Manual Webhook",
+      "human_readable": "Manual Process",
       "encoded_icon": null
     },
     {

--- a/clients/admin-ui/src/constants.ts
+++ b/clients/admin-ui/src/constants.ts
@@ -109,15 +109,15 @@ export const USER_PRIVILEGES: UserPrivileges[] = [
     scope: "privacy-request:view_data",
   },
   {
-    privilege: "Create manual webhooks",
+    privilege: "Create manual processes",
     scope: "webhook:create_or_update",
   },
   {
-    privilege: "Read manual webhooks",
+    privilege: "Read manual processes",
     scope: "webhook:read",
   },
   {
-    privilege: "Delete manual webhooks",
+    privilege: "Delete manual processes",
     scope: "webhook:delete",
   },
 ];

--- a/clients/admin-ui/src/features/privacy-requests/manual-processing/ManualProcessingList.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/manual-processing/ManualProcessingList.tsx
@@ -229,7 +229,7 @@ const ManualProcessingList: React.FC<ManualProcessingListProps> = ({
                     <Td colSpan={3} pl="0">
                       <Center>
                         <Text>
-                          You don&lsquo;t have any Manual Webhook connections
+                          You don&lsquo;t have any Manual Process connections
                           set up yet.
                         </Text>
                       </Center>

--- a/src/fides/api/ops/models/connectionconfig.py
+++ b/src/fides/api/ops/models/connectionconfig.py
@@ -70,7 +70,7 @@ class ConnectionType(enum.Enum):
             ConnectionType.bigquery.value: "BigQuery",
             ConnectionType.manual.value: "Manual Connector",
             ConnectionType.email.value: "Email Connector",
-            ConnectionType.manual_webhook.value: "Manual Webhook",
+            ConnectionType.manual_webhook.value: "Manual Process",
             ConnectionType.timescale.value: "TimescaleDB",
             ConnectionType.fides.value: "Fides Connector",
             ConnectionType.sovrn.value: "Sovrn",

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -310,7 +310,7 @@ class TestGetConnections:
             {
                 "identifier": "manual_webhook",
                 "type": "manual",
-                "human_readable": "Manual Webhook",
+                "human_readable": "Manual Process",
                 "encoded_icon": None,
             }
         ]


### PR DESCRIPTION
Closes #2460

### Code Changes

* Replaced "webhook" when it appears in user-visible strings
* Replaced the constant in Python where the human readable name is often referenced, even from the UI.

### Steps to Confirm

* [ ] Create a manual ~~webhook~~ process

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Note that the connector search compares by non-human-readable type, so "webhook" will still have results. See: https://github.com/ethyca/fides/issues/2460#issuecomment-1447232997
