### PR TITLE
Remaining TCF UI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The types of changes are:
 ### Added
 
 - Tab component for `fides-js` [#3782](https://github.com/ethyca/fides/pull/3782)
+- Various other UI components for `fides-js` to support upcoming TCF modal [#3803](https://github.com/ethyca/fides/pull/3803)
 ### Developer Experience
 
 - Changed where db-dependent routers were imported to avoid dependency issues [#3741](https://github.com/ethyca/fides/pull/3741)

--- a/clients/fides-js/src/components/ConsentModal.tsx
+++ b/clients/fides-js/src/components/ConsentModal.tsx
@@ -8,7 +8,7 @@ import {
 import NoticeToggles from "./NoticeToggles";
 import CloseButton from "./CloseButton";
 import GpcInfo from "./GpcInfo";
-import TcfTabs from "./TcfTabs";
+import TcfTabs from "./Tcf/TcfTabs";
 
 type NoticeKeys = Array<PrivacyNotice["notice_key"]>;
 
@@ -62,7 +62,7 @@ const ConsentModal = ({
         </p>
         <GpcInfo />
         {showTcf ? (
-          <TcfTabs />
+          <TcfTabs notices={notices} />
         ) : (
           <div className="fides-modal-notices">
             <NoticeToggles

--- a/clients/fides-js/src/components/NoticeToggles.tsx
+++ b/clients/fides-js/src/components/NoticeToggles.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact";
+import { ComponentChildren, h } from "preact";
 
 import { ConsentMechanism, PrivacyNotice } from "../lib/consent-types";
 import Toggle from "./Toggle";
@@ -10,10 +10,12 @@ const NoticeToggle = ({
   notice,
   checked,
   onToggle,
+  children,
 }: {
   notice: PrivacyNotice;
   checked: boolean;
   onToggle: (noticeKey: PrivacyNotice["notice_key"]) => void;
+  children: ComponentChildren;
 }) => {
   const {
     isOpen,
@@ -58,7 +60,7 @@ const NoticeToggle = ({
           disabled={notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY}
         />
       </div>
-      <p {...getDisclosureProps()}>{notice.description}</p>
+      <div {...getDisclosureProps()}>{children}</div>
     </div>
   );
 };
@@ -94,7 +96,9 @@ const NoticeToggles = ({
               notice={notice}
               checked={checked}
               onToggle={handleToggle}
-            />
+            >
+              {notice.description}
+            </NoticeToggle>
             {!isLast ? <Divider /> : null}
           </div>
         );

--- a/clients/fides-js/src/components/NoticeToggles.tsx
+++ b/clients/fides-js/src/components/NoticeToggles.tsx
@@ -11,11 +11,13 @@ export const NoticeToggle = ({
   checked,
   onToggle,
   children,
+  badge,
 }: {
   notice: PrivacyNotice;
   checked: boolean;
   onToggle: (noticeKey: PrivacyNotice["notice_key"]) => void;
   children: ComponentChildren;
+  badge?: string;
 }) => {
   const {
     isOpen,
@@ -48,7 +50,10 @@ export const NoticeToggle = ({
           {...getButtonProps()}
           className="fides-notice-toggle-trigger"
         >
-          {notice.name}
+          <span className="fides-flex-center">
+            {notice.name}
+            {badge ? <span className="fides-notice-badge">{badge}</span> : null}
+          </span>
           <GpcBadgeForNotice notice={notice} value={checked} />
         </span>
 

--- a/clients/fides-js/src/components/NoticeToggles.tsx
+++ b/clients/fides-js/src/components/NoticeToggles.tsx
@@ -6,7 +6,7 @@ import Divider from "./Divider";
 import { useDisclosure } from "../lib/hooks";
 import { GpcBadgeForNotice } from "./GpcBadge";
 
-const NoticeToggle = ({
+export const NoticeToggle = ({
   notice,
   checked,
   onToggle,

--- a/clients/fides-js/src/components/Tcf/CookiesTable.tsx
+++ b/clients/fides-js/src/components/Tcf/CookiesTable.tsx
@@ -1,0 +1,24 @@
+import { h } from "preact";
+
+const CookiesTable = () => (
+  <table className="fides-cookies-table">
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>Cookie</th>
+        <th>Domain</th>
+        <th>Duration</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Store and/or access information on a device</td>
+        <td>_cookie_</td>
+        <td>domain</td>
+        <td>45 days</td>
+      </tr>
+    </tbody>
+  </table>
+);
+
+export default CookiesTable;

--- a/clients/fides-js/src/components/Tcf/FilterButtons.tsx
+++ b/clients/fides-js/src/components/Tcf/FilterButtons.tsx
@@ -1,0 +1,28 @@
+import { h } from "preact";
+import { useState } from "preact/hooks";
+
+const FilterButtons = () => {
+  const filters = [{ name: "All vendors" }, { name: "Global vendors" }];
+  const [activeButtonIndex, setActiveButtonIndex] = useState(0);
+
+  return (
+    <div className="fides-filter-button-group">
+      {filters.map(({ name }, idx) => {
+        const selected = idx === activeButtonIndex;
+        return (
+          <button
+            role="radio"
+            type="button"
+            aria-checked={selected}
+            onClick={() => setActiveButtonIndex(idx)}
+            className="fides-filter-button"
+          >
+            {name}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default FilterButtons;

--- a/clients/fides-js/src/components/Tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/Tcf/TcfPurposes.tsx
@@ -5,9 +5,7 @@ import FilterButtons from "./FilterButtons";
 import CookiesTable from "./CookiesTable";
 
 const TcfPurposes = ({ notices }: { notices: Array<PrivacyNotice> }) => {
-  const handleToggle = () => {
-    console.log("test");
-  };
+  const handleToggle = () => {};
   return (
     <div>
       <FilterButtons />

--- a/clients/fides-js/src/components/Tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/Tcf/TcfPurposes.tsx
@@ -1,40 +1,44 @@
 import { h } from "preact";
 import { NoticeToggle } from "../NoticeToggles";
 import { PrivacyNotice } from "../../lib/consent-types";
+import FilterButtons from "./FilterButtons";
 
 const TcfPurposes = ({ notices }: { notices: Array<PrivacyNotice> }) => {
   const handleToggle = () => {
     console.log("test");
   };
   return (
-    <NoticeToggle notice={notices[0]} checked onToggle={handleToggle}>
-      <div style={{ padding: "0.5em" }}>
-        <NoticeToggle
-          notice={notices[1]}
-          checked
-          onToggle={handleToggle}
-          badge="gvl"
-        >
-          <div style={{ padding: "0.5em" }}>
-            <p>
-              Advertising presented to you on this service can be based on
-              limited data, such as the website or app you are using, your
-              non-precise location, your device type or which content you are
-              (or have been) interacting with (for example, to limit the number
-              of times an ad is presented to you).
-            </p>
-            <p className="fides-background-dark" style={{ padding: "0.5em" }}>
-              A car manufacturer wants to promote its electric vehicles to
-              environmentally conscious users living in the city after office
-              hours. The advertising is presented on a page with related content
-              (such as an article on climate change actions) after 6:30 p.m. to
-              users whose non-precise location suggests that they are in an
-              urban zone.
-            </p>
-          </div>
-        </NoticeToggle>
-      </div>
-    </NoticeToggle>
+    <div>
+      <FilterButtons />
+      <NoticeToggle notice={notices[0]} checked onToggle={handleToggle}>
+        <div style={{ padding: "0.5em" }}>
+          <NoticeToggle
+            notice={notices[1]}
+            checked
+            onToggle={handleToggle}
+            badge="gvl"
+          >
+            <div style={{ padding: "0.5em" }}>
+              <p>
+                Advertising presented to you on this service can be based on
+                limited data, such as the website or app you are using, your
+                non-precise location, your device type or which content you are
+                (or have been) interacting with (for example, to limit the
+                number of times an ad is presented to you).
+              </p>
+              <p className="fides-background-dark" style={{ padding: "0.5em" }}>
+                A car manufacturer wants to promote its electric vehicles to
+                environmentally conscious users living in the city after office
+                hours. The advertising is presented on a page with related
+                content (such as an article on climate change actions) after
+                6:30 p.m. to users whose non-precise location suggests that they
+                are in an urban zone.
+              </p>
+            </div>
+          </NoticeToggle>
+        </div>
+      </NoticeToggle>
+    </div>
   );
 };
 

--- a/clients/fides-js/src/components/Tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/Tcf/TcfPurposes.tsx
@@ -2,6 +2,7 @@ import { h } from "preact";
 import { NoticeToggle } from "../NoticeToggles";
 import { PrivacyNotice } from "../../lib/consent-types";
 import FilterButtons from "./FilterButtons";
+import CookiesTable from "./CookiesTable";
 
 const TcfPurposes = ({ notices }: { notices: Array<PrivacyNotice> }) => {
   const handleToggle = () => {
@@ -38,6 +39,7 @@ const TcfPurposes = ({ notices }: { notices: Array<PrivacyNotice> }) => {
           </NoticeToggle>
         </div>
       </NoticeToggle>
+      <CookiesTable />
     </div>
   );
 };

--- a/clients/fides-js/src/components/Tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/Tcf/TcfPurposes.tsx
@@ -1,0 +1,36 @@
+import { h } from "preact";
+import { NoticeToggle } from "../NoticeToggles";
+import { PrivacyNotice } from "../../lib/consent-types";
+
+const TcfPurposes = ({ notices }: { notices: Array<PrivacyNotice> }) => {
+  const handleToggle = () => {
+    console.log("test");
+  };
+  return (
+    <NoticeToggle notice={notices[0]} checked onToggle={handleToggle}>
+      <div style={{ padding: "0.5em" }}>
+        <NoticeToggle notice={notices[1]} checked onToggle={handleToggle}>
+          <div style={{ padding: "0.5em" }}>
+            <p>
+              Advertising presented to you on this service can be based on
+              limited data, such as the website or app you are using, your
+              non-precise location, your device type or which content you are
+              (or have been) interacting with (for example, to limit the number
+              of times an ad is presented to you).
+            </p>
+            <p className="fides-background-dark" style={{ padding: "0.5em" }}>
+              A car manufacturer wants to promote its electric vehicles to
+              environmentally conscious users living in the city after office
+              hours. The advertising is presented on a page with related content
+              (such as an article on climate change actions) after 6:30 p.m. to
+              users whose non-precise location suggests that they are in an
+              urban zone.
+            </p>
+          </div>
+        </NoticeToggle>
+      </div>
+    </NoticeToggle>
+  );
+};
+
+export default TcfPurposes;

--- a/clients/fides-js/src/components/Tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/Tcf/TcfPurposes.tsx
@@ -9,7 +9,12 @@ const TcfPurposes = ({ notices }: { notices: Array<PrivacyNotice> }) => {
   return (
     <NoticeToggle notice={notices[0]} checked onToggle={handleToggle}>
       <div style={{ padding: "0.5em" }}>
-        <NoticeToggle notice={notices[1]} checked onToggle={handleToggle}>
+        <NoticeToggle
+          notice={notices[1]}
+          checked
+          onToggle={handleToggle}
+          badge="gvl"
+        >
           <div style={{ padding: "0.5em" }}>
             <p>
               Advertising presented to you on this service can be based on

--- a/clients/fides-js/src/components/Tcf/TcfTabs.tsx
+++ b/clients/fides-js/src/components/Tcf/TcfTabs.tsx
@@ -1,16 +1,17 @@
 import { h } from "preact";
 import { useRef, useState } from "preact/hooks";
-
-const TCF_TABS = [
-  { name: "Purposes", content: "one" },
-  { name: "Features", content: "two" },
-  { name: "Vendors", content: "three" },
-];
+import TcfPurposes from "./TcfPurposes";
+import { PrivacyNotice } from "~/fides";
 
 const KEY_ARROW_RIGHT = "ArrowRight";
 const KEY_ARROW_LEFT = "ArrowLeft";
 
-const TcfTabs = () => {
+const TcfTabs = ({ notices }: { notices: Array<PrivacyNotice> }) => {
+  const tcfTabs = [
+    { name: "Purposes", content: <TcfPurposes notices={notices} /> },
+    { name: "Features", content: "two" },
+    { name: "Vendors", content: "three" },
+  ];
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   const inputRefs = [
     useRef<HTMLButtonElement>(null),
@@ -22,12 +23,12 @@ const TcfTabs = () => {
     if (event.code === KEY_ARROW_RIGHT) {
       event.preventDefault();
       newActiveTab =
-        activeTabIndex === TCF_TABS.length - 1 ? 0 : activeTabIndex + 1;
+        activeTabIndex === tcfTabs.length - 1 ? 0 : activeTabIndex + 1;
     }
     if (event.code === KEY_ARROW_LEFT) {
       event.preventDefault();
       newActiveTab =
-        activeTabIndex === 0 ? TCF_TABS.length - 1 : activeTabIndex - 1;
+        activeTabIndex === 0 ? tcfTabs.length - 1 : activeTabIndex - 1;
     }
     if (newActiveTab != null) {
       setActiveTabIndex(newActiveTab);
@@ -37,7 +38,7 @@ const TcfTabs = () => {
   return (
     <div className="fides-tabs">
       <ul role="tablist" className="fides-tab-list">
-        {TCF_TABS.map(({ name }, idx) => (
+        {tcfTabs.map(({ name }, idx) => (
           <li role="presentation" key={name}>
             <button
               id={`fides-tab-${name}`}
@@ -58,7 +59,7 @@ const TcfTabs = () => {
         ))}
       </ul>
       <div className="tabpanel-container">
-        {TCF_TABS.map(({ name, content }, idx) => (
+        {tcfTabs.map(({ name, content }, idx) => (
           <section
             role="tabpanel"
             id={`fides-panel-${name}`}

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -546,3 +546,22 @@ div#fides-modal .fides-modal-button-group {
 .fides-background-dark {
   background-color: var(--fides-overlay-background-dark-color);
 }
+
+.fides-notice-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  margin-left: 0.6em;
+  text-transform: uppercase;
+  padding: 0 4px;
+  font-weight: 600;
+  border-radius: var(--fides-overlay-button-border-radius);
+  background: #718096;
+  color: white;
+  font-size: 0.7em;
+}
+
+.fides-flex-center {
+  display: flex;
+  align-items: center;
+}

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -587,3 +587,22 @@ div#fides-modal .fides-modal-button-group {
   color: var(--fides-overlay-primary-button-text-color);
   border-radius: var(--fides-overlay-button-border-radius);
 }
+
+/* Table */
+
+.fides-cookies-table {
+  border-collapse: collapse;
+  width: 100%;
+  text-align: left;
+}
+
+.fides-cookies-table th {
+  text-transform: uppercase;
+}
+
+.fides-cookies-table td,
+.fides-cookies-table th {
+  border: 1px solid var(--fides-overlay-row-divider-color);
+  padding-left: 1.1em;
+  padding-right: 0.6em;
+}

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -42,6 +42,8 @@
   /* Dividers */
   --fides-overlay-row-divider-color: #e2e8f0;
   --fides-overlay-row-hover-color: var(--fides-overlay-hover-color);
+  /* Badge */
+  --fides-overlay-badge-background-color: #718096;
 
   /* Everything else */
   --fides-overlay-font-family: Inter, sans-serif;
@@ -507,6 +509,8 @@ div#fides-modal .fides-modal-button-group {
   color: var(--fides-overlay-gpc-overridden-text-color);
 }
 
+/* Tabs */
+
 .fides-tab-list {
   padding: 0;
   display: flex;
@@ -543,9 +547,7 @@ div#fides-modal .fides-modal-button-group {
   outline: 0;
 }
 
-.fides-background-dark {
-  background-color: var(--fides-overlay-background-dark-color);
-}
+/* GVL Badge */
 
 .fides-notice-badge {
   display: inline-flex;
@@ -556,14 +558,12 @@ div#fides-modal .fides-modal-button-group {
   padding: 0 4px;
   font-weight: 600;
   border-radius: var(--fides-overlay-button-border-radius);
-  background: #718096;
+  background: var(--fides-overlay-badge-background-color);
   color: white;
   font-size: 0.7em;
 }
-
-.fides-flex-center {
-  display: flex;
-  align-items: center;
+.fides-background-dark {
+  background-color: var(--fides-overlay-background-dark-color);
 }
 
 /* Filter button */
@@ -582,6 +582,7 @@ div#fides-modal .fides-modal-button-group {
   border: none;
   padding: 0.3em 1em;
 }
+
 .fides-filter-button[aria-checked="true"] {
   background-color: var(--fides-overlay-primary-button-background-color);
   color: var(--fides-overlay-primary-button-text-color);
@@ -605,4 +606,10 @@ div#fides-modal .fides-modal-button-group {
   border: 1px solid var(--fides-overlay-row-divider-color);
   padding-left: 1.1em;
   padding-right: 0.6em;
+}
+
+/* General classes */
+.fides-flex-center {
+  display: flex;
+  align-items: center;
 }

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -565,3 +565,25 @@ div#fides-modal .fides-modal-button-group {
   display: flex;
   align-items: center;
 }
+
+/* Filter button */
+
+.fides-filter-button-group {
+  background-color: var(
+    --fides-overlay-secondary-button-background-hover-color
+  );
+  border-radius: var(--fides-overlay-button-border-radius);
+  width: fit-content;
+  padding: 0.3em;
+}
+
+.fides-filter-button {
+  background-color: transparent;
+  border: none;
+  padding: 0.3em 1em;
+}
+.fides-filter-button[aria-checked="true"] {
+  background-color: var(--fides-overlay-primary-button-background-color);
+  color: var(--fides-overlay-primary-button-text-color);
+  border-radius: var(--fides-overlay-button-border-radius);
+}

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -433,10 +433,9 @@ div#fides-modal .fides-modal-button-group {
 }
 
 .fides-notice-toggle .fides-notice-toggle-title {
-  padding: 0.5em;
+  padding-inline: 0.5em 0;
   display: flex;
   justify-content: space-between;
-  min-height: 40px;
   align-items: center;
 }
 
@@ -445,6 +444,8 @@ div#fides-modal .fides-modal-button-group {
   display: flex;
   justify-content: space-between;
   margin-right: 0.5em;
+  min-height: 40px;
+  align-items: center;
 }
 
 .fides-notice-toggle .fides-notice-toggle-title:hover {

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -581,6 +581,7 @@ div#fides-modal .fides-modal-button-group {
   background-color: transparent;
   border: none;
   padding: 0.3em 1em;
+  cursor: pointer;
 }
 
 .fides-filter-button[aria-checked="true"] {

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -12,6 +12,7 @@
   --fides-overlay-gpc-applied-text-color: white;
   --fides-overlay-gpc-overridden-background-color: #e53e3e;
   --fides-overlay-gpc-overridden-text-color: white;
+  --fides-overlay-background-dark-color: #e2e8f0;
   /* Buttons */
   --fides-overlay-primary-button-background-color: var(
     --fides-overlay-primary-color
@@ -540,4 +541,8 @@ div#fides-modal .fides-modal-button-group {
 }
 .fides-tab-button:focus:not(:focus-visible) {
   outline: 0;
+}
+
+.fides-background-dark {
+  background-color: var(--fides-overlay-background-dark-color);
 }

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -678,6 +678,7 @@ describe("Consent banner", () => {
         );
         cy.get("span")
           .contains("Test privacy notice with gpc enabled")
+          .parent()
           .within(() => {
             cy.get("span").contains("Global Privacy Control applied");
           });
@@ -1055,6 +1056,7 @@ describe("Consent banner", () => {
         );
         cy.get("span")
           .contains("Test privacy notice")
+          .parent()
           .within(() => {
             cy.get("span").contains("Global Privacy Control overridden");
           });
@@ -1579,16 +1581,19 @@ describe("Consent banner", () => {
       cy.get("#fides-modal-link").click();
       cy.get(".fides-notice-toggle")
         .contains("Applied")
+        .parent()
         .within(() => {
           cy.get(".fides-gpc-label").contains("applied");
         });
       cy.get(".fides-notice-toggle")
         .contains("Notice only")
+        .parent()
         .within(() => {
           cy.get(".fides-gpc-label").should("not.exist");
         });
       cy.get(".fides-notice-toggle")
         .contains("Overridden")
+        .parent()
         .within(() => {
           cy.get(".fides-gpc-label").contains("overridden");
         });


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3723

### Description Of Changes

Adds generic UI components for more TCF components.

Here's a bunch of them combined into one view:
![image](https://github.com/ethyca/fides/assets/24641006/8790ce7b-da59-4a62-94cd-85f50616509c)

### Code Changes

* [x] Allow toggles to take children components so that we can nest more data inside of them
![image](https://github.com/ethyca/fides/assets/24641006/8cb548e4-ef4a-4ac8-9b13-64aa264be5aa)

* [x] Add a `badge` prop to toggles so that we can render a GVL badge
![image](https://github.com/ethyca/fides/assets/24641006/29c8d5bf-04ee-44b0-949c-e80ac35186c4)

* [x] Adds a "filter" button group
![image](https://github.com/ethyca/fides/assets/24641006/32028056-46e0-48db-a7a6-8b2e41fd30b0)

* [x] Adds a cookies table
![image](https://github.com/ethyca/fides/assets/24641006/e03d7356-382c-47ff-912b-92bb12166397)


### Steps to Confirm

* Edit the `fides-js-components-demo.html` component so that `tcfEnabled` is `true`
* Run `turbo dev` in privacy center
* Visit `/fides-js-components-demo.html` and open the modal
* See the hodge podge of UI components 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
