### PR TITLE
Adds System Manager Endpoints [#2607]

### DIFF
--- a/src/fides/api/ops/api/v1/endpoints/user_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/user_endpoints.py
@@ -229,7 +229,6 @@ def update_system_manager(
     All systems the user manages are replaced with those in the request body.
     """
     user = validate_user_id(db, user_id)
-    logger.info("Updating systems for which user {} is system manager", user_id)
 
     if len(set(systems)) != len(systems):
         raise HTTPException(
@@ -243,6 +242,8 @@ def update_system_manager(
             status_code=HTTP_404_NOT_FOUND,
             detail=f"Cannot add user {user_id} as system manager. System(s) not found.",
         )
+
+    logger.info("Updating systems for which user {} is system manager", user_id)
 
     # Adding new systems for which the user is not already a manager
     for system in retrieved_systems:
@@ -289,13 +290,18 @@ def get_user_system(
     """
     system: System = get_system_by_fides_key(db, system_key)
     user = validate_user_id(db, user_id)
-    logger.info("Getting systems for which user {} is system manager", user_id)
 
     if not system in user.systems:
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND,
             detail=f"User {user_id} is not a manager of system {system.fides_key}",
         )
+
+    logger.info(
+        "Getting system {} for which user {} is system manager",
+        system.fides_key,
+        user_id,
+    )
 
     return system
 

--- a/src/fides/api/ops/api/v1/endpoints/user_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/user_endpoints.py
@@ -1,22 +1,30 @@
 import json
-from typing import Optional
+from typing import List, Optional
 
 import jose.exceptions
 from fastapi import Depends, HTTPException, Security
+from fideslang.models import System as SystemSchema
+from fideslang.validation import FidesKey
 from loguru import logger
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Query, Session
 from starlette.status import (
     HTTP_200_OK,
     HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
     HTTP_401_UNAUTHORIZED,
     HTTP_404_NOT_FOUND,
 )
 
+from fides.api.ctl.sql_models import System  # type: ignore[attr-defined]
 from fides.api.ops.api import deps
 from fides.api.ops.api.deps import get_db
 from fides.api.ops.api.v1 import urn_registry as urls
+from fides.api.ops.api.v1.endpoints.user_permission_endpoints import validate_user_id
 from fides.api.ops.api.v1.scope_registry import (
     SCOPE_REGISTRY,
+    SYSTEM_MANAGER_DELETE,
+    SYSTEM_MANAGER_READ,
+    SYSTEM_MANAGER_UPDATE,
     USER_PASSWORD_RESET,
     USER_UPDATE,
 )
@@ -42,6 +50,18 @@ from fides.lib.oauth.schemas.user import (
 )
 
 router = APIRouter(tags=["Users"], prefix=V1_URL_PREFIX)
+
+
+def get_system_by_fides_key(db: Session, system_key: FidesKey) -> System:
+    """Load a system by FidesKey or throw a 404"""
+    system = System.get_by(db, field="fides_key", value=system_key)
+
+    if not system:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"No system found with fides_key {system_key}.",
+        )
+    return system
 
 
 def _validate_current_user(user_id: str, user_from_token: FidesUser) -> None:
