### PR TITLE
Fix NextJS errors & warnings for Cookie House sample app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The types of changes are:
 ### Fixed
 
 - Flaky custom field Cypress test on systems page [#3408](https://github.com/ethyca/fides/pull/3408)
+- Fix NextJS errors & warnings for Cookie House sample app [#3447](https://github.com/ethyca/fides/pull/3447)
 
 ## [2.14.0](https://github.com/ethyca/fides/compare/2.13.0...2.14.0)
 

--- a/clients/sample-app/src/components/GeolocationSelect/index.tsx
+++ b/clients/sample-app/src/components/GeolocationSelect/index.tsx
@@ -50,15 +50,20 @@ const GeolocationSelect = ({ menuPlacement }: GeolocationSelectProps) => {
     (option) => option.value === geolocation
   );
 
-  // Whenever the user selects geolocation option, reload the page and change the URL query param to suit
-  // e.g. select "New York" -> navigate to http://localhost:3000?geolocation=US-NY
+  // Whenever the user selects geolocation option, change the URL query param to suit
+  // (e.g. select "New York" -> navigate to http://localhost:3000?geolocation=US-NY)
+  // Then, after updating the URL, force a page reload to run the fides.js script again, etc.
   const onGeolocationSelect = (option: SingleValue<GeolocationOption>) => {
     if (!option) {
       router.query = {};
-      router.push({ pathname: router.pathname, query: {} });
+      router
+        .push({ pathname: router.pathname, query: {} })
+        .then(() => router.reload());
     } else {
       const { value } = option;
-      router.push({ pathname: router.pathname, query: { geolocation: value } });
+      router
+        .push({ pathname: router.pathname, query: { geolocation: value } })
+        .then(() => router.reload());
     }
   };
 

--- a/clients/sample-app/src/pages/_document.tsx
+++ b/clients/sample-app/src/pages/_document.tsx
@@ -8,11 +8,7 @@ import Document, {
 } from "next/document";
 
 /**
- * Define a custom Document, so that we can load some external scripts for all pages:
- * 1) Fides.js, for consent management
- * 2) Google Tag Manager, for managing tags
- * 3) etc.
- *
+ * Define a custom Document, so that we can load external stylesheets, scripts, etc.
  * See https://nextjs.org/docs/pages/building-your-application/routing/custom-document
  */
 class SampleAppDocument extends Document {

--- a/clients/sample-app/src/pages/_document.tsx
+++ b/clients/sample-app/src/pages/_document.tsx
@@ -1,0 +1,46 @@
+import Document, {
+  DocumentContext,
+  DocumentInitialProps,
+  Head,
+  Html,
+  Main,
+  NextScript,
+} from "next/document";
+
+/**
+ * Define a custom Document, so that we can load some external scripts for all pages:
+ * 1) Fides.js, for consent management
+ * 2) Google Tag Manager, for managing tags
+ * 3) etc.
+ *
+ * See https://nextjs.org/docs/pages/building-your-application/routing/custom-document
+ */
+class SampleAppDocument extends Document {
+  static async getInitialProps(
+    ctx: DocumentContext
+  ): Promise<DocumentInitialProps> {
+    const initialProps = await Document.getInitialProps(ctx);
+    return initialProps;
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <meta
+            name="description"
+            content="Sample Project used within Fides (github.com/ethyca/fides)"
+          />
+          <link rel="icon" href="/favicon.ico" />
+          <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default SampleAppDocument;

--- a/clients/sample-app/src/pages/index.tsx
+++ b/clients/sample-app/src/pages/index.tsx
@@ -63,30 +63,34 @@ const IndexPage = ({ gtmContainerId, privacyCenterUrl, products }: Props) => {
     <>
       <Head>
         <title>Cookie House</title>
-        <meta
-          name="description"
-          content="Sample Project used within Fides (github.com/ethyca/fides)"
-        />
-        <link rel="icon" href="/favicon.ico" />
-        <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
-        {/* Insert the fides.js script */}
-        <script src={fidesScriptTagUrl} />
       </Head>
+      {/**
+      Insert the fides.js script. Note that "beforeInteractive" would be more
+      efficient, but since we dynamically change the URL we want this to render
+      client-side and whenever we select a new location.
+      */}
+      <Script
+        id="fides-js"
+        strategy="afterInteractive"
+        src={fidesScriptTagUrl}
+      />
       {/* Insert the GTM script, if a container ID was provided */}
-      <Script id="google-tag-manager" strategy="afterInteractive">
-        {`
-          (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-          })(window,document,'script','dataLayer','${gtmContainerId}');
-        `}
-        {`
+      {gtmContainerId ? (
+        <Script id="google-tag-manager" strategy="afterInteractive">
+          {`
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','${gtmContainerId}');
+          `}
+          {`
           if (window.Fides) {
             window.Fides.gtm();
           }
-        `}
-      </Script>
+          `}
+        </Script>
+      ) : null}
       <Home privacyCenterUrl={privacyCenterUrl} products={products} />
     </>
   );

--- a/clients/sample-app/src/pages/landing.tsx
+++ b/clients/sample-app/src/pages/landing.tsx
@@ -6,10 +6,6 @@ const LandingPage = () => (
   <>
     <Head>
       <title>Welcome to Fides</title>
-      <meta
-        name="description"
-        content="Sample Project used within Fides (github.com/ethyca/fides)"
-      />
       <link rel="icon" href="/favicon.ico" />
       <meta charSet="utf-8" />
       {/* eslint-disable-next-line @next/next/google-font-display, @next/next/no-page-custom-font */}


### PR DESCRIPTION
Closes #3437 

### Code Changes

* [X] Use `next/script` for all external scripts (fides.js, google tag manager) to prevent NextJS from deleting our dynamic style tag (#3437)
* [X] Use custom Document (`_document.tsx`) to remove warning about including external CSS stylesheet
* [X] Trigger a full-page reload when selecting a new geolocation

### Steps to Confirm

* [X] Run `nox -s "fides_env(test)"` locally and interact with the Cookie House
* [X] Run E2E tests using the plus test environment

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This fixes a few lingering NextJS warnings that we've been ignoring for how we include external scripts, stylesheets, etc. In doing so, we also fix #3437 which was messing up the rendering of our banner 👍 