### PR TITLE
[Backend] Track Privacy Experience that surfaced Notices/ Pull data from request headers

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -2053,6 +2053,9 @@ dataset:
         data_categories:
         - system.operations
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+      - name: anonymized_ip_address
+        data_categories:
+        - system.operations
       - name: created_at
         data_categories:
         - system.operations
@@ -2083,11 +2086,23 @@ dataset:
         data_categories:
         - system.operations
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+      - name: method
+        data_categories:
+        - system.operations
+        data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
       - name: phone_number
         data_categories:
         - user
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
       - name: preference
+        data_categories:
+        - system.operations
+        data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+      - name: privacy_experience_config_history_id
+        data_categories:
+        - system.operations
+        data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+      - name: privacy_experience_history_id
         data_categories:
         - system.operations
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified

--- a/docs/fides/docs/development/postman/Fides.postman_collection.json
+++ b/docs/fides/docs/development/postman/Fides.postman_collection.json
@@ -5698,7 +5698,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n   \"browser_identity\": {\n       \"ga_client_id\": \"UA-XXXXXXXXX\",\n       \"ljt_readerID\": \"test_sovrn_id\",\n       \"fides_user_device_id\": \"{{fides_user_device_id}}\"\n   },\n   \"preferences\": [{\n       \"privacy_notice_history_id\": \"{{privacy_notice_history_id}}\",\n       \"preference\": \"opt_out\"\n   }],\n   \"user_geography\": \"us_ca\",\n   \"privacy_experience_history_id\": \"{{privacy_experience_history_id}}\",\n   \"method\": \"buttons\"\n}",
+							"raw": "{\n   \"browser_identity\": {\n       \"ga_client_id\": \"UA-XXXXXXXXX\",\n       \"ljt_readerID\": \"test_sovrn_id\",\n       \"fides_user_device_id\": \"{{fides_user_device_id}}\"\n   },\n   \"preferences\": [{\n       \"privacy_notice_history_id\": \"{{privacy_notice_history_id}}\",\n       \"preference\": \"opt_out\"\n   }],\n   \"user_geography\": \"us_ca\",\n   \"privacy_experience_history_id\": \"{{privacy_experience_history_id}}\",\n   \"method\": \"button\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/docs/fides/docs/development/postman/Fides.postman_collection.json
+++ b/docs/fides/docs/development/postman/Fides.postman_collection.json
@@ -5698,7 +5698,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n   \"browser_identity\": {\n       \"ga_client_id\": \"UA-XXXXXXXXX\",\n       \"ljt_readerID\": \"test_sovrn_id\",\n       \"fides_user_device_id\": \"{{fides_user_device_id}}\"\n   },\n   \"preferences\": [{\n       \"privacy_notice_history_id\": \"{{privacy_notice_history_id}}\",\n       \"preference\": \"opt_out\"\n   }],\n   \"request_origin\": \"privacy_center\",\n   \"url_recorded\": \"example.com/privacy_center\",\n   \"user_agent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/324.42 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/425.24\",\n   \"user_geography\": \"us_ca\"\n}",
+							"raw": "{\n   \"browser_identity\": {\n       \"ga_client_id\": \"UA-XXXXXXXXX\",\n       \"ljt_readerID\": \"test_sovrn_id\",\n       \"fides_user_device_id\": \"{{fides_user_device_id}}\"\n   },\n   \"preferences\": [{\n       \"privacy_notice_history_id\": \"{{privacy_notice_history_id}}\",\n       \"preference\": \"opt_out\"\n   }],\n   \"user_geography\": \"us_ca\",\n   \"experience_config_history_id\": \"{{experience-config-id}}\",\n   \"privacy_experience_history_id\": \"{{privacy_experience_history_id}}\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -6116,6 +6116,11 @@
 		},
 		{
 			"key": "experience-config-id",
+			"value": "",
+			"type": "string"
+		},
+		{
+			"key": "privacy_experience_history_id",
 			"value": "",
 			"type": "string"
 		}

