### PR TITLE
clean up ui on integration tab

### DIFF
--- a/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
@@ -64,14 +64,14 @@ const DisableConnectionModal: React.FC<DataConnectionProps> = ({
     <>
       {isSwitch ? (
         <Flex justifyContent="space-between" alignItems="center">
-            <Text fontSize="sm">Enable integration</Text>
-            <Switch
-              marginLeft="8px"
-              colorScheme="complimentary"
-              isChecked={!disabled}
-              onChange={onOpen}
-            />
-          </Flex>
+          <Text fontSize="sm">Enable integration</Text>
+          <Switch
+            marginLeft="8px"
+            colorScheme="complimentary"
+            isChecked={!disabled}
+            onChange={onOpen}
+          />
+        </Flex>
       ) : (
         <MenuItem
           _focus={{ color: "complimentary.500", bg: "gray.100" }}

--- a/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/DisableConnectionModal.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Flex,
   MenuItem,
   Modal,
   ModalBody,
@@ -8,7 +9,6 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  Spacer,
   Stack,
   Switch,
   Text,
@@ -63,15 +63,15 @@ const DisableConnectionModal: React.FC<DataConnectionProps> = ({
   return (
     <>
       {isSwitch ? (
-        <>
-          <Spacer />
-          <Text fontSize="md">{disabled ? "Enable" : "Disable"}</Text>
-          <Switch
-            colorScheme="complimentary"
-            isChecked={!disabled}
-            onChange={onOpen}
-          />
-        </>
+        <Flex justifyContent="space-between" alignItems="center">
+            <Text fontSize="sm">Enable integration</Text>
+            <Switch
+              marginLeft="8px"
+              colorScheme="complimentary"
+              isChecked={!disabled}
+              onChange={onOpen}
+            />
+          </Flex>
       ) : (
         <MenuItem
           _focus={{ color: "complimentary.500", bg: "gray.100" }}

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionForm.tsx
@@ -79,7 +79,7 @@ const ConnectionForm = ({ connectionConfig, systemFidesKey }: Props) => {
         ) : null}
         <Restrict scopes={[ScopeRegistryEnum.CONNECTOR_TEMPLATE_REGISTER]}>
           <Button
-            colorScheme="primary"
+            variant="outline"
             type="submit"
             minWidth="auto"
             data-testid="upload-btn"

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/DeleteConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/DeleteConnectionModal.tsx
@@ -1,5 +1,7 @@
 import {
   Button,
+  Flex,
+  IconButton,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -13,6 +15,8 @@ import {
   useDisclosure,
 } from "@fidesui/react";
 import React from "react";
+
+import { TrashCanSolidIcon } from "~/features/common/Icon/TrashCanSolidIcon";
 
 type DataConnectionProps = {
   connectionKey: string;
@@ -44,20 +48,18 @@ const DeleteConnectionModal: React.FC<DataConnectionProps> = ({
     <>
       <>
         <Spacer />
-        <Button
-          bg="red.500"
-          color="white"
-          isDisabled={deleteResult.isLoading}
-          isLoading={deleteResult.isLoading}
-          loadingText="Deleting"
-          size="sm"
-          variant="solid"
-          onClick={onOpen}
-          _active={{ bg: "red.400" }}
-          _hover={{ bg: "red.300" }}
-        >
-          Delete
-        </Button>
+        <Flex alignItems="center">
+          <Text fontSize="sm">Delete Integration</Text>
+          <IconButton
+            marginLeft="8px"
+            aria-label="Delete integration"
+            variant="outline"
+            icon={<TrashCanSolidIcon />}
+            isDisabled={deleteResult.isLoading}
+            onClick={onOpen}
+            size="sm"
+          />
+        </Flex>
       </>
 
       <Modal isCentered isOpen={isOpen} onClose={closeIfComplete}>

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/OrphanedConnectionModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/OrphanedConnectionModal.tsx
@@ -106,9 +106,7 @@ const OrphanedConnectionModal: React.FC<DataConnectionProps> = ({
         loadingText="Deleting"
         onClick={onOpen}
         size="sm"
-        variant="solid"
-        color="white"
-        colorScheme="primary"
+        variant="outline"
       >
         Link integration
       </Button>

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -373,7 +373,15 @@ export const ConnectorParameters: React.FC<ConnectorParametersProps> = ({
 
   return (
     <>
-      <Box color="gray.700" fontSize="14px" mb={4} h="80px">
+      <Box
+        borderRadius="6px"
+        border="1px"
+        borderColor="gray.200"
+        backgroundColor="gray.50"
+        fontSize="14px"
+        p={4}
+        mb={4}
+      >
         Connect to your {connectionOption!.human_readable} environment by
         providing credential information below. Once you have saved your
         integration credentials, you can review what data is included when

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -13,6 +13,7 @@ import {
   NumberInput,
   NumberInputField,
   NumberInputStepper,
+  Spacer,
   Tooltip,
   VStack,
 } from "@fidesui/react";
@@ -278,6 +279,25 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
       {(props: FormikProps<Values>) => (
         <Form noValidate>
           <VStack align="stretch" gap="16px">
+            <ButtonGroup size="sm" spacing="8px" variant="outline">
+              {connectionConfig ? (
+                <DisableConnectionModal
+                  connection_key={connectionConfig?.key}
+                  disabled={isDisabledConnection}
+                  connection_type={connectionConfig?.connection_type}
+                  access_type={connectionConfig?.access}
+                  name={connectionConfig?.name ?? connectionConfig.key}
+                  isSwitch
+                />
+              ) : null}
+              {connectionConfig ? (
+                <DeleteConnectionModal
+                  connectionKey={connectionConfig.key}
+                  onDelete={onDelete}
+                  deleteResult={deleteResult}
+                />
+              ) : null}
+            </ButtonGroup>
             {/* Connection Identifier */}
             <Field
               id="instance_key"
@@ -345,7 +365,6 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
             ) : null}
             <ButtonGroup size="sm" spacing="8px" variant="outline">
               <Button
-                colorScheme="gray.700"
                 isDisabled={
                   !connectionConfig?.key ||
                   isSubmitting ||
@@ -361,6 +380,7 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
               {connectionOption.type === SystemType.MANUAL ? (
                 <DSRCustomizationModal connectionConfig={connectionConfig} />
               ) : null}
+              <Spacer />
               <Button
                 bg="primary.800"
                 color="white"
@@ -375,23 +395,6 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
               >
                 Save
               </Button>
-              {connectionConfig ? (
-                <DisableConnectionModal
-                  connection_key={connectionConfig?.key}
-                  disabled={isDisabledConnection}
-                  connection_type={connectionConfig?.connection_type}
-                  access_type={connectionConfig?.access}
-                  name={connectionConfig?.name ?? connectionConfig.key}
-                  isSwitch
-                />
-              ) : null}
-              {connectionConfig ? (
-                <DeleteConnectionModal
-                  connectionKey={connectionConfig.key}
-                  onDelete={onDelete}
-                  deleteResult={deleteResult}
-                />
-              ) : null}
             </ButtonGroup>
           </VStack>
         </Form>


### PR DESCRIPTION
Closes #3801 and #3776 

### Description Of Changes

- move disable toggle and delete button to top
- update look of buttons
- add grey square around directions


### Code Changes

* [ ] these are all css updates

### Steps to Confirm

* [ ] run fides with `nox -s dev` and cd to clients/admin-ui to run `turbo run dev`
* [ ] create a system 
* [ ] the ui should appear closer to the [designs](https://www.figma.com/file/dmEwdK3xZwjKfGVQ9t66xe/Fides-v.2-Master-Working-Files?type=design&node-id=7683-155091&mode=design&t=40qwh1ZFZIsINx4v-0) 
Note: the remaining work to update the UI will be done in the next sprint 
* [ ] The toggle should now always say Enable Integration  

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
