### PR TITLE
Add min width to data use tab

### DIFF
--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationStep.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationStep.tsx
@@ -34,7 +34,7 @@ const PrivacyDeclarationStep = ({ system }: Props) => {
   };
 
   return (
-    <Stack spacing={3} data-testid="privacy-declaration-step">
+    <Stack spacing={3} data-testid="privacy-declaration-step" minWidth={580}>
       <Heading as="h3" size="md">
         Data uses
       </Heading>


### PR DESCRIPTION
Closes #4099

### Code Changes

* [ ] Add min width to data use tab

### Steps to Confirm

* [ ] run fides 
* [ ] add a system 
* [ ] click the data use tab
* [ ] shrink then grow the size of the window
* [ ] verify there is no jumping of the data use section under the tabs 
* [ ] add a data use 
* [ ] shrink then grow the size of the window
* [ ] verify there is no jumping of the data use section under the tabs 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
