### PR TITLE
fix: update EU based cookiehouse geo strings

### DIFF
--- a/clients/sample-app/src/components/GeolocationSelect/index.tsx
+++ b/clients/sample-app/src/components/GeolocationSelect/index.tsx
@@ -18,8 +18,8 @@ const geolocationOptions: GeolocationOption[] = [
   { value: "US-CA", label: "California", flag: "us-ca" },
   { value: "US-VA", label: "Virginia", flag: "us" },
   { value: "US-NY", label: "New York", flag: "us" },
-  { value: "FR-IDG", label: "Paris", flag: "fr" },
-  { value: "DE-HE", label: "Frankfurt", flag: "de" },
+  { value: "EU-FR", label: "Paris", flag: "fr" },
+  { value: "EU-DE", label: "Frankfurt", flag: "de" },
 ];
 
 // By default, each "option" in a <select> menu are plaintext labels, which is a


### PR DESCRIPTION
Closes #3762 

### Description Of Changes

1. Modify Geostrings to match seed 


### Code Changes

* [ ] Modified Strings

### Steps to Confirm

* [ ] Launch Cookiehouse and click on Germany
* [ ] Click on France
* [ ] See banner pop up in both scenarios

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
