### PR TITLE
fix: change Version to Fides Core Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The types of changes are:
 ### Changed
 * Improved standard layout for large width screens and polished misc. pages [#2869](https://github.com/ethyca/fides/pull/2869)
 * Deprecated adding scopes to users directly; you can only add roles. [#2848](https://github.com/ethyca/fides/pull/2848/files)
-* Changed about page to say "Fides Core Version:" over "Fides Version. [#2899](https://github.com/ethyca/fides/pull/2899)
+* Changed About Fides page to say "Fides Core Version:" over "Version". [#2899](https://github.com/ethyca/fides/pull/2899)
 
 ### Fixed
 * Restricted Contributors from being able to create Owners [#2888](https://github.com/ethyca/fides/pull/2888)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The types of changes are:
 ### Changed
 * Improved standard layout for large width screens and polished misc. pages [#2869](https://github.com/ethyca/fides/pull/2869)
 * Deprecated adding scopes to users directly; you can only add roles. [#2848](https://github.com/ethyca/fides/pull/2848/files)
+* Changed about page to say "Fides Core Version:" over "Fides Version. [#2899](https://github.com/ethyca/fides/pull/2899)
 
 ### Fixed
 * Restricted Contributors from being able to create Owners [#2888](https://github.com/ethyca/fides/pull/2888)

--- a/clients/admin-ui/src/pages/management/about.tsx
+++ b/clients/admin-ui/src/pages/management/about.tsx
@@ -29,7 +29,7 @@ const About: NextPage = () => {
 
         <Box>
           <Text as="span" fontWeight="bold">
-            Version:{" "}
+            Fides Core Version:{" "}
           </Text>
           <Text as="pre" display="inline">
             {features.version}


### PR DESCRIPTION
This allows end users on FidesPlus to see the Fides Core it is using and not to be confused with Fides Plus.

Closes #TBD

### Code Changes

* [ ] Changes the text `Version:` to `Fides Core Version:`

### Steps to Confirm

* [ ] Sign in and go to About page

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
