### PR TITLE
Removing the stubbed advanced settings

### DIFF
--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -144,21 +144,6 @@ type ConnectorParametersProps = {
   connectionConfig?: ConnectionConfigurationResponse;
 };
 
-/**
- * We do not support advanced settings in the UI yet, but the backend requires at least
- * a payload that looks like it. We stuff one into handleSubmit for now
- * See fides#2458
- */
-const STUBBED_ADVANCED_SETTINGS = {
-  advanced_settings: {
-    identity_types: {
-      email: false,
-      phone_number: false,
-      cookie_ids: [],
-    },
-  },
-};
-
 export const useConnectorForm = ({
   secretsSchema,
   systemFidesKey,
@@ -253,10 +238,7 @@ export const useConnectorForm = ({
         }
 
         if (connectionOption.type !== SystemType.MANUAL) {
-          const secretsPayload =
-            connectionOption.type === SystemType.EMAIL
-              ? { ...values, ...STUBBED_ADVANCED_SETTINGS }
-              : values;
+          const secretsPayload = values;
 
           await upsertConnectionConfigSecrets(
             secretsPayload,


### PR DESCRIPTION
Closes #3534 

### Code Changes

* [ ] Removed the usage of `STUBBED_ADVANCED_SETTINGS` from the front-end

### Steps to Confirm

* [ ] Created a new system and added a generic consent connector under the integrations tab, verified I no longer saw the identity_type error
* [ ] Repeated this for a generic erasure connector

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Each of the schemas for the email connector secrets define a default value for the advanced settings, we don't need to use this front-end placeholder anymore.
