### PR TITLE
Autogenerate ts types

### DIFF
--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -22,6 +22,7 @@
     "lint:fix": "eslint . --fix --ext .ts,.tsx",
     "lint-staged:fix": "lint-staged --diff=main",
     "openapi:generate": "openapi --input http://localhost:8080/openapi.json --output ./src/types/api --exportCore false --exportServices false --indent 2",
+    "openapi:generate-dictionary": "openapi --input http://localhost:8081/openapi.json --output ./src/types/dictionary-api --exportCore false --exportServices false --indent 2",
     "start": "next start",
     "test": "jest --watchAll",
     "test:ci": "jest"

--- a/clients/admin-ui/src/types/api/models/ExperienceMeta.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceMeta.ts
@@ -13,13 +13,13 @@ export type ExperienceMeta = {
    */
   version_hash?: string;
   /**
-   * The TC string corresponding to a user opting in to all available options
+   * The fides string (TC String + AC String) corresponding to a user opting in to all available options
    */
-  accept_all_tc_string?: string;
-  accept_all_tc_mobile_data?: TCMobileData;
+  accept_all_fides_string?: string;
+  accept_all_fides_mobile_data?: TCMobileData;
   /**
-   * The TC string corresponding to a user opting out of all available options
+   * The fides string (TC String + AC String) corresponding to a user opting out of all available options
    */
-  reject_all_tc_string?: string;
-  reject_all_tc_mobile_data?: TCMobileData;
+  reject_all_fides_string?: string;
+  reject_all_fides_mobile_data?: TCMobileData;
 };

