### PR TITLE
[Backend] Further Deduplicate PrivacyExperience and PrivacyExperienceConfig 

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -1474,15 +1474,6 @@ dataset:
     - name: created_at
       data_categories: [system.operations]
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-    - name: delivery_mechanism
-      data_categories: [system.operations]
-      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-    - name: disabled
-      data_categories: [system.operations]
-      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-    - name: experience_config_history_id
-      data_categories: [ system.operations ]
-      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
     - name: experience_config_id
       data_categories: [system.operations]
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
@@ -1493,9 +1484,6 @@ dataset:
       data_categories: [system.operations]
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
     - name: updated_at
-      data_categories: [system.operations]
-      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-    - name: version
       data_categories: [system.operations]
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
   - name: privacyexperienceconfig
@@ -1573,33 +1561,6 @@ dataset:
     - name: save_button_label
       data_categories: [ system.operations ]
     - name: title
-      data_categories: [system.operations]
-    - name: updated_at
-      data_categories: [system.operations]
-    - name: version
-      data_categories: [system.operations]
-  - name: privacyexperiencehistory
-    description: 'Stores the history of an experience for a region for consent reporting'
-    data_categories: []
-    data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-    fields:
-    - name: component
-      data_categories: [system.operations]
-    - name: created_at
-      data_categories: [system.operations]
-    - name: delivery_mechanism
-      data_categories: [system.operations]
-    - name: disabled
-      data_categories: [system.operations]
-    - name: experience_config_history_id
-      data_categories: [system.operations]
-    - name: experience_config_id
-      data_categories: [system.operations]
-    - name: id
-      data_categories: [system.operations]
-    - name: privacy_experience_id
-      data_categories: [system.operations]
-    - name: region
       data_categories: [system.operations]
     - name: updated_at
       data_categories: [system.operations]
