### PR TITLE
Privacy declaration with composite ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The types of changes are:
 
 ### Fixed
 * Restricted Contributors from being able to create Owners [#2888](https://github.com/ethyca/fides/pull/2888)
+* Allow multiple data uses as long as their processing activity name is different [#2905](https://github.com/ethyca/fides/pull/2905)
 
 ### Fixed
 * Allow for dynamic aspect ratio for logo on Privacy Center 404 [#2895](https://github.com/ethyca/fides/pull/2895)

--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -265,6 +265,7 @@ describe("System management page", () => {
 
     it("Can go directly to a system's edit page", () => {
       cy.visit("/systems/configure/fidesctl_system");
+      cy.wait("@getFidesctlSystem");
       cy.getByTestId("input-name").should("have.value", "Fidesctl System");
 
       cy.intercept("GET", "/api/v1/system/*", {
@@ -495,7 +496,7 @@ describe("System management page", () => {
     });
 
     it("can have multiple of the same data use if the names are different", () => {
-      cy.visit("/system");
+      cy.visit(SYSTEM_ROUTE);
       cy.getByTestId("system-fidesctl_system").within(() => {
         cy.getByTestId("more-btn").click();
         cy.getByTestId("edit-btn").click();

--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -448,13 +448,13 @@ describe("System management page", () => {
         cy.getByTestId("more-btn").click();
         cy.getByTestId("edit-btn").click();
       });
-      // "improve.system" and "test-1" are already being used
+      // "improve.system" and "Store system data." are already being used
       cy.getByTestId("tab-Data uses").click();
       cy.getByTestId("add-btn").click();
       cy.wait(["@getDataCategories", "@getDataSubjects", "@getDataUses"]);
       cy.getByTestId("new-declaration-form").within(() => {
         cy.getByTestId("input-data_use").type(`improve.system{enter}`);
-        cy.getByTestId("input-name").type(`test-1{enter}`);
+        cy.getByTestId("input-name").type(`Store system data.{enter}`);
         cy.getByTestId("input-data_categories").type(`user.biometric{enter}`);
         cy.getByTestId("input-data_subjects").type(`anonymous{enter}`);
         cy.getByTestId("save-btn").click();
@@ -485,12 +485,34 @@ describe("System management page", () => {
       cy.getByTestId(`accordion-header-improve.system`);
       cy.getByTestId(`accordion-header-advertising`).click();
 
-      // try to change 'advertising' to 'improve.system'
+      // try to change 'advertising' to 'improve.system' and make their names match
       cy.getByTestId("advertising-form").within(() => {
         cy.getByTestId("input-data_use").type(`improve.system{enter}`);
+        cy.getByTestId("input-name").clear().type(`Store system data.{enter}`);
         cy.getByTestId("save-btn").click();
       });
       cy.getByTestId("toast-error-msg");
+    });
+
+    it("can have multiple of the same data use if the names are different", () => {
+      cy.visit("/system");
+      cy.getByTestId("system-fidesctl_system").within(() => {
+        cy.getByTestId("more-btn").click();
+        cy.getByTestId("edit-btn").click();
+      });
+      // "improve.system" and "Store system data." are already being used
+      // use "improve.system" again but a different name
+      cy.getByTestId("tab-Data uses").click();
+      cy.getByTestId("add-btn").click();
+      cy.wait(["@getDataCategories", "@getDataSubjects", "@getDataUses"]);
+      cy.getByTestId("new-declaration-form").within(() => {
+        cy.getByTestId("input-data_use").type(`improve.system{enter}`);
+        cy.getByTestId("input-name").type(`A different description.{enter}`);
+        cy.getByTestId("input-data_categories").type(`user.biometric{enter}`);
+        cy.getByTestId("input-data_subjects").type(`anonymous{enter}`);
+        cy.getByTestId("save-btn").click();
+      });
+      cy.getByTestId("toast-success-msg");
     });
 
     describe("delete privacy declaration", () => {

--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -319,6 +319,7 @@ describe("System management page", () => {
       cy.wait(["@getDataCategories", "@getDataSubjects", "@getDataUses"]);
       cy.getByTestId("new-declaration-form").within(() => {
         cy.getByTestId("input-data_use").type(`${secondDataUse}{enter}`);
+        cy.getByTestId("input-name").type(`test-1{enter}`);
         cy.getByTestId("input-data_categories").type(`user.biometric{enter}`);
         cy.getByTestId("input-data_subjects").type(`anonymous{enter}`);
         cy.getByTestId("save-btn").click();
@@ -441,18 +442,19 @@ describe("System management page", () => {
       });
     });
 
-    it("warns when a data use is being added that is already used", () => {
+    it("warns when a data use and processing activity is being added that is already used", () => {
       cy.visit(SYSTEM_ROUTE);
       cy.getByTestId("system-fidesctl_system").within(() => {
         cy.getByTestId("more-btn").click();
         cy.getByTestId("edit-btn").click();
       });
-      // "improve.system" is already being used
+      // "improve.system" and "test-1" are already being used
       cy.getByTestId("tab-Data uses").click();
       cy.getByTestId("add-btn").click();
       cy.wait(["@getDataCategories", "@getDataSubjects", "@getDataUses"]);
       cy.getByTestId("new-declaration-form").within(() => {
         cy.getByTestId("input-data_use").type(`improve.system{enter}`);
+        cy.getByTestId("input-name").type(`test-1{enter}`);
         cy.getByTestId("input-data_categories").type(`user.biometric{enter}`);
         cy.getByTestId("input-data_subjects").type(`anonymous{enter}`);
         cy.getByTestId("save-btn").click();

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationAccordion.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationAccordion.tsx
@@ -8,22 +8,21 @@ import {
 } from "@fidesui/react";
 import { Form, Formik } from "formik";
 
-import { PrivacyDeclaration } from "~/types/api";
-
 import {
   DataProps,
   PrivacyDeclarationFormComponents,
   usePrivacyDeclarationForm,
   ValidationSchema,
 } from "./PrivacyDeclarationForm";
+import { PrivacyDeclarationWithId } from "./types";
 
 interface AccordionProps extends DataProps {
-  privacyDeclarations: PrivacyDeclaration[];
+  privacyDeclarations: PrivacyDeclarationWithId[];
   onEdit: (
-    oldDeclaration: PrivacyDeclaration,
-    newDeclaration: PrivacyDeclaration
+    oldDeclaration: PrivacyDeclarationWithId,
+    newDeclaration: PrivacyDeclarationWithId
   ) => Promise<boolean>;
-  onDelete: (declaration: PrivacyDeclaration) => Promise<boolean>;
+  onDelete: (declaration: PrivacyDeclarationWithId) => Promise<boolean>;
 }
 
 const PrivacyDeclarationAccordionItem = ({
@@ -31,11 +30,11 @@ const PrivacyDeclarationAccordionItem = ({
   onEdit,
   onDelete,
   ...dataProps
-}: { privacyDeclaration: PrivacyDeclaration } & Omit<
+}: { privacyDeclaration: PrivacyDeclarationWithId } & Omit<
   AccordionProps,
   "privacyDeclarations"
 >) => {
-  const handleEdit = (newValues: PrivacyDeclaration) =>
+  const handleEdit = (newValues: PrivacyDeclarationWithId) =>
     onEdit(privacyDeclaration, newValues);
 
   const { initialValues, renderHeader, handleSubmit } =
@@ -100,7 +99,7 @@ const PrivacyDeclarationAccordion = ({
         // The closest is 'data_use' but that is only enforced on the frontend and can change
         // This results in the "Saved" indicator not appearing if you change the 'data_use' in the form
         // The fix would be to enforce a key, either on the backend, or through a significant workaround on the frontend
-        key={dec.data_use}
+        key={dec.id}
         privacyDeclaration={dec}
         {...props}
       />

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationForm.tsx
@@ -52,7 +52,9 @@ const transformPrivacyDeclarationToHaveId = (
   privacyDeclaration: PrivacyDeclaration
 ) => ({
   ...privacyDeclaration,
-  id: `${privacyDeclaration.data_use} - ${privacyDeclaration.name}`,
+  id: privacyDeclaration.name
+    ? `${privacyDeclaration.data_use} - ${privacyDeclaration.name}`
+    : privacyDeclaration.data_use,
 });
 
 export const transformPrivacyDeclarationsToHaveId = (

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationManager.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationManager.tsx
@@ -4,17 +4,24 @@ import { useMemo, useState } from "react";
 import { PrivacyDeclaration, System } from "~/types/api";
 
 import PrivacyDeclarationAccordion from "./PrivacyDeclarationAccordion";
-import { DataProps, PrivacyDeclarationForm } from "./PrivacyDeclarationForm";
+import {
+  DataProps,
+  PrivacyDeclarationForm,
+  transformPrivacyDeclarationsToHaveId,
+} from "./PrivacyDeclarationForm";
+import { PrivacyDeclarationWithId } from "./types";
 
-type FormValues = PrivacyDeclaration;
-
-const transformFormValuesToDeclaration = (
-  formValues: FormValues
-): PrivacyDeclaration => ({
-  ...formValues,
-  // Fill in an empty string for name because of https://github.com/ethyca/fideslang/issues/98
-  name: formValues.name ?? "",
-});
+const transformDeclarationForSubmission = (
+  formValues: PrivacyDeclarationWithId
+): PrivacyDeclaration => {
+  // Remove the id which is only a frontend artifact
+  const { id, ...values } = formValues;
+  return {
+    ...values,
+    // Fill in an empty string for name because of https://github.com/ethyca/fideslang/issues/98
+    name: values.name ?? "",
+  };
+};
 
 interface Props {
   system: System;
@@ -35,22 +42,24 @@ const PrivacyDeclarationManager = ({
 
   const [showNewForm, setShowNewForm] = useState(false);
   const [newDeclaration, setNewDeclaration] = useState<
-    PrivacyDeclaration | undefined
+    PrivacyDeclarationWithId | undefined
   >(undefined);
 
   const accordionDeclarations = useMemo(() => {
-    if (!newDeclaration) {
-      return system.privacy_declarations;
-    }
-    return system.privacy_declarations.filter(
-      (pd) => pd.data_use !== newDeclaration.data_use
+    const declarations = transformPrivacyDeclarationsToHaveId(
+      system.privacy_declarations
     );
+    if (!newDeclaration) {
+      return declarations;
+    }
+    return declarations.filter((pd) => pd.id !== newDeclaration.id);
   }, [newDeclaration, system]);
 
   const checkAlreadyExists = (values: PrivacyDeclaration) => {
     if (
-      accordionDeclarations.filter((d) => d.data_use === values.data_use)
-        .length > 0
+      accordionDeclarations.filter(
+        (d) => d.data_use === values.data_use && d.name === values.name
+      ).length > 0
     ) {
       onCollision();
       return true;
@@ -59,23 +68,23 @@ const PrivacyDeclarationManager = ({
   };
 
   const handleSave = async (
-    updatedDeclarations: PrivacyDeclaration[],
+    updatedDeclarations: PrivacyDeclarationWithId[],
     isDelete?: boolean
   ) => {
     const transformedDeclarations = updatedDeclarations.map((d) =>
-      transformFormValuesToDeclaration(d)
+      transformDeclarationForSubmission(d)
     );
     const success = await onSave(transformedDeclarations, isDelete);
     return success;
   };
 
   const handleEditDeclaration = async (
-    oldDeclaration: PrivacyDeclaration,
-    updatedDeclaration: PrivacyDeclaration
+    oldDeclaration: PrivacyDeclarationWithId,
+    updatedDeclaration: PrivacyDeclarationWithId
   ) => {
     // Do not allow editing a privacy declaration to have the same data use as one that already exists
     if (
-      updatedDeclaration.data_use !== oldDeclaration.data_use &&
+      updatedDeclaration.id !== oldDeclaration.id &&
       checkAlreadyExists(updatedDeclaration)
     ) {
       return false;
@@ -83,12 +92,12 @@ const PrivacyDeclarationManager = ({
     // Because the data use can change, we also need a reference to the old declaration in order to
     // make sure we are replacing the proper one
     const updatedDeclarations = accordionDeclarations.map((dec) =>
-      dec.data_use === oldDeclaration.data_use ? updatedDeclaration : dec
+      dec.id === oldDeclaration.id ? updatedDeclaration : dec
     );
     return handleSave(updatedDeclarations);
   };
 
-  const saveNewDeclaration = async (values: PrivacyDeclaration) => {
+  const saveNewDeclaration = async (values: PrivacyDeclarationWithId) => {
     if (checkAlreadyExists(values)) {
       return false;
     }
@@ -104,14 +113,18 @@ const PrivacyDeclarationManager = ({
     setNewDeclaration(undefined);
   };
 
-  const handleDelete = async (declarationToDelete: PrivacyDeclaration) => {
-    const updatedDeclarations = system.privacy_declarations.filter(
-      (dec) => dec.data_use !== declarationToDelete.data_use
-    );
+  const handleDelete = async (
+    declarationToDelete: PrivacyDeclarationWithId
+  ) => {
+    const updatedDeclarations = transformPrivacyDeclarationsToHaveId(
+      system.privacy_declarations
+    ).filter((dec) => dec.id !== declarationToDelete.id);
     return handleSave(updatedDeclarations, true);
   };
 
-  const handleDeleteNew = async (declarationToDelete: PrivacyDeclaration) => {
+  const handleDeleteNew = async (
+    declarationToDelete: PrivacyDeclarationWithId
+  ) => {
     const success = await handleDelete(declarationToDelete);
     if (success) {
       setShowNewForm(false);

--- a/clients/admin-ui/src/features/system/privacy-declarations/types.ts
+++ b/clients/admin-ui/src/features/system/privacy-declarations/types.ts
@@ -1,0 +1,11 @@
+import { PrivacyDeclaration } from "~/types/api";
+
+/**
+ * This is because privacy declarations do not have an ID on the backend.
+ * It is very useful for React rendering to have a stable ID. We currently
+ * make this the composite of data_use - name, but even better may be to
+ * give it a UUID (or to have the backend actually enforce this!)
+ */
+export interface PrivacyDeclarationWithId extends PrivacyDeclaration {
+  id: string;
+}


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2894

### Code Changes

* [x] Uses a new type `PrivacyDeclarationWithId` to facilitate name and data use comparisons
  * In retrospect, this was a _little_ overkill, as it doesn't actually solve [this problem](https://github.com/ethyca/fides/blob/main/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationAccordion.tsx/#L99-L102). It gets us a lot closer though—we could probably use a javascript UUID package and replace the ID there and be fairly close. However, I think it'd be better if the backend gave an ID instead 😄 
  * The 🔑 thing here was updating the `key` value to be a composite instead of just based off of `data_use`
* [x] Update various logic that used to only compare data uses to also compare names of privacy declarations
* [x] Update tests

### Steps to Confirm

* [x] Add data uses on a system
* [x] You should be able to add the same data use as long as the name of it is different. If the name and data use are the same, you'll get an error
* [x] Also try deleting

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
