### PR TITLE
Release 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,15 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.9.0...main)
 
+## [2.9.1](https://github.com/ethyca/fides/compare/2.9.0...2.9.1)
+
 ### Added
 * Added Attentive erasure email connector [#2782](https://github.com/ethyca/fides/pull/2782)
 
 ### Changed
 * Removed dataset based email connectors [#2782](https://github.com/ethyca/fides/pull/2782)
 * Changed Auth0's authentication strategy from `bearer` to `oauth2_client_credentials` [#2820](https://github.com/ethyca/fides/pull/2820)
-* renamed the privacy declarations field "Privacy declaration name (deprecated)" to "Processing Activity"
+* renamed the privacy declarations field "Privacy declaration name (deprecated)" to "Processing Activity" [#711](https://github.com/ethyca/fidesplus/issues/711)
 
 
 ### Fixed
@@ -31,7 +33,7 @@ The types of changes are:
 
 ### Removed
 
-* removed the `privacyDeclarationDeprecatedFields` flag
+* removed the `privacyDeclarationDeprecatedFields` flag [#711](https://github.com/ethyca/fidesplus/issues/711)
 
 ## [2.9.0](https://github.com/ethyca/fides/compare/2.8.3...2.9.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fides/compare/2.9.0...main)
+## [Unreleased](https://github.com/ethyca/fides/compare/2.9.1...main)
 
 ## [2.9.1](https://github.com/ethyca/fides/compare/2.9.0...2.9.1)
 


### PR DESCRIPTION
# Release Checklist

The release checklist is a manual set of checks done before each release to ensure functionality of the most critical components of the application. Some of these steps are redundant with automated tests, while others are _only_ tested here as part of this check.

This checklist should be copy/pasted into the final pre-release PR, and checked off as you complete each step.

## Pre-Release Steps

### General

- [x] Quickstart verified working and up-to-date
- [x] `nox -s "fides_env(test)"` works (verify the admin UI on localhost:8080, privacy center, CLI and webserver)
- [x] `nox -s "build(sample)"` works on the release branch, creating the sample images (this is also prereq for `fides deploy up`)
- [x] `fides deploy up --no-pull` works using the images built in previous step (verify the admin UI, privacy center, CLI and webserver)

```
mkdir ~/fides-2-1-0-test
cd ~/fides-2-1-0-test
python3 -m venv venv
source venv/bin/activate
pip install git+https://github.com/ethyca/fides.git@<branch>
fides deploy up --no-pull
fides status
fides deploy down
rm -rf ~/fides-2-1-0-test
exit
```

Next, run the following checks against the environment you've spun up using `fides deploy up --no-pull`:

### API

- [x] Verify that the generated API docs are correct

### CLI

Run these from within `nox -s dev -- shell`

- [x] Make sure to login your CLI user by running `fides user login -u root_user -p Testpassword1!`
- [x] Run a `fides push`
- [x] Run a `fides pull`
- [x] Run a `fides evaluate`
- [x] Generate a dataset with `fides generate dataset db --credentials-id app_postgres test.yml`
- [x] Scan a database with `fides scan dataset db --credentials-id app_postgres`

### Admin UI

- [x] Every navigation button works
- [x] DSR approval succeeds
- [x] DSR execution succeeds

### Privacy Center

- [x] Every navigation button works
- [x] DSR submission succeeds
- [x] Consent request submission succeeds

### Documentation

- [x] Verify that the CHANGELOG is formatted correctly and clean up verbiage where needed
- [x] Verify that the CHANGELOG is representative of the actual changes

## Post-Release Steps

- [x] Verify the ethyca-fides release is published to PyPi: <https://pypi.org/project/ethyca-fides/#history>
- [x] Verify the fides release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides>
- [x] Verify the fides-privacy-center release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-privacy-center>
- [x] Verify the fides-sample-app release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-sample-app>
- [x] Smoke test the PyPi & DockerHub releases with a clean `pip install ethyca-fides` and `fides deploy up`