### PR TITLE
Fixing system history bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The types of changes are:
 - CORS configuration page [#4073](https://github.com/ethyca/fides/pull/4073)
 - Refactored `fides.js` components so that they can take data structures that are not necessarily privacy notices [#3870](https://github.com/ethyca/fides/pull/3870)
 - Moved the initial TCF layer to the banner [#4142](https://github.com/ethyca/fides/pull/4142)
+- Misc copy changes for the system history table and modal [#4146](https://github.com/ethyca/fides/pull/4146)
 
 ### Fixed
 - Allows CDN to cache empty experience responses from fides.js API  [#4113](https://github.com/ethyca/fides/pull/4113)

--- a/clients/admin-ui/src/features/system/history/SystemHistoryTable.tsx
+++ b/clients/admin-ui/src/features/system/history/SystemHistoryTable.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import {
   Button,
   Flex,
@@ -8,131 +9,58 @@ import {
   Thead,
   Tr,
 } from "@fidesui/react";
-import _ from "lodash";
 import React, { useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import NextArrow from "~/features/common/Icon/NextArrow";
 import PrevArrow from "~/features/common/Icon/PrevArrow";
 import {
-  DictOption,
   selectAllDictEntries,
   useGetSystemHistoryQuery,
 } from "~/features/plus/plus.slice";
-import { PrivacyDeclaration, SystemHistoryResponse } from "~/types/api";
+import { selectAllSystems } from "~/features/system/system.slice";
+import { SystemHistoryResponse } from "~/types/api";
 import { SystemResponse } from "~/types/api/models/SystemResponse";
 
+import {
+  alignPrivacyDeclarations,
+  assignSystemNames,
+  assignVendorLabels,
+  describeSystemChange,
+  formatDateAndTime,
+} from "./helpers";
 import SystemHistoryModal from "./modal/SystemHistoryModal";
 
 interface Props {
   system: SystemResponse;
 }
 
-// Helper function to format date and time
-const formatDateAndTime = (dateString: string) => {
-  const date = new Date(dateString);
-  const userLocale = navigator.language;
-
-  const timeOptions: Intl.DateTimeFormatOptions = {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: true,
-    timeZoneName: "short",
-  };
-
-  const dateOptions: Intl.DateTimeFormatOptions = {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  };
-
-  const formattedTime = date.toLocaleTimeString(userLocale, timeOptions);
-  const formattedDate = date.toLocaleDateString(userLocale, dateOptions);
-
-  return { formattedTime, formattedDate };
-};
-
-function alignArrays(
-  before: PrivacyDeclaration[],
-  after: PrivacyDeclaration[]
-) {
-  const allNames = new Set([...before, ...after].map((item) => item.data_use));
-  const alignedBefore: PrivacyDeclaration[] = [];
-  const alignedAfter: PrivacyDeclaration[] = [];
-
-  allNames.forEach((data_use) => {
-    const firstItem = before.find((item) => item.data_use === data_use) || {
-      data_use: "",
-      data_categories: [],
-    };
-    const secondItem = after.find((item) => item.data_use === data_use) || {
-      data_use: "",
-      data_categories: [],
-    };
-    alignedBefore.push(firstItem);
-    alignedAfter.push(secondItem);
-  });
-
-  return [alignedBefore, alignedAfter];
-}
-
-const lookupVendorLabel = (vendor_id: string, options: DictOption[]) =>
-  options.find((option) => option.value === vendor_id)?.label ?? vendor_id;
-
-const itemsPerPage = 10;
+const ITEMS_PER_PAGE = 10;
 
 const SystemHistoryTable = ({ system }: Props) => {
   const [currentPage, setCurrentPage] = useState(1);
   const { data } = useGetSystemHistoryQuery({
     system_key: system.fides_key,
     page: currentPage,
-    size: itemsPerPage,
+    size: ITEMS_PER_PAGE,
   });
   const [isModalOpen, setModalOpen] = useState(false);
   const [selectedHistory, setSelectedHistory] =
     useState<SystemHistoryResponse | null>(null);
   const dictionaryOptions = useAppSelector(selectAllDictEntries);
+  const systems = useAppSelector(selectAllSystems);
 
   const systemHistories = data?.items || [];
 
   const openModal = (history: SystemHistoryResponse) => {
-    // Align the privacy_declarations arrays
-    const beforePrivacyDeclarations =
-      history?.before?.privacy_declarations || [];
-    const afterPrivacyDeclarations = history?.after?.privacy_declarations || [];
-    const [alignedBefore, alignedAfter] = alignArrays(
-      beforePrivacyDeclarations,
-      afterPrivacyDeclarations
-    );
+    // Align the before and after privacy declaration lists so they have the same number of entries
+    history = alignPrivacyDeclarations(history);
+    // Look up the vendor labels from the vendor IDs
+    history = assignVendorLabels(history, dictionaryOptions);
+    // Look up the system names for the source and destination fides_keys
+    history = assignSystemNames(history, systems);
 
-    // Create new initialValues objects with the aligned arrays
-    const alignedBeforeInitialValues = {
-      ...history?.before,
-      privacy_declarations: alignedBefore,
-    };
-    const alignedAfterInitialValues = {
-      ...history?.after,
-      privacy_declarations: alignedAfter,
-    };
-
-    if (dictionaryOptions) {
-      alignedBeforeInitialValues.vendor_id = lookupVendorLabel(
-        alignedBeforeInitialValues.vendor_id,
-        dictionaryOptions
-      );
-      alignedAfterInitialValues.vendor_id = lookupVendorLabel(
-        alignedAfterInitialValues.vendor_id,
-        dictionaryOptions
-      );
-    }
-
-    setSelectedHistory({
-      before: alignedBeforeInitialValues,
-      after: alignedAfterInitialValues,
-      edited_by: history.edited_by,
-      system_id: history.system_id,
-      created_at: history.created_at,
-    });
+    setSelectedHistory(history);
     setModalOpen(true);
   };
 
@@ -141,111 +69,9 @@ const SystemHistoryTable = ({ system }: Props) => {
     setSelectedHistory(null);
   };
 
-  const describeSystemChange = (history: SystemHistoryResponse) => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { edited_by, before, after, created_at } = history;
-
-    const uniqueKeys = new Set([...Object.keys(before), ...Object.keys(after)]);
-
-    const addedFields: string[] = [];
-    const removedFields: string[] = [];
-    const changedFields: string[] = [];
-
-    Array.from(uniqueKeys).forEach((key) => {
-      // @ts-ignore
-      const beforeValue = before[key];
-      // @ts-ignore
-      const afterValue = after[key];
-
-      // Handle booleans separately
-      if (typeof beforeValue === "boolean" || typeof afterValue === "boolean") {
-        if (beforeValue !== afterValue) {
-          changedFields.push(key);
-        }
-        return;
-      }
-
-      // Handle numbers separately
-      if (typeof beforeValue === "number" || typeof afterValue === "number") {
-        if (beforeValue !== afterValue) {
-          changedFields.push(key);
-        }
-        return;
-      }
-
-      // If both values are null or empty, skip
-      if (
-        (_.isNil(beforeValue) || _.isEmpty(beforeValue)) &&
-        (_.isNil(afterValue) || _.isEmpty(afterValue))
-      ) {
-        return;
-      }
-
-      // For all other types
-      if (!_.isEqual(beforeValue, afterValue)) {
-        if (_.isNil(beforeValue) || _.isEmpty(beforeValue)) {
-          addedFields.push(key);
-        } else if (_.isNil(afterValue) || _.isEmpty(afterValue)) {
-          removedFields.push(key);
-        } else {
-          changedFields.push(key);
-        }
-      }
-    });
-
-    const changeDescriptions: Array<[string, JSX.Element]> = [];
-
-    if (addedFields.length > 0) {
-      // eslint-disable-next-line react/jsx-key
-      changeDescriptions.push(["added ", <b>{addedFields.join(", ")}</b>]);
-    }
-
-    if (removedFields.length > 0) {
-      // eslint-disable-next-line react/jsx-key
-      changeDescriptions.push(["removed ", <b>{removedFields.join(", ")}</b>]);
-    }
-
-    if (changedFields.length > 0) {
-      // eslint-disable-next-line react/jsx-key
-      changeDescriptions.push(["changed ", <b>{changedFields.join(", ")}</b>]);
-    }
-
-    if (changeDescriptions.length === 0) {
-      return null;
-    }
-
-    const lastDescription = changeDescriptions.pop();
-
-    const descriptionList =
-      changeDescriptions.length > 0 ? (
-        <>
-          {changeDescriptions.map((desc, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <React.Fragment key={i}>
-              {desc}
-              {i < changeDescriptions.length - 1 ? ", " : ""}
-            </React.Fragment>
-          ))}
-          {changeDescriptions.length >= 2 ? ", and " : " and "}
-          {lastDescription}
-        </>
-      ) : (
-        lastDescription
-      );
-
-    const { formattedTime, formattedDate } = formatDateAndTime(created_at);
-
-    return (
-      <>
-        <b>{edited_by}</b> {descriptionList} on {formattedDate} at{" "}
-        {formattedTime}
-      </>
-    );
-  };
-
   const { formattedTime, formattedDate } = formatDateAndTime(system.created_at);
 
-  const totalPages = data ? Math.ceil(data.total / itemsPerPage) : 0;
+  const totalPages = data ? Math.ceil(data.total / ITEMS_PER_PAGE) : 0;
 
   const handleNextPage = () => {
     if (currentPage < totalPages) {
@@ -313,8 +139,8 @@ const SystemHistoryTable = ({ system }: Props) => {
           marginLeft="24px"
         >
           <Text fontSize="xs" lineHeight={4} fontWeight="600" paddingX={2}>
-            {(currentPage - 1) * itemsPerPage + 1} -{" "}
-            {Math.min(currentPage * itemsPerPage, data?.total || 0)} of{" "}
+            {(currentPage - 1) * ITEMS_PER_PAGE + 1} -{" "}
+            {Math.min(currentPage * ITEMS_PER_PAGE, data?.total || 0)} of{" "}
             {data?.total || 0}
           </Text>
           <Button

--- a/clients/admin-ui/src/features/system/history/helpers.tsx
+++ b/clients/admin-ui/src/features/system/history/helpers.tsx
@@ -173,7 +173,8 @@ export const assignSystemNames = (
   history: SystemHistoryResponse,
   systems: SystemResponse[]
 ): SystemHistoryResponse => {
-  const transformList = (list: any[]): string[] => list.map((item) => {
+  const transformList = (list: any[]): string[] =>
+    list.map((item) => {
       const system = systems.find((s) => s.fides_key === item.fides_key);
       return system && system.name ? system.name : item.fides_key;
     });

--- a/clients/admin-ui/src/features/system/history/helpers.tsx
+++ b/clients/admin-ui/src/features/system/history/helpers.tsx
@@ -1,0 +1,246 @@
+import _ from "lodash";
+import React from "react";
+
+import { DictOption } from "~/features/plus/plus.slice";
+import { PrivacyDeclaration } from "~/types/api/models/PrivacyDeclaration";
+import { SystemHistoryResponse } from "~/types/api/models/SystemHistoryResponse";
+import { SystemResponse } from "~/types/api/models/SystemResponse";
+
+// Helper function to format date and time
+export const formatDateAndTime = (dateString: string) => {
+  const date = new Date(dateString);
+  const userLocale = navigator.language;
+
+  const timeOptions: Intl.DateTimeFormatOptions = {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+    timeZoneName: "short",
+  };
+
+  const dateOptions: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+
+  const formattedTime = date.toLocaleTimeString(userLocale, timeOptions);
+  const formattedDate = date.toLocaleDateString(userLocale, dateOptions);
+
+  return { formattedTime, formattedDate };
+};
+
+export function alignArrays(
+  before: PrivacyDeclaration[],
+  after: PrivacyDeclaration[]
+) {
+  const allNames = new Set([...before, ...after].map((item) => item.data_use));
+  const alignedBefore: PrivacyDeclaration[] = [];
+  const alignedAfter: PrivacyDeclaration[] = [];
+
+  allNames.forEach((data_use) => {
+    const firstItem = before.find((item) => item.data_use === data_use) || {
+      data_use: "",
+      data_categories: [],
+    };
+    const secondItem = after.find((item) => item.data_use === data_use) || {
+      data_use: "",
+      data_categories: [],
+    };
+    alignedBefore.push(firstItem);
+    alignedAfter.push(secondItem);
+  });
+
+  return [alignedBefore, alignedAfter];
+}
+
+const lookupVendorLabel = (vendor_id: string, options: DictOption[]) =>
+  options.find((option) => option.value === vendor_id)?.label ?? vendor_id;
+
+export const getUiLabel = (key: string): string => {
+  const keyMapping: Record<string, string> = {
+    privacy_declarations: "data uses",
+    ingress: "sources",
+    egress: "destinations",
+  };
+
+  return keyMapping[key] || key;
+};
+
+export const describeSystemChange = (history: SystemHistoryResponse) => {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { edited_by, before, after, created_at } = history;
+
+  const uniqueKeys = new Set([...Object.keys(before), ...Object.keys(after)]);
+
+  const addedFields: string[] = [];
+  const removedFields: string[] = [];
+  const changedFields: string[] = [];
+
+  Array.from(uniqueKeys).forEach((originalKey) => {
+    const key = getUiLabel(originalKey);
+    // @ts-ignore
+    const beforeValue = before[originalKey];
+    // @ts-ignore
+    const afterValue = after[originalKey];
+
+    // Handle booleans separately
+    if (typeof beforeValue === "boolean" || typeof afterValue === "boolean") {
+      if (beforeValue !== afterValue) {
+        changedFields.push(key);
+      }
+      return;
+    }
+
+    // Handle numbers separately
+    if (typeof beforeValue === "number" || typeof afterValue === "number") {
+      if (beforeValue !== afterValue) {
+        changedFields.push(key);
+      }
+      return;
+    }
+
+    // If both values are null or empty, skip
+    if (
+      (_.isNil(beforeValue) || _.isEmpty(beforeValue)) &&
+      (_.isNil(afterValue) || _.isEmpty(afterValue))
+    ) {
+      return;
+    }
+
+    // For all other types
+    if (!_.isEqual(beforeValue, afterValue)) {
+      if (_.isNil(beforeValue) || _.isEmpty(beforeValue)) {
+        addedFields.push(key);
+      } else if (_.isNil(afterValue) || _.isEmpty(afterValue)) {
+        removedFields.push(key);
+      } else {
+        changedFields.push(key);
+      }
+    }
+  });
+
+  const changeDescriptions: Array<[string, JSX.Element]> = [];
+
+  if (addedFields.length > 0) {
+    // eslint-disable-next-line react/jsx-key
+    changeDescriptions.push(["added ", <b>{addedFields.join(", ")}</b>]);
+  }
+
+  if (removedFields.length > 0) {
+    // eslint-disable-next-line react/jsx-key
+    changeDescriptions.push(["removed ", <b>{removedFields.join(", ")}</b>]);
+  }
+
+  if (changedFields.length > 0) {
+    // eslint-disable-next-line react/jsx-key
+    changeDescriptions.push(["changed ", <b>{changedFields.join(", ")}</b>]);
+  }
+
+  if (changeDescriptions.length === 0) {
+    return null;
+  }
+
+  const lastDescription = changeDescriptions.pop();
+
+  const descriptionList =
+    changeDescriptions.length > 0 ? (
+      <>
+        {changeDescriptions.map((desc, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <React.Fragment key={i}>
+            {desc}
+            {i < changeDescriptions.length - 1 ? ", " : ""}
+          </React.Fragment>
+        ))}
+        {changeDescriptions.length >= 2 ? ", and " : " and "}
+        {lastDescription}
+      </>
+    ) : (
+      lastDescription
+    );
+
+  const { formattedTime, formattedDate } = formatDateAndTime(created_at);
+
+  return (
+    <>
+      <b>{edited_by}</b> {descriptionList} on {formattedDate} at {formattedTime}
+    </>
+  );
+};
+
+export const assignSystemNames = (
+  history: SystemHistoryResponse,
+  systems: SystemResponse[]
+): SystemHistoryResponse => {
+  const transformList = (list: any[]): string[] => list.map((item) => {
+      const system = systems.find((s) => s.fides_key === item.fides_key);
+      return system && system.name ? system.name : item.fides_key;
+    });
+
+  const modifiedBefore = { ...history.before };
+  const modifiedAfter = { ...history.after };
+
+  if (modifiedBefore.ingress) {
+    modifiedBefore.ingress = transformList(modifiedBefore.ingress);
+  }
+
+  if (modifiedBefore.egress) {
+    modifiedBefore.egress = transformList(modifiedBefore.egress);
+  }
+
+  if (modifiedAfter.ingress) {
+    modifiedAfter.ingress = transformList(modifiedAfter.ingress);
+  }
+
+  if (modifiedAfter && modifiedAfter.egress) {
+    modifiedAfter.egress = transformList(modifiedAfter.egress);
+  }
+
+  return { ...history, before: modifiedBefore, after: modifiedAfter };
+};
+
+export const assignVendorLabels = (
+  history: SystemHistoryResponse,
+  dictionaryOptions: DictOption[]
+): SystemHistoryResponse => {
+  // Return the unmodified history if dictionaryOptions is empty
+  if (_.isEmpty(dictionaryOptions)) {
+    return history;
+  }
+
+  return {
+    ...history,
+    before: {
+      ...history.before,
+      vendor_id: lookupVendorLabel(history.before.vendor_id, dictionaryOptions),
+    },
+    after: {
+      ...history.after,
+      vendor_id: lookupVendorLabel(history.after.vendor_id, dictionaryOptions),
+    },
+  };
+};
+
+export const alignPrivacyDeclarations = (
+  history: SystemHistoryResponse
+): SystemHistoryResponse => {
+  const beforePrivacyDeclarations = history.before.privacy_declarations || [];
+  const afterPrivacyDeclarations = history.after.privacy_declarations || [];
+  const [alignedBefore, alignedAfter] = alignArrays(
+    beforePrivacyDeclarations,
+    afterPrivacyDeclarations
+  );
+
+  return {
+    ...history,
+    before: {
+      ...history.before,
+      privacy_declarations: alignedBefore,
+    },
+    after: {
+      ...history.after,
+      privacy_declarations: alignedAfter,
+    },
+  };
+};

--- a/clients/admin-ui/src/features/system/history/modal/SystemDataForm.tsx
+++ b/clients/admin-ui/src/features/system/history/modal/SystemDataForm.tsx
@@ -163,7 +163,7 @@ const SystemDataForm: React.FC<SystemDataFormProps> = ({ initialValues }) => {
               initialValues.privacy_declarations.map(
                 (_: PrivacyDeclaration, index: number) => (
                   <>
-                    <SystemDataGroup heading="Data use declaration">
+                    <SystemDataGroup heading="Data use">
                       <SystemDataTextField
                         label="Declaration name (optional)"
                         name={`privacy_declarations[${index}].name`}

--- a/clients/admin-ui/src/features/system/history/modal/SystemHistoryModal.tsx
+++ b/clients/admin-ui/src/features/system/history/modal/SystemHistoryModal.tsx
@@ -18,7 +18,12 @@ import SystemDataForm from "./SystemDataForm";
 
 const getBadges = (before: Record<string, any>, after: Record<string, any>) => {
   const badges = [];
-  const specialFields = new Set(["egress", "ingress", "privacy_declarations"]);
+  const specialFields = new Set([
+    "egress",
+    "ingress",
+    "privacy_declarations",
+    "vendor_id",
+  ]);
 
   if (before.egress || after.egress || before.ingress || after.ingress) {
     badges.push("Data Flow");


### PR DESCRIPTION
### Description Of Changes

Fixing misc bugs

- `ingress` and `egress` now show up in the UI as `source` and `destination`
- The system name is displayed for source and destination changes instead of the fides_key
- Fixed issue with `System Information` badge showing for data use changes
- `privacy_decralations` now show up in the UI as `data use`

### Code Changes

* [ ] Moved helper functions for the system history feature into a helpers file

### Steps to Confirm

* [ ] Start fidesplus
* [ ] Create a system
* [ ] Add a data use
* [ ] Verify an entry was created in the history table and that the change reads "added data use"
* [ ] Click on the row to open the modal, verify that only the `Data Use` badge shows up
* [ ] Create a second system and assign this new system as the source and destination for the first system
* [ ] Verify the entry in the history table reads "added source" and "added destination"
* [ ] Click on the row to open the modal, verify the system name is displayed for source and destination instead of the fides_key

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
