### PR TITLE
CurrentPrivacyPreference > Special Purpose Unique Constraint Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The types of changes are:
 
 ### Fixed
 - Allows CDN to cache empty experience responses from fides.js API  [#4113](https://github.com/ethyca/fides/pull/4113)
+- `identity_special_purpose` unique constraint definition [#4174](https://github.com/ethyca/fides/pull/4174/files)
 
 ## [2.20.2](https://github.com/ethyca/fides/compare/2.20.1...2.20.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The types of changes are:
 
 ### Fixed
 - Allows CDN to cache empty experience responses from fides.js API  [#4113](https://github.com/ethyca/fides/pull/4113)
-- `identity_special_purpose` unique constraint definition [#4174](https://github.com/ethyca/fides/pull/4174/files)
+- Fixed `identity_special_purpose` unique constraint definition [#4174](https://github.com/ethyca/fides/pull/4174/files)
 
 ## [2.20.2](https://github.com/ethyca/fides/compare/2.20.1...2.20.2)
 

--- a/src/fides/api/alembic/migrations/versions/4cb3b5af4160_update_special_feature_unique_constraint.py
+++ b/src/fides/api/alembic/migrations/versions/4cb3b5af4160_update_special_feature_unique_constraint.py
@@ -1,0 +1,37 @@
+"""update_special_feature_unique_constraint
+
+Revision ID: 4cb3b5af4160
+Revises: 66df7d9b8103
+Create Date: 2023-09-27 22:58:43.064996
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4cb3b5af4160"
+down_revision = "66df7d9b8103"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        "identity_special_purpose", "currentprivacypreference", type_="unique"
+    )
+    op.create_unique_constraint(
+        "identity_special_purpose",
+        "currentprivacypreference",
+        ["provided_identity_id", "special_purpose"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "identity_special_purpose", "currentprivacypreference", type_="unique"
+    )
+    op.create_unique_constraint(
+        "identity_special_purpose",
+        "currentprivacypreference",
+        ["provided_identity_id", "purpose"],
+    )

--- a/src/fides/api/alembic/migrations/versions/4cb3b5af4160_update_special_feature_unique_constraint.py
+++ b/src/fides/api/alembic/migrations/versions/4cb3b5af4160_update_special_feature_unique_constraint.py
@@ -1,7 +1,7 @@
 """update_special_feature_unique_constraint
 
 Revision ID: 4cb3b5af4160
-Revises: 66df7d9b8103
+Revises: 8c54e1e5bdc4
 Create Date: 2023-09-27 22:58:43.064996
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "4cb3b5af4160"
-down_revision = "66df7d9b8103"
+down_revision = "8c54e1e5bdc4"
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/alembic/migrations/versions/4cb3b5af4160_update_special_purpose_unique_constraint.py
+++ b/src/fides/api/alembic/migrations/versions/4cb3b5af4160_update_special_purpose_unique_constraint.py
@@ -1,4 +1,4 @@
-"""update_special_feature_unique_constraint
+"""update_special_purpose_unique_constraint
 
 Revision ID: 4cb3b5af4160
 Revises: 8c54e1e5bdc4

--- a/src/fides/api/models/privacy_preference.py
+++ b/src/fides/api/models/privacy_preference.py
@@ -693,7 +693,7 @@ class CurrentPrivacyPreference(LastSavedMixin, Base):
             name="fides_user_device_identity_purpose",
         ),
         UniqueConstraint(
-            "provided_identity_id", "purpose", name="identity_special_purpose"
+            "provided_identity_id", "special_purpose", name="identity_special_purpose"
         ),
         UniqueConstraint(
             "fides_user_device_provided_identity_id",


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4173

### Description Of Changes

We need unique constraints on CurrentPrivacyPreference and LastServedNotice to force those tables to store a single preference for a given dimension and a.given identity across time and versions of a notice.   A "provided identity" and "special purpose" were not being indexed in the CurrentPrivacyPreference table. 


### Code Changes

* [ ] Drops the current "identity_special_purpose " unique constraint and recreates with the correct field values. 

### Steps to Confirm

* [ ] Run migrations and then check in postgres:

```sql
 \d currentprivacypreference
...
Indexes:
"identity_special_purpose" UNIQUE CONSTRAINT, btree (provided_identity_id, special_purpose)

```
* [ ] It would be helpful to run through the other UNIQUE CONSTRAINTS on CurrentPrivacyPreference and LastServedNotice and help me verify that there aren't any others that I incorrectly defined.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
