### PR TITLE
Fixing misc test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,10 @@ module = [
   "botocore.*",
   "bson.*",
   "celery.*",
+  "citext.*",
   "dask.*",
   "deepdiff.*",
+  "defusedxml.ElementTree.*",
   "fideslang.*",
   "fideslog.*",
   "firebase_admin.*",
@@ -62,7 +64,6 @@ module = [
   "twilio.*",
   "uvicorn.*",
   "validators.*",
-  "citext.*",
 ]
 ignore_missing_imports = true
 

--- a/src/fides/api/util/unsafe_file_util.py
+++ b/src/fides/api/util/unsafe_file_util.py
@@ -51,7 +51,7 @@ def verify_zip(zip_file: ZipFile, max_file_size: Optional[int] = None) -> None:
         with zip_file.open(file_info) as file:
             # wraps the file read in an iterator that stops once no bytes
             # are returned or the max file size is reached
-            for chunk in iter(lambda: file.read(CHUNK_SIZE), b""):
+            for chunk in iter(lambda f=file: f.read(CHUNK_SIZE), b""):  # type: ignore
                 file_size += len(chunk)
 
                 if file_size > max_file_size:

--- a/tests/fixtures/saas_example_fixtures.py
+++ b/tests/fixtures/saas_example_fixtures.py
@@ -658,7 +658,7 @@ def planet_express_invalid_dataset() -> str:
 
 @pytest.fixture
 def planet_express_icon() -> str:
-    return encode_file_contents(
+    return load_as_string(
         "tests/fixtures/saas/test_data/planet_express/planet_express.svg"
     )
 


### PR DESCRIPTION
### Description Of Changes

Misc bug fixes for issues that made it to the `main` branch.

### Code Changes

* [ ] Added `defusedxml.ElementTree.*` to `pyproject.toml`'s `tool.mypy.overrides`
* [ ] Updated `verify_zip` function in `unsafe_file_utils` to resolve mypy errors
* [ ] Corrected the SVG file generated in the fixtures for `test_connector_template_loaders`, reading it as a string without base64 encoding it.

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
