### PR TITLE
API endpoint for Consent reporting

### DIFF
--- a/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
@@ -135,9 +135,9 @@ def report_consent_requests(
     updated_lt: Optional[datetime] = None,
     updated_gt: Optional[datetime] = None,
 ) -> Union[StreamingResponse, AbstractPage[ConsentReport]]:
-    """Provides a paginated, sorted list of all consent requests."""
+    """Provides a paginated list of all consent requests sorted by the most recently updated."""
 
-    query = Consent.query(db)
+    query = Consent.query(db).order_by(Consent.updated_at.desc())
     query = _filter_consent(
         query,
         data_use,

--- a/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
@@ -143,18 +143,18 @@ def report_consent_requests(
         data_use,
         has_gpc_flag,
         opt_in,
-        created_gt,
         created_lt,
-        updated_gt,
+        created_gt,
         updated_lt,
+        updated_gt,
     )
     paginated = paginate(query, params)
-    paginated.items = [
+    paginated.items = [  # type: ignore
         _prepare_consent_report(
             db=db,
             consent=item,
         )
-        for item in paginated.items
+        for item in paginated.items  # type: ignore
     ]
     return paginated
 

--- a/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
@@ -83,14 +83,14 @@ def _filter_consent(
 ) -> Query:
     if data_use:
         query = query.filter(Consent.data_use == data_use)
-    if has_gpc_flag:
+    if has_gpc_flag is not None:
         query = query.filter(Consent.has_gpc_flag == has_gpc_flag)
-    if opt_in:
+    if opt_in is not None:
         query = query.filter(Consent.opt_in == opt_in)
 
     for end, start, field_name in [
         [created_lt, created_gt, "created"],
-        [updated_lt, updated_gt, "completed"],
+        [updated_lt, updated_gt, "updated"],
     ]:
         if end is None or start is None:
             continue
@@ -111,9 +111,9 @@ def _filter_consent(
     if created_gt:
         query = query.filter(Consent.created_at > created_gt)
     if updated_lt:
-        query = query.filter(Consent.created_at < created_lt)
+        query = query.filter(Consent.updated_at < updated_lt)
     if updated_gt:
-        query = query.filter(Consent.created_at > created_gt)
+        query = query.filter(Consent.updated_at > updated_gt)
     return query
 
 

--- a/src/fides/api/ops/models/privacy_request.py
+++ b/src/fides/api/ops/models/privacy_request.py
@@ -880,16 +880,18 @@ class ProvidedIdentity(Base):  # pylint: disable=R0904
     def as_identity_schema(self) -> Identity:
         """Creates an Identity schema from a ProvidedIdentity record in the application DB."""
         identity = Identity()
-        if any([
-            not self.field_name,
-            not self.encrypted_value,
-        ]):
+        if any(
+            [
+                not self.field_name,
+                not self.encrypted_value,
+            ]
+        ):
             return identity
 
         setattr(
             identity,
-            self.field_name.value,
-            self.encrypted_value.get("value"),
+            self.field_name.value,  # type:ignore
+            self.encrypted_value.get("value"),  # type:ignore
         )
         return identity
 

--- a/src/fides/api/ops/models/privacy_request.py
+++ b/src/fides/api/ops/models/privacy_request.py
@@ -47,7 +47,7 @@ from fides.api.ops.schemas.external_https import (
     WebhookJWE,
 )
 from fides.api.ops.schemas.masking.masking_secrets import MaskingSecretCache
-from fides.api.ops.schemas.redis_cache import Identity
+from fides.api.ops.schemas.redis_cache import Identity, IdentityBase
 from fides.api.ops.tasks import celery_app
 from fides.api.ops.util.cache import (
     FidesopsRedis,
@@ -877,9 +877,9 @@ class ProvidedIdentity(Base):  # pylint: disable=R0904
         )
         return hashed_value
 
-    def as_identity_schema(self) -> Identity:
+    def as_identity_schema(self) -> IdentityBase:
         """Creates an Identity schema from a ProvidedIdentity record in the application DB."""
-        identity = Identity()
+        identity = IdentityBase()
         if any(
             [
                 not self.field_name,

--- a/src/fides/api/ops/models/privacy_request.py
+++ b/src/fides/api/ops/models/privacy_request.py
@@ -877,6 +877,22 @@ class ProvidedIdentity(Base):  # pylint: disable=R0904
         )
         return hashed_value
 
+    def as_identity_schema(self) -> Identity:
+        """Creates an Identity schema from a ProvidedIdentity record in the application DB."""
+        identity = Identity()
+        if any([
+            not self.field_name,
+            not self.encrypted_value,
+        ]):
+            return identity
+
+        setattr(
+            identity,
+            self.field_name.value,
+            self.encrypted_value.get("value"),
+        )
+        return identity
+
 
 class Consent(Base):
     """The DB ORM model for Consent."""

--- a/src/fides/api/ops/schemas/privacy_request.py
+++ b/src/fides/api/ops/schemas/privacy_request.py
@@ -15,7 +15,7 @@ from fides.api.ops.models.privacy_request import (
 from fides.api.ops.schemas.api import BulkResponse, BulkUpdateFailed
 from fides.api.ops.schemas.base_class import BaseSchema
 from fides.api.ops.schemas.policy import PolicyResponse as PolicySchema
-from fides.api.ops.schemas.redis_cache import Identity
+from fides.api.ops.schemas.redis_cache import Identity, IdentityBase
 from fides.api.ops.util.encryption.aes_gcm_encryption_scheme import (
     verify_encryption_key,
 )

--- a/src/fides/api/ops/schemas/privacy_request.py
+++ b/src/fides/api/ops/schemas/privacy_request.py
@@ -66,7 +66,7 @@ class Consent(BaseSchema):
 class ConsentReport(Consent):
     """Schema for reporting Consent requests."""
 
-    identity: Identity
+    identity: IdentityBase
     created_at: datetime
     updated_at: datetime
 

--- a/src/fides/api/ops/schemas/privacy_request.py
+++ b/src/fides/api/ops/schemas/privacy_request.py
@@ -63,6 +63,14 @@ class Consent(BaseSchema):
     conflicts_with_gpc: bool = False
 
 
+class ConsentReport(Consent):
+    """Schema for reporting Consent requests."""
+
+    identity: Identity
+    created_at: datetime
+    updated_at: datetime
+
+
 class PrivacyRequestCreate(BaseSchema):
     """Data required to create a PrivacyRequest"""
 

--- a/src/fides/api/ops/schemas/redis_cache.py
+++ b/src/fides/api/ops/schemas/redis_cache.py
@@ -21,5 +21,13 @@ class IdentityBase(BaseSchema):
 class Identity(IdentityBase):
     """Some PII grouping pertaining to a human"""
 
+    # These are repeated so we can continue to forbid extra fields
+    phone_number: Optional[PhoneNumber] = None
+    email: Optional[EmailStr] = None
     ga_client_id: Optional[str] = None
     ljt_readerID: Optional[str] = None
+
+    class Config:
+        """Only allow phone_number, and email."""
+
+        extra = Extra.forbid

--- a/src/fides/api/ops/schemas/redis_cache.py
+++ b/src/fides/api/ops/schemas/redis_cache.py
@@ -6,11 +6,21 @@ from fides.api.custom_types import PhoneNumber
 from fides.api.ops.schemas.base_class import BaseSchema
 
 
-class Identity(BaseSchema):
-    """Some PII grouping pertaining to a human"""
+class IdentityBase(BaseSchema):
+    """The minimum fields required to represent an identity."""
 
     phone_number: Optional[PhoneNumber] = None
     email: Optional[EmailStr] = None
+
+    class Config:
+        """Only allow phone_number, and email."""
+
+        extra = Extra.forbid
+
+
+class Identity(IdentityBase):
+    """Some PII grouping pertaining to a human"""
+
     ga_client_id: Optional[str] = None
     ljt_readerID: Optional[str] = None
 

--- a/src/fides/api/ops/schemas/redis_cache.py
+++ b/src/fides/api/ops/schemas/redis_cache.py
@@ -23,8 +23,3 @@ class Identity(IdentityBase):
 
     ga_client_id: Optional[str] = None
     ljt_readerID: Optional[str] = None
-
-    class Config:
-        """Only allow phone_number, email, and GA client id to be supplied"""
-
-        extra = Extra.forbid

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -1845,6 +1845,13 @@ def system_manager(db: Session, system) -> System:
 
 
 @pytest.fixture(scope="function")
+def empty_provided_identity(db):
+    provided_identity = ProvidedIdentity.create(db, data={"field_name": "email"})
+    yield provided_identity
+    provided_identity.delete(db)
+
+
+@pytest.fixture(scope="function")
 def provided_identity_and_consent_request(db):
     provided_identity_data = {
         "privacy_request_id": None,

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Generator, List, Optional
@@ -40,6 +41,7 @@ from fides.api.ops.models.privacy_notice import (
 )
 from fides.api.ops.models.privacy_preference import PrivacyPreferenceHistory
 from fides.api.ops.models.privacy_request import (
+    Consent,
     ConsentRequest,
     PrivacyRequest,
     PrivacyRequestStatus,
@@ -1884,7 +1886,9 @@ def executable_consent_request(
 
 @pytest.fixture(scope="function")
 def privacy_preference_history(
-    db, provided_identity_and_consent_request, privacy_notice
+    db,
+    provided_identity_and_consent_request,
+    privacy_notice,
 ):
     provided_identity, consent_request = provided_identity_and_consent_request
     privacy_notice_history = privacy_notice.histories[0]
@@ -1906,3 +1910,35 @@ def privacy_preference_history(
     )
     yield preference_history_record
     preference_history_record.delete(db)
+
+
+@pytest.fixture(scope="function")
+def consent_records(
+    db,
+    provided_identity_and_consent_request,
+):
+    provided_identity, consent_request = provided_identity_and_consent_request
+    consent_request.cache_identity_verification_code("abcdefg")
+
+    consent_data = [
+        {
+            "data_use": "email",
+            "data_use_description": None,
+            "opt_in": True,
+        },
+        {
+            "data_use": "location",
+            "data_use_description": "Location data",
+            "opt_in": False,
+        },
+    ]
+
+    records = []
+    for data in deepcopy(consent_data):
+        data["provided_identity_id"] = provided_identity.id
+        records.append(Consent.create(db, data=data))
+
+    yield records
+
+    for record in records:
+        record.delete(db)

--- a/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
@@ -97,9 +97,8 @@ class TestConsentRequestReporting:
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
-        for idx in [0]:
-            item = data["items"][idx]
-            assert item["data_use"] == "email"
+        item = data["items"][0]
+        assert item["data_use"] == "email"
 
     def test_consent_request_report_filters_opt_in(
         self,
@@ -116,9 +115,8 @@ class TestConsentRequestReporting:
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
-        for idx in [0]:
-            item = data["items"][idx]
-            assert item["opt_in"] == True
+        item = data["items"][0]
+        assert item["opt_in"] == True
 
     def test_consent_request_report_filters_gpc_flag(
         self,

--- a/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
@@ -82,6 +82,44 @@ class TestConsentRequestReporting:
                 == consent_record.provided_identity.encrypted_value["value"]
             )
 
+    def test_consent_request_report_filters_data_use(
+        self,
+        url,
+        generate_auth_header,
+        api_client,
+        consent_records,
+    ):
+        auth_header = generate_auth_header(scopes=[CONSENT_READ])
+        response = api_client.get(
+            url + "?data_use=email",
+            headers=auth_header,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        for idx in [0]:
+            item = data["items"][idx]
+            assert item["data_use"] == "email"
+
+    def test_consent_request_report_filters_opt_in(
+        self,
+        url,
+        generate_auth_header,
+        api_client,
+        consent_records,
+    ):
+        auth_header = generate_auth_header(scopes=[CONSENT_READ])
+        response = api_client.get(
+            url + "?opt_in=true",
+            headers=auth_header,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        for idx in [0]:
+            item = data["items"][idx]
+            assert item["opt_in"] == True
+
 
 class TestConsentRequest:
     @pytest.fixture(scope="function")

--- a/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
@@ -71,6 +71,9 @@ class TestConsentRequestReporting:
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2
+        # Reverse the fixture list so that items are sorted in the same way
+        # the API returns them
+        consent_records.sort(reverse=True)
         for idx in [0, 1]:
             item = data["items"][idx]
             consent_record = consent_records[idx]

--- a/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
@@ -120,6 +120,25 @@ class TestConsentRequestReporting:
             item = data["items"][idx]
             assert item["opt_in"] == True
 
+    def test_consent_request_report_filters_gpc_flag(
+        self,
+        url,
+        generate_auth_header,
+        api_client,
+        consent_records,
+    ):
+        auth_header = generate_auth_header(scopes=[CONSENT_READ])
+        response = api_client.get(
+            url + "?has_gpc_flag=false",
+            headers=auth_header,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        for idx in [0, 1]:
+            item = data["items"][idx]
+            assert item["has_gpc_flag"] == False
+
 
 class TestConsentRequest:
     @pytest.fixture(scope="function")

--- a/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
@@ -73,7 +73,7 @@ class TestConsentRequestReporting:
         assert data["total"] == 2
         # Reverse the fixture list so that items are sorted in the same way
         # the API returns them
-        consent_records.sort(reverse=True)
+        consent_records.sort(key=lambda consent: consent.updated_at, reverse=True)
         for idx in [0, 1]:
             item = data["items"][idx]
             consent_record = consent_records[idx]

--- a/tests/ops/models/test_privacy_request.py
+++ b/tests/ops/models/test_privacy_request.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from time import sleep
-from typing import List
+from typing import List, Tuple
 from uuid import uuid4
 
 import pytest
@@ -22,6 +22,7 @@ from fides.api.ops.models.privacy_request import (
     PrivacyRequestError,
     PrivacyRequestNotifications,
     PrivacyRequestStatus,
+    ProvidedIdentity,
     can_run_checkpoint,
 )
 from fides.api.ops.schemas.redis_cache import Identity
@@ -33,8 +34,25 @@ from fides.core.config import CONFIG
 paused_location = CollectionAddress("test_dataset", "test_collection")
 
 
+def test_provided_identity_to_identity(
+    provided_identity_and_consent_request: Tuple,
+) -> None:
+    provided_identity = provided_identity_and_consent_request[0]
+    identity = provided_identity.as_identity_schema()
+    assert identity.email == "test@email.com"
+
+
+def test_blank_provided_identity_to_identity(
+    empty_provided_identity: ProvidedIdentity,
+) -> None:
+    identity = empty_provided_identity.as_identity_schema()
+    assert identity.email is None
+
+
 def test_privacy_request(
-    db: Session, policy: Policy, privacy_request: PrivacyRequest
+    db: Session,
+    policy: Policy,
+    privacy_request: PrivacyRequest,
 ) -> None:
     from_db = PrivacyRequest.get(db=db, object_id=privacy_request.id)
     assert from_db is not None


### PR DESCRIPTION
Closes #3053 

### Code Changes

* [x] Adds `GET /api/v1/consent-request/`
* [x] and filters for `page`, `opt_in`, `data_use`, `has_gpc_flag`, `created_at` and `updated_at`

### Steps to Confirm

* [ ] `nox -s "fides_env(dev)"`
* [ ] Create some consent requests under various identities
* [ ] Obtain a token with the `consent:read` scope
* [ ] Send `GET` requests to `/api/v1/consent-request/` with various permutations of the filters

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated