### PR TITLE
Don't update default experience configs on startup - only create them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The types of changes are:
 - Disable connector dropdown in integration tab on save [#3552](https://github.com/ethyca/fides/pull/3552)
 - Handles an edge case for non-existent identities with the Kustomer API [#3513](https://github.com/ethyca/fides/pull/3513)
 - remove the configure privacy request tile from the home screen [#3555](https://github.com/ethyca/fides/pull/3555)
+- Only create default experience configs on startup, not update [#3605](https://github.com/ethyca/fides/pull/3605)
 
 ### Developer Experience
 

--- a/src/fides/api/util/consent_util.py
+++ b/src/fides/api/util/consent_util.py
@@ -33,9 +33,7 @@ from fides.api.models.privacy_request import (
 )
 from fides.api.models.sql_models import DataUse, System  # type: ignore[attr-defined]
 from fides.api.schemas.privacy_experience import (
-    ExperienceConfigCreate,
     ExperienceConfigCreateWithId,
-    ExperienceConfigUpdate,
 )
 from fides.api.schemas.privacy_notice import PrivacyNoticeCreation, PrivacyNoticeWithId
 from fides.api.schemas.redis_cache import Identity
@@ -580,3 +578,5 @@ def create_default_experience_config(
             data=experience_config_schema.dict(exclude_unset=True),
             check_name=False,
         )
+
+    return None

--- a/src/fides/api/util/consent_util.py
+++ b/src/fides/api/util/consent_util.py
@@ -546,16 +546,14 @@ def load_default_experience_configs_on_startup(
         experience_configs = yaml.safe_load(file).get("privacy_experience_configs", [])
 
         for experience_config_data in experience_configs:
-            upsert_default_experience_config(db, experience_config_data)
+            create_default_experience_config(db, experience_config_data)
 
 
-def upsert_default_experience_config(
+def create_default_experience_config(
     db: Session, experience_config_data: dict
-) -> Tuple[bool, PrivacyExperienceConfig]:
-    """Upserts an experience config - intended to be used for upserting default
-    configs on startup.  The id is specified upfront.
+) -> Optional[PrivacyExperienceConfig]:
+    """Create a default experience config on startup.  The id is specified upfront.
 
-    Returns whether the resource is new, and the experience config object.
     Split from load_default_experience_configs_on_startup for easier testing
     of a function that runs on application startup.
     """
@@ -573,31 +571,12 @@ def upsert_default_experience_config(
         db=db, object_id=experience_config_schema.id
     )
 
-    if existing_experience_config:
+    if not existing_experience_config:
         logger.info(
-            "Checking default experience config {} for updates",
-            existing_experience_config.id,
+            "Creating default experience config {}", experience_config_schema.id
         )
-
-        dry_update: PrivacyExperienceConfig = existing_experience_config.dry_update(
-            data=experience_config_schema.dict(exclude_unset=True)
+        return PrivacyExperienceConfig.create(
+            db,
+            data=experience_config_schema.dict(exclude_unset=True),
+            check_name=False,
         )
-        # Validating some required fields if this is an overlay
-        ExperienceConfigCreate.from_orm(dry_update)
-
-        del experience_config_data["component"]
-        del experience_config_data["id"]
-        # This is important for making sure config is only updated if it actually changed
-        update_data = ExperienceConfigUpdate(**experience_config_data)
-        experience_config_data_dict: Dict = update_data.dict(exclude_unset=True)
-
-        existing_experience_config.update(db=db, data=experience_config_data_dict)
-        return False, existing_experience_config
-
-    logger.info("Creating default experience config {}", experience_config_schema.id)
-    new_experience_config = PrivacyExperienceConfig.create(
-        db,
-        data=experience_config_schema.dict(exclude_unset=True),
-        check_name=False,
-    )
-    return True, new_experience_config

--- a/src/fides/api/util/consent_util.py
+++ b/src/fides/api/util/consent_util.py
@@ -591,4 +591,8 @@ def create_default_experience_config(
             check_name=False,
         )
 
+    logger.info(
+        "Found existing experience config {}, not creating a new default experience config",
+        experience_config_schema.id,
+    )
     return None


### PR DESCRIPTION
Closes #3604 

### Code Changes

* [ ] Remove the code that updates any default experience configs that already exist to match the out-of-the-box experience configs in the yaml file.

### Steps to Confirm

* [ ] Startup the application
* [ ] Verify you have two default experience configs created automatically on startup
* [ ] Update an experience config via the admin UI
* [ ] Bring the application down
* [ ] Start the application again
* [ ] Verify that your edits to that default experience config remain

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Only create default experience configs on startup - don't update existing ones.