### PR TITLE
[#2911] Remove policy key from submission modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The types of changes are:
 ### Fixed
 
 * Restricted Contributors from being able to create Owners [#2888](https://github.com/ethyca/fides/pull/2888)
+* Remove policy key from Privacy Center submission modal [#2912](https://github.com/ethyca/fides/pull/2912)
 
 ### Fixed
 * Allow for dynamic aspect ratio for logo on Privacy Center 404 [#2895](https://github.com/ethyca/fides/pull/2895)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,6 @@ The types of changes are:
 * Restricted Contributors from being able to create Owners [#2888](https://github.com/ethyca/fides/pull/2888)
 * Remove policy key from Privacy Center submission modal [#2912](https://github.com/ethyca/fides/pull/2912)
 * Allow multiple data uses as long as their processing activity name is different [#2905](https://github.com/ethyca/fides/pull/2905)
-
-### Fixed
 * Allow for dynamic aspect ratio for logo on Privacy Center 404 [#2895](https://github.com/ethyca/fides/pull/2895)
 * Allow for dynamic aspect ratio for logo on consent page [#2895](https://github.com/ethyca/fides/pull/2895)
 

--- a/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestModal.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestModal.tsx
@@ -107,7 +107,7 @@ export const PrivacyRequestModal: React.FC<RequestModalProps> = ({
   }
 
   if (currentView === ModalViews.RequestSubmitted) {
-    form = <RequestSubmitted onClose={onClose} action={action} />;
+    form = <RequestSubmitted onClose={onClose} />;
   }
 
   return (

--- a/clients/privacy-center/components/modals/privacy-request-modal/RequestSubmitted.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/RequestSubmitted.tsx
@@ -11,12 +11,10 @@ import {
 
 type RequestSubmittedProps = {
   onClose: () => void;
-  action: any;
 };
 
 const RequestSubmitted: React.FC<RequestSubmittedProps> = ({
   onClose,
-  action,
 }) => (
   <>
     <HStack justifyContent="center" data-testid="request-submitted">
@@ -39,7 +37,7 @@ const RequestSubmitted: React.FC<RequestSubmittedProps> = ({
 
     <ModalBody>
       <Text fontSize="sm" color="gray.500" mb={4}>
-        Thanks for your {action.policy_key} Request. A member of our team will
+        Thanks for your request. A member of our team will
         review and be in contact with you shortly.
       </Text>
     </ModalBody>

--- a/clients/privacy-center/components/modals/privacy-request-modal/RequestSubmitted.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/RequestSubmitted.tsx
@@ -13,9 +13,7 @@ type RequestSubmittedProps = {
   onClose: () => void;
 };
 
-const RequestSubmitted: React.FC<RequestSubmittedProps> = ({
-  onClose,
-}) => (
+const RequestSubmitted: React.FC<RequestSubmittedProps> = ({ onClose }) => (
   <>
     <HStack justifyContent="center" data-testid="request-submitted">
       <Image
@@ -37,8 +35,8 @@ const RequestSubmitted: React.FC<RequestSubmittedProps> = ({
 
     <ModalBody>
       <Text fontSize="sm" color="gray.500" mb={4}>
-        Thanks for your request. A member of our team will
-        review and be in contact with you shortly.
+        Thanks for your request. A member of our team will review and be in
+        contact with you shortly.
       </Text>
     </ModalBody>
 


### PR DESCRIPTION
Closes #2911

### Code Changes

* Removes the policy key in the modal post ID verification

<img width="458" alt="image" src="https://user-images.githubusercontent.com/39230492/227588054-08763756-4544-41bc-b4d8-df38fc8d389f.png">

### Steps to Confirm

* Launch privacy center, configured to connect to a Fides instance with ID verification enabled
* Submit access request
* View confirmation modal

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

