### PR TITLE
Fix get config test regression

### DIFF
--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -967,6 +967,7 @@ class TestGetConfig:
             "security",
             "execution",
             "storage",
+            "consent",
         }
 
         for key in config.keys():
@@ -1073,3 +1074,8 @@ class TestGetConfig:
                 )
                 == 0
             ), "Unexpected config API change, please review with Ethyca security team"
+
+        consent_keys = set(config["consent"].keys())
+        assert (
+            len(consent_keys.difference(set(["override_vendor_purposes"]))) == 0
+        ), "Unexpected config API change, please review with Ethyca security team"


### PR DESCRIPTION
### Description Of Changes

A test regression slipped through and this remedies that.


### Code Changes

* [ ] Update the `test_get_config` test

### Steps to Confirm

* [ ] ensure the `test_get_config` test passes

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
