### PR TITLE
[Backend] Remove Automatic SafeStr serialization from PrivacyExperienceConfig.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The types of changes are:
 - Disable connector dropdown in integration tab on save [#3552](https://github.com/ethyca/fides/pull/3552)
 - Handles an edge case for non-existent identities with the Kustomer API [#3513](https://github.com/ethyca/fides/pull/3513)
 - remove the configure privacy request tile from the home screen [#3555](https://github.com/ethyca/fides/pull/3555)
+- Updated Privacy Experience Safe Strings Serialization [#3600](https://github.com/ethyca/fides/pull/3600/)
 
 ### Developer Experience
 

--- a/src/fides/api/api/v1/endpoints/connection_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/connection_endpoints.py
@@ -35,6 +35,7 @@ from fides.api.models.connectionconfig import (
     ConnectionType,
 )
 from fides.api.models.datasetconfig import DatasetConfig
+from fides.api.models.sql_models import Dataset as CtlDataset  # type: ignore[attr-defined]
 from fides.api.oauth.utils import verify_oauth_client
 from fides.api.schemas.connection_configuration import connection_secrets_schemas
 from fides.api.schemas.connection_configuration.connection_config import (
@@ -48,7 +49,6 @@ from fides.api.schemas.connection_configuration.connection_secrets import (
     TestStatusMessage,
 )
 from fides.api.service.connectors import get_connector
-from fides.api.models.sql_models import Dataset as CtlDataset  # type: ignore[attr-defined]
 from fides.api.util.api_router import APIRouter
 from fides.api.util.connection_util import (
     patch_connection_configs,

--- a/src/fides/api/api/v1/endpoints/dataset_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/dataset_endpoints.py
@@ -52,9 +52,7 @@ from fides.api.models.datasetconfig import (
     convert_dataset_to_graph,
     to_graph_field,
 )
-from fides.api.models.sql_models import (  # type: ignore[attr-defined]
-    Dataset as CtlDataset,
-)
+from fides.api.models.sql_models import Dataset as CtlDataset  # type: ignore[attr-defined]
 from fides.api.oauth.utils import verify_oauth_client
 from fides.api.schemas.api import BulkUpdateFailed
 from fides.api.schemas.dataset import (

--- a/src/fides/api/api/v1/endpoints/privacy_experience_config_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_experience_config_endpoints.py
@@ -35,7 +35,10 @@ from fides.api.schemas.privacy_experience import (
     ExperienceConfigUpdate,
 )
 from fides.api.util.api_router import APIRouter
-from fides.api.util.consent_util import PRIVACY_EXPERIENCE_ESCAPE_FIELDS
+from fides.api.util.consent_util import (
+    PRIVACY_EXPERIENCE_ESCAPE_FIELDS,
+    UNESCAPE_SAFESTR_HEADER,
+)
 
 router = APIRouter(tags=["Privacy Experience Config"], prefix=urls.V1_URL_PREFIX)
 
@@ -80,7 +83,7 @@ def experience_config_list(
     Returns a list of PrivacyExperienceConfig resources.  These resources have common titles, descriptions, and
     labels that can be shared between multiple experiences.
     """
-    should_unescape = request.headers.get("unescape-safestr")
+    should_unescape = request.headers.get(UNESCAPE_SAFESTR_HEADER)
     privacy_experience_config_query: Query = db.query(PrivacyExperienceConfig)
 
     if component:
@@ -208,7 +211,7 @@ def experience_config_detail(
     Returns a PrivacyExperienceConfig.
     """
     logger.info("Retrieving experience config with id '{}'.", experience_config_id)
-    should_unescape = request.headers.get("unescape-safestr")
+    should_unescape = request.headers.get(UNESCAPE_SAFESTR_HEADER)
 
     experience_config = get_experience_config_or_error(db, experience_config_id)
     if should_unescape:

--- a/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
@@ -29,6 +29,7 @@ from fides.api.util.api_router import APIRouter
 from fides.api.util.consent_util import (
     PRIVACY_EXPERIENCE_ESCAPE_FIELDS,
     PRIVACY_NOTICE_ESCAPE_FIELDS,
+    UNESCAPE_SAFESTR_HEADER,
     get_fides_user_device_id_provided_identity,
 )
 from fides.core.config import CONFIG
@@ -122,7 +123,7 @@ def privacy_experience_list(
         )
 
     results: List[PrivacyExperience] = []
-    should_unescape = request.headers.get("unescape-safestr")
+    should_unescape = request.headers.get(UNESCAPE_SAFESTR_HEADER)
     for privacy_experience in experience_query.order_by(
         PrivacyExperience.created_at.desc()
     ):

--- a/src/fides/api/api/v1/endpoints/privacy_notice_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_notice_endpoints.py
@@ -29,6 +29,7 @@ from fides.api.schemas import privacy_notice as schemas
 from fides.api.util.api_router import APIRouter
 from fides.api.util.consent_util import (
     PRIVACY_NOTICE_ESCAPE_FIELDS,
+    UNESCAPE_SAFESTR_HEADER,
     create_privacy_notices_util,
     ensure_unique_ids,
     prepare_privacy_notice_patches,
@@ -88,7 +89,7 @@ def get_privacy_notice_list(
         systems_applicable=systems_applicable,
         region=region,
     )
-    should_unescape = request.headers.get("unescape-safestr")
+    should_unescape = request.headers.get(UNESCAPE_SAFESTR_HEADER)
     privacy_notices = notice_query.order_by(PrivacyNotice.created_at.desc())
     return paginate(
         [
@@ -187,7 +188,7 @@ def get_privacy_notice(
     """
     Return a single PrivacyNotice
     """
-    should_unescape = request.headers.get("unescape-safestr")
+    should_unescape = request.headers.get(UNESCAPE_SAFESTR_HEADER)
     notice = get_privacy_notice_or_error(db, privacy_notice_id)
     if should_unescape:
         notice = transform_fields(

--- a/src/fides/api/api/v1/endpoints/utils.py
+++ b/src/fides/api/api/v1/endpoints/utils.py
@@ -137,9 +137,7 @@ def validate_start_and_end_filters(
             )
 
 
-def transform_fields(
-    transformation: Callable, model: object, fields: List[str]
-) -> object:
+def transform_fields(transformation: Callable, model: Base, fields: List[str]) -> Base:
     """
     Takes a callable and returns a transformed object.
     """

--- a/src/fides/api/models/datasetconfig.py
+++ b/src/fides/api/models/datasetconfig.py
@@ -19,9 +19,8 @@ from fides.api.graph.config import (
 )
 from fides.api.graph.data_type import parse_data_type_string
 from fides.api.models.connectionconfig import ConnectionConfig, ConnectionType
-from fides.api.models.sql_models import (  # type: ignore[attr-defined]
-    Dataset as CtlDataset,
-)
+from fides.api.models.sql_models import Dataset as CtlDataset  # type: ignore[attr-defined]
+
 from fides.api.util.saas_util import merge_datasets
 
 

--- a/src/fides/api/schemas/privacy_experience.py
+++ b/src/fides/api/schemas/privacy_experience.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional
 from pydantic import Extra, Field, root_validator, validator
 
 from fides.api.api.v1.endpoints.utils import human_friendly_list
-from fides.api.custom_types import SafeStr
 from fides.api.models.privacy_experience import BannerEnabled, ComponentType
 from fides.api.models.privacy_notice import PrivacyNoticeRegion
 from fides.api.schemas.base_class import FidesSchema
@@ -22,14 +21,14 @@ class ExperienceConfigSchema(FidesSchema):
     but cannot be updated later.
     """
 
-    accept_button_label: Optional[SafeStr] = Field(
+    accept_button_label: Optional[str] = Field(
         description="Overlay 'Accept button displayed on the Banner and Privacy Preferences' or Privacy Center 'Confirmation button label'"
     )
-    acknowledge_button_label: Optional[SafeStr] = Field(
+    acknowledge_button_label: Optional[str] = Field(
         description="Overlay 'Acknowledge button label for notice only banner'"
     )
     banner_enabled: Optional[BannerEnabled] = Field(description="Overlay 'Banner'")
-    description: Optional[SafeStr] = Field(
+    description: Optional[str] = Field(
         description="Overlay 'Banner Description' or Privacy Center 'Description'"
     )
     disabled: Optional[bool] = Field(
@@ -39,25 +38,25 @@ class ExperienceConfigSchema(FidesSchema):
         default=False,
         description="Whether the given ExperienceConfig is a global default",
     )
-    privacy_policy_link_label: Optional[SafeStr] = Field(
+    privacy_policy_link_label: Optional[str] = Field(
         description="Overlay and Privacy Center 'Privacy policy link label'"
     )
-    privacy_policy_url: Optional[SafeStr] = Field(
+    privacy_policy_url: Optional[str] = Field(
         description="Overlay and Privacy Center 'Privacy policy URl'"
     )
-    privacy_preferences_link_label: Optional[SafeStr] = Field(
+    privacy_preferences_link_label: Optional[str] = Field(
         description="Overlay 'Privacy preferences link label'"
     )
     regions: Optional[List[PrivacyNoticeRegion]] = Field(
         description="Regions using this ExperienceConfig"
     )
-    reject_button_label: Optional[SafeStr] = Field(
+    reject_button_label: Optional[str] = Field(
         description="Overlay 'Reject button displayed on the Banner and 'Privacy Preferences' of Privacy Center 'Reject button label'"
     )
-    save_button_label: Optional[SafeStr] = Field(
+    save_button_label: Optional[str] = Field(
         description="Overlay 'Privacy preferences 'Save' button label"
     )
-    title: Optional[SafeStr] = Field(
+    title: Optional[str] = Field(
         description="Overlay 'Banner title' or Privacy Center 'title'"
     )
 
@@ -79,12 +78,12 @@ class ExperienceConfigCreate(ExperienceConfigSchema):
     It also establishes some fields _required_ for creation
     """
 
-    accept_button_label: SafeStr
+    accept_button_label: str
     component: ComponentType
-    description: SafeStr
-    reject_button_label: SafeStr
-    save_button_label: SafeStr
-    title: SafeStr
+    description: str
+    reject_button_label: str
+    save_button_label: str
+    title: str
 
     @root_validator
     def validate_attributes(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/fides/api/util/consent_util.py
+++ b/src/fides/api/util/consent_util.py
@@ -1,4 +1,4 @@
-from html import escape, unescape
+from html import escape
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 
 import yaml

--- a/src/fides/api/util/consent_util.py
+++ b/src/fides/api/util/consent_util.py
@@ -53,6 +53,7 @@ PRIVACY_EXPERIENCE_ESCAPE_FIELDS = [
     "save_button_label",
     "title",
 ]
+UNESCAPE_SAFESTR_HEADER = "unescape-safestr"
 
 
 def filter_privacy_preferences_for_propagation(

--- a/src/fides/api/util/data_category.py
+++ b/src/fides/api/util/data_category.py
@@ -6,9 +6,7 @@ from fideslang.validation import FidesKey
 from sqlalchemy.orm import Session
 
 from fides.api import common_exceptions
-from fides.api.models.sql_models import (  # type: ignore[attr-defined]
-    DataCategory as DataCategoryDbModel,
-)
+from fides.api.models.sql_models import DataCategory as DataCategoryDbModel  # type: ignore[attr-defined]
 
 
 def generate_fides_data_categories() -> Type[EnumType]:

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -1445,7 +1445,7 @@ def privacy_notice(db: Session) -> Generator:
         data={
             "name": "example privacy notice",
             "notice_key": "example_privacy_notice",
-            "description": "a sample privacy notice configuration",
+            "description": "user&#x27;s description &lt;script /&gt;",
             "regions": [
                 PrivacyNoticeRegion.us_ca,
                 PrivacyNoticeRegion.us_co,
@@ -2201,7 +2201,7 @@ def experience_config_privacy_center(db: Session) -> Generator:
         db=db,
         data={
             "accept_button_label": "Accept all",
-            "description": "We care about your privacy",
+            "description": "user&#x27;s description &lt;script /&gt;",
             "component": "privacy_center",
             "reject_button_label": "Reject all",
             "save_button_label": "Save",
@@ -2244,7 +2244,7 @@ def experience_config_overlay(db: Session) -> Generator:
             "description": "On this page you can opt in and out of these data uses cases",
             "disabled": False,
             "privacy_preferences_link_label": "Manage preferences",
-            "privacy_policy_link_label": "View our privacy policy",
+            "privacy_policy_link_label": "View our company&#x27;s privacy policy",
             "privacy_policy_url": "example.com/privacy",
             "reject_button_label": "Reject all",
             "save_button_label": "Save",

--- a/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
@@ -26,8 +26,8 @@ from fides.api.models.connectionconfig import (
 from fides.api.models.datasetconfig import DatasetConfig
 from fides.api.models.manual_webhook import AccessManualWebhook
 from fides.api.models.privacy_request import PrivacyRequestStatus
-from fides.api.oauth.roles import APPROVER, OWNER, VIEWER
 from fides.api.models.sql_models import Dataset
+from fides.api.oauth.roles import APPROVER, OWNER, VIEWER
 from tests.fixtures.application_fixtures import integration_secrets
 from tests.fixtures.saas.connection_template_fixtures import instantiate_connector
 

--- a/tests/ops/api/v1/endpoints/test_privacy_experience_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_experience_config_endpoints.py
@@ -70,11 +70,9 @@ class TestGetExperienceConfigList:
         experience_config_privacy_center,
         experience_config_overlay,
     ) -> None:
+        unescape_header = {"Unescape-Safestr": "true"}
         auth_header = generate_auth_header(scopes=[scopes.PRIVACY_EXPERIENCE_READ])
-        response = api_client.get(
-            url,
-            headers=auth_header,
-        )
+        response = api_client.get(url, headers={**auth_header, **unescape_header})
         assert response.status_code == 200
         resp = response.json()
         assert resp["total"] == 4  # Two default configs loaded on startup plus two here
@@ -99,6 +97,9 @@ class TestGetExperienceConfigList:
 
         second_config = data[1]
         assert second_config["id"] == experience_config_privacy_center.id
+        assert (
+            second_config["description"] == "user's description <script />"
+        )  # Unescaped due to header
         assert second_config["component"] == "privacy_center"
         assert second_config["banner_enabled"] is None
         assert second_config["disabled"] is True
@@ -126,6 +127,29 @@ class TestGetExperienceConfigList:
         assert fourth_config["disabled"] is False
         assert fourth_config["regions"] == []
         assert fourth_config["component"] == "overlay"
+
+    @pytest.mark.usefixtures(
+        "privacy_experience_privacy_center",
+        "privacy_experience_overlay",
+        "experience_config_overlay",
+    )
+    def test_get_experience_config_list_no_unescape_header(
+        self,
+        api_client: TestClient,
+        url,
+        generate_auth_header,
+        experience_config_privacy_center,
+    ) -> None:
+        auth_header = generate_auth_header(scopes=[scopes.PRIVACY_EXPERIENCE_READ])
+        response = api_client.get(url, headers=auth_header)
+        assert response.status_code == 200
+        resp = response.json()["items"]
+
+        second_config = resp[1]
+        assert second_config["id"] == experience_config_privacy_center.id
+        assert (
+            second_config["description"] == "user&#x27;s description &lt;script /&gt;"
+        )  # Still escaped
 
     @pytest.mark.usefixtures(
         "privacy_experience_overlay",
@@ -440,7 +464,7 @@ class TestCreateExperienceConfig:
                 "accept_button_label": "Yes",
                 "banner_enabled": "always_disabled",
                 "component": "privacy_center",
-                "description": "We take your privacy seriously",
+                "description": "We take your company's privacy seriously",
                 "privacy_policy_link_label": "Manage your privacy",
                 "privacy_policy_url": "example.com/privacy",
                 "reject_button_label": "No",
@@ -454,7 +478,9 @@ class TestCreateExperienceConfig:
         assert resp["accept_button_label"] == "Yes"
         assert resp["banner_enabled"] == "always_disabled"
         assert resp["component"] == "privacy_center"
-        assert resp["description"] == "We take your privacy seriously"
+        assert (
+            resp["description"] == "We take your company's privacy seriously"
+        )  # Returned in the response, unescaped, for display
         assert resp["privacy_policy_link_label"] == "Manage your privacy"
         assert resp["privacy_policy_url"] == "example.com/privacy"
         assert resp["regions"] == []
@@ -470,6 +496,10 @@ class TestCreateExperienceConfig:
         assert experience_config.privacy_policy_link_label == "Manage your privacy"
         assert experience_config.experiences.all() == []
         assert experience_config.histories.count() == 1
+        assert (
+            experience_config.description
+            == "We take your company&#x27;s privacy seriously"
+        )  # Saved in the db escaped
         history = experience_config.histories[0]
         assert history.version == 1.0
         assert history.component == ComponentType.privacy_center
@@ -860,6 +890,32 @@ class TestGetExperienceConfigDetail:
             == experience_config_overlay.experience_config_history_id
         )
         assert resp["title"] == "Manage your consent"
+        assert (
+            resp["privacy_policy_link_label"]
+            == "View our company&#x27;s privacy policy"
+        )  # Escaped without request header
+
+    @pytest.mark.usefixtures(
+        "privacy_experience_overlay",
+    )
+    def test_get_experience_config_detail_with_unescape_header(
+        self,
+        api_client: TestClient,
+        url,
+        generate_auth_header,
+        experience_config_overlay,
+    ) -> None:
+        unescape_header = {"Unescape-Safestr": "true"}
+        auth_header = generate_auth_header(scopes=[scopes.PRIVACY_EXPERIENCE_READ])
+        response = api_client.get(url, headers={**auth_header, **unescape_header})
+        assert response.status_code == 200
+        resp = response.json()
+
+        assert resp["id"] == experience_config_overlay.id
+        assert resp["component"] == "overlay"
+        assert (
+            resp["privacy_policy_link_label"] == "View our company's privacy policy"
+        )  # Unescaped with request header
 
 
 class TestUpdateExperienceConfig:
@@ -1028,6 +1084,34 @@ class TestUpdateExperienceConfig:
             response.json()["detail"]
             == "Cannot set as the default. Only one default overlay config can be in the system."
         )
+
+    def test_update_experience_config_with_fields_that_should_be_escaped(
+        self,
+        api_client: TestClient,
+        url,
+        generate_auth_header,
+        overlay_experience_config,
+        db,
+    ) -> None:
+        """Failing if duplicate regions in request to avoid unexpected behavior"""
+        auth_header = generate_auth_header(scopes=[scopes.PRIVACY_EXPERIENCE_UPDATE])
+        response = api_client.patch(
+            url,
+            json={
+                "title": "We care about you and your family's privacy",
+            },
+            headers=auth_header,
+        )
+        assert response.status_code == 200
+        assert (
+            response.json()["experience_config"]["title"]
+            == "We care about you and your family's privacy"
+        )  # Unescaped in response
+        db.refresh(overlay_experience_config)
+        assert (
+            overlay_experience_config.title
+            == "We care about you and your family&#x27;s privacy"
+        )  # But stored escaped
 
     def test_attempt_to_update_component_type(
         self,

--- a/tests/ops/api/v1/endpoints/test_privacy_experience_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_experience_endpoints.py
@@ -43,9 +43,9 @@ class TestGetPrivacyExperiences:
         privacy_notice,
         privacy_experience_privacy_center,
     ):
-        resp = api_client.get(
-            url,
-        )
+        unescape_header = {"Unescape-Safestr": "true"}
+
+        resp = api_client.get(url, headers=unescape_header)
         assert resp.status_code == 200
         data = resp.json()
 
@@ -62,6 +62,7 @@ class TestGetPrivacyExperiences:
         # Assert experience config is nested
         experience_config = resp["experience_config"]
         assert experience_config["title"] == "Control your privacy"
+        assert experience_config["description"] == "user's description <script />"
         assert experience_config["banner_enabled"] is None
         assert experience_config["accept_button_label"] == "Accept all"
         assert experience_config["reject_button_label"] == "Reject all"
@@ -78,6 +79,29 @@ class TestGetPrivacyExperiences:
         assert resp["privacy_notices"][0]["default_preference"] == "opt_out"
         assert resp["privacy_notices"][0]["current_preference"] is None
         assert resp["privacy_notices"][0]["outdated_preference"] is None
+        assert (
+            resp["privacy_notices"][0]["description"] == "user's description <script />"
+        )
+
+    def test_get_experiences_unescaped(
+        self,
+        api_client,
+        url,
+        privacy_notice,
+        privacy_experience_privacy_center,
+    ):
+        # Assert not escaped without proper request header
+        resp = api_client.get(url)
+        resp = resp.json()["items"][0]
+        experience_config = resp["experience_config"]
+        assert (
+            experience_config["description"]
+            == "user&#x27;s description &lt;script /&gt;"
+        )
+        assert (
+            resp["privacy_notices"][0]["description"]
+            == "user&#x27;s description &lt;script /&gt;"
+        )
 
     def test_get_privacy_experiences_show_disabled_filter(
         self,

--- a/tests/ops/api/v1/endpoints/test_privacy_notice_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_notice_endpoints.py
@@ -503,7 +503,7 @@ class TestGetPrivacyNotices:
     @pytest.mark.usefixtures(
         "system",
     )
-    def test_can_unescape(
+    def test_can_unescape_list_notices(
         self,
         db,
         api_client: TestClient,
@@ -667,7 +667,6 @@ class TestGetPrivacyNoticeDetail:
         )
         assert resp.status_code == 200
         data = resp.json()
-        print(f"Unescaped Response: {data}")
         assert data["description"] == "user&#x27;s description &lt;script /&gt;"
 
         # now request with the unescape header
@@ -1784,6 +1783,40 @@ class TestPostPrivacyNotices:
 
         overlay_exp.delete(db)
 
+    def test_post_privacy_notice_response_escaped(
+        self, api_client, generate_auth_header, db
+    ):
+        auth_header = generate_auth_header(scopes=[scopes.PRIVACY_NOTICE_CREATE])
+        maybe_dangerous_description = "user's description <script />"
+        resp = api_client.post(
+            V1_URL_PREFIX + PRIVACY_NOTICE,
+            headers=auth_header,
+            json=[
+                {
+                    "name": "test privacy notice 1",
+                    "notice_key": "test_privacy_notice_1",
+                    "description": maybe_dangerous_description,
+                    "regions": [
+                        PrivacyNoticeRegion.eu_be.value,
+                        PrivacyNoticeRegion.us_ca.value,
+                    ],
+                    "consent_mechanism": ConsentMechanism.opt_in.value,
+                    "data_uses": ["marketing.advertising"],
+                    "enforcement_level": EnforcementLevel.system_wide.value,
+                    "displayed_in_overlay": True,
+                }
+            ],
+        )
+        assert resp.status_code == 200
+        created_notice_data = resp.json()[0]
+        assert (
+            created_notice_data["description"] == "user's description <script />"
+        )  # Returned as normal in create response
+        created_notice = db.query(PrivacyNotice).get(created_notice_data["id"])
+        assert (
+            created_notice.description == "user&#x27;s description &lt;script /&gt;"
+        )  # But saved in escaped format
+
     def test_post_privacy_notice_duplicate_regions(
         self,
         api_client: TestClient,
@@ -2586,6 +2619,133 @@ class TestPatchPrivacyNotices:
         )
         db.refresh(db_notice)
 
+        assert response_notice["name"] == db_notice.name
+        assert response_notice["version"] == db_notice.version
+        assert response_notice["created_at"] == db_notice.created_at.isoformat()
+        assert response_notice["updated_at"] == db_notice.updated_at.isoformat()
+        assert response_notice["disabled"] == db_notice.disabled
+        assert response_notice["regions"] == [
+            region.value for region in db_notice.regions
+        ]
+        assert response_notice["consent_mechanism"] == db_notice.consent_mechanism.value
+        assert response_notice["data_uses"] == db_notice.data_uses
+
+        overlay_exp, privacy_center_exp = PrivacyExperience.get_experiences_by_region(
+            db, PrivacyNoticeRegion.us_ca
+        )
+        assert overlay_exp.component == ComponentType.overlay
+
+        assert privacy_center_exp.component == ComponentType.privacy_center
+
+    def test_patch_privacy_notice_escaping(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        patch_privacy_notice_payload: dict[str, Any],
+        privacy_notice: PrivacyNotice,
+        url,
+        db,
+    ):
+        """
+        Test escape behavior when patching notices
+        """
+        overlay_exp, privacy_center_exp = PrivacyExperience.get_experiences_by_region(
+            db, PrivacyNoticeRegion.us_ca
+        )
+        assert overlay_exp is None
+        assert privacy_center_exp is None
+
+        auth_header = generate_auth_header(scopes=[scopes.PRIVACY_NOTICE_UPDATE])
+
+        before_update = datetime.now().isoformat()
+        maybe_dangerous_description = "user's description <script />"
+        patch_privacy_notice_payload["description"] = maybe_dangerous_description
+
+        resp = api_client.patch(
+            url, headers=auth_header, json=[patch_privacy_notice_payload]
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        response_notice = resp.json()[0]
+
+        # assert our response object has the updated values
+        assert response_notice["name"] == patch_privacy_notice_payload["name"]
+        assert response_notice["id"] == patch_privacy_notice_payload["id"]
+        assert response_notice["regions"] == patch_privacy_notice_payload["regions"]
+        assert (
+            response_notice["consent_mechanism"]
+            == patch_privacy_notice_payload["consent_mechanism"]
+        )
+        assert response_notice["data_uses"] == patch_privacy_notice_payload["data_uses"]
+        assert response_notice["version"] == 2.0
+        assert response_notice["created_at"] < before_update
+        assert response_notice["updated_at"] < datetime.now().isoformat()
+        assert response_notice["updated_at"] > before_update
+        assert response_notice["disabled"]
+        assert response_notice["notice_key"] == "updated_privacy_notice_key"
+        assert (
+            response_notice["description"] == maybe_dangerous_description
+        ), "Unescaped in response"
+
+        # assert our old history record has the old privacy notice data
+        history_record: PrivacyNoticeHistory = (
+            PrivacyNoticeHistory.query(db=db)
+            .filter(PrivacyNoticeHistory.privacy_notice_id == privacy_notice.id)
+            .filter(PrivacyNoticeHistory.version == 1.0)
+        ).first()
+        assert (
+            history_record.name
+            == privacy_notice.name
+            != patch_privacy_notice_payload["name"]
+        )
+        assert (
+            history_record.regions
+            == privacy_notice.regions
+            != patch_privacy_notice_payload["regions"]
+        )
+        assert (
+            history_record.consent_mechanism
+            == privacy_notice.consent_mechanism
+            != patch_privacy_notice_payload["consent_mechanism"]
+        )
+        assert (
+            history_record.data_uses
+            == privacy_notice.data_uses
+            != patch_privacy_notice_payload["data_uses"]
+        )
+        assert history_record.version == 1.0
+        assert (
+            history_record.disabled
+            == privacy_notice.disabled
+            != patch_privacy_notice_payload["disabled"]
+        )
+
+        # assert there's a new history record with the new privacy notice data
+        history_record: PrivacyNoticeHistory = (
+            PrivacyNoticeHistory.query(db=db)
+            .filter(PrivacyNoticeHistory.privacy_notice_id == privacy_notice.id)
+            .filter(PrivacyNoticeHistory.version == 2.0)
+        ).first()
+        assert history_record.name == patch_privacy_notice_payload["name"]
+        assert [
+            region.value for region in history_record.regions
+        ] == patch_privacy_notice_payload["regions"]
+        assert (
+            history_record.consent_mechanism.value
+            == patch_privacy_notice_payload["consent_mechanism"]
+        )
+        assert history_record.data_uses == patch_privacy_notice_payload["data_uses"]
+        assert history_record.version == 2.0
+        assert history_record.disabled == patch_privacy_notice_payload["disabled"]
+
+        # assert the db privacy notice record has the updated values
+        db_notice: PrivacyNotice = PrivacyNotice.get(
+            db=db, object_id=response_notice["id"]
+        )
+        db.refresh(db_notice)
+        assert (
+            db_notice.description == "user&#x27;s description &lt;script /&gt;"
+        )  # Escaped in db
         assert response_notice["name"] == db_notice.name
         assert response_notice["version"] == db_notice.version
         assert response_notice["created_at"] == db_notice.created_at.isoformat()

--- a/tests/ops/service/privacy_request/test_email_batch_send.py
+++ b/tests/ops/service/privacy_request/test_email_batch_send.py
@@ -540,7 +540,7 @@ class TestConsentEmailBatchSend:
                         privacy_notice_history=PrivacyNoticeHistorySchema(
                             name="example privacy notice",
                             notice_key="example_privacy_notice",
-                            description="a sample privacy notice configuration",
+                            description="user&#x27;s description &lt;script /&gt;",  # This isn't actually sent in the email
                             regions=["us_ca", "us_co"],
                             consent_mechanism="opt_in",
                             data_uses=["marketing.advertising", "third_party_sharing"],
@@ -670,7 +670,7 @@ class TestConsentEmailBatchSend:
                         privacy_notice_history=PrivacyNoticeHistorySchema(
                             name="example privacy notice",
                             notice_key="example_privacy_notice",
-                            description="a sample privacy notice configuration",
+                            description="user&#x27;s description &lt;script /&gt;",
                             regions=["us_ca", "us_co"],
                             consent_mechanism="opt_in",
                             data_uses=["marketing.advertising", "third_party_sharing"],

--- a/tests/ops/util/test_consent_util.py
+++ b/tests/ops/util/test_consent_util.py
@@ -559,6 +559,10 @@ class TestLoadDefaultNotices:
             unescape(notice.internal_description)
             == "This is a contrived template for testing.  This field's for internal testing!"
         )
+        assert (
+            notice.internal_description
+            == "This is a contrived template for testing.  This field&#x27;s for internal testing!"
+        )  # Stored escaped
         assert notice.regions == [PrivacyNoticeRegion.us_ak]
         assert notice.consent_mechanism == ConsentMechanism.opt_in
         assert notice.enforcement_level == EnforcementLevel.system_wide
@@ -997,7 +1001,7 @@ class TestUpsertDefaultExperienceConfig:
             "is_default": True,
             "id": "test_id",
             "privacy_preferences_link_label": "D",
-            "privacy_policy_link_label": "E",
+            "privacy_policy_link_label": "E's label",
             "privacy_policy_url": "F",
             "reject_button_label": "G",
             "save_button_label": "H",
@@ -1020,7 +1024,9 @@ class TestUpsertDefaultExperienceConfig:
         assert experience_config.is_default is True
         assert experience_config.id == "test_id"
         assert experience_config.privacy_preferences_link_label == "D"
-        assert experience_config.privacy_policy_link_label == "E"
+        assert (
+            experience_config.privacy_policy_link_label == "E&#x27;s label"
+        )  # Escaped
         assert experience_config.privacy_policy_url == "F"
         assert experience_config.regions == []
         assert experience_config.reject_button_label == "G"
@@ -1046,7 +1052,7 @@ class TestUpsertDefaultExperienceConfig:
         assert history.is_default is True
         assert history.id != "test_id"
         assert history.privacy_preferences_link_label == "D"
-        assert history.privacy_policy_link_label == "E"
+        assert history.privacy_policy_link_label == "E&#x27;s label"
         assert history.privacy_policy_url == "F"
         assert history.reject_button_label == "G"
         assert history.save_button_label == "H"


### PR DESCRIPTION
Closes #3301 

### Code Changes

- [ ] Escape experience configs before saving in the db. Unescape before returning.
- [ ] Escape default experience configs before saving from yaml file
- [ ] Unescape embedded experience configs and privacy notices in the PrivacyExperience response
- [ ] Unescape notices in the response before returning after create and update.

### Steps to Confirm

* [ ] Save suspicious characters when creating or updating ExperienceConfigs in various string fields: POST {host}}/experience-config or PATCH {{host}}/experience-config/{{experience-config-id}} - and verify that when you fetch these experience configs, that the strings are unescaped (but they are escaped in the db)
* [ ] Also privacy notices embedded in an experience with odd characters are unescaped {{host}}/privacy-experience/?region=us_ca

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Strings that are escaped on ExperienceConfigs are currently surfaced in their escaped form.
