### PR TITLE
css fixes for fides embed modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ The types of changes are:
 - `Security` in case of vulnerabilities.
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.22.0...main)
+
+### Added
 - Added support for 3 additional config variables in Fides.js: fidesEmbed, fidesDisableSaveApi, and fidesTcString [#4262](https://github.com/ethyca/fides/pull/4262)
 - Added support for fidesEmbed, fidesDisableSaveApi, and fidesTcString to be passed into Fides.js via query param, cookie, or window object [#4297](https://github.com/ethyca/fides/pull/4297)
+
+### Fixed
+- Cleans up CSS for fidesEmbed mode [#4306](https://github.com/ethyca/fides/pull/4306)
 
 ### Added
 - Added a `FidesPreferenceToggled` event to Fides.js to track when user preferences change without being saved [#4253](https://github.com/ethyca/fides/pull/4253)

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -5,6 +5,7 @@
   /* Colors */
   --fides-overlay-primary-color: #8243f2;
   --fides-overlay-background-color: #f7fafc;
+  --fides-embedded-overlay-background-color: white;
   --fides-overlay-font-color: #4a5568;
   --fides-overlay-font-color-dark: #2d3748;
   --fides-overlay-hover-color: #edf2f7;
@@ -318,11 +319,13 @@ div.fides-modal-content {
 }
 
 /*Fides Embed*/
+
 div#fides-embed-container:focus-visible,
 div#fides-embed-container div#fides-modal:focus-visible {
   outline: none;
 }
 
+/* Disable "sticky" footer when embedded */
 div#fides-embed-container div#fides-modal .fides-modal-footer {
   position: inherit;
 }
@@ -330,7 +333,7 @@ div#fides-embed-container div#fides-modal .fides-modal-footer {
 div#fides-embed-container .fides-modal-container,
 div#fides-embed-container .fides-modal-overlay {
   position: initial;
-  background-color: white;
+  background-color: var(--fides-embedded-overlay-background-color);
 }
 
 div#fides-embed-container .fides-modal-content {

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -5,7 +5,7 @@
   /* Colors */
   --fides-overlay-primary-color: #8243f2;
   --fides-overlay-background-color: #f7fafc;
-  --fides-embedded-overlay-background-color: white;
+  --fides-overlay-embed-background-color: transparent;
   --fides-overlay-font-color: #4a5568;
   --fides-overlay-font-color-dark: #2d3748;
   --fides-overlay-hover-color: #edf2f7;
@@ -333,7 +333,7 @@ div#fides-embed-container div#fides-modal .fides-modal-footer {
 div#fides-embed-container .fides-modal-container,
 div#fides-embed-container .fides-modal-overlay {
   position: initial;
-  background-color: var(--fides-embedded-overlay-background-color);
+  background-color: var(--fides-overlay-embed-background-color);
 }
 
 div#fides-embed-container .fides-modal-content {

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -318,15 +318,26 @@ div.fides-modal-content {
 }
 
 /*Fides Embed*/
+div#fides-embed-container:focus-visible,
+div#fides-embed-container div#fides-modal:focus-visible {
+  outline: none;
+}
+
+div#fides-embed-container div#fides-modal .fides-modal-footer {
+  position: inherit;
+}
+
 div#fides-embed-container .fides-modal-container,
 div#fides-embed-container .fides-modal-overlay {
   position: initial;
-  display: inline;
+  background-color: white;
 }
 
 div#fides-embed-container .fides-modal-content {
   position: initial;
   transform: none;
+  border: none;
+  max-height: none;
 }
 
 div#fides-embed-container .fides-close-button {

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -138,6 +138,9 @@
     <style>
       body {
         margin: 16px;
+        height: 100vh;
+        overflow: scroll;
+        overflow-x: hidden;
       }
       pre {
         background-color: #eee;


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4307

### Description Of Changes

Cleans up CSS for fides embed modal. Specifically does 2 things:
1. Removes outline from modal in embed mode
2. Fixes mobile responsiveness (flex) in embed mode


### Code Changes

* [ ] CSS updates for embed mode

### Steps to Confirm

* [ ] Nav to site with `?fides_embed=true` with TCF enabled, see embedded modal 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
