### PR TITLE
Fixing OAuth2 redirect URL

### DIFF
--- a/src/fides/api/api/v1/endpoints/health.py
+++ b/src/fides/api/api/v1/endpoints/health.py
@@ -1,13 +1,11 @@
 from typing import Dict, List, Literal, Optional
 
-from fastapi import Depends, HTTPException, status
+from fastapi import HTTPException, status
 from loguru import logger
 from pydantic import BaseModel
 from redis.exceptions import ResponseError
-from sqlalchemy.orm import Session
 
 import fides
-from fides.api.api.deps import get_db
 from fides.api.common_exceptions import RedisConnectionError
 from fides.api.db.database import DatabaseHealth, get_db_health
 from fides.api.tasks import celery_app, get_worker_ids

--- a/tests/ctl/api/test_seed.py
+++ b/tests/ctl/api/test_seed.py
@@ -510,7 +510,7 @@ class TestLoadSamples:
             # expected to exist; the others defined in the sample_connections.yml
             # will be ignored since they are missing secrets!
             assert sorted([e.key for e in connections]) == [
-                "postgres_connector",
+                "cookie_house_postgresql_database",
                 "stripe_connector",
             ]
             assert sorted([e.fides_key for e in dataset_configs]) == [

--- a/tests/fixtures/saas_example_fixtures.py
+++ b/tests/fixtures/saas_example_fixtures.py
@@ -285,7 +285,7 @@ def oauth2_authorization_code_configuration() -> OAuth2AuthorizationCodeConfigur
 
 @pytest.fixture(scope="function")
 def oauth2_authorization_code_connection_config(
-    db: Session, oauth2_authorization_code_configuration
+    db: Session, oauth2_authorization_code_configuration, system
 ) -> Generator:
     secrets = {
         "domain": "localhost",
@@ -324,6 +324,7 @@ def oauth2_authorization_code_connection_config(
             "access": AccessLevel.write,
             "secrets": secrets,
             "saas_config": saas_config,
+            "system_id": system.id,
         },
     )
     yield connection_config

--- a/tests/ops/api/v1/endpoints/test_oauth_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_oauth_endpoints.py
@@ -15,7 +15,7 @@ from fides.api.cryptography.schemas.jwt import (
 )
 from fides.api.models.authentication_request import AuthenticationRequest
 from fides.api.models.client import ClientDetail
-from fides.api.models.connectionconfig import ConnectionTestStatus
+from fides.api.models.connectionconfig import ConnectionConfig, ConnectionTestStatus
 from fides.api.oauth.jwt import generate_jwe
 from fides.api.oauth.roles import OWNER
 from fides.api.oauth.utils import extract_payload
@@ -550,7 +550,7 @@ class TestCallback:
         db,
         api_client: TestClient,
         callback_url,
-        oauth2_authorization_code_connection_config,
+        oauth2_authorization_code_connection_config: ConnectionConfig,
     ):
         get_access_token_mock.return_value = None
         connection_status_mock.return_value = Mock(
@@ -572,7 +572,7 @@ class TestCallback:
         assert response.history[0].status_code == 307  # HTTP status for redirection
         assert (
             response.history[0].headers["location"]
-            == "http://test.com?status=succeeded"
+            == f"http://test.com/systems/configure/{oauth2_authorization_code_connection_config.system.fides_key}?status=succeeded"
         )
 
         authentication_request.delete(db)
@@ -588,7 +588,7 @@ class TestCallback:
         db,
         api_client: TestClient,
         callback_url,
-        oauth2_authorization_code_connection_config,
+        oauth2_authorization_code_connection_config: ConnectionConfig,
     ):
         get_access_token_mock.return_value = None
         connection_status_mock.return_value = Mock(
@@ -609,7 +609,8 @@ class TestCallback:
         get_access_token_mock.assert_called_once()
         assert response.history[0].status_code == 307  # HTTP status for redirection
         assert (
-            response.history[0].headers["location"] == "http://test.com?status=failed"
+            response.history[0].headers["location"]
+            == f"http://test.com/systems/configure/{oauth2_authorization_code_connection_config.system.fides_key}?status=failed"
         )
 
         authentication_request.delete(db)


### PR DESCRIPTION
### Description Of Changes

When a user configures an integration that uses the OAuth2 authorization code flow, they must follow an authorization URL to enter their credentials and authenticate the connection. When the authorization URL is generated, we also store the referrer to be able to redirect the user back to the system configuration page after authorization. There is a scenario where the referrer URL is the generic system URL (http://localhost:3000/add-systems/manual) and not the unique system path (http://localhost:3000/systems/configure/salesforce). This causes the user to be redirected to a generic system creation page after authorization instead of the system's configuration page.

### Code Changes

* [ ] Only use the schema (http) and netloc (localhost:3000) and generate the rest of the URL

### Steps to Confirm

* [ ] Navigate to Data Map > Add Systems
* [ ] Create a Salesforce system and hit save and **do not follow the link in the toast**
![image](https://github.com/ethyca/fides/assets/2092272/9eeab011-00e1-4e30-9f74-36915de2b7cf)
* [ ] Enter the credentials
* [ ] Verify the URL you are on is still http://base-url/add-systems/manual
* [ ] Click `Authorize connection`
* [ ] Verify you are redirected to the system configuration page for the system you just created

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
