### PR TITLE
Custom fields kebob menu for more actions

### DIFF
--- a/clients/admin-ui/src/features/common/table/FidesTable.tsx
+++ b/clients/admin-ui/src/features/common/table/FidesTable.tsx
@@ -140,6 +140,7 @@ export const FidesTable = <T extends FidesObject>({
                       {...cellProps}
                       p={5}
                       verticalAlign="baseline"
+                      width={cell.column.width}
                       onClick={
                         cell.column.Header !== "Enable" && onRowClick
                           ? () => {

--- a/clients/admin-ui/src/features/common/table/FidesTable.tsx
+++ b/clients/admin-ui/src/features/common/table/FidesTable.tsx
@@ -11,8 +11,14 @@ import {
   Thead,
   Tr,
 } from "@fidesui/react";
-import React, { ReactNode } from "react";
-import { Column, useGlobalFilter, useSortBy, useTable } from "react-table";
+import React, { ReactNode, useMemo } from "react";
+import {
+  Column,
+  Hooks,
+  useGlobalFilter,
+  useSortBy,
+  useTable,
+} from "react-table";
 
 import GlobalFilter from "~/features/datamap/datamap-table/filters/global-accordion-filter/global-accordion-filter";
 
@@ -27,6 +33,7 @@ type Props<T extends FidesObject> = {
   showSearchBar?: boolean;
   footer?: ReactNode;
   onRowClick?: (row: T) => void;
+  customHooks?: Array<(hooks: Hooks<T>) => void>;
 };
 
 export const FidesTable = <T extends FidesObject>({
@@ -35,8 +42,16 @@ export const FidesTable = <T extends FidesObject>({
   showSearchBar,
   footer,
   onRowClick,
+  customHooks,
 }: Props<T>) => {
-  const tableInstance = useTable({ columns, data }, useGlobalFilter, useSortBy);
+  const plugins = useMemo(() => {
+    if (customHooks) {
+      return [useGlobalFilter, useSortBy, ...customHooks];
+    }
+    return [useGlobalFilter, useSortBy];
+  }, [customHooks]);
+
+  const tableInstance = useTable({ columns, data }, ...plugins);
 
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     tableInstance;
@@ -119,7 +134,6 @@ export const FidesTable = <T extends FidesObject>({
               >
                 {row.cells.map((cell) => {
                   const { key: cellKey, ...cellProps } = cell.getCellProps();
-
                   return (
                     <Td
                       key={cellKey}

--- a/clients/admin-ui/src/features/custom-fields/CustomFieldsTable.tsx
+++ b/clients/admin-ui/src/features/custom-fields/CustomFieldsTable.tsx
@@ -15,7 +15,7 @@ import {
 } from "common/table";
 import EmptyTableState from "common/table/EmptyTableState";
 import React, { useMemo, useState } from "react";
-import { Column } from "react-table";
+import { Column, Hooks } from "react-table";
 
 import { useAppSelector } from "~/app/hooks";
 import {
@@ -24,7 +24,7 @@ import {
 } from "~/features/plus/plus.slice";
 import { CustomFieldDefinitionWithId, ScopeRegistryEnum } from "~/types/api";
 
-import { EnableCustomFieldCell, FieldTypeCell } from "./cells";
+import { EnableCustomFieldCell, FieldTypeCell, MoreActionsCell } from "./cells";
 import { CustomFieldModal } from "./CustomFieldModal";
 
 export const CustomFieldsTable = () => {
@@ -35,6 +35,17 @@ export const CustomFieldsTable = () => {
   const [activeCustomField, setActiveCustomField] = useState<
     CustomFieldDefinitionWithId | undefined
   >(undefined);
+
+  const tableHook = (hooks: Hooks<CustomFieldDefinitionWithId>) => {
+    hooks.visibleColumns.push((visibleColumns) => [
+      ...visibleColumns,
+      {
+        id: "more-actions",
+        Header: <div />,
+        Cell: MoreActionsCell,
+      },
+    ]);
+  };
 
   // Permissions
   const userCanUpdate = useHasPermission([
@@ -116,8 +127,11 @@ export const CustomFieldsTable = () => {
           data={customFields}
           showSearchBar
           onRowClick={userCanUpdate ? handleRowClick : undefined}
+          customHooks={[tableHook]}
           footer={
-            <FidesTableFooter totalColumns={columns.length}>
+            // +1 for total columns because our hook adds a column for the
+            // more actions menu
+            <FidesTableFooter totalColumns={columns.length + 1}>
               <Restrict
                 scopes={[ScopeRegistryEnum.CUSTOM_FIELD_DEFINITION_CREATE]}
               >

--- a/clients/admin-ui/src/features/custom-fields/cells.tsx
+++ b/clients/admin-ui/src/features/custom-fields/cells.tsx
@@ -1,3 +1,11 @@
+import {
+  Button,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  MoreIcon,
+} from "@fidesui/react";
 import React from "react";
 import { CellProps } from "react-table";
 
@@ -31,5 +39,44 @@ export const EnableCustomFieldCell = (
       title="Disable custom field"
       message="Are you sure you want to disable this custom field?"
     />
+  );
+};
+
+const MENU_ITEM_PROPS = { _hover: { color: "complimentary.500" } };
+
+export const MoreActionsCell = (cellProps: CellProps<any, any>) => {
+  // Need to stopPropagation on all button calls here since the table row itself
+  // also has a click handler. We want the buttons in this cell to take precedence
+  // over the row handler
+  const handleDelete = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    e.stopPropagation();
+    console.log("delete");
+  };
+  const handleEdit = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    e.stopPropagation();
+    console.log("edit");
+  };
+  return (
+    <Menu size="sm">
+      <MenuButton
+        as={Button}
+        variant="outline"
+        data-testid="more-actions-btn"
+        size="xs"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <MoreIcon />
+      </MenuButton>
+      <MenuList>
+        <MenuItem {...MENU_ITEM_PROPS} onClick={handleDelete}>
+          Delete
+        </MenuItem>
+        <MenuItem {...MENU_ITEM_PROPS} onClick={handleEdit}>
+          Edit
+        </MenuItem>
+      </MenuList>
+    </Menu>
   );
 };

--- a/clients/admin-ui/src/features/custom-fields/cells.tsx
+++ b/clients/admin-ui/src/features/custom-fields/cells.tsx
@@ -5,10 +5,14 @@ import {
   MenuItem,
   MenuList,
   MoreIcon,
+  Text,
+  useDisclosure,
+  WarningIcon,
 } from "@fidesui/react";
 import React from "react";
 import { CellProps } from "react-table";
 
+import ConfirmationModal from "~/features/common/ConfirmationModal";
 import Restrict from "~/features/common/Restrict";
 import { EnableCell, MapCell } from "~/features/common/table/";
 import { FIELD_TYPE_MAP } from "~/features/custom-fields/constants";
@@ -46,13 +50,13 @@ export const EnableCustomFieldCell = (
 const MENU_ITEM_PROPS = { _hover: { color: "complimentary.500" } };
 
 export const MoreActionsCell = ({ row, column }: CellProps<any, any>) => {
+  const modal = useDisclosure();
   // Need to stopPropagation on all button calls here since the table row itself
   // also has a click handler. We want the buttons in this cell to take precedence
   // over the row handler
   const handleDelete = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
-    // @ts-ignore revisit with react-table v8
-    column.onDelete(row.original);
+    modal.onOpen();
   };
 
   const handleEdit = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -62,30 +66,52 @@ export const MoreActionsCell = ({ row, column }: CellProps<any, any>) => {
   };
 
   return (
-    <Menu size="sm">
-      <MenuButton
-        as={Button}
-        variant="outline"
-        data-testid="more-actions-btn"
-        size="xs"
-        onClick={(e) => {
-          e.stopPropagation();
+    <>
+      <Menu size="sm">
+        <MenuButton
+          as={Button}
+          variant="outline"
+          data-testid="more-actions-btn"
+          size="xs"
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          <MoreIcon />
+        </MenuButton>
+        <MenuList>
+          <Restrict scopes={[ScopeRegistryEnum.CUSTOM_FIELD_DELETE]}>
+            <MenuItem {...MENU_ITEM_PROPS} onClick={handleDelete}>
+              Delete
+            </MenuItem>
+          </Restrict>
+          <Restrict scopes={[ScopeRegistryEnum.CUSTOM_FIELD_UPDATE]}>
+            <MenuItem {...MENU_ITEM_PROPS} onClick={handleEdit}>
+              Edit
+            </MenuItem>
+          </Restrict>
+        </MenuList>
+      </Menu>
+      <ConfirmationModal
+        isOpen={modal.isOpen}
+        onClose={modal.onClose}
+        onConfirm={() => {
+          // @ts-ignore revisit with react-table v8
+          column.onDelete(row.original);
+          modal.onClose();
         }}
-      >
-        <MoreIcon />
-      </MenuButton>
-      <MenuList>
-        <Restrict scopes={[ScopeRegistryEnum.CUSTOM_FIELD_DELETE]}>
-          <MenuItem {...MENU_ITEM_PROPS} onClick={handleDelete}>
-            Delete
-          </MenuItem>
-        </Restrict>
-        <Restrict scopes={[ScopeRegistryEnum.CUSTOM_FIELD_UPDATE]}>
-          <MenuItem {...MENU_ITEM_PROPS} onClick={handleEdit}>
-            Edit
-          </MenuItem>
-        </Restrict>
-      </MenuList>
-    </Menu>
+        title="Delete custom field"
+        message={
+          <Text color="gray.500">
+            Are you sure you want to delete this custom field? This will remove
+            the custom field and all stored values and this action can&apos;t be
+            undone.
+          </Text>
+        }
+        continueButtonText="Confirm"
+        isCentered
+        icon={<WarningIcon />}
+      />
+    </>
   );
 };

--- a/clients/admin-ui/src/features/custom-fields/cells.tsx
+++ b/clients/admin-ui/src/features/custom-fields/cells.tsx
@@ -9,10 +9,11 @@ import {
 import React from "react";
 import { CellProps } from "react-table";
 
+import Restrict from "~/features/common/Restrict";
 import { EnableCell, MapCell } from "~/features/common/table/";
 import { FIELD_TYPE_MAP } from "~/features/custom-fields/constants";
 import { useUpdateCustomFieldDefinitionMutation } from "~/features/plus/plus.slice";
-import { CustomFieldDefinition } from "~/types/api";
+import { CustomFieldDefinition, ScopeRegistryEnum } from "~/types/api";
 
 export const FieldTypeCell = (
   cellProps: CellProps<typeof FIELD_TYPE_MAP, string>
@@ -44,18 +45,22 @@ export const EnableCustomFieldCell = (
 
 const MENU_ITEM_PROPS = { _hover: { color: "complimentary.500" } };
 
-export const MoreActionsCell = (cellProps: CellProps<any, any>) => {
+export const MoreActionsCell = ({ row, column }: CellProps<any, any>) => {
   // Need to stopPropagation on all button calls here since the table row itself
   // also has a click handler. We want the buttons in this cell to take precedence
   // over the row handler
   const handleDelete = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
-    console.log("delete");
+    // @ts-ignore revisit with react-table v8
+    column.onDelete(row.original);
   };
+
   const handleEdit = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
-    console.log("edit");
+    // @ts-ignore revisit with react-table v8
+    column.onEdit(row.original);
   };
+
   return (
     <Menu size="sm">
       <MenuButton
@@ -70,12 +75,16 @@ export const MoreActionsCell = (cellProps: CellProps<any, any>) => {
         <MoreIcon />
       </MenuButton>
       <MenuList>
-        <MenuItem {...MENU_ITEM_PROPS} onClick={handleDelete}>
-          Delete
-        </MenuItem>
-        <MenuItem {...MENU_ITEM_PROPS} onClick={handleEdit}>
-          Edit
-        </MenuItem>
+        <Restrict scopes={[ScopeRegistryEnum.CUSTOM_FIELD_DELETE]}>
+          <MenuItem {...MENU_ITEM_PROPS} onClick={handleDelete}>
+            Delete
+          </MenuItem>
+        </Restrict>
+        <Restrict scopes={[ScopeRegistryEnum.CUSTOM_FIELD_UPDATE]}>
+          <MenuItem {...MENU_ITEM_PROPS} onClick={handleEdit}>
+            Edit
+          </MenuItem>
+        </Restrict>
       </MenuList>
     </Menu>
   );

--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -241,6 +241,13 @@ export const plusApi = createApi({
       }),
       invalidatesTags: ["CustomFieldDefinition"],
     }),
+    deleteCustomFieldDefinition: build.mutation<void, { id: string }>({
+      query: ({ id }) => ({
+        url: `custom-metadata/custom-field-definition/${id}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["CustomFieldDefinition"],
+    }),
 
     // Custom Metadata Custom Field Definition By Resource Type
     getCustomFieldDefinitionsByResourceType: build.query<
@@ -261,6 +268,7 @@ export const {
   useAddCustomFieldDefinitionMutation,
   useCreateClassifyInstanceMutation,
   useDeleteCustomFieldMutation,
+  useDeleteCustomFieldDefinitionMutation,
   useGetAllAllowListQuery,
   useGetAllClassifyInstancesQuery,
   useGetClassifyDatasetQuery,


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3127

### Code Changes

* [x] Adds a new cell type `MoreActionsCell`
* [x] Extends `FidesTable` to take custom hooks
  * [x] At first I tried to just add a column to the `columns` definition but that appeared to require an accessor which this column doesn't need. I browsed through some react table examples from their documentation and [came across this one](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/v7/examples/row-selection?from-embed=&file=/src/App.js:1291-2049) which passes an extra hook to render the extra column, so that's the strategy I used
* [x] Add edit/delete functionality 
* [x] Add confirmation modal for deleting
* [x] Add deleting a custom field to the plus.slice

### Steps to Confirm

* Run fidesplus backend with `npm run dev` in admin-ui for the front end
* Add some custom fields either through the edit system form or by editing a taxonomy entry
* You should now see a kebob menu on the right hand side of the table
* Clicking on the menu then "edit" should bring up the edit modal
* Clicking on the menu then "delete" should bring up a confirmation modal
  * Confirming should delete the custom field

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes


https://user-images.githubusercontent.com/24641006/234098530-d6093f0a-6aa6-459e-94e7-52951e4f7149.mov


