### PR TITLE
try publishing beta (main) tags to real PyPI

### DIFF
--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -48,10 +48,15 @@ jobs:
       - name: Build the wheel
         run: python setup.py bdist_wheel
 
+      # If the tag matches either a release tag or a beta tag, allow publishing to PyPi, e.g.:
+      #   2.10.0 --> match (production release tag)
+      #   2.10.0b1 --> match (beta release tag, used on main)
+      #   2.10.0.a0 --> no match (alpha tag, used on feature branches)
+      #   2.10.0.dev0 --> no match (arbitrary development tag)
       - name: Check Prod Tag
         id: check-tag
         run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+(b[0-9]*)?$ ]]; then
               echo ::set-output name=match::true
           fi
 


### PR DESCRIPTION
Closes n/a

### Code Changes

* update tag regex to route beta tags in "real" PyPI publishing in CI, rather than test PyPI

### Steps to Confirm

* I think we'll need to merge this to main in order to test it out!

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

We want to try out a new publishing pattern where we publish to "real" PyPI (not test PyPI) on "beta" tags (e.g. `2.10.1b1`),  which should only be generated on `main` commits. this will allow us to get a prerelease version of `fides` into `fidesplus` if desired, without having to go to testpypi, i.e. via `fidesplus`'s `requirements.txt`. this is particularly helpful in cases where there is feature development on `fidesplus` that _requries_ changes in `fides` that have not yet been released.
