### PR TITLE
Implement a notification banner to show up on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The types of changes are:
 * Serialise `bson.ObjectId` types in SAR data packages [#2785](https://github.com/ethyca/fides/pull/2785)
 * The ability to assign users as system managers for a specific system [#2714](https://github.com/ethyca/fides/pull/2714)
 * New endpoints to add and remove users as system managers [#2726](https://github.com/ethyca/fides/pull/2726)
-
+* Warning about access control migration to the UI [#2842](https://github.com/ethyca/fides/pull/2842)
 
 ### Changed
 

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -13,6 +13,7 @@ import {
 } from "~/features/privacy-requests/privacy-requests.slice";
 
 import ConfigurationNotificationBanner from "../privacy-requests/configuration/ConfigurationNotificationBanner";
+import NotificationBanner from "./NotificationBanner";
 
 const Layout = ({
   children,
@@ -39,7 +40,7 @@ const Layout = ({
     skip,
   });
 
-  const showNotificationBanner =
+  const showConfigurationBanner =
     features.flags.privacyRequestsConfiguration &&
     (!activeMessagingProvider || !activeStorage) &&
     isValidNotificationRoute;
@@ -52,13 +53,14 @@ const Layout = ({
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Header />
+      <NotificationBanner />
       <NavTopBar />
       <Flex as="main" px={9} py={10} gap="40px" height="100%">
         <Box flex={0} flexShrink={0}>
           <NavSideBar />
         </Box>
         <Flex direction="column" flex={1} minWidth={0}>
-          {showNotificationBanner ? <ConfigurationNotificationBanner /> : null}
+          {showConfigurationBanner ? <ConfigurationNotificationBanner /> : null}
           {children}
         </Flex>
       </Flex>

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -53,6 +53,7 @@ const Layout = ({
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Header />
+      {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
       <NotificationBanner />
       <NavTopBar />
       <Flex as="main" px={9} py={10} gap="40px" height="100%">

--- a/clients/admin-ui/src/features/common/NotificationBanner.tsx
+++ b/clients/admin-ui/src/features/common/NotificationBanner.tsx
@@ -1,0 +1,53 @@
+import {
+  useDisclosure,
+  Alert,
+  AlertIcon,
+  Box,
+  AlertDescription,
+  CloseButton,
+} from "@fidesui/react";
+
+import { useAppDispatch, useAppSelector } from "~/app/hooks";
+import {
+  selectShowNotificationBanner,
+  setShowNotificationBanner,
+} from "./features";
+
+const DESCRIPTION =
+  "Ethyca has updated how permissions work from a scope-based model to a role-based permissions scheme. To update user roles, please log in as your root user and upgrade the roles as you see fit.";
+
+const NotificationBanner = () => {
+  const showBanner = useAppSelector(selectShowNotificationBanner);
+  const dispatch = useAppDispatch();
+
+  const { isOpen: isVisible, onClose } = useDisclosure({
+    defaultIsOpen: showBanner,
+  });
+
+  const handleClose = () => {
+    dispatch(setShowNotificationBanner(false));
+    onClose();
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <Alert status="info" overflow="visible">
+      <AlertIcon />
+      <Box>
+        <AlertDescription>{DESCRIPTION}</AlertDescription>
+      </Box>
+      <CloseButton
+        alignSelf="flex-start"
+        position="relative"
+        right={-1}
+        top={-1}
+        onClick={handleClose}
+      />
+    </Alert>
+  );
+};
+
+export default NotificationBanner;

--- a/clients/admin-ui/src/features/common/NotificationBanner.tsx
+++ b/clients/admin-ui/src/features/common/NotificationBanner.tsx
@@ -1,13 +1,14 @@
 import {
-  useDisclosure,
   Alert,
+  AlertDescription,
   AlertIcon,
   Box,
-  AlertDescription,
   CloseButton,
+  useDisclosure,
 } from "@fidesui/react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
+
 import {
   selectShowNotificationBanner,
   setShowNotificationBanner,

--- a/clients/admin-ui/src/features/common/NotificationBanner.tsx
+++ b/clients/admin-ui/src/features/common/NotificationBanner.tsx
@@ -8,6 +8,8 @@ import {
 } from "@fidesui/react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
+import { RoleRegistryEnum } from "~/types/api";
+import { selectThisUsersRoles } from "../user-management";
 
 import {
   selectShowNotificationBanner,
@@ -20,6 +22,8 @@ const DESCRIPTION =
 const NotificationBanner = () => {
   const showBanner = useAppSelector(selectShowNotificationBanner);
   const dispatch = useAppDispatch();
+
+  const userRoles = useAppSelector(selectThisUsersRoles);
 
   // if the user hasn't logged out, it's possible `showBanner` can be undefined
   // since the redux store hasn't reinitialized. in this case, we _do_ want to show the banner
@@ -35,6 +39,11 @@ const NotificationBanner = () => {
   };
 
   if (!isVisible) {
+    return null;
+  }
+
+  // Anyone who is not only a viewer should not see this banner
+  if (userRoles.length === 1 && userRoles[0] !== RoleRegistryEnum.VIEWER) {
     return null;
   }
 

--- a/clients/admin-ui/src/features/common/NotificationBanner.tsx
+++ b/clients/admin-ui/src/features/common/NotificationBanner.tsx
@@ -20,8 +20,12 @@ const NotificationBanner = () => {
   const showBanner = useAppSelector(selectShowNotificationBanner);
   const dispatch = useAppDispatch();
 
+  // if the user hasn't logged out, it's possible `showBanner` can be undefined
+  // since the redux store hasn't reinitialized. in this case, we _do_ want to show the banner
+  const defaultIsOpen = showBanner === undefined ? true : showBanner;
+
   const { isOpen: isVisible, onClose } = useDisclosure({
-    defaultIsOpen: showBanner,
+    defaultIsOpen,
   });
 
   const handleClose = () => {

--- a/clients/admin-ui/src/features/common/NotificationBanner.tsx
+++ b/clients/admin-ui/src/features/common/NotificationBanner.tsx
@@ -8,8 +8,8 @@ import {
 } from "@fidesui/react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
+import { selectThisUsersRoles } from "~/features/user-management";
 import { RoleRegistryEnum } from "~/types/api";
-import { selectThisUsersRoles } from "../user-management";
 
 import {
   selectShowNotificationBanner,

--- a/clients/admin-ui/src/features/common/features/features.slice.ts
+++ b/clients/admin-ui/src/features/common/features/features.slice.ts
@@ -20,9 +20,10 @@ export const FLAG_NAMES = Object.keys(FLAG_CONFIG) as Array<
 
 type FeaturesState = {
   flags: Partial<FlagConfig>;
+  showNotificationBanner: boolean;
 };
 
-const initialState: FeaturesState = { flags: {} };
+const initialState: FeaturesState = { flags: {}, showNotificationBanner: true };
 
 const featuresSlice = createSlice({
   name: "features",
@@ -53,6 +54,9 @@ const featuresSlice = createSlice({
     reset(draftState) {
       draftState.flags = {};
     },
+    setShowNotificationBanner(draftState, action: PayloadAction<boolean>) {
+      draftState.showNotificationBanner = action.payload;
+    },
   },
 });
 
@@ -68,6 +72,17 @@ export const selectEnvFlags = createSelector(
   (flags): FlagsFor<FlagConfig> =>
     flagsForEnv({ ...FLAG_CONFIG, ...flags }, process.env.NEXT_PUBLIC_APP_ENV)
 );
+
+/**
+ * Notification banner specific. If we one day end up with more notification
+ * related logic, we should move this to its own slice.
+ */
+export const selectShowNotificationBanner = createSelector(
+  selectFeatures,
+  (state) => state.showNotificationBanner
+);
+
+export const { setShowNotificationBanner } = featuresSlice.actions;
 
 export const useFlags = () => {
   const dispatch = useAppDispatch();

--- a/clients/admin-ui/src/features/user-management/user-management.slice.ts
+++ b/clients/admin-ui/src/features/user-management/user-management.slice.ts
@@ -6,7 +6,12 @@ import { utf8ToB64 } from "common/utils";
 import type { RootState } from "~/app/store";
 import { BASE_URL } from "~/constants";
 import { selectToken, selectUser } from "~/features/auth";
-import { ScopeRegistryEnum, System, UserForcePasswordReset } from "~/types/api";
+import {
+  RoleRegistryEnum,
+  ScopeRegistryEnum,
+  System,
+  UserForcePasswordReset,
+} from "~/types/api";
 
 import {
   User,
@@ -239,6 +244,27 @@ export const selectThisUsersScopes = createSelector(
     ).data;
 
     return permissions ? permissions.total_scopes : emptyScopes;
+  }
+);
+
+const emptyRoles: RoleRegistryEnum[] = [];
+/**
+ * In general, the UI should restrict based off of scopes, not roles to allow
+ * for flexibility when adding or removing roles.
+ * There are however, some unique cases where it is more useful to restrict
+ * off of role than scope. Make sure you use this selector intentionally!
+ */
+export const selectThisUsersRoles = createSelector(
+  [(RootState) => RootState, selectUser],
+  (RootState, user) => {
+    if (!user) {
+      return emptyRoles;
+    }
+    const permissions = userApi.endpoints.getUserPermissions.select(user.id)(
+      RootState
+    ).data;
+
+    return permissions?.roles ?? emptyRoles;
   }
 );
 

--- a/clients/admin-ui/src/home/HomeLayout.tsx
+++ b/clients/admin-ui/src/home/HomeLayout.tsx
@@ -20,15 +20,10 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
       <link rel="icon" href="/favicon.ico" />
     </Head>
     <Header />
+    {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
     <NotificationBanner />
     <NavTopBar />
-    <Flex
-      as="main"
-      flexDirection="column"
-      gap="40px"
-      width="100vw"
-      height="100%"
-    >
+    <Flex as="main" flexDirection="column" gap="40px" height="100%">
       {children}
     </Flex>
   </Flex>

--- a/clients/admin-ui/src/home/HomeLayout.tsx
+++ b/clients/admin-ui/src/home/HomeLayout.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from "react";
 
 import Header from "~/features/common/Header";
 import { NavTopBar } from "~/features/common/nav/v2/NavTopBar";
+import NotificationBanner from "~/features/common/NotificationBanner";
 
 type HomeLayoutProps = {
   children: ReactNode;
@@ -12,18 +13,25 @@ type HomeLayoutProps = {
 };
 
 const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
-  <div data-testid={title}>
+  <Flex data-testid={title} direction="column" height="100vh">
     <Head>
       <title>Fides Admin UI - {title}</title>
       <meta name="description" content="" />
       <link rel="icon" href="/favicon.ico" />
     </Head>
     <Header />
+    <NotificationBanner />
     <NavTopBar />
-    <Flex flexDirection="column" gap="40px" width="100vw">
+    <Flex
+      as="main"
+      flexDirection="column"
+      gap="40px"
+      width="100vw"
+      height="100%"
+    >
       {children}
     </Flex>
-  </div>
+  </Flex>
 );
 
 export default HomeLayout;


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/676

### Code Changes

* [x] Adds a NotificationBanner component
* [x] Adds state to redux for whether or not to show the banner
* [x] Tweaks to `HomeLayout` similar to https://github.com/ethyca/fides/pull/2812/files 

### Steps to Confirm

* [ ] Create a user who only has the "viewer" role via the new role assignment UI
* [ ] Log in as that user
* [ ] You should see the notification banner when you start the app
* [ ] Exit out of it
* [ ] Click around and make sure it doesn't come back
* [ ] Log out of the app
* [ ] Log back in and you should see the banner again
* [ ] Log out and then log in as the root user (or a user who isn't a viewer)
* [ ] You should not see the banner at all

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

I wasn't sure if we wanted to add a check against the fides version here? Or how we determine when we will remove this banner. 

https://user-images.githubusercontent.com/24641006/225382627-95f2e99e-57dc-4e4c-862d-18ef985b7868.mov



