### PR TITLE
consider rc tags as latest release when generating beta tags

### DIFF
--- a/noxfiles/git_nox.py
+++ b/noxfiles/git_nox.py
@@ -4,12 +4,14 @@ import re
 from enum import Enum
 from typing import List, Optional
 
-import nox
 from packaging.version import Version
+
+import nox
 
 RELEASE_BRANCH_REGEX = r"release-(([0-9]+\.)+[0-9]+)"
 RELEASE_TAG_REGEX = r"(([0-9]+\.)+[0-9]+)"
 VERSION_TAG_REGEX = r"{version}{tag_type}([0-9]+)"
+RC_TAG_REGEX = r"(([0-9]+\.)+[0-9]+)rc([0-9]+)"
 GENERIC_TAG_REGEX = r"{tag_type}([0-9]+)$"
 
 INITIAL_TAG_INCREMENT = 0
@@ -104,8 +106,13 @@ def tag(session: nox.Session, action: str) -> None:
         session.error(f"Invalid action: {action}")
 
 
-def next_release_increment(session: nox.Session, all_tags: List) -> Version:
-    """Helper to generate the next release 'increment' based on latest release tag found"""
+def next_release_increment(
+    session: nox.Session, all_tags: List, treat_rc_as_release: bool = False
+) -> Version:
+    """Helper to generate the next release 'increment' based on latest release tag found
+
+    If `treat_rc_as_release` is `True`, also treat `rc` tags as releases
+    """
 
     releases = sorted(  # sorted by Version - what we want!
         (
@@ -115,9 +122,23 @@ def next_release_increment(session: nox.Session, all_tags: List) -> Version:
         ),
         reverse=True,
     )
-    latest_release = releases[0]
+    latest_release = releases[0] if releases else None
     if not latest_release:  # this would be bad...
         session.error("Could not identify the latest release!")
+
+    if treat_rc_as_release:
+        rc_releases = sorted(  # sorted by Version - what we want!
+            (
+                Version(tag.name)
+                for tag in all_tags
+                if re.fullmatch(RC_TAG_REGEX, tag.name)
+            ),
+            reverse=True,
+        )
+        latest_rc_release = rc_releases[0] if rc_releases else None
+        if latest_rc_release and latest_rc_release > latest_release:
+            latest_release = latest_rc_release
+
     return Version(
         f"{latest_release.major}.{latest_release.minor}.{latest_release.micro + 1}"
     )
@@ -192,14 +213,18 @@ def generate_tag(session: nox.Session, branch_name: str, all_tags: List) -> str:
             session, all_tags, release_branch_match.group(1), TagType.RC
         )
 
-    next_release = next_release_increment(session, all_tags)
-
     if branch_name == "main":  # main
+        # we consider `rc` tags as releases when generating beta tags while on `main``
+        # this keeps our tags based off `main` _ahead_ of our `rc` tags
+        next_release = next_release_increment(
+            session, all_tags, treat_rc_as_release=True
+        )
         session.log(
             f"Current branch '{branch_name}' matched main branch. Generating a new {TagType.BETA.name.lower()} tag"
         )
         return increment_tag(session, all_tags, next_release, TagType.BETA)
 
+    next_release = next_release_increment(session, all_tags)
     # feature branch, if we've made it here
     if "release" in branch_name:
         session.warn(

--- a/noxfiles/test_git_nox.py
+++ b/noxfiles/test_git_nox.py
@@ -34,6 +34,26 @@ class TestGitNox:
                 ["2.9.0", "2.10.0"],
                 "2.10.1b0",
             ),  # out of order releases with version >= 10 to ensure numerical sort
+            (
+                "main",
+                ["2.18.0", "2.17.0rc1", "2.19.1rc0", "2.19.0rc0"],
+                "2.19.2b0",
+            ),  # beta tags should be an increment ahead of rc tag version, if it is ahead of our newest release
+            (
+                "main",
+                ["2.18.0", "2.17.0rc1", "2.16.0rc0"],
+                "2.18.1b0",
+            ),  # beta tags should ignore rc tags if they are not ahead of latest release
+            (
+                "main",
+                ["2.9.0", "2.17.0rc1", "2.16.0rc0"],
+                "2.17.1b0",
+            ),  # ensure rc version check is robust with numerical sort
+            (
+                "some-test-feature-branch",
+                ["2.18.0", "2.17.0rc1", "2.19.0rc0"],
+                "2.18.1a0",
+            ),  # alpha tags should ignore rc tags when determining next increment
             ("some-test-feature-branch", ["2.9.1"], "2.9.2a0"),
             ("some-test-feature-branch", ["2.9.1", "2.9.0"], "2.9.2a0"),
             (

--- a/noxfiles/test_git_nox.py
+++ b/noxfiles/test_git_nox.py
@@ -50,6 +50,11 @@ class TestGitNox:
                 "2.17.1b0",
             ),  # ensure rc version check is robust with numerical sort
             (
+                "main",
+                ["2.9.0", "2.19.1rc0", "2.19.2b1", "2.16.0rc0"],
+                "2.19.2b2",
+            ),  # ensure we still increment well when using rc version check
+            (
                 "some-test-feature-branch",
                 ["2.18.0", "2.17.0rc1", "2.19.0rc0"],
                 "2.18.1a0",


### PR DESCRIPTION
Closes n/a

### Description Of Changes

A slight change to our tagging utility so that it takes into account existing `rc` tags when generating a `beta` tag on `main`.  So if we are in _the process_ of releasing e.g. `2.20.0` and therefore have `2.20.0rc0` but _not_ an official `2.20.0` tag, when we run `nox -s tag` on `main` it will generate `2.20.1b0` as the tag.

This makes it easy for us to ensure our packages built from the latest of `main` will always be _ahead_ of our published `rc` packages, which is important in keeping the `double-edge-slim` images (and therefore our `plus-nightly` environment!) based off of `main` of both repos.

As part of this, we'll also want to tweak our release process to generate a tag on `main` as soon as we cut release branches (i.e. beginning of the release process), rather than after we publish the release as we do now. 

The primary motivation here was to avoid `plus-nightly` from accidentally pulling in the `rc` versions of OSS `fides` during the release process, which has been happening and causing some confusion and unpredictability.

### Code Changes

* [x] when generating a `beta` tag (i.e. when on `main`) and determining the next release version increment, check for `rc` tags and evaluate their "release version", and compare it against the latest _official_ "release version" tag

### Steps to Confirm

* [ ] automated test coverage is solid here, otherwise we'll need to wait till the next release process to test live 👍 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
