### PR TITLE
Set isServiceSpecific to true during TC string generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 - Determine if the TCF overlay needs to surface based on backend calculated version hash [#4356](https://github.com/ethyca/fides/pull/4356)
 - Moved Experiences and Preferences endpoints to Plus to take advantage of dynamic GVL  [#4367](https://github.com/ethyca/fides/pull/4367)
 - "is_service_specific" default updated when building TC strings on the backend [#4377](https://github.com/ethyca/fides/pull/4377)
+- "isServiceSpecific" default updated when building TC strings on the frontend [#4384](https://github.com/ethyca/fides/pull/4384)
 - Redact cli, database, and redis configuration information from GET api/v1/config API request responses. [#4379](https://github.com/ethyca/fides/pull/4379)
 
 

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -73,6 +73,7 @@ export const generateFidesString = async ({
     tcModel.cmpId = CMP_ID;
     tcModel.cmpVersion = CMP_VERSION;
     tcModel.consentScreen = 1; // todo- On which 'screen' consent was captured; this is a CMP proprietary number encoded into the TC string
+    tcModel.isServiceSpecific = true;
 
     // Narrow the GVL to say we've only showed these vendors provided by our experience
     tcModel.gvl.narrowVendorsTo(uniqueGvlVendorIds(experience));

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -6,7 +6,7 @@
  */
 
 import { CmpApi, TCData } from "@iabtechlabtcf/cmpapi";
-import { TCModel, TCString, GVL } from "@iabtechlabtcf/core";
+import { TCModel, TCString, GVL, Segment } from "@iabtechlabtcf/core";
 import { makeStub } from "./tcf/stub";
 
 import { EnabledIds } from "./tcf/types";
@@ -132,7 +132,10 @@ export const generateFidesString = async ({
       // the user is not given choice by a CMP.
       // See https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/
       // and https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/63#issuecomment-581798996
-      encodedString = TCString.encode(tcModel);
+      encodedString = TCString.encode(tcModel, {
+        // We choose just CORE and VENDORS_DISCLOSED for now (PROD#1312)
+        segments: [Segment.CORE, Segment.VENDORS_DISCLOSED],
+      });
 
       // Attach the AC string
       const acString = generateAcString({ tcStringPreferences });


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1312

### Description Of Changes

Updates TC string generation code to specify `isServiceSpecific=true`. Also forces encoded segments, see ticket for reasoning behind that!

### Code Changes

* [x] Set `isServiceSpecific=true` on the `tcModel` when we are creating the string
* [x] Specify which segments we want to encode

### Steps to Confirm

* [ ] See steps in the ticket

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
