### PR TITLE
fix unit tests for saas connector type endpoints

### DIFF
--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -32,7 +32,7 @@ from fides.lib.models.client import ClientDetail
 class TestGetConnections:
     @pytest.fixture(scope="function")
     def url(self, oauth_client: ClientDetail, policy) -> str:
-        return V1_URL_PREFIX + CONNECTION_TYPES
+        return V1_URL_PREFIX + CONNECTION_TYPES + "?size=100&"
 
     def test_get_connection_types_not_authenticated(self, api_client, url):
         resp = api_client.get(url, headers={})
@@ -107,7 +107,7 @@ class TestGetConnections:
             for saas_template in expected_saas_templates
         ]
 
-        resp = api_client.get(url + f"?search={search}", headers=auth_header)
+        resp = api_client.get(url + f"search={search}", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()["items"]
 
@@ -133,7 +133,7 @@ class TestGetConnections:
             for saas_template in expected_saas_templates
         ]
 
-        resp = api_client.get(url + f"?search={search}", headers=auth_header)
+        resp = api_client.get(url + f"search={search}", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()["items"]
 
@@ -179,7 +179,7 @@ class TestGetConnections:
             for saas_template in expected_saas_types
         ]
 
-        resp = api_client.get(url + f"?search={search}", headers=auth_header)
+        resp = api_client.get(url + f"search={search}", headers=auth_header)
 
         assert resp.status_code == 200
         data = resp.json()["items"]
@@ -214,7 +214,7 @@ class TestGetConnections:
             for saas_template in expected_saas_types
         ]
 
-        resp = api_client.get(url + f"?search={search}", headers=auth_header)
+        resp = api_client.get(url + f"search={search}", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()["items"]
         # 2 constant non-saas connection types match the search string
@@ -238,15 +238,15 @@ class TestGetConnections:
     def test_search_system_type(self, api_client, generate_auth_header, url):
         auth_header = generate_auth_header(scopes=[CONNECTION_TYPE_READ])
 
-        resp = api_client.get(url + "?system_type=nothing", headers=auth_header)
+        resp = api_client.get(url + "system_type=nothing", headers=auth_header)
         assert resp.status_code == 422
 
-        resp = api_client.get(url + "?system_type=saas", headers=auth_header)
+        resp = api_client.get(url + "system_type=saas", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()["items"]
         assert len(data) == len(ConnectorRegistry.connector_types())
 
-        resp = api_client.get(url + "?system_type=database", headers=auth_header)
+        resp = api_client.get(url + "system_type=database", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()["items"]
         assert len(data) == 9
@@ -261,7 +261,7 @@ class TestGetConnections:
 
         search = "str"
         resp = api_client.get(
-            url + f"?search={search}&system_type=saas", headers=auth_header
+            url + f"search={search}&system_type=saas", headers=auth_header
         )
         assert resp.status_code == 200
         data = resp.json()["items"]
@@ -273,7 +273,7 @@ class TestGetConnections:
         assert len(data) == len(expected_saas_types)
 
         resp = api_client.get(
-            url + "?search=re&system_type=database", headers=auth_header
+            url + "search=re&system_type=database", headers=auth_header
         )
         assert resp.status_code == 200
         data = resp.json()["items"]
@@ -282,7 +282,7 @@ class TestGetConnections:
     def test_search_manual_system_type(self, api_client, generate_auth_header, url):
         auth_header = generate_auth_header(scopes=[CONNECTION_TYPE_READ])
 
-        resp = api_client.get(url + "?system_type=manual", headers=auth_header)
+        resp = api_client.get(url + "system_type=manual", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()["items"]
         assert len(data) == 1
@@ -298,7 +298,7 @@ class TestGetConnections:
     def test_search_email_type(self, api_client, generate_auth_header, url):
         auth_header = generate_auth_header(scopes=[CONNECTION_TYPE_READ])
 
-        resp = api_client.get(url + "?system_type=email", headers=auth_header)
+        resp = api_client.get(url + "system_type=email", headers=auth_header)
         assert resp.status_code == 200
         data = resp.json()["items"]
         assert len(data) == 2
@@ -338,15 +338,15 @@ class TestGetConnectionsActionTypeParams:
 
     @pytest.fixture(scope="function")
     def url(self) -> str:
-        return V1_URL_PREFIX + CONNECTION_TYPES
+        return V1_URL_PREFIX + CONNECTION_TYPES + "?size=100&"
 
     @pytest.fixture(scope="function")
     def url_with_params(self) -> str:
         return (
             V1_URL_PREFIX
             + CONNECTION_TYPES
-            + "?"
-            + "consent={consent}"
+            + "?size=100"
+            + "&consent={consent}"
             + "&access={access}"
             + "&erasure={erasure}"
         )
@@ -580,7 +580,7 @@ class TestGetConnectionsActionTypeParams:
         # now run another request, this time omitting non-specified filter params
         # rather than setting them to false explicitly. we should get identical results.
         if action_types:
-            the_url = url + "?"
+            the_url = url
             if ActionType.consent in action_types:
                 the_url += "consent=true&"
             if ActionType.access in action_types:


### PR DESCRIPTION
Closes n/a

ops unit tests were broken because we now have > 50 connection types and our tests relied on all connection types being returned from the endpoints. our default page size is 50, so by increasing to explicitly set `100` as a page size, we can mitigate the problem.

longer term, once we have >100 connector types, we can look to incorporate paging into the tests. but i wanted a quick fix for now 😄 

### Code Changes

* set `size=100` on our tests getting `connection_types` that need all connector types.

### Steps to Confirm

- automated tests should pass

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated


