### PR TITLE
add version_added to TaxonomyEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The types of changes are:
 
 ### Fixed
 - Allows CDN to cache empty experience responses from fides.js API  [#4113](https://github.com/ethyca/fides/pull/4113)
-- added version_added,version_deprecated, and replaced_by to data use, data subject, and data category APIs [#4135](https://github.com/ethyca/fides/pull/4135)
+- added version_added, version_deprecated, and replaced_by to data use, data subject, and data category APIs [#4135](https://github.com/ethyca/fides/pull/4135)
 
 ## [2.20.1](https://github.com/ethyca/fides/compare/2.20.0...2.20.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The types of changes are:
 
 ### Fixed
 - Allows CDN to cache empty experience responses from fides.js API  [#4113](https://github.com/ethyca/fides/pull/4113)
-- added version_added to data use, data subject, and data category APIs [#4135](https://github.com/ethyca/fides/pull/4135)
+- added version_added,version_deprecated, and replaced_by to data use, data subject, and data category APIs [#4135](https://github.com/ethyca/fides/pull/4135)
 
 ## [2.20.1](https://github.com/ethyca/fides/compare/2.20.0...2.20.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The types of changes are:
 
 ### Fixed
 - Allows CDN to cache empty experience responses from fides.js API  [#4113](https://github.com/ethyca/fides/pull/4113)
+- added version_added to data use, data subject, and data category APIs [#4135](https://github.com/ethyca/fides/pull/4135)
 
 ## [2.20.1](https://github.com/ethyca/fides/compare/2.20.0...2.20.1)
 

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -78,8 +78,8 @@ describe("Taxonomy management page", () => {
           description: "description",
           parent_key: undefined,
           version_added: "2.0.0",
-          version_deprecated: "",
-          replaced_by: "",
+          version_deprecated: null,
+          replaced_by: null,
         },
       };
       cy.intercept("PUT", "/api/v1/data_category*", taxonomyPayload).as(
@@ -294,8 +294,8 @@ describe("Taxonomy management page", () => {
             strategy: "INCLUDE",
           },
           version_added: "2.0.0",
-          version_deprecated: "",
-          replaced_by: "",
+          version_deprecated: null,
+          replaced_by: null
         };
         expect(body).to.eql(expected);
       });

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -78,8 +78,6 @@ describe("Taxonomy management page", () => {
           description: "description",
           parent_key: undefined,
           version_added: "2.0.0",
-          version_deprecated: undefined,
-          replaced_by: undefined,
         },
       };
       cy.intercept("PUT", "/api/v1/data_category*", taxonomyPayload).as(
@@ -294,8 +292,6 @@ describe("Taxonomy management page", () => {
             strategy: "INCLUDE",
           },
           version_added: "2.0.0",
-          version_deprecated: undefined,
-          replaced_by: undefined,
         };
         expect(body).to.eql(expected);
       });

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -295,7 +295,7 @@ describe("Taxonomy management page", () => {
           },
           version_added: "2.0.0",
           version_deprecated: null,
-          replaced_by: null
+          replaced_by: null,
         };
         expect(body).to.eql(expected);
       });

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -77,6 +77,7 @@ describe("Taxonomy management page", () => {
           name: "name",
           description: "description",
           parent_key: undefined,
+          version_added: "2.0.0",
         },
       };
       cy.intercept("PUT", "/api/v1/data_category*", taxonomyPayload).as(
@@ -290,6 +291,7 @@ describe("Taxonomy management page", () => {
             values: rightValues,
             strategy: "INCLUDE",
           },
+          version_added: "2.0.0",
         };
         expect(body).to.eql(expected);
       });

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -78,6 +78,8 @@ describe("Taxonomy management page", () => {
           description: "description",
           parent_key: undefined,
           version_added: "2.0.0",
+          version_deprecated: "",
+          replaced_by: "",
         },
       };
       cy.intercept("PUT", "/api/v1/data_category*", taxonomyPayload).as(
@@ -292,6 +294,8 @@ describe("Taxonomy management page", () => {
             strategy: "INCLUDE",
           },
           version_added: "2.0.0",
+          version_deprecated: "",
+          replaced_by: "",
         };
         expect(body).to.eql(expected);
       });

--- a/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
+++ b/clients/admin-ui/cypress/e2e/taxonomy.cy.ts
@@ -78,8 +78,8 @@ describe("Taxonomy management page", () => {
           description: "description",
           parent_key: undefined,
           version_added: "2.0.0",
-          version_deprecated: null,
-          replaced_by: null,
+          version_deprecated: undefined,
+          replaced_by: undefined,
         },
       };
       cy.intercept("PUT", "/api/v1/data_category*", taxonomyPayload).as(
@@ -294,8 +294,8 @@ describe("Taxonomy management page", () => {
             strategy: "INCLUDE",
           },
           version_added: "2.0.0",
-          version_deprecated: null,
-          replaced_by: null,
+          version_deprecated: undefined,
+          replaced_by: undefined,
         };
         expect(body).to.eql(expected);
       });

--- a/clients/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/admin-ui/src/features/taxonomy/hooks.tsx
@@ -79,6 +79,8 @@ const transformTaxonomyBaseToInitialValues = (
   parent_key: t.parent_key ?? "",
   is_default: t.is_default ?? false,
   version_added: t.version_added ?? "",
+  version_deprecated: t.version_deprecated ?? "",
+  replaced_by: t.replaced_by ?? "",
   customFieldValues,
 });
 

