### PR TITLE
docs: fix 404'ing link to code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Fides Code of Conduct
 
-The Fides project, which includes Fideslang, adheres to the following [Code of Conduct](https://docs.ethyca.com/fides/community/code_of_conduct).
+The Fides project, which includes Fideslang, adheres to the following [Code of Conduct](https://docs.ethyca.com/community/code_of_conduct).
 
 The Fides core team welcomes any contributions and suggestions to help make the community a better place 🤝


### PR DESCRIPTION
No associated issue (this is a tiny docs change).

### Description Of Changes

This change fixes a 404'ing link to the Fides Code of Conduct.


### Code Changes

n/a

### Steps to Confirm

* Verify new link works and is correct

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
