### PR TITLE
Remove deprecated fields from form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,22 +17,23 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.18.0...main)
 
+### Changed
+- Removed deprecated fields from the taxonomy editor [#3909](https://github.com/ethyca/fides/pull/3909)
+
+
 ## [2.18.0](https://github.com/ethyca/fides/compare/2.17.0...2.18.0)
 
 ### Added
 - Additional consent reporting calls from `fides-js` [#3845](https://github.com/ethyca/fides/pull/3845)
 - Additional consent reporting calls from privacy center [#3847](https://github.com/ethyca/fides/pull/3847)
 - Access support for Recurly [#3595](https://github.com/ethyca/fides/pull/3595)
+- HTTP Logging for the Privacy Center [#3783](https://github.com/ethyca/fides/pull/3783)
+- UI support for OAuth2 authorization flow [#3819](https://github.com/ethyca/fides/pull/3819)
+- Changes in the `data` directory now trigger a server reload (for local development) [#3874](https://github.com/ethyca/fides/pull/3874)
 
 ### Fixed
 - Fix datamap zoom for low system counts [#3835](https://github.com/ethyca/fides/pull/3835)
 - Fixed connector forms with external dataset reference fields [#3873](https://github.com/ethyca/fides/pull/3873)
-
-### Added
-
-- HTTP Logging for the Privacy Center [#3783](https://github.com/ethyca/fides/pull/3783)
-- UI support for OAuth2 authorization flow [#3819](https://github.com/ethyca/fides/pull/3819)
-- Changes in the `data` directory now trigger a server reload (for local development) [#3874](https://github.com/ethyca/fides/pull/3874)
 
 ### Changed
 

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -170,7 +170,12 @@ describe("Taxonomy management page", () => {
       );
     });
 
-    it("Can render an extended form for Data Uses", () => {
+    /*
+     * These fields are deprecated.
+     * This test is being kept so it can be updated
+     * with new fields in the future
+     */
+    it.skip("Can render an extended form for Data Uses", () => {
       cy.getByTestId("tab-Data Uses").click();
 
       // check an entity that has optional fields filled in ("provides")

--- a/clients/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/admin-ui/src/features/taxonomy/hooks.tsx
@@ -12,17 +12,13 @@ import {
   DataSubjectRightsEnum,
   DataUse,
   IncludeExcludeEnum,
-  LegalBasisEnum,
   ResourceTypes,
-  SpecialCategoriesEnum,
 } from "~/types/api";
 
 import { YesNoOptions } from "../common/constants";
 import {
-  CustomCreatableSelect,
   CustomRadioGroup,
   CustomSelect,
-  CustomTextInput,
 } from "../common/form/inputs";
 import { enumToOptions } from "../common/helpers";
 import {
@@ -221,12 +217,6 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
     name: "Data use name",
     description: "Data use description",
     parent_key: "Parent data use",
-    legal_basis: "Legal basis",
-    special_category: "Special category",
-    recipient: "Recipient",
-    legitimate_interest: "Legitimate interest",
-    legitimate_interest_impact_assessment:
-      "Legitimate interest impact assessment",
   };
 
   const [createDataUseMutationTrigger] = useCreateDataUseMutation();
@@ -235,23 +225,6 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
 
   const transformFormValuesToEntity = (formValues: DataUse) => ({
     ...formValues,
-    // text inputs don't like having undefined, so we originally converted
-    // to "", but on submission we need to convert back to undefined
-    legitimate_interest_impact_assessment:
-      formValues.legitimate_interest_impact_assessment === ""
-        ? undefined
-        : formValues.legitimate_interest_impact_assessment,
-    legitimate_interest: !!(
-      formValues.legitimate_interest?.toString() === "true"
-    ),
-    legal_basis:
-      formValues.legal_basis?.toString() === ""
-        ? undefined
-        : formValues.legal_basis,
-    special_category:
-      formValues.special_category?.toString() === ""
-        ? undefined
-        : formValues.special_category,
   });
 
   const customFields = useCustomFields({
@@ -300,15 +273,6 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
     );
     return {
       ...base,
-      legal_basis: du.legal_basis,
-      special_category: du.special_category,
-      recipients: du.recipients ?? [],
-      legitimate_interest:
-        du.legitimate_interest == null
-          ? "false"
-          : du.legitimate_interest.toString(),
-      legitimate_interest_impact_assessment:
-        du.legitimate_interest_impact_assessment ?? "",
     };
   };
 
@@ -330,47 +294,11 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
     return result;
   };
 
-  const legalBases = enumToOptions(LegalBasisEnum);
-  const specialCategories = enumToOptions(SpecialCategoriesEnum);
-
   const renderExtraFormFields = (formValues: DataUse) => (
-    <>
-      <CustomSelect
-        name="legal_basis"
-        label={labels.legal_basis}
-        options={legalBases}
-        isClearable
-      />
-      <CustomSelect
-        name="special_category"
-        label={labels.special_category}
-        options={specialCategories}
-        isClearable
-      />
-      <CustomCreatableSelect
-        name="recipients"
-        label={labels.recipient}
-        options={[]}
-        size="sm"
-        disableMenu
-        isMulti
-      />
-      <CustomRadioGroup
-        name="legitimate_interest"
-        label={labels.legitimate_interest}
-        options={YesNoOptions}
-      />
-      {formValues.legitimate_interest?.toString() === "true" ? (
-        <CustomTextInput
-          name="legitimate_interest_impact_assessment"
-          label={labels.legitimate_interest_impact_assessment}
-        />
-      ) : null}
-      <CustomFieldsList
+    <CustomFieldsList
         resourceFidesKey={formValues.fides_key}
         resourceType={resourceType}
       />
-    </>
   );
 
   return {

--- a/clients/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/admin-ui/src/features/taxonomy/hooks.tsx
@@ -16,10 +16,7 @@ import {
 } from "~/types/api";
 
 import { YesNoOptions } from "../common/constants";
-import {
-  CustomRadioGroup,
-  CustomSelect,
-} from "../common/form/inputs";
+import { CustomRadioGroup, CustomSelect } from "../common/form/inputs";
 import { enumToOptions } from "../common/helpers";
 import {
   useCreateDataSubjectMutation,
@@ -296,9 +293,9 @@ export const useDataUse = (): TaxonomyHookData<DataUse> => {
 
   const renderExtraFormFields = (formValues: DataUse) => (
     <CustomFieldsList
-        resourceFidesKey={formValues.fides_key}
-        resourceType={resourceType}
-      />
+      resourceFidesKey={formValues.fides_key}
+      resourceType={resourceType}
+    />
   );
 
   return {


### PR DESCRIPTION
Closes #3907 

> [!NOTE]
> Depends on #3901 being merged

### Description Of Changes

This removes some deprecated data use fields from the taxonomy editor.


### Code Changes

* [ ] Remove deprecated fields
* [ ] Skip old test

### Steps to Confirm

* [ ] Run fides and the admin  ui
* [ ] Go to taxonomy page and click into the data use tab
* [ ] Check that the deprecated fields described in #3907 are removed
* [ ] Create a new data use

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
