### PR TITLE
Performance Refactor for `privacy-experience`

### DIFF
--- a/noxfiles/drill.yml
+++ b/noxfiles/drill.yml
@@ -1,33 +1,59 @@
 # This file is used by "drill", a load testing utility
 # https://github.com/fcsonline/drill
 
-concurrency: 1 # How many instances of the `plan` get run concurrently
+concurrency: 5 # How many instances of the `plan` get run concurrently
 base: 'http://localhost:8080'
-iterations: 1 # The webserver shows performance issues quickly, so we only need 10 iterations
-rampup: 2 # The number of seconds between concurrent runsThe serial steps to running this plan
+iterations: 10 # The webserver shows performance issues quickly, so we only need 10 iterations
+rampup: 2 # The number of seconds between starting concurrent runs
 
-# Sequential stress-test plan
+# This plan is run in its entirety, sequentially, for each iteration
 plan:
   - name: Health Check
     request:
       method: GET
       url: /health
 
-  - name: Worker Health Check
-    request:
-      method: GET
-      url: /health/workers
-
-  - name: Database Health Check
-    request:
-      method: GET
-      url: /health/database
-
   - name: Login
+    assign: login
     request:
       method: POST
       body: '{"username": "root_user", "password": "VGVzdHBhc3N3b3JkMSE="}'
       headers:
         Content-Type: 'application/json'
       url: /api/v1/login
-      assign: login
+
+  - name: Get Privacy-Experience [Basic]
+    request:
+      method: GET
+      url: /api/v1/privacy-experience
+
+  - name: Get Privacy-Experience [Include GVL]
+    request:
+      method: GET
+      url: /api/v1/privacy-experience?include_gvl=1
+
+  - name: Get Data Privacy Types
+    request:
+      method: GET
+      headers:
+        Authorization: "Bearer {{ login.body.token_data.access_token }}"
+      url: /api/v1/{{ item }}
+    with_items:
+      - data_use
+      - data_category
+      - data_subject
+      - data_qualifier
+
+  - name: Get Systems
+    request:
+      method: GET
+      headers:
+        Authorization: "Bearer {{ login.body.token_data.access_token }}"
+      url: /api/v1/system
+
+  - name: Get Datasets
+    request:
+      method: GET
+      headers:
+        Authorization: "Bearer {{ login.body.token_data.access_token }}"
+      url: /api/v1/dataset

--- a/noxfiles/drill.yml
+++ b/noxfiles/drill.yml
@@ -1,7 +1,7 @@
 # This file is used by "drill", a load testing utility
 # https://github.com/fcsonline/drill
 
-concurrency: 1 # How many instances of the `plan` get run concurrently
+concurrency: 5 # How many instances of the `plan` get run concurrently
 base: 'http://localhost:8080'
 iterations: 5 # How many times to run the plan
 rampup: 1 # The number of seconds between starting concurrent runs

--- a/noxfiles/drill.yml
+++ b/noxfiles/drill.yml
@@ -1,16 +1,33 @@
 # This file is used by "drill", a load testing utility
+# https://github.com/fcsonline/drill
 
-concurrency: 4
+concurrency: 1 # How many instances of the `plan` get run concurrently
 base: 'http://localhost:8080'
-# There is a rate-limiter on the webserver, default is set to 2000 requests/min
-iterations: 400
-rampup: 3
+iterations: 1 # The webserver shows performance issues quickly, so we only need 10 iterations
+rampup: 2 # The number of seconds between concurrent runsThe serial steps to running this plan
 
+# Sequential stress-test plan
 plan:
   - name: Health Check
     request:
+      method: GET
       url: /health
 
   - name: Worker Health Check
     request:
+      method: GET
       url: /health/workers
+
+  - name: Database Health Check
+    request:
+      method: GET
+      url: /health/database
+
+  - name: Login
+    request:
+      method: POST
+      body: '{"username": "root_user", "password": "VGVzdHBhc3N3b3JkMSE="}'
+      headers:
+        Content-Type: 'application/json'
+      url: /api/v1/login
+      assign: login