@@ -2199,7 +2160,7 @@ dataset:
         data_categories:
         - system.operations
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-      - name: privacy_experience_history_id
+      - name: privacy_experience_id
         data_categories:
         - system.operations
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The types of changes are:
 - Enabled Privacy Experience beta flag [#3364](https://github.com/ethyca/fides/pull/3364)
 - Removed ExperienceConfig.delivery_mechanism constraint [#3387](https://github.com/ethyca/fides/pull/3387)
 - Updated privacy experience UI forms to reflect updated experience config fields [#3402](https://github.com/ethyca/fides/pull/3402)
+- Reduced duplication between PrivacyExperience and PrivacyExperienceConfig [#3470](https://github.com/ethyca/fides/pull/3470)
 
 ### Developer Experience
 

--- a/docs/fides/docs/development/postman/Fides.postman_collection.json
+++ b/docs/fides/docs/development/postman/Fides.postman_collection.json
@@ -5670,7 +5670,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n   \"browser_identity\": {\n       \"ga_client_id\": \"UA-XXXXXXXXX\",\n       \"ljt_readerID\": \"test_sovrn_id\",\n       \"fides_user_device_id\": \"{{fides_user_device_id}}\"\n   },\n   \"preferences\": [{\n       \"privacy_notice_history_id\": \"{{privacy_notice_history_id}}\",\n       \"preference\": \"opt_out\"\n   }],\n   \"user_geography\": \"us_ca\",\n   \"privacy_experience_history_id\": \"{{privacy_experience_history_id}}\",\n   \"method\": \"button\"\n}",
+							"raw": "{\n   \"browser_identity\": {\n       \"ga_client_id\": \"UA-XXXXXXXXX\",\n       \"ljt_readerID\": \"test_sovrn_id\",\n       \"fides_user_device_id\": \"{{fides_user_device_id}}\"\n   },\n   \"preferences\": [{\n       \"privacy_notice_history_id\": \"{{privacy_notice_history_id}}\",\n       \"preference\": \"opt_out\"\n   }],\n   \"user_geography\": \"us_ca\",\n   \"privacy_experience_id\": \"{{privacy_experience_id}}\",\n   \"method\": \"button\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -6088,11 +6088,6 @@
 		},
 		{
 			"key": "experience-config-id",
-			"value": "",
-			"type": "string"
-		},
-		{
-			"key": "privacy_experience_history_id",
 			"value": "",
 			"type": "string"
 		}

--- a/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
@@ -16,7 +16,11 @@ from starlette.status import (
 from fides.api.api import deps
 from fides.api.api.v1 import urn_registry as urls
 from fides.api.api.v1.endpoints.utils import fides_limiter
-from fides.api.models.privacy_experience import ComponentType, PrivacyExperience
+from fides.api.models.privacy_experience import (
+    ComponentType,
+    PrivacyExperience,
+    PrivacyExperienceConfig,
+)
 from fides.api.models.privacy_notice import PrivacyNotice, PrivacyNoticeRegion
 from fides.api.models.privacy_request import ProvidedIdentity
 from fides.api.schemas.privacy_experience import PrivacyExperienceResponse
@@ -90,9 +94,13 @@ def privacy_experience_list(
     experience_query = db.query(PrivacyExperience)
 
     if show_disabled is False:
-        experience_query = experience_query.filter(
-            PrivacyExperience.disabled.is_(False)
-        )
+        # This field is actually stored on the PrivacyExperienceConfig.  This is a useful filter in that
+        # it forces the ExperienceConfig to exist, and it has to be enabled.
+        experience_query = experience_query.join(
+            PrivacyExperienceConfig,
+            PrivacyExperienceConfig.id == PrivacyExperience.experience_config_id,
+        ).filter(PrivacyExperienceConfig.disabled.is_(False))
+
     if region is not None:
         experience_query = experience_query.filter(PrivacyExperience.region == region)
     if component is not None:

--- a/src/fides/api/ctl/migrations/versions/317e6197c76a_reduce_experience_and_config_duplication.py
+++ b/src/fides/api/ctl/migrations/versions/317e6197c76a_reduce_experience_and_config_duplication.py
@@ -1,0 +1,250 @@
+"""reduce experience and config duplication
+
+Revision ID: 317e6197c76a
+Revises: b8248ce6b8a1
+Create Date: 2023-06-05 23:24:43.174826
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "317e6197c76a"
+down_revision = "b8248ce6b8a1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index(
+        "ix_privacyexperiencehistory_experience_config_history_id",
+        table_name="privacyexperiencehistory",
+    )
+    op.drop_index(
+        "ix_privacyexperiencehistory_experience_config_id",
+        table_name="privacyexperiencehistory",
+    )
+    op.drop_index(
+        "ix_privacyexperiencehistory_id", table_name="privacyexperiencehistory"
+    )
+    op.drop_index(
+        "ix_privacyexperiencehistory_privacy_experience_id",
+        table_name="privacyexperiencehistory",
+    )
+    op.drop_index(
+        "ix_privacyexperiencehistory_region", table_name="privacyexperiencehistory"
+    )
+    op.drop_constraint(
+        "privacypreferencehistory_privacy_experience_history_id_fkey",
+        "privacypreferencehistory",
+        type_="foreignkey",
+    )
+
+    op.drop_table("privacyexperiencehistory")
+
+    op.drop_index(
+        "ix_privacyexperience_experience_config_history_id",
+        table_name="privacyexperience",
+    )
+    op.drop_constraint(
+        "privacyexperience_experience_config_history_id_fkey",
+        "privacyexperience",
+        type_="foreignkey",
+    )
+
+    op.drop_column("privacyexperience", "disabled")
+    op.drop_column("privacyexperience", "version")
+    op.drop_column("privacyexperience", "experience_config_history_id")
+
+    op.drop_index(
+        "ix_privacypreferencehistory_privacy_experience_history_id",
+        table_name="privacypreferencehistory",
+    )
+    op.drop_column("privacypreferencehistory", "privacy_experience_history_id")
+
+    op.add_column(
+        "privacypreferencehistory",
+        sa.Column("privacy_experience_id", sa.String(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_privacypreferencehistory_privacy_experience_id"),
+        "privacypreferencehistory",
+        ["privacy_experience_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "privacypreferencehistory_privacy_experience_id_fkey",
+        "privacypreferencehistory",
+        "privacyexperience",
+        ["privacy_experience_id"],
+        ["id"],
+    )
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    op.create_table(
+        "privacyexperiencehistory",
+        sa.Column("id", sa.VARCHAR(length=255), autoincrement=False, nullable=False),
+        sa.Column(
+            "created_at",
+            postgresql.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            postgresql.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.Column("disabled", sa.BOOLEAN(), autoincrement=False, nullable=False),
+        sa.Column("component", sa.VARCHAR(), autoincrement=False, nullable=False),
+        sa.Column(
+            "version",
+            postgresql.DOUBLE_PRECISION(precision=53),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column(
+            "privacy_experience_id", sa.VARCHAR(), autoincrement=False, nullable=False
+        ),
+        sa.Column("region", sa.VARCHAR(), autoincrement=False, nullable=False),
+        sa.Column(
+            "experience_config_id", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+        sa.Column(
+            "experience_config_history_id",
+            sa.VARCHAR(),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["experience_config_history_id"],
+            ["privacyexperienceconfighistory.id"],
+            name="privacyexperiencehistory_experience_config_history_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["experience_config_id"],
+            ["privacyexperienceconfig.id"],
+            name="privacyexperiencehistory_experience_config_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["privacy_experience_id"],
+            ["privacyexperience.id"],
+            name="privacyexperiencehistory_privacy_experience_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="privacyexperiencehistory_pkey"),
+    )
+
+    op.add_column(
+        "privacypreferencehistory",
+        sa.Column(
+            "privacy_experience_history_id",
+            sa.VARCHAR(),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+
+    op.create_foreign_key(
+        "privacypreferencehistory_privacy_experience_history_id_fkey",
+        "privacypreferencehistory",
+        "privacyexperiencehistory",
+        ["privacy_experience_history_id"],
+        ["id"],
+    )
+
+    op.drop_index(
+        op.f("ix_privacypreferencehistory_privacy_experience_id"),
+        table_name="privacypreferencehistory",
+    )
+    op.drop_constraint(
+        "privacypreferencehistory_privacy_experience_id_fkey",
+        "privacypreferencehistory",
+        type_="foreignkey",
+    )
+    op.drop_column("privacypreferencehistory", "privacy_experience_id")
+
+    op.create_index(
+        "ix_privacypreferencehistory_privacy_experience_history_id",
+        "privacypreferencehistory",
+        ["privacy_experience_history_id"],
+        unique=False,
+    )
+
+    op.add_column(
+        "privacyexperience",
+        sa.Column(
+            "experience_config_history_id",
+            sa.VARCHAR(),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "privacyexperience",
+        sa.Column(
+            "version",
+            postgresql.DOUBLE_PRECISION(precision=53),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "privacyexperience",
+        sa.Column(
+            "disabled",
+            sa.BOOLEAN(),
+            server_default="t",
+            autoincrement=False,
+            nullable=False,
+        ),
+    )
+    op.create_foreign_key(
+        "privacyexperience_experience_config_history_id_fkey",
+        "privacyexperience",
+        "privacyexperienceconfighistory",
+        ["experience_config_history_id"],
+        ["id"],
+    )
+
+    op.create_index(
+        "ix_privacyexperience_experience_config_history_id",
+        "privacyexperience",
+        ["experience_config_history_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_privacyexperiencehistory_region",
+        "privacyexperiencehistory",
+        ["region"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_privacyexperiencehistory_privacy_experience_id",
+        "privacyexperiencehistory",
+        ["privacy_experience_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_privacyexperiencehistory_id",
+        "privacyexperiencehistory",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_privacyexperiencehistory_experience_config_id",
+        "privacyexperiencehistory",
+        ["experience_config_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_privacyexperiencehistory_experience_config_history_id",
+        "privacyexperiencehistory",
+        ["experience_config_history_id"],
+        unique=False,
+    )

--- a/src/fides/api/db/base.py
+++ b/src/fides/api/db/base.py
@@ -18,7 +18,6 @@ from fides.api.models.privacy_experience import (
     PrivacyExperience,
     PrivacyExperienceConfig,
     PrivacyExperienceConfigHistory,
-    PrivacyExperienceHistory,
 )
 from fides.api.models.privacy_notice import (
     PrivacyNotice,

--- a/src/fides/api/models/privacy_experience.py
+++ b/src/fides/api/models/privacy_experience.py
@@ -175,28 +175,15 @@ class PrivacyExperienceConfigHistory(ExperienceConfigBase, Base):
     )
 
 
-class PrivacyExperienceBase:
-    """Base Privacy Experience fields that are common between privacy experiences and historical records"""
-
-    disabled = Column(Boolean, nullable=False, default=False)
-    component = Column(EnumColumn(ComponentType), nullable=False)
-    region = Column(EnumColumn(PrivacyNoticeRegion), nullable=False, index=True)
-    version = Column(Float, nullable=False, default=1.0)
-
-    # Attribute that can be added as the result of "get_related_privacy_notices". Privacy notices aren't directly
-    # related to experiences.
-    privacy_notices: List[PrivacyNotice] = []
-
-    # Attribute that is cached on the PrivacyExperience object by "get_should_show_banner", calculated at runtime
-    show_banner: bool
-
-
-class PrivacyExperience(PrivacyExperienceBase, Base):
+class PrivacyExperience(Base):
     """Stores Privacy Experiences for a given just a single region.  The Experience describes how to surface
     multiple Privacy Notices to the end user in a given region.
 
     There can only be one component per region.
     """
+
+    component = Column(EnumColumn(ComponentType), nullable=False)
+    region = Column(EnumColumn(PrivacyNoticeRegion), nullable=False, index=True)
 
     experience_config_id = Column(
         String,
@@ -205,20 +192,8 @@ class PrivacyExperience(PrivacyExperienceBase, Base):
         index=True,
     )
 
-    experience_config_history_id = Column(
-        String,
-        ForeignKey(PrivacyExperienceConfigHistory.id_field_path),
-        nullable=True,
-        index=True,
-    )  # Also links to the historical record, so if the version of config gets updated, that
-    # triggers a new version of the experience.
-
     # There can only be one component per region
     __table_args__ = (UniqueConstraint("region", "component", name="region_component"),)
-
-    histories = relationship(
-        "PrivacyExperienceHistory", backref="privacy_experience", lazy="dynamic"
-    )
 
     experience_config = relationship(
         "PrivacyExperienceConfig",
@@ -226,17 +201,12 @@ class PrivacyExperience(PrivacyExperienceBase, Base):
         uselist=False,
     )
 
-    @hybridproperty
-    def privacy_experience_history_id(self) -> Optional[str]:
-        """Convenience property that returns the historical privacy experience id for the current version.
+    # Attribute that can be added as the result of "get_related_privacy_notices". Privacy notices aren't directly
+    # related to experiences.
+    privacy_notices: List[PrivacyNotice] = []
 
-        Note that there are possibly many historical records for the given experience, this just returns the current
-        corresponding historical record.
-        """
-        history: PrivacyExperienceHistory = self.histories.filter_by(  # type: ignore # pylint: disable=no-member
-            version=self.version
-        ).first()
-        return history.id if history else None
+    # Attribute that is cached on the PrivacyExperience object by "get_should_show_banner", calculated at runtime
+    show_banner: bool
 
     def get_should_show_banner(
         self, db: Session, show_disabled: Optional[bool] = True
@@ -314,27 +284,6 @@ class PrivacyExperience(PrivacyExperienceBase, Base):
 
         return notices
 
-    @classmethod
-    def create(
-        cls: Type[PrivacyExperience],
-        db: Session,
-        *,
-        data: dict[str, Any],
-        check_name: bool = False,
-    ) -> PrivacyExperience:
-        """Create a privacy experience and the clone this record into the history table for record keeping"""
-        privacy_experience = super().create(db=db, data=data, check_name=check_name)
-
-        # create the history after the initial object creation succeeds, to avoid
-        # writing history if the creation fails and so that we can get the generated ID
-        data.pop("id", None)
-        history_data = {
-            **data,
-            "privacy_experience_id": privacy_experience.id,
-        }
-        PrivacyExperienceHistory.create(db, data=history_data, check_name=False)
-        return privacy_experience
-
     @staticmethod
     def create_default_experience_for_region(
         db: Session, region: PrivacyNoticeRegion, component: ComponentType
@@ -351,28 +300,11 @@ class PrivacyExperience(PrivacyExperienceBase, Base):
 
         if default_config:
             experience_data["experience_config_id"] = default_config.id
-            experience_data[
-                "experience_config_history_id"
-            ] = default_config.experience_config_history_id
 
         return PrivacyExperience.create(
             db=db,
             data=experience_data,
         )
-
-    def update(self, db: Session, *, data: dict[str, Any]) -> PrivacyExperience:
-        """
-        Overrides the base update method to automatically bump the version of the
-        PrivacyExperience record and also create a new PrivacyExperienceHistory entry
-        """
-        resource, updated = update_if_modified(self, db=db, data=data)
-
-        if updated:
-            history_data = create_historical_data_from_record(resource)
-            history_data["privacy_experience_id"] = resource.id
-            PrivacyExperienceHistory.create(db, data=history_data, check_name=False)
-
-        return resource  # type: ignore[return-value]
 
     @staticmethod
     def get_experience_by_region_and_component(
@@ -413,7 +345,7 @@ class PrivacyExperience(PrivacyExperienceBase, Base):
         Note that neither the Experience Config or Experience are deleted; we're only removing
         a FK if it exists.
         """
-        return self.update(
+        return self.update(  # type: ignore[return-value]
             db,
             data={"experience_config_id": None, "experience_config_history_id": None},
         )
@@ -428,7 +360,7 @@ class PrivacyExperience(PrivacyExperienceBase, Base):
         ] = PrivacyExperienceConfig.get_default_config(
             db, self.component  # type: ignore[arg-type]
         )
-        return self.update(
+        return self.update(  # type: ignore[return-value]
             db,
             data={
                 "experience_config_id": default_config.id if default_config else None,
@@ -437,28 +369,6 @@ class PrivacyExperience(PrivacyExperienceBase, Base):
                 else None,
             },
         )
-
-
-class PrivacyExperienceHistory(PrivacyExperienceBase, Base):
-    """Stores the history of a privacy experience for a given region for Consent Reporting"""
-
-    version = Column(Float, nullable=False, default=1.0)
-    privacy_experience_id = Column(
-        String, ForeignKey(PrivacyExperience.id_field_path), nullable=False, index=True
-    )
-    experience_config_id = Column(
-        String,
-        ForeignKey(PrivacyExperienceConfig.id_field_path),
-        nullable=True,
-        index=True,
-    )
-
-    experience_config_history_id = Column(
-        String,
-        ForeignKey(PrivacyExperienceConfigHistory.id_field_path),
-        nullable=True,
-        index=True,
-    )
 
 
 def get_privacy_notices_by_region_and_component(
@@ -605,8 +515,6 @@ def upsert_privacy_experiences_after_config_update(
             "component": experience_config.component,
             "region": region,
             "experience_config_id": experience_config.id,
-            "experience_config_history_id": experience_config.experience_config_history_id,
-            "disabled": experience_config.disabled,
         }
 
         # If existing experience exists, link to experience config

--- a/src/fides/api/models/privacy_preference.py
+++ b/src/fides/api/models/privacy_preference.py
@@ -113,10 +113,10 @@ class PrivacyPreferenceHistory(Base):
         nullable=True,
         index=True,
     )
-    # The specific version of experience under which the user was presented the relevant notice
-    # Minimal information stored here, mostly the region, version, component type, and how it was delivered.
-    privacy_experience_history_id = Column(
-        String, ForeignKey("privacyexperiencehistory.id"), nullable=True, index=True
+    # The specific experience under which the user was presented the relevant notice
+    # Minimal information stored here, mostly just region and component type
+    privacy_experience_id = Column(
+        String, ForeignKey("privacyexperience.id"), nullable=True, index=True
     )
     # The specific historical record the user consented to
     privacy_notice_history_id = Column(

--- a/src/fides/api/schemas/privacy_experience.py
+++ b/src/fides/api/schemas/privacy_experience.py
@@ -163,7 +163,6 @@ class PrivacyExperience(FidesSchema):
 
     region: PrivacyNoticeRegion
     component: Optional[ComponentType]
-    disabled: Optional[bool] = False
     experience_config: Optional[ExperienceConfigSchemaWithId]
 
     class Config:
@@ -190,8 +189,6 @@ class PrivacyExperienceResponse(PrivacyExperienceWithId):
 
     created_at: datetime
     updated_at: datetime
-    version: float
-    privacy_experience_history_id: str
     show_banner: Optional[bool]
     privacy_notices: Optional[List[PrivacyNoticeResponseWithUserPreferences]]
     experience_config: Optional[ExperienceConfigResponse]

--- a/src/fides/api/schemas/privacy_preference.py
+++ b/src/fides/api/schemas/privacy_preference.py
@@ -28,7 +28,7 @@ class PrivacyPreferencesRequest(FidesSchema):
     code: Optional[SafeStr]
     preferences: conlist(ConsentOptionCreate, max_items=50)  # type: ignore
     policy_key: Optional[FidesKey]  # Will use default consent policy if not supplied
-    privacy_experience_history_id: Optional[SafeStr]
+    privacy_experience_id: Optional[SafeStr]
     user_geography: Optional[PrivacyNoticeRegion]
     method: Optional[ConsentMethod]
 
@@ -99,8 +99,8 @@ class ConsentReportingSchema(FidesSchema):
     experience_config_history_id: Optional[str] = Field(
         title="The historical config for the experience that the user was presented - contains the experience language"
     )
-    privacy_experience_history_id: Optional[str] = Field(
-        title="The historical id of the experience that the user was presented - contains the experience type, region, and delivery mechanism"
+    privacy_experience_id: Optional[str] = Field(
+        title="The id of the experience that the user was presented - contains the experience type and region"
     )
     truncated_ip_address: Optional[str] = Field(title="Truncated ip address")
     method: Optional[ConsentMethod] = Field(title="Method of consent preference")

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -2032,12 +2032,8 @@ def privacy_preference_history(
             "anonymized_ip_address": "92.158.1.0",
             "email": "test@email.com",
             "method": "button",
-            "privacy_experience_config_history_id": privacy_experience_privacy_center.histories[
-                0
-            ].experience_config_history_id,
-            "privacy_experience_history_id": privacy_experience_privacy_center.histories[
-                0
-            ].id,
+            "privacy_experience_config_history_id": privacy_experience_privacy_center.experience_config.experience_config_history_id,
+            "privacy_experience_id": privacy_experience_privacy_center.id,
             "preference": "opt_out",
             "privacy_notice_history_id": privacy_notice_history.id,
             "provided_identity_id": provided_identity.id,
@@ -2112,18 +2108,12 @@ def privacy_experience_privacy_center(
         db=db,
         data={
             "component": ComponentType.privacy_center,
-            "disabled": True,
             "region": PrivacyNoticeRegion.us_co,
             "experience_config_id": experience_config_privacy_center.id,
-            "experience_config_history_id": experience_config_privacy_center.histories[
-                0
-            ].id,
         },
     )
 
     yield privacy_experience
-    for history in privacy_experience.histories:
-        history.delete(db)
     privacy_experience.delete(db)
 
 
@@ -2161,12 +2151,8 @@ def privacy_experience_overlay(db: Session, experience_config_overlay) -> Genera
             "component": ComponentType.overlay,
             "region": PrivacyNoticeRegion.us_ca,
             "experience_config_id": experience_config_overlay.id,
-            "experience_config_history_id": experience_config_overlay.histories[0].id,
-            "disabled": False,
         },
     )
 
     yield privacy_experience
-    for history in privacy_experience.histories:
-        history.delete(db)
     privacy_experience.delete(db)

--- a/tests/ops/api/v1/endpoints/test_privacy_experience_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_experience_config_endpoints.py
@@ -663,26 +663,8 @@ class TestCreateExperienceConfig:
         experience = experience_config.experiences[0]
         assert experience.region == PrivacyNoticeRegion.us_ny
         assert experience.component == ComponentType.overlay
-        assert experience.disabled is False
-        assert experience.version == 1.0
         assert experience.experience_config_id == experience_config.id
-        assert experience.experience_config_history_id == experience_config_history.id
 
-        # Created Experience History
-        assert experience.histories.count() == 1
-        experience_history = experience.histories[0]
-        assert experience_history.region == PrivacyNoticeRegion.us_ny
-        assert experience_history.component == ComponentType.overlay
-        assert experience_history.disabled is False
-        assert experience_history.version == 1.0
-        assert experience_history.experience_config_id == experience_config.id
-        assert (
-            experience_history.experience_config_history_id
-            == experience_config_history.id
-        )
-        assert experience_history.privacy_experience_id == experience.id
-
-        experience_history.delete(db)
         experience.delete(db)
         experience_config_history.delete(db)
         experience_config.delete(db)
@@ -700,20 +682,16 @@ class TestCreateExperienceConfig:
         """
         Specifying a TX region to be used with the new ExperienceConfig can
         cause an existing TX PrivacyExperience to be linked to the current ExperienceConfig
-        with its version bumped
         """
 
         privacy_experience = PrivacyExperience.create(
             db,
             data={
-                "disabled": False,
                 "component": ComponentType.overlay,
                 "region": PrivacyNoticeRegion.us_tx,
             },
         )
 
-        assert privacy_experience.version == 1.0
-        assert privacy_experience.histories.count() == 1.0
         assert privacy_experience.experience_config_id is None
 
         auth_header = generate_auth_header(
@@ -773,7 +751,7 @@ class TestCreateExperienceConfig:
         )
         assert experience_config_history.experience_config_id == experience_config.id
 
-        # Updated Privacy Experience - TX Privacy Experience automatically linked, and bumped to 2.0
+        # Updated Privacy Experience - TX Privacy Experience automatically linked
         assert experience_config.experiences.count() == 1
         experience = experience_config.experiences[0]
         db.refresh(experience)
@@ -782,30 +760,11 @@ class TestCreateExperienceConfig:
         )  # Linked experience is the same Texas experience from above
         assert experience.region == PrivacyNoticeRegion.us_tx
         assert experience.component == ComponentType.overlay
-        assert experience.disabled is False
-        assert experience.version == 2.0
         assert experience.experience_config_id == experience_config.id
-        assert experience.experience_config_history_id == experience_config_history.id
-
-        # Created Experience History - new version of Privacy Experience created due to config being linked
-        assert experience.histories.count() == 2
-        experience_history = experience.histories[-1]
-        assert experience_history.region == PrivacyNoticeRegion.us_tx
-        assert experience_history.component == ComponentType.overlay
-        assert experience_history.disabled is False
-        assert experience_history.version == 2.0
-        assert experience_history.experience_config_id == experience_config.id
-        assert (
-            experience_history.experience_config_history_id
-            == experience_config_history.id
-        )
-        assert experience_history.privacy_experience_id == experience.id
 
         assert response.json()["linked_regions"] == ["us_tx"]
         assert response.json()["unlinked_regions"] == []
 
-        for history in experience.histories:
-            history.delete(db)
         experience.delete(db)
         experience_config_history.delete(db)
         experience_config.delete(db)
@@ -1138,8 +1097,6 @@ class TestUpdateExperienceConfig:
         assert response.json()["linked_regions"] == []
         assert response.json()["unlinked_regions"] == []
 
-        for history in privacy_experience_overlay.histories:
-            history.delete(db)
         privacy_experience_overlay.delete(db)
 
         for history in experience_config.histories:
@@ -1263,26 +1220,8 @@ class TestUpdateExperienceConfig:
         experience = overlay_experience_config.experiences[0]
         assert experience.region == PrivacyNoticeRegion.us_ny
         assert experience.component == ComponentType.overlay
-        assert experience.disabled is False
-        assert experience.version == 1.0
         assert experience.experience_config_id == overlay_experience_config.id
-        assert experience.experience_config_history_id == experience_config_history.id
 
-        # Created Experience History
-        assert experience.histories.count() == 1
-        experience_history = experience.histories[0]
-        assert experience_history.region == PrivacyNoticeRegion.us_ny
-        assert experience_history.component == ComponentType.overlay
-        assert experience_history.disabled is False
-        assert experience_history.version == 1.0
-        assert experience_history.experience_config_id == overlay_experience_config.id
-        assert (
-            experience_history.experience_config_history_id
-            == experience_config_history.id
-        )
-        assert experience_history.privacy_experience_id == experience.id
-
-        experience_history.delete(db)
         experience.delete(db)
 
         assert response.json()["linked_regions"] == ["us_ny"]
@@ -1300,20 +1239,16 @@ class TestUpdateExperienceConfig:
         Existing ExperienceConfig is updated to add TX.  A Texas Privacy Experience already exists.
 
         This should cause the existing Texas PrivacyExperience to be given a FK to the existing ExperienceConfig record
-        with its version bumped as its config has changed.
         """
 
         privacy_experience = PrivacyExperience.create(
             db,
             data={
-                "disabled": False,
                 "component": ComponentType.overlay,
                 "region": PrivacyNoticeRegion.us_tx,
             },
         )
 
-        assert privacy_experience.version == 1.0
-        assert privacy_experience.histories.count() == 1.0
         assert privacy_experience.experience_config_id is None
 
         auth_header = generate_auth_header(scopes=[scopes.PRIVACY_EXPERIENCE_UPDATE])
@@ -1358,7 +1293,7 @@ class TestUpdateExperienceConfig:
             == overlay_experience_config.id
         )
 
-        # Updated Privacy Experience - TX Privacy Experience automatically linked, and bumped to 2.0
+        # Updated Privacy Experience - TX Privacy Experience automatically linked
         assert overlay_experience_config.experiences.count() == 1
         experience = overlay_experience_config.experiences[0]
         db.refresh(experience)
@@ -1367,30 +1302,11 @@ class TestUpdateExperienceConfig:
         )  # Linked experience is the same Texas experience from above
         assert experience.region == PrivacyNoticeRegion.us_tx
         assert experience.component == ComponentType.overlay
-        assert experience.disabled is False
-        assert experience.version == 2.0
         assert experience.experience_config_id == overlay_experience_config.id
-        assert experience.experience_config_history_id == experience_config_history.id
-
-        # Created Experience History - new version of Privacy Experience created due to config being linked
-        assert experience.histories.count() == 2
-        experience_history = experience.histories[-1]
-        assert experience_history.region == PrivacyNoticeRegion.us_tx
-        assert experience_history.component == ComponentType.overlay
-        assert experience_history.disabled is False
-        assert experience_history.version == 2.0
-        assert experience_history.experience_config_id == overlay_experience_config.id
-        assert (
-            experience_history.experience_config_history_id
-            == experience_config_history.id
-        )
-        assert experience_history.privacy_experience_id == experience.id
 
         assert response.json()["linked_regions"] == ["us_tx"]
         assert response.json()["unlinked_regions"] == []
 
-        for history in experience.histories:
-            history.delete(db)
         experience.delete(db)
 
     def test_update_experience_config_experience_also_updated(
@@ -1412,14 +1328,11 @@ class TestUpdateExperienceConfig:
         privacy_experience = PrivacyExperience.create(
             db,
             data={
-                "disabled": False,
                 "component": ComponentType.overlay,
                 "region": PrivacyNoticeRegion.us_tx,
             },
         )
 
-        assert privacy_experience.version == 1.0
-        assert privacy_experience.histories.count() == 1.0
         assert privacy_experience.experience_config_id is None
 
         auth_header = generate_auth_header(scopes=[scopes.PRIVACY_EXPERIENCE_UPDATE])
@@ -1464,7 +1377,7 @@ class TestUpdateExperienceConfig:
             == overlay_experience_config.id
         )
 
-        # Updated Privacy Experience - TX Privacy Experience automatically linked, and bumped to 2.0
+        # Updated Privacy Experience - TX Privacy Experience automatically linked
         assert overlay_experience_config.experiences.count() == 1
         experience = overlay_experience_config.experiences[0]
         db.refresh(experience)
@@ -1473,32 +1386,11 @@ class TestUpdateExperienceConfig:
         )  # Linked experience is the same Texas experience from above
         assert experience.region == PrivacyNoticeRegion.us_tx
         assert experience.component == ComponentType.overlay
-        assert (
-            experience.disabled is True
-        ), "Experience disabled because it was linked to a disabled config"
-        assert experience.version == 2.0
         assert experience.experience_config_id == overlay_experience_config.id
-        assert experience.experience_config_history_id == experience_config_history.id
-
-        # Created Experience History - new version of Privacy Experience created due to config being linked
-        assert experience.histories.count() == 2
-        experience_history = experience.histories[-1]
-        assert experience_history.region == PrivacyNoticeRegion.us_tx
-        assert experience_history.component == ComponentType.overlay
-        assert experience_history.disabled is True
-        assert experience_history.version == 2.0
-        assert experience_history.experience_config_id == overlay_experience_config.id
-        assert (
-            experience_history.experience_config_history_id
-            == experience_config_history.id
-        )
-        assert experience_history.privacy_experience_id == experience.id
 
         assert response.json()["linked_regions"] == ["us_tx"]
         assert response.json()["unlinked_regions"] == []
 
-        for history in experience.histories:
-            history.delete(db)
         experience.delete(db)
 
     def test_update_experience_config_to_remove_region(
@@ -1516,16 +1408,12 @@ class TestUpdateExperienceConfig:
         privacy_experience = PrivacyExperience.create(
             db,
             data={
-                "disabled": False,
                 "component": ComponentType.overlay,
                 "region": PrivacyNoticeRegion.us_tx,
                 "experience_config_id": overlay_experience_config.id,
-                "experience_config_history_id": overlay_experience_config.experience_config_history_id,
             },
         )
 
-        assert privacy_experience.version == 1.0
-        assert privacy_experience.histories.count() == 1.0
         assert privacy_experience.experience_config_id == overlay_experience_config.id
 
         db.refresh(overlay_experience_config)
@@ -1560,35 +1448,13 @@ class TestUpdateExperienceConfig:
             == overlay_experience_config.id
         )
 
-        # Updated Privacy Experience - TX Privacy Experience automatically *unlinked*, and bumped to 2.0
+        # Updated Privacy Experience - TX Privacy Experience automatically *unlinked*
         assert overlay_experience_config.experiences.count() == 0
         db.refresh(privacy_experience)
 
-        assert privacy_experience.version == 2.0
         assert (
             privacy_experience.experience_config_id
             == "pri-7ae3-f06b-4096-970f-0bbbdef-over"
         )  # Default overlay experience config linked instead
-        assert privacy_experience.experience_config_history_id is not None
-        assert (
-            privacy_experience.experience_config_history_id
-            != privacy_experience.experience_config_id
-        )  # Sanity check
 
-        # Created Experience History - new version of Privacy Experience created due to config being *unlinked*
-        assert privacy_experience.histories.count() == 2
-        experience_history = privacy_experience.histories[-1]
-        assert experience_history.region == PrivacyNoticeRegion.us_tx
-        assert experience_history.component == ComponentType.overlay
-        assert experience_history.disabled is False
-        assert experience_history.version == 2.0
-        assert (
-            experience_history.experience_config_id
-            == "pri-7ae3-f06b-4096-970f-0bbbdef-over"
-        )  # Default overlay experience config linked instead
-        assert experience_history.experience_config_history_id is not None
-        assert experience_history.privacy_experience_id == privacy_experience.id
-
-        for history in privacy_experience.histories:
-            history.delete(db)
         privacy_experience.delete(db)

--- a/tests/ops/api/v1/endpoints/test_privacy_notice_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_notice_endpoints.py
@@ -1696,13 +1696,11 @@ class TestPostPrivacyNotices:
         assert (
             overlay_exp.experience_config_id is not None
         )  # And automatically linked to a default config
-        assert overlay_exp.experience_config_history_id is not None
         overlay_copy = (
             overlay_exp.experience_config
         )  # Overlay Experience linked to default overlay copy
         assert overlay_copy.component == ComponentType.overlay
         assert overlay_copy.is_default
-
         assert privacy_center_exp is None
 
         (
@@ -1710,10 +1708,7 @@ class TestPostPrivacyNotices:
             ca_privacy_center_exp,
         ) = PrivacyExperience.get_experiences_by_region(db, PrivacyNoticeRegion.us_ca)
 
-        overlay_exp.histories[0].delete(db)
         overlay_exp.delete(db)
-
-        ca_overlay_exp.histories[0].delete(db)
         ca_overlay_exp.delete(db)
 
     def test_post_privacy_notice_no_notice_key(
@@ -1775,10 +1770,7 @@ class TestPostPrivacyNotices:
         assert privacy_center_exp is None
 
         assert overlay_exp.component == ComponentType.overlay
-        assert overlay_exp.version == 1.0
-        assert overlay_exp.disabled is False
         assert overlay_exp.experience_config_id is not None
-        assert overlay_exp.experience_config_history_id is not None
 
         (
             ca_overlay_exp,
@@ -1788,12 +1780,8 @@ class TestPostPrivacyNotices:
         assert ca_privacy_center_exp is None
 
         assert ca_overlay_exp.component == ComponentType.overlay
-        assert ca_overlay_exp.version == 1.0
-        assert ca_overlay_exp.disabled is False
         assert ca_overlay_exp.experience_config_id is not None
-        assert ca_overlay_exp.experience_config_history_id is not None
 
-        overlay_exp.histories[0].delete(db)
         overlay_exp.delete(db)
 
     def test_post_privacy_notice_duplicate_regions(
@@ -2613,10 +2601,8 @@ class TestPatchPrivacyNotices:
             db, PrivacyNoticeRegion.us_ca
         )
         assert overlay_exp.component == ComponentType.overlay
-        assert overlay_exp.version == 1.0
 
         assert privacy_center_exp.component == ComponentType.privacy_center
-        assert privacy_center_exp.version == 1.0
 
     def test_patch_multiple_privacy_notices(
         self,

--- a/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
@@ -291,7 +291,7 @@ class TestSavePrivacyPreferencesPrivacyCenter:
         assert privacy_preference_history.request_origin is None
         assert privacy_preference_history.user_agent == "testclient"
         assert privacy_preference_history.privacy_experience_config_history_id is None
-        assert privacy_preference_history.privacy_experience_history_id is None
+        assert privacy_preference_history.privacy_experience_id is None
         assert mock_anonymize.call_args.args[0] == "testclient"
         assert privacy_preference_history.anonymized_ip_address == masked_ip
         assert privacy_preference_history.url_recorded is None
@@ -978,7 +978,7 @@ class TestSavePrivacyPreferencesForFidesDeviceId:
             ],
             "policy_key": consent_policy.key,
             "user_geography": "us_ca",
-            "privacy_experience_history_id": privacy_experience_overlay.histories[0].id,
+            "privacy_experience_id": privacy_experience_overlay.id,
             "method": "button",
         }
 
@@ -1027,15 +1027,12 @@ class TestSavePrivacyPreferencesForFidesDeviceId:
         request_body,
     ):
         """Privacy experiences need to be valid when setting preferences"""
-        request_body["privacy_experience_history_id"] = "bad_id"
+        request_body["privacy_experience_id"] = "bad_id"
         response = api_client.patch(
             url, json=request_body, headers={"Origin": "http://localhost:8080"}
         )
         assert response.status_code == 404
-        assert (
-            response.json()["detail"]
-            == f"Privacy Experience History 'bad_id' not found."
-        )
+        assert response.json()["detail"] == f"Privacy Experience 'bad_id' not found."
 
     @mock.patch(
         "fides.api.api.v1.endpoints.privacy_preference_endpoints.anonymize_ip_address"
@@ -1111,11 +1108,11 @@ class TestSavePrivacyPreferencesForFidesDeviceId:
         )  # Retrieved from request headers
         assert (
             privacy_preference_history.privacy_experience_config_history_id
-            == privacy_experience_overlay.histories[0].experience_config_history_id
+            == privacy_experience_overlay.experience_config.experience_config_history_id
         )
         assert (
-            privacy_preference_history.privacy_experience_history_id
-            == privacy_experience_overlay.histories[0].id
+            privacy_preference_history.privacy_experience_id
+            == privacy_experience_overlay.id
         )
         assert privacy_preference_history.anonymized_ip_address == masked_ip
         assert privacy_preference_history.url_recorded is None
@@ -1234,13 +1231,11 @@ class TestHistoricalPreferences:
         assert response_body["truncated_ip_address"] == "92.158.1.0"
         assert (
             response_body["experience_config_history_id"]
-            == privacy_experience_privacy_center.histories[
-                0
-            ].experience_config_history_id
+            == privacy_experience_privacy_center.experience_config.experience_config_history_id
         )
         assert (
-            response_body["privacy_experience_history_id"]
-            == privacy_experience_privacy_center.histories[0].id
+            response_body["privacy_experience_id"]
+            == privacy_experience_privacy_center.id
         )
 
     def test_get_historical_preferences_ordering(


### PR DESCRIPTION
Closes #3465 

❗ Contains data migration; check downrev before merge

### Code Changes

Continue to deduplicate info between PrivacyExperience and PrivacyExperienceConfig.

- Remove common fields between the models like PrivacyExperience.disabled and PrivacyExperience.experience_config_history_id - these are at risk of getting out of sync
- Now that we've removed most of the fields from PrivacyExperience and it is largely just a linking table, I don't think we need to version this. Remove PrivacyExperience.version, and the entire PrivacyExperienceHistory table.
- PrivacyPreferenceHistory was referencing the PrivacyExperienceHistory id, but now that this doesn't exist, have it reference the PrivacyExperience id instead.
- When filtering PrivacyExperiences on disabled, actually filter the corresponding field on the PrivacyExperienceConfig resource.

### Steps to Confirm

* [ ] `nox -s dev -- shell`
* [ ] Get a privacy experience for a specific region, ex. {{host}}/privacy-experience/?region=eu_ee
* [ ] Note that version, disabled, and experience_config_history_id have been removed from the response, (but `version` and `disabled` are still present in the embedded `experience_config` object)
* [ ] Note both the "id" of that experience, and the historical `id` of one of the notices embedded in that experience
* [ ] Save privacy preferences with {{host}}/privacy-preferences. Note that fides_user_device_id must be a valid uuid4.  Note that a new field in this request is `privacy_experience_id`
```
{
   "browser_identity": {
       "ga_client_id": "UA-XXXXXXXXX",
       "ljt_readerID": "test_sovrn_id",
       "fides_user_device_id": "{{fides_user_device_id}}"
   },
   "preferences": [{
       "privacy_notice_history_id": "{{privacy_notice_history_id}}",
       "preference": "opt_out"
   }],
   "user_geography": "us_ca",
   "privacy_experience_id": "{{privacy_experience_id}}",
   "method": "button"
}
```
* [ ] Get the historical preferences {{host}}/historical-privacy-preferences and verify both the `privacy_notice_history_id` and `privacy_experience_id` as well as the `experience_config_history_id` which was lifted from the experience and added here for record keeping

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Further side effects of https://github.com/ethyca/fides/pull/3387

Now that we've relaxed a lot of the constraints around privacy experiences we no longer need as many fields on the PrivacyExperience table.  There used to be necessary duplication between PrivacyExperience and PrivacyExperienceConfig but now this isn't required and we're just at risk of the tables getting out of sync.  This surfaced when testing "creating experiences out of the box - as an area that had gotten out of sync).  h/t to @adamsachs for also raising the importance of what tables were storing which information here: https://github.com/ethyca/fides/pull/3387#discussion_r1214456787

Primarily I deduplicate all the info between the two tables except for "component" and stop tracking history of privacy experiences now that there's barely anything on this table.

Saving privacy preferences should now pass on the "experience id" instead of the "experience history id" (because it doesn't exist)
