### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -150,7 +150,7 @@ jobs:
           - "lib"
 
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     continue-on-error: true
     steps:
       - name: Download container

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -142,7 +142,7 @@ jobs:
     needs: Build
     strategy:
       matrix:
-        python_version: ["3.8.14", "3.9.14", "3.10.7"]
+        python_version: ["3.9.14", "3.10.7"]
         test_selection:
           - "ctl-not-external"
           - "ops-unit"

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: These are the currently supported/tested Python Versions
-        python_version: ["3.8.14", "3.9.14", "3.10.7"]
+        python_version: ["3.9.14", "3.10.7"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -193,7 +193,7 @@ jobs:
     strategy:
       max-parallel: 1 # This prevents collisions in shared external resources
       matrix:
-        python_version: ["3.8.14", "3.9.14", "3.10.7"]
+        python_version: ["3.9.14", "3.10.7"]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # In PRs run with the "unsafe" label, or run on a "push" event to main
@@ -230,7 +230,7 @@ jobs:
     strategy:
       max-parallel: 1 # This prevents collisions in shared external resources
       matrix:
-        python_version: ["3.8.14", "3.9.14", "3.10.7"]
+        python_version: ["3.9.14", "3.10.7"]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # In PRs run with the "unsafe" label, or run on a "push" event to main
@@ -272,7 +272,7 @@ jobs:
     strategy:
       max-parallel: 1 # This prevents collisions in shared external resources
       matrix:
-        python_version: ["3.8.14", "3.9.14", "3.10.7"]
+        python_version: ["3.9.14", "3.10.7"]
     steps:
       - name: Download container
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Closes #2985 

### Code Changes

* [x] Updates the `ops-unit` time limit to 20 minutes
* [x] Drops CI support for Python version 3.8


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated