### PR TITLE
Remove duplicate `FidesUpdated` event and trigger `FidesInitialized` twice instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The types of changes are:
 ### Changed
 - Determine if the TCF overlay needs to surface based on backend calculated version hash [#4356](https://github.com/ethyca/fides/pull/4356)
 - Refactor Fides.js embedded modal to not use A11y dialog [#4355](https://github.com/ethyca/fides/pull/4355)
+- Only call `FidesUpdated` when a preference has been saved, not during initialization [#4365](https://github.com/ethyca/fides/pull/4365)
 
 ### Fixed
 - Bug where vendor opt-ins would not initialize properly based on a `fides_string` in the TCF overlay [#4368](https://github.com/ethyca/fides/pull/4368)

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -72,7 +72,6 @@ import {
   experienceIsValid,
   FidesCookie,
   hasSavedTcfPreferences,
-  isNewFidesCookie,
   isPrivacyExperience,
   tcfConsentCookieObjHasSomeConsentSet,
   transformTcfPreferencesToCookieKeys,
@@ -225,7 +224,7 @@ const init = async (config: FidesConfig) => {
   Object.assign(_Fides, updatedFides);
 
   // Dispatch the "FidesInitialized" event to update listeners with the initial state.
-  // TODO: Suppress duplicate event if the cookie state is unchanged from an early initialization above?
+  // TODO PROD-1280: Suppress duplicate event if the cookie state is unchanged from an early initialization?
   dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
 };
 

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -213,7 +213,6 @@ const init = async (config: FidesConfig) => {
   if (initialFides) {
     Object.assign(_Fides, initialFides);
     dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
-    dispatchFidesEvent("FidesUpdated", cookie, config.options.debug);
   }
   const experience = initialFides?.experience ?? config.experience;
   const updatedFides = await initialize({
@@ -225,14 +224,9 @@ const init = async (config: FidesConfig) => {
   });
   Object.assign(_Fides, updatedFides);
 
-  // Dispatch the "FidesInitialized" event to update listeners with the initial
-  // state. Skip if we already initialized due to an existing cookie.
-  // For convenience, also dispatch the "FidesUpdated" event; this allows
-  // listeners to ignore the initialization event if they prefer
-  if (isNewFidesCookie(cookie)) {
-    dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
-  }
-  dispatchFidesEvent("FidesUpdated", cookie, config.options.debug);
+  // Dispatch the "FidesInitialized" event to update listeners with the initial state.
+  // TODO: Suppress duplicate event if the cookie state is unchanged from an early initialization above?
+  dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
 };
 
 // The global Fides object; this is bound to window.Fides if available

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -224,7 +224,6 @@ const init = async (config: FidesConfig) => {
   Object.assign(_Fides, updatedFides);
 
   // Dispatch the "FidesInitialized" event to update listeners with the initial state.
-  // TODO PROD-1280: Suppress duplicate event if the cookie state is unchanged from an early initialization?
   dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
 };
 

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -48,10 +48,7 @@ import { gtm } from "./integrations/gtm";
 import { meta } from "./integrations/meta";
 import { shopify } from "./integrations/shopify";
 
-import {
-  FidesCookie,
-  buildCookieConsentForExperiences,
-} from "./lib/cookie";
+import { FidesCookie, buildCookieConsentForExperiences } from "./lib/cookie";
 import {
   FidesConfig,
   FidesOptionOverrides,
@@ -125,7 +122,6 @@ const init = async (config: FidesConfig) => {
   Object.assign(_Fides, updatedFides);
 
   // Dispatch the "FidesInitialized" event to update listeners with the initial state.
-  // TODO PROD-1280: Suppress duplicate event if the cookie state is unchanged from an early initialization?
   dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
 };
 

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -109,12 +109,11 @@ const init = async (config: FidesConfig) => {
     getOverrideFidesOptions();
   // eslint-disable-next-line no-param-reassign
   config.options = { ...config.options, ...overrideOptions };
-  const cookie = getInitialCookie(config);
+  let cookie = getInitialCookie(config);
   const initialFides = getInitialFides({ ...config, cookie });
   if (initialFides) {
     Object.assign(_Fides, initialFides);
     dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
-    dispatchFidesEvent("FidesUpdated", cookie, config.options.debug);
   }
   const experience = initialFides?.experience ?? config.experience;
   const updatedFides = await initialize({
@@ -126,14 +125,9 @@ const init = async (config: FidesConfig) => {
   });
   Object.assign(_Fides, updatedFides);
 
-  // Dispatch the "FidesInitialized" event to update listeners with the initial
-  // state. Skip if we already initialized due to an existing cookie.
-  // For convenience, also dispatch the "FidesUpdated" event; this allows
-  // listeners to ignore the initialization event if they prefer
-  if (isNewFidesCookie(cookie)) {
-    dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
-  }
-  dispatchFidesEvent("FidesUpdated", cookie, config.options.debug);
+  // Dispatch the "FidesInitialized" event to update listeners with the initial state.
+  // TODO: Suppress duplicate event if the cookie state is unchanged from an early initialization above?
+  dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
 };
 
 // The global Fides object; this is bound to window.Fides if available

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -51,7 +51,6 @@ import { shopify } from "./integrations/shopify";
 import {
   FidesCookie,
   buildCookieConsentForExperiences,
-  isNewFidesCookie,
 } from "./lib/cookie";
 import {
   FidesConfig,
@@ -109,7 +108,7 @@ const init = async (config: FidesConfig) => {
     getOverrideFidesOptions();
   // eslint-disable-next-line no-param-reassign
   config.options = { ...config.options, ...overrideOptions };
-  let cookie = getInitialCookie(config);
+  const cookie = getInitialCookie(config);
   const initialFides = getInitialFides({ ...config, cookie });
   if (initialFides) {
     Object.assign(_Fides, initialFides);
@@ -126,7 +125,7 @@ const init = async (config: FidesConfig) => {
   Object.assign(_Fides, updatedFides);
 
   // Dispatch the "FidesInitialized" event to update listeners with the initial state.
-  // TODO: Suppress duplicate event if the cookie state is unchanged from an early initialization above?
+  // TODO PROD-1280: Suppress duplicate event if the cookie state is unchanged from an early initialization?
   dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
 };
 

--- a/clients/fides-js/src/lib/events.ts
+++ b/clients/fides-js/src/lib/events.ts
@@ -4,7 +4,7 @@ import { debugLog } from "./consent-utils";
 /**
  * Defines the available event names:
  * - FidesInitialized: dispatched when initialization is complete, from Fides.init()
- * - FidesUpdated: dispatched when preferences are updated, from updateConsentPreferences() or Fides.init()
+ * - FidesUpdated: dispatched when preferences are updated from updateConsentPreferences()
  * - FidesUIShown: dispatched when either the banner or modal is shown to the user
  * - FidesUIChanged: dispatched when preferences are changed but not saved, i.e. "dirty".
  * - FidesModalClosed: dispatched when the modal is closed
@@ -45,11 +45,13 @@ export type FidesEvent = CustomEvent<FidesEventDetail>;
  *
  * Example usage:
  * ```
+ * window.addEventListener("FidesInitialized", (evt) => console.log("Fides.consent initialized:", evt.detail.consent));
  * window.addEventListener("FidesUpdated", (evt) => console.log("Fides.consent updated:", evt.detail.consent));
  * ```
  *
- * The snippet above will print a console log whenever consent preferences are initialized/updated, like:
+ * The snippet above will print a console log whenever consent preferences are updated, like:
  * ```
+ * Fides.consent initialized: { data_sales_and_sharing: false }
  * Fides.consent updated: { data_sales_and_sharing: true }
  * ```
  */

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -1399,7 +1399,7 @@ describe("Fides-js TCF", () => {
         cy.getByTestId("consent-modal").within(() => {
           cy.get("button").contains("Opt in to all").click();
         });
-        cy.get("@FidesUpdated").should("have.been.calledTwice");
+        cy.get("@FidesUpdated").should("have.been.calledOnce");
         cy.get("@TCFEvent2")
           .its("lastCall.args")
           .then(([tcData, success]) => {

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -343,7 +343,7 @@ describe("Fides-js TCF", () => {
         cy.getByTestId("consent-modal").within(() => {
           cy.get("button").contains("Opt in to all").click();
         });
-        cy.get("@FidesUpdated").should("have.been.calledTwice");
+        cy.get("@FidesUpdated").should("have.been.calledOnce");
         cy.window().then((win) => {
           win.__tcfapi("getTCData", 2, cy.stub().as("getTCData"));
           cy.get("@getTCData")
@@ -1331,12 +1331,12 @@ describe("Fides-js TCF", () => {
 
     describe("setting fields", () => {
       it("can opt in to all and set legitimate interests", () => {
-        cy.get("@FidesUpdated").should("have.been.calledOnce");
+        cy.get("@FidesUpdated").should("not.have.been.called");
         cy.getByTestId("consent-modal").within(() => {
           cy.get("button").contains("Opt in to all").click();
         });
         // On slow connections, we should explicitly wait for FidesUpdated
-        cy.get("@FidesUpdated").should("have.been.calledTwice");
+        cy.get("@FidesUpdated").should("have.been.calledOnce");
         cy.get("@TCFEvent")
           .its("lastCall.args")
           .then(([tcData, success]) => {
@@ -2191,8 +2191,8 @@ describe("Fides-js TCF", () => {
       cy.get("button").contains("Save").click();
       cy.wait("@patchPrivacyPreference");
       cy.get("@FidesUpdated")
-        .should("have.been.calledTwice")
-        .its("secondCall.args.0.detail.fides_string")
+        .should("have.been.calledOnce")
+        .its("lastCall.args.0.detail.fides_string")
         .then((fidesString) => {
           const parts = fidesString.split(",");
           expect(parts.length).to.eql(2);
@@ -2221,7 +2221,7 @@ describe("Fides-js TCF", () => {
       });
       cy.get("button").contains("Save").click();
       cy.wait("@patchPrivacyPreference");
-      cy.get("@FidesUpdated").should("have.been.calledTwice");
+      cy.get("@FidesUpdated").should("have.been.calledOnce");
       // Call getTCData
       cy.window().then((win) => {
         win.__tcfapi("getTCData", 2, cy.stub().as("getTCData"));
@@ -2271,8 +2271,7 @@ describe("Fides-js TCF", () => {
       });
 
       cy.get("@FidesInitialized")
-        .should("have.been.calledOnce")
-        .its("firstCall.args.0.detail.tcf_consent")
+        .its("lastCall.args.0.detail.tcf_consent")
         .then((tcfConsent) => {
           // TC string setting worked
           expect(tcfConsent.purpose_consent_preferences).to.eql({

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -407,7 +407,7 @@ describe("Consent banner", () => {
 
         it("can remove all cookies when rejecting all", () => {
           cy.contains("button", "Reject Test").click();
-          cy.get("@FidesUpdated").should("have.been.calledTwice");
+          cy.get("@FidesUpdated").should("have.been.calledOnce");
           cy.getAllCookies().then((allCookies) => {
             expect(allCookies.map((c) => c.name)).to.eql([CONSENT_COOKIE_NAME]);
           });
@@ -418,7 +418,7 @@ describe("Consent banner", () => {
           // opt out of the first notice
           cy.getByTestId("toggle-one").click();
           cy.getByTestId("Save test-btn").click();
-          cy.get("@FidesUpdated").should("have.been.calledTwice");
+          cy.get("@FidesUpdated").should("have.been.calledOnce");
           cy.getAllCookies().then((allCookies) => {
             expect(allCookies.map((c) => c.name)).to.eql([
               CONSENT_COOKIE_NAME,
@@ -1105,7 +1105,7 @@ describe("Consent banner", () => {
           [PRIVACY_NOTICE_KEY_1]: false,
           [PRIVACY_NOTICE_KEY_2]: true,
         });
-      cy.get("@FidesUpdated").should("not.have.been.called")
+      cy.get("@FidesUpdated").should("not.have.been.called");
       cy.get("@FidesUIChanged").should("not.have.been.called");
     });
 
@@ -1360,7 +1360,9 @@ describe("Consent banner", () => {
           analytics: true,
         });
         cy.get("@FidesInitialized")
-          .should("have.been.calledOnce")
+          // TODO PROD-1280: Suppress duplicate event if the cookie state is unchanged from an early initialization?
+          // .should("have.been.calledOnce")
+          .should("have.been.calledTwice")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
             data_sales: false,
@@ -1407,7 +1409,9 @@ describe("Consent banner", () => {
           analytics: true,
         });
         cy.get("@FidesInitialized")
-          .should("have.been.calledOnce")
+          // TODO PROD-1280: Suppress duplicate event if the cookie state is unchanged from an early initialization?
+          // .should("have.been.calledOnce")
+          .should("have.been.calledTwice")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
             data_sales: false,

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -1360,8 +1360,6 @@ describe("Consent banner", () => {
           analytics: true,
         });
         cy.get("@FidesInitialized")
-          // TODO PROD-1280: Suppress duplicate event if the cookie state is unchanged from an early initialization?
-          // .should("have.been.calledOnce")
           .should("have.been.calledTwice")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
@@ -1409,8 +1407,6 @@ describe("Consent banner", () => {
           analytics: true,
         });
         cy.get("@FidesInitialized")
-          // TODO PROD-1280: Suppress duplicate event if the cookie state is unchanged from an early initialization?
-          // .should("have.been.calledOnce")
           .should("have.been.calledTwice")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -1090,7 +1090,7 @@ describe("Consent banner", () => {
 
     // NOTE: See definition of cy.visitConsentDemo in commands.ts for where we
     // register listeners for these window events
-    it("emits both a FidesInitialized and FidesUpdated event when initialized", () => {
+    it("emits a FidesInitialized but not a FidesUpdated event when initialized", () => {
       cy.window()
         .its("Fides")
         .its("consent")
@@ -1105,51 +1105,47 @@ describe("Consent banner", () => {
           [PRIVACY_NOTICE_KEY_1]: false,
           [PRIVACY_NOTICE_KEY_2]: true,
         });
-      cy.get("@FidesUpdated")
-        .should("have.been.calledOnce")
-        .its("firstCall.args.0.detail.consent")
-        .should("deep.equal", {
-          [PRIVACY_NOTICE_KEY_1]: false,
-          [PRIVACY_NOTICE_KEY_2]: true,
-        });
+      cy.get("@FidesUpdated").should("not.have.been.called")
       cy.get("@FidesUIChanged").should("not.have.been.called");
     });
 
     describe("when preferences are changed / saved", () => {
-      it("emits another FidesUpdated event when reject all is clicked", () => {
+      it("emits a FidesUpdated event when reject all is clicked", () => {
         cy.contains("button", "Reject Test").should("be.visible").click();
         cy.get("@FidesUIChanged").should("not.have.been.called");
-        cy.get("@FidesUpdated")
-          .should("have.been.calledTwice")
-          // First call should be from initialization, before the user rejects all
+        cy.get("@FidesInitialized")
+          // First event, before the user rejects all
+          .should("have.been.calledOnce")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
             [PRIVACY_NOTICE_KEY_1]: false,
             [PRIVACY_NOTICE_KEY_2]: true,
           });
         cy.get("@FidesUpdated")
-          // Second call is when the user rejects all
-          .its("secondCall.args.0.detail.consent")
+          // Update event, when the user rejects all
+          .should("have.been.calledOnce")
+          .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
             [PRIVACY_NOTICE_KEY_1]: false,
             [PRIVACY_NOTICE_KEY_2]: true,
           });
       });
 
-      it("emits another FidesUpdated event when accept all is clicked", () => {
+      it("emits a FidesUpdated event when accept all is clicked", () => {
         cy.contains("button", "Accept Test").should("be.visible").click();
         cy.get("@FidesUIChanged").should("not.have.been.called");
-        cy.get("@FidesUpdated")
-          .should("have.been.calledTwice")
-          // First call should be from initialization, before the user accepts all
+        cy.get("@FidesInitialized")
+          // First event, before the user accepts all
+          .should("have.been.calledOnce")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
             [PRIVACY_NOTICE_KEY_1]: false,
             [PRIVACY_NOTICE_KEY_2]: true,
           });
         cy.get("@FidesUpdated")
-          // Second call is when the user accepts all
-          .its("secondCall.args.0.detail.consent")
+          // Update event, when the user accepts all
+          .should("have.been.calledOnce")
+          .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
             [PRIVACY_NOTICE_KEY_1]: true,
             [PRIVACY_NOTICE_KEY_2]: true,
@@ -1163,17 +1159,18 @@ describe("Consent banner", () => {
         cy.getByTestId("toggle-Test privacy notice").click();
         cy.getByTestId("consent-modal").contains("Save").click();
         cy.get("@FidesUIChanged").should("have.been.calledOnce");
-        cy.get("@FidesUpdated")
-          .should("have.been.calledTwice")
-          // First call should be from initialization, before the user saved preferences
+        cy.get("@FidesInitialized")
+          // First event, before the user saved preferences
+          .should("have.been.calledOnce")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
             [PRIVACY_NOTICE_KEY_1]: false,
             [PRIVACY_NOTICE_KEY_2]: true,
           });
         cy.get("@FidesUpdated")
-          // Second call is when the user saved preferences and opted-in to the first notice
-          .its("secondCall.args.0.detail.consent")
+          // Update event, when the user saved preferences and opted-in to the first notice
+          .should("have.been.calledOnce")
+          .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
             [PRIVACY_NOTICE_KEY_1]: true,
             [PRIVACY_NOTICE_KEY_2]: true,
@@ -1255,21 +1252,14 @@ describe("Consent banner", () => {
             [PRIVACY_NOTICE_KEY_2]: true,
           });
         cy.get("@FidesInitialized")
-          .should("have.been.calledOnce")
+          .should("have.been.calledTwice")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
             data_sales: false,
             tracking: false,
             analytics: true,
           });
-        cy.get("@FidesUpdated")
-          .its("firstCall.args.0.detail.consent")
-          .should("deep.equal", {
-            data_sales: false,
-            tracking: false,
-            analytics: true,
-          });
-        cy.get("@FidesUpdated")
+        cy.get("@FidesInitialized")
           .its("secondCall.args.0.detail.consent")
           .should("deep.equal", {
             [PRIVACY_NOTICE_KEY_1]: false,
@@ -1316,21 +1306,14 @@ describe("Consent banner", () => {
             [PRIVACY_NOTICE_KEY_2]: true,
           });
         cy.get("@FidesInitialized")
-          .should("have.been.calledOnce")
+          .should("have.been.calledTwice")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
             data_sales: false,
             tracking: false,
             analytics: true,
           });
-        cy.get("@FidesUpdated")
-          .its("firstCall.args.0.detail.consent")
-          .should("deep.equal", {
-            data_sales: false,
-            tracking: false,
-            analytics: true,
-          });
-        cy.get("@FidesUpdated")
+        cy.get("@FidesInitialized")
           .its("secondCall.args.0.detail.consent")
           .should("deep.equal", {
             [PRIVACY_NOTICE_KEY_1]: false,
@@ -1384,20 +1367,6 @@ describe("Consent banner", () => {
             tracking: false,
             analytics: true,
           });
-        cy.get("@FidesUpdated")
-          .its("firstCall.args.0.detail.consent")
-          .should("deep.equal", {
-            data_sales: false,
-            tracking: false,
-            analytics: true,
-          });
-        cy.get("@FidesUpdated")
-          .its("secondCall.args.0.detail.consent")
-          .should("deep.equal", {
-            data_sales: false,
-            tracking: false,
-            analytics: true,
-          });
       });
     });
 
@@ -1440,20 +1409,6 @@ describe("Consent banner", () => {
         cy.get("@FidesInitialized")
           .should("have.been.calledOnce")
           .its("firstCall.args.0.detail.consent")
-          .should("deep.equal", {
-            data_sales: false,
-            tracking: false,
-            analytics: true,
-          });
-        cy.get("@FidesUpdated")
-          .its("firstCall.args.0.detail.consent")
-          .should("deep.equal", {
-            data_sales: false,
-            tracking: false,
-            analytics: true,
-          });
-        cy.get("@FidesUpdated")
-          .its("secondCall.args.0.detail.consent")
           .should("deep.equal", {
             data_sales: false,
             tracking: false,


### PR DESCRIPTION
Closes [PROD-1280](https://ethyca.atlassian.net/browse/PROD-1280)

### Description Of Changes

`FidesUpdated` is now only called when a user makes a change, not after initialization. 


https://github.com/ethyca/fides/assets/24641006/cc23f278-9f79-450e-a6cd-c45b87b6499c



### Code Changes

* [x] Remove calls to `FidesUpdated` in initialization logic
* [x] Simplify `FidesInitialized` calls
* [x] Update tests

### Steps to Confirm

* [ ] Set up TCF or notices
* [ ] Visit the demo page and open the console
* [ ] You should see that `FidesInitialized` fired but no `FidesUpdated` fired
* [ ] You should not see `FidesUpdated` until you save your preferences

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`



[PROD-1280]: https://ethyca.atlassian.net/browse/PROD-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