### PR TITLE
Additional scenario for unflatten_dict

### DIFF
--- a/src/fides/api/util/saas_util.py
+++ b/src/fides/api/util/saas_util.py
@@ -234,7 +234,10 @@ def unflatten_dict(flat_dict: Dict[str, Any], separator: str = ".") -> Dict[str,
                         target.append({})
                     target = target[int(current_key)]
         try:
-            target[keys[-1]] = value
+            if isinstance(target, list):
+                target.append(value)
+            else:
+                target[keys[-1]] = value
         except TypeError as exc:
             raise FidesopsException(
                 f"Error unflattening dictionary, conflicting levels detected: {exc}"

--- a/tests/ops/util/test_saas_util.py
+++ b/tests/ops/util/test_saas_util.py
@@ -372,6 +372,12 @@ class TestUnflattenDict:
             {"A.0.B": "C", "A.0.D": "E", "A.1.F": "G", "A.1.H": "I"}
         ) == {"A": [{"B": "C", "D": "E"}, {"F": "G", "H": "I"}]}
 
+    def test_array_with_scalar_value(self):
+        assert unflatten_dict({"A.0": "B"}) == {"A": ["B"]}
+
+    def test_array_with_scalar_values(self):
+        assert unflatten_dict({"A.0": "B", "A.1": "C"}) == {"A": ["B", "C"]}
+
     def test_overwrite_existing_values(self):
         assert unflatten_dict({"A.B": 1, "A.B": 2}) == {"A": {"B": 2}}
 


### PR DESCRIPTION
### Description Of Changes

Adding support for the following scenario
`unflatten_dict({"A.0": "B", "A.1": "C"}) == {"A": ["B", "C"]}`

This would previously throw an exception since the 0 and 1 indices would be treated as strings instead of ints.

### Code Changes

* [ ] Updated `unflatten_dict` to include new scenario

### Steps to Confirm

* [ ] New unit tests

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
