### PR TITLE
2898 alert system manager downgrade to approver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The types of changes are:
 * Removing payment types from Stripe connector params [#2915](https://github.com/ethyca/fides/pull/2915)
 * Change Privacy Center email placeholder text [#2935](https://github.com/ethyca/fides/pull/2935)
 * Restricted setting Approvers as System Managers [#2891](https://github.com/ethyca/fides/pull/2891)
+* Adds confirmation modal when downgrading user to "approver" role via Admin UI [#2924](https://github.com/ethyca/fides/pull/2924)
+
 
 ### Fixed
 

--- a/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
+++ b/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
@@ -185,7 +185,7 @@ const PermissionsForm = () => {
               testId="downgrade-to-approver-confirmation-modal"
               continueButtonText="Yes"
               message={
-                <Text>Approvers cannot be system managers. Any systems assigned to this user will be removed. Are you sure you wish to proceed? </Text>
+                <Text>Switching to an approver role will remove all assigned systems. Do you wish to proceed?</Text>
               }
           />
         </Form>

--- a/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
+++ b/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
@@ -90,7 +90,7 @@ const PermissionsForm = () => {
     toast(successToastParams("Permissions updated"));
   };
 
-  // This prevents users with contributor role from being able to assign owner roles
+  // This prevents logged-in users with contributor role from being able to assign owner roles
   const isOwner = useHasRole([RoleRegistryEnum.OWNER]);
 
   if (!activeUserId) {

--- a/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
+++ b/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
@@ -8,6 +8,7 @@ import {
   useDisclosure,
   useToast,
 } from "@fidesui/react";
+import ConfirmationModal from "common/ConfirmationModal";
 import { useHasRole } from "common/Restrict";
 import { Form, Formik } from "formik";
 import NextLink from "next/link";
@@ -21,7 +22,6 @@ import { errorToastParams, successToastParams } from "~/features/common/toast";
 import { ROLES } from "~/features/user-management/constants";
 import { RoleRegistryEnum, System } from "~/types/api";
 
-import ConfirmationModal from "common/ConfirmationModal";
 import RoleOption from "./RoleOption";
 import {
   selectActiveUserId,
@@ -104,9 +104,6 @@ const PermissionsForm = () => {
     if (!activeUserId) {
       return;
     }
-    console.log(assignedSystems);
-    console.log(values.roles);
-    console.log(Boolean(values.roles.includes(RoleRegistryEnum.APPROVER)));
     if (
       assignedSystems.length > 0 &&
       values.roles.includes(RoleRegistryEnum.APPROVER)

--- a/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
+++ b/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
@@ -1,16 +1,25 @@
-import {Button, ButtonGroup, Flex, Spinner, Stack, Text, useDisclosure, useToast,} from "@fidesui/react";
-import {useHasRole} from "common/Restrict";
-import {Form, Formik} from "formik";
+import {
+  Button,
+  ButtonGroup,
+  Flex,
+  Spinner,
+  Stack,
+  Text,
+  useDisclosure,
+  useToast,
+} from "@fidesui/react";
+import { useHasRole } from "common/Restrict";
+import { Form, Formik } from "formik";
 import NextLink from "next/link";
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 
-import {useAppSelector} from "~/app/hooks";
-import {USER_MANAGEMENT_ROUTE} from "~/constants";
-import {getErrorMessage, isErrorResult} from "~/features/common/helpers";
+import { useAppSelector } from "~/app/hooks";
+import { USER_MANAGEMENT_ROUTE } from "~/constants";
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import QuestionTooltip from "~/features/common/QuestionTooltip";
-import {errorToastParams, successToastParams} from "~/features/common/toast";
-import {ROLES} from "~/features/user-management/constants";
-import {RoleRegistryEnum, System} from "~/types/api";
+import { errorToastParams, successToastParams } from "~/features/common/toast";
+import { ROLES } from "~/features/user-management/constants";
+import { RoleRegistryEnum, System } from "~/types/api";
 
 import ConfirmationModal from "common/ConfirmationModal";
 import RoleOption from "./RoleOption";
@@ -63,7 +72,7 @@ const PermissionsForm = () => {
 
   const updatePermissions = async (values: FormValues) => {
     if (chooseApproverIsOpen) {
-      chooseApproverClose()
+      chooseApproverClose();
     }
     if (!activeUserId) {
       return;
@@ -89,20 +98,23 @@ const PermissionsForm = () => {
       return;
     }
     toast(successToastParams("Permissions updated"));
-  }
+  };
 
   const handleSubmit = async (values: FormValues) => {
     if (!activeUserId) {
       return;
     }
-    console.log(assignedSystems)
-    console.log(values.roles)
-    console.log(Boolean(values.roles.includes(RoleRegistryEnum.APPROVER)))
-    if ((assignedSystems.length > 0) && (values.roles.includes(RoleRegistryEnum.APPROVER))) {
+    console.log(assignedSystems);
+    console.log(values.roles);
+    console.log(Boolean(values.roles.includes(RoleRegistryEnum.APPROVER)));
+    if (
+      assignedSystems.length > 0 &&
+      values.roles.includes(RoleRegistryEnum.APPROVER)
+    ) {
       // approvers cannot be system managers on back-end
-      chooseApproverOpen()
+      chooseApproverOpen();
     } else {
-      await updatePermissions(values)
+      await updatePermissions(values);
     }
   };
 
@@ -178,15 +190,18 @@ const PermissionsForm = () => {
             </ButtonGroup>
           </Stack>
           <ConfirmationModal
-              isOpen={chooseApproverIsOpen}
-              onClose={chooseApproverClose}
-              onConfirm={() => updatePermissions(values)}
-              title="Change role to Approver"
-              testId="downgrade-to-approver-confirmation-modal"
-              continueButtonText="Yes"
-              message={
-                <Text>Switching to an approver role will remove all assigned systems. Do you wish to proceed?</Text>
-              }
+            isOpen={chooseApproverIsOpen}
+            onClose={chooseApproverClose}
+            onConfirm={() => updatePermissions(values)}
+            title="Change role to Approver"
+            testId="downgrade-to-approver-confirmation-modal"
+            continueButtonText="Yes"
+            message={
+              <Text>
+                Switching to an approver role will remove all assigned systems.
+                Do you wish to proceed?
+              </Text>
+            }
           />
         </Form>
       )}

--- a/clients/admin-ui/src/features/user-management/RoleOption.tsx
+++ b/clients/admin-ui/src/features/user-management/RoleOption.tsx
@@ -43,11 +43,10 @@ const RoleOption = ({
 
   const handleRoleChange = () => {
     setFieldValue("roles", [roleKey]);
-  }
+  };
 
   const handleClick = () => {
-
-    handleRoleChange()
+    handleRoleChange();
   };
 
   const buttonTitle = isDisabled
@@ -114,14 +113,14 @@ const RoleOption = ({
 
   return (
     <Button
-        onClick={handleClick}
-        justifyContent="start"
-        variant="outline"
-        height="inherit"
-        p={4}
-        data-testid={`role-option-${label}`}
-        title={buttonTitle}
-        disabled={isDisabled}
+      onClick={handleClick}
+      justifyContent="start"
+      variant="outline"
+      height="inherit"
+      p={4}
+      data-testid={`role-option-${label}`}
+      title={buttonTitle}
+      disabled={isDisabled}
     >
       {label}
     </Button>

--- a/clients/admin-ui/src/features/user-management/RoleOption.tsx
+++ b/clients/admin-ui/src/features/user-management/RoleOption.tsx
@@ -40,21 +40,13 @@ const RoleOption = ({
 }: Props) => {
   const { setFieldValue } = useFormikContext<FormValues>();
   const assignSystemsModal = useDisclosure();
-  const {
-    isOpen: chooseApproverIsOpen,
-    onOpen: chooseApproverOpen,
-    onClose: chooseApproverClose,
-  } = useDisclosure();
 
   const handleRoleChange = () => {
     setFieldValue("roles", [roleKey]);
   }
 
   const handleClick = () => {
-    if ((assignedSystems.length > 0) && (roleKey === RoleRegistryEnum.APPROVER)) {
-      // approvers cannot be system managers on back-end
-      chooseApproverOpen()
-    }
+
     handleRoleChange()
   };
 
@@ -121,31 +113,18 @@ const RoleOption = ({
   }
 
   return (
-    <Box>
-      <Button
-          onClick={handleClick}
-          justifyContent="start"
-          variant="outline"
-          height="inherit"
-          p={4}
-          data-testid={`role-option-${label}`}
-          title={buttonTitle}
-          disabled={isDisabled}
-      >
-        {label}
-      </Button>
-      <ConfirmationModal
-          isOpen={chooseApproverIsOpen}
-          onClose={chooseApproverClose}
-          onConfirm={() => handleRoleChange}
-          title="Change role to Approver"
-          testId={`choose-role-option-${label}-confirmation-modal`}
-          continueButtonText="Yes"
-          message={
-            <Text>Approvers cannot be system managers. Any systems assigned to this user will be removed. Are you sure you wish to proceed? </Text>
-          }
-      />
-    </Box>
+    <Button
+        onClick={handleClick}
+        justifyContent="start"
+        variant="outline"
+        height="inherit"
+        p={4}
+        data-testid={`role-option-${label}`}
+        title={buttonTitle}
+        disabled={isDisabled}
+    >
+      {label}
+    </Button>
   );
 };
 

--- a/clients/admin-ui/src/features/user-management/RoleOption.tsx
+++ b/clients/admin-ui/src/features/user-management/RoleOption.tsx
@@ -2,7 +2,6 @@
  * A component for choosing a role, meant to be embedded in a Formik form
  */
 import {
-  Box,
   Button,
   Flex,
   GreenCheckCircleIcon,
@@ -11,6 +10,7 @@ import {
   useDisclosure,
 } from "@fidesui/react";
 import { useFormikContext } from "formik";
+import React from "react";
 
 import { RoleRegistryEnum, System } from "~/types/api";
 
@@ -18,8 +18,6 @@ import QuestionTooltip from "../common/QuestionTooltip";
 import AssignSystemsModal from "./AssignSystemsModal";
 import { AssignSystemsDeleteTable } from "./AssignSystemsTable";
 import { type FormValues } from "./PermissionsForm";
-import React from "react";
-import ConfirmationModal from "common/ConfirmationModal";
 
 interface Props {
   label: string;

--- a/clients/admin-ui/src/features/user-management/RoleOption.tsx
+++ b/clients/admin-ui/src/features/user-management/RoleOption.tsx
@@ -2,6 +2,7 @@
  * A component for choosing a role, meant to be embedded in a Formik form
  */
 import {
+  Box,
   Button,
   Flex,
   GreenCheckCircleIcon,
@@ -17,6 +18,8 @@ import QuestionTooltip from "../common/QuestionTooltip";
 import AssignSystemsModal from "./AssignSystemsModal";
 import { AssignSystemsDeleteTable } from "./AssignSystemsTable";
 import { type FormValues } from "./PermissionsForm";
+import React from "react";
+import ConfirmationModal from "common/ConfirmationModal";
 
 interface Props {
   label: string;
@@ -37,9 +40,22 @@ const RoleOption = ({
 }: Props) => {
   const { setFieldValue } = useFormikContext<FormValues>();
   const assignSystemsModal = useDisclosure();
+  const {
+    isOpen: chooseApproverIsOpen,
+    onOpen: chooseApproverOpen,
+    onClose: chooseApproverClose,
+  } = useDisclosure();
+
+  const handleRoleChange = () => {
+    setFieldValue("roles", [roleKey]);
+  }
 
   const handleClick = () => {
-    setFieldValue("roles", [roleKey]);
+    if ((assignedSystems.length > 0) && (roleKey === RoleRegistryEnum.APPROVER)) {
+      // approvers cannot be system managers on back-end
+      chooseApproverOpen()
+    }
+    handleRoleChange()
   };
 
   const buttonTitle = isDisabled
@@ -105,18 +121,31 @@ const RoleOption = ({
   }
 
   return (
-    <Button
-      onClick={handleClick}
-      justifyContent="start"
-      variant="outline"
-      height="inherit"
-      p={4}
-      data-testid={`role-option-${label}`}
-      title={buttonTitle}
-      disabled={isDisabled}
-    >
-      {label}
-    </Button>
+    <Box>
+      <Button
+          onClick={handleClick}
+          justifyContent="start"
+          variant="outline"
+          height="inherit"
+          p={4}
+          data-testid={`role-option-${label}`}
+          title={buttonTitle}
+          disabled={isDisabled}
+      >
+        {label}
+      </Button>
+      <ConfirmationModal
+          isOpen={chooseApproverIsOpen}
+          onClose={chooseApproverClose}
+          onConfirm={() => handleRoleChange}
+          title="Change role to Approver"
+          testId={`choose-role-option-${label}-confirmation-modal`}
+          continueButtonText="Yes"
+          message={
+            <Text>Approvers cannot be system managers. Any systems assigned to this user will be removed. Are you sure you wish to proceed? </Text>
+          }
+      />
+    </Box>
   );
 };
 

--- a/clients/admin-ui/src/features/user-management/RoleOption.tsx
+++ b/clients/admin-ui/src/features/user-management/RoleOption.tsx
@@ -43,10 +43,6 @@ const RoleOption = ({
     setFieldValue("roles", [roleKey]);
   };
 
-  const handleClick = () => {
-    handleRoleChange();
-  };
-
   const buttonTitle = isDisabled
     ? "You do not have sufficient permissions to assign this role."
     : undefined;
@@ -111,7 +107,7 @@ const RoleOption = ({
 
   return (
     <Button
-      onClick={handleClick}
+      onClick={handleRoleChange}
       justifyContent="start"
       variant="outline"
       height="inherit"


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2898

### Code Changes

* [ ] Adds confirmation modal when attempting to downgrade user to approver if they are assigned systems.

### Steps to Confirm

* [ ] Assign user as anything other than approver, and assign systems
* [ ] Click save
* [ ] Assign user to approver
* [ ] Click save
* [ ] See confirmation modal
* [ ] Confirm nothing happens if you click `cancel`
* [ ] Confirm user is saved with approver role if you click `yes`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
