### PR TITLE
Adding a temporary version check to migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The types of changes are:
 - Reduce verbosity of privacy center logging further [#3915](https://github.com/ethyca/fides/pull/3915)
 - Resolved an issue where the integration dropdown input lost focus during typing. [#3917](https://github.com/ethyca/fides/pull/3917)
 - Fixed dataset issue that was preventing the Vend connector from loading during server startup [#3923](https://github.com/ethyca/fides/pull/3923)
+- Adding version check to version-dependent migration script [#3951](https://github.com/ethyca/fides/pull/3951)
 
 ### Changed
 - Systems and Privacy Declaration schema and data migration to support the Dictionary [#3901](https://github.com/ethyca/fides/pull/3901)


### PR DESCRIPTION
Closes #3950

### Description Of Changes

Adding a version check to call `array_cat` with the appropriate types

### Code Changes

* [ ] Updated `fd52d5f08c17_system_dictionary_data_migration.py`

### Steps to Confirm

* [ ] Run migrations scripts on PostgreSQL 12
* [ ] Run migration scripts on PostgreSQL 14

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
