### PR TITLE
PROD-1305 adds fides_disable_banner config option, fix bug with triggering fidesUIShown event for fidesEmbed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.23.1...main)
 
+### Added
+- Adds fides_disable_banner config option to Fides.js [#4378](https://github.com/ethyca/fides/pull/4378)
+
 ### Changed
 - Add filtering and pagination to bulk vendor add table [#4351](https://github.com/ethyca/fides/pull/4351)
 - Determine if the TCF overlay needs to surface based on backend calculated version hash [#4356](https://github.com/ethyca/fides/pull/4356)

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -57,7 +57,6 @@ const Overlay: FunctionComponent<Props> = ({
     id: "fides-modal",
     role: "alertdialog",
     title: experience?.experience_config?.title || "",
-    useOverlowStyling: !options.fidesEmbed,
     onClose: dispatchCloseEvent,
   });
 
@@ -76,10 +75,10 @@ const Overlay: FunctionComponent<Props> = ({
   }, [instance, dispatchCloseEvent, options.fidesEmbed]);
 
   useEffect(() => {
-    if (options.fidesEmbed && instance) {
-      handleOpenModal();
+    if (options.fidesEmbed) {
+      onOpen();
     }
-  }, [options, instance, handleOpenModal]);
+  }, [options, onOpen]);
 
   useEffect(() => {
     const delayBanner = setTimeout(() => {
@@ -115,6 +114,7 @@ const Overlay: FunctionComponent<Props> = ({
 
   const showBanner = useMemo(
     () =>
+      !options.fidesDisableBanner &&
       experience.show_banner &&
       shouldResurfaceConsent(experience, cookie) &&
       !options.fidesEmbed,

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -309,6 +309,7 @@ _Fides = {
     tcfEnabled: true,
     fidesEmbed: false,
     fidesDisableSaveApi: false,
+    fidesDisableBanner: false,
     fidesString: null,
     apiOptions: null,
   },

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -148,6 +148,7 @@ _Fides = {
     tcfEnabled: false,
     fidesEmbed: false,
     fidesDisableSaveApi: false,
+    fidesDisableBanner: false,
     fidesString: null,
     apiOptions: null,
   },

--- a/clients/fides-js/src/lib/a11y-dialog.tsx
+++ b/clients/fides-js/src/lib/a11y-dialog.tsx
@@ -6,26 +6,21 @@
 import A11yDialogLib from "a11y-dialog";
 import { useCallback, useEffect, useState } from "preact/hooks";
 
-const useA11yDialogInstance = (addOverlowStyling: Boolean) => {
+const useA11yDialogInstance = () => {
   const [instance, setInstance] = useState<A11yDialogLib | null>(null);
-  const container = useCallback(
-    (node: Element) => {
-      if (node !== null) {
-        const dialog = new A11yDialogLib(node);
-        if (addOverlowStyling) {
-          dialog
-            .on("show", () => {
-              document.documentElement.style.overflowY = "hidden";
-            })
-            .on("hide", () => {
-              document.documentElement.style.overflowY = "";
-            });
-        }
-        setInstance(dialog);
-      }
-    },
-    [addOverlowStyling]
-  );
+  const container = useCallback((node: Element) => {
+    if (node !== null) {
+      const dialog = new A11yDialogLib(node);
+      dialog
+        .on("show", () => {
+          document.documentElement.style.overflowY = "hidden";
+        })
+        .on("hide", () => {
+          document.documentElement.style.overflowY = "";
+        });
+      setInstance(dialog);
+    }
+  }, []);
   return { instance, container };
 };
 
@@ -33,16 +28,10 @@ interface Props {
   role: "dialog" | "alertdialog";
   id: string;
   title: string;
-  useOverlowStyling: Boolean;
   onClose?: () => void;
 }
-export const useA11yDialog = ({
-  role,
-  id,
-  onClose,
-  useOverlowStyling,
-}: Props) => {
-  const { instance, container: ref } = useA11yDialogInstance(useOverlowStyling);
+export const useA11yDialog = ({ role, id, onClose }: Props) => {
+  const { instance, container: ref } = useA11yDialogInstance();
   const isAlertDialog = role === "alertdialog";
   const titleId = `${id}-title`;
 

--- a/clients/fides-js/src/lib/consent-constants.ts
+++ b/clients/fides-js/src/lib/consent-constants.ts
@@ -25,6 +25,12 @@ export const FIDES_OVERRIDE_OPTIONS_VALIDATOR_MAP: {
     validationRegex: /^(true|false)$/,
   },
   {
+    fidesOption: "fidesDisableBanner",
+    fidesOptionType: "boolean",
+    fidesOverrideKey: "fides_disable_banner",
+    validationRegex: /^(true|false)$/,
+  },
+  {
     fidesOption: "fidesString",
     fidesOptionType: "string",
     fidesOverrideKey: "fides_string",

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -72,6 +72,9 @@ export type FidesOptions = {
   // Whether we should disable saving consent preferences to the Fides API.
   fidesDisableSaveApi: boolean;
 
+  // Whether we should disable the banner
+  fidesDisableBanner: boolean;
+
   // An explicitly passed-in TC string that supersedes the cookie, and prevents any API calls to fetch
   // experiences / preferences. Only available when TCF is enabled. Optional.
   fidesString: string | null;
@@ -341,12 +344,13 @@ export type UserGeolocation = {
 export type OverrideOptions = {
   fides_string: string;
   fides_disable_save_api: boolean;
+  fides_disable_banner: boolean;
   fides_embed: boolean;
 };
 
 export type FidesOptionOverrides = Pick<
   FidesOptions,
-  "fidesString" | "fidesDisableSaveApi" | "fidesEmbed"
+  "fidesString" | "fidesDisableSaveApi" | "fidesEmbed" | "fidesDisableBanner"
 >;
 
 export enum ButtonType {

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -197,11 +197,7 @@ export const getInitialCookie = ({ consent, options }: FidesConfig) => {
   );
 
   // Load any existing user preferences from the browser cookie
-  const cookie: FidesCookie = getOrMakeFidesCookie(
-    consentDefaults,
-    options.debug
-  );
-  return cookie;
+  return getOrMakeFidesCookie(consentDefaults, options.debug);
 };
 
 /**

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -73,6 +73,7 @@ export type PrivacyCenterClientSettings = Pick<
   | "PRIVACY_CENTER_URL"
   | "FIDES_EMBED"
   | "FIDES_DISABLE_SAVE_API"
+  | "FIDES_DISABLE_BANNER"
   | "FIDES_STRING"
   | "IS_FORCED_TCF"
 >;
@@ -330,6 +331,7 @@ export const loadPrivacyCenterEnvironment =
       PRIVACY_CENTER_URL: settings.PRIVACY_CENTER_URL,
       FIDES_EMBED: settings.FIDES_EMBED,
       FIDES_DISABLE_SAVE_API: settings.FIDES_DISABLE_SAVE_API,
+      FIDES_DISABLE_BANNER: settings.FIDES_DISABLE_BANNER,
       FIDES_STRING: settings.FIDES_STRING,
       IS_FORCED_TCF: settings.IS_FORCED_TCF,
     };

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -49,6 +49,7 @@ export interface PrivacyCenterSettings {
   PRIVACY_CENTER_URL: string; // e.g. http://localhost:3000
   FIDES_EMBED: boolean | false; // (optional) Whether we should "embed" the fides.js overlay UI (ie. “Layer 2”) into a web page
   FIDES_DISABLE_SAVE_API: boolean | false; // (optional) Whether we should disable saving consent preferences to the Fides API
+  FIDES_DISABLE_BANNER: boolean | false; // (optional) Whether we should disable showing the banner
   FIDES_STRING: string | null; // (optional) An explicitly passed-in string that supersedes the cookie. Can contain both TC and AC strings
   IS_FORCED_TCF: boolean; // whether to force the privacy center to use the fides-tcf.js bundle
 }
@@ -297,6 +298,10 @@ export const loadPrivacyCenterEnvironment =
       FIDES_DISABLE_SAVE_API: process.env
         .FIDES_PRIVACY_CENTER__FIDES_DISABLE_SAVE_API
         ? process.env.FIDES_PRIVACY_CENTER__FIDES_DISABLE_SAVE_API === "true"
+        : false,
+      FIDES_DISABLE_BANNER: process.env
+        .FIDES_PRIVACY_CENTER__FIDES_DISABLE_BANNER
+        ? process.env.FIDES_PRIVACY_CENTER__FIDES_DISABLE_BANNER === "true"
         : false,
       FIDES_STRING: process.env.FIDES_PRIVACY_CENTER__FIDES_STRING || null,
       IS_FORCED_TCF: process.env.FIDES_PRIVACY_CENTER__IS_FORCED_TCF

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -137,6 +137,28 @@ describe("Fides-js TCF", () => {
         cy.get("div#fides-banner").should("not.exist");
       });
     });
+    it("should not render the banner if fides_disable_banner is true", () => {
+      cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
+      cy.fixture("consent/experience_tcf.json").then((experience) => {
+        stubConfig({
+          options: {
+            isOverlayEnabled: true,
+            tcfEnabled: true,
+            fidesDisableBanner: true,
+          },
+          experience: experience.items[0],
+        });
+      });
+      cy.waitUntilFidesInitialized().then(() => {
+        // The banner has a delay, so in order to assert its non-existence, we have
+        // to give it a chance to come up first. Otherwise, the following gets will
+        // pass regardless.
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+        cy.get("@FidesUIShown").should("not.have.been.called");
+        cy.get("div#fides-banner").should("not.exist");
+      });
+    });
   });
 
   describe("initial layer", () => {
@@ -1047,6 +1069,7 @@ describe("Fides-js TCF", () => {
         });
       });
       cy.get("#fides-tab-Purposes");
+      cy.get("@FidesUIShown").should("have.been.calledOnce");
       // Purposes
       cy.getByTestId("toggle-Purposes").within(() => {
         cy.get("input").should("be.checked");
@@ -1079,6 +1102,25 @@ describe("Fides-js TCF", () => {
       cy.get("#fides-tab-Vendors").click();
       cy.getByTestId(`toggle-${SYSTEM_1.name}`).within(() => {
         cy.get("input").should("be.checked");
+      });
+    });
+    it("automatically renders the second layer even when fides_disable_banner is true", () => {
+      cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
+      cy.fixture("consent/experience_tcf.json").then((experience) => {
+        stubConfig({
+          options: {
+            isOverlayEnabled: true,
+            tcfEnabled: true,
+            fidesEmbed: true,
+            fidesDisableBanner: true,
+          },
+          experience: experience.items[0],
+        });
+      });
+      cy.waitUntilFidesInitialized().then(() => {
+        cy.get("@FidesUIShown").should("have.been.calledOnce");
+        cy.get("div#fides-banner").should("not.exist");
+        cy.get("div#fides-consent-content").should("exist");
       });
     });
     it("can opt in to some and opt out of others", () => {

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -146,6 +146,7 @@ export default async function handler(
         environment.settings.FIDES_API_URL,
       fidesEmbed: environment.settings.FIDES_EMBED,
       fidesDisableSaveApi: environment.settings.FIDES_DISABLE_SAVE_API,
+      fidesDisableBanner: environment.settings.FIDES_DISABLE_BANNER,
       fidesString,
       // Custom API override functions must be passed into custom Fides extensions via Fides.init(...)
       apiOptions: null,


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1305

### Description Of Changes

Adds fides_disable_banner config option, and as part of this, fixes bug where fidesUIShown event was not triggered for fidesEmbed mode.

### Code Changes

* [ ] Adds `fides_disable_banner` to config options through `init`, as well as through all 3 override options: cookie, window obj, and query param

### Steps to Confirm

* [ ] Add `fides_disable_banner` as query param on a site that should show the fides banner
* [ ] Confirm banner is not shown, but that the "manage consent preferences" link still works to open the consent modal

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
