### PR TITLE
PROD-1330: logging for root user access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.24.0...main)
 
+### Added
+- Logging when root user and client credentials are used [#4432](https://github.com/ethyca/fides/pull/4432)
+
 
 ## [2.24.0](https://github.com/ethyca/fides/compare/2.23.3...2.24.0)
 

--- a/src/fides/api/api/v1/endpoints/oauth_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/oauth_endpoints.py
@@ -105,7 +105,9 @@ async def acquire_access_token(
     )
 
     if client_id == CONFIG.security.oauth_root_client_id:
-        logger.warning("Root user access token acquired!")
+        logger.warning(
+            "OAuth Root Client ID was used to generate an API access token. If unexpected, review security settings (FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID)"
+        )
 
     return AccessToken(access_token=access_code)
 

--- a/src/fides/api/api/v1/endpoints/oauth_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/oauth_endpoints.py
@@ -83,10 +83,6 @@ async def acquire_access_token(
     else:
         raise AuthenticationFailure(detail="Authentication Failure")
 
-    root_user = client_id == CONFIG.security.oauth_root_client_id
-    if root_user:
-        logger.info("Root user access token requested")
-
     # scopes/roles params are only used if client is root client, otherwise we use the client's associated scopes and/or roles
     client_detail = ClientDetail.get(
         db,
@@ -108,7 +104,7 @@ async def acquire_access_token(
         CONFIG.security.app_encryption_key
     )
 
-    if root_user:
+    if client_id == CONFIG.security.oauth_root_client_id:
         logger.warning("Root user access token acquired!")
 
     return AccessToken(access_token=access_code)

--- a/src/fides/api/api/v1/endpoints/oauth_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/oauth_endpoints.py
@@ -83,6 +83,10 @@ async def acquire_access_token(
     else:
         raise AuthenticationFailure(detail="Authentication Failure")
 
+    root_user = client_id == CONFIG.security.oauth_root_client_id
+    if root_user:
+        logger.info("Root user access token requested")
+
     # scopes/roles params are only used if client is root client, otherwise we use the client's associated scopes and/or roles
     client_detail = ClientDetail.get(
         db,
@@ -103,6 +107,10 @@ async def acquire_access_token(
     access_code = client_detail.create_access_code_jwe(
         CONFIG.security.app_encryption_key
     )
+
+    if root_user:
+        logger.warning("Root user access token acquired!")
+
     return AccessToken(access_token=access_code)
 
 

--- a/src/fides/api/api/v1/endpoints/user_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/user_endpoints.py
@@ -528,6 +528,7 @@ def user_login(
         and config.security.root_username == user_data.username
         and config.security.root_password == user_data.password
     ):
+        logger.warning("Performing root user login!")
         client_check = ClientDetail.get(
             db,
             object_id=config.security.oauth_root_client_id,

--- a/src/fides/api/api/v1/endpoints/user_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/user_endpoints.py
@@ -550,7 +550,10 @@ def user_login(
             created_at=datetime.utcnow(),
         )
 
-        logger.warning("Successful root user login!")
+        logger.warning(
+            "Root Username & Password were used to login! If unexpected, review security settings (FIDES__SECURITY__ROOT_USERNAME and FIDES__SECURITY__ROOT_PASSWORD)"
+        )
+
     else:
         user_check: Optional[FidesUser] = FidesUser.get_by(
             db, field="username", value=user_data.username

--- a/src/fides/api/api/v1/endpoints/user_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/user_endpoints.py
@@ -528,7 +528,6 @@ def user_login(
         and config.security.root_username == user_data.username
         and config.security.root_password == user_data.password
     ):
-        logger.warning("Performing root user login!")
         client_check = ClientDetail.get(
             db,
             object_id=config.security.oauth_root_client_id,
@@ -550,6 +549,8 @@ def user_login(
             username=config.security.root_username,
             created_at=datetime.utcnow(),
         )
+
+        logger.warning("Successful root user login!")
     else:
         user_check: Optional[FidesUser] = FidesUser.get_by(
             db, field="username", value=user_data.username

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -242,7 +242,7 @@ def read_other_paths(request: Request) -> Response:
     return get_admin_index_as_response()
 
 
-def warn_root_user_enabled():
+def warn_root_user_enabled() -> None:
     """
     Log a startup warning if root user is enabled.
     Extracted as a function because this may need to be done in multiple places,

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -250,7 +250,7 @@ def warn_root_user_enabled() -> None:
     """
     if CONFIG.security.root_username or CONFIG.security.oauth_root_client_id:
         logger.warning(
-            "Security warning: you are running Fides with a root user configured! This is not recommended in production deployments"
+            "Root Username & Password are configured and can be used to login as a root user. If unexpected, review security settings (FIDES__SECURITY__ROOT_USERNAME and FIDES__SECURITY__ROOT_PASSWORD)"
         )
 
 

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -242,6 +242,18 @@ def read_other_paths(request: Request) -> Response:
     return get_admin_index_as_response()
 
 
+def warn_root_user_enabled():
+    """
+    Log a startup warning if root user is enabled.
+    Extracted as a function because this may need to be done in multiple places,
+    depending on how the server is started.
+    """
+    if CONFIG.security.root_username or CONFIG.security.oauth_root_client_id:
+        logger.warning(
+            "Security warning: you are running Fides with a root user configured! This is not recommended in production deployments"
+        )
+
+
 @app.on_event("startup")
 async def setup_server() -> None:
     """Run all of the required setup steps for the webserver.
@@ -283,6 +295,8 @@ async def setup_server() -> None:
     if not CONFIG.logging.serialization:
         logger.info(FIDES_ASCII_ART)
 
+    warn_root_user_enabled()
+
     logger.info("Fides startup complete! v{}", VERSION)
     startup_time = round(perf_counter() - start_time, 3)
     logger.info("Server setup completed in {} seconds", startup_time)
@@ -299,6 +313,9 @@ def start_webserver(port: int = 8080) -> None:
         server.config.port,
         server.config.log_level,
     )
+
+    warn_root_user_enabled()
+
     server.run()
 
 

--- a/src/fides/api/models/client.py
+++ b/src/fides/api/models/client.py
@@ -4,7 +4,6 @@ import json
 from datetime import datetime
 from typing import Any
 
-from loguru import logger
 from sqlalchemy import ARRAY, Column, ForeignKey, String
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import Session

--- a/src/fides/api/models/client.py
+++ b/src/fides/api/models/client.py
@@ -145,7 +145,6 @@ def _get_root_client_detail(
     """
     Return a root ClientDetail
     """
-    logger.info("Retrieving root user client details")
     if not config.security.oauth_root_client_secret_hash:
         raise ValueError("A root client hash is required")
 

--- a/src/fides/api/models/client.py
+++ b/src/fides/api/models/client.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 from typing import Any
 
+from loguru import logger
 from sqlalchemy import ARRAY, Column, ForeignKey, String
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import Session
@@ -144,7 +145,7 @@ def _get_root_client_detail(
     """
     Return a root ClientDetail
     """
-
+    logger.info("Retrieving root user client details")
     if not config.security.oauth_root_client_secret_hash:
         raise ValueError("A root client hash is required")
 


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1330

### Description Of Changes

To help mitigate and be aware of a potential security weakness in production deployments, we've decided to provide some logging when the root user is in use. Specifically, we're providing:
- a warning message on server startup (both fides and fidesplus)
- a warning message whenever the root user credentials are successfully used for a user "login"
- a warning message whenever the root oauth client credentials are used to successfully acquire a client access token

Below is some logging i captured on my local fides server with representative actions as root user, to get an idea of what logs look like. To me, the only real questions are:
- ~should we change "info message when token is merely requested, warning if the token is actually acquired" to either be warning for both, or just warn when the token is requested?~ edit: answered in comments and adjusted code
- ~is the info message on every root user API call too noisy? i definitely think a warn-level log on every root user API call is too noisy, which is why i went with info for now. but would be curious to hear others' POV.~ edit: answered in comments and adjusted code

-------
Sample logging output on representative actions from local fides server

- on (fides) server startup:
```
fides  | 2023-11-15 13:55:46.954 | DEBUG    | fides.api.util.cache:get_cache:188 - Redis connection succeeded.
fides  | 2023-11-15 13:55:46.954 | DEBUG    | fides.api.app_setup:check_redis:221 - Connection to cache succeeded
fides  | 2023-11-15 13:55:46.956 | INFO     | fides.api.service.privacy_request.email_batch_service:initiate_scheduled_batch_email_send:136 - Initiating scheduler for batch email send
fides  | 2023-11-15 13:55:47.024 | DEBUG    | fides.api.main:setup_server:282 - Sending startup analytics events...
fides  | 2023-11-15 13:55:47.024 | INFO     | fides.api.main:setup_server:296 -
fides  |
fides  | ███████╗██╗██████╗ ███████╗███████╗
fides  | ██╔════╝██║██╔══██╗██╔════╝██╔════╝
fides  | █████╗  ██║██║  ██║█████╗  ███████╗
fides  | ██╔══╝  ██║██║  ██║██╔══╝  ╚════██║
fides  | ██║     ██║██████╔╝███████╗███████║
fides  | ╚═╝     ╚═╝╚═════╝ ╚══════╝╚══════╝
fides  |
fides  | 2023-11-15 13:55:47.025 | WARNING  | fides.api.main:warn_root_user_enabled:252 - Security warning: you are running Fides with a root user configured! This is not recommended in production deployments
fides  | 2023-11-15 13:55:47.025 | INFO     | fides.api.main:setup_server:300 - Fides startup complete! v2.24.1b0.post0.dev6
fides  | 2023-11-15 13:55:47.025 | INFO     | fides.api.main:setup_server:302 - Server setup completed in 4.628 seconds
```

- on root user login from admin UI:
```
fides  | 2023-11-17 14:46:04.378 | INFO     | fides.api.main:log_request:166 - Request received | {'method': 'POST', 'status_code': 403, 'handler_time': '22.441ms', 'path': '/api/v1/login/'}
fides  | 2023-11-17 14:46:18.070 | INFO     | fides.api.main:log_request:166 - Request received | {'method': 'GET', 'status_code': 200, 'handler_time': '46.585ms', 'path': '/health'}
fides  | 2023-11-17 14:46:22.383 | WARNING  | fides.api.api.v1.endpoints.user_endpoints:user_login:553 - Successful root user login!
fides  | 2023-11-17 14:46:22.384 | INFO     | fides.api.api.v1.endpoints.user_endpoints:user_login:583 - Creating login access token
fides  | 2023-11-17 14:46:22.391 | INFO     | fides.api.main:log_request:166 - Request received | {'method': 'POST', 'status_code': 200, 'handler_time': '15.822ms', 'path': '/api/v1/login/'}
```


- root client authentication from swagger API UI:
```
fides  | 2023-11-15 14:08:00.977 | INFO     | fides.api.api.v1.endpoints.oauth_endpoints:acquire_access_token:105 - Creating access token
fides  | 2023-11-15 14:08:00.982 | WARNING  | fides.api.api.v1.endpoints.oauth_endpoints:acquire_access_token:112 - Root user access token acquired!
fides  | 2023-11-15 14:08:00.987 | INFO     | fides.api.main:log_request:166 - Request received | {'method': 'POST', 'status_code': 200, 'handler_time': '560.952ms', 'path': '/api/v1/oauth/token'}
```



### Code Changes

* [x] log messaging described above

### Steps to Confirm

* [x] ran fides locally and performed root user actions, checked logs
* [ ] should confirm with fidesplus that the same logging occurs (likely want to use an alpha tag)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
