### PR TITLE
use config proxy for purpose override flag check

### DIFF
--- a/src/fides/api/util/tcf/tcf_experience_contents.py
+++ b/src/fides/api/util/tcf/tcf_experience_contents.py
@@ -33,6 +33,7 @@ from fides.api.schemas.tcf import (
 )
 from fides.api.util.tcf import AC_PREFIX
 from fides.config import CONFIG
+from fides.config.config_proxy import ConfigProxy
 
 PURPOSE_DATA_USES: List[str] = []
 for purpose in MAPPED_PURPOSES.values():
@@ -154,7 +155,8 @@ def get_legal_basis_override_subquery(db: Session) -> Alias:
 
     Otherwise, we return the override!
     """
-    if not CONFIG.consent.override_vendor_purposes:
+    config_proxy = ConfigProxy(db)
+    if not config_proxy.consent.override_vendor_purposes:
         return db.query(
             PrivacyDeclaration.id,
             PrivacyDeclaration.legal_basis_for_processing.label(

--- a/src/fides/config/config_proxy.py
+++ b/src/fides/config/config_proxy.py
@@ -73,6 +73,12 @@ class SecuritySettingsProxy(ConfigProxyBase):
     cors_origins: List[AnyUrl]
 
 
+class ConsentSettingsProxy(ConfigProxyBase):
+    prefix = "consent"
+
+    override_vendor_purposes: bool
+
+
 class ConfigProxy:
     """
     ConfigProxy instances allow access to "resolved" config properties
@@ -99,6 +105,7 @@ class ConfigProxy:
         self.execution = ExecutionSettingsProxy(db)
         self.storage = StorageSettingsProxy(db)
         self.security = SecuritySettingsProxy(db)
+        self.consent = ConsentSettingsProxy(db)
 
     def load_current_cors_domains_into_middleware(self, app: FastAPI) -> None:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,11 +186,34 @@ def enable_ac(config):
 
 
 @pytest.fixture(scope="function")
-def enable_override_vendor_purposes(config):
+def enable_override_vendor_purposes(config, db):
     assert config.test_mode
     config.consent.override_vendor_purposes = True
+    ApplicationConfig.create_or_update(
+        db,
+        data={"config_set": {"consent": {"override_vendor_purposes": True}}},
+    )
     yield config
     config.consent.override_vendor_purposes = False
+    ApplicationConfig.create_or_update(
+        db,
+        data={"config_set": {"consent": {"override_vendor_purposes": False}}},
+    )
+
+
+@pytest.fixture(scope="function")
+def enable_override_vendor_purposes_api_set(db):
+    """Enable override vendor purposes via api_set setting, not via traditional app config"""
+    ApplicationConfig.create_or_update(
+        db,
+        data={"api_set": {"consent": {"override_vendor_purposes": True}}},
+    )
+    yield
+    # reset back to false on teardown
+    ApplicationConfig.create_or_update(
+        db,
+        data={"api_set": {"consent": {"override_vendor_purposes": False}}},
+    )
 
 
 @pytest.fixture

--- a/tests/ops/models/test_privacy_preference.py
+++ b/tests/ops/models/test_privacy_preference.py
@@ -1653,15 +1653,24 @@ class TestDeterminePrivacyPreferenceHistoryRelevantSystems:
             == []
         )
 
-    @pytest.mark.usefixtures(
-        "enable_override_vendor_purposes", "purpose_three_consent_publisher_override"
+    @pytest.mark.usefixtures("purpose_three_consent_publisher_override")
+    @pytest.mark.parametrize(
+        "override_fixture",
+        [
+            "enable_override_vendor_purposes",
+            "enable_override_vendor_purposes_api_set",  # ensure override functionality works when config is set via API
+        ],
     )
     def test_determine_relevant_systems_for_with_purpose_override(
         self,
+        override_fixture,
+        request,
         db,
         system_with_no_uses,
     ):
         """Relevant system calculation takes into account legal basis overrides"""
+        request.getfixturevalue(override_fixture)
+
         # Add data use to system that corresponds to purpose 3.  Also has LI legal basis, but override sets it
         # to Consent
         pd_1 = PrivacyDeclaration.create(

--- a/tests/ops/util/test_tcf_privacy_declarations.py
+++ b/tests/ops/util/test_tcf_privacy_declarations.py
@@ -41,14 +41,22 @@ class TestBaseTCFQuery:
             "functional.storage": 1,
         }
 
-    @pytest.mark.usefixtures("enable_override_vendor_purposes")
-    def test_privacy_declaration_purpose_overrides(self, db, emerse_system):
+    @pytest.mark.parametrize(
+        "override_fixture",
+        [
+            "enable_override_vendor_purposes",
+            "enable_override_vendor_purposes_api_set",  # ensure override functionality works when config is set via API
+        ],
+    )
+    def test_privacy_declaration_purpose_overrides(
+        self, override_fixture, request, db, emerse_system
+    ):
         """Comprehensive test of the various scenarios for privacy declaration purpose overrides when building the
         base TCF query
 
         Some of the specifics aren't configurations that would be allowed for emerse, but ignore that here.
         """
-
+        request.getfixturevalue(override_fixture)
         # As some test setup, override purpose 7 declaration to have an inflexible legal basis
         purpose_7_decl = next(
             decl


### PR DESCRIPTION
Closes [PROD-1513](https://ethyca.atlassian.net/browse/PROD-1513)

### Description Of Changes

Use the config proxy for resolving the `consent.override_vendor_purposes` config property in the context of generating the TCF experience, such that we respect any value set for the config via the API.

Note that for https://ethyca.atlassian.net/browse/PROD-1416 we will likely need further changes, because we need to use the config proxy in a different codepath that's not quite as straightforward.


### Code Changes

* [x] update config proxy to support the `consent` config section and the  `override_vendor_purposes` property specifically
* [x] use the config proxy to resolve `consent.override_vendor_purposes` when building the TCF experience

### Steps to Confirm

* [x] tested locally using an alpha tag/prerelease fidesplus BE and using the google ads with purpose 2 example referenced in the jira ticket: https://www.loom.com/share/ebdac13ab4294bd4b52d2b754dfa609d

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated


[PROD-1513]: https://ethyca.atlassian.net/browse/PROD-1513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