### PR TITLE
Fix approver error msg

### DIFF
--- a/clients/admin-ui/cypress/e2e/user-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/user-management.cy.ts
@@ -95,10 +95,9 @@ describe("User management", () => {
         .then((rows) => {
           expect(rows.length).to.eql(numUsers);
         })
-        .first()
-        cy.getByTestId("user-systems-badge")
-        cy.contains("4")
-      ;
+        .first();
+      cy.getByTestId("user-systems-badge");
+      cy.contains("4");
     });
   });
 
@@ -307,6 +306,26 @@ describe("User management", () => {
         cy.intercept("GET", "/api/v1/system", {
           fixture: "systems/systems.json",
         }).as("getSystems");
+      });
+
+      describe("approver cannot have systems", () => {
+        beforeEach(() => {
+          cy.visit(`/user-management/profile/${USER_1_ID}`);
+          cy.getByTestId("tab-Permissions").click();
+          cy.wait("@getSystems");
+          cy.wait("@getUserManagedSystems");
+        });
+
+        it("can warn when assigning an approver", () => {
+          cy.getByTestId("role-option-Approver").click();
+          cy.getByTestId("save-btn").click();
+          cy.getByTestId("downgrade-to-approver-confirmation-modal").within(
+            () => {
+              cy.getByTestId("continue-btn").click();
+            }
+          );
+          cy.wait("@updatePermission");
+        });
       });
 
       describe("in role option", () => {

--- a/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
+++ b/clients/admin-ui/src/features/user-management/PermissionsForm.tsx
@@ -71,17 +71,20 @@ const PermissionsForm = () => {
     useUpdateUserPermissionsMutation();
 
   const updatePermissions = async (values: FormValues) => {
-    let skipAssigningSystems = false;
     if (chooseApproverIsOpen) {
-      // Unassigning systems from viewer role happens automatically on BE when the role is saved.
-      // If we attempt to assign systems to the viewer role, the BE will throw an error,
-      // so we skip calling the endpoint.
-      skipAssigningSystems = true;
       chooseApproverClose();
     }
     if (!activeUserId) {
       return;
     }
+
+    // Unassigning systems from an approver happens automatically on BE when the role is saved.
+    // If we attempt to assign systems to the approver role, the BE will throw an error,
+    // so we skip calling the endpoint.
+    const skipAssigningSystems = values.roles.includes(
+      RoleRegistryEnum.APPROVER
+    );
+
     const userPermissionsResult = await updateUserPermissionMutationTrigger({
       user_id: activeUserId,
       // Scopes are not editable in the UI, but make sure we retain whatever scopes

--- a/clients/admin-ui/src/features/user-management/user-management.slice.ts
+++ b/clients/admin-ui/src/features/user-management/user-management.slice.ts
@@ -163,7 +163,17 @@ export const userApi = createApi({
         method: "PUT",
         body: payload,
       }),
-      invalidatesTags: ["User"],
+      invalidatesTags: (result, error, arg) => {
+        // The backend will change managed systems if the role becomes "Approver"
+        // so make sure we refetch for the managed systems in this case
+        if (arg.payload.roles?.includes(RoleRegistryEnum.APPROVER)) {
+          return [
+            "User",
+            { type: "Managed Systems" as const, id: arg.user_id },
+          ];
+        }
+        return ["User"];
+      },
     }),
     deleteUser: build.mutation<{ success: boolean; id: string }, string>({
       query: (id) => ({


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2952

And also another small bug I found where "ghost" systems showed up. Steps to repro:
* Assign a system i.e. System A to a user (i.e. Viewer) and save
* Change this user to an approver. This will remove System A on the backend, and the UI will look like System A is no longer on the approver
* But if you now click back to Viewer, the UI would still show System A, even though it's not assigned.

### Code Changes

* [x] Tweak check for when to make system manager PUT
* [x] Fix "ghost" systems showing up by doing a lil redux cache busting
* [x] Adds a cypress test (this actually doesn't test exactly this bug, as it is difficult to test in cypress when an API call is _not_ made)

### Steps to Confirm

* [ ] Follow the steps in https://github.com/ethyca/fides/issues/2952 for the first bug
* [ ] Follow the steps at the top of this PR description for the second bug

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes


https://user-images.githubusercontent.com/24641006/228876778-a66bda49-d649-4676-8415-8ccd65efc4c4.mov


