### PR TITLE
Allow connection configs with duplicate names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The types of changes are:
 - Add Systems Applicable Filter to Privacy Experience List [#3654](https://github.com/ethyca/fides/pull/3654)
 - Privacy center and fides-js now pass in `Unescape-Safestr` as a header so that special characters can be rendered properly [#3706](https://github.com/ethyca/fides/pull/3706)
 - Fixed ValidationError for saving PrivacyPreferences [#3719](https://github.com/ethyca/fides/pull/3719)
+- Fixed issue preventing ConnectionConfigs with duplicate names from saving [#3770](https://github.com/ethyca/fides/pull/3770)
 
 ### Developer Experience
 

--- a/src/fides/api/db/base_class.py
+++ b/src/fides/api/db/base_class.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, Type, TypeVar
+from typing import Any, Optional, Type, TypeVar
 from uuid import uuid4
 
 from fideslang.models import FidesKey  # type: ignore
@@ -226,7 +226,13 @@ class OrmWrappedFidesBase(FidesBase):
         return db_obj
 
     @classmethod
-    def create_or_update(cls: Type[T], db: Session, *, data: dict[str, Any]) -> T:
+    def create_or_update(
+        cls: Type[T],
+        db: Session,
+        *,
+        data: dict[str, Any],
+        check_name: Optional[bool] = True,
+    ) -> T:
         """Create an object, or update the existing version.
 
         There's an edge case where `data["id"]` and `data["key"]` can point attempt
@@ -239,7 +245,7 @@ class OrmWrappedFidesBase(FidesBase):
         if db_obj:
             db_obj.update(db=db, data=data)  # type: ignore
         else:
-            db_obj = cls.create(db=db, data=data)
+            db_obj = cls.create(db=db, data=data, check_name=check_name)  # type: ignore
         return db_obj
 
     @classmethod

--- a/src/fides/api/models/authentication_request.py
+++ b/src/fides/api/models/authentication_request.py
@@ -15,9 +15,7 @@ class AuthenticationRequest(Base):
     state = Column(String, index=True, unique=True, nullable=False)
 
     @classmethod
-    def create_or_update(
-        cls, db: Session, *, data: Dict[str, Any]
-    ) -> "AuthenticationRequest":
+    def create_or_update(cls, db: Session, *, data: Dict[str, Any]) -> "AuthenticationRequest":  # type: ignore[override]
         """
         Look up authentication request by connection_key. If found, update this authentication request, otherwise
         create a new one.

--- a/src/fides/api/models/datasetconfig.py
+++ b/src/fides/api/models/datasetconfig.py
@@ -120,7 +120,7 @@ class DatasetConfig(Base):
         return dataset
 
     @classmethod
-    def create_or_update(cls, db: Session, *, data: Dict[str, Any]) -> "DatasetConfig":
+    def create_or_update(cls, db: Session, *, data: Dict[str, Any]) -> "DatasetConfig":  # type: ignore[override]
         """
         Look up dataset by config and fides_key. If found, update this dataset, otherwise
         create a new one.

--- a/src/fides/api/util/connection_util.py
+++ b/src/fides/api/util/connection_util.py
@@ -213,7 +213,9 @@ def patch_connection_configs(
             config_dict["system_id"] = system.id
 
         try:
-            connection_config = ConnectionConfig.create_or_update(db, data=config_dict)
+            connection_config = ConnectionConfig.create_or_update(
+                db, data=config_dict, check_name=False
+            )
             created_or_updated.append(
                 ConnectionConfigurationResponse(**connection_config.__dict__)
             )

--- a/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
@@ -706,14 +706,36 @@ class TestPatchConnections:
         assert call_args[4] is None
         assert call_args[5] is None
 
-    def test_patch_connections_no_name(
-        self, api_client, generate_auth_header, url, payload
-    ):
+    def test_patch_connections_no_name(self, api_client, generate_auth_header, url):
+        # two connection configs without names
+        payload = [
+            {
+                "key": "postgres_db_1",
+                "connection_type": "postgres",
+                "access": "write",
+                "secrets": {
+                    "url": None,
+                    "host": "http://localhost",
+                    "port": 5432,
+                    "dbname": "test",
+                    "db_schema": "test",
+                    "username": "test",
+                    "password": "test",
+                },
+            },
+            {
+                "key": "mongo_db_1",
+                "connection_type": "mongodb",
+                "access": "read",
+            },
+        ]
         auth_header = generate_auth_header(scopes=[CONNECTION_CREATE_OR_UPDATE])
-        del payload[0]["name"]
         response = api_client.patch(url, headers=auth_header, json=payload)
+
         assert 200 == response.status_code
+        assert len(response.json()["succeeded"]) == 2
         assert response.json()["succeeded"][0]["name"] is None
+        assert response.json()["succeeded"][1]["name"] is None
 
 
 class TestGetConnections:


### PR DESCRIPTION
Closes #3757 

### Description Of Changes

We needed to disable the name checking for the `ConnectionConfig` model since it is possible for multiple connections to have a `name` of `None` now that we don't require it in the front end. The concept of `check_name` is something we already had in various parts of the code so I just extended the use of it for our purposes.

### Code Changes

* [ ] Updated `base_class.py` to allow the `check_name` param for `create_or_update` (defaults to `True`)
* [ ] Updated the `ConnectionConfig.create_or_update` call in the `patch_connection_configs` function to include `check_name=False`

### Steps to Confirm

* [x] Create a system with a connection
* [x] Create another system with a connection, this second connection should save correctly

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`