### PR TITLE
[#3103] update `RuleTarget.data_category` API validation

### DIFF
--- a/src/fides/api/ctl/sql_models.py
+++ b/src/fides/api/ctl/sql_models.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 from enum import Enum as EnumType
 from typing import Any, Dict, List, Optional, Set, Type
 
-from fideslang.models import Dataset as FideslangDataset
+from fideslang.models import (
+    DataCategory as FideslangDataCategory,
+    Dataset as FideslangDataset,
+)
 from pydantic import BaseModel
 from sqlalchemy import ARRAY, BOOLEAN, JSON, Column
 from sqlalchemy import Enum as EnumColumn
@@ -147,6 +150,18 @@ class DataCategory(Base, FidesBase):
 
     parent_key = Column(Text)
     is_default = Column(BOOLEAN, default=False)
+
+    def to_fideslang_obj(self) -> FideslangDataCategory:
+        """
+        Convert the DataCategory to a Fideslang DataCategory object.
+        """
+        return FideslangDataCategory(
+            name=self.name,
+            description=self.description,
+            fides_key=self.fides_key,
+            tags=self.tags,
+            parent_key=self.parent_key,
+        )
 
 
 class DataQualifier(Base, FidesBase):

--- a/src/fides/api/ops/api/v1/endpoints/policy_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/policy_endpoints.py
@@ -491,6 +491,11 @@ def create_or_update_rule_targets(
                     "client_id": client.id,
                 },
             )
+            logger.debug(
+                "Create/update succeess for rule target {} on rule {}",
+                schema.key,
+                rule_key,
+            )
         except KeyOrNameAlreadyExists as exc:
             logger.warning(
                 "Create/update failed for rule target {} on rule {}: {}",

--- a/src/fides/api/ops/api/v1/endpoints/policy_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/policy_endpoints.py
@@ -492,7 +492,7 @@ def create_or_update_rule_targets(
                 },
             )
             logger.debug(
-                "Create/update succeess for rule target {} on rule {}",
+                "Create/update success for rule target {} on rule {}",
                 schema.key,
                 rule_key,
             )

--- a/src/fides/api/ops/models/policy.py
+++ b/src/fides/api/ops/models/policy.py
@@ -2,7 +2,6 @@
 from enum import Enum as EnumType
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from fideslang import DEFAULT_TAXONOMY
 from fideslang.models import DataCategory as FideslangDataCategory
 from fideslang.validation import FidesKey
 from sqlalchemy import Column
@@ -172,7 +171,7 @@ class Policy(Base):
 
 
 def _get_ref_from_taxonomy(fides_key: FidesKey) -> FideslangDataCategory:
-    """Returns the DataCategory model from the DEFAULT_TAXONOMY corresponding to fides_key."""
+    """Returns the DataCategory model corresponding to fides_key."""
     for item in get_fides_data_category_superset():
         if item.fides_key == fides_key:
             return item
