### PR TITLE
feature branch builds, ci automation

### DIFF
--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -60,7 +60,7 @@ jobs:
               echo ::set-output name=match::true
           fi
 
-      # We don't upload to Test PyPI if it is a real release
+      # We only upload to Test PyPI if it is a non-"prod" tag (not release or beta)
       - name: Upload to test pypi
         if: steps.check-tag.outputs.match != 'true'
         run: twine upload --repository testpypi dist/*
@@ -68,10 +68,20 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
 
-
+      # Upload to PyPI if it is a "prod" tag (release or beta)
       - name: Upload to pypi
         if: steps.check-tag.outputs.match == 'true'
         run: twine upload dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
+      # Notify Fidesplus about a feature (non-prod) tag to trigger an integrated build
+      - name: Send Repository Dispatch Event
+        if: steps.check-tag.outputs.match != 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          client-payload: '{"tag": "${{ github.ref_name }}"}'
+          event-type: new-fides-feature-tag
+          repository: ethyca/fidesplus
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ The types of changes are:
 - Data model around PrivacyExperiences to better keep Privacy Notices and Experiences in sync [#3292](https://github.com/ethyca/fides/pull/3292)
 - UI calls to support new PrivacyExperiences data model [#3313](https://github.com/ethyca/fides/pull/3313)
 
+### Developer Experience
+
+- Add dispatch event when publishing a non-prod tag [#3317](https://github.com/ethyca/fides/pull/3317)
+
 ## [2.13.0](https://github.com/ethyca/fides/compare/2.12.1...2.13.0)
 
 ### Added

--- a/noxfiles/git_nox.py
+++ b/noxfiles/git_nox.py
@@ -72,7 +72,6 @@ def get_current_tag(
     "action",
     [
         nox.param("dry", id="dry"),
-        nox.param("local", id="local"),
         nox.param("push", id="push"),
     ],
 )
@@ -88,7 +87,6 @@ def tag(session: nox.Session, action: str) -> None:
 
     Parameters:
         - tag(dry) = Show the tag that would be applied.
-        - tag(local) = Tag local commit but don't push it.
         - tag(push) = Tag the current commit and push it. NOTE: This will trigger a new CI job to publish the tag.
     """
     from git.repo import Repo
@@ -102,10 +100,6 @@ def tag(session: nox.Session, action: str) -> None:
     # if no args are passed, it's a dry run
     if action == "dry":
         session.log(f"Dry-run -- would generate tag: {generated_tag}")
-
-    elif action == "local":
-        session.log(f"Tagging current HEAD commit with tag: {generated_tag}")
-        repo.create_tag(generated_tag)
 
     elif action == "push":
         repo.create_tag(generated_tag)


### PR DESCRIPTION
partially closes #2919 

related to https://github.com/ethyca/fidesplus/pull/892

### Code Changes

* [x] dispatch an event to `fidesplus` on a prerelease/feature tag, passing along the tag name
    * event will be used to trigger a build of an integrated image using the version of `fides` that was just tagged
* [x] remove the `tag(local)` nox session as it was not very useful and could easily cause problems if used

### Steps to Confirm

* [x] i think we'll want to get https://github.com/ethyca/fidesplus/pull/892 merged first so that we can test the dispatch event here actually triggering an action over in `fidesplus`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This is the `fides` side change that allows to automatically trigger, on feature tags, a build of an integrated image using the version of `fides` that was just tagged