### PR TITLE
remove fields from dataset form

### DIFF
--- a/clients/admin-ui/cypress/e2e/datasets.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datasets.cy.ts
@@ -100,7 +100,6 @@ describe("Dataset", () => {
         "have.value",
         "User's unique ID"
       );
-      cy.getByTestId("input-data_qualifier").should("contain", "Identified");
       cy.getByTestId("selected-categories").children().should("have.length", 1);
       cy.getByTestId("taxonomy-entity-user.unique_id");
     });
@@ -118,7 +117,6 @@ describe("Dataset", () => {
         "have.value",
         "User information"
       );
-      cy.getByTestId("input-data_qualifier").should("contain", "Identified");
       cy.getByTestId("selected-categories").children().should("have.length", 0);
     });
 
@@ -135,19 +133,6 @@ describe("Dataset", () => {
       cy.getByTestId("input-description").should(
         "have.value",
         "Data collected about users for our analytics system."
-      );
-      cy.getByTestId("input-retention").should(
-        "have.value",
-        "30 days after account deletion"
-      );
-      cy.getByTestId("input-data_qualifier").should("contain", "Identified");
-      cy.getByTestId("input-third_country_transfers").should(
-        "contain",
-        "Canada"
-      );
-      cy.getByTestId("input-third_country_transfers").should(
-        "contain",
-        "United Kingdom"
       );
       cy.getByTestId("selected-categories").children().should("have.length", 0);
     });

--- a/clients/admin-ui/src/features/dataset/EditDatasetForm.tsx
+++ b/clients/admin-ui/src/features/dataset/EditDatasetForm.tsx
@@ -3,20 +3,15 @@ import { Form, Formik } from "formik";
 import { useState } from "react";
 import { useSelector } from "react-redux";
 
-import { COUNTRY_OPTIONS } from "~/features/common/countries";
 import { selectDataCategories } from "~/features/taxonomy/taxonomy.slice";
 import { Dataset } from "~/types/api";
 
-import { CustomSelect, CustomTextInput } from "../common/form/inputs";
-import { DATA_QUALIFIERS, DATASET } from "./constants";
+import { CustomTextInput } from "../common/form/inputs";
+import { DATASET } from "./constants";
 import DataCategoryInput from "./DataCategoryInput";
 
 export const FORM_ID = "edit-field-drawer";
 
-const DATA_QUALIFIERS_OPTIONS = DATA_QUALIFIERS.map((qualifier) => ({
-  label: qualifier.label,
-  value: qualifier.key,
-}));
 
 type FormValues = Partial<Dataset>;
 
