### PR TITLE
Restore password validation in user management

### DIFF
--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -372,7 +372,7 @@ export const CustomTextInput = ({
     );
   }
   return (
-    <FormControl isInvalid={isInvalid}>
+    <FormControl isInvalid={isInvalid} isRequired={isRequired}>
       <VStack alignItems="start">
         <Flex alignItems="center">
           <Label htmlFor={props.id || props.name} fontSize="sm" my={0} mr={1}>

--- a/clients/admin-ui/src/features/user-management/UserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/UserForm.tsx
@@ -139,6 +139,7 @@ const UserForm = ({
                 variant="block"
                 placeholder="Enter new username"
                 disabled={!isNewUser}
+                isRequired
               />
               <CustomTextInput
                 name="first_name"
@@ -162,6 +163,7 @@ const UserForm = ({
                   placeholder="********"
                   type="password"
                   tooltip="Password must contain at least 8 characters, 1 number, 1 capital letter, 1 lowercase letter, and at least 1 symbol."
+                  isRequired
                 />
               ) : null}
             </Stack>

--- a/clients/admin-ui/src/features/user-management/UserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/UserForm.tsx
@@ -90,9 +90,11 @@ const UserForm = ({
       dispatch(setActiveUserId(result.data.id));
     }
   };
-  const validationSchema = canChangePassword
-    ? ValidationSchema
-    : ValidationSchema.omit(["password"]);
+
+  const validationSchema =
+    canChangePassword || isNewUser
+      ? ValidationSchema
+      : ValidationSchema.omit(["password"]);
 
   return (
     <Formik


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2849

### Code Changes

* [x] Restore password validation when creating a new user
* [x] Also adds a red asterisk for the required fields

### Steps to Confirm

* [ ] See steps in the issue

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Note that adding the `isRequired` field is a bit of data duplication because [formik doesn't currently have a way to use the Yup validation schema](https://github.com/jaredpalmer/formik/issues/1241) to determine a field is required, so we pass it in. 
