### PR TITLE
Update datamap references in admin UI

### DIFF
--- a/clients/admin-ui/package-lock.json
+++ b/clients/admin-ui/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
-        "@fidesui/components": "^0.6.0",
+        "@fidesui/components": "^0.7.0",
         "@fidesui/react": "^0.0.23",
         "@fontsource/inter": "^4.5.15",
         "@monaco-editor/react": "^4.4.6",
@@ -1720,9 +1720,9 @@
       }
     },
     "node_modules/@fidesui/components": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@fidesui/components/-/components-0.6.0.tgz",
-      "integrity": "sha512-e+J1E65V5Xv5Oq803uOlcLr0N4bQR7zTFbcsKsywzLV++hnuonyIGu4rHLO1vXoA90udbEX81EeixJPvPXmhcg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@fidesui/components/-/components-0.7.0.tgz",
+      "integrity": "sha512-kQl1ZGctrfBSmGOaBILSAPlwbRaR/j0bY6v0adrMJbrnlZRfN90fEYAwhi/mPCP+lkQpuNGZCPUmaBGPTTXFBQ==",
       "dependencies": {
         "@fidesui/react": "^0.0.23",
         "chakra-react-select": "^3.3.7"
@@ -15824,9 +15824,9 @@
       "dev": true
     },
     "@fidesui/components": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@fidesui/components/-/components-0.6.0.tgz",
-      "integrity": "sha512-e+J1E65V5Xv5Oq803uOlcLr0N4bQR7zTFbcsKsywzLV++hnuonyIGu4rHLO1vXoA90udbEX81EeixJPvPXmhcg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@fidesui/components/-/components-0.7.0.tgz",
+      "integrity": "sha512-kQl1ZGctrfBSmGOaBILSAPlwbRaR/j0bY6v0adrMJbrnlZRfN90fEYAwhi/mPCP+lkQpuNGZCPUmaBGPTTXFBQ==",
       "requires": {
         "@fidesui/react": "^0.0.23",
         "chakra-react-select": "^3.3.7"

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
-    "@fidesui/components": "^0.6.0",
+    "@fidesui/components": "^0.7.0",
     "@fidesui/react": "^0.0.23",
     "@fontsource/inter": "^4.5.15",
     "@monaco-editor/react": "^4.4.6",

--- a/clients/admin-ui/src/constants.ts
+++ b/clients/admin-ui/src/constants.ts
@@ -141,7 +141,6 @@ export const CONNECTION_TYPE_ROUTE = "/connection_type";
 // UI ROUTES
 export const ADD_SYSTEMS_ROUTE = "/add-systems";
 export const ADD_SYSTEMS_MANUAL_ROUTE = "/add-systems/manual";
-export const DATAMAP_ROUTE = "/datamap";
 export const DATASTORE_CONNECTION_ROUTE = "/datastore-connection";
 export const PRIVACY_REQUESTS_ROUTE = "/privacy-requests";
 export const PRIVACY_REQUESTS_CONFIGURATION_ROUTE =

--- a/clients/admin-ui/src/features/common/hooks/useInterzoneNav.ts
+++ b/clients/admin-ui/src/features/common/hooks/useInterzoneNav.ts
@@ -1,4 +1,5 @@
-import { SYSTEM_ROUTE } from "~/constants";
+import { DATAMAP_ROUTE, SYSTEM_ROUTE } from "@fidesui/components";
+
 import { useFeatures } from "~/features/common/features";
 import { resolveLink } from "~/features/common/nav/zone-config";
 
@@ -6,7 +7,7 @@ export const useInterzoneNav = () => {
   const features = useFeatures();
 
   const datamapRoute = resolveLink({
-    href: "/datamap",
+    href: DATAMAP_ROUTE,
     basePath: "/",
   });
 

--- a/clients/admin-ui/src/features/common/nav/zone-config.ts
+++ b/clients/admin-ui/src/features/common/nav/zone-config.ts
@@ -7,7 +7,7 @@ export const ZONE_CONFIG = configureZones({
 
   zones: [
     {
-      basePath: "/datamap",
+      basePath: "/plus",
       development: {
         host: "localhost:4000",
       },

--- a/clients/admin-ui/src/home/constants.ts
+++ b/clients/admin-ui/src/home/constants.ts
@@ -4,7 +4,8 @@ import {
   DATASTORE_CONNECTION_ROUTE,
   PRIVACY_REQUESTS_ROUTE,
   SYSTEM_ROUTE,
-} from "~/constants";
+} from "@fidesui/components";
+
 import { ScopeRegistryEnum } from "~/types/api";
 
 import { ModuleCardConfig } from "./types";

--- a/clients/admin-ui/src/home/tile-config.test.ts
+++ b/clients/admin-ui/src/home/tile-config.test.ts
@@ -1,3 +1,4 @@
+import { DATAMAP_ROUTE } from "@fidesui/components";
 import { describe, expect, it } from "@jest/globals";
 
 import { ScopeRegistryEnum } from "~/types/api";
@@ -21,7 +22,7 @@ describe("configureTiles", () => {
       userScopes: ALL_SCOPES_FOR_TILES,
     });
 
-    expect(tiles.filter((t) => t.href === "/datamap").length).toEqual(0);
+    expect(tiles.filter((t) => t.href === DATAMAP_ROUTE).length).toEqual(0);
   });
 
   it("includes datamap view if plus", () => {
@@ -30,7 +31,7 @@ describe("configureTiles", () => {
       hasPlus: true,
       userScopes: ALL_SCOPES_FOR_TILES,
     });
-    expect(tiles.filter((t) => t.href === "/datamap").length).toEqual(1);
+    expect(tiles.filter((t) => t.href === DATAMAP_ROUTE).length).toEqual(1);
   });
 
   describe("configure by scopes", () => {


### PR DESCRIPTION
Relies on https://github.com/ethyca/fidesui/pull/47

Needed for https://github.com/ethyca/fidesplus/issues/256

### Code Changes

* [x] Update references from `/datamap` to `/plus/datamap`
* [x] Bump fidesui (which has the nav change from `/datamap` --> `/plus/datamap`


### Steps to Confirm

* [ ] `npm run dev`
* [ ] Hover over the "Data map" nav bar link. It should point to `/plus/datamap`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Companion to https://github.com/ethyca/fidesplus/pull/778
