### PR TITLE
** don't merge ** -- update release publishing

### DIFF
--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -35,19 +35,32 @@ jobs:
         run: nox -s "push(dev)"
 
       - name: Check Prod Tag
-        id: check-tag
+        id: check-prod-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+              echo "match=true" >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=match::false
+              echo "match=false" >> $GITHUB_OUTPUT
           fi
+      - name: Check RC Tag
+        id: check-rc-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)$ ]]; then
+              echo "match=true" >> $GITHUB_OUTPUT
+          else
+              echo "match=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Push Fides Prod Tags
-        if: steps.check-tag.outputs.match == 'true'
+        if: steps.check-prod-tag.outputs.match == 'true'
         run: nox -s "push(prod)"
 
-      # if not a prod tag, then we run the git-tag job to publish images with a git tag
+      - name: Push Fides RC Tags
+        if: steps.check-rc-tag.outputs.match == 'true'
+        run: nox -s "push(rc)"
+
+      # if not a prod or RC tag, then we run the git-tag job to publish images with a git tag
       # if one exists on the current commit. the job is a no-op if the commit hasn't been tagged
       - name: Push Fides Commit Tags
-        if: steps.check-tag.outputs.match == 'false'
+        if: steps.check-prod-tag.outputs.match == 'false'
         run: nox -s "push(git-tag)"

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -48,16 +48,17 @@ jobs:
       - name: Build the wheel
         run: python setup.py bdist_wheel
 
-      # If the tag matches either a release tag or a beta tag, allow publishing to PyPi, e.g.:
+      # If the tag matches either a release, beta or RC tag, allow publishing to PyPi, e.g.:
       #   2.10.0 --> match (production release tag)
       #   2.10.0b1 --> match (beta release tag, used on main)
+      #   2.10.0rc1 --> match (RC release tag, used on release branches)
       #   2.10.0.a0 --> no match (alpha tag, used on feature branches)
       #   2.10.0.dev0 --> no match (arbitrary development tag)
       - name: Check Prod Tag
         id: check-tag
         run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+(b[0-9]*)?$ ]]; then
-              echo ::set-output name=match::true
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+((b|rc)[0-9]*)?$ ]]; then
+              echo "match=true" >> $GITHUB_OUTPUT
           fi
 
       # We don't upload to Test PyPI if it is a real release

--- a/noxfiles/constants_nox.py
+++ b/noxfiles/constants_nox.py
@@ -32,7 +32,6 @@ IMAGE_NAME = "fides"
 IMAGE = f"{REGISTRY}/{IMAGE_NAME}"
 IMAGE_LOCAL = f"{IMAGE}:local"
 IMAGE_LOCAL_UI = f"{IMAGE}:local-ui"
