### PR TITLE
Hide message and storage configuration in ui 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The types of changes are:
 * Access support for Shippo [#2484](https://github.com/ethyca/fides/pull/2484)
 * Feature flags can be set such that they cannot be modified by the user [#2966](https://github.com/ethyca/fides/pull/2966)
 
+### Changed
+* Set `privacyDeclarationDeprecatedFields` flags to false and set `userCannotModify` to true [2987](https://github.com/ethyca/fides/pull/2987)
+
 ## [2.10.0](https://github.com/ethyca/fides/compare/2.9.2...2.10.0)
 
 ### Added

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -1,9 +1,10 @@
 {
   "privacyRequestsConfiguration": {
     "description": "The configuration link in the Privacy Requests sidebar where a user can configure a messaging provider and storage.",
-    "development": true,
-    "test": true,
-    "production": false
+    "development": false,
+    "test": false,
+    "production": false,
+    "userCannotModify": true
   },
   "datasetClassificationUpdates": {
     "description": "Enable per-collection dataset classification instead of bulk updates.",


### PR DESCRIPTION
Closes #[2890](https://github.com/ethyca/fides/issues/2890)

### Code Changes

* [ ] Set `privacyDeclarationDeprecatedFields` flags to false and set `userCannotModify` to true

### Steps to Confirm

* [ ] run fides
* [ ] nav to management > about fides
* [ ] verify there is no flag 
* [ ] verify there is no configuration tab under Privacy Request 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
