### PR TITLE
System level cookie handling

### DIFF
--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -261,6 +261,7 @@ describe("System management page", () => {
         }).as("getFidesctlSystem");
       });
       cy.visit(SYSTEM_ROUTE);
+      cy.wait("@getUserPermission");
     });
 
     it("Can go directly to a system's edit page", () => {
@@ -278,11 +279,27 @@ describe("System management page", () => {
     });
 
     it("Can go to a system's edit page by clicking its card", () => {
-      cy.visit(SYSTEM_ROUTE);
       cy.getByTestId("system-fidesctl_system").within(() => {
         cy.getByTestId("system-box").click();
       });
       cy.url().should("contain", "/systems/configure/fidesctl_system");
+    });
+
+    it("Can persist fields not directly in the form", () => {
+      cy.visit("/systems/configure/fidesctl_system");
+      cy.wait("@getFidesctlSystem");
+      cy.getByTestId("input-name").type("edit");
+      cy.getByTestId("save-btn").click();
+      cy.wait("@putSystem").then((interception) => {
+        const { body } = interception.request;
+        expect(body.cookies).to.eql([
+          {
+            name: "test_cookie",
+            path: "/",
+            domain: "https://www.example.com",
+          },
+        ]);
+      });
     });
 
     it.skip("Can go through the edit flow", () => {

--- a/clients/admin-ui/cypress/fixtures/systems/system.json
+++ b/clients/admin-ui/cypress/fixtures/systems/system.json
@@ -44,5 +44,6 @@
   "responsibility": "Controller",
   "dpo": "Derek P. Officer",
   "joint_controller": "Julia Controller",
-  "data_security_practices": []
+  "data_security_practices": [],
+  "cookies": []
 }

--- a/clients/admin-ui/cypress/fixtures/systems/systems.json
+++ b/clients/admin-ui/cypress/fixtures/systems/systems.json
@@ -31,7 +31,14 @@
       "link": null
     },
     "ingress": [],
-    "egress": []
+    "egress": [],
+    "cookies": [
+      {
+        "name": "test_cookie",
+        "path": "/",
+        "domain": "https://www.example.com"
+      }
+    ]
   },
   {
     "fides_key": "demo_analytics_system",
@@ -73,7 +80,8 @@
       "is_required": true,
       "progress": "Complete",
       "link": "https://example.org/analytics_system_data_protection_impact_assessment"
-    }
+    },
+    "cookies": []
   },
   {
     "fides_key": "demo_marketing_system",
@@ -115,6 +123,7 @@
       "is_required": false,
       "progress": null,
       "link": null
-    }
+    },
+    "cookies": []
   }
 ]

--- a/clients/admin-ui/cypress/fixtures/systems/systems_with_data_uses.json
+++ b/clients/admin-ui/cypress/fixtures/systems/systems_with_data_uses.json
@@ -43,7 +43,14 @@
       "link": null
     },
     "ingress": [],
-    "egress": []
+    "egress": [],
+    "cookies": [
+      {
+        "name": "test_cookie",
+        "path": "/",
+        "domain": "https://www.example.com"
+      }
+    ]
   },
   {
     "fides_key": "demo_analytics_system",
@@ -84,7 +91,8 @@
       "is_required": true,
       "progress": "Complete",
       "link": "https://example.org/analytics_system_data_protection_impact_assessment"
-    }
+    },
+    "cookies": []
   },
   {
     "fides_key": "demo_marketing_system",
@@ -125,6 +133,7 @@
       "is_required": false,
       "progress": null,
       "link": null
-    }
+    },
+    "cookies": []
   }
 ]

--- a/clients/admin-ui/src/features/system/form.ts
+++ b/clients/admin-ui/src/features/system/form.ts
@@ -124,6 +124,7 @@ export const transformFormValuesToSystem = (formValues: FormValues): System => {
     fidesctl_meta: formValues.fidesctl_meta,
     organization_fides_key: formValues.organization_fides_key,
     dpa_progress: formValues.dpa_progress,
+    cookies: formValues.cookies,
     cookie_max_age_seconds: formValues.cookie_max_age_seconds
       ? formValues.cookie_max_age_seconds
       : undefined,

--- a/clients/admin-ui/src/types/api/models/BasicSystemResponse.ts
+++ b/clients/admin-ui/src/types/api/models/BasicSystemResponse.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { ContactDetails } from "./ContactDetails";
+import type { Cookies } from "./Cookies";
 import type { DataFlow } from "./DataFlow";
 import type { DataProtectionImpactAssessment } from "./DataProtectionImpactAssessment";
 import type { DataResponsibilityTitle } from "./DataResponsibilityTitle";
@@ -211,5 +212,9 @@ export type BasicSystemResponse = {
    * A URL that points to the system's publicly accessible legitimate interest disclosure.
    */
   legitimate_interest_disclosure_url?: string;
+  /**
+   * System-level cookies unassociated with a data use to deliver services and functionality
+   */
+  cookies?: Array<Cookies>;
   created_at: string;
 };

--- a/clients/admin-ui/src/types/api/models/System.ts
+++ b/clients/admin-ui/src/types/api/models/System.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { ContactDetails } from "./ContactDetails";
+import type { Cookies } from "./Cookies";
 import type { DataFlow } from "./DataFlow";
 import type { DataProtectionImpactAssessment } from "./DataProtectionImpactAssessment";
 import type { DataResponsibilityTitle } from "./DataResponsibilityTitle";
@@ -209,4 +210,8 @@ export type System = {
    * A URL that points to the system's publicly accessible legitimate interest disclosure.
    */
   legitimate_interest_disclosure_url?: string;
+  /**
+   * System-level cookies unassociated with a data use to deliver services and functionality
+   */
+  cookies?: Array<Cookies>;
 };

--- a/clients/admin-ui/src/types/api/models/SystemResponse.ts
+++ b/clients/admin-ui/src/types/api/models/SystemResponse.ts
@@ -209,6 +209,10 @@ export type SystemResponse = {
    * A URL that points to the system's publicly accessible legitimate interest disclosure.
    */
   legitimate_interest_disclosure_url?: string;
+  /**
+   * System-level cookies unassociated with a data use to deliver services and functionality
+   */
+  cookies?: Array<Cookies>;
   created_at: string;
   /**
    *
@@ -220,5 +224,4 @@ export type SystemResponse = {
    * System managers of the current system
    */
   data_stewards?: Array<UserResponse>;
-  cookies?: Array<Cookies>;
 };


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1319

### Description Of Changes

Frontend change needed to make sure https://github.com/ethyca/fides/pull/4383 doesn't break things for the UI!


### Code Changes

* [x] Auto update types
* [x] Made sure to pass the new `cookies` field along
* [x] Update cypress tests and fixtures

### Steps to Confirm

* [ ] Run `nox -s dev` in `fides`
* [ ] Using `localhost:8080/docs`, POST a system such as
```
{
  "fides_key": "system_a",
  "system_type": "system",
  "name": "System A",
  "description": "test description",
  "privacy_declarations": [],
  "cookies": [
    {
      "name": "test_cookie",
      "path": "/",
      "domain": "https://www.example.com"
    }
  ]
}
```
* [ ] View that system in the admin ui
* [ ] Edit anything about that system and save
* [ ] Now go back to the docs site and do a GET on all systems
* [ ] `system_a` should still have its cookie field

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
