### PR TITLE
Prod 1328 Track more granular consent method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The types of changes are:
 
 ### Added
 - Adds support for custom get experiences fn and custom patch notices served fn [#4410](https://github.com/ethyca/fides/pull/4410)
-- Adds more granularity to tracking consent method, updates custom save preferences fn to take consent method [#4419](https://github.com/ethyca/fides/pull/4419)
+- Adds more granularity to tracking consent method, updates custom savePreferencesFn and FidesUpdated event to take consent method [#4419](https://github.com/ethyca/fides/pull/4419)
 
 ### Changed
 - Button ordering in fides.js UI [#4407](https://github.com/ethyca/fides/pull/4407)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Added
 - Adds support for custom get experiences fn and custom patch notices served fn [#4410](https://github.com/ethyca/fides/pull/4410)
+- Adds more granularity to tracking consent method, updates custom save preferences fn to take consent method [#4419](https://github.com/ethyca/fides/pull/4419)
 
 ### Changed
 - Button ordering in fides.js UI [#4407](https://github.com/ethyca/fides/pull/4407)

--- a/clients/admin-ui/src/types/api/models/ConsentMethod.ts
+++ b/clients/admin-ui/src/types/api/models/ConsentMethod.ts
@@ -6,7 +6,11 @@
  * An enumeration.
  */
 export enum ConsentMethod {
-  BUTTON = "button",
+  BUTTON = "button", // deprecated- keeping for backwards-compatibility
+  REJECT = "reject",
+  ACCEPT = "accept",
+  SAVE = "save",
+  DISMISS = "dismiss",
   GPC = "gpc",
   INDIVIDUAL_NOTICE = "individual_notice",
 }

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -90,7 +90,10 @@ export const NoticeConsentButtons = ({
   const { experience_config: config, privacy_notices: notices } = experience;
 
   const handleAcceptAll = () => {
-    onSave(ConsentMethod.accept, notices.map((n) => n.notice_key));
+    onSave(
+      ConsentMethod.accept,
+      notices.map((n) => n.notice_key)
+    );
   };
 
   const handleRejectAll = () => {

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -1,11 +1,12 @@
-import { h, VNode } from "preact";
+import { VNode, h } from "preact";
 import Button from "./Button";
 import {
   ButtonType,
-  PrivacyExperience,
   ConsentMechanism,
-  PrivacyNotice,
+  ConsentMethod,
   ExperienceConfig,
+  PrivacyExperience,
+  PrivacyNotice,
 } from "../lib/consent-types";
 import PrivacyPolicyLink from "./PrivacyPolicyLink";
 
@@ -66,7 +67,7 @@ type NoticeKeys = Array<PrivacyNotice["notice_key"]>;
 
 interface NoticeConsentButtonProps {
   experience: PrivacyExperience;
-  onSave: (noticeKeys: NoticeKeys) => void;
+  onSave: (consentMethod: ConsentMethod, noticeKeys: NoticeKeys) => void;
   onManagePreferencesClick?: () => void;
   enabledKeys: NoticeKeys;
   isAcknowledge: boolean;
@@ -89,11 +90,12 @@ export const NoticeConsentButtons = ({
   const { experience_config: config, privacy_notices: notices } = experience;
 
   const handleAcceptAll = () => {
-    onSave(notices.map((n) => n.notice_key));
+    onSave(ConsentMethod.accept, notices.map((n) => n.notice_key));
   };
 
   const handleRejectAll = () => {
     onSave(
+      ConsentMethod.reject,
       notices
         .filter((n) => n.consent_mechanism === ConsentMechanism.NOTICE_ONLY)
         .map((n) => n.notice_key)
@@ -101,7 +103,7 @@ export const NoticeConsentButtons = ({
   };
 
   const handleSave = () => {
-    onSave(enabledKeys);
+    onSave(ConsentMethod.save, enabledKeys);
   };
 
   if (isAcknowledge) {

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -86,7 +86,10 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   };
 
   const handleUpdatePreferences = useCallback(
-    (consentMethod: ConsentMethod, enabledPrivacyNoticeKeys: Array<PrivacyNotice["notice_key"]>) => {
+    (
+      consentMethod: ConsentMethod,
+      enabledPrivacyNoticeKeys: Array<PrivacyNotice["notice_key"]>
+    ) => {
       const consentPreferencesToSave = createConsentPreferencesToSave(
         privacyNotices,
         enabledPrivacyNoticeKeys,
@@ -154,7 +157,10 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
               experience={experience}
               onManagePreferencesClick={onManagePreferencesClick}
               enabledKeys={draftEnabledNoticeKeys}
-              onSave={(consentMethod: ConsentMethod, keys: Array<PrivacyNotice["notice_key"]>) => {
+              onSave={(
+                consentMethod: ConsentMethod,
+                keys: Array<PrivacyNotice["notice_key"]>
+              ) => {
                 handleUpdatePreferences(consentMethod, keys);
                 onSave();
               }}
@@ -183,7 +189,10 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
           <NoticeConsentButtons
             experience={experience}
             enabledKeys={draftEnabledNoticeKeys}
-            onSave={(consentMethod: ConsentMethod, keys: Array<PrivacyNotice["notice_key"]>) => {
+            onSave={(
+              consentMethod: ConsentMethod,
+              keys: Array<PrivacyNotice["notice_key"]>
+            ) => {
               handleUpdatePreferences(consentMethod, keys);
               onClose();
             }}

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -86,7 +86,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   };
 
   const handleUpdatePreferences = useCallback(
-    (enabledPrivacyNoticeKeys: Array<PrivacyNotice["notice_key"]>) => {
+    (consentMethod: ConsentMethod, enabledPrivacyNoticeKeys: Array<PrivacyNotice["notice_key"]>) => {
       const consentPreferencesToSave = createConsentPreferencesToSave(
         privacyNotices,
         enabledPrivacyNoticeKeys,
@@ -96,7 +96,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
       updateConsentPreferences({
         consentPreferencesToSave,
         experience,
-        consentMethod: ConsentMethod.button,
+        consentMethod,
         options,
         userLocationString: fidesRegionString,
         cookie,
@@ -154,8 +154,8 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
               experience={experience}
               onManagePreferencesClick={onManagePreferencesClick}
               enabledKeys={draftEnabledNoticeKeys}
-              onSave={(keys) => {
-                handleUpdatePreferences(keys);
+              onSave={(consentMethod: ConsentMethod, keys: Array<PrivacyNotice["notice_key"]>) => {
+                handleUpdatePreferences(consentMethod, keys);
                 onSave();
               }}
               isAcknowledge={isAllNoticeOnly}
@@ -183,8 +183,8 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
           <NoticeConsentButtons
             experience={experience}
             enabledKeys={draftEnabledNoticeKeys}
-            onSave={(keys) => {
-              handleUpdatePreferences(keys);
+            onSave={(consentMethod: ConsentMethod, keys: Array<PrivacyNotice["notice_key"]>) => {
+              handleUpdatePreferences(consentMethod, keys);
               onClose();
             }}
             isInModal

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -1,13 +1,13 @@
 import { VNode, h } from "preact";
 
-import { PrivacyExperience } from "../../lib/consent-types";
-import { ConsentButtons } from "../ConsentButtons";
-import type { EnabledIds, TcfModels } from "../../lib/tcf/types";
+import {ConsentMethod, PrivacyExperience} from "../../lib/consent-types";
+import {ConsentButtons} from "../ConsentButtons";
+import type {EnabledIds, TcfModels} from "../../lib/tcf/types";
 
 interface TcfConsentButtonProps {
   experience: PrivacyExperience;
   onManagePreferencesClick?: () => void;
-  onSave: (keys: EnabledIds) => void;
+  onSave: (consentMethod: ConsentMethod, keys: EnabledIds) => void;
   firstButton?: VNode;
   isMobile: boolean;
   includePrivacyPolicy?: boolean;
@@ -48,7 +48,7 @@ export const TcfConsentButtons = ({
         ...(experience.tcf_system_legitimate_interests || []),
       ]),
     };
-    onSave(allIds);
+    onSave(ConsentMethod.accept, allIds);
   };
   const handleRejectAll = () => {
     const emptyIds: EnabledIds = {
@@ -60,7 +60,7 @@ export const TcfConsentButtons = ({
       vendorsConsent: [],
       vendorsLegint: [],
     };
-    onSave(emptyIds);
+    onSave(ConsentMethod.reject, emptyIds);
   };
 
   return (

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -1,8 +1,8 @@
 import { VNode, h } from "preact";
 
-import {ConsentMethod, PrivacyExperience} from "../../lib/consent-types";
-import {ConsentButtons} from "../ConsentButtons";
-import type {EnabledIds, TcfModels} from "../../lib/tcf/types";
+import { ConsentMethod, PrivacyExperience } from "../../lib/consent-types";
+import { ConsentButtons } from "../ConsentButtons";
+import type { EnabledIds, TcfModels } from "../../lib/tcf/types";
 
 interface TcfConsentButtonProps {
   experience: PrivacyExperience;

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -1,5 +1,5 @@
-import { h, FunctionComponent, Fragment } from "preact";
-import { useState, useCallback, useMemo } from "preact/hooks";
+import {Fragment, FunctionComponent, h} from "preact";
+import {useCallback, useMemo, useState} from "preact/hooks";
 import ConsentBanner from "../ConsentBanner";
 import PrivacyPolicyLink from "../PrivacyPolicyLink";
 
@@ -11,26 +11,26 @@ import {
 
 import "../fides.css";
 import Overlay from "../Overlay";
-import { TcfConsentButtons } from "./TcfConsentButtons";
-import { OverlayProps } from "../types";
+import {TcfConsentButtons} from "./TcfConsentButtons";
+import {OverlayProps} from "../types";
 
 import type {
   EnabledIds,
   TCFFeatureRecord,
   TCFFeatureSave,
+  TcfModels,
   TCFPurposeConsentRecord,
   TCFPurposeLegitimateInterestsRecord,
   TCFPurposeSave,
+  TcfSavePreferences,
   TCFSpecialFeatureSave,
   TCFSpecialPurposeSave,
-  TCFVendorSave,
-  TcfSavePreferences,
   TCFVendorConsentRecord,
   TCFVendorLegitimateInterestsRecord,
-  TcfModels,
+  TCFVendorSave,
 } from "../../lib/tcf/types";
 
-import { updateConsentPreferences } from "../../lib/preferences";
+import {updateConsentPreferences} from "../../lib/preferences";
 import {
   ButtonType,
   ConsentMethod,
@@ -38,17 +38,14 @@ import {
   PrivacyExperience,
   ServingComponent,
 } from "../../lib/consent-types";
-import { generateFidesString } from "../../lib/tcf";
-import {
-  FidesCookie,
-  transformTcfPreferencesToCookieKeys,
-} from "../../lib/cookie";
+import {generateFidesString} from "../../lib/tcf";
+import {FidesCookie, transformTcfPreferencesToCookieKeys,} from "../../lib/cookie";
 import InitialLayer from "./InitialLayer";
 import TcfTabs from "./TcfTabs";
 import Button from "../Button";
-import { useConsentServed } from "../../lib/hooks";
+import {useConsentServed} from "../../lib/hooks";
 import VendorInfoBanner from "./VendorInfoBanner";
-import { dispatchFidesEvent } from "../../lib/events";
+import {dispatchFidesEvent} from "../../lib/events";
 
 const resolveConsentValueFromTcfModel = (
   model:
@@ -293,7 +290,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
   });
 
   const handleUpdateAllPreferences = useCallback(
-    (enabledIds: EnabledIds) => {
+    (consentMethod: ConsentMethod, enabledIds: EnabledIds) => {
       const tcf = createTcfSavePayload({
         experience,
         enabledIds,
@@ -302,7 +299,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
       updateConsentPreferences({
         consentPreferencesToSave: [],
         experience,
-        consentMethod: ConsentMethod.button,
+        consentMethod,
         options,
         userLocationString: fidesRegionString,
         cookie,
@@ -361,8 +358,8 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
               <TcfConsentButtons
                 experience={experience}
                 onManagePreferencesClick={onManagePreferencesClick}
-                onSave={(keys) => {
-                  handleUpdateAllPreferences(keys);
+                onSave={(consentMethod: ConsentMethod, keys: EnabledIds) => {
+                  handleUpdateAllPreferences(consentMethod, keys);
                   onSave();
                 }}
                 isMobile={isMobile}
@@ -394,8 +391,8 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
         />
       )}
       renderModalFooter={({ onClose, isMobile }) => {
-        const onSave = (keys: EnabledIds) => {
-          handleUpdateAllPreferences(keys);
+        const onSave = (consentMethod: ConsentMethod, keys: EnabledIds) => {
+          handleUpdateAllPreferences(consentMethod, keys);
           onClose();
         };
         return (
@@ -407,7 +404,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
                 <Button
                   buttonType={ButtonType.SECONDARY}
                   label={experience.experience_config?.save_button_label}
-                  onClick={() => onSave(draftIds)}
+                  onClick={() => onSave(ConsentMethod.save, draftIds)}
                   className="fides-save-button"
                 />
               }

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -1,5 +1,5 @@
-import {Fragment, FunctionComponent, h} from "preact";
-import {useCallback, useMemo, useState} from "preact/hooks";
+import { Fragment, FunctionComponent, h } from "preact";
+import { useCallback, useMemo, useState } from "preact/hooks";
 import ConsentBanner from "../ConsentBanner";
 import PrivacyPolicyLink from "../PrivacyPolicyLink";
 
@@ -11,8 +11,8 @@ import {
 
 import "../fides.css";
 import Overlay from "../Overlay";
-import {TcfConsentButtons} from "./TcfConsentButtons";
-import {OverlayProps} from "../types";
+import { TcfConsentButtons } from "./TcfConsentButtons";
+import { OverlayProps } from "../types";
 
 import type {
   EnabledIds,
@@ -30,7 +30,7 @@ import type {
   TCFVendorSave,
 } from "../../lib/tcf/types";
 
-import {updateConsentPreferences} from "../../lib/preferences";
+import { updateConsentPreferences } from "../../lib/preferences";
 import {
   ButtonType,
   ConsentMethod,
@@ -38,14 +38,17 @@ import {
   PrivacyExperience,
   ServingComponent,
 } from "../../lib/consent-types";
-import {generateFidesString} from "../../lib/tcf";
-import {FidesCookie, transformTcfPreferencesToCookieKeys,} from "../../lib/cookie";
+import { generateFidesString } from "../../lib/tcf";
+import {
+  FidesCookie,
+  transformTcfPreferencesToCookieKeys,
+} from "../../lib/cookie";
 import InitialLayer from "./InitialLayer";
 import TcfTabs from "./TcfTabs";
 import Button from "../Button";
-import {useConsentServed} from "../../lib/hooks";
+import { useConsentServed } from "../../lib/hooks";
 import VendorInfoBanner from "./VendorInfoBanner";
-import {dispatchFidesEvent} from "../../lib/events";
+import { dispatchFidesEvent } from "../../lib/events";
 
 const resolveConsentValueFromTcfModel = (
   model:

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -96,11 +96,13 @@ export type FidesApiOptions = {
   /**
    * Intake a custom function that is called instead of the internal Fides API to save user preferences.
    *
+   * @param {object} consentMethod - method that was used to obtain consent
    * @param {object} consent - updated version of Fides.consent with the user's saved preferences for Fides notices
    * @param {string} fides_string - updated version of Fides.fides_string with the user's saved preferences for TC/AC/etc notices
    * @param {object} experience - current version of the privacy experience that was shown to the user
    */
   savePreferencesFn?: (
+    consentMethod: ConsentMethod,
     consent: CookieKeyConsent,
     fides_string: string | undefined,
     experience: PrivacyExperience

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -398,7 +398,11 @@ export enum ButtonType {
 }
 
 export enum ConsentMethod {
-  button = "button",
+  button = "button", // deprecated- keeping for backwards-compatibility
+  reject = "reject",
+  accept = "accept",
+  save = "save",
+  dismiss = "dismiss",
   gpc = "gpc",
   individual_notice = "api",
 }

--- a/clients/fides-js/src/lib/events.ts
+++ b/clients/fides-js/src/lib/events.ts
@@ -71,7 +71,11 @@ export const dispatchFidesEvent = (
         extraDetails?.servingComponent
           ? `from ${extraDetails.servingComponent} `
           : ""
-      }with cookie ${JSON.stringify(cookie)}`
+      }with cookie ${JSON.stringify(cookie)} ${
+        extraDetails?.consentMethod
+          ? `using consent method ${extraDetails.consentMethod} `
+          : ""
+      }`
     );
     window.dispatchEvent(event);
   }

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -131,5 +131,5 @@ export const updateConsentPreferences = async ({
   }
 
   // 6. Dispatch a "FidesUpdated" event
-  dispatchFidesEvent("FidesUpdated", cookie, options.debug);
+  dispatchFidesEvent("FidesUpdated", cookie, options.debug, { consentMethod });
 };

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -45,6 +45,7 @@ async function savePreferencesApi(
     ...(tcf ?? []),
   };
   await patchUserPreference(
+    consentMethod,
     privacyPreferenceCreate,
     options,
     cookie,

--- a/clients/fides-js/src/services/api.ts
+++ b/clients/fides-js/src/services/api.ts
@@ -1,5 +1,6 @@
 import {
-  ComponentType, ConsentMethod,
+  ComponentType,
+  ConsentMethod,
   EmptyExperience,
   FidesApiOptions,
   FidesOptions,

--- a/clients/fides-js/src/services/api.ts
+++ b/clients/fides-js/src/services/api.ts
@@ -1,5 +1,5 @@
 import {
-  ComponentType,
+  ComponentType, ConsentMethod,
   EmptyExperience,
   FidesApiOptions,
   FidesOptions,
@@ -114,6 +114,7 @@ const PATCH_FETCH_OPTIONS: RequestInit = {
  * Sends user consent preference downstream to Fides or custom API
  */
 export const patchUserPreference = async (
+  consentMethod: ConsentMethod,
   preferences: PrivacyPreferencesRequest,
   options: FidesOptions,
   cookie: FidesCookie,
@@ -124,6 +125,7 @@ export const patchUserPreference = async (
     debugLog(options.debug, "Calling custom save preferences fn");
     try {
       await options.apiOptions.savePreferencesFn(
+        consentMethod,
         cookie.consent,
         cookie.fides_string,
         experience

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -323,7 +323,12 @@ describe("Fides-js TCF", () => {
         cy.getByTestId("consent-modal").within(() => {
           cy.get("button").contains("Opt in to all").click();
         });
-        cy.get("@FidesUpdated").should("have.been.calledOnce");
+        cy.get("@FidesUpdated")
+          .should("have.been.calledOnce")
+          .its("lastCall.args.0.detail.extraDetails.consentMethod")
+          .then((consentMethod) => {
+            expect(consentMethod).to.eql(ConsentMethod.accept);
+          });
         cy.window().then((win) => {
           win.__tcfapi("getTCData", 2, cy.stub().as("getTCData"));
           cy.get("@getTCData")
@@ -871,20 +876,24 @@ describe("Fides-js TCF", () => {
             cy.get("#fides-modal-link").click();
             cy.getByTestId("consent-modal").within(() => {
               cy.get("button").contains("Opt out of all").click();
-              cy.get("@FidesUpdated").then(() => {
-                // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-                expect(spyObject).to.be.called;
-                const spy = spyObject.getCalls();
-                const { args } = spy[0];
-                expect(args[0]).to.equal(ConsentMethod.reject);
-                expect(args[1]).to.deep.equal({
-                  data_sales: true,
-                  tracking: false,
+              cy.get("@FidesUpdated")
+                .should("have.been.calledOnce")
+                .its("lastCall.args.0.detail.extraDetails.consentMethod")
+                .then((consentMethod) => {
+                  expect(consentMethod).to.eql(ConsentMethod.accept);
+                  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                  expect(spyObject).to.be.called;
+                  const spy = spyObject.getCalls();
+                  const { args } = spy[0];
+                  expect(args[0]).to.equal(ConsentMethod.reject);
+                  expect(args[1]).to.deep.equal({
+                    data_sales: true,
+                    tracking: false,
+                  });
+                  // the TC str is dynamically updated upon save preferences with diff timestamp, so we do a fuzzy match
+                  expect(args[2]).to.contain(".IABE,1~");
+                  expect(args[3]).to.deep.equal(privacyExperience.items[0]);
                 });
-                // the TC str is dynamically updated upon save preferences with diff timestamp, so we do a fuzzy match
-                expect(args[2]).to.contain(".IABE,1~");
-                expect(args[3]).to.deep.equal(privacyExperience.items[0]);
-              });
               // timeout means API call not made, which is expected
               cy.on("fail", (error) => {
                 if (error.message.indexOf("Timed out retrying") !== 0) {
@@ -1293,7 +1302,12 @@ describe("Fides-js TCF", () => {
           cy.get("button").contains("Opt in to all").click();
         });
         // On slow connections, we should explicitly wait for FidesUpdated
-        cy.get("@FidesUpdated").should("have.been.calledOnce");
+        cy.get("@FidesUpdated")
+          .should("have.been.calledOnce")
+          .its("lastCall.args.0.detail.extraDetails.consentMethod")
+          .then((consentMethod) => {
+            expect(consentMethod).to.eql(ConsentMethod.accept);
+          });
         cy.get("@TCFEvent")
           .its("lastCall.args")
           .then(([tcData, success]) => {
@@ -1357,7 +1371,12 @@ describe("Fides-js TCF", () => {
         cy.getByTestId("consent-modal").within(() => {
           cy.get("button").contains("Opt in to all").click();
         });
-        cy.get("@FidesUpdated").should("have.been.calledOnce");
+        cy.get("@FidesUpdated")
+          .should("have.been.calledOnce")
+          .its("lastCall.args.0.detail.extraDetails.consentMethod")
+          .then((consentMethod) => {
+            expect(consentMethod).to.eql(ConsentMethod.accept);
+          });
         cy.get("@TCFEvent2")
           .its("lastCall.args")
           .then(([tcData, success]) => {
@@ -2622,7 +2641,12 @@ describe("Fides-js TCF", () => {
       cy.wait("@patchPrivacyPreference").then((interception) => {
         expect(interception.request.body.method).to.eql(ConsentMethod.accept);
       });
-      cy.get("@FidesUpdated").should("have.been.calledOnce");
+      cy.get("@FidesUpdated")
+        .should("have.been.calledOnce")
+        .its("lastCall.args.0.detail.extraDetails.consentMethod")
+        .then((consentMethod) => {
+          expect(consentMethod).to.eql(ConsentMethod.accept);
+        });
       // Call getTCData
       cy.window().then((win) => {
         win.__tcfapi("getTCData", 2, cy.stub().as("getTCData"));

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -204,7 +204,7 @@ describe("Consent banner", () => {
               ],
               privacy_experience_id: "132345243",
               user_geography: "us_ca",
-              method: ConsentMethod.button,
+              method: ConsentMethod.save,
             };
             // uuid is generated automatically if the user has no saved consent cookie
             generatedUserDeviceId = body.browser_identity.fides_user_device_id;
@@ -336,7 +336,7 @@ describe("Consent banner", () => {
             ],
             privacy_experience_id: "132345243",
             user_geography: "us_ca",
-            method: ConsentMethod.button,
+            method: ConsentMethod.save,
           };
           expect(body).to.eql(expected);
         });
@@ -1586,6 +1586,9 @@ describe("Consent banner", () => {
               (p: ConsentOptionCreate) => p.served_notice_history_id
             )
           ).to.eql(expected);
+          expect(preferenceInterception.request.body.method).to.eql(
+            ConsentMethod.reject
+          );
         });
       });
     });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -409,7 +409,12 @@ describe("Consent banner", () => {
 
         it("can remove all cookies when rejecting all", () => {
           cy.contains("button", "Reject Test").click();
-          cy.get("@FidesUpdated").should("have.been.calledOnce");
+          cy.get("@FidesUpdated")
+            .should("have.been.calledOnce")
+            .its("lastCall.args.0.detail.extraDetails.consentMethod")
+            .then((consentMethod) => {
+              expect(consentMethod).to.eql(ConsentMethod.reject);
+            });
           cy.getAllCookies().then((allCookies) => {
             expect(allCookies.map((c) => c.name)).to.eql([CONSENT_COOKIE_NAME]);
           });
@@ -420,7 +425,12 @@ describe("Consent banner", () => {
           // opt out of the first notice
           cy.getByTestId("toggle-one").click();
           cy.getByTestId("Save test-btn").click();
-          cy.get("@FidesUpdated").should("have.been.calledOnce");
+          cy.get("@FidesUpdated")
+            .should("have.been.calledOnce")
+            .its("lastCall.args.0.detail.extraDetails.consentMethod")
+            .then((consentMethod) => {
+              expect(consentMethod).to.eql(ConsentMethod.save);
+            });
           cy.getAllCookies().then((allCookies) => {
             expect(allCookies.map((c) => c.name)).to.eql([
               CONSENT_COOKIE_NAME,
@@ -1172,6 +1182,11 @@ describe("Consent banner", () => {
             [PRIVACY_NOTICE_KEY_1]: false,
             [PRIVACY_NOTICE_KEY_2]: true,
           });
+        cy.get("@FidesUpdated")
+          .its("lastCall.args.0.detail.extraDetails.consentMethod")
+          .then((consentMethod) => {
+            expect(consentMethod).to.eql(ConsentMethod.reject);
+          });
       });
 
       it("emits a FidesUpdated event when accept all is clicked", () => {
@@ -1193,6 +1208,11 @@ describe("Consent banner", () => {
             [PRIVACY_NOTICE_KEY_1]: true,
             [PRIVACY_NOTICE_KEY_2]: true,
           });
+        cy.get("@FidesUpdated")
+          .its("lastCall.args.0.detail.extraDetails.consentMethod")
+          .then((consentMethod) => {
+            expect(consentMethod).to.eql(ConsentMethod.accept);
+          });
       });
 
       it("emits a FidesUIChanged event when preferences are changed and a FidesUpdated event when preferences are saved", () => {
@@ -1210,6 +1230,7 @@ describe("Consent banner", () => {
             [PRIVACY_NOTICE_KEY_1]: false,
             [PRIVACY_NOTICE_KEY_2]: true,
           });
+
         cy.get("@FidesUpdated")
           // Update event, when the user saved preferences and opted-in to the first notice
           .should("have.been.calledOnce")
@@ -1217,6 +1238,11 @@ describe("Consent banner", () => {
           .should("deep.equal", {
             [PRIVACY_NOTICE_KEY_1]: true,
             [PRIVACY_NOTICE_KEY_2]: true,
+          });
+        cy.get("@FidesUpdated")
+          .its("lastCall.args.0.detail.extraDetails.consentMethod")
+          .then((consentMethod) => {
+            expect(consentMethod).to.eql(ConsentMethod.save);
           });
       });
     });

--- a/src/fides/api/models/privacy_preference.py
+++ b/src/fides/api/models/privacy_preference.py
@@ -52,7 +52,11 @@ class RequestOrigin(Enum):
 
 
 class ConsentMethod(Enum):
-    button = "button"
+    button = "button"  # deprecated- keeping for backwards-compatibility
+    reject = "reject"
+    accept = "accept"
+    save = "save"
+    dismiss = "dismiss"
     gpc = "gpc"
     individual_notice = "individual_notice"
 


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1328

### Description Of Changes

Adds new enum members to `ConsentMethod`, ensure we're passing these new granular consent methods in our overlay components, and update our custom save preferences fn to intake consent method.

### Steps to Confirm

* [ ] Run e2e tests

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
