### PR TITLE
Removing erroneous dataset fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The types of changes are:
 - Code reload now works when running `nox -s dev` [#3914](https://github.com/ethyca/fides/pull/3914)
 - Reduce verbosity of privacy center logging further [#3915](https://github.com/ethyca/fides/pull/3915)
 - Resolved an issue where the integration dropdown input lost focus during typing. [#3917](https://github.com/ethyca/fides/pull/3917)
+- Fixed dataset issue that was preventing the Vend connector from loading during server startup [#3923](https://github.com/ethyca/fides/pull/3923)
 
 ### Changed
 

--- a/data/saas/dataset/vend_dataset.yml
+++ b/data/saas/dataset/vend_dataset.yml
@@ -403,31 +403,3 @@ dataset:
             data_categories: [system.operations]
             fidesops_meta:
               data_type: integer
-          - name: page_info
-            fidesops_meta:
-              data_type: object
-            fields:
-              - name: start_cursor
-                data_categories: [system.operations]
-                fidesops_meta:
-                  data_type: string
-              - name: end_cursor
-                data_categories: [system.operations]
-                fidesops_meta:
-                  data_type: string
-              - name: has_next_page
-                data_categories: [system.operations]
-                fidesops_meta:
-                  data_type: boolean
-          - name: version
-            fidesops_meta:
-              data_type: object
-            fields:
-              - name: min
-                data_categories: [system.operations]
-                fidesops_meta:
-                  data_type: integer
-              - name: max
-                data_categories: [system.operations]
-                fidesops_meta:
-                  data_type: integer


### PR DESCRIPTION
Closes #3921

### Description Of Changes

The dataset validator changed recently to detect extra collection fields. The dataset for Vend had duplicate `version` fields for the `sales` collection

### Code Changes

* [ ] Removed erroneous fields from the Vend dataset

### Steps to Confirm

* [ ] Run `nox -s "fides_env(test)"`
* [ ] Create a new system
* [ ] Search Vend from the integration search dropdown, it should be visible


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
