### PR TITLE
Lib -> Ops Type Hinting Fixes

### DIFF
--- a/src/fides/api/ctl/database/seed.py
+++ b/src/fides/api/ctl/database/seed.py
@@ -436,14 +436,15 @@ async def load_samples(async_session: AsyncSession) -> None:
         sample_connections = load_sample_connections_from_project()
         with sync_session() as db_session:
             for connection in sample_connections:
+                assert connection.key
                 # If the connection config already exists, skip creation!
                 # NOTE: This creates an edge case where the sample data was
                 # created previously, but has since changed. By not deleting &
                 # recreating here, we allow the "old" data to persist. That's an
                 # acceptable risk here, so we log an INFO message to provide a
                 # breadcrumb back to this code.
-                connection_config = ConnectionConfig.get_by(
-                    db=db_session, field="key", value=connection.key  # type: ignore[arg-type]
+                connection_config: Optional[ConnectionConfig] = ConnectionConfig.get_by(
+                    db=db_session, field="key", value=connection.key
                 )
                 if connection_config:
                     log.debug(
@@ -474,7 +475,7 @@ async def load_samples(async_session: AsyncSession) -> None:
 
                     # Check that it succeeded!
                     connection_config = ConnectionConfig.get_by(
-                        db=db_session, field="key", value=connection.key  # type: ignore[arg-type]
+                        db=db_session, field="key", value=connection.key
                     )
                     if not connection_config:
                         log.debug(
@@ -501,7 +502,7 @@ async def load_samples(async_session: AsyncSession) -> None:
 
                 # Check that it succeeded!
                 connection_config = ConnectionConfig.get_by(
-                    db=db_session, field="key", value=connection.key  # type: ignore[arg-type]
+                    db=db_session, field="key", value=connection.key
                 )
                 if not connection_config:
                     log.debug(f"Failed to create sample connection '{connection.key}'")

--- a/src/fides/api/ctl/database/seed.py
+++ b/src/fides/api/ctl/database/seed.py
@@ -436,7 +436,7 @@ async def load_samples(async_session: AsyncSession) -> None:
         sample_connections = load_sample_connections_from_project()
         with sync_session() as db_session:
             for connection in sample_connections:
-                assert connection.key
+                assert connection.key, "Connection Key expected!"
                 # If the connection config already exists, skip creation!
                 # NOTE: This creates an edge case where the sample data was
                 # created previously, but has since changed. By not deleting &

--- a/src/fides/api/ops/api/deps.py
+++ b/src/fides/api/ops/api/deps.py
@@ -3,10 +3,8 @@ from typing import Generator
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
-from fides.api.ops.api.v1.urn_registry import TOKEN, V1_URL_PREFIX
 from fides.api.ops.common_exceptions import FunctionalityNotConfigured
 from fides.api.ops.db.session import get_db_engine, get_db_session
-from fides.api.ops.schemas.oauth import OAuth2ClientCredentialsBearer
 from fides.api.ops.util.cache import get_cache as get_redis_connection
 from fides.core.config import CONFIG, FidesConfig
 from fides.core.config import get_config as get_app_config
@@ -54,11 +52,3 @@ def get_cache() -> Generator:
             "Application redis cache required, but it is currently disabled! Please update your application configuration to enable integration with a redis cache."
         )
     yield get_redis_connection()
-
-
-def oauth2_scheme() -> OAuth2ClientCredentialsBearer:
-    """Creates the oauth2 scheme from the token.
-
-    This should be overridden by the installing package.
-    """
-    return OAuth2ClientCredentialsBearer(tokenUrl=f"{V1_URL_PREFIX}{TOKEN}")

--- a/src/fides/api/ops/api/v1/endpoints/oauth_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/oauth_endpoints.py
@@ -229,7 +229,7 @@ def oauth_callback(code: str, state: str, db: Session = Depends(get_db)) -> None
         db, field="key", value=authentication_request.connection_key
     )
     verify_oauth_connection_config(connection_config)
-    assert connection_config  # For mypy
+    assert connection_config, "Connection config expected!"  # fixes mypy
 
     try:
         authentication = (

--- a/src/fides/api/ops/api/v1/endpoints/oauth_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/oauth_endpoints.py
@@ -225,11 +225,11 @@ def oauth_callback(code: str, state: str, db: Session = Depends(get_db)) -> None
             detail="No authentication request found for the given state.",
         )
 
-    connection_config = ConnectionConfig.get_by(
+    connection_config: Optional[ConnectionConfig] = ConnectionConfig.get_by(
         db, field="key", value=authentication_request.connection_key
     )
-    assert connection_config
     verify_oauth_connection_config(connection_config)
+    assert connection_config  # For mypy
 
     try:
         authentication = (

--- a/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_request_endpoints.py
@@ -761,10 +761,13 @@ def get_request_preview_queries(
                 )
             dataset_configs.append(dataset_config)
     try:
-        connection_configs = [
-            ConnectionConfig.get(db=db, object_id=dataset.connection_config_id)
-            for dataset in dataset_configs
-        ]
+        connection_configs: List[ConnectionConfig] = []
+        for dataset in dataset_configs:
+            connection_config: Optional[ConnectionConfig] = ConnectionConfig.get(
+                db=db, object_id=dataset.connection_config_id
+            )
+            if connection_config:
+                connection_configs.append(connection_config)
 
         try:
             dataset_graph: DatasetGraph = DatasetGraph(
@@ -782,7 +785,7 @@ def get_request_preview_queries(
         traversal: Traversal = Traversal(dataset_graph, identity_seed)
         queries: Dict[CollectionAddress, str] = collect_queries(
             traversal,
-            TaskResources(EMPTY_REQUEST, Policy(), connection_configs, db),  # type: ignore[arg-type]
+            TaskResources(EMPTY_REQUEST, Policy(), connection_configs, db),
         )
         return [
             DryRunDatasetResponse(

--- a/src/fides/api/ops/api/v1/urn_registry.py
+++ b/src/fides/api/ops/api/v1/urn_registry.py
@@ -172,9 +172,6 @@ USER_FORCE_PASSWORD_RESET = "/user/{user_id}/force-reset-password"
 SYSTEM_MANAGER = "/user/{user_id}/system-manager"
 SYSTEM_MANAGER_DETAIL = "/user/{user_id}/system-manager/{system_key}"
 
-# User Permission URLs
-USER_PERMISSIONS = "/user/{user_id}/permission"
-
 # Login URLs
 LOGIN = "/login"
 LOGOUT = "/logout"

--- a/src/fides/api/ops/models/datasetconfig.py
+++ b/src/fides/api/ops/models/datasetconfig.py
@@ -41,8 +41,8 @@ class DatasetConfig(Base):
     )
 
     connection_config = relationship(
-        ConnectionConfig,
-        backref="datasets",
+        "ConnectionConfig",
+        back_populates="datasets",
     )
 
     ctl_dataset = relationship(

--- a/src/fides/api/ops/models/messaging.py
+++ b/src/fides/api/ops/models/messaging.py
@@ -14,7 +14,7 @@ from sqlalchemy_utils.types.encrypted.encrypted_type import (
 )
 
 from fides.api.ops.common_exceptions import MessageDispatchException
-from fides.api.ops.db.base_class import Base, JSONTypeOverride, OrmWrappedFidesBase
+from fides.api.ops.db.base_class import Base, JSONTypeOverride
 from fides.api.ops.schemas.messaging.messaging import (
     EMAIL_MESSAGING_SERVICES,
     SMS_MESSAGING_SERVICES,
@@ -96,12 +96,14 @@ class MessagingConfig(Base):
     )  # Type bytea in the db
 
     @classmethod
-    def get_configuration(cls, db: Session, service_type: str) -> OrmWrappedFidesBase:
+    def get_configuration(cls, db: Session, service_type: str) -> MessagingConfig:
         """
         Fetches the configured MessagingConfig record by service type. Once fetched this function validates that
         the MessagingConfig is configured with secrets.
         """
-        instance = cls.get_by(db=db, field="service_type", value=service_type)
+        instance: Optional[MessagingConfig] = cls.get_by(
+            db=db, field="service_type", value=service_type
+        )
         if not instance:
             raise MessageDispatchException(
                 f"No messaging config found for service_type {service_type}."

--- a/src/fides/api/ops/service/connectors/fides_connector.py
+++ b/src/fides/api/ops/service/connectors/fides_connector.py
@@ -182,6 +182,6 @@ def filter_fides_connector_datasets(
     return {
         dataset.fides_key
         for connector_config in connector_configs
-        for dataset in connector_config.datasets  # type: ignore[attr-defined]
+        for dataset in connector_config.datasets
         if connector_config.connection_type == ConnectionType.fides
     }

--- a/src/fides/api/ops/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/ops/service/messaging/message_dispatch_service.py
@@ -138,7 +138,7 @@ def dispatch_message(
         raise MessageDispatchException("No notification service type configured.")
 
     logger.info("Retrieving message config")
-    messaging_config = MessagingConfig.get_configuration(
+    messaging_config: MessagingConfig = MessagingConfig.get_configuration(
         db=db, service_type=service_type
     )
     logger.info(

--- a/src/fides/api/ops/service/messaging/messaging_crud_service.py
+++ b/src/fides/api/ops/service/messaging/messaging_crud_service.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fideslang.validation import FidesKey
 from loguru import logger
 from sqlalchemy.orm import Session
@@ -13,7 +15,9 @@ from fides.api.ops.schemas.messaging.messaging import (
 def update_messaging_config(
     db: Session, key: FidesKey, config: MessagingConfigRequest
 ) -> MessagingConfigResponse:
-    existing_config_with_key = MessagingConfig.get_by(db=db, field="key", value=key)
+    existing_config_with_key: Optional[MessagingConfig] = MessagingConfig.get_by(
+        db=db, field="key", value=key
+    )
     if not existing_config_with_key:
         raise MessagingConfigNotFoundException(
             f"No messaging config found with key {key}"
@@ -45,7 +49,9 @@ def create_or_update_messaging_config(
 
 def delete_messaging_config(db: Session, key: FidesKey) -> None:
     logger.info("Finding messaging config with key '{}'", key)
-    messaging_config = MessagingConfig.get_by(db, field="key", value=key)
+    messaging_config: Optional[MessagingConfig] = MessagingConfig.get_by(
+        db, field="key", value=key
+    )
     if not messaging_config:
         raise MessagingConfigNotFoundException(
             f"No messaging config found with key {key}"
@@ -55,7 +61,9 @@ def delete_messaging_config(db: Session, key: FidesKey) -> None:
 
 
 def get_messaging_config_by_key(db: Session, key: FidesKey) -> MessagingConfigResponse:
-    config = MessagingConfig.get_by(db=db, field="key", value=key)
+    config: Optional[MessagingConfig] = MessagingConfig.get_by(
+        db=db, field="key", value=key
+    )
     if not config:
         raise MessagingConfigNotFoundException(
             f"No messaging config found with key {key}"

--- a/tests/ops/api/v1/endpoints/test_user_permission_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_permission_endpoints.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 from starlette.status import (
     HTTP_200_OK,


### PR DESCRIPTION
### Code Changes

* [x] Assert connection.key exists in seed.py script.  Restore type hints as an optional connection config
* [x] Remove unused oauth2_schema
* [x] Restore connection config type hint and move assert for mypy after the connection config has been verified to exist
* [x] Restore connectio nconfig type hints in get_request_preview_queries and assert that the list of connection configs has no Nones in it so we can remove the ignore when we collect queries
* [x] Remove duplicated USER_PERMISSIONS endpoint
* [x] Make ConnectionConfig.delete return an optional FidesBase to match other delete overrides 
    * [x] Move system import to the top of the file
    * [x] Add ConnectionConfig.datasets relationship explicitly with a back populates
    * [x] Update the DatasetConfig.connection_config relationship definition now that we've added a back populates on the other model
    * [x] Remove having to ignore that connection_config.datasets exists
* [x] Override MessagingConfig.get_configuration to return a MessagingConfig type.
* [x] Restore optional MessagingConfig type hints 

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

[Changes around type hints. Previously several models were importing from their models from a mixture of fides.lib.db.base import Base or from fides.lib.db.base_class import Base. Now that we're importing models from src/fides/api/ops/db/base_class.py, there were some type issues that surfaced.

MessagingConfig and ConnectionConfig were some of the models that imported from a different location than the other models 
