### PR TITLE
Fix bug where modal does not reflect draft state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The types of changes are:
 - Fix CLI output showing a version warning for Snowflake [#3434](https://github.com/ethyca/fides/pull/3434)
 - Flaky custom field Cypress test on systems page [#3408](https://github.com/ethyca/fides/pull/3408)
 - Fix NextJS errors & warnings for Cookie House sample app [#3411](https://github.com/ethyca/fides/pull/3411)
+- Fix bug where `fides-js` toggles were not reflecting changes from rejecting or accepting all notices [#3522](https://github.com/ethyca/fides/pull/3522)
 
 ### Changed
 

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -29,6 +29,16 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
       privacyPreferencesLabel = "Manage preferences",
   } = experience;
 
+  const handleRejectAll = () => {
+    onRejectAll();
+    onClose();
+  };
+
+  const handleAcceptAll = () => {
+    onAcceptAll();
+    onClose();
+  };
+
   return (
     <div
       id="fides-banner-container"
@@ -60,16 +70,12 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
               <Button
                 buttonType={ButtonType.PRIMARY}
                 label={rejectButtonLabel}
-                onClick={() => {
-                  onRejectAll();
-                }}
+                onClick={handleRejectAll}
               />
               <Button
                 buttonType={ButtonType.PRIMARY}
                 label={acceptButtonLabel}
-                onClick={() => {
-                  onAcceptAll();
-                }}
+                onClick={handleAcceptAll}
               />
             </span>
           </div>

--- a/clients/fides-js/src/components/ConsentModal.tsx
+++ b/clients/fides-js/src/components/ConsentModal.tsx
@@ -1,5 +1,4 @@
 import { h } from "preact";
-import { useMemo, useState } from "preact/hooks";
 import { Attributes } from "../lib/a11y-dialog";
 import Button from "./Button";
 import {
@@ -10,36 +9,30 @@ import {
 import NoticeToggles from "./NoticeToggles";
 import CloseButton from "./CloseButton";
 
+type NoticeKeys = Array<PrivacyNotice["notice_key"]>;
+
 const ConsentModal = ({
   attributes,
   experience,
   notices,
+  enabledNoticeKeys,
+  onChange,
   onClose,
   onSave,
-  onAcceptAll,
   onRejectAll,
+  onAcceptAll,
 }: {
   attributes: Attributes;
   experience: ExperienceConfig;
   notices: PrivacyNotice[];
+  enabledNoticeKeys: NoticeKeys;
   onClose: () => void;
-  onSave: (enabledNoticeKeys: Array<PrivacyNotice["notice_key"]>) => void;
-  onAcceptAll: () => void;
+  onChange: (enabledNoticeKeys: NoticeKeys) => void;
+  onSave: (enabledNoticeKeys: NoticeKeys) => void;
   onRejectAll: () => void;
+  onAcceptAll: () => void;
 }) => {
   const { container, overlay, dialog, title, closeButton } = attributes;
-
-  const initialEnabledNoticeKeys = useMemo(
-    () =>
-      Object.keys(window.Fides.consent).filter(
-        (key) => window.Fides.consent[key]
-      ),
-    []
-  );
-
-  const [enabledNoticeKeys, setEnabledNoticeKeys] = useState<
-    Array<PrivacyNotice["notice_key"]>
-  >(initialEnabledNoticeKeys);
 
   const handleSave = () => {
     onSave(enabledNoticeKeys);
@@ -87,7 +80,7 @@ const ConsentModal = ({
           <NoticeToggles
             notices={notices}
             enabledNoticeKeys={enabledNoticeKeys}
-            onChange={setEnabledNoticeKeys}
+            onChange={onChange}
           />
         </div>
         <div className="fides-modal-button-group">

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -322,6 +322,32 @@ describe("Consent banner", () => {
         });
       });
 
+      it("can persist state between modal and banner", () => {
+        cy.get("div#fides-banner").within(() => {
+          cy.get("button").contains("Accept Test").click();
+        });
+        // Now check that the change persisted by opening the modal
+        cy.get("[id='fides-modal-link']").click();
+        cy.getByTestId("toggle-Test privacy notice").within(() => {
+          cy.get("input").should("have.attr", "checked");
+        });
+        cy.getByTestId("toggle-Essential").within(() => {
+          cy.get("input").should("have.attr", "checked");
+        });
+        // Now reject all
+        cy.getByTestId("fides-modal-content").within(() => {
+          cy.get("button").contains("Reject Test").click();
+        });
+        // Check the modal again
+        cy.get("[id='fides-modal-link']").click();
+        cy.getByTestId("toggle-Test privacy notice").within(() => {
+          cy.get("input").should("not.have.attr", "checked");
+        });
+        cy.getByTestId("toggle-Essential").within(() => {
+          cy.get("input").should("not.have.attr", "checked");
+        });
+      });
+
       it("overwrites privacy notices that no longer exist", () => {
         const uuid = "4fbb6edf-34f6-4717-a6f1-541fd1e5d585";
         const CREATED_DATE = "2022-12-24T12:00:00.000Z";


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3514

### Code Changes

* [x] Hoist state to the overlay. The banner can actually also control the state of the toggles, so it's best to have the parent control the state. Refactor some of the save functions to be more streamlined
* [x] Add a test for this case

### Steps to Confirm

* See repro steps in the original ticket

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Incidentally, I believe this is a regression after we incorporated the a11y-dialog library. Before, we were unmounting the Modal when we hid it. The library hides the modal instead, so the component doesn't unmount. However, we had some logic [which checked the window object in the modal](https://github.com/ethyca/fides/blob/main/clients/fides-js/src/components/ConsentModal.tsx#L32-L38) and set the toggle states that way. That bit of logic doesn't retrigger since the component doesn't mount again, so it becomes stale.

Now that we are only hiding the component, we have to be a little more careful with how we control the state. I think this way makes a bit more intuitive sense, or at least it is more explicit about tracking state.

https://github.com/ethyca/fides/assets/24641006/0c111b23-dacc-4900-882d-48c4515f3998

