### PR TITLE
Remove most Redis connection test logs

### DIFF
--- a/src/fides/api/app_setup.py
+++ b/src/fides/api/app_setup.py
@@ -189,11 +189,9 @@ async def run_database_startup() -> None:
 
 def check_redis() -> None:
     """Check that Redis is healthy."""
-
     logger.info("Running Cache connection test...")
-
     try:
-        get_cache()
+        get_cache(should_log=True)
     except (RedisConnectionError, RedisError, ResponseError) as e:
         logger.error("Connection to cache failed: {}", str(e))
         return

--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -157,7 +157,7 @@ class FidesopsRedis(Redis):
         return None
 
 
-def get_cache() -> FidesopsRedis:
+def get_cache(should_log: Optional[bool] = False) -> FidesopsRedis:
     """Return a singleton connection to our Redis cache"""
     global _connection  # pylint: disable=W0603
     if _connection is None:
@@ -174,15 +174,18 @@ def get_cache() -> FidesopsRedis:
             ssl_ca_certs=CONFIG.redis.ssl_ca_certs,
             ssl_cert_reqs=CONFIG.redis.ssl_cert_reqs,
         )
-        logger.debug("New Redis connection created.")
+        if should_log:
+            logger.debug("New Redis connection created.")
 
-    logger.debug("Testing Redis connection...")
+    if should_log:
+        logger.debug("Testing Redis connection...")
     try:
         connected = _connection.ping()
     except ConnectionErrorFromRedis:
         connected = False
     else:
-        logger.debug("Redis connection succeeded.")
+        if should_log:
+            logger.debug("Redis connection succeeded.")
 
     if not connected:
         logger.debug("Redis connection failed.")


### PR DESCRIPTION
This is a small PR to alleviate the number of Redis connection test logs we see. It's currently logging on every healthcheck, which is excessive, and also pollutes downstream logging services for our customers.

<img width="1552" alt="Screenshot 2023-06-21 at 12 32 47" src="https://github.com/ethyca/fides/assets/1667340/64025189-1cf3-46a1-8553-e4eb2b6a2cd1">

@RobertKeyser is perma-using filters like `... -("Testing Redis connection..." OR "Redis connection succeeded.")` so it'd be nice to avoid wastage.