### PR TITLE
Dispatch Fides.js lifecycle events on window (FidesInitialized, FidesUpdated) and cross-publish to Fides.gtm() integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The types of changes are:
 - Add `notice_key` field to Privacy Notice UI form [#3403](https://github.com/ethyca/fides/pull/3403)
 - Add `identity` query param to the consent reporting API view [#3418](https://github.com/ethyca/fides/pull/3418)
 - Use `rollup-plugin-postcss` to bundle and optimize the `fides.js` components CSS [#3431](https://github.com/ethyca/fides/pull/3431)
+- Dispatch Fides.js lifecycle events on window (FidesInitialized, FidesUpdated) and cross-publish to Fides.gtm() integration [#3454](https://github.com/ethyca/fides/pull/3454)
+
 
 ### Fixed
 

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -72,9 +72,10 @@ import {
   transformConsentToFidesUserPreference,
   validateOptions,
 } from "./lib/consent-utils";
+import { dispatchFidesEvent } from "./lib/events";
 import { fetchExperience } from "./services/fides/api";
 import { getGeolocation } from "./services/external/geolocation";
-import { OverlayProps } from "~/components/Overlay";
+import { OverlayProps } from "./components/Overlay";
 import { updateConsentPreferences } from "./lib/preferences";
 
 export type Fides = {
@@ -250,6 +251,12 @@ const init = async ({
   _Fides.options = options;
   _Fides.initialized = true;
 
+  // Dispatch the "FidesInitialized" event to update listeners with the initial
+  // state. For convenience, also dispatch the "FidesUpdated" event; this allows
+  // listeners to ignore the initialization event if they prefer
+  dispatchFidesEvent("FidesInitialized", cookie);
+  dispatchFidesEvent("FidesUpdated", cookie);
+
   automaticallyApplyGPCPreferences(
     cookie,
     fidesRegionString,
@@ -287,14 +294,15 @@ if (typeof window !== "undefined") {
 
 // Export everything from ./lib/* to use when importing fides.mjs as a module
 // TODO: pretty sure we need ./services/* too?
-export * from "./lib/consent";
 export * from "./components";
+export * from "./lib/consent";
 export * from "./lib/consent-context";
 export * from "./lib/consent-types";
 export * from "./lib/consent-links";
 export * from "./lib/consent-utils";
 export * from "./lib/consent-value";
 export * from "./lib/cookie";
+export * from "./lib/events";
 
 // DEFER: this default export isn't very useful, it's just the Fides type
 export default Fides;

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -29,14 +29,7 @@ const pushFidesVariableToGTM = (fidesEvent: {
   };
 
   // Push to the GTM dataLayer
-  if (fidesEvent.type === "FidesInitialized") {
-    // NOTE: For backwards-compatibility, we don't provide an "event" for the
-    // initialization event, just for updates.
-    // TODO: check if adding the "event" to the existing behaviour would be a breaking change... probably not?
-    dataLayer.push({ Fides });
-  } else {
-    dataLayer.push({ event: fidesEvent.type, Fides });
-  }
+  dataLayer.push({ event: fidesEvent.type, Fides });
 };
 
 /**
@@ -54,7 +47,7 @@ export const gtm = () => {
   );
 
   // If Fides was already initialized, publish a synthetic event immediately
-  if (window.Fides.initialized) {
+  if (window.Fides?.initialized) {
     pushFidesVariableToGTM({
       type: "FidesInitialized",
       detail: { consent: window.Fides.consent },

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -1,3 +1,6 @@
+import { CookieKeyConsent } from "../lib/cookie";
+import { FidesEventDetail } from "../lib/events";
+
 declare global {
   interface Window {
     dataLayer?: any[];
@@ -5,15 +8,56 @@ declare global {
 }
 
 /**
- * Call Fides.gtm to configure Google Tag Manager. The user's consent choices will be
- * pushed into GTM's `dataLayer` under `Fides.consent`.
+ * Defines the structure of the Fides variable pushed to the GTM data layer
  */
-export const gtm = () => {
+interface FidesVariable {
+  consent: CookieKeyConsent;
+}
+
+// Helper function to push the Fides variable to the GTM data layer from a FidesEvent
+const pushFidesVariableToGTM = (fidesEvent: {
+  type: string;
+  detail: FidesEventDetail;
+}) => {
+  // Initialize the dataLayer object, just in case we run before GTM is initialized
   const dataLayer = window.dataLayer ?? [];
   window.dataLayer = dataLayer;
-  dataLayer.push({
-    Fides: {
-      consent: window.Fides.consent,
-    },
-  });
+
+  // Construct the Fides variable that will be pushed to GTM
+  const Fides: FidesVariable = {
+    consent: fidesEvent.detail.consent,
+  };
+
+  // Push to the GTM dataLayer
+  if (fidesEvent.type === "FidesInitialized") {
+    // NOTE: For backwards-compatibility, we don't provide an "event" for the
+    // initialization event, just for updates.
+    // TODO: check if adding the "event" to the existing behaviour would be a breaking change... probably not?
+    dataLayer.push({ Fides });
+  } else {
+    dataLayer.push({ event: fidesEvent.type, Fides });
+  }
+};
+
+/**
+ * Call Fides.gtm() to configure the Fides <> Google Tag Manager integration.
+ * The user's consent choices will automatically be pushed into GTM's
+ * `dataLayer` under `Fides.consent` variable.
+ */
+export const gtm = () => {
+  // Listen for Fides events and cross-publish them to GTM
+  window.addEventListener("FidesInitialized", (event) =>
+    pushFidesVariableToGTM(event)
+  );
+  window.addEventListener("FidesUpdated", (event) =>
+    pushFidesVariableToGTM(event)
+  );
+
+  // If Fides was already initialized, publish a synthetic event immediately
+  if (window.Fides.initialized) {
+    pushFidesVariableToGTM({
+      type: "FidesInitialized",
+      detail: { consent: window.Fides.consent },
+    });
+  }
 };

--- a/clients/fides-js/src/integrations/meta.ts
+++ b/clients/fides-js/src/integrations/meta.ts
@@ -82,6 +82,8 @@ type MetaOptions = {
 /**
  * Call Fides.meta to configure Meta Pixel tracking.
  *
+ * DEFER: Update this integration to support async Fides events
+ *
  * @example
  * Fides.meta({
  *   consent: Fides.consent.data_sales,

--- a/clients/fides-js/src/integrations/shopify.ts
+++ b/clients/fides-js/src/integrations/shopify.ts
@@ -33,6 +33,8 @@ const applyOptions = (options: ShopifyOptions) => {
  * Call Fides.shopify to configure Shopify customer privacy. Currently the only consent option
  * Shopify allows to be configured is user tracking.
  *
+ * DEFER: Update this integration to support async Fides events
+ *
  * @example
  * Fides.shopify({ tracking: Fides.consent.data_sales })
  */

--- a/clients/fides-js/src/lib/events.ts
+++ b/clients/fides-js/src/lib/events.ts
@@ -1,0 +1,39 @@
+import { FidesCookie } from "./cookie";
+
+/**
+ * Defines the available event names:
+ * - FidesInitialized: dispatched when initialization is complete, from Fides.init()
+ * - FidesUpdated: dispatched when preferences are updated, from updateConsentPreferences() or Fides.init()
+ */
+export type FidesEvent = "FidesInitialized" | "FidesUpdated";
+
+/**
+ * Defines the properties available on event.detail. As of now, these are an
+ * explicit subset of properties from the Fides cookie
+ * TODO: add identity and meta?
+ */
+export type FidesEventDetail = Pick<FidesCookie, "consent">;
+
+/**
+ * Dispatch a custom event on the window object, providing the current Fides
+ * state on the "detail" property of the event.
+ * 
+ * Example usage:
+ * ```
+ * window.addEventListener("FidesUpdated", (evt) => console.log("Fides.consent updated:", evt.detail.consent));
+ * ```
+ * 
+ * The snippet above will print a console log whenever consent preferences are initialized/updated, like:
+ * ```
+ * Fides.consent updated: { data_sales_and_sharing: true }
+ * ```
+ */
+export const dispatchFidesEvent = (eventName: FidesEvent, cookie: FidesCookie) => {
+  if (typeof window !== "undefined" && typeof CustomEvent !== "undefined") {
+    // Pick a subset of the Fides cookie properties to provide as event detail
+    const { consent }: FidesEventDetail = cookie;
+    const detail: FidesEventDetail = { consent };
+    const event = new CustomEvent(eventName, { detail });
+    window.dispatchEvent(event);
+  }
+};

--- a/clients/fides-js/src/lib/events.ts
+++ b/clients/fides-js/src/lib/events.ts
@@ -5,7 +5,15 @@ import { FidesCookie } from "./cookie";
  * - FidesInitialized: dispatched when initialization is complete, from Fides.init()
  * - FidesUpdated: dispatched when preferences are updated, from updateConsentPreferences() or Fides.init()
  */
-export type FidesEvent = "FidesInitialized" | "FidesUpdated";
+export type FidesEventType = "FidesInitialized" | "FidesUpdated";
+
+// Bonus points: update the WindowEventMap interface with our custom event types
+declare global {
+  interface WindowEventMap {
+    FidesInitialized: FidesEvent;
+    FidesUpdated: FidesEvent;
+  }
+}
 
 /**
  * Defines the properties available on event.detail. As of now, these are an
@@ -14,26 +22,31 @@ export type FidesEvent = "FidesInitialized" | "FidesUpdated";
  */
 export type FidesEventDetail = Pick<FidesCookie, "consent">;
 
+export type FidesEvent = CustomEvent<FidesEventDetail>;
+
 /**
  * Dispatch a custom event on the window object, providing the current Fides
  * state on the "detail" property of the event.
- * 
+ *
  * Example usage:
  * ```
  * window.addEventListener("FidesUpdated", (evt) => console.log("Fides.consent updated:", evt.detail.consent));
  * ```
- * 
+ *
  * The snippet above will print a console log whenever consent preferences are initialized/updated, like:
  * ```
  * Fides.consent updated: { data_sales_and_sharing: true }
  * ```
  */
-export const dispatchFidesEvent = (eventName: FidesEvent, cookie: FidesCookie) => {
+export const dispatchFidesEvent = (
+  type: FidesEventType,
+  cookie: FidesCookie
+) => {
   if (typeof window !== "undefined" && typeof CustomEvent !== "undefined") {
     // Pick a subset of the Fides cookie properties to provide as event detail
     const { consent }: FidesEventDetail = cookie;
     const detail: FidesEventDetail = { consent };
-    const event = new CustomEvent(eventName, { detail });
+    const event = new CustomEvent(type, { detail });
     window.dispatchEvent(event);
   }
 };

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -6,6 +6,7 @@ import {
 } from "./consent-types";
 import { debugLog, transformUserPreferenceToBoolean } from "./consent-utils";
 import { CookieKeyConsent, FidesCookie, saveFidesCookie } from "./cookie";
+import { dispatchFidesEvent } from "./events";
 import { patchUserPreferenceToFidesServer } from "../services/fides/api";
 
 /**
@@ -49,6 +50,9 @@ export const updateConsentPreferences = ({
     });
   });
 
+  // Update the cookie object
+  cookie.consent = consentCookieKey;
+
   // 1. Save preferences to Fides API
   debugLog(debug, "Saving preferences to Fides API");
   const privacyPreferenceCreate: PrivacyPreferencesRequest = {
@@ -67,9 +71,12 @@ export const updateConsentPreferences = ({
 
   // 2. Update the window.Fides.consent object
   debugLog(debug, "Updating window.Fides");
-  window.Fides.consent = consentCookieKey;
+  window.Fides.consent = cookie.consent;
 
   // 3. Save preferences to the cookie
   debugLog(debug, "Saving preferences to cookie");
-  saveFidesCookie({ ...cookie, consent: consentCookieKey });
+  saveFidesCookie(cookie);
+
+  // 4. Dispatch a "FidesUpdated" event
+  dispatchFidesEvent("FidesUpdated", cookie)
 };

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -51,6 +51,7 @@ export const updateConsentPreferences = ({
   });
 
   // Update the cookie object
+  // eslint-disable-next-line no-param-reassign
   cookie.consent = consentCookieKey;
 
   // 1. Save preferences to Fides API
@@ -78,5 +79,5 @@ export const updateConsentPreferences = ({
   saveFidesCookie(cookie);
 
   // 4. Dispatch a "FidesUpdated" event
-  dispatchFidesEvent("FidesUpdated", cookie)
+  dispatchFidesEvent("FidesUpdated", cookie);
 };

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -1057,7 +1057,7 @@ describe("Consent banner", () => {
       cy.contains("button", "Accept Test").should("be.visible").click();
       cy.get("@dataLayerPush")
         .should("have.been.calledTwice")
-          // First call should be from initialization, before the user accepts all
+        // First call should be from initialization, before the user accepts all
         .its("firstCall.args.0")
         .should("deep.equal", {
           event: "FidesInitialized",

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -560,7 +560,7 @@ describe("Consent banner", () => {
         cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
       });
     });
-    
+
     describe("when no GPC flag is found, and notices apply to GPC", () => {
       beforeEach(() => {
         cy.on("window:before:load", (win) => {
@@ -621,7 +621,7 @@ describe("Consent banner", () => {
         cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
       });
     });
-    
+
     describe("when experience component is not an overlay", () => {
       beforeEach(() => {
         stubConfig({
@@ -939,8 +939,7 @@ describe("Consent banner", () => {
     });
   });
 
-  // TODO: remove .only()
-  describe.only("when listening for fides.js events", () => {
+  describe("when listening for fides.js events", () => {
     beforeEach(() => {
       cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
       stubConfig({
@@ -966,7 +965,7 @@ describe("Consent banner", () => {
           consent: {
             [PRIVACY_NOTICE_KEY_1]: false,
             [PRIVACY_NOTICE_KEY_2]: false,
-          }
+          },
         });
       cy.get("@FidesUpdated")
         .should("have.been.calledOnce")
@@ -975,7 +974,7 @@ describe("Consent banner", () => {
           consent: {
             [PRIVACY_NOTICE_KEY_1]: false,
             [PRIVACY_NOTICE_KEY_2]: false,
-          }
+          },
         });
     });
 
@@ -989,7 +988,7 @@ describe("Consent banner", () => {
             consent: {
               [PRIVACY_NOTICE_KEY_1]: false,
               [PRIVACY_NOTICE_KEY_2]: false,
-            }
+            },
           });
         cy.get("@FidesUpdated")
           .its("secondCall.args.0.detail")
@@ -997,7 +996,7 @@ describe("Consent banner", () => {
             consent: {
               [PRIVACY_NOTICE_KEY_1]: false,
               [PRIVACY_NOTICE_KEY_2]: false,
-            }
+            },
           });
       });
 
@@ -1010,7 +1009,7 @@ describe("Consent banner", () => {
             consent: {
               [PRIVACY_NOTICE_KEY_1]: false,
               [PRIVACY_NOTICE_KEY_2]: false,
-            }
+            },
           });
         cy.get("@FidesUpdated")
           .its("secondCall.args.0.detail")
@@ -1018,12 +1017,14 @@ describe("Consent banner", () => {
             consent: {
               [PRIVACY_NOTICE_KEY_1]: true,
               [PRIVACY_NOTICE_KEY_2]: true,
-            }
+            },
           });
       });
 
       it("emits another FidesUpdated event when customized preferences are saved", () => {
-        cy.contains("button", "Manage preferences").should("be.visible").click();
+        cy.contains("button", "Manage preferences")
+          .should("be.visible")
+          .click();
         cy.getByTestId("toggle-Test privacy notice").click();
         cy.getByTestId("consent-modal").contains("Save").click();
         cy.get("@FidesUpdated")
@@ -1033,7 +1034,7 @@ describe("Consent banner", () => {
             consent: {
               [PRIVACY_NOTICE_KEY_1]: false,
               [PRIVACY_NOTICE_KEY_2]: false,
-            }
+            },
           });
         cy.get("@FidesUpdated")
           .its("secondCall.args.0.detail")
@@ -1041,7 +1042,7 @@ describe("Consent banner", () => {
             consent: {
               [PRIVACY_NOTICE_KEY_1]: true,
               [PRIVACY_NOTICE_KEY_2]: false,
-            }
+            },
           });
       });
     });
@@ -1050,7 +1051,7 @@ describe("Consent banner", () => {
       cy.contains("button", "Accept Test").should("be.visible").click();
       cy.get("@dataLayerPush")
         .should("have.been.calledTwice")
-        .its("firstCall.args.0.detail")
+        .its("firstCall.args.0")
         .should("deep.equal", {
           // TODO: add the event name, once I'm sure this isn't a breaking change
           // event: "FidesInitialized",
@@ -1058,19 +1059,19 @@ describe("Consent banner", () => {
             consent: {
               [PRIVACY_NOTICE_KEY_1]: false,
               [PRIVACY_NOTICE_KEY_2]: false,
-            }
-          }
+            },
+          },
         });
       cy.get("@dataLayerPush")
-        .its("secondCall.args.0.detail")
+        .its("secondCall.args.0")
         .should("deep.equal", {
           event: "FidesUpdated",
           Fides: {
             consent: {
               [PRIVACY_NOTICE_KEY_1]: true,
               [PRIVACY_NOTICE_KEY_2]: true,
-            }
-          }
+            },
+          },
         });
     });
   });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -939,6 +939,7 @@ describe("Consent banner", () => {
     });
   });
 
+  // TODO: remove .only()
   describe.only("when listening for fides.js events", () => {
     beforeEach(() => {
       cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
@@ -1046,7 +1047,31 @@ describe("Consent banner", () => {
     });
 
     it("pushes events to the GTM integration", () => {
-
+      cy.contains("button", "Accept Test").should("be.visible").click();
+      cy.get("@dataLayerPush")
+        .should("have.been.calledTwice")
+        .its("firstCall.args.0.detail")
+        .should("deep.equal", {
+          // TODO: add the event name, once I'm sure this isn't a breaking change
+          // event: "FidesInitialized",
+          Fides: {
+            consent: {
+              [PRIVACY_NOTICE_KEY_1]: false,
+              [PRIVACY_NOTICE_KEY_2]: false,
+            }
+          }
+        });
+      cy.get("@dataLayerPush")
+        .its("secondCall.args.0.detail")
+        .should("deep.equal", {
+          event: "FidesUpdated",
+          Fides: {
+            consent: {
+              [PRIVACY_NOTICE_KEY_1]: true,
+              [PRIVACY_NOTICE_KEY_2]: true,
+            }
+          }
+        });
     });
   });
 });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -983,6 +983,7 @@ describe("Consent banner", () => {
         cy.contains("button", "Reject Test").should("be.visible").click();
         cy.get("@FidesUpdated")
           .should("have.been.calledTwice")
+          // First call should be from initialization, before the user rejects all
           .its("firstCall.args.0.detail")
           .should("deep.equal", {
             consent: {
@@ -991,6 +992,7 @@ describe("Consent banner", () => {
             },
           });
         cy.get("@FidesUpdated")
+          // Second call is when the user rejects all
           .its("secondCall.args.0.detail")
           .should("deep.equal", {
             consent: {
@@ -1004,6 +1006,7 @@ describe("Consent banner", () => {
         cy.contains("button", "Accept Test").should("be.visible").click();
         cy.get("@FidesUpdated")
           .should("have.been.calledTwice")
+          // First call should be from initialization, before the user accepts all
           .its("firstCall.args.0.detail")
           .should("deep.equal", {
             consent: {
@@ -1012,6 +1015,7 @@ describe("Consent banner", () => {
             },
           });
         cy.get("@FidesUpdated")
+          // Second call is when the user accepts all
           .its("secondCall.args.0.detail")
           .should("deep.equal", {
             consent: {
@@ -1029,6 +1033,7 @@ describe("Consent banner", () => {
         cy.getByTestId("consent-modal").contains("Save").click();
         cy.get("@FidesUpdated")
           .should("have.been.calledTwice")
+          // First call should be from initialization, before the user saved preferences
           .its("firstCall.args.0.detail")
           .should("deep.equal", {
             consent: {
@@ -1037,6 +1042,7 @@ describe("Consent banner", () => {
             },
           });
         cy.get("@FidesUpdated")
+          // Second call is when the user saved preferences and opted-in to the first notice
           .its("secondCall.args.0.detail")
           .should("deep.equal", {
             consent: {
@@ -1051,6 +1057,7 @@ describe("Consent banner", () => {
       cy.contains("button", "Accept Test").should("be.visible").click();
       cy.get("@dataLayerPush")
         .should("have.been.calledTwice")
+          // First call should be from initialization, before the user accepts all
         .its("firstCall.args.0")
         .should("deep.equal", {
           event: "FidesInitialized",
@@ -1062,6 +1069,7 @@ describe("Consent banner", () => {
           },
         });
       cy.get("@dataLayerPush")
+        // Second call is when the user accepts all
         .its("secondCall.args.0")
         .should("deep.equal", {
           event: "FidesUpdated",

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -129,6 +129,7 @@ describe("Consent banner", () => {
         cy.get("#fides-modal-link").should("not.be.visible");
       });
     });
+
     describe("when only legacy consent exists", () => {
       beforeEach(() => {
         stubConfig(
@@ -500,6 +501,7 @@ describe("Consent banner", () => {
           });
       });
     });
+
     describe("when GPC flag is found, and no notices apply to GPC", () => {
       beforeEach(() => {
         cy.on("window:before:load", (win) => {
@@ -558,6 +560,7 @@ describe("Consent banner", () => {
         cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
       });
     });
+    
     describe("when no GPC flag is found, and notices apply to GPC", () => {
       beforeEach(() => {
         cy.on("window:before:load", (win) => {
@@ -618,6 +621,7 @@ describe("Consent banner", () => {
         cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
       });
     });
+    
     describe("when experience component is not an overlay", () => {
       beforeEach(() => {
         stubConfig({
@@ -932,6 +936,117 @@ describe("Consent banner", () => {
           expect(false).is.eql(true);
         });
       });
+    });
+  });
+
+  describe.only("when listening for fides.js events", () => {
+    beforeEach(() => {
+      cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
+      stubConfig({
+        options: {
+          isOverlayDisabled: false,
+        },
+      });
+    });
+    // NOTE: See definition of cy.visitConsentDemo in commands.ts for where we
+    // register listeners for these window events
+    it("emits both a FidesInitialized and FidesUpdated event when initialized", () => {
+      cy.window()
+        .its("Fides")
+        .its("consent")
+        .should("eql", {
+          [PRIVACY_NOTICE_KEY_1]: false,
+          [PRIVACY_NOTICE_KEY_2]: false,
+        });
+      cy.get("@FidesInitialized")
+        .should("have.been.calledOnce")
+        .its("firstCall.args.0.detail")
+        .should("deep.equal", {
+          consent: {
+            [PRIVACY_NOTICE_KEY_1]: false,
+            [PRIVACY_NOTICE_KEY_2]: false,
+          }
+        });
+      cy.get("@FidesUpdated")
+        .should("have.been.calledOnce")
+        .its("firstCall.args.0.detail")
+        .should("deep.equal", {
+          consent: {
+            [PRIVACY_NOTICE_KEY_1]: false,
+            [PRIVACY_NOTICE_KEY_2]: false,
+          }
+        });
+    });
+
+    describe("when preferences are updated", () => {
+      it("emits another FidesUpdated event when reject all is clicked", () => {
+        cy.contains("button", "Reject Test").should("be.visible").click();
+        cy.get("@FidesUpdated")
+          .should("have.been.calledTwice")
+          .its("firstCall.args.0.detail")
+          .should("deep.equal", {
+            consent: {
+              [PRIVACY_NOTICE_KEY_1]: false,
+              [PRIVACY_NOTICE_KEY_2]: false,
+            }
+          });
+        cy.get("@FidesUpdated")
+          .its("secondCall.args.0.detail")
+          .should("deep.equal", {
+            consent: {
+              [PRIVACY_NOTICE_KEY_1]: false,
+              [PRIVACY_NOTICE_KEY_2]: false,
+            }
+          });
+      });
+
+      it("emits another FidesUpdated event when accept all is clicked", () => {
+        cy.contains("button", "Accept Test").should("be.visible").click();
+        cy.get("@FidesUpdated")
+          .should("have.been.calledTwice")
+          .its("firstCall.args.0.detail")
+          .should("deep.equal", {
+            consent: {
+              [PRIVACY_NOTICE_KEY_1]: false,
+              [PRIVACY_NOTICE_KEY_2]: false,
+            }
+          });
+        cy.get("@FidesUpdated")
+          .its("secondCall.args.0.detail")
+          .should("deep.equal", {
+            consent: {
+              [PRIVACY_NOTICE_KEY_1]: true,
+              [PRIVACY_NOTICE_KEY_2]: true,
+            }
+          });
+      });
+
+      it("emits another FidesUpdated event when customized preferences are saved", () => {
+        cy.contains("button", "Manage preferences").should("be.visible").click();
+        cy.getByTestId("toggle-Test privacy notice").click();
+        cy.getByTestId("consent-modal").contains("Save").click();
+        cy.get("@FidesUpdated")
+          .should("have.been.calledTwice")
+          .its("firstCall.args.0.detail")
+          .should("deep.equal", {
+            consent: {
+              [PRIVACY_NOTICE_KEY_1]: false,
+              [PRIVACY_NOTICE_KEY_2]: false,
+            }
+          });
+        cy.get("@FidesUpdated")
+          .its("secondCall.args.0.detail")
+          .should("deep.equal", {
+            consent: {
+              [PRIVACY_NOTICE_KEY_1]: true,
+              [PRIVACY_NOTICE_KEY_2]: false,
+            }
+          });
+      });
+    });
+
+    it("pushes events to the GTM integration", () => {
+
     });
   });
 });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -1053,8 +1053,7 @@ describe("Consent banner", () => {
         .should("have.been.calledTwice")
         .its("firstCall.args.0")
         .should("deep.equal", {
-          // TODO: add the event name, once I'm sure this isn't a breaking change
-          // event: "FidesInitialized",
+          event: "FidesInitialized",
           Fides: {
             consent: {
               [PRIVACY_NOTICE_KEY_1]: false,

--- a/clients/privacy-center/cypress/e2e/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent.cy.ts
@@ -258,31 +258,18 @@ describe("Consent settings", () => {
 
           // GTM configuration
           expect(win)
-            .to.have.nested.property("dataLayer")
-            .that.eql([
-              {
-                event: "FidesInitialized",
-                Fides: {
-                  consent: {
-                    data_sales: false,
-                    tracking: false,
-                    analytics: true,
-                    gpc_test: true,
-                  },
+            .to.have.nested.property("dataLayer[0]")
+            .that.eql({
+              event: "FidesInitialized",
+              Fides: {
+                consent: {
+                  data_sales: false,
+                  tracking: false,
+                  analytics: true,
+                  gpc_test: true,
                 },
               },
-              {
-                event: "FidesUpdated",
-                Fides: {
-                  consent: {
-                    data_sales: false,
-                    tracking: false,
-                    analytics: true,
-                    gpc_test: true,
-                  },
-                },
-              },
-            ]);
+            });
 
           // Meta Pixel configuration
           expect(win)
@@ -366,29 +353,17 @@ describe("Consent settings", () => {
 
           // GTM configuration
           expect(win)
-            .to.have.nested.property("dataLayer")
-            .that.eql([
-              {
-                event: "FidesInitialized",
-                Fides: {
-                  consent: {
-                    data_sales: true,
-                    tracking: true,
-                    analytics: true,
-                  },
+            .to.have.nested.property("dataLayer[0]")
+            .that.eql({
+              event: "FidesInitialized",
+              Fides: {
+                consent: {
+                  data_sales: true,
+                  tracking: true,
+                  analytics: true,
                 },
               },
-              {
-                event: "FidesUpdated",
-                Fides: {
-                  consent: {
-                    data_sales: true,
-                    tracking: true,
-                    analytics: true,
-                  },
-                },
-              },
-            ]);
+            });
 
           // Meta Pixel configuration
           expect(win)

--- a/clients/privacy-center/cypress/e2e/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent.cy.ts
@@ -261,6 +261,7 @@ describe("Consent settings", () => {
             .to.have.nested.property("dataLayer")
             .that.eql([
               {
+                event: "FidesInitialized",
                 Fides: {
                   consent: {
                     data_sales: false,
@@ -357,6 +358,7 @@ describe("Consent settings", () => {
             .to.have.nested.property("dataLayer")
             .that.eql([
               {
+                event: "FidesInitialized",
                 Fides: {
                   consent: {
                     data_sales: true,

--- a/clients/privacy-center/cypress/e2e/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent.cy.ts
@@ -271,6 +271,17 @@ describe("Consent settings", () => {
                   },
                 },
               },
+              {
+                event: "FidesUpdated",
+                Fides: {
+                  consent: {
+                    data_sales: false,
+                    tracking: false,
+                    analytics: true,
+                    gpc_test: true,
+                  },
+                },
+              },
             ]);
 
           // Meta Pixel configuration
@@ -359,6 +370,16 @@ describe("Consent settings", () => {
             .that.eql([
               {
                 event: "FidesInitialized",
+                Fides: {
+                  consent: {
+                    data_sales: true,
+                    tracking: true,
+                    analytics: true,
+                  },
+                },
+              },
+              {
+                event: "FidesUpdated",
                 Fides: {
                   consent: {
                     data_sales: true,

--- a/clients/privacy-center/cypress/support/commands.ts
+++ b/clients/privacy-center/cypress/support/commands.ts
@@ -60,9 +60,14 @@ Cypress.Commands.add("visitConsentDemo", (options?: FidesConfig) => {
     onBeforeLoad: (win) => {
       // eslint-disable-next-line no-param-reassign
       win.fidesConfig = options;
+
       // Add event listeners for Fides.js events
       win.addEventListener("FidesInitialized", cy.stub().as("FidesInitialized"));
       win.addEventListener("FidesUpdated", cy.stub().as("FidesUpdated"));
+
+      // Add GTM stub
+      win.dataLayer = []
+      cy.stub(win.dataLayer, "push").as("dataLayerPush");
     },
   });
 });
@@ -170,6 +175,7 @@ declare global {
 declare global {
   interface Window {
     fidesConfig?: FidesConfig;
+    dataLayer?: Array<any>;
   }
 }
 

--- a/clients/privacy-center/cypress/support/commands.ts
+++ b/clients/privacy-center/cypress/support/commands.ts
@@ -62,11 +62,15 @@ Cypress.Commands.add("visitConsentDemo", (options?: FidesConfig) => {
       win.fidesConfig = options;
 
       // Add event listeners for Fides.js events
-      win.addEventListener("FidesInitialized", cy.stub().as("FidesInitialized"));
+      win.addEventListener(
+        "FidesInitialized",
+        cy.stub().as("FidesInitialized")
+      );
       win.addEventListener("FidesUpdated", cy.stub().as("FidesUpdated"));
 
       // Add GTM stub
-      win.dataLayer = []
+      // eslint-disable-next-line no-param-reassign
+      win.dataLayer = [];
       cy.stub(win.dataLayer, "push").as("dataLayerPush");
     },
   });

--- a/clients/privacy-center/cypress/support/commands.ts
+++ b/clients/privacy-center/cypress/support/commands.ts
@@ -60,6 +60,9 @@ Cypress.Commands.add("visitConsentDemo", (options?: FidesConfig) => {
     onBeforeLoad: (win) => {
       // eslint-disable-next-line no-param-reassign
       win.fidesConfig = options;
+      // Add event listeners for Fides.js events
+      win.addEventListener("FidesInitialized", cy.stub().as("FidesInitialized"));
+      win.addEventListener("FidesUpdated", cy.stub().as("FidesUpdated"));
     },
   });
 });

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -175,7 +175,7 @@
       }
 
       // Once Fides.js is initialized, show some debug information on the page
-      window.addEventListener("FidesInitialized", () => {
+      const onInitialized = () => {
         console.log("Fides has been initialized!");
         // Pretty-print the fides consent object and add it to the page.
         document.getElementById("consent-json").textContent = JSON.stringify(
@@ -205,7 +205,14 @@
           consent: Fides.consent.tracking,
           dataUse: Fides.consent.data_sales,
         });
-      });
+      };
+
+      // Handle both synchronous & asynchronous initialization
+      if (Fides.initialized) {
+        onInitialized();
+      } else {
+        window.addEventListener("FidesInitialized", onInitialized);
+      }
     })();
   </script>
 </html>

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -174,41 +174,35 @@
         return;
       }
 
-      // DEFER: Ensure we only render the consent config to the DOM once Fides is fully initialized
-      // https://github.com/ethyca/fides/issues/3350
-      let timerId = setInterval(() => {
-        if (window.Fides?.initialized) {
-          console.log("Fides has been initialized!");
-          // Pretty-print the fides consent object and add it to the page.
-          document.getElementById("consent-json").textContent = JSON.stringify(
-            Fides.consent,
-            null,
-            2
-          );
+      // Once Fides.js is initialized, show some debug information on the page
+      window.addEventListener("FidesInitialized", () => {
+        console.log("Fides has been initialized!");
+        // Pretty-print the fides consent object and add it to the page.
+        document.getElementById("consent-json").textContent = JSON.stringify(
+          Fides.consent,
+          null,
+          2
+        );
 
-          // Pretty-print the fides experience config object and add it to the page.
-          document.getElementById("consent-experience").textContent =
-            JSON.stringify(Fides.experience, null, 2);
+        // Pretty-print the fides experience config object and add it to the page.
+        document.getElementById("consent-experience").textContent =
+          JSON.stringify(Fides.experience, null, 2);
 
-          // Pretty-print the fides geolocation object and add it to the page.
-          document.getElementById("consent-geolocation").textContent =
-            JSON.stringify(Fides.geolocation, null, 2);
+        // Pretty-print the fides geolocation object and add it to the page.
+        document.getElementById("consent-geolocation").textContent =
+          JSON.stringify(Fides.geolocation, null, 2);
 
-          // Pretty-print the fides options object and add it to the page.
-          document.getElementById("consent-options").textContent =
-            JSON.stringify(Fides.options, null, 2);
+        // Pretty-print the fides options object and add it to the page.
+        document.getElementById("consent-options").textContent =
+          JSON.stringify(Fides.options, null, 2);
 
-          // Test behavior of integrations that can be configured without/before their platform scripts.
-          Fides.gtm();
-          Fides.meta({
-            consent: Fides.consent.tracking,
-            dataUse: Fides.consent.data_sales,
-          });
-          clearInterval(timerId);
-        } else {
-          console.log("Fides not yet initialized, waiting. . .");
-        }
-      }, 100);
+        // Test behavior of integrations that can be configured without/before their platform scripts.
+        Fides.gtm();
+        Fides.meta({
+          consent: Fides.consent.tracking,
+          dataUse: Fides.consent.data_sales,
+        });
+      });
     })();
   </script>
 </html>

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -193,8 +193,11 @@
           JSON.stringify(Fides.geolocation, null, 2);
 
         // Pretty-print the fides options object and add it to the page.
-        document.getElementById("consent-options").textContent =
-          JSON.stringify(Fides.options, null, 2);
+        document.getElementById("consent-options").textContent = JSON.stringify(
+          Fides.options,
+          null,
+          2
+        );
 
         // Test behavior of integrations that can be configured without/before their platform scripts.
         Fides.gtm();

--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -70,8 +70,11 @@
           JSON.stringify(Fides.geolocation, null, 2);
 
         // Pretty-print the fides options object and add it to the page.
-        document.getElementById("consent-options").textContent =
-          JSON.stringify(Fides.options, null, 2);
+        document.getElementById("consent-options").textContent = JSON.stringify(
+          Fides.options,
+          null,
+          2
+        );
 
         // Test behavior of integrations that can be configured without/before their platform scripts.
         Fides.gtm();

--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -51,41 +51,35 @@
         return;
       }
 
-      // DEFER: Ensure we only render the consent config to the DOM once Fides is fully initialized
-      // https://github.com/ethyca/fides/issues/3350
-      let timerId = setInterval(() => {
-        if (window.Fides?.initialized) {
-          console.log("Fides has been initialized!");
-          // Pretty-print the fides consent object and add it to the page.
-          document.getElementById("consent-json").textContent = JSON.stringify(
-            Fides.consent,
-            null,
-            2
-          );
+      // Once Fides.js is initialized, show some debug information on the page
+      window.addEventListener("FidesInitialized", () => {
+        console.log("Fides has been initialized!");
+        // Pretty-print the fides consent object and add it to the page.
+        document.getElementById("consent-json").textContent = JSON.stringify(
+          Fides.consent,
+          null,
+          2
+        );
 
-          // Pretty-print the fides experience config object and add it to the page.
-          document.getElementById("consent-experience").textContent =
-            JSON.stringify(Fides.experience, null, 2);
+        // Pretty-print the fides experience config object and add it to the page.
+        document.getElementById("consent-experience").textContent =
+          JSON.stringify(Fides.experience, null, 2);
 
-          // Pretty-print the fides geolocation object and add it to the page.
-          document.getElementById("consent-geolocation").textContent =
-            JSON.stringify(Fides.geolocation, null, 2);
+        // Pretty-print the fides geolocation object and add it to the page.
+        document.getElementById("consent-geolocation").textContent =
+          JSON.stringify(Fides.geolocation, null, 2);
 
-          // Pretty-print the fides options object and add it to the page.
-          document.getElementById("consent-options").textContent =
-            JSON.stringify(Fides.options, null, 2);
+        // Pretty-print the fides options object and add it to the page.
+        document.getElementById("consent-options").textContent =
+          JSON.stringify(Fides.options, null, 2);
 
-          // Test behavior of integrations that can be configured without/before their platform scripts.
-          Fides.gtm();
-          Fides.meta({
-            consent: Fides.consent.tracking,
-            dataUse: Fides.consent.data_sales,
-          });
-          clearInterval(timerId);
-        } else {
-          console.log("Fides not yet initialized, waiting. . .");
-        }
-      }, 100);
+        // Test behavior of integrations that can be configured without/before their platform scripts.
+        Fides.gtm();
+        Fides.meta({
+          consent: Fides.consent.tracking,
+          dataUse: Fides.consent.data_sales,
+        });
+      });
     })();
   </script>
 </html>

--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -51,7 +51,6 @@
         return;
       }
 
-
       // Once Fides.js is initialized, show some debug information on the page
       const onInitialized = () => {
         console.log("Fides has been initialized!");

--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -51,8 +51,9 @@
         return;
       }
 
+
       // Once Fides.js is initialized, show some debug information on the page
-      window.addEventListener("FidesInitialized", () => {
+      const onInitialized = () => {
         console.log("Fides has been initialized!");
         // Pretty-print the fides consent object and add it to the page.
         document.getElementById("consent-json").textContent = JSON.stringify(
@@ -82,7 +83,14 @@
           consent: Fides.consent.tracking,
           dataUse: Fides.consent.data_sales,
         });
-      });
+      };
+
+      // Handle both synchronous & asynchronous initialization
+      if (Fides.initialized) {
+        onInitialized();
+      } else {
+        window.addEventListener("FidesInitialized", onInitialized);
+      }
     })();
   </script>
 </html>

--- a/clients/sample-app/src/components/Home/index.tsx
+++ b/clients/sample-app/src/components/Home/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import { useCallback, useState } from "react";
 import { Product, UserData } from "../../types";
 import Button from "../Button";

--- a/clients/sample-app/src/pages/index.tsx
+++ b/clients/sample-app/src/pages/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-sync-scripts */
 import { GetServerSideProps } from "next";
 import Head from "next/head";
 import Script from "next/script";
@@ -65,14 +64,22 @@ const IndexPage = ({ gtmContainerId, privacyCenterUrl, products }: Props) => {
         <title>Cookie House</title>
       </Head>
       {/**
-      Insert the fides.js script. Note that "beforeInteractive" would be more
-      efficient, but since we dynamically change the URL we want this to render
-      client-side and whenever we select a new location.
+      Insert the fides.js script and run the GTM integration once ready
+      DEFER: using "beforeInteractive" here triggers a lint warning from NextJS
+      as it should only be used in the _document.tsx file. This still works and
+      ensures that fides.js fires earlier than other scripts, but isn't a best
+      practice.
       */}
       <Script
         id="fides-js"
-        strategy="afterInteractive"
+        strategy="beforeInteractive"
         src={fidesScriptTagUrl}
+        onReady={() => {
+          // Enable the GTM integration, if GTM is configured
+          if (gtmContainerId) {
+            (window as any).Fides.gtm();
+          }
+        }}
       />
       {/* Insert the GTM script, if a container ID was provided */}
       {gtmContainerId ? (
@@ -83,11 +90,6 @@ const IndexPage = ({ gtmContainerId, privacyCenterUrl, products }: Props) => {
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
             })(window,document,'script','dataLayer','${gtmContainerId}');
-          `}
-          {`
-          if (window.Fides) {
-            window.Fides.gtm();
-          }
           `}
         </Script>
       ) : null}


### PR DESCRIPTION
Closes #3350 
Closes #3348

### Code Changes

* [X] Dispatch a "FidesInitialized" event on `window` when `Fides.init()` completes successfully
* [X] Dispatch a "FidesUpdated" event on `window` whenever preferences are updated
* [X] Update `Fides.gtm()` Google Tag Manager integration to listen for lifecycle events and publish to GTM whenever consent preferences are initialized/updated
* [X] Add Cypress tests to clients/privacy-center to listen for Fides.js events
* [x] Add "FidesInitialized" event name to GTM, once we confirm that wouldn't be a breaking change

### Steps to Confirm

* [X] Run privacy center Cypress tests
* [x] Run sample app locally with Google Tag Manager configured

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This exposes two new custom events on the `window` object to allow a user to listen for Fides.js lifecycle events and integrate consent state changes into their own custom Javascript handling. This is needed now that we allow preferences to change at runtime via the banner/modal components!

For example, you might integrate Fides.js into your website like:
```
<script src="privacy.example.com.fides.js" />
<script>
  window.addEventListener("FidesUpdated", (event) => {
    if (event.detail.consent.data_sales_and_sharing) {
      // enable data sales code
    }
  });
</script>
```

This PR also updates the `Fides.gtm()` integration to listen to the same lifecycle events and cross-publish them to GTM. This ensures GTM stays up to date if consent preferences are updated by the banner/modal.