### PR TITLE
Notice only rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.15.0...main)
 
+### Added
+- Support for acknowledge button for notice-only Privacy Notices and to disable toggling them off [#3546](https://github.com/ethyca/fides/pull/3546)
+
 ### Fixed
 - Fix race condition with consent modal link rendering [#3521](https://github.com/ethyca/fides/pull/3521)
 

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -11,7 +11,7 @@ interface BannerProps {
   onClose: () => void;
   bannerIsOpen: boolean;
   /** Shows acknowledge button instead of Accept all/ Reject all */
-  showAcknowledge: boolean;
+  isAcknowledgeOnly: boolean;
 }
 
 const ConsentBanner: FunctionComponent<BannerProps> = ({
@@ -21,7 +21,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
   onManagePreferences,
   onClose,
   bannerIsOpen,
-  showAcknowledge,
+  isAcknowledgeOnly,
 }) => {
   const {
     title = "Manage your consent",
@@ -63,7 +63,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
             {description}
           </div>
           <div id="fides-banner-buttons" className="fides-banner-buttons">
-            {showAcknowledge ? (
+            {isAcknowledgeOnly ? (
               <span
                 id="fides-acknowledge-button"
                 className="fides-banner-buttons-right"

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent } from "preact";
+import { h, FunctionComponent, Fragment } from "preact";
 import { ButtonType, ExperienceConfig } from "../lib/consent-types";
 import Button from "./Button";
 import CloseButton from "./CloseButton";
@@ -10,6 +10,8 @@ interface BannerProps {
   onManagePreferences: () => void;
   onClose: () => void;
   bannerIsOpen: boolean;
+  /** Shows acknowledge button instead of Accept all/ Reject all */
+  showAcknowledge: boolean;
 }
 
 const ConsentBanner: FunctionComponent<BannerProps> = ({
@@ -19,6 +21,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
   onManagePreferences,
   onClose,
   bannerIsOpen,
+  showAcknowledge,
 }) => {
   const {
     title = "Manage your consent",
@@ -27,6 +30,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
     reject_button_label: rejectButtonLabel = "Reject All",
     privacy_preferences_link_label:
       privacyPreferencesLabel = "Manage preferences",
+    acknowledge_button_label: acknowledgeButtonLabel = "Ok",
   } = experience;
 
   const handleRejectAll = () => {
@@ -59,25 +63,40 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
             {description}
           </div>
           <div id="fides-banner-buttons" className="fides-banner-buttons">
-            <span className="fides-banner-buttons-left">
-              <Button
-                buttonType={ButtonType.TERTIARY}
-                label={privacyPreferencesLabel}
-                onClick={onManagePreferences}
-              />
-            </span>
-            <span className="fides-banner-buttons-right">
-              <Button
-                buttonType={ButtonType.PRIMARY}
-                label={rejectButtonLabel}
-                onClick={handleRejectAll}
-              />
-              <Button
-                buttonType={ButtonType.PRIMARY}
-                label={acceptButtonLabel}
-                onClick={handleAcceptAll}
-              />
-            </span>
+            {showAcknowledge ? (
+              <span
+                id="fides-acknowledge-button"
+                className="fides-banner-buttons-right"
+              >
+                <Button
+                  buttonType={ButtonType.PRIMARY}
+                  label={acknowledgeButtonLabel}
+                  onClick={onAcceptAll}
+                />
+              </span>
+            ) : (
+              <>
+                <span className="fides-banner-buttons-left">
+                  <Button
+                    buttonType={ButtonType.TERTIARY}
+                    label={privacyPreferencesLabel}
+                    onClick={onManagePreferences}
+                  />
+                </span>
+                <span className="fides-banner-buttons-right">
+                  <Button
+                    buttonType={ButtonType.PRIMARY}
+                    label={rejectButtonLabel}
+                    onClick={handleRejectAll}
+                  />
+                  <Button
+                    buttonType={ButtonType.PRIMARY}
+                    label={acceptButtonLabel}
+                    onClick={handleAcceptAll}
+                  />
+                </span>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -1,107 +1,39 @@
-import { h, FunctionComponent, Fragment } from "preact";
-import { ButtonType, ExperienceConfig } from "../lib/consent-types";
-import Button from "./Button";
+import { h, FunctionComponent, VNode } from "preact";
+import { ExperienceConfig } from "../lib/consent-types";
 import CloseButton from "./CloseButton";
 
 interface BannerProps {
   experience: ExperienceConfig;
-  onAcceptAll: () => void;
-  onRejectAll: () => void;
-  onManagePreferences: () => void;
   onClose: () => void;
   bannerIsOpen: boolean;
-  /** Shows acknowledge button instead of Accept all/ Reject all */
-  isAcknowledgeOnly: boolean;
+  buttonGroup: VNode;
 }
 
 const ConsentBanner: FunctionComponent<BannerProps> = ({
   experience,
-  onAcceptAll,
-  onRejectAll,
-  onManagePreferences,
+  buttonGroup,
   onClose,
   bannerIsOpen,
-  isAcknowledgeOnly,
-}) => {
-  const {
-    title = "Manage your consent",
-    description = "This website processes your data respectfully, so we require your consent to use cookies.",
-    accept_button_label: acceptButtonLabel = "Accept All",
-    reject_button_label: rejectButtonLabel = "Reject All",
-    privacy_preferences_link_label:
-      privacyPreferencesLabel = "Manage preferences",
-    acknowledge_button_label: acknowledgeButtonLabel = "Ok",
-  } = experience;
-
-  const handleRejectAll = () => {
-    onRejectAll();
-    onClose();
-  };
-
-  const handleAcceptAll = () => {
-    onAcceptAll();
-    onClose();
-  };
-
-  return (
-    <div
-      id="fides-banner-container"
-      className={`fides-banner fides-banner-bottom ${
-        bannerIsOpen ? "" : "fides-banner-hidden"
-      } `}
-    >
-      <div id="fides-banner">
-        <div id="fides-banner-inner">
-          <CloseButton ariaLabel="Close banner" onClick={onClose} />
-          <div id="fides-banner-title" className="fides-banner-title">
-            {title}
-          </div>
-          <div
-            id="fides-banner-description"
-            className="fides-banner-description"
-          >
-            {description}
-          </div>
-          <div id="fides-banner-buttons" className="fides-banner-buttons">
-            {isAcknowledgeOnly ? (
-              <span
-                id="fides-acknowledge-button"
-                className="fides-banner-buttons-right"
-              >
-                <Button
-                  buttonType={ButtonType.PRIMARY}
-                  label={acknowledgeButtonLabel}
-                  onClick={onAcceptAll}
-                />
-              </span>
-            ) : (
-              <>
-                <span className="fides-banner-buttons-left">
-                  <Button
-                    buttonType={ButtonType.TERTIARY}
-                    label={privacyPreferencesLabel}
-                    onClick={onManagePreferences}
-                  />
-                </span>
-                <span className="fides-banner-buttons-right">
-                  <Button
-                    buttonType={ButtonType.PRIMARY}
-                    label={rejectButtonLabel}
-                    onClick={handleRejectAll}
-                  />
-                  <Button
-                    buttonType={ButtonType.PRIMARY}
-                    label={acceptButtonLabel}
-                    onClick={handleAcceptAll}
-                  />
-                </span>
-              </>
-            )}
-          </div>
+}) => (
+  <div
+    id="fides-banner-container"
+    className={`fides-banner fides-banner-bottom ${
+      bannerIsOpen ? "" : "fides-banner-hidden"
+    } `}
+  >
+    <div id="fides-banner">
+      <div id="fides-banner-inner">
+        <CloseButton ariaLabel="Close banner" onClick={onClose} />
+        <div id="fides-banner-title" className="fides-banner-title">
+          {experience.title}
         </div>
+        <div id="fides-banner-description" className="fides-banner-description">
+          {experience.description}
+        </div>
+        {buttonGroup}
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 export default ConsentBanner;

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -60,7 +60,7 @@ const ConsentButtons = ({
   }
 
   return (
-    <div id="fides-banner-buttons" className="fides-banner-buttons">
+    <div id="fides-button-group">
       {onManagePreferencesClick ? (
         <div>
           <Button

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -1,0 +1,98 @@
+import { h } from "preact";
+import Button from "./Button";
+import {
+  ButtonType,
+  PrivacyExperience,
+  ConsentMechanism,
+  PrivacyNotice,
+} from "../lib/consent-types";
+
+type NoticeKeys = Array<PrivacyNotice["notice_key"]>;
+
+const ConsentButtons = ({
+  experience,
+  onManagePreferencesClick,
+  onSave,
+  enabledKeys,
+  isInModal,
+}: {
+  experience: PrivacyExperience;
+  onSave: (noticeKeys: NoticeKeys) => void;
+  onManagePreferencesClick?: () => void;
+  enabledKeys: NoticeKeys;
+  isInModal?: boolean;
+}) => {
+  if (!experience.experience_config || !experience.privacy_notices) {
+    return null;
+  }
+
+  const { experience_config: config, privacy_notices: notices } = experience;
+  const isAllNoticeOnly = notices.every(
+    (n) => n.consent_mechanism === ConsentMechanism.NOTICE_ONLY
+  );
+
+  const handleAcceptAll = () => {
+    onSave(notices.map((n) => n.notice_key));
+  };
+
+  const handleRejectAll = () => {
+    onSave(
+      notices
+        .filter((n) => n.consent_mechanism === ConsentMechanism.NOTICE_ONLY)
+        .map((n) => n.notice_key)
+    );
+  };
+
+  if (isAllNoticeOnly) {
+    return (
+      <div
+        className={`fides-acknowledge-button-container ${
+          isInModal ? "" : "fides-banner-acknowledge"
+        }`}
+      >
+        <Button
+          buttonType={ButtonType.PRIMARY}
+          label={config.acknowledge_button_label}
+          onClick={handleAcceptAll}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div id="fides-banner-buttons" className="fides-banner-buttons">
+      {onManagePreferencesClick ? (
+        <div>
+          <Button
+            buttonType={ButtonType.TERTIARY}
+            label={config.privacy_preferences_link_label}
+            onClick={onManagePreferencesClick}
+          />
+        </div>
+      ) : null}
+      <div className={isInModal ? "fides-modal-button-group" : undefined}>
+        {isInModal ? (
+          <Button
+            buttonType={ButtonType.SECONDARY}
+            label={config.save_button_label}
+            onClick={() => {
+              onSave(enabledKeys);
+            }}
+          />
+        ) : null}
+        <Button
+          buttonType={ButtonType.PRIMARY}
+          label={config.reject_button_label}
+          onClick={handleRejectAll}
+        />
+        <Button
+          buttonType={ButtonType.PRIMARY}
+          label={config.accept_button_label}
+          onClick={handleAcceptAll}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ConsentButtons;

--- a/clients/fides-js/src/components/ConsentModal.tsx
+++ b/clients/fides-js/src/components/ConsentModal.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact";
+import { h, Fragment } from "preact";
 import { Attributes } from "../lib/a11y-dialog";
 import Button from "./Button";
 import {
@@ -21,6 +21,7 @@ const ConsentModal = ({
   onSave,
   onRejectAll,
   onAcceptAll,
+  shouldAcknowledge,
 }: {
   attributes: Attributes;
   experience: ExperienceConfig;
@@ -31,6 +32,7 @@ const ConsentModal = ({
   onSave: (enabledNoticeKeys: NoticeKeys) => void;
   onRejectAll: () => void;
   onAcceptAll: () => void;
+  shouldAcknowledge: boolean;
 }) => {
   const { container, overlay, dialog, title, closeButton } = attributes;
 
@@ -83,22 +85,33 @@ const ConsentModal = ({
             onChange={onChange}
           />
         </div>
+
         <div className="fides-modal-button-group">
-          <Button
-            label={experience.save_button_label}
-            buttonType={ButtonType.SECONDARY}
-            onClick={handleSave}
-          />
-          <Button
-            label={experience.reject_button_label}
-            buttonType={ButtonType.PRIMARY}
-            onClick={handleRejectAll}
-          />
-          <Button
-            label={experience.accept_button_label}
-            buttonType={ButtonType.PRIMARY}
-            onClick={handleAcceptAll}
-          />
+          {shouldAcknowledge ? (
+            <Button
+              label={experience.acknowledge_button_label}
+              buttonType={ButtonType.PRIMARY}
+              onClick={onAcceptAll}
+            />
+          ) : (
+            <>
+              <Button
+                label={experience.save_button_label}
+                buttonType={ButtonType.SECONDARY}
+                onClick={handleSave}
+              />
+              <Button
+                label={experience.reject_button_label}
+                buttonType={ButtonType.PRIMARY}
+                onClick={handleRejectAll}
+              />
+              <Button
+                label={experience.accept_button_label}
+                buttonType={ButtonType.PRIMARY}
+                onClick={handleAcceptAll}
+              />
+            </>
+          )}
         </div>
         {experience.privacy_policy_link_label &&
         experience.privacy_policy_url ? (

--- a/clients/fides-js/src/components/ConsentModal.tsx
+++ b/clients/fides-js/src/components/ConsentModal.tsx
@@ -21,7 +21,7 @@ const ConsentModal = ({
   onSave,
   onRejectAll,
   onAcceptAll,
-  shouldAcknowledge,
+  isAcknowledgeOnly,
 }: {
   attributes: Attributes;
   experience: ExperienceConfig;
@@ -32,7 +32,8 @@ const ConsentModal = ({
   onSave: (enabledNoticeKeys: NoticeKeys) => void;
   onRejectAll: () => void;
   onAcceptAll: () => void;
-  shouldAcknowledge: boolean;
+  /** Shows acknowledge button instead of Accept all/ Reject all */
+  isAcknowledgeOnly: boolean;
 }) => {
   const { container, overlay, dialog, title, closeButton } = attributes;
 
@@ -87,7 +88,7 @@ const ConsentModal = ({
         </div>
 
         <div className="fides-modal-button-group">
-          {shouldAcknowledge ? (
+          {isAcknowledgeOnly ? (
             <Button
               label={experience.acknowledge_button_label}
               buttonType={ButtonType.PRIMARY}

--- a/clients/fides-js/src/components/ConsentModal.tsx
+++ b/clients/fides-js/src/components/ConsentModal.tsx
@@ -1,11 +1,6 @@
-import { h, Fragment } from "preact";
+import { h, VNode } from "preact";
 import { Attributes } from "../lib/a11y-dialog";
-import Button from "./Button";
-import {
-  ButtonType,
-  PrivacyNotice,
-  ExperienceConfig,
-} from "../lib/consent-types";
+import { PrivacyNotice, ExperienceConfig } from "../lib/consent-types";
 import NoticeToggles from "./NoticeToggles";
 import CloseButton from "./CloseButton";
 
@@ -17,11 +12,7 @@ const ConsentModal = ({
   notices,
   enabledNoticeKeys,
   onChange,
-  onClose,
-  onSave,
-  onRejectAll,
-  onAcceptAll,
-  isAcknowledgeOnly,
+  buttonGroup,
 }: {
   attributes: Attributes;
   experience: ExperienceConfig;
@@ -29,28 +20,9 @@ const ConsentModal = ({
   enabledNoticeKeys: NoticeKeys;
   onClose: () => void;
   onChange: (enabledNoticeKeys: NoticeKeys) => void;
-  onSave: (enabledNoticeKeys: NoticeKeys) => void;
-  onRejectAll: () => void;
-  onAcceptAll: () => void;
-  /** Shows acknowledge button instead of Accept all/ Reject all */
-  isAcknowledgeOnly: boolean;
+  buttonGroup: VNode;
 }) => {
   const { container, overlay, dialog, title, closeButton } = attributes;
-
-  const handleSave = () => {
-    onSave(enabledNoticeKeys);
-    onClose();
-  };
-
-  const handleAcceptAll = () => {
-    onAcceptAll();
-    onClose();
-  };
-
-  const handleRejectAll = () => {
-    onRejectAll();
-    onClose();
-  };
 
   return (
     // @ts-ignore A11yDialog ref obj type isn't quite the same
@@ -86,34 +58,7 @@ const ConsentModal = ({
             onChange={onChange}
           />
         </div>
-
-        <div className="fides-modal-button-group">
-          {isAcknowledgeOnly ? (
-            <Button
-              label={experience.acknowledge_button_label}
-              buttonType={ButtonType.PRIMARY}
-              onClick={onAcceptAll}
-            />
-          ) : (
-            <>
-              <Button
-                label={experience.save_button_label}
-                buttonType={ButtonType.SECONDARY}
-                onClick={handleSave}
-              />
-              <Button
-                label={experience.reject_button_label}
-                buttonType={ButtonType.PRIMARY}
-                onClick={handleRejectAll}
-              />
-              <Button
-                label={experience.accept_button_label}
-                buttonType={ButtonType.PRIMARY}
-                onClick={handleAcceptAll}
-              />
-            </>
-          )}
-        </div>
+        {buttonGroup}
         {experience.privacy_policy_link_label &&
         experience.privacy_policy_url ? (
           <a

--- a/clients/fides-js/src/components/NoticeToggles.tsx
+++ b/clients/fides-js/src/components/NoticeToggles.tsx
@@ -83,10 +83,7 @@ const NoticeToggles = ({
   return (
     <div>
       {notices.map((notice, idx) => {
-        const checked =
-          notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY
-            ? true
-            : enabledNoticeKeys.indexOf(notice.notice_key) !== -1;
+        const checked = enabledNoticeKeys.indexOf(notice.notice_key) !== -1;
         const isLast = idx === notices.length - 1;
         return (
           <div>

--- a/clients/fides-js/src/components/NoticeToggles.tsx
+++ b/clients/fides-js/src/components/NoticeToggles.tsx
@@ -1,6 +1,6 @@
 import { h } from "preact";
 
-import { PrivacyNotice } from "../lib/consent-types";
+import { ConsentMechanism, PrivacyNotice } from "../lib/consent-types";
 import Toggle from "./Toggle";
 import Divider from "./Divider";
 import { useDisclosure } from "../lib/hooks";
@@ -52,6 +52,7 @@ const NoticeToggle = ({
           id={notice.notice_key}
           checked={checked}
           onChange={onToggle}
+          disabled={notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY}
         />
       </div>
       <p {...getDisclosureProps()}>{notice.description}</p>
@@ -82,7 +83,10 @@ const NoticeToggles = ({
   return (
     <div>
       {notices.map((notice, idx) => {
-        const checked = enabledNoticeKeys.indexOf(notice.notice_key) !== -1;
+        const checked =
+          notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY
+            ? true
+            : enabledNoticeKeys.indexOf(notice.notice_key) !== -1;
         const isLast = idx === notices.length - 1;
         return (
           <div>

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -186,7 +186,7 @@ const Overlay: FunctionComponent<OverlayProps> = ({
           onClose={() => {
             setBannerIsOpen(false);
           }}
-          showAcknowledge={isAllNoticeOnly}
+          isAcknowledgeOnly={isAllNoticeOnly}
         />
       ) : null}
       <ConsentModal
@@ -199,7 +199,7 @@ const Overlay: FunctionComponent<OverlayProps> = ({
         onAcceptAll={handleAcceptAll}
         onRejectAll={handleRejectAll}
         onSave={handleUpdatePreferences}
-        shouldAcknowledge={isAllNoticeOnly}
+        isAcknowledgeOnly={isAllNoticeOnly}
       />
     </div>
   );

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -1,6 +1,7 @@
 import { h, FunctionComponent } from "preact";
 import { useEffect, useState, useCallback, useMemo } from "preact/hooks";
 import {
+  ConsentMechanism,
   ConsentMethod,
   FidesOptions,
   PrivacyExperience,
@@ -165,6 +166,10 @@ const Overlay: FunctionComponent<OverlayProps> = ({
     return null;
   }
 
+  const isAllNoticeOnly = privacyNotices.every(
+    (n) => n.consent_mechanism === ConsentMechanism.NOTICE_ONLY
+  );
+
   return (
     <div id="fides-js-root">
       {showBanner ? (
@@ -177,6 +182,7 @@ const Overlay: FunctionComponent<OverlayProps> = ({
           onClose={() => {
             setBannerIsOpen(false);
           }}
+          showAcknowledge={isAllNoticeOnly}
         />
       ) : null}
       <ConsentModal

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -154,7 +154,11 @@ const Overlay: FunctionComponent<OverlayProps> = ({
     handleUpdatePreferences(privacyNotices.map((n) => n.notice_key));
   };
   const handleRejectAll = () => {
-    handleUpdatePreferences([]);
+    handleUpdatePreferences(
+      privacyNotices
+        .filter((n) => n.consent_mechanism === ConsentMechanism.NOTICE_ONLY)
+        .map((n) => n.notice_key)
+    );
   };
 
   if (!hasMounted) {
@@ -171,7 +175,7 @@ const Overlay: FunctionComponent<OverlayProps> = ({
   );
 
   return (
-    <div id="fides-js-root">
+    <div>
       {showBanner ? (
         <ConsentBanner
           experience={experience.experience_config}

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -199,6 +199,7 @@ const Overlay: FunctionComponent<OverlayProps> = ({
         onAcceptAll={handleAcceptAll}
         onRejectAll={handleRejectAll}
         onSave={handleUpdatePreferences}
+        shouldAcknowledge={isAllNoticeOnly}
       />
     </div>
   );

--- a/clients/fides-js/src/components/Toggle.tsx
+++ b/clients/fides-js/src/components/Toggle.tsx
@@ -5,11 +5,13 @@ const Toggle = ({
   id,
   checked,
   onChange,
+  disabled,
 }: {
   name: string;
   id: string;
   checked: boolean;
   onChange: (noticeKey: string) => void;
+  disabled?: boolean;
 }) => {
   const labelId = `toggle-${id}`;
   return (
@@ -29,6 +31,7 @@ const Toggle = ({
         defaultChecked={checked}
         role="switch"
         aria-labelledby={labelId}
+        disabled={disabled}
       />
       {/* Mark as `hidden` so it will fall back to a regular checkbox if CSS is not available */}
       <span className="fides-toggle-display" hidden />

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -166,6 +166,10 @@ span.fides-banner-buttons-right {
   float: right;
 }
 
+span#fides-acknowledge-button .fides-banner-button {
+  min-width: 168px;
+}
+
 button.fides-banner-button {
   font-size: var(--fides-overlay-font-size-buttons);
   display: inline-block;

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -158,7 +158,7 @@ div#fides-banner-description {
   flex: 1;
 }
 
-div#fides-banner-buttons {
+div#fides-button-group {
   margin-top: 0.5em;
   display: flex;
   justify-content: space-between;

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -160,14 +160,18 @@ div#fides-banner-description {
 
 div#fides-banner-buttons {
   margin-top: 0.5em;
+  display: flex;
+  justify-content: space-between;
 }
 
-span.fides-banner-buttons-right {
-  float: right;
+div.fides-acknowledge-button-container {
+  margin-top: 0.5em;
+  display: flex;
+  justify-content: end;
 }
 
-span#fides-acknowledge-button .fides-banner-button {
-  min-width: 168px;
+div.fides-banner-acknowledge .fides-banner-button {
+  max-width: 168px;
 }
 
 button.fides-banner-button {
@@ -276,6 +280,7 @@ div#fides-modal .fides-modal-description {
 
 div#fides-modal .fides-modal-button-group {
   display: flex;
+  width: 100%;
 }
 
 .fides-close-button {

--- a/clients/fides-js/src/lib/consent-value.ts
+++ b/clients/fides-js/src/lib/consent-value.ts
@@ -1,5 +1,5 @@
 import { ConsentContext } from "./consent-context";
-import { ConsentValue, UserConsentPreference } from "./consent-types";
+import { ConsentValue, PrivacyNotice } from "./consent-types";
 import { transformUserPreferenceToBoolean } from "./consent-utils";
 
 export const resolveLegacyConsentValue = (
@@ -22,18 +22,17 @@ export const resolveLegacyConsentValue = (
 };
 
 export const resolveConsentValue = (
-  value: UserConsentPreference,
-  context: ConsentContext,
-  current_preference?: UserConsentPreference | null,
-  has_gpc_flag?: boolean
+  notice: PrivacyNotice,
+  context: ConsentContext
 ): boolean => {
-  if (current_preference) {
-    return transformUserPreferenceToBoolean(current_preference);
+  if (notice.current_preference) {
+    return transformUserPreferenceToBoolean(notice.current_preference);
   }
-  const gpcEnabled = !!has_gpc_flag && context.globalPrivacyControl === true;
+  const gpcEnabled =
+    !!notice.has_gpc_flag && context.globalPrivacyControl === true;
   if (gpcEnabled) {
     return false;
   }
 
-  return transformUserPreferenceToBoolean(value);
+  return transformUserPreferenceToBoolean(notice.default_preference);
 };

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -230,16 +230,9 @@ export const buildCookieConsentForExperiences = (
   if (!experience.privacy_notices) {
     return cookieConsent;
   }
-  experience.privacy_notices.forEach(
-    ({ notice_key, current_preference, default_preference, has_gpc_flag }) => {
-      cookieConsent[notice_key] = resolveConsentValue(
-        default_preference,
-        context,
-        current_preference,
-        has_gpc_flag
-      );
-    }
-  );
+  experience.privacy_notices.forEach((notice) => {
+    cookieConsent[notice.notice_key] = resolveConsentValue(notice, context);
+  });
   debugLog(debug, `Returning cookie consent for experiences.`, cookieConsent);
   return cookieConsent;
 };

--- a/clients/privacy-center/components/consent/ConsentItem.tsx
+++ b/clients/privacy-center/components/consent/ConsentItem.tsx
@@ -24,6 +24,7 @@ export type ConsentItemProps = {
   value: boolean;
   gpcStatus: GpcStatus;
   onChange: (value: boolean) => void;
+  disabled?: boolean;
 };
 
 const ConsentItem = ({
@@ -35,6 +36,7 @@ const ConsentItem = ({
   value,
   gpcStatus,
   onChange,
+  disabled,
 }: ConsentItemProps) => {
   const handleRadioChange = (radioValue: string) => {
     onChange(radioValue === "true");
@@ -85,6 +87,7 @@ const ConsentItem = ({
             <RadioGroup
               value={value ? "true" : "false"}
               onChange={handleRadioChange}
+              isDisabled={disabled}
             >
               <Stack direction="row">
                 <Radio value="true" colorScheme="whatsapp">

--- a/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
@@ -130,10 +130,21 @@ const NoticeDrivenConsent = () => {
 
     const preferences: ConsentOptionCreate[] = Object.entries(
       draftPreferences
-    ).map(([key, value]) => ({
-      privacy_notice_history_id: key,
-      preference: value ?? UserConsentPreference.OPT_OUT,
-    }));
+    ).map(([key, value]) => {
+      const notice = experience?.privacy_notices?.find(
+        (n) => n.privacy_notice_history_id === key
+      );
+      if (notice?.consent_mechanism === ConsentMechanism.NOTICE_ONLY) {
+        return {
+          privacy_notice_history_id: key,
+          preference: UserConsentPreference.ACKNOWLEDGE,
+        };
+      }
+      return {
+        privacy_notice_history_id: key,
+        preference: value ?? UserConsentPreference.OPT_OUT,
+      };
+    });
 
     const payload: PrivacyPreferencesRequest = {
       browser_identity: identities,

--- a/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
@@ -18,6 +18,7 @@ import {
 import { getGpcStatusFromNotice } from "~/features/consent/helpers";
 
 import {
+  ConsentMechanism,
   ConsentMethod,
   ConsentOptionCreate,
   PrivacyNoticeResponseWithUserPreferences,
@@ -111,6 +112,7 @@ const NoticeDrivenConsent = () => {
         url: undefined,
         value,
         gpcStatus,
+        disabled: notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY,
       };
     });
   }, [consentContext, experience, draftPreferences]);
@@ -175,7 +177,8 @@ const NoticeDrivenConsent = () => {
   return (
     <Stack spacing={6} paddingX={12}>
       {items.map((item, index) => {
-        const { id, highlight, url, name, description, historyId } = item;
+        const { id, highlight, url, name, description, historyId, disabled } =
+          item;
         const handleChange = (value: boolean) => {
           const pref = value
             ? UserConsentPreference.OPT_IN
@@ -197,6 +200,7 @@ const NoticeDrivenConsent = () => {
               value={item.value}
               gpcStatus={item.gpcStatus}
               onChange={handleChange}
+              disabled={disabled}
             />
           </React.Fragment>
         );

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -4,6 +4,7 @@ import {
   ConsentMethod,
   FidesCookie,
   LegacyConsentConfig,
+  PrivacyNotice,
 } from "fides-js";
 import {
   ConsentMechanism,
@@ -98,6 +99,35 @@ const stubConfig = (
     }
     cy.visitConsentDemo(updatedConfig);
   });
+};
+
+const mockPrivacyNotice = (params: Partial<PrivacyNotice>) => {
+  const notice = {
+    name: "Test privacy notice with GPC enabled",
+    disabled: false,
+    origin: "12435134",
+    description: "a test sample privacy notice configuration",
+    internal_description:
+      "a test sample privacy notice configuration for internal use",
+    regions: ["us_ca"],
+    consent_mechanism: ConsentMechanism.OPT_OUT,
+    default_preference: UserConsentPreference.OPT_IN,
+    current_preference: undefined,
+    outdated_preference: undefined,
+    has_gpc_flag: true,
+    data_uses: ["advertising", "third_party_sharing"],
+    enforcement_level: EnforcementLevel.SYSTEM_WIDE,
+    displayed_in_overlay: true,
+    displayed_in_api: true,
+    displayed_in_privacy_center: false,
+    id: "pri_4bed96d0-b9e3-4596-a807-26b783836374",
+    created_at: "2023-04-24T21:29:08.870351+00:00",
+    updated_at: "2023-04-24T21:29:08.870351+00:00",
+    version: 1.0,
+    privacy_notice_history_id: "pri_b09058a7-9f54-4360-8da5-4521e8975d4f",
+    notice_key: "advertising",
+  };
+  return { ...notice, ...params };
 };
 
 const PRIVACY_NOTICE_KEY_1 = "advertising";
@@ -448,32 +478,10 @@ describe("Consent banner", () => {
         stubConfig({
           experience: {
             privacy_notices: [
-              {
-                name: "Test privacy notice with GPC enabled",
-                disabled: false,
-                origin: "12435134",
-                description: "a test sample privacy notice configuration",
-                internal_description:
-                  "a test sample privacy notice configuration for internal use",
-                regions: ["us_ca"],
-                consent_mechanism: ConsentMechanism.OPT_OUT,
-                default_preference: UserConsentPreference.OPT_IN,
-                current_preference: undefined,
-                outdated_preference: undefined,
+              mockPrivacyNotice({
+                name: "Test privacy notice with gpc enabled",
                 has_gpc_flag: true,
-                data_uses: ["advertising", "third_party_sharing"],
-                enforcement_level: EnforcementLevel.SYSTEM_WIDE,
-                displayed_in_overlay: true,
-                displayed_in_api: true,
-                displayed_in_privacy_center: false,
-                id: "pri_4bed96d0-b9e3-4596-a807-26b783836374",
-                created_at: "2023-04-24T21:29:08.870351+00:00",
-                updated_at: "2023-04-24T21:29:08.870351+00:00",
-                version: 1.0,
-                privacy_notice_history_id:
-                  "pri_b09058a7-9f54-4360-8da5-4521e8975d4f",
-                notice_key: "advertising",
-              },
+              }),
             ],
           },
         });
@@ -541,32 +549,10 @@ describe("Consent banner", () => {
         stubConfig({
           experience: {
             privacy_notices: [
-              {
-                name: "Test privacy notice with GPC enabled",
-                disabled: false,
-                origin: "12435134",
-                description: "a test sample privacy notice configuration",
-                internal_description:
-                  "a test sample privacy notice configuration for internal use",
-                regions: ["us_ca"],
-                consent_mechanism: ConsentMechanism.OPT_OUT,
-                default_preference: UserConsentPreference.OPT_IN,
-                current_preference: undefined,
-                outdated_preference: undefined,
+              mockPrivacyNotice({
+                name: "Test privacy notice with GPC disabled",
                 has_gpc_flag: false,
-                data_uses: ["advertising", "third_party_sharing"],
-                enforcement_level: EnforcementLevel.SYSTEM_WIDE,
-                displayed_in_overlay: true,
-                displayed_in_api: true,
-                displayed_in_privacy_center: false,
-                id: "pri_4bed96d0-b9e3-4596-a807-26b783836374",
-                created_at: "2023-04-24T21:29:08.870351+00:00",
-                updated_at: "2023-04-24T21:29:08.870351+00:00",
-                version: 1.0,
-                privacy_notice_history_id:
-                  "pri_b09058a7-9f54-4360-8da5-4521e8975d4f",
-                notice_key: "advertising",
-              },
+              }),
             ],
           },
         });
@@ -600,34 +586,7 @@ describe("Consent banner", () => {
         cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
         stubConfig({
           experience: {
-            privacy_notices: [
-              {
-                name: "Test privacy notice with GPC enabled",
-                disabled: false,
-                origin: "12435134",
-                description: "a test sample privacy notice configuration",
-                internal_description:
-                  "a test sample privacy notice configuration for internal use",
-                regions: ["us_ca"],
-                consent_mechanism: ConsentMechanism.OPT_OUT,
-                default_preference: UserConsentPreference.OPT_IN,
-                current_preference: undefined,
-                outdated_preference: undefined,
-                has_gpc_flag: true,
-                data_uses: ["advertising", "third_party_sharing"],
-                enforcement_level: EnforcementLevel.SYSTEM_WIDE,
-                displayed_in_overlay: true,
-                displayed_in_api: true,
-                displayed_in_privacy_center: false,
-                id: "pri_4bed96d0-b9e3-4596-a807-26b783836374",
-                created_at: "2023-04-24T21:29:08.870351+00:00",
-                updated_at: "2023-04-24T21:29:08.870351+00:00",
-                version: 1.0,
-                privacy_notice_history_id:
-                  "pri_b09058a7-9f54-4360-8da5-4521e8975d4f",
-                notice_key: "advertising",
-              },
-            ],
+            privacy_notices: [mockPrivacyNotice({ has_gpc_flag: true })],
           },
         });
       });
@@ -882,32 +841,13 @@ describe("Consent banner", () => {
         stubConfig({
           experience: {
             privacy_notices: [
-              {
+              mockPrivacyNotice({
                 name: "Test privacy notice",
-                disabled: false,
-                origin: "12435134",
-                description: "a test sample privacy notice configuration",
-                internal_description:
-                  "a test sample privacy notice configuration for internal use",
-                regions: ["us_ca"],
+                has_gpc_flag: true,
                 consent_mechanism: ConsentMechanism.OPT_IN,
                 default_preference: UserConsentPreference.OPT_IN,
                 current_preference: UserConsentPreference.OPT_IN,
-                outdated_preference: undefined,
-                has_gpc_flag: true,
-                data_uses: ["advertising", "third_party_sharing"],
-                enforcement_level: EnforcementLevel.SYSTEM_WIDE,
-                displayed_in_overlay: true,
-                displayed_in_api: true,
-                displayed_in_privacy_center: false,
-                id: "pri_4bed96d0-b9e3-4596-a807-26b783836374",
-                created_at: "2023-04-24T21:29:08.870351+00:00",
-                updated_at: "2023-04-24T21:29:08.870351+00:00",
-                version: 1.0,
-                privacy_notice_history_id:
-                  "pri_b09058a7-9f54-4360-8da5-4521e8975d4f",
-                notice_key: "advertising",
-              },
+              }),
             ],
           },
         });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -481,6 +481,16 @@ describe("Consent banner", () => {
     });
 
     describe("when there are only notice-only notices", () => {
+      const expected = [
+        {
+          privacy_notice_history_id: "one",
+          preference: "acknowledge",
+        },
+        {
+          privacy_notice_history_id: "two",
+          preference: "acknowledge",
+        },
+      ];
       beforeEach(() => {
         cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
         stubConfig({
@@ -504,24 +514,25 @@ describe("Consent banner", () => {
         });
       });
 
-      it("renders an acknowledge button", () => {
+      it("renders an acknowledge button in the banner", () => {
         cy.get("div#fides-banner").within(() => {
           cy.get("button").contains("OK");
           cy.get("button").contains("Accept Test").should("not.exist");
           cy.get("button").contains("OK").click();
           cy.wait("@patchPrivacyPreference").then((interception) => {
             const { body } = interception.request;
-            const expected = [
-              {
-                privacy_notice_history_id: "one",
-                preference: "acknowledge",
-              },
-              {
-                privacy_notice_history_id: "two",
-                preference: "acknowledge",
-              },
-            ];
+            expect(body.preferences).to.eql(expected);
+          });
+        });
+      });
 
+      it("renders an acknowledge button in the modal", () => {
+        cy.get("#fides-modal-link").click();
+        cy.getByTestId("consent-modal").within(() => {
+          cy.get("button").contains("Accept Test").should("not.exist");
+          cy.get("button").contains("OK").click();
+          cy.wait("@patchPrivacyPreference").then((interception) => {
+            const { body } = interception.request;
             expect(body.preferences).to.eql(expected);
           });
         });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -205,7 +205,7 @@ describe("Consent banner", () => {
           ).contains(
             "This test website is overriding the banner description label."
           );
-          cy.get("div#fides-banner-buttons.fides-banner-buttons").within(() => {
+          cy.get("div#fides-button-group").within(() => {
             cy.get(
               "button#fides-banner-button-tertiary.fides-banner-button.fides-banner-button-tertiary"
             ).contains("Manage preferences");

--- a/clients/privacy-center/cypress/e2e/consent-notices.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-notices.cy.ts
@@ -8,6 +8,7 @@ import { API_URL } from "../support/constants";
 const VERIFICATION_CODE = "112358";
 const PRIVACY_NOTICE_ID_1 = "pri_b4360591-3cc7-400d-a5ff-a9f095ab3061";
 const PRIVACY_NOTICE_ID_2 = "pri_b558ab1f-5367-4f0d-94b1-ec06a81ae821";
+const PRIVACY_NOTICE_ID_3 = "pri_4bed96d0-b9e3-4596-a807-26b783836375";
 const PRIVACY_EXPERIENCE_ID = "pri_041acb07-c99b-4085-a435-c0d6f3a42b6f";
 const GEOLOCATION_API_URL = "https://www.example.com/location";
 const SETTINGS = {
@@ -86,6 +87,9 @@ describe("Privacy notice driven consent", () => {
       cy.getByTestId(`consent-item-${PRIVACY_NOTICE_ID_2}`).within(() => {
         cy.getRadio().should("be.checked");
       });
+      cy.getByTestId(`consent-item-${PRIVACY_NOTICE_ID_3}`).within(() => {
+        cy.getRadio().should("be.checked").should("be.disabled");
+      });
 
       // Opt in to the opt in notice
       cy.getByTestId(`consent-item-${PRIVACY_NOTICE_ID_1}`).within(() => {
@@ -102,7 +106,7 @@ describe("Privacy notice driven consent", () => {
         expect(id).to.eql(PRIVACY_EXPERIENCE_ID);
         expect(
           preferences.map((p: ConsentOptionCreate) => p.preference)
-        ).to.eql(["opt_in", "opt_in"]);
+        ).to.eql(["opt_in", "opt_in", "acknowledge"]);
         cy.waitUntilCookieExists(CONSENT_COOKIE_NAME).then(() => {
           cy.getCookie(CONSENT_COOKIE_NAME).then((cookieJson) => {
             const cookie = JSON.parse(
@@ -186,7 +190,7 @@ describe("Privacy notice driven consent", () => {
         const { preferences } = body;
         expect(
           preferences.map((p: ConsentOptionCreate) => p.preference)
-        ).to.eql(["opt_in", "opt_in"]);
+        ).to.eql(["opt_in", "opt_in", "acknowledge"]);
       });
     });
   });

--- a/clients/privacy-center/cypress/fixtures/consent/experience.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience.json
@@ -76,6 +76,30 @@
           "default_preference": "opt_in",
           "current_preference": null,
           "outdated_preference": null
+        },
+        {
+          "name": "Essential",
+          "notice_key": "essential",
+          "description": "Notify the user about data processing activities that are essential to your services functionality. Typically consent is not required for this.",
+          "internal_description": null,
+          "origin": null,
+          "regions": ["us_ca"],
+          "consent_mechanism": "notice_only",
+          "data_uses": ["provide.service"],
+          "enforcement_level": "system_wide",
+          "disabled": false,
+          "has_gpc_flag": false,
+          "displayed_in_privacy_center": true,
+          "displayed_in_overlay": true,
+          "displayed_in_api": true,
+          "id": "pri_4bed96d0-b9e3-4596-a807-26b783836375",
+          "created_at": "2023-04-24T21:29:08.870351+00:00",
+          "updated_at": "2023-04-24T21:29:08.870351+00:00",
+          "version": 1.0,
+          "privacy_notice_history_id": "pri_b09058a7-9f54-4360-8da5-4521e8975d4e",
+          "default_preference": "opt_in",
+          "current_preference": null,
+          "outdated_preference": null
         }
       ]
     }

--- a/clients/privacy-center/cypress/fixtures/consent/test_banner_options.json
+++ b/clients/privacy-center/cypress/fixtures/consent/test_banner_options.json
@@ -71,7 +71,7 @@
         "description": "Notify the user about data processing activities that are essential to your services functionality. Typically consent is not required for this.",
         "regions": ["us_ca"],
         "consent_mechanism": "notice_only",
-        "default_preference": "opt_out",
+        "default_preference": "opt_in",
         "current_preference": null,
         "outdated_preference": null,
         "has_gpc_flag": false,

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -84,7 +84,7 @@
                 "Notify the user about data processing activities that are essential to your services functionality. Typically consent is not required for this.",
               regions: ["us_ca"],
               consent_mechanism: "notice_only",
-              default_preference: "opt_out",
+              default_preference: "opt_in",
               current_preference: null,
               outdated_preference: null,
               has_gpc_flag: true,


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3443

### Code Changes

* [x] Conditionally render acknowledge button in the banner
* [x] Conditionally render acknowledge button in the modal
* [x] Make notice-only notices disabled and set to true in both fides-js and privacy center
* [x] Update tests
* [x] Refactored the button component out of the banner and modal since they have similar logic. A few style tweaks ensued. It also cuts down on our bundle size by about ~.1kb now that we are using more shared components and styles!
  * [x] This diff is pretty big, but is mostly contained to this commit https://github.com/ethyca/fides/pull/3546/commits/6dfec803b5190ce95ba973615b8467b585030e65


### Steps to Confirm

* Edit your `fides-js-demo-components.html` such that both notices are `notice_only` and have a default preference of `opt_in` (which all `notice_only` notices should have)
* `turbo dev` in the `fides-js` folder and visit http://localhost:3000/fides-js-components-demo.html
* You should see the banner render "OK" instead of accept/reject
* Click the modal link to view the notice-only notices which can't be toggled off. You should also see "OK" here instead of the 3 buttons
* Clicking "OK" should send an acknowledge preference
* Visit localhost:3000. You'll need to populate your notices with notice only ones. You should see the radio button becomes disabled

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

<img width="1252" alt="image" src="https://github.com/ethyca/fides/assets/24641006/a418f3a0-3c6b-429e-9324-6389ffd2bf21">

<img width="1243" alt="image" src="https://github.com/ethyca/fides/assets/24641006/76181952-14f3-4c63-9328-1fbfa5625519">

When only one notice is notice-only
<img width="1236" alt="image" src="https://github.com/ethyca/fides/assets/24641006/033b7617-2093-44a3-83b7-b78d96df9237">

Privacy center if we make a notice notice-only
<img width="715" alt="image" src="https://github.com/ethyca/fides/assets/24641006/2501553e-dd3a-438a-93bb-1a8f5d45c521">

