### PR TITLE
ignore type checker on `click` decorators to bypass known library issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The types of changes are:
 - Treat underscores as special characters in user passwords [#3717](https://github.com/ethyca/fides/pull/3717)
 - Allow Privacy Notices banner and modal to scroll as needed [#3713](https://github.com/ethyca/fides/pull/3713)
 - Make malicious url test more robust to environmental differences [#3748](https://github.com/ethyca/fides/pull/3748)
+- Ignore type checker on click decorators to bypass known issue with `click` version `8.1.4` [#3746](https://github.com/ethyca/fides/pull/3746)
 
 ### Changed
 

--- a/src/fides/cli/__init__.py
+++ b/src/fides/cli/__init__.py
@@ -64,7 +64,7 @@ APP = fides.__name__
 PACKAGE = "ethyca-fides"
 
 
-@group(
+@group(  # type: ignore
     context_settings=CONTEXT_SETTINGS,
     invoke_without_command=True,
     name="fides",

--- a/src/fides/cli/commands/annotate.py
+++ b/src/fides/cli/commands/annotate.py
@@ -14,7 +14,7 @@ def annotate(ctx: click.Context) -> None:
     """
 
 
-@annotate.command(name="dataset")
+@annotate.command(name="dataset")  # type: ignore
 @click.pass_context
 @click.argument("input_filename", type=str)
 @click.option(

--- a/src/fides/cli/commands/deploy.py
+++ b/src/fides/cli/commands/deploy.py
@@ -30,7 +30,7 @@ def deploy(ctx: click.Context) -> None:
     """
 
 
-@deploy.command()
+@deploy.command()  # type: ignore
 @click.pass_context
 @click.option(
     "--no-pull",

--- a/src/fides/cli/commands/generate.py
+++ b/src/fides/cli/commands/generate.py
@@ -39,7 +39,7 @@ def generate_dataset(ctx: click.Context) -> None:
     """
 
 
-@generate_dataset.command(name="db")
+@generate_dataset.command(name="db")  # type: ignore
 @click.pass_context
 @click.argument("output_filename", type=str)
 @credentials_id_option
@@ -77,7 +77,7 @@ def generate_dataset_gcp(ctx: click.Context) -> None:
     """
 
 
-@generate_dataset_gcp.command(name="bigquery")
+@generate_dataset_gcp.command(name="bigquery")  # type: ignore
 @click.pass_context
 @click.argument("dataset_name", type=str)
 @click.argument("output_filename", type=str)
@@ -119,7 +119,7 @@ def generate_dataset_aws(ctx: click.Context) -> None:
     """
 
 
-@generate_dataset_aws.command(name="dynamodb")
+@generate_dataset_aws.command(name="dynamodb")  # type: ignore
 @click.pass_context
 @click.argument("output_filename", type=str)
 @credentials_id_option
@@ -165,7 +165,7 @@ def generate_system(ctx: click.Context) -> None:
     """
 
 
-@generate_system.command(name="okta")
+@generate_system.command(name="okta")  # type: ignore
 @click.pass_context
 @click.argument("output_filename", type=str)
 @credentials_id_option
@@ -205,7 +205,7 @@ def generate_system_okta(
     )
 
 
-@generate_system.command(name="aws")
+@generate_system.command(name="aws")  # type: ignore
 @click.pass_context
 @click.argument("output_filename", type=str)
 @credentials_id_option

--- a/src/fides/cli/commands/ungrouped.py
+++ b/src/fides/cli/commands/ungrouped.py
@@ -37,7 +37,7 @@ from fides.core.api_helpers import get_server_resource, list_server_resources
 from fides.core.utils import git_is_dirty
 
 
-@click.command()
+@click.command()  # type: ignore
 @click.pass_context
 @resource_type_argument
 @fides_key_argument
@@ -61,7 +61,7 @@ def delete(ctx: click.Context, resource_type: str, fides_key: str) -> None:
     )
 
 
-@click.command(name="get")
+@click.command(name="get")  # type: ignore
 @click.pass_context
 @resource_type_argument
 @fides_key_argument
@@ -82,7 +82,7 @@ def get_resource(ctx: click.Context, resource_type: str, fides_key: str) -> None
     echo_green(yaml.dump({resource_type: [resource]}))
 
 
-@click.command(name="ls")
+@click.command(name="ls")  # type: ignore
 @click.pass_context
 @resource_type_argument
 @with_analytics
@@ -117,7 +117,7 @@ def list_resources(ctx: click.Context, verbose: bool, resource_type: str) -> Non
             echo_red(f"No {resource_type.capitalize()} resources found!")
 
 
-@click.command()
+@click.command()  # type: ignore
 @click.pass_context
 @click.argument("fides_dir", default=".", type=click.Path(exists=True))
 @click.option(
@@ -162,7 +162,7 @@ def status(ctx: click.Context) -> None:
     )
 
 
-@click.command()
+@click.command()  # type: ignore
 @click.pass_context
 @click.option("--port", "-p", type=int, default=8080)
 def webserver(ctx: click.Context, port: int = 8080) -> None:
@@ -190,7 +190,7 @@ def worker(ctx: click.Context) -> None:
     start_worker()
 
 
-@click.command()
+@click.command()  # type: ignore
 @click.pass_context
 @dry_flag
 @click.option(
@@ -216,7 +216,7 @@ def push(ctx: click.Context, dry: bool, diff: bool, manifests_dir: str) -> None:
     )
 
 
-@click.command()
+@click.command()  # type: ignore
 @click.pass_context
 @manifests_dir_argument
 @click.option(
@@ -310,7 +310,7 @@ def parse(ctx: click.Context, manifests_dir: str, verbose: bool = False) -> None
         pretty_echo(taxonomy.dict(), color="green")
 
 
-@click.command()
+@click.command()  # type: ignore
 @click.pass_context
 @manifests_dir_argument
 @click.option(

--- a/src/fides/cli/commands/view.py
+++ b/src/fides/cli/commands/view.py
@@ -16,7 +16,7 @@ def view(ctx: click.Context) -> None:
     """
 
 
-@view.command(name="config")
+@view.command(name="config")  # type: ignore
 @click.pass_context
 @click.argument("section", default="", type=str)
 @click.option(

--- a/src/fides/cli/options.py
+++ b/src/fides/cli/options.py
@@ -7,6 +7,11 @@ from typing import Callable
 import rich_click as click
 from fideslang import model_list
 
+# Note - the type: ignore comments throughout this file are a workaround
+# for a known issue with the `click` library:
+# https://github.com/pallets/click/issues/2558
+# If/when that issue is resolved, they can be removed.
+
 
 def coverage_threshold_option(command: Callable) -> Callable:
     """An option decorator that sets a required coverage percentage."""
@@ -16,7 +21,7 @@ def coverage_threshold_option(command: Callable) -> Callable:
         type=click.IntRange(0, 100),
         default=100,
         help="Set the coverage percentage for a passing scan.",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -25,7 +30,7 @@ def resource_type_argument(command: Callable) -> Callable:
     command = click.argument(
         "resource_type",
         type=click.Choice(model_list, case_sensitive=False),
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -34,7 +39,7 @@ def fides_key_argument(command: Callable) -> Callable:
     command = click.argument(
         "fides_key",
         type=str,
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -44,7 +49,7 @@ def fides_key_option(command: Callable) -> Callable:
         "-k",
         "--fides-key",
         default="",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -52,7 +57,7 @@ def manifests_dir_argument(command: Callable) -> Callable:
     "Add the manifests_dir argument."
     command = click.argument(
         "manifests_dir", type=click.Path(exists=True), default=".fides/"
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -60,7 +65,7 @@ def dry_flag(command: Callable) -> Callable:
     "Add a flag that prevents side-effects."
     command = click.option(
         "--dry", is_flag=True, help="Do not upload results to the Fides webserver."
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -71,7 +76,7 @@ def yes_flag(command: Callable) -> Callable:
         "-y",
         is_flag=True,
         help="Automatically responds `yes` to any prompts.",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -82,7 +87,7 @@ def verbose_flag(command: Callable) -> Callable:
         "-v",
         is_flag=True,
         help="Enable verbose output.",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -92,7 +97,7 @@ def include_null_flag(command: Callable) -> Callable:
         "--include-null",
         is_flag=True,
         help="Include null attributes.",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -104,7 +109,7 @@ def organization_fides_key_option(command: Callable) -> Callable:
         default="default_organization",
         show_default=True,
         help="The `organization_fides_key` of the `Organization` you want to specify.",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -116,7 +121,7 @@ def output_directory_option(command: Callable) -> Callable:
         default=".fides/",
         show_default=True,
         help="The output directory for the data map to be exported to.",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -126,7 +131,7 @@ def credentials_id_option(command: Callable) -> Callable:
         "--credentials-id",
         type=str,
         help="Use credentials keys defined within Fides config.",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -136,7 +141,7 @@ def connection_string_option(command: Callable) -> Callable:
         "--connection-string",
         type=str,
         help="Use the connection string option to connect to a database.",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -146,7 +151,7 @@ def okta_org_url_option(command: Callable) -> Callable:
         "--org-url",
         type=str,
         help="Connect to Okta using an 'Org URL'. _Requires options `--org-url` & `--token`._",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -156,7 +161,7 @@ def okta_token_option(command: Callable) -> Callable:
         "--token",
         type=str,
         help="Connect to Okta using a token. _Requires options `--org-url` and `--token`._",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -166,7 +171,7 @@ def aws_access_key_id_option(command: Callable) -> Callable:
         "--access_key_id",
         type=str,
         help="Connect to AWS using an `Access Key ID`. _Requires options `--access_key_id`, `--secret_access_key` & `--region`._",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -176,7 +181,7 @@ def aws_secret_access_key_option(command: Callable) -> Callable:
         "--secret_access_key",
         type=str,
         help="Connect to AWS using an `Access Key`. _Requires options `--access_key_id`, `--secret_access_key` & `--region`._",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -186,7 +191,7 @@ def aws_region_option(command: Callable) -> Callable:
         "--region",
         type=str,
         help="Connect to AWS using a specific `Region`. _Requires options `--access_key_id`, `--secret_access_key` & `--region`._",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -227,7 +232,7 @@ def username_option(command: Callable) -> Callable:
         help="If not provided, will be pulled from the config file or prompted for.",
         default="",
         callback=prompt_username,
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -238,7 +243,7 @@ def password_option(command: Callable) -> Callable:
         help="If not provided, will be pulled from the config file or prompted for.",
         default="",
         callback=prompt_password,
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -247,7 +252,7 @@ def first_name_option(command: Callable) -> Callable:
         "-f",
         "--first-name",
         default="",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
@@ -256,15 +261,15 @@ def last_name_option(command: Callable) -> Callable:
         "-l",
         "--last-name",
         default="",
-    )(command)
+    )(command)  # type: ignore
     return command
 
 
 def username_argument(command: Callable) -> Callable:
-    command = click.argument("username", type=str)(command)
+    command = click.argument("username", type=str)(command) # type: ignore
     return command
 
 
 def password_argument(command: Callable) -> Callable:
-    command = click.argument("password", type=str)(command)
+    command = click.argument("password", type=str)(command) # type: ignore
     return command


### PR DESCRIPTION
Closes #3745 

### Description Of Changes

Ignore type checker on problematic function calls with decorator wrappers. This is due to a change in `click` version `8.1.4` that many others are also hitting: https://github.com/pallets/click/issues/2558

See issue descriptions (ours and theirs) for more detail/context.

Follow up tech debt ticket to revert this eventually, when possible: https://github.com/ethyca/fides/issues/3749

### Code Changes

* [ ] add comment to ignore type checker on problematic function calls

### Steps to Confirm

* [ ] `mypy` static check passes in CI

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
