### PR TITLE
fides: add `System` model support for new tcf fields

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -1142,6 +1142,21 @@ dataset:
     - name: data_security_practices
       data_categories:
       - system.operations
+    - name: cookie_max_age_seconds
+      data_categories:
+      - system.operations
+    - name: cookie_refresh
+      data_categories:
+      - system.operations
+    - name: uses_cookies
+      data_categories:
+      - system.operations
+    - name: uses_non_cookie_access
+      data_categories:
+      - system.operations
+    - name: legitimate_interest_disclosure_url
+      data_categories:
+      - system.operations
     - name: user_id
       data_categories:
       - user.unique_id
@@ -1551,6 +1566,9 @@ dataset:
       data_categories:
       - system.operations
     - name: legal_basis_for_processing
+      data_categories:
+      - system.operations
+    - name: flexible_legal_basis_for_processing
       data_categories:
       - system.operations
     - name: impact_assessment_location

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The types of changes are:
 - Added an option to link to vendor tab from an experience config description [#4191](https://github.com/ethyca/fides/pull/4191)
 - Added two toggles for vendors in the TCF overlay, one for Consent, and one for Legitimate Interest [#4189](https://github.com/ethyca/fides/pull/4189)
 - Added two toggles for purposes in the TCF overlay, one for Consent, and one for Legitimate Interest [#4234](https://github.com/ethyca/fides/pull/4234)
+- Added support for new TCF-related fields on `System` and `PrivacyDeclaration` models [#4228](https://github.com/ethyca/fides/pull/4228)
 
 
 ### Changed

--- a/src/fides/api/alembic/migrations/versions/81886da90395_add_legal_basis_dimension.py
+++ b/src/fides/api/alembic/migrations/versions/81886da90395_add_legal_basis_dimension.py
@@ -4,7 +4,7 @@ We've previously been saving preferences against purposes, vendors, and systems,
 need to instead save preferences against a purpose/vendor AND a legal basis.
 
 Revision ID: 81886da90395
-Revises: 4cb3b5af4160
+Revises: 9b98aba5bba8
 Create Date: 2023-09-30 17:39:46.251444
 
 """

--- a/src/fides/api/alembic/migrations/versions/c5a218831820_additional_tcf_fields_system.py
+++ b/src/fides/api/alembic/migrations/versions/c5a218831820_additional_tcf_fields_system.py
@@ -1,0 +1,89 @@
+"""additional tcf fields system
+
+Revision ID: c5a218831820
+Revises: 81226042d7d4
+Create Date: 2023-10-05 15:40:09.294013
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c5a218831820"
+down_revision = "81226042d7d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "ctl_systems",
+        sa.Column("cookie_max_age_seconds", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "ctl_systems",
+        sa.Column(
+            "uses_cookies",
+            sa.Boolean(),
+            nullable=False,
+            server_default="f",
+        ),
+    )
+    op.add_column(
+        "ctl_systems",
+        sa.Column(
+            "cookie_refresh",
+            sa.Boolean(),
+            nullable=False,
+            server_default="f",
+        ),
+    )
+    op.add_column(
+        "ctl_systems",
+        sa.Column(
+            "uses_non_cookie_access",
+            sa.Boolean(),
+            nullable=False,
+            server_default="f",
+        ),
+    )
+    op.add_column(
+        "ctl_systems",
+        sa.Column("legitimate_interest_disclosure_url", sa.String(), nullable=True),
+    )
+
+    op.add_column(
+        "privacydeclaration",
+        sa.Column(
+            "flexible_legal_basis_for_processing",
+            sa.Boolean(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column(
+        "ctl_systems",
+        "cookie_max_age_seconds",
+    )
+    op.drop_column(
+        "ctl_systems",
+        "uses_cookies",
+    )
+    op.drop_column(
+        "ctl_systems",
+        "cookie_refresh",
+    )
+    op.drop_column(
+        "ctl_systems",
+        "uses_non_cookie_access",
+    )
+    op.drop_column(
+        "ctl_systems",
+        "legitimate_interest_disclosure_url",
+    )
+    op.drop_column(
+        "privacydeclaration",
+        "flexible_legal_basis_for_processing",
+    )

--- a/src/fides/api/models/sql_models.py
+++ b/src/fides/api/models/sql_models.py
@@ -397,6 +397,13 @@ class System(Base, FidesBase):
     dpo = Column(String)
     joint_controller_info = Column(String)
     data_security_practices = Column(String)
+    cookie_max_age_seconds = Column(Integer)
+    uses_cookies = Column(BOOLEAN(), default=False, server_default="f", nullable=False)
+    cookie_refresh = Column(BOOLEAN(), default=False, server_default="f", nullable=False)
+    uses_non_cookie_access = Column(
+        BOOLEAN(), default=False, server_default="f", nullable=False
+    )
+    legitimate_interest_disclosure_url = Column(String)
 
     privacy_declarations = relationship(
         "PrivacyDeclaration",
@@ -465,6 +472,7 @@ class PrivacyDeclaration(Base):
 
     features = Column(ARRAY(String), server_default="{}", nullable=False)
     legal_basis_for_processing = Column(String)
+    flexible_legal_basis_for_processing = Column(BOOLEAN())
     impact_assessment_location = Column(String)
     retention_period = Column(String)
     processes_special_category_data = Column(

--- a/src/fides/api/models/sql_models.py
+++ b/src/fides/api/models/sql_models.py
@@ -399,7 +399,9 @@ class System(Base, FidesBase):
     data_security_practices = Column(String)
     cookie_max_age_seconds = Column(Integer)
     uses_cookies = Column(BOOLEAN(), default=False, server_default="f", nullable=False)
-    cookie_refresh = Column(BOOLEAN(), default=False, server_default="f", nullable=False)
+    cookie_refresh = Column(
+        BOOLEAN(), default=False, server_default="f", nullable=False
+    )
     uses_non_cookie_access = Column(
         BOOLEAN(), default=False, server_default="f", nullable=False
     )

--- a/src/fides/api/schemas/tcf.py
+++ b/src/fides/api/schemas/tcf.py
@@ -7,7 +7,7 @@ from fideslang.gvl import (
     MAPPED_SPECIAL_PURPOSES,
 )
 from fideslang.gvl.models import Feature, MappedPurpose
-from pydantic import Field, root_validator, validator
+from pydantic import AnyUrl, Field, root_validator, validator
 
 from fides.api.models.privacy_notice import UserConsentPreference
 from fides.api.schemas.base_class import FidesSchema
@@ -74,6 +74,11 @@ class CommonVendorFields(FidesSchema):
     has_vendor_id: Optional[bool]
     name: Optional[str]
     description: Optional[str]
+    cookie_max_age_seconds: Optional[int]
+    uses_cookies: Optional[bool]
+    cookie_refresh: Optional[bool]
+    uses_non_cookie_access: Optional[bool]
+    legitimate_interest_disclosure_url: Optional[AnyUrl]
 
 
 class TCFVendorConsentRecord(UserSpecificConsentDetails, CommonVendorFields):

--- a/src/fides/api/schemas/tcf.py
+++ b/src/fides/api/schemas/tcf.py
@@ -74,11 +74,6 @@ class CommonVendorFields(FidesSchema):
     has_vendor_id: Optional[bool]
     name: Optional[str]
     description: Optional[str]
-    cookie_max_age_seconds: Optional[int]
-    uses_cookies: Optional[bool]
-    cookie_refresh: Optional[bool]
-    uses_non_cookie_access: Optional[bool]
-    legitimate_interest_disclosure_url: Optional[AnyUrl]
 
 
 class TCFVendorConsentRecord(UserSpecificConsentDetails, CommonVendorFields):
@@ -115,6 +110,11 @@ class TCFVendorRelationships(CommonVendorFields):
     special_purposes: List[EmbeddedLineItem] = []
     features: List[EmbeddedLineItem] = []
     special_features: List[EmbeddedLineItem] = []
+    cookie_max_age_seconds: Optional[int]
+    uses_cookies: Optional[bool]
+    cookie_refresh: Optional[bool]
+    uses_non_cookie_access: Optional[bool]
+    legitimate_interest_disclosure_url: Optional[AnyUrl]
 
 
 class TCFFeatureRecord(NonVendorSection, Feature):

--- a/src/fides/api/util/tcf/tcf_experience_contents.py
+++ b/src/fides/api/util/tcf/tcf_experience_contents.py
@@ -426,49 +426,47 @@ def build_purpose_or_feature_section_and_update_vendor_map(
 
 
 def populate_vendor_relationships_basic_attributes(
-    vendor_map,
+    vendor_map: Dict[str, TCFVendorRelationships],
     matching_privacy_declarations: Query,
-):
+) -> Dict[str, TCFVendorRelationships]:
     """Populates TCFVendorRelationships records for all vendors that we're displaying in the overlay.
     Ensures that these TCFVendorRelationships records have the "basic" TCF attributes populated.
     """
     for privacy_declaration_row in matching_privacy_declarations:
         vendor_id, system_identifier = get_system_identifiers(privacy_declaration_row)
-        if vendor_id:  # this only applies to GVL vendors
-            # Add top-level entry to the vendor relationship map
-            if system_identifier not in vendor_map:
-                vendor_map[system_identifier] = TCFVendorRelationships(
-                    id=system_identifier,  # Identify system by vendor id if it exists, otherwise use system id.
-                    name=privacy_declaration_row.system_name,
-                    description=privacy_declaration_row.system_description,
-                    has_vendor_id=bool(
-                        vendor_id
-                    ),  # Has_vendor_id will let us separate data between systems and vendors
-                    cookie_max_age_seconds=privacy_declaration_row.system_cookie_max_age_seconds,
-                    uses_cookies=privacy_declaration_row.system_uses_cookies,
-                    cookie_refresh=privacy_declaration_row.system_cookie_refresh,
-                    uses_non_cookie_access=privacy_declaration_row.system_uses_non_cookie_access,
-                    legitimate_interest_disclosure_url=privacy_declaration_row.system_legitimate_interest_disclosure_url,
-                )
 
-            else:
-                # otherwise just ensure that our basic attributes are populated on the vendor relationship entry
-                vendor_relationships = vendor_map[system_identifier]
-                vendor_relationships.cookie_max_age_seconds = (
-                    privacy_declaration_row.system_cookie_max_age_seconds
-                )
-                vendor_relationships.uses_cookies = (
-                    privacy_declaration_row.system_uses_cookies
-                )
-                vendor_relationships.cookie_refresh = (
-                    privacy_declaration_row.system_cookie_refresh
-                )
-                vendor_relationships.uses_non_cookie_access = (
-                    privacy_declaration_row.system_uses_non_cookie_access
-                )
-                vendor_relationships.legitimate_interest_disclosure_url = (
-                    privacy_declaration_row.system_legitimate_interest_disclosure_url
-                )
+        # Get the existing TCFVendorRelationships record or create a new one.
+        # Add to the vendor map if it wasn't added in a previous section.
+        vendor_relationship_record = vendor_map.get(system_identifier)
+        if not vendor_relationship_record:
+            vendor_relationship_record = TCFVendorRelationships(
+                id=system_identifier,  # Identify system by vendor id if it exists, otherwise use system id.
+                name=privacy_declaration_row.system_name,
+                description=privacy_declaration_row.system_description,
+                has_vendor_id=bool(
+                    vendor_id  # This will let us separate data between systems and vendors later
+                ),
+            )
+            vendor_map[system_identifier] = vendor_relationship_record
+
+        # Now add basic attributes to the VendorRelationships record
+        vendor_relationship_record.cookie_max_age_seconds = (
+            privacy_declaration_row.system_cookie_max_age_seconds
+        )
+        vendor_relationship_record.uses_cookies = (
+            privacy_declaration_row.system_uses_cookies
+        )
+        vendor_relationship_record.cookie_refresh = (
+            privacy_declaration_row.system_cookie_refresh
+        )
+        vendor_relationship_record.uses_non_cookie_access = (
+            privacy_declaration_row.system_uses_non_cookie_access
+        )
+        vendor_relationship_record.legitimate_interest_disclosure_url = (
+            privacy_declaration_row.system_legitimate_interest_disclosure_url
+        )
+
+    return vendor_map
 
 
 def get_tcf_contents(
@@ -564,7 +562,11 @@ def get_tcf_contents(
         matching_privacy_declaration_query=matching_privacy_declarations,
     )
 
-    populate_vendor_relationships_basic_attributes(
+    # Finally, add missing TCFVendorRelationships records for vendors that weren't already added
+    # via the special_features, features, and special_purposes section.  Every vendor in the overlay
+    # should show up in this section. Add the basic attributes to the vendor here to avoid duplication
+    # in other vendor sections.
+    updated_vendor_relationships_map = populate_vendor_relationships_basic_attributes(
         vendor_map=updated_vendor_relationships_map,
         matching_privacy_declarations=matching_privacy_declarations,
     )

--- a/src/fides/api/util/tcf/tcf_experience_contents.py
+++ b/src/fides/api/util/tcf/tcf_experience_contents.py
@@ -184,6 +184,13 @@ def get_matching_privacy_declarations(db: Session) -> Query:
             System.fides_key.label("system_fides_key"),
             System.name.label("system_name"),
             System.description.label("system_description"),
+            System.cookie_max_age_seconds.label("system_cookie_max_age_seconds"),
+            System.uses_cookies.label("system_uses_cookies"),
+            System.cookie_refresh.label("system_cookie_refresh"),
+            System.uses_non_cookie_access.label("system_uses_non_cookie_access"),
+            System.legitimate_interest_disclosure_url.label(
+                "system_legitimate_interest_disclosure_url"
+            ),
             System.vendor_id,
             PrivacyDeclaration.data_use,
             PrivacyDeclaration.legal_basis_for_processing,
@@ -398,6 +405,11 @@ def build_purpose_or_feature_section_and_update_vendor_map(
                     has_vendor_id=bool(
                         vendor_id
                     ),  # Has_vendor_id will let us separate data between systems and vendors
+                    cookie_max_age_seconds=privacy_declaration_row.system_cookie_max_age_seconds,
+                    uses_cookies=privacy_declaration_row.system_uses_cookies,
+                    cookie_refresh=privacy_declaration_row.system_cookie_refresh,
+                    uses_non_cookie_access=privacy_declaration_row.system_uses_non_cookie_access,
+                    legitimate_interest_disclosure_url=privacy_declaration_row.system_legitimate_interest_disclosure_url,
                 )
 
             # Embed the purpose/feature under the system if it doesn't exist

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -477,6 +477,11 @@ class TestSystemCreate:
             dpo="John Doe, CIPT",
             joint_controller_info="Jane Doe",
             data_security_practices="We encrypt all your data in transit and at rest",
+            cookie_max_age_seconds="31536000",
+            uses_cookies=True,
+            cookie_refresh=True,
+            uses_non_cookie_access=True,
+            legitimate_interest_disclosure_url="http://www.example.com/legitimate_interest_disclosure",
             privacy_declarations=[
                 models.PrivacyDeclaration(
                     name="declaration-name",
@@ -654,6 +659,14 @@ class TestSystemCreate:
             system.data_security_practices
             == "We encrypt all your data in transit and at rest"
         )
+        assert system.cookie_max_age_seconds == 31536000
+        assert system.uses_cookies == True
+        assert system.cookie_refresh == True
+        assert system.uses_non_cookie_access == True
+        assert (
+            system.legitimate_interest_disclosure_url
+            == "http://www.example.com/legitimate_interest_disclosure"
+        )
         assert system.data_stewards == []
         assert [cookie.name for cookie in systems[0].cookies] == ["essential_cookie"]
         assert [
@@ -679,6 +692,7 @@ class TestSystemCreate:
         assert privacy_decl.data_shared_with_third_parties is True
         assert privacy_decl.third_parties == "Third Party Marketing Dept."
         assert privacy_decl.shared_categories == ["user"]
+        assert privacy_decl.flexible_legal_basis_for_processing is None
 
     async def test_system_create_minimal_request_body(
         self, generate_auth_header, db, test_config, system_create_request_body

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -660,9 +660,9 @@ class TestSystemCreate:
             == "We encrypt all your data in transit and at rest"
         )
         assert system.cookie_max_age_seconds == 31536000
-        assert system.uses_cookies == True
-        assert system.cookie_refresh == True
-        assert system.uses_non_cookie_access == True
+        assert system.uses_cookies is True
+        assert system.cookie_refresh is True
+        assert system.uses_non_cookie_access is True
         assert (
             system.legitimate_interest_disclosure_url
             == "http://www.example.com/legitimate_interest_disclosure"

--- a/tests/ops/util/test_tcf_experience_contents.py
+++ b/tests/ops/util/test_tcf_experience_contents.py
@@ -224,6 +224,17 @@ class TestTCFContents:
             tcf_contents.tcf_vendor_consents[0].description
             == "My TCF System Description"
         )
+
+        # assert some additional TCF attributes are set to their defaults here
+        assert tcf_contents.tcf_vendor_consents[0].cookie_max_age_seconds is None
+        assert tcf_contents.tcf_vendor_consents[0].uses_cookies is False
+        assert tcf_contents.tcf_vendor_consents[0].uses_non_cookie_access is False
+        assert tcf_contents.tcf_vendor_consents[0].cookie_refresh is False
+        assert (
+            tcf_contents.tcf_vendor_consents[0].legitimate_interest_disclosure_url
+            is None
+        )
+
         assert len(tcf_contents.tcf_vendor_consents[0].purpose_consents) == 1
         assert tcf_contents.tcf_vendor_consents[0].purpose_consents[0].id == 8
 
@@ -233,6 +244,94 @@ class TestTCFContents:
             tcf_contents.tcf_vendor_relationships[0].description
             == "My TCF System Description"
         )
+        # assert some additional TCF attributes are set to their defaults here
+        assert tcf_contents.tcf_vendor_relationships[0].cookie_max_age_seconds is None
+        assert tcf_contents.tcf_vendor_relationships[0].uses_cookies is False
+        assert tcf_contents.tcf_vendor_relationships[0].uses_non_cookie_access is False
+        assert tcf_contents.tcf_vendor_relationships[0].cookie_refresh is False
+        assert (
+            tcf_contents.tcf_vendor_relationships[0].legitimate_interest_disclosure_url
+            is None
+        )
+        assert len(tcf_contents.tcf_vendor_relationships[0].special_purposes) == 1
+        assert tcf_contents.tcf_vendor_relationships[0].special_purposes[0].id == 1
+
+    def test_system_exists_with_tcf_purpose_and_vendor_including_tcf_fields_set(
+        self, db, tcf_system
+    ):
+        """System has vendor id so we return preferences against a "vendor" instead of the system
+
+        Vendor has some TCF-specific attributes set, ensure they are being surfaced properly in the overlay.
+        """
+        tcf_system.cookie_max_age_seconds = 31536000
+        tcf_system.uses_cookies = True
+        tcf_system.cookie_refresh = True
+        tcf_system.uses_non_cookie_access = True
+        tcf_system.legitimate_interest_disclosure_url = "http://test.com/disclosure_url"
+        tcf_system.save(db)
+
+        tcf_contents = get_tcf_contents(db)
+        assert_length_of_tcf_sections(
+            tcf_contents,
+            p_c_len=1,
+            p_li_len=0,
+            f_len=0,
+            sp_len=1,
+            sf_len=0,
+            v_c_len=1,
+            v_li_len=0,
+            v_r_len=1,
+            s_c_len=0,
+            s_li_len=0,
+            s_r_len=0,
+        )
+
+        assert tcf_contents.tcf_purpose_consents[0].id == 8
+        assert tcf_contents.tcf_purpose_consents[0].data_uses == [
+            "analytics.reporting.content_performance"
+        ]
+        assert tcf_contents.tcf_purpose_consents[0].vendors == [
+            EmbeddedVendor(id="sendgrid", name="TCF System Test")
+        ]
+
+        assert tcf_contents.tcf_vendor_consents[0].id == "sendgrid"
+        assert tcf_contents.tcf_vendor_consents[0].name == "TCF System Test"
+        assert (
+            tcf_contents.tcf_vendor_consents[0].description
+            == "My TCF System Description"
+        )
+
+        # assert some additional TCF attributes are set to their defaults here
+        assert tcf_contents.tcf_vendor_consents[0].cookie_max_age_seconds == 31536000
+        assert tcf_contents.tcf_vendor_consents[0].uses_cookies is True
+        assert tcf_contents.tcf_vendor_consents[0].uses_non_cookie_access is True
+        assert tcf_contents.tcf_vendor_consents[0].cookie_refresh is True
+        assert (
+            tcf_contents.tcf_vendor_consents[0].legitimate_interest_disclosure_url
+            == "http://test.com/disclosure_url"
+        )
+
+        assert len(tcf_contents.tcf_vendor_consents[0].purpose_consents) == 1
+        assert tcf_contents.tcf_vendor_consents[0].purpose_consents[0].id == 8
+
+        assert tcf_contents.tcf_vendor_relationships[0].id == "sendgrid"
+        assert tcf_contents.tcf_vendor_relationships[0].name == "TCF System Test"
+        assert (
+            tcf_contents.tcf_vendor_relationships[0].description
+            == "My TCF System Description"
+        )
+        # assert some additional TCF attributes are set to their defaults here
+        assert (
+            tcf_contents.tcf_vendor_relationships[0].cookie_max_age_seconds == 31536000
+        )
+        assert tcf_contents.tcf_vendor_relationships[0].uses_cookies is True
+        assert tcf_contents.tcf_vendor_relationships[0].uses_non_cookie_access is True
+        assert tcf_contents.tcf_vendor_relationships[0].cookie_refresh is True
+        assert (
+            tcf_contents.tcf_vendor_relationships[0].legitimate_interest_disclosure_url
+            == "http://test.com/disclosure_url"
+        )
+
         assert len(tcf_contents.tcf_vendor_relationships[0].special_purposes) == 1
         assert tcf_contents.tcf_vendor_relationships[0].special_purposes[0].id == 1
 

--- a/tests/ops/util/test_tcf_experience_contents.py
+++ b/tests/ops/util/test_tcf_experience_contents.py
@@ -146,7 +146,7 @@ class TestTCFContents:
             v_r_len=0,
             s_c_len=1,
             s_li_len=0,
-            s_r_len=0,
+            s_r_len=1,
         )
 
     def test_system_has_feature_on_different_declaration_than_relevant_use(
@@ -220,6 +220,17 @@ class TestTCFContents:
             s_li_len=0,
             s_r_len=0,
         )
+
+        vendor_relationship = tcf_contents.tcf_vendor_relationships[0]
+        assert vendor_relationship.features == []
+        assert vendor_relationship.special_purposes == []
+        assert vendor_relationship.special_features == []
+        assert vendor_relationship.id == "sendgrid"
+        assert vendor_relationship.cookie_max_age_seconds is None
+        assert vendor_relationship.uses_cookies is False
+        assert vendor_relationship.uses_non_cookie_access is False
+        assert vendor_relationship.cookie_refresh is False
+        assert vendor_relationship.legitimate_interest_disclosure_url is None
 
     @pytest.mark.usefixtures("tcf_system")
     def test_system_exists_with_tcf_purpose_and_vendor(self, db):
@@ -687,7 +698,7 @@ class TestTCFContents:
             v_r_len=0,
             s_c_len=1,
             s_li_len=1,
-            s_r_len=0,
+            s_r_len=1,
         )
 
         first_purpose = tcf_contents.tcf_purpose_consents[0]
@@ -889,7 +900,7 @@ class TestTCFContents:
             v_r_len=0,
             s_c_len=1,
             s_li_len=2,
-            s_r_len=0,
+            s_r_len=2,
         )
         assert len(tcf_contents.tcf_purpose_consents[0].vendors) == 0
         assert tcf_contents.tcf_purpose_consents[0].id == 4

--- a/tests/ops/util/test_tcf_experience_contents.py
+++ b/tests/ops/util/test_tcf_experience_contents.py
@@ -191,6 +191,36 @@ class TestTCFContents:
             s_r_len=0,
         )
 
+    def test_system_has_declaration_no_features_special_features_special_purposes(
+        self, tcf_system, db
+    ):
+        """Assert that a VendorRelationship record is created even if no features, special features or special purposes are present.
+        VendorRelationship is still used to store basic Vendor attributes.
+        """
+        decl = tcf_system.privacy_declarations[0]
+        decl.features = []
+        decl.save(db)
+
+        decl_2 = tcf_system.privacy_declarations[1]
+        decl_2.delete(db)
+
+        tcf_contents = get_tcf_contents(db)
+
+        assert_length_of_tcf_sections(
+            tcf_contents,
+            p_c_len=1,
+            p_li_len=0,
+            f_len=0,
+            sp_len=0,
+            sf_len=0,
+            v_c_len=1,
+            v_li_len=0,
+            v_r_len=1,
+            s_c_len=0,
+            s_li_len=0,
+            s_r_len=0,
+        )
+
     @pytest.mark.usefixtures("tcf_system")
     def test_system_exists_with_tcf_purpose_and_vendor(self, db):
         """System has vendor id so we return preferences against a "vendor" instead of the system"""
@@ -225,14 +255,13 @@ class TestTCFContents:
             == "My TCF System Description"
         )
 
-        # assert some additional TCF attributes are set to their defaults here
-        assert tcf_contents.tcf_vendor_consents[0].cookie_max_age_seconds is None
-        assert tcf_contents.tcf_vendor_consents[0].uses_cookies is False
-        assert tcf_contents.tcf_vendor_consents[0].uses_non_cookie_access is False
-        assert tcf_contents.tcf_vendor_consents[0].cookie_refresh is False
-        assert (
-            tcf_contents.tcf_vendor_consents[0].legitimate_interest_disclosure_url
-            is None
+        # assert some additional TCF attributes are NOT set on the consents object - only on VendorRelationships
+        assert not hasattr(
+            tcf_contents.tcf_vendor_consents[0], "cookie_max_age_seconds"
+        )
+        assert not hasattr(tcf_contents.tcf_vendor_consents[0], "uses_cookies")
+        assert not hasattr(
+            tcf_contents.tcf_vendor_consents[0], "legitimate_interest_disclosure_url"
         )
 
         assert len(tcf_contents.tcf_vendor_consents[0].purpose_consents) == 1
@@ -244,7 +273,7 @@ class TestTCFContents:
             tcf_contents.tcf_vendor_relationships[0].description
             == "My TCF System Description"
         )
-        # assert some additional TCF attributes are set to their defaults here
+        # assert some additional TCF attributes are set to their defaults here - this is where they belong!
         assert tcf_contents.tcf_vendor_relationships[0].cookie_max_age_seconds is None
         assert tcf_contents.tcf_vendor_relationships[0].uses_cookies is False
         assert tcf_contents.tcf_vendor_relationships[0].uses_non_cookie_access is False
@@ -301,14 +330,13 @@ class TestTCFContents:
             == "My TCF System Description"
         )
 
-        # assert some additional TCF attributes are set to their defaults here
-        assert tcf_contents.tcf_vendor_consents[0].cookie_max_age_seconds == 31536000
-        assert tcf_contents.tcf_vendor_consents[0].uses_cookies is True
-        assert tcf_contents.tcf_vendor_consents[0].uses_non_cookie_access is True
-        assert tcf_contents.tcf_vendor_consents[0].cookie_refresh is True
-        assert (
-            tcf_contents.tcf_vendor_consents[0].legitimate_interest_disclosure_url
-            == "http://test.com/disclosure_url"
+        # assert some additional TCF attributes are NOT set on the consents object - only on VendorRelationships
+        assert not hasattr(
+            tcf_contents.tcf_vendor_consents[0], "cookie_max_age_seconds"
+        )
+        assert not hasattr(tcf_contents.tcf_vendor_consents[0], "uses_cookies")
+        assert not hasattr(
+            tcf_contents.tcf_vendor_consents[0], "legitimate_interest_disclosure_url"
         )
 
         assert len(tcf_contents.tcf_vendor_consents[0].purpose_consents) == 1
@@ -320,7 +348,8 @@ class TestTCFContents:
             tcf_contents.tcf_vendor_relationships[0].description
             == "My TCF System Description"
         )
-        # assert some additional TCF attributes are set to their defaults here
+
+        # assert some additional TCF attributes are being populated properly based on the System record
         assert (
             tcf_contents.tcf_vendor_relationships[0].cookie_max_age_seconds == 31536000
         )
@@ -481,7 +510,7 @@ class TestTCFContents:
             sf_len=0,
             v_c_len=1,
             v_li_len=0,
-            v_r_len=0,
+            v_r_len=1,
             s_c_len=0,
             s_li_len=0,
             s_r_len=0,
@@ -695,7 +724,7 @@ class TestTCFContents:
             sf_len=0,
             v_c_len=1,
             v_li_len=1,
-            v_r_len=0,
+            v_r_len=1,
             s_c_len=0,
             s_li_len=0,
             s_r_len=0,
@@ -760,7 +789,7 @@ class TestTCFContents:
             sf_len=0,
             v_c_len=1,
             v_li_len=1,
-            v_r_len=0,
+            v_r_len=1,
             s_c_len=0,
             s_li_len=0,
             s_r_len=0,


### PR DESCRIPTION
Closes #4227 

### Description Of Changes

Adds support in fides for the new fields on the `System` and `PrivacyDeclaration` model added to fideslang.

- `System.cookie_max_age_seconds`
- `System.cookie_refresh`
- `System.uses_cookies`
- `System.uses_non_cookie_access`
- `System.legitimate_interest_disclosure_url`
- `PrivacyDeclaration.flexible_legal_basis_for_processing`

### Code Changes

* [x] update `System` db model
* [x] DB migration to update `ctl_systems` table
* [x] update system API tests to cover new fields
* [x] update TCF overlay generation to include and populate these fields in the vendor records
* [ ] ~(maybe) update admin UI forms to expose these new fields?~ split into https://github.com/ethyca/fides/issues/4248
* [ ] ~(maybe) update TCF overlay UI to leverage these new fields?~ split into https://github.com/ethyca/fides/issues/4255

### Steps to Confirm

* [x] additional fields can't be set yet in the datamap UI - but i ensured they could be set manually via API using the following payload with a `PUT /system`

```
{"fides_key":"ts1","organization_fides_key":"default_organization","tags":[],"name":"ts1","description":"","registry_id":null,"meta":null,"fidesctl_meta":null,"system_type":"","data_responsibility_title":null,"egress":null,"ingress":null,"privacy_declarations":[{"name":"pd1", "flexible_legal_basis_for_profiling": true, "data_categories":["system.operations"],"data_use":"analytics.reporting.ad_performance","data_subjects":[],"features":[],"impact_assessment_location":"","retention_period":"","processes_special_category_data":false,"data_shared_with_third_parties":false,"customFieldValues":{},"cookies":[],"id":""}],"joint_controller":null,"third_country_transfers":null,"administrating_department":"","data_protection_impact_assessment":null,"vendor_id":null,"dataset_references":[],"processes_personal_data":true,"exempt_from_privacy_regulations":false,"reason_for_exemption":null,"uses_profiling":false,"legal_basis_for_profiling":[],"does_international_transfers":false,"legal_basis_for_transfers":[],"requires_data_protection_assessments":false,"dpa_location":null,"dpa_progress":null,"privacy_policy":null,"legal_name":"","legal_address":"","responsibility":[],"dpo":"","joint_controller_info":"","data_security_practices":"","cookie_max_age_seconds":355,"uses_cookies":true,"cookie_refresh":true,"uses_non_cookie_access":true,"legitimate_interest_disclosure_url":"http://testurl.com","created_at":"2023-10-11T16:15:54.925759+00:00","connection_configs":null,"data_stewards":[],"cookies":[]}
```
* [ ] confirm that a sample TCF overlay has these fields populated



### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
