### PR TITLE
Create Consent Privacy Requests when Enforcement is System Wide Only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The types of changes are:
 ### Changed
 
 - Removed `pyodbc` in favor of `pymssql` for handling SQL Server connections [#3435](https://github.com/ethyca/fides/pull/3435)
-
+- Only create a PrivacyRequest when saving consent if at least one notice has system-wide enforcement [#3626](https://github.com/ethyca/fides/pull/3626)
 ### Fixed
 
 - Fix race condition with consent modal link rendering [#3521](https://github.com/ethyca/fides/pull/3521)

--- a/src/fides/api/api/v1/endpoints/privacy_preference_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_preference_endpoints.py
@@ -38,7 +38,11 @@ from fides.api.api.v1.urn_registry import (
 from fides.api.db.seed import DEFAULT_CONSENT_POLICY
 from fides.api.models.fides_user import FidesUser
 from fides.api.models.privacy_experience import PrivacyExperience
-from fides.api.models.privacy_notice import PrivacyNotice, PrivacyNoticeHistory
+from fides.api.models.privacy_notice import (
+    EnforcementLevel,
+    PrivacyNotice,
+    PrivacyNoticeHistory,
+)
 from fides.api.models.privacy_preference import (
     CurrentPrivacyPreference,
     PrivacyPreferenceHistory,
@@ -341,6 +345,7 @@ def _save_privacy_preferences_for_identities(
         fides_user_provided_identity, ProvidedIdentityType.fides_user_device_id
     )
 
+    needs_server_side_propagation: bool = False
     for privacy_preference in request_data.preferences:
         historical_preference: PrivacyPreferenceHistory = PrivacyPreferenceHistory.create(
             db=db,
@@ -377,9 +382,15 @@ def _save_privacy_preferences_for_identities(
         upserted_current_preference: CurrentPrivacyPreference = (
             historical_preference.current_privacy_preference
         )
-
         created_historical_preferences.append(historical_preference)
         upserted_current_preferences.append(upserted_current_preference)
+
+        if (
+            historical_preference.privacy_notice_history.enforcement_level
+            == EnforcementLevel.system_wide
+        ):
+            # At least one privacy notice has expected system wide enforcement
+            needs_server_side_propagation = True
 
     identity = (
         request_data.browser_identity if request_data.browser_identity else Identity()
@@ -392,30 +403,32 @@ def _save_privacy_preferences_for_identities(
             verified_provided_identity.encrypted_value["value"],  # type:ignore[index]
         )
 
-    # Privacy Request needs to be created with respect to the *historical* privacy preferences
-    privacy_request_results: BulkPostPrivacyRequests = create_privacy_request_func(
-        db=db,
-        config_proxy=ConfigProxy(db),
-        data=[
-            PrivacyRequestCreate(
-                identity=identity,
-                policy_key=request_data.policy_key or DEFAULT_CONSENT_POLICY,
-            )
-        ],
-        authenticated=True,
-        privacy_preferences=created_historical_preferences,
-    )
-
-    if privacy_request_results.failed or not privacy_request_results.succeeded:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=privacy_request_results.failed[0].message,
+    if needs_server_side_propagation:
+        # Privacy Request needs to be created with respect to the *historical* privacy preferences
+        privacy_request_results: BulkPostPrivacyRequests = create_privacy_request_func(
+            db=db,
+            config_proxy=ConfigProxy(db),
+            data=[
+                PrivacyRequestCreate(
+                    identity=identity,
+                    policy_key=request_data.policy_key or DEFAULT_CONSENT_POLICY,
+                )
+            ],
+            authenticated=True,
+            privacy_preferences=created_historical_preferences,
         )
 
-    if consent_request:
-        # If we have a verified user identity, go ahead and update the associated ConsentRequest for record keeping
-        consent_request.privacy_request_id = privacy_request_results.succeeded[0].id
-        consent_request.save(db=db)
+        if privacy_request_results.failed or not privacy_request_results.succeeded:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=privacy_request_results.failed[0].message,
+            )
+
+        if consent_request:
+            # If we have a verified user identity, go ahead and update the associated ConsentRequest for record keeping
+            consent_request.privacy_request_id = privacy_request_results.succeeded[0].id
+            consent_request.save(db=db)
+
     return upserted_current_preferences
 
 

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -1570,6 +1570,23 @@ def privacy_notice_us_co_provide_service_operations(db: Session) -> Generator:
 
 
 @pytest.fixture(scope="function")
+def privacy_experience_france_overlay(
+    db: Session, experience_config_overlay
+) -> Generator:
+    privacy_experience = PrivacyExperience.create(
+        db=db,
+        data={
+            "component": ComponentType.overlay,
+            "region": PrivacyNoticeRegion.eu_fr,
+            "experience_config_id": experience_config_overlay.id,
+        },
+    )
+
+    yield privacy_experience
+    privacy_experience.delete(db)
+
+
+@pytest.fixture(scope="function")
 def privacy_notice_eu_fr_provide_service_frontend_only(db: Session) -> Generator:
     privacy_notice = PrivacyNotice.create(
         db=db,


### PR DESCRIPTION
Closes #3618 

### Code Changes

* [x] Update both endpoints that save new-style privacy preferences (through the privacy center and just against fides user device id) to only create and queue a privacy request if at least one of the privacy preferences is attached to a notice with system wide enforcement.

### Steps to Confirm

* [x] Save privacy preferences against one of the default out-of-the-box notices.  Via the API directly, it is:
PATCH {{host}}/privacy-preferences
```
{
   "browser_identity": {
       "ga_client_id": "UA-XXXXXXXXX",
       "ljt_readerID": "test_sovrn_id",
       "fides_user_device_id": "<uuid4 here>"
   },
   "preferences": [{
       "privacy_notice_history_id": "{{privacy_notice_history_id}}",
       "preference": "opt_out"
   }],
   "user_geography": "us_ca",
   "privacy_experience_id": "{{privacy_experience_id}}",
   "method": "button"
}

```
* [x] Verify that no privacy request was created in admin UI http://localhost:3000/privacy-requests
* [x] Update that privacy notice to have an enforcement level of system wide: via the API it is:
PATCH {{host}}/privacy-notice
```
[
  {
    "id": "{{privacy_notice_id}}",
    "enforcement_level": "system_wide"
  }
]
```
* [x] Save privacy preferences again - you'll have to update the privacy notice history id as it just changed
* [x] Note that a privacy request was created because there was at least one notice that had an enforcement level of system wide
* [x] Fetch historical preferences - you should have two records created, one should have a privacy request attached, the other should have the privacy request id as null GET {{host}}/historical-privacy-preferences


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

Only create PrivacyRequests when there is at least one notice where enforcement == "System wide".
