### PR TITLE
Fides-js accessibility wrap up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.15.0...main)
 
+### Fixed
+- Remove the `fides-js` banner from tab order when it is hidden and move the overlay components to the top of the tab order. [#3510](https://github.com/ethyca/fides/pull/3510)
+
 
 ## [2.15.0](https://github.com/ethyca/fides/compare/2.14.1...2.15.0)
 

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -77,6 +77,7 @@ div#fides-banner-container {
   transition: transform 1s;
   display: flex;
   justify-content: center;
+  visibility: visible;
 }
 
 div#fides-banner {
@@ -105,6 +106,7 @@ div#fides-banner-container.fides-banner-bottom {
 
 div#fides-banner-container.fides-banner-bottom.fides-banner-hidden {
   transform: translateY(150%);
+  visibility: hidden;
 }
 
 div#fides-banner-container.fides-banner-top {
@@ -114,6 +116,7 @@ div#fides-banner-container.fides-banner-top {
 
 div#fides-banner-container.fides-banner-top.fides-banner-hidden {
   transform: translateY(-150%);
+  visibility: hidden;
 }
 
 /* Responsive banner */

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -76,7 +76,7 @@ div#fides-banner-container {
   z-index: 1;
   width: 100%;
   transform: translateY(0%);
-  transition: transform 1s;
+  transition: transform 1s, visibility 1s;
   display: flex;
   justify-content: center;
   visibility: visible;

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -54,6 +54,8 @@
 div#fides-overlay {
   font-family: var(--fides-overlay-font-family);
   font-size: var(--fides-overlay-font-size-body);
+  z-index: 1000;
+  position: fixed;
 
   /* CSS reset values, adapted from https://www.joshwcomeau.com/css/custom-css-reset/ */
   line-height: calc(1em + 0.4rem);

--- a/clients/fides-js/src/lib/consent.tsx
+++ b/clients/fides-js/src/lib/consent.tsx
@@ -44,7 +44,7 @@ export const initOverlay = async ({
         // Create our own parent element and append to body
         parentElem = document.createElement("div");
         parentElem.id = overlayParentId;
-        document.body.appendChild(parentElem);
+        document.body.prepend(parentElem);
       }
 
       if (experience.component === ComponentType.OVERLAY) {


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3309

### Code Changes

The bulk of the a11y work was done while developing, but this should cover the straggling items.

* [x] Makes the banner not come up in the tab order when it's hidden
* [x] Prepend the overlay instead of appending so that the banner is the first tabbed to item

### Steps to Confirm

* Bring up either cookie house or `fides-js-components-demo.html`
* As a keyboard user, tab into the page. You should immediately be tabbing through the banner (before, you'd have to tab through the whole page before getting to the banner. this is far more noticeable on cookie house than the demo page)
* Close the banner. Tab through the page. You should be able to tab through without issue (before, there would be a few tabs where it looked like nothing was happening, since it was tabbing through the hidden banner)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

I went through a few sites, and I don't think there's actual regulation on where a banner should appear in a tab order. [This blog post](https://uxdesign.cc/cookie-banners-and-accessibility-d476bf9ee4fc) recommends having them come up as soon as possible, though I ran into some sites that have them at the very end (where you have to tab through the entire page, including footers, before you can get to the banner. example: https://stackoverflow.com/) but other sites make sure they're the first thing you tab through. example: https://liveramp.com/). I thought it made sense to have it come up as soon as possible, though this means we `document.body.prepend` instead of `document.body.appendChild`. In other words, the overlay becomes the top DOM element. Because of this, I also gave the overlay an overall high z-index to increase the chance we stay on top of the host site's elements (we probably wanted this anyway)

There might be other ways to have the banner receive focus first other than doing a prepend:
* use the `autoFocus` attr on a button in the banner, however this apparently has [a11y drawbacks](https://www.boia.org/blog/accessibility-tips-be-cautious-when-using-autofocus) (vscode warns against it)
* use a [portal](https://github.com/developit/preact-portal). I don't _think_ we need one, since we're already controlling where in the DOM we are injecting our overlay, but I think that might be a standard way of doing this kind of thing. however, adding preact-portal is another >1kb! 

I haven't come across any drawbacks with prepending instead of appending yet, but we'll see! 
