### PR TITLE
make name not required on privacy declaration

### DIFF
--- a/src/fides/api/ctl/migrations/versions/48d9caacebd4_create_privacy_declarations_table.py
+++ b/src/fides/api/ctl/migrations/versions/48d9caacebd4_create_privacy_declarations_table.py
@@ -38,7 +38,7 @@ def upgrade():
             server_default=sa.text("now()"),
             nullable=True,
         ),
-        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=True),
         sa.Column("egress", sa.ARRAY(sa.String()), nullable=True),
         sa.Column("ingress", sa.ARRAY(sa.String()), nullable=True),
         sa.Column("data_use", sa.String(), nullable=False),

--- a/src/fides/api/ctl/sql_models.py
+++ b/src/fides/api/ctl/sql_models.py
@@ -345,7 +345,7 @@ class PrivacyDeclaration(Base):
     """
 
     name = Column(
-        String, index=True, nullable=False
+        String, index=True, nullable=True
     )  # labeled as Processing Activity in the UI
     ### keep egress/ingress as JSON blobs as they have always been
     egress = Column(ARRAY(String))

--- a/src/fides/data/sample_project/sample_resources/sample_systems.yml
+++ b/src/fides/data/sample_project/sample_resources/sample_systems.yml
@@ -20,7 +20,6 @@ system:
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-        name: Store Cookie House eCommerce application user cookie ID
 
   - fides_key: cookie_house_postgres
     name: Cookie House PostgreSQL Database
@@ -40,7 +39,6 @@ system:
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
         dataset_references:
           - postgres_example_test_dataset
-        name: Cookie House user primary database data
 
   - fides_key: cookie_house_mongo
     name: Cookie House Customer Database
@@ -59,7 +57,6 @@ system:
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
         dataset_references:
           - mongo_test
-        name: Cookie House user data mongo DB
 
   - fides_key: cookie_house_marketing
     name: Cookie House Marketing System
@@ -76,4 +73,3 @@ system:
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-        name: Store Cookie House marketing application data


### PR DESCRIPTION
follow up to  https://github.com/ethyca/fides/pull/3098

per conversation with @NevilleS we're actually trying to move away from relying on the `name` property, so we shouldn't require it on the BE, even if we do want to use it as part of the uniqueness criteria.

i decided to update the migration in-place since the original PR was merged _minutes_ ago...are we OK with that??

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
