### PR TITLE
Privacy notice table updates

### DIFF
--- a/clients/admin-ui/src/features/common/table/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/cells.tsx
@@ -1,4 +1,5 @@
 import {
+  Badge,
   Box,
   Flex,
   Switch,
@@ -48,13 +49,17 @@ export const MapCell = <T extends object>({
   value,
   backgroundColor,
 }: MapCellProps<T>) => (
-  <Tag
+  <Badge
     size="sm"
-    backgroundColor={backgroundColor || "primary.400"}
-    color="white"
+    width="fit-content"
+    data-testid="status-badge"
+    textTransform="uppercase"
+    fontWeight="400"
+    color="gray.600"
+    px={2}
   >
     {map.get(value) ?? value}
-  </Tag>
+  </Badge>
 );
 
 export const MultiTagCell = <T extends object>({

--- a/clients/admin-ui/src/features/common/table/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/cells.tsx
@@ -41,14 +41,9 @@ export const DateCell = <T extends object>({ value }: CellProps<T, string>) =>
 
 type MapCellProps<T extends object> = CellProps<T, string> & {
   map: Map<string, string>;
-  backgroundColor?: string;
 };
 
-export const MapCell = <T extends object>({
-  map,
-  value,
-  backgroundColor,
-}: MapCellProps<T>) => (
+export const MapCell = <T extends object>({ map, value }: MapCellProps<T>) => (
   <Badge
     size="sm"
     width="fit-content"

--- a/clients/admin-ui/src/features/custom-fields/cells.tsx
+++ b/clients/admin-ui/src/features/custom-fields/cells.tsx
@@ -56,14 +56,7 @@ export const FieldTypeCell = (
     ? cellProps.value
     : "open-text";
   /* eslint-enable */
-  return (
-    <MapCell
-      map={FIELD_TYPE_MAP}
-      backgroundColor="gray.500"
-      {...cellProps}
-      value={value}
-    />
-  );
+  return <MapCell map={FIELD_TYPE_MAP} {...cellProps} value={value} />;
 };
 
 export const EnableCustomFieldCell = (

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
@@ -6,7 +6,6 @@ import {
   FidesTable,
   FidesTableFooter,
   TitleCell,
-  WrappedCell,
 } from "common/table";
 import NextLink from "next/link";
 import { useRouter } from "next/router";

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
@@ -54,26 +54,20 @@ export const PrivacyNoticesTable = () => {
         Cell: TitleCell,
       },
       {
-        Header: "Description",
-        accessor: "description",
-        Cell: WrappedCell,
-      },
-      {
         Header: "Mechanism",
         accessor: "consent_mechanism",
         Cell: MechanismCell,
       },
       { Header: "Locations", accessor: "regions", Cell: LocationCell },
-      { Header: "Created", accessor: "created_at", Cell: DateCell },
       { Header: "Last update", accessor: "updated_at", Cell: DateCell },
+      {
+        Header: "Status",
+        Cell: PrivacyNoticeStatusCell,
+      },
       {
         Header: "Enable",
         accessor: "disabled",
         Cell: EnablePrivacyNoticeCell,
-      },
-      {
-        Header: "Status",
-        Cell: PrivacyNoticeStatusCell,
       },
     ];
     // Only render the "Enable" column with toggle if user has permission to toggle

--- a/clients/admin-ui/src/features/privacy-notices/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/cells.tsx
@@ -9,35 +9,72 @@ import { usePatchPrivacyNoticesMutation } from "~/features/privacy-notices/priva
 import { PrivacyNoticeResponse } from "~/types/api";
 
 export const MechanismCell = (
-  cellProps: CellProps<typeof MECHANISM_MAP, string>
-) => <MapCell map={MECHANISM_MAP} {...cellProps} />;
+  cellProps: CellProps<PrivacyNoticeResponse, string>
+) => {
+  const tagValue = MECHANISM_MAP.get(cellProps.row.original.consent_mechanism);
+  return (
+    <Badge
+      size="sm"
+      width="fit-content"
+      data-testid="status-badge"
+      textTransform="uppercase"
+      fontWeight="400"
+      color="gray.600"
+      px={2}
+    >
+      {tagValue}
+    </Badge>
+  )
+}
+{/* <MapCell map={MECHANISM_MAP} {...cellProps} />; */ }
 
 type TagNames = "available" | "enabled" | "inactive";
 
 const systemsApplicableTags: Record<TagNames, TagProps & { tooltip: string }> =
-  {
-    available: {
-      backgroundColor: "orange.100",
-      color: "orange.800",
-      tooltip:
-        "This notice is associated with a system + data use and can be enabled",
-    },
-    enabled: {
-      backgroundColor: "green.100",
-      color: "green.800",
-      tooltip: "This notice is active and available for consumers",
-    },
-    inactive: {
-      backgroundColor: "gray.100",
-      color: "gray.800",
-      tooltip:
-        "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
-    },
-  };
+{
+  available: {
+    backgroundColor: "orange.100",
+    color: "orange.800",
+    tooltip:
+      "This notice is associated with a system + data use and can be enabled",
+  },
+  enabled: {
+    backgroundColor: "green.100",
+    color: "green.800",
+    tooltip: "This notice is active and available for consumers",
+  },
+  inactive: {
+    backgroundColor: "gray.100",
+    color: "gray.800",
+    tooltip:
+      "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
+  },
+};
 
 export const LocationCell = (
   cellProps: CellProps<PrivacyNoticeResponse, string[]>
-) => <MultiTagCell map={PRIVACY_NOTICE_REGION_MAP} {...cellProps} />;
+) => {
+  const regions = cellProps.row.original.regions;
+  let tagValue = undefined;
+  if (regions.length > 1) {
+    tagValue = regions.length + " locations";
+  } else {
+    tagValue = PRIVACY_NOTICE_REGION_MAP.get(regions[0]);
+  }
+  return (
+    <Badge
+      size="sm"
+      width="fit-content"
+      data-testid="status-badge"
+      textTransform="uppercase"
+      fontWeight="400"
+      color="gray.600"
+      px={2}
+    >
+      {tagValue}
+    </Badge>
+  )
+}
 
 export const EnablePrivacyNoticeCell = (
   cellProps: CellProps<PrivacyNoticeResponse, boolean>
@@ -95,7 +132,8 @@ export const PrivacyNoticeStatusCell = (
         {...tagProps}
         data-testid="status-badge"
         textTransform="uppercase"
-        fontWeight="600"
+        fontWeight="400"
+        color="gray.600"
         px={2}
       >
         {tagValue}

--- a/clients/admin-ui/src/features/privacy-notices/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/cells.tsx
@@ -15,31 +15,31 @@ export const MechanismCell = (
 type TagNames = "available" | "enabled" | "inactive";
 
 const systemsApplicableTags: Record<TagNames, TagProps & { tooltip: string }> =
-{
-  available: {
-    backgroundColor: "orange.100",
-    color: "orange.800",
-    tooltip:
-      "This notice is associated with a system + data use and can be enabled",
-  },
-  enabled: {
-    backgroundColor: "green.100",
-    color: "green.800",
-    tooltip: "This notice is active and available for consumers",
-  },
-  inactive: {
-    backgroundColor: "gray.100",
-    color: "gray.800",
-    tooltip:
-      "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
-  },
-};
+  {
+    available: {
+      backgroundColor: "orange.100",
+      color: "orange.800",
+      tooltip:
+        "This notice is associated with a system + data use and can be enabled",
+    },
+    enabled: {
+      backgroundColor: "green.100",
+      color: "green.800",
+      tooltip: "This notice is active and available for consumers",
+    },
+    inactive: {
+      backgroundColor: "gray.100",
+      color: "gray.800",
+      tooltip:
+        "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
+    },
+  };
 
 export const LocationCell = (
   cellProps: CellProps<PrivacyNoticeResponse, string>
 ) => {
   const { row } = cellProps;
-  const region = row.original.regions;
+  const region = row.original.regions ? row.original.regions : ["No locations"];
   let tagValue;
   if (region.length > 1) {
     tagValue = `${region.length} locations`;

--- a/clients/admin-ui/src/features/privacy-notices/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/cells.tsx
@@ -31,25 +31,25 @@ export const MechanismCell = (
 type TagNames = "available" | "enabled" | "inactive";
 
 const systemsApplicableTags: Record<TagNames, TagProps & { tooltip: string }> =
-{
-  available: {
-    backgroundColor: "orange.100",
-    color: "orange.800",
-    tooltip:
-      "This notice is associated with a system + data use and can be enabled",
-  },
-  enabled: {
-    backgroundColor: "green.100",
-    color: "green.800",
-    tooltip: "This notice is active and available for consumers",
-  },
-  inactive: {
-    backgroundColor: "gray.100",
-    color: "gray.800",
-    tooltip:
-      "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
-  },
-};
+  {
+    available: {
+      backgroundColor: "orange.100",
+      color: "orange.800",
+      tooltip:
+        "This notice is associated with a system + data use and can be enabled",
+    },
+    enabled: {
+      backgroundColor: "green.100",
+      color: "green.800",
+      tooltip: "This notice is active and available for consumers",
+    },
+    inactive: {
+      backgroundColor: "gray.100",
+      color: "gray.800",
+      tooltip:
+        "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
+    },
+  };
 
 export const LocationCell = (
   cellProps: CellProps<PrivacyNoticeResponse, string>

--- a/clients/admin-ui/src/features/privacy-notices/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/cells.tsx
@@ -3,53 +3,37 @@ import React from "react";
 import { CellProps } from "react-table";
 
 import { PRIVACY_NOTICE_REGION_MAP } from "~/features/common/privacy-notice-regions";
-import { EnableCell } from "~/features/common/table/";
+import { EnableCell, MapCell } from "~/features/common/table/";
 import { MECHANISM_MAP } from "~/features/privacy-notices/constants";
 import { usePatchPrivacyNoticesMutation } from "~/features/privacy-notices/privacy-notices.slice";
 import { PrivacyNoticeResponse } from "~/types/api";
 
 export const MechanismCell = (
-  cellProps: CellProps<PrivacyNoticeResponse, string>
-) => {
-  const { row } = cellProps;
-  const tagValue = MECHANISM_MAP.get(row.original.consent_mechanism);
-  return (
-    <Badge
-      size="sm"
-      width="fit-content"
-      data-testid="status-badge"
-      textTransform="uppercase"
-      fontWeight="400"
-      color="gray.600"
-      px={2}
-    >
-      {tagValue}
-    </Badge>
-  );
-};
+  cellProps: CellProps<typeof MECHANISM_MAP, string>
+) => <MapCell map={MECHANISM_MAP} {...cellProps} />;
 
 type TagNames = "available" | "enabled" | "inactive";
 
 const systemsApplicableTags: Record<TagNames, TagProps & { tooltip: string }> =
-  {
-    available: {
-      backgroundColor: "orange.100",
-      color: "orange.800",
-      tooltip:
-        "This notice is associated with a system + data use and can be enabled",
-    },
-    enabled: {
-      backgroundColor: "green.100",
-      color: "green.800",
-      tooltip: "This notice is active and available for consumers",
-    },
-    inactive: {
-      backgroundColor: "gray.100",
-      color: "gray.800",
-      tooltip:
-        "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
-    },
-  };
+{
+  available: {
+    backgroundColor: "orange.100",
+    color: "orange.800",
+    tooltip:
+      "This notice is associated with a system + data use and can be enabled",
+  },
+  enabled: {
+    backgroundColor: "green.100",
+    color: "green.800",
+    tooltip: "This notice is active and available for consumers",
+  },
+  inactive: {
+    backgroundColor: "gray.100",
+    color: "gray.800",
+    tooltip:
+      "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
+  },
+};
 
 export const LocationCell = (
   cellProps: CellProps<PrivacyNoticeResponse, string>

--- a/clients/admin-ui/src/features/privacy-notices/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/cells.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { CellProps } from "react-table";
 
 import { PRIVACY_NOTICE_REGION_MAP } from "~/features/common/privacy-notice-regions";
-import { EnableCell, MapCell, MultiTagCell } from "~/features/common/table/";
+import { EnableCell } from "~/features/common/table/";
 import { MECHANISM_MAP } from "~/features/privacy-notices/constants";
 import { usePatchPrivacyNoticesMutation } from "~/features/privacy-notices/privacy-notices.slice";
 import { PrivacyNoticeResponse } from "~/types/api";
@@ -11,7 +11,8 @@ import { PrivacyNoticeResponse } from "~/types/api";
 export const MechanismCell = (
   cellProps: CellProps<PrivacyNoticeResponse, string>
 ) => {
-  const tagValue = MECHANISM_MAP.get(cellProps.row.original.consent_mechanism);
+  const { row } = cellProps;
+  const tagValue = MECHANISM_MAP.get(row.original.consent_mechanism);
   return (
     <Badge
       size="sm"
@@ -26,42 +27,40 @@ export const MechanismCell = (
     </Badge>
   );
 };
-{
-  /* <MapCell map={MECHANISM_MAP} {...cellProps} />; */
-}
 
 type TagNames = "available" | "enabled" | "inactive";
 
 const systemsApplicableTags: Record<TagNames, TagProps & { tooltip: string }> =
-  {
-    available: {
-      backgroundColor: "orange.100",
-      color: "orange.800",
-      tooltip:
-        "This notice is associated with a system + data use and can be enabled",
-    },
-    enabled: {
-      backgroundColor: "green.100",
-      color: "green.800",
-      tooltip: "This notice is active and available for consumers",
-    },
-    inactive: {
-      backgroundColor: "gray.100",
-      color: "gray.800",
-      tooltip:
-        "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
-    },
-  };
+{
+  available: {
+    backgroundColor: "orange.100",
+    color: "orange.800",
+    tooltip:
+      "This notice is associated with a system + data use and can be enabled",
+  },
+  enabled: {
+    backgroundColor: "green.100",
+    color: "green.800",
+    tooltip: "This notice is active and available for consumers",
+  },
+  inactive: {
+    backgroundColor: "gray.100",
+    color: "gray.800",
+    tooltip:
+      "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
+  },
+};
 
 export const LocationCell = (
-  cellProps: CellProps<PrivacyNoticeResponse, string[]>
+  cellProps: CellProps<PrivacyNoticeResponse, string>
 ) => {
-  const regions = cellProps.row.original.regions;
-  let tagValue = undefined;
-  if (regions.length > 1) {
-    tagValue = regions.length + " locations";
+  const { row } = cellProps;
+  const region = row.original.regions;
+  let tagValue;
+  if (region.length > 1) {
+    tagValue = `${region.length} locations`;
   } else {
-    tagValue = PRIVACY_NOTICE_REGION_MAP.get(regions[0]);
+    tagValue = PRIVACY_NOTICE_REGION_MAP.get(region[0]);
   }
   return (
     <Badge

--- a/clients/admin-ui/src/features/privacy-notices/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/cells.tsx
@@ -24,32 +24,34 @@ export const MechanismCell = (
     >
       {tagValue}
     </Badge>
-  )
+  );
+};
+{
+  /* <MapCell map={MECHANISM_MAP} {...cellProps} />; */
 }
-{/* <MapCell map={MECHANISM_MAP} {...cellProps} />; */ }
 
 type TagNames = "available" | "enabled" | "inactive";
 
 const systemsApplicableTags: Record<TagNames, TagProps & { tooltip: string }> =
-{
-  available: {
-    backgroundColor: "orange.100",
-    color: "orange.800",
-    tooltip:
-      "This notice is associated with a system + data use and can be enabled",
-  },
-  enabled: {
-    backgroundColor: "green.100",
-    color: "green.800",
-    tooltip: "This notice is active and available for consumers",
-  },
-  inactive: {
-    backgroundColor: "gray.100",
-    color: "gray.800",
-    tooltip:
-      "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
-  },
-};
+  {
+    available: {
+      backgroundColor: "orange.100",
+      color: "orange.800",
+      tooltip:
+        "This notice is associated with a system + data use and can be enabled",
+    },
+    enabled: {
+      backgroundColor: "green.100",
+      color: "green.800",
+      tooltip: "This notice is active and available for consumers",
+    },
+    inactive: {
+      backgroundColor: "gray.100",
+      color: "gray.800",
+      tooltip:
+        "This privacy notice cannot be enabled because the linked data use has not been assigned to a system",
+    },
+  };
 
 export const LocationCell = (
   cellProps: CellProps<PrivacyNoticeResponse, string[]>
@@ -73,8 +75,8 @@ export const LocationCell = (
     >
       {tagValue}
     </Badge>
-  )
-}
+  );
+};
 
 export const EnablePrivacyNoticeCell = (
   cellProps: CellProps<PrivacyNoticeResponse, boolean>

--- a/clients/admin-ui/src/types/api/models/PrivacyNoticeResponse.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyNoticeResponse.ts
@@ -16,8 +16,8 @@ export type PrivacyNoticeResponse = {
   description?: string;
   internal_description?: string;
   origin?: string;
-  regions?: Array<PrivacyNoticeRegion>;
-  consent_mechanism?: ConsentMechanism;
+  regions: Array<PrivacyNoticeRegion>;
+  consent_mechanism: ConsentMechanism;
   data_uses?: Array<string>;
   enforcement_level?: EnforcementLevel;
   disabled?: boolean;

--- a/clients/admin-ui/src/types/api/models/PrivacyNoticeResponse.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyNoticeResponse.ts
@@ -16,8 +16,8 @@ export type PrivacyNoticeResponse = {
   description?: string;
   internal_description?: string;
   origin?: string;
-  regions: Array<PrivacyNoticeRegion>;
-  consent_mechanism: ConsentMechanism;
+  regions?: Array<PrivacyNoticeRegion>;
+  consent_mechanism?: ConsentMechanism;
   data_uses?: Array<string>;
   enforcement_level?: EnforcementLevel;
   disabled?: boolean;


### PR DESCRIPTION
Closes #4077 

### Description Of Changes

Privacy notice table updates - remove created and description columns, update location and consent mechanism tabs, and rearrange column order


### Code Changes

* [ ] update the privacy notice table and cells
* [ ] update the privacy notice response type so region and consent mechanism is not optional 

### Steps to Confirm

* [ ] confirm no descriptions & last update columns
* [ ] If locations > 1 then show a tag with # of locations
* [ ] if locations = 1 then show a tag with the location 
* [ ] column order should be title, mechanism, location, last update, status, enable 
* [ ] style matches design 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
