### PR TITLE
Render linebreaks in the Fides.js overlay descriptions, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.15.0...main)
 
+### Fixed
+
+- Render linebreaks in the Fides.js overlay descriptions, etc. [#3665](https://github.com/ethyca/fides/pull/3665)
+
 ## [2.15.0](https://github.com/ethyca/fides/compare/2.14.1...2.15.0)
 
 ### Added
@@ -69,7 +73,6 @@ The types of changes are:
 - Update to latest asyncpg dependency to avoid build error [#3614](https://github.com/ethyca/fides/pull/3614)
 - Fix bug where editing a data use on a system could delete existing data uses [#3627](https://github.com/ethyca/fides/pull/3627)
 - Restrict Privacy Center debug logging to development-only [#3638](https://github.com/ethyca/fides/pull/3638)
-- Render linebreaks in the Fides.js overlay descriptions, etc. [#3665](https://github.com/ethyca/fides/pull/3665)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The types of changes are:
 - Update to latest asyncpg dependency to avoid build error [#3614](https://github.com/ethyca/fides/pull/3614)
 - Fix bug where editing a data use on a system could delete existing data uses [#3627](https://github.com/ethyca/fides/pull/3627)
 - Restrict Privacy Center debug logging to development-only [#3638](https://github.com/ethyca/fides/pull/3638)
+- Render linebreaks in the Fides.js overlay descriptions, etc. [#3665](https://github.com/ethyca/fides/pull/3665)
 
 ### Changed
 

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -56,6 +56,7 @@ div#fides-overlay {
   font-size: var(--fides-overlay-font-size-body);
   z-index: 1000;
   position: fixed;
+  white-space: pre-line;
 
   /* CSS reset values, adapted from https://www.joshwcomeau.com/css/custom-css-reset/ */
   line-height: calc(1em + 0.4rem);


### PR DESCRIPTION
### Description Of Changes

Often, we're going to want to use line breaks to break up paragraphs of legalese in the overlays - adding `whitespace: pre-line` allows the browser to do this without any fancy rich text components 👍 

For example, if I use a string like this:
```
We use cookies and similar methods to recognize visitors and remember their preferences.

We also use them to measure ad campaign effectiveness, target ads and analyze site traffic. Learn more about these methods, including how to manage them, by clicking ‘Manage Preferences.’ By clicking ‘accept’ you consent to the of these methods by us and our third parties. By clicking ‘reject’ you decline the use of these methods.",
```

Compare:
| Before (`whitespace: normal`) | After (`whitespace: pre-line`) |
|---|---|
| <img width="652" alt="image" src="https://github.com/ethyca/fides/assets/1834295/5ca65039-da83-464b-9441-ca25ddaa8f4f"> | <img width="667" alt="image" src="https://github.com/ethyca/fides/assets/1834295/d38a39cc-63cf-4052-82b1-9f4b91a2a8e4"> | 

### Code Changes

* [X] Update `fides.css` styles

### Steps to Confirm

* [X] Run `turbo build` for the `fides-js` project and open the `clients/privacy-center/public/fides-js-components-demo.html` page

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