--- a/docs/fides/docs/development/postman/Fides.postman_collection.json
+++ b/docs/fides/docs/development/postman/Fides.postman_collection.json
@@ -5698,7 +5698,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n   \"browser_identity\": {\n       \"ga_client_id\": \"UA-XXXXXXXXX\",\n       \"ljt_readerID\": \"test_sovrn_id\",\n       \"fides_user_device_id\": \"{{fides_user_device_id}}\"\n   },\n   \"preferences\": [{\n       \"privacy_notice_history_id\": \"{{privacy_notice_history_id}}\",\n       \"preference\": \"opt_out\"\n   }],\n   \"user_geography\": \"us_ca\",\n   \"experience_config_history_id\": \"{{experience-config-id}}\",\n   \"privacy_experience_history_id\": \"{{privacy_experience_history_id}}\"\n}",
+							"raw": "{\n   \"browser_identity\": {\n       \"ga_client_id\": \"UA-XXXXXXXXX\",\n       \"ljt_readerID\": \"test_sovrn_id\",\n       \"fides_user_device_id\": \"{{fides_user_device_id}}\"\n   },\n   \"preferences\": [{\n       \"privacy_notice_history_id\": \"{{privacy_notice_history_id}}\",\n       \"preference\": \"opt_out\"\n   }],\n   \"user_geography\": \"us_ca\",\n   \"privacy_experience_history_id\": \"{{privacy_experience_history_id}}\",\n   \"method\": \"buttons\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/src/fides/api/ctl/migrations/versions/2661f31daffb_track_experience_on_preferences.py
+++ b/src/fides/api/ctl/migrations/versions/2661f31daffb_track_experience_on_preferences.py
@@ -1,15 +1,16 @@
-"""store experience on historical preference
+"""track experience on preferences
 
-Revision ID: 498dbe8af963
+Revision ID: 2661f31daffb
 Revises: b546ce845e6c
