### PR TITLE
GVL vendor id update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 - Added two toggles for vendors in the TCF overlay, one for Consent, and one for Legitimate Interest [#4189](https://github.com/ethyca/fides/pull/4189)
 - Added two toggles for purposes in the TCF overlay, one for Consent, and one for Legitimate Interest [#4234](https://github.com/ethyca/fides/pull/4234)
 - Support for AC string to `fides-tcf` [#4244](https://github.com/ethyca/fides/pull/4244)
+- Support for `gvl` prefixed vendor IDs [#4247](https://github.com/ethyca/fides/pull/4247)
 
 
 ### Changed

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -14,7 +14,7 @@ import { UpdateEnabledIds } from "./TcfOverlay";
 import FilterButtons from "./FilterButtons";
 import {
   transformExperienceToVendorRecords,
-  vendorIsGvl,
+  vendorGvlEntry,
 } from "../../lib/tcf/vendors";
 import ExternalLink from "../ExternalLink";
 import DoubleToggleTable from "./DoubleToggleTable";
@@ -210,7 +210,7 @@ const TcfVendors = ({
   };
 
   const vendorsToDisplay = isFiltered
-    ? vendors.filter((v) => vendorIsGvl(v, experience.gvl))
+    ? vendors.filter((v) => vendorGvlEntry(v.id, experience.gvl))
     : vendors;
 
   return (
@@ -225,10 +225,10 @@ const TcfVendors = ({
         consentModelType="vendorsConsent"
         legintModelType="vendorsLegint"
         renderBadgeLabel={(vendor) =>
-          vendorIsGvl(vendor, experience.gvl) ? "IAB TCF" : undefined
+          vendorGvlEntry(vendor.id, experience.gvl) ? "IAB TCF" : undefined
         }
         renderToggleChild={(vendor) => {
-          const gvlVendor = vendorIsGvl(vendor, experience.gvl);
+          const gvlVendor = vendorGvlEntry(vendor.id, experience.gvl);
           // @ts-ignore the IAB-TCF lib doesn't support GVL v3 types yet
           const url: GvlVendorUrl | undefined = gvlVendor?.urls.find(
             (u: GvlVendorUrl) => u.langId === "en"

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -10,7 +10,7 @@ import { TCModel, TCString, GVL } from "@iabtechlabtcf/core";
 import { makeStub } from "./tcf/stub";
 
 import { EnabledIds } from "./tcf/types";
-import { decodeVendorId, vendorIsAc, vendorIsGvl } from "./tcf/vendors";
+import { decodeVendorId, vendorIsAc, vendorGvlEntry } from "./tcf/vendors";
 import { PrivacyExperience } from "./consent-types";
 import { FIDES_SEPARATOR } from "./tcf/constants";
 import { FidesEvent } from "./events";
@@ -75,8 +75,9 @@ export const generateTcString = async ({
         tcStringPreferences.vendorsConsent.length > 0
       ) {
         tcStringPreferences.vendorsConsent.forEach((vendorId) => {
-          if (vendorIsGvl({ id: vendorId }, experience.gvl)) {
-            tcModel.vendorConsents.set(+vendorId);
+          if (vendorGvlEntry(vendorId, experience.gvl)) {
+            const { id } = decodeVendorId(vendorId);
+            tcModel.vendorConsents.set(+id);
           }
         });
         tcStringPreferences.vendorsLegint.forEach((vendorId) => {
@@ -97,7 +98,8 @@ export const generateTcString = async ({
               skipSetLegInt = true;
             }
             if (!skipSetLegInt) {
-              tcModel.vendorLegitimateInterests.set(+vendorId);
+              const { id } = decodeVendorId(vendorId);
+              tcModel.vendorLegitimateInterests.set(+id);
             }
           }
         });

--- a/clients/fides-js/src/lib/tcf/vendors.ts
+++ b/clients/fides-js/src/lib/tcf/vendors.ts
@@ -7,7 +7,7 @@ import {
   VendorRecord,
 } from "./types";
 
-enum VendorSouces {
+enum VendorSources {
   GVL = "gvl",
   AC = "ac",
 }
@@ -41,14 +41,14 @@ export const vendorGvlEntry = (
   const { source, id } = decodeVendorId(vendorId);
   // For backwards compatibility, we also allow an undefined source but we should
   // remove this once the backend is fully using its new vendor ID scheme.
-  if (source === VendorSouces.GVL || source === undefined) {
+  if (source === VendorSources.GVL || source === undefined) {
     return gvl.vendors[id];
   }
   return undefined;
 };
 
 export const vendorIsAc = (vendorId: TCFVendorRelationships["id"]) =>
-  decodeVendorId(vendorId).source === VendorSouces.AC;
+  decodeVendorId(vendorId).source === VendorSources.AC;
 
 const transformVendorDataToVendorRecords = ({
   consents,

--- a/clients/fides-js/src/lib/tcf/vendors.ts
+++ b/clients/fides-js/src/lib/tcf/vendors.ts
@@ -12,16 +12,6 @@ enum VendorSouces {
   AC = "ac",
 }
 
-export const vendorIsGvl = (
-  vendor: Pick<TCFVendorRelationships, "id">,
-  gvl: GVLJson | undefined
-) => {
-  if (!gvl) {
-    return undefined;
-  }
-  return gvl.vendors[vendor.id];
-};
-
 /**
  * Given a vendor id such as `gvl.2`, return {source: "gvl", id: "2"};
  */
@@ -31,6 +21,30 @@ export const decodeVendorId = (vendorId: TCFVendorRelationships["id"]) => {
     return { source: undefined, id: split[0] };
   }
   return { source: split[0], id: split[1] };
+};
+
+/**
+ * Returns the associated GVL entry given a vendor ID. If the id is not found,
+ * returns `undefined`.
+ *
+ * @example If an id of `gvl.2` is passed in, return GVL Vendor #2
+ * @example If an id of `ac.2` is passed in, return undefined
+ * @example If an id of `2` is passed in, return GVL Vendor #2 (for backwards compatibility)
+ */
+export const vendorGvlEntry = (
+  vendorId: TCFVendorRelationships["id"],
+  gvl: GVLJson | undefined
+) => {
+  if (!gvl) {
+    return undefined;
+  }
+  const { source, id } = decodeVendorId(vendorId);
+  // For backwards compatibility, we also allow an undefined source but we should
+  // remove this once the backend is fully using its new vendor ID scheme.
+  if (source === VendorSouces.GVL || source === undefined) {
+    return gvl.vendors[id];
+  }
+  return undefined;
 };
 
 export const vendorIsAc = (vendorId: TCFVendorRelationships["id"]) =>

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -379,6 +379,34 @@
         "features": {},
         "specialFeatures": {},
         "vendors": {
+          "1": {
+            "id": 1,
+            "name": "Exponential Interactive, Inc d/b/a VDX.tv",
+            "purposes": [1],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "cookieMaxAgeSeconds": 7776000,
+            "usesCookies": true,
+            "cookieRefresh": true,
+            "usesNonCookieAccess": false,
+            "dataRetention": {
+              "stdRetention": 397,
+              "purposes": {},
+              "specialPurposes": {}
+            },
+            "urls": [
+              {
+                "langId": "en",
+                "privacy": "https://vdx.tv/privacy/",
+                "legIntClaim": "https://cdnx.exponential.com/wp-content/uploads/2018/04/Balancing-Assessment-for-Legitimate-Interest-Publishers-v2.pdf"
+              }
+            ],
+            "dataDeclaration": [1, 3, 4, 6, 8, 10, 11],
+            "deviceStorageDisclosureUrl": "https://vdxtv.expo.workers.dev"
+          },
           "2": {
             "id": 2,
             "name": "Captify Technologies Limited",


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4242

### Description Of Changes

Support vendor ids that are prefixed by `gvl.` 


### Code Changes

* [x] Update `vendorIsGvl` (and rename to `vendorGvlEntry` since it returns an entry, not a boolean) to look for a prefixed `gvl.`. This is still backwards compatible so that an id that is just a number will still work too
* [x] Add a cypress test

### Steps to Confirm

* Everything should still work! This is another one where, without the backend change, it's hard to see what changed, but the cypress tests provide a case of a vendor with id `gvl.1` and things still work properly

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
