### PR TITLE
AC Prefix -> gacp Prefix

### DIFF
--- a/src/fides/api/util/tcf/tc_model.py
+++ b/src/fides/api/util/tcf/tc_model.py
@@ -20,6 +20,8 @@ CONSENT_SCREEN = 1  # TODO On which 'screen' consent was captured; this is a CMP
 FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS = [1, 3, 4, 5, 6]
 gvl: Dict = load_gvl()
 
+ac_prefix = "gacp."
+
 
 def universal_vendor_id_to_gvl_id(universal_vendor_id: str) -> int:
     """Converts a universal gvl vendor id to a vendor id
@@ -29,7 +31,7 @@ def universal_vendor_id_to_gvl_id(universal_vendor_id: str) -> int:
 
     We store vendor ids as a universal vendor id internally, but need to strip this off when building TC strings.
     """
-    if "ac." in universal_vendor_id:
+    if universal_vendor_id.startswith(ac_prefix):
         raise ValueError("Skipping AC Vendor ID")
     return int(universal_vendor_id.lstrip("gvl."))
 

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -2837,7 +2837,7 @@ def ac_system(db: Session) -> System:
         db=db,
         data={
             "fides_key": f"ac_system{uuid.uuid4()}",
-            "vendor_id": "ac.8",
+            "vendor_id": "gacp.8",
             "name": f"Test AC System",
             "organization_fides_key": "default_organization",
             "system_type": "Service",


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

Incorrectly assumed "ac." was the prefix for AC vendors. It's "gacp."

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
