### PR TITLE
Remove Deprecated Data Uses

### DIFF
--- a/src/fides/api/ctl/migrations/versions/5307999c0dac_remove_deprecated_data_uses_for_.py
+++ b/src/fides/api/ctl/migrations/versions/5307999c0dac_remove_deprecated_data_uses_for_.py
@@ -1,0 +1,27 @@
+"""remove deprecated data uses for fideslang 1.4
+
+Revision ID: 5307999c0dac
+Revises: 76c02f99eec1
+Create Date: 2023-06-11 11:15:53.386526
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "5307999c0dac"
+down_revision = "76c02f99eec1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Remove all "default" Data uses
+
+    # Insert the new default data uses
+    pass
+
+
+def downgrade():
+    pass

--- a/src/fides/api/ctl/migrations/versions/5307999c0dac_remove_deprecated_data_uses_for_.py
+++ b/src/fides/api/ctl/migrations/versions/5307999c0dac_remove_deprecated_data_uses_for_.py
@@ -6,7 +6,10 @@ Create Date: 2023-06-11 11:15:53.386526
 
 """
 from alembic import op
-import sqlalchemy as sa
+
+from loguru import logger
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
 
 
 # revision identifiers, used by Alembic.
@@ -16,12 +19,12 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade():
-    # Remove all "default" Data uses
+def upgrade() -> None:
+    logger.info("Removing default data uses.")
+    bind: Connection = op.get_bind()
+    bind.execute(text("DELETE FROM ctl_data_uses WHERE is_default = TRUE;"))
 
-    # Insert the new default data uses
+
+def downgrade() -> None:
     pass
-
-
-def downgrade():
-    pass
+    # This is not reversible, because it relies on an older version of Fideslang

--- a/src/fides/api/ctl/migrations/versions/5307999c0dac_remove_deprecated_data_uses_for_.py
+++ b/src/fides/api/ctl/migrations/versions/5307999c0dac_remove_deprecated_data_uses_for_.py
@@ -24,6 +24,8 @@ def upgrade() -> None:
     bind: Connection = op.get_bind()
     bind.execute(text("DELETE FROM ctl_data_uses WHERE is_default = TRUE;"))
 
+    # This leaves the data uses empty, but the step to seed them back comes _after_ these migrations
+
 
 def downgrade() -> None:
     pass


### PR DESCRIPTION
Closes #3515 

### Code Changes

* [x] add a migration to remove the old data uses

### Steps to Confirm

* [ ] `git checkout 2.14.1; nox -s teardown -- volumes; nox -s dev` - let the server get into a running state before the next commands
* [ ] `fides user login; fides get data_use advertising` - the command should pass
* [ ] spin down the docker containers (but _do not teardown the volumes!_)
* [ ] `git checkout ThomasLaPiana-remove-deprecated-taxonomy; nox -s dev`
* [ ] `fides user login;  fides get data_use advertising` - the command should come back with an empty response
* [ ] Finally, `fides get data_use marketing` - the command should pass, and means the new data uses have been properly seeded (this is handled outside of the migration, by `seed.py`)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Quick PR to remove the "old" default data uses in favor of the new ones