### PR TITLE
Experiment with using different sample app locations

### DIFF
--- a/clients/sample-app/src/components/GeolocationSelect/index.tsx
+++ b/clients/sample-app/src/components/GeolocationSelect/index.tsx
@@ -18,8 +18,8 @@ const geolocationOptions: GeolocationOption[] = [
   { value: "US-CA", label: "California", flag: "us-ca" },
   { value: "US-VA", label: "Virginia", flag: "us" },
   { value: "US-NY", label: "New York", flag: "us" },
-  { value: "FR-IDG", label: "Paris", flag: "fr" },
-  { value: "DE-HE", label: "Frankfurt", flag: "de" },
+  { value: "EU-FR", label: "Paris", flag: "fr" },
+  { value: "EU-DE", label: "Frankfurt", flag: "de" },
 ];
 
 // By default, each "option" in a <select> menu are plaintext labels, which is a


### PR DESCRIPTION
### Description Of Changes

This is just an experiment to put our nifty feature branch tagging into action... this branch exists to make a small change to the sample app and then publish a feature branch (alpha) tag: `2.15.1a0`


### Code Changes

* [X] Change sample app location select options to include `EU-FR` and `EU-DE`

### Steps to Confirm

* [X] Publish `2.15.1a0` tag
* [ ] Hope that `fides-sample-app:2.15.1a0` is published
* [ ] Pull `fides-sample-app:2.15.1a0` into a Docker project and try it out

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
