### PR TITLE
Release Checklist Update Post 2.12.0

### DIFF
--- a/docs/fides/docs/development/releases.md
+++ b/docs/fides/docs/development/releases.md
@@ -224,5 +224,9 @@ Run these from within the test environment shell:
 * [ ] Verify the fides release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides>
 * [ ] Verify the fides-privacy-center release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-privacy-center>
 * [ ] Verify the fides-sample-app release is published to DockerHub: <https://hub.docker.com/r/ethyca/fides-sample-app>
-* [ ] Smoke test the PyPi & DockerHub releases with a clean `pip install ethyca-fides` and `fides deploy up`
+* [ ] Smoke test the PyPi & DockerHub releases:
+    * [ ] Create a fresh venv with `python3 -m venv 2_12_0_venv`
+    * [ ] Activate the venv `source 2_12_0_venv/bin/activate`
+    * [ ] `pip install ethyca-fides` 
+    * [ ] `fides deploy up`
 * [ ] Announce the release!


### PR DESCRIPTION
Closes #<issue>

### Code Changes

* [ ]  Update release checklist

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

When smoke testing fides you need to make sure you're using a fresh virtual env. If not, you'll likely get an issue like:

```
Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /opt/homebrew/lib/python3.10/site-packages/fides/data/sample_project/privacy_center/config
```

Context here: https://ethyca.slack.com/archives/CBKK8TS74/p1681757808038059?thread_ts=1681741284.094189&cid=CBKK8TS74

Note that I did have a virtual env activated but it was an old one.  I've also gotten this issue when I had a global version installed that interfered.  