### PR TITLE
handle deleted taxonomy elements in datamap export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The types of changes are:
 
 - Merge instances of RTK `createApi` into one instance for better cache invalidation [#3059](https://github.com/ethyca/fides/pull/3059)
 
+### Fixed
+
+- Datamap export mitigation for deleted taxonomy elements referenced by declarations [#3214](https://github.com/ethyca/fides/pull/3214)
+
 ## [2.12.0](https://github.com/ethyca/fides/compare/2.11.0...2.12.0)
 
 ### Added

--- a/src/fides/core/export.py
+++ b/src/fides/core/export.py
@@ -310,6 +310,11 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
                 system.get("data_protection_impact_assessment", {})
             )
         )
+
+        # variable to keep track of rows added based on system declarations
+        # used to determine whether we need to add a "placeholder" row for the system generally
+        declaration_rows = []
+
         if system.get("privacy_declarations"):
             for declaration in system["privacy_declarations"]:
                 if isinstance(
@@ -323,10 +328,12 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
                     # convert to dict for consistent processing across ORM and pydantic object
                     declaration = declaration.__dict__
 
-                data_use = formatted_data_uses[declaration["data_use"]]
+                data_use = formatted_data_uses.get(declaration["data_use"])
+                if data_use is None:  # this is an invalid data use if it's not found
+                    continue  # skip processing this declaration if the data use is invalid
                 data_categories = declaration["data_categories"] or []
                 data_subjects = [
-                    formatted_data_subjects[data_subject_fides_key]
+                    formatted_data_subjects.get(data_subject_fides_key)
                     for data_subject_fides_key in declaration["data_subjects"]
                 ]
                 dataset_references = declaration["dataset_references"] or [
@@ -363,6 +370,7 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
                     ]
                     for category in data_categories
                     for subject in data_subjects
+                    if subject is not None  # if subject reference is invalid, skip it
                     for dataset_reference in dataset_references
                 ]
                 cartesian_product_of_declaration = []
@@ -392,8 +400,12 @@ def generate_system_records(  # pylint: disable=too-many-nested-blocks, too-many
                             )
                     cartesian_product_of_declaration.append(tuple(product))
 
-                output_list += cartesian_product_of_declaration
-        else:
+                declaration_rows += cartesian_product_of_declaration
+            output_list += declaration_rows
+
+        # if we haven't added any output rows for the system based on declarations,
+        # then add a "placholder" general system row to ensure the system is captured in the output
+        if not declaration_rows:
             system_row = [
                 system["fides_key"],
                 system["name"],


### PR DESCRIPTION
‼️ This should be hotfixed for `2.12.1`

Closes https://github.com/ethyca/fidesplus/issues/858

### Code Changes

* treat defunct `data_use` or `data_subject` references from a privacy (data use) declaration as empty rows in the datamap export
* ensure at least one "placeholder" system row is returned if no rows are produced from declarations

### Steps to Confirm

- requires integration with fidesplus to properly test (will be a corresponding PR there with increased test coverage)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

A broader improvement around taxonomy element deletion is covered in https://github.com/ethyca/fides/issues/3119.
