### PR TITLE
Fix sample app `DATABASE_*` ENV vars for backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The types of changes are:
 
 - Add Google Tag Manager and Privacy Center ENV vars to sample app [#2949](https://github.com/ethyca/fides/pull/2949)
 
+## Fixed
+
+- Fix sample app `DATABASE_*` ENV vars for backwards compatibility [#3406](https://github.com/ethyca/fides/pull/3406)
+
 ### Changed
 
 - Enabled Privacy Experience beta flag [#3364](https://github.com/ethyca/fides/pull/3364)

--- a/clients/sample-app/Dockerfile
+++ b/clients/sample-app/Dockerfile
@@ -1,11 +1,5 @@
 FROM node:16-alpine as prod
 
-ENV FIDES_SAMPLE_APP__DATABASE_HOST localhost
-ENV FIDES_SAMPLE_APP__DATABASE_PORT 5432
-ENV FIDES_SAMPLE_APP__DATABASE_USER postgres
-ENV FIDES_SAMPLE_APP__DATABASE_PASSWORD postgres
-ENV FIDES_SAMPLE_APP__DATABASE_DB postgres_example
-
 RUN mkdir /home/node/app
 WORKDIR /home/node/app
 COPY package.json package-lock.json ./

--- a/clients/sample-app/docker-compose.yml
+++ b/clients/sample-app/docker-compose.yml
@@ -6,11 +6,11 @@ services:
       context: .
     environment:
       - PORT=3000
-      - DATABASE_HOST=postgres-test
-      - DATABASE_PORT=5432
-      - DATABASE_USER=postgres
-      - DATABASE_PASSWORD=postgres
-      - DATABASE_DB=postgres_example
+      - FIDES_SAMPLE_APP__DATABASE_HOST=postgres-test
+      - FIDES_SAMPLE_APP__DATABASE_PORT=5432
+      - FIDES_SAMPLE_APP__DATABASE_USER=postgres
+      - FIDES_SAMPLE_APP__DATABASE_PASSWORD=postgres
+      - FIDES_SAMPLE_APP__DATABASE_DB=postgres_example
     ports:
       - 3000:3000
     depends_on:


### PR DESCRIPTION
### Code Changes

* [X] Remove the unexpected defaults for `FIDES_SAMPLE_APP__DATABASE_*` set in the Dockerfile

### Steps to Confirm

* [X] Change to `clients/sample-app`
* [X] Run `docker compose build` to build the sample app image from the Dockerfile
* [X] Edit the `docker-compose.yml` and test:
  * [X] Using the updated `FIDES_SAMPLE_APP__DATABASE_*` format (should connect)
  * [X] Using the previous `DATABASE_*` format (should connect)
  * [X] Not specifying any ENV vars (should fail to connect, using defaults to connect to localhost)

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This is a tiny fix for a slip-up in https://github.com/ethyca/fides/pull/2949 where I added support for two different styles of ENV vars to configure the sample app:
* `FIDES_SAMPLE_APP__DATABASE_*` (prefixed, for clarity & consistency)
* `DATABASE_*` (unprefixed, for backwards-compatibility)

Turns out I accidentally didn't support the backwards-compat version since the Dockerfile was surprisingly setting those prefixed ENV vars all the time... whoops!