### PR TITLE
Remove logging from Celery app creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.13.0...main)
 
+### Changed
+
+- Remove logging within the Celery creation function [#3303](https://github.com/ethyca/fides/pull/3303)
+
 ### Added 
 
 - Add an automated test to check for `/fides-consent.js` backwards compatibility [#3289](https://github.com/ethyca/fides/pull/3289)

--- a/src/fides/api/ops/tasks/__init__.py
+++ b/src/fides/api/ops/tasks/__init__.py
@@ -44,7 +44,6 @@ def _create_celery(config: FidesConfig = CONFIG) -> Celery:
     """
     Returns a configured version of the Celery application
     """
-    logger.info("Creating Celery app...")
     app = Celery(__name__)
 
     celery_config: Dict[str, Any] = {
@@ -62,7 +61,6 @@ def _create_celery(config: FidesConfig = CONFIG) -> Celery:
 
     app.conf.update(celery_config)
 
-    logger.info("Autodiscovering tasks...")
     app.autodiscover_tasks(
         [
             "fides.api.ops.tasks",


### PR DESCRIPTION
Closes #3204 

### Code Changes

* [x] remove logging statements that get called on import

### Steps to Confirm

* [ ] `pip install` and run `fides` locally to confirm the fix

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This logging is done on the "main path" of the code, at time of import, which means that it muddies the output of the CLI which isn't a great user-experience.

This is easily the lowest-friction method of solving this issue. Otherwise, a full rework of the module's imports would have to be done.

#### Before

![image](https://github.com/ethyca/fides/assets/5105354/f9f4f0ce-8f03-46b0-9573-3133babd2630)

#### After

![image](https://github.com/ethyca/fides/assets/5105354/475a5327-64cd-4ec8-bea2-196ab0bbf8fd)

