### PR TITLE
Privacy Policy alignment in non-TCF consent overlay banner and modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,12 @@ The types of changes are:
 
 ## [2.23.3](https://github.com/ethyca/fides/compare/2.23.2...2.23.3)
 
-### Fixed 
+### Fixed
 - Fix button arrangment and spacing for TCF and non-TCF consent overlay banner and modal [#4391](https://github.com/ethyca/fides/pull/4391)
 - Replaced h1 element with div to use exisitng fides styles in consent modal [#4399](https://github.com/ethyca/fides/pull/4399)
+- Fixed privacy policy alignment for non-TCF consent overlay banner and modal [#4403](https://github.com/ethyca/fides/pull/4403)
 
-### Security 
+### Security
 -- Fix an HTML Injection vulnerability in DSR Packages
 
 ## [2.23.2](https://github.com/ethyca/fides/compare/2.23.1...2.23.2)

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -64,7 +64,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
       className={`fides-banner 
         fides-banner-bottom 
         ${bannerIsOpen ? "" : "fides-banner-hidden"} 
-        ${className}`}
+        ${className ? "" : className}`}
     >
       <div id="fides-banner">
         <div id="fides-banner-inner">

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -1007,6 +1007,6 @@ div#fides-banner-inner .fides-privacy-policy {
   div#fides-button-group {
   justify-content: flex-start;
 }
-#fides-privacy-policy-link {
+.fides-tcf-banner-container #fides-privacy-policy-link {
   margin-left: auto;
 }


### PR DESCRIPTION
Relates to PROD-1320

### Description Of Changes

As part of the release testing, an issue with alignment for the privacy policy link was identified. The issue impacted the non-TCF modal and overlay

### Code Changes

* [ ] ensure the privacy policy alignment changes only affect the TCF objects

### Steps to Confirm

* [ ] Validating this in the RC builds currently, removing the style from the non-TCF banner/overlay re-aligns the privacy policy link

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
