### PR TITLE
Disable server-side geo lookup for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The types of changes are:
 - Sort system cards alphabetically by name on "View systems" page [#3781](https://github.com/ethyca/fides/pull/3781)
 - Update admin ui to use new integration delete route [#3785](https://github.com/ethyca/fides/pull/3785)
 - Pinned `pymssql` and `cython` dependencies to avoid build issues on ARM machines [#3829](https://github.com/ethyca/fides/pull/3829)
+- Disable server-side geolocation for Fides.js [#3850](https://github.com/ethyca/fides/pull/3850)
 
 ### Removed
 

--- a/clients/privacy-center/__tests__/common/geolocation.test.ts
+++ b/clients/privacy-center/__tests__/common/geolocation.test.ts
@@ -24,7 +24,7 @@ describe("getGeolocation", () => {
           "CloudFront-Viewer-Country-Region": "NY",
         },
       });
-      const geolocation = await lookupGeolocation(req, privacyCenterSettings);
+      const geolocation = await lookupGeolocation(req);
       expect(geolocation).toEqual({
         country: "US",
         location: "US-NY",
@@ -39,7 +39,7 @@ describe("getGeolocation", () => {
           "CloudFront-Viewer-Country": "FR",
         },
       });
-      const geolocation = await lookupGeolocation(req, privacyCenterSettings);
+      const geolocation = await lookupGeolocation(req);
       expect(geolocation).toEqual({
         country: "FR",
         location: "FR",
@@ -53,7 +53,7 @@ describe("getGeolocation", () => {
           "CloudFront-Viewer-Country-Region": "NY",
         },
       });
-      const geolocation = await lookupGeolocation(req, privacyCenterSettings);
+      const geolocation = await lookupGeolocation(req);
       expect(geolocation).toBeNull();
     });
 
@@ -64,7 +64,7 @@ describe("getGeolocation", () => {
           "CloudFront-Viewer-Country": "Magicland",
         },
       });
-      const geolocation = await lookupGeolocation(req, privacyCenterSettings);
+      const geolocation = await lookupGeolocation(req);
       expect(geolocation).toBeNull();
     });
   });
