### PR TITLE
Handle decoding problems with passed in `fides_string`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The types of changes are:
 - Minor CSS improvements for the consent/TCF banners and modals [#4334](https://github.com/ethyca/fides/pull/4334)
 - Bug where not all system forms would appear to save when used with Compass [#4347](https://github.com/ethyca/fides/pull/4347)
 - Restrict TCF Privacy Experience Config if TCF is disabled [#4348](https://github.com/ethyca/fides/pull/4348)
+- Handle invalid `fides_string` when passed in as an override [#4350](https://github.com/ethyca/fides/pull/4350)
 
 ### Changed
 - Derive cookie storage info, privacy policy and legitimate interest disclosure URLs, and data retention data from the data map instead of directly from gvl.json [#4286](https://github.com/ethyca/fides/pull/4286)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The types of changes are:
 ### Changed
 - Refactor Fides.js embedded modal to not use A11y dialog [#4355](https://github.com/ethyca/fides/pull/4355)
 
+### Fixed
+- Handle invalid `fides_string` when passed in as an override [#4350](https://github.com/ethyca/fides/pull/4350)
+
 ## [2.23.0](https://github.com/ethyca/fides/compare/2.22.1...2.23.0)
 
 ### Added
@@ -47,7 +50,6 @@ The types of changes are:
 - Consistent font sizes for labels in the system form and data use forms in the Admin UI [#4346](https://github.com/ethyca/fides/pull/4346)
 - Bug where not all system forms would appear to save when used with Compass [#4347](https://github.com/ethyca/fides/pull/4347)
 - Restrict TCF Privacy Experience Config if TCF is disabled [#4348](https://github.com/ethyca/fides/pull/4348)
-- Handle invalid `fides_string` when passed in as an override [#4350](https://github.com/ethyca/fides/pull/4350)
 - Removes overflow styling for embedded modal in Fides.js [#4345](https://github.com/ethyca/fides/pull/4345)
 
 ### Changed

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -68,6 +68,7 @@ import {
 import type { Fides } from "./lib/initialize";
 import { dispatchFidesEvent } from "./lib/events";
 import {
+  buildTcfEntitiesFromCookie,
   debugLog,
   experienceIsValid,
   FidesCookie,
@@ -121,13 +122,43 @@ const getInitialPreference = (
   return tcfObject.default_preference ?? UserConsentPreference.OPT_OUT;
 };
 
-const updateCookie = async (
-  oldCookie: FidesCookie,
-  experience: PrivacyExperience
-): Promise<FidesCookie> => {
-  // ignore server-side prefs if either user has no prefs to override, or TC str override is set
+const updateCookieAndExperience = async ({
+  cookie,
+  experience,
+  debug = false,
+  hasFidesStringOverride,
+  isExperienceClientSideFetched,
+}: {
+  cookie: FidesCookie;
+  experience: PrivacyExperience;
+  debug?: boolean;
+  hasFidesStringOverride: boolean;
+  isExperienceClientSideFetched: boolean;
+}): Promise<{
+  cookie: FidesCookie;
+  experience: Partial<PrivacyExperience>;
+}> => {
+  // If string override exists, the cookie is already okay, but the experience may not be.
+  if (hasFidesStringOverride) {
+    // If we didn't get the experience until the client side fetch, we need to update the fetched
+    // experience based on the cookie here.
+    if (isExperienceClientSideFetched) {
+      debugLog(
+        debug,
+        "Overriding preferences from client-side fetched experience with cookie fides_string consent",
+        cookie.fides_string
+      );
+      const tcfEntities = buildTcfEntitiesFromCookie(experience, cookie);
+      return { cookie, experience: tcfEntities };
+    }
+    // If it's not client side fetched, we don't update anything since the cookie has already
+    // been updated earlier.
+    return { cookie, experience };
+  }
+
+  // ignore server-side prefs if user has no prefs to override
   if (!hasSavedTcfPreferences(experience)) {
-    return { ...oldCookie, fides_string: "" };
+    return { cookie: { ...cookie, fides_string: "" }, experience };
   }
 
   const tcSavePrefs: TcfSavePreferences = {};
@@ -165,7 +196,38 @@ const updateCookie = async (
     tcStringPreferences: enabledIds,
   });
   const tcfConsent = transformTcfPreferencesToCookieKeys(tcSavePrefs);
-  return { ...oldCookie, fides_string: fidesString, tcf_consent: tcfConsent };
+  return {
+    cookie: { ...cookie, fides_string: fidesString, tcf_consent: tcfConsent },
+    experience,
+  };
+};
+
+/**
+ * If a fidesString is explicitly passed in, we override the associated cookie props, which are then
+ * used to override associated props in the experience.
+ */
+const updateFidesCookieFromString = (
+  cookie: FidesCookie,
+  fidesString: string,
+  debug: boolean
+): { cookie: FidesCookie; success: boolean } => {
+  debugLog(
+    debug,
+    "Explicit fidesString detected. Proceeding to override all TCF preferences with given fidesString"
+  );
+  try {
+    const cookieKeys = transformFidesStringToCookieKeys(fidesString, debug);
+    return {
+      cookie: { ...cookie, tcf_consent: cookieKeys, fides_string: fidesString },
+      success: true,
+    };
+  } catch (error) {
+    debugLog(
+      debug,
+      `Could not decode tcString from ${fidesString}, it may be invalid. ${error}`
+    );
+    return { cookie, success: false };
+  }
 };
 
 /**
@@ -177,24 +239,17 @@ const init = async (config: FidesConfig) => {
   // eslint-disable-next-line no-param-reassign
   config.options = { ...config.options, ...overrideOptions };
   const cookie = getInitialCookie(config);
+  let hasFidesStringOverride = !!config.options.fidesString;
   if (config.options.fidesString) {
-    // If a fidesString is explicitly passed in, we override the associated cookie props, which are then used to
-    // override associated props in experience
-    debugLog(
-      config.options.debug,
-      "Explicit fidesString detected. Proceeding to override all TCF preferences with given fidesString"
-    );
-    const { cookieKeys, success } = transformFidesStringToCookieKeys(
+    const { cookie: updatedCookie, success } = updateFidesCookieFromString(
+      cookie,
       config.options.fidesString,
       config.options.debug
     );
-    if (!success) {
-      // Treat an unsuccessful transform as if no fidesString were passed in.
-      // eslint-disable-next-line no-param-reassign
-      config.options.fidesString = null;
+    if (success) {
+      Object.assign(cookie, updatedCookie);
     } else {
-      cookie.tcf_consent = cookieKeys;
-      cookie.fides_string = config.options.fidesString;
+      hasFidesStringOverride = false;
     }
   } else if (
     tcfConsentCookieObjHasSomeConsentSet(cookie.tcf_consent) &&
@@ -228,7 +283,8 @@ const init = async (config: FidesConfig) => {
     cookie,
     experience,
     renderOverlay,
-    updateCookie,
+    updateCookieAndExperience: (props) =>
+      updateCookieAndExperience({ ...props, hasFidesStringOverride }),
   });
   Object.assign(_Fides, updatedFides);
 

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -184,11 +184,18 @@ const init = async (config: FidesConfig) => {
       config.options.debug,
       "Explicit fidesString detected. Proceeding to override all TCF preferences with given fidesString"
     );
-    cookie.fides_string = config.options.fidesString;
-    cookie.tcf_consent = transformFidesStringToCookieKeys(
+    const { cookieKeys, success } = transformFidesStringToCookieKeys(
       config.options.fidesString,
       config.options.debug
     );
+    if (!success) {
+      // Treat an unsuccessful transform as if no fidesString were passed in.
+      // eslint-disable-next-line no-param-reassign
+      config.options.fidesString = null;
+    } else {
+      cookie.tcf_consent = cookieKeys;
+      cookie.fides_string = config.options.fidesString;
+    }
   } else if (
     tcfConsentCookieObjHasSomeConsentSet(cookie.tcf_consent) &&
     !cookie.fides_string &&

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -91,14 +91,14 @@ const updateCookie = async (
   oldCookie: FidesCookie,
   experience: PrivacyExperience,
   debug?: boolean
-): Promise<FidesCookie> => {
+): Promise<{ cookie: FidesCookie; experience: PrivacyExperience }> => {
   const context = getConsentContext();
   const consent = buildCookieConsentForExperiences(
     experience,
     context,
     !!debug
   );
-  return { ...oldCookie, consent };
+  return { cookie: { ...oldCookie, consent }, experience };
 };
 
 /**
@@ -122,7 +122,11 @@ const init = async (config: FidesConfig) => {
     cookie,
     experience,
     renderOverlay,
-    updateCookie,
+    updateCookieAndExperience: ({
+      cookie: oldCookie,
+      experience: effectiveExperience,
+      debug,
+    }) => updateCookie(oldCookie, effectiveExperience, debug),
   });
   Object.assign(_Fides, updatedFides);
 

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -4,7 +4,6 @@ import { meta } from "../integrations/meta";
 import { shopify } from "../integrations/shopify";
 import { getConsentContext } from "./consent-context";
 import {
-  buildTcfEntitiesFromCookie,
   CookieIdentity,
   CookieKeyConsent,
   CookieMeta,
@@ -259,15 +258,28 @@ export const initialize = async ({
   experience,
   geolocation,
   renderOverlay,
-  updateCookie,
+  updateCookieAndExperience,
 }: {
   cookie: FidesCookie;
   renderOverlay: (props: OverlayProps, parent: ContainerNode) => void;
-  updateCookie: (
-    oldCookie: FidesCookie,
-    experience: PrivacyExperience,
-    debug?: boolean
-  ) => Promise<FidesCookie>;
+  /**
+   * Once we for sure have a valid experience, this is another chance to update values
+   * before the overlay renders.
+   */
+  updateCookieAndExperience: ({
+    cookie,
+    experience,
+    debug,
+    isExperienceClientSideFetched,
+  }: {
+    cookie: FidesCookie;
+    experience: PrivacyExperience;
+    debug?: boolean;
+    isExperienceClientSideFetched: boolean;
+  }) => Promise<{
+    cookie: FidesCookie;
+    experience: Partial<PrivacyExperience>;
+  }>;
 } & FidesConfig): Promise<Partial<Fides>> => {
   let shouldInitOverlay: boolean = options.isOverlayEnabled;
   let effectiveExperience = experience;
@@ -312,34 +324,15 @@ export const initialize = async ({
       isPrivacyExperience(effectiveExperience) &&
       experienceIsValid(effectiveExperience, options)
     ) {
-      if (options.fidesString) {
-        if (fetchedClientSideExperience) {
-          // if tc str was explicitly passed in, we need to override the client-side-fetched experience with consent from the cookie
-          // we don't update cookie because it already has been overridden by the injected fidesString
-          debugLog(
-            options.debug,
-            "Overriding preferences from client-side fetched experience with cookie fides_string consent",
-            cookie.fides_string
-          );
-          const tcfEntities = buildTcfEntitiesFromCookie(
-            effectiveExperience,
-            cookie
-          );
-          Object.assign(effectiveExperience, tcfEntities);
-        }
-      } else {
-        const updatedCookie = await updateCookie(
-          cookie,
-          effectiveExperience,
-          options.debug
-        );
-        debugLog(
-          options.debug,
-          "Updated cookie based on experience",
-          updatedCookie
-        );
-        Object.assign(cookie, updatedCookie);
-      }
+      const updated = await updateCookieAndExperience({
+        cookie,
+        experience: effectiveExperience,
+        debug: options.debug,
+        isExperienceClientSideFetched: fetchedClientSideExperience,
+      });
+      debugLog(options.debug, "Updated cookie and experience", updated);
+      Object.assign(cookie, updated.cookie);
+      Object.assign(effectiveExperience, updated.experience);
       if (shouldInitOverlay) {
         await initOverlay({
           experience: effectiveExperience,

--- a/clients/fides-js/src/lib/tcf/utils.ts
+++ b/clients/fides-js/src/lib/tcf/utils.ts
@@ -9,38 +9,44 @@ import { decodeFidesString, idsFromAcString } from "./fidesString";
 export const transformFidesStringToCookieKeys = (
   fidesString: string,
   debug: boolean
-): TcfCookieConsent => {
+): { cookieKeys: TcfCookieConsent; success: boolean } => {
   const { tc: tcString, ac: acString } = decodeFidesString(fidesString);
-  const tcModel: TCModel = TCString.decode(tcString);
-
   const cookieKeys: TcfCookieConsent = {};
+  try {
+    const tcModel: TCModel = TCString.decode(tcString);
+    // map tc model key to cookie key
+    TCF_KEY_MAP.forEach(({ tcfModelKey, cookieKey }) => {
+      if (tcfModelKey) {
+        const items: TcfCookieKeyConsent = {};
+        (tcModel[tcfModelKey] as Vector).forEach((consented, id) => {
+          items[id] = consented;
+        });
+        cookieKeys[cookieKey] = items;
+      }
+    });
 
-  // map tc model key to cookie key
-  TCF_KEY_MAP.forEach(({ tcfModelKey, cookieKey }) => {
-    if (tcfModelKey) {
-      const items: TcfCookieKeyConsent = {};
-      (tcModel[tcfModelKey] as Vector).forEach((consented, id) => {
-        items[id] = consented;
-      });
-      cookieKeys[cookieKey] = items;
-    }
-  });
-
-  // Set AC consents, which will only be on vendor_consents
-  const acIds = idsFromAcString(acString, debug);
-  acIds.forEach((acId) => {
-    if (!cookieKeys.vendor_consent_preferences) {
-      cookieKeys.vendor_consent_preferences = { [acId]: true };
-    } else {
-      cookieKeys.vendor_consent_preferences[acId] = true;
-    }
-  });
-  debugLog(
-    debug,
-    `Generated cookie.tcf_consent from explicit fidesString.`,
-    cookieKeys
-  );
-  return cookieKeys;
+    // Set AC consents, which will only be on vendor_consents
+    const acIds = idsFromAcString(acString, debug);
+    acIds.forEach((acId) => {
+      if (!cookieKeys.vendor_consent_preferences) {
+        cookieKeys.vendor_consent_preferences = { [acId]: true };
+      } else {
+        cookieKeys.vendor_consent_preferences[acId] = true;
+      }
+    });
+    debugLog(
+      debug,
+      `Generated cookie.tcf_consent from explicit fidesString.`,
+      cookieKeys
+    );
+    return { cookieKeys, success: true };
+  } catch (error) {
+    debugLog(
+      debug,
+      `Could not decode tcString ${tcString}, it may be invalid. ${error}`
+    );
+    return { cookieKeys, success: false };
+  }
 };
 
 export const generateFidesStringFromCookieTcfConsent = async (

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -1934,6 +1934,105 @@ describe("Fides-js TCF", () => {
           expect(tcData.vendor.legitimateInterests).to.eql({});
         });
     });
+
+    /**
+     * TEST CASE #8:
+     * 😬 1) fides_string override option exists but is invalid (via config.options.fidesString)
+     * ❌ 2) DEFER: preferences API (via a custom function)
+     * ❌ 3) local cookie (via fides_consent cookie)
+     * ❌ 4) "prefetched" experience (via config.options.experience)
+     * ✅ 5) experience API (via GET /privacy-experience)
+     *
+     * EXPECTED RESULT: ignore invalid fides_string option and render experience as-is
+     */
+    it("can handle an invalid fides_string option and continue rendering the experience", () => {
+      const fidesStringOverride = "invalid-string,1~";
+      cy.fixture("consent/experience_tcf.json").then((experience) => {
+        cy.fixture("consent/geolocation_tcf.json").then((geo) => {
+          stubConfig(
+            {
+              options: {
+                isOverlayEnabled: true,
+                tcfEnabled: true,
+                fidesString: fidesStringOverride,
+              },
+              experience: OVERRIDE.UNDEFINED,
+            },
+            geo,
+            experience
+          );
+        });
+      });
+
+      cy.waitUntilFidesInitialized().then(() => {
+        cy.window().then((win) => {
+          win.__tcfapi("addEventListener", 2, cy.stub().as("TCFEvent"));
+        });
+      });
+
+      cy.get("#fides-modal-link").click();
+
+      // Verify that all these are equal to the default experience, as if
+      // there had been no overrides.
+      // Purposes
+      cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_4.name}-consent`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_6.name}-consent`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_7.name}-consent`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_9.name}-consent`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      // Features
+      cy.get("#fides-tab-Features").click();
+      cy.getByTestId(`toggle-${SPECIAL_FEATURE_1.name}`).within(() => {
+        cy.get("input").should("not.be.checked");
+      });
+      // Vendors
+      cy.get("#fides-tab-Vendors").click();
+      cy.getByTestId(`toggle-${SYSTEM_1.name}`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${VENDOR_1.name}-consent`).within(() => {
+        cy.get("input").should("not.be.checked");
+      });
+
+      // verify CMP API
+      cy.get("@TCFEvent")
+        .its("lastCall.args")
+        .then(([tcData, success]) => {
+          expect(success).to.eql(true);
+          // Make sure our invalid fides string does not make it into tcData
+          expect(tcData.tcString).to.be.a("string");
+          expect(tcData.tcString).to.not.contain("invalid");
+          expect(tcData.eventStatus).to.eql("cmpuishown");
+          expect(tcData.purpose.consents).to.eql({
+            [PURPOSE_2.id]: true,
+            [PURPOSE_4.id]: true,
+            [PURPOSE_6.id]: true,
+            [PURPOSE_7.id]: true,
+            [PURPOSE_9.id]: true,
+            1: false,
+            2: false,
+            3: false,
+            5: false,
+            8: false,
+          });
+          expect(tcData.purpose.legitimateInterests).to.eql({
+            [PURPOSE_2.id]: true,
+            1: false,
+          });
+          expect(tcData.vendor.consents).to.eql({});
+          expect(tcData.vendor.legitimateInterests).to.eql({});
+        });
+    });
   });
 
   describe("fides_string override options", () => {

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -2178,7 +2178,7 @@ describe("Fides-js TCF", () => {
     });
   });
 
-  describe("ac string", () => {
+  describe.only("ac string", () => {
     const AC_IDS = [42, 33, 49];
     const acceptAllAcString = `1~${AC_IDS.sort().join(".")}`;
     const rejectAllAcString = "1~";
@@ -2242,13 +2242,15 @@ describe("Fides-js TCF", () => {
         expect(body.vendor_consent_preferences).to.eql(expected);
 
         // Check the cookie
-        cy.getCookie(CONSENT_COOKIE_NAME).then((cookie) => {
-          const cookieKeyConsent: FidesCookie = JSON.parse(
-            decodeURIComponent(cookie!.value)
-          );
-          const { fides_string: tcString } = cookieKeyConsent;
-          const acString = tcString?.split(",")[1];
-          expect(acString).to.eql(acceptAllAcString);
+        cy.waitUntilCookieExists(CONSENT_COOKIE_NAME).then(() => {
+          cy.getCookie(CONSENT_COOKIE_NAME).then((cookie) => {
+            const cookieKeyConsent: FidesCookie = JSON.parse(
+              decodeURIComponent(cookie!.value)
+            );
+            const { fides_string: tcString } = cookieKeyConsent;
+            const acString = tcString?.split(",")[1];
+            expect(acString).to.eql(acceptAllAcString);
+          });
         });
       });
     });
@@ -2268,13 +2270,15 @@ describe("Fides-js TCF", () => {
         expect(body.vendor_consent_preferences).to.eql(expected);
 
         // Check the cookie
-        cy.getCookie(CONSENT_COOKIE_NAME).then((cookie) => {
-          const cookieKeyConsent: FidesCookie = JSON.parse(
-            decodeURIComponent(cookie!.value)
-          );
-          const { fides_string: tcString } = cookieKeyConsent;
-          const acString = tcString?.split(",")[1];
-          expect(acString).to.eql(rejectAllAcString);
+        cy.waitUntilCookieExists(CONSENT_COOKIE_NAME).then(() => {
+          cy.getCookie(CONSENT_COOKIE_NAME).then((cookie) => {
+            const cookieKeyConsent: FidesCookie = JSON.parse(
+              decodeURIComponent(cookie!.value)
+            );
+            const { fides_string: tcString } = cookieKeyConsent;
+            const acString = tcString?.split(",")[1];
+            expect(acString).to.eql(rejectAllAcString);
+          });
         });
       });
     });

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -2178,7 +2178,7 @@ describe("Fides-js TCF", () => {
     });
   });
 
-  describe.only("ac string", () => {
+  describe("ac string", () => {
     const AC_IDS = [42, 33, 49];
     const acceptAllAcString = `1~${AC_IDS.sort().join(".")}`;
     const rejectAllAcString = "1~";


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1281

### Description Of Changes

Passing in an invalid `fides_string` will now ignore it instead of breaking the app!

In the video, both with and without a fides string give the same result.

https://github.com/ethyca/fides/assets/24641006/ad1103e5-ccb6-4451-aebe-8de27e59b648


### Code Changes

* [x] Add `try/catch` around decoding the tc string
* [x] If the decoding fails, reset the passed in `fides_string` to `null`

### Steps to Confirm

* [ ] See steps in the ticket

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`