### PR TITLE
3424 styling for banner

### DIFF
--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -69,32 +69,32 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
           {bannerDescription || ""}
         </div>
         <div
-            id="fides-consent-banner-buttons"
-            className="fides-consent-banner-buttons"
+          id="fides-consent-banner-buttons"
+          className="fides-consent-banner-buttons"
         >
           <span className="fides-consent-banner-buttons-left">
             <Button
-                buttonType={ButtonType.TERTIARY}
-                label={managePreferencesLabel}
-                onClick={handleManagePreferencesClick}
+              buttonType={ButtonType.TERTIARY}
+              label={managePreferencesLabel}
+              onClick={handleManagePreferencesClick}
             />
           </span>
           <span className="fides-consent-banner-buttons-right">
             <Button
-                buttonType={ButtonType.PRIMARY}
-                label={rejectButtonLabel}
-                onClick={() => {
-                  onRejectAll();
-                  setIsShown(false);
-                }}
+              buttonType={ButtonType.PRIMARY}
+              label={rejectButtonLabel}
+              onClick={() => {
+                onRejectAll();
+                setIsShown(false);
+              }}
             />
             <Button
-                buttonType={ButtonType.PRIMARY}
-                label={confirmationButtonLabel}
-                onClick={() => {
-                  onAcceptAll();
-                  setIsShown(false);
-                }}
+              buttonType={ButtonType.PRIMARY}
+              label={confirmationButtonLabel}
+              onClick={() => {
+                onAcceptAll();
+                setIsShown(false);
+              }}
             />
           </span>
         </div>

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -55,7 +55,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
         isShown ? "" : "fides-consent-banner-hidden"
       } `}
     >
-      <div>
+      <div id="fides-consent-banner-inner">
         <div
           id="fides-consent-banner-title"
           className="fides-consent-banner-title"
@@ -68,32 +68,36 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
         >
           {bannerDescription || ""}
         </div>
-      </div>
-      <div
-        id="fides-consent-banner-buttons"
-        className="fides-consent-banner-buttons"
-      >
-        <Button
-          buttonType={ButtonType.SECONDARY}
-          label={managePreferencesLabel}
-          onClick={handleManagePreferencesClick}
-        />
-        <Button
-          buttonType={ButtonType.PRIMARY}
-          label={rejectButtonLabel}
-          onClick={() => {
-            onRejectAll();
-            setIsShown(false);
-          }}
-        />
-        <Button
-          buttonType={ButtonType.PRIMARY}
-          label={confirmationButtonLabel}
-          onClick={() => {
-            onAcceptAll();
-            setIsShown(false);
-          }}
-        />
+        <div
+            id="fides-consent-banner-buttons"
+            className="fides-consent-banner-buttons"
+        >
+          <span className="fides-consent-banner-buttons-left">
+            <Button
+                buttonType={ButtonType.TERTIARY}
+                label={managePreferencesLabel}
+                onClick={handleManagePreferencesClick}
+            />
+          </span>
+          <span className="fides-consent-banner-buttons-right">
+            <Button
+                buttonType={ButtonType.PRIMARY}
+                label={rejectButtonLabel}
+                onClick={() => {
+                  onRejectAll();
+                  setIsShown(false);
+                }}
+            />
+            <Button
+                buttonType={ButtonType.PRIMARY}
+                label={confirmationButtonLabel}
+                onClick={() => {
+                  onAcceptAll();
+                  setIsShown(false);
+                }}
+            />
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/clients/fides-js/src/lib/overlay.module.css
+++ b/clients/fides-js/src/lib/overlay.module.css
@@ -5,7 +5,7 @@
   /* Colors */
   --fides-consent-overlay-primary-color: #8243f2;
   --fides-consent-overlay-background-color: #f7fafc;
-  --ides-consent-overlay-font-color: #4a5568;
+  --fides-consent-overlay-font-color: #4a5568;
   --fides-consent-overlay-font-color-dark: #2d3748;
   --fides-consent-overlay-hover-color: #edf2f7;
   /* Buttons */
@@ -27,10 +27,10 @@
   );
   /* Text */
   --fides-consent-overlay-title-font-color: var(
-    --ides-consent-overlay-font-color
+    --fides-consent-overlay-font-color
   );
   --fides-consent-overlay-body-font-color: var(
-    --ides-consent-overlay-font-color
+    --fides-consent-overlay-font-color
   );
   --fides-consent-overlay-link-font-color: var(
     --fides-consent-overlay-font-color-dark

--- a/clients/fides-js/src/lib/overlay.module.css
+++ b/clients/fides-js/src/lib/overlay.module.css
@@ -133,18 +133,8 @@ div#fides-consent-banner-buttons {
   font-size: var(--fides-consent-overlay-font-size-buttons);
 }
 
-div#fides-consent-banner-buttons.fides-consent-banner-buttons-right {
+span.fides-consent-banner-buttons-right {
   float: right;
-}
-
-div#fides-consent-banner-buttons.fides-consent-banner-buttons-left {
-  background: none;
-  border: none;
-  padding: 0;
-  color: var(--fides-consent-overlay-link-font-color);
-  text-decoration: underline;
-  cursor: pointer;
-  line-height: 2em;
 }
 
 button.fides-consent-banner-button {
@@ -194,6 +184,16 @@ button.fides-consent-banner-button.fides-consent-banner-button-secondary:hover {
   background: var(
     --fides-consent-overlay-secondary-button-background-hover-color
   );
+}
+
+button.fides-consent-banner-button.fides-consent-banner-button-tertiary {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--fides-consent-overlay-link-font-color);
+  text-decoration: underline;
+  cursor: pointer;
+  line-height: 2em;
 }
 
 /** Modal */

--- a/clients/fides-js/src/lib/overlay.module.css
+++ b/clients/fides-js/src/lib/overlay.module.css
@@ -5,7 +5,8 @@
   /* Colors */
   --fides-consent-overlay-primary-color: #8243f2;
   --fides-consent-overlay-background-color: #f7fafc;
-  --fides-consent-overlay-font-color: #4a5568;
+  --fides-consent-overlay-font-color-light: #4a5568;
+  --fides-consent-overlay-font-color-dark: #2d3748;
   --fides-consent-overlay-hover-color: #edf2f7;
   /* Buttons */
   --fides-consent-overlay-primary-button-background-color: var(
@@ -26,10 +27,13 @@
   );
   /* Text */
   --fides-consent-overlay-title-font-color: var(
-    --fides-consent-overlay-font-color
+    --fides-consent-overlay-font-color-light
   );
   --fides-consent-overlay-body-font-color: var(
-    --fides-consent-overlay-font-color
+    --fides-consent-overlay-font-color-light
+  );
+  --fides-consent-overlay-link-font-color: var(
+    --fides-consent-overlay-font-color-dark
   );
   /* Switches */
   --fides-consent-overlay-primary-active-color: var(
@@ -46,8 +50,9 @@
 
   /* Everything else */
   --fides-consent-overlay-font-family: "inherit";
-  --fides-consent-overlay-font-size: 16px;
-  --fides-consent-overlay-font-size-title: 18px;
+  --fides-consent-overlay-font-size-body: 12px;
+  --fides-consent-overlay-font-size-title: 16px;
+  --fides-consent-overlay-font-size-buttons: 14px;
   --fides-consent-overlay-padding: 0.75em 2em 1em;
   --fides-consent-overlay-button-border-radius: 4px;
   --fides-consent-overlay-button-padding: 0.5em 1em;
@@ -60,7 +65,7 @@
 
 div#fides-consent-banner {
   font-family: var(--fides-consent-overlay-font-family);
-  font-size: var(--fides-consent-overlay-font-size);
+  font-size: var(--fides-consent-overlay-font-size-body);
   background: var(--fides-consent-overlay-background-color);
   color: var(--fides-consent-overlay-body-font-color);
   box-sizing: border-box;
@@ -74,6 +79,10 @@ div#fides-consent-banner {
   justify-content: space-between;
   align-items: center;
   transition: transform 1s;
+}
+
+div#fides-consent-banner-inner {
+  width: 100%;
 }
 
 div#fides-consent-banner.fides-consent-banner-bottom {
@@ -104,6 +113,7 @@ div#fides-consent-banner.fides-consent-banner-top.fides-consent-banner-hidden {
 
 div#fides-consent-banner-title {
   font-size: var(--fides-consent-overlay-font-size-title);
+  font-weight: 600;
   margin-top: 0.5em;
   margin-right: 2em;
   min-width: 33%;
@@ -119,9 +129,22 @@ div#fides-consent-banner-description {
 }
 
 div#fides-consent-banner-buttons {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  margin-top: 0.5em;
+  font-size: var(--fides-consent-overlay-font-size-buttons);
+}
+
+div#fides-consent-banner-buttons.fides-consent-banner-buttons-right {
+  float: right;
+}
+
+div#fides-consent-banner-buttons.fides-consent-banner-buttons-left {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--fides-consent-overlay-link-font-color);
+  text-decoration: underline;
+  cursor: pointer;
+  line-height: 2em;
 }
 
 button.fides-consent-banner-button {
@@ -136,7 +159,6 @@ button.fides-consent-banner-button {
   background: var(--fides-consent-overlay-primary-button-background-color);
   color: var(--fides-consent-overlay-primary-button-text-color);
   border: 1px solid;
-  border-radius: var(--fides-consent-overlay-button-border-radius);
 
   font-family: inherit;
   font-size: 100%;
@@ -177,7 +199,7 @@ button.fides-consent-banner-button.fides-consent-banner-button-secondary:hover {
 /** Modal */
 div#fides-consent-modal {
   font-family: var(--fides-consent-overlay-font-family);
-  font-size: var(--fides-consent-overlay-font-size);
+  font-size: var(--fides-consent-overlay-font-size-body);
   color: var(--fides-consent-overlay-body-font-color);
   box-sizing: border-box;
   padding: var(--fides-consent-overlay-padding);

--- a/clients/fides-js/src/lib/overlay.module.css
+++ b/clients/fides-js/src/lib/overlay.module.css
@@ -5,7 +5,7 @@
   /* Colors */
   --fides-consent-overlay-primary-color: #8243f2;
   --fides-consent-overlay-background-color: #f7fafc;
-  --fides-consent-overlay-font-color-light: #4a5568;
+  --ides-consent-overlay-font-color: #4a5568;
   --fides-consent-overlay-font-color-dark: #2d3748;
   --fides-consent-overlay-hover-color: #edf2f7;
   /* Buttons */
@@ -27,10 +27,10 @@
   );
   /* Text */
   --fides-consent-overlay-title-font-color: var(
-    --fides-consent-overlay-font-color-light
+    --ides-consent-overlay-font-color
   );
   --fides-consent-overlay-body-font-color: var(
-    --fides-consent-overlay-font-color-light
+    --ides-consent-overlay-font-color
   );
   --fides-consent-overlay-link-font-color: var(
     --fides-consent-overlay-font-color-dark

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -180,7 +180,7 @@ describe("Consent banner", () => {
             "div#fides-consent-banner-buttons.fides-consent-banner-buttons"
           ).within(() => {
             cy.get(
-              "button#fides-consent-banner-button-secondary.fides-consent-banner-button.fides-consent-banner-button-secondary"
+              "button#fides-consent-banner-button-tertiary.fides-consent-banner-button.fides-consent-banner-button-tertiary"
             ).contains("Manage preferences");
             cy.get(
               "button#fides-consent-banner-button-primary.fides-consent-banner-button.fides-consent-banner-button-primary"
@@ -191,7 +191,7 @@ describe("Consent banner", () => {
             // Order matters - it should always be secondary, then primary!
             cy.get("button")
               .eq(0)
-              .should("have.id", "fides-consent-banner-button-secondary");
+              .should("have.id", "fides-consent-banner-button-tertiary");
             cy.get("button")
               .eq(1)
               .should("have.id", "fides-consent-banner-button-primary");

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -43,7 +43,7 @@
               "On this page you can opt in and out of these data uses cases",
             banner_title: "Manage your consent",
             banner_description:
-              "This test website is overriding the banner description label.",
+              "We use cookies and similar methods to recognize visitors and remember their preferences. We also use them to measure ad campaign effectiveness, target ads and analyze site traffic. Learn more about these methods, including how to manage them, by clicking ‘Manage Preferences.’ By clicking ‘accept’ you consent to the of these methods by us and our third parties. By clicking ‘reject’ you decline the use of these methods.",
             confirmation_button_label: "Accept Test",
             acknowledgement_button_label: "OK",
             reject_button_label: "Reject Test",


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3424

### Code Changes

* [ ] Updates banner styling according to Figma mocks

### Steps to Confirm

* [ ] Nav to http://localhost:3000/fides-js-components-demo.html
* [ ] See banner matches mocks (note that the mocks have a small screen width, and on a standard laptop, this will appear stretched out):

Mocks:
<img width="882" alt="Screenshot 2023-06-01 at 5 41 30 PM" src="https://github.com/ethyca/fides/assets/7697292/a6f0429b-6e10-4cae-b4d1-4261b0ffc475">


This PR:
<img width="1440" alt="Screenshot 2023-06-01 at 5 37 19 PM" src="https://github.com/ethyca/fides/assets/7697292/db108227-b37e-4a04-b201-4e32bc95f1b0">



### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
