### PR TITLE
check CustomFieldDefinition.active with custom fields bulk query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The types of changes are:
 ### Fixed
 
 - Datamap export mitigation for deleted taxonomy elements referenced by declarations [#3214](https://github.com/ethyca/fides/pull/3214)
+- Ensure inactive custom fields are not returned for datamap response [#3223](https://github.com/ethyca/fides/pull/3223)
 
 ## [2.12.0](https://github.com/ethyca/fides/compare/2.11.0...2.12.0)
 

--- a/src/fides/api/ctl/database/crud.py
+++ b/src/fides/api/ctl/database/crud.py
@@ -68,6 +68,8 @@ async def get_custom_fields_filtered(
     Utility function to construct a filtered query for custom field values based on provided mapping of
     resource types to resource IDs.
 
+    Only custom fields with an "active" CustomFieldDefinition are returned.
+
     This is for use in bulk querying of custom fields, to avoid multiple round trips to the db.
     """
     with log.contextualize(model=CustomField):
@@ -88,6 +90,8 @@ async def get_custom_fields_filtered(
                     and_(
                         CustomFieldDefinition.resource_type == resource_type.value,
                         CustomField.resource_id.in_(resource_ids),
+                        # pylint: disable=singleton-comparison
+                        CustomFieldDefinition.active == True,
                     )
                     for resource_type, resource_ids in resource_types_to_ids.items()
                 ]


### PR DESCRIPTION
Partially closes https://github.com/ethyca/fidesplus/issues/866

### Code Changes

* include check on `CustomFieldDefinition.active` property in bulk query for custom fields
* improve test coverage for this requirement

### Steps to Confirm

* requires fidesplus for manual testing

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Found when testing for `2.12.1` hotfix. Let's try to get this in the hotfix!
