### PR TITLE
Fix Cookie House Privacy Center styles for `fides deploy`

### DIFF
--- a/src/fides/data/sample_project/privacy_center/config/config.css
+++ b/src/fides/data/sample_project/privacy_center/config/config.css
@@ -16,4 +16,6 @@ Override basic theme colors by uncommenting and editing those below
   --chakra-colors-primary-400: #CC805F;
   /* Primary button color */
   --chakra-colors-primary-800: #A85936;
+  /* Button border color */
+  --chakra-colors-complimentary-500: #A85936;
 }

--- a/src/fides/data/sample_project/privacy_center/config/config.json
+++ b/src/fides/data/sample_project/privacy_center/config/config.json
@@ -3,11 +3,11 @@
   "description": "When you use our services, you’re trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
   "description_subtext": [],
   "addendum": [],
-  "logo_path": "http://localhost:3000/logo.svg",
+  "logo_path": "https://ethyca-cdn-harpocrates.s3.amazonaws.com/assets/cookiehouse_assets/logo.svg",
   "actions": [
     {
       "policy_key": "default_access_policy",
-      "icon_path": "download.svg",
+      "icon_path": "https://ethyca-cdn-harpocrates.s3.amazonaws.com/assets/cookiehouse_assets/access.svg",
       "title": "Access your data",
       "description": "We will provide you a report of all your personal data.",
       "description_subtext": [],
@@ -17,7 +17,7 @@
     },
     {
       "policy_key": "default_erasure_policy",
-      "icon_path": "delete.svg",
+      "icon_path": "https://ethyca-cdn-harpocrates.s3.amazonaws.com/assets/cookiehouse_assets/erase.svg",
       "title": "Erase your data",
       "description": "We will erase all of your personal data. This action cannot be undone.",
       "description_subtext": [],
@@ -33,7 +33,7 @@
       "description_subtext": [
         "In order to opt-out of certain consent preferences, we may need to identify your account via your email address. This is optional."
       ],
-      "icon_path": "consent.svg",
+      "icon_path": "https://ethyca-cdn-harpocrates.s3.amazonaws.com/assets/cookiehouse_assets/consent.svg",
       "identity_inputs": {
         "email": "optional"
       },


### PR DESCRIPTION
### Code Changes

* [X] Fixes the colours of the cookie house icons & borders

### Steps to Confirm

* [X] Run `nox -s "fides_env(test)"

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
