### PR TITLE
Dockerfile: Do not pip install --user, venv instead

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -57,7 +57,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           build-args: PYTHON_VERSION=${{ matrix.python_version }}
-          target: dev
+          target: prod
           outputs: type=docker,dest=/tmp/python-${{ matrix.python_version }}.tar
           push: false
           tags: ${{ env.IMAGE }}

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -57,7 +57,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           build-args: PYTHON_VERSION=${{ matrix.python_version }}
-          target: prod
+          target: dev
           outputs: type=docker,dest=/tmp/python-${{ matrix.python_version }}.tar
           push: false
           tags: ${{ env.IMAGE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The types of changes are:
 - Enabled Privacy Experience beta flag [#3364](https://github.com/ethyca/fides/pull/3364)
 - Removed ExperienceConfig.delivery_mechanism constraint [#3387](https://github.com/ethyca/fides/pull/3387)
 - Updated privacy experience UI forms to reflect updated experience config fields [#3402](https://github.com/ethyca/fides/pull/3402)
+- Use a venv in the Dockerfile for installing Python deps [#3452](https://github.com/ethyca/fides/pull/3452)
 - Bump SlowAPI Version [#3456](https://github.com/ethyca/fides/pull/3456)
 - Bump Psycopg2-binary Version [#3473](https://github.com/ethyca/fides/pull/3473)
 - Reduced duplication between PrivacyExperience and PrivacyExperienceConfig [#3470](https://github.com/ethyca/fides/pull/3470)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # If you update this, also update `DEFAULT_PYTHON_VERSION` in the GitHub workflow files
 ARG PYTHON_VERSION="3.10.11"
 
-
 #########################
 ## Compile Python Deps ##
 #########################
@@ -18,17 +17,21 @@ RUN apt-get update && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python Dependencies
+# Activate a Python venv
 RUN python3 -m venv /opt/fides
 ENV PATH="/opt/fides/bin:${PATH}"
-RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip setuptools wheel
 
+# Install Python Dependencies
+RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip setuptools wheel
 
 COPY dangerous-requirements.txt .
 RUN if [ $TARGETPLATFORM != linux/arm64 ] ; then pip install --no-cache-dir install -r dangerous-requirements.txt ; fi
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir install -r requirements.txt
+
+COPY dev-requirements.txt .
+RUN pip install --no-cache-dir install -r dev-requirements.txt
 
 ##################
 ## Backend Base ##
@@ -90,9 +93,6 @@ CMD [ "fides", "webserver" ]
 ## Development Application ##
 #############################
 FROM backend as dev
-
-COPY dev-requirements.txt .
-RUN pip install --no-cache-dir install -r dev-requirements.txt
 
 RUN pip install -e . --no-deps
 


### PR DESCRIPTION
This allows for the resulting container to be run by non-root users.

My only reasoning for this is that it was an attempt to keep from polluting/conflicting-with the system Python.

A `venv` is just as good at this, but can also be used by non-root users!

### Code Changes

* [x] Refactor Dockerfile to use a `venv` rather than `pip install --user`

### Steps to Confirm

* [ ] `docker run --rm -it --user nobody ethyca/fides:2.14.1a7` (Errors out)
* [ ] build this image and run it with `--user nobody`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
