### PR TITLE
Frontend AC string support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The types of changes are:
 - Added an option to link to vendor tab from an experience config description [#4191](https://github.com/ethyca/fides/pull/4191)
 - Added two toggles for vendors in the TCF overlay, one for Consent, and one for Legitimate Interest [#4189](https://github.com/ethyca/fides/pull/4189)
 - Added two toggles for purposes in the TCF overlay, one for Consent, and one for Legitimate Interest [#4234](https://github.com/ethyca/fides/pull/4234)
+- Support for AC string to `fides-tcf` [#4244](https://github.com/ethyca/fides/pull/4244)
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 - Added two toggles for vendors in the TCF overlay, one for Consent, and one for Legitimate Interest [#4189](https://github.com/ethyca/fides/pull/4189)
 - Added two toggles for purposes in the TCF overlay, one for Consent, and one for Legitimate Interest [#4234](https://github.com/ethyca/fides/pull/4234)
 - Support for AC string to `fides-tcf` [#4244](https://github.com/ethyca/fides/pull/4244)
+- Support for `gvl` prefixed vendor IDs [#4247](https://github.com/ethyca/fides/pull/4247)
 
 ### Changed
 - Removed `TCF_ENABLED` environment variable from the privacy center in favor of dynamically figuring out which `fides-js` bundle to send [#4131](https://github.com/ethyca/fides/pull/4131)

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -191,7 +191,7 @@ const updateCookie = async (
   });
   return {
     ...oldCookie,
-    tc_string: tcString,
+    fides_tc_string: tcString,
     tcf_consent: transformTcfPreferencesToCookieKeys(tcf),
   };
 };

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -14,7 +14,7 @@ import { UpdateEnabledIds } from "./TcfOverlay";
 import FilterButtons from "./FilterButtons";
 import {
   transformExperienceToVendorRecords,
-  vendorIsGvl,
+  vendorGvlEntry,
 } from "../../lib/tcf/vendors";
 import ExternalLink from "../ExternalLink";
 import DoubleToggleTable from "./DoubleToggleTable";
@@ -218,7 +218,7 @@ const TcfVendors = ({
   };
 
   const vendorsToDisplay = isFiltered
-    ? vendors.filter((v) => vendorIsGvl(v, experience.gvl))
+    ? vendors.filter((v) => vendorGvlEntry(v.id, experience.gvl))
     : vendors;
 
   return (
@@ -234,10 +234,10 @@ const TcfVendors = ({
         consentModelType="vendorsConsent"
         legintModelType="vendorsLegint"
         renderBadgeLabel={(vendor) =>
-          vendorIsGvl(vendor, experience.gvl) ? "IAB TCF" : undefined
+          vendorGvlEntry(vendor.id, experience.gvl) ? "IAB TCF" : undefined
         }
         renderToggleChild={(vendor) => {
-          const gvlVendor = vendorIsGvl(vendor, experience.gvl);
+          const gvlVendor = vendorGvlEntry(vendor.id, experience.gvl);
           // @ts-ignore the IAB-TCF lib doesn't support GVL v3 types yet
           const url: GvlVendorUrl | undefined = gvlVendor?.urls.find(
             (u: GvlVendorUrl) => u.langId === "en"

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -86,7 +86,7 @@ const updateCookie = async (
 ): Promise<FidesCookie> => {
   // First check if the user has never consented before
   if (!hasSavedTcfPreferences(experience)) {
-    return { ...oldCookie, tc_string: "" };
+    return { ...oldCookie, fides_tc_string: "" };
   }
 
   // Usually at this point, we'd look at the Experience from the backend and update

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -52,7 +52,7 @@ import { shopify } from "./integrations/shopify";
 
 import { FidesConfig, PrivacyExperience } from "./lib/consent-types";
 
-import { tcf } from "./lib/tcf";
+import { initializeCmpApi } from "./lib/tcf";
 import {
   getInitialCookie,
   getInitialFides,
@@ -103,6 +103,8 @@ const updateCookie = async (
 const init = async (config: FidesConfig) => {
   const cookie = getInitialCookie(config);
   const initialFides = getInitialFides({ ...config, cookie });
+  // Initialize the CMP API early so that listeners are established
+  initializeCmpApi();
   if (initialFides) {
     Object.assign(_Fides, initialFides);
     dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
@@ -126,8 +128,6 @@ const init = async (config: FidesConfig) => {
     dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
   }
   dispatchFidesEvent("FidesUpdated", cookie, config.options.debug);
-
-  tcf();
 };
 
 // The global Fides object; this is bound to window.Fides if available

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -57,7 +57,7 @@ export interface FidesCookie {
   consent: CookieKeyConsent;
   identity: CookieIdentity;
   fides_meta: CookieMeta;
-  tc_string?: string;
+  fides_tc_string?: string;
   tcf_consent: TcfCookieConsent;
 }
 

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -44,7 +44,7 @@ export type Fides = {
   consent: CookieKeyConsent;
   experience?: PrivacyExperience | EmptyExperience;
   geolocation?: UserGeolocation;
-  tc_string?: string | undefined;
+  fides_tc_string?: string | undefined;
   options: FidesOptions;
   fides_meta: CookieMeta;
   tcf_consent: TcfCookieConsent;
@@ -192,7 +192,7 @@ export const getInitialFides = ({
     identity: cookie.identity,
     experience: updatedExperience,
     tcf_consent: cookie.tcf_consent,
-    tc_string: cookie.tc_string,
+    fides_tc_string: cookie.fides_tc_string,
     geolocation,
     options,
     initialized: true,
@@ -296,7 +296,7 @@ export const initialize = async ({
     consent: cookie.consent,
     fides_meta: cookie.fides_meta,
     identity: cookie.identity,
-    tc_string: cookie.tc_string,
+    fides_tc_string: cookie.fides_tc_string,
     tcf_consent: cookie.tcf_consent,
     experience,
     geolocation,

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -85,7 +85,7 @@ export const updateConsentPreferences = async ({
   // 3. Update the window.Fides object
   debugLog(debug, "Updating window.Fides");
   window.Fides.consent = cookie.consent;
-  window.Fides.tc_string = cookie.tc_string;
+  window.Fides.fides_tc_string = cookie.fides_tc_string;
   window.Fides.tcf_consent = cookie.tcf_consent;
 
   // 4. Save preferences to the cookie in the browser

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -155,7 +155,7 @@ export const generateTcString = async ({
  * `vendors_disclosed` and our own AC string addition.
  */
 const fidesEventToTcString = (event: FidesEvent) => {
-  const { tc_string: cookieString } = event.detail;
+  const { fides_tc_string: cookieString } = event.detail;
   if (cookieString) {
     // Remove the AC portion which is separated by FIDES_SEPARATOR
     const [tcString] = cookieString.split(FIDES_SEPARATOR);
@@ -181,7 +181,8 @@ export const initializeCmpApi = () => {
       /*
        * If using with 'removeEventListener' command, add a check to see if tcData is not a boolean. */
       if (typeof tcData !== "boolean") {
-        const stringSplit = window.Fides.tc_string?.split(FIDES_SEPARATOR);
+        const stringSplit =
+          window.Fides.fides_tc_string?.split(FIDES_SEPARATOR);
         const addtlConsent = stringSplit?.length === 2 ? stringSplit[1] : "";
         next({ ...tcData, addtlConsent }, status);
       }

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -42,7 +42,7 @@ const generateAcString = ({
         .map((id) => decodeVendorId(id).id)
     )
   );
-  const vendorIds = uniqueIds.join(".");
+  const vendorIds = uniqueIds.sort().join(".");
 
   return `${AC_SPECIFICATION_VERSION}~${vendorIds}`;
 };

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -165,7 +165,7 @@ const fidesEventToTcString = (event: FidesEvent) => {
     // We only want to return the first part of the tcString, which is separated by '.'
     // This means Publisher TC is not sent either, which is okay for now since we do not set it.
     // However, if we do one day set it, we would have to decode the string and encode it again
-    // without vendor_consents
+    // without vendorsDisclosed
     return tcString.split(".")[0];
   }
   return cookieString;

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -5,13 +5,15 @@
  * In the future, this should hold interactions with the CMP API as well as string generation.
  */
 
-import { CmpApi } from "@iabtechlabtcf/cmpapi";
+import { CmpApi, TCData } from "@iabtechlabtcf/cmpapi";
 import { TCModel, TCString, GVL } from "@iabtechlabtcf/core";
 import { makeStub } from "./tcf/stub";
 
 import { EnabledIds } from "./tcf/types";
 import { vendorIsAc, vendorIsGvl } from "./tcf/vendors";
 import { PrivacyExperience } from "./consent-types";
+import { FIDES_SEPARATOR } from "./tcf/constants";
+import { FidesEvent } from "./events";
 
 // TCF
 const CMP_ID = 407;
@@ -20,9 +22,6 @@ const FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS = [1, 3, 4, 5, 6];
 
 // AC
 const AC_SPECIFICATION_VERSION = 1;
-
-// Fides
-const FIDES_SEPARATOR = ",";
 
 /**
  * Generate an AC String based on TCF-related info from privacy experience.
@@ -151,37 +150,71 @@ export const generateTcString = async ({
 };
 
 /**
- * Call tcf() to configure Fides with tcf support (if tcf is enabled).
+ * Extract just the TC string from a FidesEvent. This will also remove parts of the
+ * TC string that we do not want to surface with our CMP API events, such as
+ * `vendors_disclosed` and our own AC string addition.
  */
-export const tcf = () => {
+const fidesEventToTcString = (event: FidesEvent) => {
+  const { tc_string: cookieString } = event.detail;
+  if (cookieString) {
+    // Remove the AC portion which is separated by FIDES_SEPARATOR
+    const [tcString] = cookieString.split(FIDES_SEPARATOR);
+    // We only want to return the first part of the tcString, which is separated by '.'
+    // This means Publisher TC is not sent either, which is okay for now since we do not set it.
+    // However, if we do one day set it, we would have to decode the string and encode it again
+    // without vendor_consents
+    return tcString.split(".")[0];
+  }
+  return cookieString;
+};
+
+/**
+ * Initializes the CMP API, including setting up listeners on FidesEvents to update
+ * the CMP API accordingly.
+ */
+export const initializeCmpApi = () => {
   makeStub();
   const isServiceSpecific = true; // TODO: determine this from the backend?
-  const cmpApi = new CmpApi(CMP_ID, CMP_VERSION, isServiceSpecific);
+  const cmpApi = new CmpApi(CMP_ID, CMP_VERSION, isServiceSpecific, {
+    // Add custom AC commands
+    getTCData: (next, tcData: TCData, status) => {
+      /*
+       * If using with 'removeEventListener' command, add a check to see if tcData is not a boolean. */
+      if (typeof tcData !== "boolean") {
+        const stringSplit = window.Fides.tc_string?.split(FIDES_SEPARATOR);
+        const addtlConsent = stringSplit?.length === 2 ? stringSplit[1] : "";
+        next({ ...tcData, addtlConsent }, status);
+      }
+
+      // pass data and status along
+      next(tcData, status);
+    },
+  });
 
   // `null` value indicates that GDPR does not apply
   // Initialize api with TC str, we don't yet show UI, so we use false
   // see https://github.com/InteractiveAdvertisingBureau/iabtcf-es/tree/master/modules/cmpapi#dont-show-ui--tc-string-does-not-need-an-update
   window.addEventListener("FidesInitialized", (event) => {
-    const { tc_string: tcString } = event.detail;
+    const tcString = fidesEventToTcString(event);
     cmpApi.update(tcString ?? null, false);
   });
   // UI is visible
   // see https://github.com/InteractiveAdvertisingBureau/iabtcf-es/tree/master/modules/cmpapi#show-ui--tc-string-needs-update
   // and https://github.com/InteractiveAdvertisingBureau/iabtcf-es/tree/master/modules/cmpapi#show-ui--new-user--no-tc-string
   window.addEventListener("FidesUIShown", (event) => {
-    const { tc_string: tcString } = event.detail;
+    const tcString = fidesEventToTcString(event);
     cmpApi.update(tcString ?? null, true);
   });
   // UI is no longer visible
   // see https://github.com/InteractiveAdvertisingBureau/iabtcf-es/tree/master/modules/cmpapi#dont-show-ui--tc-string-does-not-need-an-update
   window.addEventListener("FidesModalClosed", (event) => {
-    const { tc_string: tcString } = event.detail;
+    const tcString = fidesEventToTcString(event);
     cmpApi.update(tcString ?? null, false);
   });
   // User preference collected
   // see https://github.com/InteractiveAdvertisingBureau/iabtcf-es/tree/master/modules/cmpapi#show-ui--tc-string-needs-update
   window.addEventListener("FidesUpdated", (event) => {
-    const { tc_string: tcString } = event.detail;
+    const tcString = fidesEventToTcString(event);
     cmpApi.update(tcString ?? null, false);
   });
 };

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -10,7 +10,7 @@ import { TCModel, TCString, GVL } from "@iabtechlabtcf/core";
 import { makeStub } from "./tcf/stub";
 
 import { EnabledIds } from "./tcf/types";
-import { decodeVendorId, vendorIsAc, vendorIsGvl } from "./tcf/vendors";
+import { decodeVendorId, vendorIsAc, vendorGvlEntry } from "./tcf/vendors";
 import { PrivacyExperience } from "./consent-types";
 import { FIDES_SEPARATOR } from "./tcf/constants";
 import { FidesEvent } from "./events";
@@ -75,8 +75,9 @@ export const generateTcString = async ({
         tcStringPreferences.vendorsConsent.length > 0
       ) {
         tcStringPreferences.vendorsConsent.forEach((vendorId) => {
-          if (vendorIsGvl({ id: vendorId }, experience.gvl)) {
-            tcModel.vendorConsents.set(+vendorId);
+          if (vendorGvlEntry(vendorId, experience.gvl)) {
+            const { id } = decodeVendorId(vendorId);
+            tcModel.vendorConsents.set(+id);
           }
         });
         tcStringPreferences.vendorsLegint.forEach((vendorId) => {
@@ -97,7 +98,8 @@ export const generateTcString = async ({
               skipSetLegInt = true;
             }
             if (!skipSetLegInt) {
-              tcModel.vendorLegitimateInterests.set(+vendorId);
+              const { id } = decodeVendorId(vendorId);
+              tcModel.vendorLegitimateInterests.set(+id);
             }
           }
         });

--- a/clients/fides-js/src/lib/tcf/constants.ts
+++ b/clients/fides-js/src/lib/tcf/constants.ts
@@ -1,5 +1,11 @@
 import { TcfExperienceRecords, TcfModelType } from "./types";
 
+/**
+ * We store all of our preference strings (TC, AC, etc.) together as one string so that
+ * we can have a single-source-of-truth for offline storage & syncing. The code responsible
+ * for serving our standards-compliant JS API is responsible for separating out the
+ * preference strings for consumption.
+ */
 export const FIDES_SEPARATOR = ",";
 
 export const TCF_COOKIE_KEY_TO_EXPERIENCE_KEY: {

--- a/clients/fides-js/src/lib/tcf/constants.ts
+++ b/clients/fides-js/src/lib/tcf/constants.ts
@@ -1,5 +1,7 @@
 import { TcfExperienceRecords, TcfModelType } from "./types";
 
+export const FIDES_SEPARATOR = ",";
+
 export const TCF_COOKIE_KEY_TO_EXPERIENCE_KEY: {
   cookieKey: TcfModelType;
   experienceKey: keyof TcfExperienceRecords;

--- a/clients/fides-js/src/lib/tcf/vendors.ts
+++ b/clients/fides-js/src/lib/tcf/vendors.ts
@@ -7,6 +7,11 @@ import {
   VendorRecord,
 } from "./types";
 
+enum VendorSouces {
+  GVL = "gvl",
+  AC = "ac",
+}
+
 export const vendorIsGvl = (
   vendor: Pick<TCFVendorRelationships, "id">,
   gvl: GVLJson | undefined
@@ -16,6 +21,20 @@ export const vendorIsGvl = (
   }
   return gvl.vendors[vendor.id];
 };
+
+/**
+ * Given a vendor id such as `gvl.2`, return {source: "gvl", id: "2"};
+ */
+export const decodeVendorId = (vendorId: TCFVendorRelationships["id"]) => {
+  const split = vendorId.split(".");
+  if (split.length === 1) {
+    return { source: undefined, id: split[0] };
+  }
+  return { source: split[0], id: split[1] };
+};
+
+export const vendorIsAc = (vendorId: TCFVendorRelationships["id"]) =>
+  decodeVendorId(vendorId).source === VendorSouces.AC;
 
 const transformVendorDataToVendorRecords = ({
   consents,

--- a/clients/fides-js/src/lib/tcf/vendors.ts
+++ b/clients/fides-js/src/lib/tcf/vendors.ts
@@ -7,20 +7,10 @@ import {
   VendorRecord,
 } from "./types";
 
-enum VendorSouces {
+enum VendorSources {
   GVL = "gvl",
   AC = "ac",
 }
-
-export const vendorIsGvl = (
-  vendor: Pick<TCFVendorRelationships, "id">,
-  gvl: GVLJson | undefined
-) => {
-  if (!gvl) {
-    return undefined;
-  }
-  return gvl.vendors[vendor.id];
-};
 
 /**
  * Given a vendor id such as `gvl.2`, return {source: "gvl", id: "2"};
@@ -33,8 +23,32 @@ export const decodeVendorId = (vendorId: TCFVendorRelationships["id"]) => {
   return { source: split[0], id: split[1] };
 };
 
+/**
+ * Returns the associated GVL entry given a vendor ID. If the id is not found,
+ * returns `undefined`.
+ *
+ * @example If an id of `gvl.2` is passed in, return GVL Vendor #2
+ * @example If an id of `ac.2` is passed in, return undefined
+ * @example If an id of `2` is passed in, return GVL Vendor #2 (for backwards compatibility)
+ */
+export const vendorGvlEntry = (
+  vendorId: TCFVendorRelationships["id"],
+  gvl: GVLJson | undefined
+) => {
+  if (!gvl) {
+    return undefined;
+  }
+  const { source, id } = decodeVendorId(vendorId);
+  // For backwards compatibility, we also allow an undefined source but we should
+  // remove this once the backend is fully using its new vendor ID scheme.
+  if (source === VendorSources.GVL || source === undefined) {
+    return gvl.vendors[id];
+  }
+  return undefined;
+};
+
 export const vendorIsAc = (vendorId: TCFVendorRelationships["id"]) =>
-  decodeVendorId(vendorId).source === VendorSouces.AC;
+  decodeVendorId(vendorId).source === VendorSources.AC;
 
 const transformVendorDataToVendorRecords = ({
   consents,

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -775,11 +775,13 @@ describe("Fides-js TCF", () => {
             },
           ],
         };
-        AC_IDS.forEach((id) => {
+        AC_IDS.forEach((id, idx) => {
           experience.tcf_vendor_consents.push({
             ...baseVendor,
             id: `ac.${id}`,
             name: `AC ${id}`,
+            // Set some of these vendors without purpose_consents
+            purpose_consents: idx % 2 === 0 ? [] : baseVendor.purpose_consents,
           });
         });
 

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -785,7 +785,7 @@ describe("Fides-js TCF", () => {
 
   describe("ac string", () => {
     const AC_IDS = [42, 33, 49];
-    const acceptAllAcString = `1~${AC_IDS.join(".")}`;
+    const acceptAllAcString = `1~${AC_IDS.sort().join(".")}`;
     const rejectAllAcString = "1~";
     beforeEach(() => {
       cy.fixture("consent/experience_tcf.json").then((payload) => {

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -379,6 +379,34 @@
         "features": {},
         "specialFeatures": {},
         "vendors": {
+          "1": {
+            "id": 1,
+            "name": "Exponential Interactive, Inc d/b/a VDX.tv",
+            "purposes": [1],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "cookieMaxAgeSeconds": 7776000,
+            "usesCookies": true,
+            "cookieRefresh": true,
+            "usesNonCookieAccess": false,
+            "dataRetention": {
+              "stdRetention": 397,
+              "purposes": {},
+              "specialPurposes": {}
+            },
+            "urls": [
+              {
+                "langId": "en",
+                "privacy": "https://vdx.tv/privacy/",
+                "legIntClaim": "https://cdnx.exponential.com/wp-content/uploads/2018/04/Balancing-Assessment-for-Legitimate-Interest-Publishers-v2.pdf"
+              }
+            ],
+            "dataDeclaration": [1, 3, 4, 6, 8, 10, 11],
+            "deviceStorageDisclosureUrl": "https://vdxtv.expo.workers.dev"
+          },
           "2": {
             "id": 2,
             "name": "Captify Technologies Limited",


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4212

### Description Of Changes

Support AC string in fides-js!


### Code Changes

* [x] Add a function `decodeVendorId` based on [upcoming backend refactor](https://github.com/ethyca/fidesplus/issues/1129#issue-1916394861)
* [x] Add a function vendorIsAc
* [x] Add a function generateAcString to generate an AC string (similar to the existing generateTcString)
* [x] Add [custom commands](https://github.com/InteractiveAdvertisingBureau/iabtcf-es/tree/master/modules/cmpapi#built-in-and-custom-commands) to enable sending along the `addtlConsent` field
* [x] Rename `tc_string` in the FidesCookie to `fides_tc_string`
* [x] Cypress tests

### Steps to Confirm

* This is difficult to confirm outside of Cypress tests right now since we don't have universal vendor IDs on the backend yet. But if you play around with TCF as usual, you should notice a few things:
  * When saving the cookie, we now save the tc string to `fides_tc_string`, and it'll end with `,1~"`. in theory, once we have AC vendor ids working, that string will fill in those AC ids so it'll be more like `1~[id].[id2]` etc.
  * Whenever we print out Fides events, the event will include this composite string
  * When looking at tcData events, there should not be the composite string (but it'll be included in `tcData` under `addtlConsents`. To look at tcdata events, you can paste this into your console:
  
```js
__tcfapi("getTCData", 2, (data) => console.log({data}))
```
and you should see something like

```json
{
    "data": {
        "cmpId": 407,
        "tcString": "CPzYJkAPzYJkAGXABBENAUEIAFKAAAAAAAAAABEAAAAA",
        "addtlConsent": "1~"
    }
}
```

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
