### PR TITLE
Updating DSR data pre-processor to support manual data

### DIFF
--- a/src/fides/api/service/privacy_request/dsr_package/dsr_report_builder.py
+++ b/src/fides/api/service/privacy_request/dsr_package/dsr_report_builder.py
@@ -155,7 +155,10 @@ class DsrReportBuilder:
             # pre-process data to split the dataset:collection keys
             datasets: Dict[str, Any] = defaultdict(lambda: defaultdict(list))
             for key, rows in self.dsr_data.items():
-                [dataset_name, collection_name] = key.split(":")
+                parts = key.split(":", 1)
+                dataset_name, collection_name = (
+                    parts if len(parts) > 1 else ("manual", parts[0])
+                )
                 datasets[dataset_name][collection_name].extend(rows)
 
             for dataset_name, collections in datasets.items():

--- a/tests/ops/service/test_storage_uploader_service.py
+++ b/tests/ops/service/test_storage_uploader_service.py
@@ -354,6 +354,7 @@ class TestWriteToInMemoryBuffer:
                 {"uuid": "xyz-122-333", "name": "foo1", "email": "foo@bar1"},
             ],
             "mongo:foobar": [{"_id": 1, "customer": {"x": 1, "y": [1, 2]}}],
+            "filing_cabinet": [{"id": "123"}],  # represents manual data
         }
 
     def test_json_data(self, data, privacy_request):
@@ -367,6 +368,7 @@ class TestWriteToInMemoryBuffer:
 
         zipfile = ZipFile(buff)
         assert zipfile.namelist() == [
+            "filing_cabinet.csv",
             "mongo:address.csv",
             "mysql:customer.csv",
             "mongo:foobar.csv",
@@ -435,6 +437,9 @@ class TestWriteToInMemoryBuffer:
         assert zipfile.namelist() == [
             "/main.css",
             "/back.svg",
+            "/manual/index.html",
+            "/manual/filing_cabinet/1.html",
+            "/manual/filing_cabinet/index.html",
             "/mongo/address/1.html",
             "/mongo/address/2.html",
             "/mongo/address/index.html",

--- a/tests/ops/service/test_storage_uploader_service.py
+++ b/tests/ops/service/test_storage_uploader_service.py
@@ -368,10 +368,10 @@ class TestWriteToInMemoryBuffer:
 
         zipfile = ZipFile(buff)
         assert zipfile.namelist() == [
-            "filing_cabinet.csv",
             "mongo:address.csv",
             "mysql:customer.csv",
             "mongo:foobar.csv",
+            "filing_cabinet.csv",
         ]
 
         with zipfile.open("mongo:address.csv") as address_csv:
@@ -437,9 +437,6 @@ class TestWriteToInMemoryBuffer:
         assert zipfile.namelist() == [
             "/main.css",
             "/back.svg",
-            "/manual/index.html",
-            "/manual/filing_cabinet/1.html",
-            "/manual/filing_cabinet/index.html",
             "/mongo/address/1.html",
             "/mongo/address/2.html",
             "/mongo/address/index.html",
@@ -450,6 +447,9 @@ class TestWriteToInMemoryBuffer:
             "/mysql/customer/2.html",
             "/mysql/customer/index.html",
             "/mysql/index.html",
+            "/manual/filing_cabinet/1.html",
+            "/manual/filing_cabinet/index.html",
+            "/manual/index.html",
             "/index.html",
         ]
 


### PR DESCRIPTION
Closes #3686 

### Description Of Changes
The DSR report builder pre-processes the raw DSR data to separate the collection address into its separate parts, the dataset name and the collection name. The collection address for manual integrations is just the collection name without a dataset. The missing separator `:` from manual collection addresses causes an error when generating the DSR report. The fix uses a default dataset name of `manual` for manual collection addresses. I understand that using this approach might cause a collision with a non-manual datasets named `manual` but the product team (@rsilvery) agreed this was acceptable for now.

### Code Changes

* [ ] Updated the way the collection addresses are parsed for the DSR report builder

### Steps to Confirm

* [ ] Configure a manual integration
* [ ] Submit an access request
* [ ] Verify the generated HTML report

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`