### PR TITLE
Restrict Privacy Center debug logging to development-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The types of changes are:
 
 - Removed `pyodbc` in favor of `pymssql` for handling SQL Server connections [#3435](https://github.com/ethyca/fides/pull/3435)
 - Only create a PrivacyRequest when saving consent if at least one notice has system-wide enforcement [#3626](https://github.com/ethyca/fides/pull/3626)
+
 ### Fixed
 
 - Fix race condition with consent modal link rendering [#3521](https://github.com/ethyca/fides/pull/3521)
@@ -39,6 +40,7 @@ The types of changes are:
 - Only create default experience configs on startup, not update [#3605](https://github.com/ethyca/fides/pull/3605)
 - Update to latest asyncpg dependency to avoid build error [#3614](https://github.com/ethyca/fides/pull/3614)
 - Fix bug where editing a data use on a system could delete existing data uses [#3627](https://github.com/ethyca/fides/pull/3627)
+- Restrict Privacy Center debug logging to development-only [#3638](https://github.com/ethyca/fides/pull/3638)
 
 ### Developer Experience
 

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -112,7 +112,9 @@ const loadConfigFile = async (
         path = urlString.replace("file:", "");
       }
       const file = await fsPromises.readFile(path || url, "utf-8");
-      console.log(`Loaded configuration file: ${urlString}`);
+      if (process.env.NODE_ENV === "development") {
+        console.log(`Loaded configuration file: ${urlString}`);
+      }
       return file;
     } catch (err: any) {
       // Catch "file not found" errors (ENOENT)
@@ -237,7 +239,9 @@ export const loadPrivacyCenterEnvironment =
       );
     }
     // DEFER: Log a version number here (see https://github.com/ethyca/fides/issues/3171)
-    console.log("Load Privacy Center environment for session...");
+    if (process.env.NODE_ENV === "development") {
+      console.log("Load Privacy Center environment for session...");
+    }
 
     // Load environment variables
     const settings: PrivacyCenterSettings = {


### PR DESCRIPTION
Closes #3637 

### Code Changes

* [X] Wrap remaining `console.log` statements in Privacy Center code with a `NODE_ENV == "development"` guard

### Steps to Confirm

* [X] Run `turbo dev` and confirm the "Load Privacy Center environment...", "Loaded configuration file.." logs are still present locally
* [X] Run `nox -s "fides_env(test)"` and confirm Privacy Center logs are quiet

#### Test Results: Development
<img width="485" alt="image" src="https://github.com/ethyca/fides/assets/1834295/b6f109c2-f71c-48db-b772-275a20267aac">

#### Test Results: Production
<img width="673" alt="image" src="https://github.com/ethyca/fides/assets/1834295/a5fe1aec-f586-41e4-87e1-40d527a324a7">

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

I personally added some troubleshooting logs to the Privacy Center backend for loading config files, but didn't really _think_ them through - these fire on every request, so we really can't log anything for "normal" troubleshooting!

NextJS doesn't have thorough support for log levels like DEBUG/INFO/WARN/etc., so that kind of "normal" solution doesn't apply here, so I'm just disabling the logs based on the NODE_ENV instead.