### PR TITLE
Privacy notice initial page and redux

### DIFF
--- a/clients/admin-ui/src/app/store.ts
+++ b/clients/admin-ui/src/app/store.ts
@@ -31,6 +31,7 @@ import {
 } from "user-management/index";
 
 import { STORAGE_ROOT_KEY } from "~/constants";
+import { authApi, reducer as authReducer } from "~/features/auth";
 import { baseApi } from "~/features/common/api.slice";
 import { reducer as featuresReducer } from "~/features/common/features";
 import { healthApi } from "~/features/common/health.slice";
@@ -56,10 +57,9 @@ import {
   reducer as organizationReducer,
 } from "~/features/organization";
 import { plusApi } from "~/features/plus/plus.slice";
+import { reducer as privacyNoticesReducer } from "~/features/plus/privacy-notices.slice";
 import { reducer as systemReducer } from "~/features/system";
 import { reducer as taxonomyReducer, taxonomyApi } from "~/features/taxonomy";
-
-import { authApi, reducer as authReducer } from "../features/auth";
 
 /**
  * To prevent the "redux-perist failed to create sync storage. falling back to noop storage"
@@ -109,6 +109,7 @@ const reducer = {
   datastoreConnections: datastoreConnectionReducer,
   features: featuresReducer,
   organization: organizationReducer,
+  privacyNotices: privacyNoticesReducer,
   subjectRequests: privacyRequestsReducer,
   system: systemReducer,
   taxonomy: taxonomyReducer,

--- a/clients/admin-ui/src/app/store.ts
+++ b/clients/admin-ui/src/app/store.ts
@@ -57,7 +57,7 @@ import {
   reducer as organizationReducer,
 } from "~/features/organization";
 import { plusApi } from "~/features/plus/plus.slice";
-import { reducer as privacyNoticesReducer } from "~/features/plus/privacy-notices.slice";
+import { reducer as privacyNoticesReducer } from "~/features/privacy-notices/privacy-notices.slice";
 import { reducer as systemReducer } from "~/features/system";
 import { reducer as taxonomyReducer, taxonomyApi } from "~/features/taxonomy";
 

--- a/clients/admin-ui/src/features/common/api.slice.ts
+++ b/clients/admin-ui/src/features/common/api.slice.ts
@@ -24,6 +24,7 @@ export const baseApi = createApi({
     "Dataset",
     "Datasets",
     "System",
+    "PrivacyNotices",
   ],
   endpoints: () => ({}),
 });

--- a/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
@@ -1,3 +1,4 @@
+import { FlagNames } from "~/features/common/features";
 import { ScopeRegistryEnum } from "~/types/api";
 
 import * as routes from "./routes";
@@ -7,7 +8,7 @@ export type NavConfigRoute = {
   path: string;
   exact?: boolean;
   requiresPlus?: boolean;
-  requiresFlag?: string;
+  requiresFlag?: FlagNames;
   /** This route is only available if the user has ANY of these scopes */
   scopes: ScopeRegistryEnum[];
 };
@@ -47,6 +48,13 @@ export const NAV_CONFIG: NavConfigGroup[] = [
         path: routes.PRIVACY_REQUESTS_CONFIGURATION_ROUTE,
         requiresFlag: "privacyRequestsConfiguration",
         scopes: [ScopeRegistryEnum.MESSAGING_CREATE_OR_UPDATE],
+      },
+      {
+        title: "Privacy notices",
+        path: routes.PRIVACY_NOTICES_ROUTE,
+        requiresFlag: "privacyNotices",
+        requiresPlus: true,
+        scopes: [ScopeRegistryEnum.PRIVACY_NOTICE_READ],
       },
     ],
   },

