### PR TITLE
release 2.8.0

### DIFF
--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -41,7 +41,9 @@ const Layout = ({
   });
 
   const showNotificationBanner =
-    (!activeMessagingProvider || !activeStorage) && isValidNotificationRoute;
+    features.flags.privacyRequestsConfiguration &&
+    (!activeMessagingProvider || !activeStorage) &&
+    isValidNotificationRoute;
 
   return (
     <div data-testid={title}>

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -14,6 +14,7 @@ import yaml
 from loguru import logger
 
 from fides.api.ops.api.v1 import urn_registry as ops_urls
+from fides.api.ops.api.v1.scope_registry import SCOPE_REGISTRY
 from fides.api.ops.models.connectionconfig import ConnectionType
 from fides.api.ops.models.policy import ActionType
 from fides.core.config import get_config
@@ -53,34 +54,11 @@ def create_oauth_client():
     See http://localhost:8000/api#operations-OAuth-acquire_access_token_api_v1_oauth_token_post
     See http://localhost:8000/api#operations-OAuth-acquire_access_token_api_v1_oauth_token_post
     """
-    scopes_data = [
-        "client:create",
-        "client:update",
-        "client:read",
-        "client:delete",
-        "policy:create_or_update",
-        "policy:read",
-        "policy:delete",
-        "connection:create_or_update",
-        "connection:read",
-        "connection:delete",
-        "privacy-request:read",
-        "privacy-request:delete",
-        "rule:create_or_update",
-        "rule:read",
-        "rule:delete",
-        "storage:create_or_update",
-        "storage:read",
-        "storage:delete",
-        "dataset:create_or_update",
-        "dataset:read",
-        "dataset:delete",
-    ]
     url = f"{FIDESOPS_V1_API_URL}{ops_urls.CLIENT}"
     response = requests.post(
         url,
         headers=root_oauth_header,
-        json=scopes_data,
+        json=SCOPE_REGISTRY,
     )
 
     if response.ok:


### PR DESCRIPTION
# Release Checklist

The release checklist is a manual set of checks done before each release to ensure functionality of the most critical components of the application. Some of these steps are redundant with automated tests, while others are _only_ tested here as part of this check.

This checklist should be copy/pasted into the final pre-release PR, and checked off as you complete each step.

## Pre-Release Steps

### General

- [x] Quickstart verified working and up-to-date
- [ ] Add any new tables/columns to the [database diagram](https://github.com/ethyca/fides/blob/5a485387d8af247ec6479e4115088cbbb8394d77/docs/fides/docs/development/update_erd_diagram.md) if they have not already been added
  - To check for the new tables/columns that have been added in the release, look for new migration files in the `src/fides/api/ctl/migrations` directory and inspect their contents
  - If found, look at the latest database diagram, and check whether it contains the tables/columns that were added in these migrations
  - If the diagram is not up to date, follow the steps in the link above to generate a new database diagram with the up-to-date schema, ensuring that all tables and their relationships can be clearly seen
  - Open up an issue on [fidesdocs](https://github.com/ethyca/fidesdocs/issues) to update the diagram on the new docs site
- [x] `nox -s fides_env(test)` works (verify the admin UI on localhost:8080, privacy center, CLI and webserver)
- [x] `nox -s "build(sample)"` works on the release branch, creating the sample images (this is also prereq for `fides deploy up`)
- [x] `fides deploy up --no-pull` works using the images built in previous step (verify the admin UI, privacy center, CLI and webserver)

```
mkdir ~/fides-2-1-0-test
cd ~/fides-2-1-0-test
python3 -m venv venv
source venv/bin/activate
pip install git+https://github.com/ethyca/fides.git@<branch>
fides deploy up --no-pull
fides status
fides deploy down
rm -rf ~/fides-2-1-0-test
exit
```

Next, run the following checks against the environment you've spun up using `fides deploy up --no-pull`:

### API

- [x] Verify that the generated API docs are correct
- [x] Verify that the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### CLI

Run these from within `nox -s dev -- shell`

- [x] Run a `fides push`
- [x] Run a `fides pull`
- [x] Run a `fides evaluate`
- [x] Generate a dataset with `fides generate dataset db --credentials-id app_postgres test.yml`
- [x] Scan a database with `fides scan dataset db --credentials-id app_postgres`

### Admin UI

- [x] Every navigation button works
- [x] DSR approval succeeds
- [x] DSR execution succeeds

### Privacy Center

- [x] Every navigation button works
- [x] DSR submission succeeds
- [x] Consent request submission succeeds

### Documentation

- [x] Verify that the CHANGELOG is formatted correctly and clean up verbiage where needed
- [x] Verify that the CHANGELOG is representative of the actual changes

## Post-Release Steps

- [x] Verify the ethyca-fides release is published to PyPi: <https://pypi.org/project/ethyca-fides/#history>
- [x] Verify the fides release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides>
- [x] Verify the fides-privacy-center release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-privacy-center>
- [x] Verify the fides-sample-app release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-sample-app>
- [x] Smoke test the PyPi & DockerHub releases with a clean `pip install ethyca-fides` and `fides deploy up`