### PR TITLE
Fix creating and editing manual integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The types of changes are:
 - Privacy center and fides-js now pass in `Unescape-Safestr` as a header so that special characters can be rendered properly [#3706](https://github.com/ethyca/fides/pull/3706)
 - Fixed ValidationError for saving PrivacyPreferences [#3719](https://github.com/ethyca/fides/pull/3719)
 - Fixed issue preventing ConnectionConfigs with duplicate names from saving [#3770](https://github.com/ethyca/fides/pull/3770)
+- Fixed creating and editing manual integrations [#3772](https://github.com/ethyca/fides/pull/3772) 
 
 ### Developer Experience
 

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -89,7 +89,9 @@ export const patchConnectionConfig = async (
   patchFunc: any
 ) => {
   const key =
-    [SystemType.DATABASE, SystemType.EMAIL, SystemType.MANUAL].indexOf(connectionOption.type) > -1
+    [SystemType.DATABASE, SystemType.EMAIL, SystemType.MANUAL].indexOf(
+      connectionOption.type
+    ) > -1
       ? formatKey(values.instance_key as string)
       : connectionConfig?.key;
 

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -89,7 +89,7 @@ export const patchConnectionConfig = async (
   patchFunc: any
 ) => {
   const key =
-    [SystemType.DATABASE, SystemType.EMAIL].indexOf(connectionOption.type) > -1
+    [SystemType.DATABASE, SystemType.EMAIL, SystemType.MANUAL].indexOf(connectionOption.type) > -1
       ? formatKey(values.instance_key as string)
       : connectionConfig?.key;
 

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -265,7 +265,6 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
         <Form noValidate>
           <VStack align="stretch" gap="16px">
             {/* Connection Identifier */}
-            {connectionOption.type !== SystemType.MANUAL ? (
               <Field
                 id="instance_key"
                 name="instance_key"
@@ -312,7 +311,6 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
                   </FormControl>
                 )}
               </Field>
-            ) : null}
             {/* Dynamic connector secret fields */}
 
             {connectionOption.type !== SystemType.MANUAL && secretsSchema
@@ -346,8 +344,7 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
               >
                 {testButtonLabel}
               </Button>
-              {connectionOption.type === SystemType.MANUAL &&
-              connectionConfig ? (
+              {connectionOption.type === SystemType.MANUAL ? (
                 <DSRCustomizationModal connectionConfig={connectionConfig} />
               ) : null}
               <Button

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -265,52 +265,52 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
         <Form noValidate>
           <VStack align="stretch" gap="16px">
             {/* Connection Identifier */}
-              <Field
-                id="instance_key"
-                name="instance_key"
-                validate={validateConnectionIdentifier}
-              >
-                {({ field }: { field: FieldInputProps<string> }) => (
-                  <FormControl
-                    display="flex"
-                    isRequired
-                    isInvalid={
-                      props.errors.instance_key && props.touched.instance_key
-                    }
+            <Field
+              id="instance_key"
+              name="instance_key"
+              validate={validateConnectionIdentifier}
+            >
+              {({ field }: { field: FieldInputProps<string> }) => (
+                <FormControl
+                  display="flex"
+                  isRequired
+                  isInvalid={
+                    props.errors.instance_key && props.touched.instance_key
+                  }
+                >
+                  {getFormLabel("instance_key", "Integration Identifier")}
+                  <VStack align="flex-start" w="inherit">
+                    <Input
+                      {...field}
+                      autoComplete="off"
+                      color="gray.700"
+                      isDisabled={!!connectionConfig?.key}
+                      placeholder={`A unique identifier for your new ${
+                        connectionOption!.human_readable
+                      } integration`}
+                      size="sm"
+                    />
+                    <FormErrorMessage>
+                      {props.errors.instance_key}
+                    </FormErrorMessage>
+                  </VStack>
+                  <Tooltip
+                    aria-label="The fides_key will allow fidesops to associate dataset field references appropriately. Must be a unique alphanumeric value with no spaces (underscores allowed) to represent this integration."
+                    hasArrow
+                    label="The fides_key will allow fidesops to associate dataset field references appropriately. Must be a unique alphanumeric value with no spaces (underscores allowed) to represent this integration."
+                    placement="right-start"
+                    openDelay={500}
                   >
-                    {getFormLabel("instance_key", "Integration Identifier")}
-                    <VStack align="flex-start" w="inherit">
-                      <Input
-                        {...field}
-                        autoComplete="off"
-                        color="gray.700"
-                        isDisabled={!!connectionConfig?.key}
-                        placeholder={`A unique identifier for your new ${
-                          connectionOption!.human_readable
-                        } integration`}
-                        size="sm"
+                    <Flex alignItems="center" h="32px">
+                      <CircleHelpIcon
+                        marginLeft="8px"
+                        _hover={{ cursor: "pointer" }}
                       />
-                      <FormErrorMessage>
-                        {props.errors.instance_key}
-                      </FormErrorMessage>
-                    </VStack>
-                    <Tooltip
-                      aria-label="The fides_key will allow fidesops to associate dataset field references appropriately. Must be a unique alphanumeric value with no spaces (underscores allowed) to represent this integration."
-                      hasArrow
-                      label="The fides_key will allow fidesops to associate dataset field references appropriately. Must be a unique alphanumeric value with no spaces (underscores allowed) to represent this integration."
-                      placement="right-start"
-                      openDelay={500}
-                    >
-                      <Flex alignItems="center" h="32px">
-                        <CircleHelpIcon
-                          marginLeft="8px"
-                          _hover={{ cursor: "pointer" }}
-                        />
-                      </Flex>
-                    </Tooltip>
-                  </FormControl>
-                )}
-              </Field>
+                    </Flex>
+                  </Tooltip>
+                </FormControl>
+              )}
+            </Field>
             {/* Dynamic connector secret fields */}
 
             {connectionOption.type !== SystemType.MANUAL && secretsSchema

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/DSRCustomizationForm/DSRCustomizationModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/DSRCustomizationForm/DSRCustomizationModal.tsx
@@ -106,7 +106,11 @@ const DSRCustomizationModal: React.FC<Props> = ({ connectionConfig }) => {
   return (
     <>
       {!connectionConfig ? (
-        <Tooltip label="Save an Integration first to customize the DSR">
+        <Tooltip
+          label="Save an Integration first to customize the DSR"
+          placement="top"
+          shouldWrapChildren
+        >
           {DSRButton}
         </Tooltip>
       ) : (

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/DSRCustomizationForm/DSRCustomizationModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/DSRCustomizationForm/DSRCustomizationModal.tsx
@@ -11,6 +11,7 @@ import {
   Spinner,
   useDisclosure,
   VStack,
+  Tooltip,
 } from "@fidesui/react";
 import { useAlert, useAPIHelper } from "common/hooks";
 import {
@@ -30,7 +31,7 @@ import DSRCustomizationForm from "./DSRCustomizationForm";
 import { Field } from "./types";
 
 type Props = {
-  connectionConfig: ConnectionConfigurationResponse;
+  connectionConfig?: ConnectionConfigurationResponse;
 };
 
 const DSRCustomizationModal: React.FC<Props> = ({ connectionConfig }) => {
@@ -43,7 +44,10 @@ const DSRCustomizationModal: React.FC<Props> = ({ connectionConfig }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const { data, isFetching, isLoading, isSuccess } =
-    useGetAccessManualHookQuery(connectionConfig.key);
+    useGetAccessManualHookQuery(connectionConfig? connectionConfig.key: "", {
+      skip: !connectionConfig,
+    });
+
 
   const [createAccessManualWebhook] = useCreateAccessManualWebhookMutation();
   const [patchAccessManualWebhook] = usePatchAccessManualWebhookMutation();
@@ -55,7 +59,7 @@ const DSRCustomizationModal: React.FC<Props> = ({ connectionConfig }) => {
       const params:
         | CreateAccessManualWebhookRequest
         | PatchAccessManualWebhookRequest = {
-        connection_key: connectionConfig.key as string,
+        connection_key: connectionConfig!.key as string,
         body: { ...values } as any,
       };
       if (fields.length > 0) {
@@ -83,22 +87,31 @@ const DSRCustomizationModal: React.FC<Props> = ({ connectionConfig }) => {
     };
   }, [data, isSuccess]);
 
+
+  const DSRButton = <Button
+      bg="primary.800"
+      color="white"
+      isDisabled={!connectionConfig || isSubmitting}
+      isLoading={isSubmitting}
+      loadingText="Submitting"
+      size="sm"
+      variant="solid"
+      onClick={onOpen}
+      _active={{ bg: "primary.500" }}
+      _hover={{ bg: "primary.400" }}
+    >
+      Customize DSR
+    </Button>
+
   return (
     <>
-      <Button
-        bg="primary.800"
-        color="white"
-        isDisabled={isSubmitting}
-        isLoading={isSubmitting}
-        loadingText="Submitting"
-        size="sm"
-        variant="solid"
-        onClick={onOpen}
-        _active={{ bg: "primary.500" }}
-        _hover={{ bg: "primary.400" }}
-      >
-        Customize DSR
-      </Button>
+      {!connectionConfig ? (
+      <Tooltip label="Save an Integration first to customize the DSR">
+        {DSRButton}
+      </Tooltip>
+      ): (
+        DSRButton
+      )}
       <Modal isCentered isOpen={isOpen} size="lg" onClose={onClose}>
         <ModalOverlay />
         <ModalContent minWidth="775px">

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/DSRCustomizationForm/DSRCustomizationModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/DSRCustomizationForm/DSRCustomizationModal.tsx
@@ -9,9 +9,9 @@ import {
   ModalHeader,
   ModalOverlay,
   Spinner,
+  Tooltip,
   useDisclosure,
   VStack,
-  Tooltip,
 } from "@fidesui/react";
 import { useAlert, useAPIHelper } from "common/hooks";
 import {
@@ -44,10 +44,9 @@ const DSRCustomizationModal: React.FC<Props> = ({ connectionConfig }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const { data, isFetching, isLoading, isSuccess } =
-    useGetAccessManualHookQuery(connectionConfig? connectionConfig.key: "", {
+    useGetAccessManualHookQuery(connectionConfig ? connectionConfig.key : "", {
       skip: !connectionConfig,
     });
-
 
   const [createAccessManualWebhook] = useCreateAccessManualWebhookMutation();
   const [patchAccessManualWebhook] = usePatchAccessManualWebhookMutation();
@@ -87,8 +86,8 @@ const DSRCustomizationModal: React.FC<Props> = ({ connectionConfig }) => {
     };
   }, [data, isSuccess]);
 
-
-  const DSRButton = <Button
+  const DSRButton = (
+    <Button
       bg="primary.800"
       color="white"
       isDisabled={!connectionConfig || isSubmitting}
@@ -102,14 +101,15 @@ const DSRCustomizationModal: React.FC<Props> = ({ connectionConfig }) => {
     >
       Customize DSR
     </Button>
+  );
 
   return (
     <>
       {!connectionConfig ? (
-      <Tooltip label="Save an Integration first to customize the DSR">
-        {DSRButton}
-      </Tooltip>
-      ): (
+        <Tooltip label="Save an Integration first to customize the DSR">
+          {DSRButton}
+        </Tooltip>
+      ) : (
         DSRButton
       )}
       <Modal isCentered isOpen={isOpen} size="lg" onClose={onClose}>


### PR DESCRIPTION
Closes #3752 

### Description Of Changes

Adds the integration identifier form to the manual connector creation process. The DSR customize form can only be filled out if there is a connection config. The `Customize DSR` button is disabled with a helpful on hover tooltip that explains that the integration needs to be created first. Once it's created the button will become enabled.



https://github.com/ethyca/fides/assets/17103888/aaca8e16-a5bf-4f74-973d-d9ca31fa31d0




### Code Changes

* [ ] Display integration identifier form for manual integrations
* [ ] Disable `Customize DSR` button until an integration has been created

### Steps to Confirm

* [ ] Run fides `nox -s dev` && `turbo run dev`
* [ ] Login into fides admin ui and create a system
* [ ] then try to create a manual integration
  * [ ] First create the integration
  * [ ] When saved click the `Customized DSR` button and add some DSR fields

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
