### PR TITLE
[#2784] Use BSON's JSON serialiser

### DIFF
--- a/data/dataset/mongo_example_test_dataset.yml
+++ b/data/dataset/mongo_example_test_dataset.yml
@@ -6,7 +6,7 @@ dataset:
       - name: customer_details
         fields:
           - name: _id
-            data_categories: [system.operations]
+            data_categories: [system.operations, user.unique_id]
             fides_meta:
               primary_key: True
           - name: customer_id

--- a/src/fides/api/ops/tasks/storage.py
+++ b/src/fides/api/ops/tasks/storage.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 import secrets
 import zipfile
@@ -11,6 +10,7 @@ from typing import Any, Dict, Union
 import pandas as pd
 from boto3 import Session
 from botocore.exceptions import ClientError, ParamValidationError
+from bson import json_util as json
 from loguru import logger
 
 from fides.api.ops.schemas.storage.storage import (


### PR DESCRIPTION
Closes #2784

### Description Of Changes

Pythons standard `json.dumps` method does not know how to serialise MongoDB's `ObjectId` type. This PR switches the JSON serialiser we use in our S3 upload logic to PyMongo's recommended serialiser: `bson.json_util`.

### Code Changes

* [ ] Updates the Fides S3 upload logic to use PyMongo's recommended JSON serialiser

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`