### PR TITLE
Adds polyfill service to fides-js route

### DIFF
--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -96,6 +96,11 @@ export default async function handler(
   }
   const script = `
   (function () {
+    // This polyfill service adds a fetch polyfill only when needed, depending on browser making the request 
+    var script = document.createElement('script');
+    script.src = 'https://polyfill.io/v3/polyfill.min.js?features=fetch';
+    document.head.appendChild(script);
+    
     // Include generic fides.js script
     ${fidesJS}
 


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3319

### Description Of Changes

Adds polyfill service that automatically includes a `fetch` polyfill bundle if the detected browser is not compatible with `fetch`. Using a polyfill service allows us to scale to call other features we wish to include in that bundle, with minimal overhead.

Note that in testing this ticket with browsers that do not support `fetch` (for example using Chrome 39 and Safari 10), I ran into other issues with the fides-js code that were unrelated to `fetch`, pertaining to unidentified syntax issues. Since these existed before, I plan to keep this ticket scoped to including `fetch` when needed, and open up another ticket for a fuller-scale evaluation of cross-browser support.

### Code Changes

* [ ] Include code to call polyfill service

### Steps to Confirm

* [ ] For the scope of this ticket, we only need to ensure that no regressions occur using your default / standard browser. Confirm that navigating to http://localhost:3000/fides-js-demo.html calls the polyfill service, but does not respond with any polyfill code, and all pre-existing functionality with the cookie banner is not broken:
<img width="849" alt="Screenshot 2023-07-10 at 9 20 57 AM" src="https://github.com/ethyca/fides/assets/7697292/15e17c5b-37ad-48c8-a5e2-7ade63da7c20">



### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
