### PR TITLE
move db-dependent routers up a few levels to reduce circular dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.16.0...main)
 
+### Developer Experience
+
+- Changed where db-dependent routers were imported to avoid dependency issues [#3741](https://github.com/ethyca/fides/pull/3741)
+
 ## [2.16.0](https://github.com/ethyca/fides/compare/2.15.1...2.16.0)
 
 ### Added

--- a/src/fides/api/api/v1/__init__.py
+++ b/src/fides/api/api/v1/__init__.py
@@ -5,7 +5,6 @@ All routes should get imported here and added to the CTL_ROUTER
 """
 from fastapi import APIRouter
 
-from .endpoints.admin import ADMIN_ROUTER
 from .endpoints.generate import GENERATE_ROUTER
 from .endpoints.generic import (
     DATA_CATEGORY_ROUTER,
@@ -18,7 +17,6 @@ from .endpoints.generic import (
     POLICY_ROUTER,
     REGISTRY_ROUTER,
 )
-from .endpoints.health import HEALTH_ROUTER
 from .endpoints.system import (
     SYSTEM_CONNECTION_INSTANTIATE_ROUTER,
     SYSTEM_CONNECTIONS_ROUTER,
@@ -26,8 +24,11 @@ from .endpoints.system import (
 )
 from .endpoints.validate import VALIDATE_ROUTER
 
+# ADMIN and HEALTH routers are explicitly _excluded_ here.
+# those depend directly on database modules, and therefore
+# cause circular dependency problems when initialized as
+# part of this module. see https://github.com/ethyca/fides/issues/3652
 routers = [
-    ADMIN_ROUTER,
     DATA_CATEGORY_ROUTER,
     DATA_SUBJECT_ROUTER,
     DATA_QUALIFIER_ROUTER,
@@ -35,7 +36,6 @@ routers = [
     DATASET_ROUTER,
     EVALUATION_ROUTER,
     GENERATE_ROUTER,
-    HEALTH_ROUTER,
     ORGANIZATION_ROUTER,
     POLICY_ROUTER,
     REGISTRY_ROUTER,

--- a/src/fides/api/app_setup.py
+++ b/src/fides/api/app_setup.py
@@ -5,7 +5,7 @@ from logging import DEBUG
 from os.path import dirname, join
 from typing import List, Optional, Pattern, Union
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from loguru import logger
 from redis.exceptions import RedisError, ResponseError
 from slowapi.errors import RateLimitExceeded  # type: ignore
@@ -17,6 +17,8 @@ import fides
 from fides.api.api.deps import get_api_session
 from fides.api.api.v1 import CTL_ROUTER
 from fides.api.api.v1.api import api_router
+from fides.api.api.v1.endpoints.admin import ADMIN_ROUTER
+from fides.api.api.v1.endpoints.health import HEALTH_ROUTER
 from fides.api.api.v1.exception_handlers import ExceptionHandlers
 from fides.api.common_exceptions import FunctionalityNotConfigured, RedisConnectionError
 from fides.api.db.database import configure_db
@@ -47,7 +49,16 @@ from fides.config import CONFIG
 
 VERSION = fides.__version__
 
-ROUTERS = [CTL_ROUTER, api_router]
+# DB_ROUTER holds routers that have direct DB dependencies.
+# these routers are initialized _outside_ of inner `api` module
+# to avoid cyclical dependency chains.
+# see https://github.com/ethyca/fides/issues/3652
+DB_ROUTER = APIRouter()
+DB_ROUTER.include_router(ADMIN_ROUTER)
+DB_ROUTER.include_router(HEALTH_ROUTER)
+
+
+ROUTERS = [CTL_ROUTER, api_router, DB_ROUTER]
 DEFAULT_PRIVACY_NOTICES_PATH = join(
     dirname(__file__),
     "../data/privacy_notices",


### PR DESCRIPTION
Closes #3652 

### Description Of Changes

our admin (`admin.py`) and health (`health.py`) routers have direct dependencies on the `fides.api.db.database` module, since they require direct interaction with the DB. if these routers are initialized within the `api.api.v1` module, this can easily lead to circular dependency problems on module initialization, because the `api.api.v1` module is itself imported by some classes and submodules of `api.db`. 

see #3652  and this [PR comment](https://github.com/ethyca/fides/pull/3692#issuecomment-1614508211) for context. additionally, this was motivated by @RobertKeyser attempting to import `fides.api.db.database.get_db_health` into a python shell and hitting a circular dependency.


Side note: I considered moving the router definitions themselves (i.e. their code) out of `api.api.v1` and into the higher-level `api` module. but I thought it'd be nice to keep the router definitions next to all the other routers in `api.api.v1`, and just change where the router gets loaded/initialized. i'm definitely open to alternatives, though - what i put here is just a first stab!

### Code Changes

* initialize and load the `HEALTH_ROUTER` and `ADMIN_ROUTER` as part of `api.app_setup` directly, rather than as part of the `api.api.v1.__init__.py` package initializer, as most routers are.

### Steps to Confirm

* [x] server starts (`nox -s dev`, `nox -s "fides_env(test)"`) without import/dependency problems
* [x] `/admin` and `/health` routes work on running server
* [x] automated tests run without import/dependency problems
* [x] `nox -s quickstart` runs to completion without dependency problems
* [x] `fides.api.db.database.get_db_health` can be imported standalone, without dependency problems: 
    * [ ] `nox -s dev --shell`
    * [ ] run `python3` to get a python shell
    * [ ] execute `from fides.api.db.database import get_db_health` successfully

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
