### PR TITLE
Privacy experience form

### DIFF
--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -144,4 +144,160 @@ describe("Privacy experiences", () => {
       });
     });
   });
+
+  describe("form", () => {
+    beforeEach(() => {
+      cy.intercept("PATCH", "/api/v1/privacy-experience*", {
+        fixture: "privacy-experiences/list.json",
+      }).as("patchExperiences");
+    });
+    interface Props {
+      mechanisms: ("opt_in" | "opt_out" | "notice_only")[];
+      component?: "overlay" | "privacy_center";
+    }
+    /**
+     * Helper function to swap out notices and components in a stubbed experience
+     * @example stubExperience({mechanisms: ["notice_only", "opt_in"], component: "overlay"})
+     */
+    const stubExperience = ({ mechanisms, component }: Props) => {
+      const notices = [];
+      mechanisms.forEach((mechanism) => {
+        cy.fixture(`privacy-notices/${mechanism}.json`).then((notice) =>
+          notices.push(notice)
+        );
+      });
+      cy.fixture("privacy-experiences/experience.json").then((experience) => {
+        const updatedExperience = {
+          ...experience,
+          privacy_notices: mechanisms ? notices : experience.privacy_notices,
+          component: component ?? experience.component,
+        };
+        cy.intercept("GET", "/api/v1/privacy-experience/pri*", {
+          body: updatedExperience,
+        });
+      });
+    };
+
+    it("renders opt_in notice with banner as delivery mechanism", () => {
+      stubExperience({ mechanisms: ["opt_in"], component: "overlay" });
+      cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/${OVERLAY_EXPERIENCE_ID}`);
+      cy.getByTestId("privacy-center-messaging-form").should("not.exist");
+
+      cy.getByTestId("delivery-mechanism-form").within(() => {
+        cy.getSelectValueContainer("input-delivery_mechanism").within(() => {
+          cy.get("input").should("be.disabled");
+        });
+        cy.getSelectValueContainer("input-delivery_mechanism").should(
+          "contain",
+          "Banner"
+        );
+      });
+      cy.getByTestId("banner-text-form");
+      cy.getByTestId("banner-action-form");
+    });
+
+    it("renders notice_only notice with acknowledgment btn", () => {
+      stubExperience({ mechanisms: ["notice_only"], component: "overlay" });
+      cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/${OVERLAY_EXPERIENCE_ID}`);
+      cy.getByTestId("privacy-center-messaging-form").should("not.exist");
+
+      cy.getByTestId("delivery-mechanism-form");
+      cy.getByTestId("banner-text-form");
+      cy.getByTestId("banner-action-form").within(() => {
+        cy.getByTestId("input-confirmation_button_label").should("not.exist");
+        cy.getByTestId("input-reject_button_label").should("not.exist");
+        cy.getByTestId("input-acknowledgement_button_label");
+      });
+    });
+
+    it("renders notice_only combined with other notices with confirm/reject btns", () => {
+      stubExperience({
+        mechanisms: ["notice_only", "opt_in"],
+        component: "overlay",
+      });
+      cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/${OVERLAY_EXPERIENCE_ID}`);
+      cy.getByTestId("privacy-center-messaging-form").should("not.exist");
+
+      cy.getByTestId("delivery-mechanism-form");
+      cy.getByTestId("banner-text-form");
+      cy.getByTestId("banner-action-form").within(() => {
+        cy.getByTestId("input-confirmation_button_label");
+        cy.getByTestId("input-reject_button_label");
+        cy.getByTestId("input-acknowledgement_button_label").should(
+          "not.exist"
+        );
+      });
+    });
+
+    it("renders opt_out notice with all options available", () => {
+      stubExperience({ mechanisms: ["opt_out"], component: "overlay" });
+      cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/${OVERLAY_EXPERIENCE_ID}`);
+      cy.getByTestId("privacy-center-messaging-form").should("not.exist");
+
+      cy.getByTestId("delivery-mechanism-form").within(() => {
+        cy.getSelectValueContainer("input-delivery_mechanism").within(() => {
+          cy.get("input").should("not.be.disabled");
+        });
+      });
+      cy.getByTestId("banner-text-form");
+      cy.getByTestId("banner-action-form");
+    });
+
+    it("renders privacy center overlays without banner form sections", () => {
+      stubExperience({
+        mechanisms: ["opt_in", "opt_out", "notice_only"],
+        component: "privacy_center",
+      });
+      cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/${OVERLAY_EXPERIENCE_ID}`);
+      cy.getByTestId("privacy-center-messaging-form");
+      cy.getByTestId("delivery-mechanism-form").should("not.exist");
+      cy.getByTestId("banner-text-form").should("not.exist");
+      cy.getByTestId("banner-action-form").should("not.exist");
+    });
+
+    it("can submit an overlay form", () => {
+      // opt_out is the most permissive, so use that one
+      stubExperience({ mechanisms: ["opt_out"], component: "overlay" });
+      cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/${OVERLAY_EXPERIENCE_ID}`);
+
+      const payload = {
+        delivery_mechanism: "banner",
+        banner_title: "title",
+        banner_description: "description",
+        link_label: "link label",
+        confirmation_button_label: "Accept",
+        reject_button_label: "Reject",
+      };
+      cy.selectOption("input-delivery_mechanism", "Banner");
+      Object.entries(payload).forEach(([key, value]) => {
+        cy.getByTestId(`input-${key}`).type(value);
+      });
+      cy.getByTestId("save-btn").click();
+      cy.wait("@patchExperiences").then((interception) => {
+        const { body } = interception.request;
+        Object.entries(payload).forEach(([key, value]) => {
+          expect(body[0][key]).to.eql(value);
+        });
+      });
+    });
+
+    it("can submit a privacy center form", () => {
+      stubExperience({ mechanisms: ["opt_out"], component: "privacy_center" });
+      cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/${OVERLAY_EXPERIENCE_ID}`);
+      const payload = {
+        link_label: "link label",
+        component_description: "title",
+      };
+      Object.entries(payload).forEach(([key, value]) => {
+        cy.getByTestId(`input-${key}`).type(value);
+      });
+      cy.getByTestId("save-btn").click();
+      cy.wait("@patchExperiences").then((interception) => {
+        const { body } = interception.request;
+        Object.entries(payload).forEach(([key, value]) => {
+          expect(body[0][key]).to.eql(value);
+        });
+      });
+    });
+  });
 });

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -196,12 +196,20 @@ describe("Privacy experiences", () => {
       cy.getByTestId("banner-action-form");
     });
 
-    it("renders notice_only notice with acknowledgment btn", () => {
+    it("renders notice_only notice with acknowledgment btn and banner as mechanism", () => {
       stubExperience({ mechanisms: ["notice_only"], component: "overlay" });
       cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/${OVERLAY_EXPERIENCE_ID}`);
       cy.getByTestId("privacy-center-messaging-form").should("not.exist");
 
-      cy.getByTestId("delivery-mechanism-form");
+      cy.getByTestId("delivery-mechanism-form").within(() => {
+        cy.getSelectValueContainer("input-delivery_mechanism").within(() => {
+          cy.get("input").should("be.disabled");
+        });
+        cy.getSelectValueContainer("input-delivery_mechanism").should(
+          "contain",
+          "Banner"
+        );
+      });
       cy.getByTestId("banner-text-form");
       cy.getByTestId("banner-action-form").within(() => {
         cy.getByTestId("input-confirmation_button_label").should("not.exist");

--- a/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
@@ -122,7 +122,7 @@ describe("Privacy notices", () => {
 
     it("can click a row to go to the notice page", () => {
       cy.intercept("GET", "/api/v1/privacy-notice/pri*", {
-        fixture: "privacy-notices/notice.json",
+        fixture: "privacy-notices/notice_only.json",
       }).as("getNoticeDetail");
       cy.getByTestId("row-Essential").click();
       cy.wait("@getNoticeDetail");
@@ -187,7 +187,7 @@ describe("Privacy notices", () => {
     it("should render an existing privacy notice", () => {
       cy.visit(`${PRIVACY_NOTICES_ROUTE}/${ESSENTIAL_NOTICE_ID}`);
       cy.wait("@getNoticeDetail");
-      cy.fixture("privacy-notices/notice.json").then((notice) => {
+      cy.fixture("privacy-notices/notice_only.json").then((notice) => {
         // details section
         cy.getByTestId("input-name").should("have.value", notice.name);
         cy.getByTestId("input-description").should(

--- a/clients/admin-ui/cypress/fixtures/privacy-notices/notice_only.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-notices/notice_only.json
@@ -1,0 +1,20 @@
+{
+  "name": "Essential",
+  "description": "Notify the user about data processing activities that are essential to your services functionality. Typically consent is not required for this.",
+  "internal_description": null,
+  "origin": null,
+  "regions": ["eu_fr", "eu_ie"],
+  "consent_mechanism": "notice_only",
+  "data_uses": ["provide.service"],
+  "enforcement_level": "not_applicable",
+  "disabled": false,
+  "has_gpc_flag": false,
+  "displayed_in_privacy_center": true,
+  "displayed_in_overlay": true,
+  "displayed_in_api": true,
+  "id": "pri_fbdfd4f5-eec3-4d4d-83ae-726bde1d5b3a",
+  "created_at": "2023-04-17T14:49:23.692686+00:00",
+  "updated_at": "2023-04-17T14:49:23.692686+00:00",
+  "version": 1.0,
+  "privacy_notice_history_id": "pri_469a3aaa-c9fe-4bdd-a090-c9a8b0661fdb"
+}

--- a/clients/admin-ui/cypress/fixtures/privacy-notices/opt_in.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-notices/opt_in.json
@@ -1,0 +1,20 @@
+{
+  "name": "Functional",
+  "description": "This is for data processing activities that enhance the capability or features of your site but may not be strictly necessary.",
+  "internal_description": null,
+  "origin": null,
+  "regions": ["eu_fr", "eu_ie"],
+  "consent_mechanism": "opt_in",
+  "data_uses": ["improve.system"],
+  "enforcement_level": "frontend",
+  "disabled": false,
+  "has_gpc_flag": false,
+  "displayed_in_privacy_center": true,
+  "displayed_in_overlay": true,
+  "displayed_in_api": true,
+  "id": "pri_fbdfd4f5-eec3-4d4d-83ae-726bde1d5b3a",
+  "created_at": "2023-04-17T14:49:23.692686+00:00",
+  "updated_at": "2023-04-17T14:49:23.692686+00:00",
+  "version": 1.0,
+  "privacy_notice_history_id": "pri_469a3aaa-c9fe-4bdd-a090-c9a8b0661fdb"
+}

--- a/clients/admin-ui/cypress/fixtures/privacy-notices/opt_out.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-notices/opt_out.json
@@ -1,0 +1,20 @@
+{
+  "name": "Data Sales",
+  "description": "Provide opt-out consent for the use of data in ways that may be considered “data sales” under US state privacy regulations.",
+  "internal_description": null,
+  "origin": null,
+  "regions": ["eu_fr", "eu_ie"],
+  "consent_mechanism": "opt_out",
+  "data_uses": ["advertising.third_party.personalized"],
+  "enforcement_level": "frontend",
+  "disabled": false,
+  "has_gpc_flag": false,
+  "displayed_in_privacy_center": true,
+  "displayed_in_overlay": true,
+  "displayed_in_api": true,
+  "id": "pri_fbdfd4f5-eec3-4d4d-83ae-726bde1d5b3a",
+  "created_at": "2023-04-17T14:49:23.692686+00:00",
+  "updated_at": "2023-04-17T14:49:23.692686+00:00",
+  "version": 1.0,
+  "privacy_notice_history_id": "pri_469a3aaa-c9fe-4bdd-a090-c9a8b0661fdb"
+}

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -116,7 +116,7 @@ export const stubPrivacyNoticesCrud = () => {
     fixture: "privacy-notices/list.json",
   }).as("getNotices");
   cy.intercept("GET", "/api/v1/privacy-notice/pri*", {
-    fixture: "privacy-notices/notice.json",
+    fixture: "privacy-notices/notice_only.json",
   }).as("getNoticeDetail");
   cy.intercept("POST", "/api/v1/privacy-notice", {
     fixture: "privacy-notices/list.json",

--- a/clients/admin-ui/src/features/common/form/FormSection.tsx
+++ b/clients/admin-ui/src/features/common/form/FormSection.tsx
@@ -1,14 +1,13 @@
-import { Box, Heading, Stack } from "@fidesui/react";
-import { ReactNode } from "react";
+import { Box, BoxProps, Heading, Stack } from "@fidesui/react";
 
 const FormSection = ({
   title,
   children,
+  ...props
 }: {
   title: string;
-  children: ReactNode;
-}) => (
-  <Box borderRadius="md" border="1px solid" borderColor="gray.200">
+} & BoxProps) => (
+  <Box borderRadius="md" border="1px solid" borderColor="gray.200" {...props}>
     <Heading
       as="h3"
       fontSize="sm"

--- a/clients/admin-ui/src/features/privacy-experience/form/BannerActionForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/BannerActionForm.tsx
@@ -1,10 +1,7 @@
-import { useFormikContext } from "formik";
-
 import FormSection from "~/features/common/form/FormSection";
 import { CustomTextInput } from "~/features/common/form/inputs";
-import { PrivacyExperienceCreate, PrivacyNoticeResponse } from "~/types/api";
 
-import { useExperienceFormRules } from "./helpers";
+import { ExperienceFormRules } from "./helpers";
 
 /**
  * Banner text form component.
@@ -13,16 +10,9 @@ import { useExperienceFormRules } from "./helpers";
  *   * If the experience only has notice_only notices, renders an "Acknowledgment button" instead of confirm + reject
  */
 const BannerActionForm = ({
-  privacyNotices,
-}: {
-  privacyNotices?: PrivacyNoticeResponse[];
-}) => {
-  const { initialValues } = useFormikContext<PrivacyExperienceCreate>();
-  const { hasOnlyNoticeOnlyNotices, isOverlay } = useExperienceFormRules({
-    privacyExperience: initialValues,
-    privacyNotices,
-  });
-
+  hasOnlyNoticeOnlyNotices,
+  isOverlay,
+}: ExperienceFormRules) => {
   if (!isOverlay) {
     return null;
   }

--- a/clients/admin-ui/src/features/privacy-experience/form/BannerActionForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/BannerActionForm.tsx
@@ -2,12 +2,8 @@ import { useFormikContext } from "formik";
 
 import FormSection from "~/features/common/form/FormSection";
 import { CustomTextInput } from "~/features/common/form/inputs";
-import {
-  ComponentType,
-  ConsentMechanism,
-  PrivacyExperienceCreate,
-  PrivacyNoticeResponse,
-} from "~/types/api";
+import { PrivacyExperienceCreate, PrivacyNoticeResponse } from "~/types/api";
+
 import { useExperienceFormRules } from "./helpers";
 
 /**
@@ -33,12 +29,18 @@ const BannerActionForm = ({
 
   return (
     <FormSection title="Banner actions" data-testid="banner-action-form">
-      <CustomTextInput name="link_label" label="Link label" variant="stacked" />
+      <CustomTextInput
+        name="link_label"
+        label="Link label"
+        variant="stacked"
+        isRequired
+      />
       {hasOnlyNoticeOnlyNotices ? (
         <CustomTextInput
           label="Acknowledgment button label"
           name="acknowledgement_button_label"
           variant="stacked"
+          isRequired
         />
       ) : (
         <>
@@ -46,11 +48,13 @@ const BannerActionForm = ({
             label="Confirmation button label"
             name="confirmation_button_label"
             variant="stacked"
+            isRequired
           />
           <CustomTextInput
             label="Reject button label"
             name="reject_button_label"
             variant="stacked"
+            isRequired
           />
         </>
       )}

--- a/clients/admin-ui/src/features/privacy-experience/form/BannerActionForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/BannerActionForm.tsx
@@ -8,6 +8,7 @@ import {
   PrivacyExperienceCreate,
   PrivacyNoticeResponse,
 } from "~/types/api";
+import { useExperienceFormRules } from "./helpers";
 
 /**
  * Banner text form component.
@@ -21,23 +22,19 @@ const BannerActionForm = ({
   privacyNotices?: PrivacyNoticeResponse[];
 }) => {
   const { initialValues } = useFormikContext<PrivacyExperienceCreate>();
+  const { hasOnlyNoticeOnlyNotices, isOverlay } = useExperienceFormRules({
+    privacyExperience: initialValues,
+    privacyNotices,
+  });
 
-  if (initialValues.component === ComponentType.PRIVACY_CENTER) {
+  if (!isOverlay) {
     return null;
   }
-
-  // Special rules for if the banner _only_ has notice only notices
-  const onlyNoticeOnlyNotices =
-    privacyNotices &&
-    privacyNotices.length &&
-    privacyNotices.every(
-      (notice) => notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY
-    );
 
   return (
     <FormSection title="Banner actions" data-testid="banner-action-form">
       <CustomTextInput name="link_label" label="Link label" variant="stacked" />
-      {onlyNoticeOnlyNotices ? (
+      {hasOnlyNoticeOnlyNotices ? (
         <CustomTextInput
           label="Acknowledgment button label"
           name="acknowledgement_button_label"

--- a/clients/admin-ui/src/features/privacy-experience/form/BannerActionForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/BannerActionForm.tsx
@@ -1,0 +1,70 @@
+import { useFormikContext } from "formik";
+
+import FormSection from "~/features/common/form/FormSection";
+import { CustomTextInput } from "~/features/common/form/inputs";
+import {
+  ComponentType,
+  ConsentMechanism,
+  PrivacyExperienceCreate,
+  PrivacyNoticeResponse,
+} from "~/types/api";
+
+/**
+ * Banner text form component.
+ * Rules:
+ *   * Only renders on component_type = OVERLAY
+ *   * If the experience only has notice_only notices, renders an "Acknowledgment button" instead of confirm + reject
+ */
+const BannerActionForm = ({
+  privacyNotices,
+}: {
+  privacyNotices?: PrivacyNoticeResponse[];
+}) => {
+  const { initialValues } = useFormikContext<PrivacyExperienceCreate>();
+
+  if (initialValues.component === ComponentType.PRIVACY_CENTER) {
+    return null;
+  }
+
+  // Special rules for if the banner _only_ has notice only notices
+  if (
+    privacyNotices &&
+    privacyNotices.length &&
+    privacyNotices.every(
+      (notice) => notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY
+    )
+  ) {
+    return (
+      <FormSection title="Banner actions">
+        <CustomTextInput
+          name="link_label"
+          label="Link label"
+          variant="stacked"
+        />
+        <CustomTextInput
+          label="Acknowledgment button label"
+          name="acknowledgement_button_label"
+          variant="stacked"
+        />
+      </FormSection>
+    );
+  }
+
+  return (
+    <FormSection title="Banner actions">
+      <CustomTextInput name="link_label" label="Link label" variant="stacked" />
+      <CustomTextInput
+        label="Confirmation button label"
+        name="confirmation_button_label"
+        variant="stacked"
+      />
+      <CustomTextInput
+        label="Reject button label"
+        name="reject_button_label"
+        variant="stacked"
+      />
+    </FormSection>
+  );
+};
+
+export default BannerActionForm;

--- a/clients/admin-ui/src/features/privacy-experience/form/BannerActionForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/BannerActionForm.tsx
@@ -27,42 +27,36 @@ const BannerActionForm = ({
   }
 
   // Special rules for if the banner _only_ has notice only notices
-  if (
+  const onlyNoticeOnlyNotices =
     privacyNotices &&
     privacyNotices.length &&
     privacyNotices.every(
       (notice) => notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY
-    )
-  ) {
-    return (
-      <FormSection title="Banner actions">
-        <CustomTextInput
-          name="link_label"
-          label="Link label"
-          variant="stacked"
-        />
+    );
+
+  return (
+    <FormSection title="Banner actions" data-testid="banner-action-form">
+      <CustomTextInput name="link_label" label="Link label" variant="stacked" />
+      {onlyNoticeOnlyNotices ? (
         <CustomTextInput
           label="Acknowledgment button label"
           name="acknowledgement_button_label"
           variant="stacked"
         />
-      </FormSection>
-    );
-  }
-
-  return (
-    <FormSection title="Banner actions">
-      <CustomTextInput name="link_label" label="Link label" variant="stacked" />
-      <CustomTextInput
-        label="Confirmation button label"
-        name="confirmation_button_label"
-        variant="stacked"
-      />
-      <CustomTextInput
-        label="Reject button label"
-        name="reject_button_label"
-        variant="stacked"
-      />
+      ) : (
+        <>
+          <CustomTextInput
+            label="Confirmation button label"
+            name="confirmation_button_label"
+            variant="stacked"
+          />
+          <CustomTextInput
+            label="Reject button label"
+            name="reject_button_label"
+            variant="stacked"
+          />
+        </>
+      )}
     </FormSection>
   );
 };

--- a/clients/admin-ui/src/features/privacy-experience/form/BannerTextForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/BannerTextForm.tsx
@@ -2,7 +2,8 @@ import { useFormikContext } from "formik";
 
 import FormSection from "~/features/common/form/FormSection";
 import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
-import { ComponentType, PrivacyExperienceCreate } from "~/types/api";
+import { PrivacyExperienceCreate } from "~/types/api";
+
 import { useExperienceFormRules } from "./helpers";
 
 /**
@@ -26,6 +27,7 @@ const BannerTextForm = () => {
         name="banner_title"
         label="Banner title"
         variant="stacked"
+        isRequired
       />
       <CustomTextArea
         label="Banner description"

--- a/clients/admin-ui/src/features/privacy-experience/form/BannerTextForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/BannerTextForm.tsx
@@ -17,7 +17,7 @@ const BannerTextForm = () => {
   }
 
   return (
-    <FormSection title="Banner text">
+    <FormSection title="Banner text" data-testid="banner-text-form">
       <CustomTextInput
         name="banner_title"
         label="Banner title"

--- a/clients/admin-ui/src/features/privacy-experience/form/BannerTextForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/BannerTextForm.tsx
@@ -1,0 +1,35 @@
+import { useFormikContext } from "formik";
+
+import FormSection from "~/features/common/form/FormSection";
+import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
+import { ComponentType, PrivacyExperienceCreate } from "~/types/api";
+
+/**
+ * Banner text form component.
+ * Rules:
+ *   * Only renders on component_type = OVERLAY
+ */
+const BannerTextForm = () => {
+  const { initialValues } = useFormikContext<PrivacyExperienceCreate>();
+
+  if (initialValues.component === ComponentType.PRIVACY_CENTER) {
+    return null;
+  }
+
+  return (
+    <FormSection title="Banner text">
+      <CustomTextInput
+        name="banner_title"
+        label="Banner title"
+        variant="stacked"
+      />
+      <CustomTextArea
+        label="Banner description"
+        name="banner_description"
+        variant="stacked"
+      />
+    </FormSection>
+  );
+};
+
+export default BannerTextForm;

--- a/clients/admin-ui/src/features/privacy-experience/form/BannerTextForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/BannerTextForm.tsx
@@ -3,6 +3,7 @@ import { useFormikContext } from "formik";
 import FormSection from "~/features/common/form/FormSection";
 import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
 import { ComponentType, PrivacyExperienceCreate } from "~/types/api";
+import { useExperienceFormRules } from "./helpers";
 
 /**
  * Banner text form component.
@@ -11,8 +12,11 @@ import { ComponentType, PrivacyExperienceCreate } from "~/types/api";
  */
 const BannerTextForm = () => {
   const { initialValues } = useFormikContext<PrivacyExperienceCreate>();
+  const { isOverlay } = useExperienceFormRules({
+    privacyExperience: initialValues,
+  });
 
-  if (initialValues.component === ComponentType.PRIVACY_CENTER) {
+  if (!isOverlay) {
     return null;
   }
 

--- a/clients/admin-ui/src/features/privacy-experience/form/BannerTextForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/BannerTextForm.tsx
@@ -1,22 +1,14 @@
-import { useFormikContext } from "formik";
-
 import FormSection from "~/features/common/form/FormSection";
 import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
-import { PrivacyExperienceCreate } from "~/types/api";
 
-import { useExperienceFormRules } from "./helpers";
+import { ExperienceFormRules } from "./helpers";
 
 /**
  * Banner text form component.
  * Rules:
  *   * Only renders on component_type = OVERLAY
  */
-const BannerTextForm = () => {
-  const { initialValues } = useFormikContext<PrivacyExperienceCreate>();
-  const { isOverlay } = useExperienceFormRules({
-    privacyExperience: initialValues,
-  });
-
+const BannerTextForm = ({ isOverlay }: ExperienceFormRules) => {
   if (!isOverlay) {
     return null;
   }

--- a/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
@@ -33,20 +33,22 @@ const DeliveryMechanismForm = ({
   const { initialValues, setFieldValue } =
     useFormikContext<PrivacyExperienceCreate>();
 
-  const hasOptInNotices = useMemo(
-    () =>
+  const needsBanner = useMemo(() => {
+    return (
       privacyNotices &&
       privacyNotices.some(
-        (notice) => notice.consent_mechanism === ConsentMechanism.OPT_IN
-      ),
-    [privacyNotices]
-  );
+        (notice) =>
+          notice.consent_mechanism === ConsentMechanism.OPT_IN ||
+          notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY
+      )
+    );
+  }, [privacyNotices]);
 
   useEffect(() => {
-    if (hasOptInNotices) {
+    if (needsBanner) {
       setFieldValue("delivery_mechanism", DeliveryMechanism.BANNER);
     }
-  }, [hasOptInNotices, setFieldValue]);
+  }, [needsBanner, setFieldValue]);
 
   if (initialValues.component === ComponentType.PRIVACY_CENTER) {
     return null;
@@ -62,7 +64,7 @@ const DeliveryMechanismForm = ({
         label="Choose your delivery mechanism"
         options={DELIVERY_MECHANISM_OPTIONS}
         variant="stacked"
-        isDisabled={hasOptInNotices}
+        isDisabled={needsBanner}
       />
     </FormSection>
   );

--- a/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
@@ -1,0 +1,68 @@
+import { useFormikContext } from "formik";
+import { useEffect, useMemo } from "react";
+
+import FormSection from "~/features/common/form/FormSection";
+import { CustomSelect } from "~/features/common/form/inputs";
+import { enumToOptions } from "~/features/common/helpers";
+import {
+  ComponentType,
+  ConsentMechanism,
+  DeliveryMechanism,
+  PrivacyExperienceCreate,
+  PrivacyNoticeResponse,
+} from "~/types/api";
+
+const DELIVERY_MECHANISM_OPTIONS = enumToOptions(DeliveryMechanism).map(
+  (opt) => ({
+    ...opt,
+    label: `${opt.label.charAt(0).toUpperCase()}${opt.label.slice(1)}`,
+  })
+);
+
+/**
+ * Delivery mechanism form component
+ * Rules:
+ *   * Only renders on component_type = OVERLAY
+ *   * Must be "Banner" if there are any "opt-in" notices
+ */
+const DeliveryMechanismForm = ({
+  privacyNotices,
+}: {
+  privacyNotices?: PrivacyNoticeResponse[];
+}) => {
+  const { initialValues, setFieldValue } =
+    useFormikContext<PrivacyExperienceCreate>();
+
+  const hasOptInNotices = useMemo(
+    () =>
+      privacyNotices &&
+      privacyNotices.some(
+        (notice) => notice.consent_mechanism === ConsentMechanism.OPT_IN
+      ),
+    [privacyNotices]
+  );
+
+  useEffect(() => {
+    if (hasOptInNotices) {
+      setFieldValue("delivery_mechanism", DeliveryMechanism.BANNER);
+    }
+  }, [hasOptInNotices, setFieldValue]);
+
+  if (initialValues.component === ComponentType.PRIVACY_CENTER) {
+    return null;
+  }
+
+  return (
+    <FormSection title="Delivery mechanism">
+      <CustomSelect
+        name="delivery_mechanism"
+        label="Choose your delivery mechanism"
+        options={DELIVERY_MECHANISM_OPTIONS}
+        variant="stacked"
+        isDisabled={hasOptInNotices}
+      />
+    </FormSection>
+  );
+};
+
+export default DeliveryMechanismForm;

--- a/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
@@ -11,6 +11,7 @@ import {
   PrivacyExperienceCreate,
   PrivacyNoticeResponse,
 } from "~/types/api";
+import { useExperienceFormRules } from "./helpers";
 
 const DELIVERY_MECHANISM_OPTIONS = enumToOptions(DeliveryMechanism).map(
   (opt) => ({
@@ -33,16 +34,10 @@ const DeliveryMechanismForm = ({
   const { initialValues, setFieldValue } =
     useFormikContext<PrivacyExperienceCreate>();
 
-  const needsBanner = useMemo(() => {
-    return (
-      privacyNotices &&
-      privacyNotices.some(
-        (notice) =>
-          notice.consent_mechanism === ConsentMechanism.OPT_IN ||
-          notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY
-      )
-    );
-  }, [privacyNotices]);
+  const { needsBanner, isOverlay } = useExperienceFormRules({
+    privacyExperience: initialValues,
+    privacyNotices,
+  });
 
   useEffect(() => {
     if (needsBanner) {
@@ -50,7 +45,7 @@ const DeliveryMechanismForm = ({
     }
   }, [needsBanner, setFieldValue]);
 
-  if (initialValues.component === ComponentType.PRIVACY_CENTER) {
+  if (!isOverlay) {
     return null;
   }
 

--- a/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
@@ -53,7 +53,10 @@ const DeliveryMechanismForm = ({
   }
 
   return (
-    <FormSection title="Delivery mechanism">
+    <FormSection
+      title="Delivery mechanism"
+      data-testid="delivery-mechanism-form"
+    >
       <CustomSelect
         name="delivery_mechanism"
         label="Choose your delivery mechanism"

--- a/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
@@ -1,16 +1,15 @@
 import { useFormikContext } from "formik";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 
 import FormSection from "~/features/common/form/FormSection";
 import { CustomSelect } from "~/features/common/form/inputs";
 import { enumToOptions } from "~/features/common/helpers";
 import {
-  ComponentType,
-  ConsentMechanism,
   DeliveryMechanism,
   PrivacyExperienceCreate,
   PrivacyNoticeResponse,
 } from "~/types/api";
+
 import { useExperienceFormRules } from "./helpers";
 
 const DELIVERY_MECHANISM_OPTIONS = enumToOptions(DeliveryMechanism).map(

--- a/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/DeliveryMechanismForm.tsx
@@ -4,13 +4,9 @@ import { useEffect } from "react";
 import FormSection from "~/features/common/form/FormSection";
 import { CustomSelect } from "~/features/common/form/inputs";
 import { enumToOptions } from "~/features/common/helpers";
-import {
-  DeliveryMechanism,
-  PrivacyExperienceCreate,
-  PrivacyNoticeResponse,
-} from "~/types/api";
+import { DeliveryMechanism, PrivacyExperienceCreate } from "~/types/api";
 
-import { useExperienceFormRules } from "./helpers";
+import { ExperienceFormRules } from "./helpers";
 
 const DELIVERY_MECHANISM_OPTIONS = enumToOptions(DeliveryMechanism).map(
   (opt) => ({
@@ -26,17 +22,10 @@ const DELIVERY_MECHANISM_OPTIONS = enumToOptions(DeliveryMechanism).map(
  *   * Must be "Banner" if there are any "opt-in" notices
  */
 const DeliveryMechanismForm = ({
-  privacyNotices,
-}: {
-  privacyNotices?: PrivacyNoticeResponse[];
-}) => {
-  const { initialValues, setFieldValue } =
-    useFormikContext<PrivacyExperienceCreate>();
-
-  const { needsBanner, isOverlay } = useExperienceFormRules({
-    privacyExperience: initialValues,
-    privacyNotices,
-  });
+  needsBanner,
+  isOverlay,
+}: ExperienceFormRules) => {
+  const { setFieldValue } = useFormikContext<PrivacyExperienceCreate>();
 
   useEffect(() => {
     if (needsBanner) {

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyCenterMessagingForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyCenterMessagingForm.tsx
@@ -3,6 +3,7 @@ import { useFormikContext } from "formik";
 import FormSection from "~/features/common/form/FormSection";
 import { CustomTextInput } from "~/features/common/form/inputs";
 import { ComponentType, PrivacyExperienceCreate } from "~/types/api";
+import { useExperienceFormRules } from "./helpers";
 
 /**
  * Privacy center configuration form
@@ -12,7 +13,11 @@ import { ComponentType, PrivacyExperienceCreate } from "~/types/api";
 const PrivacyCenterMessagingForm = () => {
   const { initialValues } = useFormikContext<PrivacyExperienceCreate>();
 
-  if (initialValues.component === ComponentType.OVERLAY) {
+  const { isOverlay } = useExperienceFormRules({
+    privacyExperience: initialValues,
+  });
+
+  if (isOverlay) {
     return null;
   }
 

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyCenterMessagingForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyCenterMessagingForm.tsx
@@ -17,7 +17,10 @@ const PrivacyCenterMessagingForm = () => {
   }
 
   return (
-    <FormSection title="Privacy center messaging">
+    <FormSection
+      title="Privacy center messaging"
+      data-testid="privacy-center-messaging-form"
+    >
       <CustomTextInput
         name="link_label"
         label="Website link text"

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyCenterMessagingForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyCenterMessagingForm.tsx
@@ -1,0 +1,35 @@
+import { useFormikContext } from "formik";
+
+import FormSection from "~/features/common/form/FormSection";
+import { CustomTextInput } from "~/features/common/form/inputs";
+import { ComponentType, PrivacyExperienceCreate } from "~/types/api";
+
+/**
+ * Privacy center configuration form
+ * Rules:
+ *   * Only renders on component_type = privacy_center
+ */
+const PrivacyCenterMessagingForm = () => {
+  const { initialValues } = useFormikContext<PrivacyExperienceCreate>();
+
+  if (initialValues.component === ComponentType.OVERLAY) {
+    return null;
+  }
+
+  return (
+    <FormSection title="Privacy center messaging">
+      <CustomTextInput
+        name="link_label"
+        label="Website link text"
+        variant="stacked"
+      />
+      <CustomTextInput
+        name="component_description"
+        label="Privacy center heading text"
+        variant="stacked"
+      />
+    </FormSection>
+  );
+};
+
+export default PrivacyCenterMessagingForm;

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyCenterMessagingForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyCenterMessagingForm.tsx
@@ -2,7 +2,8 @@ import { useFormikContext } from "formik";
 
 import FormSection from "~/features/common/form/FormSection";
 import { CustomTextInput } from "~/features/common/form/inputs";
-import { ComponentType, PrivacyExperienceCreate } from "~/types/api";
+import { PrivacyExperienceCreate } from "~/types/api";
+
 import { useExperienceFormRules } from "./helpers";
 
 /**
@@ -30,6 +31,7 @@ const PrivacyCenterMessagingForm = () => {
         name="link_label"
         label="Website link text"
         variant="stacked"
+        isRequired
       />
       <CustomTextInput
         name="component_description"

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyCenterMessagingForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyCenterMessagingForm.tsx
@@ -1,23 +1,14 @@
-import { useFormikContext } from "formik";
-
 import FormSection from "~/features/common/form/FormSection";
 import { CustomTextInput } from "~/features/common/form/inputs";
-import { PrivacyExperienceCreate } from "~/types/api";
 
-import { useExperienceFormRules } from "./helpers";
+import { ExperienceFormRules } from "./helpers";
 
 /**
  * Privacy center configuration form
  * Rules:
  *   * Only renders on component_type = privacy_center
  */
-const PrivacyCenterMessagingForm = () => {
-  const { initialValues } = useFormikContext<PrivacyExperienceCreate>();
-
-  const { isOverlay } = useExperienceFormRules({
-    privacyExperience: initialValues,
-  });
-
+const PrivacyCenterMessagingForm = ({ isOverlay }: ExperienceFormRules) => {
   if (isOverlay) {
     return null;
   }

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/router";
 import { useMemo } from "react";
 
 import FormSection from "~/features/common/form/FormSection";
-import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { PRIVACY_EXPERIENCE_ROUTE } from "~/features/common/nav/v2/routes";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
@@ -17,11 +16,15 @@ import {
   PrivacyExperienceResponse,
 } from "~/types/api";
 
+import BannerActionForm from "./BannerActionForm";
+import BannerTextForm from "./BannerTextForm";
+import DeliveryMechanismForm from "./DeliveryMechanismForm";
 import {
   defaultInitialValues,
   transformPrivacyExperienceResponseToCreation,
   ValidationSchema,
 } from "./helpers";
+import PrivacyCenterMessagingForm from "./PrivacyCenterMessagingForm";
 
 const PrivacyNoticeForm = ({
   privacyExperience: passedInPrivacyExperience,
@@ -64,6 +67,10 @@ const PrivacyNoticeForm = ({
     }
   };
 
+  const associatedNotices = passedInPrivacyExperience
+    ? passedInPrivacyExperience.privacy_notices
+    : undefined;
+
   return (
     <Formik
       initialValues={initialValues}
@@ -73,8 +80,13 @@ const PrivacyNoticeForm = ({
     >
       {({ dirty, isValid, isSubmitting }) => (
         <Form>
+          <pre>
+            notice mechanisms:{" "}
+            {associatedNotices?.map((n) => `${n.consent_mechanism}, `)}
+          </pre>
           <Stack spacing={10}>
             <Stack spacing={6}>
+              {/* Location shows in every form */}
               <FormSection title="Locations">
                 <Box
                   border="1px solid"
@@ -95,35 +107,12 @@ const PrivacyNoticeForm = ({
                   ))}
                 </Box>
               </FormSection>
-              <FormSection title="Banner text">
-                <CustomTextInput
-                  name="banner_title"
-                  label="Banner title"
-                  variant="stacked"
-                />
-                <CustomTextArea
-                  label="Banner description"
-                  name="banner_description"
-                  variant="stacked"
-                />
-              </FormSection>
-              <FormSection title="Banner actions">
-                <CustomTextInput
-                  name="link_label"
-                  label="Link label"
-                  variant="stacked"
-                />
-                <CustomTextInput
-                  label="Confirmation button label"
-                  name="confirmation_button_label"
-                  variant="stacked"
-                />
-                <CustomTextInput
-                  label="Reject button label"
-                  name="reject_button_label"
-                  variant="stacked"
-                />
-              </FormSection>
+              {/* Form subsections are responsible for their own render/don't render logic */}
+              <DeliveryMechanismForm privacyNotices={associatedNotices} />
+              <PrivacyCenterMessagingForm />
+              <BannerTextForm />
+              <BannerActionForm privacyNotices={associatedNotices} />
+              {/* End form subsections */}
             </Stack>
             <ButtonGroup size="sm" spacing={2}>
               <Button

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
@@ -71,7 +71,7 @@ const PrivacyNoticeForm = ({
     ? passedInPrivacyExperience.privacy_notices
     : undefined;
 
-  const { validationSchema } = useExperienceFormRules({
+  const { validationSchema, ...rules } = useExperienceFormRules({
     privacyExperience: initialValues,
     privacyNotices: associatedNotices,
   });
@@ -109,10 +109,10 @@ const PrivacyNoticeForm = ({
                 </Box>
               </FormSection>
               {/* Form subsections are responsible for their own render/don't render logic */}
-              <DeliveryMechanismForm privacyNotices={associatedNotices} />
-              <PrivacyCenterMessagingForm />
-              <BannerTextForm />
-              <BannerActionForm privacyNotices={associatedNotices} />
+              <DeliveryMechanismForm {...rules} />
+              <PrivacyCenterMessagingForm {...rules} />
+              <BannerTextForm {...rules} />
+              <BannerActionForm {...rules} />
               {/* End form subsections */}
             </Stack>
             <ButtonGroup size="sm" spacing={2}>

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
@@ -22,6 +22,7 @@ import DeliveryMechanismForm from "./DeliveryMechanismForm";
 import {
   defaultInitialValues,
   transformPrivacyExperienceResponseToCreation,
+  useExperienceFormRules,
 } from "./helpers";
 import PrivacyCenterMessagingForm from "./PrivacyCenterMessagingForm";
 
@@ -70,11 +71,17 @@ const PrivacyNoticeForm = ({
     ? passedInPrivacyExperience.privacy_notices
     : undefined;
 
+  const { validationSchema } = useExperienceFormRules({
+    privacyExperience: initialValues,
+    privacyNotices: associatedNotices,
+  });
+
   return (
     <Formik
       initialValues={initialValues}
       enableReinitialize
       onSubmit={handleSubmit}
+      validationSchema={validationSchema}
     >
       {({ dirty, isValid, isSubmitting }) => (
         <Form>

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
@@ -78,10 +78,6 @@ const PrivacyNoticeForm = ({
     >
       {({ dirty, isValid, isSubmitting }) => (
         <Form>
-          <pre>
-            notice mechanisms:{" "}
-            {associatedNotices?.map((n) => `${n.consent_mechanism}, `)}
-          </pre>
           <Stack spacing={10}>
             <Stack spacing={6}>
               {/* Location shows in every form */}

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
@@ -1,0 +1,155 @@
+import { Box, Button, ButtonGroup, Stack, Tag, useToast } from "@fidesui/react";
+import { Form, Formik } from "formik";
+import { useRouter } from "next/router";
+import { useMemo } from "react";
+
+import FormSection from "~/features/common/form/FormSection";
+import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
+import { PRIVACY_EXPERIENCE_ROUTE } from "~/features/common/nav/v2/routes";
+import { errorToastParams, successToastParams } from "~/features/common/toast";
+import {
+  usePatchPrivacyExperienceMutation,
+  usePostPrivacyExperienceMutation,
+} from "~/features/privacy-experience/privacy-experience.slice";
+import {
+  PrivacyExperienceCreate,
+  PrivacyExperienceResponse,
+} from "~/types/api";
+
+import {
+  defaultInitialValues,
+  transformPrivacyExperienceResponseToCreation,
+  ValidationSchema,
+} from "./helpers";
+
+const PrivacyNoticeForm = ({
+  privacyExperience: passedInPrivacyExperience,
+}: {
+  privacyExperience?: PrivacyExperienceResponse;
+}) => {
+  const router = useRouter();
+  const toast = useToast();
+  const initialValues = passedInPrivacyExperience
+    ? transformPrivacyExperienceResponseToCreation(passedInPrivacyExperience)
+    : defaultInitialValues;
+
+  const [patchExperiencesMutationTrigger] = usePatchPrivacyExperienceMutation();
+  const [postExperiencesMutationTrigger] = usePostPrivacyExperienceMutation();
+
+  const isEditing = useMemo(
+    () => !!passedInPrivacyExperience,
+    [passedInPrivacyExperience]
+  );
+
+  const handleSubmit = async (values: PrivacyExperienceCreate) => {
+    let result;
+    if (isEditing) {
+      result = await patchExperiencesMutationTrigger([values]);
+    } else {
+      result = await postExperiencesMutationTrigger([values]);
+    }
+
+    if (isErrorResult(result)) {
+      toast(errorToastParams(getErrorMessage(result.error)));
+    } else {
+      toast(
+        successToastParams(
+          `Privacy experience ${isEditing ? "updated" : "created"}`
+        )
+      );
+      if (!isEditing) {
+        router.push(PRIVACY_EXPERIENCE_ROUTE);
+      }
+    }
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      enableReinitialize
+      onSubmit={handleSubmit}
+      validationSchema={ValidationSchema}
+    >
+      {({ dirty, isValid, isSubmitting }) => (
+        <Form>
+          <Stack spacing={10}>
+            <Stack spacing={6}>
+              <FormSection title="Locations">
+                <Box
+                  border="1px solid"
+                  borderColor="gray.200"
+                  borderRadius="md"
+                  p={5}
+                  m={0}
+                >
+                  {initialValues.regions.map((r) => (
+                    <Tag
+                      key={r}
+                      mr="2"
+                      backgroundColor="primary.400"
+                      color="white"
+                    >
+                      {r}
+                    </Tag>
+                  ))}
+                </Box>
+              </FormSection>
+              <FormSection title="Banner text">
+                <CustomTextInput
+                  name="banner_title"
+                  label="Banner title"
+                  variant="stacked"
+                />
+                <CustomTextArea
+                  label="Banner description"
+                  name="banner_description"
+                  variant="stacked"
+                />
+              </FormSection>
+              <FormSection title="Banner actions">
+                <CustomTextInput
+                  name="link_label"
+                  label="Link label"
+                  variant="stacked"
+                />
+                <CustomTextInput
+                  label="Confirmation button label"
+                  name="confirmation_button_label"
+                  variant="stacked"
+                />
+                <CustomTextInput
+                  label="Reject button label"
+                  name="reject_button_label"
+                  variant="stacked"
+                />
+              </FormSection>
+            </Stack>
+            <ButtonGroup size="sm" spacing={2}>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  router.back();
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                isDisabled={isSubmitting || !dirty || !isValid}
+                isLoading={isSubmitting}
+                data-testid="save-btn"
+              >
+                Save
+              </Button>
+            </ButtonGroup>
+          </Stack>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default PrivacyNoticeForm;

--- a/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/PrivacyExperienceForm.tsx
@@ -22,7 +22,6 @@ import DeliveryMechanismForm from "./DeliveryMechanismForm";
 import {
   defaultInitialValues,
   transformPrivacyExperienceResponseToCreation,
-  ValidationSchema,
 } from "./helpers";
 import PrivacyCenterMessagingForm from "./PrivacyCenterMessagingForm";
 
@@ -76,7 +75,6 @@ const PrivacyNoticeForm = ({
       initialValues={initialValues}
       enableReinitialize
       onSubmit={handleSubmit}
-      validationSchema={ValidationSchema}
     >
       {({ dirty, isValid, isSubmitting }) => (
         <Form>

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -1,0 +1,45 @@
+import * as Yup from "yup";
+
+import {
+  ComponentType,
+  DeliveryMechanism,
+  PrivacyExperienceCreate,
+  PrivacyExperienceResponse,
+} from "~/types/api";
+
+export const defaultInitialValues: PrivacyExperienceCreate = {
+  regions: [],
+  component: ComponentType.OVERLAY,
+  delivery_mechanism: DeliveryMechanism.LINK,
+};
+
+export const transformPrivacyExperienceResponseToCreation = (
+  experience: PrivacyExperienceResponse
+): PrivacyExperienceCreate => {
+  // Remove the fields not needed for editing/creation
+  const {
+    created_at: createdAt,
+    updated_at: updatedAt,
+    privacy_experience_history_id: historyId,
+    version,
+    ...rest
+  } = experience;
+  return {
+    ...rest,
+
+    regions: experience.regions ?? defaultInitialValues.regions,
+    component: experience.component ?? defaultInitialValues.component,
+    delivery_mechanism:
+      experience.delivery_mechanism ?? defaultInitialValues.delivery_mechanism,
+  };
+};
+
+export const ValidationSchema = Yup.object().shape({
+  name: Yup.string().required().label("Title"),
+  data_uses: Yup.array(Yup.string())
+    .min(1, "Must assign at least one data use")
+    .label("Data uses"),
+  regions: Yup.array(Yup.string())
+    .min(1, "Must assign at least one location")
+    .label("Locations"),
+});

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -63,6 +63,12 @@ const acknowledgeValidationSchema = Yup.object().shape({
     .label("Acknowledgment button label"),
 });
 
+export interface ExperienceFormRules {
+  isOverlay: boolean;
+  needsBanner: boolean;
+  hasOnlyNoticeOnlyNotices: boolean;
+}
+
 /**
  * Use the various rules/conditions of a privacy experience form
  */
@@ -72,7 +78,7 @@ export const useExperienceFormRules = ({
 }: {
   privacyExperience: PrivacyExperienceCreate;
   privacyNotices?: PrivacyNoticeResponse[];
-}) => {
+}): ExperienceFormRules & { validationSchema: any } => {
   const isOverlay = useMemo(
     () => privacyExperience.component === ComponentType.OVERLAY,
     [privacyExperience.component]
@@ -80,7 +86,7 @@ export const useExperienceFormRules = ({
 
   const needsBanner = useMemo(
     () =>
-      privacyNotices &&
+      !!privacyNotices &&
       privacyNotices.some(
         (notice) =>
           notice.consent_mechanism === ConsentMechanism.OPT_IN ||
@@ -91,8 +97,8 @@ export const useExperienceFormRules = ({
 
   const hasOnlyNoticeOnlyNotices = useMemo(
     () =>
-      privacyNotices &&
-      privacyNotices.length &&
+      !!privacyNotices &&
+      privacyNotices.length > 0 &&
       privacyNotices.every(
         (notice) => notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY
       ),

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -1,5 +1,3 @@
-import * as Yup from "yup";
-
 import {
   ComponentType,
   DeliveryMechanism,
@@ -21,7 +19,9 @@ export const transformPrivacyExperienceResponseToCreation = (
     created_at: createdAt,
     updated_at: updatedAt,
     privacy_experience_history_id: historyId,
+    privacy_experience_template_id: templateId,
     version,
+    privacy_notices: notices,
     ...rest
   } = experience;
   return {
@@ -33,13 +33,3 @@ export const transformPrivacyExperienceResponseToCreation = (
       experience.delivery_mechanism ?? defaultInitialValues.delivery_mechanism,
   };
 };
-
-export const ValidationSchema = Yup.object().shape({
-  name: Yup.string().required().label("Title"),
-  data_uses: Yup.array(Yup.string())
-    .min(1, "Must assign at least one data use")
-    .label("Data uses"),
-  regions: Yup.array(Yup.string())
-    .min(1, "Must assign at least one location")
-    .label("Locations"),
-});

--- a/clients/admin-ui/src/features/privacy-experience/privacy-experience.slice.ts
+++ b/clients/admin-ui/src/features/privacy-experience/privacy-experience.slice.ts
@@ -4,7 +4,7 @@ import type { RootState } from "~/app/store";
 import { baseApi } from "~/features/common/api.slice";
 import {
   Page_PrivacyExperienceResponse_,
-  PrivacyExperience,
+  PrivacyExperienceCreate,
   PrivacyExperienceResponse,
   PrivacyNoticeRegion,
 } from "~/types/api";
@@ -57,7 +57,10 @@ const privacyExperienceApi = baseApi.injectEndpoints({
         { type: "Privacy Experiences", id: arg },
       ],
     }),
-    postPrivacyExperience: build.mutation<PrivacyExperience[], void>({
+    postPrivacyExperience: build.mutation<
+      PrivacyExperienceResponse[],
+      PrivacyExperienceCreate[]
+    >({
       query: (payload) => ({
         method: "POST",
         url: `privacy-experience/`,

--- a/clients/admin-ui/src/pages/consent/privacy-experience/[id].tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-experience/[id].tsx
@@ -14,6 +14,7 @@ import { useRouter } from "next/router";
 import Layout from "~/features/common/Layout";
 import { PRIVACY_EXPERIENCE_ROUTE } from "~/features/common/nav/v2/routes";
 import { COMPONENT_MAP } from "~/features/privacy-experience/constants";
+import PrivacyExperienceForm from "~/features/privacy-experience/form/PrivacyExperienceForm";
 import { useGetPrivacyExperienceByIdQuery } from "~/features/privacy-experience/privacy-experience.slice";
 import { ComponentType } from "~/types/api";
 
@@ -83,7 +84,7 @@ const PrivacyExperienceDetailPage = () => {
             </BreadcrumbItem>
             <BreadcrumbItem color="complimentary.500">
               <NextLink href="#">
-                {COMPONENT_MAP.get(data.component) ?? data.component}
+                {COMPONENT_MAP.get(data.component || "") ?? data.component}
               </NextLink>
             </BreadcrumbItem>
           </Breadcrumb>
@@ -97,7 +98,7 @@ const PrivacyExperienceDetailPage = () => {
           privacy notices and must be delivered with a banner.
         </Text>
         <Box data-testid="privacy-experience-detail-page">
-          Work in progress!
+          <PrivacyExperienceForm privacyExperience={data} />
         </Box>
       </Box>
     </Layout>

--- a/clients/admin-ui/src/pages/consent/privacy-experience/index.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-experience/index.tsx
@@ -8,7 +8,7 @@ import { PRIVACY_EXPERIENCE_ROUTE } from "~/features/common/nav/v2/routes";
 import PrivacyExperiencesTable from "~/features/privacy-experience/PrivacyExperiencesTable";
 
 const PrivacyExperiencePage = () => (
-  <Layout title="Privacy notices">
+  <Layout title="Privacy experiences">
     <Box mb={4}>
       <Heading fontSize="2xl" fontWeight="semibold" mb={2} data-testid="header">
         Privacy experience

--- a/clients/admin-ui/src/types/api/index.ts
+++ b/clients/admin-ui/src/types/api/index.ts
@@ -204,7 +204,7 @@ export type { PolicyWebhookUpdateResponse } from "./models/PolicyWebhookUpdateRe
 export type { PostgreSQLDocsSchema } from "./models/PostgreSQLDocsSchema";
 export type { PrivacyDeclaration } from "./models/PrivacyDeclaration";
 export type { PrivacyDeclarationResponse } from "./models/PrivacyDeclarationResponse";
-export type { PrivacyExperience } from "./models/PrivacyExperience";
+export type { PrivacyExperienceCreate } from "./models/PrivacyExperienceCreate";
 export type { PrivacyExperienceResponse } from "./models/PrivacyExperienceResponse";
 export type { PrivacyExperienceWithId } from "./models/PrivacyExperienceWithId";
 export type { PrivacyNoticeCreation } from "./models/PrivacyNoticeCreation";

--- a/clients/admin-ui/src/types/api/models/PrivacyExperienceCreate.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyExperienceCreate.ts
@@ -7,9 +7,11 @@ import type { DeliveryMechanism } from "./DeliveryMechanism";
 import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
 
 /**
- * Base for PrivacyExperience API objects
+ * An API representation of a PrivacyNotice.
+ * This model doesn't include an `id` so that it can be used for creation.
+ * It also establishes some fields _required_ for creation
  */
-export type PrivacyExperience = {
+export type PrivacyExperienceCreate = {
   disabled?: boolean;
   component: ComponentType;
   delivery_mechanism: DeliveryMechanism;

--- a/clients/admin-ui/src/types/api/models/PrivacyExperienceResponse.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyExperienceResponse.ts
@@ -12,9 +12,9 @@ import type { PrivacyNoticeResponse } from "./PrivacyNoticeResponse";
  */
 export type PrivacyExperienceResponse = {
   disabled?: boolean;
-  component: ComponentType;
-  delivery_mechanism: DeliveryMechanism;
-  regions: Array<PrivacyNoticeRegion>;
+  component?: ComponentType;
+  delivery_mechanism?: DeliveryMechanism;
+  regions?: Array<PrivacyNoticeRegion>;
   component_title?: string;
   component_description?: string;
   banner_title?: string;

--- a/clients/admin-ui/src/types/api/models/PrivacyExperienceWithId.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyExperienceWithId.ts
@@ -12,9 +12,9 @@ import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
  */
 export type PrivacyExperienceWithId = {
   disabled?: boolean;
-  component: ComponentType;
-  delivery_mechanism: DeliveryMechanism;
-  regions: Array<PrivacyNoticeRegion>;
+  component?: ComponentType;
+  delivery_mechanism?: DeliveryMechanism;
+  regions?: Array<PrivacyNoticeRegion>;
   component_title?: string;
   component_description?: string;
   banner_title?: string;


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3126

### Code Changes

* [x] Add new `PrivacyExperienceForm.tsx`
  * [x] This one has a few subcomponents which control the various form rendering logic from privacy experiences
  * [x] Other than that, it's pretty similar to `PrivacyNoticeForm.tsx`
* [x] Cypress tests, including a handy function to easily test different experiences backed by varying notices

### Steps to Confirm

* Same setup as described in https://github.com/ethyca/fides/pull/3186
* Click into one of the experiences
* You should be able to fill out the form and persist the data 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

https://www.loom.com/share/556bc39d3f6b4f7ca50a4c2cef14929a


https://user-images.githubusercontent.com/24641006/236256514-8be4a0c7-e771-4719-bb93-9ce28ef5571b.mov


