### PR TITLE
Fixing migration and index name

### DIFF
--- a/src/fides/api/alembic/migrations/versions/52b2cfd1af47_fix_messaging_template_indexes.py
+++ b/src/fides/api/alembic/migrations/versions/52b2cfd1af47_fix_messaging_template_indexes.py
@@ -1,0 +1,38 @@
+"""fix message template indexes
+
+Revision ID: 52b2cfd1af47
+Revises: f17f92237383
+Create Date: 2023-09-15 21:29:23.060892
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "52b2cfd1af47"
+down_revision = "f17f92237383"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index("ix_messagingtemplate_id", table_name="messaging_template")
+    op.drop_index("ix_messagingtemplate_key", table_name="messaging_template")
+    op.create_index(
+        op.f("ix_messaging_template_id"), "messaging_template", ["id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_messaging_template_key"), "messaging_template", ["key"], unique=True
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_messaging_template_key"), table_name="messaging_template")
+    op.drop_index(op.f("ix_messaging_template_id"), table_name="messaging_template")
+    op.create_index(
+        "ix_messagingtemplate_key", "messaging_template", ["key"], unique=False
+    )
+    op.create_index(
+        "ix_messagingtemplate_id", "messaging_template", ["id"], unique=False
+    )

--- a/src/fides/api/models/system_history.py
+++ b/src/fides/api/models/system_history.py
@@ -28,7 +28,9 @@ class SystemHistory(Base):
     after = Column(MutableDict.as_mutable(JSONB), nullable=False)
 
     __table_args__ = (
-        Index("idx_system_history_created_at_system_id", "created_at", "system_id"),
+        Index(
+            "idx_plus_system_history_created_at_system_id", "created_at", "system_id"
+        ),
     )
 
     @property


### PR DESCRIPTION
Closes #4105

### Description Of Changes

The `alembic revision --autogenerate` command was generating for some tables added in previous tickets. This was due to naming mismatches in the classes or in the migrations themselves.

### Code Changes

* [ ] Updating index name for `plus_system_history` table
* [ ] Adding migration to fix incorrect index names for the `messaging_template` table

### Steps to Confirm

```
nox -s shell
cd src/fides/api/alembic/
alembic revision --autogenerate -m "check check"
```
Open the generated file and verify there are no mentions of `plus_system_history` or `plus_system_history`
```
def upgrade():
    # ### commands auto generated by Alembic - please adjust! ###
    pass
    # ### end Alembic commands ###


def downgrade():
    # ### commands auto generated by Alembic - please adjust! ###
    pass
    # ### end Alembic commands ###
```

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