@@ -191,3 +211,114 @@ def user_logout(
     logger.info("Logging out user.")
     if client:
         client.delete(db)
+
+
+@router.put(
+    urls.SYSTEM_MANAGER,
+    dependencies=[Security(verify_oauth_client, scopes=[SYSTEM_MANAGER_UPDATE])],
+    response_model=List[SystemSchema],
+)
+def update_system_manager(
+    *,
+    db: Session = Depends(deps.get_db),
+    user_id: str,
+    systems: List[FidesKey],
+) -> List[SystemSchema]:
+    """
+    Endpoint to override the systems for which a user is "system manager".
+    All systems the user manages are replaced with those in the request body.
+    """
+    user = validate_user_id(db, user_id)
+    logger.info("Updating systems for which user {} is system manager", user_id)
+
+    if len(set(systems)) != len(systems):
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=f"Cannot add user {user_id} as system manager. Duplicate systems in request body.",
+        )
+
+    retrieved_systems: Query = db.query(System).filter(System.fides_key.in_(systems))
+    if retrieved_systems.count() != len(systems):
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Cannot add user {user_id} as system manager. System(s) not found.",
+        )
+
+    # Adding new systems for which the user is not already a manager
+    for system in retrieved_systems:
+        if user not in system.users:
+            user.set_as_system_manager(db, system)
+
+    # Removing systems for which the user in no longer a manager
+    for system in user.systems:
+        if system not in retrieved_systems:
+            user.remove_as_system_manager(db, system)
+
+    return user.systems
+
+
+@router.get(
+    urls.SYSTEM_MANAGER,
+    dependencies=[Security(verify_oauth_client, scopes=[SYSTEM_MANAGER_READ])],
+    response_model=List[SystemSchema],
+)
+def get_user_systems(
+    *,
+    db: Session = Depends(deps.get_db),
+    user_id: str,
+) -> List[SystemSchema]:
+    """
+    Endpoint to retrieve all the systems for which a user is "system manager".
+    """
+    user = validate_user_id(db, user_id)
+    logger.info("Getting systems for which user {} is system manager", user_id)
+
+    return user.systems
+
+
+@router.get(
+    urls.SYSTEM_MANAGER_DETAIL,
+    dependencies=[Security(verify_oauth_client, scopes=[SYSTEM_MANAGER_READ])],
+    response_model=SystemSchema,
+)
+def get_user_system(
+    *, db: Session = Depends(deps.get_db), user_id: str, system_key: FidesKey
+) -> SystemSchema:
+    """
+    Endpoint to retrieve a single system managed by the given user.
+    """
+    system: System = get_system_by_fides_key(db, system_key)
+    user = validate_user_id(db, user_id)
+    logger.info("Getting systems for which user {} is system manager", user_id)
+
+    if not system in user.systems:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"User {user_id} is not a manager of system {system.fides_key}",
+        )
+
+    return system
+
+
+@router.delete(
+    urls.SYSTEM_MANAGER_DETAIL,
+    dependencies=[Security(verify_oauth_client, scopes=[SYSTEM_MANAGER_DELETE])],
+    status_code=HTTP_204_NO_CONTENT,
+)
+def remove_user_as_system_manager(
+    *, db: Session = Depends(deps.get_db), user_id: str, system_key: FidesKey
+) -> None:
+    """
+    Endpoint to remove user as system manager from the given system
+    """
+    user = validate_user_id(db, user_id)
+    system: System = get_system_by_fides_key(db, system_key)
+
+    if not system in user.systems:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Cannot delete user as system manager. User {user_id} is not a manager of system {system.fides_key}.",
+        )
+
+    user.remove_as_system_manager(db, system)
+    logger.info("Removed user {} as system manager of {}", user_id, system.fides_key)

--- a/src/fides/api/ops/api/v1/scope_registry.py
+++ b/src/fides/api/ops/api/v1/scope_registry.py
@@ -49,6 +49,7 @@ SAAS_CONFIG = "saas_config"
 SCOPE = "scope"
 STORAGE = "storage"
 SYSTEM = "system"
+SYSTEM_MANAGER = "system_manager"
 TAXONOMY = "taxonomy"
 TRANSFER = "transfer"
 UPDATE = "update"
@@ -182,6 +183,11 @@ SYSTEM_READ = f"{SYSTEM}:{READ}"
 SYSTEM_UPDATE = f"{SYSTEM}:{UPDATE}"
 SYSTEM_DELETE = f"{SYSTEM}:{DELETE}"
 
+
+SYSTEM_MANAGER_READ = f"{SYSTEM_MANAGER}:{READ}"
+SYSTEM_MANAGER_UPDATE = f"{SYSTEM_MANAGER}:{UPDATE}"
+SYSTEM_MANAGER_DELETE = f"{SYSTEM_MANAGER}:{DELETE}"
+
 TAXONOMY_CREATE = f"{TAXONOMY}:{CREATE}"
 TAXONOMY_UPDATE = f"{TAXONOMY}:{UPDATE}"
 TAXONOMY_DELETE = f"{TAXONOMY}:{DELETE}"
