### PR TITLE
Fix `scan dataset` commands not respecting `--local` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,23 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.11.0...main)
 
 ### Added
+
 - Access and erasure support for Aircall [#2589](https://github.com/ethyca/fides/pull/2589)
 - Access and erasure support for Klaviyo [#2501](https://github.com/ethyca/fides/pull/2501)
 
 ### Changed
+
 - The `cursor` pagination strategy now also searches for data outside of the `data_path` when determining the cursor value [#3068](https://github.com/ethyca/fides/pull/3068)
 
 ### Removed
+
 - Removed the warning about access control migration [#3055](https://github.com/ethyca/fides/pull/3055)
 - Remove `customFields` feature flag [#3080](https://github.com/ethyca/fides/pull/3080)
+
+### Fixed
+
+- The `--local` flag is now respected for the `scan dataset db` command [#3096](https://github.com/ethyca/fides/pull/3096)
+
 
 ## [2.11.0](https://github.com/ethyca/fides/compare/2.10.0...2.11.0)
 

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -5,6 +5,7 @@ import nox
 from constants_nox import COMPOSE_FILE_LIST
 from run_infrastructure import run_infrastructure
 
+
 @nox.session()
 def seed_test_data(session: nox.Session) -> None:
     """Seed test data in the Postgres application database."""

--- a/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/consent_request_endpoints.py
@@ -10,7 +10,7 @@ from fastapi_pagination.ext.sqlalchemy import paginate
 from fideslang.validation import FidesKey
 from loguru import logger
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, Query
+from sqlalchemy.orm import Query, Session
 from starlette.responses import StreamingResponse
 from starlette.status import (
     HTTP_200_OK,
@@ -47,11 +47,12 @@ from fides.api.ops.models.privacy_request import (
     ProvidedIdentityType,
 )
 from fides.api.ops.schemas.messaging.messaging import MessagingMethod
-from fides.api.ops.schemas.privacy_request import BulkPostPrivacyRequests, ConsentReport
+from fides.api.ops.schemas.privacy_request import BulkPostPrivacyRequests
 from fides.api.ops.schemas.privacy_request import Consent as ConsentSchema
 from fides.api.ops.schemas.privacy_request import (
     ConsentPreferences,
     ConsentPreferencesWithVerificationCode,
+    ConsentReport,
     ConsentRequestResponse,
     ConsentWithExecutableStatus,
     PrivacyRequestCreate,

--- a/src/fides/cli/__init__.py
+++ b/src/fides/cli/__init__.py
@@ -23,6 +23,7 @@ from .commands.user import user
 from .commands.util import deploy, init, status, webserver, worker
 from .commands.view import view
 
+# Refactor how "local" commands work, by putting it on the command itself instead of at the top level
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 LOCAL_COMMANDS = [deploy, evaluate, generate, init, scan, parse, view, webserver]
 LOCAL_COMMAND_DICT = {

--- a/src/fides/cli/__init__.py
+++ b/src/fides/cli/__init__.py
@@ -4,7 +4,7 @@ Entrypoint for the Fides command-line.
 from importlib.metadata import version
 from platform import system
 
-import rich_click as click
+from rich_click import group, option, pass_context, version_option, echo, Context, secho
 from fideslog.sdk.python.client import AnalyticsClient
 
 import fides
@@ -12,6 +12,7 @@ from fides.cli.utils import check_server
 from fides.core.config import get_config
 
 from . import cli_formatting
+from .exceptions import LocalModeException
 from .commands.annotate import annotate
 from .commands.core import evaluate, parse, pull, push
 from .commands.crud import delete, get_resource, list_resources
@@ -23,12 +24,8 @@ from .commands.user import user
 from .commands.util import deploy, init, status, webserver, worker
 from .commands.view import view
 
-# Refactor how "local" commands work, by putting it on the command itself instead of at the top level
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 LOCAL_COMMANDS = [deploy, evaluate, generate, init, scan, parse, view, webserver]
-LOCAL_COMMAND_DICT = {
-    command.name or str(command): command for command in LOCAL_COMMANDS
-}
 API_COMMANDS = [
     annotate,
     database,
@@ -42,7 +39,6 @@ API_COMMANDS = [
     worker,
     user,
 ]
-API_COMMAND_DICT = {command.name or str(command): command for command in API_COMMANDS}
 ALL_COMMANDS = API_COMMANDS + LOCAL_COMMANDS
 SERVER_CHECK_COMMAND_NAMES = [
     command.name for command in API_COMMANDS if command.name not in ["status", "worker"]
@@ -52,26 +48,26 @@ APP = fides.__name__
 PACKAGE = "ethyca-fides"
 
 
-@click.group(
+@group(
     context_settings=CONTEXT_SETTINGS,
     invoke_without_command=True,
     name="fides",
 )
-@click.version_option(version=VERSION)
-@click.option(
+@version_option(version=VERSION)
+@option(
     "--config-path",
     "-f",
     "config_path",
     show_default=True,
     help="Path to a Fides config file. _Defaults to `.fides/fides.toml`._",
 )
-@click.option(
+@option(
     "--local",
     is_flag=True,
-    help="Run in `local_mode`. This mode doesn't make API calls and can be used without the API server/database.",
+    help="Run in `local_mode`. Where possible, this will force commands to run without the need for a server.",
 )
-@click.pass_context
-def cli(ctx: click.Context, config_path: str, local: bool) -> None:
+@pass_context
+def cli(ctx: Context, config_path: str, local: bool) -> None:
     """
     __Command-line tool for the Fides privacy engineering platform.__
 
@@ -82,22 +78,22 @@ def cli(ctx: click.Context, config_path: str, local: bool) -> None:
 
     ctx.ensure_object(dict)
     config = get_config(config_path, verbose=True)
-
-    # Dynamically add commands to the CLI
-    cli.commands = LOCAL_COMMAND_DICT
+    command = ctx.invoked_subcommand
 
     if not (local or config.cli.local_mode):
         config.cli.local_mode = False
-        cli.commands = {**cli.commands, **API_COMMAND_DICT}
     else:
         config.cli.local_mode = True
 
+    if config.cli.local_mode and command not in LOCAL_COMMANDS:
+        raise LocalModeException(command)
+
     # Run the help command if no subcommand is passed
-    if not ctx.invoked_subcommand:
-        click.echo(cli.get_help(ctx))
+    if not command:
+        echo(cli.get_help(ctx))
 
     # Check the server health and version if an API command is invoked
-    if ctx.invoked_subcommand in SERVER_CHECK_COMMAND_NAMES:
+    if command in SERVER_CHECK_COMMAND_NAMES:
         check_server(VERSION, str(config.cli.server_url), quiet=True)
 
     # Analytics requires explicit opt-in

--- a/src/fides/cli/commands/scan.py
+++ b/src/fides/cli/commands/scan.py
@@ -73,6 +73,7 @@ def scan_dataset_db(
         coverage_threshold=coverage_threshold,
         url=config.cli.server_url,
         headers=config.user.auth_header,
+        local=config.cli.local_mode,
     )
 
 

--- a/src/fides/cli/exceptions.py
+++ b/src/fides/cli/exceptions.py
@@ -4,7 +4,7 @@ from rich_click import secho
 class LocalModeException(Exception):
     """Raise an error when `local_mode` is enabled with an incompatible command."""
 
-    def __init__(self, command):
+    def __init__(self, command: str):
         self.command = command
         self.message = f"> Command: `{self.command}` not compatible with `local_mode`!"
         secho(self.message, fg="red")

--- a/src/fides/cli/exceptions.py
+++ b/src/fides/cli/exceptions.py
@@ -1,0 +1,11 @@
+from rich_click import secho
+
+
+class LocalModeException(Exception):
+    """Raise an error when `local_mode` is enabled with an incompatible command."""
+
+    def __init__(self, command):
+        self.command = command
+        self.message = f"> Command: `{self.command}` not compatible with `local_mode`!"
+        secho(self.message, fg="red")
+        raise SystemExit(1)

--- a/src/fides/core/dataset.py
+++ b/src/fides/core/dataset.py
@@ -247,6 +247,7 @@ def scan_dataset_db(
     coverage_threshold: int,
     url: AnyHttpUrl,
     headers: Dict[str, str],
+    local: bool = False,
 ) -> None:
     """
     Given a database connection string, fetches collections
@@ -255,11 +256,15 @@ def scan_dataset_db(
     """
     manifest_taxonomy = parse(manifest_dir) if manifest_dir else None
     manifest_datasets = manifest_taxonomy.dataset if manifest_taxonomy else []
-    server_datasets = get_all_server_datasets(
-        url=url, headers=headers, exclude_datasets=manifest_datasets
-    )
 
-    if not server_datasets:
+    if not local:
+        server_datasets = (
+            get_all_server_datasets(
+                url=url, headers=headers, exclude_datasets=manifest_datasets
+            )
+            or []
+        )
+    else:
         server_datasets = []
 
     dataset_keys = [

--- a/tests/ctl/cli/test_cli.py
+++ b/tests/ctl/cli/test_cli.py
@@ -51,6 +51,16 @@ def test_init_opt_in(test_cli_runner: CliRunner) -> None:
     assert result.exit_code == 0
 
 
+@pytest.mark.unit
+def test_local_flag_invalid_command(test_cli_runner: CliRunner) -> None:
+    result = test_cli_runner.invoke(
+        cli,
+        ["--local", "export"],
+    )
+    print(result.output)
+    assert result.exit_code == 1
+
+
 class TestView:
     @pytest.mark.unit
     def test_view_config(self, test_cli_runner: CliRunner) -> None:

--- a/tests/ctl/cli/test_cli.py
+++ b/tests/ctl/cli/test_cli.py
@@ -482,6 +482,28 @@ class TestScan:
         print(result.output)
         assert result.exit_code == 0
 
+    @pytest.mark.integration
+    def test_scan_dataset_db_local_flag(
+        self, test_config_path: str, test_cli_runner: CliRunner
+    ) -> None:
+        result = test_cli_runner.invoke(
+            cli,
+            [
+                "-f",
+                test_config_path,
+                "--local",
+                "scan",
+                "dataset",
+                "db",
+                "--credentials-id",
+                "postgres_1",
+                "--coverage-threshold",
+                "0",
+            ],
+        )
+        print(result.output)
+        assert result.exit_code == 0
+
     @pytest.mark.external
     def test_scan_system_aws_environment_credentials(
         self, test_config_path: str, test_cli_runner: CliRunner

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -1,5 +1,5 @@
-from copy import deepcopy
 import logging
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Generator, List, Optional
 from unittest import mock

--- a/tests/fixtures/saas/klaviyo_fixtures.py
+++ b/tests/fixtures/saas/klaviyo_fixtures.py
@@ -28,7 +28,7 @@ def klaviyo_secrets(saas_config):
     return {
         "domain": pydash.get(saas_config, "klaviyo.domain") or secrets["domain"],
         "api_key": pydash.get(saas_config, "klaviyo.api_key") or secrets["api_key"],
-        "revision": pydash.get(saas_config, "klaviyo.revision") or secrets["revision"]
+        "revision": pydash.get(saas_config, "klaviyo.revision") or secrets["revision"],
     }
 
 
@@ -107,28 +107,28 @@ def klaviyo_dataset_config(
     dataset.delete(db=db)
     ctl_dataset.delete(db=db)
 
+
 @pytest.fixture(scope="function")
 def klaviyo_create_erasure_data(
     klaviyo_connection_config: ConnectionConfig, klaviyo_erasure_identity_email: str
 ) -> None:
-
     klaviyo_secrets = klaviyo_connection_config.secrets
     base_url = f"https://{klaviyo_secrets['domain']}"
     headers = {
         "Authorization": f"Klaviyo-API-Key {klaviyo_secrets['api_key']}",
-        "revision": klaviyo_secrets['revision']
+        "revision": klaviyo_secrets["revision"],
     }
     # user
     body = {
         "data": {
             "type": "profile",
-            "attributes": {
-                "email": klaviyo_erasure_identity_email
-            }
+            "attributes": {"email": klaviyo_erasure_identity_email},
         }
     }
 
-    users_response = requests.post(url=f"{base_url}/api/profiles/", headers=headers, json=body)
+    users_response = requests.post(
+        url=f"{base_url}/api/profiles/", headers=headers, json=body
+    )
     user = users_response.json()
 
     yield user

--- a/tests/ops/integration_tests/saas/test_klaviyo_task.py
+++ b/tests/ops/integration_tests/saas/test_klaviyo_task.py
@@ -1,4 +1,5 @@
 import random
+
 import pytest
 import requests
 
@@ -54,17 +55,14 @@ async def test_klaviyo_access_request_task(
     assert_rows_match(
         v[f"{dataset_name}:profiles"],
         min_size=1,
-        keys=[
-            "type",
-            "id",
-            "attributes",
-            "links",
-            "relationships"
-        ],
+        keys=["type", "id", "attributes", "links", "relationships"],
     )
 
     # verify we only returned data for our identity email
-    assert v[f"{dataset_name}:profiles"][0]['attributes']["email"] == klaviyo_identity_email
+    assert (
+        v[f"{dataset_name}:profiles"][0]["attributes"]["email"]
+        == klaviyo_identity_email
+    )
     user_id = v[f"{dataset_name}:profiles"][0]["id"]
 
 
@@ -107,13 +105,7 @@ async def test_klaviyo_erasure_request_task(
     assert_rows_match(
         v[f"{dataset_name}:profiles"],
         min_size=1,
-        keys=[
-            "type",
-            "id",
-            "attributes",
-            "links",
-            "relationships"
-        ],
+        keys=["type", "id", "attributes", "links", "relationships"],
     )
 
     x = await graph_task.run_erasure(
@@ -134,16 +126,16 @@ async def test_klaviyo_erasure_request_task(
     base_url = f"https://{klaviyo_secrets['domain']}"
     headers = {
         "Authorization": f"Klaviyo-API-Key {klaviyo_secrets['api_key']}",
-        "revision": klaviyo_secrets['revision']
+        "revision": klaviyo_secrets["revision"],
     }
 
     # user
     response = requests.get(
         url=f"{base_url}/api/profiles",
         headers=headers,
-        params={"filter": "equals(email,'"+klaviyo_erasure_identity_email+"')"},
+        params={"filter": "equals(email,'" + klaviyo_erasure_identity_email + "')"},
     )
-    
+
     assert response.status_code == 200
 
     CONFIG.execution.masking_strict = masking_strict


### PR DESCRIPTION
Closes #3035 

### Code Changes

* [x] refactor `local`/`API` command logic at the top-level
* [x] add `local` flags to the dataset scanning functions

### Steps to Confirm

* [ ] `fides --local scan dataset db --credentials-id app_postgres`
* [ ] the command fails connecting to the database (as opposed to a webserver that isn't running)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] ~~Relevant Follow-Up Issues Created~~
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Quick fix for a bug that @nicolas-ethyca found