### PR TITLE
Reduce verbosity of privacy center logging further

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The types of changes are:
 ### Fixed
 - Fixed issue when generating masked values for invalid data paths (#3906)[https://github.com/ethyca/fides/pull/3906]
 - Code reload now works when running `nox -s dev` (#3914)[https://github.com/ethyca/fides/pull/3914]
+- Reduce verbosity of privacy center logging further (#3915)[https://github.com/ethyca/fides/pull/3915]
 
 ## [2.18.0](https://github.com/ethyca/fides/compare/2.17.0...2.18.0)
 

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -88,6 +88,7 @@ export default async function handler(
   const fidesConfigJSON = JSON.stringify(fidesConfig);
 
   if (process.env.NODE_ENV === "development") {
+    // eslint-disable-next-line no-console
     console.log(
       "Bundling generic fides.js & Privacy Center configuration together..."
     );

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { promises as fsPromises } from "fs";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { CacheControl, stringify } from "cache-control-parser";
@@ -88,9 +87,11 @@ export default async function handler(
   };
   const fidesConfigJSON = JSON.stringify(fidesConfig);
 
-  console.log(
-    "Bundling generic fides.js & Privacy Center configuration together..."
-  );
+  if (process.env.NODE_ENV === "development") {
+    console.log(
+      "Bundling generic fides.js & Privacy Center configuration together..."
+    );
+  }
   const fidesJSBuffer = await fsPromises.readFile("public/lib/fides.js");
   const fidesJS: string = fidesJSBuffer.toString();
   if (!fidesJS || fidesJS === "") {


### PR DESCRIPTION
### Description Of Changes

Small change to suppress the "Bundling generic fides.js & Privacy Center configuration together..." log message in production, as this'll current log every time the fides.js bundle is requested!

### Code Changes

* [X] Only log if `process.env.NODE_ENV === "development"`

### Steps to Confirm

* n/a

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
