### PR TITLE
Removing required flag for the dataset field

### DIFF
--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/DatasetConfigField.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/DatasetConfigField.tsx
@@ -270,7 +270,6 @@ const DatasetConfigField: React.FC<Props> = ({
         }}
         name={fieldName}
         options={dropdownOptions}
-        isRequired
         onOpen={onOpen}
         isLoading={isLoading}
       />


### PR DESCRIPTION
Closes #3657

### Description Of Changes

Removing the "required" asterisk from the database field in the integration configuration form.

### Code Changes

* [ ] Removed `isRequired` from `DatasetConfigField`

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
