### PR TITLE
Update cy tests for Manage your vendors page after removing Add Vendors btn

### DIFF
--- a/clients/admin-ui/cypress/e2e/consent-configuration.cy.ts
+++ b/clients/admin-ui/cypress/e2e/consent-configuration.cy.ts
@@ -57,8 +57,6 @@ describe("Consent configuration", () => {
       cy.visit(CONFIGURE_CONSENT_ROUTE);
       cy.getByTestId("empty-state");
       cy.get("body").click(0, 0);
-      cy.getByTestId("add-vendor-btn").click();
-      cy.getByTestId("add-vendor-modal-content");
     });
   });
 
@@ -112,7 +110,6 @@ describe("Consent configuration", () => {
       cy.getByTestId("subrow-cell_2_Data use").contains("Improve Service");
       cy.getByTestId("subrow-cell_3_Cookie name").contains("cookie2");
       cy.getByTestId("subrow-cell_3_Data use").contains("Improve Service");
-      cy.getByTestId("add-vendor-btn");
     });
   });
 
@@ -152,7 +149,7 @@ describe("Consent configuration", () => {
         cy.visit(CONFIGURE_CONSENT_ROUTE);
       });
 
-      it("can add a vendor without the dictionary", () => {
+      it.skip("can add a vendor without the dictionary", () => {
         cy.getByTestId("add-vendor-btn").click();
         cy.getByTestId("input-name").type("test vendor");
         cy.selectOption(
@@ -190,7 +187,7 @@ describe("Consent configuration", () => {
         });
       });
 
-      it("can manually add more data uses", () => {
+      it.skip("can manually add more data uses", () => {
         cy.getByTestId("add-vendor-btn").click();
         cy.getByTestId("add-data-use-btn").should("be.disabled");
         cy.getByTestId("input-name").type("test vendor");
@@ -284,7 +281,7 @@ describe("Consent configuration", () => {
         cy.visit(CONFIGURE_CONSENT_ROUTE);
       });
 
-      it("can fill in dictionary suggestions", () => {
+      it.skip("can fill in dictionary suggestions", () => {
         cy.getByTestId("add-vendor-btn").click();
         cy.getByTestId("input-vendor_id")
           .click()
@@ -737,7 +734,7 @@ describe("Consent configuration", () => {
         });
       });
 
-      it("can create a vendor that is not in the dictionary", () => {
+      it.skip("can create a vendor that is not in the dictionary", () => {
         cy.getByTestId("add-vendor-btn").click();
         cy.getByTestId("input-vendor_id").type("custom vendor{enter}");
         cy.selectOption(


### PR DESCRIPTION
### Description Of Changes

Fix cypress tests after removing the Add Vendor button https://github.com/ethyca/fides/pull/4509

### Steps to Confirm

* [ ] all test passing 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
