### PR TITLE
Use Fides String instead of TC String language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The types of changes are:
 - Allow Admin UI users to turn on Configure Consent flag [#4246](https://github.com/ethyca/fides/pull/4246)
 - Styling improvements for the fides.js consent banners and modals [#4222](https://github.com/ethyca/fides/pull/4222)
 - Changed vendor form on configuring consent page to use two-part selection for consent uses [#4251](https://github.com/ethyca/fides/pull/4251)
+- Changed naming convention "fides_string" instead of "tc_string" for developer friendly consent API's [#4267](https://github.com/ethyca/fides/pull/4267)
 
 ### Fixed
 - TCF overlay can initialize its consent preferences from a cookie [#4124](https://github.com/ethyca/fides/pull/4124)

--- a/src/fides/api/api/v1/endpoints/privacy_preference_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_preference_endpoints.py
@@ -332,7 +332,7 @@ def save_privacy_preferences_with_verified_identity(
     Creates historical records for these preferences for record keeping, and also updates current preferences.
     Creates a privacy request to propagate preferences to third party systems where applicable.
     """
-    tc_string: Optional[str] = data.tc_string
+    fides_string: Optional[str] = data.fides_string
     data = update_request_with_decoded_tc_string_fields(data, db)
 
     verify_privacy_notice_and_historical_records(
@@ -372,8 +372,8 @@ def save_privacy_preferences_with_verified_identity(
                 original_request_data=data,
             )
         )
-        saved_preferences_response.tc_mobile_data = convert_tc_string_to_mobile_data(
-            tc_string
+        saved_preferences_response.fides_mobile_data = convert_tc_string_to_mobile_data(
+            fides_string
         )
 
         return saved_preferences_response
@@ -704,19 +704,19 @@ def update_request_with_decoded_tc_string_fields(
     request_body: PrivacyPreferencesRequest, db: Session
 ) -> PrivacyPreferencesRequest:
     """Update the request body with the decoded values of the TC string if applicable"""
-    if request_body.tc_string:
+    if request_body.fides_string:
         tcf_contents: TCFExperienceContents = get_tcf_contents(
             db
         )  # TODO cache this so we're not building each time privacy preference is saved
         try:
             decoded_preference_request_body: TCStringFidesPreferences = (
-                decode_tc_string_to_preferences(request_body.tc_string, tcf_contents)
+                decode_tc_string_to_preferences(request_body.fides_string, tcf_contents)
             )
         except DecodeTCStringError as exc:
             raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=exc.args[0])
 
         # Remove the TC string from the request body now that we've decoded it
-        request_body.tc_string = None
+        request_body.fides_string = None
         # Add the individual sections from the TC string to the request body
         for decoded_tcf_section in decoded_preference_request_body.__fields__:
             setattr(
@@ -746,7 +746,7 @@ def save_privacy_preferences(
     Creates historical records for these preferences for record keeping, and also updates current preferences.
     Creates a privacy request to propagate preferences to third party systems if applicable.
     """
-    tc_string: Optional[str] = data.tc_string
+    fides_string: Optional[str] = data.fides_string
     data = update_request_with_decoded_tc_string_fields(data, db)
 
     verify_privacy_notice_and_historical_records(
@@ -778,8 +778,8 @@ def save_privacy_preferences(
                 original_request_data=data,
             )
         )
-        saved_preferences_response.tc_mobile_data = convert_tc_string_to_mobile_data(
-            tc_string
+        saved_preferences_response.fides_mobile_data = convert_tc_string_to_mobile_data(
+            fides_string
         )
 
         return saved_preferences_response

--- a/src/fides/api/schemas/privacy_experience.py
+++ b/src/fides/api/schemas/privacy_experience.py
@@ -190,16 +190,16 @@ class ExperienceMeta(FidesSchema):
         description="A hashed value that can be compared to previously-fetched "
         "hash values to determine if the Experience has meaningfully changed"
     )
-    accept_all_tc_string: Optional[str] = Field(
-        description="The TC string corresponding to a user opting in to all "
+    accept_all_fides_string: Optional[str] = Field(
+        description="The fides string (TC String + AC String) corresponding to a user opting in to all "
         "available options"
     )
-    accept_all_tc_mobile_data: Optional[TCMobileData] = None
-    reject_all_tc_string: Optional[str] = Field(
-        description="The TC string corresponding to a user opting out of all "
+    accept_all_fides_mobile_data: Optional[TCMobileData] = None
+    reject_all_fides_string: Optional[str] = Field(
+        description="The fides string (TC String + AC String) corresponding to a user opting out of all "
         "available options"
     )
-    reject_all_tc_mobile_data: Optional[TCMobileData] = None
+    reject_all_fides_mobile_data: Optional[TCMobileData] = None
 
 
 class PrivacyExperienceResponse(TCFExperienceContents, PrivacyExperienceWithId):

--- a/src/fides/api/schemas/privacy_preference.py
+++ b/src/fides/api/schemas/privacy_preference.py
@@ -115,8 +115,8 @@ class PrivacyPreferencesRequest(TCStringFidesPreferences):
 
     browser_identity: Identity
     code: Optional[SafeStr]
-    tc_string: Optional[str] = Field(
-        description="If supplied, TC string is decoded and preferences saved for purpose_consent, "
+    fides_string: Optional[str] = Field(
+        description="If supplied, TC strings and AC strings are decoded and preferences saved for purpose_consent, "
         "purpose_legitimate_interests, vendor_consent, vendor_legitimate_interests, and special_features"
     )
     preferences: conlist(ConsentOptionCreate, max_items=200) = []  # type: ignore
@@ -151,11 +151,11 @@ class PrivacyPreferencesRequest(TCStringFidesPreferences):
                     f"Duplicate preferences saved against TCF component: '{field_name}'"
                 )
 
-        if values.get("tc_string"):
+        if values.get("fides_string"):
             for field in TCStringFidesPreferences.__fields__:
                 if values.get(field):
                     raise ValueError(
-                        f"Cannot supply value for '{field}' and 'tc_string' simultaneously when saving privacy preferences."
+                        f"Cannot supply value for '{field}' and 'fides_string' simultaneously when saving privacy preferences."
                     )
 
         return values
@@ -334,7 +334,7 @@ class SavePrivacyPreferencesResponse(FidesSchema):
     special_feature_preferences: List[CurrentPrivacyPreferenceSchema] = []
     system_consent_preferences: List[CurrentPrivacyPreferenceSchema] = []
     system_legitimate_interests_preferences: List[CurrentPrivacyPreferenceSchema] = []
-    tc_mobile_data: Optional[TCMobileData] = None
+    fides_mobile_data: Optional[TCMobileData] = None
 
 
 class CurrentPrivacyPreferenceReportingSchema(TCFAttributes):

--- a/src/fides/api/util/tcf/experience_meta.py
+++ b/src/fides/api/util/tcf/experience_meta.py
@@ -79,8 +79,8 @@ def build_experience_tcf_meta(tcf_contents: TCFExperienceContents) -> Dict:
 
     return ExperienceMeta(
         version_hash=build_tcf_version_hash(tcf_contents),
-        accept_all_tc_string=accept_all_mobile_data.IABTCF_TCString,
-        reject_all_tc_string=reject_all_mobile_data.IABTCF_TCString,
-        accept_all_tc_mobile_data=accept_all_mobile_data,
-        reject_all_tc_mobile_data=reject_all_mobile_data,
+        accept_all_fides_string=accept_all_mobile_data.IABTCF_TCString,
+        reject_all_fides_string=reject_all_mobile_data.IABTCF_TCString,
+        accept_all_fides_mobile_data=accept_all_mobile_data,
+        reject_all_fides_mobile_data=reject_all_mobile_data,
     ).dict()

--- a/tests/ops/api/v1/endpoints/test_privacy_experience_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_experience_endpoints.py
@@ -598,10 +598,10 @@ class TestGetPrivacyExperiences:
         assert resp["privacy_notices"][0]["outdated_served"] is None
         meta = resp["meta"]
         assert not meta["version_hash"]
-        assert not meta["accept_all_tc_string"]
-        assert not meta["accept_all_tc_mobile_data"]
-        assert not meta["reject_all_tc_string"]
-        assert not meta["reject_all_tc_mobile_data"]
+        assert not meta["accept_all_fides_string"]
+        assert not meta["accept_all_fides_mobile_data"]
+        assert not meta["reject_all_fides_string"]
+        assert not meta["reject_all_fides_mobile_data"]
 
     @pytest.mark.usefixtures(
         "privacy_notice_us_ca_provide",
@@ -690,10 +690,10 @@ class TestGetTCFPrivacyExperiences:
         assert resp.json()["items"][0]["tcf_system_consents"] == []
         meta = resp.json()["items"][0]["meta"]
         assert not meta["version_hash"]
-        assert not meta["accept_all_tc_string"]
-        assert not meta["accept_all_tc_mobile_data"]
-        assert not meta["reject_all_tc_string"]
-        assert not meta["reject_all_tc_mobile_data"]
+        assert not meta["accept_all_fides_string"]
+        assert not meta["accept_all_fides_mobile_data"]
+        assert not meta["reject_all_fides_string"]
+        assert not meta["reject_all_fides_mobile_data"]
 
     @pytest.mark.usefixtures(
         "privacy_experience_france_overlay",
@@ -723,10 +723,10 @@ class TestGetTCFPrivacyExperiences:
         assert resp.json()["items"][0]["gvl"] == {}
         meta = resp.json()["items"][0]["meta"]
         assert not meta["version_hash"]
-        assert not meta["accept_all_tc_string"]
-        assert not meta["accept_all_tc_mobile_data"]
-        assert not meta["reject_all_tc_string"]
-        assert not meta["reject_all_tc_mobile_data"]
+        assert not meta["accept_all_fides_string"]
+        assert not meta["accept_all_fides_mobile_data"]
+        assert not meta["reject_all_fides_string"]
+        assert not meta["reject_all_fides_mobile_data"]
 
         # Has notices = True flag will keep this experience from appearing altogether
         resp = api_client.get(
@@ -824,10 +824,10 @@ class TestGetTCFPrivacyExperiences:
         assert resp.json()["items"][0]["gvl"]["gvlSpecificationVersion"] == 3
         meta = resp.json()["items"][0]["meta"]
         assert meta["version_hash"] == "75fb2dafef58"
-        assert meta["accept_all_tc_string"]
-        assert meta["accept_all_tc_mobile_data"]
-        assert meta["reject_all_tc_string"]
-        assert meta["reject_all_tc_mobile_data"]
+        assert meta["accept_all_fides_string"]
+        assert meta["accept_all_fides_mobile_data"]
+        assert meta["reject_all_fides_string"]
+        assert meta["reject_all_fides_mobile_data"]
 
     @pytest.mark.usefixtures(
         "privacy_experience_france_overlay",

--- a/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
@@ -187,7 +187,7 @@ class TestSavePrivacyPreferencesPrivacyCenter:
         )
         assert response.status_code == 200
         assert len(response.json()["preferences"]) == 1
-        assert response.json()["tc_mobile_data"] is None
+        assert response.json()["fides_mobile_data"] is None
 
         response_json = response.json()["preferences"][0]
         created_privacy_preference_history_id = response_json[
@@ -294,7 +294,7 @@ class TestSavePrivacyPreferencesPrivacyCenter:
         )
         assert response.status_code == 200
         assert len(response.json()["preferences"]) == 1
-        assert response.json()["tc_mobile_data"] is None
+        assert response.json()["fides_mobile_data"] is None
 
         response_json = response.json()["preferences"][0]
         created_privacy_preference_history_id = response_json[
@@ -367,7 +367,7 @@ class TestSavePrivacyPreferencesPrivacyCenter:
         )
         assert response.status_code == 200
         assert len(response.json()["preferences"]) == 1
-        assert response.json()["tc_mobile_data"] is None
+        assert response.json()["fides_mobile_data"] is None
 
         response_json = response.json()["preferences"][0]
         created_privacy_preference_history_id = response_json[
@@ -659,7 +659,7 @@ class TestSavePrivacyPreferencesPrivacyCenter:
 
         assert response.status_code == 200
         assert len(response.json()["preferences"]) == 2
-        assert response.json()["tc_mobile_data"] is None
+        assert response.json()["fides_mobile_data"] is None
 
         response_json = response.json()["preferences"]
 
@@ -781,7 +781,7 @@ class TestSavePrivacyPreferencesPrivacyCenter:
         )
 
         assert response.status_code == 200
-        assert response.json()["tc_mobile_data"] is None
+        assert response.json()["fides_mobile_data"] is None
         assert len(response.json()["preferences"]) == 0
         assert len(response.json()["feature_preferences"]) == 1
 
@@ -994,7 +994,7 @@ class TestSavePrivacyPreferencesPrivacyCenter:
         )
         assert response.status_code == 200
         assert len(response.json()["preferences"]) == 1
-        assert response.json()["tc_mobile_data"] is None
+        assert response.json()["fides_mobile_data"] is None
 
         response_json = response.json()["preferences"][0]
         created_privacy_preference_history_id = response_json[
@@ -1439,7 +1439,7 @@ class TestSavePrivacyPreferencesForFidesDeviceId:
             url, json=request_body, headers={"Origin": "http://localhost:8080"}
         )
         assert response.status_code == 200
-        assert response.json()["tc_mobile_data"] is None
+        assert response.json()["fides_mobile_data"] is None
         response_json = response.json()["preferences"][0]
         assert response_json["preference"] == "opt_out"
         assert (
@@ -1713,7 +1713,7 @@ class TestSavePrivacyPreferencesForFidesDeviceId:
         assert len(response.json()["special_feature_preferences"]) == 1
         assert len(response.json()["system_consent_preferences"]) == 0
         assert len(response.json()["system_legitimate_interests_preferences"]) == 1
-        assert response.json()["tc_mobile_data"] is None
+        assert response.json()["fides_mobile_data"] is None
 
         purpose_response = response.json()["purpose_consent_preferences"][0]
         assert purpose_response["preference"] == "opt_out"
@@ -2509,7 +2509,7 @@ class TestSavePrivacyPreferencesTCStringOnly:
             "browser_identity": {
                 "fides_user_device_id": fides_user_device_id,
             },
-            "tc_string": tc_string,
+            "fides_string": tc_string,
             "purpose_consent_preferences": [{"id": 1, "preference": "opt_out"}],
         }
         response = api_client.patch(
@@ -2518,7 +2518,7 @@ class TestSavePrivacyPreferencesTCStringOnly:
         assert response.status_code == 422
         assert (
             response.json()["detail"][0]["msg"]
-            == "Cannot supply value for 'purpose_consent_preferences' and 'tc_string' simultaneously when saving privacy preferences."
+            == "Cannot supply value for 'purpose_consent_preferences' and 'fides_string' simultaneously when saving privacy preferences."
         )
 
     def test_save_privacy_preferences_bad_tc_string(self, api_client, url):
@@ -2529,7 +2529,7 @@ class TestSavePrivacyPreferencesTCStringOnly:
             "browser_identity": {
                 "fides_user_device_id": fides_user_device_id,
             },
-            "tc_string": tc_string,
+            "fides_string": tc_string,
         }
         response = api_client.patch(
             url, json=minimal_request_body, headers={"Origin": "http://localhost:8080"}
@@ -2548,7 +2548,7 @@ class TestSavePrivacyPreferencesTCStringOnly:
             "browser_identity": {
                 "fides_user_device_id": fides_user_device_id,
             },
-            "tc_string": tc_string,
+            "fides_string": tc_string,
         }
         response = api_client.patch(
             url, json=minimal_request_body, headers={"Origin": "http://localhost:8080"}
@@ -2567,7 +2567,7 @@ class TestSavePrivacyPreferencesTCStringOnly:
             "browser_identity": {
                 "fides_user_device_id": fides_user_device_id,
             },
-            "tc_string": tc_string,
+            "fides_string": tc_string,
         }
         response = api_client.patch(
             url, json=minimal_request_body, headers={"Origin": "http://localhost:8080"}
@@ -2589,7 +2589,7 @@ class TestSavePrivacyPreferencesTCStringOnly:
             "browser_identity": {
                 "fides_user_device_id": fides_user_device_id,
             },
-            "tc_string": tc_string,
+            "fides_string": tc_string,
         }
         response = api_client.patch(
             url, json=minimal_request_body, headers={"Origin": "http://localhost:8080"}
@@ -2648,7 +2648,7 @@ class TestSavePrivacyPreferencesTCStringOnly:
             is None
         )
 
-        mobile_data = response.json()["tc_mobile_data"]
+        mobile_data = response.json()["fides_mobile_data"]
         assert mobile_data == {
             "IABTCF_CmpSdkID": 12,
             "IABTCF_CmpSdkVersion": 1,


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/1163

### Description Of Changes

Use more generic "fides_string" instead of "tc_string" language in GET Experience and PATCH Privacy Preferences endpoints to pave the way for both a TC and AC string being combined in one string.


### Code Changes

* [x] Updated request and response bodies for Getting Experiences and Saving Preferences related to TC strings

### Steps to Confirm
- GET TCF Privacy experiences or PATCH preferences and verify request and response keys.
[See internal dev docs for expected behavior](https://ethyca.atlassian.net/wiki/spaces/EN/pages/2805006351/2023-10-04+Developer-Friendly+Consent+API+Documentation)


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
