### PR TITLE
targeted advertising

### DIFF
--- a/src/fides/data/privacy_notices/privacy_notice_templates.yml
+++ b/src/fides/data/privacy_notices/privacy_notice_templates.yml
@@ -137,6 +137,7 @@ privacy_notices:
     - is
     - "no"
     - li
+    - ca_qc
   consent_mechanism: opt_in
   data_uses:
     - analytics
@@ -240,9 +241,44 @@ privacy_notices:
   data_uses:
     - marketing.advertising.first_party.targeted
     - marketing.advertising.third_party.targeted
-  enforcement_level: [please update - system wide]
+  enforcement_level: system_wide
   disabled: False
   has_gpc_flag: True
+  displayed_in_privacy_center: False
+  displayed_in_overlay: True
+  displayed_in_api: True
+- name: Targeted Advertising and Marketing
+  notice_key: targeted_advertising_marketing
+  id: [not sure what to put here]
+  description: We may use some of your information and share it with partners for the purpose of marketing tracking and targeted advertising. You can learn more about what information is used for this purpose in our privacy notice.
+  internal_description: Advertising, targeting, or marketing cookies and services are technologies that tracks users' browsing behavior across websites. These technologies enable targeted advertising and marketing campaigns by collecting information about users' interests, preferences, and online activities. Marketing technologies typically require user consent under privacy regulations.
+  regions:
+    - ca_qc
+  consent_mechanism: opt_in
+  data_uses:
+    - marketing.advertising.first_party.targeted
+    - marketing.advertising.third_party.targeted
+  enforcement_level: frontend
+  disabled: False
+  has_gpc_flag: True
+  displayed_in_privacy_center: False
+  displayed_in_overlay: True
+  displayed_in_api: True
+- name: Essential
+  notice_key: essential
+  id: [not sure what to put here]
+  description: This website uses cookies and services to enable core website features, assist with privacy compliance, and provide a seamless user experience. These cookies and services are used to facilitate features such as navigation, remember user preferences, and ensure the security of the website. 
+  internal_description: Essential cookies and services, also known as strictly necessary, are technologies that are crucial for the proper functioning of a website. These technologies are typically exempt from requiring user consent under privacy regulations because they are essential for the website to deliver its basic functionalities and services or to comply with legal obligations such as tracking user consent.
+  regions:
+    - ca_qc
+  consent_mechanism: notice_only
+  data_uses:
+    - essential
+    - personalize
+    - improve.system
+  enforcement_level: not_applicable
+  disabled: False
+  has_gpc_flag: False
   displayed_in_privacy_center: False
   displayed_in_overlay: True
   displayed_in_api: True

--- a/src/fides/data/privacy_notices/privacy_notice_templates.yml
+++ b/src/fides/data/privacy_notices/privacy_notice_templates.yml
@@ -218,3 +218,31 @@ privacy_notices:
   displayed_in_privacy_center: True
   displayed_in_overlay: True
   displayed_in_api: False
+- name: Targeted Advertising
+  notice_key: targeted_advertising
+  id: [not sure what to put here]
+  description: We may use some of your information and share it with partners for the purpose of targeted advertising. You can learn more about what information is used for this purpose in our privacy notice.
+  internal_description: Targeted advertising" means displaying advertisements to a consumer where the advertisement is selected based on personal data obtained or inferred from that consumer's activities over time and across nonaffiliated Internet web sites or online applications to predict such consumer's preferences or interests.
+  regions:
+    - ca_ab
+    - ca_bc
+    - ca_mb
+    - ca_nb
+    - ca_nl
+    - ca_ns
+    - ca_on
+    - ca_pe
+    - ca_sk
+    - ca_nt
+    - ca_nu
+    - ca_yt
+  consent_mechanism: opt_out
+  data_uses:
+    - marketing.advertising.first_party.targeted
+    - marketing.advertising.third_party.targeted
+  enforcement_level: [please update - system wide]
+  disabled: False
+  has_gpc_flag: True
+  displayed_in_privacy_center: False
+  displayed_in_overlay: True
+  displayed_in_api: True

--- a/src/fides/data/privacy_notices/privacy_notice_templates.yml
+++ b/src/fides/data/privacy_notices/privacy_notice_templates.yml
@@ -221,7 +221,7 @@ privacy_notices:
   displayed_in_api: False
 - name: Targeted Advertising
   notice_key: targeted_advertising
