### PR TITLE
[#807] adds fides_user_device_id to ProvidedIdentityType Enum

### DIFF
--- a/src/fides/api/ctl/migrations/versions/3842d1acac5f_adds_fides_device_id_enum.py
+++ b/src/fides/api/ctl/migrations/versions/3842d1acac5f_adds_fides_device_id_enum.py
@@ -1,0 +1,37 @@
+"""adds fides_user_device_id enum
+
+Revision ID: 3842d1acac5f
+Revises: 8342453518cc
+Create Date: 2023-04-21 20:10:01.389078
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "3842d1acac5f"
+down_revision = "8342453518cc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE providedidentitytype RENAME TO providedidentitytype_old")
+    op.execute(
+        "CREATE TYPE providedidentitytype AS ENUM('email', 'phone_number', 'ga_client_id', 'ljt_readerID', 'fides_user_device_id')"
+    )
+    op.execute(
+        "ALTER TABLE providedidentity ALTER COLUMN field_name TYPE providedidentitytype USING field_name::text::providedidentitytype"
+    )
+    op.execute("DROP TYPE providedidentitytype_old")
+
+
+def downgrade():
+    op.execute("ALTER TYPE providedidentitytype RENAME TO providedidentitytype_old")
+    op.execute(
+        "CREATE TYPE providedidentitytype AS ENUM('email', 'phone_number', 'ga_client_id', 'ljt_readerID')"
+    )
+    op.execute(
+        "ALTER TABLE providedidentity ALTER COLUMN field_name TYPE providedidentitytype USING field_name::text::providedidentitytype"
+    )
+    op.execute("DROP TYPE providedidentitytype_old")

--- a/src/fides/api/ops/models/privacy_request.py
+++ b/src/fides/api/ops/models/privacy_request.py
@@ -812,6 +812,7 @@ class ProvidedIdentityType(EnumType):
     phone_number = "phone_number"
     ga_client_id = "ga_client_id"
     ljt_readerID = "ljt_readerID"
+    fides_user_device_id = "fides_user_device_id"
 
 
 class ProvidedIdentity(Base):  # pylint: disable=R0904


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/807

### Code Changes

* [ ] Adds `fides_user_device_id` to `ProvidedIdentityType` enum and migration

### Steps to Confirm

* [ ] `nox -s dev -- shell`
* [ ] `pip install ipython`
* [ ] `ipython` then enter the following:
```
from fides.api.ops.models.privacy_request import ProvidedIdentityType, ProvidedIdentity
from fides.core.config import get_config
from fides.lib.db.session import get_db_session
db = get_db_session(get_config())()
pi = ProvidedIdentity.create(db=db, data={"field_name": "fides_user_device_id"})
assert pi.field_name.value == "fides_user_device_id"
```

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated