### PR TITLE
fix: more defensive string replacement to handle Nones

### DIFF
--- a/scripts/verify_fideslang_2_data_migration.py
+++ b/scripts/verify_fideslang_2_data_migration.py
@@ -122,6 +122,9 @@ fideslang_1_use = fideslang.models.DataUse(
 orphaned_data_category = fideslang.models.DataCategory(
     fides_key="user.observed.custom", parent_key="user.observed"
 )
+orphaned_data_category_no_parent = fideslang.models.DataCategory(
+    fides_key="custom_category_no_parent", parent_key=None
+)
 
 # This is used to test Privacy Notices
 old_notice = PrivacyNoticeCreation(
@@ -186,7 +189,11 @@ def create_outdated_objects() -> None:
         url=SERVER_URL,
         headers=AUTH_HEADER,
         taxonomy=fideslang.models.Taxonomy(
-            data_category=[orphaned_data_category, fideslang_1_category],
+            data_category=[
+                orphaned_data_category,
+                orphaned_data_category_no_parent,
+                fideslang_1_category,
+            ],
             data_use=[fideslang_1_use],
         ),
     )
@@ -299,7 +306,12 @@ def verify_migration(server_url: str, auth_header: Dict[str, str]) -> None:
     server_orphaned_category: fideslang.models.DataCategory = partial_get(
         resource_key="user.behavior.custom", resource_type="data_category"
     )
-    assert server_orphaned_category, server_orphaned_category
+    assert server_orphaned_category
+
+    server_orphaned_category_no_parent: fideslang.models.DataCategory = partial_get(
+        resource_key="custom_category_no_parent", resource_type="data_category"
+    )
+    assert server_orphaned_category_no_parent
     print("> Verified Data Categories.")
 
     # Verify Privacy Notices

--- a/scripts/verify_fideslang_2_data_migration.py
+++ b/scripts/verify_fideslang_2_data_migration.py
@@ -122,9 +122,6 @@ fideslang_1_use = fideslang.models.DataUse(
 orphaned_data_category = fideslang.models.DataCategory(
     fides_key="user.observed.custom", parent_key="user.observed"
 )
-orphaned_data_category_no_parent = fideslang.models.DataCategory(
-    fides_key="custom_category_no_parent", parent_key=None
-)
 
 # This is used to test Privacy Notices
 old_notice = PrivacyNoticeCreation(
@@ -189,11 +186,7 @@ def create_outdated_objects() -> None:
         url=SERVER_URL,
         headers=AUTH_HEADER,
         taxonomy=fideslang.models.Taxonomy(
-            data_category=[
-                orphaned_data_category,
-                orphaned_data_category_no_parent,
-                fideslang_1_category,
-            ],
+            data_category=[orphaned_data_category, fideslang_1_category],
             data_use=[fideslang_1_use],
         ),
     )
@@ -306,12 +299,7 @@ def verify_migration(server_url: str, auth_header: Dict[str, str]) -> None:
     server_orphaned_category: fideslang.models.DataCategory = partial_get(
         resource_key="user.behavior.custom", resource_type="data_category"
     )
-    assert server_orphaned_category
-
-    server_orphaned_category_no_parent: fideslang.models.DataCategory = partial_get(
-        resource_key="custom_category_no_parent", resource_type="data_category"
-    )
-    assert server_orphaned_category_no_parent
+    assert server_orphaned_category, server_orphaned_category
     print("> Verified Data Categories.")
 
     # Verify Privacy Notices

--- a/src/fides/api/alembic/migrations/versions/1ea164cee8bc_fideslang_2_data_migrations.py
+++ b/src/fides/api/alembic/migrations/versions/1ea164cee8bc_fideslang_2_data_migrations.py
@@ -72,7 +72,7 @@ def _replace_matching_data_label(
     Helper function to do string replacement for updated fides_keys.
     """
     for old, new in data_label_map.items():
-        if data_label.startswith(old):
+        if data_label and data_label.startswith(old):
             return data_label.replace(old, new)
 
     return data_label


### PR DESCRIPTION
Closes n/a

### Description Of Changes

Our fideslang 2.0 migration was failing to run on a deployed env seemingly because there are custom data uses that do not have a parent, i.e. top-level custom taxonomy elements. This is a valid server/data state. See stack trace from the failed migration below.

This fix makes the string replacement that was choking more defensive.

### Code Changes

* [x] check that value to replace is not `None` (more precisely that it's truthy)

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