@@ -294,6 +300,9 @@ SCOPE_DOCS = {
     SYSTEM_READ: "Read systems",
     SYSTEM_DELETE: "Delete systems",
     SYSTEM_UPDATE: "Update systems",
+    SYSTEM_MANAGER_READ: "Read systems users can manager",
+    SYSTEM_MANAGER_DELETE: "Delete systems user can manager",
+    SYSTEM_MANAGER_UPDATE: "Update systems user can manager",
     TAXONOMY_CREATE: "Create local taxonomy",
     TAXONOMY_DELETE: "Delete local taxonomy",
     TAXONOMY_UPDATE: "Update local taxonomy",

--- a/src/fides/api/ops/api/v1/urn_registry.py
+++ b/src/fides/api/ops/api/v1/urn_registry.py
@@ -139,6 +139,8 @@ USERS = "/user"
 USER_DETAIL = "/user/{user_id}"
 USER_PASSWORD_RESET = "/user/{user_id}/reset-password"
 USER_FORCE_PASSWORD_RESET = "/user/{user_id}/force-reset-password"
+SYSTEM_MANAGER = "/user/{user_id}/system-manager"
+SYSTEM_MANAGER_DETAIL = "/user/{user_id}/system-manager/{system_key}"
 
 # User Permission URLs
 USER_PERMISSIONS = "/user/{user_id}/permission"

--- a/src/fides/lib/oauth/roles.py
+++ b/src/fides/lib/oauth/roles.py
@@ -36,6 +36,7 @@ from fides.api.ops.api.v1.scope_registry import (
     SCOPE_READ,
     SCOPE_REGISTRY,
     STORAGE_READ,
+    SYSTEM_MANAGER_READ,
     SYSTEM_READ,
     USER_READ,
     WEBHOOK_READ,
@@ -97,6 +98,7 @@ viewer_scopes = [  # Intentionally omitted USER_PERMISSION_READ
     SYSTEM_READ,
     MESSAGING_READ,
     WEBHOOK_READ,
+    SYSTEM_MANAGER_READ,
     SAAS_CONFIG_READ,
     USER_READ,
 ]

--- a/tests/ops/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_endpoints.py
@@ -19,6 +19,9 @@ from fides.api.ops.api.v1.scope_registry import (
     PRIVACY_REQUEST_READ,
     SCOPE_REGISTRY,
     STORAGE_READ,
+    SYSTEM_MANAGER_DELETE,
+    SYSTEM_MANAGER_READ,
+    SYSTEM_MANAGER_UPDATE,
     USER_CREATE,
     USER_DELETE,
     USER_PASSWORD_RESET,
@@ -1228,3 +1231,277 @@ class TestUserLogout:
         # Even though client doesn't exist, we still return a 204
         response = api_client.post(url, headers=auth_header, json={})
         assert response.status_code == HTTP_204_NO_CONTENT
+
+
+class TestUpdateSystemsManagedByUser:
+    @pytest.fixture(scope="function")
+    def url(self, user) -> str:
+        return V1_URL_PREFIX + f"/user/{user.id}/system-manager"
+
+    def test_update_system_manager_not_authenticated(
+        self, api_client: TestClient, url: str
+    ) -> None:
+        resp = api_client.put(url, headers={})
+        assert resp.status_code == HTTP_401_UNAUTHORIZED
+
+    def test_update_system_manager_wrong_scope(
+        self, api_client: TestClient, generate_auth_header, url
+    ):
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_READ])
+        resp = api_client.put(url, headers=auth_header)
+        assert resp.status_code == HTTP_403_FORBIDDEN
+
+    def test_update_system_manager_user_not_found(
+        self, api_client: TestClient, generate_auth_header, url
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_UPDATE])
+        resp = api_client.put(
+            V1_URL_PREFIX + f"/user/bad_user/system-manager",
+            headers=auth_header,
+            json=["bad_fides_key"],
+        )
+        assert resp.status_code == HTTP_404_NOT_FOUND
+        assert resp.json()["detail"] == f"No user found with id bad_user."
+
+    def test_update_system_manager_system_not_found(
+        self, api_client: TestClient, generate_auth_header, url, user
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_UPDATE])
+        resp = api_client.put(url, headers=auth_header, json=["bad_fides_key"])
+        assert resp.status_code == HTTP_404_NOT_FOUND
+        assert (
+            resp.json()["detail"]
+            == f"Cannot add user {user.id} as system manager. System(s) not found."
+        )
+
+    def test_update_system_manager_dupe_systems_in_request(
+        self, api_client: TestClient, generate_auth_header, url, system, user
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_UPDATE])
+        resp = api_client.put(
+            url, headers=auth_header, json=[system.fides_key, system.fides_key]
+        )
+        assert resp.status_code == HTTP_400_BAD_REQUEST
+        assert (
+            resp.json()["detail"]
+            == f"Cannot add user {user.id} as system manager. Duplicate systems in request body."
+        )
+
+    def test_update_system_manager(
+        self, api_client: TestClient, generate_auth_header, url, system, user, db
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_UPDATE])
+        resp = api_client.put(url, headers=auth_header, json=[system.fides_key])
+        assert resp.status_code == HTTP_200_OK
+        response_body = resp.json()
+        assert len(response_body) == 1
+        assert response_body[0]["fides_key"] == system.fides_key
+
+        db.refresh(user)
+        assert user.systems == [system]
+
+    def test_update_system_manager_user_is_already_a_manager(
+        self, api_client: TestClient, generate_auth_header, url, system, user, db
+    ) -> None:
+        assert user.systems == []
+        user.set_as_system_manager(db, system)
+        assert user.systems == [system]
+
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_UPDATE])
+        resp = api_client.put(url, headers=auth_header, json=[system.fides_key])
+        assert resp.status_code == HTTP_200_OK
+        response_body = resp.json()
+        assert len(response_body) == 1
+        assert response_body[0]["fides_key"] == system.fides_key
+
+        db.refresh(user)
+        assert user.systems == [system]
+
+    def test_update_system_manager_existing_system_not_in_request(
+        self, api_client: TestClient, generate_auth_header, url, system, user, db
+    ) -> None:
+        assert user.systems == []
+        user.set_as_system_manager(db, system)
+        assert user.systems == [system]
+
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_UPDATE])
+        resp = api_client.put(url, headers=auth_header, json=[])
+        assert resp.status_code == HTTP_200_OK
+        response_body = resp.json()
+        assert len(response_body) == 0
+
+        db.refresh(user)
+        assert user.systems == []
+
+
+class TestGetSystemsUserManages:
+    @pytest.fixture(scope="function")
+    def url(self, user) -> str:
+        return V1_URL_PREFIX + f"/user/{user.id}/system-manager"
+
+    def test_get_systems_managed_by_user_not_authenticated(
+        self, api_client: TestClient, url: str
+    ) -> None:
+        resp = api_client.get(url, headers={})
+        assert resp.status_code == HTTP_401_UNAUTHORIZED
+
+    def test_get_systems_managed_by_user_wrong_scope(
+        self, api_client: TestClient, generate_auth_header, url
+    ):
+        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_READ])
+        resp = api_client.get(url, headers=auth_header)
+        assert resp.status_code == HTTP_403_FORBIDDEN
+
+    def test_get_systems_managed_by_user_not_found(
+        self, api_client: TestClient, generate_auth_header, url
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_READ])
+        resp = api_client.get(
+            V1_URL_PREFIX + f"/user/bad_user/system-manager", headers=auth_header
+        )
+        assert resp.status_code == HTTP_404_NOT_FOUND
+        assert resp.json()["detail"] == f"No user found with id bad_user."
+
+    def test_get_systems_managed_by_user_none_exist(
+        self, api_client: TestClient, generate_auth_header, url
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_READ])
+        resp = api_client.get(url, headers=auth_header)
+        assert resp.status_code == HTTP_200_OK
+        assert resp.json() == []
+
+    def test_get_systems_managed_by_user(
+        self, api_client: TestClient, generate_auth_header, url, user, system, db
+    ) -> None:
+        user.set_as_system_manager(db, system)
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_READ])
+        resp = api_client.get(url, headers=auth_header, json=["bad_fides_key"])
+        assert resp.status_code == HTTP_200_OK
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["fides_key"] == system.fides_key
+
+
+class TestGetSpecificSystemUserManages:
+    @pytest.fixture(scope="function")
+    def url(self, user, system) -> str:
+        return V1_URL_PREFIX + f"/user/{user.id}/system-manager/{system.fides_key}"
+
+    def test_get_system_managed_by_user_not_authenticated(
+        self, api_client: TestClient, url: str
+    ) -> None:
+        resp = api_client.get(url, headers={})
+        assert resp.status_code == HTTP_401_UNAUTHORIZED
+
+    def test_get_system_managed_by_user_wrong_scope(
+        self, api_client: TestClient, generate_auth_header, url
+    ):
+        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_READ])
+        resp = api_client.get(url, headers=auth_header)
+        assert resp.status_code == HTTP_403_FORBIDDEN
+
+    def test_get_system_managed_by_user_not_found(
+        self, api_client: TestClient, generate_auth_header, url, system
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_READ])
+        resp = api_client.get(
+            V1_URL_PREFIX + f"/user/bad_user/system-manager/{system.fides_key}",
+            headers=auth_header,
+        )
+        assert resp.status_code == HTTP_404_NOT_FOUND
+        assert resp.json()["detail"] == f"No user found with id bad_user."
+
+    def test_get_system_managed_by_user_system_does_not_exist(
+        self, api_client: TestClient, generate_auth_header, url, user
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_READ])
+        resp = api_client.get(
+            V1_URL_PREFIX + f"/user/{user.id}/system-manager/bad_system",
+            headers=auth_header,
+        )
+        assert resp.status_code == HTTP_404_NOT_FOUND
+        assert resp.json()["detail"] == f"No system found with fides_key bad_system."
+
+    def test_get_system_not_managed_by_user(
+        self, api_client: TestClient, generate_auth_header, url, user, system
+    ) -> None:
+        assert not user.systems
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_READ])
+        resp = api_client.get(url, headers=auth_header)
+        assert resp.status_code == HTTP_404_NOT_FOUND
+        assert (
+            resp.json()["detail"]
+            == f"User {user.id} is not a manager of system {system.fides_key}"
+        )
+
+    def test_get_system_managed_by_user(
+        self, api_client: TestClient, generate_auth_header, url, user, system, db
+    ) -> None:
+        user.set_as_system_manager(db, system)
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_READ])
+        resp = api_client.get(url, headers=auth_header)
+        assert resp.status_code == HTTP_200_OK
+        assert resp.json()["fides_key"] == system.fides_key
+
+
+class TestRemoveUserAsSystemManager:
+    @pytest.fixture(scope="function")
+    def url(self, user, system) -> str:
+        return V1_URL_PREFIX + f"/user/{user.id}/system-manager/{system.fides_key}"
+
+    def test_delete_user_as_system_manager_not_authenticated(
+        self, api_client: TestClient, url: str
+    ) -> None:
+        resp = api_client.delete(url, headers={})
+        assert resp.status_code == HTTP_401_UNAUTHORIZED
+
+    def test_delete_user_as_system_manager_wrong_scope(
+        self, api_client: TestClient, generate_auth_header, url
+    ):
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_READ])
+        resp = api_client.delete(url, headers=auth_header)
+        assert resp.status_code == HTTP_403_FORBIDDEN
+
+    def test_delete_user_as_system_manager_user_not_found(
+        self, api_client: TestClient, generate_auth_header, url, system
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_DELETE])
+        resp = api_client.delete(
+            V1_URL_PREFIX + f"/user/bad_user/system-manager/{system.fides_key}",
+            headers=auth_header,
+        )
+        assert resp.status_code == HTTP_404_NOT_FOUND
+        assert resp.json()["detail"] == f"No user found with id bad_user."
+
+    def test_delete_user_as_system_manager_from_nonexistent_system(
+        self, api_client: TestClient, generate_auth_header, url, user
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_DELETE])
+        resp = api_client.delete(
+            V1_URL_PREFIX + f"/user/{user.id}/system-manager/bad_system",
+            headers=auth_header,
+        )
+        assert resp.status_code == HTTP_404_NOT_FOUND
+        assert resp.json()["detail"] == f"No system found with fides_key bad_system."
+
+    def test_remove_user_from_system_not_managed_by_user(
+        self, api_client: TestClient, generate_auth_header, url, user, system
+    ) -> None:
+        assert not user.systems
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_DELETE])
+        resp = api_client.delete(url, headers=auth_header)
+        assert resp.status_code == HTTP_404_NOT_FOUND
+        assert (
+            resp.json()["detail"]
+            == f"Cannot delete user as system manager. User {user.id} is not a manager of system {system.fides_key}."
+        )
+
+    def test_delete_user_as_system_manager(
+        self, api_client: TestClient, generate_auth_header, url, user, system, db
+    ) -> None:
+        user.set_as_system_manager(db, system)
+        auth_header = generate_auth_header(scopes=[SYSTEM_MANAGER_DELETE])
+        resp = api_client.delete(url, headers=auth_header)
+        assert resp.status_code == HTTP_204_NO_CONTENT
+
+        db.refresh(user)
+        assert user.systems == []


### PR DESCRIPTION
❗ Depends on #2609 
Closes #2607

### Code Changes

#### Update systems for which user is system manager. 
Replaces all systems with systems in the request body. An empty list would remove a user as manager of all systems.
- PUT /user/{user_id}/system-manager
```json
["demo_analytics_system", "demo_marketing_system"]
```

#### Get all systems for which user is system manager. 
- GET /user/{user_id}/system-manager


#### Get details about a single system a user manages
- GET /user/{user_id}/system-manager/{system_key}

#### Remove user as system manager from a specific system.
- DELETE /user/{user_id}/system-manager/{system_key}

#### Adds new system manager scopes.  
#### Adds the read scopes to the viewer role.

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

- Add new endpoints to manage system managers. PUT system managers replaces all the systems the user manages with those in the request body.

