### PR TITLE
Notice toggle error toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.20.0...main)
 
-### Fixed
-- Enable toggles in various tables now render an error toast if an error occurs [#4095](https://github.com/ethyca/fides/pull/4095)
-
 ## [2.20.0](https://github.com/ethyca/fides/compare/2.19.1...2.20.0)
 
 ### Added
@@ -42,6 +39,7 @@ The types of changes are:
 
 - Ensures that fides.js toggles are not hidden by other CSS libs [#4075](https://github.com/ethyca/fides/pull/4075)
 - Migrate system > meta > vendor > id to system > meta [#4088](https://github.com/ethyca/fides/pull/4088)
+- Enable toggles in various tables now render an error toast if an error occurs [#4095](https://github.com/ethyca/fides/pull/4095)
 
 ## [2.19.1](https://github.com/ethyca/fides/compare/2.19.0...2.19.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.20.0...main)
 
+### Fixed
+- Enable toggles in various tables now render an error toast if an error occurs [#4095](https://github.com/ethyca/fides/pull/4095)
+
 ## [2.20.0](https://github.com/ethyca/fides/compare/2.19.1...2.20.0)
 
 ### Added

--- a/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
@@ -184,6 +184,22 @@ describe("Privacy notices", () => {
           cy.getByTestId("status-badge").contains("inactive");
         });
       });
+
+      it("can show an error if disable toggle fails", () => {
+        cy.intercept("PATCH", "/api/v1/privacy-notice*", {
+          statusCode: 422,
+          body: {
+            detail:
+              "Privacy Notice 'Analytics test' has already assigned notice key 'analytics' to region 'PrivacyNoticeRegion.ie'",
+          },
+        }).as("patchNoticesError");
+        cy.getByTestId("row-Data Sales").within(() => {
+          cy.getByTestId("toggle-Enable").click();
+        });
+        cy.wait("@patchNoticesError").then(() => {
+          cy.getByTestId("toast-error-msg");
+        });
+      });
     });
   });
 

--- a/clients/admin-ui/src/features/common/table/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/cells.tsx
@@ -6,6 +6,7 @@ import {
   Tag,
   Text,
   useDisclosure,
+  useToast,
   WarningIcon,
 } from "@fidesui/react";
 import ConfirmationModal from "common/ConfirmationModal";
