### PR TITLE
mark 'export' CLI command as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ The types of changes are:
 
 - Use prettier to format *all* source files in client packages [#3240](https://github.com/ethyca/fides/pull/3240)
 
+### Deprecated
+- Deprecate `fides export` CLI command as it is moving to `fidesplus` [#3264](https://github.com/ethyca/fides/pull/3264)
+
 ## [2.12.1](https://github.com/ethyca/fides/compare/2.12.0...2.12.1)
 
 ### Changed

--- a/src/fides/cli/commands/export.py
+++ b/src/fides/cli/commands/export.py
@@ -12,7 +12,7 @@ from fides.core import export as _export
 from fides.core import parse as _parse
 
 
-@click.group(name="export")
+@click.group(name="export", deprecated=True)
 @click.pass_context
 def export(ctx: click.Context) -> None:
     """


### PR DESCRIPTION
partially closes https://github.com/ethyca/fidesplus/issues/879

### Code Changes

* add deprecation flag to `fides export` CLI command

### Steps to Confirm

* [x] ran `fides export datamap --csv -d .` in a `fides` container shell and got the following output
<img width="723" alt="image" src="https://github.com/ethyca/fides/assets/9750285/88a90d58-c3c2-4132-91ea-d2bb50326819">

* [x] verified using `2.12.2a1` tag that in `fidesplus` we can override this command and route it to the `fidesplus` version that is not deprecated and is based on the migrated backing code in `fidesplus`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created:
    * [x] https://github.com/ethyca/fides/issues/3265
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Initially we were going to remove the command [wholesale](https://github.com/ethyca/fides/pull/3256). That PR can stay open for another release or two as we allow the command to be "phased out" more smoothly by being marked as deprecated. The `fides export` command in `fidesplus` will be able to override this deprecated command here and use all the code in `fidesplus`. This code should be effectively frozen until it is officially removed and phased out in the near future: https://github.com/ethyca/fides/issues/3265
