### PR TITLE
PROD-1241 Adds support for custom get preferences fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The types of changes are:
 ### Added
 - Adds fides_disable_banner config option to Fides.js [#4378](https://github.com/ethyca/fides/pull/4378)
 
+### Added
+- Added support for a custom get preferences API call provided through Fides.init [#4375](https://github.com/ethyca/fides/pull/4375)
+
 ### Changed
 - Add filtering and pagination to bulk vendor add table [#4351](https://github.com/ethyca/fides/pull/4351)
 - Determine if the TCF overlay needs to surface based on backend calculated version hash [#4356](https://github.com/ethyca/fides/pull/4356)

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -51,7 +51,7 @@ import { shopify } from "./integrations/shopify";
 import { FidesCookie, buildCookieConsentForExperiences } from "./lib/cookie";
 import {
   FidesConfig,
-  FidesOptionOverrides,
+  FidesOverrides,
   OverrideOptions,
   PrivacyExperience,
 } from "./lib/consent-types";
@@ -62,7 +62,7 @@ import {
   initialize,
   getInitialCookie,
   getInitialFides,
-  getOverrideFidesOptions,
+  getOverrides,
 } from "./lib/initialize";
 import type { Fides } from "./lib/initialize";
 
@@ -101,11 +101,13 @@ const updateCookie = async (
  * Initialize the global Fides object with the given configuration values
  */
 const init = async (config: FidesConfig) => {
-  const overrideOptions: Partial<FidesOptionOverrides> =
-    getOverrideFidesOptions();
+  const overrides: Partial<FidesOverrides> = await getOverrides(config);
   // eslint-disable-next-line no-param-reassign
-  config.options = { ...config.options, ...overrideOptions };
-  const cookie = getInitialCookie(config);
+  config.options = { ...config.options, ...overrides.overrideOptions };
+  const cookie = {
+    ...getInitialCookie(config),
+    ...overrides.overrideConsentPrefs?.consent,
+  };
   const initialFides = getInitialFides({ ...config, cookie });
   if (initialFides) {
     Object.assign(_Fides, initialFides);

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -83,6 +83,15 @@ export type FidesOptions = {
   apiOptions: FidesApiOptions | null;
 };
 
+export type GetPreferencesFnResp = {
+  // Overrides the value for Fides.consent for the user’s notice-based preferences (e.g. { data_sales: false })
+  consent?: CookieKeyConsent;
+  // Overrides the value for Fides.fides_string for the user’s TCF+AC preferences (e.g. 1a2a3a.AAABA,1~123.121)
+  fides_string?: string;
+  // An explicit version hash for provided fides_string when calculating whether consent should be re-triggered
+  version_hash?: string;
+};
+
 export type FidesApiOptions = {
   /**
    * Intake a custom function that is called instead of the internal Fides API to save user preferences.
@@ -91,11 +100,17 @@ export type FidesApiOptions = {
    * @param {string} fides_string - updated version of Fides.fides_string with the user's saved preferences for TC/AC/etc notices
    * @param {object} experience - current version of the privacy experience that was shown to the user
    */
-  savePreferencesFn: (
+  savePreferencesFn?: (
     consent: CookieKeyConsent,
     fides_string: string | undefined,
     experience: PrivacyExperience
   ) => Promise<void>;
+  /**
+   * Intake a custom function that is used to override users' saved preferences.
+   *
+   * @param {object} fides - global Fides obj containing global config options and other state at time of init
+   */
+  getPreferencesFn?: (fides: FidesConfig) => Promise<GetPreferencesFnResp>;
 };
 
 export class SaveConsentPreference {

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -368,6 +368,11 @@ export type FidesOptionOverrides = Pick<
   "fidesString" | "fidesDisableSaveApi" | "fidesEmbed" | "fidesDisableBanner"
 >;
 
+export type FidesOverrides = {
+  overrideOptions: Partial<FidesOptionOverrides>;
+  overrideConsentPrefs: GetPreferencesFnResp | null;
+};
+
 export enum ButtonType {
   PRIMARY = "primary",
   SECONDARY = "secondary",

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -320,7 +320,6 @@ export const initialize = async ({
       isPrivacyExperience(effectiveExperience) &&
       experienceIsValid(effectiveExperience, options)
     ) {
-      // get custom prefs
       const updated = await updateCookieAndExperience({
         cookie,
         experience: effectiveExperience,

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -143,7 +143,7 @@ const automaticallyApplyGPCPreferences = ({
 };
 
 /**
- * Gets and validates Fides override options provided through URL query params, cookie or window obj.
+ * Gets and validates Fides override options provided through URL query params, cookie, or window obj.
  *
  * If the same override option is provided in multiple ways, load the value in this order:
  * 1) query param  (top priority)
@@ -320,6 +320,7 @@ export const initialize = async ({
       isPrivacyExperience(effectiveExperience) &&
       experienceIsValid(effectiveExperience, options)
     ) {
+      // get custom prefs
       const updated = await updateCookieAndExperience({
         cookie,
         experience: effectiveExperience,

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -1,6 +1,8 @@
 import {
   ConsentMethod,
+  FidesConfig,
   FidesOptions,
+  GetPreferencesFnResp,
   LastServedConsentSchema,
   PrivacyExperience,
   PrivacyPreferencesRequest,
@@ -16,6 +18,28 @@ import {
 import { dispatchFidesEvent } from "./events";
 import { patchUserPreferenceToFidesServer } from "../services/fides/api";
 import { TcfSavePreferences } from "./tcf/types";
+
+/**
+ * Helper function to get preferences from an external API
+ */
+export async function getConsentPreferences(
+  config: FidesConfig
+): Promise<GetPreferencesFnResp | null> {
+  if (!config.options.apiOptions?.getPreferencesFn) {
+    return null;
+  }
+  debugLog(config.options.debug, "Calling custom get preferences fn");
+  try {
+    return await config.options.apiOptions.getPreferencesFn(config);
+  } catch (e) {
+    debugLog(
+      config.options.debug,
+      "Error retrieving preferences from API, continuing. Error: ",
+      e
+    );
+    return null;
+  }
+}
 
 /**
  * Helper function to save preferences to an API, either custom or internal

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -1427,7 +1427,7 @@ describe("Fides-js TCF", () => {
   /**
    * There are the following potential sources of user preferences:
    * 1) fides_string override option (via config.options.fidesString)
-   * 2) DEFER: preferences API (via a custom function)
+   * 2) preferences API (via a custom function)
    * 3) local cookie (via fides_consent cookie)
    * 4) "prefetched" experience (via config.options.experience)
    * 5) experience API (via GET /privacy-experience)
@@ -1462,7 +1462,7 @@ describe("Fides-js TCF", () => {
     /**
      * TEST CASE #1:
      * ❌ 1) fides_string override option (via config.options.fidesString)
-     * ❌ 2) DEFER: preferences API (via a custom function)
+     * ❌ 2) preferences API (via a custom function)
      * ✅ 3) local cookie (via fides_consent cookie)
      * ✅ 4) "prefetched" experience (via config.options.experience)
      * ❌ 5) experience API (via GET /privacy-experience)
@@ -1550,7 +1550,7 @@ describe("Fides-js TCF", () => {
     /**
      * TEST CASE #2:
      * ❌ 1) fides_string override option (via config.options.fidesString)
-     * ❌ 2) DEFER: preferences API (via a custom function)
+     * ❌ 2) preferences API (via a custom function)
      * ✅ 3) local cookie (via fides_consent cookie)
      * ❌ 4) "prefetched" experience (via config.options.experience)
      * ❌ 5) experience API (via GET /privacy-experience)
@@ -1579,7 +1579,7 @@ describe("Fides-js TCF", () => {
     /**
      * TEST CASE #3:
      * ❌ 1) fides_string override option (via config.options.fidesString)
-     * ❌ 2) DEFER: preferences API (via a custom function)
+     * ❌ 2) preferences API (via a custom function)
      * ❌ 3) local cookie (via fides_consent cookie)
      * ❌ 4) "prefetched" experience (via config.options.experience)
      * ❌ 5) experience API (via GET /privacy-experience)
@@ -1607,7 +1607,7 @@ describe("Fides-js TCF", () => {
     /**
      * TEST CASE #4:
      * ✅ 1) fides_string override option (via config.options.fidesString)
-     * ❌ 2) DEFER: preferences API (via a custom function)
+     * ❌ 2) preferences API (via a custom function)
      * ✅ 3) local cookie (via fides_consent cookie)
      * ✅ 4) "prefetched" experience (via config.options.experience)
      * ❌ 5) experience API (via GET /privacy-experience)
@@ -1699,7 +1699,7 @@ describe("Fides-js TCF", () => {
     /**
      * TEST CASE #5:
      * ✅ 1) fides_string override option (via config.options.fidesString)
-     * ❌ 2) DEFER: preferences API (via a custom function)
+     * ❌ 2) preferences API (via a custom function)
      * ❌ 3) local cookie (via fides_consent cookie)
      * ✅ 4) "prefetched" experience (via config.options.experience)
      * ❌ 5) experience API (via GET /privacy-experience)
@@ -1790,7 +1790,7 @@ describe("Fides-js TCF", () => {
     /**
      * TEST CASE #6:
      * ✅ 1) fides_string override option (via config.options.fidesString)
-     * ❌ 2) DEFER: preferences API (via a custom function)
+     * ❌ 2) preferences API (via a custom function)
      * ✅ 3) local cookie (via fides_consent cookie)
      * ❌ 4) "prefetched" experience (via config.options.experience)
      * ❌ 5) experience API (via GET /privacy-experience)
@@ -1821,7 +1821,7 @@ describe("Fides-js TCF", () => {
     /**
      * TEST CASE #7:
      * ✅ 1) fides_string override option (via config.options.fidesString)
-     * ❌ 2) DEFER: preferences API (via a custom function)
+     * ❌ 2) preferences API (via a custom function)
      * ✅ 3) local cookie (via fides_consent cookie)
      * ❌ 4) "prefetched" experience (via config.options.experience)
      * ✅ 5) experience API (via GET /privacy-experience)
@@ -1922,7 +1922,7 @@ describe("Fides-js TCF", () => {
     /**
      * TEST CASE #8:
      * 😬 1) fides_string override option exists but is invalid (via config.options.fidesString)
-     * ❌ 2) DEFER: preferences API (via a custom function)
+     * ❌ 2) preferences API (via a custom function)
      * ❌ 3) local cookie (via fides_consent cookie)
      * ❌ 4) "prefetched" experience (via config.options.experience)
      * ✅ 5) experience API (via GET /privacy-experience)
@@ -2014,6 +2014,230 @@ describe("Fides-js TCF", () => {
             [PURPOSE_2.id]: true,
             1: false,
           });
+          expect(tcData.vendor.consents).to.eql({});
+          expect(tcData.vendor.legitimateInterests).to.eql({});
+        });
+    });
+    /**
+     * TEST CASE #9:
+     * ✅ 1) fides_string override option (via config.options.fidesString)
+     * ✅ 2) preferences API (via a custom function)
+     * ✅ 3) local cookie (via fides_consent cookie)
+     * ❌ 4) "prefetched" experience (via config.options.experience)
+     * ✅ 5) experience API (via GET /privacy-experience)
+     *
+     * EXPECTED RESULT: use preferences from fides_string option
+     */
+    it("prefers preferences from fides_string option when fides_string override, custom pref API and cookie exist and experience is fetched from API", () => {
+      // This fide str override opts in to all
+      const fidesStringOverride =
+        "CP0gqMAP0gqMAGXABBENATEIABaAAEAAAAAAABEAAAAA,1~";
+      const fidesString =
+        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA.IABE,1~";
+      const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
+      setFidesCookie();
+      cy.fixture("consent/experience_tcf.json").then((experience) => {
+        cy.fixture("consent/geolocation_tcf.json").then((geo) => {
+          const apiOptions = {
+            getPreferencesFn: async () => ({ fides_string: fidesString }),
+          };
+          const spyObject = cy.spy(apiOptions, "getPreferencesFn");
+          stubConfig(
+            {
+              options: {
+                isOverlayEnabled: true,
+                tcfEnabled: true,
+                apiOptions,
+                fidesString: fidesStringOverride,
+              },
+              experience: OVERRIDE.UNDEFINED,
+            },
+            geo,
+            experience
+          );
+          cy.waitUntilFidesInitialized().then(() => {
+            cy.window().then((win) => {
+              win.__tcfapi("addEventListener", 2, cy.stub().as("TCFEvent"));
+            });
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+            expect(spyObject).to.be.called;
+          });
+        });
+      });
+      // Open the modal
+      cy.get("#fides-modal-link").click();
+
+      // Verify the toggles
+      // Purposes
+      cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
+        // this purpose is set to true in the experience, but since it was not defined in the fides_string,
+        // it should use the default preference set in the experience which is true
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_4.name}-consent`).within(() => {
+        // this purpose was previously set to true from the experience, but it is overridden by the fides_string
+        cy.get("input").should("not.be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_6.name}-consent`).within(() => {
+        cy.get("input").should("not.be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_7.name}-consent`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_9.name}-consent`).within(() => {
+        // this purpose is set to true in the experience, but since it was not defined in the fides_string,
+        // it should use the default preference set in the experience which is false
+        cy.get("input").should("not.be.checked");
+      });
+      // Features
+      cy.get("#fides-tab-Features").click();
+      cy.getByTestId(`toggle-${SPECIAL_FEATURE_1.name}`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      // Vendors
+      // this purpose is set to true in the experience, but since it was not defined in the fides_string,
+      // it should use the default preference set in the experience which is true
+      cy.get("#fides-tab-Vendors").click();
+      cy.getByTestId(`toggle-${SYSTEM_1.name}`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${VENDOR_1.name}-consent`).within(() => {
+        cy.get("input").should("not.be.checked");
+      });
+
+      // verify CMP API
+      cy.get("@TCFEvent")
+        .its("lastCall.args")
+        .then(([tcData, success]) => {
+          expect(success).to.eql(true);
+          expect(tcData.tcString).to.eql(expectedTCString);
+          expect(tcData.eventStatus).to.eql("cmpuishown");
+          expect(tcData.purpose.consents).to.eql({
+            [PURPOSE_2.id]: false,
+            [PURPOSE_4.id]: false,
+            [PURPOSE_6.id]: false,
+            [PURPOSE_7.id]: true,
+            1: false,
+            2: false,
+            3: false,
+            5: false,
+          });
+          expect(tcData.purpose.legitimateInterests).to.eql({});
+          expect(tcData.vendor.consents).to.eql({});
+          expect(tcData.vendor.legitimateInterests).to.eql({});
+        });
+    });
+    /**
+     * TEST CASE #10:
+     * ❌ 1) fides_string override option (via config.options.fidesString)
+     * ✅ 2) preferences API (via a custom function)
+     * ✅ 3) local cookie (via fides_consent cookie)
+     * ❌ 4) "prefetched" experience (via config.options.experience)
+     * ✅ 5) experience API (via GET /privacy-experience)
+     *
+     * EXPECTED RESULT: use preferences from preferences API, overrides cookie tcf_version_hash if returned in preferences API
+     */
+    it("prefers preferences from preferences API when custom pref API and cookie exist and experience is fetched from API", () => {
+      const fidesString =
+        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA.IABE,1~";
+      const versionHash = "091834y";
+      const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
+      setFidesCookie();
+      cy.fixture("consent/experience_tcf.json").then((experience) => {
+        cy.fixture("consent/geolocation_tcf.json").then((geo) => {
+          const apiOptions = {
+            getPreferencesFn: async () => ({
+              fides_string: fidesString,
+              version_hash: versionHash,
+            }),
+          };
+          const spyObject = cy.spy(apiOptions, "getPreferencesFn");
+          stubConfig(
+            {
+              options: {
+                isOverlayEnabled: true,
+                tcfEnabled: true,
+                apiOptions,
+              },
+              experience: OVERRIDE.UNDEFINED,
+            },
+            geo,
+            experience
+          );
+          cy.waitUntilFidesInitialized().then(() => {
+            cy.window().then((win) => {
+              win.__tcfapi("addEventListener", 2, cy.stub().as("TCFEvent"));
+            });
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+            expect(spyObject).to.be.called;
+            // confirm cookie reflects version_hash from custom preferences API
+            cy.get("@FidesInitialized")
+              .should("have.been.calledOnce")
+              .its("firstCall.args.0.detail.tcf_version_hash")
+              .should("deep.equal", versionHash);
+          });
+        });
+      });
+
+      // Open the modal
+      cy.get("#fides-modal-link").click();
+
+      // Verify the toggles
+      // Purposes
+      cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
+        // this purpose is set to true in the experience, but since it was not defined in the fides_string,
+        // it should use the default preference set in the experience which is true
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_4.name}-consent`).within(() => {
+        // this purpose was previously set to true from the experience, but it is overridden by the fides_string
+        cy.get("input").should("not.be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_6.name}-consent`).within(() => {
+        cy.get("input").should("not.be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_7.name}-consent`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${PURPOSE_9.name}-consent`).within(() => {
+        // this purpose is set to true in the experience, but since it was not defined in the fides_string,
+        // it should use the default preference set in the experience which is false
+        cy.get("input").should("not.be.checked");
+      });
+      // Features
+      cy.get("#fides-tab-Features").click();
+      cy.getByTestId(`toggle-${SPECIAL_FEATURE_1.name}`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      // Vendors
+      // this purpose is set to true in the experience, but since it was not defined in the fides_string,
+      // it should use the default preference set in the experience which is true
+      cy.get("#fides-tab-Vendors").click();
+      cy.getByTestId(`toggle-${SYSTEM_1.name}`).within(() => {
+        cy.get("input").should("be.checked");
+      });
+      cy.getByTestId(`toggle-${VENDOR_1.name}-consent`).within(() => {
+        cy.get("input").should("not.be.checked");
+      });
+
+      // verify CMP API
+      cy.get("@TCFEvent")
+        .its("lastCall.args")
+        .then(([tcData, success]) => {
+          expect(success).to.eql(true);
+          expect(tcData.tcString).to.eql(expectedTCString);
+          expect(tcData.eventStatus).to.eql("cmpuishown");
+          expect(tcData.purpose.consents).to.eql({
+            [PURPOSE_2.id]: false,
+            [PURPOSE_4.id]: false,
+            [PURPOSE_6.id]: false,
+            [PURPOSE_7.id]: true,
+            1: false,
+            2: false,
+            3: false,
+            5: false,
+          });
+          expect(tcData.purpose.legitimateInterests).to.eql({});
           expect(tcData.vendor.consents).to.eql({});
           expect(tcData.vendor.legitimateInterests).to.eql({});
         });


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1241

### Description Of Changes

Adds support for custom get preferences fn


### Code Changes

* [ ] Implements custom get preferences fn
* [ ] Adds test coverage

### Steps to Confirm

* [ ] Run regression testing on TCF banner / modal.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
