### PR TITLE
fix up url typo in test

### DIFF
--- a/tests/ops/models/test_privacy_preference.py
+++ b/tests/ops/models/test_privacy_preference.py
@@ -136,7 +136,7 @@ class TestPrivacyPreferenceHistory:
                 "secondary_user_ids": {"ga_client_id": "test"},
                 "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/324.42 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/425.24",
                 "user_geography": "us_ca",
-                "url_recorded": "https://example.com/privacy_center",
+                "url_recorded": "http://example.com/privacy_center",
             },
             check_name=False,
         )


### PR DESCRIPTION
Closes n/a

### Description Of Changes

we had a [small typo in our test in this PR](https://github.com/ethyca/fides/commit/9904b4f7f87da2b3a3a2cefefc1ad20cff1ee32b#diff-414f2caccaa58158d216b278fb0ae93cc810941e12bbc6507f83718602cd08deR139), fix this up to avoid test failures


### Code Changes

* [x] fix typo in test

### Steps to Confirm

n/a

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
