### PR TITLE
Add initial state to suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The types of changes are:
 - Forcing hidden sections to use display none [#4299](https://github.com/ethyca/fides/pull/4299)
 - Handles Hubspot requiring and email to be formatted as email when processing an erasure [#4322](https://github.com/ethyca/fides/pull/4322)
 - Minor CSS improvements for the consent/TCF banners and modals [#4334](https://github.com/ethyca/fides/pull/4334)
+- Bug where not all system forms would appear to save when used with Compass [#4347](https://github.com/ethyca/fides/pull/4347)
 
 ### Changed
 - Derive cookie storage info, privacy policy and legitimate interest disclosure URLs, and data retention data from the data map instead of directly from gvl.json [#4286](https://github.com/ethyca/fides/pull/4286)

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -27,8 +27,9 @@ describe("System management with Plus features", () => {
 
   describe("vendor list", () => {
     beforeEach(() => {
-      cy.visit(`${SYSTEM_ROUTE}/configure/demo_analytics_system`);
       stubVendorList();
+      cy.visit(`${SYSTEM_ROUTE}/configure/demo_analytics_system`);
+      cy.wait("@getDictionaryEntries");
     });
 
     it("can display the vendor list dropdown", () => {

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -117,9 +117,9 @@ describe("System management with Plus features", () => {
           fixture: "taxonomy/custom-metadata/custom-field/list.json",
         }
       ).as("getCustomFields");
-      cy.intercept("PUT", `/api/v1/plus/custom-metadata/custom-field`, {
-        fixture: "taxonomy/custom-metadata/custom-field/update-party.json",
-      }).as("updateParty");
+      cy.intercept("POST", `/api/v1/plus/custom-metadata/custom-field/bulk`, {
+        body: {},
+      }).as("bulkUpdateCustomField");
     });
 
     it("can populate initial custom metadata", () => {
@@ -140,35 +140,31 @@ describe("System management with Plus features", () => {
 
       cy.wait("@putSystem");
 
-      // There are two custom field updates that will take place, but order is not stable
       const expectedValues = [
         {
+          custom_field_definition_id:
+            "id-custom-field-definition-pokemon-party",
           id: "id-custom-field-pokemon-party",
           resource_id: "demo_analytics_system",
           value: ["Charmander", "Eevee", "Snorlax", "Bulbasaur"],
         },
         {
+          custom_field_definition_id:
+            "id-custom-field-definition-starter-pokemon",
           id: "id-custom-field-starter-pokemon",
           resource_id: "demo_analytics_system",
           value: "Squirtle",
         },
       ];
-      cy.wait(["@updateParty", "@updateParty"]).then((interceptions) => {
-        expectedValues.forEach((expected) => {
-          const interception = interceptions.find(
-            (i) => i.request.body.id === expected.id
-          );
-          expect(interception.request.body.resource_id).to.eql(
-            expected.resource_id
-          );
-          expect(interception.request.body.value).to.eql(expected.value);
-        });
+      cy.wait("@bulkUpdateCustomField").then((interception) => {
+        expect(interception.request.body.upsert).to.eql(expectedValues);
       });
     });
   });
 
   describe("bulk system/vendor adding page", () => {
     beforeEach(() => {
+      stubPlus(true);
       stubSystemVendors();
     });
 
@@ -202,6 +198,10 @@ describe("System management with Plus features", () => {
           enabled: false,
           service_health: null,
           service_error: null,
+        },
+        fidesplus_version: "",
+        fides_cloud: {
+          enabled: false,
         },
       });
       cy.visit(ADD_SYSTEMS_ROUTE);

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -243,7 +243,7 @@ export const stubDatamap = () => {
 };
 
 export const stubSystemVendors = () => {
-  cy.intercept("GET", "/api/v1/plus/dictionary/created-vendors", {
+  cy.intercept("GET", "/api/v1/plus/dictionary/system-vendors", {
     fixture: "systems/system-vendors.json",
   }).as("getSystemVendors");
 };

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -175,7 +175,7 @@ const SystemInformationForm = ({
         // Reset state such that isDirty will be checked again before next save
         formikHelpers.resetForm({ values });
         onSuccess(result.data);
-        dispatch(setSuggestions("hiding"));
+        dispatch(setSuggestions("initial"));
       }
     };
 

--- a/clients/admin-ui/src/features/system/dictionary-form/dict-suggestion.slice.ts
+++ b/clients/admin-ui/src/features/system/dictionary-form/dict-suggestion.slice.ts
@@ -2,13 +2,15 @@ import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import { type RootState } from "~/app/store";
 
-export type Suggestions = "showing" | "hiding";
+// `initial` is like `hiding`, although it helps to know when we are setting
+// an initial value vs reverting to a previous value
+export type Suggestions = "showing" | "hiding" | "initial";
 
 type State = {
   suggestions: Suggestions;
 };
 const initialState: State = {
-  suggestions: "hiding",
+  suggestions: "initial",
 };
 
 export const dictSuggestionsSlice = createSlice({
@@ -16,8 +18,12 @@ export const dictSuggestionsSlice = createSlice({
   initialState,
   reducers: {
     toggleSuggestions: (draftState) => {
-      draftState.suggestions =
-        draftState.suggestions === "hiding" ? "showing" : "hiding";
+      if (draftState.suggestions === "initial") {
+        draftState.suggestions = "showing";
+      } else {
+        draftState.suggestions =
+          draftState.suggestions === "hiding" ? "showing" : "hiding";
+      }
     },
     setSuggestions: (draftState, action: PayloadAction<Suggestions>) => {
       draftState.suggestions = action.payload;

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -1399,6 +1399,7 @@ describe("Fides-js TCF", () => {
         cy.getByTestId("consent-modal").within(() => {
           cy.get("button").contains("Opt in to all").click();
         });
+        cy.get("@FidesUpdated").should("have.been.calledTwice");
         cy.get("@TCFEvent2")
           .its("lastCall.args")
           .then(([tcData, success]) => {

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -407,6 +407,7 @@ describe("Consent banner", () => {
 
         it("can remove all cookies when rejecting all", () => {
           cy.contains("button", "Reject Test").click();
+          cy.get("@FidesUpdated").should("have.been.calledTwice");
           cy.getAllCookies().then((allCookies) => {
             expect(allCookies.map((c) => c.name)).to.eql([CONSENT_COOKIE_NAME]);
           });
@@ -417,6 +418,7 @@ describe("Consent banner", () => {
           // opt out of the first notice
           cy.getByTestId("toggle-one").click();
           cy.getByTestId("Save test-btn").click();
+          cy.get("@FidesUpdated").should("have.been.calledTwice");
           cy.getAllCookies().then((allCookies) => {
             expect(allCookies.map((c) => c.name)).to.eql([
               CONSENT_COOKIE_NAME,


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1255

### Description Of Changes

This was a very strange bug, and I think it was introduced by https://github.com/ethyca/fides/pull/4294#discussion_r1362890811 but even that seems to be a bit of a red herring... 

First I found that if I reverted that particular change described in that comment, things worked. I did a diff between `systemBody` and `result.data`, then added all the fields until I found the one that was causing things to break which was mysteriously `third_country_transfers`. There's no rhyme or reason to this as far as I can tell, so I dug further...

Then I realized the only fields that were being reset were the dictionary fields, so I looked specifically at `useDictSuggestion`.

It seems like this line https://github.com/ethyca/fides/blob/aking/prod-1255/fix-system-info-saving/clients/admin-ui/src/features/system/dictionary-form/DictSuggestionInputs.tsx/#L88-L92 was causing problems. The `initialValues` were properly set, but that bit of code would reset all those fields to empty strings so `values` would be incorrect. Again, this only happens when `third_country_transfers` is included, which is very strange, and I suspect is not entirely the root cause and may be a red herring (or a sign of something else).

By adding a new suggestion state `initial` we can get around this—that line will only fire when we actually want "presuggestions" which I think works pretty well.


https://github.com/ethyca/fides/assets/24641006/9d99385c-1b5b-4d14-994b-423a2d73f3df



### Code Changes

* [x] Add a new `initial` state to suggestions

### Steps to Confirm

* [ ] See steps in Roger's bug report.
* [ ] Make sure "pre suggestions" still work

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
