### PR TITLE
Material Design Icon & Font Awesome 5 Support for Privacy Center Icons

### DIFF
--- a/clients/privacy-center/components/Card.tsx
+++ b/clients/privacy-center/components/Card.tsx
@@ -1,5 +1,8 @@
-import { Flex, Image, Text } from "@fidesui/react";
+import { Flex, Icon, Image, Text } from "@fidesui/react";
 import React from "react";
+import * as mdIcons from 'react-icons/md'
+import * as faIcons from 'react-icons/fa'
+
 
 type CardProps = {
   title: string;
@@ -48,7 +51,13 @@ const Card: React.FC<CardProps> = ({
       outline: "none",
     }}
   >
+    { 
+    iconPath.toLowerCase().startsWith('md:') ? // Material Design icons
+    <Icon boxSize="32px" as={mdIcons[iconPath.split(':')[1] as keyof typeof mdIcons]} color="complimentary.500"></Icon> :
+    iconPath.toLowerCase().startsWith('fa:') ? // FontAwesome icons
+    <Icon boxSize="32px" as={faIcons[iconPath.split(':')[1] as keyof typeof faIcons]} color="complimentary.500"></Icon> :
     <Image alt={description} boxSize="32px" src={iconPath} />
+    }
     <Text
       color="gray.600"
       fontSize="md"

--- a/clients/privacy-center/package-lock.json
+++ b/clients/privacy-center/package-lock.json
@@ -23,6 +23,7 @@
         "next": "12.2.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-icons": "^4.8.0",
         "react-phone-number-input": "^3.2.19",
         "react-redux": "^8.0.5",
         "redux-persist": "^6.0.0",
@@ -15872,6 +15873,14 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -29541,6 +29550,12 @@
         "use-callback-ref": "^1.2.5",
         "use-sidecar": "^1.0.5"
       }
+    },
+    "react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/clients/privacy-center/package.json
+++ b/clients/privacy-center/package.json
@@ -40,6 +40,7 @@
     "next": "12.2.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.8.0",
     "react-phone-number-input": "^3.2.19",
     "react-redux": "^8.0.5",
     "redux-persist": "^6.0.0",


### PR DESCRIPTION
Now, the `icon_path` fields can accept FontAwesome 5 and Material Design icons instead of just a path to an svg. This maintains compatibility with the path-based method by inspecting the value of icon_path. If it starts with `md:`, it will be a Material Design icon; if it starts with `fa:`, it will be a FontAwesome icon. See https://react-icons.github.io/react-icons/icons?name=md and https://react-icons.github.io/react-icons/icons?name=fa for a complete listing of icon names that it accepts.

Example with custom icons:
<img width="967" alt="image" src="https://user-images.githubusercontent.com/39230492/227361355-5d403147-ea6e-4597-bc7f-a5c03c5a28f9.png">

```
<truncated>
      "icon_path": "md:MdCloudDownload",
      "title": "Access your data",
<truncated>
      "policy_key": "default_erasure_policy",
      "icon_path": "fa:FaSkull",
      "title": "Erase your data",
<truncated>
  "includeConsent": true,
  "consent": {
    "icon_path": "/consent.svg",
<truncated>
```

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