-IMAGE_DEV = f"{IMAGE}:dev"
 IMAGE_LATEST = f"{IMAGE}:latest"
 
 # Image names for the secondary apps

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -5,7 +5,6 @@ from typing import List
 import nox
 from constants_nox import (
     IMAGE,
-    IMAGE_DEV,
     IMAGE_LATEST,
     IMAGE_LOCAL,
     IMAGE_LOCAL_UI,
@@ -147,6 +146,7 @@ def build(session: nox.Session, image: str, machine_type: str = "") -> None:
     "tag",
     [
         nox.param("prod", id="prod"),
+        nox.param("rc", id="rc"),
         nox.param("dev", id="dev"),
         nox.param("git-tag", id="git-tag"),
     ],
@@ -161,6 +161,7 @@ def push(session: nox.Session, tag: str) -> None:
     Params:
 
     prod - Tags images with the current version of the application
+    rc - Tags images with `rc`
     dev - Tags images with `dev`
     git-tag - Tags images with the git tag of the current commit, if it exists
 
@@ -170,16 +171,24 @@ def push(session: nox.Session, tag: str) -> None:
     privacy_center_prod = f"{PRIVACY_CENTER_IMAGE}:{get_current_tag()}"
     sample_app_prod = f"{SAMPLE_APP_IMAGE}:{get_current_tag()}"
 
-    if tag == "dev":
-        # Push the ethyca/fides image, tagging with :dev
-        session.run("docker", "tag", fides_image_prod, IMAGE_DEV, external=True)
-        session.run("docker", "push", IMAGE_DEV, external=True)
+    def push_images_non_prod(
+        tag_suffix: str,  # e.g. `:dev`, `:rc`, `:{some_git_tag}`
+    ):
+        """
+        Consolidate logic for pushing docker images with non-prod tags,
+        e.g. `:dev`, `:rc`, `:{some_git_tag}`
+        """
+        # Push the ethyca/fides image, tagging with :{tag_suffix}
+        session.run(
+            "docker", "tag", fides_image_prod, f"{IMAGE}:{tag_suffix}", external=True
+        )
+        session.run("docker", "push", f"{IMAGE}:{tag_suffix}", external=True)
 
-        # Push the extra images, tagging with :dev
-        #   - ethyca/fides-privacy-center:dev
-        #   - ethyca/fides-sample-app:dev
-        privacy_center_dev = f"{PRIVACY_CENTER_IMAGE}:dev"
-        sample_app_dev = f"{SAMPLE_APP_IMAGE}:dev"
+        # Push the extra images, tagging with :{tag_suffix}
+        #   - ethyca/fides-privacy-center:{tag_suffix}
+        #   - ethyca/fides-sample-app:{tag_suffix}
+        privacy_center_dev = f"{PRIVACY_CENTER_IMAGE}:{tag_suffix}"
+        sample_app_dev = f"{SAMPLE_APP_IMAGE}:{tag_suffix}"
         session.run(
             "docker", "tag", privacy_center_prod, privacy_center_dev, external=True
         )
@@ -187,11 +196,13 @@ def push(session: nox.Session, tag: str) -> None:
         session.run("docker", "tag", sample_app_prod, sample_app_dev, external=True)
         session.run("docker", "push", sample_app_dev, external=True)
 
+    if tag in ("dev", "rc"):
+        push_images_non_prod(tag)
     if tag == "git-tag":
         # if we have an existing git tag on the current commit, we push up
         # a set of images that's tagged specifically with this git tag.
         # this publishes images that correspond to commits that have been explicitly tagged,
-        # e.g. RC builds, `beta` tags on `main`, `alpha` tags for feature branch builds.
+        # e.g. `beta` tags on `main`, `alpha` tags for feature branch builds.
         existing_commit_tag = get_current_tag(existing=True)
         if existing_commit_tag is None:
             session.log(
@@ -208,22 +219,7 @@ def push(session: nox.Session, tag: str) -> None:
         session.log(
             f"Found git tag {existing_commit_tag} on the current commit, pushing corresponding git-tag images!"
         )
-        custom_image_tag = f"{IMAGE}:{existing_commit_tag}"
-        # Push the ethyca/fides image, tagging with :{current_head_git_tag}
-        session.run("docker", "tag", fides_image_prod, custom_image_tag, external=True)
-        session.run("docker", "push", custom_image_tag, external=True)
-
-        # Push the extra images, tagging with :{current_head_git_tag}
-        #   - ethyca/fides-privacy-center:{current_head_git_tag}
-        #   - ethyca/fides-sample-app:{current_head_git_tag}
-        privacy_center_dev = f"{PRIVACY_CENTER_IMAGE}:{existing_commit_tag}"
-        sample_app_dev = f"{SAMPLE_APP_IMAGE}:{existing_commit_tag}"
-        session.run(
-            "docker", "tag", privacy_center_prod, privacy_center_dev, external=True
-        )
-        session.run("docker", "push", privacy_center_dev, external=True)
-        session.run("docker", "tag", sample_app_prod, sample_app_dev, external=True)
-        session.run("docker", "push", sample_app_dev, external=True)
+        push_images_non_prod(existing_commit_tag)
 
     if tag == "prod":
         # Example: "ethyca/fides:2.0.0" and "ethyca/fides:latest"


### PR DESCRIPTION
⚠️ i don't think we want to merge this until we're done with the `2.11.0` release. doing so may cause disruptions to the ongoing release process

related to #2919

### Code Changes

* publish `rc` tags to pypi, not testpypi. this will allow us to pull in `rc` versions of `fides` into `fidesplus` via a "prod" build using `requirements.txt` rather than having to rely on edge builds, which are a bit less transparent and predictable
* publish docker images based on `rc` tags with an `ethyca-fides:rc` image tag, to allow for a _fixed_ tag that provides the latest RC docker image. this will help in automating the infra for an "rc testing" environment - it can point at this fixed tag, in the same way that our staging env points at the `:dev` tag currently
* update our use of `::set-output` in GH actions as that's being [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) shortly!

### Steps to Confirm

* it'll be a bit hard to test that this all works 100% smoothly until we have an rc tag to publish
* that being said, i did do _some_ manual testing with an [`alpha` feature tag](https://github.com/ethyca/fides/releases/tag/2.10.1a4). that published well. this was mainly a test of the general refactors that are part of this PR, not of the changes in logic specific to the RC tags. but the logic changes are _pretty_ straightforward, so hopefully no bugs there!🤞 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This would be part of some proposed changes to our release process on `fidesplus`, where instead of relying on edge builds for RC testing, we have specific RC artifacts that are explicitly and transparently tied to a particular rc tag on `fides` - via `requirements.txt`, not via an edge build. 