### PR TITLE
Fix overlay rendering issue by finding/creating a dedicated parent element for Preact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.14.0...main)
 
+### Fixed
+
+- Fix overlay rendering issue by finding/creating a dedicated parent element for Preact [#3397](https://github.com/ethyca/fides/pull/3397)
+
 ### Changed
+
 - Enabled Privacy Experience beta flag [#3364](https://github.com/ethyca/fides/pull/3364)
 
 ## [2.14.0](https://github.com/ethyca/fides/compare/2.13.0...2.14.0)

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -265,4 +265,5 @@ export * from "./lib/consent-utils";
 export * from "./lib/consent-value";
 export * from "./lib/cookie";
 
-export default _Fides;
+// DEFER: this default export isn't very useful, it's just the Fides type
+export default Fides;

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -265,4 +265,4 @@ export * from "./lib/consent-utils";
 export * from "./lib/consent-value";
 export * from "./lib/cookie";
 
-export default Fides;
+export default _Fides;

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -27,6 +27,7 @@
  *           isDisabled: false,
  *           isGeolocationEnabled: false,
  *           geolocationApiUrl: "",
+ *           overlayParentId: null,
  *           privacyCenterUrl: "http://localhost:3000"
  *         }
  *   });
@@ -238,6 +239,7 @@ _Fides = {
     isOverlayDisabled: true,
     isGeolocationEnabled: false,
     geolocationApiUrl: "",
+    overlayParentId: null,
     privacyCenterUrl: "",
   },
   fides_meta: {},

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -19,14 +19,17 @@ export type FidesOptions = {
   // Whether or not debug log statements should be enabled
   debug: boolean;
 
+  // API URL for getting user geolocation
+  geolocationApiUrl: string;
+
   // Whether or not the banner should be globally disabled
   isOverlayDisabled: boolean;
 
   // Whether user geolocation should be enabled. Requires geolocationApiUrl
   isGeolocationEnabled: boolean;
 
-  // API URL for getting user geolocation
-  geolocationApiUrl: string;
+  // ID of the parent DOM element where the overlay should be inserted (default: "fides-overlay")
+  overlayParentId?: string;
 
   // URL for the Privacy Center, used to customize consent preferences. Required.
   privacyCenterUrl: string;

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -29,7 +29,7 @@ export type FidesOptions = {
   isGeolocationEnabled: boolean;
 
   // ID of the parent DOM element where the overlay should be inserted (default: "fides-overlay")
-  overlayParentId?: string;
+  overlayParentId: string | null;
 
   // URL for the Privacy Center, used to customize consent preferences. Required.
   privacyCenterUrl: string;

--- a/clients/fides-js/src/lib/consent.tsx
+++ b/clients/fides-js/src/lib/consent.tsx
@@ -28,8 +28,22 @@ export const initOverlay = async ({
     try {
       debugLog(
         options.debug,
-        "Rendering Fides overlay CSS & HTML into the DOM..."
+        "Rendering Fides overlay CSS & HTML into the DOM... (updated!)"
       );
+
+      // TODO: clean this up
+      const rootElementId = "fides-overlay";
+      let root = document.getElementById(rootElementId);
+      if (!root) {
+        debugLog(
+          options.debug,
+          "Root #fides-overlay not found, inserting before rendering..."
+        );
+        // Create our own root element and append to body first
+        root = document.createElement("div");
+        root.id = rootElementId;
+        document.body.appendChild(root);
+      }
 
       if (experience.component === ComponentType.OVERLAY) {
         if (experience.delivery_mechanism === DeliveryMechanism.BANNER) {
@@ -41,7 +55,7 @@ export const initOverlay = async ({
               experience={experience}
               geolocation={geolocation}
             />,
-            document.body
+            root
           );
           debugLog(options.debug, "Fides overlay is now showing!");
         } else if (experience.delivery_mechanism === DeliveryMechanism.LINK) {
@@ -58,9 +72,11 @@ export const initOverlay = async ({
   // Ensure we only render the overlay to the DOM once it's loaded
   if (document?.readyState !== "complete") {
     debugLog(options.debug, "DOM not loaded, adding event listener");
-    document.addEventListener("DOMContentLoaded", async () => {
-      debugLog(options.debug, "DOM fully loaded and parsed");
-      await renderFidesOverlay();
+    document.addEventListener("readystatechange", async () => {
+      if (document.readyState === "complete") {
+        debugLog(options.debug, "DOM fully loaded and parsed");
+        await renderFidesOverlay();
+      }
     });
   } else {
     await renderFidesOverlay();

--- a/clients/fides-js/src/lib/consent.tsx
+++ b/clients/fides-js/src/lib/consent.tsx
@@ -28,7 +28,7 @@ export const initOverlay = async ({
     try {
       debugLog(
         options.debug,
-        "Rendering Fides overlay CSS & HTML into the DOM... (updated!)"
+        "Rendering Fides overlay CSS & HTML into the DOM..."
       );
 
       // Find or create the parent element where we should insert the overlay

--- a/clients/fides-js/src/lib/consent.tsx
+++ b/clients/fides-js/src/lib/consent.tsx
@@ -9,7 +9,7 @@ import { showModalLinkAndSetOnClick } from "./consent-links";
 /**
  * Initialize the Fides Consent overlay components.
  *
- * (see the type definition of ConsentBannerOptions for what options are available)
+ * (see the type definition of FidesOptions for what options are available)
  */
 export const initOverlay = async ({
   consentDefaults,
@@ -31,18 +31,18 @@ export const initOverlay = async ({
         "Rendering Fides overlay CSS & HTML into the DOM... (updated!)"
       );
 
-      // TODO: clean this up
-      const rootElementId = "fides-overlay";
-      let root = document.getElementById(rootElementId);
-      if (!root) {
+      // Find or create the parent element where we should insert the overlay
+      const overlayParentId = options.overlayParentId || "fides-overlay";
+      let parentElem = document.getElementById(overlayParentId);
+      if (!parentElem) {
         debugLog(
           options.debug,
-          "Root #fides-overlay not found, inserting before rendering..."
+          `Parent element not found (#${overlayParentId}), creating and appending to body...`
         );
-        // Create our own root element and append to body first
-        root = document.createElement("div");
-        root.id = rootElementId;
-        document.body.appendChild(root);
+        // Create our own parent element and append to body
+        parentElem = document.createElement("div");
+        parentElem.id = overlayParentId;
+        document.body.appendChild(parentElem);
       }
 
       if (experience.component === ComponentType.OVERLAY) {
@@ -55,7 +55,7 @@ export const initOverlay = async ({
               experience={experience}
               geolocation={geolocation}
             />,
-            root
+            parentElem
           );
           debugLog(options.debug, "Fides overlay is now showing!");
         } else if (experience.delivery_mechanism === DeliveryMechanism.LINK) {

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -32,13 +32,17 @@ import {
  * FIDES_PRIVACY_CENTER__FIDES_API_URL=https://fides.example.com/api/v1
  */
 export interface PrivacyCenterSettings {
+  // Privacy center settings
   FIDES_API_URL: string; // e.g. http://localhost:8080/api/v1
-  CONFIG_JSON_URL: string; // e.g. file:///app/config/config.json
   CONFIG_CSS_URL: string; // e.g. file:///app/config/config.css
+  CONFIG_JSON_URL: string; // e.g. file:///app/config/config.json
+
+  // Fides.js options
   DEBUG: boolean; // whether console logs are enabled for consent components
-  IS_OVERLAY_DISABLED: boolean; // whether we should render privacy-experience-driven components
-  IS_GEOLOCATION_ENABLED: boolean; // whether we should use geolocation to drive privacy experience
   GEOLOCATION_API_URL: string; // e.g. http://location-cdn.com
+  IS_GEOLOCATION_ENABLED: boolean; // whether we should use geolocation to drive privacy experience
+  IS_OVERLAY_DISABLED: boolean; // whether we should render privacy-experience-driven components
+  OVERLAY_PARENT_ID?: string; // (optional) ID of the parent DOM element where the overlay should be inserted
   PRIVACY_CENTER_URL: string; // e.g. http://localhost:3000
 }
 
@@ -51,9 +55,10 @@ export type PrivacyCenterClientSettings = Pick<
   PrivacyCenterSettings,
   | "FIDES_API_URL"
   | "DEBUG"
-  | "IS_OVERLAY_DISABLED"
-  | "IS_GEOLOCATION_ENABLED"
   | "GEOLOCATION_API_URL"
+  | "IS_GEOLOCATION_ENABLED"
+  | "IS_OVERLAY_DISABLED"
+  | "OVERLAY_PARENT_ID"
   | "PRIVACY_CENTER_URL"
 >;
 
@@ -243,6 +248,8 @@ export const loadPrivacyCenterEnvironment =
       CONFIG_CSS_URL:
         process.env.FIDES_PRIVACY_CENTER__CONFIG_CSS_URL ||
         "file:///app/config/config.css",
+
+      // Overlay options
       DEBUG: process.env.FIDES_PRIVACY_CENTER__DEBUG === "true" || false,
       IS_OVERLAY_DISABLED:
         process.env.FIDES_PRIVACY_CENTER__IS_OVERLAY_DISABLED === "false" ||
@@ -252,6 +259,7 @@ export const loadPrivacyCenterEnvironment =
         false,
       GEOLOCATION_API_URL:
         process.env.FIDES_PRIVACY_CENTER__GEOLOCATION_API_URL || "",
+      OVERLAY_PARENT_ID: process.env.FIDES_PRIVACY_CENTER__OVERLAY_PARENT_ID,
       PRIVACY_CENTER_URL:
         process.env.FIDES_PRIVACY_CENTER__PRIVACY_CENTER_URL ||
         "http://localhost:3000",

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -42,7 +42,7 @@ export interface PrivacyCenterSettings {
   GEOLOCATION_API_URL: string; // e.g. http://location-cdn.com
   IS_GEOLOCATION_ENABLED: boolean; // whether we should use geolocation to drive privacy experience
   IS_OVERLAY_DISABLED: boolean; // whether we should render privacy-experience-driven components
-  OVERLAY_PARENT_ID?: string; // (optional) ID of the parent DOM element where the overlay should be inserted
+  OVERLAY_PARENT_ID: string | null; // (optional) ID of the parent DOM element where the overlay should be inserted
   PRIVACY_CENTER_URL: string; // e.g. http://localhost:3000
 }
 
@@ -259,7 +259,8 @@ export const loadPrivacyCenterEnvironment =
         false,
       GEOLOCATION_API_URL:
         process.env.FIDES_PRIVACY_CENTER__GEOLOCATION_API_URL || "",
-      OVERLAY_PARENT_ID: process.env.FIDES_PRIVACY_CENTER__OVERLAY_PARENT_ID,
+      OVERLAY_PARENT_ID:
+        process.env.FIDES_PRIVACY_CENTER__OVERLAY_PARENT_ID || null,
       PRIVACY_CENTER_URL:
         process.env.FIDES_PRIVACY_CENTER__PRIVACY_CENTER_URL ||
         "http://localhost:3000",
@@ -278,6 +279,7 @@ export const loadPrivacyCenterEnvironment =
       IS_OVERLAY_DISABLED: settings.IS_OVERLAY_DISABLED,
       IS_GEOLOCATION_ENABLED: settings.IS_GEOLOCATION_ENABLED,
       GEOLOCATION_API_URL: settings.GEOLOCATION_API_URL,
+      OVERLAY_PARENT_ID: settings.OVERLAY_PARENT_ID,
       PRIVACY_CENTER_URL: settings.PRIVACY_CENTER_URL,
     };
 

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -74,9 +74,10 @@ export default async function handler(
     },
     options: {
       debug: environment.settings.DEBUG,
-      isOverlayDisabled: environment.settings.IS_OVERLAY_DISABLED,
-      isGeolocationEnabled: environment.settings.IS_GEOLOCATION_ENABLED,
       geolocationApiUrl: environment.settings.GEOLOCATION_API_URL,
+      isGeolocationEnabled: environment.settings.IS_GEOLOCATION_ENABLED,
+      isOverlayDisabled: environment.settings.IS_OVERLAY_DISABLED,
+      overlayParentId: environment.settings.OVERLAY_PARENT_ID,
       privacyCenterUrl: environment.settings.PRIVACY_CENTER_URL,
     },
     geolocation,

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -113,6 +113,7 @@
           isOverlayDisabled: false,
           isGeolocationEnabled: false,
           geolocationApiUrl: "",
+          overlayParentId: null,
           privacyCenterUrl: "http://localhost:3000",
         },
       };


### PR DESCRIPTION
Closes #3293 

### Code Changes

* [X] Add a `overlayParentId` option that defaults to `fides-overlay` to specify the parent element ID
* [X] Either find _or_ create that parent element when rendering the overlay via `Preact.render()`
* [X] Use `readystatechange` event listening to ensure DOM is loaded

### Steps to Confirm

* [X] Manually edit your local privacy center setting to enable the overlay, populate with notices, etc. (easier said than done!)
* [X] Run `nox -s "fides_env(test)"` to run everything locally
* [X] Open the sample app in a location where the banner would be displayed
* [X] Ensure the banner renders correctly and the rest of the app is maintained

#### Before (Banner Disabled)
<img width="1680" alt="image" src="https://github.com/ethyca/fides/assets/1834295/e59fee75-2bcc-4087-8463-528ecb45cccf">

Notice how `document.body` contains a `div` with `id="__next"` and a few other things...

#### Before (Banner Enabled)
<img width="1680" alt="image" src="https://github.com/ethyca/fides/assets/1834295/3e2f47a7-f24b-4ff6-9aff-f273c39b3810">

Notice how `document.body` no longer has the Next root and instead we've replaced it with our own `div` with `id="fides-js-root"`

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [X] Update `CHANGELOG.md`
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This fixes a rendering issue I ran into when doing some E2E testing locally. I can't pinpoint exactly why this is fundamentally required because in our testing of "simpler" pages like the static HTML demo page we use, this doesn't seem to happen - I think it must be an interaction between the NextJS VDOM and our own.

This just defensively adds a parent element to the `document.body` where we insert our root node to keep it away from thrashing with other running React apps, etc.