### PR TITLE
Adding OAuth2 client credentials support for Auth0 connector

### DIFF
--- a/data/saas/config/auth0_config.yml
+++ b/data/saas/config/auth0_config.yml
@@ -7,15 +7,26 @@ saas_config:
 
   connector_params:
     - name: domain
-    - name: access_token
+    - name: client_id
+      label: Client ID
+    - name: client_secret
 
   client_config:
     protocol: https
     host: <domain>
     authentication:
-      strategy: bearer
+      strategy: oauth2_client_credentials
       configuration:
-        token: <access_token>
+        token_request:
+          method: POST
+          path: /oauth/token
+          body: |
+            {
+              "grant_type": "client_credentials",
+              "audience": "https://<domain>/api/v2/",
+              "client_id": <client_id>
+              "client_secret": <client_secret>
+            }
 
   test_request:
     method: GET

--- a/tests/fixtures/saas/auth0_fixtures.py
+++ b/tests/fixtures/saas/auth0_fixtures.py
@@ -31,6 +31,9 @@ def auth0_secrets(saas_config):
         "domain": pydash.get(saas_config, "auth0.domain") or secrets["domain"],
         "access_token": pydash.get(saas_config, "auth0.access_token")
         or secrets["access_token"],
+        "client_id": pydash.get(saas_config, "auth0.client_id") or secrets["client_id"],
+        "client_secret": pydash.get(saas_config, "auth0.client_secret")
+        or secrets["client_secret"],
     }
 
 
@@ -165,7 +168,7 @@ def auth0_erasure_data(
     user = users_response.json()
     assert users_response.ok
     error_message = (
-        f"User with email {auth0_erasure_identity_email} could not be added to auth0"
+        f"User with email {auth0_erasure_identity_email} could not be added to Auth0"
     )
     poll_for_existence(
         _user_exists,
@@ -186,7 +189,7 @@ def auth0_erasure_data(
 
 def _user_exists(auth0_erasure_identity_email: str, auth0_secrets):
     """
-    Confirm whether user exists by calling user search by email api and comparing resulting firstname str.
+    Confirm whether user exists by calling user search by email API and comparing resulting firstname str.
     Returns user ID if it exists, returns None if it does not.
     """
     base_url = f"https://{auth0_secrets['domain']}"

--- a/tests/ops/integration_tests/saas/test_auth0_task.py
+++ b/tests/ops/integration_tests/saas/test_auth0_task.py
@@ -13,14 +13,12 @@ from fides.core.config import CONFIG
 from tests.ops.graph.graph_test_util import assert_rows_match
 
 
-@pytest.mark.skip(reason="Pending development of OAuth2 JWT Bearer authentication")
 @pytest.mark.integration_saas
 @pytest.mark.integration_auth0
 def test_auth0_connection_test(auth0_connection_config) -> None:
     get_connector(auth0_connection_config).test_connection()
 
 
-@pytest.mark.skip(reason="Pending development of OAuth2 JWT Bearer authentication")
 @pytest.mark.integration_saas
 @pytest.mark.integration_auth0
 async def test_auth0_access_request_task(
@@ -93,7 +91,6 @@ async def test_auth0_access_request_task(
     )
 
 
-@pytest.mark.skip(reason="Pending development of OAuth2 JWT Bearer authentication")
 @pytest.mark.integration_saas
 @pytest.mark.integration_auth0
 async def test_auth0_erasure_request_task(


### PR DESCRIPTION
Closes #2777
### Code Changes

* [ ] Changed Auth0's authentication strategy from `bearer` to `oauth2_client_credentials`

### Steps to Confirm

* [ ] Verified with integration tests and via admin UI

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`