### PR TITLE
remove pymssql as a package requirement

### DIFF
--- a/dangerous-requirements.txt
+++ b/dangerous-requirements.txt
@@ -1,0 +1,3 @@
+# These requirements are dangerous on certain platforms
+Cython==0.29.35
+pymssql==2.2.7

--- a/noxfiles/ci_nox.py
+++ b/noxfiles/ci_nox.py
@@ -2,9 +2,9 @@
 from functools import partial
 from typing import Callable, Dict
 
-import nox
 from nox.command import CommandFailed
 
+import nox
 from constants_nox import (
     CONTAINER_NAME,
     IMAGE_NAME,
@@ -266,7 +266,7 @@ def collect_tests(session: nox.Session) -> None:
     errors within the test code.
     """
     session.install(".")
-    install_requirements(session)
+    install_requirements(session, include_dangerous=True)
     command = ("pytest", "tests/", "--collect-only")
     session.run(*command)
 

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 
 import nox
-
 from constants_nox import COMPOSE_FILE_LIST
 from run_infrastructure import run_infrastructure
 
@@ -51,9 +50,11 @@ def teardown(session: nox.Session, volumes: bool = False, images: bool = False) 
     session.log("Teardown complete")
 
 
-def install_requirements(session: nox.Session) -> None:
+def install_requirements(session: nox.Session, include_dangerous=False) -> None:
     session.install("-r", "requirements.txt")
     session.install("-r", "dev-requirements.txt")
+    if include_dangerous:
+        session.install("-r", "dangerous-requirements.txt")
 
 
 @nox.session()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ boto3==1.26.1
 celery[pytest]==5.2.7
 colorama>=0.4.3
 cryptography==38.0.3
-Cython==0.29.35 # workaround eeded for https://github.com/ethyca/fides/issues/3824
 dask==2022.9.2
 deepdiff==6.3.0
 defusedxml==0.7.1
@@ -37,7 +36,6 @@ pydantic==1.10.9
 pydash==6.0.2
 PyJWT==2.4.0
 pymongo==3.13.0
-pymssql>=2.1.5, <2.2.8 # workaround needed for https://github.com/ethyca/fides/issues/3824
 PyMySQL==1.0.2
 python-jose[cryptography]==3.3.0
 pyyaml>=5,<7

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import pathlib
+from typing import List
 
 from setuptools import find_packages, setup
 
@@ -13,6 +14,43 @@ long_description = open("README.md", encoding="utf-8").read()
 
 install_requires = open("requirements.txt", encoding="utf-8").read().strip().split("\n")
 dev_requires = open("dev-requirements.txt", encoding="utf-8").read().strip().split("\n")
+dangerous_requires = (
+    open("dangerous-requirements.txt", encoding="utf-8").read().strip().split("\n")
+)
+
+
+def optional_requirements(
+    dependency_names: List[str], requires: List[str] = dangerous_requires
+) -> List[str]:
+    """
+    Matches the provided dependency names to lines in `optional-requirements.txt`,
+    and returns the full dependency string for each one.
+    Prevents the need to store version numbers in two places.
+    """
+
+    requirements: List[str] = []
+
+    for dependency in dependency_names:
+        for optional_dependency in requires:
+            if optional_dependency.startswith(dependency):
+                requirements.append(optional_dependency)
+                break
+
+    if len(requirements) == len(dependency_names):
+        return requirements
+
+    raise ModuleNotFoundError
+
+
+# Human-Readable Extras
+# Versions are read from corresponding lines in `optional-requirements.txt`
+extras = {
+    "mssql": optional_requirements(["pymssql"], dangerous_requires),
+}
+dangerous_extras = ["mssql"]  # These extras break on certain platforms
+extras["all"] = sum(
+    [value for key, value in extras.items() if key not in dangerous_extras], []
+)
 
 ###################
 ## Package Setup ##
@@ -35,6 +73,7 @@ setup(
     license="Apache License 2.0",
     install_requires=install_requires,
     dev_requires=dev_requires,
+    extras_require=extras,
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Closes #3824 

### Description Of Changes

We previously thought we'd successfully worked around our `pymssql`/`Cython` compatibility issues on mac ARMs in https://github.com/ethyca/fides/pull/3829 by using different versions of `pymssql` for our Docker builds as compared with our package dependencies (`requirements.txt`).

From what I can see, I think we were mistaken on the second piece of that - i.e., I don't think we'd actually solved the package dependency problem. We mistakenly assumed we'd solved the issue because I was able to successfully `pip install -e .` from the root of `fides` locally, but I think that we were actually getting cached `pymssql-2.2.7.whl` files when doing that, and so we weren't truly evaluating whether the problem -- which manifested when _building_ `pymssql` wheels on a mac `ARM` -- was fixed. This surfaced when I started to investigate @eastandwestwind's problems with `nox -s fides_env` locally - i tried using `--no-cache-dir` in my `pip install e .` or `pip install -r requirements.txt` commands and i couldn't get it to succeed no matter the python version i ran: i kept on running into the known cython issue when building the `pymssql` wheel. 

On a quick glance, I didn't see any substantive updates to the [pyssmql repo](https://github.com/pymssql/pymssql) that would help address this. @eastandwestwind and i spent a _little_ bit of time trying to coerce our `requirements.txt` to effectively perform the same install as we do in the `Dockerfile` with (`--no-build-isolation`) for our `pymssql` requirement, but that didn't pan out.

I think that simply removing `pymssql` from our base `requirements.txt` is a suitable near/medium term workaround. We still ship `pymssql` built in to our baked docker images, and anyone (even on a mac ARM) building a docker image locally (e.g. thru `fides deploy up` or `nox -s fides_env`) should still get `pymssql` installed and therefore our `mssql` integration should function.

for the users who are simply `pip install fides` and running the fides CLI, they won't get the `pymssql` dependency built or installed, ~but then again -- do they really need it? i think the only context in which they'd need is when spinning up the full application via CLI, which happens via `fides deploy up`, and that uses the built docker images anyway!~ actually, as @ThomasLaPiana pointed out, they do need it - for the `database scan` CLI functionality. because of this, we're going to look to provide this as an extra/optional dependency as we used to do with `pyodbc`, so that CLI users can still get the `pymssql` dependency if they need it and their system is compatible.

drawbacks:
- our `collect-tests` CI job relies on installation via `requirements.txt` _and_ it requires `pymssql` to be installed because that's imported by some of our tests. i gave a first shot of a workaround (that brings back a `dangerous-requirements.txt` favorite 😬)  in https://github.com/ethyca/fides/commit/7f89939681e04dab4837a9cfbf8644766443c53e but it's certainly not beautiful, i just wanted to get something up as a POC
- in order to get the `pymssql` dependency installed in the fides CLI (when installing via `pip install`), users will need to specify the `pymssql` extra (e.g. `ethyca-fides[pymssql]==2.17.1`, i think?)
- another obvious readability/maintainability downside is having some discrepancy between our `requirements.txt` and what's _actually_ installed on our Docker images. that feels like it's certainly a price worth paying to avoid this mess, for now (i.e. until `pymssql` gets this properly addressed). it's also in _pretty_ clear plain sight, if one just reads the `Dockerfile`!
- i suppose one real-world edge case would be importing `fides` into another python runtime/application and then trying to leverage pymssql functionality...but that seems like a real stretch. 



### Code Changes

* [x] remove `pymssql` from `requirements.txt`
* [x] remove `cython` from `requirements.txt` since it no longer needs to be specified - this was part of what we _thought_ was an effective workaround

### Steps to Confirm

* [ ] ran `pip install -e . --no-cache-dir` from the repo root successfully, in a fresh python venv. i was able to follow that up with a successful `fides deploy up` and successfully running `fides --version` (i.e. invoked the CLI)
* [ ] ran `nox -s fides_env(test)` successfully
* [ ] ran `nox -s dev` successfully
* [ ]  `pip install ".[mssql]"` should fail
* [ ] `pip install .` should succeed

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