--- a/clients/admin-ui/src/features/plus/privacy-notices.slice.ts
+++ b/clients/admin-ui/src/features/plus/privacy-notices.slice.ts
@@ -1,0 +1,79 @@
+import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+import type { RootState } from "~/app/store";
+import { baseApi } from "~/features/common/api.slice";
+import {
+  Page_PrivacyNoticeResponse_,
+  PrivacyNoticeRegion,
+  PrivacyNoticeResponse,
+} from "~/types/api";
+
+export interface State {
+  activePrivacyNoticeId?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+const initialState: State = {};
+
+interface PrivacyNoticesParams {
+  show_disabled?: boolean;
+  region?: PrivacyNoticeRegion;
+  systems_applicable?: boolean;
+  page?: number;
+  size?: number;
+}
+
+const privacyNoticesApi = baseApi.injectEndpoints({
+  endpoints: (build) => ({
+    getAllPrivacyNotices: build.query<
+      Page_PrivacyNoticeResponse_,
+      PrivacyNoticesParams
+    >({
+      query: () => ({ url: `privacy-notice/` }),
+      providesTags: () => ["PrivacyNotices"],
+    }),
+  }),
+});
+
+export const { useGetAllPrivacyNoticesQuery } = privacyNoticesApi;
+
+export const privacyNoticesSlice = createSlice({
+  name: "privacyNotices",
+  initialState,
+  reducers: {
+    setActivePrivacyNoticeId: (
+      draftState,
+      action: PayloadAction<string | undefined>
+    ) => {
+      draftState.activePrivacyNoticeId = action.payload;
+    },
+  },
+});
+
+export const { setActivePrivacyNoticeId } = privacyNoticesSlice.actions;
+
+export const { reducer } = privacyNoticesSlice;
+
+const selectPrivacyNotices = (state: RootState) => state.privacyNotices;
+export const selectPage = createSelector(
+  selectPrivacyNotices,
+  (state) => state.page
+);
+
+export const selectPageSize = createSelector(
+  selectPrivacyNotices,
+  (state) => state.pageSize
+);
+
+const emptyPrivacyNotices: PrivacyNoticeResponse[] = [];
+export const selectAllPrivacyNotices = createSelector(
+  [(RootState) => RootState, selectPage, selectPageSize],
+  (RootState, page, pageSize) => {
+    const data = privacyNoticesApi.endpoints.getAllPrivacyNotices.select({
+      page,
+      size: pageSize,
+    })(RootState)?.data;
+    return data ? data.items : emptyPrivacyNotices;
+  }
+);

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
@@ -1,0 +1,35 @@
+import { Box, List, ListItem, Text } from "@fidesui/react";
+
+import { useAppSelector } from "~/app/hooks";
+
+import {
+  selectAllPrivacyNotices,
+  selectPage,
+  selectPageSize,
+  useGetAllPrivacyNoticesQuery,
+} from "./privacy-notices.slice";
+
+const PrivacyNoticesTable = () => {
+  // Subscribe to get all privacy notices
+  const page = useAppSelector(selectPage);
+  const pageSize = useAppSelector(selectPageSize);
+  useGetAllPrivacyNoticesQuery({ page, size: pageSize });
+
+  const privacyNotices = useAppSelector(selectAllPrivacyNotices);
+
+  if (privacyNotices.length === 0) {
+    return <Text>No privacy notices found.</Text>;
+  }
+
+  return (
+    <Box>
+      <List>
+        {privacyNotices.map((notice) => (
+          <ListItem key={notice.id}>{notice.name}</ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default PrivacyNoticesTable;

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
@@ -25,7 +25,9 @@ const PrivacyNoticesTable = () => {
     <Box>
       <List>
         {privacyNotices.map((notice) => (
-          <ListItem key={notice.id}>{notice.name}</ListItem>
+          <ListItem key={notice.id}>
+            {notice.name} - {notice.consent_mechanism}
+          </ListItem>
         ))}
       </List>
     </Box>

--- a/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
+++ b/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
@@ -14,7 +14,10 @@ export interface State {
   pageSize?: number;
 }
 
-const initialState: State = {};
+const initialState: State = {
+  page: 1,
+  pageSize: 10,
+};
 
 interface PrivacyNoticesParams {
   show_disabled?: boolean;

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -28,6 +28,7 @@
     "description": "Page to configure consent privacy notices",
     "development": true,
     "test": true,
-    "production": false
+    "production": false,
+    "userCannotModify": true
   }
 }

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -23,5 +23,11 @@
     "development": true,
     "test": true,
     "production": false
+  },
+  "privacyNotices": {
+    "description": "Page to configure consent privacy notices",
+    "development": true,
+    "test": true,
+    "production": false
   }
 }

--- a/clients/admin-ui/src/pages/consent/privacy-notices.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices.tsx
@@ -1,0 +1,11 @@
+import { Box } from "@fidesui/react";
+
+import Layout from "~/features/common/Layout";
+
+const PrivacyNoticesPage = () => (
+  <Layout title="Privacy notices">
+    <Box>Work in progress, check back later!</Box>
+  </Layout>
+);
+
+export default PrivacyNoticesPage;

--- a/clients/admin-ui/src/pages/consent/privacy-notices.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices.tsx
@@ -1,10 +1,9 @@
-import { Box } from "@fidesui/react";
-
 import Layout from "~/features/common/Layout";
+import PrivacyNoticesTable from "~/features/privacy-notices/PrivacyNoticesTable";
 
 const PrivacyNoticesPage = () => (
   <Layout title="Privacy notices">
-    <Box>Work in progress, check back later!</Box>
+    <PrivacyNoticesTable />
   </Layout>
 );
 


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/736

### Code Changes

* [x] Add privacy notice page and flag
* [x] Add privacy notice GET and state to redux store
* [x] Add a very basic "table" component just to show the API call is working
* [x] Add the page to the nav

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
