### PR TITLE
Fix incorrect merge to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.8.2...main)
 
+### Changed
+
+* Removed "progressive" navigation that would hide Admin UI tabs until Systems / Connections were configured [#2762](https://github.com/ethyca/fides/pull/2762)
+
+### Developer Experience
+
+* Retired legacy `navV2` feature flag [#2762](https://github.com/ethyca/fides/pull/2762)
+
 ## [2.8.2](https://github.com/ethyca/fides/compare/2.8.1...2.8.2)
 
 ### Fixed
@@ -29,14 +37,6 @@ The types of changes are:
 ### Fixed
 
 * Disabled hiding Admin UI based on user scopes [#2771](https://github.com/ethyca/fides/pull/2771)
-
-### Changed
-
-* Removed "progressive" navigation that would hide Admin UI tabs until Systems / Connections were configured [#2762](https://github.com/ethyca/fides/pull/2762)
-
-### Developer Experience
-
-* Retired legacy `navV2` feature flag [#2762](https://github.com/ethyca/fides/pull/2762)
 
 ## [2.8.0](https://github.com/ethyca/fides/compare/2.7.1...2.8.0)
 


### PR DESCRIPTION
Merging #2762 put the CHANGELOG entries into 2.8.1 incorrectly, they should have gone into Unreleased 👍 