### PR TITLE
Fix layout of datamap page

### DIFF
--- a/.github/workflows/frontend_checks.yml
+++ b/.github/workflows/frontend_checks.yml
@@ -71,7 +71,7 @@ jobs:
           install: false
           start: npm run cy:start
           wait-on: "http://localhost:3000"
-          wait-on-timeout: 120
+          wait-on-timeout: 180
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The types of changes are:
 * Access support for Shippo [#2484](https://github.com/ethyca/fides/pull/2484)
 * Feature flags can be set such that they cannot be modified by the user [#2966](https://github.com/ethyca/fides/pull/2966)
 * Added the datamap UI to make it open source [#2988](https://github.com/ethyca/fides/pull/2988)
+* Introduced a `FixedLayout` component (from the datamap UI) for pages that need to be a fixed height and scroll within [#2992](https://github.com/ethyca/fides/pull/2992)
 
 ### Changed
 * Set `privacyDeclarationDeprecatedFields` flags to false and set `userCannotModify` to true [2987](https://github.com/ethyca/fides/pull/2987)

--- a/clients/admin-ui/src/features/common/FixedLayout.tsx
+++ b/clients/admin-ui/src/features/common/FixedLayout.tsx
@@ -22,7 +22,6 @@ const FixedLayout = ({
   // Ideally we could have one common layout used by *all* pages, but we couldn't
   // come up with a common method here without introducing other gotchas, so having
   // a slightly different layout was decided as the most maintainable option
-  // (see https://github.com/ethyca/fidesplus/pull/709)
   <Flex data-testid={title} direction="column" height="100vh">
     <Head>
       <title>Fides Admin UI - {title}</title>

--- a/clients/admin-ui/src/features/common/FixedLayout.tsx
+++ b/clients/admin-ui/src/features/common/FixedLayout.tsx
@@ -1,0 +1,51 @@
+import { Box, Flex } from "@fidesui/react";
+import Head from "next/head";
+import React from "react";
+
+import Header from "~/features/common/Header";
+import { NavSideBar } from "~/features/common/nav/v2/NavSideBar";
+import { NavTopBar } from "~/features/common/nav/v2/NavTopBar";
+
+const FixedLayout = ({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title: string;
+}) => (
+  // NOTE: unlike the main Layout, this layout specifies a fixed height
+  // of 100vh for the page, and overflow="auto" for the main content area. This
+  // allows the content area to fitting the *viewport* height, which is a
+  // special case layout needed by the datamap spatial & table views so that we
+  // scroll within those elements instead of scrolling the overall page itself
+  //
+  // Ideally we could have one common layout used by *all* pages, but we couldn't
+  // come up with a common method here without introducing other gotchas, so having
+  // a slightly different layout was decided as the most maintainable option
+  // (see https://github.com/ethyca/fidesplus/pull/709)
+  <Flex data-testid={title} direction="column" height="100vh">
+    <Head>
+      <title>Fides Admin UI - {title}</title>
+      <meta name="description" content="Privacy Engineering Platform" />
+      <link rel="icon" href="/favicon.ico" />
+    </Head>
+    <Header />
+    <NavTopBar />
+    <Flex
+      as="main"
+      overflow="auto"
+      flexGrow={1}
+      paddingTop={10}
+      paddingLeft={10}
+      gap={10}
+    >
+      <Box flex={0} flexShrink={0}>
+        <NavSideBar />
+      </Box>
+      <Flex direction="column" flex={1} minWidth={0}>
+        {children}
+      </Flex>
+    </Flex>
+  </Flex>
+);
+export default FixedLayout;

--- a/clients/admin-ui/src/features/common/SearchBar.tsx
+++ b/clients/admin-ui/src/features/common/SearchBar.tsx
@@ -43,14 +43,15 @@ const SearchBar = ({
         {...props}
       />
       {onClear ? (
-        <InputRightElement width="3.5rem" display="flex" alignItems="center">
+        <InputRightElement>
           <Button
+            borderLeftRadius={0}
+            height="95%"
+            right="14px"
+            flexShrink={0}
             fontWeight="light"
             size="sm"
             onClick={onClear}
-            // Prevent the button from overlapping with the input's focus rect
-            height="95%"
-            width="95%"
           >
             Clear
           </Button>

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -79,7 +79,7 @@ const TextInput = ({
     setType(type === "password" ? "text" : "password");
 
   return (
-    <InputGroup size="sm" mr="2">
+    <InputGroup size="sm">
       <Input
         {...props}
         type={type}
@@ -206,7 +206,6 @@ const SelectInput = ({
       chakraStyles={{
         container: (provided) => ({
           ...provided,
-          mr: 2,
           flexGrow: 1,
           backgroundColor: "white",
         }),
@@ -305,7 +304,7 @@ const CreatableSelectInput = ({
       size={size}
       classNamePrefix="custom-creatable-select"
       chakraStyles={{
-        container: (provided) => ({ ...provided, mr: 2, flexGrow: 1 }),
+        container: (provided) => ({ ...provided, flexGrow: 1 }),
         dropdownIndicator: (provided) => ({
           ...provided,
           background: "white",
@@ -351,7 +350,7 @@ export const CustomTextInput = ({
         <Grid templateColumns="1fr 3fr">
           <Label htmlFor={props.id || props.name}>{label}</Label>
           <Flex alignItems="center">
-            <Flex flexDir="column" flexGrow={1}>
+            <Flex flexDir="column" flexGrow={1} mr="2">
               <TextInput
                 {...field}
                 isDisabled={disabled}
@@ -422,7 +421,7 @@ export const CustomSelect = ({
             {label}
           </Label>
           <Flex alignItems="center" data-testid={`input-${field.name}`}>
-            <Flex flexDir="column" flexGrow={1}>
+            <Flex flexDir="column" flexGrow={1} mr={2}>
               <SelectInput
                 options={options}
                 fieldName={field.name}
@@ -505,7 +504,7 @@ export const CustomCreatableSelect = ({
         <Grid templateColumns="1fr 3fr">
           <Label htmlFor={props.id || props.name}>{label}</Label>
           <Flex alignItems="center" data-testid={`input-${field.name}`}>
-            <Flex flexDir="column" flexGrow={1}>
+            <Flex flexDir="column" flexGrow={1} mr={2}>
               <CreatableSelectInput
                 fieldName={field.name}
                 options={options}
@@ -573,7 +572,6 @@ export const CustomTextArea = ({
     <Textarea
       {...field}
       size="sm"
-      mr={2}
       {...textAreaProps}
       data-testid={`input-${field.name}`}
     />
@@ -605,7 +603,7 @@ export const CustomTextArea = ({
         <Grid templateColumns="1fr 3fr">
           {label ? <FormLabel>{label}</FormLabel> : null}
           <Flex>
-            <Flex flexDir="column" flexGrow={1}>
+            <Flex flexDir="column" flexGrow={1} mr={2}>
               {innerTextArea}
               <ErrorMessage
                 isInvalid={isInvalid}

--- a/clients/admin-ui/src/pages/datamap/index.tsx
+++ b/clients/admin-ui/src/pages/datamap/index.tsx
@@ -1,8 +1,8 @@
 import type { NextPage } from "next";
 import React, { useMemo } from "react";
 
+import FixedLayout from "~/features/common/FixedLayout";
 import { DirtyFormConfirmationModal } from "~/features/common/hooks/useIsAnyFormDirty";
-import Layout from "~/features/common/Layout";
 import Datamap from "~/features/datamap/Datamap";
 import DatamapGraphStore from "~/features/datamap/datamap-graph/DatamapGraphContext";
 import DatamapTableContext, {
@@ -16,14 +16,14 @@ const Home: NextPage = () => {
   );
 
   return (
-    <Layout title="Data map">
+    <FixedLayout title="View Map">
       <DatamapTableContext.Provider value={datamapTableContextValue}>
         <DatamapGraphStore>
           <Datamap />
           <DirtyFormConfirmationModal />
         </DatamapGraphStore>
       </DatamapTableContext.Provider>
-    </Layout>
+    </FixedLayout>
   );
 };
 

--- a/clients/admin-ui/src/theme/index.ts
+++ b/clients/admin-ui/src/theme/index.ts
@@ -12,6 +12,17 @@ const theme = extendTheme({
     },
   },
   components: {
+    Accordion: {
+      baseStyle: {
+        button: {
+          // Remove annoying focus outline, unless for a11y visibility
+          // NOTE: Upgrading to Chakra 2.2.0+ will fix this globally:
+          // (see https://chakra-ui.com/changelog/2.2.0#all-components)
+          _focus: { boxShadow: "none" },
+          _focusVisible: { boxShadow: "outline" },
+        },
+      },
+    },
     Button,
     Divider: {
       baseStyle: {


### PR DESCRIPTION
Progress on https://github.com/ethyca/fides/issues/2976

### Code Changes

* [x] Brings in the Layout component from the datamap UI as `FixedLayout`. It seemed like the conclusion was the only way to get the fixed/inside scrolling that the datamap UI has was to use a different layout component
* [x] Brought in more of the polish UI I missed from https://github.com/ethyca/fidesplus/pull/790

### Steps to Confirm

* [ ] Hopefully everything looks right now!!!

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met - no, I'll update the ticket since I didn't dedupe the PrivacyDeclaration components here. I think we can punt on that since I need to get back to privacy notice work this sprint
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This branch should now have everything needed to run the datamap UI from admin UI. if anything looks different from the original datamap UI, do flag it!
