### PR TITLE
Narrow vendors disclosed to only the vendors we show in the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.22.0...main)
 
-### Changed
-- Vendors disclosed string is now narrowed to only the vendors shown in the UI, not the whole GVL [#4250](https://github.com/ethyca/fides/pull/4250)
-
 ## [2.22.0](https://github.com/ethyca/fides/compare/2.21.0...2.22.0)
 
 ### Added
@@ -42,6 +39,7 @@ The types of changes are:
 - Allow Admin UI users to turn on Configure Consent flag [#4246](https://github.com/ethyca/fides/pull/4246)
 - Styling improvements for the fides.js consent banners and modals [#4222](https://github.com/ethyca/fides/pull/4222)
 - Changed vendor form on configuring consent page to use two-part selection for consent uses [#4251](https://github.com/ethyca/fides/pull/4251)
+- Vendors disclosed string is now narrowed to only the vendors shown in the UI, not the whole GVL [#4250](https://github.com/ethyca/fides/pull/4250)
 
 ### Fixed
 - TCF overlay can initialize its consent preferences from a cookie [#4124](https://github.com/ethyca/fides/pull/4124)
@@ -52,6 +50,7 @@ The types of changes are:
 - Updating the unflatten_dict util to accept flattened dict values [#4200](https://github.com/ethyca/fides/pull/4200)
 - Minor CSS styling fixes for the consent modal [#4252](https://github.com/ethyca/fides/pull/4252)
 - Additional styling fixes for issues caused by a CSS reset [#4268](https://github.com/ethyca/fides/pull/4268)
+- Bug where vendor legitimate interests would not be set unless vendor consents were first set [#4250](https://github.com/ethyca/fides/pull/4250)
 
 ## [2.21.0](https://github.com/ethyca/fides/compare/2.20.2...2.21.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The types of changes are:
 - Added our CMP ID [#4233](https://github.com/ethyca/fides/pull/4233)
 - Allow Admin UI users to turn on Configure Consent flag [#4246](https://github.com/ethyca/fides/pull/4246)
 - Styling improvements for the fides.js consent banners and modals [#4222](https://github.com/ethyca/fides/pull/4222)
+- Vendors disclosed string is now narrowed to only the vendors shown in the UI, not the whole GVL [#4250](https://github.com/ethyca/fides/pull/4250)
 
 ### Fixed
 - TCF overlay can initialize its consent preferences from a cookie [#4124](https://github.com/ethyca/fides/pull/4124)

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -10,7 +10,12 @@ import { TCModel, TCString, GVL } from "@iabtechlabtcf/core";
 import { makeStub } from "./tcf/stub";
 
 import { EnabledIds } from "./tcf/types";
-import { decodeVendorId, vendorIsAc, vendorGvlEntry } from "./tcf/vendors";
+import {
+  decodeVendorId,
+  vendorIsAc,
+  vendorGvlEntry,
+  uniqueGvlVendorIds,
+} from "./tcf/vendors";
 import { PrivacyExperience } from "./consent-types";
 import { FIDES_SEPARATOR } from "./tcf/constants";
 import { FidesEvent } from "./events";
@@ -70,11 +75,7 @@ export const generateTcString = async ({
     tcModel.consentScreen = 1; // todo- On which 'screen' consent was captured; this is a CMP proprietary number encoded into the TC string
 
     // Narrow the GVL to say we've only showed these vendors provided by our experience
-    const vendorIds = [
-      ...(experience.tcf_vendor_consents?.map((v) => +v.id) || []),
-      ...(experience.tcf_vendor_legitimate_interests?.map((v) => +v.id) || []),
-    ];
-    tcModel.gvl.narrowVendorsTo(vendorIds);
+    tcModel.gvl.narrowVendorsTo(uniqueGvlVendorIds(experience));
 
     if (tcStringPreferences) {
       // Set vendors on tcModel

--- a/clients/fides-js/src/lib/tcf/vendors.ts
+++ b/clients/fides-js/src/lib/tcf/vendors.ts
@@ -50,6 +50,27 @@ export const vendorGvlEntry = (
 export const vendorIsAc = (vendorId: TCFVendorRelationships["id"]) =>
   decodeVendorId(vendorId).source === VendorSources.AC;
 
+export const uniqueGvlVendorIds = (experience: PrivacyExperience): number[] => {
+  const {
+    tcf_vendor_consents: vendorConsents = [],
+    tcf_vendor_legitimate_interests: vendorLegints = [],
+  } = experience;
+
+  // List of i.e. [gvl.2, ac.3, gvl.4]
+  const universalIds = Array.from(
+    new Set([
+      ...vendorConsents.map((v) => v.id),
+      ...vendorLegints.map((v) => v.id),
+    ])
+  );
+  // Filter to just i.e. [gvl.2, gvl.4]
+  const gvlIds = universalIds.filter((uid) =>
+    vendorGvlEntry(uid, experience.gvl)
+  );
+  // Return [2,4] as numbers
+  return gvlIds.map((uid) => +decodeVendorId(uid).id);
+};
+
 const transformVendorDataToVendorRecords = ({
   consents,
   legints,

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -384,6 +384,7 @@ describe("Fides-js TCF", () => {
     });
 
     describe("saving preferences", () => {
+      const expectedVendorsDisclosed = "IABE";
       it("can opt in to all", () => {
         cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
         cy.getByTestId("consent-modal").within(() => {
@@ -449,6 +450,11 @@ describe("Fides-js TCF", () => {
           )
             .property(`${SYSTEM_1.id}`)
             .is.eql(true);
+
+          // Confirm vendors_disclosed section
+          expect(
+            cookieKeyConsent.tc_string?.endsWith(`.${expectedVendorsDisclosed}`)
+          ).to.eql(true);
         });
       });
 
@@ -516,6 +522,10 @@ describe("Fides-js TCF", () => {
           )
             .property(`${SYSTEM_1.id}`)
             .is.eql(false);
+          // Confirm vendors_disclosed section
+          expect(
+            cookieKeyConsent.tc_string?.endsWith(`.${expectedVendorsDisclosed}`)
+          ).to.eql(true);
         });
       });
 
@@ -590,6 +600,10 @@ describe("Fides-js TCF", () => {
           expect(
             cookieKeyConsent.tcf_consent.system_consent_preferences
           ).to.eql({});
+          // Confirm vendors_disclosed section
+          expect(
+            cookieKeyConsent.tc_string?.endsWith(`.${expectedVendorsDisclosed}`)
+          ).to.eql(true);
         });
       });
     });

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -422,7 +422,7 @@ describe("Fides-js TCF", () => {
     });
 
     describe("saving preferences", () => {
-      const expectedVendorsDisclosed = "IABE";
+      const expectedEndOfFidesString = ".IABE,1~";
       it("can opt in to all", () => {
         cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
         cy.getByTestId("consent-modal").within(() => {
@@ -491,7 +491,7 @@ describe("Fides-js TCF", () => {
 
           // Confirm vendors_disclosed section
           expect(
-            cookieKeyConsent.tc_string?.endsWith(`.${expectedVendorsDisclosed}`)
+            cookieKeyConsent.fides_tc_string?.endsWith(expectedEndOfFidesString)
           ).to.eql(true);
         });
       });
@@ -562,7 +562,7 @@ describe("Fides-js TCF", () => {
             .is.eql(false);
           // Confirm vendors_disclosed section
           expect(
-            cookieKeyConsent.tc_string?.endsWith(`.${expectedVendorsDisclosed}`)
+            cookieKeyConsent.fides_tc_string?.endsWith(expectedEndOfFidesString)
           ).to.eql(true);
         });
       });
@@ -640,7 +640,7 @@ describe("Fides-js TCF", () => {
           ).to.eql({});
           // Confirm vendors_disclosed section
           expect(
-            cookieKeyConsent.tc_string?.endsWith(`.${expectedVendorsDisclosed}`)
+            cookieKeyConsent.fides_tc_string?.endsWith(expectedEndOfFidesString)
           ).to.eql(true);
         });
       });


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4165

### Description Of Changes

The library we use wants to put every vendor in the GVL as part of the `vendors_disclosed` string. According to the docs, we should only put the vendors we've disclosed, i.e. the ones we've shown in the UI (makes sense!). There's a `vendors_disclosed` field we can set, but that appears to always be overwritten by the library to set the whole GVL. I believe the way around this is to use the [library's `narrowVendorsTo` function](https://github.com/InteractiveAdvertisingBureau/iabtcf-es/tree/master/modules/core#narrow-the-list-of-vendors)

Part of this ticket is also to not surface the vendor disclosed part of the string to the CMP API—that's covered in https://github.com/ethyca/fides/pull/4244


### Code Changes

* [x] Narrow the GVL to just the vendors we show in the UI
* [x] Add test

### Steps to Confirm

* Set up your TCF environment
* Opt in to some vendors. Inspect your cookie's `tc_string` object. it should have two parts, separated by a period. The second part should be very short (it used to be a very long string that ended with `AAAAAAAAAAAAAAAAQ`)
* If you decode this string [here](https://iabtcf.com/#/decode) you should see that there are only a few vendors disclosed (the ones shown in the UI)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
