### PR TITLE
Overhaul Roles and Roles Mapping [#2720]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The types of changes are:
 * Add warning to 'fides deploy' when installed outside of a virtual environment [#2641](https://github.com/ethyca/fides/pull/2641)
 * Redesigned the default/init config file to be auto-documented. Also updates the `fides init` logic and analytics consent logic [#2694](https://github.com/ethyca/fides/pull/2694)
 * Change how config creation/import is handled across the application [#2622](https://github.com/ethyca/fides/pull/2622)
+* Updates Roles->Scopes Mapping [#2744](https://github.com/ethyca/fides/pull/2744)
 
 ### Developer Experience
 

--- a/scripts/setup/user.py
+++ b/scripts/setup/user.py
@@ -6,7 +6,7 @@ from loguru import logger
 from fides.api.ops.api.v1 import urn_registry as urls
 from fides.api.ops.api.v1.scope_registry import SCOPE_REGISTRY
 from fides.core.config import CONFIG
-from fides.lib.oauth.roles import ADMIN
+from fides.lib.oauth.roles import OWNER
 
 from . import constants
 

--- a/src/fides/api/ctl/migrations/versions/9f38dad37628_redo_roles_scopes_mapping.py
+++ b/src/fides/api/ctl/migrations/versions/9f38dad37628_redo_roles_scopes_mapping.py
@@ -1,0 +1,59 @@
+"""Redo roles scopes mapping
+
+Revision ID: 9f38dad37628
+Revises: eb1e6ec39b83
+Create Date: 2023-03-03 16:53:03.553992
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+from sqlalchemy import text
+from sqlalchemy.engine import ResultProxy
+
+revision = "9f38dad37628"
+down_revision = "eb1e6ec39b83"
+branch_labels = None
+depends_on = None
+
+
+def swap_roles(old_role: str, new_role: str):
+    bind = op.get_bind()
+    matched_rows: ResultProxy = bind.execute(
+        text("SELECT * FROM fidesuserpermissions WHERE :old_role = ANY(roles);"),
+        {"old_role": old_role},
+    )
+    for row in matched_rows:
+        current_roles = row["roles"]
+        current_roles.remove(old_role)
+        current_roles.append(new_role)
+        bind.execute(
+            text("UPDATE fidesuserpermissions SET roles= :roles WHERE id= :id"),
+            {"roles": sorted(list(set(current_roles))), "id": row["id"]},
+        )
+
+    matched_client_rows: ResultProxy = bind.execute(
+        text("SELECT * FROM client WHERE :old_role = ANY(roles);"),
+        {"old_role": old_role},
+    )
+    for row in matched_client_rows:
+        client_roles = row["roles"]
+        client_roles.remove(old_role)
+        client_roles.append(new_role)
+        bind.execute(
+            text("UPDATE client SET roles= :roles WHERE id= :id"),
+            {"roles": sorted(list(set(client_roles))), "id": row["id"]},
+        )
+
+
+def upgrade():
+    swap_roles("admin", "owner")
+    swap_roles("viewer_and_privacy_request_manager", "viewer_and_approver")
+    swap_roles("privacy_request_manager", "approver")
+
+
+def downgrade():
+    swap_roles("owner", "admin")
+    swap_roles("viewer_and_approver", "viewer_and_privacy_request_manager")
+    swap_roles("approver", "privacy_request_manager")

--- a/src/fides/core/config/security_settings.py
+++ b/src/fides/core/config/security_settings.py
@@ -9,7 +9,7 @@ from slowapi.wrappers import parse_many  # type: ignore
 
 from fides.api.ops.api.v1.scope_registry import SCOPE_REGISTRY
 from fides.lib.cryptography.cryptographic_util import generate_salt, hash_with_salt
-from fides.lib.oauth.roles import ADMIN
+from fides.lib.oauth.roles import OWNER
 
 from .fides_settings import FidesSettings
 
@@ -98,7 +98,7 @@ class SecuritySettings(FidesSettings):
         description="The list of scopes that are given to the root user.",
     )
     root_user_roles: List[str] = Field(
-        default=[ADMIN],
+        default=[OWNER],
         description="The list of roles that are given to the root user.",
     )
     root_password: Optional[str] = Field(

--- a/src/fides/lib/oauth/roles.py
+++ b/src/fides/lib/oauth/roles.py
@@ -10,51 +10,56 @@ from fides.api.ops.api.v1.scope_registry import (
     CONSENT_READ,
     DATAMAP_READ,
     DATASET_READ,
+    MESSAGING_CREATE_OR_UPDATE,
+    MESSAGING_DELETE,
     MESSAGING_READ,
     POLICY_READ,
     PRIVACY_REQUEST_CALLBACK_RESUME,
-    PRIVACY_REQUEST_CREATE,
-    PRIVACY_REQUEST_DELETE,
     PRIVACY_REQUEST_NOTIFICATIONS_CREATE_OR_UPDATE,
     PRIVACY_REQUEST_NOTIFICATIONS_READ,
     PRIVACY_REQUEST_READ,
     PRIVACY_REQUEST_REVIEW,
-    PRIVACY_REQUEST_TRANSFER,
     PRIVACY_REQUEST_UPLOAD_DATA,
     PRIVACY_REQUEST_VIEW_DATA,
     RULE_READ,
     SAAS_CONFIG_READ,
     SCOPE_READ,
     SCOPE_REGISTRY,
+    STORAGE_CREATE_OR_UPDATE,
+    STORAGE_DELETE,
     STORAGE_READ,
     USER_READ,
     WEBHOOK_READ,
 )
 
-PRIVACY_REQUEST_MANAGER = "privacy_request_manager"
+APPROVER = "approver"
+CONTRIBUTOR = "contributor"
+OWNER = "owner"
 VIEWER = "viewer"
-VIEWER_AND_PRIVACY_REQUEST_MANAGER = "viewer_and_privacy_request_manager"
-ADMIN = "admin"
+VIEWER_AND_APPROVER = "viewer_and_approver"
 
 
 class RoleRegistry(Enum):
-    """Enum of available roles"""
+    """Enum of available roles
 
-    admin = ADMIN
-    viewer_and_privacy_request_manager = VIEWER_AND_PRIVACY_REQUEST_MANAGER
+    Owner - Full admin
+    Viewer - Can view everything
+    Approver - Limited viewer but can approve Privacy Requests
+    Viewer + Approver = Full View and can approve Privacy Requests
+    Contributor - Can't configure storage and messaging
+    """
+
+    owner = OWNER
+    viewer_approver = VIEWER_AND_APPROVER
     viewer = VIEWER
-    privacy_request_manager = PRIVACY_REQUEST_MANAGER
+    approver = APPROVER
+    contributor = CONTRIBUTOR
 
 
-privacy_request_manager_scopes = [
-    PRIVACY_REQUEST_CREATE,
+approver_scopes = [
     PRIVACY_REQUEST_REVIEW,
     PRIVACY_REQUEST_READ,
-    PRIVACY_REQUEST_DELETE,
     PRIVACY_REQUEST_CALLBACK_RESUME,
-    PRIVACY_REQUEST_NOTIFICATIONS_CREATE_OR_UPDATE,
-    PRIVACY_REQUEST_NOTIFICATIONS_READ,
-    PRIVACY_REQUEST_TRANSFER,
     PRIVACY_REQUEST_UPLOAD_DATA,
     PRIVACY_REQUEST_VIEW_DATA,
 ]
@@ -81,13 +86,20 @@ viewer_scopes = [  # Intentionally omitted USER_PERMISSION_READ
     USER_READ,
 ]
 
+not_contributor_scopes = [
+    STORAGE_CREATE_OR_UPDATE,
+    STORAGE_DELETE,
+    MESSAGING_CREATE_OR_UPDATE,
+    MESSAGING_DELETE,
+    PRIVACY_REQUEST_NOTIFICATIONS_CREATE_OR_UPDATE,
+]
+
 ROLES_TO_SCOPES_MAPPING: Dict[str, List] = {
-    ADMIN: sorted(SCOPE_REGISTRY),
-    VIEWER_AND_PRIVACY_REQUEST_MANAGER: sorted(
-        list(set(viewer_scopes + privacy_request_manager_scopes))
-    ),
+    OWNER: sorted(SCOPE_REGISTRY),
+    VIEWER_AND_APPROVER: sorted(list(set(viewer_scopes + approver_scopes))),
     VIEWER: sorted(viewer_scopes),
-    PRIVACY_REQUEST_MANAGER: sorted(privacy_request_manager_scopes),
+    APPROVER: sorted(approver_scopes),
+    CONTRIBUTOR: sorted(list(set(SCOPE_REGISTRY) - set(not_contributor_scopes))),
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,10 +43,7 @@ from fides.lib.models.client import ClientDetail
 from fides.lib.models.fides_user import FidesUser
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
 from fides.lib.oauth.jwt import generate_jwe
-from fides.lib.oauth.roles import (
-    PRIVACY_REQUEST_MANAGER,
-    VIEWER_AND_PRIVACY_REQUEST_MANAGER,
-)
+from fides.lib.oauth.roles import APPROVER, CONTRIBUTOR, VIEWER_AND_APPROVER
 from tests.fixtures.application_fixtures import *
 from tests.fixtures.bigquery_fixtures import *
 from tests.fixtures.email_fixtures import *
@@ -665,16 +662,14 @@ def config_proxy(db):
 
 @pytest.fixture(scope="function")
 def oauth_role_client(db: Session) -> Generator:
-    """Return a client that has the admin role for authentication purposes"""
+    """Return a client that has all roles for authentication purposes
+    This is not a typical state but this client will then work with any
+    roles a token is given
+    """
     client = ClientDetail(
         hashed_secret="thisisatest",
         salt="thisisstillatest",
-        roles=[
-            ADMIN,
-            PRIVACY_REQUEST_MANAGER,
-            VIEWER,
-            VIEWER_AND_PRIVACY_REQUEST_MANAGER,
-        ],
+        roles=[OWNER, APPROVER, VIEWER, VIEWER_AND_APPROVER, CONTRIBUTOR],
     )  # Intentionally adding all roles here so the client will always
     # have a role that matches a role on a token for testing
     db.add(client)
@@ -718,10 +713,10 @@ def _generate_auth_role_header(
 
 
 @pytest.fixture
-def admin_client(db):
-    """Return a client with an "admin" role for authentication purposes."""
+def owner_client(db):
+    """Return a client with an "owner" role for authentication purposes."""
     client = ClientDetail(
-        hashed_secret="thisisatest", salt="thisisstillatest", scopes=[], roles=[ADMIN]
+        hashed_secret="thisisatest", salt="thisisstillatest", scopes=[], roles=[OWNER]
     )
     db.add(client)
     db.commit()
@@ -744,11 +739,11 @@ def viewer_client(db):
 
 
 @pytest.fixture
-def admin_user(db):
+def owner_user(db):
     user = FidesUser.create(
         db=db,
         data={
-            "username": "test_fides_admin_user",
+            "username": "test_fides_owner_user",
             "password": "TESTdcnG@wzJeu0&%3Qe2fGo7",
         },
     )
@@ -756,12 +751,12 @@ def admin_user(db):
         hashed_secret="thisisatest",
         salt="thisisstillatest",
         scopes=[],
-        roles=[ADMIN],
+        roles=[OWNER],
         user_id=user.id,
     )
 
     FidesUserPermissions.create(
-        db=db, data={"user_id": user.id, "scopes": [], "roles": [ADMIN]}
+        db=db, data={"user_id": user.id, "scopes": [], "roles": [OWNER]}
     )
 
     db.add(client)

--- a/tests/ctl/cli/test_cli.py
+++ b/tests/ctl/cli/test_cli.py
@@ -14,7 +14,7 @@ from fides.cli import cli
 from fides.core.config import CONFIG
 from fides.core.user import get_user_permissions
 from fides.core.utils import get_auth_header, read_credentials_file
-from fides.lib.oauth.roles import ADMIN
+from fides.lib.oauth.roles import OWNER
 
 OKTA_URL = "https://dev-78908748.okta.com"
 
@@ -951,7 +951,7 @@ class TestUser:
             credentials.user_id, get_auth_header(), CONFIG.cli.server_url
         )
         assert scopes == SCOPE_REGISTRY
-        assert roles == [ADMIN]
+        assert roles == [OWNER]
 
     @pytest.mark.unit
     def test_user_permissions_valid(
@@ -992,7 +992,7 @@ class TestUser:
             CONFIG.cli.server_url,
         )
         assert scopes == SCOPE_REGISTRY
-        assert roles == [ADMIN]
+        assert roles == [OWNER]
 
     @pytest.mark.unit
     def test_user_permissions_not_found(

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -71,7 +71,7 @@ from fides.lib.models.audit_log import AuditLog, AuditLogAction
 from fides.lib.models.client import ClientDetail
 from fides.lib.models.fides_user import FidesUser
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
-from fides.lib.oauth.roles import ADMIN, VIEWER
+from fides.lib.oauth.roles import OWNER, VIEWER
 
 logging.getLogger("faker").setLevel(logging.ERROR)
 # disable verbose faker logging
@@ -1628,59 +1628,3 @@ def system(db: Session) -> System:
         },
     )
     return system
-
-
-@pytest.fixture
-def admin_user(db):
-    user = FidesUser.create(
-        db=db,
-        data={
-            "username": "test_fides_admin_user",
-            "password": "TESTdcnG@wzJeu0&%3Qe2fGo7",
-        },
-    )
-    client = ClientDetail(
-        hashed_secret="thisisatest",
-        salt="thisisstillatest",
-        scopes=[],
-        roles=[ADMIN],
-        user_id=user.id,
-    )
-
-    FidesUserPermissions.create(
-        db=db, data={"user_id": user.id, "scopes": [], "roles": [ADMIN]}
-    )
-
-    db.add(client)
-    db.commit()
-    db.refresh(client)
-    yield user
-    user.delete(db)
-
-
-@pytest.fixture
-def viewer_user(db):
-    user = FidesUser.create(
-        db=db,
-        data={
-            "username": "test_fides_viewer_user",
-            "password": "TESTdcnG@wzJeu0&%3Qe2fGo7",
-        },
-    )
-    client = ClientDetail(
-        hashed_secret="thisisatest",
-        salt="thisisstillatest",
-        scopes=[],
-        roles=[VIEWER],
-        user_id=user.id,
-    )
-
-    FidesUserPermissions.create(
-        db=db, data={"user_id": user.id, "scopes": [], "roles": [VIEWER]}
-    )
-
-    db.add(client)
-    db.commit()
-    db.refresh(client)
-    yield user
-    user.delete(db)

--- a/tests/lib/test_client_model.py
+++ b/tests/lib/test_client_model.py
@@ -18,7 +18,7 @@ from fides.lib.cryptography.schemas.jwt import (
 )
 from fides.lib.models.client import ClientDetail, _get_root_client_detail
 from fides.lib.oauth.oauth_util import extract_payload
-from fides.lib.oauth.roles import ADMIN, VIEWER
+from fides.lib.oauth.roles import OWNER, VIEWER
 
 
 def test_create_client_and_secret(db, config):
@@ -133,23 +133,23 @@ def test_get_client_with_scopes(db, oauth_client, config):
     assert oauth_client.hashed_secret == "thisisatest"
 
 
-def test_get_client_with_roles(db, admin_client, config):
-    client = ClientDetail.get(db, object_id=admin_client.id, config=config)
+def test_get_client_with_roles(db, owner_client, config):
+    client = ClientDetail.get(db, object_id=owner_client.id, config=config)
     assert client
-    assert client.id == admin_client.id
+    assert client.id == owner_client.id
     assert client.scopes == []
-    assert client.roles == [ADMIN]
-    assert admin_client.hashed_secret == "thisisatest"
+    assert client.roles == [OWNER]
+    assert owner_client.hashed_secret == "thisisatest"
 
 
 def test_get_client_root_client(db, config):
     client = ClientDetail.get(
-        db, object_id="fidesadmin", config=config, scopes=SCOPE_REGISTRY, roles=[ADMIN]
+        db, object_id="fidesadmin", config=config, scopes=SCOPE_REGISTRY, roles=[OWNER]
     )
     assert client
     assert client.id == config.security.oauth_root_client_id
     assert client.scopes == SCOPE_REGISTRY
-    assert client.roles == [ADMIN]
+    assert client.roles == [OWNER]
 
 
 def test_get_root_client_no_scopes(db, config):
@@ -191,16 +191,16 @@ def test_client_create_access_code_jwe(oauth_client, config):
     assert token_data[JWE_PAYLOAD_ROLES] == []
 
 
-def test_client_create_access_code_jwe_admin_client(admin_client, config):
+def test_client_create_access_code_jwe_owner_client(owner_client, config):
 
-    jwe = admin_client.create_access_code_jwe(config.security.app_encryption_key)
+    jwe = owner_client.create_access_code_jwe(config.security.app_encryption_key)
 
     token_data = json.loads(extract_payload(jwe, config.security.app_encryption_key))
 
-    assert token_data[JWE_PAYLOAD_CLIENT_ID] == admin_client.id
+    assert token_data[JWE_PAYLOAD_CLIENT_ID] == owner_client.id
     assert token_data[JWE_PAYLOAD_SCOPES] == []
     assert token_data[JWE_ISSUED_AT] is not None
-    assert token_data[JWE_PAYLOAD_ROLES] == [ADMIN]
+    assert token_data[JWE_PAYLOAD_ROLES] == [OWNER]
 
 
 def test_client_create_access_code_jwe_viewer_client(viewer_client, config):

--- a/tests/lib/test_oauth_util.py
+++ b/tests/lib/test_oauth_util.py
@@ -509,9 +509,6 @@ class TestRolesToScopesMapping:
 
     def test_approver_roles(self):
         approver_scopes = set(ROLES_TO_SCOPES_MAPPING[APPROVER])
-        assert approver_scopes.issubset(
-            set(ROLES_TO_SCOPES_MAPPING[VIEWER_AND_APPROVER])
-        )
-        assert not ROLES_TO_SCOPES_MAPPING[VIEWER_AND_APPROVER].issubset(
-            set(approver_scopes)
-        )
+        viewer_and_approver_scopes = set(ROLES_TO_SCOPES_MAPPING[VIEWER_AND_APPROVER])
+        assert approver_scopes.issubset(viewer_and_approver_scopes)
+        assert not viewer_and_approver_scopes.issubset(approver_scopes)

--- a/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
@@ -33,7 +33,7 @@ from fides.api.ops.models.privacy_request import (
 from fides.api.ops.schemas.messaging.messaging import MessagingActionType
 from fides.api.ops.schemas.redis_cache import Identity
 from fides.lib.models.client import ClientDetail
-from fides.lib.oauth.roles import ADMIN, PRIVACY_REQUEST_MANAGER, VIEWER
+from fides.lib.oauth.roles import APPROVER, OWNER, VIEWER
 from tests.fixtures.application_fixtures import integration_secrets
 
 page_size = Params().size
@@ -90,17 +90,17 @@ class TestPatchConnections:
         response = api_client.patch(url, headers=auth_header, json=payload)
         assert 403 == response.status_code
 
-    def test_patch_connections_privacy_request_manager_role(
+    def test_patch_connections_approver_role(
         self, api_client: TestClient, generate_role_header, url, payload
     ) -> None:
-        auth_header = generate_role_header(roles=[PRIVACY_REQUEST_MANAGER])
+        auth_header = generate_role_header(roles=[APPROVER])
         response = api_client.patch(url, headers=auth_header, json=payload)
         assert 403 == response.status_code
 
-    def test_patch_connection_admin_role(
+    def test_patch_connection_owner_role(
         self, url, api_client, db: Session, generate_role_header
     ):
-        auth_header = generate_role_header(roles=[ADMIN])
+        auth_header = generate_role_header(roles=[OWNER])
         payload = [
             {
                 "name": "My Post-Execution Webhook",

--- a/tests/ops/api/v1/endpoints/test_oauth_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_oauth_endpoints.py
@@ -37,7 +37,7 @@ from fides.lib.cryptography.schemas.jwt import (
 from fides.lib.models.client import ClientDetail
 from fides.lib.oauth.jwt import generate_jwe
 from fides.lib.oauth.oauth_util import extract_payload
-from fides.lib.oauth.roles import ADMIN
+from fides.lib.oauth.roles import OWNER
 
 
 class TestCreateClient:
@@ -432,7 +432,7 @@ class TestAcquireAccessToken:
         assert data["client_id"] == extracted_token[JWE_PAYLOAD_CLIENT_ID]
         assert extracted_token[JWE_PAYLOAD_SCOPES] == SCOPE_REGISTRY
 
-        assert extracted_token[JWE_PAYLOAD_ROLES] == [ADMIN]
+        assert extracted_token[JWE_PAYLOAD_ROLES] == [OWNER]
 
     def test_get_access_token(self, db, url, api_client):
         new_client, secret = ClientDetail.create_client_and_secret(
@@ -567,10 +567,11 @@ class TestReadRoleMapping:
         response_body = json.loads(response.text)
 
         assert 200 == response.status_code
-        assert set(response_body["admin"]) == set(SCOPE_REGISTRY)
+        assert set(response_body["owner"]) == set(SCOPE_REGISTRY)
         assert set(response_body.keys()) == {
-            "admin",
-            "viewer_and_privacy_request_manager",
-            "privacy_request_manager",
+            "owner",
+            "viewer_and_approver",
+            "approver",
             "viewer",
+            "contributor",
         }

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -92,7 +92,7 @@ from fides.lib.cryptography.schemas.jwt import (
 from fides.lib.models.audit_log import AuditLog, AuditLogAction
 from fides.lib.models.client import ClientDetail
 from fides.lib.oauth.jwt import generate_jwe
-from fides.lib.oauth.roles import PRIVACY_REQUEST_MANAGER, VIEWER
+from fides.lib.oauth.roles import APPROVER, VIEWER
 
 page_size = Params().size
 
@@ -592,10 +592,10 @@ class TestGetPrivacyRequests:
         response = api_client.get(url, headers=auth_header)
         assert 403 == response.status_code
 
-    def test_get_privacy_requests_privacy_request_manager_role(
+    def test_get_privacy_requests_approver_role(
         self, api_client: TestClient, generate_role_header, url
     ):
-        auth_header = generate_role_header(roles=[PRIVACY_REQUEST_MANAGER])
+        auth_header = generate_role_header(roles=[APPROVER])
         response = api_client.get(url, headers=auth_header)
         assert 200 == response.status_code
 
@@ -1827,13 +1827,13 @@ class TestApprovePrivacyRequest:
     @mock.patch(
         "fides.api.ops.service.privacy_request.request_runner_service.run_privacy_request.delay"
     )
-    def test_approve_privacy_request_privacy_request_manager_role(
+    def test_approve_privacy_request_approver_role(
         self, _, url, api_client, generate_role_header, privacy_request, db
     ):
         privacy_request.status = PrivacyRequestStatus.pending
         privacy_request.save(db=db)
 
-        auth_header = generate_role_header(roles=[PRIVACY_REQUEST_MANAGER])
+        auth_header = generate_role_header(roles=[APPROVER])
         body = {"request_ids": [privacy_request.id]}
         response = api_client.patch(url, headers=auth_header, json=body)
         assert response.status_code == 200

--- a/tests/ops/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_endpoints.py
@@ -44,7 +44,7 @@ from fides.lib.models.fides_user import FidesUser
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
 from fides.lib.oauth.jwt import generate_jwe
 from fides.lib.oauth.oauth_util import extract_payload
-from fides.lib.oauth.roles import ADMIN, VIEWER
+from fides.lib.oauth.roles import OWNER, VIEWER
 from tests.conftest import generate_auth_header_for_user
 
 page_size = Params().size
@@ -437,8 +437,8 @@ class TestDeleteUser:
         assert permissions_search is None
 
         # Admin client who made the request is not deleted
-        admin_client_search = ClientDetail.get_by(db, field="id", value=user.client.id)
-        assert admin_client_search is not None
+        owner_client_search = ClientDetail.get_by(db, field="id", value=user.client.id)
+        assert owner_client_search is not None
 
 
 class TestGetUsers:
@@ -1007,17 +1007,17 @@ class TestUserLogin:
         assert "user_data" in list(response.json().keys())
         assert response.json()["user_data"]["id"] == user.id
 
-    def test_login_uses_existing_client_with_roles(self, url, admin_user, api_client):
+    def test_login_uses_existing_client_with_roles(self, url, owner_user, api_client):
         body = {
-            "username": admin_user.username,
+            "username": owner_user.username,
             "password": str_to_b64_str("TESTdcnG@wzJeu0&%3Qe2fGo7"),
         }
 
-        existing_client_id = admin_user.client.id
+        existing_client_id = owner_user.client.id
         response = api_client.post(url, headers={}, json=body)
         assert response.status_code == HTTP_200_OK
 
-        assert admin_user.client is not None
+        assert owner_user.client is not None
         assert "token_data" in list(response.json().keys())
         token = response.json()["token_data"]["access_token"]
         token_data = json.loads(
@@ -1025,10 +1025,10 @@ class TestUserLogin:
         )
         assert token_data["client-id"] == existing_client_id
         assert token_data["scopes"] == []
-        assert token_data["roles"] == [ADMIN]  # Uses roles on existing client
+        assert token_data["roles"] == [OWNER]  # Uses roles on existing client
 
         assert "user_data" in list(response.json().keys())
-        assert response.json()["user_data"]["id"] == admin_user.id
+        assert response.json()["user_data"]["id"] == owner_user.id
 
     def test_login_as_root_user(self, api_client, url):
         body = {
@@ -1046,7 +1046,7 @@ class TestUserLogin:
         )
         assert token_data["client-id"] == CONFIG.security.oauth_root_client_id
         assert token_data["scopes"] == SCOPE_REGISTRY  # Uses all scopes
-        assert token_data["roles"] == [ADMIN]  # Uses admin role
+        assert token_data["roles"] == [OWNER]  # Uses owner role
 
         assert "user_data" in list(response.json().keys())
         data = response.json()["user_data"]

--- a/tests/ops/api/v1/endpoints/test_user_permission_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_permission_endpoints.py
@@ -23,7 +23,7 @@ from fides.core.config import CONFIG
 from fides.lib.models.client import ClientDetail
 from fides.lib.models.fides_user import FidesUser
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
-from fides.lib.oauth.roles import ADMIN, VIEWER
+from fides.lib.oauth.roles import OWNER, VIEWER
 from tests.conftest import generate_auth_header_for_user, generate_role_header_for_user
 
 
@@ -198,7 +198,7 @@ class TestCreateUserPermissions:
         db.add(client)
         db.commit()
 
-        body = {"user_id": user.id, "roles": [ADMIN]}
+        body = {"user_id": user.id, "roles": [OWNER]}
         response = api_client.post(
             f"{V1_URL_PREFIX}/user/{user.id}/permission", headers=auth_header, json=body
         )
@@ -207,9 +207,9 @@ class TestCreateUserPermissions:
         assert HTTP_201_CREATED == response.status_code
         assert response_body["id"] == permissions.id
         assert permissions.scopes == []
-        assert permissions.roles == [ADMIN]
+        assert permissions.roles == [OWNER]
         db.refresh(client)
-        assert client.roles == [ADMIN]
+        assert client.roles == [OWNER]
         user.delete(db)
 
 
@@ -406,7 +406,7 @@ class TestEditUserPermissions:
             user_id=user.id,
         )
 
-        body = {"id": permissions.id, "roles": [ADMIN]}
+        body = {"id": permissions.id, "roles": [OWNER]}
         response = api_client.put(
             f"{V1_URL_PREFIX}/user/{user.id}/permission", headers=auth_header, json=body
         )
@@ -415,15 +415,15 @@ class TestEditUserPermissions:
         assert (
             response_body["scopes"] == []
         ), "Scopes removed as they were not specified in the request"
-        assert response_body["roles"] == [ADMIN]
+        assert response_body["roles"] == [OWNER]
 
         client: ClientDetail = ClientDetail.get_by(db, field="user_id", value=user.id)
         assert client.scopes == []
-        assert client.roles == [ADMIN]
+        assert client.roles == [OWNER]
 
         db.refresh(permissions)
         assert permissions.scopes == []
-        assert permissions.roles == [ADMIN]
+        assert permissions.roles == [OWNER]
 
         user.delete(db)
 
@@ -574,7 +574,7 @@ class TestGetUserPermissions:
         assert response_body["id"] == oauth_root_client.id
         assert response_body["user_id"] == oauth_root_client.id
         assert response_body["scopes"] == SCOPE_REGISTRY
-        assert response_body["roles"] == [ADMIN]
+        assert response_body["roles"] == [OWNER]
 
     def test_get_root_user_permissions_by_non_root_user(
         self, db, api_client, oauth_root_client, auth_user
@@ -650,12 +650,12 @@ class TestGetUserPermissions:
         )
         assert response.status_code == 403
 
-    def test_get_other_user_roles_as_admin(self, db, api_client, auth_user, admin_user):
+    def test_get_other_user_roles_as_owner(self, db, api_client, auth_user, owner_user):
         FidesUserPermissions.create(
             db=db, data={"user_id": auth_user.id, "roles": [VIEWER]}
         )
 
-        auth_header = generate_role_header_for_user(admin_user, roles=[ADMIN])
+        auth_header = generate_role_header_for_user(owner_user, roles=[OWNER])
 
         response = api_client.get(
             f"{V1_URL_PREFIX}/user/{auth_user.id}/permission",


### PR DESCRIPTION
Closes #2720 

### Code Changes

* [ ] The concept of backend roles is a very new feature.  But in the off chance someone has added a role to their user, added a data migration to swap out old roles with new roles on FidesUserPermission and Client tables
* [ ]  Updated Roles -> Scopes mapping to reflect new roles
* [ ] Reduced Approver (Formerly Privacy Request Manager) scopes.  Previously they had all privacy-request-* scopes, but discussed with product to refine
* [ ] Adjusted test fixtures related to users and clients with roles to have the correct names and new roles
* [ ] Get rid of some duplicate fixtures that were in two places.

### Steps to Confirm


* [ ] Create a user via the API with a client that has permissions to do so:
POST {{host}}/user
```json
{
    "username": "test_user",
    "password": "Testpassword1!"

}
```
* [ ] Update the role of that user, one of `owner`,  `viewer_and_approver` and `approver`, `contributor`, `viewer`

PUT {{host}}/user/{{user_id}}/permission
```json
{
    "id": "{user_id}",
    "roles": ["viewer"]
}

``` 
* [ ] Login as that user in the admin UI
* [ ] Navigate through various parts of the UI with different roles and observe in the network tab that some routes are restricted depending on your role.  Note that which scopes go with which role are still in flux.


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

We recently added some backend roles associated with lists of scopes here: https://github.com/ethyca/fides/pull/2671, the roles were Admin, Viewer, Privacy Request Manager, and Viewer + Privacy Request Manager.

Requirements have changed, and roles need to be renamed/rearranged.

New Roles are:

		- Owner: Full Admin
		- Viewer: Can view everything
		- Contributor: Can manage most things but can't adjust storage and messaging configs
		- Approver: Limited view but can approve privacy requests
		- Viewer + Approver: Full view and can approve privacy requests
