### PR TITLE
Replace h1 with p in consent overlay modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ The types of changes are:
 - "is_service_specific" default updated when building TC strings on the backend [#4377](https://github.com/ethyca/fides/pull/4377)
 - Redact cli, database, and redis configuration information from GET api/v1/config API request responses. [#4379](https://github.com/ethyca/fides/pull/4379)
 
+### Fixed
+- Replaced h1 element with p to use exisitng fides styles in consent modal [#4396](https://github.com/ethyca/fides/pull/4396)
+
 ## [2.23.2](https://github.com/ethyca/fides/compare/2.23.1...2.23.2)
 
 ### Fixed

--- a/clients/fides-js/src/components/ConsentContent.tsx
+++ b/clients/fides-js/src/components/ConsentContent.tsx
@@ -33,13 +33,13 @@ const ConsentModal = ({
         className={className}
       >
         <div className="fides-modal-body">
-          <h1
+          <p
             data-testid="fides-modal-title"
             {...title}
             className="fides-modal-title"
           >
             {experience.title}
-          </h1>
+          </p>
           <p
             data-testid="fides-modal-description"
             className="fides-modal-description"


### PR DESCRIPTION
Closes FIDES-247

### Description Of Changes

Requested by a user that noticed the `h1` element used in the consent overlay modal could detract from SEO.

Found that there is an existing style variable for this (`--fides-overlay-font-size-title`) that was in some cases being overridden by the `h1` element if styled.

Switching to a `p` allowed the expected style to be used


### Code Changes

* [x] Replaced the h1 element with a `p` element in `ConsentContent.tsx`

### Steps to Confirm

* [ ] Tested and validated the change to the consent overlay using the expected variable (graphic below)

With styled `h1`:
<img width="665" alt="image" src="https://github.com/ethyca/fides/assets/6758661/8b6e42d2-7807-41e3-bf73-b65265c3288f">

Without styled `h1`:
<img width="662" alt="image" src="https://github.com/ethyca/fides/assets/6758661/3b0adcbc-99e7-4523-bc36-7498459de96e">


After change to a `p`:
<img width="672" alt="image" src="https://github.com/ethyca/fides/assets/6758661/66bc4595-1cbc-472c-90b2-56986137f40e">


This could potentially result in some change in default appearance for the overlay, which should be reviewed (not a one person choice I think)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
