### PR TITLE
Turn on configureConsent flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The types of changes are:
 - Update frontend to use new legal basis dimension on vendors [#4216](https://github.com/ethyca/fides/pull/4216)
 - Updated privacy center patch preferences call to handle updated API response [#4235](https://github.com/ethyca/fides/pull/4235)
 - Added our CMP ID [#4233](https://github.com/ethyca/fides/pull/4233)
+- Allow admin-ui users to turn on Configure Consent flag [#4246](https://github.com/ethyca/fides/pull/4246)
 
 ### Fixed
 - TCF overlay can initialize its consent preferences from a cookie [#4124](https://github.com/ethyca/fides/pull/4124)

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -23,7 +23,7 @@
     "development": true,
     "test": true,
     "production": false,
-    "userCannotModify": true
+    "userCannotModify": false
   },
   "standaloneConnections": {
     "description": "Allow the creation of standalone connections for testing",

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -22,8 +22,7 @@
     "description": "Page to configure vendors and cookies for consent",
     "development": true,
     "test": true,
-    "production": false,
-    "userCannotModify": false
+    "production": false
   },
   "standaloneConnections": {
     "description": "Allow the creation of standalone connections for testing",


### PR DESCRIPTION
### Description Of Changes

Allow users to view the new page to configure vendors and cookies for consent by toggling the Configure consent flag.

### Code Changes

* [ ] update configureConsent flag's userCannotModify to false

### Steps to Confirm

* [ ] run fides frontend and plus backend 
* [ ] in fides nav to /management/about
* [ ] toggle the Configure consent flag 
* [ ] verify the /consent/configure page is visible when on and inaccessible when off

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
