### PR TITLE
Update to new GitHub Actions Output Function - #3531 

### DIFF
--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -33,33 +33,33 @@ jobs:
         id: check-prod-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+            echo match=true >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=match::false
+            echo match=false >> $GITHUB_OUTPUT
           fi
       - name: Check RC Tag
         id: check-rc-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+            echo match=true >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=match::false
+            echo match=false >> $GITHUB_OUTPUT
           fi
       - name: Check alpha Tag
         id: check-alpha-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+a[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+            echo match=true >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=match::false
+            echo match=false >> $GITHUB_OUTPUT
           fi
       - name: Check beta Tag
         id: check-beta-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+            echo match=true >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=match::false
+            echo match=false >> $GITHUB_OUTPUT
           fi
 
       # if neither prod, rc, beta or alpha git tag, then push images with the ":dev" tag

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -33,33 +33,33 @@ jobs:
         id: check-prod-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo match=true >> $GITHUB_OUTPUT
+            echo "match=true" >> $GITHUB_OUTPUT
           else
-            echo match=false >> $GITHUB_OUTPUT
+            echo "match=false" >> $GITHUB_OUTPUT
           fi
       - name: Check RC Tag
         id: check-rc-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]]; then
-            echo match=true >> $GITHUB_OUTPUT
+            echo "match=true" >> $GITHUB_OUTPUT
           else
-            echo match=false >> $GITHUB_OUTPUT
+            echo "match=false" >> $GITHUB_OUTPUT
           fi
       - name: Check alpha Tag
         id: check-alpha-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+a[0-9]+$ ]]; then
-            echo match=true >> $GITHUB_OUTPUT
+            echo "match=true" >> $GITHUB_OUTPUT
           else
-            echo match=false >> $GITHUB_OUTPUT
+            echo "match=false" >> $GITHUB_OUTPUT
           fi
       - name: Check beta Tag
         id: check-beta-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$ ]]; then
-            echo match=true >> $GITHUB_OUTPUT
+            echo "match=true" >> $GITHUB_OUTPUT
           else
-            echo match=false >> $GITHUB_OUTPUT
+            echo "match=false" >> $GITHUB_OUTPUT
           fi
 
       # if neither prod, rc, beta or alpha git tag, then push images with the ":dev" tag

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -53,33 +53,33 @@ jobs:
         id: check-prod-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+            echo match=true >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=match::false
+            echo match=false >> $GITHUB_OUTPUT
           fi
       - name: Check RC Tag
         id: check-rc-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+            echo match=true >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=match::false
+            echo match=false >> $GITHUB_OUTPUT
           fi
       - name: Check alpha Tag
         id: check-alpha-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+a[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+            echo match=true >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=match::false
+            echo match=false >> $GITHUB_OUTPUT
           fi
       - name: Check beta Tag
         id: check-beta-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+            echo match=true >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=match::false
+            echo match=false >> $GITHUB_OUTPUT
           fi
 
       # Prod and 'beta' tags go to PyPI; 'rc', 'alpha', all other tags and untagged commits go to TestPyPI

--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -53,33 +53,33 @@ jobs:
         id: check-prod-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo match=true >> $GITHUB_OUTPUT
+            echo "match=true" >> $GITHUB_OUTPUT
           else
-            echo match=false >> $GITHUB_OUTPUT
+            echo "match=false" >> $GITHUB_OUTPUT
           fi
       - name: Check RC Tag
         id: check-rc-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]]; then
-            echo match=true >> $GITHUB_OUTPUT
+            echo "match=true" >> $GITHUB_OUTPUT
           else
-            echo match=false >> $GITHUB_OUTPUT
+            echo "match=false" >> $GITHUB_OUTPUT
           fi
       - name: Check alpha Tag
         id: check-alpha-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+a[0-9]+$ ]]; then
-            echo match=true >> $GITHUB_OUTPUT
+            echo "match=true" >> $GITHUB_OUTPUT
           else
-            echo match=false >> $GITHUB_OUTPUT
+            echo "match=false" >> $GITHUB_OUTPUT
           fi
       - name: Check beta Tag
         id: check-beta-tag
         run: |
           if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$ ]]; then
-            echo match=true >> $GITHUB_OUTPUT
+            echo "match=true" >> $GITHUB_OUTPUT
           else
-            echo match=false >> $GITHUB_OUTPUT
+            echo "match=false" >> $GITHUB_OUTPUT
           fi
 
       # Prod and 'beta' tags go to PyPI; 'rc', 'alpha', all other tags and untagged commits go to TestPyPI


### PR DESCRIPTION
This PR updates the GH Actions `set-output` function to the new method of using the env var `$GITHUB_OUTPUT`
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Old style: `echo "::set-output name={name}::{value}"`
New style: `echo "{name}={value}" >> $GITHUB_OUTPUT` 

Closes #3531 

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
