### PR TITLE
Increasing SafeStr character limit from 500 to 32000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The types of changes are:
 
 - Removed `pyodbc` in favor of `pymssql` for handling SQL Server connections [#3435](https://github.com/ethyca/fides/pull/3435)
 - Only create a PrivacyRequest when saving consent if at least one notice has system-wide enforcement [#3626](https://github.com/ethyca/fides/pull/3626)
+- Increased the character limit for the `SafeStr` type from 500 to 32000 [#3647](https://github.com/ethyca/fides/pull/3647)
 
 ### Docs
 

--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -22,8 +22,8 @@ class SafeStr(str):
         # HTML Escapes
         value = escape(value)
 
-        if len(value) > 500:
-            raise ValueError("Value must be 500 characters or less.")
+        if len(value) > 32000:
+            raise ValueError("Value must be 32000 characters or less.")
 
         return value
 


### PR DESCRIPTION
Closes #3646

### Code Changes

* [ ] Increasing `SafeStr` character limit from 500 to 32000

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Increased the character limit to account for large known inputs such as CSS or PEM encoded certificates.
