### PR TITLE
Add privacy center new line css

### DIFF
--- a/clients/privacy-center/config/config.css
+++ b/clients/privacy-center/config/config.css
@@ -16,6 +16,6 @@ Override basic theme colors by uncommenting and editing those below
   /* --chakra-colors-primary-400: #464B83; */
   /* Primary button color */
   /* --chakra-colors-primary-800: #111439; */
-  /* respect new line breaks /n */
-  /* white-space: pre-line; */
+  /* respect new line breaks \n */
+  white-space: pre-line;
 }

--- a/clients/privacy-center/config/config.css
+++ b/clients/privacy-center/config/config.css
@@ -16,4 +16,6 @@ Override basic theme colors by uncommenting and editing those below
   /* --chakra-colors-primary-400: #464B83; */
   /* Primary button color */
   /* --chakra-colors-primary-800: #111439; */
+  /* respect new line breaks /n */
+  /* white-space: pre-line; */
 }

--- a/src/fides/data/sample_project/privacy_center/config/config.css
+++ b/src/fides/data/sample_project/privacy_center/config/config.css
@@ -18,6 +18,6 @@ Override basic theme colors by uncommenting and editing those below
   --chakra-colors-primary-800: #A85936;
   /* Button border color */
   --chakra-colors-complimentary-500: #A85936;
-  /* respect new line breaks /n */
+  /* respect new line breaks \n */
   white-space: pre-line;
 }

--- a/src/fides/data/sample_project/privacy_center/config/config.css
+++ b/src/fides/data/sample_project/privacy_center/config/config.css
@@ -18,4 +18,6 @@ Override basic theme colors by uncommenting and editing those below
   --chakra-colors-primary-800: #A85936;
   /* Button border color */
   --chakra-colors-complimentary-500: #A85936;
+  /* respect new line breaks /n */
+  white-space: pre-line;
 }


### PR DESCRIPTION
Closes #4145 

### Code Changes

* [ ] add `white-space: pre-line;` to privacy center css to respect new lines

### Steps to Confirm

* [ ] run fides
* [ ] update `page.description` on line 92 of `fides/clients/privacy-center/config/config.json` with a `\n`
* [ ] verify the new line is respected 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
