### PR TITLE
3260 Adds ability for fides.js to fetch its own geolocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The types of changes are:
 - Add infrastructure for "overlay" consent components (Preact, CSS bundling, etc.) and initial version of consent banner [#3191](https://github.com/ethyca/fides/pull/3191)
 - Add the modal component of the "overlay" consent components [#3291](https://github.com/ethyca/fides/pull/3291)
 - Track Privacy Experience with Privacy Preferences [#3311](https://github.com/ethyca/fides/pull/3311)
+- Add ability for `fides-js` to fetch its own geolocation [#3356](https://github.com/ethyca/fides/pull/3356)
 
 ### Fixed
 


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3049

### Code Changes

* [ ] Adds tests to confirm fides.js can fetch its own geolocation

### Steps to Confirm

No core code changes, only tests added. If you wish to test, you'll have to look at console logs for now (until we get full stack working with real experience API calls):
* [ ] in `fides-js-components-demo.html`, update `experience` and `geolocation` `fidesConfig` props to null or undefined
* [ ] Set `options.geolocationApiUrl` to a valid geolocation api url (ask me for one)
* [ ] Set `options.isGeolocationEnabled` to `true`
* [ ] `cd /clients`, then `npm run dev-pc`
* [ ] Navigate to `http://localhost:3000/fides-js-components-demo.html`, open console
* [ ] Reload page, and see console log statement with geolocation data: e.g. `Got location response from geolocation API, returning: {country: "US", ip: "63.173.339.012:13489", location: "US-CA", region: "CA"}`


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
