### PR TITLE
Transform null names to an empty string before submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The types of changes are:
 - Fix bug where linking an integration would not update the tab when creating a new system [#3662](https://github.com/ethyca/fides/pull/3662)
 - Fix dataset yaml not properly reflecting the dataset in the dropdown of system integrations tab [#3666](https://github.com/ethyca/fides/pull/3666)
 - Fix privacy notices not being able to be edited via the UI after the addition of the `cookies` field [#3670](https://github.com/ethyca/fides/pull/3670)
+- Add a transform in the case of `null` name fields in privacy declarations for the data use forms [#3683](https://github.com/ethyca/fides/pull/3683)
 
 ### Changed
 

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationManager.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationManager.tsx
@@ -78,9 +78,15 @@ const PrivacyDeclarationManager = ({
     updatedDeclarations: PrivacyDeclarationResponse[],
     isDelete?: boolean
   ) => {
+    // The API can return a null name, but cannot receive a null name,
+    // so do an additional transform here (fides#3862)
+    const transformedDeclarations = updatedDeclarations.map((d) => ({
+      ...d,
+      name: d.name ?? "",
+    }));
     const systemBodyWithDeclaration = {
       ...system,
-      privacy_declarations: updatedDeclarations,
+      privacy_declarations: transformedDeclarations,
     };
     const handleResult = (
       result:


### PR DESCRIPTION
FE fix to get around https://github.com/ethyca/fides/issues/3682

### Description Of Changes

https://github.com/ethyca/fides/pull/3571 refactored the privacy declaration form a bit so that we could include `cookies` fields. As part of that, there was a change where we only transformed the declaration was being edited, whereas previously we had transformed _all_ declarations prior to submission.

This PR restores doing an additional transform to all declarations right before sending to the API.


### Code Changes

* [x] Add one more transform function

### Steps to Confirm

* Run `nox -s fides_env -- prod`
* On one of the existing systems that already has a data use, try to add another data use
* You should be able to add one without getting any errors

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
~* [ ] Issue Requirements are Met~ --> no they are not! but this is a smaller FE workaround 
* [x] Update `CHANGELOG.md`
