### PR TITLE
refactor privacy declaration upsert to maintain constant IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The types of changes are:
 - Fix a typo in the Admin UI [#3166](https://github.com/ethyca/fides/pull/3166)
 - The `--local` flag is now respected for the `scan dataset db` command [#3096](https://github.com/ethyca/fides/pull/3096)
 - Fixing issue where connectors with external dataset references would fail to save [#3142](https://github.com/ethyca/fides/pull/3142)
+- Ensure privacy declaration IDs are stable across updates through system API [#3188](https://github.com/ethyca/fides/pull/3188)
 
 ### Developer Experience
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -969,6 +969,31 @@ def system(db: Session) -> System:
 
 
 @pytest.fixture(scope="function")
+def system_multiple_decs(db: Session, system: System) -> System:
+    """
+    Add an additional PrivacyDeclaration onto the base System to test scenarios with
+    multiple PrivacyDeclarations on a given system
+    """
+    PrivacyDeclaration.create(
+        db=db,
+        data={
+            "name": "Collect data for third party sharing",
+            "system_id": system.id,
+            "data_categories": ["user.device.cookie_id"],
+            "data_use": "third_party_sharing",
+            "data_qualifier": "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
+            "data_subjects": ["customer"],
+            "dataset_references": None,
+            "egress": None,
+            "ingress": None,
+        },
+    )
+
+    db.refresh(system)
+    return system
+
+
+@pytest.fixture(scope="function")
 def system_third_party_sharing(db: Session) -> System:
     system_third_party_sharing = System.create(
         db=db,


### PR DESCRIPTION
Closes #3187 

### Code Changes

* change privacy declaration upsert logic used by `/system` APIs to update `PrivacyDeclaration` records in place when "matched" using `data_use` and `name` as matching criteria
* add in BE validation to prevent a request from specifying "duplicate" `PrivacyDeclaration`s based on the above matching criteria
    * this validation is now important on the BE since our upsert logic now relies on this assumption being true
* add automated test coverage around this use cases
    * there may still be some edge cases we need to cover here...

### Steps to Confirm

* i did some testing in the UI with these changes, while checking the DB records, and things generally looked good. but would appreciate others hitting this hard with the API and with the UI
    * NOTE - as of now, if you change the "data use" or the "processing activity" of an existing declaration in the UI, it's going to create a new DB record. that's expected, and we will look to prevent this edge case by making those fields "read only" in the UI after creation.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

See issue for more context. This is needed to get custom fields working with privacy declarations, i.e. "data use declarations".
