### PR TITLE
PROD-1480: Update logging level for 'Retrieved FidesUserPermission record for current user' message to Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The types of changes are:
 - New purposes endpoint and indices to improve system lookups [#4452](https://github.com/ethyca/fides/pull/4452)
 - Add support for global TCF Purpose Overrides [#4464](https://github.com/ethyca/fides/pull/4464)
 
+### Changed
+- Change log level for FidesUserPermission retrieval to `debug` [#4482](https://github.com/ethyca/fides/pull/4482)
+
 ### Fixed
 - Fix type errors when TCF vendors have no dataDeclaration [#4465](https://github.com/ethyca/fides/pull/4465)
 - Fixed an error where editing an AC system would mistakenly lock it for GVL [#4471](https://github.com/ethyca/fides/pull/4471)

--- a/src/fides/api/api/v1/endpoints/user_permission_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/user_permission_endpoints.py
@@ -150,7 +150,7 @@ async def get_user_permissions(
                 roles=CONFIG.security.root_user_roles,
             )
 
-        logger.info("Retrieved FidesUserPermission record for current user")
+        logger.debug("Retrieved FidesUserPermission record for current user")
         return FidesUserPermissions.get_by(db, field="user_id", value=current_user.id)
 
     # To look up the permissions of another user, that user must exist and the current user must


### PR DESCRIPTION
Closes PROD-1480

### Description Of Changes

Changes the log level of `Retrieved FidesUserPermission record for current user` message to `DEBUG` instead of `INFO`. When a user is browsing around the Admin UI, these logs show up almost every other line and make it harder to follow logs. They still have value, but I believe that `DEBUG` is a better level for them.

### Code Changes

* [ ] Change function from `logger.info()` to `logger.debug()`
 
### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
