### PR TITLE
re-enable custom fields for new data use form

### DIFF
--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
@@ -30,8 +30,8 @@ import {
   CustomFieldsList,
   CustomFieldValues,
   useCustomFields,
-} from "../../common/custom-fields";
-import SystemFormInputGroup from "../SystemFormInputGroup";
+} from "~/features/common/custom-fields";
+import SystemFormInputGroup from "~/features/system/SystemFormInputGroup";
 
 export const ValidationSchema = Yup.object().shape({
   data_categories: Yup.array(Yup.string())

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
@@ -8,12 +8,18 @@ import { useMemo } from "react";
 import * as Yup from "yup";
 
 import {
+  CustomFieldsList,
+  CustomFieldValues,
+  useCustomFields,
+} from "~/features/common/custom-fields";
+import {
   CustomCreatableSelect,
   CustomSelect,
   CustomSwitch,
   CustomTextInput,
 } from "~/features/common/form/inputs";
 import { FormGuard } from "~/features/common/hooks/useIsAnyFormDirty";
+import SystemFormInputGroup from "~/features/system/SystemFormInputGroup";
 import {
   DataCategory,
   Dataset,
@@ -25,13 +31,6 @@ import {
   SpecialCategoryLegalBasisEnum,
 } from "~/types/api";
 import { Cookies } from "~/types/api/models/Cookies";
-
-import {
-  CustomFieldsList,
-  CustomFieldValues,
-  useCustomFields,
-} from "~/features/common/custom-fields";
-import SystemFormInputGroup from "~/features/system/SystemFormInputGroup";
 
 export const ValidationSchema = Yup.object().shape({
   data_categories: Yup.array(Yup.string())

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
@@ -233,13 +233,13 @@ const PrivacyDeclarationFormTab = ({
     handleCloseDictModal();
   };
 
-  const handleSubmit = (values: PrivacyDeclarationResponse) => {
+  const handleSubmit = async (values: PrivacyDeclarationResponse) => {
     handleCloseForm();
     if (currentDeclaration) {
-      handleEditDeclaration(currentDeclaration, values);
-    } else {
-      handleCreateDeclaration(values);
-    }
+      return handleEditDeclaration(currentDeclaration, values);
+    } 
+      return handleCreateDeclaration(values);
+    
   };
 
   const handleDelete = async (
@@ -300,6 +300,7 @@ const PrivacyDeclarationFormTab = ({
           initialValues={currentDeclaration}
           onSubmit={handleSubmit}
           onCancel={handleCloseForm}
+          includeCustomFields={includeCustomFields}
           {...dataProps}
         />
       </PrivacyDeclarationFormModal>

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
@@ -237,9 +237,8 @@ const PrivacyDeclarationFormTab = ({
     handleCloseForm();
     if (currentDeclaration) {
       return handleEditDeclaration(currentDeclaration, values);
-    } 
-      return handleCreateDeclaration(values);
-    
+    }
+    return handleCreateDeclaration(values);
   };
 
   const handleDelete = async (


### PR DESCRIPTION
Fixes Fidesplus issue [1080](https://github.com/ethyca/fidesplus/issues/1080)

### Description Of Changes

Adds custom fields section to new data use form

![Screenshot 2023-09-08 at 2 44 50 PM](https://github.com/ethyca/fides/assets/6394496/184e399e-f974-4e6a-a204-c06f56eaaa82)

### Steps to Confirm

* [ ] add a custom field for "system:data use"
* [ ] view the data use form 
* [ ] save a value in the new custom field

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
