### PR TITLE
Persist filter modal state after it's closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ The types of changes are:
 - "isServiceSpecific" default updated when building TC strings on the frontend [#4384](https://github.com/ethyca/fides/pull/4384)
 - Redact cli, database, and redis configuration information from GET api/v1/config API request responses. [#4379](https://github.com/ethyca/fides/pull/4379)
 
+### Fixed
+- Persist bulk system add filter modal state [#4412](https://github.com/ethyca/fides/pull/4412)
+
 ## [2.23.3](https://github.com/ethyca/fides/compare/2.23.2...2.23.3)
 
 ### Fixed

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -270,6 +270,15 @@ describe("System management with Plus features", () => {
       cy.getByTestId("column-vendor_id").should("exist");
     });
 
+    it("filter modal state is persisted after modal is closed", () => {
+      cy.visit(ADD_SYSTEMS_MULTIPLE_ROUTE);
+      cy.getByTestId("filter-multiple-systems-btn").click();
+      cy.get("#checkbox-gvl").check({ force: true });
+      cy.getByTestId("filter-done-btn").click();
+      cy.getByTestId("filter-multiple-systems-btn").click();
+      cy.get("#checkbox-gvl").should("be.checked");
+    });
+
     it("pagination menu updates pagesize", () => {
       cy.visit(ADD_SYSTEMS_MULTIPLE_ROUTE);
 

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -233,7 +233,6 @@ const SystemInformationForm = ({
   };
 
   const handleVendorSelected = (newVendorId: string) => {
-    console.log("hello from handleVendorSelected");
     if (
       features.tcf &&
       extractVendorSource(newVendorId) === VendorSources.GVL

--- a/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
+++ b/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
@@ -259,13 +259,11 @@ export const AddMultipleSystems = ({ redirectRoute }: Props) => {
           totalSelectSystemsLength > 1 ? "s" : ""
         }`}
       />
-      {isFilterOpen ? (
-        <MultipleSystemsFilterModal
-          isOpen={isFilterOpen}
-          onClose={onCloseFilter}
-          tableInstance={tableInstance}
-        />
-      ) : null}
+      <MultipleSystemsFilterModal
+        isOpen={isFilterOpen}
+        onClose={onCloseFilter}
+        tableInstance={tableInstance}
+      />
       <TableActionBar>
         <GlobalFilterV2
           globalFilter={globalFilter}

--- a/clients/admin-ui/src/features/system/add-multiple-systems/MultipleSystemsFilterModal.tsx
+++ b/clients/admin-ui/src/features/system/add-multiple-systems/MultipleSystemsFilterModal.tsx
@@ -31,6 +31,7 @@ const FilterCheckbox = ({
   value,
 }: FilterCheckboxProps) => (
   <Checkbox
+    id={`checkbox-${value}`}
     value={value}
     key={value}
     height="20px"
@@ -138,6 +139,7 @@ const MultipleSystemsFilterModal = <T,>({
               Reset Filters
             </Button>
             <Button
+              data-testid="filter-done-btn"
               colorScheme="primary"
               size="sm"
               onClick={onClose}


### PR DESCRIPTION
Closes [PROD-1354
](https://ethyca.atlassian.net/browse/PROD-1354)

### Description Of Changes

Persist filter modal state after it's closed.


https://github.com/ethyca/fides/assets/17103888/75377db2-0279-4706-b65a-89958ecf77ca




### Code Changes

* [ ] Stop removing the modal from the DOM when it's not displayed

### Steps to Confirm

* [ ] go to bulk add vendors page
* [ ] open the filter modal
* [ ] apply a filter and close the modal
* [ ] open the modal again. The filter options should still be checked

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
