### PR TITLE
Backend: Update TCF Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The types of changes are:
 
 ### Changed
 - Derive cookie storage info, privacy policy and legitimate interest disclosure URLs, and data retention data from the data map instead of directly from gvl.json [#4286](https://github.com/ethyca/fides/pull/4286)
+- Updated TCF Version for backend consent reporting [#4305](https://github.com/ethyca/fides/pull/4305)
 
 ### Fixed
 - Stacks that do not have any purposes will no longer render an empty purpose block [#4278](https://github.com/ethyca/fides/pull/4278)

--- a/src/fides/api/models/privacy_experience.py
+++ b/src/fides/api/models/privacy_experience.py
@@ -659,7 +659,7 @@ def cache_saved_and_served_on_consent_record(
         )
     )
     if saved_preference:
-        if saved_preference.record_matches_current_version:
+        if saved_preference.record_is_current:
             consent_record.current_preference = saved_preference.preference
         else:
             consent_record.outdated_preference = saved_preference.preference
@@ -675,7 +675,7 @@ def cache_saved_and_served_on_consent_record(
     )
 
     if served_record:
-        if served_record.record_matches_current_version:
+        if served_record.record_is_current:
             consent_record.current_served = True
         else:
             consent_record.outdated_served = True

--- a/src/fides/api/models/privacy_preference.py
+++ b/src/fides/api/models/privacy_preference.py
@@ -41,7 +41,7 @@ from fides.api.util.tcf.tcf_experience_contents import (
 )
 from fides.config import CONFIG
 
-CURRENT_TCF_VERSION = "2.0"
+CURRENT_TCF_VERSION = "2.2"
 
 
 class RequestOrigin(Enum):
@@ -674,9 +674,13 @@ class LastSavedMixin:
         return relationship(PrivacyNoticeHistory)
 
     @property
-    def record_matches_current_version(self) -> bool:
+    def record_is_current(self) -> bool:
         """Returns True if the latest saved preference corresponds to the
-        latest version for this notice or TCF component"""
+        latest version for this notice
+
+        For TCF - just return True, and don't use the tcf_version to say a preference is outdated. We'll
+        use other criteria to determine if consent needs to be resurfaced.
+        """
 
         if self.privacy_notice and self.privacy_notice_history_id:
             return (
@@ -684,10 +688,7 @@ class LastSavedMixin:
                 == self.privacy_notice_history_id
             )
 
-        if self.tcf_version:
-            return self.tcf_version == CURRENT_TCF_VERSION
-
-        return False
+        return True
 
 
 class CurrentPrivacyPreference(LastSavedMixin, Base):

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -1515,6 +1515,11 @@ def served_notice_history_for_tcf_purpose(
         },
         check_name=False,
     )
+    pref_1.tcf_version = "2.0"
+    pref_1.save(db)
+    pref_1.last_served_record.tcf_version = "2.0"
+    pref_1.last_served_record.save(db)
+
     yield pref_1
     pref_1.delete(db)
 
@@ -2340,6 +2345,12 @@ def privacy_preference_history_for_tcf_purpose_consent(
         },
         check_name=False,
     )
+    preference_history_record.tcf_version = "2.0"
+    preference_history_record.save(db)
+
+    preference_history_record.current_privacy_preference.tcf_version = "2.0"
+    preference_history_record.current_privacy_preference.save(db)
+
     yield preference_history_record
     preference_history_record.delete(db)
 

--- a/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_preference_endpoints.py
@@ -2232,7 +2232,7 @@ class TestHistoricalPreferences:
         assert response_body["system_legitimate_interests"] is None
         assert response_body["feature"] is None
         assert response_body["special_feature"] is None
-        assert response_body["tcf_version"] == CURRENT_TCF_VERSION
+        assert response_body["tcf_version"] == "2.0"
 
         assert response_body["request_timestamp"] is not None
         assert response_body["request_origin"] == "tcf_overlay"

--- a/tests/ops/models/test_privacy_experience.py
+++ b/tests/ops/models/test_privacy_experience.py
@@ -1320,6 +1320,12 @@ class TestCacheSavedAndServedOnConsentRecord:
         privacy_preference_history_for_tcf_purpose_consent,
         served_notice_history_for_tcf_purpose,
     ):
+        """For TCF preferences, preferences saved against a purpose in an older TCF version are still returned
+        as the current preference, not the outdated preference, same with TCF served.
+
+        For TCF, just because a preference was saved against an older TCF version, doesn't mean its necessarily "outdated".
+        For Privacy Notices, however, we do consider them outdated.
+        """
         privacy_preference_history_for_tcf_purpose_consent.current_privacy_preference.tcf_version = (
             "1.0"
         )
@@ -1341,13 +1347,13 @@ class TestCacheSavedAndServedOnConsentRecord:
             tcf_purpose_consent_record.default_preference
             == UserConsentPreference.opt_out
         )
-        assert tcf_purpose_consent_record.current_preference is None
+        assert tcf_purpose_consent_record.outdated_preference is None
         assert (
-            tcf_purpose_consent_record.outdated_preference
+            tcf_purpose_consent_record.current_preference
             == UserConsentPreference.opt_out
         )
-        assert tcf_purpose_consent_record.current_served is None
-        assert tcf_purpose_consent_record.outdated_served is True
+        assert tcf_purpose_consent_record.current_served is True
+        assert tcf_purpose_consent_record.outdated_served is None
 
     @pytest.mark.usefixtures(
         "privacy_preference_history_for_tcf_purpose_consent",

--- a/tests/ops/models/test_privacy_preference.py
+++ b/tests/ops/models/test_privacy_preference.py
@@ -2060,13 +2060,13 @@ class TestLastServedNotice:
         last_served = (
             served_notice_history_us_ca_provide_for_fides_user.last_served_record
         )
-        assert last_served.record_matches_current_version is True
+        assert last_served.record_is_current is True
 
         privacy_notice_us_ca_provide.update(db, data={"description": "new_description"})
         assert privacy_notice_us_ca_provide.version == 2.0
         assert privacy_notice_us_ca_provide.description == "new_description"
 
-        assert last_served.record_matches_current_version is False
+        assert last_served.record_is_current is False
 
     def test_served_latest_tcf_version(
         self,
@@ -2074,11 +2074,11 @@ class TestLastServedNotice:
         served_notice_history_for_tcf_purpose,
     ):
         last_served = served_notice_history_for_tcf_purpose.last_served_record
-        assert last_served.record_matches_current_version is True
+        assert last_served.record_is_current is True
 
-        # Just for demonstration
+        # TCF Version is not used to determine if a preference is outdated for TCF
         last_served.update(db, data={"tcf_version": "1.0"})
-        assert last_served.record_matches_current_version is False
+        assert last_served.record_is_current is True
 
     def test_get_last_served_for_notice_and_fides_user_device(
         self,


### PR DESCRIPTION
Closes https://github.com/ethyca/fidesplus/issues/1167

### Description Of Changes

Update hardcoded TCF Version saved for consent reporting to 2.2.

### Code Changes

* [x] Updated TCF_VERSION for consent reporting
* [x] Stop using this field for TCF to deem a saved preference is "outdated" - this isn't very relevant for TCF, we'll have other criteria to determine if consent needs to be resurfaced.
* [x] Rename related method from `record_matches_current_version` to `record_is_current` and change it's default value to True instead of False. Other than Privacy Notices which I am comparing the latest version of the notice to the version on the saved preference, everything else, I'll just say is "True"

### Steps to Confirm

* [ ] Easiest way is to go to checkout main which has TCF at an earlier version.  Set up TCF per usual:
* [ ]  Fetch Privacy Experiences, I'm going to select a consent purpose of 10 against which to save preferences
```
curl -X 'GET' \
  'http://localhost:8080/api/v1/privacy-experience?show_disabled=true&fides_user_device_id=6f8692dc-43f7-4dc5-97bb-4560c73f5503&systems_applicable=false&include_gvl=false&include_meta=false&page=1&size=50' \
  -H 'accept: application/json'
```
* [ ] PATCH privacy preferences via the API with a fides user device id
PATCH http://localhost:8080/api/v1/privacy-preferences
```
{
  "purpose_consent_preferences": [{"id": 10, "preference": "opt_in"}],
  "browser_identity": {
    "fides_user_device_id": "6f8692dc-43f7-4dc5-97bb-4560c73f5503"
  }
}```
* [ ] Now checkout this branch, and fetch experiences, your saved TCF preference should show up under "current_preference` instead of `outdated_preference` even though the version has changed. 
```
curl -X 'GET' \
  'http://localhost:8080/api/v1/privacy-experience?show_disabled=true&fides_user_device_id=6f8692dc-43f7-4dc5-97bb-4560c73f5503&systems_applicable=false&include_gvl=false&include_meta=false&page=1&size=50' \
  -H 'accept: application/json'
```json
...
 "tcf_purpose_consents": [
        {
          "id": 10,
          "name": "Develop and improve services",
          "data_uses": [
            "functional.service.improve"
          ],
          "default_preference": "opt_out",
          "current_preference": "opt_in",
          "outdated_preference": null,
          "current_served": null,
          "outdated_served": null,
          "vendors": [
            {
              "id": "gacp.8",
              "name": "Third Party Payments"
            }
          ],
          "systems": [
            {
              "id": "ctl_c5c78785-5eb5-4a03-94a2-8a1ba03931b9",
              "name": "PostgreSQL System"
            }
          ]
        }
      ]
```

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
