### PR TITLE
Fix Parallel Docker Platform Builds

### DIFF
--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -12,8 +12,69 @@ env:
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
 jobs:
-  push-fides:
+  ParseTags:
     runs-on: ubuntu-latest
+    outputs:
+      prod_tag: { { steps.check-prod-tag.outputs.match } }
+      rc_tag: { { steps.check-rc-tag.outputs.match } }
+      alpha_tag: { { steps.check-alpha-tag.outputs.match } }
+      beta_tag: { { steps.check-beta-tag.outputs.match } }
+    steps:
+      - name: Check Prod Tag
+        id: check-prod-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "match=true" >> $GITHUB_OUTPUT
+          else
+            echo "match=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check RC Tag
+        id: check-rc-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]]; then
+            echo "match=true" >> $GITHUB_OUTPUT
+          else
+            echo "match=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check alpha Tag
+        id: check-alpha-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+a[0-9]+$ ]]; then
+            echo "match=true" >> $GITHUB_OUTPUT
+          else
+            echo "match=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check beta Tag
+        id: check-beta-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$ ]]; then
+            echo "match=true" >> $GITHUB_OUTPUT
+          else
+            echo "match=false" >> $GITHUB_OUTPUT
+          fi
+
+      # if an RC git tag, also notify Fidesinfra to trigger a redeploy of rc env, to pick up our newly published images
+      - name: Send Repository Dispatch Event (RC redeploy)
+        if: steps.check-rc-tag.outputs.match == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: trigger-fidesinfra-deploy-fides-rc
+          repository: ethyca/fidesinfra
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+
+  Push:
+    runs-on: ubuntu-latest
+    needs: ParseTags
+    strategy:
+      # This matrix will effectively _try_ to run every permutation in parallel,
+      # skipping all of the tasks that don't match. This leaves a ton of "skipped" jobs
+      # but is the fastest way to get this working without overhauling the tag check logic.
+      matrix:
+        application: ["fides", "sample_app", "privacy_center"]
+        platform: ["x86", "ARM"]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -28,71 +89,28 @@ jobs:
       - name: Install Dev Requirements
         run: pip install -r dev-requirements.txt
 
-
-      - name: Check Prod Tag
-        id: check-prod-tag
-        run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-          else
-            echo "match=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Check RC Tag
-        id: check-rc-tag
-        run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-          else
-            echo "match=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Check alpha Tag
-        id: check-alpha-tag
-        run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+a[0-9]+$ ]]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-          else
-            echo "match=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Check beta Tag
-        id: check-beta-tag
-        run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$ ]]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-          else
-            echo "match=false" >> $GITHUB_OUTPUT
-          fi
-
       # if neither prod, rc, beta or alpha git tag, then push images with the ":dev" tag
       - name: Push Fides Dev Tag
-        if: steps.check-prod-tag.outputs.match == 'false' && steps.check-rc-tag.outputs.match == 'false' && steps.check-beta-tag.outputs.match == 'false' && steps.check-alpha-tag.outputs.match == 'false'
-        run: nox -s "push(dev)"
+        if: needs.ParseTags.prod_tag.outputs.match == 'false' && needs.ParseTags.rc_tag.outputs.match == 'false' && needs.ParseTags.beta_tag.outputs.match == 'false' && needs.ParseTags.alpha_tag.outputs.match == 'false'
+        run: nox -s "push({{ matrix.application }},dev,{{ matrix.platform }})"
 
       # if a prod git tag, then we run the prod job to publish images tagged with the version number and a constant ":latest" tag
       - name: Push Fides Prod Tags
-        if: steps.check-prod-tag.outputs.match == 'true'
-        run: nox -s "push(prod)"
+        if: needs.ParseTags.prod_tag.outputs.match == 'true'
+        run: nox -s "push({{ matrix.application }},prod,{{ matrix.platform }})"
 
       # if an RC git tag, then we run the rc job to publish images with an ":rc" tag
       - name: Push Fides RC Tags