--- a/noxfiles/drill.yml
+++ b/noxfiles/drill.yml
@@ -3,7 +3,7 @@
 
 concurrency: 5 # How many instances of the `plan` get run concurrently
 base: 'http://localhost:8080'
-iterations: 5 # How many times to run the plan
+iterations: 20 # How many times to run the plan
 rampup: 1 # The number of seconds between starting concurrent runs
 
 # This plan is run in its entirety, sequentially, for each iteration

--- a/noxfiles/drill.yml
+++ b/noxfiles/drill.yml
@@ -1,9 +1,9 @@
 # This file is used by "drill", a load testing utility
 # https://github.com/fcsonline/drill
 
-concurrency: 5 # How many instances of the `plan` get run concurrently
+concurrency: 1 # How many instances of the `plan` get run concurrently
 base: 'http://localhost:8080'
-iterations: 10 # The webserver shows performance issues quickly, so we only need 10 iterations
+iterations: 2 # How many times to run the plan
 rampup: 2 # The number of seconds between starting concurrent runs
 
 # This plan is run in its entirety, sequentially, for each iteration
@@ -32,17 +32,33 @@ plan:
       method: GET
       url: /api/v1/privacy-experience?include_gvl=1
 
-  - name: Get Data Privacy Types
+  - name: Get Data Use
     request:
       method: GET
       headers:
         Authorization: "Bearer {{ login.body.token_data.access_token }}"
-      url: /api/v1/{{ item }}
-    with_items:
-      - data_use
-      - data_category
-      - data_subject
-      - data_qualifier
+      url: /api/v1/data_use
+
+  - name: Get Data Category
+    request:
+      method: GET
+      headers:
+        Authorization: "Bearer {{ login.body.token_data.access_token }}"
+      url: /api/v1/data_category
+
+  - name: Get Data Qualifier
+    request:
+      method: GET
+      headers:
+        Authorization: "Bearer {{ login.body.token_data.access_token }}"
+      url: /api/v1/data_qualifier
+
+  - name: Get Data Subject
+    request:
+      method: GET
+      headers:
+        Authorization: "Bearer {{ login.body.token_data.access_token }}"
+      url: /api/v1/data_subject
 
   - name: Get Systems
     request:

--- a/noxfiles/drill.yml
+++ b/noxfiles/drill.yml
@@ -3,8 +3,8 @@
 
 concurrency: 1 # How many instances of the `plan` get run concurrently
 base: 'http://localhost:8080'
-iterations: 2 # How many times to run the plan
-rampup: 2 # The number of seconds between starting concurrent runs
+iterations: 5 # How many times to run the plan
+rampup: 1 # The number of seconds between starting concurrent runs
 
 # This plan is run in its entirety, sequentially, for each iteration
 plan:
@@ -26,11 +26,15 @@ plan:
     request:
       method: GET
       url: /api/v1/privacy-experience
+    tags:
+      - privacy-experience
 
   - name: Get Privacy-Experience [Include GVL]
     request:
       method: GET
       url: /api/v1/privacy-experience?include_gvl=1
+    tags:
+      - privacy-experience
 
   - name: Get Data Use
     request:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ deepdiff==6.3.0
 defusedxml==0.7.1
 expandvars==0.9.0
 fastapi[all]==0.89.1
-fastapi-caching[redis]==0.3.0
 fastapi-pagination[sqlalchemy]==0.11.4
 fideslang==2.1.0
 fideslog==1.2.10