-Create Date: 2023-05-15 20:54:13.623611
+Create Date: 2023-05-16 20:05:29.478005
 
 """
 import sqlalchemy as sa
+import sqlalchemy_utils
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "498dbe8af963"
+revision = "2661f31daffb"
 down_revision = "b546ce845e6c"
 branch_labels = None
 depends_on = None
@@ -18,7 +19,14 @@ depends_on = None
 def upgrade():
     op.add_column(
         "privacypreferencehistory",
-        sa.Column("anonymized_ip_address", sa.String(), nullable=True),
+        sa.Column(
+            "anonymized_ip_address",
+            sqlalchemy_utils.types.encrypted.encrypted_type.StringEncryptedType(),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "privacypreferencehistory", sa.Column("method", sa.String(), nullable=True)
     )
     op.add_column(
         "privacypreferencehistory",
@@ -77,4 +85,5 @@ def downgrade():
     )
     op.drop_column("privacypreferencehistory", "privacy_experience_history_id")
     op.drop_column("privacypreferencehistory", "privacy_experience_config_history_id")
+    op.drop_column("privacypreferencehistory", "method")
     op.drop_column("privacypreferencehistory", "anonymized_ip_address")

--- a/src/fides/api/ctl/migrations/versions/498dbe8af963_store_experience_on_historical_.py
+++ b/src/fides/api/ctl/migrations/versions/498dbe8af963_store_experience_on_historical_.py
@@ -1,0 +1,80 @@
+"""store experience on historical preference
+
+Revision ID: 498dbe8af963
+Revises: b546ce845e6c
+Create Date: 2023-05-15 20:54:13.623611
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "498dbe8af963"
+down_revision = "b546ce845e6c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "privacypreferencehistory",
+        sa.Column("anonymized_ip_address", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "privacypreferencehistory",
+        sa.Column("privacy_experience_config_history_id", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "privacypreferencehistory",
+        sa.Column("privacy_experience_history_id", sa.String(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_privacypreferencehistory_privacy_experience_config_history_id"),
+        "privacypreferencehistory",
+        ["privacy_experience_config_history_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_privacypreferencehistory_privacy_experience_history_id"),
+        "privacypreferencehistory",
+        ["privacy_experience_history_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "privacypreferencehistory_privacy_experience_history_id_fkey",
+        "privacypreferencehistory",
+        "privacyexperiencehistory",
+        ["privacy_experience_history_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "privacypreferencehistory_privacy_experience_config_history_fkey",
+        "privacypreferencehistory",
+        "privacyexperienceconfighistory",
+        ["privacy_experience_config_history_id"],
+        ["id"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "privacypreferencehistory_privacy_experience_history_id_fkey",
+        "privacypreferencehistory",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "privacypreferencehistory_privacy_experience_config_history_fkey",
+        "privacypreferencehistory",
+        type_="foreignkey",
+    )
+    op.drop_index(
+        op.f("ix_privacypreferencehistory_privacy_experience_history_id"),
+        table_name="privacypreferencehistory",
+    )
+    op.drop_index(
+        op.f("ix_privacypreferencehistory_privacy_experience_config_history_id"),
+        table_name="privacypreferencehistory",
+    )
+    op.drop_column("privacypreferencehistory", "privacy_experience_history_id")
+    op.drop_column("privacypreferencehistory", "privacy_experience_config_history_id")
+    op.drop_column("privacypreferencehistory", "anonymized_ip_address")

--- a/src/fides/api/ops/api/v1/endpoints/privacy_experience_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_experience_endpoints.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from fastapi import Depends, HTTPException, Request, Security
+from fastapi import Depends, HTTPException, Security
 from fastapi_pagination import Page, Params
 from fastapi_pagination import paginate as fastapi_paginate
 from fastapi_pagination.bases import AbstractPage
@@ -57,7 +57,6 @@ def privacy_experience_list(
     has_notices: Optional[bool] = None,
     has_config: Optional[bool] = None,
     fides_user_device_id: Optional[str] = None,
-    request: Request,
 ) -> AbstractPage[PrivacyExperience]:
     """
     Returns a list of PrivacyExperience records for individual regions with
@@ -127,7 +126,6 @@ def privacy_experience_detail(
     privacy_experience_id: str,
     show_disabled: Optional[bool] = True,
     fides_user_device_id: Optional[str] = None,
-    request: Request,
 ) -> PrivacyExperience:
     """
     Return a privacy experience for a given region with relevant notices embedded.

--- a/src/fides/api/ops/api/v1/endpoints/privacy_notice_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_notice_endpoints.py
@@ -371,6 +371,7 @@ def update_privacy_notices(
     for update_data, existing_notice in updates_and_existing:
         existing_notice.update(db, data=update_data.dict(exclude_unset=True))
         notices.append(existing_notice)
+
         affected_regions.update(existing_notice.regions)
 
     # After updating all notices, make sure experiences exist to back all notices.

--- a/src/fides/api/ops/api/v1/endpoints/privacy_preference_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_preference_endpoints.py
@@ -545,8 +545,12 @@ def get_historical_consent_report(
                 "privacy_experience_history_id"
             ),
             PrivacyPreferenceHistory.privacy_experience_config_history_id.label(
-                "privacy_experience_config_history_id"
+                "experience_config_history_id"
             ),
+            PrivacyPreferenceHistory.anonymized_ip_address.label(
+                "truncated_ip_address"
+            ),
+            PrivacyPreferenceHistory.method.label("method"),
         )
         .outerjoin(
             PrivacyRequest,

--- a/src/fides/api/ops/api/v1/endpoints/privacy_preference_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_preference_endpoints.py
@@ -370,6 +370,7 @@ def _save_privacy_preferences_for_identities(
                 "hashed_email": hashed_email,
                 "hashed_fides_user_device": hashed_device_id,
                 "hashed_phone_number": hashed_phone_number,
+                "method": request_data.method,
                 "phone_number": phone_number,
                 "preference": privacy_preference.preference,
                 "privacy_notice_history_id": privacy_preference.privacy_notice_history_id,

--- a/src/fides/api/ops/api/v1/endpoints/privacy_preference_endpoints.py
+++ b/src/fides/api/ops/api/v1/endpoints/privacy_preference_endpoints.py
@@ -12,12 +12,7 @@ from fastapi_pagination.ext.sqlalchemy import paginate
 from loguru import logger
 from sqlalchemy import literal
 from sqlalchemy.orm import Query, Session
-from starlette.status import (
-    HTTP_200_OK,
-    HTTP_400_BAD_REQUEST,
-    HTTP_404_NOT_FOUND,
-    HTTP_422_UNPROCESSABLE_ENTITY,
-)
+from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 from fides.api.ctl.database.seed import DEFAULT_CONSENT_POLICY
 from fides.api.ops.api.deps import get_db
@@ -41,15 +36,11 @@ from fides.api.ops.api.v1.urn_registry import (
     V1_URL_PREFIX,
 )
 from fides.api.ops.models.fides_user import FidesUser
-from fides.api.ops.models.privacy_experience import (
-    PrivacyExperienceConfigHistory,
-    PrivacyExperienceHistory,
-)
+from fides.api.ops.models.privacy_experience import PrivacyExperienceHistory
 from fides.api.ops.models.privacy_notice import PrivacyNotice, PrivacyNoticeHistory
 from fides.api.ops.models.privacy_preference import (
     CurrentPrivacyPreference,
     PrivacyPreferenceHistory,
-    RequestOrigin,
 )
 from fides.api.ops.models.privacy_request import (
     ConsentRequest,

--- a/src/fides/api/ops/models/privacy_experience.py
+++ b/src/fides/api/ops/models/privacy_experience.py
@@ -321,8 +321,6 @@ class PrivacyExperience(PrivacyExperienceBase, Base):
 
             PrivacyExperienceHistory.create(db, data=history_data, check_name=False)
 
-        # Cache privacy notices for display
-        self.privacy_notices = self.get_related_privacy_notices(db)
         return self
 
     @staticmethod

--- a/src/fides/api/ops/models/privacy_preference.py
+++ b/src/fides/api/ops/models/privacy_preference.py
@@ -53,7 +53,14 @@ class PrivacyPreferenceHistory(Base):
     affected_system_status = Column(
         MutableDict.as_mutable(JSONB), server_default="{}", default=dict
     )
-    anonymized_ip_address = Column(String)
+    anonymized_ip_address = Column(
+        StringEncryptedType(
+            type_in=String(),
+            key=CONFIG.security.app_encryption_key,
+            engine=AesGcmEngine,
+            padding="pkcs5",
+        ),
+    )
     created_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)
     # Encrypted email, for reporting
     email = Column(
@@ -83,6 +90,8 @@ class PrivacyPreferenceHistory(Base):
     hashed_fides_user_device = Column(String, index=True)
     # Hashed phone number, for searching
     hashed_phone_number = Column(String, index=True)
+    # Buttons, individual notices
+    method = Column(String)
     # Encrypted phone number, for reporting
     phone_number = Column(
         StringEncryptedType(

--- a/src/fides/api/ops/models/privacy_preference.py
+++ b/src/fides/api/ops/models/privacy_preference.py
@@ -19,10 +19,6 @@ from fides.api.ops.common_exceptions import (
     PrivacyNoticeHistoryNotFound,
 )
 from fides.api.ops.db.base_class import Base, JSONTypeOverride
-from fides.api.ops.models.privacy_experience import (
-    PrivacyExperienceConfigHistory,
-    PrivacyExperienceHistory,
-)
 from fides.api.ops.models.privacy_notice import (
     PrivacyNotice,
     PrivacyNoticeHistory,
@@ -41,6 +37,12 @@ class RequestOrigin(Enum):
     privacy_center = "privacy_center"
     overlay = "overlay"
     api = "api"
+
+
+class ConsentMethod(Enum):
+    button = "button"
+    gpc = "gpc"
+    individual_notice = "api"
 
 
 class PrivacyPreferenceHistory(Base):
@@ -90,8 +92,8 @@ class PrivacyPreferenceHistory(Base):
     hashed_fides_user_device = Column(String, index=True)
     # Hashed phone number, for searching
     hashed_phone_number = Column(String, index=True)
-    # Buttons, individual notices
-    method = Column(String)
+    # Button, individual notices
+    method = Column(EnumColumn(ConsentMethod))
     # Encrypted phone number, for reporting
     phone_number = Column(
         StringEncryptedType(
@@ -107,14 +109,14 @@ class PrivacyPreferenceHistory(Base):
     # Contains the version, language, button labels, description, etc.
     privacy_experience_config_history_id = Column(
         String,
-        ForeignKey(PrivacyExperienceConfigHistory.id),
+        ForeignKey("privacyexperienceconfighistory.id"),
         nullable=True,
         index=True,
     )
     # The specific version of experience under which the user was presented the relevant notice
     # Minimal information stored here, mostly the region, version, component type, and how it was delivered.
     privacy_experience_history_id = Column(
-        String, ForeignKey(PrivacyExperienceHistory.id), nullable=True, index=True
+        String, ForeignKey("privacyexperiencehistory.id"), nullable=True, index=True
     )
     # The specific historical record the user consented to
     privacy_notice_history_id = Column(

--- a/src/fides/api/ops/schemas/privacy_preference.py
+++ b/src/fides/api/ops/schemas/privacy_preference.py
@@ -27,7 +27,7 @@ class ConsentOptionCreate(FidesSchema):
     preference: UserConsentPreference
 
 
-class PrivacyPreferencesCreateWithCode(FidesSchema):
+class PrivacyPreferencesRequest(FidesSchema):
     """Schema for saving privacy preferences and accompanying user data
     including the verification code."""
 
@@ -35,10 +35,19 @@ class PrivacyPreferencesCreateWithCode(FidesSchema):
     code: Optional[SafeStr]
     preferences: conlist(ConsentOptionCreate, max_items=50)  # type: ignore
     policy_key: Optional[FidesKey]  # Will use default consent policy if not supplied
+    experience_config_history_id: Optional[SafeStr]
+    privacy_experience_history_id: Optional[SafeStr]
+    user_geography: Optional[PrivacyNoticeRegion]
+
+
+class PrivacyPreferencesCreate(PrivacyPreferencesRequest):
+    """Schema for creating privacy preferences that is supplemented with information
+    from the request headers"""
+
+    anonymized_ip_address: Optional[str]
     request_origin: Optional[RequestOrigin]
     url_recorded: Optional[SafeStr]
     user_agent: Optional[SafeStr]
-    user_geography: Optional[PrivacyNoticeRegion]
 
 
 class MinimalPrivacyPreferenceHistorySchema(FidesSchema):
@@ -93,6 +102,12 @@ class ConsentReportingSchema(FidesSchema):
         title="URL of page where preference was recorded"
     )
     user_agent: Optional[str] = Field(title="User agent")
+    experience_config_history_id: Optional[str] = Field(
+        title="The historical config for the experience that the user was presented - contains the experience language"
+    )
+    privacy_experience_history_id: Optional[str] = Field(
+        title="The historical id of the experience that the user was presented - contains the experience type, region, and delivery mechanism"
+    )
 
 
 class CurrentPrivacyPreferenceSchema(FidesSchema):

--- a/src/fides/api/ops/schemas/privacy_preference.py
+++ b/src/fides/api/ops/schemas/privacy_preference.py
@@ -10,7 +10,7 @@ from fides.api.ops.models.privacy_notice import (
     PrivacyNoticeRegion,
     UserConsentPreference,
 )
-from fides.api.ops.models.privacy_preference import RequestOrigin
+from fides.api.ops.models.privacy_preference import ConsentMethod, RequestOrigin
 from fides.api.ops.models.privacy_request import (
     ExecutionLogStatus,
     PrivacyRequestStatus,
@@ -110,7 +110,7 @@ class ConsentReportingSchema(FidesSchema):
         title="The historical id of the experience that the user was presented - contains the experience type, region, and delivery mechanism"
     )
     truncated_ip_address: Optional[str] = Field(title="Truncated ip address")
-    method: Optional[str] = Field(title="Method of consent preference")
+    method: Optional[ConsentMethod] = Field(title="Method of consent preference")
 
 
 class CurrentPrivacyPreferenceSchema(FidesSchema):

--- a/src/fides/api/ops/schemas/privacy_preference.py
+++ b/src/fides/api/ops/schemas/privacy_preference.py
@@ -28,8 +28,7 @@ class ConsentOptionCreate(FidesSchema):
 
 
 class PrivacyPreferencesRequest(FidesSchema):
-    """Schema for saving privacy preferences and accompanying user data
-    including the verification code."""
+    """Request body for creating PrivacyPreferences."""
 
     browser_identity: Identity
     code: Optional[SafeStr]
@@ -37,7 +36,7 @@ class PrivacyPreferencesRequest(FidesSchema):
     policy_key: Optional[FidesKey]  # Will use default consent policy if not supplied
     privacy_experience_history_id: Optional[SafeStr]
     user_geography: Optional[PrivacyNoticeRegion]
-    method: Optional[SafeStr]
+    method: Optional[ConsentMethod]
 
 
 class PrivacyPreferencesCreate(PrivacyPreferencesRequest):

--- a/src/fides/api/ops/schemas/privacy_preference.py
+++ b/src/fides/api/ops/schemas/privacy_preference.py
@@ -109,6 +109,8 @@ class ConsentReportingSchema(FidesSchema):
     privacy_experience_history_id: Optional[str] = Field(
         title="The historical id of the experience that the user was presented - contains the experience type, region, and delivery mechanism"
     )
+    truncated_ip_address: Optional[str] = Field(title="Truncated ip address")
+    method: Optional[str] = Field(title="Method of consent preference")
 
 
 class CurrentPrivacyPreferenceSchema(FidesSchema):

--- a/src/fides/api/ops/schemas/privacy_preference.py
+++ b/src/fides/api/ops/schemas/privacy_preference.py
@@ -38,6 +38,7 @@ class PrivacyPreferencesRequest(FidesSchema):
     experience_config_history_id: Optional[SafeStr]
     privacy_experience_history_id: Optional[SafeStr]
     user_geography: Optional[PrivacyNoticeRegion]
+    method: Optional[SafeStr]
 
 
 class PrivacyPreferencesCreate(PrivacyPreferencesRequest):

--- a/src/fides/api/ops/schemas/privacy_preference.py
+++ b/src/fides/api/ops/schemas/privacy_preference.py
@@ -35,7 +35,6 @@ class PrivacyPreferencesRequest(FidesSchema):
     code: Optional[SafeStr]
     preferences: conlist(ConsentOptionCreate, max_items=50)  # type: ignore
     policy_key: Optional[FidesKey]  # Will use default consent policy if not supplied
-    experience_config_history_id: Optional[SafeStr]
     privacy_experience_history_id: Optional[SafeStr]
     user_geography: Optional[PrivacyNoticeRegion]
     method: Optional[SafeStr]
@@ -43,9 +42,10 @@ class PrivacyPreferencesRequest(FidesSchema):
 
 class PrivacyPreferencesCreate(PrivacyPreferencesRequest):
     """Schema for creating privacy preferences that is supplemented with information
-    from the request headers"""
+    from the request headers and the experience"""
 
     anonymized_ip_address: Optional[str]
+    experience_config_history_id: Optional[SafeStr]
     request_origin: Optional[RequestOrigin]
     url_recorded: Optional[SafeStr]
     user_agent: Optional[SafeStr]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,7 @@ async def async_session(test_client):
 @pytest.fixture(scope="session")
 def api_client():
     """Return a client used to make API requests"""
+
     with TestClient(app) as c:
         yield c
 

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -2011,6 +2011,7 @@ def privacy_preference_history(
     db,
     provided_identity_and_consent_request,
     privacy_notice,
+    privacy_experience_privacy_center_link,
 ):
     provided_identity, consent_request = provided_identity_and_consent_request
     privacy_notice_history = privacy_notice.histories[0]
@@ -2018,7 +2019,15 @@ def privacy_preference_history(
     preference_history_record = PrivacyPreferenceHistory.create(
         db=db,
         data={
+            "anonymized_ip_address": "92.158.1.0",
             "email": "test@email.com",
+            "method": "buttons",
+            "privacy_experience_config_history_id": privacy_experience_privacy_center_link.histories[
+                0
+            ].experience_config_history_id,
+            "privacy_experience_history_id": privacy_experience_privacy_center_link.histories[
+                0
+            ].id,
             "preference": "opt_out",
             "privacy_notice_history_id": privacy_notice_history.id,
             "provided_identity_id": provided_identity.id,

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -2021,7 +2021,7 @@ def privacy_preference_history(
         data={
             "anonymized_ip_address": "92.158.1.0",
             "email": "test@email.com",
-            "method": "buttons",
+            "method": "button",
             "privacy_experience_config_history_id": privacy_experience_privacy_center_link.histories[
                 0
             ].experience_config_history_id,

--- a/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
@@ -1158,6 +1158,7 @@ class TestHistoricalPreferences:
         privacy_preference_history,
         privacy_request_with_consent_policy,
         system,
+        privacy_experience_privacy_center_link,
     ) -> None:
         privacy_preference_history.privacy_request_id = (
             privacy_request_with_consent_policy.id
@@ -1216,6 +1217,18 @@ class TestHistoricalPreferences:
         assert (
             response_body["user_agent"]
             == "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/324.42 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/425.24"
+        )
+        assert response_body["method"] == "buttons"
+        assert response_body["truncated_ip_address"] == "92.158.1.0"
+        assert (
+            response_body["experience_config_history_id"]
+            == privacy_experience_privacy_center_link.histories[
+                0
+            ].experience_config_history_id
+        )
+        assert (
+            response_body["privacy_experience_history_id"]
+            == privacy_experience_privacy_center_link.histories[0].id
         )
 
     def test_get_historical_preferences_ordering(

--- a/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
@@ -975,9 +975,6 @@ class TestSavePrivacyPreferencesForFidesDeviceId:
             ],
             "policy_key": consent_policy.key,
             "user_geography": "us_ca",
-            "experience_config_history_id": privacy_experience_overlay_banner.histories[
-                0
-            ].experience_config_history_id,
             "privacy_experience_history_id": privacy_experience_overlay_banner.histories[
                 0
             ].id,
@@ -1008,20 +1005,19 @@ class TestSavePrivacyPreferencesForFidesDeviceId:
 
     def test_save_privacy_preferences_bad_experience_id(
         self,
-        db,
         api_client,
         url,
         request_body,
     ):
         """Privacy experiences need to be valid when setting preferences"""
-        request_body["experience_config_history_id"] = "bad_id"
+        request_body["privacy_experience_history_id"] = "bad_id"
         response = api_client.patch(
             url, json=request_body, headers={"Origin": "http://localhost:8080"}
         )
         assert response.status_code == 404
         assert (
             response.json()["detail"]
-            == f"Experience Config History with it 'bad_id' not found."
+            == f"Privacy Experience History 'bad_id' not found."
         )
 
     @mock.patch(

--- a/tests/ops/models/test_privacy_preference.py
+++ b/tests/ops/models/test_privacy_preference.py
@@ -2,6 +2,7 @@ import pytest
 from sqlalchemy.exc import InvalidRequestError
 
 from fides.api.ops.api.v1.endpoints.privacy_preference_endpoints import (
+    anonymize_ip_address,
     extract_identity_from_provided_identity,
 )
 from fides.api.ops.common_exceptions import (
@@ -552,3 +553,26 @@ class TestPrivacyPreferenceHistory:
 
         new_preference_history_record_for_device.delete(db)
         preference_history_record_for_device.delete(db)
+
+
+class TestAnonymizeIpAddress:
+    def test_anonymize_ip_address_empty_string(self):
+        assert anonymize_ip_address("") is None
+
+    def test_anonymize_ip_address_none(self):
+        assert anonymize_ip_address(None) is None
+
+    def test_anonymize_bad_ip_address(self):
+        assert anonymize_ip_address("bad_address") is None
+
+    def test_anonymize_ip_address_list(self):
+        assert anonymize_ip_address("[]") is None
+
+    def test_anonymize_ipv4(self):
+        assert anonymize_ip_address("12.214.31.144") == "12.214.31.0"
+
+    def test_anonymize_ipv6(self):
+        assert (
+            anonymize_ip_address("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+            == "2001:0db8:85a3:0000:0000:0000:0000:0000"
+        )


### PR DESCRIPTION
❗ Contains migration
❗ Dependent on #3292 

Closes #3133 
Closes #3196 

### Description Of Changes


Start tracking additional fields when saving consent preferences to demonstrate compliance and move some of the existing fields from the request body to extract from request headers.


### Code Changes

Start tracking new fields:
- `PrivacyPreferenceHistory.anonymized_ip_address` which is really a truncated version of the ip address and stored encrypted
- `PrivacyPreferenceHistory.method` - The method of consent preference in a modal (buttons, individual notices)
- `PrivacyPreferenceHistory.privacy_experience_config_history_id` - the particular version of the Config that surfaced the notice (contains the copy)
- `PrivacyPreferenceHistory.privacy_experience_history_id` - the particular Experience - contains the region, type, and delivery mechanism
- Starts surfacing these new fields in the historical report

Start pulling some fields off of request headers or experience themselves:
- `request_origin` (privacy center/overlay now comes off of the experience)
- `user_agent` now comes off of request headers
- `url_recorded` is now retrieved from the `Referer` header
- `privacy_experience_config_history_id` is pulled off of the experience if applicable

Bug fix:
- Fixes saving preferences with for users under a fides user device id - bug where uniqueness constraint was being violated

### Steps to Confirm

In the postman collection
* [ ] Save some notices `POST {{host}}/privacy-notice`
* [ ] Save a preference for those notices `PATCH {{host}}/privacy-preferences`
   - Verify `method`, `experience_config_history_id` and `privacy_experience_history` can be passed in now
* [ ] Get historical privacy preferences `GET {{host}}/historical-privacy-preferences `
    * [ ] Verify truncated ip address is in the response

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
