### PR TITLE
String override initialization bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The types of changes are:
 ### Changed
 - Refactor Fides.js embedded modal to not use A11y dialog [#4355](https://github.com/ethyca/fides/pull/4355)
 
+### Fixed
+- Bug where vendor opt-ins would not initialize properly based on a `fides_string` in the TCF overlay [#4368](https://github.com/ethyca/fides/pull/4368)
+
 ## [2.23.0](https://github.com/ethyca/fides/compare/2.22.1...2.23.0)
 
 ### Added

--- a/clients/fides-js/src/lib/tcf/utils.ts
+++ b/clients/fides-js/src/lib/tcf/utils.ts
@@ -17,10 +17,14 @@ export const transformFidesStringToCookieKeys = (
 
   // map tc model key to cookie key
   TCF_KEY_MAP.forEach(({ tcfModelKey, cookieKey }) => {
+    const isVendorKey =
+      tcfModelKey === "vendorConsents" ||
+      tcfModelKey === "vendorLegitimateInterests";
     if (tcfModelKey) {
       const items: TcfCookieKeyConsent = {};
       (tcModel[tcfModelKey] as Vector).forEach((consented, id) => {
-        items[id] = consented;
+        const key = isVendorKey ? `gvl.${id}` : id;
+        items[key] = consented;
       });
       cookieKeys[cookieKey] = items;
     }

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -276,7 +276,7 @@
       ],
       "tcf_vendor_consents": [
         {
-          "id": "2",
+          "id": "gvl.2",
           "has_vendor_id": true,
           "name": "Captify",
           "description": "A longer description",
@@ -314,7 +314,7 @@
         {
           "cookie_max_age_seconds": 360000,
           "cookie_refresh": true,
-          "id": "2",
+          "id": "gvl.2",
           "has_vendor_id": true,
           "name": "Captify",
           "description": "A longer description",

--- a/clients/privacy-center/cypress/fixtures/consent/notices_served_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/notices_served_tcf.json
@@ -93,7 +93,7 @@
     "purpose_consent": null,
     "purpose_legitimate_interests": null,
     "special_purpose": null,
-    "vendor_consent": "2",
+    "vendor_consent": "gvl.2",
     "vendor_legitimate_interests": null,
     "feature": null,
     "special_feature": null,


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1295

### Description Of Changes

There was a bug where vendor IDs weren't being parsed from the `fides_string` to the cookie properly. The cookie expects these IDs to be prefixed by `gvl` (since all TCF vendors in the experience will be prefixed by `gvl`, and that allows `updateExperienceFromCookieConsent` to work properly) but the TC string has no concept of our prefixed IDs.

https://www.loom.com/share/81339746560b4f7cbae7200fd1e6470e?sid=9fc5ad92-130b-4886-8ce5-e1f3718793d3


### Code Changes

* [x] Add a little bit of logic to add a `gvl` prefix when decoding from TC string to cookie
* [x] Update tests/fixtures to use id `gvl.2` instead of `2` now that our backend has been changed to always send `gvl` prefixed IDs
* [x] Add test specific to this bug

### Steps to Confirm

* [ ] See repro steps in the ticket!

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created https://ethyca.atlassian.net/browse/PROD-1298
* [x] Update `CHANGELOG.md`

