### PR TITLE
Remove features and special purposes toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The types of changes are:
 ### Changed
 - Added further config options to customize the privacy center [#4090](https://github.com/ethyca/fides/pull/4090)
 - Refactored `fides.js` components so that they can take data structures that are not necessarily privacy notices [#3870](https://github.com/ethyca/fides/pull/3870)
+- Features and Special Purposes in the TCF modal do not render toggles [#4139](https://github.com/ethyca/fides/pull/4139)
 
 ### Fixed
 - Allows CDN to cache empty experience responses from fides.js API  [#4113](https://github.com/ethyca/fides/pull/4113)

--- a/clients/fides-js/src/components/DataUseToggle.tsx
+++ b/clients/fides-js/src/components/DataUseToggle.tsx
@@ -16,6 +16,7 @@ const DataUseToggle = ({
   gpcBadge,
   disabled,
   isHeader,
+  includeToggle = true,
 }: {
   dataUse: DataUse;
   checked: boolean;
@@ -25,6 +26,7 @@ const DataUseToggle = ({
   gpcBadge?: VNode;
   disabled?: boolean;
   isHeader?: boolean;
+  includeToggle?: boolean;
 }) => {
   const {
     isOpen,
@@ -70,14 +72,15 @@ const DataUseToggle = ({
           </span>
           {gpcBadge}
         </span>
-
-        <Toggle
-          name={dataUse.name || ""}
-          id={dataUse.key}
-          checked={checked}
-          onChange={onToggle}
-          disabled={disabled}
-        />
+        {includeToggle ? (
+          <Toggle
+            name={dataUse.name || ""}
+            id={dataUse.key}
+            checked={checked}
+            onChange={onToggle}
+            disabled={disabled}
+          />
+        ) : null}
       </div>
       {children ? <div {...getDisclosureProps()}>{children}</div> : null}
     </div>

--- a/clients/fides-js/src/components/tcf/TcfFeatures.tsx
+++ b/clients/fides-js/src/components/tcf/TcfFeatures.tsx
@@ -10,11 +10,13 @@ const FeatureBlock = ({
   allFeatures,
   enabledIds,
   onChange,
+  hideToggles,
 }: {
   label: string;
   allFeatures: TCFFeatureRecord[] | undefined;
   enabledIds: string[];
   onChange: (newIds: string[]) => void;
+  hideToggles?: boolean;
 }) => {
   if (!allFeatures || allFeatures.length === 0) {
     return null;
@@ -44,6 +46,7 @@ const FeatureBlock = ({
         onToggle={handleToggleAll}
         checked={allChecked}
         isHeader
+        includeToggle={!hideToggles}
       />
       {allFeatures.map((f) => {
         const vendors = [...(f.vendors || []), ...(f.systems || [])];
@@ -54,6 +57,7 @@ const FeatureBlock = ({
               handleToggle(f);
             }}
             checked={enabledIds.indexOf(`${f.id}`) !== -1}
+            includeToggle={!hideToggles}
           >
             <div>
               <p className="fides-tcf-toggle-content">{f.description}</p>
@@ -98,6 +102,7 @@ const TcfFeatures = ({
       onChange={(newEnabledIds) =>
         onChange({ newEnabledIds, modelType: "features" })
       }
+      hideToggles
     />
     <FeatureBlock
       label="Special features"

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -114,14 +114,6 @@ const createTcfSavePayload = ({
     modelList: experience.tcf_purposes,
     enabledIds: enabledIds.purposes,
   }) as TCFPurposeSave[],
-  special_purpose_preferences: transformTcfModelToTcfSave({
-    modelList: experience.tcf_special_purposes,
-    enabledIds: enabledIds.specialPurposes,
-  }) as TCFSpecialPurposeSave[],
-  feature_preferences: transformTcfModelToTcfSave({
-    modelList: experience.tcf_features,
-    enabledIds: enabledIds.features,
-  }) as TCFFeatureSave[],
   special_feature_preferences: transformTcfModelToTcfSave({
     modelList: experience.tcf_special_features,
     enabledIds: enabledIds.specialFeatures,

--- a/clients/fides-js/src/components/tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/tcf/TcfPurposes.tsx
@@ -12,15 +12,22 @@ const PurposeToggle = ({
   purpose,
   onToggle,
   checked,
+  includeToggle = true,
 }: {
   purpose: TCFPurposeRecord;
   onToggle: () => void;
   checked: boolean;
+  includeToggle?: boolean;
 }) => {
   const dataUse = { key: purpose.name, name: purpose.name };
   const vendors = [...(purpose.vendors || []), ...(purpose.systems || [])];
   return (
-    <DataUseToggle dataUse={dataUse} checked={checked} onToggle={onToggle}>
+    <DataUseToggle
+      dataUse={dataUse}
+      checked={checked}
+      onToggle={onToggle}
+      includeToggle={includeToggle}
+    >
       <div>
         <p className="fides-tcf-toggle-content">{purpose.description}</p>
         <p className="fides-tcf-illustration fides-background-dark">
@@ -48,11 +55,13 @@ const PurposeBlock = ({
   allPurposes,
   enabledIds,
   onChange,
+  hideToggles,
 }: {
   label: string;
   allPurposes: TCFPurposeRecord[] | undefined;
   enabledIds: string[];
   onChange: (newIds: string[]) => void;
+  hideToggles?: boolean;
 }) => {
   if (!allPurposes || allPurposes.length === 0) {
     return null;
@@ -84,6 +93,7 @@ const PurposeBlock = ({
         onToggle={handleToggleAll}
         checked={allChecked}
         isHeader
+        includeToggle={!hideToggles}
       />
       {allPurposes.map((p) => (
         <PurposeToggle
@@ -92,6 +102,7 @@ const PurposeBlock = ({
             handleToggle(p);
           }}
           checked={enabledIds.indexOf(`${p.id}`) !== -1}
+          includeToggle={!hideToggles}
         />
       ))}
     </div>
@@ -138,6 +149,7 @@ const TcfPurposes = ({
         onChange={(newEnabledIds) =>
           onChange({ newEnabledIds, modelType: "specialPurposes" })
         }
+        hideToggles
       />
     </div>
   );

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -109,16 +109,6 @@ const updateCookie = async (
       id: purpose.id,
       preference: getInitialPreference(purpose),
     })),
-    special_purpose_preferences: experience.tcf_special_purposes?.map(
-      (purpose) => ({
-        id: purpose.id,
-        preference: getInitialPreference(purpose),
-      })
-    ),
-    feature_preferences: experience.tcf_features?.map((feature) => ({
-      id: feature.id,
-      preference: getInitialPreference(feature),
-    })),
     special_feature_preferences: experience.tcf_special_features?.map(
       (feature) => ({
         id: feature.id,

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -226,16 +226,12 @@ const hasActionNeededTcfPreference = (
  */
 export const hasSavedTcfPreferences = (experience: PrivacyExperience) =>
   hasCurrentPreference(experience.tcf_purposes) ||
-  hasCurrentPreference(experience.tcf_special_purposes) ||
-  hasCurrentPreference(experience.tcf_features) ||
   hasCurrentPreference(experience.tcf_special_features) ||
   hasCurrentPreference(experience.tcf_vendors) ||
   hasCurrentPreference(experience.tcf_systems);
 
 export const hasActionNeededTcfPreferences = (experience: PrivacyExperience) =>
   hasActionNeededTcfPreference(experience.tcf_purposes) ||
-  hasActionNeededTcfPreference(experience.tcf_special_purposes) ||
-  hasActionNeededTcfPreference(experience.tcf_features) ||
   hasActionNeededTcfPreference(experience.tcf_special_features) ||
   hasActionNeededTcfPreference(experience.tcf_vendors) ||
   hasActionNeededTcfPreference(experience.tcf_systems);

--- a/clients/fides-js/src/lib/tcf/types.ts
+++ b/clients/fides-js/src/lib/tcf/types.ts
@@ -130,8 +130,6 @@ export type TCFVendorSave = {
 export type TcfSavePreferences = Pick<
   PrivacyPreferencesRequest,
   | "purpose_preferences"
-  | "special_purpose_preferences"
-  | "feature_preferences"
   | "special_feature_preferences"
   | "vendor_preferences"
   | "system_preferences"

--- a/clients/privacy-center/cypress.config.ts
+++ b/clients/privacy-center/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
-    baseUrl: "http://localhost:3001",
+    baseUrl: "http://localhost:3000",
   },
 
   defaultCommandTimeout: 5000,

--- a/clients/privacy-center/cypress.config.ts
+++ b/clients/privacy-center/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
-    baseUrl: "http://localhost:3000",
+    baseUrl: "http://localhost:3001",
   },
 
   defaultCommandTimeout: 5000,

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -50,6 +50,10 @@ const FEATURE_2 = {
   id: 2,
   name: "Link different devices",
 };
+const SPECIAL_FEATURE_1 = {
+  id: 1,
+  name: "Use precise geolocation data",
+};
 
 describe("Fides-js TCF", () => {
   beforeEach(() => {
@@ -184,18 +188,18 @@ describe("Fides-js TCF", () => {
         cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
           cy.get("input").should("be.checked");
         });
-        cy.getByTestId("toggle-Special purposes").within(() => {
-          cy.get("input").should("be.checked");
-        });
-        cy.getByTestId(`toggle-${SPECIAL_PURPOSE_1.name}`).within(() => {
-          cy.get("input").should("be.checked");
-        });
+        cy.get(".fides-notice-toggle-header").contains("Special purposes");
+        cy.get(".fides-notice-toggle-title").contains(SPECIAL_PURPOSE_1.name);
+        cy.getByTestId("toggle-Special purposes").should("not.exist");
+        cy.getByTestId(`toggle-${SPECIAL_PURPOSE_1.name}`).should("not.exist");
 
         cy.get("#fides-tab-Features").click();
-        cy.getByTestId(`toggle-${FEATURE_1.name}`).within(() => {
-          cy.get("input").should("not.be.checked");
-        });
-        cy.getByTestId(`toggle-${FEATURE_2.name}`).within(() => {
+        cy.get(".fides-notice-toggle-header").contains("Features");
+        cy.get(".fides-notice-toggle-title").contains(FEATURE_1.name);
+        cy.get(".fides-notice-toggle-title").contains(FEATURE_2.name);
+        cy.getByTestId(`toggle-${FEATURE_1.name}`).should("not.exist");
+        cy.getByTestId(`toggle-${FEATURE_2.name}`).should("not.exist");
+        cy.getByTestId(`toggle-${SPECIAL_FEATURE_1.name}`).within(() => {
           cy.get("input").should("not.be.checked");
         });
 
@@ -275,12 +279,10 @@ describe("Fides-js TCF", () => {
               { id: PURPOSE_4.id, preference: "opt_in" },
               { id: PURPOSE_2.id, preference: "opt_in" },
             ]);
-            expect(body.special_purpose_preferences).to.eql([
-              { id: SPECIAL_PURPOSE_1.id, preference: "opt_in" },
-            ]);
-            expect(body.feature_preferences).to.eql([
-              { id: FEATURE_1.id, preference: "opt_in" },
-              { id: FEATURE_2.id, preference: "opt_in" },
+            expect(body.special_purpose_preferences).to.eql(undefined);
+            expect(body.feature_preferences).to.eql(undefined);
+            expect(body.special_feature_preferences).to.eql([
+              { id: SPECIAL_FEATURE_1.id, preference: "opt_in" },
             ]);
             expect(body.vendor_preferences).to.eql([
               { id: VENDOR_2.id, preference: "opt_in" },
@@ -303,12 +305,10 @@ describe("Fides-js TCF", () => {
               { id: PURPOSE_4.id, preference: "opt_out" },
               { id: PURPOSE_2.id, preference: "opt_out" },
             ]);
-            expect(body.special_purpose_preferences).to.eql([
-              { id: SPECIAL_PURPOSE_1.id, preference: "opt_out" },
-            ]);
-            expect(body.feature_preferences).to.eql([
-              { id: FEATURE_1.id, preference: "opt_out" },
-              { id: FEATURE_2.id, preference: "opt_out" },
+            expect(body.special_purpose_preferences).to.eql(undefined);
+            expect(body.feature_preferences).to.eql(undefined);
+            expect(body.special_feature_preferences).to.eql([
+              { id: SPECIAL_FEATURE_1.id, preference: "opt_out" },
             ]);
             expect(body.vendor_preferences).to.eql([
               { id: VENDOR_2.id, preference: "opt_out" },
@@ -323,10 +323,9 @@ describe("Fides-js TCF", () => {
       it("can opt in to some and opt out of others", () => {
         cy.getByTestId("consent-modal").within(() => {
           cy.getByTestId(`toggle-${PURPOSE_1.name}`).click();
-          cy.getByTestId(`toggle-${SPECIAL_PURPOSE_1.name}`).click();
 
           cy.get("#fides-tab-Features").click();
-          cy.getByTestId(`toggle-${FEATURE_1.name}`).click();
+          cy.getByTestId(`toggle-${SPECIAL_FEATURE_1.name}`).click();
 
           cy.get("#fides-tab-Vendors").click();
           cy.getByTestId(`toggle-${VENDOR_1.name}`).click();
@@ -340,12 +339,10 @@ describe("Fides-js TCF", () => {
               { id: PURPOSE_4.id, preference: "opt_in" },
               { id: PURPOSE_2.id, preference: "opt_in" },
             ]);
-            expect(body.special_purpose_preferences).to.eql([
-              { id: SPECIAL_PURPOSE_1.id, preference: "opt_out" },
-            ]);
-            expect(body.feature_preferences).to.eql([
-              { id: FEATURE_1.id, preference: "opt_in" },
-              { id: FEATURE_2.id, preference: "opt_out" },
+            expect(body.special_purpose_preferences).to.eql(undefined);
+            expect(body.feature_preferences).to.eql(undefined);
+            expect(body.special_feature_preferences).to.eql([
+              { id: SPECIAL_FEATURE_1.id, preference: "opt_in" },
             ]);
             expect(body.vendor_preferences).to.eql([
               { id: VENDOR_2.id, preference: "opt_in" },

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -304,7 +304,25 @@
           ]
         }
       ],
-      "tcf_special_features": []
+      "tcf_special_features": [
+        {
+          "default_preference": "opt_out",
+          "current_preference": null,
+          "outdated_preference": null,
+          "current_served": null,
+          "outdated_served": null,
+          "id": 1,
+          "name": "Use precise geolocation data",
+          "description": "With your acceptance, your precise location (within a radius of less than 500 metres) may be used in support of the purposes explained in this notice.",
+          "vendors": [],
+          "systems": [
+            {
+              "id": "ctl_5ac0f598-7c7f-4712-95ec-f9bb6d88feb6",
+              "name": "test"
+            }
+          ]
+        }
+      ]
     }
   ],
   "total": 1,


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4137

### Description Of Changes

Removes toggles from Features and Special Purposes since users aren't supposed to be able to change those preferences. 

![image](https://github.com/ethyca/fides/assets/24641006/1e986416-02da-4f8e-90fb-c47e608fc494)
![image](https://github.com/ethyca/fides/assets/24641006/a1da9291-1d7e-429c-890c-55407382cad4)

Can still expand them
![image](https://github.com/ethyca/fides/assets/24641006/057d18fd-8b69-4cc9-81f8-33bd4999509b)



### Code Changes

* [x] Add a flag for conditionally showing toggles
* [x] Remove payload for saving to Features or Special Purposes
* [x] Update cypress tests

### Steps to Confirm

* `nox -s dev`
* Add a system with a purpose data use and a special purpose data use. I used `analytics.reporting.campain_insights` for purpose, and `essential.fraud_detection` for special purpose. Make sure they have legal bases (campaign insights should probably be `Consent` and fraud detection `legitimate interest`)
* Add a feature and a special feature. I used `Link different devices` for feature, and `Use precise geolocation data` for special feature. Note that this is a select input, and you have to hit enter after adding the feature 
![image](https://github.com/ethyca/fides/assets/24641006/26364bf5-798f-4e92-b73f-f0236aa51a86)
* Start up the privacy center via `FIDES_PRIVACY_CENTER__TCF_ENABLED=true turbo dev`
* Visit `/fides-js-demo.html`. You should see the features and special purposes rendered but without a toggle

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
