### PR TITLE
Consent Privacy Request Status when Identity Verification Required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The types of changes are:
 * Allow string dates to stay strings in cache decoding [#2695](https://github.com/ethyca/fides/pull/2695)
 * Admin UI
   * Remove Identifiability (Data Qualifier) from taxonomy editor [2684](https://github.com/ethyca/fides/pull/2684)
+* Fix Privacy Request Status when submitting a consent request when identity verification is required [#2736](https://github.com/ethyca/fides/pull/2736)
 
 ## [2.7.0](https://github.com/ethyca/fides/compare/2.6.6...2.7.0)
 

--- a/src/fides/api/ops/api/v1/endpoints/drp_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/drp_endpoints.py
@@ -93,7 +93,10 @@ async def create_drp_privacy_request(
         )
 
     privacy_request_kwargs: Dict[str, Any] = build_required_privacy_request_kwargs(
-        None, policy.id, config_proxy.execution.subject_identity_verification_required
+        None,
+        policy.id,
+        config_proxy.execution.subject_identity_verification_required,
+        authenticated=False,
     )
 
     try:

--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -1633,6 +1633,7 @@ def create_privacy_request_func(
             privacy_request_data.requested_at,
             policy.id,
             config_proxy.execution.subject_identity_verification_required,
+            authenticated,
         )
         for field in optional_fields:
             attr = getattr(privacy_request_data, field)

--- a/src/fides/api/ops/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/ops/service/privacy_request/request_runner_service.py
@@ -554,7 +554,8 @@ def initiate_privacy_request_completion_email(
             service_type=config_proxy.notifications.notification_service_type,
             message_body_params=AccessRequestCompleteBodyParams(
                 download_links=access_result_urls,
-                subject_request_download_time_in_days=CONFIG.security.subject_request_download_link_ttl_seconds / 86400,
+                subject_request_download_time_in_days=CONFIG.security.subject_request_download_link_ttl_seconds
+                / 86400,
             ),
         )
     if policy.get_rules_for_action(action_type=ActionType.erasure):

--- a/src/fides/api/ops/service/privacy_request/request_service.py
+++ b/src/fides/api/ops/service/privacy_request/request_service.py
@@ -22,6 +22,7 @@ def build_required_privacy_request_kwargs(
     requested_at: Optional[datetime],
     policy_id: str,
     verification_required: bool,
+    authenticated: bool,
 ) -> Dict[str, Any]:
     """Build kwargs required for creating privacy request
 
@@ -30,7 +31,7 @@ def build_required_privacy_request_kwargs(
     """
     status = (
         PrivacyRequestStatus.identity_unverified
-        if verification_required
+        if verification_required and not authenticated
         else PrivacyRequestStatus.pending
     )
     return {

--- a/tests/fixtures/saas/vend_fixtures.py
+++ b/tests/fixtures/saas/vend_fixtures.py
@@ -27,15 +27,13 @@ secrets = get_secrets("vend")
 def vend_secrets(saas_config):
     return {
         "domain": pydash.get(saas_config, "vend.domain") or secrets["domain"],
-        "token": pydash.get(saas_config, "vend.token") or secrets["token"]
+        "token": pydash.get(saas_config, "vend.token") or secrets["token"],
     }
 
 
 @pytest.fixture(scope="session")
 def vend_identity_email(saas_config):
-    return (
-        pydash.get(saas_config, "vend.identity_email") or secrets["identity_email"]
-    )
+    return pydash.get(saas_config, "vend.identity_email") or secrets["identity_email"]
 
 
 @pytest.fixture(scope="function")
@@ -60,10 +58,9 @@ def vend_dataset() -> Dict[str, Any]:
         "vend_instance",
     )[0]
 
+
 @pytest.fixture(scope="function")
-def vend_connection_config(
-    db: Session, vend_config, vend_secrets
-) -> Generator:
+def vend_connection_config(db: Session, vend_config, vend_secrets) -> Generator:
     fides_key = vend_config["fides_key"]
     connection_config = ConnectionConfig.create(
         db=db,
@@ -78,6 +75,7 @@ def vend_connection_config(
     )
     yield connection_config
     connection_config.delete(db)
+
 
 @pytest.fixture
 def vend_dataset_config(
@@ -121,13 +119,15 @@ def vend_create_erasure_data(
         "first_name": "Ethyca",
         "last_name": "Test Erasure",
         "email": vend_erasure_identity_email,
-        "do_not_email": "true"
+        "do_not_email": "true",
     }
 
-    customers_response = requests.post(url=f"{base_url}/api/2.0/customers", headers=headers, json=body)
+    customers_response = requests.post(
+        url=f"{base_url}/api/2.0/customers", headers=headers, json=body
+    )
     customer = customers_response.json()
 
-    # there is no endpoint to create a sale so we cannot test it 
+    # there is no endpoint to create a sale so we cannot test it
     sleep(60)
 
     yield customer

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -77,8 +77,6 @@ from fides.api.ops.schemas.messaging.messaging import (
 from fides.api.ops.schemas.policy import PolicyResponse
 from fides.api.ops.schemas.redis_cache import Identity
 from fides.api.ops.task import graph_task
-from fides.api.ops.task.graph_task import run_access_request
-from fides.api.ops.task.task_resources import TaskResources
 from fides.api.ops.tasks import MESSAGING_QUEUE_NAME
 from fides.api.ops.util.cache import (
     get_encryption_cache_key,

--- a/tests/ops/service/privacy_request/request_runner_service_test.py
+++ b/tests/ops/service/privacy_request/request_runner_service_test.py
@@ -1986,7 +1986,7 @@ class TestPrivacyRequestsEmailNotifications:
                     service_type=MessagingServiceType.MAILGUN.value,
                     message_body_params=AccessRequestCompleteBodyParams(
                         subject_request_download_time_in_days=download_time_in_days,
-                        download_links=[upload_mock.return_value]
+                        download_links=[upload_mock.return_value],
                     ),
                 ),
                 call(

--- a/tests/ops/service/privacy_request/test_request_service.py
+++ b/tests/ops/service/privacy_request/test_request_service.py
@@ -1,10 +1,13 @@
+from datetime import datetime
+
 import pytest
 from httpx import HTTPStatusError
 
 from fides.api.ctl.database.seed import create_or_update_parent_user
 from fides.api.ops.api.v1.urn_registry import LOGIN, V1_URL_PREFIX
-from fides.api.ops.models.privacy_request import PrivacyRequest
+from fides.api.ops.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
 from fides.api.ops.service.privacy_request.request_service import (
+    build_required_privacy_request_kwargs,
     poll_server_for_completion,
 )
 from fides.core.config import CONFIG
@@ -108,3 +111,40 @@ async def test_poll_server_for_completion_non_200(async_api_client, db, policy):
             client=async_api_client,
             poll_interval_seconds=1,
         )
+
+
+class TestBuildPrivacyRequestRequiredKwargs:
+    def test_build_required_privacy_request_kwargs_authenticated(self):
+        resp = build_required_privacy_request_kwargs(
+            requested_at=datetime.now(),
+            policy_id="test_id",
+            verification_required=True,
+            authenticated=True,
+        )
+        assert resp["requested_at"] is not None
+        assert resp["policy_id"] == "test_id"
+        assert resp["status"] == PrivacyRequestStatus.pending
+
+    def test_build_required_privacy_request_kwargs_not_authenticated(self):
+        resp = build_required_privacy_request_kwargs(
+            requested_at=datetime.now(),
+            policy_id="test_id",
+            verification_required=True,
+            authenticated=False,
+        )
+        assert resp["requested_at"] is not None
+        assert resp["policy_id"] == "test_id"
+        assert resp["status"] == PrivacyRequestStatus.identity_unverified
+
+    def test_build_required_privacy_request_kwargs_identity_verification_not_required(
+        self,
+    ):
+        resp = build_required_privacy_request_kwargs(
+            requested_at=datetime.now(),
+            policy_id="test_id",
+            verification_required=False,
+            authenticated=False,
+        )
+        assert resp["requested_at"] is not None
+        assert resp["policy_id"] == "test_id"
+        assert resp["status"] == PrivacyRequestStatus.pending


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2735

### Code Changes

* [ ] Update the logic as to which initial status a Privacy Request is given.  If the request is already authenticated, even if subject_identity_verification_required=True, this should be a `PENDING` request, not "identity unverified".  This was putting the consent request in a non-executable state. It's identity was already verified, but the privacy request is sitting there in the wrong state and can't be manually approved.

### Steps to Confirm

* [x]  Set your `src/fides/data/test_env/fides.test_env.toml` file to have `subject_identity_verification_required = true`
* [x] Update one consent option in the test env config.json to be executable. Rebuild the privacy center
* [x]  Run `nox -s fides_env(dev)`
* [x] Setup mailgun locally
* [x] Go to the privacy center. Do a hard refresh
* [x] Click on Manage your consent and enter an email you control
* [x] Go to your email and retrieve the verification code
* [x] Return to the privacy center and enter the code into the `Enter verification code` modal and click submit
* [x] Update your consent preferences and click save
* [x] Login to the admin app.  You should see the associated privacy request with a status of "New" instead of "Identity Unverified"

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

 When updating consent preferences, and subject_identity_verification_required is True, Privacy Request should be put in a status of "pending" not "identity_unverified" as identity was verified before the consent preferences were saved.


![Screenshot 2023-03-02 at 2 42 14 PM](https://user-images.githubusercontent.com/9755598/222547227-71108522-9840-4de8-8cc7-4b97246eed02.png)


