### PR TITLE
Fix dynamic class name for TCF-variant of consent banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The types of changes are:
 - Fix button arrangment and spacing for TCF and non-TCF consent overlay banner and modal [#4391](https://github.com/ethyca/fides/pull/4391)
 - Replaced h1 element with div to use exisitng fides styles in consent modal [#4399](https://github.com/ethyca/fides/pull/4399)
 - Fixed privacy policy alignment for non-TCF consent overlay banner and modal [#4403](https://github.com/ethyca/fides/pull/4403)
+- Fix dynamic class name for TCF-variant of consent banner [#4404](https://github.com/ethyca/fides/pull/4403)
 
 ### Security
 -- Fix an HTML Injection vulnerability in DSR Packages

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -64,7 +64,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
       className={`fides-banner 
         fides-banner-bottom 
         ${bannerIsOpen ? "" : "fides-banner-hidden"} 
-        ${className ? "" : className}`}
+        ${className ? className : ""}`}
     >
       <div id="fides-banner">
         <div id="fides-banner-inner">

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -61,10 +61,9 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
   return (
     <div
       id="fides-banner-container"
-      className={`fides-banner 
-        fides-banner-bottom 
+      className={`fides-banner fides-banner-bottom 
         ${bannerIsOpen ? "" : "fides-banner-hidden"} 
-        ${className ? className : ""}`}
+        ${className || ""}`}
     >
       <div id="fides-banner">
         <div id="fides-banner-inner">


### PR DESCRIPTION
### Description Of Changes

Fixes an accidentally-backwards ternary I added to #4403! Whoops.

### Code Changes

* [X] Update `ConsentBanner`

### Steps to Confirm

* [x] Check the correct classes and CSS are added for TCF and non-TCF variants of banner:
  * [X] Regular banner does not add `fides-tcf-banner-container` class
  * [X] Regular banner does not add `undefined` class
  * [X] TCF banner adds `fides-tcf-banner-container` class

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
