### PR TITLE
Replace hamburger menu with delete icon in user management table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The types of changes are:
 
 ### Changed
 * Updated the check for if a user can assign owner roles to be scope-based instead of role-based [#2964](https://github.com/ethyca/fides/pull/2964)
+* Replaced menu in user management table with delete icon [#2958](https://github.com/ethyca/fides/pull/2958)
 
 ### Developer Experience
 * Nox commands for git tagging to support feature branch builds [#2979](https://github.com/ethyca/fides/pull/2979)

--- a/clients/admin-ui/cypress/e2e/user-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/user-management.cy.ts
@@ -57,11 +57,6 @@ describe("User management", () => {
         cy.visit("/user-management");
         cy.wait("@getAllUsers");
 
-        // try via the menu button
-        cy.getByTestId(`row-${USER_1_ID}`).within(() => {
-          cy.getByTestId("menu-btn").should("not.exist");
-        });
-
         // try via clicking the row
         cy.getByTestId(`row-${USER_1_ID}`).click();
         cy.url().should("not.contain", "profile");
@@ -211,10 +206,7 @@ describe("User management", () => {
     it("can delete a user via the menu", () => {
       cy.visit("/user-management");
       cy.getByTestId(`row-${USER_1_ID}`).within(() => {
-        cy.getByTestId("menu-btn").click();
-      });
-      cy.getByTestId(`menu-${USER_1_ID}`).within(() => {
-        cy.getByTestId("delete-btn").click();
+        cy.getByTestId("delete-user-btn").click();
       });
       cy.getByTestId("delete-user-modal");
       cy.getByTestId("submit-btn").should("be.disabled");

--- a/clients/admin-ui/src/features/user-management/UserManagementRow.tsx
+++ b/clients/admin-ui/src/features/user-management/UserManagementRow.tsx
@@ -1,18 +1,12 @@
 import {
   Badge,
-  Button,
-  ButtonGroup, IconButton,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
-  MoreIcon,
-  Portal,
+  ButtonGroup,
+  IconButton,
   Td,
-  Text,
   Tr,
   useDisclosure,
 } from "@fidesui/react";
+import { TrashCanSolidIcon } from "common/Icon/TrashCanSolidIcon";
 import { useRouter } from "next/router";
 import React from "react";
 import {
@@ -29,7 +23,6 @@ import { ScopeRegistryEnum } from "~/types/api";
 
 import DeleteUserModal from "./DeleteUserModal";
 import { User } from "./types";
-import {TrashCanSolidIcon} from "common/Icon/TrashCanSolidIcon";
 
 interface UserManagementRowProps {
   user: User;
@@ -124,11 +117,7 @@ const UserManagementRow: React.FC<UserManagementRowProps> = ({ user }) => {
         <Td pl={0} py={1} onClick={handleEditUser}>
           {user.created_at ? new Date(user.created_at).toUTCString() : null}
         </Td>
-        <Restrict
-          scopes={[
-            ScopeRegistryEnum.USER_DELETE,
-          ]}
-        >
+        <Restrict scopes={[ScopeRegistryEnum.USER_DELETE]}>
           <Td pr={0} py={1} textAlign="end" position="relative">
             <ButtonGroup>
               <IconButton

--- a/clients/admin-ui/src/features/user-management/UserManagementRow.tsx
+++ b/clients/admin-ui/src/features/user-management/UserManagementRow.tsx
@@ -1,7 +1,7 @@
 import {
   Badge,
   Button,
-  ButtonGroup,
+  ButtonGroup, IconButton,
   Menu,
   MenuButton,
   MenuItem,
@@ -29,6 +29,7 @@ import { ScopeRegistryEnum } from "~/types/api";
 
 import DeleteUserModal from "./DeleteUserModal";
 import { User } from "./types";
+import {TrashCanSolidIcon} from "common/Icon/TrashCanSolidIcon";
 
 interface UserManagementRowProps {
   user: User;
@@ -125,44 +126,19 @@ const UserManagementRow: React.FC<UserManagementRowProps> = ({ user }) => {
         </Td>
         <Restrict
           scopes={[
-            ScopeRegistryEnum.USER_UPDATE,
             ScopeRegistryEnum.USER_DELETE,
           ]}
         >
           <Td pr={0} py={1} textAlign="end" position="relative">
             <ButtonGroup>
-              <Menu>
-                <MenuButton
-                  as={Button}
-                  size="xs"
-                  bg="white"
-                  data-testid="menu-btn"
-                >
-                  <MoreIcon color="gray.700" w={18} h={18} />
-                </MenuButton>
-                <Portal>
-                  <MenuList shadow="xl" data-testid={`menu-${user.id}`}>
-                    <Restrict scopes={[ScopeRegistryEnum.USER_UPDATE]}>
-                      <MenuItem
-                        _focus={{ color: "complimentary.500", bg: "gray.100" }}
-                        onClick={handleEditUser}
-                        data-testid="edit-btn"
-                      >
-                        <Text fontSize="sm">Edit</Text>
-                      </MenuItem>
-                    </Restrict>
-                    <Restrict scopes={[ScopeRegistryEnum.USER_DELETE]}>
-                      <MenuItem
-                        _focus={{ color: "complimentary.500", bg: "gray.100" }}
-                        onClick={deleteModal.onOpen}
-                        data-testid="delete-btn"
-                      >
-                        <Text fontSize="sm">Delete</Text>
-                      </MenuItem>
-                    </Restrict>
-                  </MenuList>
-                </Portal>
-              </Menu>
+              <IconButton
+                aria-label="delete"
+                icon={<TrashCanSolidIcon />}
+                variant="outline"
+                size="sm"
+                onClick={deleteModal.onOpen}
+                data-testid="delete-user-btn"
+              />
             </ButtonGroup>
           </Td>
         </Restrict>


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2860

### Code Changes

* [ ] Replace hamburger menu with delete icon in user management table

### Steps to Confirm

* [ ] Nav to user management table
* [ ] Instead of seeing menu with `edit` and `delete` options:
<img width="316" alt="Screenshot 2023-03-31 at 11 43 14 AM" src="https://user-images.githubusercontent.com/7697292/229167601-66af52f4-5c69-472e-a1e8-c348ea43b16b.png">

you should instead see the delete trash icon:
<img width="223" alt="Screenshot 2023-03-31 at 11 43 20 AM" src="https://user-images.githubusercontent.com/7697292/229167676-d7724b94-54fc-453c-9974-07b20d713b74.png">

when it's clicked, you should be prompted to confirm username to delete user:

<img width="542" alt="Screenshot 2023-03-31 at 11 43 26 AM" src="https://user-images.githubusercontent.com/7697292/229167799-c29c64db-fed8-4617-848b-f2b9fe676cad.png">


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
