### PR TITLE
make malicious url test more robust to env differences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The types of changes are:
 - Reorganized some `api.api.v1` code to avoid circular dependencies on `quickstart` [#3692](https://github.com/ethyca/fides/pull/3692)
 - Treat underscores as special characters in user passwords [#3717](https://github.com/ethyca/fides/pull/3717)
 - Allow Privacy Notices banner and modal to scroll as needed [#3713](https://github.com/ethyca/fides/pull/3713)
+- Make malicious url test more robust to environmental differences [#3748](https://github.com/ethyca/fides/pull/3748)
 
 ### Changed
 

--- a/tests/ops/util/test_api_router.py
+++ b/tests/ops/util/test_api_router.py
@@ -1,3 +1,6 @@
+from unittest import mock
+from unittest.mock import Mock
+
 import pytest
 from starlette.status import HTTP_200_OK, HTTP_404_NOT_FOUND
 from starlette.testclient import TestClient
@@ -46,11 +49,25 @@ class TestApiRouter:
         )
         assert resp_4.status_code == HTTP_404_NOT_FOUND
 
+    @mock.patch("fides.api.main.get_admin_index_as_response")
     def test_malicious_url(
         self,
+        mock_admin_index_response: Mock,
         api_client: TestClient,
         url,
     ) -> None:
+        """
+        Assert that malicious URLs that attempt path traversal attacks
+        are NOT treated as legitimate URLs, and instead the basic "admin" index
+        response is returned.
+        """
+
+        # admin index response changes depending on environment.
+        # we mock the value here to give ourselves a consistent response to evaluate against.
+        # what we want to ensure is that the admin index response is what gets returned,
+        # indicating that the attempted path traversal does not occur.
+        mock_admin_index_response.return_value = "<h1>Privacy is a Human Right!</h1>"
+
         malicious_paths = [
             "../../../../../../../../../etc/passwd",
             "..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd",


### PR DESCRIPTION
Closes #3736 

### Description Of Changes

Mock the admin UI response for our test case to get a more predictable value.

It's not ideal, since there's a slight chance this could lead to false positives in the test case if we adjust our code around this area, so we'll just need to be a bit careful there. But I think it's a good enough test for now - and certainly better than getting false negatives all the time!

### Code Changes

* [ ] Mock the `get_admin_index_as_response` function for our `test_malicious_url` test case to get a more predictable value to evaluate in the test

### Steps to Confirm

* [ ] just need to make sure CI passes really

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
