### PR TITLE
Fix support for nested `options.customOptionsPath`

### DIFF
--- a/clients/fides-js/__tests__/lib/consent-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/consent-utils.test.ts
@@ -136,6 +136,12 @@ describe("getWindowObjFromPath", () => {
       expected: undefined,
     },
     {
+      label: "nested path does not exist",
+      path: ["window", "nonexistent-path", "nested"],
+      window: windowMock1,
+      expected: undefined,
+    },
+    {
       label: "path is one level deep",
       path: ["window", "fides_overrides"],
       window: windowMock1,

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -257,16 +257,42 @@ export const shouldResurfaceConsent = (
 };
 
 /**
- * Get fides override options from a custom path
+ * Descend down the provided path on the "window" object and return the nested
+ * override options object located at the given path.
+ * 
+ * If any part of the path is invalid, return `undefined`.
+ * 
+ * 
+ * For example, given a window object like this:
+ * ```
+ * window.custom_overrides = { nested_obj: { fides_string: "foo" } } };
+ * ```
+ * 
+ * Then expect the following:
+ * ```
+ * const overrides = getWindowObjFromPath(["window", "custom_overrides", "nested_obj"])
+ * console.assert(overrides.fides_string === "foo");
+ * ```
  */
 export const getWindowObjFromPath = (
   path: string[]
 ): OverrideOptions | undefined => {
+  // Implicitly start from the global "window" object
   if (path[0] === "window") {
     path.shift();
   }
-  // @ts-ignore
-  return path.reduce((record, item) => record[item], window);
+  // Descend down the provided path (starting from `window`)
+  let record: any = window;
+  while (path.length > 0) {
+    const key = path.shift();
+    // If we ever encounter an invalid key or a non-object value, return undefined
+    if (typeof(key) === "undefined" || typeof(record[key]) !== "object") {
+      return undefined;
+    }
+    // Keep descending!
+    record = record[key];
+  }
+  return record;
 };
 
 export const getGpcStatusFromNotice = ({

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -259,15 +259,15 @@ export const shouldResurfaceConsent = (
 /**
  * Descend down the provided path on the "window" object and return the nested
  * override options object located at the given path.
- * 
+ *
  * If any part of the path is invalid, return `undefined`.
- * 
- * 
+ *
+ *
  * For example, given a window object like this:
  * ```
  * window.custom_overrides = { nested_obj: { fides_string: "foo" } } };
  * ```
- * 
+ *
  * Then expect the following:
  * ```
  * const overrides = getWindowObjFromPath(["window", "custom_overrides", "nested_obj"])
@@ -286,7 +286,7 @@ export const getWindowObjFromPath = (
   while (path.length > 0) {
     const key = path.shift();
     // If we ever encounter an invalid key or a non-object value, return undefined
-    if (typeof(key) === "undefined" || typeof(record[key]) !== "object") {
+    if (typeof key === "undefined" || typeof record[key] !== "object") {
       return undefined;
     }
     // Keep descending!

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -2585,7 +2585,7 @@ describe("Fides-js TCF", () => {
         });
     });
 
-    it.only("uses fides_string when set via window obj at custom config path", () => {
+    it("uses fides_string when set via window obj at custom config path", () => {
       const fidesStringOverride =
         "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA.IABE,1~";
       const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
@@ -2636,7 +2636,7 @@ describe("Fides-js TCF", () => {
         });
     });
 
-    it.only("does not error when window obj at custom config path doesn't exist", () => {
+    it("does not error when window obj at custom config path doesn't exist", () => {
       cy.fixture("consent/experience_tcf.json").then((experience) => {
         stubConfig(
           {
@@ -2673,7 +2673,7 @@ describe("Fides-js TCF", () => {
         });
     });
 
-    it.only("does not error when window obj at nested custom config path doesn't exist", () => {
+    it("does not error when window obj at nested custom config path doesn't exist", () => {
       cy.fixture("consent/experience_tcf.json").then((experience) => {
         stubConfig(
           {


### PR DESCRIPTION
Fixes #PROD-1243

### Description Of Changes

When testing PROD-1243 (from #4462) I found that I could cause `Fides.init(...)` to crash by supplying a nested `options.customOptionsPath` that didn't exist, e.g.
```
Fides.init({
  options: {
    customOptionsPath: "window.nonexistent_object.nested.path",
  },
  ...
})
```

This throws an error like:
```
(uncaught exception)TypeError: Cannot read properties of undefined (reading 'nested')
```

### Code Changes

* [X] Added failing Cypress tests to `consent-banner-tcf.cy.ts`
* [X] Added failing unit tests to `consent-utils.test.ts`
* [X] Fix `getWindowObjFromPath` to be defensive when descending nested paths

### Steps to Confirm

* [X] Run Cypress tests & unit tests 👍 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [x] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