@@ -74,7 +74,7 @@ describe("getGeolocation", () => {
       const req = createRequest({
         url: "https://privacy.example.com/fides.js?geolocation=FR-IDF",
       });
-      const geolocation = await lookupGeolocation(req, privacyCenterSettings);
+      const geolocation = await lookupGeolocation(req);
       expect(geolocation).toEqual({
         country: "FR",
         location: "FR-IDF",
@@ -86,7 +86,7 @@ describe("getGeolocation", () => {
       const req = createRequest({
         url: "https://privacy.example.com/fides.js?geolocation=America",
       });
-      const geolocation = await lookupGeolocation(req, privacyCenterSettings);
+      const geolocation = await lookupGeolocation(req);
       expect(geolocation).toBeNull();
     });
   });
@@ -99,7 +99,7 @@ describe("getGeolocation", () => {
           "CloudFront-Viewer-Country": "FR",
         },
       });
-      const geolocation = await lookupGeolocation(req, privacyCenterSettings);
+      const geolocation = await lookupGeolocation(req);
       expect(geolocation).toEqual({
         country: "US",
         location: "US-CA",
@@ -113,7 +113,7 @@ describe("getGeolocation", () => {
       const req = createRequest({
         url: "https://privacy.example.com/fides.js",
       });
-      const geolocation = await lookupGeolocation(req, privacyCenterSettings);
+      const geolocation = await lookupGeolocation(req);
       expect(geolocation).toBeNull();
     });
   });
@@ -138,7 +138,7 @@ describe("getGeolocation", () => {
         url: "https://privacy.example.com/fides.js",
       });
 
-      const geolocation = await lookupGeolocation(req, privacyCenterSettings);
+      const geolocation = await lookupGeolocation(req);
       expect(geolocation).toEqual({
         country: "US",
         location: "US-CA",

--- a/clients/privacy-center/__tests__/common/geolocation.test.ts
+++ b/clients/privacy-center/__tests__/common/geolocation.test.ts
@@ -119,7 +119,7 @@ describe("getGeolocation", () => {
   });
 
   describe("when using geolocation URL", () => {
-    it("fetches data from geolocation URL", async () => {
+    it.skip("fetches data from geolocation URL", async () => {
       privacyCenterSettings.IS_GEOLOCATION_ENABLED = true;
       privacyCenterSettings.GEOLOCATION_API_URL = "some-geolocation-api.com";
       privacyCenterSettings.IS_OVERLAY_ENABLED = true;

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -30,7 +30,6 @@ export const lookupGeolocation = async (
   req: NextApiRequest,
   settings: PrivacyCenterClientSettings
 ): Promise<UserGeolocation | null> => {
-
   // Check for a provided "geolocation" query param
   const { geolocation: geolocationQuery } = req.query;
   if (

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -1,6 +1,5 @@
 import type { NextApiRequest } from "next";
 import { UserGeolocation } from "fides-js";
-import { PrivacyCenterClientSettings } from "~/app/server-environment";
 
 // Regex to validate a location string, which must:
 // 1) Start with a 2-3 character country code (e.g. "US")

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -26,7 +26,7 @@ export const LOCATION_HEADERS = [
  *
  */
 export const lookupGeolocation = async (
-  req: NextApiRequest,
+  req: NextApiRequest
 ): Promise<UserGeolocation | null> => {
   // Check for a provided "geolocation" query param
   const { geolocation: geolocationQuery } = req.query;

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest } from "next";
-import { getGeolocation, UserGeolocation } from "fides-js";
+import { UserGeolocation } from "fides-js";
 import { PrivacyCenterClientSettings } from "~/app/server-environment";
 
 // Regex to validate a location string, which must:
@@ -28,7 +28,6 @@ export const LOCATION_HEADERS = [
  */
 export const lookupGeolocation = async (
   req: NextApiRequest,
-  settings: PrivacyCenterClientSettings
 ): Promise<UserGeolocation | null> => {
   // Check for a provided "geolocation" query param
   const { geolocation: geolocationQuery } = req.query;

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -30,7 +30,6 @@ export const lookupGeolocation = async (
   req: NextApiRequest,
   settings: PrivacyCenterClientSettings
 ): Promise<UserGeolocation | null> => {
-  // DEFER: read headers to determine & return the request's IP address
 
   // Check for a provided "geolocation" query param
   const { geolocation: geolocationQuery } = req.query;
@@ -65,13 +64,7 @@ export const lookupGeolocation = async (
     }
   }
 
-  // Get geolocation using API URL, if provided and overlay is enabled, else null is returned
-  if (settings.IS_OVERLAY_ENABLED) {
-    return getGeolocation(
-      settings.IS_GEOLOCATION_ENABLED,
-      settings.GEOLOCATION_API_URL,
-      settings.DEBUG
-    );
-  }
+  // DEFER: read headers to determine & return the request's IP address
+  // Get geolocation if settings.IS_OVERLAY_ENABLED && settings.IS_GEOLOCATION_ENABLED && settings.GEOLOCATION_API_URL
   return null;
 };

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -72,7 +72,7 @@ export default async function handler(
 
   // Check if a geolocation was provided via headers, query param, or obtainable via a geolocation URL;
   // if so, inject into the bundle, along with privacy experience
-  const geolocation = await lookupGeolocation(req, environment.settings);
+  const geolocation = await lookupGeolocation(req);
   let experience;
   if (geolocation) {
     const fidesRegionString = constructFidesRegionString(geolocation);


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/3849

### Description Of Changes

Disable server-side geo lookup for now, to unblock release.


### Code Changes

* [ ] Remove code that gets geolocation on server 

### Steps to Confirm

* [ ]  Make sure IS_GEOLOCATION_ENABLED is true and GEOLOCATION_API_URL is set up
* [ ] Using an env with notices/experiences, nav to http://localhost:3000/fides-js-demo.html
* [ ] See Consent Experience and Geolocation sections of the page are NOT pre-populated with data

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
