### PR TITLE
Migrate system > meta > vendor > id if it exists to system > vendor_id.

### DIFF
--- a/src/fides/api/alembic/migrations/versions/671358247251_migrate_meta_vendor.py
+++ b/src/fides/api/alembic/migrations/versions/671358247251_migrate_meta_vendor.py
@@ -1,0 +1,87 @@
+"""migrate meta vendor
+
+Revision ID: 671358247251
+Revises: ad2e3f9a6850
+Create Date: 2023-09-13 20:52:58.425483
+
+"""
+import json
+from typing import Optional, Dict
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+from sqlalchemy import text
+from sqlalchemy.engine import ResultProxy, Connection
+from sqlalchemy.sql.elements import TextClause
+
+revision = "671358247251"
+down_revision = "ad2e3f9a6850"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Migrate system > meta > vendor > id to system > vendor_id if applicable"""
+    bind: Connection = op.get_bind()
+    existing_systems: ResultProxy = bind.execute(
+        text("select id, meta, vendor_id from ctl_systems;")
+    )
+
+    for row in existing_systems:
+        # Locate system > meta > vendor > id if it exists!
+        meta: Optional[Dict] = row["meta"] or {}
+        if not meta:
+            continue
+
+        meta_vendor: Optional[Dict] = meta.get("vendor", {})
+        meta_vendor_id: Optional[str] = None
+
+        if isinstance(meta_vendor, dict):  # Just double checking
+            meta_vendor_id = meta_vendor.get("id", None)
+
+        existing_vendor_id: Optional[str] = row["vendor_id"]
+
+        # Don't replace it if a value already exists!
+        if meta_vendor_id and not existing_vendor_id:
+            # Also remove the vendor key altogether here
+            meta.pop("vendor")
+            update_vendor_id_query: TextClause = text(
+                "UPDATE ctl_systems SET vendor_id= :meta_vendor_id, meta=:updated_meta WHERE id= :id"
+            )
+            bind.execute(
+                update_vendor_id_query,
+                {
+                    "id": row["id"],
+                    "meta_vendor_id": meta_vendor_id,
+                    "updated_meta": json.dumps(meta),
+                },
+            )
+
+
+def downgrade():
+    """Migrate system > vendor_id to system > meta > vendor > id if applicable"""
+    bind: Connection = op.get_bind()
+    existing_systems: ResultProxy = bind.execute(
+        text("select id, meta, vendor_id from ctl_systems;")
+    )
+
+    for row in existing_systems:
+        existing_vendor_id: Optional[str] = row["vendor_id"]
+        if not existing_vendor_id:
+            continue
+
+        meta: Dict = row["meta"] or {}
+        if "vendor" not in meta:
+            meta["vendor"] = {}
+            meta["vendor"]["id"] = existing_vendor_id
+
+        update_vendor_id_query: TextClause = text(
+            "UPDATE ctl_systems SET meta = :updated_meta, vendor_id = null WHERE id= :id"
+        )
+        bind.execute(
+            update_vendor_id_query,
+            {"id": row["id"], "updated_meta": json.dumps(meta)},
+        )


### PR DESCRIPTION
Closes #4084 

### Description Of Changes

Migrate system > meta > vendor > id _if it exists_  and **vendor_id doesn't already exist** to system > vendor id.  Remove the "vendor" key from meta dict if applicable and the migration took place on that row.


#### Before
```sql
fides=# select id, meta, vendor_id from ctl_systems order by id
;
                    id                    |                 meta                  | vendor_id 
------------------------------------------+---------------------------------------+-----------
 ctl_0118fbbd-282e-4d31-bc8b-5777d713cf3a | {"health": 2, "vendor": {"id": "87"}} | 
 ctl_25efee31-7fb7-41cb-a660-5141cc79c23e | {"health": 1}                         | 
 ctl_40f88ca0-810d-4af0-a26e-64aff9181e59 | {"health": 3, "vendor": {"id": "29"}} | 21
 ctl_483e730c-3dba-4fe9-b59f-dc2ac562bc95 | {}                                    | 
 ctl_a179bd58-8d6e-40ce-9c88-17e18f14e3b4 | {"vendor": {"id": "1111"}}            | 
(5 rows)
```
#### After
Note: `ctl_40f88ca0-810d-4af0-a26e-64aff9181e59` didn't migrate because there was also a `vendor_id`. I also left the old record there. Logging in this case.

```sql
fides=# select id, meta, vendor_id from ctl_systems order by id
;
                    id                    |                 meta                  | vendor_id 
------------------------------------------+---------------------------------------+-----------
 ctl_0118fbbd-282e-4d31-bc8b-5777d713cf3a | {"health": 2}                         | 87
 ctl_25efee31-7fb7-41cb-a660-5141cc79c23e | {"health": 1}                         | 
 ctl_40f88ca0-810d-4af0-a26e-64aff9181e59 | {"health": 3, "vendor": {"id": "29"}} | 21
 ctl_483e730c-3dba-4fe9-b59f-dc2ac562bc95 | {}                                    | 
 ctl_a179bd58-8d6e-40ce-9c88-17e18f14e3b4 | {}                                    | 1111
```


### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
