### PR TITLE
Add custom fields page

### DIFF
--- a/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
@@ -128,6 +128,13 @@ export const NAV_CONFIG: NavConfigGroup[] = [
         ],
       },
       {
+        title: "Custom fields",
+        path: routes.CUSTOM_FIELDS_ROUTE,
+        scopes: [ScopeRegistryEnum.CUSTOM_FIELD_READ],
+        requiresPlus: true,
+        requiresFlag: "customFieldManagement",
+      },
+      {
         title: "About Fides",
         path: routes.ABOUT_ROUTE,
         scopes: [ScopeRegistryEnum.USER_READ], // temporary scope while we don't have a scope for beta features

--- a/clients/admin-ui/src/features/common/nav/v2/routes.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/routes.ts
@@ -17,3 +17,4 @@ export const USER_MANAGEMENT_ROUTE = "/user-management";
 export const ORGANIZATION_MANAGEMENT_ROUTE = "/management/organization";
 export const TAXONOMY_ROUTE = "/taxonomy";
 export const ABOUT_ROUTE = "/management/about";
+export const CUSTOM_FIELDS_ROUTE = "/management/custom-fields";

--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -202,6 +202,15 @@ export const plusApi = createApi({
       invalidatesTags: ["CustomFields"],
     }),
 
+    getAllCustomFieldDefinitions: build.query<
+      CustomFieldDefinitionWithId[],
+      void
+    >({
+      query: () => ({
+        url: `custom-metadata/custom-field-definition`,
+      }),
+      providesTags: ["CustomFieldDefinition"],
+    }),
     // Custom Metadata Custom Field Definition
     addCustomFieldDefinition: build.mutation<
       CustomFieldDefinitionWithId,
@@ -259,6 +268,7 @@ export const {
   useUpdateScanMutation,
   useUpsertAllowListMutation,
   useUpsertCustomFieldMutation,
+  useGetAllCustomFieldDefinitionsQuery,
 } = plusApi;
 
 export const selectHealth: (state: RootState) => HealthCheck | undefined =
@@ -358,4 +368,10 @@ export const selectClassifyInstanceFieldMap = createSelector(
 export const selectClassifyInstanceField = createSelector(
   [selectClassifyInstanceFieldMap, selectActiveField],
   (fieldMap, active) => (active ? fieldMap.get(active.name) : undefined)
+);
+
+const emptySelectAllCustomFields: CustomFieldDefinitionWithId[] = [];
+export const selectAllCustomFieldDefinitions = createSelector(
+  plusApi.endpoints.getAllCustomFieldDefinitions.select(),
+  ({ data }) => data || emptySelectAllCustomFields
 );

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -18,6 +18,13 @@
     "test": true,
     "production": false
   },
+  "customFieldManagement": {
+    "description": "Management page to configure custom fields",
+    "development": true,
+    "test": true,
+    "production": false,
+    "userCannotModify": true
+  },
   "privacyNotices": {
     "description": "Page to configure consent privacy notices",
     "development": true,

--- a/clients/admin-ui/src/pages/management/custom-fields.tsx
+++ b/clients/admin-ui/src/pages/management/custom-fields.tsx
@@ -1,0 +1,39 @@
+import { Box, Heading, Text } from "@fidesui/react";
+import type { NextPage } from "next";
+
+import { useAppSelector } from "~/app/hooks";
+import Layout from "~/features/common/Layout";
+import {
+  selectAllCustomFieldDefinitions,
+  useGetAllCustomFieldDefinitionsQuery,
+} from "~/features/plus/plus.slice";
+
+const CustomFields: NextPage = () => {
+  useGetAllCustomFieldDefinitionsQuery();
+  const customFields = useAppSelector(selectAllCustomFieldDefinitions);
+
+  return (
+    <Layout title="Organization">
+      <Box data-testid="organization-management">
+        <Heading marginBottom={4} fontSize="2xl">
+          Manage custom fields
+        </Heading>
+        <Box maxWidth="600px">
+          <Text marginBottom={10} fontSize="sm">
+            Custom fields provide organizations with the capability to capture
+            metrics that are unique to their specific needs, allowing them to
+            create customized reports. These fields can be added to either
+            systems or elements within a taxonomy, and once added, they become
+            reportable fields that are visible on the data map.
+          </Text>
+          <Box background="gray.50" padding={2}>
+            {customFields.map((customField) => (
+              <Box key={customField.id}>{customField.name}</Box>
+            ))}
+          </Box>
+        </Box>
+      </Box>
+    </Layout>
+  );
+};
+export default CustomFields;

--- a/clients/admin-ui/src/pages/management/custom-fields.tsx
+++ b/clients/admin-ui/src/pages/management/custom-fields.tsx
@@ -13,8 +13,8 @@ const CustomFields: NextPage = () => {
   const customFields = useAppSelector(selectAllCustomFieldDefinitions);
 
   return (
-    <Layout title="Organization">
-      <Box data-testid="organization-management">
+    <Layout title="Custom fields">
+      <Box data-testid="custom-fields-management">
         <Heading marginBottom={4} fontSize="2xl">
           Manage custom fields
         </Heading>


### PR DESCRIPTION
Closes #3078 

### Code Changes

* [ ] Add custom fields page that's hidden behind a feature flag so it won't show up in prod builds. That flag cannot be modified.
* [ ] Add new `useGetAllCustomFieldDefinitionsQuery` hook

### Steps to Confirm

* [ ] Run the admin ui, add a couple custom fields ( including taxonomy ones ), and make sure the custom field names show on the new page 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This uses the same setup that privacy consent notices uses for feature flags so it will only show up in dev and test envs.

<img width="1112" alt="Screenshot 2023-04-17 at 15 46 35" src="https://user-images.githubusercontent.com/17103888/232594455-ba24b85f-ab03-4d84-885c-00defaec8d55.png">
