### PR TITLE
Update Admin UI Layout to fill viewport height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 ### Developer Experience
 
 * Retired legacy `navV2` feature flag [#2762](https://github.com/ethyca/fides/pull/2762)
+* Update Admin UI Layout to fill viewport height [#2812](https://github.com/ethyca/fides/pull/2812)
 
 ## [2.8.2](https://github.com/ethyca/fides/compare/2.8.1...2.8.2)
 

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -45,15 +45,15 @@ const Layout = ({
     isValidNotificationRoute;
 
   return (
-    <div data-testid={title}>
+    <Flex data-testid={title} direction="column" height="100vh">
       <Head>
         <title>Fides Admin UI - {title}</title>
-        <meta name="description" content="Generated from FidesUI template" />
+        <meta name="description" content="Privacy Engineering Platform" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Header />
       <NavTopBar />
-      <Flex as="main" px={9} py={10} gap="40px">
+      <Flex as="main" px={9} py={10} gap="40px" height="100%">
         <Box flex={0} flexShrink={0}>
           <NavSideBar />
         </Box>
@@ -62,7 +62,7 @@ const Layout = ({
           {children}
         </Flex>
       </Flex>
-    </div>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
### Code Changes

* [X] Update `Layout.tsx` to fill the viewport with `nav`, `header`, and `main` divs

### Steps to Confirm

* [X] Visually compare before / after and ensure there are no noticeable changes

| Before | After |
|---|---|
|![fides-nightly fides-staging ethyca com_add-systems](https://user-images.githubusercontent.com/1834295/224773511-61b988ca-c442-4a13-9307-b6c926836a0d.png)| ![localhost_3000_](https://user-images.githubusercontent.com/1834295/224773527-60561004-a074-420f-8e0d-67b90112bbde.png)|

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [X] Update `CHANGELOG.md`

### Description Of Changes

This is a small CSS change to ensure the _overall_ app layout is consistent between the Fides and Fides Plus Admin UIs. In the Plus UI we have some pages that need to fill the viewport height, so the overall Layout needs to include `height=100vh` over there - by doing the same here, it just means we're less likely to get some minor discrepancies in app layouts over time without noticing.

Note: this should have *no* visual effect on the existing app pages! I looked at all of them (home, privacy requests, data map, management) and confirmed this... it might seem like a useless PR but I promise this makes sense 😛 