### PR TITLE
Flexible Legal Basis = True Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The types of changes are:
 - Button ordering in fides.js UI [#4407](https://github.com/ethyca/fides/pull/4407)
 - Add different classnames to consent buttons for easier selection [#4411](https://github.com/ethyca/fides/pull/4411)
 - Updates default consent preference to opt-out for TCF when fides_string exists [#4430](https://github.com/ethyca/fides/pull/4430)
+- Flexible legal basis for processing has a db default of True [#4434](https://github.com/ethyca/fides/pull/4434)
 
 ### Fixed
 - Persist bulk system add filter modal state [#4412](https://github.com/ethyca/fides/pull/4412)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ defusedxml==0.7.1
 expandvars==0.9.0
 fastapi[all]==0.89.1
 fastapi-pagination[sqlalchemy]==0.11.4
-fideslang==2.2.2a0
+fideslang==2.2.2
 fideslog==1.2.10
 firebase-admin==5.3.0
 GitPython==3.1.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ defusedxml==0.7.1
 expandvars==0.9.0
 fastapi[all]==0.89.1
 fastapi-pagination[sqlalchemy]==0.11.4
-fideslang==2.2.1
+fideslang @ git+https://github.com/ethyca/fideslang.git@d273421ccadb4833c19dc31e30de7ec332dc6a78#egg=fideslang
 fideslog==1.2.10
 firebase-admin==5.3.0
 GitPython==3.1.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ defusedxml==0.7.1
 expandvars==0.9.0
 fastapi[all]==0.89.1
 fastapi-pagination[sqlalchemy]==0.11.4
-fideslang @ git+https://github.com/ethyca/fideslang.git@d273421ccadb4833c19dc31e30de7ec332dc6a78#egg=fideslang
+fideslang==2.2.2a0
 fideslog==1.2.10
 firebase-admin==5.3.0
 GitPython==3.1.35

--- a/src/fides/api/alembic/migrations/versions/1af6950f4625_update_flexible_legal_basis_default.py
+++ b/src/fides/api/alembic/migrations/versions/1af6950f4625_update_flexible_legal_basis_default.py
@@ -1,0 +1,50 @@
+"""update_flexible_legal_basis_default
+
+Revision ID: 1af6950f4625
+Revises: 3cc39a6ce32b
+Create Date: 2023-11-15 22:15:38.688530
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, ResultProxy
+
+revision = "1af6950f4625"
+down_revision = "3cc39a6ce32b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind: Connection = op.get_bind()
+
+    bind.execute(
+        text(
+            """
+            UPDATE privacydeclaration 
+            SET flexible_legal_basis_for_processing = false 
+            WHERE flexible_legal_basis_for_processing IS NULL;
+            """
+        )
+    )
+
+    op.alter_column(
+        "privacydeclaration",
+        "flexible_legal_basis_for_processing",
+        existing_type=sa.BOOLEAN(),
+        server_default="t",
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "privacydeclaration",
+        "flexible_legal_basis_for_processing",
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+        server_default=None,
+    )

--- a/src/fides/api/models/sql_models.py
+++ b/src/fides/api/models/sql_models.py
@@ -475,7 +475,9 @@ class PrivacyDeclaration(Base):
 
     features = Column(ARRAY(String), server_default="{}", nullable=False)
     legal_basis_for_processing = Column(String)
-    flexible_legal_basis_for_processing = Column(BOOLEAN())
+    flexible_legal_basis_for_processing = Column(
+        BOOLEAN(), server_default="t", nullable=False
+    )
     impact_assessment_location = Column(String)
     retention_period = Column(String)
     processes_special_category_data = Column(

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -691,7 +691,7 @@ class TestSystemCreate:
         assert privacy_decl.data_shared_with_third_parties is True
         assert privacy_decl.third_parties == "Third Party Marketing Dept."
         assert privacy_decl.shared_categories == ["user"]
-        assert privacy_decl.flexible_legal_basis_for_processing is None
+        assert privacy_decl.flexible_legal_basis_for_processing is True
 
     async def test_system_create_minimal_request_body(
         self, generate_auth_header, db, test_config, system_create_request_body


### PR DESCRIPTION
❗ ~Contains migration; check downrev~
❗ ~Dependent on fideslang release of https://github.com/ethyca/fideslang/pull/184~

Closes #PROD-1264


### Description Of Changes

Make "flexible legal basis for processing" non nullable and True by default in the backend.


### Code Changes

- Update PrivacyDeclaration.flexible_legal_basis_for_processing to get rid of the third state. Make it required, and set the server default to True, to match what should happen when systems are created outside of Compass.
- Add a migration that first updates existing flexible_legal_basis_for_processing to False if it is currently null, then adds the new server default and makes it required.

### Steps to Confirm

* [ ] Creating a system without this field specified via the API (POST System) will set this value to True by default in the backend.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
