### PR TITLE
use regex in docker version check to specifically target semantic ver…

### DIFF
--- a/src/fides/core/deploy.py
+++ b/src/fides/core/deploy.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import webbrowser
 from functools import partial
@@ -89,9 +90,19 @@ def check_docker_version(
             raise DockerCheckException(
                 "Could not determine Docker version from 'docker' commands. Please ensure that Docker is installed and running and try again."
             )
-        parsed_version = (
-            raw_version.stdout.decode("utf-8").rstrip("\n").replace("'", "")
+        stripped_version = (
+            raw_version.stdout.decode("utf-8").rstrip("\n").replace("'", "").strip()
         )
+        version_match = re.match(r"((\d+\.)+\d+)", stripped_version)
+        if (
+            not version_match
+        ):  # if this is empty, we could not find a version # matching the regex
+            raise DockerCheckException(
+                f"Could not parse your Docker version (v{stripped_version})!"
+            )
+        parsed_version = version_match.group(
+            0
+        )  # extract the version # from the regex match
 
         split_docker_version = convert_semver_to_list(parsed_version)
         split_required_docker_version = convert_semver_to_list(required_docker_version)


### PR DESCRIPTION
Closes n/a

Hopefully should patch up e2e failures on `main`, while also keeping the desired functionality in the version check...

Drafted this in a pinch, very open to suggestions!

### Code Changes

* handle some uglier docker version outputs by targeting a semver number directly with a regex

### Steps to Confirm

* works locally with at "clean" docker version (very basic regression test)
* fixes e2e test in CI runner which seemed to have an _uglier_ docker version

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