-        if: steps.check-rc-tag.outputs.match == 'true'
-        run: nox -s "push(rc)"
-
-      # if an RC git tag, also notify Fidesinfra to trigger a redeploy of rc env, to pick up our newly published images
-      - name: Send Repository Dispatch Event (RC redeploy)
-        if: steps.check-rc-tag.outputs.match == 'true'
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          event-type: trigger-fidesinfra-deploy-fides-rc
-          repository: ethyca/fidesinfra
-          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+        if: needs.ParseTags.rc_tag.outputs.match == 'true'
+        run: nox -s "push({{ matrix.application }},rc,{{ matrix.platform }})"
 
       # if an alpha or beta git tag, then we run the prerelease job to publish images with an ":prerelease" tag
       - name: Push Fides prerelease Tags
-        if: steps.check-alpha-tag.outputs.match == 'true' || steps.check-beta-tag.outputs.match == 'true'
-        run: nox -s "push(prerelease)"
+        if: needs.ParseTags.alpha_tag.outputs.match == 'true' || needs.ParseTags.beta_tag.outputs.match == 'true'
+        run: nox -s "push({{ matrix.application }},prerelease,{{ matrix.platform }})"
 
       # if not a prod git tag, then we run the git-tag job to publish images with a git tag
       # if one exists on the current commit. the job is a no-op if the commit hasn't been tagged
       - name: Push Fides Commit Tags
-        if: steps.check-prod-tag.outputs.match == 'false'
-        run: nox -s "push(git-tag)"
+        if: needs.ParseTags.prod_tag.outputs.match == 'false'
+        run: nox -s "push({{ matrix.application }},git-tag,{{ matrix.platform }})"

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -15,10 +15,10 @@ jobs:
   ParseTags:
     runs-on: ubuntu-latest
     outputs:
-      prod_tag: { { steps.check-prod-tag.outputs.match } }
-      rc_tag: { { steps.check-rc-tag.outputs.match } }
-      alpha_tag: { { steps.check-alpha-tag.outputs.match } }
-      beta_tag: { { steps.check-beta-tag.outputs.match } }
+      prod_tag: ${{ steps.check-prod-tag.outputs.match }}
+      rc_tag: ${{ steps.check-rc-tag.outputs.match }}
+      alpha_tag: ${{ steps.check-alpha-tag.outputs.match }}
+      beta_tag: ${{ steps.check-beta-tag.outputs.match }}
     steps:
       - name: Check Prod Tag
         id: check-prod-tag

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -92,25 +92,25 @@ jobs:
       # if neither prod, rc, beta or alpha git tag, then push images with the ":dev" tag
       - name: Push Fides Dev Tag
         if: needs.ParseTags.outputs.prod_tag == 'false' && needs.ParseTags.outputs.rc_tag == 'false' && needs.ParseTags.outputs.beta_tag == 'false' && needs.ParseTags.outputs.alpha_tag == 'false'
-        run: nox -s "push({{ matrix.application }},dev,{{ matrix.platform }})"
+        run: nox -s "push(${{ matrix.application }},dev,${{ matrix.platform }})"
 
       # if a prod git tag, then we run the prod job to publish images tagged with the version number and a constant ":latest" tag
       - name: Push Fides Prod Tags
         if: needs.ParseTags.outputs.prod_tag == 'true'
-        run: nox -s "push({{ matrix.application }},prod,{{ matrix.platform }})"
+        run: nox -s "push(${{ matrix.application }},prod,${{ matrix.platform }})"
 
       # if an RC git tag, then we run the rc job to publish images with an ":rc" tag
       - name: Push Fides RC Tags
         if: needs.ParseTags.outputs.rc_tag == 'true'
-        run: nox -s "push({{ matrix.application }},rc,{{ matrix.platform }})"
+        run: nox -s "push(${{ matrix.application }},rc,${{ matrix.platform }})"
 
       # if an alpha or beta git tag, then we run the prerelease job to publish images with an ":prerelease" tag
       - name: Push Fides prerelease Tags
         if: needs.ParseTags.outputs.alpha_tag == 'true' || needs.ParseTags.outputs.beta_tag == 'true'
