### PR TITLE
Fix navigating directly to a plus route

### DIFF
--- a/clients/admin-ui/cypress/e2e/datamap.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap.cy.ts
@@ -1,9 +1,10 @@
-import { stubDatamap } from "cypress/support/stubs";
+import { stubDatamap, stubPlus } from "cypress/support/stubs";
 
 describe("Datamap table and spatial view", () => {
   beforeEach(() => {
     cy.login();
     stubDatamap();
+    stubPlus(true);
   });
 
   it("Can render only render one view at a time", () => {

--- a/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
@@ -1,9 +1,12 @@
+import { stubPlus } from "cypress/support/stubs";
+
 import { PRIVACY_NOTICES_ROUTE } from "~/features/common/nav/v2/routes";
 import { RoleRegistryEnum } from "~/types/api";
 
 describe("Privacy notices", () => {
   beforeEach(() => {
     cy.login();
+    stubPlus(true);
   });
 
   describe("permissions", () => {

--- a/clients/admin-ui/cypress/e2e/routes.cy.ts
+++ b/clients/admin-ui/cypress/e2e/routes.cy.ts
@@ -1,6 +1,10 @@
 import { stubPlus } from "cypress/support/stubs";
 
-import { ADD_SYSTEMS_ROUTE } from "~/features/common/nav/v2/routes";
+import {
+  ADD_SYSTEMS_ROUTE,
+  DATAMAP_ROUTE,
+  PRIVACY_NOTICES_ROUTE,
+} from "~/features/common/nav/v2/routes";
 import { RoleRegistryEnum } from "~/types/api";
 
 describe("Routes", () => {
@@ -68,14 +72,16 @@ describe("Routes", () => {
   describe("plus", () => {
     it("non-plus cannot access plus routes", () => {
       stubPlus(false);
-      cy.visit("/datamap");
+      cy.visit(DATAMAP_ROUTE);
       cy.getByTestId("home-content");
       cy.getByTestId("cytoscape-graph").should("not.exist");
+      cy.visit(PRIVACY_NOTICES_ROUTE);
+      cy.getByTestId("home-content");
     });
 
     it("plus can access plus routes", () => {
       stubPlus(true);
-      cy.visit("/datamap");
+      cy.visit(DATAMAP_ROUTE);
       cy.getByTestId("cytoscape-graph");
     });
   });

--- a/clients/admin-ui/cypress/e2e/routes.cy.ts
+++ b/clients/admin-ui/cypress/e2e/routes.cy.ts
@@ -64,4 +64,19 @@ describe("Routes", () => {
       });
     });
   });
+
+  describe("plus", () => {
+    it("non-plus cannot access plus routes", () => {
+      stubPlus(false);
+      cy.visit("/datamap");
+      cy.getByTestId("home-content");
+      cy.getByTestId("cytoscape-graph").should("not.exist");
+    });
+
+    it("plus can access plus routes", () => {
+      stubPlus(true);
+      cy.visit("/datamap");
+      cy.getByTestId("cytoscape-graph");
+    });
+  });
 });

--- a/clients/admin-ui/src/features/auth/ProtectedRoute.tsx
+++ b/clients/admin-ui/src/features/auth/ProtectedRoute.tsx
@@ -4,9 +4,9 @@ import { ReactNode } from "react";
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { LOGIN_ROUTE, VERIFY_AUTH_INTERVAL } from "~/constants";
 import { useNav } from "~/features/common/nav/v2/hooks";
+import { useGetHealthQuery } from "~/features/plus/plus.slice";
 import { useGetUserPermissionsQuery } from "~/features/user-management";
 
-import { useGetHealthQuery } from "../plus/plus.slice";
 import { logout, selectToken, selectUser } from "./auth.slice";
 
 const useProtectedRoute = (redirectUrl: string) => {

--- a/clients/admin-ui/src/features/auth/ProtectedRoute.tsx
+++ b/clients/admin-ui/src/features/auth/ProtectedRoute.tsx
@@ -3,9 +3,10 @@ import { ReactNode } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { LOGIN_ROUTE, VERIFY_AUTH_INTERVAL } from "~/constants";
-import { canAccessRoute } from "~/features/common/nav/v2/nav-config";
+import { useNav } from "~/features/common/nav/v2/hooks";
 import { useGetUserPermissionsQuery } from "~/features/user-management";
 
+import { useGetHealthQuery } from "../plus/plus.slice";
 import { logout, selectToken, selectUser } from "./auth.slice";
 
 const useProtectedRoute = (redirectUrl: string) => {
@@ -18,6 +19,8 @@ const useProtectedRoute = (redirectUrl: string) => {
     pollingInterval: VERIFY_AUTH_INTERVAL,
     skip: !userId,
   });
+  const plusQuery = useGetHealthQuery();
+  const nav = useNav({ path: router.pathname });
 
   if (!token || !userId || permissionsQuery.isError) {
     // Reset the user information in redux only if we have stale information
@@ -30,16 +33,12 @@ const useProtectedRoute = (redirectUrl: string) => {
     return { authenticated: false, hasAccess: false };
   }
 
-  const path = router.pathname;
-  const userScopes = permissionsQuery.data
-    ? permissionsQuery.data.total_scopes
-    : [];
-
-  const hasAccess = canAccessRoute({ path, userScopes });
+  const hasAccess = !!nav.active;
   if (
     !hasAccess &&
     permissionsQuery.isSuccess &&
-    typeof window !== "undefined"
+    typeof window !== "undefined" &&
+    !plusQuery.isLoading
   ) {
     router.push("/");
   }

--- a/clients/admin-ui/src/features/common/nav/v2/nav-config.test.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/nav-config.test.ts
@@ -2,12 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 
 import { ScopeRegistryEnum } from "~/types/api";
 
-import {
-  canAccessRoute,
-  configureNavGroups,
-  findActiveNav,
-  NAV_CONFIG,
-} from "./nav-config";
+import { configureNavGroups, findActiveNav, NAV_CONFIG } from "./nav-config";
 import * as routes from "./routes";
 
 const ALL_SCOPES = [
@@ -254,46 +249,6 @@ describe("findActiveNav", () => {
 
       expect(activeNav?.title).toEqual(expected.title);
       expect(activeNav?.path).toEqual(expected.path);
-    });
-  });
-
-  describe("canAccessRoute", () => {
-    const accessTestCases = [
-      {
-        path: "/",
-        expected: true,
-        userScopes: [],
-      },
-      {
-        path: routes.ADD_SYSTEMS_ROUTE,
-        expected: false,
-        userScopes: [],
-      },
-      {
-        path: routes.ADD_SYSTEMS_ROUTE,
-        expected: true,
-        userScopes: [ScopeRegistryEnum.SYSTEM_CREATE],
-      },
-      {
-        path: routes.PRIVACY_REQUESTS_ROUTE,
-        expected: false,
-        userScopes: [ScopeRegistryEnum.SYSTEM_CREATE],
-      },
-      {
-        path: routes.PRIVACY_REQUESTS_ROUTE,
-        expected: true,
-        userScopes: [ScopeRegistryEnum.PRIVACY_REQUEST_READ],
-      },
-      {
-        path: `${routes.PRIVACY_REQUESTS_ROUTE}?queryParam`,
-        expected: true,
-        userScopes: [ScopeRegistryEnum.PRIVACY_REQUEST_READ],
-      },
-    ];
-    accessTestCases.forEach(({ path, expected, userScopes }) => {
-      it(`${path} is scope restricted`, () => {
-        expect(canAccessRoute({ path, userScopes })).toBe(expected);
-      });
     });
   });
 });

--- a/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
@@ -282,38 +282,3 @@ export const findActiveNav = ({
     path: activePath,
   };
 };
-
-/**
- * Similar to findActiveNav, but using NavConfig instead of a NavGroup
- * This may not be needed once we remove the progressive nav, since then we can
- * just check what navs are available (they would all be restricted by scope)
- */
-export const canAccessRoute = ({
-  path,
-  userScopes,
-}: {
-  path: string;
-  userScopes: ScopeRegistryEnum[];
-}) => {
-  let childMatch: NavConfigRoute | undefined;
-  const groupMatch = NAV_CONFIG.find((group) => {
-    childMatch = group.routes.find((child) =>
-      child.exact ? path === child.path : path.startsWith(child.path)
-    );
-    return childMatch;
-  });
-
-  if (!(groupMatch && childMatch)) {
-    return false;
-  }
-
-  // Special case of empty scopes
-  if (childMatch.scopes.length === 0) {
-    return true;
-  }
-
-  const scopeOverlaps = childMatch.scopes.filter((scope) =>
-    userScopes.includes(scope)
-  );
-  return scopeOverlaps.length > 0;
-};


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3002

### Code Changes

* [x] Check against the nav group directly instead of using the `canAccessRoute` function.
  * This func was useful back when we had a progressive nav, but since we got rid of that we shouldn't need it anymore
* [x] Add tests

### Steps to Confirm

* See steps in the issue

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
