### PR TITLE
remove mypy type check from CI

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -79,7 +79,6 @@ jobs:
           [
             "isort",
             "black",
-            "mypy",
             "pylint",
             "xenon",
             "check_install",


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

This is a temporary removal of our `mypy` checks while we're working on #3839 

### Code Changes

* [x] remove `mypy` from the CI checks

### Steps to Confirm

* [x] `mypy` check doesn't run in CI

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
