### PR TITLE
PROD-1396 Fix typeerror when tcf vendors have no dataDeclaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.25.0...main)
 
+### Fixed
+- Fix type errors when TCF vendors have no dataDeclaration [#4465](https://github.com/ethyca/fides/pull/4465)
+
 ## [2.25.0](https://github.com/ethyca/fides/compare/2.24.1...2.25.0)
 
 ### Added

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -109,11 +109,11 @@ const DataCategories = ({
         </tr>
       </thead>
       <tbody>
-        {declarations.map((id) => {
+        {declarations && declarations.map((id) => {
           const category = dataCategories[id];
           return (
             <tr key={id}>
-              <td>{category.name}</td>
+              <td>{category ? category.name : ""}</td>
             </tr>
           );
         })}

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -109,14 +109,15 @@ const DataCategories = ({
         </tr>
       </thead>
       <tbody>
-        {declarations && declarations.map((id) => {
-          const category = dataCategories[id];
-          return (
-            <tr key={id}>
-              <td>{category ? category.name : ""}</td>
-            </tr>
-          );
-        })}
+        {declarations &&
+          declarations.map((id) => {
+            const category = dataCategories[id];
+            return (
+              <tr key={id}>
+                <td>{category ? category.name : ""}</td>
+              </tr>
+            );
+          })}
       </tbody>
     </table>
   );

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -109,15 +109,14 @@ const DataCategories = ({
         </tr>
       </thead>
       <tbody>
-        {declarations &&
-          declarations.map((id) => {
-            const category = dataCategories[id];
-            return (
-              <tr key={id}>
-                <td>{category ? category.name : ""}</td>
-              </tr>
-            );
-          })}
+        {declarations?.map((id) => {
+          const category = dataCategories[id];
+          return (
+            <tr key={id}>
+              <td>{category?.name || ""}</td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -99,7 +99,7 @@ const DataCategories = ({
   }
 
   // @ts-ignore this type doesn't exist in v2.2 but does in v3
-  const declarations: GvlDataDeclarations = gvlVendor.dataDeclaration;
+  const declarations: GvlDataDeclarations | undefined = gvlVendor.dataDeclaration;
 
   return (
     <table className="fides-vendor-details-table">

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -99,7 +99,8 @@ const DataCategories = ({
   }
 
   // @ts-ignore this type doesn't exist in v2.2 but does in v3
-  const declarations: GvlDataDeclarations | undefined = gvlVendor.dataDeclaration;
+  const declarations: GvlDataDeclarations | undefined =
+    gvlVendor.dataDeclaration;
 
   return (
     <table className="fides-vendor-details-table">

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -274,7 +274,7 @@ describe("Fides-js TCF", () => {
         checkDefaultExperienceRender();
       });
 
-      it.only("can render IAB TCF badge on vendors and split into their own lists", () => {
+      it("can render IAB TCF badge on vendors and split into their own lists", () => {
         const newVendor = {
           // Use the new vendor id scheme
           id: "gvl.1",

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -274,7 +274,7 @@ describe("Fides-js TCF", () => {
         checkDefaultExperienceRender();
       });
 
-      it("can render IAB TCF badge on vendors and split into their own lists", () => {
+      it.only("can render IAB TCF badge on vendors and split into their own lists", () => {
         const newVendor = {
           // Use the new vendor id scheme
           id: "gvl.1",

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -390,6 +390,13 @@
         "vendorListVersion": 19,
         "tcfPolicyVersion": 4,
         "lastUpdated": "2023-09-21T16:07:34Z",
+        "dataCategories": {
+          "1": {
+            "id": 1,
+            "name": "Device Data",
+            "description": "Data that pertains to a device, including OS information and cross-device identification capabilities."
+          }
+        },
         "purposes": {
           "1": {
             "id": 1,
@@ -457,7 +464,7 @@
                 "legIntClaim": "https://www.captifytechnologies.com/privacy-notice/"
               }
             ],
-            "dataDeclaration": [],
+            "dataDeclaration": null,
             "deviceStorageDisclosureUrl": "https://static.cpx.to/gvl/deviceStorageDisclosure.json"
           }
         },


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1396

### Description Of Changes

Fix type errors when tcf vendors have no dataDeclaration. This PR fixes 2 possible errors that could arise in this case. I've also added e2e tests to confirm this is fixed.


### Code Changes

* [ ] Fix typeerrors
* [ ] Set up e2e test to confirm this is fixed

### Steps to Confirm

* [ ] Run e2e tests

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
