### PR TITLE
pin typing_extensions to version 4.5.0 to bypass pydantic bug with Li…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,7 @@ sqlalchemy-stubs==0.4
 SQLAlchemy-Utils==0.38.3
 toml>=0.10.1
 twilio==7.15.0
+typing_extensions==4.5.0
 Unidecode==1.3.4
 validators==0.20.0
 versioneer==0.19


### PR DESCRIPTION
Closes (pending, creating issue....)

### Code Changes

* pin `typing_extensions==4.5.0` in our requirements.txt to bypass https://github.com/pydantic/pydantic/issues/5821

### Steps to Confirm

* CI jobs for python < `3.10` should pass
* server should boot successfully in a python `3.9` or `3.8` environment
* app should run as normal (i.e., no regressions)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Caused by https://github.com/pydantic/pydantic/issues/5821. Our backend-check CI jobs that run on python < `3.10` were failing.