### PR TITLE
switch messaging service type db enum to use lowercase values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The types of changes are:
 * Update the CLI aesthetics & docstrings [#2703](https://github.com/ethyca/fides/pull/2703)
 * Updates Roles->Scopes Mapping [#2744](https://github.com/ethyca/fides/pull/2744)
 * Return user scopes as an enum, as well as total scopes [#2741](https://github.com/ethyca/fides/pull/2741)
+* Update `MessagingServiceType` enum to be lowercased throughout [#2746](https://github.com/ethyca/fides/pull/2746)
 
 ### Developer Experience
 

--- a/clients/admin-ui/cypress/e2e/privacy-requests.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-requests.cy.ts
@@ -169,7 +169,7 @@ describe("Privacy Requests", () => {
       cy.getByTestId("save-btn").click();
       cy.wait("@createMessagingConfiguration").then((interception) => {
         const { body } = interception.request;
-        expect(body.service_type).to.eql("MAILGUN");
+        expect(body.service_type).to.eql("mailgun");
         cy.contains(
           "Mailgun email successfully updated. You can now enter your security key."
         );

--- a/clients/admin-ui/cypress/fixtures/privacy-requests/messaging_configuration.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-requests/messaging_configuration.json
@@ -3,5 +3,5 @@
       "domain": "test-domain",
         "is_eu_domain": "false"
     },
-    "service_type": "MAILGUN"
+    "service_type": "mailgun"
   }

--- a/clients/admin-ui/src/features/privacy-requests/constants.ts
+++ b/clients/admin-ui/src/features/privacy-requests/constants.ts
@@ -15,9 +15,9 @@ export const SubjectRequestStatusMap = new Map<string, string>([
 ]);
 
 export const messagingProviders = {
-  mailgun: "MAILGUN",
-  twilio_email: "TWILIO_EMAIL",
-  twilio_text: "TWILIO_TEXT",
+  mailgun: "mailgun",
+  twilio_email: "twilio_email",
+  twilio_text: "twilio_text",
 };
 
 export const storageTypes = {

--- a/clients/admin-ui/src/types/api/models/MessagingServiceType.ts
+++ b/clients/admin-ui/src/types/api/models/MessagingServiceType.ts
@@ -3,10 +3,10 @@
 /* eslint-disable */
 
 /**
- * Enum for messaging service type. Upper-cased in the database
+ * Enum for messaging service type. Lower-cased in the database
  */
 export enum MessagingServiceType {
-  MAILGUN = "MAILGUN",
-  TWILIO_TEXT = "TWILIO_TEXT",
-  TWILIO_EMAIL = "TWILIO_EMAIL",
+  MAILGUN = "mailgun",
+  TWILIO_TEXT = "twilio_text",
+  TWILIO_EMAIL = "twilio_email",
 }

--- a/src/fides/api/ctl/migrations/versions/2f6aa5fe797a_update_messaging_service_type_enum.py
+++ b/src/fides/api/ctl/migrations/versions/2f6aa5fe797a_update_messaging_service_type_enum.py
@@ -1,0 +1,136 @@
+"""update messaging service_type enum
+
+Revision ID: 2f6aa5fe797a
+Revises: d65bbc647083
+Create Date: 2023-03-03 17:13:21.108111
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm.session import Session
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = "2f6aa5fe797a"
+down_revision = "39b209861471"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # create a temp enum type for old values
+    op.execute("alter type messagingservicetype rename to messagingservicetype_old")
+    # create a temp column for old values
+    op.alter_column(
+        "messagingconfig", "service_type", new_column_name="service_type_old"
+    )
+    # update the temp column to use the temp enum type
+    op.execute(
+        (
+            "alter table messagingconfig alter column service_type_old type messagingservicetype_old using "
+            "service_type_old::text::messagingservicetype_old"
+        )
+    )
+
+    # create the new enum type
+    messagingservicetype = postgresql.ENUM(
+        "mailgun",
+        "twilio_text",
+        "twilio_email",
+        "mailchimp_transactional",
+        name="messagingservicetype",
+        create_type=True,
+    )
+    messagingservicetype.create(op.get_bind())
+
+    # create the new column using the new enum type
+    op.add_column(
+        "messagingconfig",
+        sa.Column(
+            "service_type",
+            messagingservicetype,
+            nullable=True,  # allow it to be nullable temporarily
+            unique=True,
+        ),
+    )
+
+    # now actually migrate the old values to the new column
+    session = Session(bind=op.get_bind())
+    conn = session.connection()
+    statement = text(
+        """SELECT distinct LOWER(service_type_old::text) AS lower_service_type_old, id
+FROM messagingconfig"""
+    )
+
+    result = conn.execute(statement)
+    for row in result:
+
+        op.execute(
+            f"UPDATE messagingconfig SET service_type = '{row[0]}' WHERE id = '{row[1]}';"
+        )
+
+    # update our column to make it non-nullable now that it's populated
+    op.alter_column("messagingconfig", "service_type", nullable=False)
+
+    # and clean up our temporary resources
+    op.drop_column("messagingconfig", "service_type_old")
+    op.execute("drop type messagingservicetype_old")
+
+
+def downgrade():
+    # create a temp enum type for old values
+    op.execute("alter type messagingservicetype rename to messagingservicetype_old")
+    # create a temp column for old values
+    op.alter_column(
+        "messagingconfig", "service_type", new_column_name="service_type_old"
+    )
+    # update the temp column to use the temp enum type
+    op.execute(
+        (
+            "alter table messagingconfig alter column service_type_old type messagingservicetype_old using "
+            "service_type_old::text::messagingservicetype_old"
+        )
+    )
+
+    # create the new column with the new enum type
+    messagingservicetype = postgresql.ENUM(
+        "MAILGUN",
+        "TWILIO_TEXT",
+        "TWILIO_EMAIL",
+        "MAILCHIMP_TRANSACTIONAL",
+        name="messagingservicetype",
+        create_type=True,
+    )
+    messagingservicetype.create(op.get_bind())
+    op.add_column(
+        "messagingconfig",
+        sa.Column(
+            "service_type",
+            messagingservicetype,
+            nullable=True,  # allow it to be nullable temporarily
+            unique=True,
+        ),
+    )
+
+    # now actually migrate the old values to the new column
+    session = Session(bind=op.get_bind())
+    conn = session.connection()
+    statement = text(
+        """SELECT distinct UPPER(service_type_old::text) AS upper_service_type_old, id
+FROM messagingconfig"""
+    )
+
+    result = conn.execute(statement)
+    for row in result:
+
+        op.execute(
+            f"UPDATE messagingconfig SET service_type = '{row[0]}' WHERE id = '{row[1]}';"
+        )
+
+    # update our column to make it non-nullable now that it's populated
+    op.alter_column("messagingconfig", "service_type", nullable=False)
+
+    # and clean up our temporary resources
+    op.drop_column("messagingconfig", "service_type_old")
+    op.execute("drop type messagingservicetype_old")

--- a/src/fides/api/ops/api/v1/endpoints/messaging_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/messaging_endpoints.py
@@ -180,7 +180,7 @@ def get_active_default_config(*, db: Session = Depends(deps.get_db)) -> Messagin
                 "application/json": {
                     "example": {
                         "config_status": "configured",
-                        "detail": "Active default messaging service of type MAILGUN is fully configured",
+                        "detail": "Active default messaging service of type mailgun is fully configured",
                     }
                 }
             }

--- a/src/fides/api/ops/models/messaging.py
+++ b/src/fides/api/ops/models/messaging.py
@@ -56,10 +56,10 @@ def get_schema_for_secrets(
     """
     try:
         schema = {
-            MessagingServiceType.MAILCHIMP_TRANSACTIONAL: MessagingServiceSecretsMailchimpTransactional,
-            MessagingServiceType.MAILGUN: MessagingServiceSecretsMailgun,
-            MessagingServiceType.TWILIO_TEXT: MessagingServiceSecretsTwilioSMS,
-            MessagingServiceType.TWILIO_EMAIL: MessagingServiceSecretsTwilioEmail,
+            MessagingServiceType.mailgun: MessagingServiceSecretsMailgun,
+            MessagingServiceType.twilio_text: MessagingServiceSecretsTwilioSMS,
+            MessagingServiceType.twilio_email: MessagingServiceSecretsTwilioEmail,
+            MessagingServiceType.mailchimp_transactional: MessagingServiceSecretsMailchimpTransactional,
         }[service_type]
     except KeyError:
         raise ValueError(
@@ -127,7 +127,7 @@ class MessagingConfig(Base):
         """
         Retrieve the messaging config of the given type
         """
-        return db.query(cls).filter_by(service_type=service_type).first()
+        return db.query(cls).filter_by(service_type=service_type.value).first()
 
     def set_secrets(
         self,

--- a/src/fides/api/ops/schemas/application_config.py
+++ b/src/fides/api/ops/schemas/application_config.py
@@ -48,7 +48,7 @@ class NotificationApplicationConfig(BaseSchema):
     @classmethod
     def validate_notification_service_type(cls, value: str) -> Optional[str]:
         """Ensure the provided type is a valid value."""
-        value = value.upper()  # force uppercase for safety
+        value = value.lower()  # force lowercase for safety
         try:
             MessagingServiceType[value]
         except KeyError:

--- a/src/fides/api/ops/schemas/messaging/messaging.py
+++ b/src/fides/api/ops/schemas/messaging/messaging.py
@@ -23,18 +23,16 @@ class MessagingMethod(Enum):
 class MessagingServiceType(Enum):
     """Enum for messaging service type. Upper-cased in the database"""
 
-    MAILCHIMP_TRANSACTIONAL = "MAILCHIMP_TRANSACTIONAL"
-
-    MAILGUN = "MAILGUN"
-
-    TWILIO_TEXT = "TWILIO_TEXT"
-    TWILIO_EMAIL = "TWILIO_EMAIL"
+    mailgun = "mailgun"
+    twilio_text = "twilio_text"
+    twilio_email = "twilio_email"
+    mailchimp_transactional = "mailchimp_transactional"
 
     @classmethod
     def _missing_(
         cls: Type[MessagingServiceType], value: Any
     ) -> Optional[MessagingServiceType]:
-        value = value.upper()
+        value = value.lower()
         for member in cls:
             if member.value == value:
                 return member
@@ -42,11 +40,11 @@ class MessagingServiceType(Enum):
 
 
 EMAIL_MESSAGING_SERVICES: Tuple[str, ...] = (
-    MessagingServiceType.MAILCHIMP_TRANSACTIONAL.value,
-    MessagingServiceType.MAILGUN.value,
-    MessagingServiceType.TWILIO_EMAIL.value,
+    MessagingServiceType.mailgun.value,
+    MessagingServiceType.twilio_email.value,
+    MessagingServiceType.mailchimp_transactional.value,
 )
-SMS_MESSAGING_SERVICES: Tuple[str, ...] = (MessagingServiceType.TWILIO_TEXT.value,)
+SMS_MESSAGING_SERVICES: Tuple[str, ...] = (MessagingServiceType.twilio_text.value,)
 
 
 class MessagingActionType(str, Enum):
@@ -304,9 +302,9 @@ class MessagingConfigBase(BaseModel):
     service_type: MessagingServiceType
     details: Optional[
         Union[
-            MessagingServiceDetailsMailchimpTransactional,
             MessagingServiceDetailsMailgun,
             MessagingServiceDetailsTwilioEmail,
+            MessagingServiceDetailsMailchimpTransactional,
         ]
     ]
 
@@ -323,9 +321,9 @@ class MessagingConfigRequestBase(MessagingConfigBase):
     def validate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         service_type = values.get("service_type")
         if service_type:
-            # uppercase to match enums in database
+            # lowercase to match enums in database
             if isinstance(service_type, str):
-                service_type = service_type.upper()
+                service_type = service_type.lower()
 
             # assign the transformed service_type value back into the values dict
             values["service_type"] = service_type
@@ -339,11 +337,11 @@ class MessagingConfigRequestBase(MessagingConfigBase):
     ) -> None:
         if isinstance(service_type, MessagingServiceType):
             service_type = service_type.value
-        if service_type == MessagingServiceType.MAILGUN.value:
+        if service_type == MessagingServiceType.mailgun.value:
             if not details:
                 raise ValueError("Messaging config must include details")
             MessagingServiceDetailsMailgun.validate(details)
-        if service_type == MessagingServiceType.TWILIO_EMAIL.value:
+        if service_type == MessagingServiceType.twilio_email.value:
             if not details:
                 raise ValueError("Messaging config must include details")
             MessagingServiceDetailsTwilioEmail.validate(details)
@@ -368,10 +366,10 @@ class MessagingConfigResponse(MessagingConfigBase):
 
 
 SUPPORTED_MESSAGING_SERVICE_SECRETS = Union[
-    MessagingServiceSecretsMailchimpTransactional,
     MessagingServiceSecretsMailgun,
     MessagingServiceSecretsTwilioSMS,
     MessagingServiceSecretsTwilioEmail,
+    MessagingServiceSecretsMailchimpTransactional,
 ]
 
 

--- a/src/fides/api/ops/schemas/messaging/messaging_secrets_docs_only.py
+++ b/src/fides/api/ops/schemas/messaging/messaging_secrets_docs_only.py
@@ -33,8 +33,8 @@ class MessagingSecretsTwilioEmailDocs(
 
 
 possible_messaging_secrets = Union[
-    MessagingServiceSecretsMailchimpTransactionalDocs,
     MessagingSecretsMailgunDocs,
     MessagingSecretsTwilioSMSDocs,
     MessagingSecretsTwilioEmailDocs,
+    MessagingServiceSecretsMailchimpTransactionalDocs,
 ]

--- a/src/fides/api/ops/service/connectors/email_connector.py
+++ b/src/fides/api/ops/service/connectors/email_connector.py
@@ -242,36 +242,36 @@ def _get_email_messaging_config_service_type(db: Session) -> Optional[str]:
         (
             config
             for config in messaging_configs
-            if config.service_type == MessagingServiceType.TWILIO_EMAIL
+            if config.service_type == MessagingServiceType.twilio_email
         ),
         None,
     )
     if twilio_email_config:
         # First choice: use Twilio
-        return MessagingServiceType.TWILIO_EMAIL.value
+        return MessagingServiceType.twilio_email.value
 
     mailgun_config = next(
         (
             config
             for config in messaging_configs
-            if config.service_type == MessagingServiceType.MAILGUN
+            if config.service_type == MessagingServiceType.mailgun
         ),
         None,
     )
     if mailgun_config:
         # Second choice: use Mailgun
-        return MessagingServiceType.MAILGUN.value
+        return MessagingServiceType.mailgun.value
 
     mailchimp_transactional_config = next(
         (
             config
             for config in messaging_configs
-            if config.service_type == MessagingServiceType.MAILCHIMP_TRANSACTIONAL
+            if config.service_type == MessagingServiceType.mailchimp_transactional
         ),
         None,
     )
     if mailchimp_transactional_config:
         # Third choice: use Mailchimp Transactional
-        return MessagingServiceType.MAILCHIMP_TRANSACTIONAL.value
+        return MessagingServiceType.mailchimp_transactional.value
 
     return None

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -346,10 +346,10 @@ def _get_dispatcher_from_config_type(
 ) -> Optional[Callable]:
     """Determines which dispatcher to use based on message service type"""
     handler = {
-        MessagingServiceType.MAILGUN: _mailgun_dispatcher,
-        MessagingServiceType.MAILCHIMP_TRANSACTIONAL: _mailchimp_transactional_dispatcher,
-        MessagingServiceType.TWILIO_TEXT: _twilio_sms_dispatcher,
-        MessagingServiceType.TWILIO_EMAIL: _twilio_email_dispatcher,
+        MessagingServiceType.mailgun: _mailgun_dispatcher,
+        MessagingServiceType.mailchimp_transactional: _mailchimp_transactional_dispatcher,
+        MessagingServiceType.twilio_text: _twilio_sms_dispatcher,
+        MessagingServiceType.twilio_email: _twilio_email_dispatcher,
     }
     return handler.get(message_service_type)  # type: ignore
 

--- a/src/fides/api/ops/service/messaging/messaging_crud_service.py
+++ b/src/fides/api/ops/service/messaging/messaging_crud_service.py
@@ -29,7 +29,7 @@ def create_or_update_messaging_config(
     data = {
         "key": config.key,
         "name": config.name,
-        "service_type": config.service_type,
+        "service_type": config.service_type.value,
     }
     if config.details:
         data["details"] = config.details.__dict__  # type: ignore
@@ -40,7 +40,7 @@ def create_or_update_messaging_config(
     return MessagingConfigResponse(
         name=messaging_config.name,
         key=messaging_config.key,
-        service_type=messaging_config.service_type,
+        service_type=messaging_config.service_type.value,  # type: ignore
         details=messaging_config.details,
     )
 
@@ -67,6 +67,6 @@ def get_messaging_config_by_key(db: Session, key: FidesKey) -> MessagingConfigRe
     return MessagingConfigResponse(
         name=config.name,
         key=config.key,
-        service_type=config.service_type,
+        service_type=config.service_type.value,
         details=config.details,
     )

--- a/src/fides/core/config/notification_settings.py
+++ b/src/fides/core/config/notification_settings.py
@@ -32,13 +32,14 @@ class NotificationSettings(FidesSettings):
     def validate_notification_service_type(cls, value: Optional[str]) -> Optional[str]:
         """Ensure the provided type is a valid value."""
         if value:
+
             valid_values = [
-                "MAILCHIMP_TRANSACTIONAL",
-                "MAILGUN",
-                "TWILIO_TEXT",
-                "TWILIO_EMAIL",
+                "mailgun",
+                "twilio_text",
+                "twilio_email",
+                "mailchimp_transactional",
             ]
-            value = value.upper()  # force uppercase for safety
+            value = value.lower()  # force lowercase for safety
 
             if value not in valid_values:
                 raise ValueError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -652,7 +652,7 @@ def privacy_request_review_notification_disabled(db):
 def set_notification_service_type_mailgun(db):
     """Set default notification service type"""
     original_value = CONFIG.notifications.notification_service_type
-    CONFIG.notifications.notification_service_type = MessagingServiceType.MAILGUN.value
+    CONFIG.notifications.notification_service_type = MessagingServiceType.mailgun.value
     ApplicationConfig.update_config_set(db, CONFIG)
     db.commit()
     yield

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -267,7 +267,7 @@ def messaging_config(db: Session) -> Generator:
         data={
             "name": name,
             "key": "my_mailgun_messaging_config",
-            "service_type": MessagingServiceType.MAILGUN,
+            "service_type": MessagingServiceType.mailgun.value,
             "details": {
                 MessagingServiceDetails.API_VERSION.value: "v3",
                 MessagingServiceDetails.DOMAIN.value: "some.domain",
@@ -293,7 +293,7 @@ def messaging_config_twilio_email(db: Session) -> Generator:
         data={
             "name": name,
             "key": "my_twilio_email_config",
-            "service_type": MessagingServiceType.TWILIO_EMAIL,
+            "service_type": MessagingServiceType.twilio_email.value,
         },
     )
     messaging_config.set_secrets(
@@ -314,7 +314,7 @@ def messaging_config_twilio_sms(db: Session) -> Generator:
         data={
             "name": name,
             "key": "my_twilio_sms_config",
-            "service_type": MessagingServiceType.TWILIO_TEXT,
+            "service_type": MessagingServiceType.twilio_text.value,
         },
     )
     messaging_config.set_secrets(
@@ -336,7 +336,7 @@ def messaging_config_mailchimp_transactional(db: Session) -> Generator:
         data={
             "name": str(uuid4()),
             "key": "my_mailchimp_transactional_messaging_config",
-            "service_type": MessagingServiceType.MAILCHIMP_TRANSACTIONAL,
+            "service_type": MessagingServiceType.mailchimp_transactional,
             "details": {
                 MessagingServiceDetails.DOMAIN.value: "some.domain",
                 MessagingServiceDetails.EMAIL_FROM.value: "test@example.com",
@@ -1630,7 +1630,7 @@ def test_fides_client(
         fides_connector_example_secrets["uri"],
         fides_connector_example_secrets["username"],
         fides_connector_example_secrets["password"],
-        fides_connector_example_secrets["polling_timeout"]
+        fides_connector_example_secrets["polling_timeout"],
     )
 
 

--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -22,7 +22,7 @@ class TestPatchApplicationConfig:
         return {
             "storage": {"active_default_storage_type": StorageType.s3.value},
             "notifications": {
-                "notification_service_type": "TWILIO_TEXT",
+                "notification_service_type": "twilio_text",
                 "send_request_completion_notification": True,
                 "send_request_receipt_notification": True,
                 "send_request_review_notification": True,
@@ -173,7 +173,7 @@ class TestPatchApplicationConfig:
         updated_payload = {
             "execution": {"subject_identity_verification_required": False},
             "notifications": {
-                "notification_service_type": "MAILGUN",
+                "notification_service_type": "mailgun",
                 "send_request_completion_notification": False,
             },
         }
@@ -190,7 +190,7 @@ class TestPatchApplicationConfig:
             is False
         )
         assert (
-            response_settings["notifications"]["notification_service_type"] == "MAILGUN"
+            response_settings["notifications"]["notification_service_type"] == "mailgun"
         )
         assert (
             response_settings["notifications"]["send_request_completion_notification"]
@@ -211,7 +211,7 @@ class TestPatchApplicationConfig:
         )
         assert (
             db_settings.api_set["notifications"]["notification_service_type"]
-            == "MAILGUN"
+            == "mailgun"
         )
         assert (
             db_settings.api_set["notifications"]["send_request_completion_notification"]
@@ -368,7 +368,7 @@ class TestGetApplicationConfigApiSet:
             response_settings["notifications"]["notification_service_type"]
             == payload_single_notification_property["notifications"][
                 "notification_service_type"
-            ].upper()
+            ]
         )
 
 
@@ -382,7 +382,7 @@ class TestDeleteApplicationConfig:
         return {
             "storage": {"active_default_storage_type": StorageType.s3.value},
             "notifications": {
-                "notification_service_type": "TWILIO_TEXT",
+                "notification_service_type": "twilio_text",
                 "send_request_completion_notification": True,
                 "send_request_receipt_notification": True,
                 "send_request_review_notification": True,

--- a/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
@@ -75,7 +75,7 @@ class TestConsentRequest:
         """Overrides autouse fixture to set notification service type to twilio sms"""
         original_value = CONFIG.notifications.notification_service_type
         CONFIG.notifications.notification_service_type = (
-            MessagingServiceType.TWILIO_TEXT.value
+            MessagingServiceType.twilio_text.value
         )
         ApplicationConfig.update_config_set(db, CONFIG)
         yield

--- a/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
@@ -49,7 +49,7 @@ class TestPostMessagingConfig:
     def payload(self):
         return {
             "name": "mailgun",
-            "service_type": MessagingServiceType.MAILGUN.value,
+            "service_type": MessagingServiceType.mailgun.value,
             "details": {MessagingServiceDetails.DOMAIN.value: "my.mailgun.domain"},
         }
 
@@ -57,7 +57,7 @@ class TestPostMessagingConfig:
     def payload_twilio_email(self):
         return {
             "name": "twilio_email",
-            "service_type": MessagingServiceType.TWILIO_EMAIL.value,
+            "service_type": MessagingServiceType.twilio_email.value,
             "details": {
                 MessagingServiceDetails.TWILIO_EMAIL_FROM.value: "test@email.com"
             },
@@ -67,7 +67,7 @@ class TestPostMessagingConfig:
     def payload_mailchimp_transactional(self):
         return {
             "name": "mailchimp_transactional_email",
-            "service_type": MessagingServiceType.MAILCHIMP_TRANSACTIONAL.value,
+            "service_type": MessagingServiceType.mailchimp_transactional.value,
             "details": {
                 MessagingServiceDetails.EMAIL_FROM.value: "user@example.com",
             },
@@ -77,14 +77,14 @@ class TestPostMessagingConfig:
     def payload_twilio_sms(self):
         return {
             "name": "twilio_sms",
-            "service_type": MessagingServiceType.TWILIO_TEXT.value,
+            "service_type": MessagingServiceType.twilio_text.value,
         }
 
     @pytest.fixture(scope="function")
     def payload_twilio_sms_lowered(self):
         return {
             "name": "twilio_sms",
-            "service_type": MessagingServiceType.TWILIO_TEXT.value.lower(),
+            "service_type": MessagingServiceType.twilio_text.value.lower(),
         }
 
     def test_post_email_config_not_authenticated(
@@ -152,7 +152,7 @@ class TestPostMessagingConfig:
         assert 422 == response.status_code
         assert (
             json.loads(response.text)["detail"][0]["msg"]
-            == "value is not a valid enumeration member; permitted: 'MAILCHIMP_TRANSACTIONAL', 'MAILGUN', 'TWILIO_TEXT', 'TWILIO_EMAIL'"
+            == "value is not a valid enumeration member; permitted: 'mailgun', 'twilio_text', 'twilio_email', 'mailchimp_transactional'"
         )
 
     def test_post_email_config_with_no_key(
@@ -212,7 +212,7 @@ class TestPostMessagingConfig:
         expected_response = {
             "key": "my_mailgun_messaging_config",
             "name": "mailgun",
-            "service_type": MessagingServiceType.MAILGUN.value,
+            "service_type": MessagingServiceType.mailgun.value,
             "details": {
                 MessagingServiceDetails.API_VERSION.value: "v3",
                 MessagingServiceDetails.DOMAIN.value: "my.mailgun.domain",
@@ -235,7 +235,7 @@ class TestPostMessagingConfig:
             json={
                 "key": "my_mailgun_messaging_config",
                 "name": "mailgun",
-                "service_type": MessagingServiceType.MAILGUN.value,
+                "service_type": MessagingServiceType.mailgun.value,
             },
         )
         assert response.status_code == 422
@@ -256,13 +256,13 @@ class TestPostMessagingConfig:
             json={
                 "key": "my_new_mailgun_messaging_config",
                 "name": "mailgun",
-                "service_type": MessagingServiceType.MAILGUN.value,
+                "service_type": MessagingServiceType.mailgun.value,
                 "details": {MessagingServiceDetails.DOMAIN.value: "my.mailgun.domain"},
             },
         )
         assert response.status_code == 500
         assert (
-            f"Key (service_type)=(MAILGUN) already exists" in response.json()["detail"]
+            f"Key (service_type)=(mailgun) already exists" in response.json()["detail"]
         )
 
     def test_post_mailgun_transactional_config(
@@ -290,7 +290,7 @@ class TestPostMessagingConfig:
         expected_response = {
             "key": key,
             "name": payload_mailchimp_transactional["name"],
-            "service_type": MessagingServiceType.MAILCHIMP_TRANSACTIONAL.value,
+            "service_type": MessagingServiceType.mailchimp_transactional.value,
             "details": {MessagingServiceDetails.EMAIL_FROM.value: "user@example.com"},
         }
         assert expected_response == response_body
@@ -318,7 +318,7 @@ class TestPostMessagingConfig:
         expected_response = {
             "key": "my_twilio_email_config",
             "name": "twilio_email",
-            "service_type": MessagingServiceType.TWILIO_EMAIL.value,
+            "service_type": MessagingServiceType.twilio_email.value,
             "details": {
                 MessagingServiceDetails.TWILIO_EMAIL_FROM.value: "test@email.com"
             },
@@ -348,7 +348,7 @@ class TestPostMessagingConfig:
         expected_response = {
             "key": "my_twilio_sms_config",
             "name": "twilio_sms",
-            "service_type": MessagingServiceType.TWILIO_TEXT.value,
+            "service_type": MessagingServiceType.twilio_text.value,
             "details": None,
         }
         assert expected_response == response_body
@@ -382,7 +382,7 @@ class TestPostMessagingConfig:
         expected_response = {
             "key": "my_twilio_sms_config",
             "name": "twilio_sms",
-            "service_type": MessagingServiceType.TWILIO_TEXT.value,
+            "service_type": MessagingServiceType.twilio_text.value,
             "details": None,
         }
         assert expected_response == response_body
@@ -401,7 +401,7 @@ class TestPatchMessagingConfig:
         return {
             "key": "my_mailgun_messaging_config",
             "name": "mailgun new name",
-            "service_type": MessagingServiceType.MAILGUN.value,
+            "service_type": MessagingServiceType.mailgun.value,
             "details": {MessagingServiceDetails.DOMAIN.value: "my.mailgun.domain"},
         }
 
@@ -460,7 +460,7 @@ class TestPatchMessagingConfig:
         expected_response = {
             "key": "my_mailgun_messaging_config",
             "name": "mailgun new name",
-            "service_type": MessagingServiceType.MAILGUN.value,
+            "service_type": MessagingServiceType.mailgun.value,
             "details": {
                 MessagingServiceDetails.API_VERSION.value: "v3",
                 MessagingServiceDetails.DOMAIN.value: "my.mailgun.domain",
@@ -599,7 +599,7 @@ class TestPutMessagingConfigSecretMailchimpTransactional:
         generate_auth_header,
         messaging_config_mailchimp_transactional,
     ):
-        key = "key-123456789"
+        key = "123456789"
         auth_header = generate_auth_header([MESSAGING_CREATE_OR_UPDATE])
         response = api_client.put(
             url,
@@ -799,7 +799,7 @@ class TestGetMessagingConfigs:
                 {
                     "key": "my_mailgun_messaging_config",
                     "name": messaging_config.name,
-                    "service_type": MessagingServiceType.MAILGUN.value,
+                    "service_type": MessagingServiceType.mailgun.value,
                     "details": {
                         MessagingServiceDetails.API_VERSION.value: "v3",
                         MessagingServiceDetails.DOMAIN.value: "some.domain",
@@ -859,7 +859,7 @@ class TestGetMessagingConfig:
         assert response_body == {
             "key": "my_mailgun_messaging_config",
             "name": messaging_config.name,
-            "service_type": MessagingServiceType.MAILGUN.value,
+            "service_type": MessagingServiceType.mailgun.value,
             "details": {
                 MessagingServiceDetails.API_VERSION.value: "v3",
                 MessagingServiceDetails.DOMAIN.value: "some.domain",
@@ -907,7 +907,7 @@ class TestDeleteConfig:
             data={
                 "key": "my_twilio_sms_config",
                 "name": "twilio_sms",
-                "service_type": MessagingServiceType.TWILIO_TEXT,
+                "service_type": MessagingServiceType.twilio_text.value,
             },
         )
         url = (V1_URL_PREFIX + MESSAGING_BY_KEY).format(
@@ -927,6 +927,12 @@ class TestGetDefaultMessagingConfig:
     def url(self, messaging_config: MessagingConfig) -> str:
         return (V1_URL_PREFIX + MESSAGING_DEFAULT_BY_TYPE).format(
             service_type=messaging_config.service_type.value
+        )
+
+    @pytest.fixture(scope="function")
+    def url_uppercase(self, messaging_config: MessagingConfig) -> str:
+        return (V1_URL_PREFIX + MESSAGING_DEFAULT_BY_TYPE).format(
+            service_type=messaging_config.service_type.value.upper()
         )
 
     def test_get_default_config_not_authenticated(self, url, api_client: TestClient):
@@ -961,7 +967,7 @@ class TestGetDefaultMessagingConfig:
         auth_header = generate_auth_header([MESSAGING_READ])
         response = api_client.get(
             (V1_URL_PREFIX + MESSAGING_DEFAULT_BY_TYPE).format(
-                service_type=MessagingServiceType.MAILGUN.value
+                service_type=MessagingServiceType.mailgun.value
             ),
             headers=auth_header,
         )
@@ -983,7 +989,7 @@ class TestGetDefaultMessagingConfig:
         assert response_body == {
             "key": "my_mailgun_messaging_config",
             "name": messaging_config.name,
-            "service_type": MessagingServiceType.MAILGUN.value,
+            "service_type": MessagingServiceType.mailgun.value,
             "details": {
                 MessagingServiceDetails.API_VERSION.value: "v3",
                 MessagingServiceDetails.DOMAIN.value: "some.domain",
@@ -991,19 +997,19 @@ class TestGetDefaultMessagingConfig:
             },
         }
 
-    def test_get_default_config_lowered_url(
+    def test_get_default_config_uppered_url(
         self,
-        url,
+        url_uppercase,
         api_client: TestClient,
         generate_auth_header,
         messaging_config: MessagingConfig,
     ):
         """
-        Ensure that a lowercased URL can be used, since by default we're
-        using the uppercased enum values in our URL
+        Ensure that a uppercased URL can be used, since by default we're
+        using the lowercased enum values in our URL
         """
         auth_header = generate_auth_header([MESSAGING_READ])
-        response = api_client.get(url.lower(), headers=auth_header)
+        response = api_client.get(url_uppercase.lower(), headers=auth_header)
         assert response.status_code == 200
 
         response_body = response.json()
@@ -1011,7 +1017,7 @@ class TestGetDefaultMessagingConfig:
         assert response_body == {
             "key": "my_mailgun_messaging_config",
             "name": messaging_config.name,
-            "service_type": MessagingServiceType.MAILGUN.value,
+            "service_type": MessagingServiceType.mailgun.value,
             "details": {
                 MessagingServiceDetails.API_VERSION.value: "v3",
                 MessagingServiceDetails.DOMAIN.value: "some.domain",
@@ -1028,7 +1034,7 @@ class TestPutDefaultMessagingConfig:
     @pytest.fixture(scope="function")
     def payload(self):
         return {
-            "service_type": MessagingServiceType.MAILGUN.value,
+            "service_type": MessagingServiceType.mailgun.value,
             "details": {MessagingServiceDetails.DOMAIN.value: "my.mailgun.domain"},
         }
 
@@ -1113,14 +1119,14 @@ class TestPutDefaultMessagingConfig:
         "service_type, details",
         [
             (
-                MessagingServiceType.TWILIO_EMAIL.value,
+                MessagingServiceType.twilio_email.value,
                 {"twilio_email_from": "test_email@test.com"},
             ),
             (
-                MessagingServiceType.TWILIO_EMAIL.value.lower(),
+                MessagingServiceType.twilio_email.value.lower(),
                 {"twilio_email_from": "test_email@test.com"},
             ),
-            (MessagingServiceType.TWILIO_TEXT.value, None),
+            (MessagingServiceType.twilio_text.value, None),
         ],
     )
     def test_put_default_messaging_config_with_different_service_types(
@@ -1142,8 +1148,8 @@ class TestPutDefaultMessagingConfig:
         response_body = json.loads(response.text)
         config_key = response_body["key"]
         messaging_config = MessagingConfig.get_by(db, field="key", value=config_key)
-        assert service_type.upper() == response_body["service_type"]
-        assert service_type.upper() == messaging_config.service_type.value
+        assert service_type == response_body["service_type"]
+        assert service_type == messaging_config.service_type.value
         messaging_config.delete(db)
 
     def test_put_default_messaging_config_twice_only_one_record(
@@ -1227,7 +1233,7 @@ class TestPutDefaultMessagingConfigSecrets:
     @pytest.fixture(scope="function")
     def url(self, messaging_config) -> str:
         return (V1_URL_PREFIX + MESSAGING_DEFAULT_SECRETS).format(
-            service_type=MessagingServiceType.MAILGUN.value
+            service_type=MessagingServiceType.mailgun.value
         )
 
     @pytest.fixture(scope="function")
@@ -1264,7 +1270,7 @@ class TestPutDefaultMessagingConfigSecrets:
     ):
         auth_header = generate_auth_header([MESSAGING_CREATE_OR_UPDATE])
         url = (V1_URL_PREFIX + MESSAGING_DEFAULT_SECRETS).format(
-            service_type=MessagingServiceType.MAILGUN.value
+            service_type=MessagingServiceType.mailgun.value
         )
         # this should get a 404 because we have not added the messaging config
         # through a fixture
@@ -1402,7 +1408,7 @@ class TestGetActiveDefaultMessagingConfig:
     def notification_service_type_mailgun(self, db):
         """Set mailgun as the `notification_service_type` property"""
         original_value = CONFIG.notifications.notification_service_type
-        CONFIG.notifications.notification_service_type = "MAILGUN"
+        CONFIG.notifications.notification_service_type = "mailgun"
         ApplicationConfig.update_config_set(db, CONFIG)
         yield
         CONFIG.notifications.notification_service_type = original_value
@@ -1488,7 +1494,7 @@ class TestGetActiveDefaultMessagingConfig:
         assert response_body == {
             "key": "my_mailgun_messaging_config",
             "name": messaging_config.name,
-            "service_type": MessagingServiceType.MAILGUN.value,
+            "service_type": MessagingServiceType.mailgun.value,
             "details": {
                 MessagingServiceDetails.API_VERSION.value: "v3",
                 MessagingServiceDetails.DOMAIN.value: "some.domain",
@@ -1558,7 +1564,7 @@ class TestGetMessagingStatus:
         """Set mailgun as the `notification_service_type` property"""
         original_value = CONFIG.notifications.notification_service_type
         CONFIG.notifications.notification_service_type = (
-            MessagingServiceType.MAILGUN.value
+            MessagingServiceType.mailgun.value
         )
         ApplicationConfig.update_config_set(db, CONFIG)
         yield
@@ -1570,7 +1576,7 @@ class TestGetMessagingStatus:
         """Set twilio_text as the `notification_service_type` property"""
         original_value = CONFIG.notifications.notification_service_type
         CONFIG.notifications.notification_service_type = (
-            MessagingServiceType.TWILIO_TEXT.value
+            MessagingServiceType.twilio_text.value
         )
         ApplicationConfig.update_config_set(db, CONFIG)
         yield
@@ -1582,7 +1588,7 @@ class TestGetMessagingStatus:
         """Set twilio_email as the `notification_service_type` property"""
         original_value = CONFIG.notifications.notification_service_type
         CONFIG.notifications.notification_service_type = (
-            MessagingServiceType.TWILIO_EMAIL.value
+            MessagingServiceType.twilio_email.value
         )
         ApplicationConfig.update_config_set(db, CONFIG)
         yield
@@ -1794,7 +1800,7 @@ class TestGetMessagingStatus:
         assert response.status_code == 200
         response = MessagingConfigStatusMessage(**response.json())
         assert response.config_status == MessagingConfigStatus.configured
-        assert MessagingServiceType.MAILGUN.value in (response.detail)
+        assert MessagingServiceType.mailgun.value in (response.detail)
 
     @pytest.mark.usefixtures(
         "notification_service_type_twilio_text", "messaging_config_twilio_sms"
@@ -1815,7 +1821,7 @@ class TestGetMessagingStatus:
         assert response.status_code == 200
         response = MessagingConfigStatusMessage(**response.json())
         assert response.config_status == MessagingConfigStatus.configured
-        assert MessagingServiceType.TWILIO_TEXT.value in (response.detail)
+        assert MessagingServiceType.twilio_text.value in (response.detail)
 
 
 class TestTestMesage:

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -2021,7 +2021,7 @@ class TestApprovePrivacyRequest:
         call_args = mock_dispatch_message.call_args[1]
         task_kwargs = call_args["kwargs"]
         assert task_kwargs["to_identity"] == Identity(email="test@example.com")
-        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
+        assert task_kwargs["service_type"] == MessagingServiceType.mailgun.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -2153,7 +2153,7 @@ class TestDenyPrivacyRequest:
         call_args = mock_dispatch_message.call_args[1]
         task_kwargs = call_args["kwargs"]
         assert task_kwargs["to_identity"] == Identity(email="test@example.com")
-        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
+        assert task_kwargs["service_type"] == MessagingServiceType.mailgun.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -2224,7 +2224,7 @@ class TestDenyPrivacyRequest:
         call_args = mock_dispatch_message.call_args[1]
         task_kwargs = call_args["kwargs"]
         assert task_kwargs["to_identity"] == Identity(email="test@example.com")
-        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
+        assert task_kwargs["service_type"] == MessagingServiceType.mailgun.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -3148,7 +3148,7 @@ class TestVerifyIdentity:
         assert task_kwargs["to_identity"] == Identity(
             phone_number="+12345678910", email="test@example.com"
         )
-        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
+        assert task_kwargs["service_type"] == MessagingServiceType.mailgun.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -3256,7 +3256,7 @@ class TestVerifyIdentity:
         assert task_kwargs["to_identity"] == Identity(
             phone_number="+12345678910", email="test@example.com"
         )
-        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
+        assert task_kwargs["service_type"] == MessagingServiceType.mailgun.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -3358,7 +3358,7 @@ class TestCreatePrivacyRequestEmailVerificationRequired:
             kwargs["action_type"] == MessagingActionType.SUBJECT_IDENTITY_VERIFICATION
         )
         assert kwargs["to_identity"] == Identity(email="test@example.com")
-        assert kwargs["service_type"] == MessagingServiceType.MAILGUN.value
+        assert kwargs["service_type"] == MessagingServiceType.mailgun.value
         assert kwargs["message_body_params"] == SubjectIdentityVerificationBodyParams(
             verification_code=pr.get_cached_verification_code(),
             verification_code_ttl_seconds=CONFIG.redis.identity_verification_code_ttl_seconds,
@@ -3877,7 +3877,7 @@ class TestCreatePrivacyRequestEmailReceiptNotification:
         call_args = mock_dispatch_message.call_args[1]
         task_kwargs = call_args["kwargs"]
         assert task_kwargs["to_identity"] == Identity(email="test@example.com")
-        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
+        assert task_kwargs["service_type"] == MessagingServiceType.mailgun.value
 
         message_meta = task_kwargs["message_meta"]
         assert (
@@ -3928,7 +3928,7 @@ class TestCreatePrivacyRequestEmailReceiptNotification:
         call_args = mock_dispatch_message.call_args[1]
         task_kwargs = call_args["kwargs"]
         assert task_kwargs["to_identity"] == Identity(email="test@example.com")
-        assert task_kwargs["service_type"] == MessagingServiceType.MAILGUN.value
+        assert task_kwargs["service_type"] == MessagingServiceType.mailgun.value
 
         message_meta = task_kwargs["message_meta"]
         assert (

--- a/tests/ops/integration_tests/test_integration_email.py
+++ b/tests/ops/integration_tests/test_integration_email.py
@@ -29,6 +29,13 @@ from fides.lib.models.audit_log import AuditLog, AuditLogAction
 @pytest.mark.integration
 @mock.patch("fides.api.ops.service.connectors.email_connector.dispatch_message")
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type, m_config",
+    [
+        (MessagingServiceType.mailgun.value, "messaging_config"),
+        (MessagingServiceType.twilio_email.value, "messaging_config_twilio_email"),
+    ],
+)
 async def test_email_connector_cache_and_delayed_send(
     mock_email_dispatch,
     db,
@@ -38,13 +45,18 @@ async def test_email_connector_cache_and_delayed_send(
     privacy_request,
     example_datasets,
     email_dataset_config,
-    messaging_config,
+    service_type,
+    m_config,
+    request,
 ) -> None:
     """Run an erasure privacy request with a postgres dataset and an email dataset.
     The email dataset has three separate collections.
 
     Call the email send and verify what would have been emailed
     """
+    # load the appropriate messaging config fixture
+    messaging_config = request.getfixturevalue(m_config)
+
     privacy_request.policy = erasure_policy
     rule = erasure_policy.rules[0]
     target = rule.targets[0]
@@ -187,7 +199,7 @@ async def test_email_connector_cache_and_delayed_send(
         == MessagingActionType.MESSAGE_ERASURE_REQUEST_FULFILLMENT
     )
     assert call_args["to_identity"] == Identity(email="test@example.com")
-    assert call_args["service_type"] == MessagingServiceType.MAILGUN.value
+    assert call_args["service_type"] == service_type
     assert call_args["message_body_params"] == raw_email_template_values
 
     created_email_audit_log = (

--- a/tests/ops/service/connectors/test_consent_email_connector.py
+++ b/tests/ops/service/connectors/test_consent_email_connector.py
@@ -213,7 +213,7 @@ class TestEmailConsentConnectorMethods:
         assert call_kwargs["to_identity"].phone_number is None
         assert call_kwargs["to_identity"].ga_client_id is None
 
-        assert call_kwargs["service_type"] == "MAILGUN"
+        assert call_kwargs["service_type"] == "mailgun"
         message_body_params = call_kwargs["message_body_params"]
 
         assert message_body_params.controller == "Test Org"

--- a/tests/ops/service/messaging/message_dispatch_service_test.py
+++ b/tests/ops/service/messaging/message_dispatch_service_test.py
@@ -79,7 +79,7 @@ class TestMessageDispatchService:
             db=db,
             action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
             to_identity=Identity(**{"email": "test@email.com"}),
-            service_type=MessagingServiceType.MAILGUN.value,
+            service_type=MessagingServiceType.mailgun.value,
             message_body_params=SubjectIdentityVerificationBodyParams(
                 verification_code="2348", verification_code_ttl_seconds=600
             ),
@@ -106,13 +106,13 @@ class TestMessageDispatchService:
                 db=db,
                 action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
                 to_identity=Identity(**{"email": "test@email.com"}),
-                service_type=MessagingServiceType.MAILGUN.value,
+                service_type=MessagingServiceType.mailgun.value,
                 message_body_params=SubjectIdentityVerificationBodyParams(
                     verification_code="2348", verification_code_ttl_seconds=600
                 ),
             )
         assert (
-            exc.value.args[0] == "No messaging config found for service_type MAILGUN."
+            exc.value.args[0] == "No messaging config found for service_type mailgun."
         )
 
         mock_mailgun_dispatcher.assert_not_called()
@@ -129,7 +129,7 @@ class TestMessageDispatchService:
             data={
                 "name": "mailgun config",
                 "key": "my_mailgun_messaging_config",
-                "service_type": MessagingServiceType.MAILGUN,
+                "service_type": MessagingServiceType.mailgun,
                 "details": {
                     MessagingServiceDetails.DOMAIN.value: "some.domain",
                 },
@@ -141,7 +141,7 @@ class TestMessageDispatchService:
                 db=db,
                 action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
                 to_identity=Identity(**{"email": "test@email.com"}),
-                service_type=MessagingServiceType.MAILGUN.value,
+                service_type=MessagingServiceType.mailgun.value,
                 message_body_params=SubjectIdentityVerificationBodyParams(
                     verification_code="2348", verification_code_ttl_seconds=600
                 ),
@@ -176,7 +176,7 @@ class TestMessageDispatchService:
                     db=db,
                     action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
                     to_identity=Identity(**{"email": "test@email.com"}),
-                    service_type=MessagingServiceType.MAILGUN.value,
+                    service_type=MessagingServiceType.mailgun.value,
                     message_body_params=SubjectIdentityVerificationBodyParams(
                         verification_code="2348", verification_code_ttl_seconds=600
                     ),
@@ -196,7 +196,7 @@ class TestMessageDispatchService:
             db=db,
             action_type=MessagingActionType.TEST_MESSAGE,
             to_identity=Identity(email="test@email.com"),
-            service_type=MessagingServiceType.MAILGUN.value,
+            service_type=MessagingServiceType.mailgun.value,
         )
         body = '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <title>Fides Test message</title>\n  </head>\n  <body>\n    <main>\n      <p>This is a test message from Fides.</p>\n    </main>\n  </body>\n</html>'
         mock_mailgun_dispatcher.assert_called_with(
@@ -218,7 +218,7 @@ class TestMessageDispatchService:
             db=db,
             action_type=MessagingActionType.TEST_MESSAGE,
             to_identity=Identity(email="test@email.com"),
-            service_type=MessagingServiceType.TWILIO_EMAIL.value,
+            service_type=MessagingServiceType.twilio_email.value,
         )
         body = '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <title>Fides Test message</title>\n  </head>\n  <body>\n    <main>\n      <p>This is a test message from Fides.</p>\n    </main>\n  </body>\n</html>'
         mock_twilio_dispatcher.assert_called_with(
@@ -240,7 +240,7 @@ class TestMessageDispatchService:
             db=db,
             action_type=MessagingActionType.TEST_MESSAGE,
             to_identity=Identity(phone_number="+19198675309"),
-            service_type=MessagingServiceType.TWILIO_TEXT.value,
+            service_type=MessagingServiceType.twilio_text.value,
         )
         body = '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <title>Fides Test message</title>\n  </head>\n  <body>\n    <main>\n      <p>This is a test message from Fides.</p>\n    </main>\n  </body>\n</html>'
         mock_twilio_dispatcher.assert_called_with(
@@ -292,7 +292,7 @@ class TestMessageDispatchService:
             db=db,
             action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
             to_identity=Identity(**{"phone_number": "+12312341231"}),
-            service_type=MessagingServiceType.TWILIO_TEXT.value,
+            service_type=MessagingServiceType.twilio_text.value,
             message_body_params=SubjectIdentityVerificationBodyParams(
                 verification_code="2348", verification_code_ttl_seconds=600
             ),
@@ -311,7 +311,7 @@ class TestMessageDispatchService:
                 db=db,
                 action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
                 to_identity=Identity(phone_number=None),
-                service_type=MessagingServiceType.TWILIO_TEXT.value,
+                service_type=MessagingServiceType.twilio_text.value,
                 message_body_params=SubjectIdentityVerificationBodyParams(
                     verification_code="2348", verification_code_ttl_seconds=600
                 ),
@@ -331,14 +331,14 @@ class TestMessageDispatchService:
                 db=db,
                 action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
                 to_identity=Identity(**{"phone_number": "+12312341231"}),
-                service_type=MessagingServiceType.TWILIO_TEXT.value,
+                service_type=MessagingServiceType.twilio_text.value,
                 message_body_params=SubjectIdentityVerificationBodyParams(
                     verification_code="2348", verification_code_ttl_seconds=600
                 ),
             )
         assert (
             exc.value.args[0]
-            == "No messaging config found for service_type TWILIO_TEXT."
+            == "No messaging config found for service_type twilio_text."
         )
 
         mock_twilio_dispatcher.assert_not_called()
@@ -355,7 +355,7 @@ class TestMessageDispatchService:
             data={
                 "name": "twilio sms config",
                 "key": "my_twilio_sms_config",
-                "service_type": MessagingServiceType.TWILIO_TEXT,
+                "service_type": MessagingServiceType.twilio_text.value,
             },
         )
 
@@ -364,7 +364,7 @@ class TestMessageDispatchService:
                 db=db,
                 action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
                 to_identity=Identity(**{"phone_number": "+12312341231"}),
-                service_type=MessagingServiceType.TWILIO_TEXT.value,
+                service_type=MessagingServiceType.twilio_text.value,
                 message_body_params=SubjectIdentityVerificationBodyParams(
                     verification_code="2348", verification_code_ttl_seconds=600
                 ),
@@ -389,7 +389,7 @@ class TestMessageDispatchService:
             data={
                 "name": "twilio sms config",
                 "key": "my_twilio_sms_config",
-                "service_type": MessagingServiceType.TWILIO_TEXT,
+                "service_type": MessagingServiceType.twilio_text.value,
             },
         )
 
@@ -398,7 +398,7 @@ class TestMessageDispatchService:
                 db=db,
                 action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
                 to_identity=None,
-                service_type=MessagingServiceType.TWILIO_TEXT.value,
+                service_type=MessagingServiceType.twilio_text.value,
                 message_body_params=SubjectIdentityVerificationBodyParams(
                     verification_code="2348", verification_code_ttl_seconds=600
                 ),
@@ -419,7 +419,7 @@ class TestMessageDispatchService:
             data={
                 "name": "twilio sms config",
                 "key": "my_twilio_sms_config",
-                "service_type": MessagingServiceType.TWILIO_TEXT,
+                "service_type": MessagingServiceType.twilio_text.value,
             },
         )
 
@@ -533,7 +533,7 @@ class TestTwilioSmsDispatcher:
             db=db,
             action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
             to_identity=Identity(**{"email": "test@email.com"}),
-            service_type=MessagingServiceType.MAILGUN.value,
+            service_type=MessagingServiceType.mailgun.value,
             message_body_params=SubjectIdentityVerificationBodyParams(
                 verification_code="2348", verification_code_ttl_seconds=600
             ),
@@ -559,7 +559,7 @@ class TestTwilioSmsDispatcher:
             db=db,
             action_type=MessagingActionType.SUBJECT_IDENTITY_VERIFICATION,
             to_identity=Identity(**{"phone_number": "+12312341231"}),
-            service_type=MessagingServiceType.TWILIO_TEXT.value,
+            service_type=MessagingServiceType.twilio_text.value,
             message_body_params=SubjectIdentityVerificationBodyParams(
                 verification_code="2348", verification_code_ttl_seconds=600
             ),
@@ -583,7 +583,7 @@ class TestTwilioSmsDispatcher:
             db=db,
             action_type=MessagingActionType.CONSENT_REQUEST_EMAIL_FULFILLMENT,
             to_identity=Identity(**{"email": "sovrn_test@example.com"}),
-            service_type=MessagingServiceType.MAILGUN.value,
+            service_type=MessagingServiceType.mailgun.value,
             message_body_params=ConsentEmailFulfillmentBodyParams(
                 controller="Test Organization",
                 third_party_vendor_name="Sovrn",

--- a/tests/ops/service/privacy_request/request_runner_service_test.py
+++ b/tests/ops/service/privacy_request/request_runner_service_test.py
@@ -1983,7 +1983,7 @@ class TestPrivacyRequestsEmailNotifications:
                     db=ANY,
                     action_type=MessagingActionType.PRIVACY_REQUEST_COMPLETE_ACCESS,
                     to_identity=identity,
-                    service_type=MessagingServiceType.MAILGUN.value,
+                    service_type=MessagingServiceType.mailgun.value,
                     message_body_params=AccessRequestCompleteBodyParams(
                         subject_request_download_time_in_days=download_time_in_days,
                         download_links=[upload_mock.return_value],
@@ -1993,7 +1993,7 @@ class TestPrivacyRequestsEmailNotifications:
                     db=ANY,
                     action_type=MessagingActionType.PRIVACY_REQUEST_COMPLETE_DELETION,
                     to_identity=identity,
-                    service_type=MessagingServiceType.MAILGUN.value,
+                    service_type=MessagingServiceType.mailgun.value,
                     message_body_params=None,
                 ),
             ],


### PR DESCRIPTION
Closes #2680 

### Code Changes

* update `MessagingServiceType` Enum in python codebase to have lowercased values, update any references in code and in tests
    * switch any `.upper()` calls that coerced user-input values to instead be `.lower()`, to maintain backward compatibility and continue to support uppercased user input
* provide a DB migration to change the enum type in the DB schema, as well as a data migration to change any existing enum values in the DB to lowercased
* update FE code references to user lowercased enum values rather than uppercased

### Steps to Confirm

* ensure new system config UI still works as expected
* ensure migration works as expected:
    * run server on `main` (e.g. `nox -s dev -- ui`) and create a messaging config (e.g. using the system config UI)
    * teardown but do not delete volumes, i.e. `nox -s teardown`
    * checkout this branch, run server (e.g. `nox -s dev -- ui`) and ensure your messaging config is still present and functional (can check using the API - `GET /api/v1/messaging/default/{service_type}`, or checking the `messagingconfig` db table directly)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

- Caveat: there's a very narrow edge case where if someone in the past few days has used the UI on `main` to configure a messaging config, the UI will have set the `notification.notification_service_type` property to an uppercased value, e.g. `MAILGUN`. 
    - you may see some`500`s on calls to `GET /api/v1/messaging/default/active` and that's what is used by the messaging config UI to load the "current" messaging provider. so the messaging config UI will show up as if you have no messaging provider configured
    - if this happens, then just click on the messaging provider you had configured in the messaging config UI and its details will be loaded. you should be good to go now.