### PR TITLE
WIP [Backend] Updating Privacy Experiences when Notices Change

### DIFF
--- a/src/fides/api/ops/models/privacy_notice.py
+++ b/src/fides/api/ops/models/privacy_notice.py
@@ -26,6 +26,8 @@ class PrivacyNoticeRegion(Enum):
     us_co = "us_co"  # colorado
     us_va = "us_va"  # virginia
     us_ut = "us_ut"  # utah
+    us_ia = "us_ia"  # iowa
+    us_ct = "us_ct"  # connecticut
     eu_be = "eu_be"  # belgium
     eu_bg = "eu_bg"  # bulgaria
     eu_cz = "eu_cz"  # czechia

--- a/src/fides/api/ops/schemas/privacy_experience.py
+++ b/src/fides/api/ops/schemas/privacy_experience.py
@@ -19,8 +19,8 @@ class PrivacyExperience(BaseSchema):
 
     disabled: Optional[bool] = False
     component: ComponentType
-    delivery_mechanism: DeliveryMechanism
-    regions: Optional[conlist(PrivacyNoticeRegion, min_items=1)]  # type: ignore
+    delivery_mechanism: Optional[DeliveryMechanism]
+    regions: conlist(PrivacyNoticeRegion, min_items=1)  # type: ignore
     component_title: Optional[SafeStr]
     component_description: Optional[SafeStr]
     banner_title: Optional[SafeStr]

--- a/src/fides/api/ops/util/privacy_experience_util.py
+++ b/src/fides/api/ops/util/privacy_experience_util.py
@@ -1,0 +1,132 @@
+from typing import List, Set
+
+from sqlalchemy.orm import Session
+from fides.api.ops.models.privacy_experience import ComponentType
+from fides.api.ops.models.privacy_notice import (
+    ConsentMechanism,
+    PrivacyNotice,
+    PrivacyNoticeRegion,
+)
+from fides.api.ops.schemas.privacy_experience import (
+    PrivacyExperience as PrivacyExperienceSchema,
+)
+
+
+def get_unique_regions(privacy_notices: List[PrivacyNotice]) -> Set[str]:
+    """Consolidates a list of privacy notice regions into a set of unique regions.  Combines "eu" regions into one region."""
+    unique_regions: Set[str] = set()
+    for notice in privacy_notices:
+        for region in notice.regions:
+            region_str = "eu" if region.value.startswith("eu") else region.value  # type: ignore[attr-defined]
+            unique_regions.add(region_str)
+
+    return unique_regions
+
+
+def region_str_to_privacy_notice_regions_list(
+    region_str: str,
+) -> List[PrivacyNoticeRegion]:
+    """
+    Takes a region str and turns it into a list of PrivacyNoticeRegions. If "eu" is supplied, split this out into
+    all eu regions.
+    """
+    return (
+        [region for region in PrivacyNoticeRegion if region.value.startswith("eu")]
+        if region_str == "eu"
+        else [PrivacyNoticeRegion(region_str)]
+    )
+
+
+def _stage_privacy_center_experiences(
+    component_type: ComponentType,
+    regions: Set[str],
+    pending_experiences: List[PrivacyExperienceSchema],
+    combine_into_one: bool = False,
+) -> None:
+    """Stages privacy experiences schemas with the given component type and regions. Updates pending_experiences in place.
+    Can combine all the regions into one schema, or create a separate schema for each region.
+
+    Effectively treats the "eu" as the same region.
+    """
+    experience_regions: List[PrivacyNoticeRegion] = []
+    for region in regions:
+        if combine_into_one:
+            expanded_regions = region_str_to_privacy_notice_regions_list(region)
+            experience_regions.extend(expanded_regions)
+
+        else:
+            experience_regions = region_str_to_privacy_notice_regions_list(region)
+            pending_experiences.append(
+                PrivacyExperienceSchema(
+                    component=component_type, regions=experience_regions
+                )
+            )
+
+    if combine_into_one:
+        pending_experiences.append(
+            PrivacyExperienceSchema(
+                component=component_type, regions=experience_regions
+            )
+        )
+
+
+def create_privacy_experiences_from_notices(
+    db: Session,
+) -> List[PrivacyExperienceSchema]:
+    """Stage privacy experiences schemas from privacy notices"""
+    pending_experiences: List[PrivacyExperienceSchema] = []
+
+    unique_opt_in_overlay_regions: Set[str] = get_unique_regions(
+        db.query(PrivacyNotice).filter(  # type: ignore[arg-type]
+            PrivacyNotice.consent_mechanism == ConsentMechanism.opt_in,
+            PrivacyNotice.displayed_in_overlay.is_(True),
+        )
+    )
+    _stage_privacy_center_experiences(
+        component_type=ComponentType.overlay,
+        regions=unique_opt_in_overlay_regions,
+        pending_experiences=pending_experiences,
+        combine_into_one=False,
+    )
+
+    unique_opt_out_overlay_regions: Set[str] = get_unique_regions(
+        db.query(PrivacyNotice).filter(  # type: ignore[arg-type]
+            PrivacyNotice.consent_mechanism == ConsentMechanism.opt_out,
+            PrivacyNotice.displayed_in_overlay.is_(True),
+        )
+    )
+    new_regions = unique_opt_out_overlay_regions - unique_opt_in_overlay_regions
+    _stage_privacy_center_experiences(
+        component_type=ComponentType.overlay,
+        regions=new_regions,
+        pending_experiences=pending_experiences,
+        combine_into_one=True,
+    )
+
+    unique_notice_only_regions: Set[str] = get_unique_regions(
+        db.query(PrivacyNotice).filter(  # type: ignore[arg-type]
+            PrivacyNotice.consent_mechanism == ConsentMechanism.notice_only,
+        )
+    )
+    new_regions = unique_notice_only_regions - (
+        unique_opt_out_overlay_regions | unique_opt_in_overlay_regions
+    )
+    _stage_privacy_center_experiences(
+        component_type=ComponentType.overlay,
+        regions=new_regions,
+        pending_experiences=pending_experiences,
+        combine_into_one=True,
+    )
+
+    unique_privacy_center_regions: Set[str] = get_unique_regions(
+        db.query(PrivacyNotice).filter(  # type: ignore[arg-type]
+            PrivacyNotice.displayed_in_privacy_center.is_(True)
+        )
+    )
+    _stage_privacy_center_experiences(
+        component_type=ComponentType.privacy_center,
+        regions=unique_privacy_center_regions,
+        pending_experiences=pending_experiences,
+        combine_into_one=True,
+    )
+    return pending_experiences


### PR DESCRIPTION
…ist to support the saved privacy notices.

Closes #3193 
### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
