### PR TITLE
Dockerfile: Replace `npm install` with `npm ci`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ COPY clients/fides-js/package.json ./fides-js/package.json
 COPY clients/admin-ui/package.json ./admin-ui/package.json
 COPY clients/privacy-center/package.json ./privacy-center/package.json
 
-RUN npm install
+RUN npm clean-install --no-fund
 
 COPY clients/ .
 


### PR DESCRIPTION
Generally, it's a good practice to use `npm ci` for dockerfiles to improve repeatability. This PR replaces the `npm install` we have with `npm clean-install --no-fund`

See differences here: https://docs.npmjs.com/cli/v9/commands/npm-ci and https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci

### Code Changes

* Replace `npm install` with `npm ci`


### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

### Description Of Changes

_Write some things here about the changes and any potential caveats_
