### PR TITLE
Individual privacy notice page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The types of changes are:
 ### Added
 - Access and erasure support for Aircall [#2589](https://github.com/ethyca/fides/pull/2589)
 - Access and erasure support for Klaviyo [#2501](https://github.com/ethyca/fides/pull/2501)
+- Page to edit or add privacy notices [#3058](https://github.com/ethyca/fides/pull/3058)
 
 ### Changed
 - The `cursor` pagination strategy now also searches for data outside of the `data_path` when determining the cursor value [#3068](https://github.com/ethyca/fides/pull/3068)

--- a/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
@@ -1,4 +1,8 @@
-import { stubPlus } from "cypress/support/stubs";
+import {
+  stubPlus,
+  stubPrivacyNoticesCrud,
+  stubTaxonomyEntities,
+} from "cypress/support/stubs";
 
 import { PRIVACY_NOTICES_ROUTE } from "~/features/common/nav/v2/routes";
 import { RoleRegistryEnum } from "~/types/api";
@@ -90,6 +94,7 @@ describe("Privacy notices", () => {
     beforeEach(() => {
       cy.visit(PRIVACY_NOTICES_ROUTE);
       cy.wait("@getNotices");
+      stubTaxonomyEntities();
     });
 
     it("should render a row for each privacy notice", () => {
@@ -116,9 +121,18 @@ describe("Privacy notices", () => {
     });
 
     it("can click a row to go to the notice page", () => {
+      cy.intercept("GET", "/api/v1/privacy-notice/pri*", {
+        fixture: "privacy-notices/notice.json",
+      }).as("getNoticeDetail");
       cy.getByTestId("row-Essential").click();
+      cy.wait("@getNoticeDetail");
       cy.getByTestId("privacy-notice-detail-page");
       cy.url().should("contain", ESSENTIAL_NOTICE_ID);
+    });
+
+    it("can click add button to get to a new form", () => {
+      cy.getByTestId("add-privacy-notice-btn").click();
+      cy.url().should("contain", `${PRIVACY_NOTICES_ROUTE}/new`);
     });
 
     describe("enabling and disabling", () => {
@@ -161,6 +175,138 @@ describe("Privacy notices", () => {
         // redux should requery after invalidation
         cy.wait("@getNotices");
       });
+    });
+  });
+
+  describe("edit privacy notice", () => {
+    beforeEach(() => {
+      stubPrivacyNoticesCrud();
+      stubTaxonomyEntities();
+    });
+
+    it("should render an existing privacy notice", () => {
+      cy.visit(`${PRIVACY_NOTICES_ROUTE}/${ESSENTIAL_NOTICE_ID}`);
+      cy.wait("@getNoticeDetail");
+      cy.fixture("privacy-notices/notice.json").then((notice) => {
+        // details section
+        cy.getByTestId("input-name").should("have.value", notice.name);
+        cy.getByTestId("input-description").should(
+          "have.value",
+          notice.description
+        );
+
+        // consent mechanism section
+        cy.getSelectValueContainer("input-consent_mechanism").contains(
+          "Consent not necessary"
+        );
+        cy.getSelectValueContainer("input-enforcement_level").contains(
+          "Not applicable"
+        );
+        cy.getByTestId("input-has_gpc_flag").within(() => {
+          cy.get("span").should("not.have.attr", "data-checked");
+        });
+
+        // configuration section
+        notice.data_uses.forEach((dataUse) => {
+          cy.getSelectValueContainer("input-data_uses").contains(dataUse);
+        });
+        cy.getByTestId("input-internal_description").should("have.value", "");
+        notice.regions.forEach((region) => {
+          cy.getSelectValueContainer("input-regions").contains(region);
+        });
+        [
+          "displayed_in_overlay",
+          "displayed_in_api",
+          "displayed_in_privacy_center",
+        ].forEach((displayConfig) => {
+          cy.getByTestId(`input-${displayConfig}`).within(() => {
+            cy.get("span").should("have.attr", "data-checked");
+          });
+        });
+      });
+    });
+
+    it("can make an edit", () => {
+      cy.visit(`${PRIVACY_NOTICES_ROUTE}/${ESSENTIAL_NOTICE_ID}`);
+      cy.wait("@getNoticeDetail");
+      const newName = "new name";
+      cy.getByTestId("input-name").clear().type(newName);
+
+      cy.getByTestId("save-btn").click();
+      cy.wait("@patchNotices").then((interception) => {
+        const { body } = interception.request;
+        expect(body[0].name).to.eql(newName);
+      });
+      cy.wait("@getNoticeDetail");
+    });
+  });
+
+  describe("new privacy notice", () => {
+    beforeEach(() => {
+      stubPrivacyNoticesCrud();
+      stubTaxonomyEntities();
+    });
+
+    it("should disable certain fields when notice is notice_only", () => {
+      cy.visit(`${PRIVACY_NOTICES_ROUTE}/new`);
+      cy.selectOption("input-consent_mechanism", "Consent not necessary");
+      cy.getSelectValueContainer("input-enforcement_level").within(() => {
+        cy.get("input").should("be.disabled");
+      });
+      cy.getByTestId("input-has_gpc_flag").within(() => {
+        cy.get("span").should("have.attr", "data-disabled");
+      });
+
+      // fields should not be disabled otherwise
+      cy.selectOption("input-consent_mechanism", "Opt in");
+      cy.getSelectValueContainer("input-enforcement_level").within(() => {
+        cy.get("input").should("not.be.disabled");
+      });
+      cy.getByTestId("input-has_gpc_flag").within(() => {
+        cy.get("span").should("not.have.attr", "data-disabled");
+      });
+    });
+
+    it("can create a new privacy notice", () => {
+      cy.visit(`${PRIVACY_NOTICES_ROUTE}/new`);
+      cy.getByTestId("new-privacy-notice-page");
+      const notice = {
+        name: "my notice",
+        description: "my description",
+        consent_mechanism: "opt_in",
+        enforcement_level: "system_wide",
+        has_gpc_flag: true,
+        data_uses: ["advertising"],
+        internal_description: "our very important notice, do not touch",
+        regions: ["us_ca"],
+        displayed_in_privacy_center: true,
+        displayed_in_api: false,
+        displayed_in_overlay: true,
+      };
+
+      // details section
+      cy.getByTestId("input-name").type(notice.name);
+      cy.getByTestId("input-description").type(notice.description);
+
+      // consent mechanism section
+      cy.selectOption("input-consent_mechanism", "Opt in");
+      cy.selectOption("input-enforcement_level", "System wide");
+      cy.getByTestId("input-has_gpc_flag").click();
+
+      // configuration section
+      cy.selectOption("input-data_uses", notice.data_uses[0]);
+      cy.getByTestId("input-internal_description").type(
+        notice.internal_description
+      );
+      cy.selectOption("input-regions", notice.regions[0]);
+      cy.getByTestId("input-displayed_in_api").click();
+
+      cy.getByTestId("save-btn").click();
+      cy.wait("@postNotices").then((interception) => {
+        const { body } = interception.request;
+        expect(body[0]).to.eql(notice);
+      });
+      cy.wait("@getNotices");
     });
   });
 });

--- a/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
@@ -197,7 +197,7 @@ describe("Privacy notices", () => {
 
         // consent mechanism section
         cy.getSelectValueContainer("input-consent_mechanism").contains(
-          "Consent not necessary"
+          "Notice only"
         );
         cy.getSelectValueContainer("input-enforcement_level").contains(
           "Not applicable"
@@ -249,7 +249,7 @@ describe("Privacy notices", () => {
 
     it("should disable certain fields when notice is notice_only", () => {
       cy.visit(`${PRIVACY_NOTICES_ROUTE}/new`);
-      cy.selectOption("input-consent_mechanism", "Consent not necessary");
+      cy.selectOption("input-consent_mechanism", "Notice only");
       cy.getSelectValueContainer("input-enforcement_level").within(() => {
         cy.get("input").should("be.disabled");
       });

--- a/clients/admin-ui/cypress/e2e/taxonomy-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy-plus.cy.ts
@@ -32,26 +32,6 @@ describe("Taxonomy management with Plus features", () => {
       });
   };
 
-  // TODO: Extract these to a cypress support file.
-  const getSelectValueContainer = (selectorId: string) =>
-    cy.getByTestId(selectorId).find(`.custom-select__value-container`);
-
-  const getSelectOptionList = (selectorId: string) =>
-    cy.getByTestId(selectorId).click().find(`.custom-select__menu-list`);
-
-  const selectOption = (selectorId: string, optionText: string) => {
-    getSelectOptionList(selectorId).contains(optionText).click();
-  };
-
-  const removeMultiValue = (selectorId: string, optionText: string) =>
-    getSelectValueContainer(selectorId)
-      .contains(optionText)
-      .siblings(".custom-select__multi-value__remove")
-      .click();
-
-  const clearSingleValue = (selectorId: string) =>
-    cy.getByTestId(selectorId).find(".custom-select__clear-indicator").click();
-
   describe("Defining custom lists", () => {
     beforeEach(() => {
       navigateToEditor();
@@ -143,8 +123,8 @@ describe("Taxonomy management with Plus features", () => {
     it("can create a multi-select custom field", () => {
       cy.getByTestId("create-custom-fields-form").within(() => {
         cy.getByTestId("custom-input-name").type("Multi-select");
-        selectOption("input-field_type", "Multiple select");
-        selectOption("input-allow_list_id", "Prime numbers");
+        cy.selectOption("input-field_type", "Multiple select");
+        cy.selectOption("input-allow_list_id", "Prime numbers");
       });
 
       cy.intercept(
@@ -224,27 +204,27 @@ describe("Taxonomy management with Plus features", () => {
 
     it("initializes form fields with values returned by the API", () => {
       cy.getByTestId("custom-fields-list");
-      getSelectValueContainer(testIdSingle).contains("Squirtle");
+      cy.getSelectValueContainer(testIdSingle).contains("Squirtle");
 
       ["Charmander", "Eevee", "Snorlax"].forEach((value) => {
-        getSelectValueContainer(testIdMulti).contains(value);
+        cy.getSelectValueContainer(testIdMulti).contains(value);
       });
     });
 
     it("allows choosing and changing selections", () => {
       cy.getByTestId("custom-fields-list");
 
-      clearSingleValue(testIdSingle);
-      selectOption(testIdSingle, "Snorlax");
-      getSelectValueContainer(testIdSingle).contains("Snorlax");
-      clearSingleValue(testIdSingle);
+      cy.clearSingleValue(testIdSingle);
+      cy.selectOption(testIdSingle, "Snorlax");
+      cy.getSelectValueContainer(testIdSingle).contains("Snorlax");
+      cy.clearSingleValue(testIdSingle);
 
-      removeMultiValue(testIdMulti, "Eevee");
-      removeMultiValue(testIdMulti, "Snorlax");
-      selectOption(testIdMulti, "Eevee");
+      cy.removeMultiValue(testIdMulti, "Eevee");
+      cy.removeMultiValue(testIdMulti, "Snorlax");
+      cy.selectOption(testIdMulti, "Eevee");
 
       ["Charmander", "Eevee"].forEach((value) => {
-        getSelectValueContainer(testIdMulti).contains(value);
+        cy.getSelectValueContainer(testIdMulti).contains(value);
       });
 
       cy.intercept(

--- a/clients/admin-ui/cypress/fixtures/privacy-notices/notice.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-notices/notice.json
@@ -1,0 +1,20 @@
+{
+  "name": "Essential",
+  "description": "Notify the user about data processing activities that are essential to your services functionality. Typically consent is not required for this.",
+  "internal_description": null,
+  "origin": null,
+  "regions": ["eu_fr", "eu_ie"],
+  "consent_mechanism": "notice_only",
+  "data_uses": ["provide.service"],
+  "enforcement_level": "not_applicable",
+  "disabled": false,
+  "has_gpc_flag": false,
+  "displayed_in_privacy_center": true,
+  "displayed_in_overlay": true,
+  "displayed_in_api": true,
+  "id": "pri_fbdfd4f5-eec3-4d4d-83ae-726bde1d5b3a",
+  "created_at": "2023-04-17T14:49:23.692686+00:00",
+  "updated_at": "2023-04-17T14:49:23.692686+00:00",
+  "version": 1.0,
+  "privacy_notice_history_id": "pri_469a3aaa-c9fe-4bdd-a090-c9a8b0661fdb"
+}

--- a/clients/admin-ui/cypress/support/commands.ts
+++ b/clients/admin-ui/cypress/support/commands.ts
@@ -139,7 +139,7 @@ declare global {
       /**
        * Clears the value of a CustomSelect that is a single select
        *
-       * @example removeMultiValue("input-multifield", "Eevee");
+       * @example removeMultiValue("input-singlefield");
        */
       clearSingleValue(selectorId: string): void;
     }

--- a/clients/admin-ui/cypress/support/commands.ts
+++ b/clients/admin-ui/cypress/support/commands.ts
@@ -33,6 +33,31 @@ Cypress.Commands.add("login", () => {
   });
 });
 
+const getSelectOptionList = (selectorId: string) =>
+  cy.getByTestId(selectorId).click().find(`.custom-select__menu-list`);
+
+Cypress.Commands.add("getSelectValueContainer", (selectorId) =>
+  cy.getByTestId(selectorId).find(`.custom-select__value-container`)
+);
+
+Cypress.Commands.add("selectOption", (selectorId, optionText) => {
+  getSelectOptionList(selectorId).contains(optionText).click();
+});
+
+Cypress.Commands.add(
+  "removeMultiValue",
+  (selectorId: string, optionText: string) =>
+    cy
+      .getSelectValueContainer(selectorId)
+      .contains(optionText)
+      .siblings(".custom-select__multi-value__remove")
+      .click()
+);
+
+Cypress.Commands.add("clearSingleValue", (selectorId) =>
+  cy.getByTestId(selectorId).find(".custom-select__clear-indicator").click()
+);
+
 Cypress.Commands.add("assumeRole", (role) => {
   cy.fixture("scopes/roles-to-scopes.json").then((mapping) => {
     const scopes: ScopeRegistryEnum[] = mapping[role];
@@ -89,6 +114,34 @@ declare global {
        * @example cy.assumeRole(RoleRegistryEnum.OWNER)
        */
       assumeRole(role: RoleRegistryEnum): void;
+      /**
+       * Get the container of a CustomSelect
+       * @example cy.selectValueContainer("input-allow_list_id")
+       */
+      getSelectValueContainer(
+        selectorId: string
+      ): Chainable<JQuery<HTMLElement>>;
+      /**
+       * Selects an option from a CustomSelect component
+       *
+       * @example cy.selectOption("input-allow_list_id", "Prime numbers");
+       */
+      selectOption(
+        selectorId: string,
+        optionText: string
+      ): Chainable<JQuery<HTMLElement>>;
+      /**
+       * Removes a value from a CustomSelect that is a multiselect
+       *
+       * @example removeMultiValue("input-multifield", "Eevee");
+       */
+      removeMultiValue(selectorId: string, optionText: string): void;
+      /**
+       * Clears the value of a CustomSelect that is a single select
+       *
+       * @example removeMultiValue("input-multifield", "Eevee");
+       */
+      clearSingleValue(selectorId: string): void;
     }
   }
 }

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -111,6 +111,21 @@ export const stubPrivacyRequestsConfigurationCrud = () => {
   }).as("createMessagingConfiguration");
 };
 
+export const stubPrivacyNoticesCrud = () => {
+  cy.intercept("GET", "/api/v1/privacy-notice/*", {
+    fixture: "privacy-notices/list.json",
+  }).as("getNotices");
+  cy.intercept("GET", "/api/v1/privacy-notice/pri*", {
+    fixture: "privacy-notices/notice.json",
+  }).as("getNoticeDetail");
+  cy.intercept("POST", "/api/v1/privacy-notice", {
+    fixture: "privacy-notices/list.json",
+  }).as("postNotices");
+  cy.intercept("PATCH", "/api/v1/privacy-notice", {
+    fixture: "privacy-notices/list.json",
+  }).as("patchNotices");
+};
+
 export const CONNECTION_STRING =
   "postgresql://postgres:fidesctl@fidesctl-db:5432/fidesctl_test";
 

--- a/clients/admin-ui/src/features/common/form/FormSection.tsx
+++ b/clients/admin-ui/src/features/common/form/FormSection.tsx
@@ -1,0 +1,28 @@
+import { Box, Heading } from "@fidesui/react";
+import { ReactNode } from "react";
+
+const FormSection = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) => (
+  <Box borderRadius="md" border="1px solid" borderColor="gray.200">
+    <Heading
+      as="h3"
+      fontSize="sm"
+      fontWeight="semibold"
+      color="gray.700"
+      py={4}
+      px={6}
+      backgroundColor="gray.50"
+      borderRadius="md"
+    >
+      {title}
+    </Heading>
+    <Box p={6}>{children}</Box>
+  </Box>
+);
+
+export default FormSection;

--- a/clients/admin-ui/src/features/common/form/FormSection.tsx
+++ b/clients/admin-ui/src/features/common/form/FormSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading } from "@fidesui/react";
+import { Box, Heading, Stack } from "@fidesui/react";
 import { ReactNode } from "react";
 
 const FormSection = ({
@@ -21,7 +21,9 @@ const FormSection = ({
     >
       {title}
     </Heading>
-    <Box p={6}>{children}</Box>
+    <Stack p={6} spacing={6}>
+      {children}
+    </Stack>
   </Box>
 );
 

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -690,34 +690,64 @@ export const CustomRadioGroup = ({
 interface CustomSwitchProps {
   label: string;
   tooltip?: string;
+  variant?: "inline" | "condensed";
 }
 export const CustomSwitch = ({
   label,
   tooltip,
+  variant = "inline",
   ...props
 }: CustomSwitchProps & FieldHookConfig<boolean>) => {
   const [field, meta] = useField({ ...props, type: "checkbox" });
   const isInvalid = !!(meta.touched && meta.error);
 
+  if (variant === "inline") {
+    return (
+      <FormControl isInvalid={isInvalid}>
+        <Grid templateColumns="1fr 3fr" justifyContent="center">
+          <Label htmlFor={props.id || props.name} my={0}>
+            {label}
+          </Label>
+          <Box display="flex" alignItems="center">
+            <Switch
+              name={field.name}
+              isChecked={field.checked}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              colorScheme="secondary"
+              mr={2}
+              data-testid={`input-${field.name}`}
+            />
+            {tooltip ? <QuestionTooltip label={tooltip} /> : null}
+          </Box>
+        </Grid>
+      </FormControl>
+    );
+  }
   return (
-    <FormControl isInvalid={isInvalid}>
-      <Grid templateColumns="1fr 3fr" justifyContent="center">
-        <Label htmlFor={props.id || props.name} my={0}>
+    <FormControl isInvalid={isInvalid} width="fit-content">
+      <Box display="flex" alignItems="center">
+        <Label
+          htmlFor={props.id || props.name}
+          fontSize="sm"
+          color="gray.500"
+          my={0}
+          mr={2}
+        >
           {label}
         </Label>
-        <Box display="flex" alignItems="center">
-          <Switch
-            name={field.name}
-            isChecked={field.checked}
-            onChange={field.onChange}
-            onBlur={field.onBlur}
-            colorScheme="secondary"
-            mr={2}
-            data-testid={`input-${field.name}`}
-          />
-          {tooltip ? <QuestionTooltip label={tooltip} /> : null}
-        </Box>
-      </Grid>
+
+        <Switch
+          name={field.name}
+          isChecked={field.checked}
+          onChange={field.onChange}
+          onBlur={field.onBlur}
+          colorScheme="secondary"
+          mr={2}
+          data-testid={`input-${field.name}`}
+        />
+        {tooltip ? <QuestionTooltip label={tooltip} /> : null}
+      </Box>
     </FormControl>
   );
 };

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -691,15 +691,30 @@ interface CustomSwitchProps {
   label: string;
   tooltip?: string;
   variant?: "inline" | "condensed";
+  isDisabled?: boolean;
 }
 export const CustomSwitch = ({
   label,
   tooltip,
   variant = "inline",
+  isDisabled,
   ...props
 }: CustomSwitchProps & FieldHookConfig<boolean>) => {
   const [field, meta] = useField({ ...props, type: "checkbox" });
   const isInvalid = !!(meta.touched && meta.error);
+
+  const innerSwitch = (
+    <Switch
+      name={field.name}
+      isChecked={field.checked}
+      onChange={field.onChange}
+      onBlur={field.onBlur}
+      colorScheme="secondary"
+      mr={2}
+      data-testid={`input-${field.name}`}
+      disabled={isDisabled}
+    />
+  );
 
   if (variant === "inline") {
     return (
@@ -709,15 +724,7 @@ export const CustomSwitch = ({
             {label}
           </Label>
           <Box display="flex" alignItems="center">
-            <Switch
-              name={field.name}
-              isChecked={field.checked}
-              onChange={field.onChange}
-              onBlur={field.onBlur}
-              colorScheme="secondary"
-              mr={2}
-              data-testid={`input-${field.name}`}
-            />
+            {innerSwitch}
             {tooltip ? <QuestionTooltip label={tooltip} /> : null}
           </Box>
         </Grid>
@@ -736,16 +743,7 @@ export const CustomSwitch = ({
         >
           {label}
         </Label>
-
-        <Switch
-          name={field.name}
-          isChecked={field.checked}
-          onChange={field.onChange}
-          onBlur={field.onBlur}
-          colorScheme="secondary"
-          mr={2}
-          data-testid={`input-${field.name}`}
-        />
+        {innerSwitch}
         {tooltip ? <QuestionTooltip label={tooltip} /> : null}
       </Box>
     </FormControl>

--- a/clients/admin-ui/src/features/data-use/data-use.slice.ts
+++ b/clients/admin-ui/src/features/data-use/data-use.slice.ts
@@ -87,3 +87,10 @@ export const selectDataUsesMap = createSelector(
   selectDataUses,
   (dataUses) => new Map(dataUses.map((dataUse) => [dataUse.name, dataUse]))
 );
+
+export const selectDataUseOptions = createSelector(selectDataUses, (dataUses) =>
+  dataUses.map((du) => ({
+    label: du.name ?? du.fides_key,
+    value: du.fides_key,
+  }))
+);

--- a/clients/admin-ui/src/features/data-use/data-use.slice.ts
+++ b/clients/admin-ui/src/features/data-use/data-use.slice.ts
@@ -90,7 +90,7 @@ export const selectDataUsesMap = createSelector(
 
 export const selectDataUseOptions = createSelector(selectDataUses, (dataUses) =>
   dataUses.map((du) => ({
-    label: du.name ?? du.fides_key,
+    label: du.fides_key,
     value: du.fides_key,
   }))
 );

--- a/clients/admin-ui/src/features/privacy-notices/ConsentMechanismForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/ConsentMechanismForm.tsx
@@ -1,0 +1,75 @@
+import { Box, Text } from "@fidesui/react";
+import { useFormikContext } from "formik";
+import { useEffect, useMemo } from "react";
+
+import FormSection from "~/features/common/form/FormSection";
+import { CustomSelect, CustomSwitch } from "~/features/common/form/inputs";
+import { enumToOptions } from "~/features/common/helpers";
+import {
+  ConsentMechanism,
+  EnforcementLevel,
+  PrivacyNoticeCreation,
+} from "~/types/api";
+
+import { ENFORCEMENT_LEVEL_MAP, MECHANISM_MAP } from "./constants";
+
+const CONSENT_MECHANISM_OPTIONS = enumToOptions(ConsentMechanism).map(
+  (opt) => ({
+    label: MECHANISM_MAP.get(opt.label) || opt.label,
+    value: opt.value,
+  })
+);
+
+const ENFORCEMENT_OPTIONS = enumToOptions(EnforcementLevel).map((opt) => ({
+  label: ENFORCEMENT_LEVEL_MAP.get(opt.label) || opt.label,
+  value: opt.value,
+}));
+
+const ConsentMechanismForm = () => {
+  const { values, setFieldValue } = useFormikContext<PrivacyNoticeCreation>();
+
+  const isNoticeOnly = useMemo(
+    () => values.consent_mechanism === ConsentMechanism.NOTICE_ONLY,
+    [values.consent_mechanism]
+  );
+
+  // Handle the special case where, if the consent mechanism is "Notice only", some fields
+  // become disabled
+  useEffect(() => {
+    if (isNoticeOnly) {
+      setFieldValue("enforcement_level", EnforcementLevel.NOT_APPLICABLE);
+      setFieldValue("has_gpc_flag", false);
+    }
+  }, [isNoticeOnly, setFieldValue]);
+
+  return (
+    <FormSection title="Consent mechanism">
+      <CustomSelect
+        label="If this use of data requires consent, you can specify the method of consent here."
+        name="consent_mechanism"
+        options={CONSENT_MECHANISM_OPTIONS}
+        variant="stacked"
+      />
+      <CustomSelect
+        label="Select the enforcement level for this consent mechanism"
+        name="enforcement_level"
+        options={ENFORCEMENT_OPTIONS}
+        variant="stacked"
+        isDisabled={isNoticeOnly}
+      />
+      <Box>
+        <Text fontSize="sm" fontWeight="medium" mb={2}>
+          Configure whether this notice conforms to the Global Privacy Control.
+        </Text>
+        <CustomSwitch
+          label="GPC Enabled"
+          name="has_gpc_flag"
+          variant="condensed"
+          isDisabled={isNoticeOnly}
+        />
+      </Box>
+    </FormSection>
+  );
+};
+
+export default ConsentMechanismForm;

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -152,13 +152,13 @@ const PrivacyNoticeForm = ({
                       variant="condensed"
                     />
                     <CustomSwitch
-                      label="API Only"
-                      name="displayed_in_api"
+                      label="Show in Privacy Overlay"
+                      name="displayed_in_overlay"
                       variant="condensed"
                     />
                     <CustomSwitch
-                      label="Show in Privacy Overlay"
-                      name="displayed_in_overlay"
+                      label="API Only"
+                      name="displayed_in_api"
                       variant="condensed"
                     />
                   </HStack>

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -36,7 +36,7 @@ import {
 } from "~/types/api";
 
 import { errorToastParams, successToastParams } from "../common/toast";
-import { MECHANISM_MAP } from "./constants";
+import { ENFORCEMENT_LEVEL_MAP, MECHANISM_MAP } from "./constants";
 import {
   defaultInitialValues,
   transformPrivacyNoticeResponseToCreation,
@@ -51,7 +51,10 @@ const CONSENT_MECHANISM_OPTIONS = enumToOptions(ConsentMechanism).map(
   })
 );
 
-const ENFORCEMENT_OPTIONS = enumToOptions(EnforcementLevel);
+const ENFORCEMENT_OPTIONS = enumToOptions(EnforcementLevel).map((opt) => ({
+  label: ENFORCEMENT_LEVEL_MAP.get(opt.label) || opt.label,
+  value: opt.value,
+}));
 
 const REGION_OPTIONS = enumToOptions(PrivacyNoticeRegion);
 

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -24,6 +24,8 @@ import {
   getErrorMessage,
   isErrorResult,
 } from "~/features/common/helpers";
+import { PRIVACY_NOTICES_ROUTE } from "~/features/common/nav/v2/routes";
+import { errorToastParams, successToastParams } from "~/features/common/toast";
 import {
   selectDataUseOptions,
   useGetAllDataUsesQuery,
@@ -34,8 +36,6 @@ import {
   PrivacyNoticeResponse,
 } from "~/types/api";
 
-import { PRIVACY_NOTICES_ROUTE } from "../common/nav/v2/routes";
-import { errorToastParams, successToastParams } from "../common/toast";
 import ConsentMechanismForm from "./ConsentMechanismForm";
 import {
   defaultInitialValues,

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -1,7 +1,8 @@
-import { Box } from "@fidesui/react";
+import { Button, ButtonGroup, Stack } from "@fidesui/react";
 
 import { PrivacyNoticeResponse } from "~/types/api";
 
+import FormSection from "../common/form/FormSection";
 import {
   defaultInitialValues,
   transformPrivacyNoticeResponseToCreation,
@@ -16,7 +17,25 @@ const PrivacyNoticeForm = ({
     ? transformPrivacyNoticeResponseToCreation(passedInPrivacyNotice)
     : defaultInitialValues;
 
-  return <Box>{initialValues.name}</Box>;
+  return (
+    <Stack spacing={10}>
+      <Stack spacing={6}>
+        <FormSection title="Privacy notice information">
+          {initialValues.name}
+        </FormSection>
+        <FormSection title="Consent mechanism">
+          {initialValues.consent_mechanism}
+        </FormSection>
+        <FormSection title="Privacy notice configuration">
+          {initialValues.data_uses}
+        </FormSection>
+      </Stack>
+      <ButtonGroup size="sm" spacing={4}>
+        <Button variant="outline">Cancel</Button>
+        <Button colorScheme="primary">Save</Button>
+      </ButtonGroup>
+    </Stack>
+  );
 };
 
 export default PrivacyNoticeForm;

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -1,0 +1,22 @@
+import { Box } from "@fidesui/react";
+
+import { PrivacyNoticeResponse } from "~/types/api";
+
+import {
+  defaultInitialValues,
+  transformPrivacyNoticeResponseToCreation,
+} from "./form";
+
+const PrivacyNoticeForm = ({
+  privacyNotice: passedInPrivacyNotice,
+}: {
+  privacyNotice?: PrivacyNoticeResponse;
+}) => {
+  const initialValues = passedInPrivacyNotice
+    ? transformPrivacyNoticeResponseToCreation(passedInPrivacyNotice)
+    : defaultInitialValues;
+
+  return <Box>{initialValues.name}</Box>;
+};
+
+export default PrivacyNoticeForm;

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -1,15 +1,45 @@
-import { Button, ButtonGroup, Stack } from "@fidesui/react";
+import { Box, Button, ButtonGroup, HStack, Stack, Text } from "@fidesui/react";
 import { Form, Formik } from "formik";
 import { useRouter } from "next/router";
 
+import { useAppSelector } from "~/app/hooks";
 import FormSection from "~/features/common/form/FormSection";
-import { PrivacyNoticeCreation, PrivacyNoticeResponse } from "~/types/api";
+import {
+  CustomSelect,
+  CustomSwitch,
+  CustomTextArea,
+  CustomTextInput,
+} from "~/features/common/form/inputs";
+import { enumToOptions } from "~/features/common/helpers";
+import {
+  selectDataUseOptions,
+  useGetAllDataUsesQuery,
+} from "~/features/data-use/data-use.slice";
+import {
+  ConsentMechanism,
+  EnforcementLevel,
+  PrivacyNoticeCreation,
+  PrivacyNoticeRegion,
+  PrivacyNoticeResponse,
+} from "~/types/api";
 
+import { MECHANISM_MAP } from "./constants";
 import {
   defaultInitialValues,
   transformPrivacyNoticeResponseToCreation,
   ValidationSchema,
 } from "./form";
+
+const CONSENT_MECHANISM_OPTIONS = enumToOptions(ConsentMechanism).map(
+  (opt) => ({
+    label: MECHANISM_MAP.get(opt.label) || opt.label,
+    value: opt.value,
+  })
+);
+
+const ENFORCEMENT_OPTIONS = enumToOptions(EnforcementLevel);
+
+const REGION_OPTIONS = enumToOptions(PrivacyNoticeRegion);
 
 const PrivacyNoticeForm = ({
   privacyNotice: passedInPrivacyNotice,
@@ -20,6 +50,9 @@ const PrivacyNoticeForm = ({
   const initialValues = passedInPrivacyNotice
     ? transformPrivacyNoticeResponseToCreation(passedInPrivacyNotice)
     : defaultInitialValues;
+
+  useGetAllDataUsesQuery();
+  const dataUseOptions = useAppSelector(selectDataUseOptions);
 
   const handleSubmit = (values: PrivacyNoticeCreation) => {
     console.log({ values });
@@ -37,13 +70,86 @@ const PrivacyNoticeForm = ({
           <Stack spacing={10}>
             <Stack spacing={6}>
               <FormSection title="Privacy notice details">
-                {initialValues.name}
+                <CustomTextInput
+                  label="Title of the consent notice as displayed to the user"
+                  name="name"
+                  variant="stacked"
+                />
+                <CustomTextArea
+                  label="Privacy notice displayed to the user"
+                  name="description"
+                  variant="stacked"
+                />
               </FormSection>
               <FormSection title="Consent mechanism">
-                {initialValues.consent_mechanism}
+                <CustomSelect
+                  label="If this use of data requires consent, you can specify the method of consent here."
+                  name="consent_mechanism"
+                  options={CONSENT_MECHANISM_OPTIONS}
+                  variant="stacked"
+                />
+                <CustomSelect
+                  label="Select the enforcement level for this consent mechanism"
+                  name="enforcement_level"
+                  options={ENFORCEMENT_OPTIONS}
+                  variant="stacked"
+                />
+                <Box>
+                  <Text fontSize="sm" fontWeight="medium" mb={2}>
+                    Configure whether this notice conforms to the Global Privacy
+                    Control.
+                  </Text>
+                  <CustomSwitch
+                    label="GPC Enabled"
+                    name="has_gpc_flag"
+                    variant="condensed"
+                  />
+                </Box>
               </FormSection>
               <FormSection title="Privacy notice configuration">
-                {initialValues.data_uses}
+                <CustomSelect
+                  name="data_uses"
+                  label="Data uses associated with this privacy notice"
+                  options={dataUseOptions}
+                  variant="stacked"
+                  isMulti
+                />
+                {/* TODO: this one doesn't exist in the backend yet */}
+                <CustomTextArea
+                  label="Description of the privacy notice (visible to internal users only)"
+                  name="internal_description"
+                  variant="stacked"
+                />
+                <CustomSelect
+                  name="regions"
+                  label="Locations where consent notice is shown to visitors"
+                  options={REGION_OPTIONS}
+                  variant="stacked"
+                  isMulti
+                />
+                <Box>
+                  <Text fontSize="sm" fontWeight="medium" mb={2}>
+                    Configure the user experience for how this notice is
+                    displayed
+                  </Text>
+                  <HStack justifyContent="space-between">
+                    <CustomSwitch
+                      label="Show in Privacy Preference Center"
+                      name="displayed_in_privacy_center"
+                      variant="condensed"
+                    />
+                    <CustomSwitch
+                      label="Show in Banner"
+                      name="displayed_in_privacy_modal"
+                      variant="condensed"
+                    />
+                    <CustomSwitch
+                      label="Show in Privacy Modal"
+                      name="displayed_in_banner"
+                      variant="condensed"
+                    />
+                  </HStack>
+                </Box>
               </FormSection>
             </Stack>
             <ButtonGroup size="sm" spacing={2}>

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -1,11 +1,14 @@
 import { Button, ButtonGroup, Stack } from "@fidesui/react";
+import { Form, Formik } from "formik";
+import { useRouter } from "next/router";
 
-import { PrivacyNoticeResponse } from "~/types/api";
+import FormSection from "~/features/common/form/FormSection";
+import { PrivacyNoticeCreation, PrivacyNoticeResponse } from "~/types/api";
 
-import FormSection from "../common/form/FormSection";
 import {
   defaultInitialValues,
   transformPrivacyNoticeResponseToCreation,
+  ValidationSchema,
 } from "./form";
 
 const PrivacyNoticeForm = ({
@@ -13,28 +16,60 @@ const PrivacyNoticeForm = ({
 }: {
   privacyNotice?: PrivacyNoticeResponse;
 }) => {
+  const router = useRouter();
   const initialValues = passedInPrivacyNotice
     ? transformPrivacyNoticeResponseToCreation(passedInPrivacyNotice)
     : defaultInitialValues;
 
+  const handleSubmit = (values: PrivacyNoticeCreation) => {
+    console.log({ values });
+  };
+
   return (
-    <Stack spacing={10}>
-      <Stack spacing={6}>
-        <FormSection title="Privacy notice information">
-          {initialValues.name}
-        </FormSection>
-        <FormSection title="Consent mechanism">
-          {initialValues.consent_mechanism}
-        </FormSection>
-        <FormSection title="Privacy notice configuration">
-          {initialValues.data_uses}
-        </FormSection>
-      </Stack>
-      <ButtonGroup size="sm" spacing={4}>
-        <Button variant="outline">Cancel</Button>
-        <Button colorScheme="primary">Save</Button>
-      </ButtonGroup>
-    </Stack>
+    <Formik
+      initialValues={initialValues}
+      enableReinitialize
+      onSubmit={handleSubmit}
+      validationSchema={ValidationSchema}
+    >
+      {({ dirty, isValid, isSubmitting }) => (
+        <Form>
+          <Stack spacing={10}>
+            <Stack spacing={6}>
+              <FormSection title="Privacy notice details">
+                {initialValues.name}
+              </FormSection>
+              <FormSection title="Consent mechanism">
+                {initialValues.consent_mechanism}
+              </FormSection>
+              <FormSection title="Privacy notice configuration">
+                {initialValues.data_uses}
+              </FormSection>
+            </Stack>
+            <ButtonGroup size="sm" spacing={2}>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  router.back();
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                isDisabled={isSubmitting || !dirty || !isValid}
+                isLoading={isSubmitting}
+                data-testid="save-btn"
+              >
+                Save
+              </Button>
+            </ButtonGroup>
+          </Stack>
+        </Form>
+      )}
+    </Formik>
   );
 };
 

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -29,8 +29,6 @@ import {
   useGetAllDataUsesQuery,
 } from "~/features/data-use/data-use.slice";
 import {
-  ConsentMechanism,
-  EnforcementLevel,
   PrivacyNoticeCreation,
   PrivacyNoticeRegion,
   PrivacyNoticeResponse,
@@ -38,7 +36,7 @@ import {
 
 import { PRIVACY_NOTICES_ROUTE } from "../common/nav/v2/routes";
 import { errorToastParams, successToastParams } from "../common/toast";
-import { ENFORCEMENT_LEVEL_MAP, MECHANISM_MAP } from "./constants";
+import ConsentMechanismForm from "./ConsentMechanismForm";
 import {
   defaultInitialValues,
   transformPrivacyNoticeResponseToCreation,
@@ -48,18 +46,6 @@ import {
   usePatchPrivacyNoticesMutation,
   usePostPrivacyNoticeMutation,
 } from "./privacy-notices.slice";
-
-const CONSENT_MECHANISM_OPTIONS = enumToOptions(ConsentMechanism).map(
-  (opt) => ({
-    label: MECHANISM_MAP.get(opt.label) || opt.label,
-    value: opt.value,
-  })
-);
-
-const ENFORCEMENT_OPTIONS = enumToOptions(EnforcementLevel).map((opt) => ({
-  label: ENFORCEMENT_LEVEL_MAP.get(opt.label) || opt.label,
-  value: opt.value,
-}));
 
 const REGION_OPTIONS = enumToOptions(PrivacyNoticeRegion);
 
@@ -131,31 +117,7 @@ const PrivacyNoticeForm = ({
                   variant="stacked"
                 />
               </FormSection>
-              <FormSection title="Consent mechanism">
-                <CustomSelect
-                  label="If this use of data requires consent, you can specify the method of consent here."
-                  name="consent_mechanism"
-                  options={CONSENT_MECHANISM_OPTIONS}
-                  variant="stacked"
-                />
-                <CustomSelect
-                  label="Select the enforcement level for this consent mechanism"
-                  name="enforcement_level"
-                  options={ENFORCEMENT_OPTIONS}
-                  variant="stacked"
-                />
-                <Box>
-                  <Text fontSize="sm" fontWeight="medium" mb={2}>
-                    Configure whether this notice conforms to the Global Privacy
-                    Control.
-                  </Text>
-                  <CustomSwitch
-                    label="GPC Enabled"
-                    name="has_gpc_flag"
-                    variant="condensed"
-                  />
-                </Box>
-              </FormSection>
+              <ConsentMechanismForm />
               <FormSection title="Privacy notice configuration">
                 <CustomSelect
                   name="data_uses"

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -137,7 +137,6 @@ const PrivacyNoticeForm = ({
                   variant="stacked"
                   isMulti
                 />
-                {/* TODO: this one doesn't exist in the backend yet */}
                 <CustomTextArea
                   label="Description of the privacy notice (visible to internal users only)"
                   name="internal_description"
@@ -163,12 +162,12 @@ const PrivacyNoticeForm = ({
                     />
                     <CustomSwitch
                       label="Show in Banner"
-                      name="displayed_in_privacy_modal"
+                      name="displayed_in_api"
                       variant="condensed"
                     />
                     <CustomSwitch
                       label="Show in Privacy Modal"
-                      name="displayed_in_banner"
+                      name="displayed_in_overlay"
                       variant="condensed"
                     />
                   </HStack>

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -152,12 +152,12 @@ const PrivacyNoticeForm = ({
                       variant="condensed"
                     />
                     <CustomSwitch
-                      label="Show in Banner"
+                      label="API Only"
                       name="displayed_in_api"
                       variant="condensed"
                     />
                     <CustomSwitch
-                      label="Show in Privacy Modal"
+                      label="Show in Privacy Overlay"
                       name="displayed_in_overlay"
                       variant="condensed"
                     />

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
@@ -12,6 +12,7 @@ import {
   Thead,
   Tr,
 } from "@fidesui/react";
+import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { ReactNode, useMemo } from "react";
 import { Column, useSortBy, useTable } from "react-table";
@@ -186,13 +187,15 @@ const PrivacyNoticesTable = () => {
           <Tr>
             <Td colSpan={columns.length} px={4} py={3.5}>
               <Restrict scopes={[ScopeRegistryEnum.PRIVACY_NOTICE_CREATE]}>
-                <Button
-                  size="xs"
-                  colorScheme="primary"
-                  data-testid="add-privacy-notice-btn"
-                >
-                  Add a privacy notice +
-                </Button>
+                <NextLink href={`${PRIVACY_NOTICES_ROUTE}/new`}>
+                  <Button
+                    size="xs"
+                    colorScheme="primary"
+                    data-testid="add-privacy-notice-btn"
+                  >
+                    Add a privacy notice +
+                  </Button>
+                </NextLink>
               </Restrict>
             </Td>
           </Tr>

--- a/clients/admin-ui/src/features/privacy-notices/constants.ts
+++ b/clients/admin-ui/src/features/privacy-notices/constants.ts
@@ -1,11 +1,11 @@
 export const MECHANISM_MAP = new Map([
   ["opt_in", "Opt in"],
-  ["notice_only", "Consent not necessary"],
+  ["notice_only", "Notice only"],
   ["opt_out", "Opt out"],
 ]);
 
 export const ENFORCEMENT_LEVEL_MAP = new Map([
   ["system_wide", "System wide"],
-  ["frontend", "Frontend"],
+  ["frontend", "Front end"],
   ["not_applicable", "Not applicable"],
 ]);

--- a/clients/admin-ui/src/features/privacy-notices/constants.ts
+++ b/clients/admin-ui/src/features/privacy-notices/constants.ts
@@ -1,5 +1,11 @@
 export const MECHANISM_MAP = new Map([
-  ["opt_in", "Opt In"],
-  ["necessary", "Necessary"],
-  ["opt_out", "Opt Out"],
+  ["opt_in", "Opt in"],
+  ["notice_only", "Consent not necessary"],
+  ["opt_out", "Opt out"],
+]);
+
+export const ENFORCEMENT_LEVEL_MAP = new Map([
+  ["system_wide", "System wide"],
+  ["frontend", "Frontend"],
+  ["not_applicable", "Not applicable"],
 ]);

--- a/clients/admin-ui/src/features/privacy-notices/form.ts
+++ b/clients/admin-ui/src/features/privacy-notices/form.ts
@@ -18,7 +18,14 @@ export const defaultInitialValues: PrivacyNoticeCreation = {
 export const transformPrivacyNoticeResponseToCreation = (
   notice: PrivacyNoticeResponse
 ): PrivacyNoticeCreation => {
-  const { created_at: createdAt, updated_at: updatedAt, ...rest } = notice;
+  // Remove the fields not needed for editing/creation
+  const {
+    created_at: createdAt,
+    updated_at: updatedAt,
+    privacy_notice_history_id: historyId,
+    version,
+    ...rest
+  } = notice;
   return {
     ...rest,
     name: notice.name ?? defaultInitialValues.name,

--- a/clients/admin-ui/src/features/privacy-notices/form.ts
+++ b/clients/admin-ui/src/features/privacy-notices/form.ts
@@ -1,3 +1,5 @@
+import * as Yup from "yup";
+
 import {
   ConsentMechanism,
   EnforcementLevel,
@@ -24,4 +26,14 @@ export const transformPrivacyNoticeResponseToCreation = (
   data_uses: notice.data_uses ?? defaultInitialValues.data_uses,
   enforcement_level:
     notice.enforcement_level ?? defaultInitialValues.enforcement_level,
+});
+
+export const ValidationSchema = Yup.object().shape({
+  name: Yup.string().required().label("Title"),
+  data_uses: Yup.array(Yup.string())
+    .min(1, "Must assign at least one data use")
+    .label("Data uses"),
+  regions: Yup.array(Yup.string())
+    .min(1, "Must assign at least one location")
+    .label("Locations"),
 });

--- a/clients/admin-ui/src/features/privacy-notices/form.ts
+++ b/clients/admin-ui/src/features/privacy-notices/form.ts
@@ -13,6 +13,10 @@ export const defaultInitialValues: PrivacyNoticeCreation = {
   consent_mechanism: ConsentMechanism.OPT_IN,
   data_uses: [],
   enforcement_level: EnforcementLevel.SYSTEM_WIDE,
+  // Match backend defaults
+  displayed_in_api: true,
+  displayed_in_overlay: true,
+  displayed_in_privacy_center: true,
 };
 
 export const transformPrivacyNoticeResponseToCreation = (

--- a/clients/admin-ui/src/features/privacy-notices/form.ts
+++ b/clients/admin-ui/src/features/privacy-notices/form.ts
@@ -1,0 +1,27 @@
+import {
+  ConsentMechanism,
+  EnforcementLevel,
+  PrivacyNoticeCreation,
+  PrivacyNoticeResponse,
+} from "~/types/api";
+
+export const defaultInitialValues: PrivacyNoticeCreation = {
+  name: "",
+  regions: [],
+  consent_mechanism: ConsentMechanism.OPT_IN,
+  data_uses: [],
+  enforcement_level: EnforcementLevel.SYSTEM_WIDE,
+};
+
+export const transformPrivacyNoticeResponseToCreation = (
+  notice: PrivacyNoticeResponse
+): PrivacyNoticeCreation => ({
+  ...notice,
+  name: notice.name ?? defaultInitialValues.name,
+  regions: notice.regions ?? defaultInitialValues.regions,
+  consent_mechanism:
+    notice.consent_mechanism ?? defaultInitialValues.consent_mechanism,
+  data_uses: notice.data_uses ?? defaultInitialValues.data_uses,
+  enforcement_level:
+    notice.enforcement_level ?? defaultInitialValues.enforcement_level,
+});

--- a/clients/admin-ui/src/features/privacy-notices/form.ts
+++ b/clients/admin-ui/src/features/privacy-notices/form.ts
@@ -17,16 +17,19 @@ export const defaultInitialValues: PrivacyNoticeCreation = {
 
 export const transformPrivacyNoticeResponseToCreation = (
   notice: PrivacyNoticeResponse
-): PrivacyNoticeCreation => ({
-  ...notice,
-  name: notice.name ?? defaultInitialValues.name,
-  regions: notice.regions ?? defaultInitialValues.regions,
-  consent_mechanism:
-    notice.consent_mechanism ?? defaultInitialValues.consent_mechanism,
-  data_uses: notice.data_uses ?? defaultInitialValues.data_uses,
-  enforcement_level:
-    notice.enforcement_level ?? defaultInitialValues.enforcement_level,
-});
+): PrivacyNoticeCreation => {
+  const { created_at: createdAt, updated_at: updatedAt, ...rest } = notice;
+  return {
+    ...rest,
+    name: notice.name ?? defaultInitialValues.name,
+    regions: notice.regions ?? defaultInitialValues.regions,
+    consent_mechanism:
+      notice.consent_mechanism ?? defaultInitialValues.consent_mechanism,
+    data_uses: notice.data_uses ?? defaultInitialValues.data_uses,
+    enforcement_level:
+      notice.enforcement_level ?? defaultInitialValues.enforcement_level,
+  };
+};
 
 export const ValidationSchema = Yup.object().shape({
   name: Yup.string().required().label("Title"),

--- a/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
+++ b/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
@@ -4,6 +4,7 @@ import type { RootState } from "~/app/store";
 import { baseApi } from "~/features/common/api.slice";
 import {
   Page_PrivacyNoticeResponse_,
+  PrivacyNoticeCreation,
   PrivacyNoticeRegion,
   PrivacyNoticeResponse,
 } from "~/types/api";
@@ -58,6 +59,17 @@ const privacyNoticesApi = baseApi.injectEndpoints({
         { type: "PrivacyNotices", id: arg },
       ],
     }),
+    postPrivacyNotice: build.mutation<
+      PrivacyNoticeResponse[],
+      PrivacyNoticeCreation[]
+    >({
+      query: (payload) => ({
+        method: "POST",
+        url: `privacy-notice/`,
+        body: payload,
+      }),
+      invalidatesTags: () => ["PrivacyNotices"],
+    }),
   }),
 });
 
@@ -65,6 +77,7 @@ export const {
   useGetAllPrivacyNoticesQuery,
   usePatchPrivacyNoticesMutation,
   useGetPrivacyNoticeByIdQuery,
+  usePostPrivacyNoticeMutation,
 } = privacyNoticesApi;
 
 export const privacyNoticesSlice = createSlice({

--- a/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
+++ b/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
@@ -50,11 +50,22 @@ const privacyNoticesApi = baseApi.injectEndpoints({
       }),
       invalidatesTags: () => ["PrivacyNotices"],
     }),
+    getPrivacyNoticeById: build.query<PrivacyNoticeResponse, string>({
+      query: (id) => ({
+        url: `privacy-notice/${id}`,
+      }),
+      providesTags: (result, error, arg) => [
+        { type: "PrivacyNotices", id: arg },
+      ],
+    }),
   }),
 });
 
-export const { useGetAllPrivacyNoticesQuery, usePatchPrivacyNoticesMutation } =
-  privacyNoticesApi;
+export const {
+  useGetAllPrivacyNoticesQuery,
+  usePatchPrivacyNoticesMutation,
+  useGetPrivacyNoticeByIdQuery,
+} = privacyNoticesApi;
 
 export const privacyNoticesSlice = createSlice({
   name: "privacyNotices",

--- a/clients/admin-ui/src/pages/consent/privacy-notices/[id].tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/[id].tsx
@@ -79,7 +79,7 @@ const PrivacyNoticeDetailPage = () => {
           </Breadcrumb>
         </Box>
       </Box>
-      <Box width={{ base: "100%", lg: "50%" }}>
+      <Box width={{ base: "100%", lg: "70%" }}>
         <Text fontSize="sm" mb={8}>
           Configure your privacy notice including consent mechanism, associated
           data uses and the locations in which this should be displayed to

--- a/clients/admin-ui/src/pages/consent/privacy-notices/[id].tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/[id].tsx
@@ -1,7 +1,20 @@
-import { Box } from "@fidesui/react";
+import { PRIVACY_REQUESTS_ROUTE } from "@fidesui/components";
+import {
+  Box,
+  Breadcrumb,
+  BreadcrumbItem,
+  Center,
+  Heading,
+  Spinner,
+  Text,
+} from "@fidesui/react";
+import NextLink from "next/link";
 import { useRouter } from "next/router";
 
 import Layout from "~/features/common/Layout";
+import { PRIVACY_NOTICES_ROUTE } from "~/features/common/nav/v2/routes";
+import { useGetPrivacyNoticeByIdQuery } from "~/features/privacy-notices/privacy-notices.slice";
+import PrivacyNoticeForm from "~/features/privacy-notices/PrivacyNoticeForm";
 
 const PrivacyNoticeDetailPage = () => {
   const router = useRouter();
@@ -13,10 +26,68 @@ const PrivacyNoticeDetailPage = () => {
       : router.query.id;
   }
 
+  const { data, isLoading } = useGetPrivacyNoticeByIdQuery(noticeId);
+
+  if (isLoading) {
+    return (
+      <Layout title="Privacy notice">
+        <Center>
+          <Spinner />
+        </Center>
+      </Layout>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Layout title="Privacy notice">
+        <Text>No privacy notice with id {noticeId} found.</Text>
+      </Layout>
+    );
+  }
+
   return (
-    <Layout title={`Privacy notice ${noticeId}`}>
-      <Box data-testid="privacy-notice-detail-page">
-        Work in progress, stay tuned!
+    <Layout title={`Privacy notice ${data.name}`}>
+      <Box mb={4}>
+        <Heading
+          fontSize="2xl"
+          fontWeight="semibold"
+          mb={2}
+          data-testid="header"
+        >
+          {data.name}
+        </Heading>
+        <Box>
+          <Breadcrumb
+            fontWeight="medium"
+            fontSize="sm"
+            color="gray.600"
+            data-testid="breadcrumbs"
+          >
+            <BreadcrumbItem>
+              <NextLink href={PRIVACY_REQUESTS_ROUTE}>
+                Privacy requests
+              </NextLink>
+            </BreadcrumbItem>
+            {/* TODO: Add Consent breadcrumb once the page exists */}
+            <BreadcrumbItem>
+              <NextLink href={PRIVACY_NOTICES_ROUTE}>Privacy notices</NextLink>
+            </BreadcrumbItem>
+            <BreadcrumbItem color="complimentary.500">
+              <NextLink href="#">{data.name}</NextLink>
+            </BreadcrumbItem>
+          </Breadcrumb>
+        </Box>
+      </Box>
+      <Box width={{ base: "100%", lg: "50%" }}>
+        <Text fontSize="sm" mb={8}>
+          Configure your privacy notice including consent mechanism, associated
+          data uses and the locations in which this should be displayed to
+          users.
+        </Text>
+        <Box data-testid="privacy-notice-detail-page">
+          <PrivacyNoticeForm privacyNotice={data} />
+        </Box>
       </Box>
     </Layout>
   );

--- a/clients/admin-ui/src/pages/consent/privacy-notices/new.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/new.tsx
@@ -1,0 +1,47 @@
+import { PRIVACY_REQUESTS_ROUTE } from "@fidesui/components";
+import { Box, Breadcrumb, BreadcrumbItem, Heading, Text } from "@fidesui/react";
+import NextLink from "next/link";
+
+import Layout from "~/features/common/Layout";
+import { PRIVACY_NOTICES_ROUTE } from "~/features/common/nav/v2/routes";
+import PrivacyNoticeForm from "~/features/privacy-notices/PrivacyNoticeForm";
+
+const NewPrivacyNoticePage = () => (
+  <Layout title="New privacy notice">
+    <Box mb={4}>
+      <Heading fontSize="2xl" fontWeight="semibold" mb={2} data-testid="header">
+        New privacy notice
+      </Heading>
+      <Box>
+        <Breadcrumb
+          fontWeight="medium"
+          fontSize="sm"
+          color="gray.600"
+          data-testid="breadcrumbs"
+        >
+          <BreadcrumbItem>
+            <NextLink href={PRIVACY_REQUESTS_ROUTE}>Privacy requests</NextLink>
+          </BreadcrumbItem>
+          {/* TODO: Add Consent breadcrumb once the page exists */}
+          <BreadcrumbItem>
+            <NextLink href={PRIVACY_NOTICES_ROUTE}>Privacy notices</NextLink>
+          </BreadcrumbItem>
+          <BreadcrumbItem color="complimentary.500">
+            <NextLink href="#">New notice</NextLink>
+          </BreadcrumbItem>
+        </Breadcrumb>
+      </Box>
+    </Box>
+    <Box width={{ base: "100%", lg: "70%" }}>
+      <Text fontSize="sm" mb={8}>
+        Configure your privacy notice including consent mechanism, associated
+        data uses and the locations in which this should be displayed to users.
+      </Text>
+      <Box data-testid="new-privacy-notice-page">
+        <PrivacyNoticeForm />
+      </Box>
+    </Box>
+  </Layout>
+);
+
+export default NewPrivacyNoticePage;

--- a/clients/admin-ui/src/pages/consent/privacy-notices/new.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/new.tsx
@@ -22,7 +22,7 @@ const NewPrivacyNoticePage = () => (
           <BreadcrumbItem>
             <NextLink href={PRIVACY_REQUESTS_ROUTE}>Privacy requests</NextLink>
           </BreadcrumbItem>
-          {/* TODO: Add Consent breadcrumb once the page exists */}
+         
           <BreadcrumbItem>
             <NextLink href={PRIVACY_NOTICES_ROUTE}>Privacy notices</NextLink>
           </BreadcrumbItem>

--- a/clients/admin-ui/src/pages/consent/privacy-notices/new.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/new.tsx
@@ -22,7 +22,6 @@ const NewPrivacyNoticePage = () => (
           <BreadcrumbItem>
             <NextLink href={PRIVACY_REQUESTS_ROUTE}>Privacy requests</NextLink>
           </BreadcrumbItem>
-         
           <BreadcrumbItem>
             <NextLink href={PRIVACY_NOTICES_ROUTE}>Privacy notices</NextLink>
           </BreadcrumbItem>


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/749

### Code Changes

* [x] New `<FormSection />` component to help out with the UI of the new forms
* [x] Formik form for privacy notice form, was mostly able to reuse our existing form components
* [x] Page for a new privacy notice form, which reuses the same component
* [x] Form can handle both edit and create
* [x] Pulled some cypress helper commands into their own file. This was previously a TODO, and it helped a lot to write the tests here, so I did in this PR, though it's not directly related. It's all in its own commit here: https://github.com/ethyca/fides/pull/3058/commits/128d168b70f0b03a4bc607f979719bb17f707285
* [x] Cypress tests

### Steps to Confirm

* Run with fidesplus edge (`nox -s fides_env -- prod_edge `) and dev server for admin-ui
* Follow the steps [here](https://github.com/ethyca/fides/pull/3001) for populating your db with privacy notices
* Once you have notices populating in your table, you should be able to click into one to edit the form
  * You should be able to save changes, refresh the page, and see your changes persist
  * If you change a consent mechanism to "notice only", the "GPC Enabled" toggle and the "Enforcement Level" should become disabled, with "GPC Enabled" toggling off, and "Enforcement Level" becoming "Not applicable"
* You should also be able to add an entirely new privacy notice
  * Note that you'll see a success toast after creation, but you likely won't see it show up in the table. to make it show up in the table, you'll need to add the data use the notice you just created uses to an existing system. This is under further design/product consideration but we decided to PR this first

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
  * [x] Tracking a few things that'll need to be addressed here in [this confluence doc](https://ethyca.atlassian.net/wiki/spaces/EN/pages/2667151659/Consent+Standup) which we can make tickets for once decisions are made
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

https://www.loom.com/share/dbcbaca1e7194c26bb91bf52e184fe4a
