### PR TITLE
update custom field definition uniqueness criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 ### Changed
 
 - Merge instances of RTK `createApi` into one instance for better cache invalidation [#3059](https://github.com/ethyca/fides/pull/3059)
+- Update custom field definition uniqueness to be case insensitive name per resource type [#3215](https://github.com/ethyca/fides/pull/3215)
 
 ## [2.12.0](https://github.com/ethyca/fides/compare/2.11.0...2.12.0)
 

--- a/src/fides/api/ctl/database/session.py
+++ b/src/fides/api/ctl/database/session.py
@@ -2,9 +2,10 @@ from typing import AsyncGenerator
 
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import sessionmaker
 
 from fides.core.config import CONFIG
+from fides.lib.db.session import ExtendedSession
 
 engine = create_async_engine(
     CONFIG.database.async_database_uri,
@@ -15,7 +16,7 @@ async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False
 sync_engine = create_engine(CONFIG.database.sync_database_uri, echo=False)
 sync_session = sessionmaker(
     sync_engine,
-    class_=Session,
+    class_=ExtendedSession,
     expire_on_commit=False,
     autocommit=False,
 )

--- a/src/fides/api/ctl/migrations/versions/15a3e7483249_make_customfielddefinition_uniqueness_.py
+++ b/src/fides/api/ctl/migrations/versions/15a3e7483249_make_customfielddefinition_uniqueness_.py
@@ -1,0 +1,53 @@
+"""make customfielddefinition uniqueness case insensitive
+
+Revision ID: 15a3e7483249
+Revises: e92da354691e
+Create Date: 2023-05-02 15:03:56.256982
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.exc import IntegrityError
+
+# revision identifiers, used by Alembic.
+revision = "15a3e7483249"
+down_revision = "e92da354691e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    try:
+        op.execute(
+            """ CREATE UNIQUE INDEX ix_plus_custom_field_definition_unique_lowername_resourcetype
+                ON plus_custom_field_definition
+                (lower(name), resource_type)
+            """
+        )
+    except IntegrityError as exc:
+        raise Exception(
+            f"Fides attempted to create new custom field definition unique index but got error: {exc}. "
+            f"Adjust custom field names to avoid case-insensitive name overlaps for the same resource type."
+        )
+
+    # remove unnecessary index of unused field
+    op.drop_index(
+        "ix_plus_custom_field_definition_field_definition",
+        table_name="plus_custom_field_definition",
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_plus_custom_field_definition_unique_lowername_resourcetype"),
+        table_name="plus_custom_field_definition",
+    )
+
+    # re-add unnecessray index of unused field in downgrade, for consistency
+    op.create_index(
+        op.f("ix_plus_custom_field_definition_field_definition"),
+        "plus_custom_field_definition",
+        ["field_definition"],
+        unique=False,
+    )

--- a/tests/ctl/core/test_custom_field_models.py
+++ b/tests/ctl/core/test_custom_field_models.py
@@ -1,0 +1,144 @@
+# pylint: disable=missing-docstring, redefined-outer-name
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from fides.api.ctl.sql_models import CustomFieldDefinition
+from fides.lib.exceptions import KeyOrNameAlreadyExists
+
+
+@pytest.fixture(autouse=True)
+def clear_custom_metadata_resources(db):
+    """
+    Fixture run on each test to clear custom field DB tables,
+    to ensure each test runs with a clean slate.
+    """
+
+    def delete_data(tables):
+        for table in tables:
+            table.query(db).delete()
+        db.commit()
+
+    tables = [
+        CustomFieldDefinition,
+    ]
+
+    delete_data(tables)
+
+    yield
+    delete_data(tables)
+
+
+def test_custom_field_definition_duplicate_name_rejected_create(db):
+    """Assert case-insensitive unique checks on name/resource type upon creation"""
+    definition1 = CustomFieldDefinition.create(
+        db=db,
+        data={
+            "name": "test1",
+            "description": "test",
+            "field_type": "string",
+            "resource_type": "system",
+            "field_definition": "string",
+        },
+    )
+    with pytest.raises(KeyOrNameAlreadyExists):
+        CustomFieldDefinition.create(
+            db=db,
+            data={
+                "name": "Test1",
+                "description": "test",
+                "field_type": "string",
+                "resource_type": "system",
+                "field_definition": "string",
+            },
+        )
+
+    # assert the second record didn't get created
+    assert len(CustomFieldDefinition.all(db)) == 1
+
+    # with a different resource type, we should allow creation
+    definition2 = CustomFieldDefinition.create(
+        db=db,
+        data={
+            "name": "Test1",
+            "description": "test",
+            "field_type": "string",
+            "resource_type": "privacy_declaration",
+            "field_definition": "string",
+        },
+    )
+
+    # assert we've got two different records created successfully
+    assert len(CustomFieldDefinition.all(db)) == 2
+    assert definition1.id != definition2.id
+
+
+def test_custom_field_definition_duplicate_name_different_resource_type_accepted(db):
+    """Assert that we can create custom field definition with same name on a different resource type"""
+    definition1 = CustomFieldDefinition.create(
+        db=db,
+        data={
+            "name": "test1",
+            "description": "test",
+            "field_type": "string",
+            "resource_type": "system",
+            "field_definition": "string",
+        },
+    )
+
+    definition2 = CustomFieldDefinition.create(
+        db=db,
+        data={
+            "name": "test1",
+            "description": "test",
+            "field_type": "string",
+            "resource_type": "privacy_declaration",  # different resource type, so this should be allowed
+            "field_definition": "string",
+        },
+    )
+
+    # assert we've got two different records created successfully
+    assert len(CustomFieldDefinition.all(db)) == 2
+    assert definition1.id != definition2.id
+
+
+def test_custom_field_definition_duplicate_name_rejected_update(db):
+    """Assert case-insensitive unique checks on name/resource type upon update"""
+
+    definition1 = CustomFieldDefinition.create(
+        db=db,
+        data={
+            "name": "test1",
+            "description": "test",
+            "field_type": "string",
+            "resource_type": "system",
+            "field_definition": "string",
+        },
+    )
+
+    definition2 = CustomFieldDefinition.create(
+        db=db,
+        data={
+            "name": "Test 1",  # space in name should allow creation, considered unique name
+            "description": "test",
+            "field_type": "string",
+            "resource_type": "system",
+            "field_definition": "string",
+        },
+    )
+
+    # assert we've got two different records created successfully
+    assert len(CustomFieldDefinition.all(db)) == 2
+    assert definition1.id != definition2.id
+
+    with pytest.raises(KeyOrNameAlreadyExists) as e:
+        definition2 = definition2.update(
+            db=db,
+            data={
+                "name": "Test1",  # if we try to update name to remove space, we should hit uniqueness error
+            },
+        )
+
+    # assert update did not go through
+    db.refresh(definition2)
+    assert definition2.name == "Test 1"


### PR DESCRIPTION
Partially closes https://github.com/ethyca/fidesplus/issues/826

### Code Changes

* create the proper unique (functional) index for the uniqueness criteria
    * include a migration that "handles" (i.e. reports with a cleaner error message) potentially invalid data on migration
    * migration also has some small unrelated cleanup on `plus_custom_field_definition` table since we're touching it
* put in some more graceful handling of the unique constraint in the sqlalchemy model class
* add in some test coverage directly on the sqlalchemy model

### Steps to Confirm

* any manual testing here would require hitting the DB directly
* manual testing at the API level will come in corresponding `fidesplus` [PR](https://github.com/ethyca/fidesplus/pull/862) that has the API which exposes this model

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

We'll now ensure custom field definition uniqueness with a case insensitive name check, per `resource_type` (location). This implements that constraint on the DB level and also has some handling of the error to give a "cleaner" exception for consumption higher up in the stack.
