### PR TITLE
Fix GVL vendor lock occurring on AC systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 
 ### Fixed
 - Fix type errors when TCF vendors have no dataDeclaration [#4465](https://github.com/ethyca/fides/pull/4465)
+- Fixed an error where editing an AC system would mistakenly lock it for GVL [#4471](https://github.com/ethyca/fides/pull/4471)
 
 ## [2.25.0](https://github.com/ethyca/fides/compare/2.24.1...2.25.0)
 

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -143,6 +143,20 @@ describe("System management with Plus features", () => {
       cy.getByTestId("input-description").should("not.be.disabled");
     });
 
+    it("does not lock editing for a non-GVL vendor when visiting 'edit system' page directly", () => {
+      cy.fixture("systems/systems.json").then((systems) => {
+        cy.intercept("GET", "/api/v1/system/*", {
+          body: {
+            ...systems[0],
+            vendor_id: "gacp.3073",
+          },
+        }).as("getSystem");
+      });
+      cy.visit("/systems/configure/fidesctl_system");
+      cy.wait("@getSystem");
+      cy.getByTestId("locked-for-GVL-notice").should("not.exist");
+    });
+
     it("allows changes to data uses for non-GVL vendors", () => {
       cy.getSelectValueContainer("input-vendor_id").type("L{enter}");
       cy.getByTestId("save-btn").click();

--- a/clients/admin-ui/src/pages/systems/configure/[id].tsx
+++ b/clients/admin-ui/src/pages/systems/configure/[id].tsx
@@ -58,7 +58,7 @@ const ConfigureSystem: NextPage = () => {
       const locked =
         isTCFEnabled &&
         !!system.vendor_id &&
-        extractVendorSource(system.fides_key) === VendorSources.GVL;
+        extractVendorSource(system.vendor_id) === VendorSources.GVL;
       dispatch(setLockedForGVL(locked));
     }
   }, [system, dispatch, isTCFEnabled]);

--- a/clients/admin-ui/src/pages/systems/configure/[id].tsx
+++ b/clients/admin-ui/src/pages/systems/configure/[id].tsx
@@ -60,6 +60,8 @@ const ConfigureSystem: NextPage = () => {
         !!system.vendor_id &&
         extractVendorSource(system.vendor_id) === VendorSources.GVL;
       dispatch(setLockedForGVL(locked));
+    } else {
+      setLockedForGVL(false);
     }
   }, [system, dispatch, isTCFEnabled]);
 


### PR DESCRIPTION
Closes #PROD-1451

### Description Of Changes

Fixes a bug where "system is locked for GVL" notice would appear on AC systems when accessing them to edit, and add a Cypress test to verify.

### Steps to Confirm

With TCF enabled:
* [ ] If you don't already have them, create a system with a GVL vendor (e.g. A.Mob) and a non-GVL vendor (e.g. FORTVISION)
* [ ] Return to "View systems" page
* [ ] Access the GVL system; form should be locked and "this system is part of the GVL" notice should show up
* [ ] Access the non-GVL system; form should be editable, no notice should be showing

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
