### PR TITLE
Remove experience prefetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The types of changes are:
 - Update admin ui to use new integration delete route [#3785](https://github.com/ethyca/fides/pull/3785)
 - Pinned `pymssql` and `cython` dependencies to avoid build issues on ARM machines [#3829](https://github.com/ethyca/fides/pull/3829)
 - Disable server-side geolocation for Fides.js [#3850](https://github.com/ethyca/fides/pull/3850)
+- Remove experience prefetching for Fides.js [#3855](https://github.com/ethyca/fides/pull/3855)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ The types of changes are:
 - Tab component for `fides-js` [#3782](https://github.com/ethyca/fides/pull/3782)
 - Added toast for successfully linking an existing integration to a system [#3826](https://github.com/ethyca/fides/pull/3826)
 - Various other UI components for `fides-js` to support upcoming TCF modal [#3803](https://github.com/ethyca/fides/pull/3803)
-- Prefetches API calls as part of Fides.js [#3698](https://github.com/ethyca/fides/pull/3698)
 - Allow items in taxonomy to be enabled or disabled [#3844](https://github.com/ethyca/fides/pull/3844)
 
 ### Developer Experience
@@ -40,8 +39,6 @@ The types of changes are:
 - Sort system cards alphabetically by name on "View systems" page [#3781](https://github.com/ethyca/fides/pull/3781)
 - Update admin ui to use new integration delete route [#3785](https://github.com/ethyca/fides/pull/3785)
 - Pinned `pymssql` and `cython` dependencies to avoid build issues on ARM machines [#3829](https://github.com/ethyca/fides/pull/3829)
-- Disable server-side geolocation for Fides.js [#3850](https://github.com/ethyca/fides/pull/3850)
-- Remove experience prefetching for Fides.js [#3855](https://github.com/ethyca/fides/pull/3855)
 
 ### Removed
 

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -3,10 +3,7 @@ import { promises as fsPromises } from "fs";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { CacheControl, stringify } from "cache-control-parser";
 
-import {
-  ConsentOption,
-  FidesConfig,
-} from "fides-js";
+import { ConsentOption, FidesConfig } from "fides-js";
 import { loadPrivacyCenterEnvironment } from "~/app/server-environment";
 import { lookupGeolocation, LOCATION_HEADERS } from "~/common/geolocation";
 

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -3,15 +3,9 @@ import { promises as fsPromises } from "fs";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { CacheControl, stringify } from "cache-control-parser";
 
-import {
-  ConsentOption,
-  FidesConfig,
-  constructFidesRegionString,
-  CONSENT_COOKIE_NAME,
-  fetchExperience,
-} from "fides-js";
+import { ConsentOption, FidesConfig } from "fides-js";
 import { loadPrivacyCenterEnvironment } from "~/app/server-environment";
-import { lookupGeolocation, LOCATION_HEADERS } from "~/common/geolocation";
+import { LOCATION_HEADERS } from "~/common/geolocation";
 
 const FIDES_JS_MAX_AGE_SECONDS = 60 * 60; // one hour
 
@@ -70,33 +64,6 @@ export default async function handler(
     }));
   }
 
-  // Check if a geolocation was provided via headers, query param, or obtainable via a geolocation URL;
-  // if so, inject into the bundle, along with privacy experience
-  const geolocation = await lookupGeolocation(req);
-  let experience;
-  if (geolocation) {
-    const fidesRegionString = constructFidesRegionString(geolocation);
-    if (fidesRegionString && environment.settings.IS_OVERLAY_ENABLED) {
-      let fidesUserDeviceId = null;
-      if (Object.keys(req.cookies).length) {
-        const fidesCookie = req.cookies[CONSENT_COOKIE_NAME];
-        if (fidesCookie) {
-          fidesUserDeviceId =
-            JSON.parse(fidesCookie)?.identity?.fides_user_device_id;
-        }
-      }
-      if (environment.settings.DEBUG) {
-        console.log("Fetching relevant experiences from server-side...");
-      }
-      experience = await fetchExperience(
-        fidesRegionString,
-        environment.settings.FIDES_API_URL,
-        fidesUserDeviceId,
-        environment.settings.DEBUG
-      );
-    }
-  }
-
   // Create the FidesConfig JSON that will be used to initialize fides.js
   const fidesConfig: FidesConfig = {
     consent: {
@@ -113,8 +80,8 @@ export default async function handler(
       fidesApiUrl: environment.settings.FIDES_API_URL,
       tcfEnabled: environment.settings.TCF_ENABLED,
     },
-    experience: experience || undefined,
-    geolocation: geolocation || undefined,
+    experience: undefined,
+    geolocation: undefined,
   };
   const fidesConfigJSON = JSON.stringify(fidesConfig);
 


### PR DESCRIPTION
Unticketed

### Description Of Changes

Removes API calls from privacy center server so that release is unblocked.


### Steps to Confirm

1. Run nox -s "fides_env(test)"
2. Open http://localhost:3001/fides.js
3. Observe no Internal Server Error

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
