### PR TITLE
support active property on taxonomy elements

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -376,6 +376,10 @@ dataset:
       data_categories:
         - system.operations
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: active
+      data_categories:
+        - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
   - name: ctl_data_qualifiers
     data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
     fields:
@@ -416,6 +420,10 @@ dataset:
       - system.operations
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
     - name: is_default
+      data_categories:
+        - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: active
       data_categories:
         - system.operations
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
@@ -467,6 +475,10 @@ dataset:
       - system.operations
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
     - name: is_default
+      data_categories:
+        - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: active
       data_categories:
         - system.operations
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
@@ -533,6 +545,10 @@ dataset:
       - system.operations
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
     - name: is_default
+      data_categories:
+        - system.operations
+      data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
+    - name: active
       data_categories:
         - system.operations
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ The types of changes are:
 - Removed "Custom field(s) successfully saved" toast [#3779](https://github.com/ethyca/fides/pull/3779)
 
 ### Added
+
 - Record when consent is served [#3777](https://github.com/ethyca/fides/pull/3777)
+- Add an `active` property to taxonomy elements [#3784](https://github.com/ethyca/fides/pull/3784)
 
 ### Fixed
 - Privacy notice UI's list of possible regions now matches the backend's list [#3787](https://github.com/ethyca/fides/pull/3787)

--- a/src/fides/api/alembic/migrations/versions/5abb65a8cb91_add_active_column_taxonomy_elements.py
+++ b/src/fides/api/alembic/migrations/versions/5abb65a8cb91_add_active_column_taxonomy_elements.py
@@ -1,0 +1,41 @@
+"""add_active_column_taxonomy_elements
+
+Revision ID: 5abb65a8cb91
+Revises: 7c562441c589
+Create Date: 2023-07-14 11:08:55.169966
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5abb65a8cb91"
+down_revision = "7c562441c589"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "ctl_data_categories",
+        sa.Column("active", sa.BOOLEAN(), nullable=False, server_default="t"),
+    )
+    op.add_column(
+        "ctl_data_subjects",
+        sa.Column("active", sa.BOOLEAN(), nullable=False, server_default="t"),
+    )
+    op.add_column(
+        "ctl_data_uses",
+        sa.Column("active", sa.BOOLEAN(), nullable=False, server_default="t"),
+    )
+    op.add_column(
+        "ctl_data_qualifiers",
+        sa.Column("active", sa.BOOLEAN(), nullable=False, server_default="t"),
+    )
+
+
+def downgrade():
+    op.drop_column("ctl_data_uses", "active")
+    op.drop_column("ctl_data_subjects", "active")
+    op.drop_column("ctl_data_categories", "active")
+    op.drop_column("ctl_data_qualifiers", "active")

--- a/src/fides/api/api/v1/endpoints/generic.py
+++ b/src/fides/api/api/v1/endpoints/generic.py
@@ -2,16 +2,13 @@
 This module generates all of the routers for the boilerplate/generic
 objects that don't require any extra logic.
 """
-from fideslang import (
+from fideslang import Dataset, Evaluation, Organization, Policy, Registry
+
+from fides.api.schemas.taxonomy_extensions import (
     DataCategory,
     DataQualifier,
-    Dataset,
     DataSubject,
     DataUse,
-    Evaluation,
-    Organization,
-    Policy,
-    Registry,
 )
 
 from .router_factory import generic_router_factory  # type: ignore[attr-defined]

--- a/src/fides/api/models/sql_models.py
+++ b/src/fides/api/models/sql_models.py
@@ -152,6 +152,7 @@ class DataCategory(Base, FidesBase):
 
     parent_key = Column(Text)
     is_default = Column(BOOLEAN, default=False)
+    active = Column(BOOLEAN, default=True, nullable=False)
 
     @classmethod
     def from_fideslang_obj(
@@ -177,6 +178,7 @@ class DataQualifier(Base, FidesBase):
 
     parent_key = Column(Text)
     is_default = Column(BOOLEAN, default=False)
+    active = Column(BOOLEAN, default=True, nullable=False)
 
 
 class DataSubject(Base, FidesBase):
@@ -188,6 +190,7 @@ class DataSubject(Base, FidesBase):
     rights = Column(JSON, nullable=True)
     automated_decisions_or_profiling = Column(BOOLEAN, nullable=True)
     is_default = Column(BOOLEAN, default=False)
+    active = Column(BOOLEAN, default=True, nullable=False)
 
 
 class DataUse(Base, FidesBase):
@@ -204,6 +207,7 @@ class DataUse(Base, FidesBase):
     legitimate_interest = Column(BOOLEAN, nullable=True)
     legitimate_interest_impact_assessment = Column(String, nullable=True)
     is_default = Column(BOOLEAN, default=False)
+    active = Column(BOOLEAN, default=True, nullable=False)
 
     @staticmethod
     def get_parent_uses_from_key(data_use_key: str) -> Set[str]:

--- a/src/fides/api/schemas/taxonomy_extensions.py
+++ b/src/fides/api/schemas/taxonomy_extensions.py
@@ -1,0 +1,29 @@
+"""
+Fides-specific extensions to the pydantic models of taxonomy elements as defined in fideslang.
+"""
+
+from fideslang.models import DataCategory as BaseDataCategory
+from fideslang.models import DataQualifier as BaseDataQualifier
+from fideslang.models import DataSubject as BaseDataSubject
+from fideslang.models import DataUse as BaseDataUse
+from pydantic import Field
+
+active_field = Field(
+    default=True, description="Indicates whether the resource is currently 'active'."
+)
+
+
+class DataUse(BaseDataUse):
+    active: bool = active_field
+
+
+class DataCategory(BaseDataCategory):
+    active: bool = active_field
+
+
+class DataQualifier(BaseDataQualifier):
+    active: bool = active_field
+
+
+class DataSubject(BaseDataSubject):
+    active: bool = active_field


### PR DESCRIPTION
Closes #3709 

### Description Of Changes

Extends taxonomy pydantic models defined in `fideslang` to add an `active` boolean property, and updates the corresponding db model for these taxonomy elements. This enables us to update and persist this property on taxonomy elements via the CRUD API.

### Code Changes

* [x] extend `fideslang` pydantic models for taxonomy elements to support an `active` boolean field
* [x] adds a corresponding an `active` property to the db model for taxonomy elements: `DataUse`, `DataSubject`, `DataQualifier`, `DataCategory`
    * [x] migration establishes a `server_default` value of `True` for the property, which means that all existing taxonomy elements on the system automatically get a value of `True`
* [x] add some test coverage around the API specifically for this new property, ensuring we can create, update and read it

### Steps to Confirm

* [ ] a manual test of some of the CRUD APIs for taxonomy elements that ensures we can create/update/read the `active` property should probably be sufficient here! see screenshot below for one of those tests

<img width="1371" alt="Screenshot 2023-07-14 at 11 11 01 AM" src="https://github.com/ethyca/fides/assets/9750285/02dd88d4-4e20-4791-9fd5-a450c0eaf8c0">


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
