### PR TITLE
Do not load fetch polyfill if fetch is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The types of changes are:
 - Privacy notice templates are disabled by default [#4010](https://github.com/ethyca/fides/pull/4010)
 - Admin UI now shows all privacy notices with an indicator of whether they apply to any systems [#4010](https://github.com/ethyca/fides/pull/4010)
 - Add case-insensitive privacy experience region filtering [#4058](https://github.com/ethyca/fides/pull/4058)
+- Adds check for fetch before loading fetch polyfill for fides.js [#4074](https://github.com/ethyca/fides/pull/4074)
 
 ## [2.19.1](https://github.com/ethyca/fides/compare/2.19.0...2.19.1)
 

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -135,12 +135,12 @@ export default async function handler(
   const script = `
   (function () {
     // This polyfill service adds a fetch polyfill only when needed, depending on browser making the request 
-    if (window.fetch) {} else {
+    if (!window.fetch) {
       var script = document.createElement('script');
       script.src = 'https://polyfill.io/v3/polyfill.min.js?features=fetch';
       document.head.appendChild(script);
     }
-    
+
     // Include generic fides.js script
     ${fidesJS}
 

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -135,9 +135,11 @@ export default async function handler(
   const script = `
   (function () {
     // This polyfill service adds a fetch polyfill only when needed, depending on browser making the request 
-    var script = document.createElement('script');
-    script.src = 'https://polyfill.io/v3/polyfill.min.js?features=fetch';
-    document.head.appendChild(script);
+    if (window.fetch) {} else {
+      var script = document.createElement('script');
+      script.src = 'https://polyfill.io/v3/polyfill.min.js?features=fetch';
+      document.head.appendChild(script);
+    }
     
     // Include generic fides.js script
     ${fidesJS}


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4072

### Description Of Changes

Check for fetch first and then load polyfill if its not defined. This reduces possibility for client errors and reduces an extra network call that could impact customers.

### Code Changes

* [ ] Adds conditional to fides.js api route

### Steps to Confirm

* [ ] Regression test that http://localhost:3000/fides-js-demo.html loads in the banner as configured

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
