### PR TITLE
Fix double toggle bug

### DIFF
--- a/clients/fides-js/src/components/tcf/DoubleToggleTable.tsx
+++ b/clients/fides-js/src/components/tcf/DoubleToggleTable.tsx
@@ -82,9 +82,10 @@ const DoubleToggleTable = <T extends Item>({
     }
   };
 
-  const handleToggleIndividual = (item: T) => {
-    const enabledIds = item.isConsent ? enabledConsentIds : enabledLegintIds;
-    const modelType = item.isConsent ? consentModelType : legintModelType;
+  const handleToggleIndividual = (item: T, legalBasis: LegalBasisEnum) => {
+    const isConsent = legalBasis === LegalBasisEnum.CONSENT;
+    const enabledIds = isConsent ? enabledConsentIds : enabledLegintIds;
+    const modelType = isConsent ? consentModelType : legintModelType;
     const purposeId = `${item.id}`;
     if (enabledIds.indexOf(purposeId) !== -1) {
       onToggle({
@@ -138,7 +139,7 @@ const DoubleToggleTable = <T extends Item>({
             name: item.name,
           }}
           onToggle={() => {
-            handleToggleIndividual(item);
+            handleToggleIndividual(item, LegalBasisEnum.LEGITIMATE_INTERESTS);
           }}
           checked={enabledLegintIds.indexOf(`${item.id}`) !== -1}
           badge={renderBadgeLabel ? renderBadgeLabel(item) : undefined}
@@ -149,7 +150,9 @@ const DoubleToggleTable = <T extends Item>({
                   name={`${item.name}-consent`}
                   id={`${item.id}-consent`}
                   checked={enabledConsentIds.indexOf(`${item.id}`) !== -1}
-                  onChange={() => handleToggleIndividual(item)}
+                  onChange={() =>
+                    handleToggleIndividual(item, LegalBasisEnum.CONSENT)
+                  }
                 />
               ) : null}
             </div>

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -344,6 +344,43 @@ describe("Fides-js TCF", () => {
           });
         });
       });
+
+      it("can toggle double toggles individually", () => {
+        cy.fixture("consent/experience_tcf.json").then((payload) => {
+          const experience = payload.items[0];
+          // Add a vendor legitimate interest which is the same as vendor consent
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          const tcf_vendor_legitimate_interests = [
+            {
+              ...experience.tcf_vendor_consents[0],
+              default_preference: "opt_in",
+              purpose_legitimate_interests: [PURPOSE_2.id],
+            },
+          ];
+          const updatedExperience = {
+            ...experience,
+            tcf_vendor_legitimate_interests,
+          };
+          stubConfig({
+            options: {
+              isOverlayEnabled: true,
+              tcfEnabled: true,
+            },
+            experience: updatedExperience,
+          });
+          cy.waitUntilFidesInitialized().then(() => {
+            cy.get("#fides-modal-link").click();
+            cy.get("#fides-tab-Vendors").click();
+            cy.getByTestId(`toggle-${VENDOR_1.name}`).click();
+            cy.getByTestId(`toggle-${VENDOR_1.name}`).within(() => {
+              cy.get("input").should("not.be.checked");
+            });
+            cy.getByTestId(`toggle-${VENDOR_1.name}-consent`).within(() => {
+              cy.get("input").should("not.be.checked");
+            });
+          });
+        });
+      });
     });
 
     describe("saving preferences", () => {
@@ -359,10 +396,9 @@ describe("Fides-js TCF", () => {
               { id: PURPOSE_7.id, preference: "opt_in" },
               { id: PURPOSE_9.id, preference: "opt_in" },
             ]);
-            // TODO: fides#4210
-            // expect(body.purpose_legitimate_interests_preferences).to.eql([
-            //   { id: PURPOSE_2.id, preference: "opt_in" },
-            // ]);
+            expect(body.purpose_legitimate_interests_preferences).to.eql([
+              { id: PURPOSE_2.id, preference: "opt_in" },
+            ]);
             expect(body.special_purpose_preferences).to.eql(undefined);
             expect(body.feature_preferences).to.eql(undefined);
             expect(body.special_feature_preferences).to.eql([
@@ -390,13 +426,12 @@ describe("Fides-js TCF", () => {
                 .is.eql(true);
             }
           );
-          // TODO: fides#4210
-          // expect(
-          //   cookieKeyConsent.tcf_consent
-          //     .purpose_legitimate_interests_preferences
-          // )
-          //   .property(`${PURPOSE_2.id}`)
-          //   .is.eql(true);
+          expect(
+            cookieKeyConsent.tcf_consent
+              .purpose_legitimate_interests_preferences
+          )
+            .property(`${PURPOSE_2.id}`)
+            .is.eql(true);
           expect(cookieKeyConsent.tcf_consent.special_feature_preferences)
             .property(`${SPECIAL_FEATURE_1.id}`)
             .is.eql(true);
@@ -428,10 +463,9 @@ describe("Fides-js TCF", () => {
               { id: PURPOSE_7.id, preference: "opt_out" },
               { id: PURPOSE_9.id, preference: "opt_out" },
             ]);
-            // TODO: fides#4210
-            // expect(body.purpose_legitimate_interests_preferences).to.eql([
-            //   { id: PURPOSE_2.id, preference: "opt_out" },
-            // ]);
+            expect(body.purpose_legitimate_interests_preferences).to.eql([
+              { id: PURPOSE_2.id, preference: "opt_out" },
+            ]);
             expect(body.special_purpose_preferences).to.eql(undefined);
             expect(body.feature_preferences).to.eql(undefined);
             expect(body.special_feature_preferences).to.eql([
@@ -459,13 +493,12 @@ describe("Fides-js TCF", () => {
                 .is.eql(false);
             }
           );
-          // TODO: fides#4210
-          // expect(
-          //   cookieKeyConsent.tcf_consent
-          //     .purpose_legitimate_interests_preferences
-          // )
-          //   .property(`${PURPOSE_2.id}`)
-          //   .is.eql(false);
+          expect(
+            cookieKeyConsent.tcf_consent
+              .purpose_legitimate_interests_preferences
+          )
+            .property(`${PURPOSE_2.id}`)
+            .is.eql(false);
           expect(cookieKeyConsent.tcf_consent.special_feature_preferences)
             .property(`${SPECIAL_FEATURE_1.id}`)
             .is.eql(false);
@@ -489,7 +522,6 @@ describe("Fides-js TCF", () => {
       it("can opt in to some and opt out of others", () => {
         cy.getByTestId("consent-modal").within(() => {
           cy.getByTestId(`toggle-${PURPOSE_4.name}-consent`).click();
-
           cy.get("#fides-tab-Features").click();
           cy.getByTestId(`toggle-${SPECIAL_FEATURE_1.name}`).click();
 
@@ -504,10 +536,9 @@ describe("Fides-js TCF", () => {
               { id: PURPOSE_7.id, preference: "opt_in" },
               { id: PURPOSE_9.id, preference: "opt_in" },
             ]);
-            // TODO: fides#4210
-            // expect(body.purpose_legitimate_interests_preferences).to.eql([
-            //   { id: PURPOSE_2.id, preference: "opt_in" },
-            // ]);
+            expect(body.purpose_legitimate_interests_preferences).to.eql([
+              { id: PURPOSE_2.id, preference: "opt_in" },
+            ]);
             expect(body.special_purpose_preferences).to.eql(undefined);
             expect(body.feature_preferences).to.eql(undefined);
             expect(body.special_feature_preferences).to.eql([
@@ -533,10 +564,12 @@ describe("Fides-js TCF", () => {
               .property(`${pid}`)
               .is.eql(true);
           });
-          // TODO: fides#4210
-          // expect(cookieKeyConsent.tcf_consent.purpose_legitimate_interests_preferences)
-          //   .property(`${PURPOSE_2.id}`)
-          //   .is.eql(false);
+          expect(
+            cookieKeyConsent.tcf_consent
+              .purpose_legitimate_interests_preferences
+          )
+            .property(`${PURPOSE_2.id}`)
+            .is.eql(true);
           expect(cookieKeyConsent.tcf_consent.purpose_consent_preferences)
             .property(`${PURPOSE_4.id}`)
             .is.eql(false);


### PR DESCRIPTION
Closes bug reported by @galvana !

### Description Of Changes

When a vendor has two toggles available, it was always setting consent instead of the proper one.
 
![toggle](https://github.com/ethyca/fides/assets/24641006/0a376090-32d4-4de0-a866-a9c76c3e52bc)


### Code Changes

* [x] Pass in a legal basis for individual toggles (we had this before I moved to the refactored DoubleVendorToggle component, and then I made a bad assumption while generalizing it 🙃 )
* [x] Add a cypress test

### Steps to Confirm

* [ ] Set up TCF with a vendor that has both legint and consent purposes
* [ ] Toggle its legitimate interest purpose
* [ ] It should work as expected

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
