### PR TITLE
Reporting for anonymous consent requests

### DIFF
--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -887,9 +887,9 @@ class ProvidedIdentity(Base):  # pylint: disable=R0904
         )
         return hashed_value
 
-    def as_identity_schema(self) -> IdentityBase:
+    def as_identity_schema(self) -> Identity:
         """Creates an Identity schema from a ProvidedIdentity record in the application DB."""
-        identity = IdentityBase()
+        identity = Identity()
         if any(
             [
                 not self.field_name,

--- a/src/fides/api/schemas/privacy_request.py
+++ b/src/fides/api/schemas/privacy_request.py
@@ -7,7 +7,6 @@ from pydantic import Field, validator
 
 from fides.api.custom_types import SafeStr
 from fides.api.models.audit_log import AuditLogAction
-from fides.api.models.policy import ActionType
 from fides.api.models.privacy_request import (
     CheckpointActionRequired,
     ExecutionLogStatus,
@@ -15,8 +14,8 @@ from fides.api.models.privacy_request import (
 )
 from fides.api.schemas.api import BulkResponse, BulkUpdateFailed
 from fides.api.schemas.base_class import FidesSchema
-from fides.api.schemas.policy import PolicyResponse as PolicySchema
-from fides.api.schemas.redis_cache import Identity, IdentityBase
+from fides.api.schemas.policy import ActionType, PolicyResponse as PolicySchema
+from fides.api.schemas.redis_cache import Identity
 from fides.api.schemas.user import PrivacyRequestReviewer
 from fides.api.util.encryption.aes_gcm_encryption_scheme import verify_encryption_key
 from fides.core.config import CONFIG

--- a/src/fides/api/schemas/privacy_request.py
+++ b/src/fides/api/schemas/privacy_request.py
@@ -7,6 +7,7 @@ from pydantic import Field, validator
 
 from fides.api.custom_types import SafeStr
 from fides.api.models.audit_log import AuditLogAction
+from fides.api.models.policy import ActionType
 from fides.api.models.privacy_request import (
     CheckpointActionRequired,
     ExecutionLogStatus,
@@ -14,7 +15,6 @@ from fides.api.models.privacy_request import (
 )
 from fides.api.schemas.api import BulkResponse, BulkUpdateFailed
 from fides.api.schemas.base_class import FidesSchema
-from fides.api.schemas.policy import ActionType
 from fides.api.schemas.policy import PolicyResponse as PolicySchema
 from fides.api.schemas.redis_cache import Identity, IdentityBase
 from fides.api.schemas.user import PrivacyRequestReviewer
@@ -65,7 +65,7 @@ class ConsentReport(Consent):
     """Schema for reporting Consent requests."""
 
     id: str
-    identity: IdentityBase
+    identity: Identity
     created_at: datetime
     updated_at: datetime
 

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -2049,6 +2049,41 @@ def privacy_preference_history(
 
 
 @pytest.fixture(scope="function")
+def anonymous_consent_records(
+    db,
+    fides_user_provided_identity_and_consent_request,
+):
+    (
+        provided_identity,
+        consent_request,
+    ) = fides_user_provided_identity_and_consent_request
+    consent_request.cache_identity_verification_code("abcdefg")
+
+    consent_data = [
+        {
+            "data_use": "email",
+            "data_use_description": None,
+            "opt_in": True,
+        },
+        {
+            "data_use": "location",
+            "data_use_description": "Location data",
+            "opt_in": False,
+        },
+    ]
+
+    records = []
+    for data in deepcopy(consent_data):
+        data["provided_identity_id"] = provided_identity.id
+        records.append(Consent.create(db, data=data))
+
+    yield records
+
+    for record in records:
+        record.delete(db)
+
+
+@pytest.fixture(scope="function")
 def consent_records(
     db,
     provided_identity_and_consent_request,


### PR DESCRIPTION
### Description Of Changes

This PR adds extra tests for the consent reporting API, including anonymous requests, use more detailed identity schemas in responses.

### Code Changes

* [ ] Use the `Identity` schema over `IdentityBase` so as to include the `fides_user_device_id` in reported consent requests

### Steps to Confirm

* [ ] Add some anonymous consent requests via the privacy centre
  * [ ] Ensure `email` is set to `optional` in the privacy centre's config for the `consent` option
  * [ ] Run the privacy centre alongside the backend and submit a request
* [ ] Call the consent reporting API at `/api/v1/consent-request/preferences/`
  * [ ] Please note: the `identity` filter will not work with anonymous `fides_user_device_id`s

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated