### PR TITLE
Updating dataset reference type name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The types of changes are:
 ### Fixed
 
 - The `--local` flag is now respected for the `scan dataset db` command [#3096](https://github.com/ethyca/fides/pull/3096)
+- Fixing issue where connectors with external dataset references would fail to save [#3142](https://github.com/ethyca/fides/pull/3142)
 
 ### Developer Experience
 

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/ConnectorParametersForm.tsx
@@ -36,7 +36,7 @@ import {
 } from "../types";
 import { fillInDefaults } from "./helpers";
 
-const FIDESOPS_DATASET_REFERENCE = "#/definitions/FidesopsDatasetReference";
+const FIDES_DATASET_REFERENCE = "#/definitions/FidesDatasetReference";
 
 type ConnectorParametersFormProps = {
   data: ConnectionTypeSecretSchemaReponse;
@@ -91,7 +91,7 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
     if (typeof value === "undefined" || value === "") {
       error = `${label} is required`;
     }
-    if (type === FIDESOPS_DATASET_REFERENCE) {
+    if (type === FIDES_DATASET_REFERENCE) {
       if (!value.includes(".")) {
         error = "Dataset reference must be dot delimited";
       } else {
@@ -117,7 +117,7 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
   );
 
   const getPlaceholder = (item: ConnectionTypeSecretSchemaProperty) => {
-    if (item.allOf?.[0].$ref === FIDESOPS_DATASET_REFERENCE) {
+    if (item.allOf?.[0].$ref === FIDES_DATASET_REFERENCE) {
       return "Enter dataset.collection.field";
     }
     return undefined;
@@ -210,7 +210,7 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
     // from a dot delimited string to a FidesopsDatasetReference
     const updatedValues = { ...values };
     Object.keys(data.properties).forEach((key) => {
-      if (data.properties[key].allOf?.[0].$ref === FIDESOPS_DATASET_REFERENCE) {
+      if (data.properties[key].allOf?.[0].$ref === FIDES_DATASET_REFERENCE) {
         const referencePath = values[key].split(".");
         updatedValues[key] = {
           dataset: referencePath.shift(),


### PR DESCRIPTION
Closes #3141

### Code Changes

* [ ] Updating the type name for external dataset references in the front-end

### Steps to Confirm

* [ ] Verified by successfully saving a connector config with external references (Yotpo Reviews)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`


### Description Of Changes
We key off of the type names to determine if we should convert a dataset reference string into a dataset reference object. The type in the front-end no longer matched the type in the backend.
