### PR TITLE
722 tie user role and system save states together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The types of changes are:
 * Changed About Fides page to say "Fides Core Version:" over "Version". [#2899](https://github.com/ethyca/fides/pull/2899)
 * Polish Admin UI header & navigation [#2897](https://github.com/ethyca/fides/pull/2897)
 * Give new users a "viewer" role by default [#2900](https://github.com/ethyca/fides/pull/2900)
+* Tie together save states for user permissions and systems [2913](https://github.com/ethyca/fides/pull/2913)
 
 
 ### Fixed

--- a/clients/admin-ui/cypress/e2e/user-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/user-management.cy.ts
@@ -258,14 +258,11 @@ describe("User management", () => {
           cy.getByTestId("row-fidesctl_system").within(() => {
             cy.getByTestId("unassign-btn").click();
           });
-          cy.getByTestId("remove-fidesctl_system-confirmation-modal").within(
-            () => {
-              cy.getByTestId("continue-btn").click({ force: true });
-            }
-          );
-          cy.wait("@removeUserManagedSystem").then((interception) => {
-            const { url } = interception.request;
-            expect(url).contains("fidesctl_system");
+          cy.getByTestId("save-btn").click();
+
+          cy.wait("@updateUserManagedSystems").then((interception) => {
+            const { body } = interception.request;
+            expect(body).to.eql([]);
           });
         });
       });
@@ -292,6 +289,7 @@ describe("User management", () => {
             });
           });
           cy.getByTestId("confirm-btn").click();
+          cy.getByTestId("save-btn").click();
 
           cy.wait("@updateUserManagedSystems").then((interception) => {
             const { body } = interception.request;
@@ -331,6 +329,7 @@ describe("User management", () => {
           });
 
           cy.getByTestId("confirm-btn").click();
+          cy.getByTestId("save-btn").click();
           cy.wait("@updateUserManagedSystems").then((interception) => {
             const { body } = interception.request;
             expect(body).to.eql([]);

--- a/clients/admin-ui/cypress/e2e/user-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/user-management.cy.ts
@@ -232,9 +232,6 @@ describe("User management", () => {
         cy.intercept("PUT", "/api/v1/user/*/system-manager", {
           fixture: "systems/systems.json",
         }).as("updateUserManagedSystems");
-        cy.intercept("DELETE", "/api/v1/user/*/system-manager/*", {
-          body: {},
-        }).as("removeUserManagedSystem");
         cy.intercept("GET", "/api/v1/system", {
           fixture: "systems/systems.json",
         }).as("getSystems");
@@ -262,7 +259,7 @@ describe("User management", () => {
 
           cy.wait("@updateUserManagedSystems").then((interception) => {
             const { body } = interception.request;
-            expect(body).to.eql([]);
+            expect(body).to.eql(["demo_analytics_system", "demo_marketing_system"]);
           });
         });
       });
@@ -291,6 +288,7 @@ describe("User management", () => {
           cy.getByTestId("confirm-btn").click();
           cy.getByTestId("save-btn").click();
 
+          cy.wait("@updatePermission")
           cy.wait("@updateUserManagedSystems").then((interception) => {
             const { body } = interception.request;
             expect(body).to.eql([
@@ -330,6 +328,7 @@ describe("User management", () => {
 
           cy.getByTestId("confirm-btn").click();
           cy.getByTestId("save-btn").click();
+          cy.wait("@updatePermission")
           cy.wait("@updateUserManagedSystems").then((interception) => {
             const { body } = interception.request;
             expect(body).to.eql([]);

--- a/clients/admin-ui/src/features/user-management/AssignSystemsModal.tsx
+++ b/clients/admin-ui/src/features/user-management/AssignSystemsModal.tsx
@@ -19,7 +19,6 @@ import {
 } from "@fidesui/react";
 import { ChangeEvent, useMemo, useState } from "react";
 
-
 import SearchBar from "~/features/common/SearchBar";
 import { useGetAllSystemsQuery } from "~/features/system";
 import { SEARCH_FILTER } from "~/features/system/SystemsManagement";
@@ -32,15 +31,17 @@ const AssignSystemsModal = ({
   onClose,
   assignedSystems,
   onAssignedSystemChange,
-}: Pick<ModalProps, "isOpen" | "onClose"> & {assignedSystems: System[], onAssignedSystemChange: (systems: System[]) => void}) => {
+}: Pick<ModalProps, "isOpen" | "onClose"> & {
+  assignedSystems: System[];
+  onAssignedSystemChange: (systems: System[]) => void;
+}) => {
   const { data: allSystems } = useGetAllSystemsQuery();
   const [searchFilter, setSearchFilter] = useState("");
-  const [selectedSystems, setSelectedSystems] = useState<System[]>(
-    assignedSystems
-  );
+  const [selectedSystems, setSelectedSystems] =
+    useState<System[]>(assignedSystems);
 
   const handleConfirm = async () => {
-    onAssignedSystemChange(selectedSystems)
+    onAssignedSystemChange(selectedSystems);
     onClose();
   };
 

--- a/clients/admin-ui/src/features/user-management/AssignSystemsTable.tsx
+++ b/clients/admin-ui/src/features/user-management/AssignSystemsTable.tsx
@@ -20,7 +20,13 @@ import {
   useGetUserManagedSystemsQuery,
 } from "./user-management.slice";
 
-export const AssignSystemsDeleteTable = ({assignedSystems, onAssignedSystemChange} : {assignedSystems: System[], onAssignedSystemChange: (systems: System[]) => void}) => {
+export const AssignSystemsDeleteTable = ({
+  assignedSystems,
+  onAssignedSystemChange,
+}: {
+  assignedSystems: System[];
+  onAssignedSystemChange: (systems: System[]) => void;
+}) => {
   const activeUserId = useAppSelector(selectActiveUserId);
   useGetUserManagedSystemsQuery(activeUserId as string, {
     skip: !activeUserId,
@@ -32,11 +38,11 @@ export const AssignSystemsDeleteTable = ({assignedSystems, onAssignedSystemChang
 
   const onDelete = (system: System) => {
     onAssignedSystemChange(
-        assignedSystems.filter(
-            (assignedSystem) => assignedSystem.fides_key !== system.fides_key
-        )
+      assignedSystems.filter(
+        (assignedSystem) => assignedSystem.fides_key !== system.fides_key
+      )
     );
-  }
+  };
 
   return (
     <Table size="sm" data-testid="assign-systems-delete-table">

--- a/clients/admin-ui/src/features/user-management/AssignSystemsTable.tsx
+++ b/clients/admin-ui/src/features/user-management/AssignSystemsTable.tsx
@@ -5,61 +5,37 @@ import {
   Table,
   Tbody,
   Td,
-  Text,
   Th,
   Thead,
   Tr,
-  useDisclosure,
-  useToast,
 } from "@fidesui/react";
-import ConfirmationModal from "common/ConfirmationModal";
-import { getErrorMessage } from "common/helpers";
-import { errorToastParams, successToastParams } from "common/toast";
 import React from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import { TrashCanSolidIcon } from "~/features/common/Icon/TrashCanSolidIcon";
 import { System } from "~/types/api";
-import { isErrorResult } from "~/types/errors";
 
 import {
   selectActiveUserId,
-  selectActiveUsersManagedSystems,
   useGetUserManagedSystemsQuery,
-  useRemoveUserManagedSystemMutation,
 } from "./user-management.slice";
 
-export const AssignSystemsDeleteTable = () => {
+export const AssignSystemsDeleteTable = ({assignedSystems, onAssignedSystemChange} : {assignedSystems: System[], onAssignedSystemChange: (systems: System[]) => void}) => {
   const activeUserId = useAppSelector(selectActiveUserId);
-  const {
-    isOpen: deleteIsOpen,
-    onOpen: onDeleteOpen,
-    onClose: onDeleteClose,
-  } = useDisclosure();
   useGetUserManagedSystemsQuery(activeUserId as string, {
     skip: !activeUserId,
   });
-  const assignedSystems = useAppSelector(selectActiveUsersManagedSystems);
-  const toast = useToast();
-  const [removeUserManagedSystemTrigger] = useRemoveUserManagedSystemMutation();
-  const handleDelete = async (system: System) => {
-    if (!activeUserId) {
-      return;
-    }
-    const result = await removeUserManagedSystemTrigger({
-      userId: activeUserId,
-      systemKey: system.fides_key,
-    });
-    if (isErrorResult(result)) {
-      toast(errorToastParams(getErrorMessage(result.error)));
-    } else {
-      toast(successToastParams("Successfully removed system"));
-      onDeleteClose();
-    }
-  };
 
   if (assignedSystems.length === 0) {
     return null;
+  }
+
+  const onDelete = (system: System) => {
+    onAssignedSystemChange(
+        assignedSystems.filter(
+            (assignedSystem) => assignedSystem.fides_key !== system.fides_key
+        )
+    );
   }
 
   return (
@@ -85,19 +61,8 @@ export const AssignSystemsDeleteTable = () => {
                 icon={<TrashCanSolidIcon />}
                 variant="outline"
                 size="sm"
-                onClick={onDeleteOpen}
+                onClick={() => onDelete(system)}
                 data-testid="unassign-btn"
-              />
-              <ConfirmationModal
-                isOpen={deleteIsOpen}
-                onClose={onDeleteClose}
-                onConfirm={() => handleDelete(system)}
-                title="Remove System"
-                testId={`remove-${system.fides_key}-confirmation-modal`}
-                continueButtonText="Yes, Remove System"
-                message={
-                  <Text>Are you sure you want to remove this system?</Text>
-                }
               />
             </Td>
           </Tr>

--- a/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
+++ b/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
@@ -10,6 +10,7 @@ import {
 import { useHasRole } from "common/Restrict";
 import { Form, Formik } from "formik";
 import NextLink from "next/link";
+import { useEffect, useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import { USER_MANAGEMENT_ROUTE } from "~/constants";
@@ -17,13 +18,15 @@ import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import QuestionTooltip from "~/features/common/QuestionTooltip";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
 import { ROLES } from "~/features/user-management/constants";
-import {RoleRegistryEnum, System} from "~/types/api";
+import { RoleRegistryEnum, System } from "~/types/api";
 
-import {useEffect, useState} from "react";
 import RoleOption from "./RoleOption";
 import {
-  selectActiveUserId, selectActiveUsersManagedSystems, useGetUserManagedSystemsQuery,
-  useGetUserPermissionsQuery, useUpdateUserManagedSystemsMutation,
+  selectActiveUserId,
+  selectActiveUsersManagedSystems,
+  useGetUserManagedSystemsQuery,
+  useGetUserPermissionsQuery,
+  useUpdateUserManagedSystemsMutation,
   useUpdateUserPermissionsMutation,
 } from "./user-management.slice";
 
@@ -41,7 +44,7 @@ const PermissionsForm = () => {
   });
   const initialManagedSystems = useAppSelector(selectActiveUsersManagedSystems);
   const [assignedSystems, setAssignedSystems] = useState<System[]>(
-      initialManagedSystems
+    initialManagedSystems
   );
   const [updateUserManagedSystemsTrigger] =
     useUpdateUserManagedSystemsMutation();
@@ -151,7 +154,7 @@ const PermissionsForm = () => {
                 colorScheme="primary"
                 type="submit"
                 isLoading={isSubmitting}
-                disabled={!dirty && (assignedSystems === initialManagedSystems)}
+                disabled={!dirty && assignedSystems === initialManagedSystems}
                 data-testid="save-btn"
               >
                 Save

--- a/clients/admin-ui/src/features/user-management/RoleOption.tsx
+++ b/clients/admin-ui/src/features/user-management/RoleOption.tsx
@@ -11,7 +11,7 @@ import {
 } from "@fidesui/react";
 import { useFormikContext } from "formik";
 
-import { RoleRegistryEnum } from "~/types/api";
+import {RoleRegistryEnum, System} from "~/types/api";
 
 import QuestionTooltip from "../common/QuestionTooltip";
 import AssignSystemsModal from "./AssignSystemsModal";
@@ -23,9 +23,11 @@ interface Props {
   roleKey: RoleRegistryEnum;
   isSelected: boolean;
   isDisabled: boolean;
+  assignedSystems: System[];
+  onAssignedSystemChange: (systems: System[]) => void;
 }
 
-const RoleOption = ({ label, roleKey, isSelected, isDisabled }: Props) => {
+const RoleOption = ({ label, roleKey, isSelected, isDisabled , assignedSystems, onAssignedSystemChange}: Props) => {
   const { setFieldValue } = useFormikContext<FormValues>();
   const assignSystemsModal = useDisclosure();
 
@@ -75,13 +77,15 @@ const RoleOption = ({ label, roleKey, isSelected, isDisabled }: Props) => {
             >
               Assign systems +
             </Button>
-            <AssignSystemsDeleteTable />
+            <AssignSystemsDeleteTable assignedSystems={assignedSystems} onAssignedSystemChange={onAssignedSystemChange}/>
             {/* By conditionally rendering the modal, we force it to reset its state
                 whenever it opens */}
             {assignSystemsModal.isOpen ? (
               <AssignSystemsModal
                 isOpen={assignSystemsModal.isOpen}
                 onClose={assignSystemsModal.onClose}
+                assignedSystems={assignedSystems}
+                onAssignedSystemChange={onAssignedSystemChange}
               />
             ) : null}
           </>

--- a/clients/admin-ui/src/features/user-management/RoleOption.tsx
+++ b/clients/admin-ui/src/features/user-management/RoleOption.tsx
@@ -11,7 +11,7 @@ import {
 } from "@fidesui/react";
 import { useFormikContext } from "formik";
 
-import {RoleRegistryEnum, System} from "~/types/api";
+import { RoleRegistryEnum, System } from "~/types/api";
 
 import QuestionTooltip from "../common/QuestionTooltip";
 import AssignSystemsModal from "./AssignSystemsModal";
@@ -27,7 +27,14 @@ interface Props {
   onAssignedSystemChange: (systems: System[]) => void;
 }
 
-const RoleOption = ({ label, roleKey, isSelected, isDisabled , assignedSystems, onAssignedSystemChange}: Props) => {
+const RoleOption = ({
+  label,
+  roleKey,
+  isSelected,
+  isDisabled,
+  assignedSystems,
+  onAssignedSystemChange,
+}: Props) => {
   const { setFieldValue } = useFormikContext<FormValues>();
   const assignSystemsModal = useDisclosure();
 
@@ -77,7 +84,10 @@ const RoleOption = ({ label, roleKey, isSelected, isDisabled , assignedSystems, 
             >
               Assign systems +
             </Button>
-            <AssignSystemsDeleteTable assignedSystems={assignedSystems} onAssignedSystemChange={onAssignedSystemChange}/>
+            <AssignSystemsDeleteTable
+              assignedSystems={assignedSystems}
+              onAssignedSystemChange={onAssignedSystemChange}
+            />
             {/* By conditionally rendering the modal, we force it to reset its state
                 whenever it opens */}
             {assignSystemsModal.isOpen ? (


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/722

### Code Changes

* [ ] Tie together save states for user role and system. This change prevents changes to system from auto-saving on the BE, and instead saves any changes to systems at the same time as the overall user permissions form.

### Steps to Confirm

* [ ] Clicking this `confirm` button when assigning systems should not save to the backend. Hard refresh should show no changes to user permissions:
<img width="1017" alt="Screenshot 2023-03-24 at 5 17 35 PM" src="https://user-images.githubusercontent.com/7697292/227582475-fcfe03c8-a391-4e44-82e1-4615401245be.png">

* [ ] Clicking the `confirm` button to assign systems, then hitting the `save` button on main form should save changes

* [ ] Clicking the trash icon should not save to the backend (until you click `save` on the main form)
<img width="694" alt="Screenshot 2023-03-24 at 5 17 45 PM" src="https://user-images.githubusercontent.com/7697292/227582760-51cdd8bf-5e47-4712-87a9-b2ac3ffe3d67.png">

* [ ] Regression test that changing user role saves on the backend, after clicking `save` button.


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
