### PR TITLE
Fix Logo aspect ratio on Privacy Center `404` page and Consent Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 
 ### Fixed
 * Allow for dynamic aspect ratio for logo on Privacy Center 404 [#2895](https://github.com/ethyca/fides/pull/2895)
+* Allow for dynamic aspect ratio for logo on consent page [#2895](https://github.com/ethyca/fides/pull/2895)
 
 ## [2.9.1](https://github.com/ethyca/fides/compare/2.9.0...2.9.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The types of changes are:
 * Improved standard layout for large width screens and polished misc. pages [#2869](https://github.com/ethyca/fides/pull/2869)
 
 ### Fixed
-* Allow for dynamic aspect ratio for logo on Privacy Center 404  [#2895](https://github.com/ethyca/fides/pull/2895)
+* Allow for dynamic aspect ratio for logo on Privacy Center 404 [#2895](https://github.com/ethyca/fides/pull/2895)
 
 ## [2.9.1](https://github.com/ethyca/fides/compare/2.9.0...2.9.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The types of changes are:
 ### Changed
 * Improved standard layout for large width screens and polished misc. pages [#2869](https://github.com/ethyca/fides/pull/2869)
 
+### Fixed
+* Allow for dynamic aspect ratio for logo on Privacy Center 404  [#2895](https://github.com/ethyca/fides/pull/2895)
+
 ## [2.9.1](https://github.com/ethyca/fides/compare/2.9.0...2.9.1)
 
 ### Added

--- a/clients/privacy-center/pages/404.tsx
+++ b/clients/privacy-center/pages/404.tsx
@@ -57,8 +57,8 @@ const Custom404 = () => (
               <Image
                 src={config.logo_path}
                 alt="Logo"
-                width="124px"
-                height="38px"
+                maxWidth="200px"
+                maxHeight="100px"
               />
             </Box>
           </Stack>
@@ -70,8 +70,8 @@ const Custom404 = () => (
               <Image
                 src={config.logo_path}
                 alt="Logo"
-                width="124px"
-                height="38px"
+                maxWidth="200px"
+                maxHeight="100px"
               />
             </Link>
           </NextLink>

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -333,8 +333,7 @@ const Consent: NextPage = () => {
         >
           <Image
             src={config.logo_path}
-            height="56px"
-            width="304px"
+            height="68px"
             alt="Logo"
           />
         </Flex>

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -331,11 +331,7 @@ const Consent: NextPage = () => {
           justifyContent="center"
           alignItems="center"
         >
-          <Image
-            src={config.logo_path}
-            height="68px"
-            alt="Logo"
-          />
+          <Image src={config.logo_path} height="68px" alt="Logo" />
         </Flex>
       </header>
 


### PR DESCRIPTION
Closes #2893 

### Code Changes

* Replace 404 logo width/height attributes to maxWidth/maxHeight
* Increase the maxWidth/maxHeight sizes to make the logo appear larger on 404 page
* Remove width constraint from consent page

### Steps to Confirm

* Launch privacy center from main (`npm run dev`)
* Replace the logo in the `config.json` with a few others:
  * https://upload.wikimedia.org/wikipedia/commons/4/46/Wikipedia-logo-v2-en_6m_articles_204_white.png
  * https://upload.wikimedia.org/wikipedia/commons/8/85/Logo-Test.png
* browse to http://localhost:3000/fake-page
* browse to consent page
* Launch privacy center from this branch (`rk-2893-privacy-center-404`)
* Repeat testing steps to confirm logos look correct

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