@@ -29,9 +24,6 @@ const EditDatasetForm = ({ values, onSubmit }: Props) => {
   const initialValues: FormValues = {
     name: values.name ?? "",
     description: values.description ?? "",
-    retention: values.retention ?? "",
-    data_qualifier: values.data_qualifier,
-    third_country_transfers: values.third_country_transfers ?? [],
     data_categories: values.data_categories,
   };
   const allDataCategories = useSelector(selectDataCategories);
@@ -64,28 +56,6 @@ const EditDatasetForm = ({ values, onSubmit }: Props) => {
             label="Description"
             tooltip={DATASET.description.tooltip}
             data-testid="description-input"
-          />
-          <CustomTextInput
-            name="retention"
-            label="Retention period"
-            tooltip={DATASET.retention.tooltip}
-            data-testid="retention-input"
-          />
-          <CustomSelect
-            name="data_qualifier"
-            label="Identifiability"
-            options={DATA_QUALIFIERS_OPTIONS}
-            tooltip={DATASET.data_qualifiers.tooltip}
-            data-testid="identifiability-input"
-          />
-          <CustomSelect
-            name="third_country_transfers"
-            label="Geographic location"
-            tooltip={DATASET.third_country_transfers.tooltip}
-            isSearchable
-            options={COUNTRY_OPTIONS}
-            data-testid="geography-input"
-            isMulti
           />
           <DataCategoryInput
             dataCategories={allDataCategories}

--- a/clients/admin-ui/src/features/dataset/EditDatasetForm.tsx
+++ b/clients/admin-ui/src/features/dataset/EditDatasetForm.tsx
@@ -12,7 +12,6 @@ import DataCategoryInput from "./DataCategoryInput";
 
 export const FORM_ID = "edit-field-drawer";
 
-
 type FormValues = Partial<Dataset>;
 
 interface Props {

--- a/clients/admin-ui/src/types/api/models/Dataset.ts
+++ b/clients/admin-ui/src/types/api/models/Dataset.ts
@@ -36,10 +36,6 @@ export type Dataset = {
    */
   data_categories?: Array<string>;
   /**
-   * Array of Data Qualifier resources identified by `fides_key`, that apply to all collections in the Dataset.
-   */
-  data_qualifier?: string;
-  /**
    *
    * The DatasetMetadata resource model.
    *
@@ -59,14 +55,6 @@ export type Dataset = {
    *
    */
   joint_controller?: ContactDetails;
-  /**
-   * An optional string to describe the retention policy for a dataset. This field can also be applied more granularly at either the Collection or field level of a Dataset.
-   */
-  retention?: string;
-  /**
-   * An optional array to identify any third countries where data is transited to. For consistency purposes, these fields are required to follow the Alpha-3 code set in [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3).
-   */
-  third_country_transfers?: Array<string>;
   /**
    * An array of objects that describe the Dataset's collections.
    */

--- a/clients/admin-ui/src/types/api/models/Dataset.ts
+++ b/clients/admin-ui/src/types/api/models/Dataset.ts
@@ -38,7 +38,7 @@ export type Dataset = {
   /**
    * Array of Data Qualifier resources identified by `fides_key`, that apply to all collections in the Dataset.
    */
-    data_qualifier?: string;
+  data_qualifier?: string;
   /**
    *
    * The DatasetMetadata resource model.
@@ -59,14 +59,14 @@ export type Dataset = {
    *
    */
   joint_controller?: ContactDetails;
-    /**
+  /**
    * An optional string to describe the retention policy for a dataset. This field can also be applied more granularly at either the Collection or field level of a Dataset.
    */
-    retention?: string;
-    /**
-     * An optional array to identify any third countries where data is transited to. For consistency purposes, these fields are required to follow the Alpha-3 code set in [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3).
-     */
-    third_country_transfers?: Array<string>;
+  retention?: string;
+  /**
+   * An optional array to identify any third countries where data is transited to. For consistency purposes, these fields are required to follow the Alpha-3 code set in [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3).
+   */
+  third_country_transfers?: Array<string>;
   /**
    * An array of objects that describe the Dataset's collections.
    */

--- a/clients/admin-ui/src/types/api/models/Dataset.ts
+++ b/clients/admin-ui/src/types/api/models/Dataset.ts
@@ -36,6 +36,10 @@ export type Dataset = {
    */
   data_categories?: Array<string>;
   /**
+   * Array of Data Qualifier resources identified by `fides_key`, that apply to all collections in the Dataset.
+   */
+    data_qualifier?: string;
+  /**
    *
    * The DatasetMetadata resource model.
    *
@@ -55,6 +59,14 @@ export type Dataset = {
    *
    */
   joint_controller?: ContactDetails;
+    /**
+   * An optional string to describe the retention policy for a dataset. This field can also be applied more granularly at either the Collection or field level of a Dataset.
+   */
+    retention?: string;
+    /**
+     * An optional array to identify any third countries where data is transited to. For consistency purposes, these fields are required to follow the Alpha-3 code set in [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3).
+     */
+    third_country_transfers?: Array<string>;
   /**
    * An array of objects that describe the Dataset's collections.
    */


### PR DESCRIPTION
Closes #[3910](https://github.com/ethyca/fides/issues/3910)

### Description Of Changes

remove retention period, identifiability, and geographic location from dataset form
![Screenshot 2023-08-07 at 3 51 36 PM](https://github.com/ethyca/fides/assets/101993653/cf62b8da-8d4f-4b28-a66c-749685e64977)


### Code Changes

* [ ] remove retention period, identifiability, and geographic location from ui only

### Steps to Confirm

* [ ] click data map > manage datasets > connect to database 
* [ ]  input the "Scannable URL" secret found [here](https://start.1password.com/open/i?a=5LPILPRDUBGWBPJWYS6QHHHLRE&v=p3bpsusghc3t45pzpsebehrd4m&i=ck4j4jubqxyyajj6q4agmrxmly&h=ethyca.1password.com)
* [ ] choose any dataset 
* [ ] click the ellipsis in the top right 
* [ ] choose modify dataset 
* [ ] verify the retention period, identifiability, and geographic location form fields are not there 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
