### PR TITLE
Fix race condition with link rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.15.0...main)
 
+### Fixed
+- Fix race condition with consent modal link rendering [#3521](https://github.com/ethyca/fides/pull/3521)
+
 
 ## [2.15.0](https://github.com/ethyca/fides/compare/2.14.1...2.15.0)
 

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -35,6 +35,8 @@ const Overlay: FunctionComponent<OverlayProps> = ({
   fidesRegionString,
   cookie,
 }) => {
+  const delayBannerMilliseconds = 100;
+  const delayModalLinkMilliseconds = 200;
   const hasMounted = useHasMounted();
   const [bannerIsOpen, setBannerIsOpen] = useState(false);
   const { instance, attributes } = useA11yDialog({
@@ -58,7 +60,7 @@ const Overlay: FunctionComponent<OverlayProps> = ({
   useEffect(() => {
     const delayBanner = setTimeout(() => {
       setBannerIsOpen(true);
-    }, 100);
+    }, delayBannerMilliseconds);
     return () => clearTimeout(delayBanner);
   }, [setBannerIsOpen]);
 
@@ -83,7 +85,7 @@ const Overlay: FunctionComponent<OverlayProps> = ({
       } else {
         debugLog(options.debug, "Modal link element not found.");
       }
-    }, 200);
+    }, delayModalLinkMilliseconds);
     return () => clearTimeout(delayModalLinkBinding);
   }, [options.modalLinkId, options.debug, handleOpenModal]);
 

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -69,8 +69,8 @@ const Overlay: FunctionComponent<OverlayProps> = ({
       const modalLinkEl = document.getElementById(modalLinkId);
       if (modalLinkEl) {
         debugLog(
-            options.debug,
-            "Modal link element found, updating it to show and trigger modal on click."
+          options.debug,
+          "Modal link element found, updating it to show and trigger modal on click."
         );
         // Update modal link to trigger modal on click
         const modalLink = modalLinkEl;

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -27,7 +27,6 @@ export interface OverlayProps {
   experience: PrivacyExperience;
   cookie: FidesCookie;
   fidesRegionString: string;
-  modalLinkEl?: HTMLElement | null;
 }
 
 const Overlay: FunctionComponent<OverlayProps> = ({
@@ -35,7 +34,6 @@ const Overlay: FunctionComponent<OverlayProps> = ({
   options,
   fidesRegionString,
   cookie,
-  modalLinkEl,
 }) => {
   const hasMounted = useHasMounted();
   const [bannerIsOpen, setBannerIsOpen] = useState(false);
@@ -65,23 +63,29 @@ const Overlay: FunctionComponent<OverlayProps> = ({
   }, [setBannerIsOpen]);
 
   useEffect(() => {
-    if (modalLinkEl) {
-      debugLog(
-        options.debug,
-        "Modal link element found, updating it to show and trigger modal on click."
-      );
-      // Update modal link to trigger modal on click
-      const modalLink = modalLinkEl;
-      modalLink.onclick = () => {
-        handleOpenModal();
-        setBannerIsOpen(false);
-      };
-      // Update to show the pre-existing modal link in the DOM
-      modalLink.classList.add("fides-modal-link-shown");
-    } else {
-      debugLog(options.debug, "Modal link element not found.");
-    }
-  }, [modalLinkEl, options.debug, handleOpenModal]);
+    // use a delay to ensure that link exists in the DOM
+    const delayModalLinkBinding = setTimeout(() => {
+      const modalLinkId = options.modalLinkId || "fides-modal-link";
+      const modalLinkEl = document.getElementById(modalLinkId);
+      if (modalLinkEl) {
+        debugLog(
+            options.debug,
+            "Modal link element found, updating it to show and trigger modal on click."
+        );
+        // Update modal link to trigger modal on click
+        const modalLink = modalLinkEl;
+        modalLink.onclick = () => {
+          handleOpenModal();
+          setBannerIsOpen(false);
+        };
+        // Update to show the pre-existing modal link in the DOM
+        modalLink.classList.add("fides-modal-link-shown");
+      } else {
+        debugLog(options.debug, "Modal link element not found.");
+      }
+    }, 200);
+    return () => clearTimeout(delayModalLinkBinding);
+  }, [options.modalLinkId, options.debug, handleOpenModal]);
 
   const showBanner = useMemo(
     () => experience.show_banner && hasActionNeededNotices(experience),

--- a/clients/fides-js/src/lib/consent.tsx
+++ b/clients/fides-js/src/lib/consent.tsx
@@ -19,14 +19,6 @@ export const initOverlay = async ({
   debugLog(options.debug, "Initializing Fides consent overlays...");
 
   async function renderFidesOverlay(): Promise<void> {
-    // Check if there are any notices within the experience that do not have a user preference
-    const noticesWithNoUserPreferenceExist = hasActionNeededNotices(experience);
-    const modalLinkId = options.modalLinkId || "fides-modal-link";
-    const modalLinkEl = document.getElementById(modalLinkId);
-    // If we don't have new notices and modal link does not exist, don't render overlay
-    if (!noticesWithNoUserPreferenceExist && !modalLinkEl) {
-      return Promise.resolve();
-    }
     try {
       debugLog(
         options.debug,
@@ -55,7 +47,6 @@ export const initOverlay = async ({
             experience={experience}
             cookie={cookie}
             fidesRegionString={fidesRegionString}
-            modalLinkEl={modalLinkEl}
           />,
           parentElem
         );

--- a/clients/fides-js/src/lib/consent.tsx
+++ b/clients/fides-js/src/lib/consent.tsx
@@ -1,7 +1,7 @@
 import { h, render } from "preact";
 
 import { ComponentType } from "./consent-types";
-import { debugLog, hasActionNeededNotices } from "./consent-utils";
+import { debugLog } from "./consent-utils";
 
 import Overlay, { OverlayProps } from "../components/Overlay";
 


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3483, closes https://github.com/ethyca/fides/issues/3488

### Code Changes

* [ ] Implement 200 ms wait before showing the modal link on the page. This does 2 things: 1) Allows some time for the link element to render in the DOM. It was technically possible before that it was not rendered on the page before our fides.js `renderFidesOverlay()` method was called 2) Since our banner animates after 100 ms, this also gives enough time to ensure the link is not clickable before the banner is displayed on the page.
* [ ] Remove duplicate check for new notices before rendering the banner.

### Steps to Confirm

* [ ] Nav to http://localhost:3000/fides-js-components-demo.html, confirm consent modal link does not render to the page before banner animates.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