-        run: nox -s "push({{ matrix.application }},prerelease,{{ matrix.platform }})"
+        run: nox -s "push(${{ matrix.application }},prerelease,${{ matrix.platform }})"
 
       # if not a prod git tag, then we run the git-tag job to publish images with a git tag
       # if one exists on the current commit. the job is a no-op if the commit hasn't been tagged
       - name: Push Fides Commit Tags
         if: needs.ParseTags.outputs.prod_tag == 'false'
-        run: nox -s "push({{ matrix.application }},git-tag,{{ matrix.platform }})"
+        run: nox -s "push(${{ matrix.application }},git-tag,${{ matrix.platform }})"

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -91,26 +91,26 @@ jobs:
 
       # if neither prod, rc, beta or alpha git tag, then push images with the ":dev" tag
       - name: Push Fides Dev Tag
-        if: needs.ParseTags.prod_tag.outputs.match == 'false' && needs.ParseTags.rc_tag.outputs.match == 'false' && needs.ParseTags.beta_tag.outputs.match == 'false' && needs.ParseTags.alpha_tag.outputs.match == 'false'
+        if: needs.ParseTags.outputs.prod_tag == 'false' && needs.ParseTags.outputs.rc_tag == 'false' && needs.ParseTags.outputs.beta_tag == 'false' && needs.ParseTags.outputs.alpha_tag == 'false'
         run: nox -s "push({{ matrix.application }},dev,{{ matrix.platform }})"
 
       # if a prod git tag, then we run the prod job to publish images tagged with the version number and a constant ":latest" tag
       - name: Push Fides Prod Tags
-        if: needs.ParseTags.prod_tag.outputs.match == 'true'
+        if: needs.ParseTags.outputs.prod_tag == 'true'
         run: nox -s "push({{ matrix.application }},prod,{{ matrix.platform }})"
 
       # if an RC git tag, then we run the rc job to publish images with an ":rc" tag
       - name: Push Fides RC Tags
-        if: needs.ParseTags.rc_tag.outputs.match == 'true'
+        if: needs.ParseTags.outputs.rc_tag == 'true'
         run: nox -s "push({{ matrix.application }},rc,{{ matrix.platform }})"
 
       # if an alpha or beta git tag, then we run the prerelease job to publish images with an ":prerelease" tag
       - name: Push Fides prerelease Tags
-        if: needs.ParseTags.alpha_tag.outputs.match == 'true' || needs.ParseTags.beta_tag.outputs.match == 'true'
+        if: needs.ParseTags.outputs.alpha_tag == 'true' || needs.ParseTags.outputs.beta_tag == 'true'
         run: nox -s "push({{ matrix.application }},prerelease,{{ matrix.platform }})"
 
       # if not a prod git tag, then we run the git-tag job to publish images with a git tag
       # if one exists on the current commit. the job is a no-op if the commit hasn't been tagged
       - name: Push Fides Commit Tags
-        if: needs.ParseTags.prod_tag.outputs.match == 'false'
+        if: needs.ParseTags.outputs.prod_tag == 'false'
         run: nox -s "push({{ matrix.application }},git-tag,{{ matrix.platform }})"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.19.0...main)
 
