### PR TITLE
Remove features and special purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The types of changes are:
 ### Changed
 - Added further config options to customize the privacy center [#4090](https://github.com/ethyca/fides/pull/4090)
 - Refactored `fides.js` components so that they can take data structures that are not necessarily privacy notices [#3870](https://github.com/ethyca/fides/pull/3870)
+- Changed TCF modal to not render "Features" or "Special Purposes" [#4138](https://github.com/ethyca/fides/pull/4138)
 
 ### Fixed
 - Allows CDN to cache empty experience responses from fides.js API  [#4113](https://github.com/ethyca/fides/pull/4113)

--- a/clients/fides-js/src/components/tcf/LegalBasisDropdown.tsx
+++ b/clients/fides-js/src/components/tcf/LegalBasisDropdown.tsx
@@ -15,7 +15,7 @@ export const useLegalBasisDropdown = ({
   allSpecialPurposes,
 }: {
   allPurposes: Pick<TCFPurposeRecord, "legal_bases">[] | undefined;
-  allSpecialPurposes: Pick<TCFPurposeRecord, "legal_bases">[] | undefined;
+  allSpecialPurposes?: Pick<TCFPurposeRecord, "legal_bases">[] | undefined;
 }) => {
   const [legalBasisFilter, setLegalBasisFilter] = useState(
     LegalBasisForProcessingEnum.CONSENT

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -42,8 +42,6 @@ export const TcfConsentButtons = ({
   const handleAcceptAll = () => {
     const allIds: EnabledIds = {
       purposes: getAllIds(experience.tcf_purposes),
-      specialPurposes: getAllIds(experience.tcf_special_purposes),
-      features: getAllIds(experience.tcf_features),
       specialFeatures: getAllIds(experience.tcf_special_features),
       vendors: getAllIds(experience.tcf_vendors),
       systems: getAllIds(experience.tcf_systems),
@@ -53,8 +51,6 @@ export const TcfConsentButtons = ({
   const handleRejectAll = () => {
     const emptyIds: EnabledIds = {
       purposes: [],
-      specialPurposes: [],
-      features: [],
       specialFeatures: [],
       vendors: [],
       systems: [],

--- a/clients/fides-js/src/components/tcf/TcfFeatures.tsx
+++ b/clients/fides-js/src/components/tcf/TcfFeatures.tsx
@@ -5,35 +5,39 @@ import { PrivacyExperience } from "../../lib/consent-types";
 import type { UpdateEnabledIds } from "./TcfOverlay";
 import DataUseToggle from "../DataUseToggle";
 
-const FeatureBlock = ({
-  label,
-  allFeatures,
-  enabledIds,
+const TcfFeatures = ({
+  allSpecialFeatures,
+  enabledSpecialFeatureIds,
   onChange,
 }: {
-  label: string;
-  allFeatures: TCFFeatureRecord[] | undefined;
-  enabledIds: string[];
-  onChange: (newIds: string[]) => void;
+  allSpecialFeatures: PrivacyExperience["tcf_special_features"];
+  enabledSpecialFeatureIds: string[];
+  onChange: (payload: UpdateEnabledIds) => void;
 }) => {
-  if (!allFeatures || allFeatures.length === 0) {
+  const modelType = "specialFeatures";
+  const label = "Special features";
+  const handleChange = (newIds: string[]) => {
+    onChange({ newEnabledIds: newIds, modelType });
+  };
+  if (!allSpecialFeatures || allSpecialFeatures.length === 0) {
     return null;
   }
 
-  const allChecked = allFeatures.length === enabledIds.length;
+  const allChecked =
+    allSpecialFeatures.length === enabledSpecialFeatureIds.length;
   const handleToggle = (feature: TCFFeatureRecord) => {
     const featureId = `${feature.id}`;
-    if (enabledIds.indexOf(featureId) !== -1) {
-      onChange(enabledIds.filter((e) => e !== featureId));
+    if (enabledSpecialFeatureIds.indexOf(featureId) !== -1) {
+      handleChange(enabledSpecialFeatureIds.filter((e) => e !== featureId));
     } else {
-      onChange([...enabledIds, featureId]);
+      handleChange([...enabledSpecialFeatureIds, featureId]);
     }
   };
   const handleToggleAll = () => {
     if (allChecked) {
-      onChange([]);
+      handleChange([]);
     } else {
-      onChange(allFeatures.map((f) => `${f.id}`));
+      handleChange(allSpecialFeatures.map((f) => `${f.id}`));
     }
   };
 
@@ -45,7 +49,7 @@ const FeatureBlock = ({
         checked={allChecked}
         isHeader
       />
-      {allFeatures.map((f) => {
+      {allSpecialFeatures.map((f) => {
         const vendors = [...(f.vendors || []), ...(f.systems || [])];
         return (
           <DataUseToggle
@@ -53,7 +57,7 @@ const FeatureBlock = ({
             onToggle={() => {
               handleToggle(f);
             }}
-            checked={enabledIds.indexOf(`${f.id}`) !== -1}
+            checked={enabledSpecialFeatureIds.indexOf(`${f.id}`) !== -1}
           >
             <div>
               <p className="fides-tcf-toggle-content">{f.description}</p>
@@ -76,38 +80,5 @@ const FeatureBlock = ({
     </div>
   );
 };
-
-const TcfFeatures = ({
-  allFeatures,
-  allSpecialFeatures,
-  enabledFeatureIds,
-  enabledSpecialFeatureIds,
-  onChange,
-}: {
-  allFeatures: PrivacyExperience["tcf_features"];
-  allSpecialFeatures: PrivacyExperience["tcf_special_features"];
-  enabledFeatureIds: string[];
-  enabledSpecialFeatureIds: string[];
-  onChange: (payload: UpdateEnabledIds) => void;
-}) => (
-  <div>
-    <FeatureBlock
-      label="Features"
-      allFeatures={allFeatures}
-      enabledIds={enabledFeatureIds}
-      onChange={(newEnabledIds) =>
-        onChange({ newEnabledIds, modelType: "features" })
-      }
-    />
-    <FeatureBlock
-      label="Special features"
-      allFeatures={allSpecialFeatures}
-      enabledIds={enabledSpecialFeatureIds}
-      onChange={(newEnabledIds) =>
-        onChange({ newEnabledIds, modelType: "specialFeatures" })
-      }
-    />
-  </div>
-);
 
 export default TcfFeatures;

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -70,8 +70,6 @@ const getEnabledIds = (modelList: TcfModels) => {
 
 export interface EnabledIds {
   purposes: string[];
-  specialPurposes: string[];
-  features: string[];
   specialFeatures: string[];
   vendors: string[];
   systems: string[];
@@ -114,14 +112,6 @@ const createTcfSavePayload = ({
     modelList: experience.tcf_purposes,
     enabledIds: enabledIds.purposes,
   }) as TCFPurposeSave[],
-  special_purpose_preferences: transformTcfModelToTcfSave({
-    modelList: experience.tcf_special_purposes,
-    enabledIds: enabledIds.specialPurposes,
-  }) as TCFSpecialPurposeSave[],
-  feature_preferences: transformTcfModelToTcfSave({
-    modelList: experience.tcf_features,
-    enabledIds: enabledIds.features,
-  }) as TCFFeatureSave[],
   special_feature_preferences: transformTcfModelToTcfSave({
     modelList: experience.tcf_special_features,
     enabledIds: enabledIds.specialFeatures,
@@ -157,8 +147,6 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
   const initialEnabledIds: EnabledIds = useMemo(() => {
     const {
       tcf_purposes: purposes,
-      tcf_special_purposes: specialPurposes,
-      tcf_features: features,
       tcf_special_features: specialFeatures,
       tcf_vendors: vendors,
       tcf_systems: systems,
@@ -166,8 +154,6 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
 
     return {
       purposes: getEnabledIds(purposes),
-      specialPurposes: getEnabledIds(specialPurposes),
-      features: getEnabledIds(features),
       specialFeatures: getEnabledIds(specialFeatures),
       vendors: getEnabledIds(vendors),
       systems: getEnabledIds(systems),

--- a/clients/fides-js/src/components/tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/tcf/TcfPurposes.tsx
@@ -100,21 +100,16 @@ const PurposeBlock = ({
 
 const TcfPurposes = ({
   allPurposes,
-  allSpecialPurposes,
   enabledPurposeIds,
-  enabledSpecialPurposeIds,
   onChange,
 }: {
   allPurposes: PrivacyExperience["tcf_purposes"];
-  allSpecialPurposes: PrivacyExperience["tcf_special_purposes"];
   enabledPurposeIds: string[];
-  enabledSpecialPurposeIds: string[];
   onChange: (payload: UpdateEnabledIds) => void;
 }) => {
   const { filtered, legalBasisFilter, setLegalBasisFilter } =
     useLegalBasisDropdown({
       allPurposes,
-      allSpecialPurposes,
     });
 
   return (
@@ -129,14 +124,6 @@ const TcfPurposes = ({
         enabledIds={enabledPurposeIds}
         onChange={(newEnabledIds) =>
           onChange({ newEnabledIds, modelType: "purposes" })
-        }
-      />
-      <PurposeBlock
-        label="Special purposes"
-        allPurposes={filtered.specialPurposes as TCFPurposeRecord[]}
-        enabledIds={enabledSpecialPurposeIds}
-        onChange={(newEnabledIds) =>
-          onChange({ newEnabledIds, modelType: "specialPurposes" })
         }
       />
     </div>

--- a/clients/fides-js/src/components/tcf/TcfTabs.tsx
+++ b/clients/fides-js/src/components/tcf/TcfTabs.tsx
@@ -24,9 +24,7 @@ const TcfTabs = ({
       content: (
         <TcfPurposes
           allPurposes={experience.tcf_purposes}
-          allSpecialPurposes={experience.tcf_special_purposes}
           enabledPurposeIds={enabledIds.purposes}
-          enabledSpecialPurposeIds={enabledIds.specialPurposes}
           onChange={onChange}
         />
       ),
@@ -35,9 +33,7 @@ const TcfTabs = ({
       name: "Features",
       content: (
         <TcfFeatures
-          allFeatures={experience.tcf_features}
           allSpecialFeatures={experience.tcf_special_features}
-          enabledFeatureIds={enabledIds.features}
           enabledSpecialFeatureIds={enabledIds.specialFeatures}
           onChange={onChange}
         />

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -109,16 +109,6 @@ const updateCookie = async (
       id: purpose.id,
       preference: getInitialPreference(purpose),
     })),
-    special_purpose_preferences: experience.tcf_special_purposes?.map(
-      (purpose) => ({
-        id: purpose.id,
-        preference: getInitialPreference(purpose),
-      })
-    ),
-    feature_preferences: experience.tcf_features?.map((feature) => ({
-      id: feature.id,
-      preference: getInitialPreference(feature),
-    })),
     special_feature_preferences: experience.tcf_special_features?.map(
       (feature) => ({
         id: feature.id,

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -226,16 +226,12 @@ const hasActionNeededTcfPreference = (
  */
 export const hasSavedTcfPreferences = (experience: PrivacyExperience) =>
   hasCurrentPreference(experience.tcf_purposes) ||
-  hasCurrentPreference(experience.tcf_special_purposes) ||
-  hasCurrentPreference(experience.tcf_features) ||
   hasCurrentPreference(experience.tcf_special_features) ||
   hasCurrentPreference(experience.tcf_vendors) ||
   hasCurrentPreference(experience.tcf_systems);
 
 export const hasActionNeededTcfPreferences = (experience: PrivacyExperience) =>
   hasActionNeededTcfPreference(experience.tcf_purposes) ||
-  hasActionNeededTcfPreference(experience.tcf_special_purposes) ||
-  hasActionNeededTcfPreference(experience.tcf_features) ||
   hasActionNeededTcfPreference(experience.tcf_special_features) ||
   hasActionNeededTcfPreference(experience.tcf_vendors) ||
   hasActionNeededTcfPreference(experience.tcf_systems);

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -165,10 +165,6 @@ export const generateTcString = async ({
       );
     }
 
-    // note that we cannot set consent for special purposes nor features because the IAB policy states
-    // the user is not given choice by a CMP.
-    // See https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/
-    // and https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/63#issuecomment-581798996
     encodedString = TCString.encode(tcModel);
   }
   return Promise.resolve(encodedString);

--- a/clients/fides-js/src/lib/tcf/types.ts
+++ b/clients/fides-js/src/lib/tcf/types.ts
@@ -130,8 +130,6 @@ export type TCFVendorSave = {
 export type TcfSavePreferences = Pick<
   PrivacyPreferencesRequest,
   | "purpose_preferences"
-  | "special_purpose_preferences"
-  | "feature_preferences"
   | "special_feature_preferences"
   | "vendor_preferences"
   | "system_preferences"

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -42,13 +42,9 @@ const STACK_1 = {
   id: 7,
   name: "Selection of personalised advertising, advertising measurement, and audience research",
 };
-const FEATURE_1 = {
+const SPECIAL_FEATURE_1 = {
   id: 1,
-  name: "Match and combine offline data sources",
-};
-const FEATURE_2 = {
-  id: 2,
-  name: "Link different devices",
+  name: "Use precise geolocation data",
 };
 
 describe("Fides-js TCF", () => {
@@ -184,18 +180,9 @@ describe("Fides-js TCF", () => {
         cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
           cy.get("input").should("be.checked");
         });
-        cy.getByTestId("toggle-Special purposes").within(() => {
-          cy.get("input").should("be.checked");
-        });
-        cy.getByTestId(`toggle-${SPECIAL_PURPOSE_1.name}`).within(() => {
-          cy.get("input").should("be.checked");
-        });
 
         cy.get("#fides-tab-Features").click();
-        cy.getByTestId(`toggle-${FEATURE_1.name}`).within(() => {
-          cy.get("input").should("not.be.checked");
-        });
-        cy.getByTestId(`toggle-${FEATURE_2.name}`).within(() => {
+        cy.getByTestId(`toggle-${SPECIAL_FEATURE_1.name}`).within(() => {
           cy.get("input").should("not.be.checked");
         });
 
@@ -275,12 +262,10 @@ describe("Fides-js TCF", () => {
               { id: PURPOSE_4.id, preference: "opt_in" },
               { id: PURPOSE_2.id, preference: "opt_in" },
             ]);
-            expect(body.special_purpose_preferences).to.eql([
-              { id: SPECIAL_PURPOSE_1.id, preference: "opt_in" },
-            ]);
-            expect(body.feature_preferences).to.eql([
-              { id: FEATURE_1.id, preference: "opt_in" },
-              { id: FEATURE_2.id, preference: "opt_in" },
+            expect(body.special_purpose_preferences).to.eql(undefined);
+            expect(body.feature_preferences).to.eql(undefined);
+            expect(body.special_feature_preferences).to.eql([
+              { id: SPECIAL_FEATURE_1.id, preference: "opt_in" },
             ]);
             expect(body.vendor_preferences).to.eql([
               { id: VENDOR_2.id, preference: "opt_in" },
@@ -303,12 +288,10 @@ describe("Fides-js TCF", () => {
               { id: PURPOSE_4.id, preference: "opt_out" },
               { id: PURPOSE_2.id, preference: "opt_out" },
             ]);
-            expect(body.special_purpose_preferences).to.eql([
-              { id: SPECIAL_PURPOSE_1.id, preference: "opt_out" },
-            ]);
-            expect(body.feature_preferences).to.eql([
-              { id: FEATURE_1.id, preference: "opt_out" },
-              { id: FEATURE_2.id, preference: "opt_out" },
+            expect(body.special_purpose_preferences).to.eql(undefined);
+            expect(body.feature_preferences).to.eql(undefined);
+            expect(body.special_feature_preferences).to.eql([
+              { id: SPECIAL_FEATURE_1.id, preference: "opt_out" },
             ]);
             expect(body.vendor_preferences).to.eql([
               { id: VENDOR_2.id, preference: "opt_out" },
@@ -323,10 +306,9 @@ describe("Fides-js TCF", () => {
       it("can opt in to some and opt out of others", () => {
         cy.getByTestId("consent-modal").within(() => {
           cy.getByTestId(`toggle-${PURPOSE_1.name}`).click();
-          cy.getByTestId(`toggle-${SPECIAL_PURPOSE_1.name}`).click();
 
           cy.get("#fides-tab-Features").click();
-          cy.getByTestId(`toggle-${FEATURE_1.name}`).click();
+          cy.getByTestId(`toggle-${SPECIAL_FEATURE_1.name}`).click();
 
           cy.get("#fides-tab-Vendors").click();
           cy.getByTestId(`toggle-${VENDOR_1.name}`).click();
@@ -340,12 +322,10 @@ describe("Fides-js TCF", () => {
               { id: PURPOSE_4.id, preference: "opt_in" },
               { id: PURPOSE_2.id, preference: "opt_in" },
             ]);
-            expect(body.special_purpose_preferences).to.eql([
-              { id: SPECIAL_PURPOSE_1.id, preference: "opt_out" },
-            ]);
-            expect(body.feature_preferences).to.eql([
-              { id: FEATURE_1.id, preference: "opt_in" },
-              { id: FEATURE_2.id, preference: "opt_out" },
+            expect(body.special_purpose_preferences).to.eql(undefined);
+            expect(body.feature_preferences).to.eql(undefined);
+            expect(body.special_feature_preferences).to.eql([
+              { id: SPECIAL_FEATURE_1.id, preference: "opt_in" },
             ]);
             expect(body.vendor_preferences).to.eql([
               { id: VENDOR_2.id, preference: "opt_in" },

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -304,7 +304,25 @@
           ]
         }
       ],
-      "tcf_special_features": []
+      "tcf_special_features": [
+        {
+          "default_preference": "opt_out",
+          "current_preference": null,
+          "outdated_preference": null,
+          "current_served": null,
+          "outdated_served": null,
+          "id": 1,
+          "name": "Use precise geolocation data",
+          "description": "With your acceptance, your precise location (within a radius of less than 500 metres) may be used in support of the purposes explained in this notice.",
+          "vendors": [],
+          "systems": [
+            {
+              "id": "ctl_5ac0f598-7c7f-4712-95ec-f9bb6d88feb6",
+              "name": "test"
+            }
+          ]
+        }
+      ]
     }
   ],
   "total": 1,


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4137

### Description Of Changes

Removes rendering of Features and Special Purposes. The exception is inside the Vendor details, we can still see special purposes, for instance:
![image](https://github.com/ethyca/fides/assets/24641006/60f1bc4e-63c1-45c4-8385-866e40831ea4)

Purposes (no special purposes!)
![image](https://github.com/ethyca/fides/assets/24641006/ca8f27f6-6d9a-4094-8b34-3e2c8d38f946)

Features (only special features!)
![image](https://github.com/ethyca/fides/assets/24641006/31bf5f05-79eb-492a-939f-56fda6caf24e)



### Code Changes

* [x] Removed features and special purposes and refactored code to accommodate
* [x] Updated cypress tests (which include a payload that does have features and special purposes, but we make sure we don't save them)

### Steps to Confirm

* `nox -s dev`
* Add a system with a purpose data use and a special purpose data use. I used `analytics.reporting.campain_insights` for purpose, and `essential.fraud_detection` for special purpose. Make sure they have legal bases (campaign insights should probably be `Consent` and fraud detection `legitimate interest`)
* Add a feature and a special feature. I used `Match and combine offline data sources` for feature, and `Use precise geolocation data` for special feature. Note that this is a select input, and you have to hit enter after adding the feature 
![image](https://github.com/ethyca/fides/assets/24641006/26364bf5-798f-4e92-b73f-f0236aa51a86)
* Start up the privacy center via `FIDES_PRIVACY_CENTER__TCF_ENABLED=true turbo dev`
* Visit `/fides-js-demo.html`. You should not see any features or special purposes show up even though they are in the data map

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
