### PR TITLE
Fixup table select states

### DIFF
--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -3,11 +3,12 @@ import {
   ArrowUpIcon,
   Badge,
   Checkbox,
+  CheckboxProps,
   Flex,
   Text,
 } from "@fidesui/react";
 import { HeaderContext } from "@tanstack/react-table";
-import { HTMLProps, ReactNode, useState } from "react";
+import { ReactNode } from "react";
 
 export const DefaultCell = ({ value }: { value: string }) => (
   <Flex alignItems="center" height="100%">
@@ -32,35 +33,18 @@ export const BadgeCell = ({
   </Flex>
 );
 
-type IndeterminateCheckboxCellProps = {
-  indeterminate?: boolean;
-  initialValue?: boolean;
-  manualDisable?: boolean;
-  dataTestId?: string;
-} & HTMLProps<HTMLInputElement>;
-
 export const IndeterminateCheckboxCell = ({
-  indeterminate,
-  initialValue,
-  manualDisable,
   dataTestId,
   ...rest
-}: IndeterminateCheckboxCellProps) => {
-  const [initialCheckBoxValue] = useState(initialValue);
-
-  return (
-    <Flex alignItems="center" justifyContent="center">
-      <Checkbox
-        data-testid={dataTestId || undefined}
-        isChecked={initialCheckBoxValue || rest.checked}
-        isDisabled={initialCheckBoxValue || manualDisable}
-        onChange={rest.onChange}
-        isIndeterminate={!rest.checked && indeterminate}
-        colorScheme="purple"
-      />
-    </Flex>
-  );
-};
+}: CheckboxProps & { dataTestId?: string }) => (
+  <Flex alignItems="center" justifyContent="center">
+    <Checkbox
+      data-testid={dataTestId || undefined}
+      {...rest}
+      colorScheme="purple"
+    />
+  </Flex>
+);
 
 type DefaultHeaderCellProps<T, V> = {
   value: V;

--- a/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
+++ b/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
@@ -111,35 +111,40 @@ export const AddMultipleSystems = ({ redirectRoute }: Props) => {
         id: "select",
         header: ({ table }) => (
           <IndeterminateCheckboxCell
-            {...{
-              dataTestId: "select-page-checkbox",
-              checked: table.getIsAllPageRowsSelected(),
-              indeterminate: table
+            dataTestId="select-page-checkbox"
+            isChecked={table.getIsAllPageRowsSelected()}
+            isDisabled={
+              allRowsLinkedToSystem ||
+              table
                 .getPaginationRowModel()
-                .rows.filter((r) => !r.original.linked_system)
-                .some((r) => r.getIsSelected()),
-              onChange: (e) => {
-                table.getToggleAllPageRowsSelectedHandler()(e);
-                setIsRowSelectionBarOpen((prev) => !prev);
-              },
-              manualDisable:
-                allRowsLinkedToSystem ||
-                table
-                  .getPaginationRowModel()
-                  .rows.filter((r) => r.original.linked_system).length ===
-                  table.getState().pagination.pageSize,
+                .rows.filter((r) => r.original.linked_system).length ===
+                table.getState().pagination.pageSize
+            }
+            isIndeterminate={table
+              .getPaginationRowModel()
+              .rows.filter((r) => r.getCanSelect())
+              .some((r) => !r.getIsSelected())}
+            onChange={() => {
+              table.setRowSelection((old) => {
+                const rowSelection: RowSelectionState = { ...old };
+                table.getRowModel().rows.forEach((row) => {
+                  if (row.getCanSelect()) {
+                    rowSelection[row.id] = !rowSelection[row.id];
+                  }
+                });
+
+                return rowSelection;
+              });
+              setIsRowSelectionBarOpen((prev) => !prev);
             }}
           />
         ),
         cell: ({ row }) => (
           <IndeterminateCheckboxCell
-            {...{
-              checked: row.getIsSelected(),
-              disabled: !row.getCanSelect(),
-              indeterminate: row.getIsSomeSelected(),
-              onChange: row.getToggleSelectedHandler(),
-              initialValue: row.original.linked_system,
-            }}
+            isChecked={row.getIsSelected()}
+            isDisabled={!row.getCanSelect()}
+            isIndeterminate={row.getIsSomeSelected()}
+            onChange={row.getToggleSelectedHandler()}
           />
         ),
         meta: {


### PR DESCRIPTION
Closes N/A

### Description Of Changes

While working on https://github.com/ethyca/fides/pull/4498 I realized the table wasn't keeping track of checkbox state quite right. This resulted in some workaround logic in the `IndeterminateCheckbox` component. This removes that workaround logic now that the `rowSelection` states should be accurate


### Code Changes

* [x] Simplify checkbox logic

### Steps to Confirm

* [ ] Try out the bulk add table for systems and make sure all checkboxes still respond as they currently do

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Update `CHANGELOG.md`

