### PR TITLE
Enable toggle for privacy notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The types of changes are:
 - Table for privacy notices [#3001](https://github.com/ethyca/fides/pull/3001)
 - Query params on connection type endpoint to filter by supported action type [#2996](https://github.com/ethyca/fides/pull/2996)
 - Scope restrictions for privacy notice table in the UI [#3007](https://github.com/ethyca/fides/pull/3007)
+- Toggle for enabling/disabling privacy notices in the UI [#3010](https://github.com/ethyca/fides/pull/3010)
 
 ### Changed
 

--- a/clients/admin-ui/cypress/fixtures/privacy-notices/list.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-notices/list.json
@@ -8,7 +8,7 @@
       "consent_mechanism": "opt_out",
       "data_uses": ["advertising.third_party.personalized"],
       "enforcement_level": "frontend",
-      "disabled": false,
+      "disabled": true,
       "has_gpc_flag": false,
       "displayed_in_privacy_center": true,
       "displayed_in_privacy_modal": true,

--- a/clients/admin-ui/src/features/common/ConfirmationModal.tsx
+++ b/clients/admin-ui/src/features/common/ConfirmationModal.tsx
@@ -2,6 +2,7 @@
 import { ThemingProps } from "@chakra-ui/system";
 import {
   Button,
+  Center,
   Modal,
   ModalBody,
   ModalContent,
@@ -26,6 +27,7 @@ interface Props {
   returnFocusOnClose?: boolean;
   isCentered?: boolean;
   testId?: string;
+  icon?: ReactNode;
 }
 const ConfirmationModal = ({
   isOpen,
@@ -41,6 +43,7 @@ const ConfirmationModal = ({
   returnFocusOnClose,
   isCentered,
   testId = "confirmation-modal",
+  icon,
 }: Props) => (
   <Modal
     isOpen={isOpen}
@@ -50,8 +53,13 @@ const ConfirmationModal = ({
     isCentered={isCentered}
   >
     <ModalOverlay />
-    <ModalContent textAlign="center" p={2} data-testid={testId}>
-      {title ? <ModalHeader fontWeight="medium">{title}</ModalHeader> : null}
+    <ModalContent textAlign="center" p={6} data-testid={testId}>
+      {icon ? <Center mb={2}>{icon}</Center> : null}
+      {title ? (
+        <ModalHeader fontWeight="medium" pb={0}>
+          {title}
+        </ModalHeader>
+      ) : null}
       {message ? <ModalBody>{message}</ModalBody> : null}
       <ModalFooter>
         <SimpleGrid columns={2} width="100%">

--- a/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
+++ b/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
@@ -39,10 +39,22 @@ const privacyNoticesApi = baseApi.injectEndpoints({
       }),
       providesTags: () => ["PrivacyNotices"],
     }),
+    patchPrivacyNotices: build.mutation<
+      PrivacyNoticeResponse[],
+      Partial<PrivacyNoticeResponse>[]
+    >({
+      query: (payload) => ({
+        method: "PATCH",
+        url: `privacy-notice/`,
+        body: payload,
+      }),
+      invalidatesTags: () => ["PrivacyNotices"],
+    }),
   }),
 });
 
-export const { useGetAllPrivacyNoticesQuery } = privacyNoticesApi;
+export const { useGetAllPrivacyNoticesQuery, usePatchPrivacyNoticesMutation } =
+  privacyNoticesApi;
 
 export const privacyNoticesSlice = createSlice({
   name: "privacyNotices",

--- a/clients/admin-ui/src/features/system/system.slice.ts
+++ b/clients/admin-ui/src/features/system/system.slice.ts
@@ -61,7 +61,7 @@ const systemApi = baseApi.injectEndpoints({
         method: "PUT",
         body: patch,
       }),
-      invalidatesTags: ["Datamap", "System"],
+      invalidatesTags: ["Datamap", "System", "PrivacyNotices"],
     }),
   }),
 });


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/740

### Code Changes

* [x] Refactor enable column of table to pull straight from the data instead of having a UI "draft" view
  * [x] This is because we decided to do with the save/cancel buttons for the toggles, and instead just have the toggle directly hit the endpoint. This simplifies the table code quite a bit!
* [x] Redux endpoint for patching privacy notices
* [x] Update the toggle cell to call the endpoint
* [x] Confirmation modal on disabling a notice
* [x] Add cypress tests

### Steps to Confirm

* Set up your privacy notices as described in https://github.com/ethyca/fides/pull/3001
* Disable a privacy notice. You should get a confirmation modal
* Re-enable it
* Refresh the page and make sure your changes persist

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

https://user-images.githubusercontent.com/24641006/230660969-8a9a50bd-1033-4698-831d-4b87617a954e.mov

