### PR TITLE
Fix quickstart instructions for Apple Silicon Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ In order to get started quickly with Fides, a sample project is bundled within t
 Due to platform differences, the following dependencies and steps are also required:
 
 ```bash
-brew install freetds openssl
+brew install freetds openssl@1.1
 ```
 
 **Add the following to your run commands (i.e. `.zshrc`), updating any path/versions to match yours**
 
 ```bash
-export LDFLAGS="-L/opt/homebrew/Cellar/freetds/1.3.18/lib -L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"`
-export CFLAGS="-I/opt/homebrew/Cellar/freetds/1.3.18/include"
+export LDFLAGS="-L/opt/homebrew/Cellar/freetds/1.3.18_1/lib -L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
+export CFLAGS="-I/opt/homebrew/Cellar/freetds/1.3.18_1/include"
 ```
 
 #### Download and install Fides


### PR DESCRIPTION
### Description Of Changes

* Updates the `brew install` command for openssl as the default install doesn't include openssl 1.1 
* Updates the shell config (e.g. .zshrc) flags for Apple Silicon Macs to include the latest hardcoded freetds version. (There must be a better way of doing this but it'll work until the next freetds update).



### Code Changes

* See commit

### Steps to Confirm

* [ ] Open a Markdown preview of README.md on this branch

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
