### PR TITLE
Forcing hidden sections to use display none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 
 ### Fixed
 - Stacks that do not have any purposes will no longer render an empty purpose block [#4278](https://github.com/ethyca/fides/pull/4278)
+- Forcing hidden sections to use display none [#4299](https://github.com/ethyca/fides/pull/4299)
 
 ## [2.22.0](https://github.com/ethyca/fides/compare/2.21.0...2.22.0)
 

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -844,6 +844,10 @@ div#fides-banner-inner .fides-privacy-policy {
   overflow: hidden;
 }
 
+.tabpanel-container section[hidden] {
+  display: none;
+}
+
 /* All on off buttons */
 .fides-all-on-off-buttons {
   display: flex;


### PR DESCRIPTION
### Description Of Changes

Sections with a hidden attribute need to stay hidden regardless of externally defined CSS rules
```
<section hidden...>
```

### Code Changes

* [ ] Updating `fides.css` to specify `section[hidden]` as `display: none`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`