### PR TITLE
Fix Compass button states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The types of changes are:
 ### Added
 - Tooltip and styling for disabled rows in add multiple vendor view [#4498](https://github.com/ethyca/fides/pull/4498)
 
+### Fixed
+- Fixed incorrect Compass button behavior in system form [#4508](https://github.com/ethyca/fides/pull/4508)
+
 ## [2.26.0](https://github.com/ethyca/fides/compare/2.25.0...main)
 
 ### Added

--- a/clients/admin-ui/src/features/system/VendorSelector.tsx
+++ b/clients/admin-ui/src/features/system/VendorSelector.tsx
@@ -3,6 +3,10 @@ import {
   FormControl,
   HStack,
   IconButton,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
   Spacer,
   Text,
   VStack,
@@ -35,20 +39,37 @@ const CompassButton = ({
   active: boolean;
   disabled: boolean;
   onRefreshSuggestions: () => void;
-}) => (
-  <VStack>
-    <Spacer minHeight="18px" />
-    <IconButton
-      size="sm"
-      isDisabled={disabled}
-      onClick={() => onRefreshSuggestions()}
-      aria-label="Update information from Compass"
-      bg={active ? "complimentary.500" : "gray.100"}
-      icon={<CompassIcon color={active ? "white" : "gray.700"} boxSize={4} />}
-      data-testid="refresh-suggestions-btn"
-    />
-  </VStack>
-);
+}) => {
+  const bgColor = { bg: active ? "complimentary.500" : "gray.100" };
+  return (
+    <VStack>
+      <Spacer minHeight="18px" />
+      <Menu>
+        <MenuButton
+          as={IconButton}
+          size="sm"
+          isDisabled={disabled}
+          icon={
+            <CompassIcon color={active ? "white" : "gray.700"} boxSize={4} />
+          }
+          aria-label="Update information from Compass"
+          data-testid="refresh-suggestions-btn"
+          _hover={{
+            _disabled: bgColor,
+          }}
+          {...bgColor}
+        />
+        <MenuList>
+          <MenuItem onClick={onRefreshSuggestions}>
+            <Text fontSize="xs" lineHeight={4}>
+              Reset to Compass defaults
+            </Text>
+          </MenuItem>
+        </MenuList>
+      </Menu>
+    </VStack>
+  );
+};
 
 interface Props {
   fieldsSeparated: boolean;
@@ -88,7 +109,7 @@ const VendorSelector = ({
   options,
   onVendorSelected,
 }: Props) => {
-  const isShowingSuggestions = useAppSelector(selectSuggestions);
+  const isShowingDictSuggestions = useAppSelector(selectSuggestions);
   const [initialField, meta, { setValue }] = useField({
     name: fieldsSeparated ? "vendor_id" : "name",
   });
@@ -108,6 +129,8 @@ const VendorSelector = ({
   const suggestions = options.filter((opt) =>
     opt.label.toLowerCase().startsWith(searchParam.toLowerCase())
   );
+
+  const hasVendorSuggestions = !!searchParam && suggestions.length > 0;
 
   const handleTabPressed = () => {
     if (suggestions.length > 0 && searchParam !== suggestions[0].label) {
@@ -208,10 +231,7 @@ const VendorSelector = ({
                   }),
                   menu: (provided) => ({
                     ...provided,
-                    visibility:
-                      searchParam && suggestions.length > 0
-                        ? "visible"
-                        : "hidden",
+                    visibility: hasVendorSuggestions ? "visible" : "hidden",
                   }),
                   dropdownIndicator: (provided) => ({
                     ...provided,
@@ -238,7 +258,7 @@ const VendorSelector = ({
                 }}
               >
                 <span style={{ color: "transparent" }}>{searchParam}</span>
-                {searchParam && suggestions.length > 0 ? (
+                {hasVendorSuggestions ? (
                   <span style={{ color: "#824EF2" }}>
                     {suggestions[0].label.substring(searchParam.length)}
                   </span>
@@ -253,8 +273,8 @@ const VendorSelector = ({
           </VStack>
         </FormControl>
         <CompassButton
-          active={!!values.vendor_id}
-          disabled={!values.vendor_id || isShowingSuggestions === "showing"}
+          active={!!values.vendor_id || hasVendorSuggestions}
+          disabled={!values.vendor_id || isShowingDictSuggestions === "showing"}
           onRefreshSuggestions={() => onVendorSelected(values.vendor_id)}
         />
       </HStack>

--- a/clients/admin-ui/src/features/system/VendorSelector.tsx
+++ b/clients/admin-ui/src/features/system/VendorSelector.tsx
@@ -109,7 +109,7 @@ const VendorSelector = ({
   options,
   onVendorSelected,
 }: Props) => {
-  const isShowingDictSuggestions = useAppSelector(selectSuggestions);
+  const dictSuggestionsState = useAppSelector(selectSuggestions);
   const [initialField, meta, { setValue }] = useField({
     name: fieldsSeparated ? "vendor_id" : "name",
   });
@@ -274,7 +274,7 @@ const VendorSelector = ({
         </FormControl>
         <CompassButton
           active={!!values.vendor_id || hasVendorSuggestions}
-          disabled={!values.vendor_id || isShowingDictSuggestions === "showing"}
+          disabled={!values.vendor_id || dictSuggestionsState === "showing"}
           onRefreshSuggestions={() => onVendorSelected(values.vendor_id)}
         />
       </HStack>


### PR DESCRIPTION
Closes #PROD-1449

### Description Of Changes

Fixes a few bugged/incorrect states of the Compass button in the system information form:

* The button is now highlighted in purple while suggestions are being made in the typeahead, instead of only when a vendor is selected
* The button no longer has a hover state when it's disabled (i.e. if suggestions are already being shown, or if no vendor is selected)
* The button is now a menu button
 
### Code Changes

* [ ] Changes to styling on VendorSelector component and its nested CompassButton
* [ ] Changed some variable names to clarify what's a suggestion from the vendor selector and what's a suggestion from Compass for the form

### Steps to Confirm

With Compass enabled:

* [x] Go to the "add a system" form
* [x] Type the name of a GVL vendor into the typeahead (e.g. "Adtelligence")
* [x] While the typeahead is showing a suggestion in purple, the Compass button should also be purple
* [x] Accept the suggestions for the vendor
* [x] Compass button should be disabled; mouse over button and confirm color doesn't change
* [x] Save the system
* [x] Make changes to the system, then save again
* [x] Click the Compass button, then "Update to Compass defaults"; original suggestions from Compass should be shown again

[Loom demo](https://www.loom.com/share/f1c8904833074652b3604384b54e374e)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
