### PR TITLE
fix: send redeploy trigger after x86 build

### DIFF
--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -56,16 +56,10 @@ jobs:
             echo "match=false" >> $GITHUB_OUTPUT
           fi
 
-      # if an RC git tag, also notify Fidesinfra to trigger a redeploy of rc env, to pick up our newly published images
-      - name: Send Repository Dispatch Event (RC redeploy)
-        if: steps.check-rc-tag.outputs.match == 'true'
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          event-type: trigger-fidesinfra-deploy-fides-rc
-          repository: ethyca/fidesinfra
-          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
-
-  Push:
+  # the x86 platform execution is split out in order to trigger downstream dependencies
+  # as soon as it completes. the ARM execution takes significantly longer and so it
+  # runs _after_ we trigger downstream any downstream dependencies.
+  PushX86:
     runs-on: ubuntu-latest
     needs: ParseTags
     strategy:
@@ -74,7 +68,7 @@ jobs:
       # but is the fastest way to get this working without overhauling the tag check logic.
       matrix:
         application: ["fides", "sample_app", "privacy_center"]
-        platform: ["x86", "ARM"]
+        platform: ["x86"]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -114,3 +108,68 @@ jobs:
       - name: Push Fides Commit Tags
         if: needs.ParseTags.outputs.prod_tag == 'false'
         run: nox -s "push(${{ matrix.application }},git-tag,${{ matrix.platform }})"
+
+      ### trigger downstream dependencies ###
+
+      # if an RC git tag, notify Fidesinfra to trigger a redeploy of rc env, to pick up our newly published images
+      - name: Send Repository Dispatch Event (RC redeploy)
+        if: steps.check-rc-tag.outputs.match == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: trigger-fidesinfra-deploy-fides-rc
+          repository: ethyca/fidesinfra
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+
+  PushARM:
+    runs-on: ubuntu-latest
+    needs: ParseTags
+    strategy:
+      # This matrix will effectively _try_ to run every permutation in parallel,
+      # skipping all of the tasks that don't match. This leaves a ton of "skipped" jobs
+      # but is the fastest way to get this working without overhauling the tag check logic.
+      matrix:
+        application: ["fides", "sample_app", "privacy_center"]
+        platform: ["ARM"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # This is required to properly tag images
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_TOKEN }}
+
+      - name: Install Dev Requirements
+        run: pip install -r dev-requirements.txt
+
+      # if neither prod, rc, beta or alpha git tag, then push images with the ":dev" tag
+      - name: Push Fides Dev Tag
+        if: needs.ParseTags.outputs.prod_tag == 'false' && needs.ParseTags.outputs.rc_tag == 'false' && needs.ParseTags.outputs.beta_tag == 'false' && needs.ParseTags.outputs.alpha_tag == 'false'
+        run: nox -s "push(${{ matrix.application }},dev,${{ matrix.platform }})"
+
+      # if a prod git tag, then we run the prod job to publish images tagged with the version number and a constant ":latest" tag
+      - name: Push Fides Prod Tags
+        if: needs.ParseTags.outputs.prod_tag == 'true'
+        run: nox -s "push(${{ matrix.application }},prod,${{ matrix.platform }})"
+
+      # if an RC git tag, then we run the rc job to publish images with an ":rc" tag
+      - name: Push Fides RC Tags
+        if: needs.ParseTags.outputs.rc_tag == 'true'
+        run: nox -s "push(${{ matrix.application }},rc,${{ matrix.platform }})"
+
+      # if an alpha or beta git tag, then we run the prerelease job to publish images with an ":prerelease" tag
+      - name: Push Fides prerelease Tags
+        if: needs.ParseTags.outputs.alpha_tag == 'true' || needs.ParseTags.outputs.beta_tag == 'true'
+        run: nox -s "push(${{ matrix.application }},prerelease,${{ matrix.platform }})"
+
+      # if not a prod git tag, then we run the git-tag job to publish images with a git tag
+      # if one exists on the current commit. the job is a no-op if the commit hasn't been tagged
+      - name: Push Fides Commit Tags
+        if: needs.ParseTags.outputs.prod_tag == 'false'
+        run: nox -s "push(${{ matrix.application }},git-tag,${{ matrix.platform }})"
+
+      ### trigger downstream dependencies ###
+
+      # intentionally left blank -- no downstream dependencies on ARM images!


### PR DESCRIPTION
Closes n/a

### Description Of Changes

Found a small bug in the recent [PR](https://github.com/ethyca/fides/pull/4013) merged to parallelize our docker builds. we need to send a notification to `fidesinfra` to redeploy the `fides-rc` env _after_ our images are published, not before.

I took the chance to ensure this notification is sent after specifically the x86 images are built (rather than the ARM images). to do this, i split up the actions that build x86 and ARM images in a rather rudimentary way. it seemed like the simplest option for now, but there's probably something more clever that can be done!


### Code Changes

* [ ] split up x86 and ARM build/push jobs into their own actions to allow triggers after x86 push completes
* [ ] trigger the downstream rc redeploy event _after_ the x86 image push completes

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
