### PR TITLE
Fix dataset yaml not properly reflecting dataset in dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The types of changes are:
 - Fix bug where editing a data use on a system could delete existing data uses [#3627](https://github.com/ethyca/fides/pull/3627)
 - Restrict Privacy Center debug logging to development-only [#3638](https://github.com/ethyca/fides/pull/3638)
 - Fix bug where linking an integration would not update the tab when creating a new system [#3662](https://github.com/ethyca/fides/pull/3662)
+- Fix dataset yaml not properly reflecting the dataset in the dropdown of system integrations tab [#3666](https://github.com/ethyca/fides/pull/3666)
 
 ### Changed
 

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -382,7 +382,10 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
               : null}
             {SystemType.DATABASE === connectionOption.type &&
             !isCreatingConnectionConfig ? (
-              <DatasetConfigField dropdownOptions={datasetDropdownOptions} />
+              <DatasetConfigField
+                dropdownOptions={datasetDropdownOptions}
+                connectionConfig={connectionConfig}
+              />
             ) : null}
             <ButtonGroup size="sm" spacing="8px" variant="outline">
               <Button

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/DatasetConfigField.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/DatasetConfigField.tsx
@@ -66,7 +66,6 @@ export const DatasetSelect = ({
       isInvalid={isInvalid}
       isRequired={isRequired}
     >
-      {/* <VStack align="flex-start" w="inherit"> */}
       {label ? (
         <Label htmlFor={props.id || props.name} {...labelProps}>
           {label}
@@ -107,7 +106,6 @@ export const DatasetSelect = ({
         />
         {tooltip ? <QuestionTooltip label={tooltip} /> : null}
       </Flex>
-      {/* </VStack> */}
     </FormControl>
   );
 };


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3667

### Description Of Changes

The function that tries to match a dataset to its yaml was failing because the query to get all datasets was passing in a prop that filtered when it shouldn't. It turns out the prop was just missing!


### Code Changes

* [x] Provide the missing prop

### Steps to Confirm

* See steps in original bug ticket

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
