### PR TITLE
Flagging sensitive inputs as passwords to mask values during entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The types of changes are:
 ### Fixed
 - Privacy notice UI's list of possible regions now matches the backend's list [#3787](https://github.com/ethyca/fides/pull/3787)
 - Admin UI "property does not existing" build issue [#3831](https://github.com/ethyca/fides/pull/3831)
+- Flagging sensitive inputs as passwords to mask values during entry [#3843](https://github.com/ethyca/fides/pull/3843)
 
 ## [2.16.0](https://github.com/ethyca/fides/compare/2.15.1...2.16.0)
 

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -172,6 +172,7 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
               {item.type !== "integer" && (
                 <Input
                   {...field}
+                  type={item.sensitive ? "password" : "text"}
                   placeholder={getPlaceholder(item)}
                   autoComplete="off"
                   color="gray.700"


### PR DESCRIPTION
Closes #3842

### Description Of Changes

Using a field's `sensitive` property to determine if an `Input` should behave as a password or text input.


### Code Changes

* [ ] Updated the inputs in the `ConnectorParametersForm` to set sensitive fields to be password inputs.

### Steps to Confirm

- [ ] Create or navigate to a system and navigate to the integration tab
- [ ] Select an integration from the dropdown
- [ ] Start typing in one of the password or API key fields
- [ ] Notice the values are shown as asterisks

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
