### PR TITLE
Custom fields table enhancements

### DIFF
--- a/clients/admin-ui/src/features/common/table/FidesTable.tsx
+++ b/clients/admin-ui/src/features/common/table/FidesTable.tsx
@@ -11,7 +11,6 @@ import {
   Thead,
   Tr,
 } from "@fidesui/react";
-import { useRouter } from "next/router";
 import React, { ReactNode } from "react";
 import { Column, useGlobalFilter, useSortBy, useTable } from "react-table";
 
@@ -25,22 +24,18 @@ interface FidesObject {
 type Props<T extends FidesObject> = {
   columns: Column<T>[];
   data: T[];
-  userCanUpdate: boolean;
-  redirectRoute: string;
   showSearchBar?: boolean;
   footer?: ReactNode;
+  onRowClick?: (row: T) => void;
 };
 
 export const FidesTable = <T extends FidesObject>({
   columns,
   data,
-  userCanUpdate,
-  redirectRoute,
   showSearchBar,
   footer,
+  onRowClick,
 }: Props<T>) => {
-  const router = useRouter();
-
   const tableInstance = useTable({ columns, data }, useGlobalFilter, useSortBy);
 
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
@@ -110,18 +105,13 @@ export const FidesTable = <T extends FidesObject>({
           {rows.map((row) => {
             prepareRow(row);
             const { key: rowKey, ...rowProps } = row.getRowProps();
-            const onClick = () => {
-              if (userCanUpdate) {
-                router.push(`${redirectRoute}/${row.original.id}`);
-              }
-            };
             const rowName = row.original.name;
             return (
               <Tr
                 key={rowKey}
                 {...rowProps}
                 _hover={
-                  userCanUpdate
+                  onRowClick
                     ? { backgroundColor: "gray.50", cursor: "pointer" }
                     : undefined
                 }
@@ -137,7 +127,11 @@ export const FidesTable = <T extends FidesObject>({
                       p={5}
                       verticalAlign="baseline"
                       onClick={
-                        cell.column.Header !== "Enable" ? onClick : undefined
+                        cell.column.Header !== "Enable" && onRowClick
+                          ? () => {
+                              onRowClick(row.original);
+                            }
+                          : undefined
                       }
                     >
                       {cell.render("Cell")}

--- a/clients/admin-ui/src/features/custom-fields/CustomFieldModal.tsx
+++ b/clients/admin-ui/src/features/custom-fields/CustomFieldModal.tsx
@@ -10,7 +10,10 @@ import {
   SimpleGrid,
   Text,
 } from "@fidesui/react";
-import { ReactNode, useRef } from "react";
+import {
+  FIELD_TYPE_OPTIONS,
+  RESOURCE_TYPE_OPTIONS,
+} from "common/custom-fields";
 import FormSection from "common/form/FormSection";
 import { CustomSelect, CustomTextInput } from "common/form/inputs";
 import {
@@ -21,21 +24,20 @@ import {
   FormikHelpers,
   FormikProps,
 } from "formik";
+import { ReactNode, useRef } from "react";
 import * as Yup from "yup";
+
+import { CreateCustomLists } from "~/features/common/custom-fields/CreateCustomLists";
 import {
   AllowedTypes,
   CustomFieldDefinition,
+  CustomFieldDefinitionWithId,
   ResourceTypes,
 } from "~/types/api";
-import {
-  FIELD_TYPE_OPTIONS,
-  RESOURCE_TYPE_OPTIONS,
-} from "common/custom-fields";
 
 type HeaderProps = {
   children: ReactNode;
 };
-import { CreateCustomLists } from "~/features/common/custom-fields/CreateCustomLists";
 
 const CustomFieldHeader = ({ children }: HeaderProps) => (
   <ModalHeader
@@ -62,6 +64,7 @@ type ModalProps = {
   isOpen: boolean;
   onClose: () => void;
   isLoading: boolean;
+  customField?: CustomFieldDefinitionWithId;
 };
 
 const initialValuesTemplate: CustomFieldDefinition = {
@@ -75,7 +78,9 @@ export const CustomFieldModal = ({
   isOpen,
   onClose,
   isLoading,
+  customField,
 }: ModalProps) => {
+  const initialValues = customField ?? initialValuesTemplate;
   const createCustomListsRef = useRef(null);
 
   return (
@@ -97,10 +102,7 @@ export const CustomFieldModal = ({
       >
         <CustomFieldHeader>Edit Custom Field</CustomFieldHeader>
         <ModalBody px={6} py={0}>
-          <Formik
-            initialValues={initialValuesTemplate}
-            onSubmit={async () => {}}
-          >
+          <Formik initialValues={initialValues} onSubmit={async () => {}}>
             {({ dirty, isValid, isSubmitting }) => (
               <Form
                 style={{

--- a/clients/admin-ui/src/features/custom-fields/CustomFieldsTable.tsx
+++ b/clients/admin-ui/src/features/custom-fields/CustomFieldsTable.tsx
@@ -48,6 +48,11 @@ export const CustomFieldsTable = () => {
     }
   };
 
+  const handleCloseModal = () => {
+    setActiveCustomField(undefined);
+    onClose();
+  };
+
   const columns: Column<CustomFieldDefinitionWithId>[] = useMemo(
     () => [
       {
@@ -131,7 +136,7 @@ export const CustomFieldsTable = () => {
         <CustomFieldModal
           customField={activeCustomField}
           isOpen={isOpen}
-          onClose={onClose}
+          onClose={handleCloseModal}
           isLoading={false}
         />
       </Box>

--- a/clients/admin-ui/src/features/custom-fields/CustomFieldsTable.tsx
+++ b/clients/admin-ui/src/features/custom-fields/CustomFieldsTable.tsx
@@ -14,7 +14,7 @@ import {
   WrappedCell,
 } from "common/table";
 import EmptyTableState from "common/table/EmptyTableState";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { Column } from "react-table";
 
 import { useAppSelector } from "~/app/hooks";
@@ -32,10 +32,22 @@ export const CustomFieldsTable = () => {
   const customFields = useAppSelector(selectAllCustomFieldDefinitions);
   const { isOpen, onClose, onOpen } = useDisclosure();
 
+  const [activeCustomField, setActiveCustomField] = useState<
+    CustomFieldDefinitionWithId | undefined
+  >(undefined);
+
   // Permissions
   const userCanUpdate = useHasPermission([
     ScopeRegistryEnum.CUSTOM_FIELD_UPDATE,
   ]);
+
+  const handleRowClick = (customField: CustomFieldDefinitionWithId) => {
+    if (userCanUpdate) {
+      setActiveCustomField(customField);
+      onOpen();
+    }
+  };
+
   const columns: Column<CustomFieldDefinitionWithId>[] = useMemo(
     () => [
       {
@@ -97,9 +109,8 @@ export const CustomFieldsTable = () => {
         <FidesTable<CustomFieldDefinitionWithId>
           columns={columns}
           data={customFields}
-          userCanUpdate={userCanUpdate}
-          redirectRoute=""
           showSearchBar
+          onRowClick={userCanUpdate ? handleRowClick : undefined}
           footer={
             <FidesTableFooter totalColumns={columns.length}>
               <Restrict
@@ -117,7 +128,12 @@ export const CustomFieldsTable = () => {
             </FidesTableFooter>
           }
         />
-        <CustomFieldModal isOpen={isOpen} onClose={onClose} isLoading={false} />
+        <CustomFieldModal
+          customField={activeCustomField}
+          isOpen={isOpen}
+          onClose={onClose}
+          isLoading={false}
+        />
       </Box>
     </>
   );

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
@@ -11,6 +11,7 @@ import {
 } from "common/table";
 import EmptyTableState from "common/table/EmptyTableState";
 import NextLink from "next/link";
+import { useRouter } from "next/router";
 import React, { useMemo } from "react";
 import { Column } from "react-table";
 
@@ -28,6 +29,7 @@ import {
 import { PrivacyNoticeResponse, ScopeRegistryEnum } from "~/types/api";
 
 export const PrivacyNoticesTable = () => {
+  const router = useRouter();
   // Subscribe to get all privacy notices
   const page = useAppSelector(selectPage);
   const pageSize = useAppSelector(selectPageSize);
@@ -38,6 +40,11 @@ export const PrivacyNoticesTable = () => {
   const userCanUpdate = useHasPermission([
     ScopeRegistryEnum.PRIVACY_NOTICE_UPDATE,
   ]);
+  const handleRowClick = ({ id }: PrivacyNoticeResponse) => {
+    if (userCanUpdate) {
+      router.push(`${PRIVACY_NOTICES_ROUTE}/${id}`);
+    }
+  };
 
   const columns: Column<PrivacyNoticeResponse>[] = useMemo(
     () => [
@@ -94,8 +101,7 @@ export const PrivacyNoticesTable = () => {
     <FidesTable<PrivacyNoticeResponse>
       columns={columns}
       data={privacyNotices}
-      userCanUpdate={userCanUpdate}
-      redirectRoute={PRIVACY_NOTICES_ROUTE}
+      onRowClick={userCanUpdate ? handleRowClick : undefined}
       footer={
         <FidesTableFooter totalColumns={columns.length}>
           <Restrict scopes={[ScopeRegistryEnum.PRIVACY_NOTICE_CREATE]}>


### PR DESCRIPTION
Part of https://github.com/ethyca/fides/issues/3127

### Code Changes

* [x] Refactor FidesTable to take a `onRowClick` prop. this removes the need for `userCanUpdate` and `redirectRoute` as props
* [x] Refactors PrivacyNoticesTable to use the new props
* [x] Passes a handler from CustomFieldsTable to the updated FidesTable so that it can open the modal
* [x] Saves the `activeCustomField` in state and passes it into the custom field modal. the custom field modal can now take that field and render it if it wasn't passed initial values

### Steps to Confirm

* Run fidesplus backend with `npm run dev` admin ui
* Add some custom fields either through the edit system form or by editing a taxonomy entry
* Click on a row in the table
* The modal should come up with the name of the field
* Privacy notices table still works

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

https://user-images.githubusercontent.com/24641006/234064811-087c0b5b-48e5-4da9-8c63-7ef52eebfc24.mov