--- a/clients/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/admin-ui/src/features/taxonomy/hooks.tsx
@@ -78,6 +78,7 @@ const transformTaxonomyBaseToInitialValues = (
   description: t.description ?? "",
   parent_key: t.parent_key ?? "",
   is_default: t.is_default ?? false,
+  version_added: t.version_added ?? "",
   customFieldValues,
 });
 

--- a/clients/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/admin-ui/src/features/taxonomy/hooks.tsx
@@ -78,9 +78,9 @@ const transformTaxonomyBaseToInitialValues = (
   description: t.description ?? "",
   parent_key: t.parent_key ?? "",
   is_default: t.is_default ?? false,
-  version_added: t.version_added ?? null,
-  version_deprecated: t.version_deprecated ?? null,
-  replaced_by: t.replaced_by ?? null,
+  version_added: t.version_added ?? undefined,
+  version_deprecated: t.version_deprecated ?? undefined,
+  replaced_by: t.replaced_by ?? undefined,
   customFieldValues,
 });
 

--- a/clients/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/admin-ui/src/features/taxonomy/hooks.tsx
@@ -78,9 +78,9 @@ const transformTaxonomyBaseToInitialValues = (
   description: t.description ?? "",
   parent_key: t.parent_key ?? "",
   is_default: t.is_default ?? false,
-  version_added: t.version_added ?? "",
-  version_deprecated: t.version_deprecated ?? "",
-  replaced_by: t.replaced_by ?? "",
+  version_added: t.version_added ?? null,
+  version_deprecated: t.version_deprecated ?? null,
+  replaced_by: t.replaced_by ?? null,
   customFieldValues,
 });
 
@@ -348,7 +348,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
         // @ts-ignore for the same reason as above
         entity.rights.length
           ? // @ts-ignore for the same reason as above
