### PR TITLE
Backend: Assume Universal Vendor Ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The types of changes are:
 - Added our CMP ID [#4233](https://github.com/ethyca/fides/pull/4233)
 - Allow Admin UI users to turn on Configure Consent flag [#4246](https://github.com/ethyca/fides/pull/4246)
 - Styling improvements for the fides.js consent banners and modals [#4222](https://github.com/ethyca/fides/pull/4222)
+- Assume Universal Vendor ID usage in TC String translation [#4256](https://github.com/ethyca/fides/pull/4256)
 
 ### Fixed
 - TCF overlay can initialize its consent preferences from a cookie [#4124](https://github.com/ethyca/fides/pull/4124)

--- a/src/fides/api/util/tcf/tc_model.py
+++ b/src/fides/api/util/tcf/tc_model.py
@@ -21,6 +21,17 @@ FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS = [1, 3, 4, 5, 6]
 gvl: Dict = load_gvl()
 
 
+def universal_vendor_id_to_id(universal_vendor_id: str) -> int:
+    """Converts a universal vendor id to a vendor id
+
+    For example, converts "gvl.42" to integer 42.
+    Throws a ValueError if the id cannot be converted to an integer.
+
+    We store vendor ids as a universal vendor id internally, but need to strip this off when building TC strings.
+    """
+    return int(universal_vendor_id.lstrip("gvl.").lstrip("ac."))
+
+
 class TCModel(FidesSchema):
     """Base internal TC schema to store and validate key details from which to later build the TC String"""
 
@@ -288,7 +299,7 @@ def _build_vendor_consents_and_legitimate_interests(
 
     for vendor_consent in vendor_consents:
         try:
-            int(vendor_consent.id)
+            vendor_consent_id: int = universal_vendor_id_to_id(vendor_consent.id)
         except ValueError:
             # Early check that filters out non-integer vendor ids.  Later we'll run a separate
             # check that ensures this id is also in the gvl.
@@ -297,11 +308,11 @@ def _build_vendor_consents_and_legitimate_interests(
         if vendor_consent.purpose_consents:
             # This vendor should only be in "vendor_consents" in the first place, if consent_purposes is populated.
             # This is just to check
-            vendor_consent_ids.append(int(vendor_consent.id))
+            vendor_consent_ids.append(vendor_consent_id)
 
     for vendor_legitimate_interest in vendor_legitimate_interests:
         try:
-            int(vendor_legitimate_interest.id)
+            vendor_li_id: int = universal_vendor_id_to_id(vendor_legitimate_interest.id)
         except ValueError:
             # Early check that filters out non-integer vendor ids.  Later we'll run a separate
             # check that ensures this id is also in the gvl.
@@ -316,7 +327,7 @@ def _build_vendor_consents_and_legitimate_interests(
         if leg_int_purpose_ids and not bool(
             set(leg_int_purpose_ids) & set(FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS)
         ):
-            vendor_legitimate_interest_ids.append(int(vendor_legitimate_interest.id))
+            vendor_legitimate_interest_ids.append(vendor_li_id)
 
     return vendor_consent_ids, vendor_legitimate_interest_ids
 
@@ -339,7 +350,7 @@ def _build_vendors_disclosed(tcf_contents: TCFExperienceContents) -> List[int]:
     The DisclosedVendors is an optional TC String segment that records which vendors have been disclosed to a
     given user by a CMP. It may be used by a CMP while storing TC Strings, but must not be included in the TC String
     when returned by the CMP API."""
-    all_vendor_ids: List[str] = [vendor_id for vendor_id in gvl.get("vendors", {})]
+    all_vendor_ids: List[int] = [int(vendor_id) for vendor_id in gvl.get("vendors", {})]
     vendors_disclosed = set()
 
     vendor_main_lists: List[List] = [
@@ -350,8 +361,12 @@ def _build_vendors_disclosed(tcf_contents: TCFExperienceContents) -> List[int]:
 
     for vendor_list in vendor_main_lists:
         for vendor in vendor_list:
-            if str.isdigit(vendor.id) and vendor.id in all_vendor_ids:
-                vendors_disclosed.add(int(vendor.id))
+            try:
+                vendor_id: int = universal_vendor_id_to_id(vendor.id)
+            except ValueError:
+                continue
+            if vendor_id in all_vendor_ids:
+                vendors_disclosed.add(vendor_id)
 
     return sorted(list(vendors_disclosed))
 

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -1528,7 +1528,7 @@ def served_notice_history_for_vendor_legitimate_interests(
         data={
             "serving_component": "tcf_overlay",
             "fides_user_device_provided_identity_id": fides_user_provided_identity.id,
-            "vendor_legitimate_interests": "sendgrid",
+            "vendor_legitimate_interests": "gvl.42",
         },
         check_name=False,
     )
@@ -2386,7 +2386,7 @@ def privacy_preference_history_for_vendor(
             "anonymized_ip_address": "92.158.1.0",
             "email": "test@email.com",
             "method": "button",
-            "vendor_consent": "sendgrid",
+            "vendor_consent": "gvl.42",
             "privacy_experience_config_history_id": None,
             "privacy_experience_id": privacy_experience_france_overlay.id,
             "preference": "opt_out",
@@ -2417,7 +2417,7 @@ def privacy_preference_history_for_vendor_legitimate_interests(
             "anonymized_ip_address": "92.158.1.0",
             "email": "test@email.com",
             "method": "button",
-            "vendor_legitimate_interests": "sendgrid",
+            "vendor_legitimate_interests": "gvl.42",
             "privacy_experience_config_history_id": None,
             "privacy_experience_id": privacy_experience_france_overlay.id,
             "preference": "opt_out",
@@ -2780,7 +2780,7 @@ def tcf_system(db: Session) -> System:
         db=db,
         data={
             "fides_key": f"tcf-system_key-f{uuid4()}",
-            "vendor_id": "sendgrid",
+            "vendor_id": "gvl.42",
             "name": f"TCF System Test",
             "description": "My TCF System Description",
             "organization_fides_key": "default_organization",
@@ -2841,7 +2841,7 @@ def captify_technologies_system(db: Session) -> System:
         db=db,
         data={
             "fides_key": f"captify_{uuid.uuid4()}",
-            "vendor_id": "2",
+            "vendor_id": "gvl.2",
             "name": f"Captify",
             "description": "Captify is a search intelligence platform that helps brands and advertisers leverage search insights to improve their ad targeting and relevance.",
             "organization_fides_key": "default_organization",
@@ -2891,7 +2891,7 @@ def emerse_system(db: Session) -> System:
         db=db,
         data={
             "fides_key": f"emerse{uuid.uuid4()}",
-            "vendor_id": "8",
+            "vendor_id": "gvl.8",
             "name": f"Emerse",
             "description": "Emerse Sverige AB is a provider of programmatic advertising solutions, offering advertisers and publishers tools to manage and optimize their digital ad campaigns.",
             "organization_fides_key": "default_organization",
@@ -2957,7 +2957,7 @@ def skimbit_system(db):
         db=db,
         data={
             "fides_key": f"skimbit{uuid.uuid4()}",
-            "vendor_id": "46",
+            "vendor_id": "gvl.46",
             "name": f"Skimbit (Skimlinks, Taboola)",
             "description": "Skimbit, a Taboola company, specializes in data-driven advertising and provides tools for brands and advertisers to analyze customer behavior and deliver targeted and personalized ads.",
             "organization_fides_key": "default_organization",

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -2830,6 +2830,35 @@ def tcf_system(db: Session) -> System:
     return system
 
 
+@pytest.fixture(scope="function")
+def ac_system(db: Session) -> System:
+    """Test AC System - will be fleshed out further later"""
+    system = System.create(
+        db=db,
+        data={
+            "fides_key": f"ac_system{uuid.uuid4()}",
+            "vendor_id": "ac.8",
+            "name": f"Test AC System",
+            "organization_fides_key": "default_organization",
+            "system_type": "Service",
+        },
+    )
+
+    PrivacyDeclaration.create(
+        db=db,
+        data={
+            "system_id": system.id,
+            "data_use": "functional.storage",
+            "legal_basis_for_processing": "Consent",
+            "features": [
+                "Match and combine data from other data sources",  # Feature 1
+                "Link different devices",  # Feature 2
+            ],
+        },
+    )
+    return system
+
+
 # Detailed systems with attributes for TC string testing
 # Please don't update them!
 

--- a/tests/ops/api/v1/endpoints/test_privacy_experience_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_experience_endpoints.py
@@ -784,7 +784,7 @@ class TestGetTCFPrivacyExperiences:
         )
 
         assert len(resp.json()["items"][0]["tcf_vendor_consents"]) == 1
-        assert resp.json()["items"][0]["tcf_vendor_consents"][0]["id"] == "sendgrid"
+        assert resp.json()["items"][0]["tcf_vendor_consents"][0]["id"] == "gvl.42"
         assert (
             resp.json()["items"][0]["tcf_vendor_consents"][0]["purpose_consents"][0][
                 "id"
@@ -823,7 +823,7 @@ class TestGetTCFPrivacyExperiences:
         assert resp.json()["items"][0]["tcf_system_legitimate_interests"] == []
         assert resp.json()["items"][0]["gvl"]["gvlSpecificationVersion"] == 3
         meta = resp.json()["items"][0]["meta"]
-        assert meta["version_hash"] == "75fb2dafef58"
+        assert meta["version_hash"] == "f2db7626ca0b"
         assert meta["accept_all_tc_string"]
         assert meta["accept_all_tc_mobile_data"]
         assert meta["reject_all_tc_string"]
@@ -904,7 +904,7 @@ class TestGetTCFPrivacyExperiences:
         self, db, api_client, url, privacy_experience_france_tcf_overlay, system
     ):
         """System has purpose 2 with legitimate interests legal basis"""
-        system.vendor_id = "sendgrid"
+        system.vendor_id = "gvl.42"
         system.save(db)
         privacy_declaration = system.privacy_declarations[0]
         privacy_declaration.data_use = "marketing.advertising.first_party.contextual"

--- a/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
@@ -2608,12 +2608,12 @@ class TestSavePrivacyPreferencesTCStringOnly:
         assert len(response_body["system_consent_preferences"]) == 0
         assert len(response_body["system_legitimate_interests_preferences"]) == 0
 
-        first_record = response_body["purpose_consent_preferences"][0]
-        assert first_record["purpose_consent"] == 1
-        assert first_record["preference"] == "opt_in"
+        first_purpose_consent_record = response_body["purpose_consent_preferences"][0]
+        assert first_purpose_consent_record["purpose_consent"] == 1
+        assert first_purpose_consent_record["preference"] == "opt_in"
         saved_current_privacy_preference_record = db.query(
             CurrentPrivacyPreference
-        ).get(first_record["id"])
+        ).get(first_purpose_consent_record["id"])
         assert saved_current_privacy_preference_record.purpose_consent == 1
         assert (
             saved_current_privacy_preference_record.preference
@@ -2621,7 +2621,7 @@ class TestSavePrivacyPreferencesTCStringOnly:
         )
 
         privacy_preference_history_record = db.query(PrivacyPreferenceHistory).get(
-            first_record["privacy_preference_history_id"]
+            first_purpose_consent_record["privacy_preference_history_id"]
         )
         assert (
             privacy_preference_history_record.current_privacy_preference
@@ -2646,6 +2646,61 @@ class TestSavePrivacyPreferencesTCStringOnly:
         assert (
             privacy_preference_history_record.privacy_experience_config_history_id
             is None
+        )
+
+        # There were no purpose legitimate interests in the string, but purpose 2 was disclosed
+        # to the user in the experience.  We opt out here.
+        first_purpose_li_record = response_body[
+            "purpose_legitimate_interests_preferences"
+        ][0]
+        assert first_purpose_li_record["purpose_legitimate_interests"] == 2
+        assert first_purpose_li_record["preference"] == "opt_out"
+        saved_current_privacy_preference_record = db.query(
+            CurrentPrivacyPreference
+        ).get(first_purpose_li_record["id"])
+        assert saved_current_privacy_preference_record.purpose_legitimate_interests == 2
+        assert (
+            saved_current_privacy_preference_record.preference
+            == UserConsentPreference.opt_out
+        )
+
+        # Vendor 2 was in the vendor consents section
+        first_vendor_consent_record = response_body["vendor_consent_preferences"][0]
+        assert first_vendor_consent_record["vendor_consent"] == "gvl.2"
+        assert first_vendor_consent_record["preference"] == "opt_in"
+        saved_current_privacy_preference_record = db.query(
+            CurrentPrivacyPreference
+        ).get(first_vendor_consent_record["id"])
+        assert saved_current_privacy_preference_record.vendor_consent == "gvl.2"
+        assert (
+            saved_current_privacy_preference_record.preference
+            == UserConsentPreference.opt_in
+        )
+
+        # Vendor 8 was not opted in in the vendor consents section, but was disclosed to the
+        # customer in the vendor consents section, so we opt out.
+        second_vendor_consent_record = response_body["vendor_consent_preferences"][1]
+        assert second_vendor_consent_record["vendor_consent"] == "gvl.8"
+        assert second_vendor_consent_record["preference"] == "opt_out"
+        saved_current_privacy_preference_record = db.query(
+            CurrentPrivacyPreference
+        ).get(second_vendor_consent_record["id"])
+        assert saved_current_privacy_preference_record.vendor_consent == "gvl.8"
+        assert (
+            saved_current_privacy_preference_record.preference
+            == UserConsentPreference.opt_out
+        )
+
+        special_feature_record = response_body["special_feature_preferences"][0]
+        assert special_feature_record["special_feature"] == 2
+        assert special_feature_record["preference"] == "opt_in"
+        saved_current_privacy_preference_record = db.query(
+            CurrentPrivacyPreference
+        ).get(special_feature_record["id"])
+        assert saved_current_privacy_preference_record.special_feature == 2
+        assert (
+            saved_current_privacy_preference_record.preference
+            == UserConsentPreference.opt_in
         )
 
         mobile_data = response.json()["tc_mobile_data"]

--- a/tests/ops/api/v1/endpoints/test_served_notice_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_served_notice_endpoints.py
@@ -47,7 +47,7 @@ class TestSaveNoticesServedForFidesDeviceId:
                 "fides_user_device_id": "f7e54703-cd57-495e-866d-042e67c81734",
             },
             "tcf_purpose_consents": [5],
-            "tcf_vendor_consents": ["sendgrid"],
+            "tcf_vendor_consents": ["gvl.42"],
             "tcf_special_features": [2],
             "tcf_system_legitimate_interests": [system.id],
             "privacy_experience_id": privacy_experience_france_tcf_overlay.id,
@@ -421,7 +421,7 @@ class TestSaveNoticesServedForFidesDeviceId:
         # Assert vendor served portion of response
         assert vendor_served["purpose_consent"] is None
         assert vendor_served["purpose_legitimate_interests"] is None
-        assert vendor_served["vendor_consent"] == "sendgrid"
+        assert vendor_served["vendor_consent"] == "gvl.42"
         assert vendor_served["vendor_legitimate_interests"] is None
         assert vendor_served["feature"] is None
         assert vendor_served["special_purpose"] is None
@@ -475,7 +475,7 @@ class TestSaveNoticesServedForFidesDeviceId:
         assert last_served_vendor.purpose_legitimate_interests is None
         assert last_served_vendor.privacy_notice_id is None
         assert last_served_vendor.privacy_notice_history_id is None
-        assert last_served_vendor.vendor_consent == "sendgrid"
+        assert last_served_vendor.vendor_consent == "gvl.42"
         assert last_served_vendor.vendor_legitimate_interests is None
         assert last_served_vendor.feature is None
         assert last_served_vendor.created_at is not None
@@ -488,7 +488,7 @@ class TestSaveNoticesServedForFidesDeviceId:
             vendor_served_history.fides_user_device_provided_identity_id
             == last_served_vendor.fides_user_device_provided_identity_id
         )
-        assert vendor_served_history.vendor_consent == "sendgrid"
+        assert vendor_served_history.vendor_consent == "gvl.42"
         assert vendor_served_history.vendor_legitimate_interests is None
         assert (
             vendor_served_history.privacy_experience_id

--- a/tests/ops/models/test_privacy_experience.py
+++ b/tests/ops/models/test_privacy_experience.py
@@ -1450,7 +1450,7 @@ class TestCacheSavedAndServedOnConsentRecord:
         self, db, fides_user_provided_identity
     ):
         vendor_record = TCFVendorConsentRecord(
-            id="sendgrid", name="test", description="test", has_vendor_id=False
+            id="gvl.42", name="test", description="test", has_vendor_id=False
         )
         cache_saved_and_served_on_consent_record(
             db,
@@ -1472,7 +1472,7 @@ class TestCacheSavedAndServedOnConsentRecord:
         self, db, fides_user_provided_identity
     ):
         vendor_record = TCFVendorLegitimateInterestsRecord(
-            id="sendgrid", name="test", description="test", has_vendor_id=True
+            id="gvl.42", name="test", description="test", has_vendor_id=True
         )
         cache_saved_and_served_on_consent_record(
             db,

--- a/tests/ops/models/test_privacy_preference.py
+++ b/tests/ops/models/test_privacy_preference.py
@@ -485,7 +485,7 @@ class TestPrivacyPreferenceHistory:
         preference_history_record = PrivacyPreferenceHistory.create(
             db=db,
             data={
-                "vendor_consent": "sendgrid",
+                "vendor_consent": "gvl.42",
                 "email": None,
                 "fides_user_device": fides_user_device_id,
                 "fides_user_device_provided_identity_id": fides_user_provided_identity.id,
@@ -521,7 +521,7 @@ class TestPrivacyPreferenceHistory:
             preference_history_record.fides_user_device_provided_identity
             == fides_user_provided_identity
         )
-        assert preference_history_record.vendor_consent == "sendgrid"
+        assert preference_history_record.vendor_consent == "gvl.42"
         assert preference_history_record.vendor_legitimate_interests is None
         assert preference_history_record.purpose_consent is None
         assert preference_history_record.purpose_legitimate_interests is None
@@ -553,7 +553,7 @@ class TestPrivacyPreferenceHistory:
         current_privacy_preference_id = current_privacy_preference.id
         assert current_privacy_preference.preference == UserConsentPreference.opt_out
         assert current_privacy_preference.privacy_notice_history is None
-        assert current_privacy_preference.vendor_consent == "sendgrid"
+        assert current_privacy_preference.vendor_consent == "gvl.42"
         assert current_privacy_preference.tcf_version == CURRENT_TCF_VERSION
 
         # Save preferences again with an "opt in" preference for this privacy notice
@@ -561,7 +561,7 @@ class TestPrivacyPreferenceHistory:
             db=db,
             data={
                 "preference": "opt_in",
-                "vendor_consent": "sendgrid",
+                "vendor_consent": "gvl.42",
                 "fides_user_device_provided_identity_id": fides_user_provided_identity.id,
                 "request_origin": "tcf_overlay",
                 "secondary_user_ids": {"ga_client_id": "test"},
@@ -573,13 +573,13 @@ class TestPrivacyPreferenceHistory:
 
         assert next_preference_history_record.preference == UserConsentPreference.opt_in
         assert next_preference_history_record.privacy_notice_history is None
-        assert next_preference_history_record.vendor_consent == "sendgrid"
+        assert next_preference_history_record.vendor_consent == "gvl.42"
 
         # Assert CurrentPrivacyPreference record upserted
         db.refresh(current_privacy_preference)
         assert current_privacy_preference.preference == UserConsentPreference.opt_in
         assert current_privacy_preference.privacy_notice_history is None
-        assert current_privacy_preference.vendor_consent == "sendgrid"
+        assert current_privacy_preference.vendor_consent == "gvl.42"
         assert current_privacy_preference.vendor_legitimate_interests is None
         assert current_privacy_preference.purpose_consent is None
         assert current_privacy_preference.purpose_legitimate_interests is None

--- a/tests/ops/util/test_tcf_experience_contents.py
+++ b/tests/ops/util/test_tcf_experience_contents.py
@@ -215,10 +215,10 @@ class TestTCFContents:
             "analytics.reporting.content_performance"
         ]
         assert tcf_contents.tcf_purpose_consents[0].vendors == [
-            EmbeddedVendor(id="sendgrid", name="TCF System Test")
+            EmbeddedVendor(id="gvl.42", name="TCF System Test")
         ]
 
-        assert tcf_contents.tcf_vendor_consents[0].id == "sendgrid"
+        assert tcf_contents.tcf_vendor_consents[0].id == "gvl.42"
         assert tcf_contents.tcf_vendor_consents[0].name == "TCF System Test"
         assert (
             tcf_contents.tcf_vendor_consents[0].description
@@ -227,7 +227,7 @@ class TestTCFContents:
         assert len(tcf_contents.tcf_vendor_consents[0].purpose_consents) == 1
         assert tcf_contents.tcf_vendor_consents[0].purpose_consents[0].id == 8
 
-        assert tcf_contents.tcf_vendor_relationships[0].id == "sendgrid"
+        assert tcf_contents.tcf_vendor_relationships[0].id == "gvl.42"
         assert tcf_contents.tcf_vendor_relationships[0].name == "TCF System Test"
         assert (
             tcf_contents.tcf_vendor_relationships[0].description
@@ -340,10 +340,10 @@ class TestTCFContents:
             for use in purpose.data_uses
         } == {"functional.storage", "analytics.reporting.content_performance"}
         assert tcf_contents.tcf_purpose_consents[0].vendors == [
-            EmbeddedVendor(id="sendgrid", name="TCF System Test")
+            EmbeddedVendor(id="gvl.42", name="TCF System Test")
         ]
 
-        assert tcf_contents.tcf_vendor_consents[0].id == "sendgrid"
+        assert tcf_contents.tcf_vendor_consents[0].id == "gvl.42"
         assert tcf_contents.tcf_vendor_consents[0].name == "TCF System Test"
         assert (
             tcf_contents.tcf_vendor_consents[0].description
@@ -395,10 +395,10 @@ class TestTCFContents:
             "marketing.advertising.negative_targeting",
         ]
         assert tcf_contents.tcf_purpose_consents[0].vendors == [
-            EmbeddedVendor(id="sendgrid", name="TCF System Test")
+            EmbeddedVendor(id="gvl.42", name="TCF System Test")
         ]
 
-        assert tcf_contents.tcf_vendor_consents[0].id == "sendgrid"
+        assert tcf_contents.tcf_vendor_consents[0].id == "gvl.42"
         assert len(tcf_contents.tcf_vendor_consents[0].purpose_consents) == 1
         assert tcf_contents.tcf_vendor_consents[0].purpose_consents[0].id == 2
 
@@ -428,14 +428,14 @@ class TestTCFContents:
             == "Ensure security, prevent and detect fraud, and fix errors"
         )
         assert tcf_contents.tcf_special_purposes[0].vendors == [
-            EmbeddedVendor(id="sendgrid", name="TCF System Test")
+            EmbeddedVendor(id="gvl.42", name="TCF System Test")
         ]
 
-        assert tcf_contents.tcf_vendor_consents[0].id == "sendgrid"
+        assert tcf_contents.tcf_vendor_consents[0].id == "gvl.42"
         assert len(tcf_contents.tcf_vendor_consents[0].purpose_consents) == 1
         assert tcf_contents.tcf_vendor_consents[0].purpose_consents[0].id == 8
 
-        assert tcf_contents.tcf_vendor_relationships[0].id == "sendgrid"
+        assert tcf_contents.tcf_vendor_relationships[0].id == "gvl.42"
         assert len(tcf_contents.tcf_vendor_relationships[0].special_purposes) == 1
         assert tcf_contents.tcf_vendor_relationships[0].special_purposes[0].id == 1
 

--- a/tests/ops/util/test_tcf_experience_contents.py
+++ b/tests/ops/util/test_tcf_experience_contents.py
@@ -225,7 +225,7 @@ class TestTCFContents:
         assert vendor_relationship.features == []
         assert vendor_relationship.special_purposes == []
         assert vendor_relationship.special_features == []
-        assert vendor_relationship.id == "sendgrid"
+        assert vendor_relationship.id == "gvl.42"
         assert vendor_relationship.cookie_max_age_seconds is None
         assert vendor_relationship.uses_cookies is False
         assert vendor_relationship.uses_non_cookie_access is False
@@ -331,10 +331,10 @@ class TestTCFContents:
             "analytics.reporting.content_performance"
         ]
         assert tcf_contents.tcf_purpose_consents[0].vendors == [
-            EmbeddedVendor(id="sendgrid", name="TCF System Test")
+            EmbeddedVendor(id="gvl.42", name="TCF System Test")
         ]
 
-        assert tcf_contents.tcf_vendor_consents[0].id == "sendgrid"
+        assert tcf_contents.tcf_vendor_consents[0].id == "gvl.42"
         assert tcf_contents.tcf_vendor_consents[0].name == "TCF System Test"
         assert (
             tcf_contents.tcf_vendor_consents[0].description
@@ -353,7 +353,7 @@ class TestTCFContents:
         assert len(tcf_contents.tcf_vendor_consents[0].purpose_consents) == 1
         assert tcf_contents.tcf_vendor_consents[0].purpose_consents[0].id == 8
 
-        assert tcf_contents.tcf_vendor_relationships[0].id == "sendgrid"
+        assert tcf_contents.tcf_vendor_relationships[0].id == "gvl.42"
         assert tcf_contents.tcf_vendor_relationships[0].name == "TCF System Test"
         assert (
             tcf_contents.tcf_vendor_relationships[0].description


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/1129

### Description Of Changes

Update all-things TCF on the BE (namely, overlay generation and preferences saving) to account for new "universal vendor ID" scheme.

In other words, we assume that TCF vendor preferences are saved against universal vendor ids, and also that universal vendor ids are returned in the experience.

Therefore, the main thing that needs to change on the backend is the translation to and from the TC string itself.

### Code Changes


- Vendor ID -> GVL Universal Vendor ID: Save privacy preferences under universal vendor id when unpacking vendor preferences from a TC string by adding the gvl prefix
- Universal Vendor ID -> Vendor ID: When building a TCModel from the TCF Experience (a prerequisite to building TC strings), convert universal vendor ids to vendor ids (integers)


### Steps to Confirm
* [ ] Set tcf_enabled=true in `fides.toml`
* [ ] `nox -s dev -- shell`
* [ ] Create [GVL system locally, Instructions here] - this creates a system with vendor id "gvl.8"(https://ethyca.atlassian.net/wiki/spaces/EN/pages/2809724964/API+How-to+Create+GVL+System+Locally)
* [ ] PATCH Privacy Preferences using the following accept-all TC string for the given system above:
PATCH http://localhost:8080/api/v1/privacy-preferences
```json
{
  "browser_identity": {
    "fides_user_device_id": "932209c6-e765-472c-b614-68f9b95b3278"
  },
  "tc_string": "CPzevcAPzevcAGXABBENAUEAALAAAEOAAAAAAEAEACACAAAA.IAEAEAAA"
}
```
* [ ] Verify vendor consent and legitimate preferences were saved against id "gvl.8" and tc_mobile_data > IABTCF_VendorConsents="00000001" and IABTCF_VendorLegitimateInterests="00000001":
```json
  "vendor_consent_preferences": [
    {
      "purpose_consent": null,
      "purpose_legitimate_interests": null,
      "special_purpose": null,
      "vendor_consent": "gvl.8",
      "vendor_legitimate_interests": null,
      "feature": null,
      "special_feature": null,
      "system_consent": null,
      "system_legitimate_interests": null,
      "id": "cur_dc981346-1dcb-4c21-adf1-7f8e0a88746e",
      "preference": "opt_in",
      "privacy_notice_history": null,
      "privacy_preference_history_id": "pri_25d3af5e-520b-4ae1-8903-0f6c0e0888ae"
    }
```
* [ ] Fetch the TCF Privacy Experience for EEA with include_meta=True and the same fides user device id from above (to retrieve currently saved preferences)
```bash
curl -X 'GET' \
  'http://localhost:8080/api/v1/privacy-experience?show_disabled=true&region=eea&fides_user_device_id=932209c6-e765-472c-b614-68f9b95b3278&systems_applicable=false&include_gvl=false&include_meta=true&page=1&size=50' \
  -H 'accept: application/json'
```
* [ ] Assert vendor consents and vendor legitimate interests are what is expected ("00000001") in the tc mobile data section, that the vendor consents and legitimate interests have "gvl.8" in them, and the previously saved preferences of opt-in for all are surfaced.


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
