### PR TITLE
Updating Cypress tests

### DIFF
--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -85,7 +85,6 @@ describe("System management page", () => {
           cy.url().should("contain", ADD_SYSTEMS_MANUAL_ROUTE);
           cy.wait("@getSystems");
           cy.getByTestId("input-name").type(system.name);
-          cy.getByTestId("input-fides_key").type(system.fides_key);
           cy.getByTestId("input-description").type(system.description);
 
           cy.getByTestId("save-btn").click();
@@ -154,7 +153,6 @@ describe("System management page", () => {
           cy.visit(ADD_SYSTEMS_MANUAL_ROUTE);
           cy.wait("@getSystems");
           cy.getByTestId("input-name").type(system.name);
-          cy.getByTestId("input-fides_key").type(system.fides_key);
           cy.getByTestId("input-description").type(system.description);
           cy.getByTestId("save-btn").click();
           cy.wait("@postSystem");

--- a/clients/cypress-e2e/cypress/e2e/smoke_test.cy.ts
+++ b/clients/cypress-e2e/cypress/e2e/smoke_test.cy.ts
@@ -61,20 +61,20 @@ describe("Smoke test", () => {
   });
 
   it("can access Mongo and Postgres connectors from the Admin UI", () => {
-    cy.intercept(`${API_URL}/connection_type`).as("getConnectionType");
-    cy.intercept(`${API_URL}/connection*`).as("getConnections");
-
     cy.visit(ADMIN_UI_URL);
     cy.login();
-    cy.get("a").contains("Privacy requests").click();
-    cy.get("a").contains("Connection manager").click();
-    cy.wait("@getConnectionType");
-    cy.getByTestId("connection-grid-item-MongoDB Connector").within(() => {
-      cy.get("button").contains("Test").click();
-    });
-    cy.getByTestId("connection-grid-item-Postgres Connector").within(() => {
-      cy.get("button").contains("Test").click();
-    });
+
+    // Postgres
+    cy.get("a").contains("Data map").click();
+    cy.getByTestId("system-cookie_house_postgresql_database").click();
+    cy.getByTestId("tab-Integrations").click();
+    cy.get("button").contains("Test").click();
+
+    // Mongo
+    cy.get("a").contains("Data map").click();
+    cy.getByTestId("system-cookie_house_customer_database").click();
+    cy.getByTestId("tab-Integrations").click();
+    cy.get("button").contains("Test").click();
   });
 
   it("can manage consent preferences from the Privacy Center", () => {


### PR DESCRIPTION
Closes #3881

### Description Of Changes

Updating the Cypress tests to handle two new scenarios

- Integrations are now linked to systems, so they won't be available in the connection management page
- `fides_keys` are no longer required for systems or integrations

### Code Changes

* [ ] Updated `smoke_test.cy.ts` to test the integrations inside their respective system pages
* [ ] Updated  `systems.ct.ts` to no longer provide a `fides_key`

### Steps to Confirm

* [ ] Verified locally

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
