### PR TITLE
Include custom columns in header row of datamap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.8.1...main)
 
+### Fixed
+
+* Resolved a bug that stopped custom fields populating the visual datamap [#2775](https://github.com/ethyca/fides/pull/2775)
+
 ## [2.8.1](https://github.com/ethyca/fides/compare/2.8.0...2.8.1)
 
 ### Fixed

--- a/src/fides/api/ctl/routes/datamap.py
+++ b/src/fides/api/ctl/routes/datamap.py
@@ -163,8 +163,7 @@ async def export_datamap(
 
     formatted_datamap = format_datamap_values(joined_system_dataset_df, custom_columns)
 
-    # prepend column names
-    formatted_datamap = [DATAMAP_COLUMNS_API] + formatted_datamap
+    formatted_datamap = [{**DATAMAP_COLUMNS_API, **custom_columns}] + formatted_datamap
     return formatted_datamap
 
 

--- a/src/fides/core/export.py
+++ b/src/fides/core/export.py
@@ -194,7 +194,6 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
             keys.append(key_string)
             output_list[0] = tuple(keys)
 
-    system_custom_field_data = {}
     known_fields = (
         "fides_key",
         "name",
@@ -219,6 +218,7 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
         "system_type",
     )
     for system in server_resources["system"]:
+        system_custom_field_data = {}
         if not isinstance(system, dict):
             system = system.__dict__
 
@@ -229,12 +229,10 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
                 keys.append(key_string)
                 output_list[0] = tuple(keys)
                 custom_columns[key_string] = key
-                child_custom_field_data = {}
                 if isinstance(value, list):
-                    child_custom_field_data[key_string] = ", ".join(value)
+                    system_custom_field_data[key_string] = ", ".join(value)
                 else:
-                    child_custom_field_data[key_string] = value
-                system_custom_field_data[system["fides_key"]] = child_custom_field_data
+                    system_custom_field_data[key_string] = value
 
         third_country_list = ", ".join(system.get("third_country_transfers") or [])
         system_dependencies = ", ".join(system.get("system_dependencies") or [])
@@ -319,17 +317,10 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
                 ]
                 cartesian_product_of_declaration = []
                 if system_custom_field_data:
-                    for product in cartesian_product_of_declaration_builder:
-                        product_fides_key = product[0]
-                        if product_fides_key in system_custom_field_data:
-                            for _, v in system_custom_field_data[
-                                product_fides_key
-                            ].items():
-                                product.append(v)
-                        cartesian_product_of_declaration.append(tuple(product))
-                        # cartesian_product_of_declaration = [
-                        #     tuple(x) for x in cartesian_product_of_declaration_builder
-                        # ]
+                    for _, v in system_custom_field_data.items():
+                        for product in cartesian_product_of_declaration_builder:
+                            product.append(v)
+                            cartesian_product_of_declaration.append(tuple(product))
                 else:
                     cartesian_product_of_declaration = [
                         tuple(x) for x in cartesian_product_of_declaration_builder
@@ -349,9 +340,8 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
                 system_egress,
             ]
             if system_custom_field_data:
-                if system["fides_key"] in system_custom_field_data:
-                    for _, v in system_custom_field_data[system["fides_key"]].items():
-                        system_row.append(v)
+                for _, v in system_custom_field_data.items():
+                    system_row.append(v)
             len_no_privacy = len(system_row)
             system_row.append(data_protection_impact_assessment["is_required"])
             system_row.append(data_protection_impact_assessment["progress"])

--- a/src/fides/core/export.py
+++ b/src/fides/core/export.py
@@ -327,12 +327,15 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
                             ].items():
                                 product.append(v)
                         cartesian_product_of_declaration.append(tuple(product))
+                        # cartesian_product_of_declaration = [
+                        #     tuple(x) for x in cartesian_product_of_declaration_builder
+                        # ]
                 else:
                     cartesian_product_of_declaration = [
                         tuple(x) for x in cartesian_product_of_declaration_builder
                     ]
 
-            output_list += cartesian_product_of_declaration
+                output_list += cartesian_product_of_declaration
         else:
             system_row = [
                 system["fides_key"],

--- a/src/fides/core/export.py
+++ b/src/fides/core/export.py
@@ -326,14 +326,13 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
                                 product_fides_key
                             ].items():
                                 product.append(v)
-                                cartesian_product_of_declaration.append(tuple(product))
-                        else:
-                            cartesian_product_of_declaration = [
-                                tuple(x)
-                                for x in cartesian_product_of_declaration_builder
-                            ]
+                        cartesian_product_of_declaration.append(tuple(product))
+                else:
+                    cartesian_product_of_declaration = [
+                        tuple(x) for x in cartesian_product_of_declaration_builder
+                    ]
 
-                output_list += cartesian_product_of_declaration
+            output_list += cartesian_product_of_declaration
         else:
             system_row = [
                 system["fides_key"],


### PR DESCRIPTION
Closes #2768

### Code Changes

* [x] Ensure custom columns are included with the header output of `/datamap`
* [x] Resolve duplication of custom fields across all rows regardless of `fides_key`

### Steps to Confirm

* [x] Bounce this branch against `fidesplus` and test the datamap UI has the custom fields

Manual detail steps:
* [ ] Using `fides` run `nox -s "fides_env(test)"`
* [ ] Using `fidesplus` run the datamap UI locally using `npm run dev`
* [ ] Ensure the datamap looks good normally without custom fields http://localhost:4000/datamap
* [ ] Execute the following sql commands against the database to populate custom fields (I used dbeaver)
 ```
insert into public.plus_custom_field_definition (id, name, description, field_type, resource_type, field_definition, active)
select 'new_id', 'country', 'country name', 'string', 'system', 'string', true;

insert into public.plus_custom_field (id, resource_type, resource_id, custom_field_definition_id, value)
select 'updated_id', 'system', 'demo_analytics_system', 'new_id', '{portugal}';
```
* [ ] Ensure the datamap looks good with custom fields populated for `demo_analytics_system` http://localhost:4000/datamap

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Found as part of the release for `2.8.0`

An additional finding around the application of the custom fields was also found and included in here
