### PR TITLE
Disable worker part of `/health` check

### DIFF
--- a/src/fides/api/api/v1/endpoints/health.py
+++ b/src/fides/api/api/v1/endpoints/health.py
@@ -90,11 +90,6 @@ async def health() -> Dict:
         workers_enabled=False,
         workers=[],
     ).dict()
-    fides_is_using_workers = not celery_app.conf["task_always_eager"]
-    if fides_is_using_workers:
-        response["workers_enabled"] = True
-        # Figure out a way to make this faster
-        response["workers"] = get_worker_ids()
 
     for _, value in response.items():
         if value == "unhealthy":

--- a/src/fides/api/api/v1/endpoints/health.py
+++ b/src/fides/api/api/v1/endpoints/health.py
@@ -8,7 +8,6 @@ from redis.exceptions import ResponseError
 import fides
 from fides.api.common_exceptions import RedisConnectionError
 from fides.api.db.database import DatabaseHealth, get_db_health
-from fides.api.tasks import celery_app, get_worker_ids
 from fides.api.util.api_router import APIRouter
 from fides.api.util.cache import get_cache
 from fides.api.util.logger import Pii


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/2517 by eliminates the high-latency part of the healthcheck. However, the real root cause is not identified yet and will have to be investigated as a follow-up issue.

### Description Of Changes

* Removes the code that checks worker health when a `/health` API request is received.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
