### PR TITLE
Custom metadata refactoring so that form is not always dirty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ The types of changes are:
 * Retired legacy `navV2` feature flag [#2762](https://github.com/ethyca/fides/pull/2762)
 * Update Admin UI Layout to fill viewport height [#2812](https://github.com/ethyca/fides/pull/2812)
 
+### Fixed
+
+* Fixed issue where unsaved changes warning would always show up when running fidesplus [#2788](https://github.com/ethyca/fides/issues/2788)
+
 ## [2.8.2](https://github.com/ethyca/fides/compare/2.8.1...2.8.2)
 
 ### Fixed

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -1,0 +1,69 @@
+import {
+  stubPlus,
+  stubSystemCrud,
+  stubTaxonomyEntities,
+} from "cypress/support/stubs";
+
+describe("System management with Plus features", () => {
+  beforeEach(() => {
+    cy.login();
+    stubSystemCrud();
+    stubTaxonomyEntities();
+    stubPlus(true);
+    cy.intercept("GET", "/api/v1/system", {
+      fixture: "systems/systems.json",
+    }).as("getSystems");
+    cy.visit("/system");
+  });
+
+  describe("custom metadata", () => {
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: "GET",
+          pathname: "/api/v1/plus/custom-metadata/allow-list",
+          query: {
+            show_values: "true",
+          },
+        },
+        {
+          fixture: "taxonomy/custom-metadata/allow-list/list.json",
+        }
+      ).as("getAllowLists");
+      cy.intercept(
+        "GET",
+        `/api/v1/plus/custom-metadata/custom-field-definition/resource-type/*`,
+
+        {
+          fixture: "taxonomy/custom-metadata/custom-field-definition/list.json",
+        }
+      ).as("getCustomFieldDefinitions");
+      cy.intercept(
+        "GET",
+        `/api/v1/plus/custom-metadata/custom-field/resource/*`,
+        {
+          fixture: "taxonomy/custom-metadata/custom-field/list.json",
+        }
+      ).as("getCustomFields");
+    });
+
+    it("can populate initial custom metadata", () => {
+      cy.getByTestId("system-fidesctl_system").within(() => {
+        cy.getByTestId("more-btn").click();
+        cy.getByTestId("edit-btn").click();
+      });
+
+      // Should not be able to save while form is untouched
+      cy.getByTestId("save-btn").should("be.disabled");
+      const testId =
+        "input-customFieldValues.id-custom-field-definition-pokemon-party";
+      cy.getByTestId(testId).contains("Charmander");
+      cy.getByTestId(testId).contains("Eevee");
+      cy.getByTestId(testId).contains("Snorlax");
+      cy.getByTestId(testId).type("Bulbasaur{enter}");
+
+      // Should be able to save now that form is dirty
+      cy.getByTestId("save-btn").should("be.enabled");
+    });
+  });
+});

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -45,6 +45,9 @@ describe("System management with Plus features", () => {
           fixture: "taxonomy/custom-metadata/custom-field/list.json",
         }
       ).as("getCustomFields");
+      cy.intercept("PUT", `/api/v1/plus/custom-metadata/custom-field`, {
+        fixture: "taxonomy/custom-metadata/custom-field/update-party.json",
+      }).as("updateParty");
     });
 
     it("can populate initial custom metadata", () => {
@@ -64,6 +67,21 @@ describe("System management with Plus features", () => {
 
       // Should be able to save now that form is dirty
       cy.getByTestId("save-btn").should("be.enabled");
+      cy.getByTestId("save-btn").click();
+
+      cy.wait("@putSystem");
+      cy.wait("@updateParty").then((interception) => {
+        expect(interception.request.body.id).to.eql(
+          "id-custom-field-pokemon-party"
+        );
+        expect(interception.request.body.resource_id).to.eql("fidesctl_system");
+        expect(interception.request.body.value).to.eql([
+          "Charmander",
+          "Eevee",
+          "Snorlax",
+          "Bulbasaur",
+        ]);
+      });
     });
   });
 });

