### PR TITLE
PROD-1383 allow cookie to be avail across whole domain

### DIFF
--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -250,6 +250,8 @@ export const saveFidesCookie = (cookie: FidesCookie) => {
     CONSENT_COOKIE_NAME,
     JSON.stringify(cookie),
     {
+      // Allows the cookie to be available for whole domain, not just the path at which it was set.
+      path: "/",
       // An explicit domain allows subdomains to access the cookie.
       domain: rootDomain,
       expires: CONSENT_COOKIE_MAX_AGE_DAYS,

--- a/clients/privacy-center/public/test/fides-js-components-demo.html
+++ b/clients/privacy-center/public/test/fides-js-components-demo.html
@@ -11,8 +11,8 @@
     <script>
       (function () {
         var src = window.fidesConfig?.options?.tcfEnabled
-          ? "../../lib/fides-tcf.js"
-          : "../../lib/fides.js";
+          ? "./lib/fides-tcf.js"
+          : "./lib/fides.js";
         document.write('<script src="' + src + '"><\/script>');
       })();
     </script>


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1383

### Description Of Changes

Fixes issue where cookie set on any path that isn't root domain does not persist across other paths on a given website.


### Code Changes

* [ ] Adds explicit `path` attr when we set the `fides_consent` cookie. 

### Steps to Confirm

* [ ] Manually tested by first copying `fides-js-components-demo.html` into a separate `/test/fides-js-components-demo.html` directory, and adjusting necessary import paths
* [ ] Navigated to http://localhost:3000/test/fides-js-components-demo.html, clicked "accept all"
* [ ] Navitated to http://localhost:3000/fides-js-components-demo.html and confirmed the `fides_consent` cookie was set and the banner did not resurface.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
