### PR TITLE
Release 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The types of changes are:
 * Allow for dynamic aspect ratio for logo on Privacy Center 404 [#2895](https://github.com/ethyca/fides/pull/2895)
 * Allow for dynamic aspect ratio for logo on consent page [#2895](https://github.com/ethyca/fides/pull/2895)
 * Align role dscription drawer of Admin UI with top nav: [#2932](https://github.com/ethyca/fides/pull/2932)
+* Fixed error message when a user is assigned to be an approver without any systems [#2953](https://github.com/ethyca/fides/pull/2953)
 
 ### Developer Experience
 

--- a/clients/admin-ui/cypress/e2e/user-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/user-management.cy.ts
@@ -95,10 +95,9 @@ describe("User management", () => {
         .then((rows) => {
           expect(rows.length).to.eql(numUsers);
         })
-        .first()
-        cy.getByTestId("user-systems-badge")
-        cy.contains("4")
-      ;
+        .first();
+      cy.getByTestId("user-systems-badge");
+      cy.contains("4");
     });
   });
 
@@ -307,6 +306,26 @@ describe("User management", () => {
         cy.intercept("GET", "/api/v1/system", {
           fixture: "systems/systems.json",
         }).as("getSystems");
+      });
+
+      describe("approver cannot have systems", () => {
+        beforeEach(() => {
+          cy.visit(`/user-management/profile/${USER_1_ID}`);
+          cy.getByTestId("tab-Permissions").click();
+          cy.wait("@getSystems");
+          cy.wait("@getUserManagedSystems");
+        });
+
+        it("can warn when assigning an approver", () => {
+          cy.getByTestId("role-option-Approver").click();
+          cy.getByTestId("save-btn").click();
+          cy.getByTestId("downgrade-to-approver-confirmation-modal").within(
+            () => {
+              cy.getByTestId("continue-btn").click();
+            }
+          );
+          cy.wait("@updatePermission");
+        });
       });
 
       describe("in role option", () => {

--- a/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
+++ b/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
@@ -71,17 +71,20 @@ const PermissionsForm = () => {
     useUpdateUserPermissionsMutation();
 
   const updatePermissions = async (values: FormValues) => {
-    let skipAssigningSystems = false;
     if (chooseApproverIsOpen) {
-      // Unassigning systems from viewer role happens automatically on BE when the role is saved.
-      // If we attempt to assign systems to the viewer role, the BE will throw an error,
-      // so we skip calling the endpoint.
-      skipAssigningSystems = true;
       chooseApproverClose();
     }
     if (!activeUserId) {
       return;
     }
+
+    // Unassigning systems from an approver happens automatically on BE when the role is saved.
+    // If we attempt to assign systems to the approver role, the BE will throw an error,
+    // so we skip calling the endpoint.
+    const skipAssigningSystems = values.roles.includes(
+      RoleRegistryEnum.APPROVER
+    );
+
     const userPermissionsResult = await updateUserPermissionMutationTrigger({
       user_id: activeUserId,
       // Scopes are not editable in the UI, but make sure we retain whatever scopes

--- a/clients/admin-ui/src/features/user-management/user-management.slice.ts
+++ b/clients/admin-ui/src/features/user-management/user-management.slice.ts
@@ -163,7 +163,17 @@ export const userApi = createApi({
         method: "PUT",
         body: payload,
       }),
-      invalidatesTags: ["User"],
+      invalidatesTags: (result, error, arg) => {
+        // The backend will change managed systems if the role becomes "Approver"
+        // so make sure we refetch for the managed systems in this case
+        if (arg.payload.roles?.includes(RoleRegistryEnum.APPROVER)) {
+          return [
+            "User",
+            { type: "Managed Systems" as const, id: arg.user_id },
+          ];
+        }
+        return ["User"];
+      },
     }),
     deleteUser: build.mutation<{ success: boolean; id: string }, string>({
       query: (id) => ({


### PR DESCRIPTION
## Pre-Release Steps

### General

From the release branch, confirm the following:
- [x] Quickstart works: `nox -s quickstart` (verify you can complete the interactive prompts from the command-line)
- [x] Test environment works: `nox -s "fides_env(test)"` (verify the admin UI on localhost:8080, privacy center on localhost:3001, CLI and webserver)
- [x] Building the sample app images works: `nox -s "build(sample)"` (creates the sample images, which is also prereq for `fides deploy up --no-pull` next)
- [x] Running the CLI deploy works: `fides deploy up --no-pull` (see instructions below...)

```
mkdir ~/fides-deploy-test
cd ~/fides-deploy-test
python3 -m venv venv
source venv/bin/activate
pip install git+https://github.com/ethyca/fides.git@<release-branch-name-here>
fides deploy up --no-pull
fides status
fides deploy down
rm -rf ~/fides-deploy-test
exit
```

Next, run the following checks using the test environment (`nox -s "fides_env(test)"`):

### API

- [x] Verify that the generated API docs are correct (http://localhost:8080/docs)

### CLI

Run these from within the test environment shell:

- [x] Make sure to login your CLI user by running `fides user login -u root_user -p Testpassword1!`
- [x] Run a `fides push`
- [x] Run a `fides pull`
- [x] Run a `fides evaluate`
- [x] Generate a dataset with `fides generate dataset db --credentials-id app_postgres test.yml`
- [x] Scan a database with `fides scan dataset db --credentials-id app_postgres`

### Privacy Center

- [x] Every navigation button works
- [x] DSR submission succeeds
- [x] Consent request submission succeeds

### Admin UI

- [x] Every navigation button works
- [x] DSR approval succeeds
- [x] DSR execution succeeds

### Documentation

- [x] Verify that the CHANGELOG is formatted correctly and clean up verbiage where needed
- [x] Verify that the CHANGELOG is representative of the actual changes

## Post-Release Steps

- [x] Verify the ethyca-fides release is published to PyPi: <https://pypi.org/project/ethyca-fides/#history>
- [x] Verify the fides release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides>
- [x] Verify the fides-privacy-center release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-privacy-center>
- [x] Verify the fides-sample-app release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-sample-app>
- [x] Smoke test the PyPi & DockerHub releases with a clean `pip install ethyca-fides` and `fides deploy up`
- [x] Announce the release