-  id: [not sure what to put here]
+  id: pri_0cde6efc-efe9-402c-ab82-5c001e5b6tar
   description: We may use some of your information and share it with partners for the purpose of targeted advertising. You can learn more about what information is used for this purpose in our privacy notice.
   internal_description: Targeted advertising" means displaying advertisements to a consumer where the advertisement is selected based on personal data obtained or inferred from that consumer's activities over time and across nonaffiliated Internet web sites or online applications to predict such consumer's preferences or interests.
   regions:
@@ -249,7 +249,7 @@ privacy_notices:
   displayed_in_api: False
 - name: Targeted Advertising and Marketing
   notice_key: targeted_advertising_marketing
-  id: [not sure what to put here]
+  id: pri_c124c60f-b278-4ae6-a6f2-9b086b763tar
   description: We may use some of your information and share it with partners for the purpose of marketing tracking and targeted advertising. You can learn more about what information is used for this purpose in our privacy notice.
   internal_description: Advertising, targeting, or marketing cookies and services are technologies that tracks users' browsing behavior across websites. These technologies enable targeted advertising and marketing campaigns by collecting information about users' interests, preferences, and online activities. Marketing technologies typically require user consent under privacy regulations.
   regions:
@@ -266,7 +266,7 @@ privacy_notices:
   displayed_in_api: False
 - name: Functional and Essential
   notice_key: functional_essential
-  id: [not sure what to put here]
+  id: pri_2ff6e1a1-2448-4db9-8a03-506810ed3fun
   description: This website uses cookies and services to enable core website features, assist with privacy compliance, and provide a seamless user experience. These cookies and services are used to facilitate features such as navigation, remember user preferences, and ensure the security of the website. 
   internal_description: Essential cookies and services, also known as strictly necessary, are technologies that are crucial for the proper functioning of a website. These technologies are typically exempt from requiring user consent under privacy regulations because they are essential for the website to deliver its basic functionalities and services or to comply with legal obligations such as tracking user consent.
   regions:

--- a/src/fides/data/privacy_notices/privacy_notice_templates.yml
+++ b/src/fides/data/privacy_notices/privacy_notice_templates.yml
@@ -241,12 +241,12 @@ privacy_notices:
   data_uses:
     - marketing.advertising.first_party.targeted
     - marketing.advertising.third_party.targeted
-  enforcement_level: system_wide
+  enforcement_level: frontend
   disabled: False
   has_gpc_flag: True
-  displayed_in_privacy_center: False
+  displayed_in_privacy_center: True
   displayed_in_overlay: True
-  displayed_in_api: True
+  displayed_in_api: False
 - name: Targeted Advertising and Marketing
   notice_key: targeted_advertising_marketing
   id: [not sure what to put here]
@@ -261,11 +261,11 @@ privacy_notices:
   enforcement_level: frontend
   disabled: False
   has_gpc_flag: True
-  displayed_in_privacy_center: False
+  displayed_in_privacy_center: True
   displayed_in_overlay: True
-  displayed_in_api: True
-- name: Essential
-  notice_key: essential
+  displayed_in_api: False
+- name: Functional and Essential
+  notice_key: functional_essential
   id: [not sure what to put here]
   description: This website uses cookies and services to enable core website features, assist with privacy compliance, and provide a seamless user experience. These cookies and services are used to facilitate features such as navigation, remember user preferences, and ensure the security of the website. 
   internal_description: Essential cookies and services, also known as strictly necessary, are technologies that are crucial for the proper functioning of a website. These technologies are typically exempt from requiring user consent under privacy regulations because they are essential for the website to deliver its basic functionalities and services or to comply with legal obligations such as tracking user consent.
@@ -279,6 +279,6 @@ privacy_notices:
   enforcement_level: not_applicable
   disabled: False
   has_gpc_flag: False
-  displayed_in_privacy_center: False
+  displayed_in_privacy_center: True
   displayed_in_overlay: True
-  displayed_in_api: True
+  displayed_in_api: False


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

* Added a notice for `Targeted Advertising` that applies to all Canadian provinces except Quebec `ca_qc`. Should be opt-out and GPC-enabled. Maps to targeted advertising use cases. 
    *  @pattisdr  to generate id
* Added a notice for `Targeted Advertising and Marketing` that applies to QC. Should be opt-in. Checking on gpc flag status. 
    *  @pattisdr  to generate id
* Added a notice for `Functional and Essential`  that applies to QC. Notice-only. 
* Added QC to the existing `Analytics` notice.



Doc: https://ethyca.atlassian.net/wiki/spaces/PM/pages/2656108545/Privacy+Notice+Templates
* Slight variance from doc because we decided to go with `frontend` vs `system-wide`