### PR TITLE
Remove notification banner from home page

### DIFF
--- a/clients/admin-ui/src/home/HomeLayout.tsx
+++ b/clients/admin-ui/src/home/HomeLayout.tsx
@@ -5,7 +5,6 @@ import { ReactNode } from "react";
 
 import Header from "~/features/common/Header";
 import { NavTopBar } from "~/features/common/nav/v2/NavTopBar";
-import NotificationBanner from "~/features/common/NotificationBanner";
 
 type HomeLayoutProps = {
   children: ReactNode;
@@ -20,8 +19,6 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, title }) => (
       <link rel="icon" href="/favicon.ico" />
     </Head>
     <Header />
-    {/* TODO: remove this in a future release (see https://github.com/ethyca/fides/issues/2844) */}
-    <NotificationBanner />
     <NavTopBar />
     <Flex as="main" flexGrow={1} flexDirection="column" gap={10}>
       {children}


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2844 (for real this time)

### Code Changes

* [x] Removes the banner from the home page

### Steps to Confirm

* Log in as a viewer
* You should no longer see the warning banner about scopes being migrated no matter which page you are on.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

In https://github.com/ethyca/fides/pull/3055, I forgot the home page has a different Layout component than the rest of the app and also had a copy of the notification banner. This removes that banner as well.

The datamap UI also uses a different Layout component, but that one never had the banner so we are okay there 👍 

