### PR TITLE
PROD-1403: Omit specific fields from system payload if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The types of changes are:
 
 ### Fixed
 - Fixed incorrect Compass button behavior in system form [#4508](https://github.com/ethyca/fides/pull/4508)
+- Omit certain fields from system payload when empty  [#4508](https://github.com/ethyca/fides/pull/4525)
 
 ## [2.26.0](https://github.com/ethyca/fides/compare/2.25.0...main)
 

--- a/clients/admin-ui/src/features/system/form.test.ts
+++ b/clients/admin-ui/src/features/system/form.test.ts
@@ -38,7 +38,7 @@ describe("transformFormValuesToSystem", () => {
     expect(payload).not.toHaveProperty("joint_controller_info");
   });
 
-  it("should keep joint controller into and adminitstrating department if not empty", () => {
+  it("should keep joint controller into and administrating department if not empty", () => {
     const formValues = {
       system_type: "",
       fides_key: "",

--- a/clients/admin-ui/src/features/system/form.test.ts
+++ b/clients/admin-ui/src/features/system/form.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "@jest/globals";
 import { transformFormValuesToSystem } from "~/features/system/form";
 
 describe("transformFormValuesToSystem", () => {
-  it("should omit joint controller into and adminitstrating department if empty", () => {
+  it("should omit joint controller into and administrating department if empty", () => {
     const formValues = {
       system_type: "",
       fides_key: "",

--- a/clients/admin-ui/src/features/system/form.test.ts
+++ b/clients/admin-ui/src/features/system/form.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { transformFormValuesToSystem } from "~/features/system/form";
+
+describe("transformFormValuesToSystem", () => {
+  it("should omit joint controller into and adminitstrating department if empty", () => {
+    const formValues = {
+      system_type: "",
+      fides_key: "",
+      tags: [],
+      name: "new system",
+      description: "",
+      dataset_references: [],
+      processes_personal_data: true,
+      exempt_from_privacy_regulations: false,
+      reason_for_exemption: "",
+      uses_profiling: false,
+      does_international_transfers: false,
+      requires_data_protection_assessments: false,
+      privacy_policy: "",
+      legal_name: "",
+      legal_address: "",
+      administrating_department: "",
+      responsibility: [],
+      joint_controller_info: "",
+      data_security_practices: "",
+      privacy_declarations: [],
+      data_stewards: "",
+      dpo: "",
+      uses_cookies: false,
+      cookie_refresh: false,
+      uses_non_cookie_access: false,
+      legitimate_interest_disclosure_url: "",
+    };
+
+    const payload = transformFormValuesToSystem(formValues);
+    expect(payload).not.toHaveProperty("administrating_department");
+    expect(payload).not.toHaveProperty("joint_controller_info");
+  });
+
+  it("should keep joint controller into and adminitstrating department if not empty", () => {
+    const formValues = {
+      system_type: "",
+      fides_key: "",
+      tags: [],
+      name: "new system",
+      description: "",
+      dataset_references: [],
+      processes_personal_data: true,
+      exempt_from_privacy_regulations: false,
+      reason_for_exemption: "",
+      uses_profiling: false,
+      does_international_transfers: false,
+      requires_data_protection_assessments: false,
+      privacy_policy: "",
+      legal_name: "",
+      legal_address: "",
+      administrating_department: "not empty",
+      responsibility: [],
+      joint_controller_info: "not empty",
+      data_security_practices: "",
+      privacy_declarations: [],
+      data_stewards: "",
+      dpo: "",
+      uses_cookies: false,
+      cookie_refresh: false,
+      uses_non_cookie_access: false,
+      legitimate_interest_disclosure_url: "",
+    };
+
+    const payload = transformFormValuesToSystem(formValues);
+    expect(payload).toHaveProperty("administrating_department");
+    expect(payload).toHaveProperty("joint_controller_info");
+  });
+});

--- a/clients/admin-ui/src/features/system/form.ts
+++ b/clients/admin-ui/src/features/system/form.ts
@@ -102,7 +102,7 @@ export const transformFormValuesToSystem = (formValues: FormValues): System => {
   const privacyPolicy =
     formValues.privacy_policy === "" ? undefined : formValues.privacy_policy;
 
-  const payload: System = {
+  let payload: System = {
     system_type: formValues.system_type,
     fides_key: key,
     name: formValues.name,
@@ -142,7 +142,7 @@ export const transformFormValuesToSystem = (formValues: FormValues): System => {
     return payload;
   }
 
-  return {
+  payload = {
     ...payload,
     dataset_references: formValues.dataset_references,
     uses_profiling: formValues.uses_profiling,
@@ -161,10 +161,18 @@ export const transformFormValuesToSystem = (formValues: FormValues): System => {
     privacy_policy: privacyPolicy,
     legal_name: formValues.legal_name,
     legal_address: formValues.legal_address,
-    administrating_department: formValues.administrating_department,
     responsibility: formValues.responsibility,
     dpo: formValues.dpo,
-    joint_controller_info: formValues.joint_controller_info,
     data_security_practices: formValues.data_security_practices,
   };
+
+  if (formValues.administrating_department) {
+    payload.administrating_department = formValues.administrating_department;
+  }
+
+  if (formValues.joint_controller_info) {
+    payload.joint_controller_info = formValues.joint_controller_info;
+  }
+
+  return payload;
 };


### PR DESCRIPTION
Closes PROD-1403

### Description Of Changes

This PR aligns the FE with how the bulk vendor add route handles these fields.

### Code Changes

* [ ] Omit `administrating_department` and `joint_controller_info` if they're empty

### Steps to Confirm

* [ ] submit a form with them empty and check the network tab to make sure they're excluded

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
