### PR TITLE
Restore Behavior: Only Queue Privacy Requests if we have Executable Preferences

### DIFF
--- a/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
@@ -273,6 +273,14 @@ def queue_privacy_request_to_propagate_consent_old_workflow(
         if pref.data_use in executable_data_uses
     ]
 
+    if not executable_consent_preferences:
+        logger.info(
+            "Skipping propagating consent preferences to third-party services as "
+            "specified consent preferences: {} are not executable.",
+            [pref.data_use for pref in consent_preferences.consent or []],
+        )
+        return None
+
     logger.info("Executable consent options: {}", executable_data_uses)
     privacy_request_results: BulkPostPrivacyRequests = create_privacy_request_func(
         db=db,

--- a/src/fides/api/ops/models/privacy_request.py
+++ b/src/fides/api/ops/models/privacy_request.py
@@ -42,10 +42,7 @@ from fides.api.ops.models.policy import (
 )
 from fides.api.ops.schemas.base_class import BaseSchema
 from fides.api.ops.schemas.drp_privacy_request import DrpPrivacyRequestCreate
-from fides.api.ops.schemas.external_https import (
-    SecondPartyResponseFormat,
-    WebhookJWE,
-)
+from fides.api.ops.schemas.external_https import SecondPartyResponseFormat, WebhookJWE
 from fides.api.ops.schemas.masking.masking_secrets import MaskingSecretCache
 from fides.api.ops.schemas.redis_cache import Identity
 from fides.api.ops.tasks import celery_app

--- a/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_consent_request_endpoints.py
@@ -631,14 +631,12 @@ class TestSaveConsent:
         assert response.status_code == 200
         assert response.json()["consent"][0]["data_use"] == "email"
         assert response.json()["consent"][0]["opt_in"] is True
-        assert (
-            run_privacy_request_mock.called
-        ), "Privacy request queued even though date_use: email is not executable for record keeping"
+        assert not run_privacy_request_mock.called, "date_use: email is not executable"
 
         db.refresh(consent_request)
         assert (
-            consent_request.privacy_request_id
-        ), "Privacy requests queued regardless of whether consent options are executable"
+            not consent_request.privacy_request_id
+        ), "No PrivacyRequest queued because none of the consent options are executable"
 
         response = api_client.post(
             f"{V1_URL_PREFIX}{CONSENT_REQUEST_VERIFY.format(consent_request_id=consent_request.id)}",

--- a/tests/ops/integration_tests/test_mongo_task.py
+++ b/tests/ops/integration_tests/test_mongo_task.py
@@ -847,7 +847,9 @@ async def test_array_querying_mongo(
     )
     # Returns fields_affected for all possible targeted fields, even though this identity only had some
     # of them actually populated
-    assert sorted(customer_detail_logs[0].fields_affected, key=lambda e: e["field_name"]) == [
+    assert sorted(
+        customer_detail_logs[0].fields_affected, key=lambda e: e["field_name"]
+    ) == [
         {
             "path": "mongo_test:customer_details:birthday",
             "field_name": "birthday",

--- a/tests/ops/models/test_consent_request.py
+++ b/tests/ops/models/test_consent_request.py
@@ -154,8 +154,8 @@ class TestQueuePrivacyRequestToPropagateConsentHelper:
             consent_preferences=consent_preferences,
             executable_consents=executable_consents,
         )
-
         assert mock_create_privacy_request.called
+
         call_kwargs = mock_create_privacy_request.call_args[1]
         assert call_kwargs["db"] == db
         assert call_kwargs["data"][0].identity.email == "test@email.com"
@@ -171,7 +171,7 @@ class TestQueuePrivacyRequestToPropagateConsentHelper:
     @mock.patch(
         "fides.api.ops.api.v1.endpoints.consent_request_endpoints.create_privacy_request_func"
     )
-    def test_privacy_request_queued_even_if_no_executable_preferences(
+    def test_do_not_queue_privacy_request_if_no_executable_preferences(
         self, mock_create_privacy_request, db, consent_policy
     ):
         mock_create_privacy_request.return_value = BulkPostPrivacyRequests(
@@ -205,7 +205,7 @@ class TestQueuePrivacyRequestToPropagateConsentHelper:
             ],
         )
 
-        assert mock_create_privacy_request.called
+        assert not mock_create_privacy_request.called
 
     @mock.patch(
         "fides.api.ops.api.v1.endpoints.consent_request_endpoints.create_privacy_request_func"


### PR DESCRIPTION
Closes Unticketed

### Code Changes

* [ ] Restore earlier behavior.  This is the behavior in the previous 2.10.0 release, and we shouldn't have changed it.  When we get a request to save preferences, after saving, we exit instead of creating a privacy request if none are executable.

### Steps to Confirm

* [ ] Save a consent preference in the privacy center with all consent options marked executable=False in the config.json
* [ ] Preferences should save but no Privacy Request should be created because there is nothing to propagate
* [ ] Mark a privacy preference as executable=True in the config.json 
* [ ] Now preferences should save and a privacy request should be created

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Reverts change I should not have made in: https://github.com/ethyca/fides/pull/3016

For the older workflow, we should only be queuing Privacy Requests if we have executable Consent Preferences.  For users with front-end only workflows, they should not have Privacy Requests created.
