### PR TITLE
PROD-1266 Removes overflow styling for embedded modal in Fides.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.23.0...main)
 
+### Fixed
+- Removes overflow styling for embedded modal in Fides.js [#4345](https://github.com/ethyca/fides/pull/4345)
+
 ## [2.23.0](https://github.com/ethyca/fides/compare/2.22.1...2.23.0)
 
 ### Added

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -57,6 +57,7 @@ const Overlay: FunctionComponent<Props> = ({
     role: "alertdialog",
     className: options.fidesEmbed ? "fides-embed" : "",
     title: experience?.experience_config?.title || "",
+    useOverlowStyling: !options.fidesEmbed,
     onClose: dispatchCloseEvent,
   });
 

--- a/clients/fides-js/src/lib/a11y-dialog.tsx
+++ b/clients/fides-js/src/lib/a11y-dialog.tsx
@@ -8,21 +8,24 @@ import { useCallback, useEffect, useState } from "preact/hooks";
 
 const useA11yDialogInstance = (addOverlowStyling: Boolean) => {
   const [instance, setInstance] = useState<A11yDialogLib | null>(null);
-  const container = useCallback((node: Element) => {
-    if (node !== null) {
-      const dialog = new A11yDialogLib(node);
-      if (addOverlowStyling) {
-        dialog
+  const container = useCallback(
+    (node: Element) => {
+      if (node !== null) {
+        const dialog = new A11yDialogLib(node);
+        if (addOverlowStyling) {
+          dialog
             .on("show", () => {
               document.documentElement.style.overflowY = "hidden";
             })
             .on("hide", () => {
               document.documentElement.style.overflowY = "";
             });
+        }
+        setInstance(dialog);
       }
-      setInstance(dialog);
-    }
-  }, [addOverlowStyling]);
+    },
+    [addOverlowStyling]
+  );
   return { instance, container };
 };
 
@@ -34,7 +37,13 @@ interface Props {
   useOverlowStyling: Boolean;
   onClose?: () => void;
 }
-export const useA11yDialog = ({ role, className, id, onClose, useOverlowStyling}: Props) => {
+export const useA11yDialog = ({
+  role,
+  className,
+  id,
+  onClose,
+  useOverlowStyling,
+}: Props) => {
   const { instance, container: ref } = useA11yDialogInstance(useOverlowStyling);
   const isAlertDialog = role === "alertdialog";
   const titleId = `${id}-title`;

--- a/clients/fides-js/src/lib/a11y-dialog.tsx
+++ b/clients/fides-js/src/lib/a11y-dialog.tsx
@@ -6,21 +6,23 @@
 import A11yDialogLib from "a11y-dialog";
 import { useCallback, useEffect, useState } from "preact/hooks";
 
-const useA11yDialogInstance = () => {
+const useA11yDialogInstance = (addOverlowStyling: Boolean) => {
   const [instance, setInstance] = useState<A11yDialogLib | null>(null);
   const container = useCallback((node: Element) => {
     if (node !== null) {
       const dialog = new A11yDialogLib(node);
-      dialog
-        .on("show", () => {
-          document.documentElement.style.overflowY = "hidden";
-        })
-        .on("hide", () => {
-          document.documentElement.style.overflowY = "";
-        });
+      if (addOverlowStyling) {
+        dialog
+            .on("show", () => {
+              document.documentElement.style.overflowY = "hidden";
+            })
+            .on("hide", () => {
+              document.documentElement.style.overflowY = "";
+            });
+      }
       setInstance(dialog);
     }
-  }, []);
+  }, [addOverlowStyling]);
   return { instance, container };
 };
 
@@ -29,10 +31,11 @@ interface Props {
   className: string;
   id: string;
   title: string;
+  useOverlowStyling: Boolean;
   onClose?: () => void;
 }
-export const useA11yDialog = ({ role, className, id, onClose }: Props) => {
-  const { instance, container: ref } = useA11yDialogInstance();
+export const useA11yDialog = ({ role, className, id, onClose, useOverlowStyling}: Props) => {
+  const { instance, container: ref } = useA11yDialogInstance(useOverlowStyling);
   const isAlertDialog = role === "alertdialog";
   const titleId = `${id}-title`;
 


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1266

### Description Of Changes

Removes overflow styling for embedded modal in Fides.js


### Code Changes

* [ ] Adds conditional to A11y dialog overflow styling

### Steps to Confirm

* [ ] Nav to http://localhost:3000/fides-js-components-demo.html?fides_embed=true
* [ ] Inspect element, and see that `style="overflow-y: hidden;"` is not added to `<html>` tag

<img width="701" alt="Screenshot 2023-10-26 at 12 25 51 PM" src="https://github.com/ethyca/fides/assets/7697292/a3469304-72ed-4b9e-9cad-abb8eb9257ab">


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
