### PR TITLE
handle different orders of custom field additions in datamap export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The types of changes are:
 
 * Fixed issue where unsaved changes warning would always show up when running fidesplus [#2788](https://github.com/ethyca/fides/issues/2788)
 * Fixed problem in datamap export with datasets that had been updated via SaaS instantiation [#2841](https://github.com/ethyca/fides/pull/2841)
+* Fixed problem in datamap export with inconsistent custom field ordering [#2859](https://github.com/ethyca/fides/pull/2859)
 
 ## [2.8.3](https://github.com/ethyca/fides/compare/2.8.2...2.8.3)
 

--- a/tests/ctl/api/test_datamap.py
+++ b/tests/ctl/api/test_datamap.py
@@ -274,6 +274,42 @@ EXPECTED_RESPONSE_TWO_CUSTOM_FIELDS_ONE_MULTIVAL_TWO_SYSTEMS = [
     PRIVACY_DECLARATION_SYSTEM_ROW_TWO_CUSTOM_FIELDS_ONE_MULTIVAL,
 ]
 
+EXPECTED_RESPONSE_TWO_SYSTEMS_TWO_CUSTOM_FIELDS_ONLY_PRIVACY_DECLARATIONS = [
+    {
+        **HEADERS_ROW_RESPONSE_PAYLOAD,
+        "system.country": "country",
+        "system.owner": "owner",
+    },
+    {
+        **NO_PRIVACY_DECLARATION_SYSTEM_ROW_RESPONSE_PAYLOAD,
+        "system.country": "usa",
+        "system.owner": "N/A",
+    },
+    {
+        **PRIVACY_DECLARATION_SYSTEM_ROW_RESPONSE_PAYLOAD,
+        "system.country": "canada",
+        "system.owner": "Jane",
+    },
+]
+
+EXPECTED_RESPONSE_TWO_SYSTEMS_TWO_CUSTOM_FIELDS_ONLY_NO_PRIVACY_DECLARATIONS = [
+    {
+        **HEADERS_ROW_RESPONSE_PAYLOAD,
+        "system.country": "country",
+        "system.owner": "owner",
+    },
+    {
+        **NO_PRIVACY_DECLARATION_SYSTEM_ROW_RESPONSE_PAYLOAD,
+        "system.country": "usa",
+        "system.owner": "John",
+    },
+    {
+        **PRIVACY_DECLARATION_SYSTEM_ROW_RESPONSE_PAYLOAD,
+        "system.country": "N/A",
+        "system.owner": "Jane",
+    },
+]
+
 
 PRIVACY_DECLARATION_WITH_NAME_SYSTEM_ROW_RESPONSE_PAYLOAD = [
     {
@@ -899,6 +935,83 @@ def test_datamap_two_custom_fields_two_systems(
     )
     assert response.status_code == 200
     assert response.json() == EXPECTED_RESPONSE_TWO_CUSTOM_FIELDS_TWO_SYSTEMS
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures(
+    "country_field_instance_no_privacy_declarations",
+    "owner_field_instance_no_privacy_declarations",
+    "owner_field_instance_privacy_declarations",
+    "country_field_instance_privacy_declarations",
+)
+def test_datamap_two_custom_fields_two_systems_added_different_order(
+    test_config,
+    test_client,
+):
+    """
+    Tests expected response with two systems - one with privacy declarations, one without -
+    and two custom fields populated on both systems. The two custom fields are populated
+    in different orders on each system, respectively. This helps surface any bugs in the code
+    that assume the same ordering of custom fields for each system (row) in the result set.
+    """
+    response = test_client.get(
+        test_config.cli.server_url + API_PREFIX + "/datamap/" + "default_organization",
+        headers=test_config.user.auth_header,
+    )
+    assert response.status_code == 200
+    assert response.json() == EXPECTED_RESPONSE_TWO_CUSTOM_FIELDS_TWO_SYSTEMS
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures(
+    "country_field_instance_no_privacy_declarations",
+    "owner_field_instance_privacy_declarations",
+    "country_field_instance_privacy_declarations",
+)
+def test_datamap_two_systems_two_custom_fields_only_privacy_declarations(
+    test_config,
+    test_client,
+):
+    """
+    Tests expected response with two systems - one with privacy declarations, one without -
+    and two custom fields populated on the system with privacy declarations,
+    and only one custom field populated on the system without privacy declarations.
+    """
+    response = test_client.get(
+        test_config.cli.server_url + API_PREFIX + "/datamap/" + "default_organization",
+        headers=test_config.user.auth_header,
+    )
+    assert response.status_code == 200
+    assert (
+        response.json()
+        == EXPECTED_RESPONSE_TWO_SYSTEMS_TWO_CUSTOM_FIELDS_ONLY_PRIVACY_DECLARATIONS
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures(
+    "country_field_instance_no_privacy_declarations",
+    "owner_field_instance_no_privacy_declarations",
+    "owner_field_instance_privacy_declarations",
+)
+def test_datamap_two_systems_two_custom_fields_only_no_privacy_declarations(
+    test_config,
+    test_client,
+):
+    """
+    Tests expected response with two systems - one with privacy declarations, one without -
+    and two custom fields populated on the system with no privacy declarations,
+    and only one custom field populated on the system with privacy declarations.
+    """
+    response = test_client.get(
+        test_config.cli.server_url + API_PREFIX + "/datamap/" + "default_organization",
+        headers=test_config.user.auth_header,
+    )
+    assert response.status_code == 200
+    assert (
+        response.json()
+        == EXPECTED_RESPONSE_TWO_SYSTEMS_TWO_CUSTOM_FIELDS_ONLY_NO_PRIVACY_DECLARATIONS
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Closes #2850 

### Code Changes

* keep an ordered list of custom field headers, in the order that they appear in the header row
* leverage that ordered list when populating custom field row data
* add some test coverage for the error case and related cases

### Steps to Confirm

* we should be able to populate the DB similar to how we're doing it in the test cases and repro with the datamap export API solely on `fides`
* even better would be to cut an edge build off this release branch (not something we've normalized, yet, but maybe we can give it a try!) and test this with the fidesplus FE
    * this will allow us to create and populate custom fields a lot more easily, and therefore stress test with more scenarios

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

i started considering a more significant refactor to the code where we don't rely on an implicit ordering at all, and we're very explicit about populating the row data based on the order of the headers. i think we should be able to do that, and it'd make the code both more robust and readable. adding in a list to just keep track of the custom field header ordering feels like duct tape. but we need a fix quick, and i'm out for the rest of the weekend, so i at least wanted to get a patch pushed up that we can work with! :) 