### PR TITLE
fix messaging 'test connection' workflow on initial save

### DIFF
--- a/clients/admin-ui/src/features/privacy-requests/configuration/MailgunEmailConfiguration.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/MailgunEmailConfiguration.tsx
@@ -166,7 +166,9 @@ const MailgunEmailConfiguration = () => {
       ) : null}
       {configurationStep === "testConnection" ? (
         <TestMessagingProviderConnectionButton
-          messagingDetails={messagingDetails}
+          messagingDetails={
+            messagingDetails || { service_type: messagingProviders.mailgun }
+          }
         />
       ) : null}
     </Box>

--- a/clients/admin-ui/src/features/privacy-requests/configuration/TwilioEmailConfiguration.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/TwilioEmailConfiguration.tsx
@@ -163,7 +163,11 @@ const TwilioEmailConfiguration = () => {
       ) : null}
       {configurationStep === "testConnection" ? (
         <TestMessagingProviderConnectionButton
-          messagingDetails={messagingDetails}
+          messagingDetails={
+            messagingDetails || {
+              service_type: messagingProviders.twilio_email,
+            }
+          }
         />
       ) : null}
     </Box>

--- a/clients/admin-ui/src/features/privacy-requests/configuration/TwilioSMS.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/TwilioSMS.tsx
@@ -117,7 +117,9 @@ const TwilioSMSConfiguration = () => {
       </Stack>
       {configurationStep === "testConnection" ? (
         <TestMessagingProviderConnectionButton
-          messagingDetails={messagingDetails}
+          messagingDetails={
+            messagingDetails || { service_type: messagingProviders.twilio_text }
+          }
         />
       ) : null}
     </Box>


### PR DESCRIPTION
Helps close #2455

specifically meant to resolve issue reported in [this comment](https://github.com/ethyca/fides/issues/2455#issuecomment-1456097873)

### Code Changes

- i noticed that the `messagingDetails` param was undefined in the case where the messaging config form loads from "scratch", i.e. there is no messaging default already present for the given service type. this is because the `getMessagingConfigurationDetails()` query against the backend gets an (expected) `404` in these cases
- since the `TestMessagingProviderConnectionButton` constructor only really requires the `service_type` from the `messagingDetails`, and we know the `service_type` already given the context of the form, i just define a dummy `messagingDetails` object with the `service_type` inferred from the context of the form, in the cases where we haven't successfully retrieved the `messagingDetails` from the API

### Steps to Confirm
Without fix:
1. start with a fresh app db (`nox -s teardown -- volumes`)
2. `nox -s dev -- ui`
3. go to configure your messaging provider (http://localhost:3000/privacy-requests/configure), click on e.g. `Mailgun Email`, fill in a domain and API key (can be whatever value you want)
4. notice this error: ![image (8)](https://user-images.githubusercontent.com/9750285/223144867-10e39869-b9c5-40ff-8787-2c14593480e3.png)

With fix:
repeat steps 1-3, notice that the "test connection" field successfully renders and you are able to successfully submit a messaging connection test (assuming your messaging config details are valid).

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

- i have no idea if this is a "proper" fix - i have no experience with our FE :) so please take it with a grain of salt and open to any other suggestions! i tried just changing the `TestMessagingProviderConnectionButton` constructor to just take a `service_type: string` (since that's all it really needs) but i couldn't get that to play nice in the forms on some quick tries - but i also don't know what i'm doing!
