### PR TITLE
Fix mount location for dev privacy center

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - "3001:3000"
     volumes:
       - type: bind
-        source: ./src/fides/data/test_env/privacy_center_config
+        source: ./src/fides/data/sample_project/privacy_center/config
         target: /app/config
         read_only: False
 


### PR DESCRIPTION
### Code Changes

* [X] Fix mount location for dev privacy center `config.json` to mount the sample project config

### Steps to Confirm

* [X] Run `nox -s quickstart` to fully exercise the dev environment setup

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* ~[ ] Update `CHANGELOG.md`~
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This is a regression for the development environment introduced by https://github.com/ethyca/fides/pull/3017. Obvious mistake is obvious!