### PR TITLE
ensure setup.py is run as fidesuser in docker build: cherry pick #4446 into `main`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -161,9 +161,10 @@ FROM backend as prod
 # Copy frontend build over
 COPY --from=built_frontend /fides/clients/admin-ui/out/ /fides/src/fides/ui-build/static/admin
 
-USER root
 # Install without a symlink
 RUN python setup.py sdist
+
+USER root
 RUN pip install dist/ethyca-fides-*.tar.gz
 
 # Remove this directory to prevent issues with catch all


### PR DESCRIPTION
cherry pick of https://github.com/ethyca/fides/pull/4446 into `main`, since it'd been merged directly into `release-2.24.1`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
