### PR TITLE
release-related cleanup based on 2.14.0 release

### DIFF
--- a/docs/fides/docs/development/releases.md
+++ b/docs/fides/docs/development/releases.md
@@ -219,6 +219,17 @@ Run these from within the test environment shell:
 * [ ] Verify that the CHANGELOG is formatted correctly and clean up verbiage where needed
 * [ ] Verify that the CHANGELOG is representative of the actual changes
 
+:warning: Note that any updates that need to be made to the CHANGELOG should **not** be commited directly to the release branch.
+Instead, they should be committed on a branch off of `main` and then PR'd and merged into `main`, before being cherry-picked
+over to the release branch. This ensures that the CHANGELOG stays consistent between the release branch and `main`.
+
+#### Publishing the release
+
+When publishing the release, be sure to include the following sections in the release description:
+
+* [ ] `## Release Pull Request` section that includes a link back to the release PR (i.e., this one!) for tracking purposes
+* [ ] `## QA Touch Test Run` section that includes a link to the QATouch test run (QA team should provide this)
+
 ### Post-Release Steps
 
 * [ ] Verify the ethyca-fides release is published to PyPi: <https://pypi.org/project/ethyca-fides/#history>

--- a/noxfiles/git_nox.py
+++ b/noxfiles/git_nox.py
@@ -4,8 +4,9 @@ import re
 from enum import Enum
 from typing import List, Optional
 
-import nox
 from packaging.version import Version
+
+import nox
 
 RELEASE_BRANCH_REGEX = r"release-(([0-9]+\.)+[0-9]+)"
 RELEASE_TAG_REGEX = r"(([0-9]+\.)+[0-9]+)"
@@ -14,10 +15,6 @@ GENERIC_TAG_REGEX = r"{tag_type}([0-9]+)$"
 
 INITIAL_TAG_INCREMENT = 0
 TAG_INCREMENT = 1
-
-# posarg options for `tag`
-ONLY_TAG = "only_tag"
-PUSH = "push"
 
 
 class TagType(Enum):
@@ -96,7 +93,6 @@ def tag(session: nox.Session, action: str) -> None:
     # generate a tag based on the current repo state
     generated_tag = generate_tag(session, repo.active_branch.name, all_tags)
 
-    # if no args are passed, it's a dry run
     if action == "dry":
         session.log(f"Dry-run -- would generate tag: {generated_tag}")
 


### PR DESCRIPTION
some minor cleanup of release related items i noticed during the 2.14.0 release process.

note @NevilleS  and @daveqnet  - this includes the updates to the release description that we discussed post-2.14.0 release. please let me know how those look to you.