### PR TITLE
Resurface TCF consent (frontend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.23.0...main)
 
+### Changed
+- Determine if the TCF overlay needs to surface based on backend calculated version hash [#4356](https://github.com/ethyca/fides/pull/4356)
+
 ## [2.23.0](https://github.com/ethyca/fides/compare/2.22.1...2.23.0)
 
 ### Added

--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -11,6 +11,7 @@ import { selectSystemsToClassify } from "~/features/system";
 import {
   AllowList,
   AllowListUpdate,
+  BulkCustomFieldRequest,
   ClassificationResponse,
   ClassifyCollection,
   ClassifyDatasetResponse,
@@ -196,7 +197,7 @@ const plusApi = baseApi.injectEndpoints({
       }),
       invalidatesTags: ["Custom Fields", "Datamap"],
     }),
-    bulkUpdateCustomFields: build.mutation<void, any>({
+    bulkUpdateCustomFields: build.mutation<void, BulkCustomFieldRequest>({
       query: (params) => ({
         url: `plus/custom-metadata/custom-field/bulk`,
         method: "POST",

--- a/clients/admin-ui/src/types/api/index.ts
+++ b/clients/admin-ui/src/types/api/index.ts
@@ -25,6 +25,7 @@ export type { BigQueryConfig } from "./models/BigQueryConfig";
 export type { BigQueryDocsSchema } from "./models/BigQueryDocsSchema";
 export type { Body_acquire_access_token_api_v1_oauth_token_post } from "./models/Body_acquire_access_token_api_v1_oauth_token_post";
 export type { Body_upload_data_api_v1_storage__request_id__post } from "./models/Body_upload_data_api_v1_storage__request_id__post";
+export type { BulkCustomFieldRequest } from "./models/BulkCustomFieldRequest";
 export type { BulkPostPrivacyRequests } from "./models/BulkPostPrivacyRequests";
 export type { BulkPutConnectionConfiguration } from "./models/BulkPutConnectionConfiguration";
 export type { BulkPutDataset } from "./models/BulkPutDataset";
@@ -210,6 +211,7 @@ export type { Page_ExperienceConfigResponse_ } from "./models/Page_ExperienceCon
 export type { Page_MessagingConfigResponse_ } from "./models/Page_MessagingConfigResponse_";
 export type { Page_PolicyResponse_ } from "./models/Page_PolicyResponse_";
 export type { Page_PolicyWebhookResponse_ } from "./models/Page_PolicyWebhookResponse_";
+export type { Page_PrivacyExperienceMetaResponse_ } from "./models/Page_PrivacyExperienceMetaResponse_";
 export type { Page_PrivacyExperienceResponse_ } from "./models/Page_PrivacyExperienceResponse_";
 export type { Page_PrivacyNoticeResponse_ } from "./models/Page_PrivacyNoticeResponse_";
 export type { Page_RuleResponseWithTargets_ } from "./models/Page_RuleResponseWithTargets_";
@@ -231,6 +233,7 @@ export type { PolicyWebhookUpdateResponse } from "./models/PolicyWebhookUpdateRe
 export type { PostgreSQLDocsSchema } from "./models/PostgreSQLDocsSchema";
 export type { PrivacyDeclaration } from "./models/PrivacyDeclaration";
 export type { PrivacyDeclarationResponse } from "./models/PrivacyDeclarationResponse";
+export type { PrivacyExperienceMetaResponse } from "./models/PrivacyExperienceMetaResponse";
 export type { PrivacyExperienceResponse } from "./models/PrivacyExperienceResponse";
 export type { PrivacyNoticeCreation } from "./models/PrivacyNoticeCreation";
 export type { PrivacyNoticeHistorySchema } from "./models/PrivacyNoticeHistorySchema";

--- a/clients/admin-ui/src/types/api/models/BulkCustomFieldRequest.ts
+++ b/clients/admin-ui/src/types/api/models/BulkCustomFieldRequest.ts
@@ -1,0 +1,13 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { CustomFieldWithId } from "./CustomFieldWithId";
+import type { ResourceTypes } from "./ResourceTypes";
+
+export type BulkCustomFieldRequest = {
+  resource_type: ResourceTypes;
+  resource_id: string;
+  upsert?: Array<CustomFieldWithId>;
+  delete?: Array<string>;
+};

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
@@ -35,7 +35,7 @@ export type ExperienceConfigCreate = {
    */
   privacy_policy_link_label?: string;
   /**
-   * Overlay and Privacy Center 'Privacy policy URl'
+   * Overlay and Privacy Center 'Privacy policy URL
    */
   privacy_policy_url?: string;
   /**

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
@@ -39,7 +39,7 @@ export type ExperienceConfigResponse = {
    */
   privacy_policy_link_label?: string;
   /**
-   * Overlay and Privacy Center 'Privacy policy URl'
+   * Overlay and Privacy Center 'Privacy policy URL
    */
   privacy_policy_url?: string;
   /**

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
@@ -38,7 +38,7 @@ export type ExperienceConfigUpdate = {
    */
   privacy_policy_link_label?: string;
   /**
-   * Overlay and Privacy Center 'Privacy policy URl'
+   * Overlay and Privacy Center 'Privacy policy URL
    */
   privacy_policy_url?: string;
   /**

--- a/clients/admin-ui/src/types/api/models/MySQLDocsSchema.ts
+++ b/clients/admin-ui/src/types/api/models/MySQLDocsSchema.ts
@@ -26,4 +26,8 @@ export type MySQLDocsSchema = {
    * The name of the specific database within the database server that you want to connect to.
    */
   dbname: string;
+  /**
+   * Indicates whether an SSH tunnel is required for the connection. Enable this option if your MySQL server is behind a firewall and requires SSH tunneling for remote connections.
+   */
+  ssh_required?: boolean;
 };

--- a/clients/admin-ui/src/types/api/models/Page_PrivacyExperienceMetaResponse_.ts
+++ b/clients/admin-ui/src/types/api/models/Page_PrivacyExperienceMetaResponse_.ts
@@ -1,0 +1,13 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { PrivacyExperienceMetaResponse } from "./PrivacyExperienceMetaResponse";
+
+export type Page_PrivacyExperienceMetaResponse_ = {
+  items: Array<PrivacyExperienceMetaResponse>;
+  total: number;
+  page: number;
+  size: number;
+  pages?: number;
+};

--- a/clients/admin-ui/src/types/api/models/PrivacyExperienceMetaResponse.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyExperienceMetaResponse.ts
@@ -1,0 +1,17 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ComponentType } from "./ComponentType";
+import type { ExperienceMeta } from "./ExperienceMeta";
+import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
+
+/**
+ * Privacy Experience Response only containing region, component, id, and meta information
+ */
+export type PrivacyExperienceMetaResponse = {
+  id: string;
+  region: PrivacyNoticeRegion;
+  component?: ComponentType;
+  meta?: ExperienceMeta;
+};

--- a/clients/admin-ui/src/types/api/models/ServingComponent.ts
+++ b/clients/admin-ui/src/types/api/models/ServingComponent.ts
@@ -10,4 +10,5 @@ export enum ServingComponent {
   BANNER = "banner",
   PRIVACY_CENTER = "privacy_center",
   TCF_OVERLAY = "tcf_overlay",
+  TCF_BANNER = "tcf_banner",
 }

--- a/clients/admin-ui/src/types/api/models/TCDecode.ts
+++ b/clients/admin-ui/src/types/api/models/TCDecode.ts
@@ -8,5 +8,5 @@ import type { TCMobileData } from "./TCMobileData";
  * Decode response schema for returning TC Mobile Data
  */
 export type TCDecode = {
-  fides_mobile_data: TCMobileData;
+  fides_mobile_data?: TCMobileData;
 };

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -54,7 +54,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
     if (bannerIsOpen) {
       onOpen();
     }
-  }, [bannerIsOpen]);
+  }, [bannerIsOpen, onOpen]);
 
   return (
     <div

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -2,7 +2,7 @@ import { h, FunctionComponent, VNode } from "preact";
 import { useEffect, useState, useCallback, useMemo } from "preact/hooks";
 import { FidesOptions, PrivacyExperience } from "../lib/consent-types";
 
-import { debugLog, hasActionNeededNotices } from "../lib/consent-utils";
+import { debugLog, resurfaceConsent } from "../lib/consent-utils";
 
 import "./fides.css";
 import { useA11yDialog } from "../lib/a11y-dialog";
@@ -116,7 +116,7 @@ const Overlay: FunctionComponent<Props> = ({
   const showBanner = useMemo(
     () =>
       experience.show_banner &&
-      hasActionNeededNotices(experience) &&
+      resurfaceConsent(experience) &&
       !options.fidesEmbed,
     [experience, options]
   );

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -66,7 +66,7 @@ const Overlay: FunctionComponent<Props> = ({
       instance.show();
       onOpen();
     }
-  }, [instance, cookie, options.debug]);
+  }, [instance, onOpen]);
 
   const handleCloseModal = useCallback(() => {
     if (instance && !options.fidesEmbed) {
@@ -116,9 +116,9 @@ const Overlay: FunctionComponent<Props> = ({
   const showBanner = useMemo(
     () =>
       experience.show_banner &&
-      resurfaceConsent(experience) &&
+      resurfaceConsent(experience, cookie) &&
       !options.fidesEmbed,
-    [experience, options]
+    [experience, options, cookie]
   );
 
   const handleManagePreferencesClick = (): void => {

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -2,7 +2,7 @@ import { h, FunctionComponent, VNode } from "preact";
 import { useEffect, useState, useCallback, useMemo } from "preact/hooks";
 import { FidesOptions, PrivacyExperience } from "../lib/consent-types";
 
-import { debugLog, resurfaceConsent } from "../lib/consent-utils";
+import { debugLog, shouldResurfaceConsent } from "../lib/consent-utils";
 
 import "./fides.css";
 import { useA11yDialog } from "../lib/a11y-dialog";
@@ -116,7 +116,7 @@ const Overlay: FunctionComponent<Props> = ({
   const showBanner = useMemo(
     () =>
       experience.show_banner &&
-      resurfaceConsent(experience, cookie) &&
+      shouldResurfaceConsent(experience, cookie) &&
       !options.fidesEmbed,
     [experience, options, cookie]
   );

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -13,7 +13,7 @@ import ConsentBanner from "../ConsentBanner";
 import { updateConsentPreferences } from "../../lib/preferences";
 import {
   debugLog,
-  hasActionNeededNotices,
+  resurfaceConsent,
   transformConsentToFidesUserPreference,
 } from "../../lib/consent-utils";
 
@@ -43,7 +43,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   >(initialEnabledNoticeKeys);
 
   const showBanner = useMemo(
-    () => experience.show_banner && hasActionNeededNotices(experience),
+    () => experience.show_banner && resurfaceConsent(experience),
     [experience]
   );
 

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -13,7 +13,6 @@ import ConsentBanner from "../ConsentBanner";
 import { updateConsentPreferences } from "../../lib/preferences";
 import {
   debugLog,
-  resurfaceConsent,
   transformConsentToFidesUserPreference,
 } from "../../lib/consent-utils";
 
@@ -41,11 +40,6 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   const [draftEnabledNoticeKeys, setDraftEnabledNoticeKeys] = useState<
     Array<PrivacyNotice["notice_key"]>
   >(initialEnabledNoticeKeys);
-
-  const showBanner = useMemo(
-    () => experience.show_banner && resurfaceConsent(experience),
-    [experience]
-  );
 
   const privacyNotices = useMemo(
     () => experience.privacy_notices ?? [],
@@ -149,32 +143,28 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
       experience={experience}
       cookie={cookie}
       onOpen={dispatchOpenOverlayEvent}
-      renderBanner={({ isOpen, onClose, onSave, onManagePreferencesClick }) =>
-        showBanner ? (
-          <ConsentBanner
-            bannerIsOpen={isOpen}
-            onOpen={dispatchOpenBannerEvent}
-            onClose={onClose}
-            experience={experienceConfig}
-            renderButtonGroup={({ isMobile }) => (
-              <NoticeConsentButtons
-                experience={experience}
-                onManagePreferencesClick={onManagePreferencesClick}
-                enabledKeys={draftEnabledNoticeKeys}
-                onSave={(keys) => {
-                  handleUpdatePreferences(keys);
-                  onSave();
-                }}
-                isAcknowledge={isAllNoticeOnly}
-                middleButton={
-                  <PrivacyPolicyLink experience={experienceConfig} />
-                }
-                isMobile={isMobile}
-              />
-            )}
-          />
-        ) : null
-      }
+      renderBanner={({ isOpen, onClose, onSave, onManagePreferencesClick }) => (
+        <ConsentBanner
+          bannerIsOpen={isOpen}
+          onOpen={dispatchOpenBannerEvent}
+          onClose={onClose}
+          experience={experienceConfig}
+          renderButtonGroup={({ isMobile }) => (
+            <NoticeConsentButtons
+              experience={experience}
+              onManagePreferencesClick={onManagePreferencesClick}
+              enabledKeys={draftEnabledNoticeKeys}
+              onSave={(keys) => {
+                handleUpdatePreferences(keys);
+                onSave();
+              }}
+              isAcknowledge={isAllNoticeOnly}
+              middleButton={<PrivacyPolicyLink experience={experienceConfig} />}
+              isMobile={isMobile}
+            />
+          )}
+        />
+      )}
       renderModalContent={() => (
         <div>
           <div className="fides-modal-notices">

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -119,23 +119,23 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
     ]
   );
 
+  const dispatchOpenBannerEvent = useCallback(() => {
+    dispatchFidesEvent("FidesUIShown", cookie, options.debug, {
+      servingComponent: ServingComponent.BANNER,
+    });
+  }, [cookie, options.debug]);
+
+  const dispatchOpenOverlayEvent = useCallback(() => {
+    dispatchFidesEvent("FidesUIShown", cookie, options.debug, {
+      servingComponent: ServingComponent.OVERLAY,
+    });
+  }, [cookie, options.debug]);
+
   if (!experience.experience_config) {
     debugLog(options.debug, "No experience config found");
     return null;
   }
   const experienceConfig = experience.experience_config;
-
-  const dispatchOpenBannerEvent = () => {
-    dispatchFidesEvent("FidesUIShown", cookie, options.debug, {
-      servingComponent: ServingComponent.BANNER,
-    });
-  };
-
-  const dispatchOpenOverlayEvent = () => {
-    dispatchFidesEvent("FidesUIShown", cookie, options.debug, {
-      servingComponent: ServingComponent.OVERLAY,
-    });
-  };
 
   return (
     <Overlay

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -5,7 +5,6 @@ import PrivacyPolicyLink from "../PrivacyPolicyLink";
 
 import {
   debugLog,
-  resurfaceConsent,
   transformConsentToFidesUserPreference,
   transformUserPreferenceToBoolean,
 } from "../../lib/consent-utils";
@@ -284,11 +283,6 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
 
   const [draftIds, setDraftIds] = useState<EnabledIds>(initialEnabledIds);
 
-  const showBanner = useMemo(
-    () => experience.show_banner && resurfaceConsent(experience),
-    [experience]
-  );
-
   const { servedNotices } = useConsentServed({
     notices: [],
     options,
@@ -355,7 +349,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
           onManagePreferencesClick();
           setActiveTabIndex(2);
         };
-        return showBanner ? (
+        return (
           <ConsentBanner
             bannerIsOpen={isOpen}
             onOpen={dispatchOpenBannerEvent}
@@ -384,7 +378,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
               <InitialLayer experience={experience} />
             </div>
           </ConsentBanner>
-        ) : null;
+        );
       }}
       renderModalContent={() => (
         <TcfTabs

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -247,6 +247,7 @@ const updateCookie = async (
     ...oldCookie,
     fides_string: tcString,
     tcf_consent: transformTcfPreferencesToCookieKeys(tcf),
+    tcf_version_hash: experience.meta?.version_hash,
   };
 };
 

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -318,23 +318,23 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
 
   const [activeTabIndex, setActiveTabIndex] = useState(0);
 
+  const dispatchOpenBannerEvent = useCallback(() => {
+    dispatchFidesEvent("FidesUIShown", cookie, options.debug, {
+      servingComponent: ServingComponent.TCF_BANNER,
+    });
+  }, [cookie, options.debug]);
+
+  const dispatchOpenOverlayEvent = useCallback(() => {
+    dispatchFidesEvent("FidesUIShown", cookie, options.debug, {
+      servingComponent: ServingComponent.TCF_OVERLAY,
+    });
+  }, [cookie, options.debug]);
+
   if (!experience.experience_config) {
     debugLog(options.debug, "No experience config found");
     return null;
   }
   const experienceConfig = experience.experience_config;
-
-  const dispatchOpenBannerEvent = () => {
-    dispatchFidesEvent("FidesUIShown", cookie, options.debug, {
-      servingComponent: ServingComponent.TCF_BANNER,
-    });
-  };
-
-  const dispatchOpenOverlayEvent = () => {
-    dispatchFidesEvent("FidesUIShown", cookie, options.debug, {
-      servingComponent: ServingComponent.TCF_OVERLAY,
-    });
-  };
 
   return (
     <Overlay

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -5,7 +5,7 @@ import PrivacyPolicyLink from "../PrivacyPolicyLink";
 
 import {
   debugLog,
-  hasActionNeededNotices,
+  resurfaceConsent,
   transformConsentToFidesUserPreference,
   transformUserPreferenceToBoolean,
 } from "../../lib/consent-utils";
@@ -285,7 +285,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
   const [draftIds, setDraftIds] = useState<EnabledIds>(initialEnabledIds);
 
   const showBanner = useMemo(
-    () => experience.show_banner && hasActionNeededNotices(experience),
+    () => experience.show_banner && resurfaceConsent(experience),
     [experience]
   );
 

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -212,15 +212,15 @@ export type ExperienceMeta = {
    */
   version_hash?: string;
   /**
-   * The TC string corresponding to a user opting in to all available options
+   * The fides string (TC String + AC String) corresponding to a user opting in to all available options
    */
-  accept_all_tc_string?: string;
-  accept_all_tc_mobile_data?: TCMobileData;
+  accept_all_fides_string?: string;
+  accept_all_fides_mobile_data?: TCMobileData;
   /**
-   * The TC string corresponding to a user opting out of all available options
+   * The fides string (TC String + AC String) corresponding to a user opting out of all available options
    */
-  reject_all_tc_string?: string;
-  reject_all_tc_mobile_data?: TCMobileData;
+  reject_all_fides_string?: string;
+  reject_all_fides_mobile_data?: TCMobileData;
 };
 
 export type PrivacyExperience = {

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -249,8 +249,9 @@ export const hasActionNeededTcfPreferences = (experience: PrivacyExperience) =>
 
 /**
  * Returns true if there are notices in the experience that require a user preference
+ * or if an experience's version hash does not match up.
  */
-export const hasActionNeededNotices = (experience: PrivacyExperience) => {
+export const resurfaceConsent = (experience: PrivacyExperience) => {
   if (experience.component === ComponentType.TCF_OVERLAY) {
     return hasActionNeededTcfPreferences(experience);
   }

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -238,7 +238,7 @@ export const hasSavedTcfPreferences = (experience: PrivacyExperience) =>
  * Returns true if there are notices in the experience that require a user preference
  * or if an experience's version hash does not match up.
  */
-export const resurfaceConsent = (
+export const shouldResurfaceConsent = (
   experience: PrivacyExperience,
   cookie: FidesCookie
 ) => {

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -9,6 +9,7 @@ import {
 import {
   ConsentMechanism,
   Cookies,
+  ExperienceMeta,
   LegacyConsentConfig,
   PrivacyExperience,
   SaveConsentPreference,
@@ -60,6 +61,7 @@ export interface FidesCookie {
   fides_meta: CookieMeta;
   fides_string?: string;
   tcf_consent: TcfCookieConsent;
+  tcf_version_hash?: ExperienceMeta["version_hash"];
 }
 
 /**

--- a/clients/privacy-center/cypress/support/mocks.ts
+++ b/clients/privacy-center/cypress/support/mocks.ts
@@ -3,6 +3,7 @@ import {
   EnforcementLevel,
   ConsentMechanism,
   UserConsentPreference,
+  FidesCookie,
 } from "fides-js";
 
 export const mockPrivacyNotice = (params: Partial<PrivacyNotice>) => {
@@ -33,4 +34,22 @@ export const mockPrivacyNotice = (params: Partial<PrivacyNotice>) => {
     cookies: [],
   };
   return { ...notice, ...params };
+};
+
+export const mockCookie = (params: Partial<FidesCookie>) => {
+  const uuid = "4fbb6edf-34f6-4717-a6f1-541fd1e5d585";
+  const CREATED_DATE = "2022-12-24T12:00:00.000Z";
+  const UPDATED_DATE = "2022-12-25T12:00:00.000Z";
+  const cookie: FidesCookie = {
+    identity: { fides_user_device_id: uuid },
+    fides_meta: {
+      version: "0.9.0",
+      createdAt: CREATED_DATE,
+      updatedAt: UPDATED_DATE,
+    },
+    consent: {},
+    tcf_consent: {},
+  };
+
+  return { ...cookie, ...params };
 };


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1281

### Description Of Changes

Rely on the backend calculated `version_hash` to determine whether or not to resurface the banner.

https://www.loom.com/share/0a3d388b388543428c1b75ede2184e21?sid=44f41194-e921-4217-b42c-70185d4c44c0


### Code Changes

* [x] Autogenerate TS types
* [x] Rework logic to surface the banner (and rename the function to `resurfaceConsent`) to compare TCF hashes and save the hash in our cookie
* [x] Remove redundant `showBanner` check
* [x] Update cypress tests
* [x] Add a `mockCookie` function to help with testing

### Steps to Confirm
See loom video for an example

* [ ] Set up TCF and save your preferences
* [ ] You should see a new field `tcf_version_hash` in your cookie
* [ ] In admin-ui, add another system with TCF properties
* [ ] Refresh your TCF page
* [ ] The banner should resurface
* [ ] Save your preferences again
* [ ] Refresh the page
* [ ] The banner should not resurface

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
