### PR TITLE
filter out untagged main commits from feature-tag dispatch event

### DIFF
--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -78,7 +78,8 @@ jobs:
 
       # Notify Fidesplus about a feature (non-prod) tag to trigger an integrated build
       - name: Send Repository Dispatch Event
-        if: steps.check-tag.outputs.match != 'true'
+        # ensure this is a non-prod tag, but NOT an untagged commit to 'main'
+        if: steps.check-tag.outputs.match != 'true' && github.ref_name != 'main'
         uses: peter-evans/repository-dispatch@v2
         with:
           client-payload: '{"tag": "${{ github.ref_name }}"}'


### PR DESCRIPTION
Closes n/a

I noticed that our "feature-tag" dispatch event, created to trigger integrated pre-release builds in `fidesplus` based on feature tags in `fides`, was a bit too trigger-happy. every commit to `main` was sending a [dispatch event](https://github.com/ethyca/fides/actions/runs/5079806741/jobs/9125995673#step:13:3) to `fidesplus` and triggering an [unexpected and unintended build action](https://github.com/ethyca/fidesplus/actions/runs/5080008359/jobs/9126441662#step:5:1) on `fidesplus` that would inevitably fail.

### Code Changes

* [x] update the conditional for the dispatch event so that it doesn't fire on untagged commits to `main` here in `fides`

### Steps to Confirm

* [x] we can ensure that we didn't _break_ anything by pushing a feature tag on this branch and confirming the dispatch event still fires: https://github.com/ethyca/fides/actions/runs/5080461653/jobs/9127447567#step:13:3
* [ ] we'll need to merge this into `main` to make sure it filters out those untagged commits as intended

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

A minor DX cleanup to avoid unnecessary build actions that inevitably fail.
