### PR TITLE
Various 2.9.0 fixes

### DIFF
--- a/clients/admin-ui/cypress/e2e/home.cy.ts
+++ b/clients/admin-ui/cypress/e2e/home.cy.ts
@@ -27,13 +27,6 @@ describe("Home page", () => {
 
   describe("permissions", () => {
     beforeEach(() => {
-      // For these tests, let's say we always have systems and connectors
-      cy.intercept("GET", "/api/v1/system", {
-        fixture: "systems/systems.json",
-      }).as("getSystems");
-      cy.intercept("GET", "/api/v1/connection*", {
-        fixture: "connectors/list.json",
-      }).as("getConnectors");
       stubPlus(true);
     });
 

--- a/clients/admin-ui/src/features/common/custom-fields/hooks.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/hooks.ts
@@ -131,6 +131,10 @@ export const useCustomFields = ({
    */
   const upsertCustomFields = useCallback(
     async (formValues: CustomFieldsFormValues) => {
+      if (!isEnabled) {
+        return;
+      }
+
       // When creating an resource, the fides key may have initially been blank. But by the time the
       // form is submitted it must not be blank (not undefined, not an empty string).
       const fidesKey = formValues.fides_key || resourceFidesKey;
@@ -190,6 +194,7 @@ export const useCustomFields = ({
       }
     },
     [
+      isEnabled,
       definitionIdToCustomField,
       deleteCustomFieldMutationTrigger,
       errorAlert,

--- a/clients/admin-ui/src/features/common/nav/v2/NavSideBar.tsx
+++ b/clients/admin-ui/src/features/common/nav/v2/NavSideBar.tsx
@@ -12,8 +12,8 @@ export const NavSideBar = () => {
   const router = useRouter();
   const nav = useNav({ path: router.pathname });
 
-  // Don't render the sidebar if no group is active or if the group only has one link.
-  if (!nav.active || nav.active.children.length <= 1) {
+  // Don't render the sidebar if no group is active
+  if (!nav.active) {
     return null;
   }
 

--- a/clients/admin-ui/src/features/common/nav/v2/nav-config.test.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/nav-config.test.ts
@@ -19,6 +19,7 @@ const ALL_SCOPES = [
   ScopeRegistryEnum.SYSTEM_UPDATE,
   ScopeRegistryEnum.CTL_DATASET_CREATE,
   ScopeRegistryEnum.USER_UPDATE,
+  ScopeRegistryEnum.USER_READ,
   ScopeRegistryEnum.DATA_CATEGORY_CREATE,
 ];
 
@@ -115,11 +116,6 @@ describe("configureNavGroups", () => {
       expect(navGroups[0]).toMatchObject({
         title: "Home",
         children: [{ title: "Home", path: "/" }],
-      });
-
-      expect(navGroups[1]).toMatchObject({
-        title: "Management",
-        children: [{ title: "About Fides", path: "/management/about" }],
       });
     });
 

--- a/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
@@ -105,7 +105,11 @@ export const NAV_CONFIG: NavConfigGroup[] = [
           ScopeRegistryEnum.USER_PERMISSION_UPDATE,
         ],
       },
-      { title: "About Fides", path: "/management/about", scopes: [] },
+      {
+        title: "About Fides",
+        path: "/management/about",
+        scopes: [ScopeRegistryEnum.USER_READ], // temporary scope while we don't have a scope for beta features
+      },
     ],
   },
 ];

--- a/clients/admin-ui/src/home/HomeContent.tsx
+++ b/clients/admin-ui/src/home/HomeContent.tsx
@@ -16,9 +16,7 @@ const COLUMNS = 3;
 
 const HomeContent: React.FC = () => {
   const router = useRouter();
-  const { connectionsCount, systemsCount, plus } = useFeatures();
-  const hasConnections = connectionsCount > 0;
-  const hasSystems = systemsCount > 0;
+  const { plus } = useFeatures();
   const userScopes = useAppSelector(selectThisUsersScopes);
 
   const list = useMemo(
@@ -26,11 +24,9 @@ const HomeContent: React.FC = () => {
       configureTiles({
         config: MODULE_CARD_ITEMS,
         hasPlus: plus,
-        hasConnections,
-        hasSystems,
         userScopes,
       }),
-    [hasConnections, hasSystems, plus, userScopes]
+    [plus, userScopes]
   );
 
   return (

--- a/clients/admin-ui/src/home/tile-config.test.ts
+++ b/clients/admin-ui/src/home/tile-config.test.ts
@@ -18,7 +18,6 @@ describe("configureTiles", () => {
     const tiles = configureTiles({
       config: MODULE_CARD_ITEMS,
       hasPlus: false,
-      hasSystems: true,
       userScopes: ALL_SCOPES_FOR_TILES,
     });
 
@@ -29,52 +28,9 @@ describe("configureTiles", () => {
     const tiles = configureTiles({
       config: MODULE_CARD_ITEMS,
       hasPlus: true,
-      hasSystems: true,
       userScopes: ALL_SCOPES_FOR_TILES,
     });
     expect(tiles.filter((t) => t.href === "/datamap").length).toEqual(1);
-  });
-
-  it("can exclude tiles that require systems or connectors", () => {
-    const tiles = configureTiles({
-      config: MODULE_CARD_ITEMS,
-      hasPlus: true,
-      hasSystems: false,
-      hasConnections: false,
-      userScopes: ALL_SCOPES_FOR_TILES,
-    });
-    expect(tiles.map((t) => t.name)).toEqual([
-      "Add systems",
-      "Configure privacy requests",
-    ]);
-  });
-
-  it("can include tiles that require systems", () => {
-    const tiles = configureTiles({
-      config: MODULE_CARD_ITEMS,
-      hasPlus: true,
-      hasSystems: true,
-      userScopes: ALL_SCOPES_FOR_TILES,
-    });
-    expect(tiles.map((t) => t.name)).toEqual([
-      "View data map",
-      "Add systems",
-      "View systems",
-      "Configure privacy requests",
-    ]);
-  });
-
-  it("can include tiles that require connectors", () => {
-    const tiles = configureTiles({
-      config: MODULE_CARD_ITEMS,
-      hasConnections: true,
-      userScopes: ALL_SCOPES_FOR_TILES,
-    });
-    expect(tiles.map((t) => t.name)).toEqual([
-      "Add systems",
-      "Configure privacy requests",
-      "Review privacy requests",
-    ]);
   });
 
   describe("configure by scopes", () => {
@@ -116,7 +72,6 @@ describe("configureTiles", () => {
       const tiles = configureTiles({
         config: MODULE_CARD_ITEMS,
         hasPlus: true,
-        hasSystems: true,
         userScopes: [ScopeRegistryEnum.DATAMAP_READ],
       });
       expect(tiles.map((t) => t.name)).toEqual(["View data map"]);
@@ -125,7 +80,6 @@ describe("configureTiles", () => {
     it("conditionally shows reviewing privacy requests", () => {
       const tiles = configureTiles({
         config: MODULE_CARD_ITEMS,
-        hasConnections: true,
         userScopes: [ScopeRegistryEnum.PRIVACY_REQUEST_REVIEW],
       });
       expect(tiles.map((t) => t.name)).toEqual(["Review privacy requests"]);
@@ -134,7 +88,6 @@ describe("configureTiles", () => {
     it("can combine scopes to show multiple tiles", () => {
       const tiles = configureTiles({
         config: MODULE_CARD_ITEMS,
-        hasConnections: true,
         userScopes: [
           ScopeRegistryEnum.PRIVACY_REQUEST_REVIEW,
           ScopeRegistryEnum.CONNECTION_CREATE_OR_UPDATE,

--- a/clients/admin-ui/src/home/tile-config.ts
+++ b/clients/admin-ui/src/home/tile-config.ts
@@ -6,8 +6,6 @@ export const configureTiles = ({
   config,
   userScopes,
   hasPlus = false,
-  hasSystems = false,
-  hasConnections = false,
 }: {
   config: ModuleCardConfig[];
   userScopes: ScopeRegistryEnum[];
@@ -19,14 +17,6 @@ export const configureTiles = ({
 
   if (!hasPlus) {
     filteredConfig = filteredConfig.filter((c) => !c.requiresPlus);
-  }
-
-  if (!hasSystems) {
-    filteredConfig = filteredConfig.filter((c) => !c.requiresSystems);
-  }
-
-  if (!hasConnections) {
-    filteredConfig = filteredConfig.filter((c) => !c.requiresConnections);
   }
 
   const filteredByScope: ModuleCardConfig[] = [];


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/701

### Code Changes

* [x] Prevent calling custom metadata upsert if it's not enabled (was showing a toast message)
* [x] Remove progressive home tiles. tiles will now always be there, regardless of if user has systems or privacy requests existing
* [x] Render the side nav bar even if there is only one item
* [x] Scope the beta features page to `USER_READ`

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

_Write some things here about the changes and any potential caveats_
