### PR TITLE
Add `userCannotModify` field to flag control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Added
 * Access support for Shippo [#2484](https://github.com/ethyca/fides/pull/2484)
+* Feature flags can be set such that they cannot be modified by the user [#2966](https://github.com/ethyca/fides/pull/2966)
 
 ## [2.10.0](https://github.com/ethyca/fides/compare/2.9.2...2.10.0)
 

--- a/clients/admin-ui/README.md
+++ b/clients/admin-ui/README.md
@@ -38,6 +38,8 @@ running the app, for example:
 
 Or you can configure the environment using `env.local` as described by the [Next.js docs](https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables).
 
+In addition, you can mark a flag as `userCannotModify: true` in `flags.json`. This will prevent the user from seeing that flag as an override-able option in the Beta Features section. However, the values given to the various environments will still be effect. Therefore, you can still control the flag with the same level of granularity via the `flags.json` file, but not via the UI.
+
 ## Preparing for production
 
 To view a production version of this site, including the backend:

--- a/clients/admin-ui/README.md
+++ b/clients/admin-ui/README.md
@@ -38,7 +38,7 @@ running the app, for example:
 
 Or you can configure the environment using `env.local` as described by the [Next.js docs](https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables).
 
-In addition, you can mark a flag as `userCannotModify: true` in `flags.json`. This will prevent the user from seeing that flag as an override-able option in the Beta Features section. However, the values given to the various environments will still be effect. Therefore, you can still control the flag with the same level of granularity via the `flags.json` file, but not via the UI.
+In addition, you can mark a flag as `userCannotModify: true` in `flags.json`. This will prevent the user from seeing that flag as an override-able option in the Beta Features section. However, the values given to the various environments will still be in effect. Therefore, you can still control the flag with the same level of granularity via the `flags.json` file, but not via the UI.
 
 ## Preparing for production
 

--- a/clients/admin-ui/src/features/common/features/FlagControl.tsx
+++ b/clients/admin-ui/src/features/common/features/FlagControl.tsx
@@ -29,6 +29,11 @@ export const FlagControl = ({
     );
   }
 
+  // Do not render a toggle if the flag is marked as not able to be modified by the user
+  if (FLAG_CONFIG[flag].userCannotModify) {
+    return null;
+  }
+
   return (
     <FormControl display="contents">
       <Box justifySelf="center">

--- a/clients/admin-ui/src/features/common/features/types.ts
+++ b/clients/admin-ui/src/features/common/features/types.ts
@@ -13,6 +13,10 @@ export type FlagEnvs<Value> = {
   test: Value;
   production: Value;
   description?: string;
+  /**
+   * If true, this flag will not show up in the UI as a toggle
+   */
+  userCannotModify?: boolean;
 };
 
 /**


### PR DESCRIPTION
Closes N/A, but seems like it will be useful for upcoming consent modeling work. It seems like there's a growing need of having feature flags but which the user cannot easily toggle. This is for the case of work that is still too in development to let users turn on, and came up already once here: https://github.com/ethyca/fides/pull/2937

### Code Changes

* [x] Adds an optional boolean field `userCannotModify` to Flags so that if it is true, it will not render in the About page

### Steps to Confirm

* [ ] Start up the admin-ui and visit the `/about` page
* [ ] In the `flags.json` file, add a field `userCannotModify: true` to one of the flags, i.e. `organizationManagement`:

```json
"organizationManagement": {
    "description": "Management page to configure Organization details for RoPA reporting, messaging, etc.",
    "development": true,
    "test": true,
    "production": false,
    "userCannotModify": true
  }
```

* [ ] Verify that the flag can no longer be toggled in the UI, but the user can still access the organization management page.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

I decided to use `userCannotModify` since I thought it was useful as by default the user _can_ modify. But I'm not too attached to that if anyone thinks it should be the other way around. 
