### PR TITLE
Close DB connections after health check

### DIFF
--- a/src/fides/api/api/v1/endpoints/health.py
+++ b/src/fides/api/api/v1/endpoints/health.py
@@ -79,7 +79,7 @@ def get_cache_health() -> str:
 )
 async def health() -> Dict:
     """Confirm that the API is running and healthy."""
-    database_health = get_db_health(CONFIG.database.sync_database_uri)
+    database_health = get_db_health(CONFIG.database.sync_database_uri) # Close this engine after use
     cache_health = get_cache_health()
     response = CoreHealthCheck(
         webserver="healthy",

--- a/src/fides/api/api/v1/endpoints/health.py
+++ b/src/fides/api/api/v1/endpoints/health.py
@@ -79,7 +79,7 @@ def get_cache_health() -> str:
 )
 async def health() -> Dict:
     """Confirm that the API is running and healthy."""
-    database_health = get_db_health(CONFIG.database.sync_database_uri) # Close this engine after use
+    database_health = get_db_health(CONFIG.database.sync_database_uri)
     cache_health = get_cache_health()
     response = CoreHealthCheck(
         webserver="healthy",


### PR DESCRIPTION
Closes #3918

### Description Of Changes

The database health check is returning an engine that appears to be leaving connections open in the connection pool.

This is typical behavior, but because some databases could be multi-tenant this is causing issues.

### Code Changes

* [ ] make sure that the database connection is closed after the health check

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
