### PR TITLE
Fix tests that relied on specific Pagination responses

### DIFF
--- a/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
@@ -812,6 +812,7 @@ class TestGetMessagingConfigs:
                 }
             ],
             "page": 1,
+            "pages": 1,
             "size": PAGE_SIZE,
             "total": 1,
         }

--- a/tests/ops/api/v1/endpoints/test_policy_webhook_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_policy_webhook_endpoints.py
@@ -106,6 +106,7 @@ class TestGetPolicyPreExecutionWebhooks:
             ],
             "total": 2,
             "page": 1,
+            "pages": 1,
             "size": 50,
         }
 
@@ -174,6 +175,7 @@ class TestGetPolicyPostExecutionWebhooks:
             ],
             "total": 2,
             "page": 1,
+            "pages": 1,
             "size": 50,
         }
 

--- a/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
@@ -160,7 +160,13 @@ class TestSavePrivacyPreferencesPrivacyCenter:
         )
         assert response.status_code == 200
         # Assert no existing privacy preferences exist for this identity
-        assert response.json() == {"items": [], "total": 0, "page": 1, "size": 50}
+        assert response.json() == {
+            "items": [],
+            "total": 0,
+            "page": 1,
+            "pages": 1,
+            "size": 50,
+        }
 
         response = api_client.patch(
             f"{V1_URL_PREFIX}{CONSENT_REQUEST_PRIVACY_PREFERENCES_WITH_ID.format(consent_request_id=consent_request.id)}",
@@ -244,7 +250,13 @@ class TestSavePrivacyPreferencesPrivacyCenter:
         )
         assert response.status_code == 200
         # Assert no existing privacy preferences exist for this identity
-        assert response.json() == {"items": [], "total": 0, "page": 1, "size": 50}
+        assert response.json() == {
+            "items": [],
+            "total": 0,
+            "page": 1,
+            "pages": 1,
+            "size": 50,
+        }
 
         request_body = {
             "browser_identity": {"ga_client_id": "test"},
@@ -880,7 +892,13 @@ class TestSavePrivacyPreferencesPrivacyCenter:
         )
         assert response.status_code == 200
         # Assert no existing privacy preferences exist for this identity
-        assert response.json() == {"items": [], "total": 0, "page": 1, "size": 50}
+        assert response.json() == {
+            "items": [],
+            "total": 0,
+            "page": 1,
+            "pages": 1,
+            "size": 50,
+        }
 
         response = api_client.patch(
             f"{V1_URL_PREFIX}{CONSENT_REQUEST_PRIVACY_PREFERENCES_WITH_ID.format(consent_request_id=consent_request.id)}",
@@ -1055,7 +1073,13 @@ class TestPrivacyPreferenceVerify:
         )
         assert response.status_code == 200
         assert verification_code in mock_verify_identity.call_args_list[0].args
-        assert response.json() == {"items": [], "total": 0, "page": 1, "size": 50}
+        assert response.json() == {
+            "items": [],
+            "total": 0,
+            "page": 1,
+            "pages": 1,
+            "size": 50,
+        }
 
     @pytest.mark.usefixtures(
         "subject_identity_verification_required",
@@ -1452,6 +1476,7 @@ class TestHistoricalPreferences:
         assert len(response.json()["items"]) == 1
         assert response.json()["total"] == 1
         assert response.json()["page"] == 1
+        assert response.json()["pages"] == 1
         assert response.json()["size"] == 50
 
         response_body = response.json()["items"][0]
@@ -1513,6 +1538,7 @@ class TestHistoricalPreferences:
         assert len(response.json()["items"]) == 1
         assert response.json()["total"] == 1
         assert response.json()["page"] == 1
+        assert response.json()["pages"] == 1
         assert response.json()["size"] == 50
 
         response_body = response.json()["items"][0]
@@ -1538,6 +1564,7 @@ class TestHistoricalPreferences:
         assert len(response.json()["items"]) == 3
         assert response.json()["total"] == 3
         assert response.json()["page"] == 1
+        assert response.json()["pages"] == 1
         assert response.json()["size"] == 50
 
         response_body = response.json()["items"]
@@ -1667,6 +1694,7 @@ class TestCurrentPrivacyPreferences:
         assert len(response.json()["items"]) == 1
         assert response.json()["total"] == 1
         assert response.json()["page"] == 1
+        assert response.json()["pages"] == 1
         assert response.json()["size"] == 50
 
         response_body = response.json()["items"][0]
@@ -1698,6 +1726,7 @@ class TestCurrentPrivacyPreferences:
         assert len(response.json()["items"]) == 3
         assert response.json()["total"] == 3
         assert response.json()["page"] == 1
+        assert response.json()["pages"] == 1
         assert response.json()["size"] == 50
 
         response_body = response.json()["items"]

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -713,6 +713,7 @@ class TestGetPrivacyRequests:
             ],
             "total": 1,
             "page": 1,
+            "pages": 1,
             "size": page_size,
         }
 
@@ -773,6 +774,7 @@ class TestGetPrivacyRequests:
             ],
             "total": 1,
             "page": 1,
+            "pages": 1,
             "size": page_size,
         }
 
@@ -1238,6 +1240,7 @@ class TestGetPrivacyRequests:
             ],
             "total": 1,
             "page": 1,
+            "pages": 1,
             "size": page_size,
         }
         assert resp == expected_resp
@@ -1690,6 +1693,7 @@ class TestGetExecutionLogs:
             ],
             "total": 3,
             "page": 1,
+            "pages": 1,
             "size": page_size,
         }
 

--- a/tests/ops/api/v1/endpoints/test_storage_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_storage_endpoints.py
@@ -504,6 +504,7 @@ class TestGetStorageConfigs:
                 }
             ],
             "page": 1,
+            "pages": 1,
             "size": PAGE_SIZE,
             "total": 1,
         }
@@ -679,6 +680,7 @@ class TestGetDefaultStorageConfigs:
                 }
             ],
             "page": 1,
+            "pages": 1,
             "size": PAGE_SIZE,
             "total": 1,
         }


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

A version update broke some tests that relied on specific response fields

### Code Changes

* [ ] fix impacted tests

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
