### PR TITLE
Bump typescript version to 4.9.5 on all clients

### DIFF
--- a/clients/admin-ui/package-lock.json
+++ b/clients/admin-ui/package-lock.json
@@ -66,7 +66,7 @@
         "lint-staged": "^13.0.3",
         "openapi-typescript-codegen": "^0.23.0",
         "prettier": "^2.6.2",
-        "typescript": "4.5.5"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -12808,9 +12808,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "devOptional": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22183,7 +22184,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "devOptional": true
     },
     "uglify-js": {

--- a/clients/admin-ui/package-lock.json
+++ b/clients/admin-ui/package-lock.json
@@ -22,7 +22,7 @@
         "immer": "^9.0.15",
         "js-yaml": "^4.1.0",
         "lodash.debounce": "^4.0.8",
-        "msw": "^0.47.4",
+        "msw": "^1.1.0",
         "narrow-minded": "^1.1.1",
         "next": "^12.3.4",
         "next-redux-wrapper": "^7.0.5",
@@ -10616,9 +10616,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "0.47.4",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.47.4.tgz",
-      "integrity": "sha512-Psftt8Yfl0+l+qqg9OlmKEsxF8S/vtda0CmlR6y8wTaWrMMzuCDa55n2hEGC0ZRDwuV6FFWc/4CjoDsBpATKBw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.1.0.tgz",
+      "integrity": "sha512-oqMvUXm1bMbwvGpoXAQVz8vXXQyQyx52HBDg3EDOK+dFXkQHssgkXEG4LfMwwZyr2Qt18I/w04XPaY4BkFTkzA==",
       "hasInstallScript": true,
       "dependencies": {
         "@mswjs/cookies": "^0.2.2",
@@ -10637,8 +10637,7 @@
         "node-fetch": "^2.6.7",
         "outvariant": "^1.3.0",
         "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.6",
+        "strict-event-emitter": "^0.4.3",
         "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
@@ -10653,7 +10652,7 @@
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.2.x <= 4.8.x"
+        "typescript": ">= 4.4.x <= 4.9.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -10692,6 +10691,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/msw/node_modules/strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg=="
     },
     "node_modules/msw/node_modules/tr46": {
       "version": "0.0.3",
@@ -12256,13 +12260,6 @@
     "node_modules/state-local": {
       "version": "1.0.7",
       "license": "MIT"
-    },
-    "node_modules/statuses": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
@@ -20819,9 +20816,9 @@
       "version": "2.1.2"
     },
     "msw": {
-      "version": "0.47.4",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.47.4.tgz",
-      "integrity": "sha512-Psftt8Yfl0+l+qqg9OlmKEsxF8S/vtda0CmlR6y8wTaWrMMzuCDa55n2hEGC0ZRDwuV6FFWc/4CjoDsBpATKBw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.1.0.tgz",
+      "integrity": "sha512-oqMvUXm1bMbwvGpoXAQVz8vXXQyQyx52HBDg3EDOK+dFXkQHssgkXEG4LfMwwZyr2Qt18I/w04XPaY4BkFTkzA==",
       "requires": {
         "@mswjs/cookies": "^0.2.2",
         "@mswjs/interceptors": "^0.17.5",
@@ -20839,8 +20836,7 @@
         "node-fetch": "^2.6.7",
         "outvariant": "^1.3.0",
         "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.6",
+        "strict-event-emitter": "^0.4.3",
         "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
@@ -20857,6 +20853,11 @@
           "requires": {
             "whatwg-url": "^5.0.0"
           }
+        },
+        "strict-event-emitter": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+          "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg=="
         },
         "tr46": {
           "version": "0.0.3"
@@ -21834,9 +21835,6 @@
     },
     "state-local": {
       "version": "1.0.7"
-    },
-    "statuses": {
-      "version": "2.0.1"
     },
     "stop-iteration-iterator": {
       "version": "1.0.0",

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -85,7 +85,7 @@
     "lint-staged": "^13.0.3",
     "openapi-typescript-codegen": "^0.23.0",
     "prettier": "^2.6.2",
-    "typescript": "4.5.5"
+    "typescript": "4.9.5"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -41,7 +41,7 @@
     "immer": "^9.0.15",
     "js-yaml": "^4.1.0",
     "lodash.debounce": "^4.0.8",
-    "msw": "^0.47.4",
+    "msw": "^1.1.0",
     "narrow-minded": "^1.1.1",
     "next": "^12.3.4",
     "next-redux-wrapper": "^7.0.5",

--- a/clients/cypress-e2e/package-lock.json
+++ b/clients/cypress-e2e/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "cypress": "^12.3.0",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@colors/colors": {
@@ -1817,9 +1817,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3270,9 +3270,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "universalify": {

--- a/clients/cypress-e2e/package.json
+++ b/clients/cypress-e2e/package.json
@@ -5,6 +5,6 @@
   },
   "devDependencies": {
     "cypress": "^12.3.0",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/clients/privacy-center/package-lock.json
+++ b/clients/privacy-center/package-lock.json
@@ -17717,7 +17717,7 @@
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-dts": "^4.1.0",
         "rollup-plugin-esbuild": "^4.8.2",
-        "typescript": "4.9.5"
+        "typescript": "^4.9.5"
       }
     }
   },
@@ -24040,7 +24040,7 @@
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-dts": "^4.1.0",
         "rollup-plugin-esbuild": "^4.8.2",
-        "typescript": "4.9.5",
+        "typescript": "^4.9.5",
         "typescript-cookie": "^1.0.4"
       }
     },


### PR DESCRIPTION
After merging #2516, I'd prefer to have the same Typescript version on Privacy Center, Admin UI, and Cypress E2E clients.