### PR TITLE
hide custom fields section when there are no custom fields created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,8 @@ The types of changes are:
 
 ### Fixed
 - Fix race condition with consent modal link rendering [#3521](https://github.com/ethyca/fides/pull/3521)
-
-
-### Fixed
 - Remove the `fides-js` banner from tab order when it is hidden and move the overlay components to the top of the tab order. [#3510](https://github.com/ethyca/fides/pull/3510)
+- Hide custom fields section when there are no custom fields created [#3554](https://github.com/ethyca/fides/pull/3554)
 
 ### Developer Experience
 

--- a/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
+++ b/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
@@ -26,7 +26,7 @@ export const CustomFieldsList = ({
     resourceType,
   });
 
-  if (!isEnabled) {
+  if (!isEnabled || sortedCustomFieldDefinitionIds.length == 0) {
     return null;
   }
 

--- a/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
+++ b/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
@@ -26,7 +26,7 @@ export const CustomFieldsList = ({
     resourceType,
   });
 
-  if (!isEnabled || sortedCustomFieldDefinitionIds.length == 0) {
+  if (!isEnabled || sortedCustomFieldDefinitionIds.length === 0) {
     return null;
   }
 


### PR DESCRIPTION
Closes #3545 

### Code Changes

Updated custom fields list to check a field is created before showing

### Steps to Confirm

* [x] verify no custom fields created 
* [x] verify the custom list section does not show on the system information or data use tabs 
* [x] create a custom field for both system and system: data use 
* [x] verify the custom list section does show on the system information or data use tabs with the respective fields you created 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
