### PR TITLE
Reverting the usage of narrows

### DIFF
--- a/clients/admin-ui/src/types/api/models/ConnectionSystemTypeMap.ts
+++ b/clients/admin-ui/src/types/api/models/ConnectionSystemTypeMap.ts
@@ -2,7 +2,6 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { narrow } from "narrow-minded";
 import type { ConnectionType } from "./ConnectionType";
 import type { SystemType } from "./SystemType";
 
@@ -17,11 +16,6 @@ export type ConnectionSystemTypeMap = {
 };
 
 export const isConnectionSystemTypeMap = (
-  obj: unknown
+  obj: any
 ): obj is ConnectionSystemTypeMap =>
-  narrow(
-    {
-      encoded_icon: "string",
-    },
-    obj
-  );
+  (obj as ConnectionSystemTypeMap).encoded_icon !== undefined;


### PR DESCRIPTION
Closes #3062

### Code Changes

* [ ] Reverting the usage of `narrows`

### Steps to Confirm

* [ ] Verified all icons render correctly in the datastore connection screens

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

I was using `narrows` but the library checks that `encoded_icon` is defined and populated, but I just need to check that `encoded_icon` is not undefined.