-            { values: entity.rights, strategy: entity.strategy }
+          { values: entity.rights, strategy: entity.strategy }
           : undefined,
       automatic_decisions_or_profiling: !!(
         entity.automated_decisions_or_profiling?.toString() === "true"

--- a/clients/admin-ui/src/features/taxonomy/hooks.tsx
+++ b/clients/admin-ui/src/features/taxonomy/hooks.tsx
@@ -348,7 +348,7 @@ export const useDataSubject = (): TaxonomyHookData<DataSubject> => {
         // @ts-ignore for the same reason as above
         entity.rights.length
           ? // @ts-ignore for the same reason as above
-          { values: entity.rights, strategy: entity.strategy }
+            { values: entity.rights, strategy: entity.strategy }
           : undefined,
       automatic_decisions_or_profiling: !!(
         entity.automated_decisions_or_profiling?.toString() === "true"

--- a/clients/admin-ui/src/features/taxonomy/types.ts
+++ b/clients/admin-ui/src/features/taxonomy/types.ts
@@ -16,6 +16,8 @@ export interface TaxonomyEntity {
   is_default?: boolean;
   active?: boolean;
   version_added?: string;
+  version_deprecated?: string;
+  replaced_by?: string;
 }
 
 export interface Labels {

--- a/clients/admin-ui/src/features/taxonomy/types.ts
+++ b/clients/admin-ui/src/features/taxonomy/types.ts
@@ -15,6 +15,7 @@ export interface TaxonomyEntity {
   parent_key?: string;
   is_default?: boolean;
   active?: boolean;
+  version_added?: string;
 }
 
 export interface Labels {

--- a/clients/admin-ui/src/types/api/models/DataCategory.ts
+++ b/clients/admin-ui/src/types/api/models/DataCategory.ts
@@ -32,4 +32,8 @@ export type DataCategory = {
    * Indicates whether the resource is currently 'active'.
    */
   active?: boolean;
+  /**
+   * This is for tracking when the daulft entity was added
+   */
+  version_added?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataCategory.ts
+++ b/clients/admin-ui/src/types/api/models/DataCategory.ts
@@ -39,9 +39,9 @@ export type DataCategory = {
   /**
    * This is for tracking when the default entity was deprecated
    */
-  version_deprecated?: string
+  version_deprecated?: string;
   /**
    * This is for tracking which default entity was used to replace this resource
-   */;
+   */
   replaced_by?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataCategory.ts
+++ b/clients/admin-ui/src/types/api/models/DataCategory.ts
@@ -33,7 +33,7 @@ export type DataCategory = {
    */
   active?: boolean;
   /**
-   * This is for tracking when the daulft entity was added
+   * This is for tracking when the default entity was added
    */
   version_added?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataCategory.ts
+++ b/clients/admin-ui/src/types/api/models/DataCategory.ts
@@ -36,4 +36,12 @@ export type DataCategory = {
    * This is for tracking when the default entity was added
    */
   version_added?: string;
+  /**
+   * This is for tracking when the default entity was deprecated
+   */
+  version_deprecated?: string
+  /**
+   * This is for tracking which default entity was used to replace this resource
+   */;
+  replaced_by?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataSubject.ts
+++ b/clients/admin-ui/src/types/api/models/DataSubject.ts
@@ -47,4 +47,8 @@ export type DataSubject = {
    * Indicates whether the resource is currently 'active'.
    */
   active?: boolean;
+  /**
+   * This is for tracking when the daulft entity was added
+   */
+  version_added?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataSubject.ts
+++ b/clients/admin-ui/src/types/api/models/DataSubject.ts
@@ -48,7 +48,7 @@ export type DataSubject = {
    */
   active?: boolean;
   /**
-   * This is for tracking when the daulft entity was added
+   * This is for tracking when the default entity was added
    */
   version_added?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataSubject.ts
+++ b/clients/admin-ui/src/types/api/models/DataSubject.ts
@@ -51,4 +51,12 @@ export type DataSubject = {
    * This is for tracking when the default entity was added
    */
   version_added?: string;
+  /**
+   * This is for tracking when the default entity was deprecated
+   */
+  version_deprecated?: string
+  /**
+   * This is for tracking which default entity was used to replace this resource
+   */;
+  replaced_by?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataSubject.ts
+++ b/clients/admin-ui/src/types/api/models/DataSubject.ts
@@ -54,9 +54,9 @@ export type DataSubject = {
   /**
    * This is for tracking when the default entity was deprecated
    */
-  version_deprecated?: string
+  version_deprecated?: string;
   /**
    * This is for tracking which default entity was used to replace this resource
-   */;
+   */
   replaced_by?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataUse.ts
+++ b/clients/admin-ui/src/types/api/models/DataUse.ts
@@ -55,4 +55,8 @@ export type DataUse = {
    * Indicates whether the resource is currently 'active'.
    */
   active?: boolean;
+  /**
+   * This is for tracking when the daulft entity was added
+   */
+  version_added?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataUse.ts
+++ b/clients/admin-ui/src/types/api/models/DataUse.ts
@@ -56,7 +56,7 @@ export type DataUse = {
    */
   active?: boolean;
   /**
-   * This is for tracking when the daulft entity was added
+   * This is for tracking when the default entity was added
    */
   version_added?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataUse.ts
+++ b/clients/admin-ui/src/types/api/models/DataUse.ts
@@ -59,4 +59,12 @@ export type DataUse = {
    * This is for tracking when the default entity was added
    */
   version_added?: string;
+  /**
+   * This is for tracking when the default entity was deprecated
+   */
+  version_deprecated?: string
+  /**
+   * This is for tracking which default entity was used to replace this resource
+   */;
+  replaced_by?: string;
 };

--- a/clients/admin-ui/src/types/api/models/DataUse.ts
+++ b/clients/admin-ui/src/types/api/models/DataUse.ts
@@ -62,9 +62,9 @@ export type DataUse = {
   /**
    * This is for tracking when the default entity was deprecated
    */
-  version_deprecated?: string
+  version_deprecated?: string;
   /**
    * This is for tracking which default entity was used to replace this resource
-   */;
+   */
   replaced_by?: string;
 };


### PR DESCRIPTION
Closes #4134 

### Description Of Changes

add version_added to TaxonomyEntity

### Steps to Confirm

- [ ] run fides 
- [ ] go to the taxonomy page
- [ ] hover over an entity
- [ ] click the pencil
- [ ] make an edit
- [ ] click Update entity
- [ ] verify there is no error and the update is saved 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
