### PR TITLE
Frontend experience id swap

### DIFF
--- a/clients/admin-ui/src/types/api/models/ConsentReport.ts
+++ b/clients/admin-ui/src/types/api/models/ConsentReport.ts
@@ -13,6 +13,7 @@ export type ConsentReport = {
   opt_in: boolean;
   has_gpc_flag?: boolean;
   conflicts_with_gpc?: boolean;
+  id: string;
   identity: IdentityBase;
   created_at: string;
   updated_at: string;

--- a/clients/admin-ui/src/types/api/models/ConsentReportingSchema.ts
+++ b/clients/admin-ui/src/types/api/models/ConsentReportingSchema.ts
@@ -33,7 +33,7 @@ export type ConsentReportingSchema = {
   url_recorded?: string;
   user_agent?: string;
   experience_config_history_id?: string;
-  privacy_experience_history_id?: string;
+  privacy_experience_id?: string;
   truncated_ip_address?: string;
   method?: ConsentMethod;
 };

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
@@ -42,9 +42,12 @@ export type ExperienceConfigCreate = {
    * Overlay 'Privacy preferences link label'
    */
   privacy_preferences_link_label?: string;
+  /**
+   * Regions using this ExperienceConfig
+   */
+  regions?: Array<PrivacyNoticeRegion>;
   reject_button_label: string;
   save_button_label: string;
   title: string;
   component: ComponentType;
-  regions: Array<PrivacyNoticeRegion>;
 };

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
@@ -46,6 +46,7 @@ export type ExperienceConfigResponse = {
    * Overlay 'Privacy preferences link label'
    */
   privacy_preferences_link_label?: string;
+  regions: Array<PrivacyNoticeRegion>;
   /**
    * Overlay 'Reject button displayed on the Banner and 'Privacy Preferences' of Privacy Center 'Reject button label'
    */
@@ -64,5 +65,4 @@ export type ExperienceConfigResponse = {
   version: number;
   created_at: string;
   updated_at: string;
-  regions: Array<PrivacyNoticeRegion>;
 };

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
@@ -46,6 +46,10 @@ export type ExperienceConfigUpdate = {
    */
   privacy_preferences_link_label?: string;
   /**
+   * Regions using this ExperienceConfig
+   */
+  regions?: Array<PrivacyNoticeRegion>;
+  /**
    * Overlay 'Reject button displayed on the Banner and 'Privacy Preferences' of Privacy Center 'Reject button label'
    */
   reject_button_label?: string;
@@ -57,8 +61,4 @@ export type ExperienceConfigUpdate = {
    * Overlay 'Banner title' or Privacy Center 'title'
    */
   title?: string;
-  /**
-   * If None, no edits will be made to regions.  If an empty list, all regions will be removed.
-   */
-  regions?: Array<PrivacyNoticeRegion>;
 };

--- a/clients/admin-ui/src/types/api/models/PrivacyExperienceResponse.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyExperienceResponse.ts
@@ -13,13 +13,10 @@ import type { PrivacyNoticeResponseWithUserPreferences } from "./PrivacyNoticeRe
 export type PrivacyExperienceResponse = {
   region: PrivacyNoticeRegion;
   component?: ComponentType;
-  disabled?: boolean;
   experience_config?: ExperienceConfigResponse;
   id: string;
   created_at: string;
   updated_at: string;
-  version: number;
-  privacy_experience_history_id: string;
   show_banner?: boolean;
   privacy_notices?: Array<PrivacyNoticeResponseWithUserPreferences>;
 };

--- a/clients/admin-ui/src/types/api/models/PrivacyNoticeRegion.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyNoticeRegion.ts
@@ -83,4 +83,11 @@ export enum PrivacyNoticeRegion {
   EU_SK = "eu_sk",
   EU_FI = "eu_fi",
   EU_SE = "eu_se",
+  GB_ENG = "gb_eng",
+  GB_SCT = "gb_sct",
+  GB_WLS = "gb_wls",
+  GB_NIR = "gb_nir",
+  ISL = "isl",
+  NOR = "nor",
+  LI = "li",
 }

--- a/clients/admin-ui/src/types/api/models/PrivacyPreferencesRequest.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyPreferencesRequest.ts
@@ -15,7 +15,7 @@ export type PrivacyPreferencesRequest = {
   code?: string;
   preferences: Array<ConsentOptionCreate>;
   policy_key?: string;
-  privacy_experience_history_id?: string;
+  privacy_experience_id?: string;
   user_geography?: PrivacyNoticeRegion;
   method?: ConsentMethod;
 };

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -50,7 +50,7 @@ const Overlay: FunctionComponent<OverlayProps> = ({
     });
     updateConsentPreferences({
       consentPreferencesToSave,
-      experienceHistoryId: experience.privacy_experience_history_id,
+      experienceId: experience.id,
       fidesApiUrl: options.fidesApiUrl,
       consentMethod: ConsentMethod.button,
       userLocationString: fidesRegionString,
@@ -71,7 +71,7 @@ const Overlay: FunctionComponent<OverlayProps> = ({
     });
     updateConsentPreferences({
       consentPreferencesToSave,
-      experienceHistoryId: experience.privacy_experience_history_id,
+      experienceId: experience.id,
       fidesApiUrl: options.fidesApiUrl,
       consentMethod: ConsentMethod.button,
       userLocationString: fidesRegionString,
@@ -97,7 +97,7 @@ const Overlay: FunctionComponent<OverlayProps> = ({
     });
     updateConsentPreferences({
       consentPreferencesToSave,
-      experienceHistoryId: experience.privacy_experience_history_id,
+      experienceId: experience.id,
       fidesApiUrl: options.fidesApiUrl,
       consentMethod: ConsentMethod.button,
       userLocationString: fidesRegionString,

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -152,7 +152,7 @@ const automaticallyApplyGPCPreferences = (
   if (consentPreferencesToSave.length > 0) {
     updateConsentPreferences({
       consentPreferencesToSave,
-      experienceHistoryId: effectiveExperience.privacy_experience_history_id,
+      experienceId: effectiveExperience.id,
       fidesApiUrl,
       consentMethod: ConsentMethod.gpc,
       userLocationString: fidesRegionString || undefined,

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -57,13 +57,10 @@ export class SaveConsentPreference {
 export type PrivacyExperience = {
   region: string; // intentionally using plain string instead of Enum, since BE is susceptible to change
   component?: ComponentType;
-  disabled?: boolean;
   experience_config?: ExperienceConfig;
   id: string;
   created_at: string;
   updated_at: string;
-  version: number;
-  privacy_experience_history_id: string;
   show_banner?: boolean;
   privacy_notices?: Array<PrivacyNotice>;
 };
@@ -174,7 +171,7 @@ export type PrivacyPreferencesRequest = {
   code?: string;
   preferences: Array<ConsentOptionCreate>;
   policy_key?: string; // Will use default consent policy if not supplied
-  privacy_experience_history_id?: string;
+  privacy_experience_id?: string;
   user_geography?: string;
   method?: ConsentMethod;
 };

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -17,7 +17,7 @@ import { patchUserPreferenceToFidesServer } from "../services/fides/api";
  */
 export const updateConsentPreferences = ({
   consentPreferencesToSave,
-  experienceHistoryId,
+  experienceId,
   fidesApiUrl,
   consentMethod,
   userLocationString,
@@ -25,7 +25,7 @@ export const updateConsentPreferences = ({
   debug = false,
 }: {
   consentPreferencesToSave: Array<SaveConsentPreference>;
-  experienceHistoryId: string;
+  experienceId: string;
   fidesApiUrl: string;
   consentMethod: ConsentMethod;
   userLocationString?: string;
@@ -59,7 +59,7 @@ export const updateConsentPreferences = ({
   const privacyPreferenceCreate: PrivacyPreferencesRequest = {
     browser_identity: cookie.identity,
     preferences: fidesUserPreferences,
-    privacy_experience_history_id: experienceHistoryId,
+    privacy_experience_id: experienceId,
     user_geography: userLocationString,
     method: consentMethod,
   };

--- a/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
@@ -138,7 +138,7 @@ const NoticeDrivenConsent = () => {
       browser_identity: identities,
       preferences,
       user_geography: region,
-      privacy_experience_history_id: experience?.privacy_experience_history_id,
+      privacy_experience_id: experience?.id,
       method: ConsentMethod.BUTTON,
       code: verificationCode,
     };

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -279,7 +279,7 @@ describe("Consent banner", () => {
                   preference: "acknowledge",
                 },
               ],
-              privacy_experience_history_id: "2342345",
+              privacy_experience_id: "132345243",
               user_geography: "us_ca",
               method: ConsentMethod.button,
             };
@@ -287,8 +287,8 @@ describe("Consent banner", () => {
             generatedUserDeviceId = body.browser_identity.fides_user_device_id;
             expect(generatedUserDeviceId).to.be.a("string");
             expect(body.preferences).to.eql(expected.preferences);
-            expect(body.privacy_experience_history_id).to.eql(
-              expected.privacy_experience_history_id
+            expect(body.privacy_experience_id).to.eql(
+              expected.privacy_experience_id
             );
             expect(body.user_geography).to.eql(expected.user_geography);
             expect(body.method).to.eql(expected.method);
@@ -376,7 +376,7 @@ describe("Consent banner", () => {
                 preference: "acknowledge",
               },
             ],
-            privacy_experience_history_id: "2342345",
+            privacy_experience_id: "132345243",
             user_geography: "us_ca",
             method: ConsentMethod.button,
           };
@@ -428,8 +428,8 @@ describe("Consent banner", () => {
                 regions: ["us_ca"],
                 consent_mechanism: ConsentMechanism.OPT_OUT,
                 default_preference: UserConsentPreference.OPT_IN,
-                current_preference: null,
-                outdated_preference: null,
+                current_preference: undefined,
+                outdated_preference: undefined,
                 has_gpc_flag: true,
                 data_uses: ["advertising", "third_party_sharing"],
                 enforcement_level: EnforcementLevel.SYSTEM_WIDE,
@@ -463,7 +463,7 @@ describe("Consent banner", () => {
                 preference: "opt_out",
               },
             ],
-            privacy_experience_history_id: "2342345",
+            privacy_experience_id: "132345243",
             user_geography: "us_ca",
             method: ConsentMethod.gpc,
           };
@@ -471,8 +471,8 @@ describe("Consent banner", () => {
           generatedUserDeviceId = body.browser_identity.fides_user_device_id;
           expect(generatedUserDeviceId).to.be.a("string");
           expect(body.preferences).to.eql(expected.preferences);
-          expect(body.privacy_experience_history_id).to.eql(
-            expected.privacy_experience_history_id
+          expect(body.privacy_experience_id).to.eql(
+            expected.privacy_experience_id
           );
           expect(body.user_geography).to.eql(expected.user_geography);
           expect(body.method).to.eql(expected.method);
@@ -521,8 +521,8 @@ describe("Consent banner", () => {
                 regions: ["us_ca"],
                 consent_mechanism: ConsentMechanism.OPT_OUT,
                 default_preference: UserConsentPreference.OPT_IN,
-                current_preference: null,
-                outdated_preference: null,
+                current_preference: undefined,
+                outdated_preference: undefined,
                 has_gpc_flag: false,
                 data_uses: ["advertising", "third_party_sharing"],
                 enforcement_level: EnforcementLevel.SYSTEM_WIDE,
@@ -581,8 +581,8 @@ describe("Consent banner", () => {
                 regions: ["us_ca"],
                 consent_mechanism: ConsentMechanism.OPT_OUT,
                 default_preference: UserConsentPreference.OPT_IN,
-                current_preference: null,
-                outdated_preference: null,
+                current_preference: undefined,
+                outdated_preference: undefined,
                 has_gpc_flag: true,
                 data_uses: ["advertising", "third_party_sharing"],
                 enforcement_level: EnforcementLevel.SYSTEM_WIDE,

--- a/clients/privacy-center/cypress/e2e/consent-notices.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-notices.cy.ts
@@ -96,11 +96,10 @@ describe("Privacy notice driven consent", () => {
       cy.getByTestId("save-btn").click();
       cy.wait("@patchPrivacyPreference").then((interception) => {
         const { body } = interception.request;
-        console.log({ body });
-        const { preferences, code, method, privacy_experience_id } = body;
+        const { preferences, code, method, privacy_experience_id: id } = body;
         expect(method).to.eql("button");
         expect(code).to.eql(VERIFICATION_CODE);
-        expect(privacy_experience_id).to.eql(PRIVACY_EXPERIENCE_ID);
+        expect(id).to.eql(PRIVACY_EXPERIENCE_ID);
         expect(
           preferences.map((p: ConsentOptionCreate) => p.preference)
         ).to.eql(["opt_in", "opt_in"]);

--- a/clients/privacy-center/cypress/e2e/consent-notices.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-notices.cy.ts
@@ -8,6 +8,7 @@ import { API_URL } from "../support/constants";
 const VERIFICATION_CODE = "112358";
 const PRIVACY_NOTICE_ID_1 = "pri_b4360591-3cc7-400d-a5ff-a9f095ab3061";
 const PRIVACY_NOTICE_ID_2 = "pri_b558ab1f-5367-4f0d-94b1-ec06a81ae821";
+const PRIVACY_EXPERIENCE_ID = "pri_041acb07-c99b-4085-a435-c0d6f3a42b6f";
 const GEOLOCATION_API_URL = "https://www.example.com/location";
 const SETTINGS = {
   IS_OVERLAY_DISABLED: false,
@@ -95,9 +96,11 @@ describe("Privacy notice driven consent", () => {
       cy.getByTestId("save-btn").click();
       cy.wait("@patchPrivacyPreference").then((interception) => {
         const { body } = interception.request;
-        const { preferences, code, method } = body;
+        console.log({ body });
+        const { preferences, code, method, privacy_experience_id } = body;
         expect(method).to.eql("button");
         expect(code).to.eql(VERIFICATION_CODE);
+        expect(privacy_experience_id).to.eql(PRIVACY_EXPERIENCE_ID);
         expect(
           preferences.map((p: ConsentOptionCreate) => p.preference)
         ).to.eql(["opt_in", "opt_in"]);

--- a/clients/privacy-center/cypress/fixtures/consent/experience.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience.json
@@ -3,7 +3,6 @@
     {
       "region": "us_ca",
       "component": "privacy_center",
-      "disabled": false,
       "experience_config": {
         "accept_button_label": "sounds good",
         "acknowledge_button_label": "ok",
@@ -28,8 +27,6 @@
       "id": "pri_041acb07-c99b-4085-a435-c0d6f3a42b6f",
       "created_at": "2023-06-02T15:22:02.604734+00:00",
       "updated_at": "2023-06-02T15:28:28.469659+00:00",
-      "version": 3.0,
-      "privacy_experience_history_id": "pri_94142e00-97da-4eb4-8f8c-9b848b65636c",
       "show_banner": false,
       "privacy_notices": [
         {

--- a/clients/privacy-center/cypress/fixtures/consent/overlay_experience.json
+++ b/clients/privacy-center/cypress/fixtures/consent/overlay_experience.json
@@ -3,7 +3,6 @@
     {
       "region": "us_ca",
       "component": "overlay",
-      "disabled": false,
       "experience_config": {
         "accept_button_label": "Accept Test",
         "acknowledge_button_label": "Got it",
@@ -28,8 +27,6 @@
       "id": "pri_b9d1af04-5852-4499-bdfb-2778a6117fb8",
       "created_at": "2023-06-02T15:18:56.110785+00:00",
       "updated_at": "2023-06-02T16:40:37.340905+00:00",
-      "version": 2.0,
-      "privacy_experience_history_id": "pri_1255e8a0-9b39-42c2-80db-edc83fba44f8",
       "show_banner": true,
       "privacy_notices": [
         {

--- a/clients/privacy-center/cypress/fixtures/consent/test_banner_options.json
+++ b/clients/privacy-center/cypress/fixtures/consent/test_banner_options.json
@@ -17,11 +17,8 @@
     "id": "132345243",
     "created_at": "2023-04-24T21:29:08.870351+00:00",
     "updated_at": "2023-04-24T21:29:08.870351+00:00",
-    "version": "1.0",
     "component": "overlay",
-    "disabled": false,
     "region": "us_ca",
-    "privacy_experience_history_id": "2342345",
     "show_banner": true,
     "experience_config": {
       "accept_button_label": "Accept Test",

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -24,15 +24,12 @@
           ],
         },
         experience: {
-          version: "1.0",
           id: "132345243",
-          disabled: false,
           region: "us_ca",
           show_banner: true,
           component: "overlay",
           created_at: "2023-04-24T21:29:08.870351+00:00",
           updated_at: "2023-04-24T21:29:08.870351+00:00",
-          privacy_experience_history_id: "2342345",
           experience_config: {
             accept_button_label: "Accept Test",
             acknowledge_button_label: "OK",

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
@@ -46,6 +46,7 @@ export type ExperienceConfigResponse = {
    * Overlay 'Privacy preferences link label'
    */
   privacy_preferences_link_label?: string;
+  regions: Array<PrivacyNoticeRegion>;
   /**
    * Overlay 'Reject button displayed on the Banner and 'Privacy Preferences' of Privacy Center 'Reject button label'
    */
@@ -64,5 +65,4 @@ export type ExperienceConfigResponse = {
   version: number;
   created_at: string;
   updated_at: string;
-  regions: Array<PrivacyNoticeRegion>;
 };

--- a/clients/privacy-center/types/api/models/PrivacyExperienceResponse.ts
+++ b/clients/privacy-center/types/api/models/PrivacyExperienceResponse.ts
@@ -13,13 +13,10 @@ import type { PrivacyNoticeResponseWithUserPreferences } from "./PrivacyNoticeRe
 export type PrivacyExperienceResponse = {
   region: PrivacyNoticeRegion;
   component?: ComponentType;
-  disabled?: boolean;
   experience_config?: ExperienceConfigResponse;
   id: string;
   created_at: string;
   updated_at: string;
-  version: number;
-  privacy_experience_history_id: string;
   show_banner?: boolean;
   privacy_notices?: Array<PrivacyNoticeResponseWithUserPreferences>;
 };

--- a/clients/privacy-center/types/api/models/PrivacyNoticeRegion.ts
+++ b/clients/privacy-center/types/api/models/PrivacyNoticeRegion.ts
@@ -83,4 +83,11 @@ export enum PrivacyNoticeRegion {
   EU_SK = "eu_sk",
   EU_FI = "eu_fi",
   EU_SE = "eu_se",
+  GB_ENG = "gb_eng",
+  GB_SCT = "gb_sct",
+  GB_WLS = "gb_wls",
+  GB_NIR = "gb_nir",
+  ISL = "isl",
+  NOR = "nor",
+  LI = "li",
 }

--- a/clients/privacy-center/types/api/models/PrivacyPreferencesRequest.ts
+++ b/clients/privacy-center/types/api/models/PrivacyPreferencesRequest.ts
@@ -15,7 +15,7 @@ export type PrivacyPreferencesRequest = {
   code?: string;
   preferences: Array<ConsentOptionCreate>;
   policy_key?: string;
-  privacy_experience_history_id?: string;
+  privacy_experience_id?: string;
   user_geography?: PrivacyNoticeRegion;
   method?: ConsentMethod;
 };


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3472

### Code Changes

* [x] Update all TS types
* [x] Follow the TS errors to fix all the changes 😄 
  * [x] Mostly this was a change where the `experience` obj no longer has a `privacy_experience_history_id`, and instead we pass in its `id`
* [x] Update corresponding tests and fixtures

### Steps to Confirm

* Saving your consent still works!

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
