### PR TITLE
Restore Legal Bases List to TCF Special Purpose Records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The types of changes are:
 - Add filtering and pagination to bulk vendor add table [#4351](https://github.com/ethyca/fides/pull/4351)
 - Determine if the TCF overlay needs to surface based on backend calculated version hash [#4356](https://github.com/ethyca/fides/pull/4356)
 - Moved Experiences and Preferences endpoints to Plus to take advantage of dynamic GVL  [#4367](https://github.com/ethyca/fides/pull/4367)
+- Add legal bases to Special Purpose schemas on the backend for display [#4387](https://github.com/ethyca/fides/pull/4387)
 - "is_service_specific" default updated when building TC strings on the backend [#4377](https://github.com/ethyca/fides/pull/4377)
 - Redact cli, database, and redis configuration information from GET api/v1/config API request responses. [#4379](https://github.com/ethyca/fides/pull/4379)
 

--- a/src/fides/api/schemas/tcf.py
+++ b/src/fides/api/schemas/tcf.py
@@ -52,6 +52,10 @@ class TCFPurposeLegitimateInterestsRecord(NonVendorSection, MappedPurpose):
 
 
 class TCFSpecialPurposeRecord(NonVendorSection, MappedPurpose):
+    """Schema for a TCF Special Purpose returned in the TCF Overlay Experience"""
+
+    legal_bases: List[str] = []  # Legal basis for processing
+
     @root_validator
     def add_default_preference(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Default preference for special purposes is acknowledge"""


### PR DESCRIPTION
Partially closes https://ethyca.atlassian.net/browse/PROD-1318

### Description Of Changes

We need legal basis for processing on top-level Special Purposes again for frontend filtering.  We're not saving against Special purpose x legal basis combination but we do need it for display.  Even though data uses can only have one legal basis for processing, surfacing this as a list in case a special purpose is claimed on multiple vendors with differing legal bases.


### Code Changes

* [ ] Added legal bases array

### Steps to Confirm

* [ ] Best viewed in fidesplus https://github.com/ethyca/fidesplus/compare/PROD-1318_sp_legal_bases?expand=1

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
