### PR TITLE
add assigned systems to user management table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The types of changes are:
 * Allow users to configure their username and password via the config file [#2884](https://github.com/ethyca/fides/pull/2884)
 * Add authentication to the `masking` endpoints as well as accompanying scopes [#2909](https://github.com/ethyca/fides/pull/2909)
 * Add an Organization Management page (beta) [#2908](https://github.com/ethyca/fides/pull/2908)
+* Adds assigned systems to user management table [#2922](https://github.com/ethyca/fides/pull/2922)
 
 ### Changed
 

--- a/clients/admin-ui/cypress/e2e/user-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/user-management.cy.ts
@@ -19,6 +19,9 @@ describe("User management", () => {
 
   describe("View users", () => {
     it("can view all users", () => {
+      cy.intercept("/api/v1/user/*/system-manager", {
+        fixture: "systems/systems.json",
+      });
       cy.visit("/user-management");
       cy.wait("@getAllUsers");
       const numUsers = 4;
@@ -26,7 +29,11 @@ describe("User management", () => {
         .find("tbody > tr")
         .then((rows) => {
           expect(rows.length).to.eql(numUsers);
-        });
+        })
+        .first()
+        cy.getByTestId("user-systems-badge")
+        cy.contains("4")
+      ;
     });
   });
 

--- a/clients/admin-ui/src/features/user-management/UserManagementRow.tsx
+++ b/clients/admin-ui/src/features/user-management/UserManagementRow.tsx
@@ -15,7 +15,10 @@ import {
 } from "@fidesui/react";
 import { useRouter } from "next/router";
 import React from "react";
-import {useGetUserManagedSystemsQuery, useGetUserPermissionsQuery} from "user-management/user-management.slice";
+import {
+  useGetUserManagedSystemsQuery,
+  useGetUserPermissionsQuery,
+} from "user-management/user-management.slice";
 
 import { ROLES } from "~/features/user-management/constants";
 
@@ -39,8 +42,8 @@ const UserManagementRow: React.FC<UserManagementRowProps> = ({ user }) => {
     skip: !user.id,
   });
   const { data: userSystems } = useGetUserManagedSystemsQuery(user.id ?? "", {
-    skip: !user.id
-  })
+    skip: !user.id,
+  });
   const permissionsLabels: string[] = [];
   if (userPermissions && userPermissions.roles) {
     userPermissions.roles.forEach((permissionRole) => {
@@ -91,21 +94,21 @@ const UserManagementRow: React.FC<UserManagementRowProps> = ({ user }) => {
           ))}
         </Td>
         <Td pl={0} py={1} onClick={handleEditUser}>
-            <Badge
-                bg="gray.500"
-                color="white"
-                paddingLeft="8px"
-                textTransform="none"
-                paddingRight="8px"
-                height="18px"
-                lineHeight="18px"
-                borderRadius="6px"
-                fontWeight="500"
-                textAlign="center"
-                data-testid="user-permissions-badge"
-            >
-              {userSystems ? userSystems.length : 0}
-            </Badge>
+          <Badge
+            bg="gray.500"
+            color="white"
+            paddingLeft="8px"
+            textTransform="none"
+            paddingRight="8px"
+            height="18px"
+            lineHeight="18px"
+            borderRadius="6px"
+            fontWeight="500"
+            textAlign="center"
+            data-testid="user-permissions-badge"
+          >
+            {userSystems ? userSystems.length : 0}
+          </Badge>
         </Td>
         <Td pl={0} py={1} onClick={handleEditUser}>
           {user.created_at ? new Date(user.created_at).toUTCString() : null}

--- a/clients/admin-ui/src/features/user-management/UserManagementRow.tsx
+++ b/clients/admin-ui/src/features/user-management/UserManagementRow.tsx
@@ -15,7 +15,7 @@ import {
 } from "@fidesui/react";
 import { useRouter } from "next/router";
 import React from "react";
-import { useGetUserPermissionsQuery } from "user-management/user-management.slice";
+import {useGetUserManagedSystemsQuery, useGetUserPermissionsQuery} from "user-management/user-management.slice";
 
 import { ROLES } from "~/features/user-management/constants";
 
@@ -38,6 +38,9 @@ const UserManagementRow: React.FC<UserManagementRowProps> = ({ user }) => {
   const { data: userPermissions } = useGetUserPermissionsQuery(user.id ?? "", {
     skip: !user.id,
   });
+  const { data: userSystems } = useGetUserManagedSystemsQuery(user.id ?? "", {
+    skip: !user.id
+  })
   const permissionsLabels: string[] = [];
   if (userPermissions && userPermissions.roles) {
     userPermissions.roles.forEach((permissionRole) => {
@@ -86,6 +89,23 @@ const UserManagementRow: React.FC<UserManagementRowProps> = ({ user }) => {
               {permission}
             </Badge>
           ))}
+        </Td>
+        <Td pl={0} py={1} onClick={handleEditUser}>
+            <Badge
+                bg="gray.500"
+                color="white"
+                paddingLeft="8px"
+                textTransform="none"
+                paddingRight="8px"
+                height="18px"
+                lineHeight="18px"
+                borderRadius="6px"
+                fontWeight="500"
+                textAlign="center"
+                data-testid="user-permissions-badge"
+            >
+              {userSystems ? userSystems.length : 0}
+            </Badge>
         </Td>
         <Td pl={0} py={1} onClick={handleEditUser}>
           {user.created_at ? new Date(user.created_at).toUTCString() : null}

--- a/clients/admin-ui/src/features/user-management/UserManagementRow.tsx
+++ b/clients/admin-ui/src/features/user-management/UserManagementRow.tsx
@@ -78,7 +78,7 @@ const UserManagementRow: React.FC<UserManagementRowProps> = ({ user }) => {
             <Badge
               bg="gray.500"
               color="white"
-              paddingLeft="8px"
+              paddingLeft="2"
               textTransform="none"
               paddingRight="8px"
               height="18px"
@@ -97,7 +97,7 @@ const UserManagementRow: React.FC<UserManagementRowProps> = ({ user }) => {
           <Badge
             bg="gray.500"
             color="white"
-            paddingLeft="8px"
+            paddingLeft="2"
             textTransform="none"
             paddingRight="8px"
             height="18px"
@@ -105,7 +105,7 @@ const UserManagementRow: React.FC<UserManagementRowProps> = ({ user }) => {
             borderRadius="6px"
             fontWeight="500"
             textAlign="center"
-            data-testid="user-permissions-badge"
+            data-testid="user-systems-badge"
           >
             {userSystems ? userSystems.length : 0}
           </Badge>

--- a/clients/admin-ui/src/features/user-management/UserManagementTable.tsx
+++ b/clients/admin-ui/src/features/user-management/UserManagementTable.tsx
@@ -72,6 +72,7 @@ const UserManagementTable: React.FC<UsersTableProps> = () => {
             <Th pl={0}>First Name</Th>
             <Th pl={0}>Last Name</Th>
             <Th pl={0}>Permissions</Th>
+            <Th pl={0}>Assigned Systems</Th>
             <Th pl={0}>Created At</Th>
           </Tr>
         </Thead>


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2861

### Code Changes

* [ ] Adds column to show number of assigned systems in user management table

<img width="1178" alt="Screenshot 2023-03-27 at 5 17 28 PM" src="https://user-images.githubusercontent.com/7697292/227985567-7cd074fe-08f8-4af5-b5c8-35d6958bb604.png">

### Steps to Confirm

* [ ] Add new users with varying amounts of systems. Confirm the number of systems assigned is reflected in user management table.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
