### PR TITLE
disable connector dropdown in integration tab on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The types of changes are:
 ### Fixed
 - Fix race condition with consent modal link rendering [#3521](https://github.com/ethyca/fides/pull/3521)
 - Remove the `fides-js` banner from tab order when it is hidden and move the overlay components to the top of the tab order. [#3510](https://github.com/ethyca/fides/pull/3510)
-- Disable connector dropdown in integration tab on save[#3552](https://github.com/ethyca/fides/pull/3552)
+- Disable connector dropdown in integration tab on save [#3552](https://github.com/ethyca/fides/pull/3552)
 
 ### Developer Experience
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,8 @@ The types of changes are:
 
 ### Fixed
 - Fix race condition with consent modal link rendering [#3521](https://github.com/ethyca/fides/pull/3521)
-
-
-### Fixed
 - Remove the `fides-js` banner from tab order when it is hidden and move the overlay components to the top of the tab order. [#3510](https://github.com/ethyca/fides/pull/3510)
+- Disable connector dropdown in integration tab on save[#3552](https://github.com/ethyca/fides/pull/3552)
 
 ### Developer Experience
 

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionForm.tsx
@@ -68,6 +68,7 @@ const ConnectionForm = ({ connectionConfig, systemFidesKey }: Props) => {
           label="Connection Type"
           selectedValue={selectedConnectionOption}
           onChange={setSelectedConnectionOption}
+          disabled={connectionConfig !== null}
         />
 
         {!connectionConfig && orphanedConnectionConfigs.length > 0 ? (

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionListDropdown.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionListDropdown.tsx
@@ -135,7 +135,7 @@ export const useConnectionListDropDown = ({
 };
 
 const ConnectionListDropdown: React.FC<SelectDropdownProps> = ({
-  disabled = false,
+  disabled,
   hasClear = true,
   label,
   list,


### PR DESCRIPTION
Closes #3535 

### Code Changes
 Updated the ConnectionListDropdown to be disabled when a connectionConfig is saved. 

### Steps to Confirm

* [x] create a new system 
* [x] nav to the integration tab - see that the dropdown in enabled and no connector is saved 
* [x] use the dropdown to create a connector 
* [x] fill in the form 
* [x] click save 
* [x] verify that once the connector saved the dropdown is disabled 
* [x] delete the connector 
* [x] verify the dropdown is enabled again 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

