### PR TITLE
avoid n+1 queries on bulk `GET /system` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 
 ### Fixed
 - Allows CDN to cache empty experience responses from fides.js API  [#4113](https://github.com/ethyca/fides/pull/4113)
+- Avoid un-optimized query pattern in bulk `GET /system` endpoint [#4120](https://github.com/ethyca/fides/pull/4120)
 
 ## [2.20.0](https://github.com/ethyca/fides/compare/2.19.1...2.20.0)
 

--- a/src/fides/api/api/v1/endpoints/system.py
+++ b/src/fides/api/api/v1/endpoints/system.py
@@ -50,7 +50,7 @@ from fides.api.schemas.connection_configuration.connection_secrets import (
 from fides.api.schemas.connection_configuration.saas_config_template_values import (
     SaasConnectionTemplateValues,
 )
-from fides.api.schemas.system import SystemResponse
+from fides.api.schemas.system import BasicSystemResponse, SystemResponse
 from fides.api.util.api_router import APIRouter
 from fides.api.util.connection_util import (
     connection_status,
@@ -361,7 +361,7 @@ async def create(
             scopes=[SYSTEM_READ],
         )
     ],
-    response_model=List[SystemResponse],
+    response_model=List[BasicSystemResponse],
     name="List",
 )
 async def ls(  # pylint: disable=invalid-name

--- a/src/fides/api/schemas/system.py
+++ b/src/fides/api/schemas/system.py
@@ -20,9 +20,25 @@ class PrivacyDeclarationResponse(PrivacyDeclaration):
     cookies: Optional[List[Cookies]] = []
 
 
-class SystemResponse(System):
-    """Extension of base pydantic model to include additional fields like `privacy_declarations`, connection_config fields
-    and cookies in responses"""
+class BasicSystemResponse(System):
+    """
+    Extension of base pydantic model to include additional fields on the DB model that
+    are relevant in API responses.
+
+    This is still meant to be a "lightweight" model that does not reference relationships
+    that may require additional querying beyond the `System` db table.
+    """
+
+    created_at: datetime
+
+
+class SystemResponse(BasicSystemResponse):
+    """Extension of base pydantic response model to include additional relationship fields that
+    may require extra DB queries, like `privacy_declarations`, connection_config fields and cookies.
+
+    This response model is generally useful for an API that returns a detailed view of _single_
+    System record. Attempting to return bulk results with this model can lead to n+1 query issues.
+    """
 
     privacy_declarations: List[PrivacyDeclarationResponse] = Field(
         description=PrivacyDeclarationResponse.__doc__,
@@ -37,8 +53,6 @@ class SystemResponse(System):
     )
 
     cookies: Optional[List[Cookies]] = []
-
-    created_at: datetime
 
 
 class SystemHistoryResponse(BaseModel):


### PR DESCRIPTION
Closes #4028 

### Description Of Changes

Narrow down what we return on the bulk `GET /system` endpoint to not have relationship fields that can lead to n+1 query problems - in this case, it was specifically the `connection_configs` property/relationship. See issue for more context.

### Code Changes

* [ ] define a narrower `BasicSystemResponse` model without any relationship-backed fields, used for the bulk `GET` endpoint. 

### Steps to Confirm

* [ ] ran locally with `nox -s "fides_env(test)"` with 4 systems, i added an additional integration onto one of those systems (i think two systems come seeded with integrations already).
    * [ ] without the change, i was seeing the `GET /system` endpoint take ~1s to respond
    * [ ] with the change, that was down to <200ms
* [ ] confirmed that `connection_configs` was no longer being returned on the bulk `GET /system` endpoint response records
* [ ] confirmed that all admin UI around this still seemed to be functional 👍 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
