### PR TITLE
fix up tagging utility

### DIFF
--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -30,14 +30,16 @@ def verify_git_tag(session: nox.Session) -> str:
     """
     existing_commit_tag = get_current_tag(existing=True)
     if existing_commit_tag is None:
-        session.error(
+        session.warn(
             "Did not find an existing git tag on the current commit, not pushing git-tag images"
         )
+        return None
 
     if not recognized_tag(existing_commit_tag):
-        session.error(
+        session.warn(
             f"Existing git tag {existing_commit_tag} is not a recognized tag, not pushing git-tag images"
         )
+        return None
 
     session.log(
         f"Found git tag {existing_commit_tag} on the current commit, pushing corresponding git-tag images!"
@@ -255,6 +257,10 @@ def push(session: nox.Session, tag: str) -> None:
         external=True,
         success_codes=[0, 1],  # Will fail if it already exists, but this is fine
     )
+
+    # special case for git-tag - if we don't find a valid one, exit gracefully
+    if tag == "git-tag" and verify_git_tag(session) is None:
+        return
 
     # Use lambdas to force lazy evaluation
     param_tag_map = {

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -30,16 +30,14 @@ def verify_git_tag(session: nox.Session) -> str:
     """
     existing_commit_tag = get_current_tag(existing=True)
     if existing_commit_tag is None:
-        session.warn(
+        session.skip(
             "Did not find an existing git tag on the current commit, not pushing git-tag images"
         )
-        return None
 
     if not recognized_tag(existing_commit_tag):
-        session.warn(
+        session.skip(
             f"Existing git tag {existing_commit_tag} is not a recognized tag, not pushing git-tag images"
         )
-        return None
 
     session.log(
         f"Found git tag {existing_commit_tag} on the current commit, pushing corresponding git-tag images!"
@@ -257,10 +255,6 @@ def push(session: nox.Session, tag: str) -> None:
         external=True,
         success_codes=[0, 1],  # Will fail if it already exists, but this is fine
     )
-
-    # special case for git-tag - if we don't find a valid one, exit gracefully
-    if tag == "git-tag" and verify_git_tag(session) is None:
-        return
 
     # Use lambdas to force lazy evaluation
     param_tag_map = {

--- a/noxfiles/git_nox.py
+++ b/noxfiles/git_nox.py
@@ -27,7 +27,7 @@ class TagType(Enum):
     BETA = "b"  # used for `main` branch
 
 
-def get_all_tags(repo):
+def get_all_tags(repo) -> List[str]:
     """
     Returns a list of all tags in the repo, sorted by committed date, latest first
     """
@@ -105,7 +105,7 @@ def tag(session: nox.Session, action: str) -> None:
         session.error(f"Invalid action: {action}")
 
 
-def next_release_increment(session: nox.Session, all_tags: List):
+def next_release_increment(session: nox.Session, all_tags: List) -> Version:
     """Helper to generate the next release 'increment' based on latest release tag found"""
 
     releases = sorted(  # sorted by Version - what we want!

--- a/noxfiles/git_nox.py
+++ b/noxfiles/git_nox.py
@@ -4,8 +4,9 @@ import re
 from enum import Enum
 from typing import List, Optional
 
-import nox
 from packaging.version import Version
+
+import nox
 
 RELEASE_BRANCH_REGEX = r"release-(([0-9]+\.)+[0-9]+)"
 RELEASE_TAG_REGEX = r"(([0-9]+\.)+[0-9]+)"
@@ -106,12 +107,18 @@ def tag(session: nox.Session, action: str) -> None:
 
 def next_release_increment(session: nox.Session, all_tags: List):
     """Helper to generate the next release 'increment' based on latest release tag found"""
-    latest_release = next(
-        tag.name for tag in all_tags if re.fullmatch(RELEASE_TAG_REGEX, tag.name)
+
+    releases = sorted(  # sorted by Version - what we want!
+        (
+            Version(tag.name)
+            for tag in all_tags
+            if re.fullmatch(RELEASE_TAG_REGEX, tag.name)
+        ),
+        reverse=True,
     )
+    latest_release = releases[0]
     if not latest_release:  # this would be bad...
         session.error("Could not identify the latest release!")
-    latest_release = Version(latest_release)
     return Version(
         f"{latest_release.major}.{latest_release.minor}.{latest_release.micro + 1}"
     )
@@ -139,24 +146,30 @@ def increment_tag(
     version_branch_tag_pattern = VERSION_TAG_REGEX.format(
         version=version_number, tag_type=tag_type.value
     )
+
     # find our latest existing tag for this version/type
     sorted_tag_matches = sorted(
         (
-            tag.name
+            re.fullmatch(version_branch_tag_pattern, tag.name)
             for tag in all_tags
             if re.fullmatch(version_branch_tag_pattern, tag.name)
         ),
+        key=lambda match: int(
+            match.group(1)
+        ),  # numeric (not alphabetical) sort of the tag increment
         reverse=True,
     )
-    latest_tag = re.fullmatch(
-        version_branch_tag_pattern,
-        sorted_tag_matches[0] if sorted_tag_matches else "",
-    )
-    if latest_tag:  # if we have an existing tag for this version/type, increment it
+
+    latest_tag_match = sorted_tag_matches[0] if sorted_tag_matches else None
+    if (
+        latest_tag_match
+    ):  # if we have an existing tag for this version/type, increment it
         session.log(
-            f"Found existing {tag_type.name.lower()} tag {latest_tag.group(0)}, incrementing it"
+            f"Found existing {tag_type.name.lower()} tag {latest_tag_match.group(0)}, incrementing it"
         )
-        tag_increment = int(latest_tag.group(1)) + TAG_INCREMENT  # increment the tag
+        tag_increment = (
+            int(latest_tag_match.group(1)) + TAG_INCREMENT
+        )  # increment the tag
         return f"{version_number}{tag_type.value}{tag_increment}"
         # return the full {version_number}{tag_type}{increment}
 

--- a/noxfiles/test_git_nox.py
+++ b/noxfiles/test_git_nox.py
@@ -24,6 +24,16 @@ class TestGitNox:
         [
             ("main", ["2.9.0"], "2.9.1b0"),
             ("main", ["2.9.1", "2.9.0"], "2.9.2b0"),
+            (
+                "main",
+                ["2.9.0", "2.9.1"],
+                "2.9.2b0",
+            ),  # releases _could_ be "out of order" chronological order, for e.g. hotfixes
+            (
+                "main",
+                ["2.9.0", "2.10.0"],
+                "2.10.1b0",
+            ),  # out of order releases with version >= 10 to ensure numerical sort
             ("some-test-feature-branch", ["2.9.1"], "2.9.2a0"),
             ("some-test-feature-branch", ["2.9.1", "2.9.0"], "2.9.2a0"),
             (
@@ -35,7 +45,12 @@ class TestGitNox:
                 "some-other-feature",
                 ["2.14.1a0", "2.14.1a1", "2.14.0"],
                 "2.14.1a2",
-            ),  # hit unsorted tags with these versions as of 2023-05-30, testing sorted list of tags
+            ),  # unsorted tags
+            (
+                "some-other-feature",
+                ["2.14.1a9", "2.14.1a10", "2.14.0"],
+                "2.14.1a11",
+            ),  # unsorted tags with current increment = 10 to ensure we're doing a numeric sort
             ("release-2.9.0", [], "2.9.0rc0"),
             ("release-2.9.0", ["2.9.0rc1"], "2.9.0rc2"),
             (


### PR DESCRIPTION
Closes n/a (reported by @NevilleS in slack)

### Code Changes

* [ ] fixed `increment_tag` function to sort increments numerically rather than alphabetically
* [ ] fixed `next_release_increment` function to sort releases by version number (using `packaging.Version`) rather than relying on datetime (not a reported bug, but noticed this in analysis)
* [ ] adjusted the `git-tag` param for `nox -s push` to gracefully exit with a warning message rather than error out, if current commit does not have a git tag
    * unrelated to the above problems, but i happened to notice was causing red-herring failures in our GH actions on `main`: https://github.com/ethyca/fides/actions/runs/5192945794/jobs/9362813520


### Steps to Confirm

* [ ] confirm `nox -s "tag(dry)"` works well if increment >= 10, e.g. if we are on `2.14.1a11`, it should output `2.14.1a12`!

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

A couple of tagging improvements to handle edge cases, and a (basically unrelated) QOL improvement for our CI actions that i happened to notice.