@@ -189,7 +188,7 @@ def _is_ancestor_of_contained_categories(
     """
     Returns True if `fides_key` is an ancestor of any item in `data_categories`.
     Warning that this algorithm is recursive, is susceptible to infinite loops and
-    other misconfigurations in the underlying DEFAULT_TAXONOMY imported from fideslang.
+    other misconfigurations in the underlying taxonomy of data categories imported from fideslang.
 
     TODO: Should we memoize this function?
     """

--- a/src/fides/api/ops/models/policy.py
+++ b/src/fides/api/ops/models/policy.py
@@ -26,7 +26,10 @@ from fides.api.ops.models.storage import (
     StorageConfig,
     get_active_default_storage_config,
 )
-from fides.api.ops.util.data_category import _validate_data_category
+from fides.api.ops.util.data_category import (
+    _validate_data_category,
+    get_fides_data_category_superset,
+)
 from fides.core.config import CONFIG
 from fides.lib.db.base_class import Base, FidesBase
 from fides.lib.models.client import ClientDetail
@@ -170,7 +173,7 @@ class Policy(Base):
 
 def _get_ref_from_taxonomy(fides_key: FidesKey) -> FideslangDataCategory:
     """Returns the DataCategory model from the DEFAULT_TAXONOMY corresponding to fides_key."""
-    for item in DEFAULT_TAXONOMY.data_category:
+    for item in get_fides_data_category_superset():
         if item.fides_key == fides_key:
             return item
 

--- a/src/fides/api/ops/util/data_category.py
+++ b/src/fides/api/ops/util/data_category.py
@@ -17,7 +17,9 @@ def get_fides_data_categories_from_db() -> List[FideslangDataCategory]:
     default taxonomy.
     """
     db: Session = get_db_session(get_config())()
-    return [cat.to_fideslang_obj() for cat in DataCategoryDbModel.all(db)]
+    all_categories = DataCategoryDbModel.all(db)
+    db.close()
+    return [cat.to_fideslang_obj() for cat in all_categories]
 
 
 def get_fides_data_categories_from_taxonomy() -> List[FideslangDataCategory]:

--- a/src/fides/api/ops/util/data_category.py
+++ b/src/fides/api/ops/util/data_category.py
@@ -1,9 +1,36 @@
 from enum import Enum as EnumType
-from typing import Type
+from typing import List, Set, Type, Union
 
 from fideslang import DEFAULT_TAXONOMY
+from fideslang.models import DataCategory as FideslangDataCategory
+from sqlalchemy.orm import Session
 
+from fides.api.ctl.sql_models import DataCategory as DataCategoryDbModel
 from fides.api.ops import common_exceptions
+from fides.core.config import get_config
+from fides.lib.db.session import get_db_session
+
+
+def get_fides_data_categories_from_db() -> List[FideslangDataCategory]:
+    """
+    Returns each DataCategory from the database as it would have been defined in the
+    default taxonomy.
+    """
+    db: Session = get_db_session(get_config())()
+    return [cat.to_fideslang_obj() for cat in DataCategoryDbModel.all(db)]
+
+
+def get_fides_data_categories_from_taxonomy() -> List[FideslangDataCategory]:
+    """Returns the list of DataCategories from the default Fides taxonomy."""
+    return DEFAULT_TAXONOMY.data_category
+
+
+def get_fides_data_category_superset() -> List[FideslangDataCategory]:
+    """Returns the union of DataCategories from the database and the default Fides taxonomy."""
+    # TODO: De-duplicate this list
+    return (
+        get_fides_data_categories_from_db() + get_fides_data_categories_from_taxonomy()
+    )
 
 
 def generate_fides_data_categories() -> Type[EnumType]:
@@ -20,8 +47,14 @@ DataCategory = generate_fides_data_categories()
 
 def _validate_data_category(data_category: str) -> str:
     """Checks that the data category passed in is currently supported."""
-    valid_categories = DataCategory.__members__.keys()
-    if data_category not in valid_categories:
+    from_db = [cat.fides_key for cat in get_fides_data_categories_from_db()]
+    from_taxonomy = [cat.fides_key for cat in get_fides_data_categories_from_taxonomy()]
+    if all(
+        [
+            data_category not in from_db,
+            data_category not in from_taxonomy,
+        ]
+    ):
         raise common_exceptions.DataCategoryNotSupported(
             f"The data category {data_category} is not supported."
         )

--- a/src/fides/api/ops/util/data_category.py
+++ b/src/fides/api/ops/util/data_category.py
@@ -1,11 +1,11 @@
 from enum import Enum as EnumType
-from typing import List, Set, Type, Union
+from typing import List, Type
 
 from fideslang import DEFAULT_TAXONOMY
 from fideslang.models import DataCategory as FideslangDataCategory
 from sqlalchemy.orm import Session
 
-from fides.api.ctl.sql_models import DataCategory as DataCategoryDbModel
+from fides.api.ctl.sql_models import DataCategory as DataCategoryDbModel  # type: ignore
 from fides.api.ops import common_exceptions
 from fides.core.config import get_config
 from fides.lib.db.session import get_db_session

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -14,8 +14,11 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 from toml import load as load_toml
 
-from fides.api.ctl.sql_models import Dataset as CtlDataset
-from fides.api.ctl.sql_models import System
+from fides.api.ctl.sql_models import (
+    DataCategory as DataCategoryDbModel,
+    Dataset as CtlDataset,
+    System,
+)
 from fides.api.ops.common_exceptions import SystemManagerException
 from fides.api.ops.models.application_config import ApplicationConfig
 from fides.api.ops.models.connectionconfig import (
@@ -84,7 +87,7 @@ from fides.lib.models.audit_log import AuditLog, AuditLogAction
 from fides.lib.models.client import ClientDetail
 from fides.lib.models.fides_user import FidesUser
 from fides.lib.models.fides_user_permissions import FidesUserPermissions
-from fides.lib.oauth.roles import APPROVER, VIEWER
+from fides.lib.oauth.roles import VIEWER
 
 logging.getLogger("faker").setLevel(logging.ERROR)
 # disable verbose faker logging
@@ -153,6 +156,20 @@ def mock_upload_logic() -> Generator:
         "fides.api.ops.service.storage.storage_uploader_service.upload_to_s3"
     ) as _fixture:
         yield _fixture
+
+
+@pytest.fixture(scope="function")
+def custom_data_category(db: Session) -> Generator:
+    category = DataCategoryDbModel.create(
+        db=db,
+        data={
+            "name": "Example Custom Data Category",
+            "description": "A custom data category for testing",
+            "fides_key": "test_custom_data_category",
+        },
+    )
+    yield category
+    category.delete(db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/ops/api/v1/endpoints/test_policy_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_policy_endpoints.py
@@ -1237,6 +1237,56 @@ class TestRuleTargets:
         response_data = resp.json()["succeeded"]
         assert len(response_data) == 2
 
+    def test_create_rule_target_with_custom_category(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        policy,
+        custom_data_category,
+    ):
+        rule = policy.rules[0]
+        data = [
+            {
+                "data_category": custom_data_category.fides_key,
+            }
+        ]
+        auth_header = generate_auth_header(scopes=[scopes.RULE_CREATE_OR_UPDATE])
+        resp = api_client.patch(
+            self.get_rule_url(policy.key, rule.key),
+            json=data,
+            headers=auth_header,
+        )
+
+        assert resp.status_code == 200
+        response_data = resp.json()["succeeded"]
+        assert len(response_data) == 1
+
+    def test_create_target_with_invalid_category(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        policy,
+    ):
+        rule = policy.rules[0]
+        invalid_data_category = "invalid_category"
+        data = [
+            {
+                "data_category": invalid_data_category,
+            }
+        ]
+        auth_header = generate_auth_header(scopes=[scopes.RULE_CREATE_OR_UPDATE])
+        resp = api_client.patch(
+            self.get_rule_url(policy.key, rule.key),
+            json=data,
+            headers=auth_header,
+        )
+
+        assert resp.status_code == 422
+        assert (
+            resp.json()["detail"][0]["msg"]
+            == f"The data category {invalid_data_category} is not supported."
+        )
+
     def test_create_duplicate_rule_targets(
         self,
         api_client: TestClient,

--- a/tests/ops/models/test_policy.py
+++ b/tests/ops/models/test_policy.py
@@ -1,5 +1,7 @@
+from fideslang.models import DataCategory as FideslangDataCategory
 import pytest
 from sqlalchemy.orm import Session
+from unittest import mock
 
 from fides.api.ops.common_exceptions import (
     DataCategoryNotSupported,
@@ -12,6 +14,7 @@ from fides.api.ops.models.policy import (
     Policy,
     Rule,
     RuleTarget,
+    _get_ref_from_taxonomy,
     _is_ancestor_of_contained_categories,
 )
 from fides.api.ops.models.storage import StorageConfig
@@ -24,6 +27,15 @@ from fides.api.ops.service.masking.strategy.masking_strategy_nullify import (
 from fides.api.ops.util.data_category import DataCategory
 from fides.api.ops.util.text import to_snake_case
 from fides.lib.models.client import ClientDetail
+
+
+@mock.patch("fides.api.ops.models.policy.get_fides_data_category_superset")
+def test_get_ref_from_taxonomy_calls_superset(
+    mock_get_ref_from_taxonomy: mock.Mock,
+) -> None:
+    mock_get_ref_from_taxonomy.return_value = [FideslangDataCategory(fides_key="user")]
+    _get_ref_from_taxonomy("user")
+    assert mock_get_ref_from_taxonomy.called
 
 
 def test_policy_sets_slug(

--- a/tests/ops/schemas/test_policy.py
+++ b/tests/ops/schemas/test_policy.py
@@ -1,0 +1,12 @@
+from pydantic.error_wrappers import ValidationError
+import pytest
+
+from fides.api.ops.schemas.policy import RuleTarget
+
+
+def test_rule_target_schema():
+    with pytest.raises(ValidationError):
+        RuleTarget(data_category="not_a_real_data_category")
+
+    rt = RuleTarget(data_category="user")
+    assert rt.data_category == "user"

--- a/tests/ops/util/test_data_category_util.py
+++ b/tests/ops/util/test_data_category_util.py
@@ -1,0 +1,44 @@
+from fideslang import DEFAULT_TAXONOMY
+import pytest
+
+from fides.api.ops import common_exceptions
+from fides.api.ops.util.data_category import (
+    _validate_data_category,
+    get_fides_data_category_superset,
+    get_fides_data_categories_from_db,
+    get_fides_data_categories_from_taxonomy,
+)
+
+
+def test_get_fides_data_categories_from_taxonomy():
+    assert len(get_fides_data_categories_from_taxonomy()) == len(
+        DEFAULT_TAXONOMY.data_category
+    )
+    for el in DEFAULT_TAXONOMY.data_category:
+        assert el in get_fides_data_categories_from_taxonomy()
+
+
+def test_get_fides_data_categories_from_db(custom_data_category):
+    from_db = get_fides_data_categories_from_db()
+    assert custom_data_category.to_fideslang_obj() in from_db
+
+
+def test_get_fides_data_category_superset(custom_data_category):
+    superset = get_fides_data_category_superset()
+    assert custom_data_category.to_fideslang_obj() in superset
+
+    for el in DEFAULT_TAXONOMY.data_category:
+        assert el in superset
+
+
+def test_validate_data_category_rejects_unknown_categories(db):
+    unknown_data_category = "unknown.test.category"
+    with pytest.raises(common_exceptions.DataCategoryNotSupported):
+        _validate_data_category(unknown_data_category)
+
+
+def test_validate_data_category_allows_custom_categories(db, custom_data_category):
+    assert (
+        _validate_data_category(custom_data_category.fides_key)
+        == custom_data_category.fides_key
+    )


### PR DESCRIPTION
Closes #3103 

### Description

Updates `RuleTarget.data_category` API validation to also check custom categories defined in the app DB. There are some limitations:
- The `DataCategory` class from the taxonomy cannot be hashed in its current form, so I'm unable to use a `Set`
- As a result the `get_fides_data_category_superset()` function returns a `List` of `DataCategory` schemas
- and to be sure the return type from `get_fides_data_category_superset()` is uniform `get_fides_data_categories_from_db()` casts the DB models into `DataCategory` schemas.

### Code Changes

* [x] adds new util functions to `util/data_category.py` to get all categories from both the DB and taxonomy, and create a superset of both
* [x] updates data category validation to use this new superset

### Steps to Confirm

* [ ] `nox -s "fides_env(test)"`
* [ ] Create a custom data category in the UI at `/taxonomy`
* [ ] Send a `PATCH` request to `/api/v1/dsr/policy/{policy_key}/rule/{rule_key}/target` with the new data category as the value:
```
[
  {
    "data_category": "<custom_data_category>"
  }
]
```
* [ ] Assert the update succeeds
* [ ] Send a `PATCH` request to `/api/v1/dsr/policy/{policy_key}/rule/{rule_key}/target` with an invalid data category as the value:
```
[
  {
    "data_category": "something_else"
  }
]
```
* [ ] Assert the update fails

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated