### PR TITLE
Update focused border color on inputs

### DIFF
--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -103,6 +103,7 @@ export const TextInput = forwardRef(
           type={type}
           pr={isPassword ? "10" : "3"}
           background="white"
+          focusBorderColor="primary.600"
         />
         {isPassword ? (
           <InputRightElement pr="2">
@@ -287,6 +288,7 @@ export const SelectInput = ({
       size={size}
       classNamePrefix="custom-select"
       placeholder={placeholder}
+      focusBorderColor="primary.600"
       chakraStyles={{
         container: (provided) => ({
           ...provided,
@@ -433,6 +435,7 @@ const CreatableSelectInput = ({
       value={selected}
       size={size}
       classNamePrefix="custom-creatable-select"
+      focusBorderColor="primary.600"
       isDisabled={isDisabled}
       chakraStyles={{
         container: (provided) => ({
@@ -784,6 +787,7 @@ export const CustomTextArea = ({
       {...textAreaProps}
       ref={textareaRef}
       style={{ overflowY: resize ? "hidden" : "visible" }}
+      focusBorderColor="primary.600"
       onChange={(event) => {
         resizeTextarea();
         field.onChange(event);
@@ -933,7 +937,7 @@ export const CustomNumberInput = ({
           <Label htmlFor={props.id || props.name}>{label}</Label>
           <Flex alignItems="center">
             <Flex flexDir="column" flexGrow={1} mr="2">
-              <NumberInput>
+              <NumberInput focusBorderColor="primary.600">
                 <NumberInputField />
                 <NumberInputStepper>
                   <NumberIncrementStepper />
@@ -971,6 +975,7 @@ export const CustomNumberInput = ({
           isDisabled={isDisabled}
           data-testid={`input-${field.name}`}
           min={minValue || undefined}
+          focusBorderColor="primary.600"
         >
           <NumberInputField />
           <NumberInputStepper>

--- a/clients/admin-ui/src/features/system/dictionary-form/DictSuggestionInputs.tsx
+++ b/clients/admin-ui/src/features/system/dictionary-form/DictSuggestionInputs.tsx
@@ -184,6 +184,7 @@ export const DictSuggestionTextArea = ({
           {...field}
           size="sm"
           data-testid={`input-${field.name}`}
+          focusBorderColor="primary.600"
           color={
             isShowingSuggestions === "showing"
               ? "complimentary.500"
@@ -317,6 +318,7 @@ export const DictSuggestionSelect = ({
             data-testid={`input-${field.name}`}
             placeholder={placeholder}
             options={options}
+            focusBorderColor="primary.600"
             chakraStyles={{
               input: (provided) => ({
                 ...provided,
@@ -446,6 +448,7 @@ export const DictSuggestionCreatableSelect = ({
             data-testid={`input-${field.name}`}
             placeholder={placeholder}
             options={options}
+            focusBorderColor="primary.600"
             chakraStyles={{
               input: (provided) => ({
                 ...provided,
@@ -550,6 +553,7 @@ export const DictSuggestionNumberInput = ({
                 ? "complimentary.500"
                 : "gray.800"
             }
+            focusBorderColor="primary.600"
             isDisabled={disabled}
           >
             <NumberInputField />

--- a/clients/admin-ui/src/theme/index.ts
+++ b/clients/admin-ui/src/theme/index.ts
@@ -37,6 +37,16 @@ const theme = extendTheme({
         size: "xl",
       },
     },
+    Switch: {
+      baseStyle: {
+        track: {
+          _focus: {
+            boxShadow: "none",
+            outline: "2px solid #272B53",
+          },
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
Closes #PROD-1437

### Description Of Changes

Updates border color on focus of form inputs to be `primary.600` instead of Chakra's default blue.

![Screenshot 2023-11-29 at 12 13 06 PM](https://github.com/ethyca/fides/assets/6394496/6763abec-4f54-44eb-9edf-5ccd23f600d2)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
