### PR TITLE
include 'id' on embedded privacy_declaration objects in system API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The types of changes are:
 - Custom fields table [#3097](https://github.com/ethyca/fides/pull/3097)
 - Endpoints to save the new-style Privacy Preferences with respect to a fides user device id [#3132](https://github.com/ethyca/fides/pull/3132)
 - Support `privacy_declaration` as a resource type for custom fields [#3149](https://github.com/ethyca/fides/pull/3149)
+- Expose `id` field of embedded `privacy_declarations` on `system` API responses [#3157](https://github.com/ethyca/fides/pull/3157)
 
 ### Changed
 

--- a/src/fides/api/ctl/routes/crud.py
+++ b/src/fides/api/ctl/routes/crud.py
@@ -80,7 +80,7 @@ for model_type, fides_model in model_map.items():
 
     if (
         model_type != "system"
-    ):  # System Create endpoint defined separately in /routes/system.py
+    ):  # System endpoints defined separately in /routes/system.py
 
         @router.post(
             "/",
@@ -125,47 +125,43 @@ for model_type, fides_model in model_map.items():
                 raise errors.ForbiddenError(resource_type, resource.fides_key)
             return await create_resource(sql_model, resource.dict(), db)
 
-    @router.get(
-        "/",
-        dependencies=[
-            Security(
-                verify_oauth_client_prod,
-                scopes=[f"{CLI_SCOPE_PREFIX_MAPPING[model_type]}:{READ}"],
-            )
-        ],
-        response_model=List[fides_model],
-        name="List",
-    )
-    async def ls(  # pylint: disable=invalid-name
-        resource_type: str = get_resource_type(router),
-        db: AsyncSession = Depends(get_async_db),
-    ) -> List:
-        """Get a list of all of the resources of this type."""
-        sql_model = sql_model_map[resource_type]
-        return await list_resource(sql_model, db)
+        @router.get(
+            "/",
+            dependencies=[
+                Security(
+                    verify_oauth_client_prod,
+                    scopes=[f"{CLI_SCOPE_PREFIX_MAPPING[model_type]}:{READ}"],
+                )
+            ],
+            response_model=List[fides_model],
+            name="List",
+        )
+        async def ls(  # pylint: disable=invalid-name
+            resource_type: str = get_resource_type(router),
+            db: AsyncSession = Depends(get_async_db),
+        ) -> List:
+            """Get a list of all of the resources of this type."""
+            sql_model = sql_model_map[resource_type]
+            return await list_resource(sql_model, db)
 
-    @router.get(
-        "/{fides_key}",
-        dependencies=[
-            Security(
-                verify_oauth_client_prod,
-                scopes=[f"{CLI_SCOPE_PREFIX_MAPPING[model_type]}:{READ}"],
-            )
-        ],
-        response_model=fides_model,
-    )
-    async def get(
-        fides_key: str,
-        resource_type: str = get_resource_type(router),
-        db: AsyncSession = Depends(get_async_db),
-    ) -> Dict:
-        """Get a resource by its fides_key."""
-        sql_model = sql_model_map[resource_type]
-        return await get_resource_with_custom_fields(sql_model, fides_key, db)
-
-    if (
-        model_type != "system"
-    ):  # System Update endpoint defined separately in /routes/system.py
+        @router.get(
+            "/{fides_key}",
+            dependencies=[
+                Security(
+                    verify_oauth_client_prod,
+                    scopes=[f"{CLI_SCOPE_PREFIX_MAPPING[model_type]}:{READ}"],
+                )
+            ],
+            response_model=fides_model,
+        )
+        async def get(
+            fides_key: str,
+            resource_type: str = get_resource_type(router),
+            db: AsyncSession = Depends(get_async_db),
+        ) -> Dict:
+            """Get a resource by its fides_key."""
+            sql_model = sql_model_map[resource_type]
+            return await get_resource_with_custom_fields(sql_model, fides_key, db)
 
         @router.put(
             "/",
@@ -209,10 +205,6 @@ for model_type, fides_model in model_map.items():
                 sql_model, resource.fides_key, resource, db
             )
             return await update_resource(sql_model, resource.dict(), db)
-
-    if (
-        model_type != "system"
-    ):  # System upsert endpoint defined separately in /routes/system.py
 
         @router.post(
             "/upsert",
@@ -296,10 +288,6 @@ for model_type, fides_model in model_map.items():
                 "inserted": result[0],
                 "updated": result[1],
             }
-
-    if (
-        model_type != "system"
-    ):  # System Delete endpoint defined separately in /routes/system.py
 
         @router.delete(
             "/{fides_key}",

--- a/src/fides/api/ctl/routes/system.py
+++ b/src/fides/api/ctl/routes/system.py
@@ -372,7 +372,6 @@ async def create(
     name="List",
 )
 async def ls(  # pylint: disable=invalid-name
-    resource_type: str = "system",
     db: AsyncSession = Depends(get_async_db),
 ) -> List:
     """Get a list of all of the resources of this type."""
@@ -391,7 +390,6 @@ async def ls(  # pylint: disable=invalid-name
 )
 async def get(
     fides_key: str,
-    resource_type: str = "system",
     db: AsyncSession = Depends(get_async_db),
 ) -> Dict:
     """Get a resource by its fides_key."""

--- a/src/fides/api/ctl/routes/system.py
+++ b/src/fides/api/ctl/routes/system.py
@@ -12,8 +12,15 @@ from sqlalchemy.orm import Session
 from starlette import status
 from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
-from fides.api.ctl.database.crud import create_resource, get_resource, update_resource
+from fides.api.ctl.database.crud import (
+    create_resource,
+    get_resource,
+    get_resource_with_custom_fields,
+    list_resource,
+    update_resource,
+)
 from fides.api.ctl.database.session import get_async_db
+from fides.api.ctl.schemas.system import SystemResponse
 from fides.api.ctl.sql_models import (  # type: ignore[attr-defined]
     DataUse,
     PrivacyDeclaration,
@@ -27,6 +34,7 @@ from fides.api.ops.api.v1.scope_registry import (
     CONNECTION_READ,
     SYSTEM_CREATE,
     SYSTEM_DELETE,
+    SYSTEM_READ,
     SYSTEM_UPDATE,
 )
 from fides.api.ops.api.v1.urn_registry import SYSTEM_CONNECTIONS, V1_URL_PREFIX
@@ -125,7 +133,7 @@ def patch_connections(
 
 @system_router.put(
     "/",
-    response_model=SystemSchema,
+    response_model=SystemResponse,
     responses={
         status.HTTP_403_FORBIDDEN: {
             "content": {
@@ -297,7 +305,7 @@ async def delete(
 
 @system_router.post(
     "/",
-    response_model=SystemSchema,
+    response_model=SystemResponse,
     status_code=status.HTTP_201_CREATED,
     dependencies=[
         Security(
@@ -350,3 +358,41 @@ async def create(
         await db.refresh(created_system)
 
     return created_system
+
+
+@system_router.get(
+    "/",
+    dependencies=[
+        Security(
+            verify_oauth_client_prod,
+            scopes=[SYSTEM_READ],
+        )
+    ],
+    response_model=List[SystemResponse],
+    name="List",
+)
+async def ls(  # pylint: disable=invalid-name
+    resource_type: str = "system",
+    db: AsyncSession = Depends(get_async_db),
+) -> List:
+    """Get a list of all of the resources of this type."""
+    return await list_resource(System, db)
+
+
+@system_router.get(
+    "/{fides_key}",
+    dependencies=[
+        Security(
+            verify_oauth_client_prod,
+            scopes=[SYSTEM_READ],
+        )
+    ],
+    response_model=SystemResponse,
+)
+async def get(
+    fides_key: str,
+    resource_type: str = "system",
+    db: AsyncSession = Depends(get_async_db),
+) -> Dict:
+    """Get a resource by its fides_key."""
+    return await get_resource_with_custom_fields(System, fides_key, db)

--- a/src/fides/api/ctl/schemas/system.py
+++ b/src/fides/api/ctl/schemas/system.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from fideslang.models import PrivacyDeclaration, System
+from pydantic import Field
+
+
+class PrivacyDeclarationResponse(PrivacyDeclaration):
+    """Extension of base pydantic model to include DB `id` field in the response"""
+
+    id: str = Field(
+        description="The database-assigned ID of the privacy declaration on the system. This is meant to be a read-only field, returned only in API responses"
+    )
+
+
+class SystemResponse(System):
+    """Extension of base pydantic model to include `privacy_declarations.id` fields in responses"""
+
+    privacy_declarations: List[PrivacyDeclarationResponse] = Field(
+        description=PrivacyDeclarationResponse.__doc__,
+    )


### PR DESCRIPTION
Closes https://github.com/ethyca/fideslang/issues/102

Adds an `id` field on the `privacy_declaration`s embedded objects returned in `system` APIs.

### Code Changes

* extend our base pydantic models defined in `fideslang` with response-specific models that include `PrivacyDeclaration.id` fields in the response objects
* update tests to work and also confirm the `id` field is present in the response

### Steps to Confirm

* made some manual API calls against the `GET /api/v1/system` endpoint and confirmed the field was present. sample response from my local:
```
{
  "fides_key": "test_system_1",
  "organization_fides_key": "default_organization",
  "tags": [],
  "name": "test system 1",
  "description": "",
  "registry_id": null,
  "meta": null,
  "fidesctl_meta": null,
  "system_type": "",
  "data_responsibility_title": "Controller",
  "egress": null,
  "ingress": null,
  "privacy_declarations": [
    {
      "id": "pri_eb5ad4c6-164a-47c1-a803-a84078b24dde",
      "name": "test",
      "data_categories": [
        "user"
      ],
      "data_use": "advertising",
      "data_qualifier": "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
      "data_subjects": [
        "commuter"
      ],
      "dataset_references": [],
      "egress": null,
      "ingress": null
    },
    {
      "id": "pri_ce89b310-3015-4373-bc94-2180b63d270e",
      "name": "test 2",
      "data_categories": [
        "user.browsing_history"
      ],
      "data_use": "advertising",
      "data_qualifier": "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
      "data_subjects": [
        "next_of_kin"
      ],
      "dataset_references": [],
      "egress": null,
      "ingress": null
    }
  ],
  "system_dependencies": [],
  "joint_controller": null,
  "third_country_transfers": [],
  "administrating_department": "Not defined",
  "data_protection_impact_assessment": {
    "is_required": false,
    "progress": null,
    "link": null
  }
}
```

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

We decided to go with this implementation rather than an update to the base model in `fideslang` as was proposed in https://github.com/ethyca/fideslang/pull/103. The two main reasons motivating that decision:
1. we don't want to allow users to specify `PriavcyDeclaration.id` fields in their request bodies - it's meant to be response/read-only
2. we don't want to muddy `fideslang` with db-specific internals like `id`. no other `fideslang` models have this `id` field exposed.

See issue for more context on why this change is needed