--- a/clients/admin-ui/src/types/api/models/PrivacyPreferencesRequest.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyPreferencesRequest.ts
@@ -28,9 +28,9 @@ export type PrivacyPreferencesRequest = {
   browser_identity: Identity;
   code?: string;
   /**
-   * If supplied, TC string is decoded and preferences saved for purpose_consent, purpose_legitimate_interests, vendor_consent, vendor_legitimate_interests, and special_features
+   * If supplied, TC strings and AC strings are decoded and preferences saved for purpose_consent, purpose_legitimate_interests, vendor_consent, vendor_legitimate_interests, and special_features
    */
-  tc_string?: string;
+  fides_string?: string;
   preferences?: Array<ConsentOptionCreate>;
   special_purpose_preferences?: Array<TCFSpecialPurposeSave>;
   feature_preferences?: Array<TCFFeatureSave>;

--- a/clients/admin-ui/src/types/api/models/SavePrivacyPreferencesResponse.ts
+++ b/clients/admin-ui/src/types/api/models/SavePrivacyPreferencesResponse.ts
@@ -19,5 +19,5 @@ export type SavePrivacyPreferencesResponse = {
   special_feature_preferences?: Array<CurrentPrivacyPreferenceSchema>;
   system_consent_preferences?: Array<CurrentPrivacyPreferenceSchema>;
   system_legitimate_interests_preferences?: Array<CurrentPrivacyPreferenceSchema>;
-  tc_mobile_data?: TCMobileData;
+  fides_mobile_data?: TCMobileData;
 };

--- a/clients/admin-ui/src/types/api/models/TCDecode.ts
+++ b/clients/admin-ui/src/types/api/models/TCDecode.ts
@@ -8,5 +8,5 @@ import type { TCMobileData } from "./TCMobileData";
  * Decode response schema for returning TC Mobile Data
  */
 export type TCDecode = {
-  tc_mobile_data: TCMobileData;
+  fides_mobile_data: TCMobileData;
 };

--- a/clients/admin-ui/src/types/api/models/TCFVendorConsentRecord.ts
+++ b/clients/admin-ui/src/types/api/models/TCFVendorConsentRecord.ts
@@ -13,11 +13,6 @@ export type TCFVendorConsentRecord = {
   has_vendor_id?: boolean;
   name?: string;
   description?: string;
-  cookie_max_age_seconds?: number;
-  uses_cookies?: boolean;
-  cookie_refresh?: boolean;
-  uses_non_cookie_access?: boolean;
-  legitimate_interest_disclosure_url?: string;
   default_preference?: UserConsentPreference;
   current_preference?: UserConsentPreference;
   outdated_preference?: UserConsentPreference;

--- a/clients/admin-ui/src/types/api/models/TCFVendorLegitimateInterestsRecord.ts
+++ b/clients/admin-ui/src/types/api/models/TCFVendorLegitimateInterestsRecord.ts
@@ -13,11 +13,6 @@ export type TCFVendorLegitimateInterestsRecord = {
   has_vendor_id?: boolean;
   name?: string;
   description?: string;
-  cookie_max_age_seconds?: number;
-  uses_cookies?: boolean;
-  cookie_refresh?: boolean;
-  uses_non_cookie_access?: boolean;
-  legitimate_interest_disclosure_url?: string;
   default_preference?: UserConsentPreference;
   current_preference?: UserConsentPreference;
   outdated_preference?: UserConsentPreference;

--- a/clients/admin-ui/src/types/api/models/TCFVendorRelationships.ts
+++ b/clients/admin-ui/src/types/api/models/TCFVendorRelationships.ts
@@ -12,12 +12,12 @@ export type TCFVendorRelationships = {
   has_vendor_id?: boolean;
   name?: string;
   description?: string;
+  special_purposes?: Array<EmbeddedLineItem>;
+  features?: Array<EmbeddedLineItem>;
+  special_features?: Array<EmbeddedLineItem>;
   cookie_max_age_seconds?: number;
   uses_cookies?: boolean;
   cookie_refresh?: boolean;
   uses_non_cookie_access?: boolean;
   legitimate_interest_disclosure_url?: string;
-  special_purposes?: Array<EmbeddedLineItem>;
-  features?: Array<EmbeddedLineItem>;
-  special_features?: Array<EmbeddedLineItem>;
 };

--- a/clients/admin-ui/src/types/dictionary-api/models/Cookie.ts
+++ b/clients/admin-ui/src/types/dictionary-api/models/Cookie.ts
@@ -5,7 +5,7 @@
 import type { CookieType } from "./CookieType";
 
 /**
- * The Cookies resource model
+ * A Compass cookie record, extending a fideslang `Cookie`
  */
 export type Cookie = {
   name: string;
@@ -52,4 +52,8 @@ export type Cookie = {
    * The version of GVL from which the record is derived
    */
   gvl_version?: string;
+  /**
+   * A unique identifier for a Cookie record to be used in the Compass data store. Combines other fields that form uniqueness criteria for a Cookie record.
+   */
+  unique_id?: string;
 };

--- a/clients/admin-ui/src/types/dictionary-api/models/DataUseDeclaration.ts
+++ b/clients/admin-ui/src/types/dictionary-api/models/DataUseDeclaration.ts
@@ -7,10 +7,7 @@ import type { LegalBasisForProcessingEnum } from "./LegalBasisForProcessingEnum"
 import type { SpecialCategoryLegalBasisEnum } from "./SpecialCategoryLegalBasisEnum";
 
 /**
- * The PrivacyDeclaration resource model.
- *
- * States a function of a system, and describes how it relates
- * to the privacy data types.
+ * A Compass data use declaration record, extending a fideslang `PrivacyDeclaration`
  */
 export type DataUseDeclaration = {
   /**

--- a/clients/admin-ui/src/types/dictionary-api/models/Vendor.ts
+++ b/clients/admin-ui/src/types/dictionary-api/models/Vendor.ts
@@ -12,9 +12,7 @@ import type { PrivacyDeclaration } from "./PrivacyDeclaration";
 import type { SystemMetadata } from "./SystemMetadata";
 
 /**
- * The System resource model.
- *
- * Describes an application and includes a list of PrivacyDeclaration resources.
+ * A Compass vendor record, extending a fideslang `System`
  */
 export type Vendor = {
   fides_key?: string;


### PR DESCRIPTION
Regularly scheduled TS type generation 🧹 

### Description Of Changes

Autogenerating TS types after the latest compass integration changes + renaming of `tc_string` to `fides_string`


### Code Changes

* [x] Added a command to autogenerate dictionary types. I thought I added this earlier (it's even in the README I added!) but it doesn't appear to be in the `package.json`
* [x] Ran scripts to autogenerate types

### Steps to Confirm

* There should be no noticeable differences

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
