### PR TITLE
Remove `customField` feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Removed
 - Removed the warning about access control migration [#3055](https://github.com/ethyca/fides/pull/3055)
+- Remove `customFields` feature flag [#3080](https://github.com/ethyca/fides/pull/3080)
 
 ## [2.11.0](https://github.com/ethyca/fides/compare/2.10.0...2.11.0)
 

--- a/clients/admin-ui/src/features/common/custom-fields/hooks.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/hooks.ts
@@ -24,8 +24,8 @@ export const useCustomFields = ({
   resourceType,
 }: UseCustomFieldsOptions) => {
   const { errorAlert, successAlert } = useAlert();
-  const { flags, plus } = useFeatures();
-  const isEnabled = flags.customFields && plus;
+  const { plus } = useFeatures();
+  const isEnabled = plus;
 
   // This keeps track of the fides key that was initially passed in. If that key started out blank,
   // then we know the API call will just 404.

--- a/clients/admin-ui/src/features/common/custom-fields/hooks.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/hooks.ts
@@ -24,8 +24,7 @@ export const useCustomFields = ({
   resourceType,
 }: UseCustomFieldsOptions) => {
   const { errorAlert, successAlert } = useAlert();
-  const { plus } = useFeatures();
-  const isEnabled = plus;
+  const { plus: isEnabled } = useFeatures();
 
   // This keeps track of the fides key that was initially passed in. If that key started out blank,
   // then we know the API call will just 404.

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -12,12 +12,6 @@
     "production": false,
     "test": false
   },
-  "customFields": {
-    "description": "Custom fields can be added to many forms throughout Fides. You can create, show, and hide custom fields that you add to Fides at any time.",
-    "development": true,
-    "test": true,
-    "production": false
-  },
   "organizationManagement": {
     "description": "Management page to configure Organization details for RoPA reporting, messaging, etc.",
     "development": true,


### PR DESCRIPTION
Closes #3046 

### Code Changes

* [ ] Remove `customFields` feature flag


### Steps to Confirm

* [ ] Confirm that custom fields always show up on the system info tab and in the taxonomy view

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes
<img width="1061" alt="Screenshot 2023-04-17 at 12 06 54" src="https://user-images.githubusercontent.com/17103888/232544916-9755bcbb-572f-4246-b471-6760da12d8c6.png">
<img width="731" alt="Screenshot 2023-04-17 at 12 06 39" src="https://user-images.githubusercontent.com/17103888/232544919-ec51e25c-ce3b-48e7-8566-9064f78bfff2.png">
