### PR TITLE
prevent duplicate privacy declaration custom field column headers

### DIFF
--- a/src/fides/core/export.py
+++ b/src/fides/core/export.py
@@ -150,10 +150,11 @@ def get_custom_field_headers(
 
     for key in custom_keys:
         key_string = f"system.{header_type}.{key}"
-        custom_columns[key_string] = key
-        keys.append(key_string)
-        output_list[0] = tuple(keys)
-        custom_field_headers.append(key_string)
+        if key_string not in keys:  # if we havent't seen the key yet
+            custom_columns[key_string] = key
+            keys.append(key_string)
+            output_list[0] = tuple(keys)
+            custom_field_headers.append(key_string)
 
     return output_list, custom_columns, custom_field_headers
 


### PR DESCRIPTION
Closes n/a

‼️ should be cherry-picked into 2.12.0 release branch

Prevent datamap export from having duplicate privacy_declaration custom field columns when >1 privacy declaration on a given system has a custom field

### Code Changes

- check if a "privacy declaration" column key exists in our running list of keys before inserting again

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

We believe this is responsible for the 500 coming back from the datamap export API as seen on our staging env in 2.12.0 rc testing
