### PR TITLE
Removing unused property from DeleteConnectionModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The types of changes are:
 
 ### Fixed
 - Privacy notice UI's list of possible regions now matches the backend's list [#3787](https://github.com/ethyca/fides/pull/3787)
+- Admin UI "property does not existing" build issue [#3831](https://github.com/ethyca/fides/pull/3831)
 
 ## [2.16.0](https://github.com/ethyca/fides/compare/2.15.1...2.16.0)
 

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -292,7 +292,6 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
               ) : null}
               {connectionConfig ? (
                 <DeleteConnectionModal
-                  connectionKey={connectionConfig.key}
                   onDelete={onDelete}
                   deleteResult={deleteResult}
                 />


### PR DESCRIPTION
Closes #3830

### Description Of Changes

Removed unused `connectionKey` property from DeleteConnectionModal


### Code Changes

* [ ] See above

### Steps to Confirm

* [ ] Run `nox -s "fides_env(test)"`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