--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -286,10 +286,6 @@ describe("System management page", () => {
       // Switch to the Data Uses tab
       cy.getByTestId("tab-Data uses").click();
 
-      // Dismiss the "Unsaved changes" modal that appears
-      // TODO: This modal only appears due to a bug: https://github.com/ethyca/fides/issues/2788, once fixed this can be removed
-      cy.getByTestId("continue-btn").click()
-
       // add another privacy declaration
       const secondDataUse = "advertising";
       cy.getByTestId("tab-Data uses").click();

--- a/clients/admin-ui/cypress/e2e/taxonomy-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy-plus.cy.ts
@@ -218,9 +218,9 @@ describe("Taxonomy management with Plus features", () => {
     });
 
     const testIdSingle =
-      "input-definitionIdToCustomFieldValue.id-custom-field-definition-starter-pokemon";
+      "input-customFieldValues.id-custom-field-definition-starter-pokemon";
     const testIdMulti =
-      "input-definitionIdToCustomFieldValue.id-custom-field-definition-pokemon-party";
+      "input-customFieldValues.id-custom-field-definition-pokemon-party";
 
     it("initializes form fields with values returned by the API", () => {
       cy.getByTestId("custom-fields-list");

--- a/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
+++ b/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
@@ -1,14 +1,10 @@
 import { Center, Divider, Flex, Spinner, Text } from "@fidesui/react";
-import { Field, FieldInputProps, useFormikContext } from "formik";
-import { useCallback, useEffect, useState } from "react";
+import { Field, FieldInputProps } from "formik";
 
-import { useAppDispatch } from "~/app/hooks";
-import { plusApi } from "~/features/plus/plus.slice";
 import { AllowedTypes, ResourceTypes } from "~/types/api";
 
 import { CustomSelect } from "../form/inputs";
 import { CustomFieldsModal } from "./CustomFieldsModal";
-import { filterWithId } from "./helpers";
 import { useCustomFields } from "./hooks";
 
 type CustomFieldsListProps = {
@@ -20,10 +16,6 @@ export const CustomFieldsList = ({
   resourceFidesKey,
   resourceType,
 }: CustomFieldsListProps) => {
-  const dispatch = useAppDispatch();
-  const [selectedKey, setSelectedKey] = useState<string | undefined>();
-  const { isSubmitting, setValues, values } = useFormikContext();
-
   const {
     idToAllowListWithOptions,
     idToCustomFieldDefinition,
@@ -34,50 +26,6 @@ export const CustomFieldsList = ({
     resourceFidesKey,
     resourceType,
   });
-
-  const handleReload = useCallback(() => {
-    setValues({ ...(values as any) });
-  }, [setValues, values]);
-
-  useEffect(() => {
-    if (!isEnabled || !resourceFidesKey) {
-      return;
-    }
-    // Append the custom field selections to the Formik form
-    if (selectedKey !== resourceFidesKey) {
-      setSelectedKey(resourceFidesKey);
-      dispatch(
-        plusApi.endpoints.getCustomFieldsForResource.initiate(resourceFidesKey)
-      ).then((response) => {
-        const data = new Map(
-          filterWithId(response.data).map((fd) => [
-            fd.custom_field_definition_id,
-            fd,
-          ])
-        );
-        const formValues: Record<string, string | string[]> = {};
-        data.forEach((value, key) => {
-          formValues[`${key}`] = value.value.toString();
-        });
-        setValues(
-          {
-            ...(values as any),
-            ...{ definitionIdToCustomFieldValue: formValues },
-          },
-          false
-        );
-      });
-    }
-  }, [dispatch, isEnabled, resourceFidesKey, selectedKey, setValues, values]);
-
-  useEffect(() => {
-    // Re-render the custom field selections after a Formik form submission
-    if (isSubmitting) {
-      setTimeout(() => {
-        handleReload();
-      });
-    }
-  }, [handleReload, isSubmitting, values]);
 
   if (!isEnabled) {
     return null;
@@ -101,7 +49,7 @@ export const CustomFieldsList = ({
             Custom fields
           </Text>
         </Flex>
-        <CustomFieldsModal reload={handleReload} resourceType={resourceType} />
+        <CustomFieldsModal resourceType={resourceType} />
         {isLoading ? (
           <Center>
             <Spinner />

--- a/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
+++ b/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
@@ -75,7 +75,7 @@ export const CustomFieldsList = ({
                 }
 
                 const { options } = allowList;
-                const name = `definitionIdToCustomFieldValue.${customFieldDefinition.id}`;
+                const name = `customFieldValues.${customFieldDefinition.id}`;
 
                 return (
                   <Field key={definitionId} name={name}>

--- a/clients/admin-ui/src/features/common/custom-fields/hooks.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/hooks.ts
@@ -115,12 +115,15 @@ export const useCustomFields = ({
    * Transformed version of definitionIdToCustomField to be easy
    * to pass into Formik
    */
-  const customFieldValues: Record<string, string | string[]> = {};
-  if (definitionIdToCustomField) {
-    definitionIdToCustomField.forEach((value, key) => {
-      customFieldValues[key] = value.value.toString();
-    });
-  }
+  const customFieldValues = useMemo(() => {
+    const values: Record<string, string | string[]> = {};
+    if (definitionIdToCustomField) {
+      definitionIdToCustomField.forEach((value, key) => {
+        values[key] = value.value.toString();
+      });
+    }
+    return values;
+  }, [definitionIdToCustomField]);
 
   /**
    * Issue a batch of upsert and delete requests that will sync the form selections to the

--- a/clients/admin-ui/src/features/common/custom-fields/hooks.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/hooks.ts
@@ -12,7 +12,7 @@ import {
 import { CustomFieldWithId, ResourceTypes } from "~/types/api";
 
 import { filterWithId } from "./helpers";
-import { CustomFieldsFormValues } from "./types";
+import { CustomFieldsFormValues, CustomFieldValues } from "./types";
 
 type UseCustomFieldsOptions = {
   resourceFidesKey?: string;
@@ -116,7 +116,7 @@ export const useCustomFields = ({
    * to pass into Formik
    */
   const customFieldValues = useMemo(() => {
-    const values: Record<string, string | string[]> = {};
+    const values: CustomFieldValues = {};
     if (definitionIdToCustomField) {
       definitionIdToCustomField.forEach((value, key) => {
         values[key] = value.value.toString();

--- a/clients/admin-ui/src/features/common/custom-fields/types.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/types.ts
@@ -28,6 +28,8 @@ export interface AllowListWithOptions extends AllowList {
   options: Option[];
 }
 
+export type CustomFieldValues = Record<string, string | string[] | undefined>;
+
 /**
  * The custom metadata fields are very dynamic and may not be rendered at all. If they are used,
  * their values are stored as a mapping from the field definition's ID to the value, which may be a
@@ -39,5 +41,5 @@ export interface CustomFieldsFormValues {
    * This is camel-cased because it is only used in UI code and must be handled specially when
    * submitting the form. It does not correspond with a snake-cased API field.
    */
-  customFieldValues?: Record<string, string | string[] | undefined>;
+  customFieldValues?: CustomFieldValues;
 }

--- a/clients/admin-ui/src/features/common/custom-fields/types.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/types.ts
@@ -39,8 +39,5 @@ export interface CustomFieldsFormValues {
    * This is camel-cased because it is only used in UI code and must be handled specially when
    * submitting the form. It does not correspond with a snake-cased API field.
    */
-  definitionIdToCustomFieldValue?: Record<
-    string,
-    string | string[] | undefined
-  >;
+  customFieldValues?: Record<string, string | string[] | undefined>;
 }

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -77,10 +77,10 @@ const SystemInformationForm = ({
       passedInSystem
         ? transformSystemToFormValues(
             passedInSystem,
-            customFields.definitionIdToCustomField
+            customFields.customFieldValues
           )
         : defaultInitialValues,
-    [passedInSystem, customFields.definitionIdToCustomField]
+    [passedInSystem, customFields.customFieldValues]
   );
 
   const [createSystemMutationTrigger, createSystemMutationResult] =

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -67,13 +67,22 @@ const SystemInformationForm = ({
   withHeader,
   children,
 }: Props) => {
+  const customFields = useCustomFields({
+    resourceType: ResourceTypes.SYSTEM,
+    resourceFidesKey: passedInSystem?.fides_key,
+  });
+
   const initialValues = useMemo(
     () =>
       passedInSystem
-        ? transformSystemToFormValues(passedInSystem)
+        ? transformSystemToFormValues(
+            passedInSystem,
+            customFields.definitionIdToCustomField
+          )
         : defaultInitialValues,
-    [passedInSystem]
+    [passedInSystem, customFields.definitionIdToCustomField]
   );
+
   const [createSystemMutationTrigger, createSystemMutationResult] =
     useCreateSystemMutation();
   const [updateSystemMutationTrigger, updateSystemMutationResult] =
@@ -89,11 +98,6 @@ const SystemInformationForm = ({
   );
 
   const toast = useToast();
-
-  const customFields = useCustomFields({
-    resourceType: ResourceTypes.SYSTEM,
-    resourceFidesKey: passedInSystem?.fides_key,
-  });
 
   const handleSubmit = async (
     values: FormValues,

--- a/clients/admin-ui/src/features/system/form.ts
+++ b/clients/admin-ui/src/features/system/form.ts
@@ -10,6 +10,7 @@ export interface FormValues
     progress?: DataProtectionImpactAssessment["progress"];
     link?: DataProtectionImpactAssessment["link"];
   };
+  definitionIdToCustomFieldValue?: Record<string, string | string[]>;
 }
 
 export const defaultInitialValues: FormValues = {
@@ -37,14 +38,26 @@ export const defaultInitialValues: FormValues = {
   },
 };
 
-export const transformSystemToFormValues = (system: System): FormValues => {
+export const transformSystemToFormValues = (
+  system: System,
+  definitionIdToCustomField?: Map<any, any>
+): FormValues => {
   const { data_protection_impact_assessment: dpia } = system;
+  const customFields: Record<string, string | string[]> = {};
+
+  if (definitionIdToCustomField) {
+    definitionIdToCustomField.forEach((value, key) => {
+      customFields[key] = value.value;
+    });
+  }
+
   return {
     ...system,
     data_protection_impact_assessment: {
       ...dpia,
       is_required: dpia?.is_required ? "true" : "false",
     },
+    definitionIdToCustomFieldValue: customFields,
   };
 };
 

--- a/clients/admin-ui/src/features/system/form.ts
+++ b/clients/admin-ui/src/features/system/form.ts
@@ -1,4 +1,7 @@
-import { CustomFieldsFormValues } from "~/features/common/custom-fields";
+import {
+  CustomFieldsFormValues,
+  CustomFieldValues,
+} from "~/features/common/custom-fields";
 import { DEFAULT_ORGANIZATION_FIDES_KEY } from "~/features/organization";
 import { DataProtectionImpactAssessment, System } from "~/types/api";
 
@@ -10,7 +13,7 @@ export interface FormValues
     progress?: DataProtectionImpactAssessment["progress"];
     link?: DataProtectionImpactAssessment["link"];
   };
-  customFieldValues?: Record<string, string | string[]>;
+  customFieldValues?: CustomFieldValues;
 }
 
 export const defaultInitialValues: FormValues = {
@@ -40,7 +43,7 @@ export const defaultInitialValues: FormValues = {
 
 export const transformSystemToFormValues = (
   system: System,
-  customFieldValues?: Record<string, string | string[]>
+  customFieldValues?: CustomFieldValues
 ): FormValues => {
   const { data_protection_impact_assessment: dpia } = system;
 

--- a/clients/admin-ui/src/features/system/form.ts
+++ b/clients/admin-ui/src/features/system/form.ts
@@ -10,7 +10,7 @@ export interface FormValues
     progress?: DataProtectionImpactAssessment["progress"];
     link?: DataProtectionImpactAssessment["link"];
   };
-  definitionIdToCustomFieldValue?: Record<string, string | string[]>;
+  customFieldValues?: Record<string, string | string[]>;
 }
 
 export const defaultInitialValues: FormValues = {
@@ -40,16 +40,9 @@ export const defaultInitialValues: FormValues = {
 
 export const transformSystemToFormValues = (
   system: System,
-  definitionIdToCustomField?: Map<any, any>
+  customFieldValues?: Record<string, string | string[]>
 ): FormValues => {
   const { data_protection_impact_assessment: dpia } = system;
-  const customFields: Record<string, string | string[]> = {};
-
-  if (definitionIdToCustomField) {
-    definitionIdToCustomField.forEach((value, key) => {
-      customFields[key] = value.value;
-    });
-  }
 
   return {
     ...system,
@@ -57,7 +50,7 @@ export const transformSystemToFormValues = (
       ...dpia,
       is_required: dpia?.is_required ? "true" : "false",
     },
-    definitionIdToCustomFieldValue: customFields,
+    customFieldValues,
   };
 };
 

--- a/clients/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/admin-ui/src/features/taxonomy/hooks.tsx
@@ -1,6 +1,9 @@
 import { ReactNode, useState } from "react";
 
-import { CustomFieldsList } from "~/features/common/custom-fields";
+import {
+  CustomFieldsList,
+  CustomFieldValues,
+} from "~/features/common/custom-fields";
 import { useCustomFields } from "~/features/common/custom-fields/hooks";
 import { RTKResult } from "~/features/common/types";
 import {
@@ -63,9 +66,15 @@ export interface TaxonomyHookData<T extends TaxonomyEntity> {
   transformEntityToInitialValues: (entity: T) => FormValues;
 }
 
+/**
+ * Transforms the attributes that are shared between taxonomy entities into values
+ * that Formik can easily handle.
+ * If the taxonomy entity has additional fields that need to be transformed,
+ * it should extend from this function.
+ */
 const transformTaxonomyBaseToInitialValues = (
   t: TaxonomyEntity,
-  customFieldValues?: Record<string, string | string[]>
+  customFieldValues?: CustomFieldValues
 ) => ({
   fides_key: t.fides_key ?? "",
   name: t.name ?? "",
@@ -75,6 +84,10 @@ const transformTaxonomyBaseToInitialValues = (
   customFieldValues,
 });
 
+/**
+ * Transforms the attributes that are shared between taxonomy entities into
+ * a taxonomy object ready to be consumed by the API
+ */
 const transformBaseFormValuesToEntity = (
   initialValues: FormValues,
   newValues: FormValues
@@ -157,7 +170,7 @@ export const useDataCategory = (): TaxonomyHookData<DataCategory> => {
     />
   );
 
-  const handleTransformEntityToInitialValues = (entity: DataCategory) =>
+  const transformEntityToInitialValues = (entity: DataCategory) =>
     transformTaxonomyBaseToInitialValues(
       entity,
       customFields.customFieldValues
@@ -174,7 +187,7 @@ export const useDataCategory = (): TaxonomyHookData<DataCategory> => {
     handleEdit,
     handleDelete,
     renderExtraFormFields,
-    transformEntityToInitialValues: handleTransformEntityToInitialValues,
+    transformEntityToInitialValues,
   };
 };
 

--- a/clients/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/admin-ui/src/features/taxonomy/hooks.tsx
@@ -63,12 +63,16 @@ export interface TaxonomyHookData<T extends TaxonomyEntity> {
   transformEntityToInitialValues: (entity: T) => FormValues;
 }
 
-const transformTaxonomyBaseToInitialValues = (t: TaxonomyEntity) => ({
+const transformTaxonomyBaseToInitialValues = (
+  t: TaxonomyEntity,
+  customFieldValues?: Record<string, string | string[]>
+) => ({
   fides_key: t.fides_key ?? "",
   name: t.name ?? "",
   description: t.description ?? "",
   parent_key: t.parent_key ?? "",
   is_default: t.is_default ?? false,
+  customFieldValues,
 });
 
 const transformBaseFormValuesToEntity = (
@@ -89,7 +93,7 @@ const transformBaseFormValuesToEntity = (
     entity.fides_key = initialValues.fides_key;
   }
 
-  delete entity.definitionIdToCustomFieldValue;
+  delete entity.customFieldValues;
 
   return entity;
 };
@@ -153,6 +157,12 @@ export const useDataCategory = (): TaxonomyHookData<DataCategory> => {
     />
   );
 
+  const handleTransformEntityToInitialValues = (entity: DataCategory) =>
+    transformTaxonomyBaseToInitialValues(
+      entity,
+      customFields.customFieldValues
+    );
+
   return {
     data,
     isLoading,
@@ -164,7 +174,7 @@ export const useDataCategory = (): TaxonomyHookData<DataCategory> => {
     handleEdit,
     handleDelete,
     renderExtraFormFields,
-    transformEntityToInitialValues: transformTaxonomyBaseToInitialValues,
+    transformEntityToInitialValues: handleTransformEntityToInitialValues,
   };
 };
 
@@ -252,7 +262,10 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
   const handleDelete = deleteDataUseMutationTrigger;
 
   const transformEntityToInitialValues = (du: DataUse) => {
-    const base = transformTaxonomyBaseToInitialValues(du);
+    const base = transformTaxonomyBaseToInitialValues(
+      du,
+      customFields.customFieldValues
+    );
     return {
       ...base,
       legal_basis: du.legal_basis,
@@ -407,7 +420,10 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
   const handleDelete = deleteDataSubjectMutationTrigger;
 
   const transformEntityToInitialValues = (ds: DataSubject) => {
-    const base = transformTaxonomyBaseToInitialValues(ds);
+    const base = transformTaxonomyBaseToInitialValues(
+      ds,
+      customFields.customFieldValues
+    );
     return {
       ...base,
       rights: ds.rights?.values ?? [],


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2788

The issue presented itself like something was wrong with the `UnmountWarning` component, but it's actually because the form was always in a "dirty" state due to some circular logic going on in the `CustomFieldsList` component (hence the problem only showing up in plus)

Originally, `CustomFieldsList` had a `useEffect` which would read in the data from the custom fields endpoint, then populate the form on the fly via `setValue`. Using `setValue` made the form always dirty, hence the unmount warning always showing up.

I went for a pretty thorough (🤞) refactoring, where instead of populating the data on the fly, populate the data via the initial values to begin with. this cleans up a lot of the `useEffect`s and various `reload` functionality, since formik is good at handling that kind of thing. 

### Code Changes

* Refactored the `useEffect`s out of `CustomFieldsList` in favor of setting initial values 
  *  Renamed the field to `customFieldValues` since the format is a bit more streamlined for formik than the original `definitionIdToCustomFieldValue` which is still used, but just as a Map
* Updated the system and taxonomy hooks to do the initial value transformation
* Remove the original cypress workaround which was accommodating for the unmount warning popping up when it wasn't supposed to
* Added a basic test for system custom metadata since there weren't any. Luckily there were taxonomy tests already in place 😌 

### Steps to Confirm

* [ ] Run the fidesplus backend (`nox -s "dev(fidesplus)"`)
* [ ] Edit an existing system (can make one manually if you don't already have one)
* [ ] Make sure if you don't make any changes, you can still go to the "Data use" tab and the unmount warning doesn't interfere
* [ ] Make changes to custom metadata. Hopefully everything still works the same.
  * [ ] ❗ This was a pretty non-trivial refactor, so could definitely use some QA to make sure I didn't break anything since I'm not super familiar with the custom metadata flow

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes


https://user-images.githubusercontent.com/24641006/225063566-2108c110-36ca-43d1-a4bb-10551f17974a.mov


