### PR TITLE
Remove 'successfully added custom fields' toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ The types of changes are:
 - Bumped supported Python versions to `3.10.12`, `3.9.17`, and `3.8.17` [#3733](https://github.com/ethyca/fides/pull/3733)
 - Add polyfill service to fides-js route [#3759](https://github.com/ethyca/fides/pull/3759)
 
+### Removed
+
+- Removed "Custom field(s) successfully saved" toast [#3779](https://github.com/ethyca/fides/pull/3779)
+
 ## [2.16.0](https://github.com/ethyca/fides/compare/2.15.1...2.16.0)
 
 ### Added

--- a/clients/admin-ui/src/features/common/custom-fields/hooks.ts
+++ b/clients/admin-ui/src/features/common/custom-fields/hooks.ts
@@ -23,7 +23,7 @@ export const useCustomFields = ({
   resourceFidesKey,
   resourceType,
 }: UseCustomFieldsOptions) => {
-  const { errorAlert, successAlert } = useAlert();
+  const { errorAlert } = useAlert();
   const { plus: isEnabled } = useFeatures();
 
   // This keeps track of the fides key that was initially passed in. If that key started out blank,
@@ -149,7 +149,10 @@ export const useCustomFields = ({
 
       // This will be undefined if the form never rendered a `CustomFieldList` that would assign
       // form values.
-      if (!customFieldValuesFromForm) {
+      if (
+        !customFieldValuesFromForm ||
+        Object.keys(customFieldValuesFromForm).length === 0
+      ) {
         return;
       }
 
@@ -184,10 +187,6 @@ export const useCustomFields = ({
             return upsertCustomFieldMutationTrigger(body);
           })
         );
-
-        successAlert(
-          `Custom field(s) successfully saved and added to this ${resourceType} form.`
-        );
       } catch (e) {
         errorAlert(
           `One or more custom fields have failed to save, please try again.`
@@ -202,9 +201,7 @@ export const useCustomFields = ({
       deleteCustomFieldMutationTrigger,
       errorAlert,
       resourceFidesKey,
-      resourceType,
       sortedCustomFieldDefinitionIds,
-      successAlert,
       upsertCustomFieldMutationTrigger,
     ]
   );


### PR DESCRIPTION
Closes [Fidesplus issue 960](https://github.com/ethyca/fidesplus/issues/960).

### Description Of Changes

Removed the "Custom field successfully saved" toast on saving a resource with custom fields, following conversation with @rsilvery today.

### Steps to Confirm

* [ ] submit changes to a system or data use for a system with one or more custom fields
* [ ] "Custom field(s) successfully saved and added to this [resource]" toast should not appear

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
