### PR TITLE
Braze Override for Email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The types of changes are:
 ### Fixed
 - TCF overlay can initialize its consent preferences from a cookie [#4124](https://github.com/ethyca/fides/pull/4124)
 - Various improvements to the TCF modal such as vendor storage disclosures, vendor counts, privacy policies, etc. [#4167](https://github.com/ethyca/fides/pull/4167)
+- An issue where Braze could not mask an email due to formatting [#4187](https://github.com/ethyca/fides/pull/4187)
 
 ## [2.21.0](https://github.com/ethyca/fides/compare/2.20.2...2.21.0)
 
@@ -55,7 +56,7 @@ The types of changes are:
 
 ## [2.20.2](https://github.com/ethyca/fides/compare/2.20.1...2.20.2)
 
-### Fixed 
+### Fixed
 - added version_added, version_deprecated, and replaced_by to data use, data subject, and data category APIs [#4135](https://github.com/ethyca/fides/pull/4135)
 - Update fides.js to not fetch experience client-side if pre-fetched experience is empty [#4149](https://github.com/ethyca/fides/pull/4149)
 - Erasure privacy requests now pause for input if there are any manual process integrations [#4115](https://github.com/ethyca/fides/pull/4115)

--- a/data/saas/config/braze_config.yml
+++ b/data/saas/config/braze_config.yml
@@ -125,16 +125,7 @@ saas_config:
                 identity: phone_number
             data_path: users
         update:
-          method: POST
-          path: /users/track
-          body: |
-            {
-              "attributes": [
-                {
-                  <all_object_fields>
-                }
-              ]
-            }
+          request_override: braze_user_update
     - name: subscription_groups
       requests:
         read:

--- a/data/saas/config/braze_config.yml
+++ b/data/saas/config/braze_config.yml
@@ -4,7 +4,7 @@ saas_config:
   type: braze
   description: A sample schema representing the Braze connector for Fides
   user_guide: https://docs.ethyca.com/user-guides/integrations/saas-integrations/braze
-  version: 0.0.4
+  version: 0.0.5
 
   connector_params:
     - name: domain

--- a/data/saas/dataset/braze_dataset.yml
+++ b/data/saas/dataset/braze_dataset.yml
@@ -9,16 +9,12 @@ dataset:
             data_categories: [system.operations]
             fidesops_meta:
               data_type: string
-          - name: external_id
-            data_categories: [user.unique_id]
-            fidesops_meta:
-              data_type: string
-              read_only: True
           - name: braze_id
             data_categories: [user.unique_id]
             fidesops_meta:
               data_type: string
               primary_key: True
+              read_only: True
           - name: first_name
             data_categories: [user.name]
             fidesops_meta:

--- a/data/saas/dataset/braze_dataset.yml
+++ b/data/saas/dataset/braze_dataset.yml
@@ -9,12 +9,16 @@ dataset:
             data_categories: [system.operations]
             fidesops_meta:
               data_type: string
+          - name: external_id
+            data_categories: [user.unique_id]
+            fidesops_meta:
+              data_type: string
+              read_only: True
           - name: braze_id
             data_categories: [user.unique_id]
             fidesops_meta:
               data_type: string
               primary_key: True
-              read_only: True
           - name: first_name
             data_categories: [user.name]
             fidesops_meta:

--- a/src/fides/api/service/saas_request/override_implementations/braze_request_overrides.py
+++ b/src/fides/api/service/saas_request/override_implementations/braze_request_overrides.py
@@ -32,10 +32,13 @@ def braze_user_update(
             privacy_request_id = row_param_values[PRIVACY_REQUEST_ID]
             all_object_fields["email"] = f"{privacy_request_id}@company.com"
 
-        update_body = {"attributes": [{dumps(all_object_fields)}]}
+        update_body = dumps({"attributes": [all_object_fields]})
         client.send(
             SaaSRequestParams(
-                method=HTTPMethod.PUT, path="/users/track", body=update_body
+                method=HTTPMethod.POST,
+                headers={"Content-Type": "application/json"},
+                path="/users/track",
+                body=update_body,
             )
         )
         rows_updated += 1

--- a/src/fides/api/service/saas_request/override_implementations/braze_request_overrides.py
+++ b/src/fides/api/service/saas_request/override_implementations/braze_request_overrides.py
@@ -1,0 +1,42 @@
+from json import dumps
+from typing import Any, Dict, List
+
+from fides.api.models.policy import Policy
+from fides.api.models.privacy_request import PrivacyRequest
+from fides.api.schemas.saas.shared_schemas import HTTPMethod, SaaSRequestParams
+from fides.api.service.connectors.saas.authenticated_client import AuthenticatedClient
+from fides.api.service.saas_request.saas_request_override_factory import (
+    SaaSRequestType,
+    register,
+)
+from fides.api.util.saas_util import PRIVACY_REQUEST_ID
+
+
+@register("braze_user_update", [SaaSRequestType.UPDATE])
+def braze_user_update(
+    client: AuthenticatedClient,
+    param_values_per_row: List[Dict[str, Any]],
+    policy: Policy,
+    privacy_request: PrivacyRequest,
+    secrets: Dict[str, Any],
+) -> int:
+    rows_updated = 0
+    # each update_params dict correspond to a record that needs to be updated
+    for row_param_values in param_values_per_row:
+        # check if the privacy_request targeted emails for erasure,
+        # if so rewrite with a format that can be accepted by Braze
+        # regardless of the masking strategy in use
+        all_object_fields = row_param_values["all_object_fields"]
+
+        if "user.contact.email" in policy.get_erasure_target_categories():
+            privacy_request_id = row_param_values[PRIVACY_REQUEST_ID]
+            all_object_fields["email"] = f"{privacy_request_id}@company.com"
+
+        update_body = {"attributes": [{dumps(all_object_fields)}]}
+        client.send(
+            SaaSRequestParams(
+                method=HTTPMethod.PUT, path="/users/track", body=update_body
+            )
+        )
+        rows_updated += 1
+    return rows_updated


### PR DESCRIPTION
Partially Closes #4179

### Description Of Changes

Found in a recent test, unclear if this is a recent change by Braze

This creates an override that allows Braze to mask email with a proper format to meet the needs of Braze.


### Code Changes

* [ ] Create an override for Braze
* [ ] Update config to use override
* [ ] Update dataset to prefer the `braze_id` over an `external_id`

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
