### PR TITLE
Parallelize Docker Publishing

### DIFF
--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -214,6 +214,7 @@ def push_fides_images(session: nox.Session, tag_suffixes: List[str]) -> None:
     session.run(*sample_app_buildx_command, external=True)
 
 
+# Add Params for building each image
 @nox.session()
 @nox.parametrize(
     "tag",

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -1,9 +1,8 @@
 """Contains the nox sessions for docker-related tasks."""
 import platform
-from typing import List, Tuple, Dict, Callable
 from multiprocessing import Pool
 from subprocess import run
-from functools import partial
+from typing import Callable, Dict, List, Tuple
 
 import nox
 from constants_nox import (
@@ -25,7 +24,11 @@ DOCKER_PLATFORM_MAP = {
     "x86_64": "linux/amd64",
 }
 DOCKER_PLATFORMS = "linux/amd64,linux/arm64"
-partial_run = partial(run, shell=True, check=True)
+
+
+def runner(args):
+    args_str = " ".join(args)
+    run(args_str, shell=True, check=True)
 
 
 def verify_git_tag(session: nox.Session) -> str:
@@ -188,11 +191,6 @@ def build(session: nox.Session, image: str, machine_type: str = "") -> None:
     session.run(*build_command, external=True)
 
 
-def session_runner(command: Tuple[str, ...], session: nox.Session) -> None:
-    """Utility function for use with multiprocessing."""
-    session.run(*command, external=True)
-
-
 def get_buildx_commands(tag_suffixes: List[str]) -> List[Tuple[str, ...]]:
     """
     Build and publish each image to Dockerhub
@@ -284,4 +282,4 @@ def push(session: nox.Session, tag: str) -> None:
     # Parallel build the various images
     number_of_processes = len(buildx_commands)
     with Pool(number_of_processes) as process_pool:
-        process_pool.map(partial_run, buildx_commands)
+        process_pool.map(runner, buildx_commands)

--- a/noxfiles/test_docker_nox.py
+++ b/noxfiles/test_docker_nox.py
@@ -2,10 +2,10 @@ from unittest import mock
 
 import pytest
 
-from docker_nox import generate_multiplatform_buildx_command, push
+from docker_nox import generate_multiplatform_buildx_command, get_buildx_commands
 
 
-class TestBuildxPrivacyCenter:
+class TestGenerateMultiplatformBuilxCommand:
     def test_single_tag(self) -> None:
         actual_result = generate_multiplatform_buildx_command(["foo"], "prod")
         expected_result = (
@@ -60,13 +60,15 @@ class TestBuildxPrivacyCenter:
         )
         assert actual_result == expected_result
 
+
+class TestGetBuildxCommands:
     @pytest.mark.parametrize(
         "tag,expected_commands",
         [
             (
                 "dev",
                 [
-                    mock.call.run(
+                    (
                         "docker",
                         "buildx",
                         "build",
@@ -77,9 +79,8 @@ class TestBuildxPrivacyCenter:
                         ".",
                         "--tag",
                         "ethyca/fides:dev",
-                        external=True,
                     ),
-                    mock.call.run(
+                    (
                         "docker",
                         "buildx",
                         "build",
@@ -90,9 +91,8 @@ class TestBuildxPrivacyCenter:
                         ".",
                         "--tag",
                         "ethyca/fides-privacy-center:dev",
-                        external=True,
                     ),
-                    mock.call.run(
+                    (
                         "docker",
                         "buildx",
                         "build",
@@ -103,14 +103,13 @@ class TestBuildxPrivacyCenter:
                         "clients/sample-app",
                         "--tag",
                         "ethyca/fides-sample-app:dev",
-                        external=True,
                     ),
                 ],
             ),
             (
                 "prerelease",
                 [
-                    mock.call.run(
+                    (
                         "docker",
                         "buildx",
                         "build",
@@ -121,9 +120,8 @@ class TestBuildxPrivacyCenter:
                         ".",
                         "--tag",
                         "ethyca/fides:prerelease",
-                        external=True,
                     ),
-                    mock.call.run(
+                    (
                         "docker",
                         "buildx",
                         "build",
@@ -134,9 +132,8 @@ class TestBuildxPrivacyCenter:
                         ".",
                         "--tag",
                         "ethyca/fides-privacy-center:prerelease",
-                        external=True,
                     ),
-                    mock.call.run(
+                    (
                         "docker",
                         "buildx",
                         "build",
@@ -147,14 +144,13 @@ class TestBuildxPrivacyCenter:
                         "clients/sample-app",
                         "--tag",
                         "ethyca/fides-sample-app:prerelease",
-                        external=True,
                     ),
                 ],
             ),
             (
                 "rc",
                 [
-                    mock.call.run(
+                    (
                         "docker",
                         "buildx",
                         "build",
@@ -165,9 +161,8 @@ class TestBuildxPrivacyCenter:
                         ".",
                         "--tag",
                         "ethyca/fides:rc",
-                        external=True,
                     ),
-                    mock.call.run(
+                    (
                         "docker",
                         "buildx",
                         "build",
@@ -178,9 +173,8 @@ class TestBuildxPrivacyCenter:
                         ".",
                         "--tag",
                         "ethyca/fides-privacy-center:rc",
-                        external=True,
                     ),
-                    mock.call.run(
+                    (
                         "docker",
                         "buildx",
                         "build",
@@ -191,119 +185,119 @@ class TestBuildxPrivacyCenter:
                         "clients/sample-app",
                         "--tag",
                         "ethyca/fides-sample-app:rc",
-                        external=True,
-                    ),
-                ],
-            ),
-            (
-                "git-tag",
-                [
-                    mock.call.run(
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides:2.9.0a4",
-                        external=True,
-                    ),
-                    mock.call.run(
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod_pc",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides-privacy-center:2.9.0a4",
-                        external=True,
-                    ),
-                    mock.call.run(
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        "clients/sample-app",
-                        "--tag",
-                        "ethyca/fides-sample-app:2.9.0a4",
-                        external=True,
-                    ),
-                ],
-            ),
-            (
-                "prod",
-                [
-                    mock.call.run(
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides:2.9.0",
-                        "--tag",
-                        "ethyca/fides:latest",
-                        external=True,
-                    ),
-                    mock.call.run(
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod_pc",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides-privacy-center:2.9.0",
-                        "--tag",
-                        "ethyca/fides-privacy-center:latest",
-                        external=True,
-                    ),
-                    mock.call.run(
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        "clients/sample-app",
-                        "--tag",
-                        "ethyca/fides-sample-app:2.9.0",
-                        "--tag",
-                        "ethyca/fides-sample-app:latest",
-                        external=True,
                     ),
                 ],
             ),
         ],
     )
-    @mock.patch("docker_nox.get_current_tag")
-    @mock.patch("docker_nox.verify_git_tag")
-    @mock.patch("nox.Session.run")
-    def test_nox_push(
+    def test_standard_tags(
         self,
-        mock_session_run: mock.MagicMock,
-        mock_verify_git_tag: mock.MagicMock,
-        mock_get_current_tag: mock.MagicMock,
         tag,
         expected_commands,
     ):
+        buildx_commands = get_buildx_commands(tag)
+
+        assert buildx_commands == expected_commands
+
+    @mock.patch("docker_nox.verify_git_tag")
+    def test_git_tag_valid(
+        self,
+        mock_verify_git_tag,
+    ):
+        expected_result = [
+            (
+                "docker",
+                "buildx",
+                "build",
+                "--push",
+                "--target=prod",
+                "--platform",
+                "linux/amd64,linux/arm64",
+                ".",
+                "--tag",
+                "ethyca/fides:2.9.0a4",
+            ),
+            (
+                "docker",
+                "buildx",
+                "build",
+                "--push",
+                "--target=prod_pc",
+                "--platform",
+                "linux/amd64,linux/arm64",
+                ".",
+                "--tag",
+                "ethyca/fides-privacy-center:2.9.0a4",
+            ),
+            (
+                "docker",
+                "buildx",
+                "build",
+                "--push",
+                "--target=prod",
+                "--platform",
+                "linux/amd64,linux/arm64",
+                "clients/sample-app",
+                "--tag",
+                "ethyca/fides-sample-app:2.9.0a4",
+            ),
+        ]
         mock_verify_git_tag.return_value = "2.9.0a4"
+        buildx_commands = get_buildx_commands(mock_verify_git_tag)
+        assert buildx_commands == expected_result
+
+    @mock.patch("docker_nox.get_current_tag")
+    def test_standard_tags(
+        self,
+        mock_get_current_tag,
+    ):
+        expected_result = (
+            [
+                (
+                    "docker",
+                    "buildx",
+                    "build",
+                    "--push",
+                    "--target=prod",
+                    "--platform",
+                    "linux/amd64,linux/arm64",
+                    ".",
+                    "--tag",
+                    "ethyca/fides:2.9.0",
+                    "--tag",
+                    "ethyca/fides:latest",
+                ),
+                (
+                    "docker",
+                    "buildx",
+                    "build",
+                    "--push",
+                    "--target=prod_pc",
+                    "--platform",
+                    "linux/amd64,linux/arm64",
+                    ".",
+                    "--tag",
+                    "ethyca/fides-privacy-center:2.9.0",
+                    "--tag",
+                    "ethyca/fides-privacy-center:latest",
+                ),
+                (
+                    "docker",
+                    "buildx",
+                    "build",
+                    "--push",
+                    "--target=prod",
+                    "--platform",
+                    "linux/amd64,linux/arm64",
+                    "clients/sample-app",
+                    "--tag",
+                    "ethyca/fides-sample-app:2.9.0",
+                    "--tag",
+                    "ethyca/fides-sample-app:latest",
+                ),
+            ],
+        )
         mock_get_current_tag.return_value = "2.9.0"
-        push(mock_session_run, tag)
-        # first call to session.run is a separate call we're not evaluating here
-        assert mock_session_run.mock_calls[1:] == expected_commands
+        buildx_commands = get_buildx_commands(tag)
+
+        assert buildx_commands == expected_result

--- a/noxfiles/test_docker_nox.py
+++ b/noxfiles/test_docker_nox.py
@@ -2,7 +2,15 @@ from unittest import mock
 
 import pytest
 
-from docker_nox import generate_multiplatform_buildx_command, get_buildx_commands
+from docker_nox import (
+    generate_multiplatform_buildx_command,
+    get_buildx_commands,
+)
+from constants_nox import (
+    DEV_TAG_SUFFIX,
+    PRERELEASE_TAG_SUFFIX,
+    RC_TAG_SUFFIX,
+)
 
 
 class TestGenerateMultiplatformBuilxCommand:
@@ -66,7 +74,7 @@ class TestGetBuildxCommands:
         "tag,expected_commands",
         [
             (
-                "dev",
+                DEV_TAG_SUFFIX,
                 [
                     (
                         "docker",
@@ -107,7 +115,7 @@ class TestGetBuildxCommands:
                 ],
             ),
             (
-                "prerelease",
+                PRERELEASE_TAG_SUFFIX,
                 [
                     (
                         "docker",
@@ -148,7 +156,7 @@ class TestGetBuildxCommands:
                 ],
             ),
             (
-                "rc",
+                RC_TAG_SUFFIX,
                 [
                     (
                         "docker",
@@ -194,16 +202,14 @@ class TestGetBuildxCommands:
         self,
         tag,
         expected_commands,
-    ):
-        buildx_commands = get_buildx_commands(tag)
+    ) -> None:
+        buildx_commands = get_buildx_commands([tag])
 
         assert buildx_commands == expected_commands
 
-    @mock.patch("docker_nox.verify_git_tag")
-    def test_git_tag_valid(
+    def test_git_tag_tag(
         self,
-        mock_verify_git_tag,
-    ):
+    ) -> None:
         expected_result = [
             (
                 "docker",
@@ -242,62 +248,55 @@ class TestGetBuildxCommands:
                 "ethyca/fides-sample-app:2.9.0a4",
             ),
         ]
-        mock_verify_git_tag.return_value = "2.9.0a4"
-        buildx_commands = get_buildx_commands(mock_verify_git_tag)
+        buildx_commands = get_buildx_commands(["2.9.0a4"])
         assert buildx_commands == expected_result
 
-    @mock.patch("docker_nox.get_current_tag")
-    def test_standard_tags(
+    def test_prod_tag(
         self,
-        mock_get_current_tag,
-    ):
-        expected_result = (
-            [
-                (
-                    "docker",
-                    "buildx",
-                    "build",
-                    "--push",
-                    "--target=prod",
-                    "--platform",
-                    "linux/amd64,linux/arm64",
-                    ".",
-                    "--tag",
-                    "ethyca/fides:2.9.0",
-                    "--tag",
-                    "ethyca/fides:latest",
-                ),
-                (
-                    "docker",
-                    "buildx",
-                    "build",
-                    "--push",
-                    "--target=prod_pc",
-                    "--platform",
-                    "linux/amd64,linux/arm64",
-                    ".",
-                    "--tag",
-                    "ethyca/fides-privacy-center:2.9.0",
-                    "--tag",
-                    "ethyca/fides-privacy-center:latest",
-                ),
-                (
-                    "docker",
-                    "buildx",
-                    "build",
-                    "--push",
-                    "--target=prod",
-                    "--platform",
-                    "linux/amd64,linux/arm64",
-                    "clients/sample-app",
-                    "--tag",
-                    "ethyca/fides-sample-app:2.9.0",
-                    "--tag",
-                    "ethyca/fides-sample-app:latest",
-                ),
-            ],
-        )
-        mock_get_current_tag.return_value = "2.9.0"
-        buildx_commands = get_buildx_commands(tag)
-
+    ) -> None:
+        expected_result = [
+            (
+                "docker",
+                "buildx",
+                "build",
+                "--push",
+                "--target=prod",
+                "--platform",
+                "linux/amd64,linux/arm64",
+                ".",
+                "--tag",
+                "ethyca/fides:2.9.0",
+                "--tag",
+                "ethyca/fides:latest",
+            ),
+            (
+                "docker",
+                "buildx",
+                "build",
+                "--push",
+                "--target=prod_pc",
+                "--platform",
+                "linux/amd64,linux/arm64",
+                ".",
+                "--tag",
+                "ethyca/fides-privacy-center:2.9.0",
+                "--tag",
+                "ethyca/fides-privacy-center:latest",
+            ),
+            (
+                "docker",
+                "buildx",
+                "build",
+                "--push",
+                "--target=prod",
+                "--platform",
+                "linux/amd64,linux/arm64",
+                "clients/sample-app",
+                "--tag",
+                "ethyca/fides-sample-app:2.9.0",
+                "--tag",
+                "ethyca/fides-sample-app:latest",
+            ),
+        ]
+        buildx_commands = get_buildx_commands(["2.9.0", "latest"])
         assert buildx_commands == expected_result

--- a/noxfiles/test_docker_nox.py
+++ b/noxfiles/test_docker_nox.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from docker_nox import (
@@ -71,10 +69,10 @@ class TestGenerateMultiplatformBuilxCommand:
 
 class TestGetBuildxCommands:
     @pytest.mark.parametrize(
-        "tag,expected_commands",
+        "tags,expected_commands",
         [
             (
-                DEV_TAG_SUFFIX,
+                [DEV_TAG_SUFFIX],
                 [
                     (
                         "docker",
@@ -115,7 +113,7 @@ class TestGetBuildxCommands:
                 ],
             ),
             (
-                PRERELEASE_TAG_SUFFIX,
+                [PRERELEASE_TAG_SUFFIX],
                 [
                     (
                         "docker",
@@ -156,7 +154,7 @@ class TestGetBuildxCommands:
                 ],
             ),
             (
-                RC_TAG_SUFFIX,
+                [RC_TAG_SUFFIX],
                 [
                     (
                         "docker",
@@ -196,107 +194,101 @@ class TestGetBuildxCommands:
                     ),
                 ],
             ),
+            (
+                ["2.9.0a4"],
+                [
+                    (
+                        "docker",
+                        "buildx",
+                        "build",
+                        "--push",
+                        "--target=prod",
+                        "--platform",
+                        "linux/amd64,linux/arm64",
+                        ".",
+                        "--tag",
+                        "ethyca/fides:2.9.0a4",
+                    ),
+                    (
+                        "docker",
+                        "buildx",
+                        "build",
+                        "--push",
+                        "--target=prod_pc",
+                        "--platform",
+                        "linux/amd64,linux/arm64",
+                        ".",
+                        "--tag",
+                        "ethyca/fides-privacy-center:2.9.0a4",
+                    ),
+                    (
+                        "docker",
+                        "buildx",
+                        "build",
+                        "--push",
+                        "--target=prod",
+                        "--platform",
+                        "linux/amd64,linux/arm64",
+                        "clients/sample-app",
+                        "--tag",
+                        "ethyca/fides-sample-app:2.9.0a4",
+                    ),
+                ],
+            ),
+            (
+                ["2.9.0", "latest"],
+                [
+                    (
+                        "docker",
+                        "buildx",
+                        "build",
+                        "--push",
+                        "--target=prod",
+                        "--platform",
+                        "linux/amd64,linux/arm64",
+                        ".",
+                        "--tag",
+                        "ethyca/fides:2.9.0",
+                        "--tag",
+                        "ethyca/fides:latest",
+                    ),
+                    (
+                        "docker",
+                        "buildx",
+                        "build",
+                        "--push",
+                        "--target=prod_pc",
+                        "--platform",
+                        "linux/amd64,linux/arm64",
+                        ".",
+                        "--tag",
+                        "ethyca/fides-privacy-center:2.9.0",
+                        "--tag",
+                        "ethyca/fides-privacy-center:latest",
+                    ),
+                    (
+                        "docker",
+                        "buildx",
+                        "build",
+                        "--push",
+                        "--target=prod",
+                        "--platform",
+                        "linux/amd64,linux/arm64",
+                        "clients/sample-app",
+                        "--tag",
+                        "ethyca/fides-sample-app:2.9.0",
+                        "--tag",
+                        "ethyca/fides-sample-app:latest",
+                    ),
+                ],
+            ),
         ],
     )
-    def test_standard_tags(
+    def test_tags(
         self,
-        tag,
+        tags,
         expected_commands,
     ) -> None:
-        buildx_commands = get_buildx_commands([tag])
+        buildx_commands = get_buildx_commands(tags)
 
         assert buildx_commands == expected_commands
-
-    def test_git_tag_tag(
-        self,
-    ) -> None:
-        expected_result = [
-            (
-                "docker",
-                "buildx",
-                "build",
-                "--push",
-                "--target=prod",
-                "--platform",
-                "linux/amd64,linux/arm64",
-                ".",
-                "--tag",
-                "ethyca/fides:2.9.0a4",
-            ),
-            (
-                "docker",
-                "buildx",
-                "build",
-                "--push",
-                "--target=prod_pc",
-                "--platform",
-                "linux/amd64,linux/arm64",
-                ".",
-                "--tag",
-                "ethyca/fides-privacy-center:2.9.0a4",
-            ),
-            (
-                "docker",
-                "buildx",
-                "build",
-                "--push",
-                "--target=prod",
-                "--platform",
-                "linux/amd64,linux/arm64",
-                "clients/sample-app",
-                "--tag",
-                "ethyca/fides-sample-app:2.9.0a4",
-            ),
-        ]
-        buildx_commands = get_buildx_commands(["2.9.0a4"])
-        assert buildx_commands == expected_result
-
-    def test_prod_tag(
-        self,
-    ) -> None:
-        expected_result = [
-            (
-                "docker",
-                "buildx",
-                "build",
-                "--push",
-                "--target=prod",
-                "--platform",
-                "linux/amd64,linux/arm64",
-                ".",
-                "--tag",
-                "ethyca/fides:2.9.0",
-                "--tag",
-                "ethyca/fides:latest",
-            ),
-            (
-                "docker",
-                "buildx",
-                "build",
-                "--push",
-                "--target=prod_pc",
-                "--platform",
-                "linux/amd64,linux/arm64",
-                ".",
-                "--tag",
-                "ethyca/fides-privacy-center:2.9.0",
-                "--tag",
-                "ethyca/fides-privacy-center:latest",
-            ),
-            (
-                "docker",
-                "buildx",
-                "build",
-                "--push",
-                "--target=prod",
-                "--platform",
-                "linux/amd64,linux/arm64",
-                "clients/sample-app",
-                "--tag",
-                "ethyca/fides-sample-app:2.9.0",
-                "--tag",
-                "ethyca/fides-sample-app:latest",
-            ),
-        ]
-        buildx_commands = get_buildx_commands(["2.9.0", "latest"])
-        assert buildx_commands == expected_result


### PR DESCRIPTION
Closes #3422 

### Code Changes

* [x] update the `nox -s push` session to use multiprocessing

### Steps to Confirm

* [ ] run `nox -s "push(dev)"` locally and confirm the output looks wild (like 6 images being built at once) and that the job finishes (might fail on `push` step of the command)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [ ] ~~Relevant Follow-Up Issues Created~~
* [ ] ~~Update `CHANGELOG.md`~~

### Description Of Changes

I thought about adding an additional parameter to build each one separately, i.e. `nox -s "push(git-tag, fides)" "push(git-tag, sample)"` etc. but felt this would also add additional complication to the CI workflows. I also couldn't think of a case where we _wouldn't_ want to build everything at once, so this seemed like the lowest-friction solution.