### PR TITLE
Allows CDN to cache empty experiences responses from fides.js API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The types of changes are:
 ### Changed
 - Added further config options to customize the privacy center [#4090](https://github.com/ethyca/fides/pull/4090)
 
+### Fixed
+- Allows CDN to cache empty experience responses from fides.js API  [#4113](https://github.com/ethyca/fides/pull/4113)
+
 ## [2.20.0](https://github.com/ethyca/fides/compare/2.19.1...2.20.0)
 
 ### Added

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -72,10 +72,11 @@ import {
 import {
   constructFidesRegionString,
   debugLog,
-  experienceIsValidAndHasNotices,
+  experienceIsValid,
   experienceHasNotices,
   transformConsentToFidesUserPreference,
   validateOptions,
+  isEmptyExperience,
 } from "./lib/consent-utils";
 import { dispatchFidesEvent } from "./lib/events";
 import { fetchExperience } from "./services/fides/api";
@@ -217,7 +218,7 @@ const init = async ({
     _Fides.geolocation = geolocation;
     _Fides.options = options;
     _Fides.initialized = true;
-    if (experienceHasNotices(experience)) {
+    if (experience && !isEmptyExperience(experience)) {
       // at this point, pre-fetched experience contains no user consent, so we populate with the Fides cookie
       updateExperienceFromCookieConsent(
         experience as PrivacyExperience,
@@ -254,7 +255,7 @@ const init = async ({
         `User location could not be obtained. Skipping overlay initialization.`
       );
       shouldInitOverlay = false;
-    } else if (!experienceHasNotices(experience)) {
+    } else if (!experience || isEmptyExperience(experience)) {
       effectiveExperience = await fetchExperience(
         fidesRegionString,
         options.fidesApiUrl,
@@ -263,7 +264,7 @@ const init = async ({
       );
     }
 
-    if (experienceIsValidAndHasNotices(effectiveExperience, options)) {
+    if (experienceIsValid(effectiveExperience, options)) {
       // Overwrite cookie consent with experience-based consent values
       cookie.consent = buildCookieConsentForExperiences(
         effectiveExperience as PrivacyExperience,

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -135,7 +135,7 @@ const automaticallyApplyGPCPreferences = (
   debug: boolean,
   effectiveExperience?: PrivacyExperience | null
 ) => {
-  if (!effectiveExperience ||!effectiveExperience.privacy_notices) {
+  if (!effectiveExperience || !effectiveExperience.privacy_notices) {
     return;
   }
 
@@ -218,7 +218,11 @@ const init = async ({
     _Fides.initialized = true;
     if (experience && Object.keys(experience).length >= 0) {
       // at this point, pre-fetched experience contains no user consent, so we populate with the Fides cookie
-      updateExperienceFromCookieConsent(experience as PrivacyExperience, cookie, options.debug);
+      updateExperienceFromCookieConsent(
+        experience as PrivacyExperience,
+        cookie,
+        options.debug
+      );
     }
     dispatchFidesEvent("FidesInitialized", cookie, options.debug);
     dispatchFidesEvent("FidesUpdated", cookie, options.debug);
@@ -259,7 +263,8 @@ const init = async ({
     }
 
     if (
-      effectiveExperience && Object.keys(effectiveExperience).length >= 0 &&
+      effectiveExperience &&
+      Object.keys(effectiveExperience).length >= 0 &&
       experienceIsValid(effectiveExperience as PrivacyExperience, options)
     ) {
       // Overwrite cookie consent with experience-based consent values
@@ -282,11 +287,11 @@ const init = async ({
   if (shouldInitOverlay) {
     if (effectiveExperience && Object.keys(effectiveExperience).length >= 0) {
       automaticallyApplyGPCPreferences(
-          cookie,
-          fidesRegionString,
-          options.fidesApiUrl,
-          options.debug,
-          effectiveExperience as PrivacyExperience
+        cookie,
+        fidesRegionString,
+        options.fidesApiUrl,
+        options.debug,
+        effectiveExperience as PrivacyExperience
       );
     }
   }

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -68,6 +68,7 @@ import {
   ConsentMethod,
   SaveConsentPreference,
   ConsentMechanism,
+  EmptyExperience,
 } from "./lib/consent-types";
 import {
   constructFidesRegionString,
@@ -231,7 +232,8 @@ const init = async ({
   }
 
   let shouldInitOverlay: boolean = options.isOverlayEnabled;
-  let effectiveExperience: PrivacyExperience | undefined | {} = experience;
+  let effectiveExperience: PrivacyExperience | undefined | EmptyExperience =
+    experience;
   let fidesRegionString: string | null = null;
 
   if (shouldInitOverlay) {

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -1,4 +1,4 @@
-export type EmptyExperience = {};
+export type EmptyExperience = Record<PropertyKey, never>;
 
 export interface FidesConfig {
   // Set the consent defaults from a "legacy" Privacy Center config.json.

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -1,10 +1,12 @@
+export type EmptyExperience = {};
+
 export interface FidesConfig {
   // Set the consent defaults from a "legacy" Privacy Center config.json.
   consent?: LegacyConsentConfig;
   // Set the "experience" to be used for this Fides.js instance -- overrides the "legacy" config.
   // If set, Fides.js will fetch neither experience config nor user geolocation.
   // If not set or is empty, Fides.js will attempt to fetch its own experience config.
-  experience?: PrivacyExperience | {};
+  experience?: PrivacyExperience | EmptyExperience;
   // Set the geolocation for this Fides.js instance. If *not* set, Fides.js will fetch its own geolocation.
   geolocation?: UserGeolocation;
   // Global options for this Fides.js instance. Fides provides defaults for all props except privacyCenterUrl

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -3,8 +3,8 @@ export interface FidesConfig {
   consent?: LegacyConsentConfig;
   // Set the "experience" to be used for this Fides.js instance -- overrides the "legacy" config.
   // If set, Fides.js will fetch neither experience config nor user geolocation.
-  // If not set, Fides.js will fetch its own experience config.
-  experience?: PrivacyExperience;
+  // If not set or is empty, Fides.js will attempt to fetch its own experience config.
+  experience?: PrivacyExperience | {};
   // Set the geolocation for this Fides.js instance. If *not* set, Fides.js will fetch its own geolocation.
   geolocation?: UserGeolocation;
   // Global options for this Fides.js instance. Fides provides defaults for all props except privacyCenterUrl

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -37,12 +37,11 @@ export const isEmptyExperience = (obj: unknown): obj is EmptyExperience =>
  * Returns true if privacy experience has notices
  */
 export const experienceHasNotices = (
-  experience: PrivacyExperience | undefined | {}
+  experience: PrivacyExperience | undefined | EmptyExperience
 ): boolean =>
   Boolean(
     experience &&
       !isEmptyExperience(experience) &&
-      // fixme: how to tell ts that privacy_notices exists on experience?
       experience.privacy_notices &&
       experience.privacy_notices.length > 0
   );
@@ -161,17 +160,16 @@ export const validateOptions = (options: FidesOptions): boolean => {
  * Determines whether experience is valid and relevant notices exist within the experience
  */
 export const experienceIsValid = (
-  effectiveExperience: PrivacyExperience | undefined | {},
+  effectiveExperience: PrivacyExperience | undefined | EmptyExperience,
   options: FidesOptions
 ): boolean => {
-  if (!experienceHasNotices(effectiveExperience)) {
+  if (!effectiveExperience || !experienceHasNotices(effectiveExperience)) {
     debugLog(
       options.debug,
       `Privacy experience has no notices. Skipping overlay initialization.`
     );
     return false;
   }
-  // @ts-ignore
   if (effectiveExperience.component !== ComponentType.OVERLAY) {
     debugLog(
       options.debug,
@@ -179,7 +177,6 @@ export const experienceIsValid = (
     );
     return false;
   }
-  // @ts-ignore
   if (!effectiveExperience.experience_config) {
     debugLog(
       options.debug,

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -27,6 +27,22 @@ export const debugLog = (
 };
 
 /**
+ * Returns true if privacy experience has notices
+ */
+export const experienceHasNotices = (
+  experience: PrivacyExperience | undefined | {}
+): boolean => {
+  if (experience && Object.keys(experience).length >= 0) {
+    const privacyExperience = experience as PrivacyExperience;
+    return Boolean(
+      privacyExperience.privacy_notices &&
+        privacyExperience.privacy_notices.length > 0
+    );
+  }
+  return false;
+};
+
+/**
  * Construct user location str to be ingested by Fides API
  * Returns null if geolocation cannot be constructed by provided params, e.g. us_ca
  */
@@ -139,30 +155,18 @@ export const validateOptions = (options: FidesOptions): boolean => {
 /**
  * Determines whether experience is valid and relevant notices exist within the experience
  */
-export const experienceIsValid = (
-  effectiveExperience: PrivacyExperience | undefined,
+export const experienceIsValidAndHasNotices = (
+  effectiveExperience: PrivacyExperience | undefined | {},
   options: FidesOptions
 ): boolean => {
-  if (!effectiveExperience) {
+  if (!experienceHasNotices(effectiveExperience)) {
     debugLog(
       options.debug,
-      `No relevant experience found. Skipping overlay initialization.`
+      `Privacy experience has no notices. Skipping overlay initialization.`
     );
     return false;
   }
-  if (
-    !(
-      effectiveExperience.privacy_notices &&
-      effectiveExperience.privacy_notices.length > 0
-    )
-  ) {
-    debugLog(
-      options.debug,
-      `No relevant notices in the privacy experience. Skipping overlay initialization.`,
-      effectiveExperience
-    );
-    return false;
-  }
+  // @ts-ignore
   if (effectiveExperience.component !== ComponentType.OVERLAY) {
     debugLog(
       options.debug,
@@ -170,6 +174,7 @@ export const experienceIsValid = (
     );
     return false;
   }
+  // @ts-ignore
   if (!effectiveExperience.experience_config) {
     debugLog(
       options.debug,

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -30,21 +30,31 @@ export const debugLog = (
 /**
  * Returns true if privacy experience is null or empty
  */
-export const isEmptyExperience = (obj: unknown): obj is EmptyExperience =>
-  typeof obj === "object" && obj != null && Object.keys(obj).length === 0;
+export const isPrivacyExperience = (
+  obj: PrivacyExperience | undefined | EmptyExperience
+): obj is PrivacyExperience => {
+  if (!obj) {
+    return false;
+  }
+  if ("id" in obj) {
+    return true;
+  }
+  return false;
+};
+// typeof obj === "object" && obj != null && Object.keys(obj).length === 0;
 
-/**
- * Returns true if privacy experience has notices
- */
-export const experienceHasNotices = (
-  experience: PrivacyExperience | undefined | EmptyExperience
-): boolean =>
-  Boolean(
-    experience &&
-      !isEmptyExperience(experience) &&
-      experience.privacy_notices &&
-      experience.privacy_notices.length > 0
-  );
+// /**
+//  * Returns true if privacy experience has notices
+//  */
+// export const experienceHasNotices = (
+//   experience: PrivacyExperience | undefined | EmptyExperience
+// ): boolean =>
+//   Boolean(
+//     experience &&
+//       !isEmptyExperience(experience) &&
+//       experience.privacy_notices &&
+//       experience.privacy_notices.length > 0
+//   );
 
 /**
  * Construct user location str to be ingested by Fides API
@@ -163,7 +173,19 @@ export const experienceIsValid = (
   effectiveExperience: PrivacyExperience | undefined | EmptyExperience,
   options: FidesOptions
 ): boolean => {
-  if (!effectiveExperience || !experienceHasNotices(effectiveExperience)) {
+  if (!isPrivacyExperience(effectiveExperience)) {
+    debugLog(
+      options.debug,
+      "No relevant experience found. Skipping overlay initialization."
+    );
+    return false;
+  }
+  if (
+    !(
+      effectiveExperience.privacy_notices &&
+      effectiveExperience.privacy_notices.length > 0
+    )
+  ) {
     debugLog(
       options.debug,
       `Privacy experience has no notices. Skipping overlay initialization.`

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -140,7 +140,7 @@ export const validateOptions = (options: FidesOptions): boolean => {
  * Determines whether experience is valid and relevant notices exist within the experience
  */
 export const experienceIsValid = (
-  effectiveExperience: PrivacyExperience | undefined | null,
+  effectiveExperience: PrivacyExperience | undefined,
   options: FidesOptions
 ): boolean => {
   if (!effectiveExperience) {

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -2,6 +2,7 @@ import { ConsentContext } from "./consent-context";
 import {
   ComponentType,
   ConsentMechanism,
+  EmptyExperience,
   FidesOptions,
   GpcStatus,
   PrivacyExperience,
@@ -27,20 +28,24 @@ export const debugLog = (
 };
 
 /**
+ * Returns true if privacy experience is null or empty
+ */
+export const isEmptyExperience = (obj: unknown): obj is EmptyExperience =>
+  typeof obj === "object" && obj != null && Object.keys(obj).length === 0;
+
+/**
  * Returns true if privacy experience has notices
  */
 export const experienceHasNotices = (
   experience: PrivacyExperience | undefined | {}
-): boolean => {
-  if (experience && Object.keys(experience).length >= 0) {
-    const privacyExperience = experience as PrivacyExperience;
-    return Boolean(
-      privacyExperience.privacy_notices &&
-        privacyExperience.privacy_notices.length > 0
-    );
-  }
-  return false;
-};
+): boolean =>
+  Boolean(
+    experience &&
+      !isEmptyExperience(experience) &&
+      // fixme: how to tell ts that privacy_notices exists on experience?
+      experience.privacy_notices &&
+      experience.privacy_notices.length > 0
+  );
 
 /**
  * Construct user location str to be ingested by Fides API
@@ -155,7 +160,7 @@ export const validateOptions = (options: FidesOptions): boolean => {
 /**
  * Determines whether experience is valid and relevant notices exist within the experience
  */
-export const experienceIsValidAndHasNotices = (
+export const experienceIsValid = (
   effectiveExperience: PrivacyExperience | undefined | {},
   options: FidesOptions
 ): boolean => {

--- a/clients/fides-js/src/services/fides/api.ts
+++ b/clients/fides-js/src/services/fides/api.ts
@@ -22,7 +22,7 @@ export const fetchExperience = async (
   fidesApiUrl: string,
   debug: boolean,
   fidesUserDeviceId?: string | null
-): Promise<PrivacyExperience | null> => {
+): Promise<PrivacyExperience | {}> => {
   debugLog(
     debug,
     `Fetching experience for userId: ${fidesUserDeviceId} in location: ${userLocationString}`
@@ -51,25 +51,19 @@ export const fetchExperience = async (
   if (!response.ok) {
     debugLog(
       debug,
-      "Error getting experience from Fides API, returning null. Response:",
+      "Error getting experience from Fides API, returning {}. Response:",
       response
     );
-    return null;
+    return {};
   }
   try {
     const body = await response.json();
-    const experience = body.items && body.items[0];
-    if (!experience) {
-      debugLog(
-        debug,
-        "No relevant experience found from Fides API, returning null. Response:",
-        body
-      );
-      return null;
-    }
+    // returning empty obj instead of undefined ensures we can properly cache on server-side for locations
+    // that have no relevant experiences
+    const experience = (body.items && body.items[0]) ?? {};
     debugLog(
       debug,
-      "Got experience response from Fides API, returning:",
+      "Got experience response from Fides API, returning: ",
       experience
     );
     return experience;
@@ -79,7 +73,7 @@ export const fetchExperience = async (
       "Error parsing experience response body from Fides API, returning {}. Response:",
       response
     );
-    return null;
+    return {};
   }
 };
 

--- a/clients/fides-js/src/services/fides/api.ts
+++ b/clients/fides-js/src/services/fides/api.ts
@@ -1,5 +1,6 @@
 import {
   ComponentType,
+  EmptyExperience,
   LastServedNoticeSchema,
   NoticesServedRequest,
   PrivacyExperience,
@@ -22,7 +23,7 @@ export const fetchExperience = async (
   fidesApiUrl: string,
   debug: boolean,
   fidesUserDeviceId?: string | null
-): Promise<PrivacyExperience | {}> => {
+): Promise<PrivacyExperience | EmptyExperience> => {
   debugLog(
     debug,
     `Fetching experience for userId: ${fidesUserDeviceId} in location: ${userLocationString}`

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -48,7 +48,7 @@ const stubConfig = (
           : Object.assign(config.consent, consent),
       experience:
         experience === OVERRIDE.EMPTY
-          ? undefined
+          ? {}
           : Object.assign(config.experience, experience),
       geolocation:
         geolocation === OVERRIDE.EMPTY


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4108

### Description Of Changes

Updates experience API to return empty obj instead of undefined when no experience was found for a specific location. This allows cache to work properly under this scenario, meaning that requests to the server will decrease overall.


### Code Changes

* [ ] Return empty obj for fides.js experience API when no experience was found
* [ ] Update e2e tests

### Steps to Confirm

* [ ] Use a prefetch enabled privacy center and fides.js via the CDN. Ensure that debug mode is on.
* [ ] Ensure the location you are in does not have a valid privacy notice
* [ ] Go to the URL where fides.js is installed (i.e. Cookie House) and inspect the console
* [ ] View the line that starts with `Got experience response from Fides API, returning:` and see that `{}` is returned instead of being undefined or null.
<img width="911" alt="Screenshot 2023-09-18 at 5 02 57 PM" src="https://github.com/ethyca/fides/assets/7697292/e004635e-9761-4ec7-92a9-7463516d7517">


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
