### PR TITLE
Purpose legal basis

### DIFF
--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -724,6 +724,10 @@ div#fides-modal .fides-modal-button-group {
   color: var(--fides-overlay-body-font-color);
 }
 
+.fides-primary-text-color {
+  color: var(--fides-overlay-primary-color);
+}
+
 /* Link */
 .fides-external-link {
   color: var(--fides-overlay-primary-color);
@@ -768,4 +772,15 @@ div#fides-modal .fides-modal-button-group {
 
 .fides-info-box p {
   margin: 0;
+}
+
+/* All on off buttons */
+.fides-all-on-off-buttons {
+  display: flex;
+  justify-content: end;
+  margin-bottom: 1em;
+}
+
+.fides-all-on-button {
+  margin-right: 0.9em;
 }

--- a/clients/fides-js/src/components/tcf/AllOnOffButtons.tsx
+++ b/clients/fides-js/src/components/tcf/AllOnOffButtons.tsx
@@ -1,0 +1,70 @@
+import { h } from "preact";
+
+import { useMemo } from "preact/hooks";
+import { EnabledIds } from "../../lib/tcf/types";
+
+const BUTTON_CLASSNAME = "fides-link-button fides-primary-text-color";
+
+interface Item {
+  id: string | number;
+}
+
+interface Props<T> {
+  enabledIds: EnabledIds;
+  onChange: (payload: EnabledIds) => void;
+  modelTypeMappings: Partial<Record<keyof EnabledIds, T[]>>;
+}
+
+const AllOnOffButtons = <T extends Item>({
+  enabledIds,
+  modelTypeMappings,
+  onChange,
+}: Props<T>) => {
+  const handleAllOff = () => {
+    const updated = { ...enabledIds };
+    const modelTypes = Object.keys(modelTypeMappings) as Array<
+      keyof EnabledIds
+    >;
+    modelTypes.forEach((modelType) => {
+      updated[modelType] = [];
+    });
+    onChange(updated);
+  };
+
+  const handleAllOn = () => {
+    const updated = { ...enabledIds };
+    Object.entries(modelTypeMappings).forEach(([modelType, items]) => {
+      updated[modelType as keyof EnabledIds] = items.map((i) => `${i.id}`);
+    });
+    onChange(updated);
+  };
+
+  const isEmpty = useMemo(
+    () =>
+      Object.values(modelTypeMappings).every(
+        (recordList) => recordList.length === 0
+      ),
+    [modelTypeMappings]
+  );
+
+  if (isEmpty) {
+    return null;
+  }
+
+  return (
+    <div className="fides-all-on-off-buttons">
+      <button
+        type="button"
+        className={`${BUTTON_CLASSNAME} fides-all-on-button`}
+        onClick={handleAllOn}
+      >
+        All on
+      </button>
+      <button type="button" className={BUTTON_CLASSNAME} onClick={handleAllOff}>
+        All off
+      </button>
+    </div>
+  );
+};
+
+export default AllOnOffButtons;

--- a/clients/fides-js/src/components/tcf/DoubleToggleTable.tsx
+++ b/clients/fides-js/src/components/tcf/DoubleToggleTable.tsx
@@ -38,7 +38,7 @@ const DoubleToggleTable = <T extends Item>({
   consentModelType,
   legintModelType,
 }: Props<T>) => {
-  const toggleAllId = `toggle-all-${title}`;
+  const toggleAllId = `all-${title}`;
   const toggleAllConsentId = `${toggleAllId}-consent`;
 
   const { allConsentChecked, allLegintChecked } = useMemo(() => {

--- a/clients/fides-js/src/components/tcf/DoubleToggleTable.tsx
+++ b/clients/fides-js/src/components/tcf/DoubleToggleTable.tsx
@@ -1,8 +1,12 @@
-/** This isn't a table _yet_, but it probably should be fides#4190 */
+/** This isn't a table _yet_, but it is aspirationally named.
+ * We should probably convert it to a table at some point fides#4190 */
 
 import { VNode, h } from "preact";
+import { useMemo } from "react";
 import DataUseToggle from "../DataUseToggle";
 import Toggle from "../Toggle";
+import { EnabledIds, LegalBasisEnum } from "../../lib/tcf/types";
+import type { UpdateEnabledIds } from "./TcfOverlay";
 
 interface Item {
   id: string | number;
@@ -13,22 +17,88 @@ interface Item {
 
 interface Props<T extends Item> {
   items: T[];
+  title: string;
   enabledConsentIds: string[];
   enabledLegintIds: string[];
   renderToggleChild: (item: T) => VNode;
-  onToggle: (item: T) => void;
+  onToggle: (payload: UpdateEnabledIds) => void;
   renderBadgeLabel?: (item: T) => string | undefined;
+  consentModelType: keyof EnabledIds;
+  legintModelType: keyof EnabledIds;
 }
 
 const DoubleToggleTable = <T extends Item>({
   items,
+  title,
   enabledConsentIds,
   enabledLegintIds,
   renderToggleChild,
   renderBadgeLabel,
   onToggle,
+  consentModelType,
+  legintModelType,
 }: Props<T>) => {
-  console.log({ enabledLegintIds, enabledConsentIds });
+  const toggleAllId = `toggle-all-${title}`;
+  const toggleAllConsentId = `${toggleAllId}-consent`;
+
+  const { allConsentChecked, allLegintChecked } = useMemo(() => {
+    const consentIds = items.filter((i) => i.isConsent).map((i) => `${i.id}`);
+    const legintIds = items.filter((i) => i.isLegint).map((i) => `${i.id}`);
+
+    const consentChecked = consentIds.every(
+      (id) => enabledConsentIds.indexOf(id) !== -1
+    );
+    const legintChecked = legintIds.every(
+      (id) => enabledLegintIds.indexOf(id) !== -1
+    );
+    return {
+      allConsentChecked: consentChecked,
+      allLegintChecked: legintChecked,
+    };
+  }, [items, enabledConsentIds, enabledLegintIds]);
+
+  const { hasConsentItems, hasLegintItems } = useMemo(
+    () => ({
+      hasConsentItems: !!items.filter((i) => i.isConsent).length,
+      hasLegintItems: !!items.filter((i) => i.isLegint).length,
+    }),
+    [items]
+  );
+
+  const handleToggleAll = (legalBasis: LegalBasisEnum) => {
+    const isConsent = legalBasis === LegalBasisEnum.CONSENT;
+    const modelType = isConsent ? consentModelType : legintModelType;
+    const allChecked = isConsent ? allConsentChecked : allLegintChecked;
+    if (allChecked) {
+      onToggle({ newEnabledIds: [], modelType });
+    } else {
+      const allItems = isConsent
+        ? items.filter((i) => i.isConsent)
+        : items.filter((i) => i.isLegint);
+      onToggle({
+        newEnabledIds: allItems.map((i) => `${i.id}`),
+        modelType,
+      });
+    }
+  };
+
+  const handleToggleIndividual = (item: T) => {
+    const enabledIds = item.isConsent ? enabledConsentIds : enabledLegintIds;
+    const modelType = item.isConsent ? consentModelType : legintModelType;
+    const purposeId = `${item.id}`;
+    if (enabledIds.indexOf(purposeId) !== -1) {
+      onToggle({
+        newEnabledIds: enabledIds.filter((e) => e !== purposeId),
+        modelType,
+      });
+    } else {
+      onToggle({
+        newEnabledIds: [...enabledIds, purposeId],
+        modelType,
+      });
+    }
+  };
+
   return (
     <div>
       {/* DEFER: ideally we use a table object, but then DataUseToggles would need to be reworked
@@ -37,6 +107,30 @@ const DoubleToggleTable = <T extends Item>({
         <span className="fides-margin-right">Legitimate interest</span>
         <span>Consent</span>
       </div>
+      <DataUseToggle
+        dataUse={{
+          key: title,
+          name: title,
+        }}
+        onToggle={() => {
+          handleToggleAll(LegalBasisEnum.LEGITIMATE_INTERESTS);
+        }}
+        isHeader
+        checked={allLegintChecked}
+        secondToggle={
+          <div style={{ width: "50px", display: "flex", marginLeft: ".2em" }}>
+            {hasConsentItems ? (
+              <Toggle
+                name={toggleAllConsentId}
+                id={toggleAllConsentId}
+                checked={allConsentChecked}
+                onChange={() => handleToggleAll(LegalBasisEnum.CONSENT)}
+              />
+            ) : null}
+          </div>
+        }
+        includeToggle={hasLegintItems}
+      />
       {items.map((item) => (
         <DataUseToggle
           dataUse={{
@@ -44,7 +138,7 @@ const DoubleToggleTable = <T extends Item>({
             name: item.name,
           }}
           onToggle={() => {
-            onToggle(item);
+            handleToggleIndividual(item);
           }}
           checked={enabledLegintIds.indexOf(`${item.id}`) !== -1}
           badge={renderBadgeLabel ? renderBadgeLabel(item) : undefined}
@@ -55,7 +149,7 @@ const DoubleToggleTable = <T extends Item>({
                   name={`${item.name}-consent`}
                   id={`${item.id}-consent`}
                   checked={enabledConsentIds.indexOf(`${item.id}`) !== -1}
-                  onChange={() => onToggle(item)}
+                  onChange={() => handleToggleIndividual(item)}
                 />
               ) : null}
             </div>

--- a/clients/fides-js/src/components/tcf/DoubleToggleTable.tsx
+++ b/clients/fides-js/src/components/tcf/DoubleToggleTable.tsx
@@ -1,0 +1,72 @@
+/** This isn't a table _yet_, but it probably should be fides#4190 */
+
+import { VNode, h } from "preact";
+import DataUseToggle from "../DataUseToggle";
+import Toggle from "../Toggle";
+
+interface Item {
+  id: string | number;
+  name?: string;
+  isConsent: boolean;
+  isLegint: boolean;
+}
+
+interface Props<T extends Item> {
+  items: T[];
+  enabledConsentIds: string[];
+  enabledLegintIds: string[];
+  renderToggleChild: (item: T) => VNode;
+  onToggle: (item: T) => void;
+  renderBadgeLabel?: (item: T) => string | undefined;
+}
+
+const DoubleToggleTable = <T extends Item>({
+  items,
+  enabledConsentIds,
+  enabledLegintIds,
+  renderToggleChild,
+  renderBadgeLabel,
+  onToggle,
+}: Props<T>) => {
+  console.log({ enabledLegintIds, enabledConsentIds });
+  return (
+    <div>
+      {/* DEFER: ideally we use a table object, but then DataUseToggles would need to be reworked
+      or we would need a separate component. */}
+      <div className="fides-legal-basis-labels">
+        <span className="fides-margin-right">Legitimate interest</span>
+        <span>Consent</span>
+      </div>
+      {items.map((item) => (
+        <DataUseToggle
+          dataUse={{
+            key: `${item.id}-legint`,
+            name: item.name,
+          }}
+          onToggle={() => {
+            onToggle(item);
+          }}
+          checked={enabledLegintIds.indexOf(`${item.id}`) !== -1}
+          badge={renderBadgeLabel ? renderBadgeLabel(item) : undefined}
+          secondToggle={
+            <div style={{ width: "50px", display: "flex", marginLeft: ".2em" }}>
+              {item.isConsent ? (
+                <Toggle
+                  name={`${item.name}-consent`}
+                  id={`${item.id}-consent`}
+                  checked={enabledConsentIds.indexOf(`${item.id}`) !== -1}
+                  onChange={() => onToggle(item)}
+                />
+              ) : null}
+            </div>
+          }
+          includeToggle={item.isLegint}
+        >
+          {renderToggleChild(item)}
+        </DataUseToggle>
+      ))}
+    </div>
+  );
+};
+
+export default DoubleToggleTable;

--- a/clients/fides-js/src/components/tcf/InitialLayer.tsx
+++ b/clients/fides-js/src/components/tcf/InitialLayer.tsx
@@ -7,10 +7,8 @@ import {
   getIdsNotRepresentedInStacks,
 } from "../../lib/tcf/stacks";
 import InitialLayerAccordion from "./InitialLayerAccordion";
-import {
-  TCFPurposeConsentRecord,
-  TCFPurposeLegitimateInterestsRecord,
-} from "../../lib/tcf/types";
+
+import { getUniquePurposeRecords } from "../../lib/tcf/purposes";
 
 const InitialLayer = ({ experience }: { experience: PrivacyExperience }) => {
   const {
@@ -19,34 +17,15 @@ const InitialLayer = ({ experience }: { experience: PrivacyExperience }) => {
     tcf_special_features: experienceSpecialFeatures = [],
   } = experience;
 
-  const uniquePurposeIds = useMemo(() => {
-    const consents = consentPurposes.map((p) => p.id);
-    const legints = legintPurposes.map((p) => p.id) ?? [];
-    const ids = new Set([...consents, ...legints]);
-    return Array.from(ids);
-  }, [consentPurposes, legintPurposes]);
+  const { uniquePurposeIds, uniquePurposes } = useMemo(
+    () => getUniquePurposeRecords({ consentPurposes, legintPurposes }),
+    [consentPurposes, legintPurposes]
+  );
 
   const specialFeatureIds = useMemo(
     () => experienceSpecialFeatures.map((sf) => sf.id),
     [experienceSpecialFeatures]
   );
-
-  const uniquePurposes = useMemo(() => {
-    const purposes: (
-      | TCFPurposeConsentRecord
-      | TCFPurposeLegitimateInterestsRecord
-    )[] = [];
-    uniquePurposeIds.forEach((id) => {
-      const consent = consentPurposes.find((p) => p.id === id);
-      const legint = legintPurposes.find((p) => p.id === id);
-      if (consent) {
-        purposes.push(consent);
-      } else if (legint) {
-        purposes.push(legint);
-      }
-    });
-    return purposes;
-  }, [uniquePurposeIds, consentPurposes, legintPurposes]);
 
   const stacks = useMemo(() => {
     if (!experience.gvl) {

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -234,14 +234,6 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
     [experience]
   );
 
-  const handleUpdateDraftState = useCallback(
-    ({ newEnabledIds, modelType }: UpdateEnabledIds) => {
-      const updated = { ...draftIds, [modelType]: newEnabledIds };
-      setDraftIds(updated);
-    },
-    [draftIds]
-  );
-
   const handleUpdateAllPreferences = useCallback(
     (enabledIds: EnabledIds) => {
       const tcf = createTcfSavePayload({ experience, enabledIds });
@@ -317,7 +309,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
             <TcfTabs
               experience={experience}
               enabledIds={draftIds}
-              onChange={handleUpdateDraftState}
+              onChange={setDraftIds}
               activeTabIndex={activeTabIndex}
               onTabChange={setActiveTabIndex}
             />

--- a/clients/fides-js/src/components/tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/tcf/TcfPurposes.tsx
@@ -1,94 +1,78 @@
 import { h } from "preact";
 
+import { useMemo } from "preact/hooks";
 import DataUseToggle from "../DataUseToggle";
 import { PrivacyExperience } from "../../lib/consent-types";
 import {
+  PurposeRecord,
   TCFPurposeConsentRecord,
   TCFPurposeLegitimateInterestsRecord,
 } from "../../lib/tcf/types";
 import { UpdateEnabledIds } from "./TcfOverlay";
+import DoubleToggleTable from "./DoubleToggleTable";
+import { getUniquePurposeRecords } from "../../lib/tcf/purposes";
 
 type TCFPurposeRecord =
   | TCFPurposeConsentRecord
   | TCFPurposeLegitimateInterestsRecord;
 
-const PurposeToggle = ({
-  purpose,
-  onToggle,
-  checked,
-  includeToggle = true,
-}: {
-  purpose: TCFPurposeRecord;
-  onToggle: () => void;
-  checked: boolean;
-  includeToggle?: boolean;
-}) => {
-  const dataUse = { key: purpose.name, name: purpose.name };
+const PurposeDetails = ({ purpose }: { purpose: TCFPurposeRecord }) => {
   const vendors = [...(purpose.vendors || []), ...(purpose.systems || [])];
   return (
-    <DataUseToggle
-      dataUse={dataUse}
-      checked={checked}
-      onToggle={onToggle}
-      includeToggle={includeToggle}
-    >
-      <div>
-        <p className="fides-tcf-toggle-content">{purpose.description}</p>
-        {purpose.illustrations.map((illustration) => (
-          <p className="fides-tcf-illustration fides-background-dark">
-            {illustration}
-          </p>
-        ))}
+    <div>
+      <p className="fides-tcf-toggle-content">{purpose.description}</p>
+      {purpose.illustrations.map((illustration) => (
+        <p className="fides-tcf-illustration fides-background-dark">
+          {illustration}
+        </p>
+      ))}
 
-        {vendors.length ? (
-          <p className="fides-tcf-toggle-content fides-background-dark fides-tcf-purpose-vendor">
-            <span className="fides-tcf-purpose-vendor-title">
-              Vendors we use for this purpose
-              <span>{vendors.length} vendor(s)</span>
-            </span>
-            <ul className="fides-tcf-purpose-vendor-list">
-              {vendors.map((v) => (
-                <li>{v.name}</li>
-              ))}
-            </ul>
-          </p>
-        ) : null}
-      </div>
-    </DataUseToggle>
+      {vendors.length ? (
+        <p className="fides-tcf-toggle-content fides-background-dark fides-tcf-purpose-vendor">
+          <span className="fides-tcf-purpose-vendor-title">
+            Vendors we use for this purpose
+            <span>{vendors.length} vendor(s)</span>
+          </span>
+          <ul className="fides-tcf-purpose-vendor-list">
+            {vendors.map((v) => (
+              <li>{v.name}</li>
+            ))}
+          </ul>
+        </p>
+      ) : null}
+    </div>
   );
 };
 
-const PurposeBlock = ({
+const SpecialPurposeBlock = ({
   label,
-  allPurposesConsent = [],
-  enabledIdsConsent,
+  allSpecialPurposes = [],
+  enabledIds,
   onChange,
   hideToggles,
 }: {
   label: string;
-  allPurposesConsent: TCFPurposeConsentRecord[] | undefined;
-  // TODO: support legint toggle (fides#4210)
-  // allPurposesLegint: TCFPurposeLegitimateInterestsRecord[] | undefined;
-  enabledIdsConsent: string[];
+  allSpecialPurposes: TCFPurposeConsentRecord[] | undefined;
+  enabledIds: string[];
   onChange: (newIds: string[]) => void;
   hideToggles?: boolean;
 }) => {
-  const allChecked = allPurposesConsent.every(
-    (p) => enabledIdsConsent.indexOf(`${p.id}`) !== -1
+  const allChecked = allSpecialPurposes.every(
+    (p) => enabledIds.indexOf(`${p.id}`) !== -1
   );
   const handleToggle = (purpose: TCFPurposeRecord) => {
     const purposeId = `${purpose.id}`;
-    if (enabledIdsConsent.indexOf(purposeId) !== -1) {
-      onChange(enabledIdsConsent.filter((e) => e !== purposeId));
+    if (enabledIds.indexOf(purposeId) !== -1) {
+      onChange(enabledIds.filter((e) => e !== purposeId));
     } else {
-      onChange([...enabledIdsConsent, purposeId]);
+      onChange([...enabledIds, purposeId]);
     }
   };
   const handleToggleAll = () => {
     if (allChecked) {
       onChange([]);
     } else {
-      onChange(allPurposesConsent.map((p) => `${p.id}`));
+      onChange(allSpecialPurposes.map((p) => `${p.id}`));
     }
   };
 
@@ -101,55 +85,90 @@ const PurposeBlock = ({
         isHeader
         includeToggle={!hideToggles}
       />
-      {allPurposesConsent.map((p) => (
-        <PurposeToggle
-          purpose={p}
-          onToggle={() => {
-            handleToggle(p);
-          }}
-          checked={enabledIdsConsent.indexOf(`${p.id}`) !== -1}
-          includeToggle={!hideToggles}
-        />
-      ))}
+      {allSpecialPurposes.map((p) => {
+        const dataUse = { key: p.name, name: p.name };
+        return (
+          <DataUseToggle
+            dataUse={dataUse}
+            checked={enabledIds.indexOf(`${p.id}`) !== -1}
+            onToggle={() => {
+              handleToggle(p);
+            }}
+            includeToggle={!hideToggles}
+          >
+            <PurposeDetails purpose={p} />
+          </DataUseToggle>
+        );
+      })}
     </div>
   );
 };
 
 const TcfPurposes = ({
-  allPurposesConsent,
+  allPurposesConsent = [],
+  allPurposesLegint = [],
   allSpecialPurposes,
   enabledPurposeConsentIds,
+  enabledPurposeLegintIds,
   enabledSpecialPurposeIds,
   onChange,
 }: {
   allPurposesConsent: TCFPurposeConsentRecord[] | undefined;
   enabledPurposeConsentIds: string[];
   allSpecialPurposes: PrivacyExperience["tcf_special_purposes"];
-  // TODO: support legint toggle (fides#4210)
-  // allPurposesLegint: TCFPurposeLegitimateInterestsRecord[] | undefined;
-  // enabledPurposeLegintIds: string[];
+  allPurposesLegint: TCFPurposeLegitimateInterestsRecord[] | undefined;
+  enabledPurposeLegintIds: string[];
   enabledSpecialPurposeIds: string[];
   onChange: (payload: UpdateEnabledIds) => void;
-}) => (
-  <div>
-    <PurposeBlock
-      label="Purposes"
-      allPurposesConsent={allPurposesConsent}
-      enabledIdsConsent={enabledPurposeConsentIds}
-      onChange={(newEnabledIds) =>
-        onChange({ newEnabledIds, modelType: "purposesConsent" })
-      }
-    />
-    <PurposeBlock
-      label="Special purposes"
-      allPurposesConsent={allSpecialPurposes}
-      enabledIdsConsent={enabledSpecialPurposeIds}
-      onChange={(newEnabledIds) =>
-        onChange({ newEnabledIds, modelType: "specialPurposes" })
-      }
-      hideToggles
-    />
-  </div>
-);
+}) => {
+  const { uniquePurposes } = useMemo(
+    () =>
+      getUniquePurposeRecords({
+        consentPurposes: allPurposesConsent,
+        legintPurposes: allPurposesLegint,
+      }),
+    [allPurposesConsent, allPurposesLegint]
+  );
+
+  const handleTogglePurpose = (purpose: PurposeRecord) => {
+    const enabledIds = purpose.isConsent
+      ? enabledPurposeConsentIds
+      : enabledPurposeLegintIds;
+    const modelType = purpose.isConsent ? "purposesConsent" : "purposesLegint";
+    const purposeId = `${purpose.id}`;
+    if (enabledIds.indexOf(purposeId) !== -1) {
+      onChange({
+        newEnabledIds: enabledIds.filter((e) => e !== purposeId),
+        modelType,
+      });
+    } else {
+      onChange({
+        newEnabledIds: [...enabledIds, purposeId],
+        modelType,
+      });
+    }
+  };
+
+  return (
+    <div>
+      <DoubleToggleTable<PurposeRecord>
+        items={uniquePurposes}
+        enabledConsentIds={enabledPurposeConsentIds}
+        enabledLegintIds={enabledPurposeLegintIds}
+        onToggle={handleTogglePurpose}
+        renderToggleChild={(purpose) => <PurposeDetails purpose={purpose} />}
+      />
+      <SpecialPurposeBlock
+        label="Special purposes"
+        allSpecialPurposes={allSpecialPurposes}
+        enabledIds={enabledSpecialPurposeIds}
+        onChange={(newEnabledIds) =>
+          onChange({ newEnabledIds, modelType: "specialPurposes" })
+        }
+        hideToggles
+      />
+    </div>
+  );
+};
 
 export default TcfPurposes;

--- a/clients/fides-js/src/components/tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/tcf/TcfPurposes.tsx
@@ -130,33 +130,17 @@ const TcfPurposes = ({
     [allPurposesConsent, allPurposesLegint]
   );
 
-  const handleTogglePurpose = (purpose: PurposeRecord) => {
-    const enabledIds = purpose.isConsent
-      ? enabledPurposeConsentIds
-      : enabledPurposeLegintIds;
-    const modelType = purpose.isConsent ? "purposesConsent" : "purposesLegint";
-    const purposeId = `${purpose.id}`;
-    if (enabledIds.indexOf(purposeId) !== -1) {
-      onChange({
-        newEnabledIds: enabledIds.filter((e) => e !== purposeId),
-        modelType,
-      });
-    } else {
-      onChange({
-        newEnabledIds: [...enabledIds, purposeId],
-        modelType,
-      });
-    }
-  };
-
   return (
     <div>
       <DoubleToggleTable<PurposeRecord>
+        title="Purposes"
         items={uniquePurposes}
         enabledConsentIds={enabledPurposeConsentIds}
         enabledLegintIds={enabledPurposeLegintIds}
-        onToggle={handleTogglePurpose}
+        onToggle={onChange}
         renderToggleChild={(purpose) => <PurposeDetails purpose={purpose} />}
+        consentModelType="purposesConsent"
+        legintModelType="purposesLegint"
       />
       <SpecialPurposeBlock
         label="Special purposes"

--- a/clients/fides-js/src/components/tcf/TcfTabs.tsx
+++ b/clients/fides-js/src/components/tcf/TcfTabs.tsx
@@ -1,5 +1,5 @@
 import { h } from "preact";
-import { useRef } from "preact/hooks";
+import { useCallback, useRef } from "preact/hooks";
 import TcfPurposes from "./TcfPurposes";
 import { PrivacyExperience } from "../../lib/consent-types";
 import type { UpdateEnabledIds } from "./TcfOverlay";
@@ -7,6 +7,7 @@ import TcfFeatures from "./TcfFeatures";
 import TcfVendors from "./TcfVendors";
 import InfoBox from "../InfoBox";
 import { EnabledIds } from "../../lib/tcf/types";
+import AllOnOffButtons from "./AllOnOffButtons";
 
 const KEY_ARROW_RIGHT = "ArrowRight";
 const KEY_ARROW_LEFT = "ArrowLeft";
@@ -20,10 +21,18 @@ const TcfTabs = ({
 }: {
   experience: PrivacyExperience;
   enabledIds: EnabledIds;
-  onChange: (payload: UpdateEnabledIds) => void;
+  onChange: (payload: EnabledIds) => void;
   activeTabIndex: number;
   onTabChange: (tabIndex: number) => void;
 }) => {
+  const handleUpdateDraftState = useCallback(
+    ({ newEnabledIds, modelType }: UpdateEnabledIds) => {
+      const updated = { ...enabledIds, [modelType]: newEnabledIds };
+      onChange(updated);
+    },
+    [enabledIds, onChange]
+  );
+
   const tcfTabs = [
     {
       name: "Purposes",
@@ -34,6 +43,14 @@ const TcfTabs = ({
             purposes by using the filter to switch between Consent and
             Legitimate Interest below.
           </InfoBox>
+          <AllOnOffButtons
+            enabledIds={enabledIds}
+            onChange={onChange}
+            modelTypeMappings={{
+              purposesLegint: experience.tcf_legitimate_interests_purposes,
+              purposesConsent: experience.tcf_consent_purposes,
+            }}
+          />
           <TcfPurposes
             allPurposesConsent={experience.tcf_consent_purposes}
             allPurposesLegint={experience.tcf_legitimate_interests_purposes}
@@ -41,7 +58,7 @@ const TcfTabs = ({
             enabledPurposeConsentIds={enabledIds.purposesConsent}
             enabledPurposeLegintIds={enabledIds.purposesLegint}
             enabledSpecialPurposeIds={enabledIds.specialPurposes}
-            onChange={onChange}
+            onChange={handleUpdateDraftState}
           />
         </div>
       ),
@@ -54,12 +71,19 @@ const TcfTabs = ({
             You can review the list of features and exercise your right to
             consent to special features below.
           </InfoBox>
+          <AllOnOffButtons
+            enabledIds={enabledIds}
+            onChange={onChange}
+            modelTypeMappings={{
+              specialFeatures: experience.tcf_special_features,
+            }}
+          />
           <TcfFeatures
             allFeatures={experience.tcf_features}
             allSpecialFeatures={experience.tcf_special_features}
             enabledFeatureIds={enabledIds.features}
             enabledSpecialFeatureIds={enabledIds.specialFeatures}
-            onChange={onChange}
+            onChange={handleUpdateDraftState}
           />
         </div>
       ),
@@ -74,11 +98,25 @@ const TcfTabs = ({
             exercise you consent for each vendor based on the legal basis they
             assert.
           </InfoBox>
+          <AllOnOffButtons
+            enabledIds={enabledIds}
+            onChange={onChange}
+            modelTypeMappings={{
+              vendorsConsent: [
+                ...(experience.tcf_consent_vendors || []),
+                ...(experience.tcf_consent_systems || []),
+              ],
+              vendorsLegint: [
+                ...(experience.tcf_legitimate_interests_vendors || []),
+                ...(experience.tcf_legitimate_interests_systems || []),
+              ],
+            }}
+          />
           <TcfVendors
             experience={experience}
             enabledVendorConsentIds={enabledIds.vendorsConsent}
             enabledVendorLegintIds={enabledIds.vendorsLegint}
-            onChange={onChange}
+            onChange={handleUpdateDraftState}
           />
         </div>
       ),

--- a/clients/fides-js/src/components/tcf/TcfTabs.tsx
+++ b/clients/fides-js/src/components/tcf/TcfTabs.tsx
@@ -35,10 +35,11 @@ const TcfTabs = ({
             Legitimate Interest below.
           </InfoBox>
           <TcfPurposes
-            // TODO(fides#4210): add legint purposes
             allPurposesConsent={experience.tcf_consent_purposes}
+            allPurposesLegint={experience.tcf_legitimate_interests_purposes}
             allSpecialPurposes={experience.tcf_special_purposes}
             enabledPurposeConsentIds={enabledIds.purposesConsent}
+            enabledPurposeLegintIds={enabledIds.purposesLegint}
             enabledSpecialPurposeIds={enabledIds.specialPurposes}
             onChange={onChange}
           />

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -201,24 +201,6 @@ const TcfVendors = ({
     return null;
   }
 
-  const handleToggle = (vendor: VendorRecord) => {
-    const enabledIds = vendor.isConsent
-      ? enabledVendorConsentIds
-      : enabledVendorLegintIds;
-    const modelType = vendor.isConsent ? "vendorsConsent" : "vendorsLegint";
-    if (enabledIds.indexOf(vendor.id) !== -1) {
-      onChange({
-        newEnabledIds: enabledIds.filter((e) => e !== vendor.id),
-        modelType,
-      });
-    } else {
-      onChange({
-        newEnabledIds: [...enabledIds, vendor.id],
-        modelType,
-      });
-    }
-  };
-
   const handleFilter = (index: number) => {
     if (index === 0) {
       setIsFiltered(false);
@@ -235,10 +217,13 @@ const TcfVendors = ({
     <div>
       <FilterButtons filters={FILTERS} onChange={handleFilter} />
       <DoubleToggleTable<VendorRecord>
+        title="Vendors"
         items={vendorsToDisplay}
         enabledConsentIds={enabledVendorConsentIds}
         enabledLegintIds={enabledVendorLegintIds}
-        onToggle={handleToggle}
+        onToggle={onChange}
+        consentModelType="vendorsConsent"
+        legintModelType="vendorsLegint"
         renderBadgeLabel={(vendor) =>
           vendorIsGvl(vendor, experience.gvl) ? "IAB TCF" : undefined
         }

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -7,19 +7,17 @@ import {
   GvlDataCategories,
   GvlVendorUrl,
   GvlDataDeclarations,
-  LegalBasisForProcessingEnum,
   VendorRecord,
 } from "../../lib/tcf/types";
 import { PrivacyExperience } from "../../lib/consent-types";
 import { UpdateEnabledIds } from "./TcfOverlay";
-import DataUseToggle from "../DataUseToggle";
 import FilterButtons from "./FilterButtons";
 import {
   transformExperienceToVendorRecords,
   vendorIsGvl,
 } from "../../lib/tcf/vendors";
 import ExternalLink from "../ExternalLink";
-import Toggle from "../Toggle";
+import DoubleToggleTable from "./DoubleToggleTable";
 
 const FILTERS = [{ name: "All vendors" }, { name: "IAB TCF vendors" }];
 
@@ -203,20 +201,11 @@ const TcfVendors = ({
     return null;
   }
 
-  const handleToggle = (
-    vendor: VendorRecord,
-    legalBasis:
-      | LegalBasisForProcessingEnum.CONSENT
-      | LegalBasisForProcessingEnum.LEGITIMATE_INTERESTS
-  ) => {
-    const enabledIds =
-      legalBasis === LegalBasisForProcessingEnum.CONSENT
-        ? enabledVendorConsentIds
-        : enabledVendorLegintIds;
-    const modelType =
-      legalBasis === LegalBasisForProcessingEnum.CONSENT
-        ? "vendorsConsent"
-        : "vendorsLegint";
+  const handleToggle = (vendor: VendorRecord) => {
+    const enabledIds = vendor.isConsent
+      ? enabledVendorConsentIds
+      : enabledVendorLegintIds;
+    const modelType = vendor.isConsent ? "vendorsConsent" : "vendorsLegint";
     if (enabledIds.indexOf(vendor.id) !== -1) {
       onChange({
         newEnabledIds: enabledIds.filter((e) => e !== vendor.id),
@@ -245,53 +234,24 @@ const TcfVendors = ({
   return (
     <div>
       <FilterButtons filters={FILTERS} onChange={handleFilter} />
-      {/* DEFER: ideally we use a table object, but then DataUseToggles would need to be reworked
-      or we would need a separate component. */}
-      <div className="fides-legal-basis-labels">
-        <span className="fides-margin-right">Legitimate interest</span>
-        <span>Consent</span>
-      </div>
-      {vendorsToDisplay.map((vendor) => {
-        const gvlVendor = vendorIsGvl(vendor, experience.gvl);
-        // @ts-ignore the IAB-TCF lib doesn't support GVL v3 types yet
-        const url: GvlVendorUrl | undefined = gvlVendor?.urls.find(
-          (u: GvlVendorUrl) => u.langId === "en"
-        );
-        const dataCategories: GvlDataCategories | undefined =
+      <DoubleToggleTable<VendorRecord>
+        items={vendorsToDisplay}
+        enabledConsentIds={enabledVendorConsentIds}
+        enabledLegintIds={enabledVendorLegintIds}
+        onToggle={handleToggle}
+        renderBadgeLabel={(vendor) =>
+          vendorIsGvl(vendor, experience.gvl) ? "IAB TCF" : undefined
+        }
+        renderToggleChild={(vendor) => {
+          const gvlVendor = vendorIsGvl(vendor, experience.gvl);
           // @ts-ignore the IAB-TCF lib doesn't support GVL v3 types yet
-          experience.gvl?.dataCategories;
-        return (
-          <DataUseToggle
-            dataUse={{
-              key: `${vendor.id}-legint`,
-              name: vendor.name,
-            }}
-            onToggle={() => {
-              handleToggle(
-                vendor,
-                LegalBasisForProcessingEnum.LEGITIMATE_INTERESTS
-              );
-            }}
-            checked={enabledVendorLegintIds.indexOf(vendor.id) !== -1}
-            badge={gvlVendor ? "IAB TCF" : undefined}
-            secondToggle={
-              <div
-                style={{ width: "50px", display: "flex", marginLeft: ".2em" }}
-              >
-                {vendor.isConsent ? (
-                  <Toggle
-                    name={`${vendor.name}-consent`}
-                    id={`${vendor.id}-consent`}
-                    checked={enabledVendorConsentIds.indexOf(vendor.id) !== -1}
-                    onChange={() =>
-                      handleToggle(vendor, LegalBasisForProcessingEnum.CONSENT)
-                    }
-                  />
-                ) : null}
-              </div>
-            }
-            includeToggle={vendor.isLegint}
-          >
+          const url: GvlVendorUrl | undefined = gvlVendor?.urls.find(
+            (u: GvlVendorUrl) => u.langId === "en"
+          );
+          const dataCategories: GvlDataCategories | undefined =
+            // @ts-ignore the IAB-TCF lib doesn't support GVL v3 types yet
+            experience.gvl?.dataCategories;
+          return (
             <div>
               {gvlVendor ? <StorageDisclosure vendor={gvlVendor} /> : null}
               <div>
@@ -312,7 +272,6 @@ const TcfVendors = ({
                 specialPurposes={vendor.special_purposes}
                 gvlVendor={gvlVendor}
               />
-
               <VendorDetails label="Features" lineItems={vendor.features} />
               <VendorDetails
                 label="Special features"
@@ -323,9 +282,9 @@ const TcfVendors = ({
                 dataCategories={dataCategories}
               />
             </div>
-          </DataUseToggle>
-        );
-      })}
+          );
+        }}
+      />
     </div>
   );
 };

--- a/clients/fides-js/src/lib/tcf/purposes.ts
+++ b/clients/fides-js/src/lib/tcf/purposes.ts
@@ -1,0 +1,32 @@
+import {
+  PurposeRecord,
+  TCFPurposeConsentRecord,
+  TCFPurposeLegitimateInterestsRecord,
+} from "./types";
+
+export const getUniquePurposeRecords = ({
+  consentPurposes = [],
+  legintPurposes = [],
+}: {
+  consentPurposes: TCFPurposeConsentRecord[] | undefined;
+  legintPurposes: TCFPurposeLegitimateInterestsRecord[] | undefined;
+}) => {
+  const uniqueIds = Array.from(
+    new Set([
+      ...consentPurposes.map((p) => p.id),
+      ...legintPurposes.map((p) => p.id),
+    ])
+  );
+  const purposes: PurposeRecord[] = [];
+  uniqueIds.forEach((id) => {
+    const consent = consentPurposes.find((p) => p.id === id);
+    const legint = legintPurposes.find((p) => p.id === id);
+    if (consent) {
+      purposes.push({ ...consent, isConsent: true, isLegint: false });
+    } else if (legint) {
+      purposes.push({ ...legint, isConsent: false, isLegint: true });
+    }
+  });
+
+  return { uniquePurposeIds: uniqueIds, uniquePurposes: purposes };
+};

--- a/clients/fides-js/src/lib/tcf/purposes.ts
+++ b/clients/fides-js/src/lib/tcf/purposes.ts
@@ -21,10 +21,16 @@ export const getUniquePurposeRecords = ({
   uniqueIds.forEach((id) => {
     const consent = consentPurposes.find((p) => p.id === id);
     const legint = legintPurposes.find((p) => p.id === id);
-    if (consent) {
-      purposes.push({ ...consent, isConsent: true, isLegint: false });
-    } else if (legint) {
-      purposes.push({ ...legint, isConsent: false, isLegint: true });
+    if (consent || legint) {
+      const record = { ...consent, ...legint } as
+        | TCFPurposeConsentRecord
+        | TCFPurposeLegitimateInterestsRecord;
+      purposes.push({
+        ...record,
+        id,
+        isConsent: !!consent,
+        isLegint: !!legint,
+      });
     }
   });
 

--- a/clients/fides-js/src/lib/tcf/types.ts
+++ b/clients/fides-js/src/lib/tcf/types.ts
@@ -5,13 +5,19 @@ import type {
   UserConsentPreference,
 } from "../consent-types";
 
-export enum LegalBasisForProcessingEnum {
+enum LegalBasisForProcessingEnum {
   CONSENT = "Consent",
   CONTRACT = "Contract",
   LEGAL_OBLIGATIONS = "Legal obligations",
   VITAL_INTERESTS = "Vital interests",
   PUBLIC_INTEREST = "Public interest",
   LEGITIMATE_INTERESTS = "Legitimate interests",
+}
+
+// These are the only relevant ones for TCF
+export enum LegalBasisEnum {
+  CONSENT = LegalBasisForProcessingEnum.CONSENT,
+  LEGITIMATE_INTERESTS = LegalBasisForProcessingEnum.LEGITIMATE_INTERESTS,
 }
 
 // Embedded items
@@ -235,6 +241,11 @@ export type VendorRecord = TCFConsentVendorRecord &
     isConsent: boolean;
     isLegint: boolean;
   };
+
+export interface PurposeRecord extends TCFPurposeConsentRecord {
+  isConsent: boolean;
+  isLegint: boolean;
+}
 
 export type GVLJson = Pick<
   GVL,

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -215,10 +215,13 @@ describe("Fides-js TCF", () => {
         cy.getByTestId("toggle-Purposes").within(() => {
           cy.get("input").should("be.checked");
         });
-        cy.getByTestId(`toggle-${PURPOSE_4.name}`).within(() => {
+        cy.getByTestId(`toggle-${PURPOSE_4.name}-consent`).within(() => {
           cy.get("input").should("be.checked");
         });
-        cy.getByTestId(`toggle-${PURPOSE_9.name}`).within(() => {
+        cy.getByTestId(`toggle-${PURPOSE_9.name}-consent`).within(() => {
+          cy.get("input").should("be.checked");
+        });
+        cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
           cy.get("input").should("be.checked");
         });
         cy.get(".fides-notice-toggle-header").contains("Special purposes");
@@ -265,17 +268,35 @@ describe("Fides-js TCF", () => {
       });
 
       it("can group toggle", () => {
-        // Toggle the parent toggle off
+        // Toggle just legitimate interests
         cy.getByTestId("toggle-Purposes").click();
-        cy.getByTestId(`toggle-${PURPOSE_4.name}`).within(() => {
+        cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
           cy.get("input").should("not.be.checked");
         });
-        cy.getByTestId(`toggle-${PURPOSE_9.name}`).within(() => {
-          cy.get("input").should("not.be.checked");
-        });
+
         // Toggle a child back on
-        cy.getByTestId(`toggle-${PURPOSE_4.name}`).click();
+        cy.getByTestId(`toggle-${PURPOSE_2.name}`).click();
         cy.getByTestId("toggle-Purposes").within(() => {
+          cy.get("input").should("be.checked");
+        });
+
+        // Do the same for consent column
+        cy.getByTestId("toggle-all-Purposes-consent").click();
+        cy.getByTestId(`toggle-${PURPOSE_4.name}-consent`).within(() => {
+          cy.get("input").should("not.be.checked");
+        });
+        // Toggle back on
+        cy.getByTestId("toggle-all-Purposes-consent").click();
+        cy.getByTestId(`toggle-${PURPOSE_4.name}-consent`).within(() => {
+          cy.get("input").should("be.checked");
+        });
+
+        // Try the all on/all off button
+        cy.get("button").contains("All off").click();
+        cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
+          cy.get("input").should("not.be.checked");
+        });
+        cy.getByTestId(`toggle-${PURPOSE_4.name}-consent`).within(() => {
           cy.get("input").should("not.be.checked");
         });
       });
@@ -423,7 +444,7 @@ describe("Fides-js TCF", () => {
 
       it("can opt in to some and opt out of others", () => {
         cy.getByTestId("consent-modal").within(() => {
-          cy.getByTestId(`toggle-${PURPOSE_4.name}`).click();
+          cy.getByTestId(`toggle-${PURPOSE_4.name}-consent`).click();
 
           cy.get("#fides-tab-Features").click();
           cy.getByTestId(`toggle-${SPECIAL_FEATURE_1.name}`).click();
@@ -658,15 +679,15 @@ describe("Fides-js TCF", () => {
 
       // Verify the toggles
       // Purposes
-      cy.getByTestId(`toggle-${PURPOSE_4.name}`).within(() => {
+      cy.getByTestId(`toggle-${PURPOSE_4.name}-consent`).within(() => {
         cy.get("input").should("not.be.checked");
       });
-      cy.getByTestId(`toggle-${PURPOSE_9.name}`).within(() => {
+      cy.getByTestId(`toggle-${PURPOSE_9.name}-consent`).within(() => {
         cy.get("input").should("be.checked");
       });
       // also verify that a purpose that was not part of the cookie is also opted out
       // (since it should have no current_preference, and default behavior is opt out)
-      cy.getByTestId(`toggle-${PURPOSE_6.name}`).within(() => {
+      cy.getByTestId(`toggle-${PURPOSE_6.name}-consent`).within(() => {
         cy.get("input").should("not.be.checked");
       });
       // Features


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4210

### Description Of Changes

Purposes now have double vendor toggles! Also did the work of enabling all for each column, as well as the All On / All Off buttons.


https://github.com/ethyca/fides/assets/24641006/2a9d8866-edac-4e05-9216-4625c3f35128


### Code Changes

* [x] Make a new component `DoubleToggleTable` to deal with double toggles for both vendors and purposes
* [x] Refactor purposes to use the new `DoubleToggleTable`
* [x] Add a header option to toggle all legitimate interests or all consents on/off at once
* [x] Add "All on"/"All off" buttons
* [x] Update cypress tests

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
