### PR TITLE
Populate 'data stewards' field in system form

### DIFF
--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -502,6 +502,7 @@ export const CustomTextInput = ({
         </Flex>
         <TextInput
           {...field}
+          value={props.value ? props.value : field.value}
           isDisabled={disabled}
           data-testid={`input-${field.name}`}
           placeholder={placeholder}

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -146,6 +146,12 @@ const SystemInformationForm = ({
     [dataProps.allDatasets]
   );
 
+  const dataStewards = useMemo(
+    () =>
+      passedInSystem?.data_stewards?.map((user) => user.username).join(", "),
+    [passedInSystem]
+  );
+
   const toast = useToast();
 
   const handleSubmit = async (
@@ -423,6 +429,7 @@ const SystemInformationForm = ({
                     label="Data stewards"
                     name="data_stewards"
                     tooltip="Who are the stewards assigned to the system?"
+                    value={dataStewards}
                     variant="stacked"
                     disabled
                   />


### PR DESCRIPTION
### Description Of Changes

Populates "data stewards" field with assigned users to system.

### Steps to Confirm

* Assign a user to a system, then enter the system details view for that system-- user's username should be shown in "data stewards" field

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
