### PR TITLE
Adjust max width of system information form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Changed
 - Simplified the file structure for HTML DSR packages [#3848](https://github.com/ethyca/fides/pull/3848)
+- Changed max width of form components in "system information" form tab [#3864](https://github.com/ethyca/fides/pull/3864)
 
 ## [2.17.0](https://github.com/ethyca/fides/compare/2.16.0...2.17.0)
 

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -152,10 +152,10 @@ const SystemInformationForm = ({
     >
       {({ dirty, values, isValid }) => (
         <Form>
-          <Stack spacing={6}>
+          <Stack spacing={6} maxWidth={{ base: "100%", lg: "70%" }}>
             {withHeader ? <SystemHeading system={passedInSystem} /> : null}
 
-            <Text fontSize="sm">
+            <Text fontSize="sm" fontWeight="medium">
               By providing a small amount of additional context for each system
               we can make reporting and understanding our tech stack much easier
               for everyone from engineering to legal teams. So let’s do this
@@ -165,13 +165,7 @@ const SystemInformationForm = ({
               System details
             </Heading>
             <Stack spacing={4}>
-              {/* While we support both designs of extra form items existing, change the width only 
-              when there are extra form items. When we move to only supporting one design, 
-              the parent container should control the width */}
-              <Stack
-                spacing={4}
-                maxWidth={!abridged ? { base: "100%", lg: "50%" } : undefined}
-              >
+              <Stack spacing={4}>
                 <CustomTextInput
                   id="name"
                   name="name"

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationStep.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationStep.tsx
@@ -38,7 +38,7 @@ const PrivacyDeclarationStep = ({ system }: Props) => {
       <Heading as="h3" size="md">
         Data uses
       </Heading>
-      <Text fontSize="sm">
+      <Text fontSize="sm" fontWeight="medium">
         Data Uses describe the business purpose for which the personal data is
         processed or collected. Within a Data Use, you assign which categories
         of personal information are collected for this purpose and for which


### PR DESCRIPTION
Closes #3778 

### Description Of Changes

Add a max width of 70% at breakpoints `lg` and above to all components of the "system information" form, to bring them in line with the other system form tabs; also, adjust font weight on "system information" and "data use" forms to match designs.  (Below screenshot is on 1440p monitor)

![Screenshot 2023-07-26 at 12 19 53 PM](https://github.com/ethyca/fides/assets/6394496/6b5e1910-0019-4618-9dca-5869576af147)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
