### PR TITLE
Use relationship counts to compute total number of vendors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The types of changes are:
 - Updating the unflatten_dict util to accept flattened dict values [#4200](https://github.com/ethyca/fides/pull/4200)
 - Minor CSS styling fixes for the consent modal [#4252](https://github.com/ethyca/fides/pull/4252)
 - Additional styling fixes for issues caused by a CSS reset [#4268](https://github.com/ethyca/fides/pull/4268)
+- Vendor count over-counting in TCF overlay [#4275](https://github.com/ethyca/fides/pull/4275)
 
 ## [2.21.0](https://github.com/ethyca/fides/compare/2.20.2...2.21.0)
 

--- a/clients/fides-js/src/components/tcf/VendorInfoBanner.tsx
+++ b/clients/fides-js/src/components/tcf/VendorInfoBanner.tsx
@@ -40,13 +40,11 @@ const VendorInfoBanner = ({
       tcf_vendor_legitimate_interests: legintVendors = [],
       tcf_system_consents: consentSystems = [],
       tcf_system_legitimate_interests: legintSystems = [],
+      tcf_vendor_relationships: vendorRelationships = [],
+      tcf_system_relationships: systemRelationships = [],
     } = experience;
 
-    const total =
-      consentSystems.length +
-      consentVendors.length +
-      legintVendors.length +
-      legintSystems.length;
+    const total = vendorRelationships.length + systemRelationships.length;
 
     const consent = consentSystems.length + consentVendors.length;
 


### PR DESCRIPTION
Closes bug @pattisdr found with vendor count over-counting

### Description Of Changes

From Dawn:
> This sum seems misleading.  I only have four vendors, all four are using consent, and one is using both consent and legitimate interests.
![image](https://github.com/ethyca/fides/assets/24641006/7e68b9c0-dece-41a2-a4f4-2fcb5f6c8066)

This fixes that count. Now that vendor relationships and vendor systems have the full list of vendors/systems, we can query off of their lengths directly instead of reconciling their uniqueness.

### Code Changes

* [x] Count based on relationships

### Steps to Confirm

* Add a vendor with both legint and consent purposes
* It should only show up as 1 vendor in the vendor count

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`
