### PR TITLE
[Backend] More Privacy Notice Data Use Validation Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The types of changes are:
 
 - The `cursor` pagination strategy now also searches for data outside of the `data_path` when determining the cursor value [#3068](https://github.com/ethyca/fides/pull/3068)
 - Moved Privacy Declarations associated with Systems to their own DB table [#3098](https://github.com/ethyca/fides/pull/3098)
-- Relaxed some data use validation for privacy notices within the same region [#3156](https://github.com/ethyca/fides/pull/3156)
+- More tests on data use validation for privacy notices within the same region [#3156](https://github.com/ethyca/fides/pull/3156)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The types of changes are:
 
 - The `cursor` pagination strategy now also searches for data outside of the `data_path` when determining the cursor value [#3068](https://github.com/ethyca/fides/pull/3068)
 - Moved Privacy Declarations associated with Systems to their own DB table [#3098](https://github.com/ethyca/fides/pull/3098)
+- Relaxed some data use validation for privacy notices within the same region [#3156](https://github.com/ethyca/fides/pull/3156)
 
 ### Removed
 

--- a/src/fides/api/ctl/sql_models.py
+++ b/src/fides/api/ctl/sql_models.py
@@ -7,20 +7,10 @@ Contains all of the SqlAlchemy models for the Fides resources.
 from __future__ import annotations
 
 from enum import Enum as EnumType
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Type,
-    TypeVar,
-)
+from typing import Any, Dict, List, Optional, Set, Type, TypeVar
 
-from fideslang.models import (
-    DataCategory as FideslangDataCategory,
-    Dataset as FideslangDataset,
-)
+from fideslang.models import DataCategory as FideslangDataCategory
+from fideslang.models import Dataset as FideslangDataset
 from pydantic import BaseModel
 from sqlalchemy import ARRAY, BOOLEAN, JSON, Column
 from sqlalchemy import Enum as EnumColumn
@@ -149,6 +139,7 @@ class ClassificationInstance(Base):
 
 
 DataCategoryType = TypeVar("DataCategoryType", bound="DataCategory")
+
 
 # Privacy Types
 class DataCategory(Base, FidesBase):

--- a/src/fides/api/ops/models/policy.py
+++ b/src/fides/api/ops/models/policy.py
@@ -14,8 +14,8 @@ from sqlalchemy_utils.types.encrypted.encrypted_type import (
     AesGcmEngine,
     StringEncryptedType,
 )
-from fides.api.ctl.sql_models import DataCategory  # type: ignore
 
+from fides.api.ctl.sql_models import DataCategory  # type: ignore
 from fides.api.ops import common_exceptions
 from fides.api.ops.common_exceptions import (
     StorageConfigNotFoundException,

--- a/src/fides/api/ops/models/privacy_notice.py
+++ b/src/fides/api/ops/models/privacy_notice.py
@@ -250,15 +250,21 @@ def check_conflicting_data_uses(
                     # we need to check for hierachical overlaps in _both_ directions
                     # i.e. whether the incoming DataUse is a parent _or_ a child of
                     # an existing DataUse
-                    if existing_use.startswith(data_use) or data_use.startswith(
-                        existing_use
-                    ):
+                    if new_data_use_conflicts_with_existing_use(existing_use, data_use):
                         raise ValidationError(
                             message=f"Privacy Notice '{notice_name}' has already assigned data use '{existing_use}' to region '{region}'"
                         )
                 # add the data use to our map, to effectively include it in validation against the
                 # following incoming records
                 region_uses.append((data_use, privacy_notice.name))
+
+
+def new_data_use_conflicts_with_existing_use(existing_use: str, new_use: str) -> bool:
+    """Data use check that prevents grandparent/parent/child, but allows siblings, aunt/child, etc.
+    Check needs to happen in both directions.
+    This assumes the supplied uses are on notices in the same region.
+    """
+    return existing_use.startswith(new_use) or new_use.startswith(existing_use)
 
 
 class PrivacyNoticeHistory(PrivacyNoticeBase, Base):

--- a/src/fides/api/ops/models/privacy_notice.py
+++ b/src/fides/api/ops/models/privacy_notice.py
@@ -247,26 +247,18 @@ def check_conflicting_data_uses(
             # check each of the incoming notice's data uses
             for data_use in privacy_notice.data_uses:
                 for existing_use, notice_name in region_uses:
-                    if not can_add_new_use(existing_use, data_use):
+                    # we need to check for hierachical overlaps in _both_ directions
+                    # i.e. whether the incoming DataUse is a parent _or_ a child of
+                    # an existing DataUse
+                    if existing_use.startswith(data_use) or data_use.startswith(
+                        existing_use
+                    ):
                         raise ValidationError(
                             message=f"Privacy Notice '{notice_name}' has already assigned data use '{existing_use}' to region '{region}'"
                         )
                 # add the data use to our map, to effectively include it in validation against the
                 # following incoming records
                 region_uses.append((data_use, privacy_notice.name))
-
-
-def can_add_new_use(existing_use: str, new_use: str) -> bool:
-    """Data use check that prevents grandparent/parent/child, but allows siblings, aunt/child, etc.
-    Check needs to happen in both directions.
-
-    This assumes the supplied uses are on notices in the same region.
-    """
-    if existing_use == new_use:
-        return False
-    if existing_use.startswith(new_use + ".") or new_use.startswith(existing_use + "."):
-        return False
-    return True
 
 
 class PrivacyNoticeHistory(PrivacyNoticeBase, Base):

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -14,11 +14,9 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 from toml import load as load_toml
 
-from fides.api.ctl.sql_models import (
-    DataCategory as DataCategoryDbModel,
-    Dataset as CtlDataset,
-    System,
-)
+from fides.api.ctl.sql_models import DataCategory as DataCategoryDbModel
+from fides.api.ctl.sql_models import Dataset as CtlDataset
+from fides.api.ctl.sql_models import System
 from fides.api.ops.common_exceptions import SystemManagerException
 from fides.api.ops.models.application_config import ApplicationConfig
 from fides.api.ops.models.connectionconfig import (

--- a/tests/ops/conftest.py
+++ b/tests/ops/conftest.py
@@ -2,9 +2,9 @@
 tests/conftest.py file.
 """
 
-from fideslang import DEFAULT_TAXONOMY
 import pytest
 import requests
+from fideslang import DEFAULT_TAXONOMY
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import ObjectDeletedError
 

--- a/tests/ops/models/test_privacy_notice.py
+++ b/tests/ops/models/test_privacy_notice.py
@@ -6,7 +6,6 @@ from fides.api.ops.models.privacy_notice import (
     PrivacyNotice,
     PrivacyNoticeHistory,
     PrivacyNoticeRegion,
-    can_add_new_use,
     check_conflicting_data_uses,
 )
 
@@ -711,4 +710,8 @@ class TestCanAddNewUse:
         ],
     )
     def test_can_add_new_use(self, existing_use, new_use, expected_can_add_result):
-        assert can_add_new_use(existing_use, new_use) == expected_can_add_result
+        can_add = not (
+            existing_use.startswith(new_use) or new_use.startswith(existing_use)
+        )
+
+        assert can_add == expected_can_add_result

--- a/tests/ops/models/test_privacy_notice.py
+++ b/tests/ops/models/test_privacy_notice.py
@@ -7,6 +7,7 @@ from fides.api.ops.models.privacy_notice import (
     PrivacyNoticeHistory,
     PrivacyNoticeRegion,
     check_conflicting_data_uses,
+    new_data_use_conflicts_with_existing_use,
 )
 
 
@@ -689,29 +690,28 @@ class TestPrivacyNoticeModel:
         ), "This is an exact match but this privacy notice is frontend only"
 
 
-class TestCanAddNewUse:
+class TestDataUseConflictFound:
     @pytest.mark.parametrize(
-        "existing_use,new_use,expected_can_add_result",
+        "existing_use,new_use,conflict_found",
         [
-            ("a", "a", False),
-            ("a", "a.b", False),
-            ("a", "a.b.c", False),
-            ("a.b.c", "a.b.c", False),
-            ("a.b.c", "a.b", False),
-            ("a.b.c", "a", False),
-            ("a.b", "a.b", False),
-            ("a.b", "a", False),
-            ("a", "c", True),
-            ("a.b", "c.d", True),
-            ("a.b", "a.c", True),
-            ("a.b.c", "a.b.d", True),
-            ("a.b", "a.c.d", True),
-            ("a.c.d", "a.b", True),
+            ("a", "a", True),
+            ("a", "a.b", True),
+            ("a", "a.b.c", True),
+            ("a.b.c", "a.b.c", True),
+            ("a.b.c", "a.b", True),
+            ("a.b.c", "a", True),
+            ("a.b", "a.b", True),
+            ("a.b", "a", True),
+            ("a", "c", False),
+            ("a.b", "c.d", False),
+            ("a.b", "a.c", False),
+            ("a.b.c", "a.b.d", False),
+            ("a.b", "a.c.d", False),
+            ("a.c.d", "a.b", False),
         ],
     )
-    def test_can_add_new_use(self, existing_use, new_use, expected_can_add_result):
-        can_add = not (
-            existing_use.startswith(new_use) or new_use.startswith(existing_use)
+    def test_new_data_use_conflicts(self, existing_use, new_use, conflict_found):
+        assert (
+            new_data_use_conflicts_with_existing_use(existing_use, new_use)
+            is conflict_found
         )
-
-        assert can_add == expected_can_add_result


### PR DESCRIPTION
Closes #3154 

### Code Changes

* [ ] More tests to confirm this "startswith" data use check is sufficient for the in-region checks we want to run.

### Steps to Confirm

* [ ]  This PR just adds more tests so nothing really to check.  If you wanted you could confirm that you could create privacy notices in the API (existing Postman collection Privacy Notices > Create Privacy Notices to have a sibling data use (For example, create a CA `advertising.first_party.personalized notice` and a California `advertising.third_party.personalized` notice) and confirm it is allowed. Confirm a parent child data use in the same region is still not allowed.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Context: https://github.com/ethyca/fides/pull/3120#discussion_r1175579109

Adding additional checks here to confirm sibling or nephew relationships are allowed in the hierarchy.  I thought this didn't work but the starts with check does handle these use cases so adding further tests here.

