### PR TITLE
Fix retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 - TCF overlay can initialize its consent preferences from a cookie [#4124](https://github.com/ethyca/fides/pull/4124)
 - Various improvements to the TCF modal such as vendor storage disclosures, vendor counts, privacy policies, etc. [#4167](https://github.com/ethyca/fides/pull/4167)
 - An issue where Braze could not mask an email due to formatting [#4187](https://github.com/ethyca/fides/pull/4187)
+- Use `stdRetention` when there is not a specific value for a purpose's data retention [#4199](https://github.com/ethyca/fides/pull/4199)
 
 ## [2.21.0](https://github.com/ethyca/fides/compare/2.20.2...2.21.0)
 

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -20,6 +20,11 @@ import ExternalLink from "../ExternalLink";
 
 const FILTERS = [{ name: "All vendors" }, { name: "IAB TCF vendors" }];
 
+interface Retention {
+  mapping: Record<number, number>;
+  default: number;
+}
+
 const VendorDetails = ({
   label,
   lineItems,
@@ -27,7 +32,7 @@ const VendorDetails = ({
 }: {
   label: string;
   lineItems: EmbeddedLineItem[] | undefined;
-  dataRetention?: Record<number, number>;
+  dataRetention?: Retention;
 }) => {
   if (!lineItems || lineItems.length === 0) {
     return null;
@@ -43,7 +48,10 @@ const VendorDetails = ({
       </thead>
       <tbody>
         {lineItems.map((item) => {
-          const retention = dataRetention ? dataRetention[item.id] : undefined;
+          let retention: string | number = "N/A";
+          if (dataRetention) {
+            retention = dataRetention.mapping[item.id] ?? dataRetention.default;
+          }
           return (
             <tr key={item.id}>
               <td>{item.name}</td>
@@ -83,13 +91,25 @@ const PurposeVendorDetails = ({
       <VendorDetails
         label="Purposes"
         lineItems={purposes as EmbeddedLineItem[]}
-        dataRetention={dataRetention ? dataRetention.purposes : undefined}
+        dataRetention={
+          dataRetention
+            ? {
+                mapping: dataRetention.purposes,
+                default: dataRetention.stdRetention,
+              }
+            : undefined
+        }
       />
       <VendorDetails
         label="Special purposes"
         lineItems={specialPurposes as EmbeddedLineItem[]}
         dataRetention={
-          dataRetention ? dataRetention.specialPurposes : undefined
+          dataRetention
+            ? {
+                mapping: dataRetention.specialPurposes,
+                default: dataRetention.stdRetention,
+              }
+            : undefined
         }
       />
     </div>


### PR DESCRIPTION
Closes N/A

### Description Of Changes

Uses the `stdRetention` number if there is no specific number of retention days for a given purpose.


### Code Changes

* [x] Fill in `stdRetention` as needed

### Steps to Confirm

* Set up your TCF environment and add a vendor from the dictionary
* Instead of `N/A`s, you should now see the default `stdRetention` value as expected

![image](https://github.com/ethyca/fides/assets/24641006/14a8c8ed-966a-404f-8d73-0684ba56542b)


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`
