### PR TITLE
Fixing typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Fixed
 - Fixed issue when generating masked values for invalid data paths (#3906)[https://github.com/ethyca/fides/pull/3906]
+- Code reload now works when running `nox -s dev` (#3914)[https://github.com/ethyca/fides/pull/3914]
 
 ## [2.18.0](https://github.com/ethyca/fides/compare/2.17.0...2.18.0)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ services:
   fides:
     container_name: fides
     image: ethyca/fides:local
-    command: uvicorn --host 0.0.0.0 --port 8080 --reload --reload-dir data --reload-dir data --reload-include='*.yml' fides.api.main:app
+    command: uvicorn --host 0.0.0.0 --port 8080 --reload --reload-dir src --reload-dir data --reload-include='*.yml' fides.api.main:app
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://0.0.0.0:8080/health" ]
+      test: ["CMD", "curl", "-f", "http://0.0.0.0:8080/health"]
       interval: 20s
       timeout: 5s
       retries: 10
@@ -78,7 +78,7 @@ services:
   fides-db:
     image: postgres:12
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 15s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Closes #3913

### Description Of Changes

Fixing typo in `docker-compose.yml` that was preventing the code reload

### Steps to Confirm

- [ ] Run nox -s dev
- [ ] Make a code change
- [ ] The server should reload

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
