### PR TITLE
[Backend] Validation on Notice Keys within Region

### DIFF
--- a/src/fides/api/models/privacy_notice.py
+++ b/src/fides/api/models/privacy_notice.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from enum import Enum
+from html import unescape
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 from fideslang.validation import FidesKey
@@ -343,7 +344,7 @@ def check_conflicting_notice_keys(
             for notice_key, notice_name in region_notice_keys:
                 if notice_key == privacy_notice.notice_key:
                     raise ValidationError(
-                        message=f"Privacy Notice '{notice_name}' has already assigned notice key '{notice_key}' to region '{region}'"
+                        message=f"Privacy Notice '{unescape(notice_name)}' has already assigned notice key '{notice_key}' to region '{region}'"
                     )
             # add the new notice key to our map
             region_notice_keys.append((privacy_notice.notice_key, privacy_notice.name))
@@ -398,7 +399,7 @@ def check_conflicting_data_uses(
                     # an existing DataUse
                     if new_data_use_conflicts_with_existing_use(existing_use, data_use):
                         raise ValidationError(
-                            message=f"Privacy Notice '{notice_name}' has already assigned data use '{existing_use}' to region '{region}'"
+                            message=f"Privacy Notice '{unescape(notice_name)}' has already assigned data use '{existing_use}' to region '{region}'"
                         )
                 # add the data use to our map, to effectively include it in validation against the
                 # following incoming records

--- a/src/fides/api/models/privacy_notice.py
+++ b/src/fides/api/models/privacy_notice.py
@@ -332,7 +332,6 @@ def check_conflicting_notice_keys(
                 (privacy_notice.notice_key, privacy_notice.name)
             )
 
-    #
     for privacy_notice in new_privacy_notices:
         if privacy_notice.disabled and ignore_disabled:
             # Skip validation if the notice is disabled

--- a/src/fides/api/models/privacy_notice.py
+++ b/src/fides/api/models/privacy_notice.py
@@ -311,6 +311,44 @@ class PrivacyNotice(PrivacyNoticeBase, Base):
 PRIVACY_NOTICE_TYPE = Union[PrivacyNotice, PrivacyNoticeTemplate]
 
 
+def check_conflicting_notice_keys(
+    new_privacy_notices: Iterable[PRIVACY_NOTICE_TYPE],
+    existing_privacy_notices: Iterable[Union[PRIVACY_NOTICE_TYPE]],
+    ignore_disabled: bool = True,  # For PrivacyNoticeTemplates, set to False
+) -> None:
+    """
+    Checks to see if new notice keys will conflict with any existing notice keys for a specific region
+    """
+    # Map regions to existing notice key, notice name
+    notice_keys_by_region: Dict[
+        PrivacyNoticeRegion, List[Tuple[str, str]]
+    ] = defaultdict(list)
+    for privacy_notice in existing_privacy_notices:
+        if privacy_notice.disabled and ignore_disabled:
+            continue
+        for region in privacy_notice.regions:
+            notice_keys_by_region[PrivacyNoticeRegion(region)].append(
+                (privacy_notice.notice_key, privacy_notice.name)
+            )
+
+    #
+    for privacy_notice in new_privacy_notices:
+        if privacy_notice.disabled and ignore_disabled:
+            # Skip validation if the notice is disabled
+            continue
+        # check each of the incoming notice's regions
+        for region in privacy_notice.regions:
+            region_notice_keys = notice_keys_by_region[PrivacyNoticeRegion(region)]
+            # check the incoming notice keys
+            for notice_key, notice_name in region_notice_keys:
+                if notice_key == privacy_notice.notice_key:
+                    raise ValidationError(
+                        message=f"Privacy Notice '{notice_name}' has already assigned notice key '{notice_key}' to region '{region}'"
+                    )
+            # add the new notice key to our map
+            region_notice_keys.append((privacy_notice.notice_key, privacy_notice.name))
+
+
 def check_conflicting_data_uses(
     new_privacy_notices: Iterable[PRIVACY_NOTICE_TYPE],
     existing_privacy_notices: Iterable[Union[PRIVACY_NOTICE_TYPE]],

--- a/src/fides/api/util/consent_util.py
+++ b/src/fides/api/util/consent_util.py
@@ -23,6 +23,7 @@ from fides.api.models.privacy_notice import (
     PrivacyNoticeTemplate,
     UserConsentPreference,
     check_conflicting_data_uses,
+    check_conflicting_notice_keys,
 )
 from fides.api.models.privacy_preference import PrivacyPreferenceHistory
 from fides.api.models.privacy_request import (
@@ -316,6 +317,7 @@ def create_privacy_notices_util(
         for privacy_notice in privacy_notice_schemas
     ]
     check_conflicting_data_uses(new_notices, existing_notices)
+    check_conflicting_notice_keys(new_notices, existing_notices)
 
     created_privacy_notices: List[PrivacyNotice] = []
     affected_regions: Set = set()
@@ -436,6 +438,11 @@ def prepare_privacy_notice_patches(
     # run the validation here on our proposed "dry-run" updates
     try:
         check_conflicting_data_uses(
+            validation_updates,
+            existing_notices.values(),
+            ignore_disabled=ignore_disabled,
+        )
+        check_conflicting_notice_keys(
             validation_updates,
             existing_notices.values(),
             ignore_disabled=ignore_disabled,

--- a/tests/ops/api/v1/endpoints/test_privacy_notice_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_notice_endpoints.py
@@ -2273,6 +2273,7 @@ class TestPatchPrivacyNotices:
 
         # conflict with identical data uses within region
         # we make the two patch payload items have the same data_use, they should fail
+        patch_privacy_notice_payload["name"] = "my notice's name"
         patch_privacy_notice_payload_updated_data_use = (
             patch_privacy_notice_payload.copy()
         )
@@ -2294,6 +2295,10 @@ class TestPatchPrivacyNotices:
             ],
         )  # direct overlap in the requests
         assert resp.status_code == 422
+        assert (
+            resp.json()["detail"]
+            == "Privacy Notice 'my notice's name' has already assigned data use 'improve' to region 'PrivacyNoticeRegion.us_ca'"
+        )
 
         # conflict with parent/child data uses within region
         # we make the two patch payload items have parent/child data uses, they should fail
@@ -2999,6 +3004,7 @@ class TestPatchPrivacyNotices:
         patch_privacy_notice_payload_us_ca_provide[
             "notice_key"
         ] = patch_privacy_notice_payload["notice_key"]
+        patch_privacy_notice_payload["name"] = "My notice's name"
         # Set disabled to False, because disabled notice keys are ignoredc
         patch_privacy_notice_payload["disabled"] = False
 
@@ -3013,7 +3019,7 @@ class TestPatchPrivacyNotices:
         assert resp.status_code == 422
         assert (
             resp.json()["detail"]
-            == "Privacy Notice 'updated privacy notice name' has already assigned notice key 'updated_privacy_notice_key' to region 'PrivacyNoticeRegion.us_ca'"
+            == "Privacy Notice 'My notice's name' has already assigned notice key 'updated_privacy_notice_key' to region 'PrivacyNoticeRegion.us_ca'"
         )
 
     def test_patching_privacy_notice_twice(

--- a/tests/ops/api/v1/endpoints/test_privacy_notice_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_notice_endpoints.py
@@ -2000,6 +2000,32 @@ class TestPostPrivacyNotices:
         assert response_notice_2["updated_at"] == db_notice_2.updated_at.isoformat()
         assert response_notice_2["disabled"] == db_notice_2.disabled
 
+    def test_post_multiple_privacy_notice_notice_key_overlap(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        notice_request: dict[str, Any],
+        notice_request_2: dict[str, Any],
+        url,
+        db,
+    ):
+        """
+        Test posting multiple new privacy notices with overlay in notice key
+        """
+
+        auth_header = generate_auth_header(scopes=[scopes.PRIVACY_NOTICE_CREATE])
+        # Override second notice to have the same notice key as the first notice
+        notice_request_2["notice_key"] = "test_privacy_notice_1"
+
+        resp = api_client.post(
+            url, headers=auth_header, json=[notice_request, notice_request_2]
+        )
+        assert resp.status_code == 422
+        assert (
+            resp.json()["detail"]
+            == "Privacy Notice 'test privacy notice 1' has already assigned notice key 'test_privacy_notice_1' to region 'us_ca'"
+        )
+
 
 class TestPatchPrivacyNotices:
     @pytest.fixture(scope="function")
@@ -2952,6 +2978,43 @@ class TestPatchPrivacyNotices:
             == db_notice_2.consent_mechanism.value
         )
         assert response_notice_2["data_uses"] == db_notice_2.data_uses
+
+    def test_patch_multiple_privacy_notices_notice_key_overlap(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        patch_privacy_notice_payload: dict[str, Any],
+        patch_privacy_notice_payload_us_ca_provide: dict[str, Any],
+        privacy_notice: PrivacyNotice,
+        privacy_notice_us_ca_provide: PrivacyNotice,
+        url,
+        db,
+    ):
+        """
+        Test patching multiple privacy notices notice_key_overlap
+        """
+
+        auth_header = generate_auth_header(scopes=[scopes.PRIVACY_NOTICE_UPDATE])
+        # Make notice keys match
+        patch_privacy_notice_payload_us_ca_provide[
+            "notice_key"
+        ] = patch_privacy_notice_payload["notice_key"]
+        # Set disabled to False, because disabled notice keys are ignoredc
+        patch_privacy_notice_payload["disabled"] = False
+
+        resp = api_client.patch(
+            url,
+            headers=auth_header,
+            json=[
+                patch_privacy_notice_payload,
+                patch_privacy_notice_payload_us_ca_provide,
+            ],
+        )
+        assert resp.status_code == 422
+        assert (
+            resp.json()["detail"]
+            == "Privacy Notice 'updated privacy notice name' has already assigned notice key 'updated_privacy_notice_key' to region 'PrivacyNoticeRegion.us_ca'"
+        )
 
     def test_patching_privacy_notice_twice(
         self,

--- a/tests/ops/models/test_privacy_notice.py
+++ b/tests/ops/models/test_privacy_notice.py
@@ -11,6 +11,7 @@ from fides.api.models.privacy_notice import (
     PrivacyNoticeRegion,
     UserConsentPreference,
     check_conflicting_data_uses,
+    check_conflicting_notice_keys,
     new_data_use_conflicts_with_existing_use,
 )
 from fides.api.models.sql_models import Cookies
@@ -695,6 +696,108 @@ class TestPrivacyNoticeModel:
                 )
         else:
             check_conflicting_data_uses(
+                new_privacy_notices=new_privacy_notices,
+                existing_privacy_notices=existing_privacy_notices,
+            )
+
+    @pytest.mark.parametrize(
+        "should_error,new_privacy_notices,existing_privacy_notices",
+        [
+            (
+                True,
+                [
+                    PrivacyNotice(
+                        name="pn_1",
+                        notice_key="pn_1",
+                        data_uses=["marketing.advertising"],
+                        regions=[PrivacyNoticeRegion.us_ca],
+                    )
+                ],
+                [
+                    PrivacyNotice(
+                        name="pn_1",
+                        notice_key="pn_1",
+                        data_uses=["improve"],
+                        regions=[PrivacyNoticeRegion.us_ca],
+                    )
+                ],
+            ),
+            (
+                True,
+                [
+                    PrivacyNotice(
+                        name="pn_2",
+                        notice_key="pn_2",
+                        data_uses=["improve"],
+                        regions=[PrivacyNoticeRegion.us_ca],
+                    ),
+                    PrivacyNotice(
+                        name="pn_2",
+                        notice_key="pn_2",
+                        data_uses=["essential.service"],
+                        regions=[PrivacyNoticeRegion.us_ca],
+                    ),
+                ],
+                [
+                    PrivacyNotice(
+                        name="pn_1",
+                        notice_key="pn_1",
+                        data_uses=["marketing.advertising"],
+                        regions=[PrivacyNoticeRegion.us_ca],
+                    )
+                ],
+            ),
+            (
+                False,
+                [
+                    PrivacyNotice(
+                        name="pn_1",
+                        notice_key="pn_1",
+                        data_uses=["marketing.advertising"],
+                        regions=[PrivacyNoticeRegion.us_ca],
+                    )
+                ],
+                [
+                    PrivacyNotice(
+                        name="pn_2",
+                        notice_key="pn_2",
+                        data_uses=["improve"],
+                        regions=[PrivacyNoticeRegion.us_ca],
+                    )
+                ],
+            ),
+            (
+                False,
+                [
+                    PrivacyNotice(
+                        name="pn_1",
+                        notice_key="pn_1",
+                        data_uses=["marketing.advertising"],
+                        regions=[PrivacyNoticeRegion.us_ca],
+                    )
+                ],
+                [
+                    PrivacyNotice(
+                        name="pn_1",
+                        notice_key="pn_1",
+                        data_uses=["improve"],
+                        regions=[PrivacyNoticeRegion.us_va],
+                    )
+                ],
+            ),
+        ],
+    )
+    def test_check_conflicting_privacy_notice_keys(
+        self, should_error, new_privacy_notices, existing_privacy_notices
+    ):
+        if should_error:
+            with pytest.raises(ValidationError):
+                check_conflicting_notice_keys(
+                    new_privacy_notices=new_privacy_notices,
+                    existing_privacy_notices=existing_privacy_notices,
+                )
+        else:
+            check_conflicting_notice_keys(
                 new_privacy_notices=new_privacy_notices,
                 existing_privacy_notices=existing_privacy_notices,
             )

--- a/tests/ops/util/test_consent_util.py
+++ b/tests/ops/util/test_consent_util.py
@@ -854,6 +854,41 @@ class TestUpsertPrivacyNoticeTemplates:
             == "Privacy Notice 'A' has already assigned data use 'essential' to region 'it'"
         )
 
+    def test_overlapping_notice_keys(self, db, load_default_data_uses):
+        """Can't have overlapping notice keys on incoming templates, and we also check these for disabled templates"""
+        with pytest.raises(HTTPException) as exc:
+            upsert_privacy_notice_templates_util(
+                db,
+                [
+                    PrivacyNoticeWithId(
+                        id="test_id_1",
+                        notice_key="a",
+                        name="A",
+                        regions=["eu_it"],
+                        consent_mechanism=ConsentMechanism.opt_in,
+                        data_uses=["essential"],
+                        enforcement_level=EnforcementLevel.system_wide,
+                        displayed_in_overlay=True,
+                    ),
+                    PrivacyNoticeWithId(
+                        id="test_id_2",
+                        notice_key="a",
+                        name="B",
+                        regions=["eu_it"],
+                        consent_mechanism=ConsentMechanism.opt_in,
+                        data_uses=["marketing"],
+                        enforcement_level=EnforcementLevel.frontend,
+                        disabled=True,
+                        displayed_in_overlay=True,
+                    ),
+                ],
+            )
+        assert exc._excinfo[1].status_code == 422
+        assert (
+            exc._excinfo[1].detail
+            == "Privacy Notice 'A' has already assigned notice key 'a' to region 'eu_it'"
+        )
+
     def test_bad_data_uses(self, db, load_default_data_uses):
         """Test data uses must exist"""
         with pytest.raises(HTTPException) as exc:

--- a/tests/ops/util/test_consent_util.py
+++ b/tests/ops/util/test_consent_util.py
@@ -864,7 +864,7 @@ class TestUpsertPrivacyNoticeTemplates:
                         id="test_id_1",
                         notice_key="a",
                         name="A",
-                        regions=["eu_it"],
+                        regions=["it"],
                         consent_mechanism=ConsentMechanism.opt_in,
                         data_uses=["essential"],
                         enforcement_level=EnforcementLevel.system_wide,
@@ -874,7 +874,7 @@ class TestUpsertPrivacyNoticeTemplates:
                         id="test_id_2",
                         notice_key="a",
                         name="B",
-                        regions=["eu_it"],
+                        regions=["it"],
                         consent_mechanism=ConsentMechanism.opt_in,
                         data_uses=["marketing"],
                         enforcement_level=EnforcementLevel.frontend,
@@ -886,7 +886,7 @@ class TestUpsertPrivacyNoticeTemplates:
         assert exc._excinfo[1].status_code == 422
         assert (
             exc._excinfo[1].detail
-            == "Privacy Notice 'A' has already assigned notice key 'a' to region 'eu_it'"
+            == "Privacy Notice 'A' has already assigned notice key 'a' to region 'it'"
         )
 
     def test_bad_data_uses(self, db, load_default_data_uses):


### PR DESCRIPTION
Closes #3353 

### Description Of Changes

When creating or updating a notice, check all existing notices, as well as any incoming notices to see if there are going to be any notice key overlaps within a specific region.

### Code Changes

* [x] Create a function patterned off of the data use check function that validates notice keys and run this when creating or updating a notice.  

### Steps to Confirm

* [ ] Via the API, run some notice key checks that should fail. For example:
POST /privacy-notice
```json
[
   {
      "name":"Profiling",
      "notice_key": "profiling",
      "regions":[
         "us_oh"
      ],
      "description":"Making a decision solely by automated means.",
      "consent_mechanism":"opt_in",
      "data_uses":[
         "personalize"
      ],
      "enforcement_level":"system_wide",
      "has_gpc_flag":false,
      "displayed_in_overlay":true
   },
   {
      "name":"Essential",
      "notice_key": "profiling",
      "regions":[
         "us_oh"
      ],
      "description":"Notify the user about data processing activities that are essential to your services' functionality. Typically consent is not required for this.",
      "consent_mechanism":"notice_only",
      "data_uses":[
         "essential.service"
      ],
      "enforcement_level":"system_wide",
      "displayed_in_overlay":true
   }
]

```

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