+### Developer Experience
+- Fixed up parallelization in docker platform builds [#4013](https://github.com/ethyca/fides/pull/4013)
+
 ## [2.19.0](https://github.com/ethyca/fides/compare/2.18.0...2.19.0)
 
 ### Added

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -201,6 +201,7 @@ def get_buildx_commands(tag_suffixes: List[str]) -> List[Tuple[str, ...]]:
     return buildx_commands
 
 
+# Let Github Actions handle the parallelization
 @nox.session()
 @nox.parametrize(
     "tag",

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -1,6 +1,4 @@
 """Contains the nox sessions for docker-related tasks."""
-from multiprocessing import Pool
-from subprocess import run
 from typing import Callable, Dict, List, Tuple
 
 import nox
@@ -17,13 +15,6 @@ from constants_nox import (
     SAMPLE_APP_IMAGE,
 )
 from git_nox import get_current_tag, recognized_tag
-
-DOCKER_PLATFORMS = "linux/amd64,linux/arm64"
-
-
-def runner(args):
-    args_str = " ".join(args)
-    run(args_str, shell=True, check=True)
 
 
 def verify_git_tag(session: nox.Session) -> str:
@@ -47,13 +38,16 @@ def verify_git_tag(session: nox.Session) -> str:
     return existing_commit_tag
 
 
-def generate_multiplatform_buildx_command(
-    image_tags: List[str], docker_build_target: str, dockerfile_path: str = "."
+def generate_buildx_command(
+    image_tags: List[str],
+    docker_build_target: str,
+    platform: str,
+    dockerfile_path: str = ".",
 ) -> Tuple[str, ...]:
     """
-    Generate the command for building and publishing a multiplatform image.
+    Generate the command for building and publishing an image.
 
-    See tests for example usage.
+    See tests for example usage in `test_docker_nox.py`
     """
     buildx_command: Tuple[str, ...] = (
         "docker",
@@ -62,7 +56,7 @@ def generate_multiplatform_buildx_command(
         "--push",
         f"--target={docker_build_target}",
         "--platform",
-        DOCKER_PLATFORMS,
+        platform,
         dockerfile_path,
     )
 
@@ -167,42 +161,11 @@ def build(session: nox.Session, image: str, machine_type: str = "") -> None:
     session.run(*build_command, external=True)
 
 
-def get_buildx_commands(tag_suffixes: List[str]) -> List[Tuple[str, ...]]:
-    """
-    Build and publish each image to Dockerhub
-    """
-    fides_tags = [f"{IMAGE}:{tag_suffix}" for tag_suffix in tag_suffixes]
-    fides_buildx_command = generate_multiplatform_buildx_command(
-        image_tags=fides_tags, docker_build_target="prod"
-    )
-
-    privacy_center_tags = [
-        f"{PRIVACY_CENTER_IMAGE}:{tag_suffix}" for tag_suffix in tag_suffixes
-    ]
-    privacy_center_buildx_command = generate_multiplatform_buildx_command(
-        image_tags=privacy_center_tags,
-        docker_build_target="prod_pc",
-    )
-
-    sample_app_tags = [
-        f"{SAMPLE_APP_IMAGE}:{tag_suffix}" for tag_suffix in tag_suffixes
-    ]
-    sample_app_buildx_command = generate_multiplatform_buildx_command(
-        image_tags=sample_app_tags,
-        docker_build_target="prod",
-        dockerfile_path="clients/sample-app",
-    )
-
-    buildx_commands = [
-        fides_buildx_command,
-        privacy_center_buildx_command,
-        sample_app_buildx_command,
-    ]
-    return buildx_commands
-
-
-# Let Github Actions handle the parallelization
 @nox.session()
+@nox.parametrize(
+    "platform",
+    [nox.param("linux/amd64", id="x86"), nox.param("linux/arm64", id="ARM")],
+)
 @nox.parametrize(
     "tag",
     [
@@ -213,7 +176,15 @@ def get_buildx_commands(tag_suffixes: List[str]) -> List[Tuple[str, ...]]:
         nox.param("git-tag", id="git-tag"),
     ],
 )
-def push(session: nox.Session, tag: str) -> None:
+@nox.parametrize(
+    "app",
+    [
+        nox.param("fides", id="fides"),
+        nox.param("privacy_center", id="privacy_center"),
+        nox.param("sample_app", id="sample_app"),
+    ],
+)
+def push(session: nox.Session, tag: str, app: str, platform: str) -> None:
     """
     Push the main image & extra apps to DockerHub:
       - ethyca/fides
@@ -228,7 +199,9 @@ def push(session: nox.Session, tag: str) -> None:
     rc - Tags images with `rc` - used for rc tags
     git-tag - Tags images with the git tag of the current commit, if it exists
 
-    NOTE: This command also handles building images, including for multiple supported architectures.
+    Example Calls:
+    nox -s "push(fides, prod, x86)"
+    nox -s "push(sample_app, prerelease, ARM)"
     """
 
     # Create the buildx builder
@@ -253,10 +226,34 @@ def push(session: nox.Session, tag: str) -> None:
         "prod": lambda: [get_current_tag(), "latest"],
     }
 
+    app_info_map = {
+        "fides": {"image": IMAGE, "target": "prod", "path": "."},
+        "privacy_center": {
+            "image": PRIVACY_CENTER_IMAGE,
+            "target": "prod_pc",
+            "path": ".",
+        },
+        "sample_app": {
+            "image": SAMPLE_APP_IMAGE,
+            "target": "prod",
+            "path": "clients/sample-app",
+        },
+    }
+    app_info: Dict[str, str] = app_info_map[app]
+
     # Get the list of Tupled commands to run
-    buildx_commands = get_buildx_commands(tag_suffixes=param_tag_map[tag]())
+    tag_suffixes: List[str] = param_tag_map[tag]()
+    full_tags: List[str] = [
+        f"{app_info['image']}:{tag_suffix}" for tag_suffix in tag_suffixes
+    ]
 
     # Parallel build the various images
-    number_of_processes = len(buildx_commands)
-    with Pool(number_of_processes) as process_pool:
-        process_pool.map(runner, buildx_commands)
+
+    buildx_command: Tuple[str, ...] = generate_buildx_command(
+        image_tags=full_tags,
+        docker_build_target=app_info["target"],
+        platform=platform,
+        dockerfile_path=app_info["path"],
+    )
+
+    session.run(*buildx_command, external=True)

--- a/noxfiles/test_docker_nox.py
+++ b/noxfiles/test_docker_nox.py
@@ -1,12 +1,17 @@
 import pytest
 
 from constants_nox import DEV_TAG_SUFFIX, PRERELEASE_TAG_SUFFIX, RC_TAG_SUFFIX
-from docker_nox import generate_multiplatform_buildx_command, get_buildx_commands
+from docker_nox import generate_buildx_command
 
 
-class TestGenerateMultiplatformBuilxCommand:
+class TestGenerateBuildxCommand:
     def test_single_tag(self) -> None:
-        actual_result = generate_multiplatform_buildx_command(["foo"], "prod")
+        actual_result = generate_buildx_command(
+            image_tags=["foo"],
+            docker_build_target="prod",
+            platform="linux/amd64",
+            dockerfile_path=".",
+        )
         expected_result = (
             "docker",
             "buildx",
@@ -14,7 +19,7 @@ class TestGenerateMultiplatformBuilxCommand:
             "--push",
             "--target=prod",
             "--platform",
-            "linux/amd64,linux/arm64",
+            "linux/amd64",
             ".",
             "--tag",
             "foo",
@@ -22,7 +27,12 @@ class TestGenerateMultiplatformBuilxCommand:
         assert actual_result == expected_result
 
     def test_multiplte_tags(self) -> None:
-        actual_result = generate_multiplatform_buildx_command(["foo", "bar"], "prod")
+        actual_result = generate_buildx_command(
+            image_tags=["foo", "bar"],
+            docker_build_target="prod",
+            platform="linux/arm64",
+            dockerfile_path=".",
+        )
         expected_result = (
             "docker",
             "buildx",
@@ -30,7 +40,7 @@ class TestGenerateMultiplatformBuilxCommand:
             "--push",
             "--target=prod",
             "--platform",
-            "linux/amd64,linux/arm64",
+            "linux/arm64",
             ".",
             "--tag",
             "foo",
@@ -40,8 +50,11 @@ class TestGenerateMultiplatformBuilxCommand:
         assert actual_result == expected_result
 
     def test_different_path(self) -> None:
-        actual_result = generate_multiplatform_buildx_command(
-            ["foo", "bar"], "prod", "other_path"
+        actual_result = generate_buildx_command(
+            image_tags=["foo", "bar"],
+            docker_build_target="prod",
+            dockerfile_path="other_path",
+            platform="linux/arm64",
         )
         expected_result = (
             "docker",
@@ -50,7 +63,7 @@ class TestGenerateMultiplatformBuilxCommand:
             "--push",
             "--target=prod",
             "--platform",
-            "linux/amd64,linux/arm64",
+            "linux/arm64",
             "other_path",
             "--tag",
             "foo",
@@ -58,230 +71,3 @@ class TestGenerateMultiplatformBuilxCommand:
             "bar",
         )
         assert actual_result == expected_result
-
-
-class TestGetBuildxCommands:
-    @pytest.mark.parametrize(
-        "tags,expected_commands",
-        [
-            (
-                [DEV_TAG_SUFFIX],
-                [
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides:dev",
-                    ),
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod_pc",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides-privacy-center:dev",
-                    ),
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        "clients/sample-app",
-                        "--tag",
-                        "ethyca/fides-sample-app:dev",
-                    ),
-                ],
-            ),
-            (
-                [PRERELEASE_TAG_SUFFIX],
-                [
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides:prerelease",
-                    ),
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod_pc",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides-privacy-center:prerelease",
-                    ),
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        "clients/sample-app",
-                        "--tag",
-                        "ethyca/fides-sample-app:prerelease",
-                    ),
-                ],
-            ),
-            (
-                [RC_TAG_SUFFIX],
-                [
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides:rc",
-                    ),
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod_pc",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides-privacy-center:rc",
-                    ),
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        "clients/sample-app",
-                        "--tag",
-                        "ethyca/fides-sample-app:rc",
-                    ),
-                ],
-            ),
-            (
-                ["2.9.0a4"],
-                [
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides:2.9.0a4",
-                    ),
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod_pc",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides-privacy-center:2.9.0a4",
-                    ),
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        "clients/sample-app",
-                        "--tag",
-                        "ethyca/fides-sample-app:2.9.0a4",
-                    ),
-                ],
-            ),
-            (
-                ["2.9.0", "latest"],
-                [
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides:2.9.0",
-                        "--tag",
-                        "ethyca/fides:latest",
-                    ),
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod_pc",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        ".",
-                        "--tag",
-                        "ethyca/fides-privacy-center:2.9.0",
-                        "--tag",
-                        "ethyca/fides-privacy-center:latest",
-                    ),
-                    (
-                        "docker",
-                        "buildx",
-                        "build",
-                        "--push",
-                        "--target=prod",
-                        "--platform",
-                        "linux/amd64,linux/arm64",
-                        "clients/sample-app",
-                        "--tag",
-                        "ethyca/fides-sample-app:2.9.0",
-                        "--tag",
-                        "ethyca/fides-sample-app:latest",
-                    ),
-                ],
-            ),
-        ],
-    )
-    def test_tags(
-        self,
-        tags,
-        expected_commands,
-    ) -> None:
-        buildx_commands = get_buildx_commands(tags)
-
-        assert buildx_commands == expected_commands

--- a/noxfiles/test_docker_nox.py
+++ b/noxfiles/test_docker_nox.py
@@ -1,6 +1,3 @@
-import pytest
-
-from constants_nox import DEV_TAG_SUFFIX, PRERELEASE_TAG_SUFFIX, RC_TAG_SUFFIX
 from docker_nox import generate_buildx_command
 
 


### PR DESCRIPTION
Closes #

### Description Of Changes

I previously had tried to get parallel Docker builds working using Python's own multiprocessing framework, however this appeared to not function as expected in GitHub Actions.

This PR iterates on that and shifts the parallel execution responsibility to GitHub Actions with a strategy matrix

Used this for reference when redesigning how the `outputs` work: [GitHub Output Docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs)

### Code Changes

* [x] Update the Nox command to only run one build command at a time (this makes parallelization easier)
* [x] update the Nox tests
* [x] refactor the `Publish Docker Images` workflow to facilitate a strategy matrix

### Steps to Confirm

* [x] pushed an `alpha` [tag](https://github.com/ethyca/fides/releases/tag/2.18.1a21) to this branch and confirmed that the resulting [CI job](https://github.com/ethyca/fides/actions/runs/6050503276) to publish docker images completed successfully and with the expected parallelized execution

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
