### PR TITLE
Add back "add vendor" buttons and styling fixes

### DIFF
--- a/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
@@ -93,7 +93,7 @@ export const NAV_CONFIG: NavConfigGroup[] = [
     title: "Consent",
     routes: [
       {
-        title: "Configure consent",
+        title: "Vendors",
         path: routes.CONFIGURE_CONSENT_ROUTE,
         requiresFlag: "configureConsent",
         requiresPlus: true,

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -26,7 +26,15 @@ export const BadgeCell = ({
   suffix?: string;
 }) => (
   <Flex alignItems="center" height="100%" mr="2">
-    <Badge textTransform="none">
+    <Badge
+      textTransform="none"
+      fontWeight="400"
+      fontSize="xs"
+      lineHeight={4}
+      color="gray.600"
+      px={2}
+      py={1}
+    >
       {value}
       {suffix ? ` ${suffix}` : null}
     </Badge>

--- a/clients/admin-ui/src/features/configure-consent/ConsentMangagementTable.tsx
+++ b/clients/admin-ui/src/features/configure-consent/ConsentMangagementTable.tsx
@@ -180,7 +180,7 @@ export const ConsentManagementTable = () => {
         cell: (props) => (
           <BadgeCell suffix="data uses" value={props.getValue()} />
         ),
-        header: (props) => <DefaultHeaderCell value="Data uses" {...props} />,
+        header: (props) => <DefaultHeaderCell value="Data use" {...props} />,
         meta: {
           width: "175px",
         },
@@ -188,7 +188,7 @@ export const ConsentManagementTable = () => {
       columnHelper.accessor((row) => row.legal_bases, {
         id: "legal_bases",
         cell: (props) => <BadgeCell suffix="bases" value={props.getValue()} />,
-        header: (props) => <DefaultHeaderCell value="Legal bases" {...props} />,
+        header: (props) => <DefaultHeaderCell value="Legal basis" {...props} />,
         meta: {
           width: "175px",
         },

--- a/clients/admin-ui/src/pages/consent/configure/index.tsx
+++ b/clients/admin-ui/src/pages/consent/configure/index.tsx
@@ -1,4 +1,12 @@
-import { Box, Breadcrumb, BreadcrumbItem, Heading, Text } from "@fidesui/react";
+import {
+  Box,
+  Breadcrumb,
+  BreadcrumbItem,
+  Heading,
+  Text,
+  Flex,
+  Spacer,
+} from "@fidesui/react";
 import { useFeatures } from "common/features";
 import NextLink from "next/link";
 import React from "react";
@@ -8,8 +16,11 @@ import Layout from "~/features/common/Layout";
 import { CONFIGURE_CONSENT_ROUTE } from "~/features/common/nav/v2/routes";
 import ConfigureConsent from "~/features/configure-consent/ConfigureConsent";
 import { ConsentManagementTable } from "~/features/configure-consent/ConsentMangagementTable";
+import AddVendor from "~/features/configure-consent/AddVendor";
 
-const ConsentMetadata = () => (
+const ConsentMetadata: React.FC<{ includeAddVendors?: boolean }> = ({
+  includeAddVendors,
+}) => (
   <>
     <Box mb={4}>
       <Heading fontSize="2xl" fontWeight="semibold" mb={2} data-testid="header">
@@ -31,9 +42,17 @@ const ConsentMetadata = () => (
         </Breadcrumb>
       </Box>
     </Box>
-    <Text fontSize="sm" mb={8} width={{ base: "100%", lg: "50%" }}>
-      Your current cookies and tracking information.
-    </Text>
+    <Flex>
+      <Text fontSize="sm" mb={8} width={{ base: "100%", lg: "50%" }}>
+        Your current cookies and tracking information.
+      </Text>
+      {includeAddVendors ? (
+        <>
+          <Spacer />
+          <AddVendor />
+        </>
+      ) : null}
+    </Flex>
   </>
 );
 
@@ -49,7 +68,7 @@ const ConfigureConsentPage = () => {
           paddingRight: "48px",
         }}
       >
-        <ConsentMetadata />
+        <ConsentMetadata includeAddVendors />
         <ConsentManagementTable />
       </FixedLayout>
     );

--- a/clients/admin-ui/src/pages/consent/configure/index.tsx
+++ b/clients/admin-ui/src/pages/consent/configure/index.tsx
@@ -18,13 +18,23 @@ import ConfigureConsent from "~/features/configure-consent/ConfigureConsent";
 import { ConsentManagementTable } from "~/features/configure-consent/ConsentMangagementTable";
 import AddVendor from "~/features/configure-consent/AddVendor";
 
-const ConsentMetadata: React.FC<{ includeAddVendors?: boolean }> = ({
+type Props = {
+  includeAddVendors?: boolean;
+  title: string;
+  breadCrumbText: string;
+  description: string;
+};
+
+const ConsentMetadata: React.FC<Props> = ({
   includeAddVendors,
+  title,
+  breadCrumbText,
+  description,
 }) => (
   <>
     <Box mb={4}>
       <Heading fontSize="2xl" fontWeight="semibold" mb={2} data-testid="header">
-        Configure consent
+        {title}
       </Heading>
       <Box>
         <Breadcrumb
@@ -37,14 +47,14 @@ const ConsentMetadata: React.FC<{ includeAddVendors?: boolean }> = ({
             <NextLink href={CONFIGURE_CONSENT_ROUTE}>Consent</NextLink>
           </BreadcrumbItem>
           <BreadcrumbItem color="complimentary.500">
-            <NextLink href="#">Configure consent</NextLink>
+            <NextLink href="#">{breadCrumbText}</NextLink>
           </BreadcrumbItem>
         </Breadcrumb>
       </Box>
     </Box>
     <Flex>
       <Text fontSize="sm" mb={8} width={{ base: "100%", lg: "50%" }}>
-        Your current cookies and tracking information.
+        {description}
       </Text>
       {includeAddVendors ? (
         <>
@@ -68,7 +78,12 @@ const ConfigureConsentPage = () => {
           paddingRight: "48px",
         }}
       >
-        <ConsentMetadata includeAddVendors />
+        <ConsentMetadata
+          includeAddVendors
+          title="Manage your vendors"
+          breadCrumbText="Vendors"
+          description="Use the table below to manage your vendors. Modify the legal basis for a vendor if permitted and view and group your views by applying different filters"
+        />
         <ConsentManagementTable />
       </FixedLayout>
     );
@@ -76,7 +91,11 @@ const ConfigureConsentPage = () => {
 
   return (
     <Layout title="Configure consent">
-      <ConsentMetadata />
+      <ConsentMetadata
+        title="Configure consent"
+        breadCrumbText="Configure consent"
+        description="Your current cookies and tracking information."
+      />
       <ConfigureConsent />
     </Layout>
   );

--- a/clients/admin-ui/src/pages/consent/configure/index.tsx
+++ b/clients/admin-ui/src/pages/consent/configure/index.tsx
@@ -2,10 +2,10 @@ import {
   Box,
   Breadcrumb,
   BreadcrumbItem,
-  Heading,
-  Text,
   Flex,
+  Heading,
   Spacer,
+  Text,
 } from "@fidesui/react";
 import { useFeatures } from "common/features";
 import NextLink from "next/link";
@@ -14,9 +14,9 @@ import React from "react";
 import FixedLayout from "~/features/common/FixedLayout";
 import Layout from "~/features/common/Layout";
 import { CONFIGURE_CONSENT_ROUTE } from "~/features/common/nav/v2/routes";
+import AddVendor from "~/features/configure-consent/AddVendor";
 import ConfigureConsent from "~/features/configure-consent/ConfigureConsent";
 import { ConsentManagementTable } from "~/features/configure-consent/ConsentMangagementTable";
-import AddVendor from "~/features/configure-consent/AddVendor";
 
 type Props = {
   includeAddVendors?: boolean;


### PR DESCRIPTION
Closes PROD-1515, PROD-1516

### Description Of Changes

This PR addresses feedback based on UAT and release testing.


### Code Changes

* [ ] Update the styling of the badge cell for the V2 table
* [ ] Update column heading text
* [ ] Update copy for the TCF consent management page
* [ ] Add the add vendor buttons back to the TCF consent management page

### Steps to Confirm

* [ ] Run fidesplus with TCF enabled `nox -s "build(slim) -- dev && nox -s "dev(slim)"`
* [ ] navigate to `/configure/consent`
* [ ] Make sure that the add vendor buttons are there and working

(Michael signed off on the styling and copy in Jira)


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
