### PR TITLE
Remove privacy center `consent.button.modalTitle` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The types of changes are:
 
 ### Fixed
 - Remove the `fides-js` banner from tab order when it is hidden and move the overlay components to the top of the tab order. [#3510](https://github.com/ethyca/fides/pull/3510)
+- Remove privacy center `consent.button.modalTitle` option [#3530](https://github.com/ethyca/fides/pull/3530)
 
 
 ## [2.15.0](https://github.com/ethyca/fides/compare/2.14.1...2.15.0)

--- a/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
+++ b/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
@@ -202,7 +202,7 @@ const ConsentRequestForm: React.FC<ConsentRequestFormProps> = ({
   return (
     <>
       <ModalHeader pt={6} pb={0}>
-        {config.consent?.button.modalTitle || config.consent?.button.title}
+        {config.consent?.button.title}
       </ModalHeader>
       <chakra.form onSubmit={handleSubmit} data-testid="consent-request-form">
         <ModalBody>

--- a/clients/privacy-center/config/config.json
+++ b/clients/privacy-center/config/config.json
@@ -43,7 +43,6 @@
         "email": "optional"
       },
       "title": "Manage your consent",
-      "modalTitle": "Manage your consent",
       "confirmButtonText": "Continue",
       "cancelButtonText": "Cancel"
     },

--- a/clients/privacy-center/types/config.ts
+++ b/clients/privacy-center/types/config.ts
@@ -51,7 +51,6 @@ export type ConsentConfig = {
     icon_path: string;
     identity_inputs?: IdentityInputs;
     title: string;
-    modalTitle?: string;
   };
   page: {
     consentOptions: ConfigConsentOption[];


### PR DESCRIPTION
### Code Changes

* [X] Remove `consent.button.modalTitle` option from Privacy Center config.json

### Steps to Confirm

* [X] Run `nox -s "fides_env(test)" and confirm privacy center config renders as expected

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

This option is a reasonable idea, but as implemented it's more confusing than helpful - since you can only override the consent modal title but not the description, it's hard to understand what's happening... let's just keep things simple here and avoid adding more tech debt 👍 