### PR TITLE
endpoint to retrieve privacy notices by data use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The types of changes are:
 - Added preliminary privacy notice page [#2995](https://github.com/ethyca/fides/pull/2995)
 - Table for privacy notices [#3001](https://github.com/ethyca/fides/pull/3001)
 - Query params on connection type endpoint to filter by supported action type [#2996](https://github.com/ethyca/fides/pull/2996)
+- Add endpoint to retrieve privacy notices grouped by their associated data uses [#2956](https://github.com/ethyca/fides/pull/2956)
 
 ### Changed
 

--- a/docs/fides/docs/development/postman/Fides.postman_collection.json
+++ b/docs/fides/docs/development/postman/Fides.postman_collection.json
@@ -5168,7 +5168,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n  {\n    \"name\": \"Profiling\",\n    \"regions\": [\n      \"us_ca\",\n      \"us_ut\"\n    ],\n    \"description\": \"Making a decision solely by automated means.\",\n    \"consent_mechanism\": \"opt_in\",\n    \"data_uses\": [\n      \"personalize\"\n    ],\n    \"enforcement_level\": \"system_wide\",\n    \"has_gpc_flag\": false\n  },\n  {\n    \"name\": \"Essential\",\n    \"regions\": [\n      \"eu\"\n    ],\n    \"description\": \"Notify the user about data processing activities that are essential to your services' functionality. Typically consent is not required for this.\",\n    \"consent_mechanism\": \"necessary\",\n    \"data_uses\": [\n      \"provide.service\"\n    ],\n    \"enforcement_level\": \"system_wide\"\n  }\n]",
+							"raw": "[\n  {\n    \"name\": \"Profiling\",\n    \"regions\": [\n      \"us_ca\",\n      \"us_ut\"\n    ],\n    \"description\": \"Making a decision solely by automated means.\",\n    \"consent_mechanism\": \"opt_in\",\n    \"data_uses\": [\n      \"personalize\"\n    ],\n    \"enforcement_level\": \"system_wide\",\n    \"has_gpc_flag\": false\n  },\n  {\n    \"name\": \"Essential\",\n    \"regions\": [\n      \"eu_de\"\n    ],\n    \"description\": \"Notify the user about data processing activities that are essential to your services' functionality. Typically consent is not required for this.\",\n    \"consent_mechanism\": \"necessary\",\n    \"data_uses\": [\n      \"provide.service\"\n    ],\n    \"enforcement_level\": \"system_wide\"\n  },\n  {\n    \"name\": \"Advertising\",\n    \"regions\": [\n    \"us_ca\"\n    ],\n    \"description\": \"Sample advertising notice\",\n    \"consent_mechanism\": \"necessary\",\n    \"data_uses\": [\n    \"advertising\"\n    ],\n    \"enforcement_level\": \"system_wide\"\n  }\n]",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -5267,6 +5267,45 @@
 									"key": "show_disabled",
 									"value": "true"
 								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Privacy Notices By Data Use",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{client_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/privacy-notice-by-data-use",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"privacy-notice-by-data-use"
 							]
 						}
 					},

--- a/src/fides/api/ctl/sql_models.py
+++ b/src/fides/api/ctl/sql_models.py
@@ -186,6 +186,26 @@ class DataUse(Base, FidesBase):
     legitimate_interest_impact_assessment = Column(String, nullable=True)
     is_default = Column(BOOLEAN, default=False)
 
+    @staticmethod
+    def get_parent_uses(data_use_key: str) -> Set[str]:
+        """
+        Utility method to traverse "up" the taxonomy hierarchy and unpack
+        a given data use fides key into a set of fides keys that include its
+        parent fides keys.
+
+        The utility takes a fides key string input to make the method more applicable -
+        since in many spots of our application we do not have a true `DataUse` instance,
+        just a "soft" reference to its fides key.
+
+        Example inputs and outputs:
+            - `a.b.c` --> [`a.b.c`, `a.b`, `a`]
+            - `a` --> [`a`]
+        """
+        parent_uses = {data_use_key}
+        while data_use_key := data_use_key.rpartition(".")[0]:
+            parent_uses.add(data_use_key)
+        return parent_uses
+
 
 # Dataset
 class Dataset(Base, FidesBase):
@@ -310,15 +330,11 @@ class System(Base, FidesBase):
         for row in db.query(System.privacy_declarations).all():
             declarations: List[dict[str, Any]] = row[0]
             for declaration in declarations:
-                data_use: str = declaration.get("data_use", None)
-                while data_use:
-                    data_uses.add(data_use)
+                if data_use := declaration.get("data_use", None):
                     if include_parents:
-                        data_use = data_use.rpartition(".")[
-                            0
-                        ]  # traverse up the hierarchy
+                        data_uses.update(DataUse.get_parent_uses(data_use))
                     else:
-                        data_use = None
+                        data_uses.add(data_use)
         return data_uses
 
 

--- a/src/fides/api/ops/api/v1/endpoints/privacy_notice_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_notice_endpoints.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from fastapi import Depends, Security
 from fastapi_pagination import Page, Params
@@ -92,9 +92,7 @@ def get_privacy_notice_list(
         Security(verify_oauth_client, scopes=[scope_registry.PRIVACY_NOTICE_READ])
     ],
 )
-def get_privacy_notice_by_data_use(
-    *, db: Session = Depends(deps.get_db)
-) -> Dict[str, Any]:
+def get_privacy_notice_by_data_use(*, db: Session = Depends(deps.get_db)) -> DataUseMap:
     """
     Endpoint to retrieve a map of `DataUse`s with their corresponding `PrivacyNotice`s
 

--- a/src/fides/api/ops/api/v1/urn_registry.py
+++ b/src/fides/api/ops/api/v1/urn_registry.py
@@ -62,6 +62,7 @@ POLICY_DETAIL = "/dsr/policy/{policy_key}"
 # Privacy Notice URLs
 PRIVACY_NOTICE = "/privacy-notice"
 PRIVACY_NOTICE_DETAIL = "/privacy-notice/{privacy_notice_id}"
+PRIVACY_NOTICE_BY_DATA_USE = "/privacy-notice-by-data-use"
 
 # Privacy request URLs
 PRIVACY_REQUESTS = "/privacy-request"

--- a/src/fides/api/ops/models/privacy_notice.py
+++ b/src/fides/api/ops/models/privacy_notice.py
@@ -215,7 +215,7 @@ def check_conflicting_data_uses(
             region_uses = uses_by_region[PrivacyNoticeRegion(region)]
             # check each of the incoming notice's data uses
             for data_use in privacy_notice.data_uses:
-                for (existing_use, notice_name) in region_uses:
+                for existing_use, notice_name in region_uses:
                     # we need to check for hierachical overlaps in _both_ directions
                     # i.e. whether the incoming DataUse is a parent _or_ a child of
                     # an existing DataUse

--- a/src/fides/api/ops/schemas/privacy_notice.py
+++ b/src/fides/api/ops/schemas/privacy_notice.py
@@ -30,10 +30,10 @@ class PrivacyNotice(BaseSchema):
     data_uses: Optional[conlist(SafeStr, min_items=1)]  # type: ignore
     enforcement_level: Optional[EnforcementLevel]
     disabled: Optional[bool] = False
-    has_gpc_flag: Optional[bool]
-    displayed_in_privacy_center: Optional[bool]
-    displayed_in_privacy_modal: Optional[bool]
-    displayed_in_banner: Optional[bool]
+    has_gpc_flag: Optional[bool] = False
+    displayed_in_privacy_center: Optional[bool] = True
+    displayed_in_privacy_modal: Optional[bool] = True
+    displayed_in_banner: Optional[bool] = True
 
     class Config:
         """Populate models with the raw value of enum fields, rather than the enum itself"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -952,6 +952,39 @@ def system(db: Session) -> System:
     return system
 
 
+@pytest.fixture(scope="function")
+def system_third_party_sharing(db: Session) -> System:
+    system_third_party_sharing = System.create(
+        db=db,
+        data={
+            "fides_key": f"system_key-f{uuid4()}",
+            "name": f"system-{uuid4()}",
+            "description": "fixture-made-system",
+            "organization_fides_key": "default_organization",
+            "system_type": "Service",
+            "data_responsibility_title": "Processor",
+            "privacy_declarations": [
+                {
+                    "name": "Collect data for third party sharing",
+                    "data_categories": ["user.device.cookie_id"],
+                    "data_use": "third_party_sharing",
+                    "data_qualifier": "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
+                    "data_subjects": ["customer"],
+                    "dataset_references": None,
+                    "egress": None,
+                    "ingress": None,
+                }
+            ],
+            "data_protection_impact_assessment": {
+                "is_required": False,
+                "progress": None,
+                "link": None,
+            },
+        },
+    )
+    return system_third_party_sharing
+
+
 @pytest.fixture
 def system_manager_client(db, system):
     """Return a client assigned to a system for authentication purposes."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -985,6 +985,72 @@ def system_third_party_sharing(db: Session) -> System:
     return system_third_party_sharing
 
 
+@pytest.fixture(scope="function")
+def system_provide_service(db: Session) -> System:
+    system_provide_service = System.create(
+        db=db,
+        data={
+            "fides_key": f"system_key-f{uuid4()}",
+            "name": f"system-{uuid4()}",
+            "description": "fixture-made-system",
+            "organization_fides_key": "default_organization",
+            "system_type": "Service",
+            "data_responsibility_title": "Processor",
+            "privacy_declarations": [
+                {
+                    "name": "The source service, system, or product being provided to the user",
+                    "data_categories": ["user.device.cookie_id"],
+                    "data_use": "provide.service",
+                    "data_qualifier": "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
+                    "data_subjects": ["customer"],
+                    "dataset_references": None,
+                    "egress": None,
+                    "ingress": None,
+                }
+            ],
+            "data_protection_impact_assessment": {
+                "is_required": False,
+                "progress": None,
+                "link": None,
+            },
+        },
+    )
+    return system_provide_service
+
+
+@pytest.fixture(scope="function")
+def system_provide_service_operations_support_optimization(db: Session) -> System:
+    system_provide_service_operations_support_optimization = System.create(
+        db=db,
+        data={
+            "fides_key": f"system_key-f{uuid4()}",
+            "name": f"system-{uuid4()}",
+            "description": "fixture-made-system",
+            "organization_fides_key": "default_organization",
+            "system_type": "Service",
+            "data_responsibility_title": "Processor",
+            "privacy_declarations": [
+                {
+                    "name": "Optimize and improve support operations in order to provide the service",
+                    "data_categories": ["user.device.cookie_id"],
+                    "data_use": "provide.service.operations.support.optimization",
+                    "data_qualifier": "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
+                    "data_subjects": ["customer"],
+                    "dataset_references": None,
+                    "egress": None,
+                    "ingress": None,
+                }
+            ],
+            "data_protection_impact_assessment": {
+                "is_required": False,
+                "progress": None,
+                "link": None,
+            },
+        },
+    )
+    return system_provide_service_operations_support_optimization
+
+
 @pytest.fixture
 def system_manager_client(db, system):
     """Return a client assigned to a system for authentication purposes."""

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -1445,6 +1445,24 @@ def privacy_notice_us_co_third_party_sharing(db: Session) -> Generator:
 
 
 @pytest.fixture(scope="function")
+def privacy_notice_us_co_provide_service_operations(db: Session) -> Generator:
+    privacy_notice = PrivacyNotice.create(
+        db=db,
+        data={
+            "name": "example privacy notice us_co provide.service.operations",
+            "description": "a sample privacy notice configuration",
+            "origin": "privacy_notice_template_2",
+            "regions": [PrivacyNoticeRegion.us_co],
+            "consent_mechanism": ConsentMechanism.opt_in,
+            "data_uses": ["provide.service.operations"],
+            "enforcement_level": EnforcementLevel.system_wide,
+        },
+    )
+
+    yield privacy_notice
+
+
+@pytest.fixture(scope="function")
 def ctl_dataset(db: Session, example_datasets):
     ds = Dataset(
         fides_key="postgres_example_subscriptions_dataset",

--- a/tests/ops/api/v1/endpoints/test_privacy_notice_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_notice_endpoints.py
@@ -994,38 +994,6 @@ class TestGetPrivacyNoticesByDataUse:
                             version=1.0,
                         )
                     ],
-                    "provide": [
-                        PrivacyNoticeResponse(
-                            id=f"{PRIVACY_NOTICE_NAME}-2",
-                            name=f"{PRIVACY_NOTICE_NAME}-2",
-                            regions=[
-                                PrivacyNoticeRegion.us_ca,
-                            ],
-                            consent_mechanism=ConsentMechanism.opt_in,
-                            data_uses=["provide"],
-                            enforcement_level=EnforcementLevel.system_wide,
-                            created_at=NOW,
-                            updated_at=NOW,
-                            version=1.0,
-                        )
-                    ],
-                    "provide.service": [],
-                    "provide.service.operations": [
-                        PrivacyNoticeResponse(
-                            id=f"{PRIVACY_NOTICE_NAME}-3",
-                            name=f"{PRIVACY_NOTICE_NAME}-3",
-                            regions=[
-                                PrivacyNoticeRegion.us_co,
-                            ],
-                            consent_mechanism=ConsentMechanism.opt_in,
-                            data_uses=["provide.service.operations"],
-                            enforcement_level=EnforcementLevel.system_wide,
-                            created_at=NOW,
-                            updated_at=NOW,
-                            version=1.0,
-                        )
-                    ],
-                    "provide.service.operations.support": [],
                     "provide.service.operations.support.optimization": [
                         PrivacyNoticeResponse(
                             id=f"{PRIVACY_NOTICE_NAME}-4",
@@ -1041,7 +1009,33 @@ class TestGetPrivacyNoticesByDataUse:
                             created_at=NOW,
                             updated_at=NOW,
                             version=1.0,
-                        )
+                        ),
+                        PrivacyNoticeResponse(
+                            id=f"{PRIVACY_NOTICE_NAME}-3",
+                            name=f"{PRIVACY_NOTICE_NAME}-3",
+                            regions=[
+                                PrivacyNoticeRegion.us_co,
+                            ],
+                            consent_mechanism=ConsentMechanism.opt_in,
+                            data_uses=["provide.service.operations"],
+                            enforcement_level=EnforcementLevel.system_wide,
+                            created_at=NOW,
+                            updated_at=NOW,
+                            version=1.0,
+                        ),
+                        PrivacyNoticeResponse(
+                            id=f"{PRIVACY_NOTICE_NAME}-2",
+                            name=f"{PRIVACY_NOTICE_NAME}-2",
+                            regions=[
+                                PrivacyNoticeRegion.us_ca,
+                            ],
+                            consent_mechanism=ConsentMechanism.opt_in,
+                            data_uses=["provide"],
+                            enforcement_level=EnforcementLevel.system_wide,
+                            created_at=NOW,
+                            updated_at=NOW,
+                            version=1.0,
+                        ),
                     ],
                 },
             ),


### PR DESCRIPTION
Partially closes #2834 (1 of 2 required endpoints)

### Code Changes

* new `GET /api/v1/privacy-notice-by-data-use` endpoint that returns a map of `DataUse`s with their corresponding `PrivacyNotice`s
    * Only `DataUse`s that are associated with a `System` are included in the map.
    * `DataUse`s that do not have any `PrivacyNotice` associated with them are included
    in the map, with empty lists.


### Steps to Confirm

* add some `System`s with privacy declarations (easiest to do thru the UI)
* add some `PrivacyNotice`s that have `DataUse`s that overlap with the privacy declarations of your `System`s (must be manual `POST /api/v1/privacy-notice` API calls for now)
* invoke the `GET /api/v1/privacy-notice-by-data-use` endpoint, and ensure the result looks as expected

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

