### PR TITLE
`PUT /config` endpoint for cors domain resetting

### DIFF
--- a/src/fides/api/api/v1/endpoints/config_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/config_endpoints.py
@@ -46,7 +46,7 @@ def get_config(
     response_model=ApplicationConfigSchema,
     response_model_exclude_unset=True,
 )
-def update_settings(
+def patch_settings(
     *,
     db: Session = Depends(deps.get_db),
     request: Request,
@@ -65,6 +65,32 @@ def update_settings(
 
     ConfigProxy(db).load_current_cors_domains_into_middleware(request.app)
 
+    return update_config.api_set
+
+
+@router.put(
+    urls.CONFIG,
+    status_code=HTTP_200_OK,
+    dependencies=[Security(verify_oauth_client, scopes=[scopes.CONFIG_UPDATE])],
+    response_model=ApplicationConfigSchema,
+    response_model_exclude_unset=True,
+)
+def put_settings(
+    *,
+    db: Session = Depends(deps.get_db),
+    data: ApplicationConfigSchema,
+) -> ApplicationConfigSchema:
+    """
+    Updates the global application settings record.
+
+    The record will look exactly as it is provided, i.e. true PUT behavior.
+    """
+    logger.info("Updating application settings")
+    update_config: ApplicationConfig = ApplicationConfig.update_api_set(
+        db,
+        data.dict(exclude_none=True),
+        merge_updates=False,
+    )
     return update_config.api_set
 
 

--- a/src/fides/api/models/application_config.py
+++ b/src/fides/api/models/application_config.py
@@ -57,7 +57,11 @@ class ApplicationConfig(Base):
 
     @classmethod
     def create_or_update(  # type: ignore[override]
-        cls, db: Session, *, data: Dict[str, Any]
+        cls,
+        db: Session,
+        *,
+        data: Dict[str, Any],
+        merge_updates: bool = True,
     ) -> ApplicationConfig:
         """
         Creates the config record if none exists, or updates the existing record.
@@ -66,12 +70,14 @@ class ApplicationConfig(Base):
         """
         existing_record = db.query(cls).first()
         if existing_record:
-            updated_record = existing_record.update(db=db, data=data)
+            updated_record = existing_record.update(
+                db=db, data=data, merge_updates=merge_updates
+            )
             return updated_record
 
         return cls.create(db=db, data=data)
 
-    def update(self, db: Session, data: Dict[str, Any]) -> ApplicationConfig:  # type: ignore[override]
+    def update(self, db: Session, data: Dict[str, Any], merge_updates: bool = True) -> ApplicationConfig:  # type: ignore[override]
         """
         Updates the config record, merging contents of the particular JSON column that
         corresponds to the updated data.
@@ -85,16 +91,23 @@ class ApplicationConfig(Base):
             if not isinstance(incoming_api_config, dict):
                 raise ValueError("`api_set` column must be a dictionary")
 
-            # update, i.e. merge, the `api_set` dict
-            self.api_set = deep_update(self.api_set, incoming_api_config)
+            if merge_updates:
+                # merge, the `api_set` dict
+                self.api_set = deep_update(self.api_set, incoming_api_config)
+            else:
+                # replace the `api_set` dict
+                self.api_set = incoming_api_config
 
         if "config_set" in data:
             incoming_config_config = data["config_set"]
             if not isinstance(incoming_config_config, dict):
                 raise ValueError("`config_set` column must be a dictionary")
 
-            # update, i.e. merge, the `config_set` dict
-            self.config_set = deep_update(self.config_set, incoming_config_config)
+            if merge_updates:
+                # update, i.e. merge, the `config_set` dict
+                self.config_set = deep_update(self.config_set, incoming_config_config)
+            else:
+                self.config_set = incoming_config_config
 
         self.save(db=db)
         return self
@@ -125,15 +138,22 @@ class ApplicationConfig(Base):
 
     @classmethod
     def update_api_set(
-        cls, db: Session, api_set_dict: Dict[str, Any]
+        cls,
+        db: Session,
+        api_set_dict: Dict[str, Any],
+        merge_updates: bool = True,
     ) -> ApplicationConfig:
         """
         Utility method to set the `api_set` column on the `applicationconfig`
         db record with the provided dictionary of data.
 
-        Updates are *merged* with any existing `api_set` data in the db.
+        Depending on `merge_updates` param, updates either:
+         - are *merged* with any existing `api_set` data in the db
+         - replace any existing `api_set` data in the db
         """
-        return cls.create_or_update(db, data={"api_set": api_set_dict})
+        return cls.create_or_update(
+            db, data={"api_set": api_set_dict}, merge_updates=merge_updates
+        )
 
     @classmethod
     def clear_api_set(cls, db: Session) -> Optional[ApplicationConfig]:

--- a/src/fides/api/schemas/application_config.py
+++ b/src/fides/api/schemas/application_config.py
@@ -68,8 +68,8 @@ class ExecutionApplicationConfig(FidesSchema):
 
 
 class SecurityApplicationConfig(FidesSchema):
-    cors_origins: List[AnyUrl] = Field(
-        default_factory=list,
+    cors_origins: Optional[List[AnyUrl]] = Field(
+        default=None,
         description="A list of client addresses allowed to communicate with the Fides webserver.",
     )
 


### PR DESCRIPTION
Closes n/a

### Description Of Changes

WIP for a `PUT /config` endpoint to help us with cors domain resetting

@TheAndrewJackson i still need to write in some tests and think about this a bit further, but on some initial testing i think this is good to get you an API to start working against?

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
