### PR TITLE
Remove Scopes and Add Viewer Role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The types of changes are:
 * Serialise `bson.ObjectId` types in SAR data packages [#2785](https://github.com/ethyca/fides/pull/2785)
 * The ability to assign users as system managers for a specific system [#2714](https://github.com/ethyca/fides/pull/2714)
 * New endpoints to add and remove users as system managers [#2726](https://github.com/ethyca/fides/pull/2726)
-
+* Add an automated migration to give users a `viewer` role [#2821](https://github.com/ethyca/fides/pull/2821)
 
 ### Changed
 

--- a/src/fides/api/ctl/migrations/versions/064dd27a6d41_add_viewer_role.py
+++ b/src/fides/api/ctl/migrations/versions/064dd27a6d41_add_viewer_role.py
@@ -1,0 +1,48 @@
+"""add viewer role
+
+Revision ID: 064dd27a6d41
+Revises: 68a518a3c050
+Create Date: 2023-03-13 23:05:38.083803
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+from sqlalchemy import text
+
+revision = "064dd27a6d41"
+down_revision = "68a518a3c050"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Automatic data migration: Set user scopes to empty, and set all user roles to viewer"""
+    bind = op.get_bind()
+    bind.execute(
+        text(
+            """
+            UPDATE fidesuserpermissions 
+            SET scopes = '{}', 
+                roles = '{viewer}';
+        """
+        )
+    )
+
+    """Automatic data migration: Similarly Update all client scopes attached to users"""
+    bind.execute(
+        text(
+            """
+                UPDATE client 
+                SET scopes = '{}', 
+                    roles = '{viewer}'
+                FROM fidesuserpermissions
+                WHERE fidesuserpermissions.user_id = client.user_id;
+            """
+        )
+    )
+
+
+def downgrade():
+    """Reverse data migration is a no-op"""

--- a/src/fides/api/ctl/migrations/versions/50180bbbb959_automigrate_viewer_role.py
+++ b/src/fides/api/ctl/migrations/versions/50180bbbb959_automigrate_viewer_role.py
@@ -1,8 +1,8 @@
-"""add viewer role
+"""automigrate viewer role
 
-Revision ID: 064dd27a6d41
+Revision ID: 50180bbbb959
 Revises: 68a518a3c050
-Create Date: 2023-03-13 23:05:38.083803
+Create Date: 2023-03-14 14:26:32.910570
 
 """
 import sqlalchemy as sa
@@ -11,13 +11,23 @@ from alembic import op
 # revision identifiers, used by Alembic.
 from sqlalchemy import text
 
-revision = "064dd27a6d41"
+revision = "50180bbbb959"
 down_revision = "68a518a3c050"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
+    op.drop_constraint(
+        "messagingconfig_service_type_key", "messagingconfig", type_="unique"
+    )
+    op.create_index(
+        op.f("ix_messagingconfig_service_type"),
+        "messagingconfig",
+        ["service_type"],
+        unique=True,
+    )
+
     """Automatic data migration: Set user scopes to empty, and set all user roles to viewer"""
     bind = op.get_bind()
     bind.execute(
@@ -45,4 +55,7 @@ def upgrade():
 
 
 def downgrade():
-    """Reverse data migration is a no-op"""
+    op.drop_index(op.f("ix_messagingconfig_service_type"), table_name="messagingconfig")
+    op.create_unique_constraint(
+        "messagingconfig_service_type_key", "messagingconfig", ["service_type"]
+    )

--- a/src/fides/api/ops/tasks/storage.py
+++ b/src/fides/api/ops/tasks/storage.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Union
 import pandas as pd
 from boto3 import Session
 from botocore.exceptions import ClientError, ParamValidationError
-
 from bson import ObjectId
 from loguru import logger
 

--- a/src/fides/data/test_env/fides.test_env.toml
+++ b/src/fides/data/test_env/fides.test_env.toml
@@ -22,6 +22,7 @@ oauth_root_client_id = "fidesadmin"
 oauth_root_client_secret = "fidesadminsecret"
 root_username = "root_user"
 root_password = "Testpassword1!"
+env = "prod"
 
 [execution]
 task_retry_count = 0

--- a/src/fides/lib/oauth/roles.py
+++ b/src/fides/lib/oauth/roles.py
@@ -5,6 +5,7 @@ from fides.api.ops.api.v1.scope_registry import (
     CLI_OBJECTS_READ,
     CLIENT_READ,
     CONFIG_READ,
+    CONFIG_UPDATE,
     CONNECTION_READ,
     CONNECTION_TYPE_READ,
     CONSENT_READ,
@@ -114,6 +115,7 @@ not_contributor_scopes = [
     MESSAGING_CREATE_OR_UPDATE,
     MESSAGING_DELETE,
     PRIVACY_REQUEST_NOTIFICATIONS_CREATE_OR_UPDATE,
+    CONFIG_UPDATE,
 ]
 
 ROLES_TO_SCOPES_MAPPING: Dict[str, List] = {

--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -10,6 +10,7 @@ from fides.api.ops.api.v1 import scope_registry as scopes
 from fides.api.ops.api.v1 import urn_registry as urls
 from fides.api.ops.models.application_config import ApplicationConfig
 from fides.api.ops.schemas.storage.storage import StorageType
+from fides.lib.oauth.roles import CONTRIBUTOR, OWNER, VIEWER
 
 
 class TestPatchApplicationConfig:
@@ -45,6 +46,27 @@ class TestPatchApplicationConfig:
         auth_header = generate_auth_header([scopes.CONFIG_READ])
         response = api_client.patch(url, headers=auth_header, json=payload)
         assert 403 == response.status_code
+
+    def test_patch_application_config_viewer_role(
+        self, api_client: TestClient, payload, url, generate_role_header
+    ):
+        auth_header = generate_role_header(roles=[VIEWER])
+        response = api_client.patch(url, headers=auth_header, json=payload)
+        assert 403 == response.status_code
+
+    def test_patch_application_config_contributor_role(
+        self, api_client: TestClient, payload, url, generate_role_header
+    ):
+        auth_header = generate_role_header(roles=[CONTRIBUTOR])
+        response = api_client.patch(url, headers=auth_header, json=payload)
+        assert 403 == response.status_code
+
+    def test_patch_application_config_admin_role(
+        self, api_client: TestClient, payload, url, generate_role_header
+    ):
+        auth_header = generate_role_header(roles=[OWNER])
+        response = api_client.patch(url, headers=auth_header, json=payload)
+        assert 200 == response.status_code
 
     def test_patch_application_config_with_invalid_key(
         self,

--- a/tests/ops/service/storage_uploader_service_test.py
+++ b/tests/ops/service/storage_uploader_service_test.py
@@ -7,9 +7,9 @@ from unittest import mock
 from unittest.mock import Mock
 from zipfile import ZipFile
 
-from bson import ObjectId
 import pandas as pd
 import pytest
+from bson import ObjectId
 from sqlalchemy.orm import Session
 
 from fides.api.ops.common_exceptions import StorageUploadError


### PR DESCRIPTION
Closes #2776 
❗ Locked to the same release as https://github.com/ethyca/fides/pull/2739

### Code Changes

* [ ] Removes CONFIG_UPDATE from `contributor` scopes - https://github.com/ethyca/fides/issues/2791#issuecomment-1465302052
* [ ] Adds a data migration to give all users a `viewer` role, removes their scopes from their permissions and client table
* [ ] Tacks on automatically generated `messagingconfig_service_type_key` unique index, leftovers from 179f2bb623ae_update_table_for_twilio.py. From Adam: i'm assuming that index got deleted in my migration along with dropping the column it refers to, i.e. with op.drop_column("messagingconfig", "service_type_old")  - since earlier in the migration i had: `op.alter_column(
        "messagingconfig", "service_type", new_column_name="service_type_old"
    )`
and so now the new migration is adding it back in to keep things in sync
* [ ] Updatest src/fides/data/test_env/fides.test_env.toml since we now develop with the more strict `prod` setting - this extends this to when we run fides test env


### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This is an automated data migration to transition to the new "roles".

Sets all user scopes to an empty list and gives all users a `viewer` role.  Someone will need to login as a root user and assign  roles.  Intentionally nothing preventing users from adding scopes to their users via the API yet.

A followup in a future sprint will get rid of `fidesuserpermission.scopes` entirely https://github.com/ethyca/fides/issues/2696