@@ -13,6 +14,10 @@ import React, { ChangeEvent } from "react";
 import { CellProps } from "react-table";
 
 import ClipboardButton from "~/features/common/ClipboardButton";
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
+import { RTKResult } from "~/types/errors";
+
+import { errorToastParams } from "../toast";
 
 export const TitleCell = <T extends object>({
   value,
@@ -91,7 +96,7 @@ export const MultiTagCell = <T extends object>({
 };
 
 type EnableCellProps<T extends object> = CellProps<T, boolean> & {
-  onToggle: (data: boolean) => Promise<any>;
+  onToggle: (data: boolean) => Promise<RTKResult>;
   title: string;
   message: string;
   /**
@@ -110,8 +115,12 @@ export const EnableCell = <T extends object>({
   isDisabled,
 }: EnableCellProps<T>) => {
   const modal = useDisclosure();
+  const toast = useToast();
   const handlePatch = async ({ enable }: { enable: boolean }) => {
-    await onToggle(enable);
+    const result = await onToggle(enable);
+    if (isErrorResult(result)) {
+      toast(errorToastParams(getErrorMessage(result.error)));
+    }
   };
 
   const handleToggle = async (event: ChangeEvent<HTMLInputElement>) => {

--- a/clients/admin-ui/src/features/custom-fields/cells.tsx
+++ b/clients/admin-ui/src/features/custom-fields/cells.tsx
@@ -66,12 +66,11 @@ export const EnableCustomFieldCell = (
     useUpdateCustomFieldDefinitionMutation();
   const { row } = cellProps;
 
-  const onToggle = async (toggle: boolean) => {
-    await updateCustomFieldDefinitionTrigger({
+  const onToggle = async (toggle: boolean) =>
+    updateCustomFieldDefinitionTrigger({
       ...row.original,
       active: toggle,
     });
-  };
 
   return (
     <EnableCell<CustomFieldDefinition>

--- a/clients/admin-ui/src/features/privacy-experience/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/cells.tsx
@@ -37,12 +37,11 @@ export const EnablePrivacyExperienceCell = (
   const [patchExperienceMutationTrigger] = usePatchExperienceConfigMutation();
 
   const { row } = cellProps;
-  const onToggle = async (toggle: boolean) => {
-    await patchExperienceMutationTrigger({
+  const onToggle = async (toggle: boolean) =>
+    patchExperienceMutationTrigger({
       id: row.original.id,
       disabled: !toggle,
     });
-  };
 
   const { regions } = row.original;
   const multipleRegions = regions ? regions.length > 1 : false;

--- a/clients/admin-ui/src/features/privacy-notices/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/cells.tsx
@@ -67,14 +67,13 @@ export const EnablePrivacyNoticeCell = (
   const [patchNoticeMutationTrigger] = usePatchPrivacyNoticesMutation();
 
   const { row } = cellProps;
-  const onToggle = async (toggle: boolean) => {
-    await patchNoticeMutationTrigger([
+  const onToggle = async (toggle: boolean) =>
+    patchNoticeMutationTrigger([
       {
         id: row.original.id,
         disabled: !toggle,
       },
     ]);
-  };
 
   const { systems_applicable: systemsApplicable, disabled: noticeIsDisabled } =
     row.original;

--- a/clients/admin-ui/src/features/privacy-notices/form.ts
+++ b/clients/admin-ui/src/features/privacy-notices/form.ts
@@ -7,7 +7,11 @@ import {
   PrivacyNoticeResponse,
 } from "~/types/api";
 
-export const defaultInitialValues: PrivacyNoticeCreation = {
+interface PrivacyNoticeUpdateOrCreate extends PrivacyNoticeCreation {
+  id?: string;
+}
+
+export const defaultInitialValues: PrivacyNoticeUpdateOrCreate = {
   name: "",
   regions: [],
   consent_mechanism: ConsentMechanism.OPT_IN,
@@ -21,27 +25,25 @@ export const defaultInitialValues: PrivacyNoticeCreation = {
 
 export const transformPrivacyNoticeResponseToCreation = (
   notice: PrivacyNoticeResponse
-): PrivacyNoticeCreation => {
-  // Remove the fields not needed for editing/creation
-  const {
-    created_at: createdAt,
-    updated_at: updatedAt,
-    privacy_notice_history_id: historyId,
-    version,
-    cookies,
-    ...rest
-  } = notice;
-  return {
-    ...rest,
-    name: notice.name ?? defaultInitialValues.name,
-    regions: notice.regions ?? defaultInitialValues.regions,
-    consent_mechanism:
-      notice.consent_mechanism ?? defaultInitialValues.consent_mechanism,
-    data_uses: notice.data_uses ?? defaultInitialValues.data_uses,
-    enforcement_level:
-      notice.enforcement_level ?? defaultInitialValues.enforcement_level,
-  };
-};
+): PrivacyNoticeUpdateOrCreate => ({
+  name: notice.name ?? defaultInitialValues.name,
+  regions: notice.regions ?? defaultInitialValues.regions,
+  consent_mechanism:
+    notice.consent_mechanism ?? defaultInitialValues.consent_mechanism,
+  data_uses: notice.data_uses ?? defaultInitialValues.data_uses,
+  enforcement_level:
+    notice.enforcement_level ?? defaultInitialValues.enforcement_level,
+  displayed_in_api: notice.displayed_in_api,
+  displayed_in_overlay: notice.displayed_in_overlay,
+  displayed_in_privacy_center: notice.displayed_in_privacy_center,
+  notice_key: notice.notice_key,
+  description: notice.description,
+  disabled: notice.disabled,
+  has_gpc_flag: notice.has_gpc_flag,
+  id: notice.id,
+  internal_description: notice.internal_description,
+  origin: notice.origin,
+});
 
 export const ValidationSchema = Yup.object().shape({
   name: Yup.string().required().label("Title"),


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4092

### Description Of Changes

![image](https://github.com/ethyca/fides/assets/24641006/deeadfc7-cfbc-4778-8a50-c35f88005a04)

New error toast for if an error comes up while enabling/disabling a privacy notice. Since this is a shared component, privacy experiences and custom fields also get the same upgrade!


### Code Changes

* [x] Inspect the result of the PATCH for errors, and render a toast if needed
* [x] Cypress test

### Steps to Confirm

* See steps in the issue

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
