### PR TITLE
Add confirmation modal on deleting a privacy declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.24.0...main)
 
+### Added
+- Added confirmation modal on deleting a data use declaration [#4439](https://github.com/ethyca/fides/pull/4439)
+
 ### Changed
 - Improved bulk vendor adding table UX [#4425](https://github.com/ethyca/fides/pull/4425)
 

--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -618,21 +618,33 @@ describe("System management page", () => {
 
     describe("delete privacy declaration", () => {
       beforeEach(() => {
-        cy.fixture("systems/systems_with_data_uses.json").then((systems) => {
-          cy.intercept("GET", "/api/v1/system/*", {
-            body: systems[0],
-          }).as("getFidesctlSystemWithDataUses");
-        });
-        cy.visit(`${SYSTEM_ROUTE}/configure/fidesctl_system`);
-        cy.wait("@getFidesctlSystemWithDataUses");
         cy.fixture("systems/system.json").then((system) => {
-          const newSystem = { ...system, fides_key: "fidesctl_system" };
+          cy.intercept("GET", "/api/v1/system/*", {
+            body: system,
+          }).as("getDemoAnalyticsSystem");
+        });
+        cy.visit(`/${SYSTEM_ROUTE}/configure/demo_analytics_system`);
+        cy.wait("@getDemoAnalyticsSystem");
+        cy.fixture("systems/system.json").then((system) => {
+          const newSystem = { ...system, fides_key: "demo_analytics_system" };
           cy.intercept("PUT", "/api/v1/system*", { body: newSystem }).as(
-            "putFidesSystem"
+            "putDemoAnalyticsSystem"
           );
         });
 
         cy.getByTestId("tab-Data uses").click();
+      });
+
+      it("can visit the privacy declaration tab", () => {
+        cy.getByTestId("privacy-declarations-table");
+        cy.getByTestId("row-functional.service.improve");
+      });
+
+      it("can show a modal on deleting a privacy declaration", () => {
+        cy.getByTestId("delete-btn").click();
+        cy.getByTestId("continue-btn").click();
+        cy.wait("@putDemoAnalyticsSystem");
+        cy.getByTestId("toast-success-msg").contains("Data use deleted");
       });
 
       it.skip("deletes a new privacy declaration", () => {

--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -461,13 +461,23 @@ describe("System management page", () => {
 
   describe("Data uses", () => {
     beforeEach(() => {
-      stubSystemCrud();
-      stubTaxonomyEntities();
-      cy.fixture("systems/systems.json").then((systems) => {
-        cy.intercept("GET", "/api/v1/system/*", {
-          body: systems[0],
-        }).as("getFidesctlSystem");
+      cy.intercept("/api/v1/system/*", {
+        fixture: "systems/system.json",
+      }).as("getDemoAnalyticsSystem");
+      cy.visit(`/${SYSTEM_ROUTE}/configure/demo_analytics_system`);
+      cy.wait("@getDemoAnalyticsSystem");
+      cy.fixture("systems/system.json").then((system) => {
+        const newSystem = { ...system, fides_key: "demo_analytics_system" };
+        cy.intercept("PUT", "/api/v1/system*", { body: newSystem }).as(
+          "putDemoAnalyticsSystem"
+        );
       });
+
+      cy.getByTestId("tab-Data uses").click();
+    });
+
+    it("shows data uses in the data use tab", () => {
+      cy.getByTestId("row-functional.service.improve");
     });
 
     it.skip("warns when a data use and processing activity is being added that is already used", () => {
@@ -618,11 +628,9 @@ describe("System management page", () => {
 
     describe("delete privacy declaration", () => {
       beforeEach(() => {
-        cy.fixture("systems/system.json").then((system) => {
-          cy.intercept("GET", "/api/v1/system/*", {
-            body: system,
-          }).as("getDemoAnalyticsSystem");
-        });
+        cy.intercept("/api/v1/system/*", {
+          fixture: "systems/system.json",
+        }).as("getDemoAnalyticsSystem");
         cy.visit(`/${SYSTEM_ROUTE}/configure/demo_analytics_system`);
         cy.wait("@getDemoAnalyticsSystem");
         cy.fixture("systems/system.json").then((system) => {
@@ -643,7 +651,6 @@ describe("System management page", () => {
       it("can show a modal on deleting a privacy declaration", () => {
         cy.getByTestId("delete-btn").click();
         cy.getByTestId("continue-btn").click();
-        cy.wait("@putDemoAnalyticsSystem");
         cy.getByTestId("toast-success-msg").contains("Data use deleted");
       });
 

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
@@ -11,9 +11,11 @@ import {
   Spacer,
   Stack,
   Text,
+  useDisclosure,
 } from "@fidesui/react";
 
 import { useAppSelector } from "~/app/hooks";
+import ConfirmationModal from "~/features/common/ConfirmationModal";
 import { selectLockedForGVL } from "~/features/system/dictionary-form/dict-suggestion.slice";
 import { DataUse, PrivacyDeclarationResponse } from "~/types/api";
 
@@ -27,37 +29,58 @@ const PrivacyDeclarationRow = ({
   title?: string;
   handleDelete?: (dec: PrivacyDeclarationResponse) => void;
   handleEdit: (dec: PrivacyDeclarationResponse) => void;
-}) => (
-  <>
-    <Box px={6} py={4}>
-      <HStack>
-        <LinkBox
-          onClick={() => handleEdit(declaration)}
-          w="100%"
-          h="100%"
-          cursor="pointer"
-        >
-          <LinkOverlay>
-            <Text>{title || declaration.data_use}</Text>
-          </LinkOverlay>
-        </LinkBox>
-        <Spacer />
-        {handleDelete ? (
-          <IconButton
-            aria-label="delete-declaration"
-            variant="outline"
-            zIndex={2}
-            size="sm"
-            onClick={() => handleDelete(declaration)}
+}) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  return (
+    <>
+      <Box px={6} py={4}>
+        <HStack>
+          <LinkBox
+            onClick={() => handleEdit(declaration)}
+            w="100%"
+            h="100%"
+            cursor="pointer"
           >
-            <DeleteIcon />
-          </IconButton>
-        ) : null}
-      </HStack>
-    </Box>
-    <Divider />
-  </>
-);
+            <LinkOverlay>
+              <Text>{title || declaration.data_use}</Text>
+            </LinkOverlay>
+          </LinkBox>
+          <Spacer />
+          {handleDelete ? (
+            <>
+              <IconButton
+                aria-label="delete-declaration"
+                variant="outline"
+                zIndex={2}
+                size="sm"
+                onClick={onOpen}
+              >
+                <DeleteIcon />
+              </IconButton>
+              <ConfirmationModal
+                isOpen={isOpen}
+                onClose={onClose}
+                onConfirm={() => handleDelete(declaration)}
+                title={"Delete data use declaration"}
+                message={
+                  <Text>
+                    You are about to delete the data use declaration{" "}
+                    <Text color="complimentary.500" as="span" fontWeight="bold">
+                      {title || declaration.data_use}
+                    </Text>
+                    , including all its cookies. Are you sure you want to
+                    continue?
+                  </Text>
+                }
+              />
+            </>
+          ) : null}
+        </HStack>
+      </Box>
+      <Divider />
+    </>
+  );
+};
 
 export const PrivacyDeclarationTabTable = ({
   heading,

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
@@ -62,7 +62,7 @@ const PrivacyDeclarationRow = ({
                 isOpen={isOpen}
                 onClose={onClose}
                 onConfirm={() => handleDelete(declaration)}
-                title={"Delete data use declaration"}
+                title="Delete data use declaration"
                 message={
                   <Text>
                     You are about to delete the data use declaration{" "}

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
@@ -73,6 +73,7 @@ const PrivacyDeclarationRow = ({
                     continue?
                   </Text>
                 }
+                isCentered
               />
             </>
           ) : null}

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
@@ -33,7 +33,7 @@ const PrivacyDeclarationRow = ({
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <>
-      <Box px={6} py={4}>
+      <Box px={6} py={4} data-testid={`row-${declaration.data_use}`}>
         <HStack>
           <LinkBox
             onClick={() => handleEdit(declaration)}
@@ -54,6 +54,7 @@ const PrivacyDeclarationRow = ({
                 zIndex={2}
                 size="sm"
                 onClick={onOpen}
+                data-testid="delete-btn"
               >
                 <DeleteIcon />
               </IconButton>
@@ -93,7 +94,7 @@ export const PrivacyDeclarationTabTable = ({
   headerButton?: React.ReactNode;
   footerButton?: React.ReactNode;
 }) => (
-  <Stack spacing={4}>
+  <Stack spacing={4} data-testid="privacy-declarations-table">
     <Box maxWidth="720px" border="1px" borderColor="gray.200" borderRadius={6}>
       <HStack
         backgroundColor="gray.50"


### PR DESCRIPTION
Closes #PROD-1317

### Description Of Changes

Adds a confirmation modal on deleting a data use which warns the user that the data use and cookies will be deleted.

![Screenshot 2023-11-17 at 4 14 59 PM](https://github.com/ethyca/fides/assets/6394496/73be15cd-ff4c-40eb-81be-58e3843af28a)

### Steps to Confirm

* [ ] View a non-locked-for-GVL system with data uses
* [ ] Delete data use declaration by clicking "delete" button in data uses tab
* [ ] Verify modal appears

[Loom video](https://www.loom.com/share/ff3a3e16812e457180b744409bfa8bcb)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
