### PR TITLE
Remove button to populate data uses from dictionary from data use table

### DIFF
--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
@@ -17,8 +17,6 @@ import { useAppSelector } from "~/app/hooks";
 import { selectLockedForGVL } from "~/features/system/dictionary-form/dict-suggestion.slice";
 import { DataUse, PrivacyDeclarationResponse } from "~/types/api";
 
-import { SparkleIcon } from "../../common/Icon/SparkleIcon";
-
 const PrivacyDeclarationRow = ({
   declaration,
   title,
@@ -99,23 +97,19 @@ export const PrivacyDeclarationTabTable = ({
 
 type Props = {
   heading: string;
-  dictionaryEnabled?: boolean;
   declarations: PrivacyDeclarationResponse[];
   handleDelete: (dec: PrivacyDeclarationResponse) => void;
   handleAdd?: () => void;
   handleEdit: (dec: PrivacyDeclarationResponse) => void;
-  handleOpenDictModal: () => void;
   allDataUses: DataUse[];
 };
 
 export const PrivacyDeclarationDisplayGroup = ({
   heading,
-  dictionaryEnabled = false,
   declarations,
   handleAdd,
   handleDelete,
   handleEdit,
-  handleOpenDictModal,
   allDataUses,
 }: Props) => {
   const declarationTitle = (declaration: PrivacyDeclarationResponse) => {
@@ -135,17 +129,6 @@ export const PrivacyDeclarationDisplayGroup = ({
   return (
     <PrivacyDeclarationTabTable
       heading={heading}
-      headerButton={
-        dictionaryEnabled ? (
-          <IconButton
-            onClick={handleOpenDictModal}
-            aria-label="Show dictionary suggestions"
-            variant="outline"
-          >
-            <SparkleIcon />
-          </IconButton>
-        ) : null
-      }
       footerButton={
         !lockedForGVL ? (
           <Button

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
@@ -33,7 +33,6 @@ import {
 import { DataUseDeclaration } from "~/types/dictionary-api";
 import { isErrorResult } from "~/types/errors";
 
-import { useFeatures } from "../../common/features";
 import PrivacyDeclarationDictModalComponents from "../dictionary-data-uses/PrivacyDeclarationDictModalComponents";
 
 interface Props {
@@ -60,13 +59,8 @@ const PrivacyDeclarationFormTab = ({
     PrivacyDeclarationResponse | undefined
   >(undefined);
 
-  const features = useFeatures();
-
-  const {
-    isOpen: showDictionaryModal,
-    onOpen: handleOpenDictModal,
-    onClose: handleCloseDictModal,
-  } = useDisclosure();
+  const { isOpen: showDictionaryModal, onClose: handleCloseDictModal } =
+    useDisclosure();
 
   const assignedCookies = [
     ...system.privacy_declarations
@@ -241,8 +235,6 @@ const PrivacyDeclarationFormTab = ({
           handleAdd={handleOpenNewForm}
           handleEdit={handleOpenEditForm}
           handleDelete={handleDelete}
-          dictionaryEnabled={features.dictionaryService}
-          handleOpenDictModal={handleOpenDictModal}
           allDataUses={dataProps.allDataUses}
         />
       )}


### PR DESCRIPTION
Closes #4427 

### Description Of Changes

Removes button from dictionary data use table.

### Steps to Confirm

With Compass enabled:
* Create a system
* View data uses populated from Compass (or add one manually)
* Sparkle button should *not* be present on table header:
![image](https://github.com/ethyca/fides/assets/6394496/c2e50529-f0f7-42d4-89e1-3e872cb539d1)


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created