### PR TITLE
Ignore Errors For Non-existent identities - Kustomer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.15.0...main)
 
+### Fixed
+- Handles an edge case for non-existent identities with the Kustomer API [#3513](https://github.com/ethyca/fides/pull/3513)
+
 
 ## [2.15.0](https://github.com/ethyca/fides/compare/2.14.1...2.15.0)
 

--- a/data/saas/config/kustomer_config.yml
+++ b/data/saas/config/kustomer_config.yml
@@ -3,7 +3,7 @@ saas_config:
   name: Kustomer
   type: kustomer
   description: A sample schema representing the Kustomer connector for Fides
-  version: 0.1.0
+  version: 0.1.1
 
   connector_params:
     - name: domain

--- a/data/saas/config/kustomer_config.yml
+++ b/data/saas/config/kustomer_config.yml
@@ -35,12 +35,14 @@ saas_config:
               - name: email
                 identity: email
             data_path: data
+            ignore_errors: true
           - method: GET
             path: /v1/customers/phone=<phone_number>
             param_values:
               - name: phone_number
                 identity: phone_number
             data_path: data
+            ignore_errors: true
         delete:
           method: DELETE
           path: /v1/customers/<customer_id>

--- a/tests/fixtures/saas/kustomer_fixtures.py
+++ b/tests/fixtures/saas/kustomer_fixtures.py
@@ -38,6 +38,12 @@ def kustomer_identity_email(saas_config):
 
 
 @pytest.fixture(scope="session")
+def kustomer_non_existent_identity_email(saas_config):
+    email_not_in_kustomer = "not_in_kustomer@example.com"
+    return email_not_in_kustomer
+
+
+@pytest.fixture(scope="session")
 def kustomer_identity_phone_number(saas_config):
     return (
         pydash.get(saas_config, "kustomer.identity_phone_number")

--- a/tests/ops/integration_tests/saas/test_kustomer_task.py
+++ b/tests/ops/integration_tests/saas/test_kustomer_task.py
@@ -212,3 +212,45 @@ async def test_kustomer_erasure_request_task(
     assert response.status_code == 404
 
     CONFIG.execution.masking_strict = masking_strict
+
+
+@pytest.mark.integration_saas
+@pytest.mark.integration_kustomer
+@pytest.mark.asyncio
+async def test_kustomer_erasure_request_task_non_existent_email(
+    db,
+    policy,
+    erasure_policy_string_rewrite,
+    kustomer_connection_config,
+    kustomer_dataset_config,
+    kustomer_non_existent_identity_email,
+    kustomer_create_erasure_data,
+) -> None:
+    """Full erasure request based on the Kustomer SaaS config"""
+
+    masking_strict = CONFIG.execution.masking_strict
+    CONFIG.execution.masking_strict = False  # Allow Delete
+
+    privacy_request = PrivacyRequest(
+        id=f"test_kustomer_erasure_request_task_non_existent_email{random.randint(0, 1000)}"
+    )
+    identity = Identity(**{"email": kustomer_non_existent_identity_email})
+    privacy_request.cache_identity(identity)
+
+    dataset_name = kustomer_connection_config.get_saas_config().fides_key
+    merged_graph = kustomer_dataset_config.get_graph()
+    graph = DatasetGraph(merged_graph)
+
+    x = await graph_task.run_erasure(
+        privacy_request,
+        erasure_policy_string_rewrite,
+        graph,
+        [kustomer_connection_config],
+        {"email": kustomer_non_existent_identity_email},
+        get_cached_data_for_erasures(privacy_request.id),
+        db,
+    )
+
+    assert x == {f"{dataset_name}:customer": 0}
+
+    CONFIG.execution.masking_strict = masking_strict


### PR DESCRIPTION
Closes #tbd

### Code Changes

* [x] Adds a failing test for an email that does not exist
* [x] ignores errors for the request

### Steps to Confirm

* [ ] Comment out `ignore_errors: true` and notice the failing test

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Originally I was looking at writing an override that would only pass when the specific 404 was encountered, but opted for `ignore_errors` - open to further discussion here!
