### PR TITLE
Backend TC String Is Service Specific should be True 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The types of changes are:
 
 ### Changed
 - Determine if the TCF overlay needs to surface based on backend calculated version hash [#4356](https://github.com/ethyca/fides/pull/4356)
+- "is_service_specific" default updated when building TC strings on the backend [#4377](https://github.com/ethyca/fides/pull/4377)
+
 
 ## [2.23.1](https://github.com/ethyca/fides/compare/2.23.0...2.23.1)
 

--- a/src/fides/api/util/tcf/tc_model.py
+++ b/src/fides/api/util/tcf/tc_model.py
@@ -22,6 +22,7 @@ from fides.api.util.tcf.tcf_experience_contents import (
 CMP_ID: int = 407
 CMP_VERSION = 1
 CONSENT_SCREEN = 1  # TODO On which 'screen' consent was captured; this is a CMP proprietary number encoded into the TC string
+IS_SERVICE_SPECIFIC = True
 
 FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS = [1, 3, 4, 5, 6]
 gvl: Dict = load_gvl()
@@ -447,6 +448,7 @@ def convert_tcf_contents_to_tc_model(
         cmp_id=CMP_ID,
         cmp_version=CMP_VERSION,
         consent_screen=CONSENT_SCREEN,
+        is_service_specific=IS_SERVICE_SPECIFIC,
         vendor_list_version=gvl.get("vendorListVersion"),
         policy_version=gvl.get("tcfPolicyVersion"),
         special_feature_optins=special_feature_opt_ins if consented else [],

--- a/tests/ops/util/test_tc_string.py
+++ b/tests/ops/util/test_tc_string.py
@@ -335,7 +335,7 @@ class TestBuildTCModel:
         m = TCModel(
             vendor_legitimate_interests=[66]
         )  # This vendor doesn't have leg int purposes, or special purposes. It does have flexible purposes,
-        # but this isn't an option right now, as is_service_specific is True
+        # but this isn't yet supported
         assert m.vendor_legitimate_interests == []
 
         m = TCModel(

--- a/tests/ops/util/test_tc_string.py
+++ b/tests/ops/util/test_tc_string.py
@@ -335,7 +335,7 @@ class TestBuildTCModel:
         m = TCModel(
             vendor_legitimate_interests=[66]
         )  # This vendor doesn't have leg int purposes, or special purposes. It does have flexible purposes,
-        # but this isn't an option right now, as is_service_specific is False
+        # but this isn't an option right now, as is_service_specific is True
         assert m.vendor_legitimate_interests == []
 
         m = TCModel(
@@ -381,7 +381,7 @@ class TestBuildTCModel:
         assert decoded.consent_language == b"EN"
         assert decoded.vendor_list_version == 24
         assert decoded.tcf_policy_version == 4
-        assert decoded.is_service_specific is False
+        assert decoded.is_service_specific is True
         assert decoded.use_non_standard_stacks is False
         assert decoded.special_features_optin == {
             1: False,
@@ -487,7 +487,7 @@ class TestBuildTCModel:
         assert decoded.consent_language == b"EN"
         assert decoded.vendor_list_version == 24
         assert decoded.tcf_policy_version == 4
-        assert decoded.is_service_specific is False
+        assert decoded.is_service_specific is True
         assert decoded.use_non_standard_stacks is False
         assert decoded.special_features_optin == {
             1: False,
@@ -621,7 +621,7 @@ class TestBuildTCModel:
         assert decoded.consent_language == b"EN"
         assert decoded.vendor_list_version == 24
         assert decoded.tcf_policy_version == 4
-        assert decoded.is_service_specific is False
+        assert decoded.is_service_specific is True
         assert decoded.use_non_standard_stacks is False
         assert decoded.special_features_optin == {
             1: False,
@@ -825,7 +825,7 @@ class TestBuildTCModel:
         assert decoded.consent_language == b"EN"
         assert decoded.vendor_list_version == 24
         assert decoded.tcf_policy_version == 4
-        assert decoded.is_service_specific is False
+        assert decoded.is_service_specific is True
         assert decoded.use_non_standard_stacks is False
         assert decoded.special_features_optin == {
             1: False,
@@ -1043,7 +1043,7 @@ class TestBuildTCModel:
         assert decoded.consent_language == b"EN"
         assert decoded.vendor_list_version == 24
         assert decoded.tcf_policy_version == 4
-        assert decoded.is_service_specific is False
+        assert decoded.is_service_specific is True
         assert decoded.use_non_standard_stacks is False
         assert decoded.special_features_optin == {
             1: False,
@@ -1162,7 +1162,7 @@ class TestBuildTCModel:
         assert decoded.consent_language == b"EN"
         assert decoded.vendor_list_version == 24
         assert decoded.tcf_policy_version == 4
-        assert decoded.is_service_specific is False
+        assert decoded.is_service_specific is True
         assert decoded.use_non_standard_stacks is False
         assert decoded.special_features_optin == {
             1: False,
@@ -1270,7 +1270,7 @@ class TestBuildTCModel:
         assert decoded.consent_language == b"EN"
         assert decoded.vendor_list_version == 24
         assert decoded.tcf_policy_version == 4
-        assert decoded.is_service_specific is False
+        assert decoded.is_service_specific is True
         assert decoded.use_non_standard_stacks is False
         assert decoded.special_features_optin == {
             1: False,
@@ -1379,7 +1379,7 @@ class TestBuildTCModel:
         assert decoded.consent_language == b"EN"
         assert decoded.vendor_list_version == 24
         assert decoded.tcf_policy_version == 4
-        assert decoded.is_service_specific is False
+        assert decoded.is_service_specific is True
         assert decoded.use_non_standard_stacks is False
         assert decoded.special_features_optin == {
             1: False,


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1311

### Description Of Changes

Google Ads considers this an error and will only accept service-specific scopes

### Code Changes

* [ ] set is_service_specific to true on TC Model which is then converted to a TC string

### Steps to Confirm

* [ ]  Enable TCF, add a system from the GVL like Emerse, and then get Privacy Experiences with include_meta=True:
```
curl -X 'GET' \
  'http://localhost:8080/api/v1/privacy-experience?show_disabled=true&region=fr&systems_applicable=false&include_gvl=false&include_meta=true&page=1&size=50' \
  -H 'accept: application/json'
```
* [ ] The accept-all string that is built should have is_service_specific set to True when decoded. Example: `CP0nQEAP0nQEAGXABBENAYEgALAAAEOAAAAAAEAEACACAAAA.IAEAEAAA,1~`


<img width="542" alt="Screenshot 2023-11-02 at 1 22 24 PM" src="https://github.com/ethyca/fides/assets/9755598/09f8fb10-6945-458f-b908-ca95cb8a50e7">



### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
