### PR TITLE
Update logging levels for privacy configuration load messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.15.0...main)
 
+### Changed
+
+- Change the level of common logging messages in the Privacy Center [#3516](https://github.com/ethyca/fides/pull/3516)
 
 ## [2.15.0](https://github.com/ethyca/fides/compare/2.14.1...2.15.0)
 

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -112,7 +112,7 @@ const loadConfigFile = async (
         path = urlString.replace("file:", "");
       }
       const file = await fsPromises.readFile(path || url, "utf-8");
-      console.log(`Loaded configuration file: ${urlString}`);
+      console.debug(`Loaded configuration file: ${urlString}`);
       return file;
     } catch (err: any) {
       // Catch "file not found" errors (ENOENT)
@@ -120,7 +120,7 @@ const loadConfigFile = async (
         continue;
       }
       // Log everything else and continue
-      console.log(
+      console.warn(
         `Failed to load configuration file from ${urlString}. Error: `,
         err
       );
@@ -237,7 +237,7 @@ export const loadPrivacyCenterEnvironment =
       );
     }
     // DEFER: Log a version number here (see https://github.com/ethyca/fides/issues/3171)
-    console.log("Load Privacy Center environment for session...");
+    console.debug("Load Privacy Center environment for session...");
 
     // Load environment variables
     const settings: PrivacyCenterSettings = {


### PR DESCRIPTION
### Code Changes

I want to be able to filter these out more easily in our logging platform. 

* Change "Loaded configuration file: ..." to `console.debug`
* Change "Failed to load configuration file from ..." to `console.warn`

### Steps to Confirm

* Make any request to the privacy center and check the server logs.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * ~documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)~
  * ~documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)~
* ~Issue Requirements are Met~
* ~Relevant Follow-Up Issues Created~
* [x] Update `CHANGELOG.md`
* ~For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated~

### Description Of Changes

This PR only changes the logging level of the server-side messages for the Privacy Center.