### PR TITLE
update data use titles and check for collison on name and data use

### DIFF
--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -293,6 +293,7 @@ describe("System management page", () => {
       cy.wait(["@getDataCategories", "@getDataSubjects", "@getDataUses"]);
       cy.getByTestId("new-declaration-form").within(() => {
         cy.getByTestId("input-data_use").type(`${secondDataUse}{enter}`);
+        cy.getByTestId("input-name").type(`test-1{enter}`);
         cy.getByTestId("input-data_categories").type(`user.biometric{enter}`);
         cy.getByTestId("input-data_subjects").type(`anonymous{enter}`);
         cy.getByTestId("save-btn").click();
@@ -410,18 +411,19 @@ describe("System management page", () => {
       stubTaxonomyEntities();
     });
 
-    it("warns when a data use is being added that is already used", () => {
+    it("warns when a data use and processing activity is being added that is already used", () => {
       cy.visit("/system");
       cy.getByTestId("system-fidesctl_system").within(() => {
         cy.getByTestId("more-btn").click();
         cy.getByTestId("edit-btn").click();
       });
-      // "improve.system" is already being used
+      // "improve.system" and "test-1" are already being used
       cy.getByTestId("tab-Data uses").click();
       cy.getByTestId("add-btn").click();
       cy.wait(["@getDataCategories", "@getDataSubjects", "@getDataUses"]);
       cy.getByTestId("new-declaration-form").within(() => {
         cy.getByTestId("input-data_use").type(`improve.system{enter}`);
+        cy.getByTestId("input-name").type(`test-1{enter}`);
         cy.getByTestId("input-data_categories").type(`user.biometric{enter}`);
         cy.getByTestId("input-data_subjects").type(`anonymous{enter}`);
         cy.getByTestId("save-btn").click();

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationForm.tsx
@@ -181,7 +181,7 @@ export const usePrivacyDeclarationForm = ({
     if (thisDataUse) {
       return initialValues.name
         ? thisDataUse.name?.concat(" - ", initialValues.name)
-        : initialValues.data_use;
+        : thisDataUse.name;
     }
     return undefined;
   }, [allDataUses, initialValues]);

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationForm.tsx
@@ -97,7 +97,7 @@ export const PrivacyDeclarationFormComponents = ({
         label="Processing Activity"
         name="name"
         variant="stacked"
-        tooltip="The personal data processing activity or activities associated with this data use."
+        tooltip="The personal data processing activity or activities associated with this data use. This will be appended to the title of this declaration."
       />
       <CustomSelect
         name="data_categories"
@@ -180,7 +180,7 @@ export const usePrivacyDeclarationForm = ({
     )[0];
     if (thisDataUse) {
       return initialValues.name
-        ? initialValues.name + " - " + thisDataUse.name
+        ? thisDataUse.name?.concat(" - ", initialValues.name)
         : initialValues.data_use;
     }
     return undefined;

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationForm.tsx
@@ -179,7 +179,9 @@ export const usePrivacyDeclarationForm = ({
       (du) => du.fides_key === initialValues.data_use
     )[0];
     if (thisDataUse) {
-      return thisDataUse.name;
+      return initialValues.name
+        ? initialValues.name + " - " + thisDataUse.name
+        : initialValues.data_use;
     }
     return undefined;
   }, [allDataUses, initialValues]);

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationManager.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationManager.tsx
@@ -43,14 +43,17 @@ const PrivacyDeclarationManager = ({
       return system.privacy_declarations;
     }
     return system.privacy_declarations.filter(
-      (pd) => pd.data_use !== newDeclaration.data_use
+      (pd) => pd.name !== newDeclaration.name
     );
   }, [newDeclaration, system]);
 
   const checkAlreadyExists = (values: PrivacyDeclaration) => {
     if (
-      accordionDeclarations.filter((d) => d.data_use === values.data_use)
-        .length > 0
+      accordionDeclarations.filter((d) =>
+        values.name
+          ? d.name === values.name && d.data_use === values.data_use
+          : d.data_use === values.data_use && d.name === ""
+      ).length > 0
     ) {
       onCollision();
       return true;
@@ -83,7 +86,7 @@ const PrivacyDeclarationManager = ({
     // Because the data use can change, we also need a reference to the old declaration in order to
     // make sure we are replacing the proper one
     const updatedDeclarations = accordionDeclarations.map((dec) =>
-      dec.data_use === oldDeclaration.data_use ? updatedDeclaration : dec
+      dec.name === oldDeclaration.name ? updatedDeclaration : dec
     );
     return handleSave(updatedDeclarations);
   };
@@ -106,7 +109,7 @@ const PrivacyDeclarationManager = ({
 
   const handleDelete = async (declarationToDelete: PrivacyDeclaration) => {
     const updatedDeclarations = system.privacy_declarations.filter(
-      (dec) => dec.data_use !== declarationToDelete.data_use
+      (dec) => dec.name !== declarationToDelete.name
     );
     return handleSave(updatedDeclarations, true);
   };

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationManager.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationManager.tsx
@@ -43,7 +43,9 @@ const PrivacyDeclarationManager = ({
       return system.privacy_declarations;
     }
     return system.privacy_declarations.filter(
-      (pd) => pd.name !== newDeclaration.name
+      (pd) =>
+        pd.name !== newDeclaration.name ||
+        pd.data_use !== newDeclaration.data_use
     );
   }, [newDeclaration, system]);
 
@@ -86,7 +88,10 @@ const PrivacyDeclarationManager = ({
     // Because the data use can change, we also need a reference to the old declaration in order to
     // make sure we are replacing the proper one
     const updatedDeclarations = accordionDeclarations.map((dec) =>
-      dec.name === oldDeclaration.name ? updatedDeclaration : dec
+      dec.name === oldDeclaration.name &&
+      dec.data_use === oldDeclaration.data_use
+        ? updatedDeclaration
+        : dec
     );
     return handleSave(updatedDeclarations);
   };
@@ -109,7 +114,9 @@ const PrivacyDeclarationManager = ({
 
   const handleDelete = async (declarationToDelete: PrivacyDeclaration) => {
     const updatedDeclarations = system.privacy_declarations.filter(
-      (dec) => dec.name !== declarationToDelete.name
+      (dec) =>
+        dec.name !== declarationToDelete.name ||
+        dec.data_use !== declarationToDelete.data_use
     );
     return handleSave(updatedDeclarations, true);
   };

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationStep.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationStep.tsx
@@ -63,7 +63,7 @@ const PrivacyDeclarationStep = ({ system }: Props) => {
   const collisionWarning = () => {
     toast(
       errorToastParams(
-        "A declaration already exists with that Processing Activity and Data Use in this system. Please supply a different data use."
+        "A declaration already exists with that Data Use and Processing Activity in this system."
       )
     );
   };

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationStep.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationStep.tsx
@@ -63,7 +63,7 @@ const PrivacyDeclarationStep = ({ system }: Props) => {
   const collisionWarning = () => {
     toast(
       errorToastParams(
-        "A declaration already exists with that data use in this system. Please supply a different data use."
+        "A declaration already exists with that Processing Activity and Data Use in this system. Please supply a different data use."
       )
     );
   };


### PR DESCRIPTION
Closes #[2894](https://github.com/ethyca/fides/issues/2894)

### Code Changes

* [ ] change data use name to data use - processing activity
* [ ] do not allow duplicates based data use and processing activity 

### Steps to Confirm

* [ ] view systems 
* [ ] edit a system 
* [ ] add a data use with no processing activity 
* [ ] add another with the same data use and a processing activity 
* [ ] try to add another with the same data use and no processing activity like the first, verify you are given a toast warning and not allowed to add 
* [ ] try to add another with the same data use and processing activity like the second, verify you are given a toast warning and not allowed to add 
* [ ] add another with different data use and same processing activity, this should be allowed 
* [ ] delete one and make sure no others are deleted 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] _Optional_: Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

