### PR TITLE
Pinning anyio version to 3.7.1 to avoid using PEP 654 ExceptionGroups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic==1.8.1
-anyio==3.4.0
+anyio==3.7.1
 APScheduler==3.9.1.post1
 asyncpg==0.27.0
 boto3==1.26.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic==1.8.1
+anyio==3.4.0
 APScheduler==3.9.1.post1
 asyncpg==0.27.0
 boto3==1.26.1


### PR DESCRIPTION
Closes #4020

### Description Of Changes

Version [4.0.0](https://anyio.readthedocs.io/en/stable/versionhistory.html) of `anyio` made a breaking change by moving to [PEP 654 exception groups](https://peps.python.org/pep-0654/) which are only natively supported in Python 3.11. I ran a check to see the earliest version of anyio we could use for our dependencies
```
nox -s shell
pip install pipdeptree
pipdeptree --reverse --packages anyio
```
```
anyio==4.0.0
├── httpcore==0.16.3 [requires: anyio>=3.0,<5.0]
│   └── httpx==0.23.1 [requires: httpcore>=0.15.0,<0.17.0]
│       └── ethyca-fides==2.19.1b0.post0.dev2 [requires: httpx==0.23.1]
├── starlette==0.22.0 [requires: anyio>=3.4.0,<5]
│   └── fastapi==0.89.1 [requires: starlette==0.22.0]
│       ├── ethyca-fides==2.19.1b0.post0.dev2 [requires: fastapi==0.89.1]
│       ├── fastapi-caching==0.3.0 [requires: fastapi]
│       │   └── ethyca-fides==2.19.1b0.post0.dev2 [requires: fastapi-caching==0.3.0]
│       └── fastapi-pagination==0.11.4 [requires: fastapi>=0.80.0]
│           └── ethyca-fides==2.19.1b0.post0.dev2 [requires: fastapi-pagination==0.11.4]
└── watchfiles==0.19.0 [requires: anyio>=3.0.0]
```
This showed that `starlette` needs at least version 3.4.0 so I pinned anyio to that version in our requirements.txt

I set a breakpoint in `main.py` and verified that the exception thrown isn't of type `ExceptionGroup`
```
root@628a473bb9a4:/fides# pytest tests/ops/api/v1/endpoints/test_messaging_endpoints.py -k test_get_active_default_app_setting_invalid --no-cov
=================================================== test session starts ====================================================
platform linux -- Python 3.10.12, pytest-7.2.2, pluggy-1.3.0 -- /opt/fides/bin/python3
cachedir: .pytest_cache
rootdir: /fides, configfile: pyproject.toml
plugins: cov-4.0.0, requests-mock-1.10.0, Faker-14.1.0, asyncio-0.19.0, env-0.6.2, celery-0.0.0, anyio-3.4.0
asyncio: mode=auto
collected 99 items / 98 deselected / 1 selected                                                                            

tests/ops/api/v1/endpoints/test_messaging_endpoints.py::TestGetActiveDefaultMessagingConfig::test_get_active_default_app_setting_invalid 
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /fides/src/fides/api/main.py(106)dispatch_log_request()
-> await prepare_and_log_request(
(Pdb) e
ValueError('Unknown notification_service_type invalid_service_type configured')
(Pdb) 
```
Meaning we weren't using Python 3.11 ExceptionGroups in any of our dependencies. I also tested with version 3.7.1 which is the version before the 4.0.0 release and verified there weren't any issues with that version either. Version 4.0.0 of anyio was released Aug 30th 2023, which coincides with the time we started seeing these errors. It looks like starlette pulled in version 4.0.0 once it was released since it was the latest version that met the requirements.
```
starlette==0.22.0 [requires: anyio>=3.4.0,<5]
```

### Code Changes

* [ ] Pinned anyio to version 3.7.1

### Steps to Confirm

* [ ] Run the tests

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`