### PR TITLE
Improve standard layout for large width screens and polish misc. pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,23 +17,26 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.9.1...main)
 
+### Changed
+* Improved standard layout for large width screens and polished misc. pages [#2869](https://github.com/ethyca/fides/pull/2869)
+
 ## [2.9.1](https://github.com/ethyca/fides/compare/2.9.0...2.9.1)
 
 ### Added
 * Added Attentive erasure email connector [#2782](https://github.com/ethyca/fides/pull/2782)
 
 ### Changed
+* Improved standard layout for large width screens and polish misc. pages [#2869](https://github.com/ethyca/fides/pull/2869)
 * Removed dataset based email connectors [#2782](https://github.com/ethyca/fides/pull/2782)
 * Changed Auth0's authentication strategy from `bearer` to `oauth2_client_credentials` [#2820](https://github.com/ethyca/fides/pull/2820)
-* renamed the privacy declarations field "Privacy declaration name (deprecated)" to "Processing Activity" [#711](https://github.com/ethyca/fidesplus/issues/711)
+* Renamed the privacy declarations field "Privacy declaration name (deprecated)" to "Processing Activity" [#711](https://github.com/ethyca/fidesplus/issues/711)
 
 
 ### Fixed
 * Fixed issue where the scopes list passed into FidesUserPermission could get mutated with the total_scopes call [#2883](https://github.com/ethyca/fides/pull/2883)
 
 ### Removed
-
-* removed the `privacyDeclarationDeprecatedFields` flag [#711](https://github.com/ethyca/fidesplus/issues/711)
+* Removed the `privacyDeclarationDeprecatedFields` flag [#711](https://github.com/ethyca/fidesplus/issues/711)
 
 ## [2.9.0](https://github.com/ethyca/fides/compare/2.8.3...2.9.0)
 

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -61,7 +61,7 @@ const Layout = ({
       {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
       <NotificationBanner />
       <NavTopBar />
-      <Flex as="main" px={9} py={10} gap="40px" height="100%" overflow="auto">
+      <Flex as="main" flexGrow={1} px={9} py={10} gap="40px" overflow="auto">
         <Box flex={0} flexShrink={0}>
           <NavSideBar />
         </Box>

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -46,7 +46,12 @@ const Layout = ({
     isValidNotificationRoute;
 
   return (
-    <Flex data-testid={title} direction="column" minWidth="1024px" height="100vh">
+    <Flex
+      data-testid={title}
+      direction="column"
+      minWidth="container.md"
+      height="100vh"
+    >
       <Head>
         <title>Fides Admin UI - {title}</title>
         <meta name="description" content="Privacy Engineering Platform" />
@@ -56,7 +61,7 @@ const Layout = ({
       {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
       <NotificationBanner />
       <NavTopBar />
-      <Flex as="main" px={9} py={10} gap="40px" overflow="auto">
+      <Flex as="main" px={9} py={10} gap="40px" height="100%" overflow="auto">
         <Box flex={0} flexShrink={0}>
           <NavSideBar />
         </Box>

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -49,7 +49,7 @@ const Layout = ({
     <Flex
       data-testid={title}
       direction="column"
-      minWidth="container.md"
+      minWidth="container.lg"
       height="100vh"
     >
       <Head>
@@ -61,7 +61,14 @@ const Layout = ({
       {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
       <NotificationBanner />
       <NavTopBar />
-      <Flex as="main" flexGrow={1} px={9} py={10} gap="40px" overflow="auto">
+      <Flex
+        as="main"
+        flexGrow={1}
+        paddingTop={10}
+        paddingX={10}
+        paddingBottom={11}
+        gap={10}
+      >
         <Box flex={0} flexShrink={0}>
           <NavSideBar />
         </Box>

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -46,7 +46,7 @@ const Layout = ({
     isValidNotificationRoute;
 
   return (
-    <Flex data-testid={title} direction="column" height="100vh">
+    <Flex data-testid={title} direction="column" minWidth="1024px" height="100vh">
       <Head>
         <title>Fides Admin UI - {title}</title>
         <meta name="description" content="Privacy Engineering Platform" />
@@ -56,7 +56,7 @@ const Layout = ({
       {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
       <NotificationBanner />
       <NavTopBar />
-      <Flex as="main" px={9} py={10} gap="40px" height="100%">
+      <Flex as="main" px={9} py={10} gap="40px" overflow="auto">
         <Box flex={0} flexShrink={0}>
           <NavSideBar />
         </Box>

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -46,10 +46,7 @@ const Layout = ({
     isValidNotificationRoute;
 
   return (
-    <Flex
-      data-testid={title}
-      direction="column"
-    >
+    <Flex data-testid={title} direction="column">
       <Head>
         <title>Fides Admin UI - {title}</title>
         <meta name="description" content="Privacy Engineering Platform" />
@@ -59,12 +56,7 @@ const Layout = ({
       {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
       <NotificationBanner />
       <NavTopBar />
-      <Flex
-        as="main"
-        flexGrow={1}
-        padding={10}
-        gap={10}
-      >
+      <Flex as="main" flexGrow={1} padding={10} gap={10}>
         <Box flex={0} flexShrink={0}>
           <NavSideBar />
         </Box>

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -49,8 +49,6 @@ const Layout = ({
     <Flex
       data-testid={title}
       direction="column"
-      minWidth="container.lg"
-      height="100vh"
     >
       <Head>
         <title>Fides Admin UI - {title}</title>
@@ -64,9 +62,7 @@ const Layout = ({
       <Flex
         as="main"
         flexGrow={1}
-        paddingTop={10}
-        paddingX={10}
-        paddingBottom={11}
+        padding={10}
         gap={10}
       >
         <Box flex={0} flexShrink={0}>

--- a/clients/admin-ui/src/features/config-wizard/AddSystem.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AddSystem.tsx
@@ -32,7 +32,7 @@ const AddSystem = () => {
 
   return (
     <Stack spacing={9} data-testid="add-systems">
-      <Stack spacing={6} w={{ base: "100%", md: "50%" }}>
+      <Stack spacing={6} w={{ base: "100%", md: "80%", xl: "50%" }}>
         <Heading as="h3" size="lg" fontWeight="semibold">
           Fides helps you map your systems to manage your privacy
         </Heading>

--- a/clients/admin-ui/src/features/config-wizard/AddSystem.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AddSystem.tsx
@@ -32,7 +32,7 @@ const AddSystem = () => {
 
   return (
     <Stack spacing={9} data-testid="add-systems">
-      <Stack spacing={6} w={{ base: "100%", md: "80%", xl: "50%" }}>
+      <Stack spacing={6} maxWidth="600px">
         <Heading as="h3" size="lg" fontWeight="semibold">
           Fides helps you map your systems to manage your privacy
         </Heading>

--- a/clients/admin-ui/src/features/config-wizard/ConfigWizardWalkthrough.tsx
+++ b/clients/admin-ui/src/features/config-wizard/ConfigWizardWalkthrough.tsx
@@ -12,7 +12,7 @@ const ConfigWizardWalkthrough = () => {
   const step = useAppSelector(selectStep);
 
   return (
-    <Stack direction={["column", "row"]} bg="white" height="100vh" width="100%">
+    <Stack direction={["column", "row"]} bg="white">
       <Box display="flex" justifyContent="center" w="100%">
         {step === 1 ? <OrganizationInfoForm /> : null}
         {step === 2 ? <AddSystem /> : null}

--- a/clients/admin-ui/src/features/datastore-connections/ConnectionFilters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/ConnectionFilters.tsx
@@ -32,7 +32,7 @@ const useConstantFilters = () => {
 const ConnectionFilters: React.FC = () => {
   const { handleSearchChange, search } = useConstantFilters();
   return (
-    <Flex minWidth="fit-content" alignItems="center" gap="4" mb={6}>
+    <Flex minWidth="fit-content" alignItems="center" gap="4" mb={6} flexWrap="wrap">
       <InputGroup size="sm" minWidth="308px">
         <InputLeftElement pointerEvents="none">
           <SearchLineIcon color="gray.300" w="17px" h="17px" />

--- a/clients/admin-ui/src/features/datastore-connections/ConnectionFilters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/ConnectionFilters.tsx
@@ -32,7 +32,13 @@ const useConstantFilters = () => {
 const ConnectionFilters: React.FC = () => {
   const { handleSearchChange, search } = useConstantFilters();
   return (
-    <Flex minWidth="fit-content" alignItems="center" gap="4" mb={6} flexWrap="wrap">
+    <Flex
+      minWidth="fit-content"
+      alignItems="center"
+      gap="4"
+      mb={6}
+      flexWrap="wrap"
+    >
       <InputGroup size="sm" minWidth="308px">
         <InputLeftElement pointerEvents="none">
           <SearchLineIcon color="gray.300" w="17px" h="17px" />

--- a/clients/admin-ui/src/home/HomeBanner.tsx
+++ b/clients/admin-ui/src/home/HomeBanner.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Spacer, Text } from "@fidesui/react";
+import { Flex, Text } from "@fidesui/react";
 import * as React from "react";
 
 import { useFeatures } from "~/features/common/features";
@@ -6,42 +6,48 @@ import { useFeatures } from "~/features/common/features";
 const HomeBanner: React.FC = () => {
   const { systemsCount } = useFeatures();
   const hasSystems = systemsCount > 0;
+  const bannerHeight = "300px";
+  const bannerTextWidth = "600px";
 
   return (
     <Flex
       background="linear-gradient(180deg, #FFFFFF 0%, #F8F8FF 100%);"
-      h="300px"
+      height={bannerHeight}
     >
+      {/* Add a scrim that blurs the background so the text is legible at small width */}
+      <Flex
+        flexShrink={0}
+        position="absolute"
+        height={bannerHeight}
+        width={bannerTextWidth}
+        maxWidth="100%"
+        backdropFilter="auto"
+        backdropBlur="5px"
+        sx={{
+          // 'mask' property needs to be prefixed in most browsers
+          WebkitMask: "linear-gradient(90deg, black 90%, transparent)",
+          Mask: "linear-gradient(90deg, black 90%, transparent)",
+        }}
+      />
       <Flex
         flexDir="column"
-        height="300px"
-        width="600px"
-        paddingTop="10"
         position="absolute"
-        paddingLeft="10"
-        paddingRight="10"
+        height={bannerHeight}
+        width={bannerTextWidth}
+        maxWidth="100%"
+        padding="10"
       >
         {hasSystems && (
           <>
-            <Text
-              fontSize="32px"
-              fontWeight="semibold"
-              h="40px"
-              lineHeight="32px"
-            >
+            <Text fontSize="3xl" fontWeight="semibold">
               Welcome back!
             </Text>
-            <Text
-              fontSize="18px"
-              fontWeight="semibold"
-              h="36px"
-              lineHeight="28px"
-            >
+            <Text marginTop="1" fontSize="lg" fontWeight="semibold">
               {`${systemsCount} system${
                 systemsCount > 1 ? "s" : ""
               } currently under management`}
             </Text>
-            <Text fontSize="14px">
+            <Text marginTop="1" fontSize="sm">
               {`Fides is currently managing privacy for ${systemsCount} system${
                 systemsCount > 1 ? "s" : ""
               }. From here you can continue adding and managing systems, process privacy requests or generate reports for your privacy compliance requirements.`}
@@ -50,23 +56,13 @@ const HomeBanner: React.FC = () => {
         )}
         {!hasSystems && (
           <>
-            <Text
-              fontSize="32px"
-              fontWeight="semibold"
-              h="40px"
-              lineHeight="32px"
-            >
+            <Text fontSize="3xl" fontWeight="semibold">
               Welcome to Fides!
             </Text>
-            <Text
-              fontSize="18px"
-              fontWeight="semibold"
-              h="36px"
-              lineHeight="28px"
-            >
+            <Text marginTop="1" fontSize="lg" fontWeight="semibold">
               Start your privacy engineering journey today
             </Text>
-            <Text fontSize="14px">
+            <Text marginTop="1" fontSize="sm">
               Step one in setting up your privacy engineering platform is adding
               the systems you need to manage. Use the links below to add and
               configure systems within Fides for data mapping and privacy
@@ -75,11 +71,10 @@ const HomeBanner: React.FC = () => {
           </>
         )}
       </Flex>
-      <Spacer />
       <Flex
         flexShrink={0}
         width="100%"
-        height="300px"
+        height={bannerHeight}
         backgroundImage="url('/images/config_splash.svg')"
         backgroundSize="cover"
         backgroundRepeat="no-repeat"

--- a/clients/admin-ui/src/home/HomeBanner.tsx
+++ b/clients/admin-ui/src/home/HomeBanner.tsx
@@ -11,6 +11,7 @@ const HomeBanner: React.FC = () => {
 
   return (
     <Flex
+      position="relative"  
       background="linear-gradient(180deg, #FFFFFF 0%, #F8F8FF 100%);"
       height={bannerHeight}
     >

--- a/clients/admin-ui/src/home/HomeBanner.tsx
+++ b/clients/admin-ui/src/home/HomeBanner.tsx
@@ -11,7 +11,7 @@ const HomeBanner: React.FC = () => {
 
   return (
     <Flex
-      position="relative"  
+      position="relative"
       background="linear-gradient(180deg, #FFFFFF 0%, #F8F8FF 100%);"
       height={bannerHeight}
     >

--- a/clients/admin-ui/src/home/HomeBanner.tsx
+++ b/clients/admin-ui/src/home/HomeBanner.tsx
@@ -12,24 +12,10 @@ const HomeBanner: React.FC = () => {
   return (
     <Flex
       position="relative"
-      background="linear-gradient(180deg, #FFFFFF 0%, #F8F8FF 100%);"
       height={bannerHeight}
+      background="linear-gradient(180deg, #FFFFFF 0%, #F8F8FF 100%);"
+      overflow="hidden"
     >
-      {/* Add a scrim that blurs the background so the text is legible at small width */}
-      <Flex
-        flexShrink={0}
-        position="absolute"
-        height={bannerHeight}
-        width={bannerTextWidth}
-        maxWidth="100%"
-        backdropFilter="auto"
-        backdropBlur="5px"
-        sx={{
-          // 'mask' property needs to be prefixed in most browsers
-          WebkitMask: "linear-gradient(90deg, black 90%, transparent)",
-          Mask: "linear-gradient(90deg, black 90%, transparent)",
-        }}
-      />
       <Flex
         flexDir="column"
         position="absolute"
@@ -72,12 +58,15 @@ const HomeBanner: React.FC = () => {
           </>
         )}
       </Flex>
+      {/* Render the background image, using a min-width here to ensure there is
+      enough left margin to avoid colliding with the banner text above */}
       <Flex
         flexShrink={0}
         width="100%"
+        minWidth="1120px"
         height={bannerHeight}
         backgroundImage="url('/images/config_splash.svg')"
-        backgroundSize="cover"
+        backgroundSize="contain"
         backgroundRepeat="no-repeat"
         backgroundPosition="right"
       />

--- a/clients/admin-ui/src/home/HomeBanner.tsx
+++ b/clients/admin-ui/src/home/HomeBanner.tsx
@@ -1,4 +1,4 @@
-import { Flex, Image, Spacer, Text } from "@fidesui/react";
+import { Box, Flex, Spacer, Text } from "@fidesui/react";
 import * as React from "react";
 
 import { useFeatures } from "~/features/common/features";
@@ -12,7 +12,15 @@ const HomeBanner: React.FC = () => {
       background="linear-gradient(180deg, #FFFFFF 0%, #F8F8FF 100%);"
       h="300px"
     >
-      <Flex flexDir="column" mt="40px" pos="absolute" px="36px" w="597px">
+      <Flex
+        flexDir="column"
+        height="300px"
+        width="600px"
+        paddingTop="10"
+        position="absolute"
+        paddingLeft="10"
+        paddingRight="10"
+      >
         {hasSystems && (
           <>
             <Text
@@ -68,9 +76,15 @@ const HomeBanner: React.FC = () => {
         )}
       </Flex>
       <Spacer />
-      <Flex flexShrink={0}>
-        <Image alt="" boxSize="100%" src="/images/config_splash.svg" />
-      </Flex>
+      <Flex
+        flexShrink={0}
+        width="100%"
+        height="300px"
+        backgroundImage="url('/images/config_splash.svg')"
+        backgroundSize="cover"
+        backgroundRepeat="no-repeat"
+        backgroundPosition="right"
+      />
     </Flex>
   );
 };

--- a/clients/admin-ui/src/home/HomeContent.tsx
+++ b/clients/admin-ui/src/home/HomeContent.tsx
@@ -28,8 +28,8 @@ const HomeContent: React.FC = () => {
   );
 
   return (
-    <Flex px="36px" data-testid="home-content">
-      <SimpleGrid columns={{ md: 2, lg: 3 }} spacing="24px">
+    <Flex paddingX={10} data-testid="home-content">
+      <SimpleGrid columns={{ md: 2, xl: 3 }} spacing="24px">
         {list
           .sort((a, b) => (a.sortOrder > b.sortOrder ? 1 : -1))
           .map((item) => {
@@ -39,7 +39,6 @@ const HomeContent: React.FC = () => {
                 <Flex
                   background={`${item.color}.50`}
                   borderRadius="8px"
-                  boxShadow="base"
                   flexDirection="column"
                   maxH="164px"
                   overflow="hidden"

--- a/clients/admin-ui/src/home/HomeContent.tsx
+++ b/clients/admin-ui/src/home/HomeContent.tsx
@@ -1,4 +1,4 @@
-import { Center, Flex, SimpleGrid, Text } from "@fidesui/react";
+import { Flex, SimpleGrid, Text } from "@fidesui/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import * as React from "react";
@@ -11,8 +11,6 @@ import { selectThisUsersScopes } from "~/features/user-management";
 
 import { MODULE_CARD_ITEMS } from "./constants";
 import { configureTiles } from "./tile-config";
-
-const COLUMNS = 3;
 
 const HomeContent: React.FC = () => {
   const router = useRouter();
@@ -30,11 +28,8 @@ const HomeContent: React.FC = () => {
   );
 
   return (
-    <Center px="36px" data-testid="home-content">
-      <SimpleGrid
-        columns={list.length >= COLUMNS ? COLUMNS : list.length}
-        spacing="24px"
-      >
+    <Flex px="36px" data-testid="home-content">
+      <SimpleGrid columns={{ md: 2, lg: 3 }} spacing="24px">
         {list
           .sort((a, b) => (a.sortOrder > b.sortOrder ? 1 : -1))
           .map((item) => {
@@ -50,6 +45,8 @@ const HomeContent: React.FC = () => {
                   overflow="hidden"
                   padding="16px 16px 20px 16px"
                   maxW="469.33px"
+                  border="1px solid"
+                  borderColor="transparent"
                   _hover={{
                     border: "1px solid",
                     borderColor: `${item.color}.500`,
@@ -96,7 +93,7 @@ const HomeContent: React.FC = () => {
             );
           })}
       </SimpleGrid>
-    </Center>
+    </Flex>
   );
 };
 

--- a/clients/admin-ui/src/home/HomeLayout.tsx
+++ b/clients/admin-ui/src/home/HomeLayout.tsx
@@ -28,12 +28,7 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
     {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
     <NotificationBanner />
     <NavTopBar />
-    <Flex
-      as="main"
-      flexGrow={1}
-      flexDirection="column"
-      gap={10}
-    >
+    <Flex as="main" flexGrow={1} flexDirection="column" gap={10}>
       {children}
     </Flex>
   </Flex>

--- a/clients/admin-ui/src/home/HomeLayout.tsx
+++ b/clients/admin-ui/src/home/HomeLayout.tsx
@@ -16,7 +16,7 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
   <Flex
     data-testid={title}
     direction="column"
-    minWidth="container.md"
+    minWidth="container.lg"
     height="100vh"
   >
     <Head>
@@ -32,8 +32,7 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
       as="main"
       flexGrow={1}
       flexDirection="column"
-      gap="40px"
-      overflow="auto"
+      gap={10}
     >
       {children}
     </Flex>

--- a/clients/admin-ui/src/home/HomeLayout.tsx
+++ b/clients/admin-ui/src/home/HomeLayout.tsx
@@ -13,17 +13,28 @@ type HomeLayoutProps = {
 };
 
 const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
-  <Flex data-testid={title} direction="column" minWidth="1024px" height="100vh">
+  <Flex
+    data-testid={title}
+    direction="column"
+    minWidth="container.md"
+    height="100vh"
+  >
     <Head>
       <title>Fides Admin UI - {title}</title>
-      <meta name="description" content="" />
+      <meta name="description" content="Privacy Engineering Platform" />
       <link rel="icon" href="/favicon.ico" />
     </Head>
     <Header />
     {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
     <NotificationBanner />
     <NavTopBar />
-    <Flex as="main" flexDirection="column" gap="40px" overflow="auto">
+    <Flex
+      as="main"
+      flexDirection="column"
+      gap="40px"
+      height="100%"
+      overflow="auto"
+    >
       {children}
     </Flex>
   </Flex>

--- a/clients/admin-ui/src/home/HomeLayout.tsx
+++ b/clients/admin-ui/src/home/HomeLayout.tsx
@@ -16,8 +16,6 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
   <Flex
     data-testid={title}
     direction="column"
-    minWidth="container.lg"
-    height="100vh"
   >
     <Head>
       <title>Fides Admin UI - {title}</title>

--- a/clients/admin-ui/src/home/HomeLayout.tsx
+++ b/clients/admin-ui/src/home/HomeLayout.tsx
@@ -30,9 +30,9 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
     <NavTopBar />
     <Flex
       as="main"
+      flexGrow={1}
       flexDirection="column"
       gap="40px"
-      height="100%"
       overflow="auto"
     >
       {children}

--- a/clients/admin-ui/src/home/HomeLayout.tsx
+++ b/clients/admin-ui/src/home/HomeLayout.tsx
@@ -13,10 +13,7 @@ type HomeLayoutProps = {
 };
 
 const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
-  <Flex
-    data-testid={title}
-    direction="column"
-  >
+  <Flex data-testid={title} direction="column">
     <Head>
       <title>Fides Admin UI - {title}</title>
       <meta name="description" content="Privacy Engineering Platform" />

--- a/clients/admin-ui/src/home/HomeLayout.tsx
+++ b/clients/admin-ui/src/home/HomeLayout.tsx
@@ -13,7 +13,7 @@ type HomeLayoutProps = {
 };
 
 const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
-  <Flex data-testid={title} direction="column" height="100vh">
+  <Flex data-testid={title} direction="column" minWidth="1024px" height="100vh">
     <Head>
       <title>Fides Admin UI - {title}</title>
       <meta name="description" content="" />
@@ -23,7 +23,7 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
     {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
     <NotificationBanner />
     <NavTopBar />
-    <Flex as="main" flexDirection="column" gap="40px" height="100%">
+    <Flex as="main" flexDirection="column" gap="40px" overflow="auto">
       {children}
     </Flex>
   </Flex>

--- a/clients/admin-ui/src/theme/index.ts
+++ b/clients/admin-ui/src/theme/index.ts
@@ -8,9 +8,6 @@ const theme = extendTheme({
       body: {
         bg: "white",
       },
-      html: {
-        height: "100%",
-      },
     },
   },
   components: {

--- a/clients/admin-ui/src/theme/index.ts
+++ b/clients/admin-ui/src/theme/index.ts
@@ -7,6 +7,7 @@ const theme = extendTheme({
     global: {
       body: {
         bg: "white",
+        minWidth: "container.lg",
       },
     },
   },


### PR DESCRIPTION
### Code Changes

* [X] Set min width on entire page to "large" 1024px (since we really don't scale down to small mobile width!)
* [X] Improve add systems layout at large width
* [X] Fix home banner layout:
  * [X] Use theme tokens for all typography
  * [X] Use background image "contain" to fit banner image to width
  * [X] Position background image to avoid overlapping with banner text
* [X] Change home screen tile grid to change from 3 -> 2 columns at large width
* [X] Fix tiles resizing on hover due to border
* [X] Add basic fluid layout to connection manager filter bar

### Steps to Confirm

* [X] Run `nox -s "fides_env(test)"` and populate with several privacy requests to allow testing scroll behaviour
* [X] View Home page at large width (1024px) and confirm banner image is legible, and tiles scroll
* [X] View Privacy Request page at large width (1024px)
* [X] Scroll Privacy Request page and ensure the full page scrolls (no persistent header)
* [X] View other pages at large width (1024px) and check layouts

| Page | Before | After |
|---|---|---|
| Home (1024px) | <img width="1024" alt="image" src="https://user-images.githubusercontent.com/1834295/226481131-7b8750fd-74b0-4250-9a98-d4a51a8f496a.png"> | <img width="1024" alt="image" src="https://user-images.githubusercontent.com/1834295/226484284-16644cf0-da99-4396-9ca8-e1bd83116349.png">| 
| Privacy Requests (1024px) | <img width="1024" alt="image" src="https://user-images.githubusercontent.com/1834295/226481211-ce5d8209-5928-453b-9ef5-f4350eddbac9.png">| <img width="1024" alt="image" src="https://user-images.githubusercontent.com/1834295/226484507-2dc5dfcf-3f49-4f7b-9657-8b3e25bafacb.png">|
| View Systems (1024px) |<img width="1023" alt="image" src="https://user-images.githubusercontent.com/1834295/226481277-c4999710-3cd2-4152-b2ae-37345bd5d4ca.png">| <img width="1024" alt="image" src="https://user-images.githubusercontent.com/1834295/226484539-d5301089-b9c1-4bc5-8765-28adfafdc35f.png">|
| Add Systems (1024px) | <img width="1023" alt="image" src="https://user-images.githubusercontent.com/1834295/226481372-492ce50a-9229-4700-850c-a9b325150ab3.png">| <img width="1023" alt="image" src="https://user-images.githubusercontent.com/1834295/226484585-e2d382a1-02fc-4d25-8e9e-fa2ae976c38e.png">|
| User Management (1024px) | <img width="1022" alt="image" src="https://user-images.githubusercontent.com/1834295/226481676-c4bb6045-86af-45e1-9ea0-22752d0dd87c.png"> |<img width="1024" alt="image" src="https://user-images.githubusercontent.com/1834295/226484632-42fcdd44-70a5-45a5-90d2-a5e41727b585.png">|

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This is a polish sweep of the Admin UI to tighten up the overall layout and improve the usability at ~large width screens and above (1024px+). Most importantly, this makes two key changes:
1. Sets a minimum width of `1024px` (medium) so that the site doesn't complete mangle itself at small widths and instead just scrolls horizontally 😄 
2. Makes the header, nav, and main layout consistently fill the viewport height (100vh) across all pages (incl. fidesplus)

⚠️ This doesn't actually make the site responsive, but it's a small step towards that ⚠️ 

Lastly this includes fixes for the home screen layout in particular, which would scroll horizontally at <1040px and squish the home tiles unreasonably. I also replaced a lot of static, `px` styles with theme tokens for consistency and improved the layout at medium width to be legible using some clever background blurring which was fun.

Note that the overall layout needs to stay consistent with `fidesplus`, which has pages that need to occupy the full viewport, so see the related PR on `fidesplus` for screenshots and tests showing why the `height: 100vh` is still needed.