### PR TITLE
publish git-tag-specific docker images

### DIFF
--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -39,6 +39,8 @@ jobs:
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo ::set-output name=match::true
+          else
+              echo ::set-output name=match::false
           fi
       - name: Push Fides Prod Tags
         if: steps.check-tag.outputs.match == 'true'

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -43,3 +43,9 @@ jobs:
       - name: Push Fides Prod Tags
         if: steps.check-tag.outputs.match == 'true'
         run: nox -s "push(prod)"
+
+      # if not a prod tag, then we run the git-tag job to publish images with a git tag
+      # if one exists on the current commit. the job is a no-op if the commit hasn't been tagged
+      - name: Push Fides Commit Tags
+        if: steps.check-tag.outputs.match == 'false'
+        run: nox -s "push(git-tag)"

--- a/noxfiles/git_nox.py
+++ b/noxfiles/git_nox.py
@@ -9,9 +9,9 @@ from packaging.version import Version
 import nox
 
 RELEASE_BRANCH_REGEX = r"release-(([0-9]+\.)+[0-9]+)"
-RC_TAG_REGEX = r"{release_version}rc([0-9]+)"
 RELEASE_TAG_REGEX = r"(([0-9]+\.)+[0-9]+)"
 VERSION_TAG_REGEX = r"{version}{tag_type}([0-9]+)"
+GENERIC_TAG_REGEX = r"{tag_type}([0-9]+)$"
 
 INITIAL_TAG_INCREMENT = 0
 TAG_INCREMENT = 1
@@ -113,6 +113,15 @@ def next_release_increment(session: nox.Session, all_tags: List):
     return Version(
         f"{latest_release.major}.{latest_release.minor}.{latest_release.micro + 1}"
     )
+
+
+def recognized_tag(tag_to_check: str) -> bool:
+    """Utility function to check whether the provided tag matches one of our recognized tag patterns"""
+    for tag_type in TagType:
+        pattern = GENERIC_TAG_REGEX.format(tag_type=tag_type.value)
+        if re.search(pattern, tag_to_check):
+            return True
+    return False
 
 
 def increment_tag(


### PR DESCRIPTION
Partially closes #2919 

### Code Changes

* include a `push` session arg that can push images corresponding to a git tag, if one exists on the current commit (`nox -s "push(git-tag)"`)
* update GH actions to invoke this `push` session on any tags that are _not_ prod tags (prod tags already publish a nice, clean, versioned docker image via the `push(prod)` session, so it's not needed and we don't want to duplicate)
    * this new nox session is a no-op if it finds no explicit git tag on the current commit, so we are OK to invoke it liberally, and it will weed out any commits where there's no tag, e.g. a "normal" commit to `main`. the `dev` tagged image will continue to be published on commits to `main`.
    * as it stands now in the PR, feature and release branch tags will _also_ publish the `:dev` image. this may or may not be desirable - the main outstanding question i've got for this PR


### Steps to Confirm

* i'll use this as a chance to actually push a tag to this branch and see if it goes thru to publish an image on dockerhub!
     * this was successful: [this](https://hub.docker.com/layers/ethyca/fides/2.10.1a2/images/sha256-88bd1681adcf4d93e2c7127d34d57e1f94116d3e4a835d2310f5016f5db5c90d?context=explore) was published by [this](https://github.com/ethyca/fides/actions/runs/4681336577/jobs/8293795569)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This should be a helpful piece for both feature-branch deployments and release-branch (rc) deployments