### PR TITLE
3037 support privacy declaration resource type for custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,12 @@ The types of changes are:
 - Endpoints for consent reporting [#3095](https://github.com/ethyca/fides/pull/3095)
 - Custom fields table [#3097](https://github.com/ethyca/fides/pull/3097)
 - Endpoints to save the new-style Privacy Preferences with respect to a fides user device id [#3132](https://github.com/ethyca/fides/pull/3132)
+- Support `privacy_declaration` as a resource type for custom fields [#3149](https://github.com/ethyca/fides/pull/3149)
 
 ### Changed
 
 - The `cursor` pagination strategy now also searches for data outside of the `data_path` when determining the cursor value [#3068](https://github.com/ethyca/fides/pull/3068)
+- Moved Privacy Declarations associated with Systems to their own DB table [#3098](https://github.com/ethyca/fides/pull/3098)
 
 ### Removed
 

--- a/src/fides/api/ctl/migrations/versions/5b03859e51b5_update_custom_field_resource_type_enum.py
+++ b/src/fides/api/ctl/migrations/versions/5b03859e51b5_update_custom_field_resource_type_enum.py
@@ -1,0 +1,74 @@
+"""update custom field resource type enum
+
+Revision ID: 5b03859e51b5
+Revises: 48d9caacebd4
+Create Date: 2023-04-19 19:22:47.566852
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5b03859e51b5"
+down_revision = "48d9caacebd4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Extra steps added here to avoid the error that enums have to be committed before they can be used.  This
+    avoids having to commit in the middle of this migration and lets the entire thing be completed in a single transaction
+    """
+    op.execute("alter type resourcetypes rename to resourcetypesold")
+
+    op.execute(
+        "create type resourcetypes as enum ('system', 'data_use', 'data_category', 'data_subject', 'privacy_declaration');"
+    )
+
+    op.execute(
+        (
+            "alter table plus_custom_field_definition alter column resource_type type resourcetypes using "
+            "resource_type::text::resourcetypes"
+        )
+    )
+    op.execute(
+        (
+            "alter table plus_custom_field alter column resource_type type resourcetypes using "
+            "resource_type::text::resourcetypes"
+        )
+    )
+
+    op.execute(("drop type resourcetypesold;"))
+
+
+def downgrade():
+    op.execute("alter type resourcetypes rename to resourcetypesold")
+
+    op.execute(
+        "create type resourcetypes as enum ('system', 'data_use', 'data_category', 'data_subject');"
+    )
+
+    # Data migration - delete rows with a resource type of 'privacy_declaration'
+    op.execute(
+        "delete from plus_custom_field where resource_type = 'privacy_declaration'"
+    )
+    # Data migration - delete rows with a resource type of 'privacy_declaration'
+    op.execute(
+        "delete from plus_custom_field_definition where resource_type = 'privacy_declaration'"
+    )
+
+    op.execute(
+        (
+            "alter table plus_custom_field_definition alter column resource_type type resourcetypes using "
+            "resource_type::text::resourcetypes"
+        )
+    )
+
+    op.execute(
+        (
+            "alter table plus_custom_field alter column resource_type type resourcetypes using "
+            "resource_type::text::resourcetypes"
+        )
+    )
+
+    op.execute(("drop type resourcetypesold;"))

--- a/src/fides/api/ctl/migrations/versions/5b03859e51b5_update_custom_field_resource_type_enum.py
+++ b/src/fides/api/ctl/migrations/versions/5b03859e51b5_update_custom_field_resource_type_enum.py
@@ -1,7 +1,7 @@
 """update custom field resource type enum
 
 Revision ID: 5b03859e51b5
-Revises: 48d9caacebd4
+Revises: 451684a726a5
 Create Date: 2023-04-19 19:22:47.566852
 
 """
@@ -9,7 +9,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "5b03859e51b5"
-down_revision = "48d9caacebd4"
+down_revision = "451684a726a5"
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/ctl/sql_models.py
+++ b/src/fides/api/ctl/sql_models.py
@@ -452,6 +452,7 @@ class ResourceTypes(str, EnumType):
     data_use = "data use"
     data_category = "data category"
     data_subject = "data subject"
+    privacy_declaration = "privacy declaration"
 
 
 class CustomFieldValueList(Base):


### PR DESCRIPTION
❗ Contains migration; check downrev before merge

partially closes #3037 

there will need to be some follow up changes on the fidesplus API side to make this fully work, but these are the necessary updates in `fides`

### Code Changes

* update sqlalchemy and DB `resource_type` enum for `CustomFieldDefinition` and `CustomField` tables/models to allow `privacy_declaration` as a value
    * include a migration for this change. migration downgrade path has to remove any records (`CustomField`s and `CustomFieldDefinition`s) that have the `privacy_declaration` as their `resource_type`

### Steps to Confirm

* The only real testing we can do on this PR specifically would be around the migrations.
    * I tested locally that migrating from a previous app state successfully added the `privacy_declaration` value to the `resourcetypes` enum
* Testing the actual application functionality will require some updates to the API, which lives in `fidesplus`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

