### PR TITLE
Fixing diff modal

### DIFF
--- a/clients/admin-ui/src/features/system/history/modal/SystemHistoryModal.tsx
+++ b/clients/admin-ui/src/features/system/history/modal/SystemHistoryModal.tsx
@@ -48,7 +48,7 @@ interface Props {
 }
 
 const SystemHistoryModal = ({ selectedHistory, isOpen, onClose }: Props) => (
-  <Modal isOpen={isOpen} onClose={onClose} size="3xl">
+  <Modal isOpen={isOpen} onClose={onClose} size="4xl">
     <ModalOverlay />
     <ModalContent>
       <ModalHeader

--- a/clients/admin-ui/src/features/system/history/modal/fields/SystemDataSwitch.tsx
+++ b/clients/admin-ui/src/features/system/history/modal/fields/SystemDataSwitch.tsx
@@ -19,13 +19,13 @@ const SystemDataSwitch = ({
 }: CustomInputProps & StringField) => {
   const { selectedHistory, formType } = useSelectedHistory();
   const [initialField] = useField(props);
-  const field = { ...initialField, value: initialField.value ?? "" };
+  const field = { ...initialField, value: initialField.value };
 
   const [shouldHighlight, setShouldHighlight] = useState(false);
 
   useEffect(() => {
-    const beforeValue = _.get(selectedHistory?.before, props.name) || "";
-    const afterValue = _.get(selectedHistory?.after, props.name) || "";
+    const beforeValue = _.get(selectedHistory?.before, props.name);
+    const afterValue = _.get(selectedHistory?.after, props.name);
 
     // Determine whether to highlight
     setShouldHighlight(beforeValue !== afterValue);
@@ -60,16 +60,18 @@ const SystemDataSwitch = ({
       paddingBottom={3}
       marginTop="-1px !important"
     >
-      <VStack alignItems="start">
+      <VStack alignItems="start" minHeight="46px">
         <Flex alignItems="center">
           <Label htmlFor={props.id || props.name} fontSize="xs" my={0} mr={1}>
             {label}
           </Label>
           {tooltip ? <QuestionTooltip label={tooltip} /> : null}
         </Flex>
-        <Tag colorScheme="gray" size="sm" m={1}>
-          {field.value ? "YES" : "NO"}
-        </Tag>
+        {field.value !== undefined && (
+          <Tag colorScheme="gray" size="sm" m={1}>
+            {field.value ? "YES" : "NO"}
+          </Tag>
+        )}
         {formType === "before" && shouldHighlight && (
           <div
             style={{

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
@@ -303,20 +303,22 @@ const PrivacyDeclarationFormTab = ({
           {...dataProps}
         />
       </PrivacyDeclarationFormModal>
-      <PrivacyDeclarationFormModal
-        isOpen={showDictionaryModal}
-        onClose={handleCloseDictModal}
-        isCentered
-        heading="Compass suggestions"
-      >
-        <PrivacyDeclarationDictModalComponents
-          alreadyHasDataUses={system.privacy_declarations.length > 0}
-          allDataUses={dataProps.allDataUses}
-          onCancel={handleCloseDictModal}
-          onAccept={handleAcceptDictSuggestions}
-          vendorId={Number(system.vendor_id)}
-        />
-      </PrivacyDeclarationFormModal>
+      {system.vendor_id ? (
+        <PrivacyDeclarationFormModal
+          isOpen={showDictionaryModal}
+          onClose={handleCloseDictModal}
+          isCentered
+          heading="Compass suggestions"
+        >
+          <PrivacyDeclarationDictModalComponents
+            alreadyHasDataUses={system.privacy_declarations.length > 0}
+            allDataUses={dataProps.allDataUses}
+            onCancel={handleCloseDictModal}
+            onAccept={handleAcceptDictSuggestions}
+            vendorId={Number(system.vendor_id)}
+          />
+        </PrivacyDeclarationFormModal>
+      ) : null}
     </Stack>
   );
 };

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
@@ -75,11 +75,11 @@ const PrivacyDeclarationFormTab = ({
 
   const unassignedCookies = system.cookies
     ? system.cookies.filter(
-        (c) =>
-          assignedCookies.filter(
-            (assigned) => assigned && assigned.name === c.name
-          ).length === 0
-      )
+      (c) =>
+        assignedCookies.filter(
+          (assigned) => assigned && assigned.name === c.name
+        ).length === 0
+    )
     : undefined;
 
   const checkAlreadyExists = (values: PrivacyDeclarationResponse) => {
@@ -264,7 +264,7 @@ const PrivacyDeclarationFormTab = ({
           dictAvailable={features.dictionaryService}
           handleAdd={handleOpenNewForm}
           handleDictSuggestion={handleOpenDictModal}
-          vendorSelected={!!system.meta.vendor}
+          vendorSelected={!!system.vendor_id}
         />
       ) : (
         <PrivacyDeclarationDisplayGroup
@@ -314,7 +314,7 @@ const PrivacyDeclarationFormTab = ({
           allDataUses={dataProps.allDataUses}
           onCancel={handleCloseDictModal}
           onAccept={handleAcceptDictSuggestions}
-          vendorId={system.meta?.vendor?.id ? system.meta.vendor.id : undefined}
+          vendorId={system.vendor_id ? system.vendor_id : undefined}
         />
       </PrivacyDeclarationFormModal>
     </Stack>

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
@@ -314,7 +314,7 @@ const PrivacyDeclarationFormTab = ({
           allDataUses={dataProps.allDataUses}
           onCancel={handleCloseDictModal}
           onAccept={handleAcceptDictSuggestions}
-          vendorId={system.vendor_id ? system.vendor_id : undefined}
+          vendorId={Number(system.vendor_id)}
         />
       </PrivacyDeclarationFormModal>
     </Stack>

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
@@ -75,11 +75,11 @@ const PrivacyDeclarationFormTab = ({
 
   const unassignedCookies = system.cookies
     ? system.cookies.filter(
-      (c) =>
-        assignedCookies.filter(
-          (assigned) => assigned && assigned.name === c.name
-        ).length === 0
-    )
+        (c) =>
+          assignedCookies.filter(
+            (assigned) => assigned && assigned.name === c.name
+          ).length === 0
+      )
     : undefined;
 
   const checkAlreadyExists = (values: PrivacyDeclarationResponse) => {


### PR DESCRIPTION
### Description Of Changes

Increased the width of the modal to account for long data category tags that can't wrap. This is a temporary solution, the modal should be able to adapt to the contents, maintain a minimum width but expand if necessary.

Also fixed an issue where fields with missing boolean values were being evaluated as false


### Code Changes

* [ ] Updated the `SystemDataSwitch.tsx` component
* [ ] Increased the width of the SystemHistoryModal from 3xl to 4xl

### Steps to Confirm

* [ ] Start fidesplus
* [ ] Navigate to the Admin UI and create a new system
* [ ] Add a data use with the `user.government_id.national_identification_number` data category
* [ ] Save the changes
* [ ] Remove the data use
* [ ] Click on the generated rows in the System History tab and verify both changes are rendered correctly

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
