### PR TITLE
use HTML property, not text, when dispatching Mailchimp Transactional emails

### DIFF
--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -408,6 +408,7 @@ def _mailchimp_transactional_dispatcher(
             "soft-bounce": "A temporary error occured with the target inbox. For example, this inbox could be full. See https://mailchimp.com/developer/transactional/docs/reputation-rejections/#bounces for more info.",
             "hard-bounce": "A permanent error occured with the target inbox. See https://mailchimp.com/developer/transactional/docs/reputation-rejections/#bounces for more info.",
             "recipient-domain-mismatch": f"You are not authorised to send email to this domain from {from_email}.",
+            "unsigned": f"The sending domain for {from_email} has not been fully configured for Mailchimp Transactional. See https://mailchimp.com/developer/transactional/docs/authentication-delivery/#authentication/ for more info.",
         }
         explanation = explanations.get(reason, "")
         raise MessageDispatchException(

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -381,7 +381,7 @@ def _mailchimp_transactional_dispatcher(
             "message": {
                 "from_email": from_email,
                 "subject": message.subject,
-                "text": message.body,
+                "html": message.body,
                 # On Mailchimp Transactional's free plan `to` must be an email of the same
                 # domain as `from_email`
                 "to": [{"email": to.strip(), "type": "to"}],


### PR DESCRIPTION
### Description

This PR updates the Mailchimp Transactional adaptor to use the `html` attribute, and subsequently render html correctly in emails.