### PR TITLE
Fix FidesUserPermissions Scopes Mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.9.0...main)
 
+### Fixed
+* Fixed issue where the scopes list passed into FidesUserPermission could get mutated with the total_scopes call [#2883](https://github.com/ethyca/fides/pull/2883)
+
 ## [2.9.0](https://github.com/ethyca/fides/compare/2.8.3...2.9.0)
 
 ### Added

--- a/src/fides/api/ops/schemas/privacy_request.py
+++ b/src/fides/api/ops/schemas/privacy_request.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List, Optional, Union
 
 from fideslang.validation import FidesKey
 from pydantic import Field, validator
-from fides.api.custom_types import SafeStr
 
+from fides.api.custom_types import SafeStr
 from fides.api.ops.models.policy import ActionType
 from fides.api.ops.models.privacy_request import (
     CheckpointActionRequired,

--- a/src/fides/lib/models/fides_user_permissions.py
+++ b/src/fides/lib/models/fides_user_permissions.py
@@ -23,7 +23,7 @@ class FidesUserPermissions(Base):
     def total_scopes(self) -> List[str]:
         """Returns the total model-level scopes the user has, either 1) scopes they are assigned directly,
         or 2) Roles they have via their scopes."""
-        all_scopes = self.scopes or []
+        all_scopes = self.scopes.copy() or []
         for role in self.roles:
             all_scopes += ROLES_TO_SCOPES_MAPPING.get(role, [])
 

--- a/src/fides/lib/oauth/api/routes/user_endpoints.py
+++ b/src/fides/lib/oauth/api/routes/user_endpoints.py
@@ -17,11 +17,7 @@ from starlette.status import (
     HTTP_404_NOT_FOUND,
 )
 
-from fides.api.ops.api.v1.scope_registry import (
-    USER_CREATE,
-    USER_DELETE,
-    USER_READ,
-)
+from fides.api.ops.api.v1.scope_registry import USER_CREATE, USER_DELETE, USER_READ
 from fides.api.ops.util.oauth_util import verify_oauth_client
 from fides.core.config import FidesConfig, get_config
 from fides.lib.exceptions import AuthorizationError

--- a/tests/ops/api/v1/endpoints/test_user_permission_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_permission_endpoints.py
@@ -614,6 +614,22 @@ class TestGetUserPermissions:
         assert HTTP_200_OK == response.status_code
         assert response_body["id"] == oauth_root_client.id
         assert response_body["user_id"] == oauth_root_client.id
+        assert len(response_body["scopes"]) == len(SCOPE_REGISTRY)
+        assert response_body["scopes"] == SCOPE_REGISTRY
+        assert response_body["roles"] == [OWNER]
+        assert response_body["total_scopes"] == sorted(SCOPE_REGISTRY)
+
+        # Intentionally calling twice to make sure scopes didn't change
+        response = api_client.get(
+            f"{V1_URL_PREFIX}/user/{oauth_root_client.id}/permission",
+            headers=root_auth_header,
+        )
+
+        response_body = response.json()
+        assert HTTP_200_OK == response.status_code
+        assert response_body["id"] == oauth_root_client.id
+        assert response_body["user_id"] == oauth_root_client.id
+        assert len(response_body["scopes"]) == len(SCOPE_REGISTRY)
         assert response_body["scopes"] == SCOPE_REGISTRY
         assert response_body["roles"] == [OWNER]
         assert response_body["total_scopes"] == sorted(SCOPE_REGISTRY)


### PR DESCRIPTION
Closes Unticketed

### Code Changes

* [ ] Copies the FidesUserPermission.scopes before modifying in the FidesUserPermission.total_scopes property

### Steps to Confirm

* [ ] Repeated calls to get user permissions should not increase the length of a user's scopes

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Calling FidesUserPermission.total_scopes could mutate whatever list was passed in for FidesUserPermission.scopes: taking every scope that was on the user's role and adding it to the list of scopes.  

This could have side effects such as a token for a root client being created that had many duplicate scopes.  Note that the root client is not a database object, but the CONFIG.security.root_user_scopes value could get mutated on subsequent calls to the get user permissions endpoint.