### PR TITLE
Hotfix - merge cached datamap settings with new data

### DIFF
--- a/clients/admin-ui/src/features/datamap/Datamap.tsx
+++ b/clients/admin-ui/src/features/datamap/Datamap.tsx
@@ -1,6 +1,8 @@
 import { Box, Center, Flex, Spinner } from "@fidesui/react";
+import { baseApi } from "common/api.slice";
 import dynamic from "next/dynamic";
-import { useCallback, useContext, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
 
 import { useAppSelector } from "~/app/hooks";
 import { useIsAnyFormDirty } from "~/features/common/hooks/useIsAnyFormDirty";
@@ -67,6 +69,19 @@ const Datamap = () => {
     selectedSystemId,
     resetSelectedSystemId,
   } = useHome();
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    /*
+    The tag needs to be invalided this way because the plusApi
+    is not a part of the baseApi yet. This will be done on the
+    API in the future.
+     */
+
+    dispatch(baseApi.util.invalidateTags(["Datamap"]));
+  }, [dispatch]);
+
   const { isLoading } = useTableInstance();
   if (isLoading) {
     return (

--- a/clients/admin-ui/src/features/datamap/SettingsBar.tsx
+++ b/clients/admin-ui/src/features/datamap/SettingsBar.tsx
@@ -9,7 +9,7 @@ import {
   Tag,
   useDisclosure,
 } from "@fidesui/react";
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 import { useAppSelector } from "~/app/hooks";
@@ -20,6 +20,7 @@ import GlobalFilter from "~/features/datamap/datamap-table/filters/global-accord
 import ExportModal from "~/features/datamap/modals/ExportModal";
 import FilterModal from "~/features/datamap/modals/FilterModal";
 import SettingsModal from "~/features/datamap/modals/SettingsModal";
+import { baseApi } from "common/api.slice";
 
 const useSettingsBar = () => {
   const isMapOpen = useAppSelector(selectIsMapOpen);
@@ -77,6 +78,16 @@ const SettingsBar: React.FC = () => {
   } = useSettingsBar();
 
   const { tableInstance } = useContext(DatamapTableContext);
+
+  useEffect(() => {
+    /*
+    The tag needs to be invalided this way because the plusApi
+    is not a part of the baseApi yet. This will be done on the
+    API in the future.
+     */
+    dispatch(baseApi.util.invalidateTags(["Datamap"]));
+  }, [dispatch, tableInstance]);
+
   if (!tableInstance) {
     return null;
   }

--- a/clients/admin-ui/src/features/datamap/SettingsBar.tsx
+++ b/clients/admin-ui/src/features/datamap/SettingsBar.tsx
@@ -9,6 +9,7 @@ import {
   Tag,
   useDisclosure,
 } from "@fidesui/react";
+import { baseApi } from "common/api.slice";
 import React, { useContext, useEffect } from "react";
 import { useDispatch } from "react-redux";
 
@@ -20,7 +21,6 @@ import GlobalFilter from "~/features/datamap/datamap-table/filters/global-accord
 import ExportModal from "~/features/datamap/modals/ExportModal";
 import FilterModal from "~/features/datamap/modals/FilterModal";
 import SettingsModal from "~/features/datamap/modals/SettingsModal";
-import { baseApi } from "common/api.slice";
 
 const useSettingsBar = () => {
   const isMapOpen = useAppSelector(selectIsMapOpen);

--- a/clients/admin-ui/src/features/datamap/SettingsBar.tsx
+++ b/clients/admin-ui/src/features/datamap/SettingsBar.tsx
@@ -9,8 +9,7 @@ import {
   Tag,
   useDisclosure,
 } from "@fidesui/react";
-import { baseApi } from "common/api.slice";
-import React, { useContext, useEffect } from "react";
+import React, { useContext } from "react";
 import { useDispatch } from "react-redux";
 
 import { useAppSelector } from "~/app/hooks";
@@ -78,15 +77,6 @@ const SettingsBar: React.FC = () => {
   } = useSettingsBar();
 
   const { tableInstance } = useContext(DatamapTableContext);
-
-  useEffect(() => {
-    /*
-    The tag needs to be invalided this way because the plusApi
-    is not a part of the baseApi yet. This will be done on the
-    API in the future.
-     */
-    dispatch(baseApi.util.invalidateTags(["Datamap"]));
-  }, [dispatch, tableInstance]);
 
   if (!tableInstance) {
     return null;


### PR DESCRIPTION
Closes #3212 

### Code Changes

* [ ] Create new `mergeColumns` function that handles combining the cached columns with the new columns

### Steps to Confirm

* [ ] Visit the datamap page so the column settings get cached
* [ ] Go create a new custom field
* [ ] create a system and populate the custom field with data
* [ ] visit the datamap table and open the settings modal. The new custom field should be in the listed columns. NOTE: it won't show up if no system is using the column
* [ ] Go back and edit the name of the custom field
* [ ] Visit the datmamp table again and check the settings modal. The column should be in the modal with the new name. It will most likely be at the bottom. That is expected.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
