### PR TITLE
Fixing spacing issues caused by a CSS reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The types of changes are:
 - Use `stdRetention` when there is not a specific value for a purpose's data retention [#4199](https://github.com/ethyca/fides/pull/4199)
 - Updating the unflatten_dict util to accept flattened dict values [#4200](https://github.com/ethyca/fides/pull/4200)
 - Minor CSS styling fixes for the consent modal [#4252](https://github.com/ethyca/fides/pull/4252)
+- Additional styling fixes for issues caused by a CSS reset [#4268](https://github.com/ethyca/fides/pull/4268)
 
 ## [2.21.0](https://github.com/ethyca/fides/compare/2.20.2...2.21.0)
 

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -817,7 +817,7 @@ div#fides-banner-inner .fides-privacy-policy {
   background-color: var(--fides-overlay-background-dark-color);
   border-radius: var(--fides-overlay-component-border-radius);
   padding: 1.1em;
-  margin-bottom: 1em;
+  margin: 1em 0;
 }
 
 .fides-info-box p {

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -248,7 +248,7 @@ const TcfVendors = ({
           return (
             <div>
               {gvlVendor ? <StorageDisclosure vendor={gvlVendor} /> : null}
-              <div>
+              <div style={{ marginBottom: "1.1em" }}>
                 {url?.privacy ? (
                   <ExternalLink href={url.privacy}>Privacy policy</ExternalLink>
                 ) : null}


### PR DESCRIPTION
### Description Of Changes

Adding a `margin-top` to `.fides-info-box` and an inline `margin-bottom` to the external links in the fides disclosure

### Steps to Confirm

info box
<img width="639" alt="image" src="https://github.com/ethyca/fides/assets/2092272/ff3a8227-7402-4171-9c0f-8c851aa52300">

disclosure
<img width="636" alt="image" src="https://github.com/ethyca/fides/assets/2092272/0c00c167-8237-4219-bce7-04dddca4c687">


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
