### PR TITLE
Bulk add vendors disable state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.26.0...main)
 
+### Added
+- Tooltip and styling for disabled rows in add multiple vendor view [#4498](https://github.com/ethyca/fides/pull/4498)
+
 ## [2.26.0](https://github.com/ethyca/fides/compare/2.25.0...main)
 
 ### Added

--- a/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
@@ -118,6 +118,7 @@ export const FidesTableV2 = <T,>({
                 : undefined
             }
             data-testid={`row-${row.id}`}
+            backgroundColor={row.getCanSelect() ? undefined : "gray.50"}
           >
             {row.getVisibleCells().map((cell) => (
               <Td

--- a/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
@@ -5,10 +5,12 @@ import {
   Td,
   Th,
   Thead,
+  Tooltip,
   Tr,
 } from "@fidesui/react";
 import {
   flexRender,
+  Row,
   RowData,
   Table as TableInstance,
 } from "@tanstack/react-table";
@@ -44,6 +46,7 @@ type Props<T> = {
   rowActionBar?: ReactNode;
   footer?: ReactNode;
   onRowClick?: (row: T) => void;
+  renderRowTooltipLabel?: (row: Row<T>) => string | undefined;
 };
 
 export const FidesTableV2 = <T,>({
@@ -51,6 +54,7 @@ export const FidesTableV2 = <T,>({
   rowActionBar,
   footer,
   onRowClick,
+  renderRowTooltipLabel,
 }: Props<T>) => (
   <TableContainer
     data-testid="fidesTable"
@@ -109,47 +113,56 @@ export const FidesTableV2 = <T,>({
       <Tbody data-testid="fidesTable-body">
         {rowActionBar}
         {tableInstance.getRowModel().rows.map((row) => (
-          <Tr
-            key={row.id}
-            height="36px"
-            _hover={
-              onRowClick
-                ? { backgroundColor: "gray.50", cursor: "pointer" }
-                : undefined
+          <Tooltip
+            key={`tooltip-${row.id}`}
+            label={
+              renderRowTooltipLabel ? renderRowTooltipLabel(row) : undefined
             }
-            data-testid={`row-${row.id}`}
-            backgroundColor={row.getCanSelect() ? undefined : "gray.50"}
+            hasArrow
+            placement="top"
           >
-            {row.getVisibleCells().map((cell) => (
-              <Td
-                key={cell.id}
-                width={
-                  cell.column.columnDef.meta?.width
-                    ? cell.column.columnDef.meta.width
-                    : "unset"
-                }
-                borderBottomWidth="1px"
-                borderBottomColor="gray.200"
-                borderRightWidth="1px"
-                borderRightColor="gray.200"
-                _first={{
-                  borderLeftWidth: "1px",
-                  borderLeftColor: "gray.200",
-                }}
-                height="inherit"
-                style={getTableTHandTDStyles(cell.column.id)}
-                onClick={
-                  cell.column.columnDef.header !== "Enable" && onRowClick
-                    ? () => {
-                        onRowClick(row.original);
-                      }
-                    : undefined
-                }
-              >
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </Td>
-            ))}
-          </Tr>
+            <Tr
+              key={row.id}
+              height="36px"
+              _hover={
+                onRowClick
+                  ? { backgroundColor: "gray.50", cursor: "pointer" }
+                  : undefined
+              }
+              data-testid={`row-${row.id}`}
+              backgroundColor={row.getCanSelect() ? undefined : "gray.50"}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <Td
+                  key={cell.id}
+                  width={
+                    cell.column.columnDef.meta?.width
+                      ? cell.column.columnDef.meta.width
+                      : "unset"
+                  }
+                  borderBottomWidth="1px"
+                  borderBottomColor="gray.200"
+                  borderRightWidth="1px"
+                  borderRightColor="gray.200"
+                  _first={{
+                    borderLeftWidth: "1px",
+                    borderLeftColor: "gray.200",
+                  }}
+                  height="inherit"
+                  style={getTableTHandTDStyles(cell.column.id)}
+                  onClick={
+                    cell.column.columnDef.header !== "Enable" && onRowClick
+                      ? () => {
+                          onRowClick(row.original);
+                        }
+                      : undefined
+                  }
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </Td>
+              ))}
+            </Tr>
+          </Tooltip>
         ))}
       </Tbody>
       {footer}

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -51,16 +51,14 @@ export const IndeterminateCheckboxCell = ({
 
   return (
     <Flex alignItems="center" justifyContent="center">
-      <Box backgroundColor="white">
-        <Checkbox
-          data-testid={dataTestId || undefined}
-          isChecked={initialCheckBoxValue || rest.checked}
-          isDisabled={initialCheckBoxValue || manualDisable}
-          onChange={rest.onChange}
-          isIndeterminate={!rest.checked && indeterminate}
-          colorScheme="purple"
-        />
-      </Box>
+      <Checkbox
+        data-testid={dataTestId || undefined}
+        isChecked={initialCheckBoxValue || rest.checked}
+        isDisabled={initialCheckBoxValue || manualDisable}
+        onChange={rest.onChange}
+        isIndeterminate={!rest.checked && indeterminate}
+        colorScheme="purple"
+      />
     </Flex>
   );
 };

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -2,7 +2,6 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   Badge,
-  Box,
   Checkbox,
   Flex,
   Text,

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -3,11 +3,12 @@ import {
   ArrowUpIcon,
   Badge,
   Checkbox,
+  CheckboxProps,
   Flex,
   Text,
 } from "@fidesui/react";
 import { HeaderContext } from "@tanstack/react-table";
-import { HTMLProps, ReactNode, useState } from "react";
+import { ReactNode } from "react";
 
 export const DefaultCell = ({ value }: { value: string }) => (
   <Flex alignItems="center" height="100%">
@@ -32,35 +33,18 @@ export const BadgeCell = ({
   </Flex>
 );
 
-type IndeterminateCheckboxCellProps = {
-  indeterminate?: boolean;
-  initialValue?: boolean;
-  manualDisable?: boolean;
-  dataTestId?: string;
-} & HTMLProps<HTMLInputElement>;
-
 export const IndeterminateCheckboxCell = ({
-  indeterminate,
-  initialValue,
-  manualDisable,
   dataTestId,
   ...rest
-}: IndeterminateCheckboxCellProps) => {
-  const [initialCheckBoxValue] = useState(initialValue);
-
-  return (
-    <Flex alignItems="center" justifyContent="center">
-      <Checkbox
-        data-testid={dataTestId || undefined}
-        isChecked={initialCheckBoxValue || rest.checked}
-        isDisabled={initialCheckBoxValue || manualDisable}
-        onChange={rest.onChange}
-        isIndeterminate={!rest.checked && indeterminate}
-        colorScheme="purple"
-      />
-    </Flex>
-  );
-};
+}: CheckboxProps & { dataTestId?: string }) => (
+  <Flex alignItems="center" justifyContent="center">
+    <Checkbox
+      data-testid={dataTestId || undefined}
+      {...rest}
+      colorScheme="purple"
+    />
+  </Flex>
+);
 
 type DefaultHeaderCellProps<T, V> = {
   value: V;

--- a/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
+++ b/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
@@ -111,35 +111,40 @@ export const AddMultipleSystems = ({ redirectRoute }: Props) => {
         id: "select",
         header: ({ table }) => (
           <IndeterminateCheckboxCell
-            {...{
-              dataTestId: "select-page-checkbox",
-              checked: table.getIsAllPageRowsSelected(),
-              indeterminate: table
+            dataTestId="select-page-checkbox"
+            isChecked={table.getIsAllPageRowsSelected()}
+            isDisabled={
+              allRowsLinkedToSystem ||
+              table
                 .getPaginationRowModel()
-                .rows.filter((r) => !r.original.linked_system)
-                .some((r) => r.getIsSelected()),
-              onChange: (e) => {
-                table.getToggleAllPageRowsSelectedHandler()(e);
-                setIsRowSelectionBarOpen((prev) => !prev);
-              },
-              manualDisable:
-                allRowsLinkedToSystem ||
-                table
-                  .getPaginationRowModel()
-                  .rows.filter((r) => r.original.linked_system).length ===
-                  table.getState().pagination.pageSize,
+                .rows.filter((r) => r.original.linked_system).length ===
+                table.getState().pagination.pageSize
+            }
+            isIndeterminate={table
+              .getPaginationRowModel()
+              .rows.filter((r) => r.getCanSelect())
+              .some((r) => !r.getIsSelected())}
+            onChange={() => {
+              table.setRowSelection((old) => {
+                const rowSelection: RowSelectionState = { ...old };
+                table.getRowModel().rows.forEach((row) => {
+                  if (row.getCanSelect()) {
+                    rowSelection[row.id] = !rowSelection[row.id];
+                  }
+                });
+
+                return rowSelection;
+              });
+              setIsRowSelectionBarOpen((prev) => !prev);
             }}
           />
         ),
         cell: ({ row }) => (
           <IndeterminateCheckboxCell
-            {...{
-              checked: row.getIsSelected(),
-              disabled: !row.getCanSelect(),
-              indeterminate: row.getIsSomeSelected(),
-              onChange: row.getToggleSelectedHandler(),
-              initialValue: row.original.linked_system,
-            }}
+            isChecked={row.getIsSelected()}
+            isDisabled={!row.getCanSelect()}
+            isIndeterminate={row.getIsSomeSelected()}
+            onChange={row.getToggleSelectedHandler()}
           />
         ),
         meta: {

--- a/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
+++ b/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
@@ -68,6 +68,9 @@ export const VendorSourceCell = ({ value }: { value: string }) => {
   );
 };
 
+const ADDED_VENDOR_TOOLTIP_LABEL =
+  "This vendor has already beed added. You can view the properties of this vendor by going to View Systems.";
+
 type MultipleSystemTable = DictSystems;
 
 const columnHelper = createColumnHelper<MultipleSystemTable>();
@@ -368,6 +371,12 @@ export const AddMultipleSystems = ({ redirectRoute }: Props) => {
             isOpen={isRowSelectionBarOpen}
           />
         }
+        renderRowTooltipLabel={(row) => {
+          if (!row.getCanSelect()) {
+            return ADDED_VENDOR_TOOLTIP_LABEL;
+          }
+          return undefined;
+        }}
       />
       <PaginationBar
         pageSizes={PAGE_SIZES}


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1329

### Description Of Changes


https://github.com/ethyca/fides/assets/24641006/a16b43a1-ced7-4241-97f1-0dfc5827d072




### Code Changes

* [x] Fix `rowSelection` initialization logic. I was trying to use a lot of the `row` getters which weren't working, and it turns out it wasn't set quite right! I _think_ this means some of the `IntermediateCheckbox` logic might be able to be simplified too, though I didn't dig into that too much (the `row.getCanSelect()` being passed to the `disabled` param wasn't actually doing anything—now it can)
* [x] Add tooltip row rendering

### Steps to Confirm

* [ ] Visit the preview environment's "Add multiple" systems page https://fides-plus-nightly-git-aking-1329add-vendors-disa-71087f-ethyca.vercel.app/add-systems/multiple
* [ ] You should see the new disabled state across the row

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