--- a/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
@@ -221,10 +221,10 @@ async def privacy_experience_list(
 
     results: List[PrivacyExperience] = []
     should_unescape: Optional[str] = request.headers.get(UNESCAPE_SAFESTR_HEADER)
-      
+
     # Builds TCF Experience Contents once here, in case multiple TCF Experiences are requested
     base_tcf_contents: TCFExperienceContents = get_tcf_contents(db)
-    
+
     await asyncio.sleep(delay=0.001)
     for privacy_experience in experience_query.order_by(
         PrivacyExperience.created_at.desc()

--- a/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
@@ -1,6 +1,7 @@
 import uuid
 from html import escape, unescape
 from typing import Dict, List, Optional
+import asyncio
 
 from fastapi import Depends, HTTPException
 from fastapi import Query as FastAPIQuery
@@ -174,6 +175,7 @@ async def privacy_experience_list(
             db=db, fides_user_device_id=fides_user_device_id
         )
 
+    await asyncio.sleep(delay=0.001)
     experience_query = db.query(PrivacyExperience)
 
     if show_disabled is False:
@@ -184,11 +186,13 @@ async def privacy_experience_list(
             PrivacyExperienceConfig.id == PrivacyExperience.experience_config_id,
         ).filter(PrivacyExperienceConfig.disabled.is_(False))
 
+    await asyncio.sleep(delay=0.001)
     if region is not None:
         experience_query = _filter_experiences_by_region_or_country(
             db=db, region=region, experience_query=experience_query
         )
 
+    await asyncio.sleep(delay=0.001)
     if component is not None:
         # Intentionally relaxes what is returned when querying for "overlay", by returning both types of overlays.
         # This way the frontend doesn't have to know which type of overlay, regular or tcf, just that it is an overlay.
@@ -200,10 +204,12 @@ async def privacy_experience_list(
                 component_search_map.get(component, [component])
             )
         )
+    await asyncio.sleep(delay=0.001)
     if has_config is True:
         experience_query = experience_query.filter(
             PrivacyExperience.experience_config_id.isnot(None)
         )
+    await asyncio.sleep(delay=0.001)
     if has_config is False:
         experience_query = experience_query.filter(
             PrivacyExperience.experience_config_id.is_(None)
@@ -211,9 +217,11 @@ async def privacy_experience_list(
 
     results: List[PrivacyExperience] = []
     should_unescape: Optional[str] = request.headers.get(UNESCAPE_SAFESTR_HEADER)
+    await asyncio.sleep(delay=0.001)
     for privacy_experience in experience_query.order_by(
         PrivacyExperience.created_at.desc()
     ):
+        await asyncio.sleep(delay=0.001)
         content_exists: bool = embed_experience_details(
             db,
             privacy_experience=privacy_experience,
@@ -228,6 +236,7 @@ async def privacy_experience_list(
             continue
 
         # Temporarily save "show_banner" on the privacy experience object
+        await asyncio.sleep(delay=0.001)
         privacy_experience.show_banner = privacy_experience.get_should_show_banner(
             db, show_disabled
         )

--- a/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
@@ -124,7 +124,7 @@ def _filter_experiences_by_region_or_country(
     response_model=Page[PrivacyExperienceResponse],
 )
 @fides_limiter.limit(CONFIG.security.public_request_rate_limit)
-def privacy_experience_list(
+async def privacy_experience_list(
     *,
     db: Session = Depends(deps.get_db),
     params: Params = Depends(),

--- a/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_experience_endpoints.py
@@ -1,7 +1,7 @@
+import asyncio
 import uuid
 from html import escape, unescape
 from typing import Dict, List, Optional
-import asyncio
 
 from fastapi import Depends, HTTPException
 from fastapi import Query as FastAPIQuery


### PR DESCRIPTION
Closes #4040 

### Description Of Changes

See below ⬇️ 

This PR will be followed up with another that focuses on adding proper Caching to that endpoint

### Code Changes

* [x] update `drill` to give us more data for A/B testing
* [x] sprinkle in `asyncio.sleep` calls to force `privacy-experience` to give up the event loop between heavy db calls

### Steps to Confirm

* [ ] run `nox -s dev` and then `nox -s load_tests`, it should be observed that the response times for all endpoints (besides `privacy-experience`) are extremely consistent, representing that they aren't being significantly blocked by `privacy-experience`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
