### PR TITLE
Remove form validation to allow both email & phone inputs for consent requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The types of changes are:
 - Update privacy centre email and phone validation to allow for both to be blank [#3432](https://github.com/ethyca/fides/pull/3432)
 - Moved connection configuration into the system portal [#3407](https://github.com/ethyca/fides/pull/3407)
 - Update `fideslang` to `1.4.1` to allow arbitrary nested metadata on `System`s and `Dataset`s `meta` property [#3463](https://github.com/ethyca/fides/pull/3463)
+- Remove form validation to allow both email & phone inputs for consent requests [#3529](https://github.com/ethyca/fides/pull/3529)
 
 ### Developer Experience
 

--- a/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
+++ b/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
@@ -240,9 +240,6 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
                   onBlur={handleBlur}
                   value={values.email}
                   isInvalid={touched.email && Boolean(errors.email)}
-                  isDisabled={Boolean(
-                    typeof values.phone !== "undefined" && values.phone
-                  )}
                 />
                 <FormErrorMessage>{errors.email}</FormErrorMessage>
               </FormControl>
@@ -252,9 +249,6 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
                 id="phone"
                 isInvalid={touched.phone && Boolean(errors.phone)}
                 isRequired={identityInputs.phone === "required"}
-                isDisabled={Boolean(
-                  typeof values.email !== "undefined" && values.email
-                )}
               >
                 <FormLabel fontSize="sm">Phone</FormLabel>
                 <PhoneInput


### PR DESCRIPTION
### Code Changes

* [X] Remove form logic that would force only a single `phone` or `email` input to be provided

### Steps to Confirm

* [X] Configure privacy center with both `phone` and `email` inputs as `optional` for consent requests
* [X] Test all permutations:
  * [X] Neither `email` nor `phone`
  * [X] Only `email`
  * [X] Only `phone`
  * [X] Both `email` and `phone`

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

In #3432 we _reintroduced_ the ability to collect multiple identity inputs on consent requests, which reversed most of the changes in #2539

However, even though #3432 restored the ability to collect both email & phone, it didn't remove the form validation, so if you tried to type in both the email & phone fields they would still disable each other!

For example, this screenshot shows where I've typed in the email field, but the phone number field then gets disabled:
<img width="445" alt="image" src="https://github.com/ethyca/fides/assets/1834295/33f5d936-51fc-476a-9747-0e9754f850c4">

This change just removes that `isDisabled` logic to allow both fields to be populated simultaneously.