### PR TITLE
Adding enabled actions to DSR workflow

### DIFF
--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -437,6 +437,7 @@ const ConnectorParametersForm: React.FC<ConnectorParametersFormProps> = ({
                           form.touched.enabled_actions &&
                           form.errors.enabled_actions
                         }
+                        isRequired
                       >
                         {getFormLabel("enabled_actions", "Enabled actions")}
                         <VStack align="flex-start" w="inherit">

--- a/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
@@ -1655,19 +1655,21 @@ def resume_privacy_request_from_requires_input(
             detail=f"Cannot resume privacy request from 'requires_input': privacy request '{privacy_request.id}' status = {privacy_request.status.value}.",  # type: ignore
         )
 
+    action_type = None
+    if privacy_request.policy.get_rules_for_action(ActionType.access):
+        action_type = ActionType.access
+    elif privacy_request.policy.get_rules_for_action(ActionType.erasure):
+        action_type = ActionType.erasure
+
     access_manual_webhooks: List[AccessManualWebhook] = AccessManualWebhook.get_enabled(
-        db
+        db, action_type
     )
     try:
         for manual_webhook in access_manual_webhooks:
             # check the access or erasure cache based on the privacy request's action type
-            if privacy_request.policy.get_rules_for_action(
-                action_type=ActionType.access
-            ):
+            if action_type == ActionType.access:
                 privacy_request.get_manual_webhook_access_input_strict(manual_webhook)
-            if privacy_request.policy.get_rules_for_action(
-                action_type=ActionType.erasure
-            ):
+            if action_type == ActionType.erasure:
                 privacy_request.get_manual_webhook_erasure_input_strict(manual_webhook)
     except (
         NoCachedManualWebhookEntry,

--- a/src/fides/api/common_exceptions.py
+++ b/src/fides/api/common_exceptions.py
@@ -135,6 +135,10 @@ class CollectionDisabled(BaseException):
     """Collection is attached to disabled ConnectionConfig"""
 
 
+class ActionDisabled(BaseException):
+    """Collection is attached to a ConnectionConfig that has not enabled the given action"""
+
+
 class NotSupportedForCollection(BaseException):
     """The given action is not supported for this type of collection"""
 

--- a/src/fides/api/models/manual_webhook.py
+++ b/src/fides/api/models/manual_webhook.py
@@ -120,7 +120,7 @@ class AccessManualWebhook(Base):
         if action_type is not None:
             query = query.filter(
                 or_(
-                    ConnectionConfig.enabled_actions.contains(action_type),
+                    ConnectionConfig.enabled_actions.contains([action_type]),
                     ConnectionConfig.enabled_actions.is_(None),
                 )
             )

--- a/src/fides/api/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/service/privacy_request/request_runner_service.py
@@ -109,7 +109,7 @@ def get_manual_webhook_access_inputs(
         return ManualWebhookResults(manual_data=manual_inputs, proceed=True)
 
     try:
-        for manual_webhook in AccessManualWebhook.get_enabled(db):
+        for manual_webhook in AccessManualWebhook.get_enabled(db, ActionType.access):
             manual_inputs[manual_webhook.connection_config.key] = [
                 privacy_request.get_manual_webhook_access_input_strict(manual_webhook)
             ]
@@ -135,7 +135,7 @@ def get_manual_webhook_erasure_inputs(
         # Don't fetch manual inputs unless this policy has an access rule
         return ManualWebhookResults(manual_data=manual_inputs, proceed=True)
     try:
-        for manual_webhook in AccessManualWebhook().get_enabled(db):
+        for manual_webhook in AccessManualWebhook().get_enabled(db, ActionType.erasure):
             manual_inputs[manual_webhook.connection_config.key] = [
                 privacy_request.get_manual_webhook_erasure_input_strict(manual_webhook)
             ]

--- a/tests/ops/integration_tests/saas/connector_runner.py
+++ b/tests/ops/integration_tests/saas/connector_runner.py
@@ -66,7 +66,7 @@ class ConnectorRunner:
 
         # create and save the connection config and dataset config to the database
         self.connection_config = _connection_config(db, self.config, secrets)
-        self.dataset_config = _dataset_config(db, self.connection_config, self.dataset)
+        self.dataset_config = dataset_config(db, self.connection_config, self.dataset)
 
     def test_connection(self):
         """Connection test using the connectors test_request"""
@@ -257,11 +257,13 @@ def _external_connection_config(db: Session, fides_key) -> ConnectionConfig:
     return connection_config
 
 
-def _dataset_config(
+def dataset_config(
     db: Session,
     connection_config: ConnectionConfig,
     dataset: Dict[str, Any],
 ) -> DatasetConfig:
+    """Helper function to persist a dataset config and link it to a connection config."""
+
     fides_key = dataset["fides_key"]
     connection_config.name = fides_key
     connection_config.key = fides_key
@@ -331,7 +333,7 @@ def _process_external_references(
             db, f"{connector_type}_external_dataset"
         )
         graph_list.append(
-            _dataset_config(
+            dataset_config(
                 db,
                 external_connection_config,
                 _external_dataset(

--- a/tests/ops/integration_tests/test_enabled_actions.py
+++ b/tests/ops/integration_tests/test_enabled_actions.py
@@ -1,0 +1,114 @@
+import pytest
+from fideslang.models import Dataset
+
+from fides.api.graph.graph import DatasetGraph
+from fides.api.models.connectionconfig import ActionType
+from fides.api.models.datasetconfig import convert_dataset_to_graph
+from fides.api.models.privacy_request import PrivacyRequest
+from fides.api.task import graph_task
+from fides.api.task.graph_task import get_cached_data_for_erasures
+from tests.ops.integration_tests.saas.connector_runner import dataset_config
+
+
+class TestEnabledActions:
+    @pytest.fixture(scope="function")
+    def mongo_postgres_dataset_graph(
+        self,
+        db,
+        example_datasets,
+        integration_postgres_config,
+        integration_mongodb_config,
+    ):
+        dataset_postgres = Dataset(**example_datasets[0])
+        dataset_config(db, integration_postgres_config, dataset_postgres.dict())
+
+        graph = convert_dataset_to_graph(
+            dataset_postgres, integration_postgres_config.key
+        )
+        dataset_mongo = Dataset(**example_datasets[1])
+        dataset_config(db, integration_mongodb_config, dataset_mongo.dict())
+
+        mongo_graph = convert_dataset_to_graph(
+            dataset_mongo, integration_mongodb_config.key
+        )
+        dataset_graph = DatasetGraph(*[graph, mongo_graph])
+        return dataset_graph
+
+    @pytest.mark.asyncio
+    async def test_access_disabled(
+        self,
+        db,
+        policy,
+        integration_postgres_config,
+        integration_mongodb_config,
+        mongo_postgres_dataset_graph,
+    ) -> None:
+        """Disable the access request for one connection config and verify the access results"""
+
+        # disable the access action type for Postgres
+        integration_postgres_config.enabled_actions = [ActionType.erasure]
+        integration_postgres_config.save(db)
+        privacy_request = PrivacyRequest(id="test_disable_postgres_access")
+
+        access_results = await graph_task.run_access_request(
+            privacy_request,
+            policy,
+            mongo_postgres_dataset_graph,
+            [integration_postgres_config, integration_mongodb_config],
+            {"email": "customer-1@example.com"},
+            db,
+        )
+
+        # assert that only mongodb results are returned
+        mongo_dataset = integration_mongodb_config.datasets[0].fides_key
+        assert {key.split(":")[0] for key in access_results} == {mongo_dataset}
+
+    @pytest.mark.asyncio
+    async def test_erasure_disabled(
+        self,
+        db,
+        policy,
+        erasure_policy,
+        integration_postgres_config,
+        integration_mongodb_config,
+        mongo_postgres_dataset_graph,
+    ) -> None:
+        """Disable the erasure request for one connection config and verify the erasure results"""
+
+        # disable the erasure action type for Postgres
+        integration_postgres_config.enabled_actions = [ActionType.access]
+        integration_postgres_config.save(db)
+        privacy_request = PrivacyRequest(id="test_disable_postgres_erasure")
+
+        access_results = await graph_task.run_access_request(
+            privacy_request,
+            policy,
+            mongo_postgres_dataset_graph,
+            [integration_postgres_config, integration_mongodb_config],
+            {"email": "customer-1@example.com"},
+            db,
+        )
+
+        # the access results should contain results from both connections
+        postgres_dataset = integration_postgres_config.datasets[0].fides_key
+        mongo_dataset = integration_mongodb_config.datasets[0].fides_key
+        assert {key.split(":")[0] for key in access_results} == {
+            postgres_dataset,
+            mongo_dataset,
+        }
+
+        erasure_results = await graph_task.run_erasure(
+            privacy_request,
+            erasure_policy,
+            mongo_postgres_dataset_graph,
+            [integration_postgres_config, integration_mongodb_config],
+            {"email": "customer-1@example.com"},
+            get_cached_data_for_erasures(privacy_request.id),
+            db,
+        )
+
+        # the erasure results should only contain results from mongodb
+        mongo_dataset = integration_mongodb_config.datasets[0].fides_key
+        assert {key.split(":")[0] for key in erasure_results} == {
+            mongo_dataset,
+        }

--- a/tests/ops/models/test_manual_webhook.py
+++ b/tests/ops/models/test_manual_webhook.py
@@ -1,6 +1,7 @@
 import pytest
 
 from fides.api.models.manual_webhook import AccessManualWebhook
+from fides.api.schemas.policy import ActionType
 
 
 class TestManualWebhook:
@@ -20,6 +21,32 @@ class TestManualWebhook:
 
     def test_get_enabled_webhooks(self, db, access_manual_webhook):
         assert AccessManualWebhook.get_enabled(db) == [access_manual_webhook]
+
+    def test_get_enabled_access_webhooks(
+        self, db, integration_manual_webhook_config, access_manual_webhook
+    ):
+        assert AccessManualWebhook.get_enabled(db, ActionType.access) == [
+            access_manual_webhook
+        ]
+
+        integration_manual_webhook_config.enabled_actions = [ActionType.erasure]
+        integration_manual_webhook_config.save(db)
+
+        # don't return webhook if the access action is disabled
+        assert AccessManualWebhook.get_enabled(db, ActionType.access) == []
+
+    def test_get_enabled_erasure_webhooks(
+        self, db, integration_manual_webhook_config, access_manual_webhook
+    ):
+        assert AccessManualWebhook.get_enabled(db, ActionType.erasure) == [
+            access_manual_webhook
+        ]
+
+        integration_manual_webhook_config.enabled_actions = [ActionType.access]
+        integration_manual_webhook_config.save(db)
+
+        # don't return webhook if the erasure action is disabled
+        assert AccessManualWebhook.get_enabled(db, ActionType.erasure) == []
 
     @pytest.mark.usefixtures("access_manual_webhook")
     def test_get_enabled_webhooks_connection_config_disabled(


### PR DESCRIPTION
### Description Of Changes

Adds `enabled_actions` checks to various parts of the `graph_task` and `request_runner_service`. Since connectors often times require access data to be able to perform an erasure, access requests are still executed but are filtered out from being included in the final DSR package. Collections for erasure and consent requests are marked as skipped if their associated connection config does not contain the correct `enabled_actions` values. A `None` value for `enabled_actions` (as will be the case for OSS instances) will allow all actions to execute.


### Code Changes

* [ ] Updated `get_enabled` on `AccessManualWebhook` to consider the `enabled_actions`
* [ ] Added `skip_if_action_disabled` in the `retry` decorator of `graph` task to consider the `enabled_actions`
* [ ] Added `filter_by_enabled_actions` to filter the results of `access_request` before returning

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
