### PR TITLE
consent/access/erasure query param filters on connection type endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The types of changes are:
 * Added the datamap UI to make it open source [#2988](https://github.com/ethyca/fides/pull/2988)
 * Introduced a `FixedLayout` component (from the datamap UI) for pages that need to be a fixed height and scroll within [#2992](https://github.com/ethyca/fides/pull/2992)
 * Added preliminary privacy notice page [#2995](https://github.com/ethyca/fides/pull/2995)
+* Query params on connection type endpoint to filter by supported action type [#2996](https://github.com/ethyca/fides/pull/2996)
 
 ### Changed
 * Set `privacyDeclarationDeprecatedFields` flags to false and set `userCannotModify` to true [2987](https://github.com/ethyca/fides/pull/2987)

--- a/docs/fides/docs/development/postman/Fides.postman_collection.json
+++ b/docs/fides/docs/development/postman/Fides.postman_collection.json
@@ -4240,6 +4240,39 @@
 					"response": []
 				},
 				{
+					"name": "Get available connectors - consent",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{client_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/connection_type?consent=true",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"connection_type"
+							],
+							"query": [
+								{
+									"key": "consent",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Get connection secrets schema",
 					"request": {
 						"auth": {

--- a/src/fides/api/ops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/connection_type_endpoints.py
@@ -42,9 +42,9 @@ def get_all_connection_types(
     erasure: Optional[bool] = None,
 ) -> AbstractPage[ConnectionSystemTypeMap]:
     """
-    Returns a list of connection options in Fidesops - includes only database and saas options here.
+    Returns a list of connection options in Fides - includes only database and saas options here.
 
-    Query params for types of requests suppported - `consent`, `access` and `erasure` - act as filters.
+    Query params for types of requests supported - `consent`, `access` and `erasure` - act as filters.
     If set to `true`, only connections that support the specified type of request will be returned.
     If no filters are specified, then no filtering is performed.
     When applied together, the filters act as a union: result sets are additive.

--- a/src/fides/api/ops/api/v1/endpoints/connection_type_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/connection_type_endpoints.py
@@ -13,6 +13,7 @@ from fides.api.ops.api.v1.urn_registry import (
     V1_URL_PREFIX,
 )
 from fides.api.ops.common_exceptions import NoSuchConnectionTypeSecretSchemaError
+from fides.api.ops.models.policy import ActionType
 from fides.api.ops.schemas.connection_configuration.connection_config import (
     ConnectionSystemTypeMap,
     SystemType,
@@ -36,11 +37,32 @@ def get_all_connection_types(
     params: Params = Depends(),
     search: Optional[str] = None,
     system_type: Optional[SystemType] = None,
+    consent: Optional[bool] = None,
+    access: Optional[bool] = None,
+    erasure: Optional[bool] = None,
 ) -> AbstractPage[ConnectionSystemTypeMap]:
-    """Returns a list of connection options in Fidesops - includes only database and saas options here."""
+    """
+    Returns a list of connection options in Fidesops - includes only database and saas options here.
+
+    Query params for types of requests suppported - `consent`, `access` and `erasure` - act as filters.
+    If set to `true`, only connections that support the specified type of request will be returned.
+    If no filters are specified, then no filtering is performed.
+    When applied together, the filters act as a union: result sets are additive.
+    """
+    action_types = set()
+    # special-case when no action type filters are provided
+    if consent is None and access is None and erasure is None:
+        action_types = {ActionType.access, ActionType.erasure, ActionType.consent}
+    else:
+        if access:
+            action_types.add(ActionType.access)
+        if erasure:
+            action_types.add(ActionType.erasure)
+        if consent:
+            action_types.add(ActionType.consent)
 
     return paginate(
-        get_connection_types(search, system_type),
+        get_connection_types(search, system_type, action_types),
         params,
     )
 

--- a/src/fides/api/ops/models/policy.py
+++ b/src/fides/api/ops/models/policy.py
@@ -50,6 +50,10 @@ class ActionType(str, EnumType):
     update = "update"
 
 
+# action types we actively support in policies/requests
+SUPPORTED_ACTION_TYPES = {ActionType.access, ActionType.consent, ActionType.erasure}
+
+
 class DrpAction(EnumType):
     """
     Enum to hold valid DRP actions. For more details, see:

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -1,3 +1,4 @@
+from typing import List, Set
 from unittest import mock
 
 import pytest
@@ -20,6 +21,7 @@ from fides.api.ops.models.connectionconfig import (
     ConnectionType,
 )
 from fides.api.ops.models.datasetconfig import DatasetConfig
+from fides.api.ops.models.policy import ActionType
 from fides.api.ops.schemas.connection_configuration.connection_config import SystemType
 from fides.api.ops.service.connectors.saas.connector_registry_service import (
     ConnectorRegistry,
@@ -314,6 +316,289 @@ class TestGetConnections:
                 "encoded_icon": None,
             },
         ]
+
+
+DOORDASH = "doordash"
+GOOGLE_ANALYTICS = "google_analytics"
+MAILCHIMP_TRANSACTIONAL = "mailchimp_transactional"
+SEGMENT = "segment"
+STRIPE = "stripe"
+ZENDESK = "zendesk"
+
+
+class TestGetConnectionsActionTypeParams:
+    """
+    Class specifically for testing the "action type" query params for the get connection types endpoint.
+
+    This testing approach (and the fixtures) mimic what's done within `test_connection_type.py` to evaluate
+    the `action_type` filtering logic.
+
+    That test specifically tests the underlying utility that is leveraged by this endpoint.
+    """
+
+    @pytest.fixture(scope="function")
+    def url(self) -> str:
+        return V1_URL_PREFIX + CONNECTION_TYPES
+
+    @pytest.fixture(scope="function")
+    def url_with_params(self) -> str:
+        return (
+            V1_URL_PREFIX
+            + CONNECTION_TYPES
+            + "?"
+            + "consent={consent}"
+            + "&access={access}"
+            + "&erasure={erasure}"
+        )
+
+    @pytest.fixture
+    def connection_type_objects(self):
+        google_analytics_template = ConnectorRegistry.get_connector_template(
+            GOOGLE_ANALYTICS
+        )
+        mailchimp_transactional_template = ConnectorRegistry.get_connector_template(
+            MAILCHIMP_TRANSACTIONAL
+        )
+        stripe_template = ConnectorRegistry.get_connector_template("stripe")
+        zendesk_template = ConnectorRegistry.get_connector_template("zendesk")
+        doordash_template = ConnectorRegistry.get_connector_template(DOORDASH)
+        segment_template = ConnectorRegistry.get_connector_template(SEGMENT)
+
+        return {
+            ConnectionType.postgres.value: {
+                "identifier": ConnectionType.postgres.value,
+                "type": SystemType.database.value,
+                "human_readable": "PostgreSQL",
+                "encoded_icon": None,
+            },
+            ConnectionType.manual_webhook.value: {
+                "identifier": ConnectionType.manual_webhook.value,
+                "type": SystemType.manual.value,
+                "human_readable": "Manual Process",
+                "encoded_icon": None,
+            },
+            GOOGLE_ANALYTICS: {
+                "identifier": GOOGLE_ANALYTICS,
+                "type": SystemType.saas.value,
+                "human_readable": google_analytics_template.human_readable,
+                "encoded_icon": google_analytics_template.icon,
+            },
+            MAILCHIMP_TRANSACTIONAL: {
+                "identifier": MAILCHIMP_TRANSACTIONAL,
+                "type": SystemType.saas.value,
+                "human_readable": mailchimp_transactional_template.human_readable,
+                "encoded_icon": mailchimp_transactional_template.icon,
+            },
+            SEGMENT: {
+                "identifier": SEGMENT,
+                "type": SystemType.saas.value,
+                "human_readable": segment_template.human_readable,
+                "encoded_icon": segment_template.icon,
+            },
+            STRIPE: {
+                "identifier": STRIPE,
+                "type": SystemType.saas.value,
+                "human_readable": stripe_template.human_readable,
+                "encoded_icon": stripe_template.icon,
+            },
+            ZENDESK: {
+                "identifier": ZENDESK,
+                "type": SystemType.saas.value,
+                "human_readable": zendesk_template.human_readable,
+                "encoded_icon": zendesk_template.icon,
+            },
+            DOORDASH: {
+                "identifier": DOORDASH,
+                "type": SystemType.saas.value,
+                "human_readable": doordash_template.human_readable,
+                "encoded_icon": doordash_template.icon,
+            },
+            ConnectionType.sovrn.value: {
+                "identifier": ConnectionType.sovrn.value,
+                "type": SystemType.email.value,
+                "human_readable": "Sovrn",
+                "encoded_icon": None,
+            },
+            ConnectionType.attentive.value: {
+                "identifier": ConnectionType.attentive.value,
+                "type": SystemType.email.value,
+                "human_readable": "Attentive",
+                "encoded_icon": None,
+            },
+        }
+
+    @pytest.mark.parametrize(
+        "action_types, assert_in_data, assert_not_in_data",
+        [
+            (
+                [],  # no filters should give us all connectors
+                [
+                    ConnectionType.postgres.value,
+                    ConnectionType.manual_webhook.value,
+                    DOORDASH,
+                    STRIPE,
+                    ZENDESK,
+                    SEGMENT,
+                    ConnectionType.attentive.value,
+                    GOOGLE_ANALYTICS,
+                    MAILCHIMP_TRANSACTIONAL,
+                    ConnectionType.sovrn.value,
+                ],
+                [],
+            ),
+            (
+                [ActionType.consent],
+                [GOOGLE_ANALYTICS, MAILCHIMP_TRANSACTIONAL, ConnectionType.sovrn.value],
+                [
+                    ConnectionType.postgres.value,
+                    ConnectionType.manual_webhook.value,
+                    DOORDASH,
+                    STRIPE,
+                    ZENDESK,
+                    SEGMENT,
+                    ConnectionType.attentive.value,
+                ],
+            ),
+            (
+                [ActionType.access],
+                [
+                    ConnectionType.postgres.value,
+                    ConnectionType.manual_webhook.value,
+                    DOORDASH,
+                    SEGMENT,
+                    STRIPE,
+                    ZENDESK,
+                ],
+                [
+                    GOOGLE_ANALYTICS,
+                    MAILCHIMP_TRANSACTIONAL,
+                    ConnectionType.sovrn.value,
+                    ConnectionType.attentive.value,
+                ],
+            ),
+            (
+                [ActionType.erasure],
+                [
+                    ConnectionType.postgres.value,
+                    SEGMENT,  # segment has DPR so it is an erasure
+                    STRIPE,
+                    ZENDESK,
+                    ConnectionType.attentive.value,
+                ],
+                [
+                    GOOGLE_ANALYTICS,
+                    MAILCHIMP_TRANSACTIONAL,
+                    ConnectionType.manual_webhook.value,  # manual webhook is not erasure
+                    DOORDASH,  # doordash does not have erasures
+                    ConnectionType.sovrn.value,
+                ],
+            ),
+            (
+                [ActionType.consent, ActionType.access],
+                [
+                    GOOGLE_ANALYTICS,
+                    MAILCHIMP_TRANSACTIONAL,
+                    ConnectionType.sovrn.value,
+                    ConnectionType.postgres.value,
+                    ConnectionType.manual_webhook.value,
+                    DOORDASH,
+                    SEGMENT,
+                    STRIPE,
+                    ZENDESK,
+                ],
+                [
+                    ConnectionType.attentive.value,
+                ],
+            ),
+            (
+                [ActionType.consent, ActionType.erasure],
+                [
+                    GOOGLE_ANALYTICS,
+                    MAILCHIMP_TRANSACTIONAL,
+                    ConnectionType.sovrn.value,
+                    ConnectionType.postgres.value,
+                    SEGMENT,  # segment has DPR so it is an erasure
+                    STRIPE,
+                    ZENDESK,
+                    ConnectionType.attentive.value,
+                ],
+                [
+                    ConnectionType.manual_webhook.value,  # manual webhook is not erasure
+                    DOORDASH,  # doordash does not have erasures
+                ],
+            ),
+            (
+                [ActionType.access, ActionType.erasure],
+                [
+                    ConnectionType.postgres.value,
+                    ConnectionType.manual_webhook.value,
+                    DOORDASH,
+                    SEGMENT,
+                    STRIPE,
+                    ZENDESK,
+                    ConnectionType.attentive.value,
+                ],
+                [
+                    GOOGLE_ANALYTICS,
+                    MAILCHIMP_TRANSACTIONAL,
+                    ConnectionType.sovrn.value,
+                ],
+            ),
+        ],
+    )
+    def test_get_connection_types_action_type_filter(
+        self,
+        action_types,
+        assert_in_data,
+        assert_not_in_data,
+        connection_type_objects,
+        generate_auth_header,
+        api_client,
+        url,
+        url_with_params,
+    ):
+        the_url = url
+        auth_header = generate_auth_header(scopes=[CONNECTION_TYPE_READ])
+        if action_types:
+            the_url = url_with_params.format(
+                consent=ActionType.consent in action_types,
+                access=ActionType.access in action_types,
+                erasure=ActionType.erasure in action_types,
+            )
+        resp = api_client.get(the_url, headers=auth_header)
+        data = resp.json()["items"]
+        assert resp.status_code == 200
+
+        for connection_type in assert_in_data:
+            obj = connection_type_objects[connection_type]
+            assert obj in data
+
+        for connection_type in assert_not_in_data:
+            obj = connection_type_objects[connection_type]
+            assert obj not in data
+
+        # now run another request, this time omitting non-specified filter params
+        # rather than setting them to false explicitly. we should get identical results.
+        if action_types:
+            the_url = url + "?"
+            if ActionType.consent in action_types:
+                the_url += "consent=true&"
+            if ActionType.access in action_types:
+                the_url += "access=true&"
+            if ActionType.erasure in action_types:
+                the_url += "erasure=true&"
+
+        resp = api_client.get(the_url, headers=auth_header)
+        data = resp.json()["items"]
+        assert resp.status_code == 200
+
+        for connection_type in assert_in_data:
+            obj = connection_type_objects[connection_type]
+            assert obj in data
+
+        for connection_type in assert_not_in_data:
+            obj = connection_type_objects[connection_type]
+            assert obj not in data
 
 
 class TestGetConnectionSecretSchema:

--- a/tests/ops/util/test_connection_type.py
+++ b/tests/ops/util/test_connection_type.py
@@ -1,4 +1,7 @@
+import pytest
+
 from fides.api.ops.models.connectionconfig import ConnectionType
+from fides.api.ops.models.policy import ActionType
 from fides.api.ops.schemas.connection_configuration.connection_config import SystemType
 from fides.api.ops.service.connectors.saas.connector_registry_service import (
     ConnectorRegistry,
@@ -38,3 +41,205 @@ def test_get_connection_types():
         "human_readable": "Sovrn",
         "encoded_icon": None,
     } in data
+
+
+DOORDASH = "doordash"
+GOOGLE_ANALYTICS = "google_analytics"
+MAILCHIMP_TRANSACTIONAL = "mailchimp_transactional"
+SEGMENT = "segment"
+STRIPE = "stripe"
+ZENDESK = "zendesk"
+
+
+@pytest.fixture
+def connection_type_objects():
+    google_analytics_template = ConnectorRegistry.get_connector_template(
+        GOOGLE_ANALYTICS
+    )
+    mailchimp_transactional_template = ConnectorRegistry.get_connector_template(
+        MAILCHIMP_TRANSACTIONAL
+    )
+    stripe_template = ConnectorRegistry.get_connector_template("stripe")
+    zendesk_template = ConnectorRegistry.get_connector_template("zendesk")
+    doordash_template = ConnectorRegistry.get_connector_template(DOORDASH)
+    segment_template = ConnectorRegistry.get_connector_template(SEGMENT)
+
+    return {
+        ConnectionType.postgres.value: {
+            "identifier": ConnectionType.postgres.value,
+            "type": SystemType.database.value,
+            "human_readable": "PostgreSQL",
+            "encoded_icon": None,
+        },
+        ConnectionType.manual_webhook.value: {
+            "identifier": ConnectionType.manual_webhook.value,
+            "type": SystemType.manual.value,
+            "human_readable": "Manual Process",
+            "encoded_icon": None,
+        },
+        GOOGLE_ANALYTICS: {
+            "identifier": GOOGLE_ANALYTICS,
+            "type": SystemType.saas.value,
+            "human_readable": google_analytics_template.human_readable,
+            "encoded_icon": google_analytics_template.icon,
+        },
+        MAILCHIMP_TRANSACTIONAL: {
+            "identifier": MAILCHIMP_TRANSACTIONAL,
+            "type": SystemType.saas.value,
+            "human_readable": mailchimp_transactional_template.human_readable,
+            "encoded_icon": mailchimp_transactional_template.icon,
+        },
+        SEGMENT: {
+            "identifier": SEGMENT,
+            "type": SystemType.saas.value,
+            "human_readable": segment_template.human_readable,
+            "encoded_icon": segment_template.icon,
+        },
+        STRIPE: {
+            "identifier": STRIPE,
+            "type": SystemType.saas.value,
+            "human_readable": stripe_template.human_readable,
+            "encoded_icon": stripe_template.icon,
+        },
+        ZENDESK: {
+            "identifier": ZENDESK,
+            "type": SystemType.saas.value,
+            "human_readable": zendesk_template.human_readable,
+            "encoded_icon": zendesk_template.icon,
+        },
+        DOORDASH: {
+            "identifier": DOORDASH,
+            "type": SystemType.saas.value,
+            "human_readable": doordash_template.human_readable,
+            "encoded_icon": doordash_template.icon,
+        },
+        ConnectionType.sovrn.value: {
+            "identifier": ConnectionType.sovrn.value,
+            "type": SystemType.email.value,
+            "human_readable": "Sovrn",
+            "encoded_icon": None,
+        },
+        ConnectionType.attentive.value: {
+            "identifier": ConnectionType.attentive.value,
+            "type": SystemType.email.value,
+            "human_readable": "Attentive",
+            "encoded_icon": None,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "action_types, assert_in_data, assert_not_in_data",
+    [
+        (
+            [ActionType.consent],
+            [GOOGLE_ANALYTICS, MAILCHIMP_TRANSACTIONAL, ConnectionType.sovrn.value],
+            [
+                ConnectionType.postgres.value,
+                ConnectionType.manual_webhook.value,
+                DOORDASH,
+                STRIPE,
+                ZENDESK,
+                SEGMENT,
+                ConnectionType.attentive.value,
+            ],
+        ),
+        (
+            [ActionType.access],
+            [
+                ConnectionType.postgres.value,
+                ConnectionType.manual_webhook.value,
+                DOORDASH,
+                SEGMENT,
+                STRIPE,
+                ZENDESK,
+            ],
+            [
+                GOOGLE_ANALYTICS,
+                MAILCHIMP_TRANSACTIONAL,
+                ConnectionType.sovrn.value,
+                ConnectionType.attentive.value,
+            ],
+        ),
+        (
+            [ActionType.erasure],
+            [
+                ConnectionType.postgres.value,
+                SEGMENT,  # segment has DPR so it is an erasure
+                STRIPE,
+                ZENDESK,
+                ConnectionType.attentive.value,
+            ],
+            [
+                GOOGLE_ANALYTICS,
+                MAILCHIMP_TRANSACTIONAL,
+                ConnectionType.manual_webhook.value,  # manual webhook is not erasure
+                DOORDASH,  # doordash does not have erasures
+                ConnectionType.sovrn.value,
+            ],
+        ),
+        (
+            [ActionType.consent, ActionType.access],
+            [
+                GOOGLE_ANALYTICS,
+                MAILCHIMP_TRANSACTIONAL,
+                ConnectionType.sovrn.value,
+                ConnectionType.postgres.value,
+                ConnectionType.manual_webhook.value,
+                DOORDASH,
+                SEGMENT,
+                STRIPE,
+                ZENDESK,
+            ],
+            [
+                ConnectionType.attentive.value,
+            ],
+        ),
+        (
+            [ActionType.consent, ActionType.erasure],
+            [
+                GOOGLE_ANALYTICS,
+                MAILCHIMP_TRANSACTIONAL,
+                ConnectionType.sovrn.value,
+                ConnectionType.postgres.value,
+                SEGMENT,  # segment has DPR so it is an erasure
+                STRIPE,
+                ZENDESK,
+                ConnectionType.attentive.value,
+            ],
+            [
+                ConnectionType.manual_webhook.value,  # manual webhook is not erasure
+                DOORDASH,  # doordash does not have erasures
+            ],
+        ),
+        (
+            [ActionType.access, ActionType.erasure],
+            [
+                ConnectionType.postgres.value,
+                ConnectionType.manual_webhook.value,
+                DOORDASH,
+                SEGMENT,
+                STRIPE,
+                ZENDESK,
+                ConnectionType.attentive.value,
+            ],
+            [
+                GOOGLE_ANALYTICS,
+                MAILCHIMP_TRANSACTIONAL,
+                ConnectionType.sovrn.value,
+            ],
+        ),
+    ],
+)
+def test_get_connection_types_action_type_filter(
+    action_types, assert_in_data, assert_not_in_data, connection_type_objects
+):
+    data = get_connection_types(action_types=action_types)
+
+    for connection_type in assert_in_data:
+        obj = connection_type_objects[connection_type]
+        assert obj in data
+
+    for connection_type in assert_not_in_data:
+        obj = connection_type_objects[connection_type]
+        assert obj not in data


### PR DESCRIPTION
Partially closes #2834 

### Code Changes

* add query params to connection type endpoint that allow for filtering of connection types based on the types of request they support (i.e. `consent`, `access`, `erasure`)

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
