### PR TITLE
Fix Snowflake Sqlalchemy warning on CLI usage

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - "**.md"
       - "clients/**"
+      - "CHANGELOG.md"
   push:
     branches:
       - "main"

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -2,10 +2,10 @@ name: Backend Code Checks
 
 on:
   pull_request:
+    # This only ignores paths if there are _no_ commits on the branch that touch other files
     paths-ignore:
       - "**.md"
       - "clients/**"
-      - "CHANGELOG.md"
   push:
     branches:
       - "main"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The types of changes are:
 - Fix sample app `DATABASE_*` ENV vars for backwards compatibility [#3406](https://github.com/ethyca/fides/pull/3406)
 - Fix overlay rendering issue by finding/creating a dedicated parent element for Preact [#3397](https://github.com/ethyca/fides/pull/3397)
 - Fix the sample app privacy center link to be configurable [#3409](https://github.com/ethyca/fides/pull/3409)
-- Prevented the CLI output showing a version warning for Snowflake [#3434](https://github.com/ethyca/fides/pull/3434)
+- Fix CLI output showing a version warning for Snowflake [#3434](https://github.com/ethyca/fides/pull/3434)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The types of changes are:
 - Fix sample app `DATABASE_*` ENV vars for backwards compatibility [#3406](https://github.com/ethyca/fides/pull/3406)
 - Fix overlay rendering issue by finding/creating a dedicated parent element for Preact [#3397](https://github.com/ethyca/fides/pull/3397)
 - Fix the sample app privacy center link to be configurable [#3409](https://github.com/ethyca/fides/pull/3409)
-- CLI output showing a version warning for Snowflake [#3434](https://github.com/ethyca/fides/pull/3434)
+- Fixed CLI output showing a version warning for Snowflake [#3434](https://github.com/ethyca/fides/pull/3434)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The types of changes are:
 - Fix sample app `DATABASE_*` ENV vars for backwards compatibility [#3406](https://github.com/ethyca/fides/pull/3406)
 - Fix overlay rendering issue by finding/creating a dedicated parent element for Preact [#3397](https://github.com/ethyca/fides/pull/3397)
 - Fix the sample app privacy center link to be configurable [#3409](https://github.com/ethyca/fides/pull/3409)
-- Fixed CLI output showing a version warning for Snowflake [#3434](https://github.com/ethyca/fides/pull/3434)
+- Prevented the CLI output showing a version warning for Snowflake [#3434](https://github.com/ethyca/fides/pull/3434)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The types of changes are:
 - Fix sample app `DATABASE_*` ENV vars for backwards compatibility [#3406](https://github.com/ethyca/fides/pull/3406)
 - Fix overlay rendering issue by finding/creating a dedicated parent element for Preact [#3397](https://github.com/ethyca/fides/pull/3397)
 - Fix the sample app privacy center link to be configurable [#3409](https://github.com/ethyca/fides/pull/3409)
+- CLI output showing a version warning for Snowflake [#3434](https://github.com/ethyca/fides/pull/3434)
 
 ### Changed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ packaging==23.0
 pandas==1.4.3
 passlib[bcrypt]==1.7.4
 plotly==5.13.1
-pyarrow==7.0.0
+pyarrow==6.0.0
 psycopg2-binary==2.9.5
 pydantic<1.10.2
 pydash==6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ packaging==23.0
 pandas==1.4.3
 passlib[bcrypt]==1.7.4
 plotly==5.13.1
-pyarrow==8.0.0
+pyarrow==7.0.0
 psycopg2-binary==2.9.5
 pydantic<1.10.2
 pydash==6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ packaging==23.0
 pandas==1.4.3
 passlib[bcrypt]==1.7.4
 plotly==5.13.1
+pyarrow==8.0.0
 psycopg2-binary==2.9.5
 pydantic<1.10.2
 pydash==6.0.2

--- a/src/fides/cli/__init__.py
+++ b/src/fides/cli/__init__.py
@@ -1,6 +1,11 @@
 """
 Entrypoint for the Fides command-line.
 """
+import warnings
+
+# Ignore the UserWarning from the Snowflake module to keep CLI output clean
+warnings.filterwarnings("ignore", category=UserWarning, module="snowflake")
+
 from importlib.metadata import version
 from platform import system
 

--- a/src/fides/cli/__init__.py
+++ b/src/fides/cli/__init__.py
@@ -1,6 +1,7 @@
 """
 Entrypoint for the Fides command-line.
 """
+# pylint: disable=wrong-import-position
 import warnings
 
 # Ignore the UserWarning from the Snowflake module to keep CLI output clean


### PR DESCRIPTION
Closes #3433 

### Code Changes

* [x] add warning suppression to the CLI init

### Steps to Confirm

* [ ] install and run `fides parse` locally - note there is no warning
* [ ] edit the `__init__.py` file and change it to `module="something"`
* [ ] run `fides parse` again and note that the warning comes back

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

### Description Of Changes

Quick fix here, suppressing the warning as specifically as possible so that we can still see other warnings come through.

We've been out-of-range for this requirement for a long time but it doesn't seem to matter, it just started showing up in the CLI though which means we probably moved some imports around

#### New
![image](https://github.com/ethyca/fides/assets/5105354/d4083740-40dc-4922-838c-ce725bb52aad)

#### Old
![image](https://github.com/ethyca/fides/assets/5105354/e865876b-4666-4335-a1a8-5d43b5b166b3)
