### PR TITLE
Fix format errors from Shippo connector

### DIFF
--- a/tests/fixtures/saas/shippo_fixtures.py
+++ b/tests/fixtures/saas/shippo_fixtures.py
@@ -26,15 +26,13 @@ secrets = get_secrets("shippo")
 def shippo_secrets(saas_config):
     return {
         "domain": pydash.get(saas_config, "shippo.domain") or secrets["domain"],
-        "api_key": pydash.get(saas_config, "shippo.api_key") or secrets["api_key"]
+        "api_key": pydash.get(saas_config, "shippo.api_key") or secrets["api_key"],
     }
 
 
 @pytest.fixture(scope="session")
 def shippo_identity_email(saas_config):
-    return (
-        pydash.get(saas_config, "shippo.identity_email") or secrets["identity_email"]
-    )
+    return pydash.get(saas_config, "shippo.identity_email") or secrets["identity_email"]
 
 
 @pytest.fixture(scope="function")
@@ -61,9 +59,7 @@ def shippo_dataset() -> Dict[str, Any]:
 
 
 @pytest.fixture(scope="function")
-def shippo_connection_config(
-    db: Session, shippo_config, shippo_secrets
-) -> Generator:
+def shippo_connection_config(db: Session, shippo_config, shippo_secrets) -> Generator:
     fides_key = shippo_config["fides_key"]
     connection_config = ConnectionConfig.create(
         db=db,
@@ -110,7 +106,6 @@ def shippo_dataset_config(
 def shippo_create_erasure_data(
     shippo_connection_config: ConnectionConfig, shippo_erasure_identity_email: str
 ) -> None:
-
     shippo_secrets = shippo_connection_config.secrets
     base_url = f"https://{shippo_secrets['domain']}"
     headers = {
@@ -119,59 +114,59 @@ def shippo_create_erasure_data(
 
     # address
     body = {
-            "name": "Ethyca Test Erasure",
-            "company": "Ethyca Test company",
-            "street1": "test street",
-            "city": "test city",
-            "state": "test state",
-            "zip": "test zip",
-            "country": "test country",
-            "email": shippo_erasure_identity_email,
+        "name": "Ethyca Test Erasure",
+        "company": "Ethyca Test company",
+        "street1": "test street",
+        "city": "test city",
+        "state": "test state",
+        "zip": "test zip",
+        "country": "test country",
+        "email": shippo_erasure_identity_email,
     }
 
-    address_response = requests.post(url=f"{base_url}/addresses", headers=headers, json=body)
+    address_response = requests.post(
+        url=f"{base_url}/addresses", headers=headers, json=body
+    )
     address = address_response.json()
     address_id = address["object_id"]
 
     # orders
     order_data = {
-            "to_address": {
-                "city": "test city",
-                "company": "test company",
-                "country": "test country",
-                "email": shippo_erasure_identity_email,
-                "name": "Ethyca test erasure",
-                "state": "test state",
-                "street1": "test street",
-                "zip": "test zip"
-            },
-            "line_items": [
-                {
-                    "quantity": 1,
-                    "sku": "HM-123",
-                    "title": "Hippo Magazines",
-                    "total_price": "12.10",
-                    "currency": "USD",
-                    "weight": "0.40",
-                    "weight_unit": "lb"
-                }
-            ],
-            "placed_at": "2023-01-31T01:28:12Z",
-            "order_number": "#1068",
-            "order_status": "PAID",
-            "shipping_cost": "12.83",
-            "shipping_cost_currency": "USD",
-            "shipping_method": "USPS First Class Package",
-            "subtotal_price": "12.10",
-            "total_price": "24.93",
-            "total_tax": "0.00",
-            "currency": "USD",
-            "weight": "0.40",
-            "weight_unit": "lb"
-        }
-    response = requests.post(
-        url=f"{base_url}/orders", headers=headers, json=order_data
-    )
+        "to_address": {
+            "city": "test city",
+            "company": "test company",
+            "country": "test country",
+            "email": shippo_erasure_identity_email,
+            "name": "Ethyca test erasure",
+            "state": "test state",
+            "street1": "test street",
+            "zip": "test zip",
+        },
+        "line_items": [
+            {
+                "quantity": 1,
+                "sku": "HM-123",
+                "title": "Hippo Magazines",
+                "total_price": "12.10",
+                "currency": "USD",
+                "weight": "0.40",
+                "weight_unit": "lb",
+            }
+        ],
+        "placed_at": "2023-01-31T01:28:12Z",
+        "order_number": "#1068",
+        "order_status": "PAID",
+        "shipping_cost": "12.83",
+        "shipping_cost_currency": "USD",
+        "shipping_method": "USPS First Class Package",
+        "subtotal_price": "12.10",
+        "total_price": "24.93",
+        "total_tax": "0.00",
+        "currency": "USD",
+        "weight": "0.40",
+        "weight_unit": "lb",
+    }
+    response = requests.post(url=f"{base_url}/orders", headers=headers, json=order_data)
     order = response.json()
     order_id = order["object_id"]
     yield address, order

--- a/tests/ops/integration_tests/saas/test_shippo_task.py
+++ b/tests/ops/integration_tests/saas/test_shippo_task.py
@@ -18,6 +18,7 @@ CONFIG = get_config()
 def test_shippo_connection_test(shippo_connection_config) -> None:
     get_connector(shippo_connection_config).test_connection()
 
+
 @pytest.mark.integration_saas
 @pytest.mark.integration_shippo
 @pytest.mark.asyncio
@@ -75,7 +76,7 @@ async def test_shippo_access_request_task(
             "email",
             "is_residential",
             "metadata",
-            "test"
+            "test",
         ],
     )
 
@@ -103,15 +104,14 @@ async def test_shippo_access_request_task(
             "shipping_cost_currency",
             "line_items",
             "notes",
-            "test"
+            "test",
         ],
     )
 
     # verify we only returned data for our identity email
-    
+
     for address in v[f"{dataset_name}:addresses"]:
         assert address["email"] == shippo_identity_email
 
     for order in v[f"{dataset_name}:orders"]:
         assert order["object_owner"] == shippo_identity_email
-

--- a/tests/ops/util/test_saas_util.py
+++ b/tests/ops/util/test_saas_util.py
@@ -343,7 +343,13 @@ def test_unflatten_dict():
     assert unflatten_dict({"A.B": "1", "A.C": "2"}) == {"A": {"B": "1", "C": "2"}}
 
     # mixed levels
-    assert unflatten_dict({"A": "1", "B.C": "2", "B.D": "3",}) == {
+    assert unflatten_dict(
+        {
+            "A": "1",
+            "B.C": "2",
+            "B.D": "3",
+        }
+    ) == {
         "A": "1",
         "B": {"C": "2", "D": "3"},
     }


### PR DESCRIPTION
### Code Changes

* [X] Run `nox -s "black(fix)"`

### Steps to Confirm

n/a

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
~* [ ] Update `CHANGELOG.md`~
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Quick fix to get the format checks on `main` passing.