### PR TITLE
Update for Braze and Domo overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 - TCF overlay can initialize its consent preferences from a cookie [#4124](https://github.com/ethyca/fides/pull/4124)
 - Various improvements to the TCF modal such as vendor storage disclosures, vendor counts, privacy policies, etc. [#4167](https://github.com/ethyca/fides/pull/4167)
 - An issue where Braze could not mask an email due to formatting [#4187](https://github.com/ethyca/fides/pull/4187)
+- An issue where email was not being overridden correctly for Braze and Domo [#4196](https://github.com/ethyca/fides/pull/4196)
 
 ## [2.21.0](https://github.com/ethyca/fides/compare/2.20.2...2.21.0)
 

--- a/src/fides/api/service/saas_request/override_implementations/braze_request_overrides.py
+++ b/src/fides/api/service/saas_request/override_implementations/braze_request_overrides.py
@@ -28,7 +28,7 @@ def braze_user_update(
         # regardless of the masking strategy in use
         all_object_fields = row_param_values["all_object_fields"]
 
-        if "user.contact.email" in policy.get_erasure_target_categories():
+        if "email" in all_object_fields:
             privacy_request_id = row_param_values[PRIVACY_REQUEST_ID]
             all_object_fields["email"] = f"{privacy_request_id}@company.com"
 

--- a/src/fides/api/service/saas_request/override_implementations/domo_request_overrides.py
+++ b/src/fides/api/service/saas_request/override_implementations/domo_request_overrides.py
@@ -31,7 +31,7 @@ def domo_user_update(
         # regardless of the masking strategy in use
         all_object_fields = row_param_values["all_object_fields"]
 
-        if "user.contact.email" in policy.get_erasure_target_categories():
+        if "email" in all_object_fields:
             privacy_request_id = row_param_values[PRIVACY_REQUEST_ID]
             all_object_fields["email"] = f"{privacy_request_id}@company.com"
             all_object_fields["alternateEmail"] = f"{privacy_request_id}@company.com"


### PR DESCRIPTION

Closes #4179

### Description Of Changes

The if was blocking the formatting of the email. This change simplifies it to block it if the key is present instead of relying on `user.contact.email` (`user.contact` is included in the policy instead)

We may also want to replicate this change to Domo overrides

### Code Changes

* [ ] Modify the if to format email correctly if present

### Steps to Confirm

* [ ] Implemented live today with the email being formatted

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
