### PR TITLE
Adding new scenario to refine_target_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.18.0...main)
 
+### Fixed
+- Fixed issue when generating masked values for invalid data paths (#3906)[https://github.com/ethyca/fides/pull/3906]
+
 ## [2.18.0](https://github.com/ethyca/fides/compare/2.17.0...2.18.0)
 
 ### Added

--- a/src/fides/api/task/refine_target_path.py
+++ b/src/fides/api/task/refine_target_path.py
@@ -116,6 +116,10 @@ def refine_target_path(
         next_levels = _enter_array(current_elem, target_path[1:], only)
         return _update_path(current_level, next_levels)
 
+    # stop recursion if current_elem is None
+    if current_elem is None:
+        return []
+
     # Simple case - value is a scalar
     return [current_level] if _match_found(current_elem, only) else []
 

--- a/src/fides/api/task/refine_target_path.py
+++ b/src/fides/api/task/refine_target_path.py
@@ -108,17 +108,13 @@ def refine_target_path(
         logger.warning("Could not locate target path {} on row", target_path)
         return []
 
-    if isinstance(current_elem, dict):
-        next_levels = refine_target_path(current_elem, target_path[1:], only)
-        return _update_path(current_level, next_levels)
-
     if isinstance(current_elem, list):
         next_levels = _enter_array(current_elem, target_path[1:], only)
         return _update_path(current_level, next_levels)
 
-    # stop recursion if current_elem is None
-    if current_elem is None:
-        return []
+    if len(target_path[1:]):
+        next_levels = refine_target_path(current_elem, target_path[1:], only)
+        return _update_path(current_level, next_levels)
 
     # Simple case - value is a scalar
     return [current_level] if _match_found(current_elem, only) else []

--- a/tests/ops/task/test_refine_target_path.py
+++ b/tests/ops/task/test_refine_target_path.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from fides.api.graph.config import FieldPath
 from fides.api.task.refine_target_path import (
     _match_found,
@@ -10,6 +12,10 @@ from fides.api.util.collection_util import FIDESOPS_DO_NOT_MASK_INDEX
 
 class TestRefineTargetPathToValue:
     """Test target paths built to specific matched values"""
+
+    def test_refine_target_path_empty_input_data(self):
+        data: Dict[str, Any] = {}
+        assert refine_target_path(data, ["A"]) == []
 
     def test_refine_target_path_value_does_not_match(self):
         data = {"A": "a", "B": "b"}
@@ -106,6 +112,10 @@ class TestRefineTargetPathToValue:
     def test_refine_target_path_with_incomplete_path(self):
         data = {"A": None}
         assert refine_target_path(data, ["A", "B"]) == []
+
+    def test_refine_target_path_none_value_at_top_level(self):
+        data = {"A": None}
+        assert refine_target_path(data, ["A"]) == ["A"]
 
     def test_refine_target_path_with_nested_none_value(self):
         data = {"A": {"B": None}}

--- a/tests/ops/task/test_refine_target_path.py
+++ b/tests/ops/task/test_refine_target_path.py
@@ -103,7 +103,7 @@ class TestRefineTargetPathToValue:
             ["A", 0, 4],
         ]
 
-    def test_refine_target_path_with_none_value(self):
+    def test_refine_target_path_with_incomplete_path(self):
         data = {"A": None}
         assert refine_target_path(data, ["A", "B"]) == []
 

--- a/tests/ops/task/test_refine_target_path.py
+++ b/tests/ops/task/test_refine_target_path.py
@@ -103,6 +103,10 @@ class TestRefineTargetPathToValue:
             ["A", 0, 4],
         ]
 
+    def test_refine_target_path_with_none_value(self):
+        data = {"A": None}
+        assert refine_target_path(data, ["A.B"]) == []
+
     def test_refine_target_path_large_data(self, sample_data):
         result = refine_target_path(
             sample_data, ["months", "march", "crops"], ["swiss chard"]

--- a/tests/ops/task/test_refine_target_path.py
+++ b/tests/ops/task/test_refine_target_path.py
@@ -107,6 +107,10 @@ class TestRefineTargetPathToValue:
         data = {"A": None}
         assert refine_target_path(data, ["A", "B"]) == []
 
+    def test_refine_target_path_with_nested_none_value(self):
+        data = {"A": {"B": None}}
+        assert refine_target_path(data, ["A", "B"]) == ["A", "B"]
+
     def test_refine_target_path_large_data(self, sample_data):
         result = refine_target_path(
             sample_data, ["months", "march", "crops"], ["swiss chard"]

--- a/tests/ops/task/test_refine_target_path.py
+++ b/tests/ops/task/test_refine_target_path.py
@@ -105,7 +105,7 @@ class TestRefineTargetPathToValue:
 
     def test_refine_target_path_with_none_value(self):
         data = {"A": None}
-        assert refine_target_path(data, ["A.B"]) == []
+        assert refine_target_path(data, ["A", "B"]) == []
 
     def test_refine_target_path_large_data(self, sample_data):
         result = refine_target_path(


### PR DESCRIPTION
Closes #3905

### Description Of Changes

Updating `refine_target_path` to return an empty path if the path is invalid, meaning the data doesn't exist at the level indicated.

### Code Changes

* [x] Added None value scenario to `refine_target_path` function

### Steps to Confirm

* [x] Added new test cases to `test_refine_target_path.py`

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
