### PR TITLE
remove the configure privacy request tile from the home screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The types of changes are:
 - Remove the `fides-js` banner from tab order when it is hidden and move the overlay components to the top of the tab order. [#3510](https://github.com/ethyca/fides/pull/3510)
 - Disable connector dropdown in integration tab on save [#3552](https://github.com/ethyca/fides/pull/3552)
 - Handles an edge case for non-existent identities with the Kustomer API [#3513](https://github.com/ethyca/fides/pull/3513)
+- remove the configure privacy request tile from the home screen [#3555](https://github.com/ethyca/fides/pull/3555)
 
 ### Developer Experience
 

--- a/clients/admin-ui/cypress/e2e/home.cy.ts
+++ b/clients/admin-ui/cypress/e2e/home.cy.ts
@@ -6,7 +6,6 @@ const ALL_TILES = [
   "View data map",
   "Add systems",
   "View systems",
-  "Configure privacy requests",
   "Review privacy requests",
 ];
 

--- a/clients/admin-ui/src/home/constants.ts
+++ b/clients/admin-ui/src/home/constants.ts
@@ -1,7 +1,6 @@
 import {
   ADD_SYSTEMS_ROUTE,
   DATAMAP_ROUTE,
-  DATASTORE_CONNECTION_ROUTE,
   PRIVACY_REQUESTS_ROUTE,
   SYSTEM_ROUTE,
 } from "~/features/common/nav/v2/routes";
@@ -15,9 +14,8 @@ import { ModuleCardConfig } from "./types";
 export enum ModuleCardKeys {
   ADD_SYSTEMS = 1,
   VIEW_SYSTEMS = 2,
-  CONFIGURE_PRIVACY_REQUESTS = 3,
-  REVIEW_PRIVACY_REQUESTS = 4,
-  VIEW_MAP = 5,
+  REVIEW_PRIVACY_REQUESTS = 3,
+  VIEW_MAP = 4,
 }
 
 export const MODULE_CARD_ITEMS: ModuleCardConfig[] = [
@@ -57,18 +55,6 @@ export const MODULE_CARD_ITEMS: ModuleCardConfig[] = [
     scopes: [ScopeRegistryEnum.SYSTEM_READ],
     requiresSystems: true,
   },
-  {
-    color: "teal",
-    description:
-      "Connect your systems and configure privacy request processing for DSRs (access and erasure).",
-    href: `${DATASTORE_CONNECTION_ROUTE}/new?step=1`,
-    key: ModuleCardKeys.CONFIGURE_PRIVACY_REQUESTS,
-    name: "Configure privacy requests",
-    sortOrder: 3,
-    title: "PR",
-    scopes: [ScopeRegistryEnum.CONNECTION_CREATE_OR_UPDATE],
-  },
-
   {
     color: "pink",
     description:

--- a/clients/admin-ui/src/home/tile-config.test.ts
+++ b/clients/admin-ui/src/home/tile-config.test.ts
@@ -85,9 +85,7 @@ describe("configureTiles", () => {
           ScopeRegistryEnum.CONNECTION_CREATE_OR_UPDATE,
         ],
       });
-      expect(tiles.map((t) => t.name)).toEqual([
-        "Review privacy requests",
-      ]);
+      expect(tiles.map((t) => t.name)).toEqual(["Review privacy requests"]);
     });
   });
 });

--- a/clients/admin-ui/src/home/tile-config.test.ts
+++ b/clients/admin-ui/src/home/tile-config.test.ts
@@ -60,14 +60,6 @@ describe("configureTiles", () => {
       expect(tiles.map((t) => t.name)).toEqual(["Add systems"]);
     });
 
-    it("conditionally shows configure privacy requests", () => {
-      const tiles = configureTiles({
-        config: MODULE_CARD_ITEMS,
-        userScopes: [ScopeRegistryEnum.CONNECTION_CREATE_OR_UPDATE],
-      });
-      expect(tiles.map((t) => t.name)).toEqual(["Configure privacy requests"]);
-    });
-
     it("conditionally shows view datamap", () => {
       const tiles = configureTiles({
         config: MODULE_CARD_ITEMS,
@@ -94,7 +86,6 @@ describe("configureTiles", () => {
         ],
       });
       expect(tiles.map((t) => t.name)).toEqual([
-        "Configure privacy requests",
         "Review privacy requests",
       ]);
     });

--- a/clients/cypress-e2e/cypress/e2e/smoke_test.cy.ts
+++ b/clients/cypress-e2e/cypress/e2e/smoke_test.cy.ts
@@ -57,6 +57,22 @@ describe("Smoke test", () => {
     });
   });
 
+  it("can access Mongo and Postgres connectors from the Admin UI", () => {
+    cy.intercept(`${API_URL}/connection_type`).as("getConnectionType");
+    cy.intercept(`${API_URL}/connection*`).as("getConnections");
+
+    cy.visit(ADMIN_UI_URL);
+    cy.login();
+    cy.get("a").contains("Privacy requests").click();
+    cy.get("a").contains("Connection manager").click();
+    cy.wait("@getConnectionType");
+    cy.getByTestId("connection-grid-item-MongoDB Connector").within(() => {
+      cy.get("button").contains("Test").click();
+    });
+    cy.getByTestId("connection-grid-item-Postgres Connector").within(() => {
+      cy.get("button").contains("Test").click();
+    });
+  });
 
   it("can manage consent preferences from the Privacy Center", () => {
     cy.visit(PRIVACY_CENTER_URL);

--- a/clients/cypress-e2e/cypress/e2e/smoke_test.cy.ts
+++ b/clients/cypress-e2e/cypress/e2e/smoke_test.cy.ts
@@ -57,23 +57,6 @@ describe("Smoke test", () => {
     });
   });
 
-  it("can access Mongo and Postgres connectors from the Admin UI", () => {
-    cy.intercept(`${API_URL}/connection_type`).as("getConnectionType");
-    cy.intercept(`${API_URL}/connection*`).as("getConnections");
-
-    cy.visit(ADMIN_UI_URL);
-    cy.login();
-    cy.get("div").contains("Configure privacy requests").click();
-    cy.wait("@getConnections");
-    cy.get("a").contains("Connection manager").click();
-    cy.wait("@getConnectionType");
-    cy.getByTestId("connection-grid-item-MongoDB Connector").within(() => {
-      cy.get("button").contains("Test").click();
-    });
-    cy.getByTestId("connection-grid-item-Postgres Connector").within(() => {
-      cy.get("button").contains("Test").click();
-    });
-  });
 
   it("can manage consent preferences from the Privacy Center", () => {
     cy.visit(PRIVACY_CENTER_URL);


### PR DESCRIPTION
Closes #3536 

### Code Changes

delete the configure privacy request tile 

### Steps to Confirm

* [x] verify there is no configure privacy request tile on the home screen

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

