### PR TITLE
ensure setup.py is run as fidesuser in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -161,9 +161,10 @@ FROM backend as prod
 # Copy frontend build over
 COPY --from=built_frontend /fides/clients/admin-ui/out/ /fides/src/fides/ui-build/static/admin
 
-USER root
 # Install without a symlink
 RUN python setup.py sdist
+
+USER root
 RUN pip install dist/ethyca-fides-*.tar.gz
 
 # Remove this directory to prevent issues with catch all


### PR DESCRIPTION
Fixes problem where fides was unable to determine its own version on our built `prod` image

### Description Of Changes

Corresponds to https://github.com/ethyca/fidesplus/pull/1230


### Code Changes

* [x] tweak `Dockerfile` to have `fidesuser` run the `setup.py` script as part of the image build process

### Steps to Confirm

* [x] ran `nox -s "fides_env(test)"` and confirmed the local env spun up well and my fides image worked as expected, including returning a valid version number on the `/health` API call

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
