### PR TITLE
Enable privacy notices and experiences by default in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The types of changes are:
 - Update EU PrivacyNoticeRegion codes and allow experience filtering to drop back to country filtering if region not found [#3630](https://github.com/ethyca/fides/pull/3630)
 - Fields with default fields are now flagged as required in the front-end [#3694](https://github.com/ethyca/fides/pull/3694)
 - In "view systems", system cards can now be clicked and link to that system's `configure/[id]` page [#3734](https://github.com/ethyca/fides/pull/3734)
+- Enable privacy notice and privacy experience feature flags by default [#3773](https://github.com/ethyca/fides/pull/3773)
 
 ## [2.15.1](https://github.com/ethyca/fides/compare/2.15.0...2.15.1)
 

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -22,13 +22,13 @@
     "description": "Page to configure consent privacy notices",
     "development": true,
     "test": true,
-    "production": false
+    "production": true
   },
   "privacyExperience": {
     "description": "Page to configure consent privacy experiences",
     "development": true,
     "test": true,
-    "production": false
+    "production": true
   },
   "standaloneConnections": {
     "description": "Allow the creation of standalone connections for testing",


### PR DESCRIPTION
Closes N/A

### Description Of Changes

Enables the privacy experience and notices flags by default

![image](https://github.com/ethyca/fides/assets/24641006/728512dc-f8fb-40c1-8cc2-f44eac91aa1f)



### Code Changes

* [x] Edit flags.json file

### Steps to Confirm

* Run `nox -s "fides_env(test)"`
* Go to localhost:8080 and confirm privacy notices and experiences are enabled by default in the management tab

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`

