### PR TITLE
PROD-1389 for TCF, any consent pref that is not defined on cookie should be assumed opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.24.0...main)
 
+### Changed
+- Updates default consent preference to opt-out for TCF when fides_string override is provided [#4430](https://github.com/ethyca/fides/pull/4430)
+
 
 ## [2.24.0](https://github.com/ethyca/fides/compare/2.23.3...2.24.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.24.0...main)
 
 ### Changed
-- Updates default consent preference to opt-out for TCF when fides_string override is provided [#4430](https://github.com/ethyca/fides/pull/4430)
+- Updates default consent preference to opt-out for TCF when fides_string exists [#4430](https://github.com/ethyca/fides/pull/4430)
 
 
 ## [2.24.0](https://github.com/ethyca/fides/compare/2.23.3...2.24.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.24.0...main)
 
-### Changed
-- Updates default consent preference to opt-out for TCF when fides_string exists [#4430](https://github.com/ethyca/fides/pull/4430)
-
 
 ## [2.24.0](https://github.com/ethyca/fides/compare/2.23.3...2.24.0)
 
@@ -47,6 +44,7 @@ The types of changes are:
 - Redact cli, database, and redis configuration information from GET api/v1/config API request responses. [#4379](https://github.com/ethyca/fides/pull/4379)
 - Button ordering in fides.js UI [#4407](https://github.com/ethyca/fides/pull/4407)
 - Add different classnames to consent buttons for easier selection [#4411](https://github.com/ethyca/fides/pull/4411)
+- Updates default consent preference to opt-out for TCF when fides_string exists [#4430](https://github.com/ethyca/fides/pull/4430)
 
 ### Fixed
 - Persist bulk system add filter modal state [#4412](https://github.com/ethyca/fides/pull/4412)

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -316,8 +316,10 @@ export const buildTcfEntitiesFromCookie = (
               Boolean(cookieConsent[item.id]),
               ConsentMechanism.OPT_IN
             )
-          : // if experience contains a tcf entity not defined by tcfEntities, we override experience current pref with the default pref
-            item.default_preference;
+          : // If experience contains a tcf entity not defined by tcfEntities, this means either:
+            // A) Most commonly, user has opted out, and opt-outs are not tracked by TC string. It's safe to assume this case.
+            // B) There is a new tcf entity that requires consent. In this case we would just resurface the banner
+            ConsentMechanism.OPT_OUT;
         return { ...item, current_preference: preference };
       });
     });

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -311,15 +311,18 @@ export const buildTcfEntitiesFromCookie = (
       const cookieConsent = cookie.tcf_consent[cookieKey] ?? {};
       // @ts-ignore the array map should ensure we will get the right record type
       tcfEntities[experienceKey] = experience[experienceKey]?.map((item) => {
+        const defaultPreference = cookie.fides_string
+          ? ConsentMechanism.OPT_OUT
+          : item.default_preference;
         const preference = Object.hasOwn(cookieConsent, item.id)
           ? transformConsentToFidesUserPreference(
               Boolean(cookieConsent[item.id]),
               ConsentMechanism.OPT_IN
             )
-          : // If experience contains a tcf entity not defined by tcfEntities, this means either:
-            // A) Most commonly, user has opted out, and opt-outs are not tracked by TC string. It's safe to assume this case.
-            // B) There is a new tcf entity that requires consent. In this case we would just resurface the banner
-            ConsentMechanism.OPT_OUT;
+          : // If experience contains a tcf entity not defined by tcfEntities, this means:
+            // A) If fides_string exists, user has probably opted out. Since opt-outs are not tracked by TC string, in this case we assume opt-out.
+            // B) There is a new tcf entity that requires consent. In this case we would use the default on the experience.
+            defaultPreference;
         return { ...item, current_preference: preference };
       });
     });

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -1634,14 +1634,14 @@ describe("Fides-js TCF", () => {
       });
       cy.getByTestId(`toggle-${PURPOSE_9.name}`).within(() => {
         // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-        // it should use the default preference set in the experience which is false
+        // it should use false as the default
         cy.get("input").should("not.be.checked");
       });
       cy.get("button").contains("Legitimate interest").click();
       cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
         // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-        // it should use the default preference set in the experience which is true
-        cy.get("input").should("be.checked");
+        // it should use false as the default
+        cy.get("input").should("not.be.checked");
       });
       // Features
       cy.get("#fides-tab-Features").click();
@@ -1650,7 +1650,7 @@ describe("Fides-js TCF", () => {
       });
       // Vendors
       // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-      // it should use the default preference set in the experience which is true
+      // it should use false as the default
       cy.get("#fides-tab-Vendors").click();
       cy.getByTestId(`toggle-${VENDOR_1.name}`).within(() => {
         cy.get("input").should("not.be.checked");
@@ -1658,7 +1658,7 @@ describe("Fides-js TCF", () => {
       cy.get("#fides-panel-Vendors").within(() => {
         cy.get("button").contains("Legitimate interest").click();
         cy.getByTestId(`toggle-${SYSTEM_1.name}`).within(() => {
-          cy.get("input").should("be.checked");
+          cy.get("input").should("not.be.checked");
         });
       });
 
@@ -1729,14 +1729,14 @@ describe("Fides-js TCF", () => {
       });
       cy.getByTestId(`toggle-${PURPOSE_9.name}`).within(() => {
         // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-        // it should use the default preference set in the experience which is false
+        // it should use false as the default
         cy.get("input").should("not.be.checked");
       });
       cy.get("button").contains("Legitimate interest").click();
       cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
         // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-        // it should use the default preference set in the experience which is true
-        cy.get("input").should("be.checked");
+        // it should use false as the default
+        cy.get("input").should("not.be.checked");
       });
       // Features
       cy.get("#fides-tab-Features").click();
@@ -1745,7 +1745,7 @@ describe("Fides-js TCF", () => {
       });
       // Vendors
       // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-      // it should use the default preference set in the experience which is true
+      // it should use false as the default
       cy.get("#fides-tab-Vendors").click();
       cy.getByTestId(`toggle-${VENDOR_1.name}`).within(() => {
         cy.get("input").should("not.be.checked");
@@ -1753,7 +1753,7 @@ describe("Fides-js TCF", () => {
       cy.get("#fides-panel-Vendors").within(() => {
         cy.get("button").contains("Legitimate interest").click();
         cy.getByTestId(`toggle-${SYSTEM_1.name}`).within(() => {
-          cy.get("input").should("be.checked");
+          cy.get("input").should("not.be.checked");
         });
       });
 
@@ -1865,14 +1865,14 @@ describe("Fides-js TCF", () => {
       });
       cy.getByTestId(`toggle-${PURPOSE_9.name}`).within(() => {
         // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-        // it should use the default preference set in the experience which is false
+        // it should use false as the default
         cy.get("input").should("not.be.checked");
       });
       cy.get("button").contains("Legitimate interest").click();
       cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
         // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-        // it should use the default preference set in the experience which is true
-        cy.get("input").should("be.checked");
+        // it should use false as the default
+        cy.get("input").should("not.be.checked");
       });
       // Features
       cy.get("#fides-tab-Features").click();
@@ -1881,7 +1881,7 @@ describe("Fides-js TCF", () => {
       });
       // Vendors
       // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-      // it should use the default preference set in the experience which is true
+      // it should use false as the default
       cy.get("#fides-tab-Vendors").click();
       cy.getByTestId(`toggle-${VENDOR_1.name}`).within(() => {
         cy.get("input").should("not.be.checked");
@@ -1889,7 +1889,7 @@ describe("Fides-js TCF", () => {
       cy.get("#fides-panel-Vendors").within(() => {
         cy.get("button").contains("Legitimate interest").click();
         cy.getByTestId(`toggle-${SYSTEM_1.name}`).within(() => {
-          cy.get("input").should("be.checked");
+          cy.get("input").should("not.be.checked");
         });
       });
 
@@ -2047,14 +2047,14 @@ describe("Fides-js TCF", () => {
       });
       cy.getByTestId(`toggle-${PURPOSE_9.name}`).within(() => {
         // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-        // it should use the default preference set in the experience which is false
+        // it should use false as the default
         cy.get("input").should("not.be.checked");
       });
       cy.get("button").contains("Legitimate interest").click();
       cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
         // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-        // it should use the default preference set in the experience which is true
-        cy.get("input").should("be.checked");
+        // it should use false as the default
+        cy.get("input").should("not.be.checked");
       });
       // Features
       cy.get("#fides-tab-Features").click();
@@ -2070,9 +2070,9 @@ describe("Fides-js TCF", () => {
         cy.get("button").contains("Legitimate interest").click();
       });
       // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-      // it should use the default preference set in the experience which is true
+      // it should use false as the default
       cy.getByTestId(`toggle-${SYSTEM_1.name}`).within(() => {
-        cy.get("input").should("be.checked");
+        cy.get("input").should("not.be.checked");
       });
 
       // verify CMP API
@@ -2166,14 +2166,14 @@ describe("Fides-js TCF", () => {
       });
       cy.getByTestId(`toggle-${PURPOSE_9.name}`).within(() => {
         // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-        // it should use the default preference set in the experience which is false
+        // it should use false as the default
         cy.get("input").should("not.be.checked");
       });
       cy.get("button").contains("Legitimate interest").click();
       cy.getByTestId(`toggle-${PURPOSE_2.name}`).within(() => {
         // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-        // it should use the default preference set in the experience which is true
-        cy.get("input").should("be.checked");
+        // it should use false as the default
+        cy.get("input").should("not.be.checked");
       });
       // Features
       cy.get("#fides-tab-Features").click();
@@ -2182,7 +2182,7 @@ describe("Fides-js TCF", () => {
       });
       // Vendors
       // this purpose is set to true in the experience, but since it was not defined in the fides_string,
-      // it should use the default preference set in the experience which is true
+      // it should use false as the default
       cy.get("#fides-tab-Vendors").click();
       cy.getByTestId(`toggle-${VENDOR_1.name}`).within(() => {
         cy.get("input").should("not.be.checked");
@@ -2191,7 +2191,7 @@ describe("Fides-js TCF", () => {
         cy.get("button").contains("Legitimate interest").click();
       });
       cy.getByTestId(`toggle-${SYSTEM_1.name}`).within(() => {
-        cy.get("input").should("be.checked");
+        cy.get("input").should("not.be.checked");
       });
 
       // verify CMP API


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1389

### Description Of Changes

For TCF, if we have a previously saved `fides_consent` cookie or a `fides_string` override,  any consent pref that is not defined on cookie.tcf_consent should be assumed opt-out, instead of using the defaults on the experience.

### Code Changes

* [ ] Updates default consent for tcf_entities on experience to be opt-out if we have any previously saved consent prefs on either cookie.tcf_consent or a fides_string override (which actually gets put on the `cookie` too).
* [ ] Update e2e tests

### Steps to Confirm

* [ ] Nav to http://localhost:3000/fides-js-components-demo.html with TCF enabled and TCF experience configured for your geo
* [ ] Click reject all, take note of the generated fides_string (window.Fides.fides_string)
* [ ] Clear cookies
* [ ] Reload page
* [ ] Add the `?fides_string` query param to the URL, e.g. http://localhost:3000/fides-js-components-demo.html?fides_string=CP1OzUAP1OzUAGXABBENATEgAAAAAAAAAAAAAAAAAAAA.IABE,1~
* [ ] Open up consent modal
* [ ] See that everything in the modal UI is opted out, instead of showing any defaults from the experience.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
