### PR TITLE
Remove banner with scope migration warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The types of changes are:
 ### Removed
 
 - Removed interzone navigation logic now that the datamap UI and admin UI are one app [#2990](https://github.com/ethyca/fides/pull/2990)
+- Removed the warning about access control migration [#3055](https://github.com/ethyca/fides/pull/3055)
 
 ### Changed
 

--- a/clients/admin-ui/src/features/common/Layout.tsx
+++ b/clients/admin-ui/src/features/common/Layout.tsx
@@ -13,7 +13,6 @@ import {
 } from "~/features/privacy-requests/privacy-requests.slice";
 
 import ConfigurationNotificationBanner from "../privacy-requests/configuration/ConfigurationNotificationBanner";
-import NotificationBanner from "./NotificationBanner";
 
 const Layout = ({
   children,
@@ -53,8 +52,6 @@ const Layout = ({
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Header />
-      {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
-      <NotificationBanner />
       <NavTopBar />
       <Flex as="main" flexGrow={1} padding={10} gap={10}>
         <Box flex={0} flexShrink={0}>

--- a/clients/admin-ui/src/features/common/NotificationBanner.tsx
+++ b/clients/admin-ui/src/features/common/NotificationBanner.tsx
@@ -19,6 +19,10 @@ import {
 const DESCRIPTION =
   "Ethyca has updated how permissions work from a scope-based model to a role-based permissions scheme. To update user roles, please log in as your root user and upgrade the roles as you see fit.";
 
+/**
+ * This component is not currently used, but could easily be used again/modified
+ * if we ever need to show another banner message to a user (see fides#2842)
+ */
 const NotificationBanner = () => {
   const showBanner = useAppSelector(selectShowNotificationBanner);
   const dispatch = useAppDispatch();

--- a/clients/admin-ui/src/features/common/features/features.slice.ts
+++ b/clients/admin-ui/src/features/common/features/features.slice.ts
@@ -19,6 +19,10 @@ export const FLAG_NAMES = Object.keys(FLAG_CONFIG) as Array<FlagNames>;
 
 type FeaturesState = {
   flags: Partial<FlagConfig>;
+  /**
+   * Not currently used, but useful for one-time messages that display on every page
+   * until acknowledged (see fides#2842)
+   */
   showNotificationBanner: boolean;
 };
 


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2844

### Code Changes

* [x] Removes the banner introduced by https://github.com/ethyca/fides/pull/2842 now that we are a few releases out

### Steps to Confirm

* Log in as a viewer
* You should no longer see the warning banner about scopes being migrated

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

I left the general framework in place since I think it'll likely still be useful to us in the future if we need a banner displayed on all of our pages again.
