### PR TITLE
Configure fides.js base URL and allow CORS

### DIFF
--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -305,7 +305,7 @@ _Fides = {
     fidesString: null,
     apiOptions: null,
     fidesTcfGdprApplies: true,
-    gppExtensionPath: "",
+    fidesJsBaseUrl: "",
     customOptionsPath: null,
     preventDismissal: false,
   },

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -195,7 +195,7 @@ _Fides = {
     fidesString: null,
     apiOptions: null,
     fidesTcfGdprApplies: false,
-    gppExtensionPath: "",
+    fidesJsBaseUrl: "",
     customOptionsPath: null,
     preventDismissal: false,
   },

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -86,8 +86,8 @@ export type FidesOptions = {
   // What the "GDPR Applies" field of TCF should default to
   fidesTcfGdprApplies: boolean;
 
-  // GPP extension path (ex: "/fides-ext-gpp.js")
-  gppExtensionPath: string;
+  // Base URL for directory of fides.js scripts
+  fidesJsBaseUrl: string;
 
   // A custom path to fetch OverrideOptions (e.g. "window.config.overrides"). Defaults to window.fides_overrides
   customOptionsPath: string | null;

--- a/clients/fides-js/src/lib/extensions.ts
+++ b/clients/fides-js/src/lib/extensions.ts
@@ -13,7 +13,7 @@ export const setupExtensions = async ({
 }) => {
   if (experience?.gpp_settings?.enabled) {
     try {
-      await import(options.gppExtensionPath);
+      await import(`${options.fidesJsBaseUrl}/fides-ext-gpp.js`);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error("Unable to import GPP extension", e);

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -53,7 +53,7 @@ export interface PrivacyCenterSettings {
   FIDES_TCF_GDPR_APPLIES: boolean; // (optional) The default for the TCF GDPR applies value (default true)
   FIDES_STRING: string | null; // (optional) An explicitly passed-in string that supersedes the cookie. Can contain both TC and AC strings
   IS_FORCED_TCF: boolean; // whether to force the privacy center to use the fides-tcf.js bundle
-  GPP_EXTENSION_PATH: string; // The path of the GPP extension file `fides-ext-gpp.js`. Defaults to `/fides-ext-gpp.js`
+  FIDES_JS_BASE_URL: string; // A base URL to a directory of fides.js scripts
   PREVENT_DISMISSAL: boolean; // whether or not the user is allowed to dismiss the banner/overlay
 }
 
@@ -80,7 +80,7 @@ export type PrivacyCenterClientSettings = Pick<
   | "FIDES_TCF_GDPR_APPLIES"
   | "FIDES_STRING"
   | "IS_FORCED_TCF"
-  | "GPP_EXTENSION_PATH"
+  | "FIDES_JS_BASE_URL"
   | "PREVENT_DISMISSAL"
 >;
 
@@ -343,9 +343,9 @@ export const loadPrivacyCenterEnvironment =
       IS_FORCED_TCF: process.env.FIDES_PRIVACY_CENTER__IS_FORCED_TCF
         ? process.env.FIDES_PRIVACY_CENTER__IS_FORCED_TCF === "true"
         : false,
-      GPP_EXTENSION_PATH:
-        process.env.FIDES_PRIVACY_CENTER__GPP_EXTENSION_PATH ||
-        "/fides-ext-gpp.js",
+      FIDES_JS_BASE_URL:
+        process.env.FIDES_PRIVACY_CENTER__FIDES_JS_BASE_URL ||
+        "http://localhost:3000",
       PREVENT_DISMISSAL: process.env.FIDES_PRIVACY_CENTER__PREVENT_DISMISSAL
         ? process.env.FIDES_PRIVACY_CENTER__PREVENT_DISMISSAL === "true"
         : false,
@@ -376,7 +376,7 @@ export const loadPrivacyCenterEnvironment =
       FIDES_TCF_GDPR_APPLIES: settings.FIDES_TCF_GDPR_APPLIES,
       FIDES_STRING: settings.FIDES_STRING,
       IS_FORCED_TCF: settings.IS_FORCED_TCF,
-      GPP_EXTENSION_PATH: settings.GPP_EXTENSION_PATH,
+      FIDES_JS_BASE_URL: settings.FIDES_JS_BASE_URL,
       PREVENT_DISMISSAL: settings.PREVENT_DISMISSAL,
     };
 

--- a/clients/privacy-center/pages/api/fides-ext-gpp-js.ts
+++ b/clients/privacy-center/pages/api/fides-ext-gpp-js.ts
@@ -52,6 +52,8 @@ export default async function handler(
   res
     .status(200)
     .setHeader("Content-Type", "application/javascript")
+    // Allow CORS since this is a static file we do not need to lock down
+    .setHeader("Access-Control-Allow-Origin", "*")
     .setHeader("Cache-Control", stringify(cacheHeaders))
     .setHeader("Vary", LOCATION_HEADERS)
     .send(gppJs);

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -152,7 +152,7 @@ export default async function handler(
       fidesString,
       // Custom API override functions must be passed into custom Fides extensions via Fides.init(...)
       apiOptions: null,
-      gppExtensionPath: environment.settings.GPP_EXTENSION_PATH,
+      fidesJsBaseUrl: environment.settings.FIDES_JS_BASE_URL,
       customOptionsPath: null,
       preventDismissal: environment.settings.PREVENT_DISMISSAL,
     },

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -215,6 +215,8 @@ export default async function handler(
   res
     .status(200)
     .setHeader("Content-Type", "application/javascript")
+    // Allow CORS since this is a static file we do not need to lock down
+    .setHeader("Access-Control-Allow-Origin", "*")
     .setHeader("Cache-Control", stringify(cacheHeaders))
     .setHeader("Vary", LOCATION_HEADERS)
     .send(script);


### PR DESCRIPTION
Finishes off https://ethyca.atlassian.net/browse/PROD-1362

### Description Of Changes

The dynamic import of the GPP JS file was not working in our test environment for two reasons:
1. Need to configure the path to the GPP extension. We decided to remove the `GPP_EXT_PATH` env var in favor of a `FIDES_JS_BASE_URL` env var that uses a directory instead of just a GPP path
2. Needed to allow CORS for these asset endpoints


### Code Changes

* [x] Allow configuration of a `FIDES_JS_BASE_URL` env var. Removes `GPP_EXT_PATH` env var which nothing is using
* [x] Add CORS headers for fides.js and fides-ext-gpp.js endpoints

### Steps to Confirm

* [ ] In fidesplus, run `nox -s "fides_env" -- prod`
* [ ] Take down the privacy center container 
* [ ] Run the privacy center locally via `FIDES_PRIVACY_CENTER__FIDES_JS_BASE_URL="http://localhost:3001" turbo dev`
  * [ ] The `fides_env` PC runs on 3001, so this replaces it while also setting a variable saying where the base url JS is
* [ ] At localhost:8080, add some TCF systems
* [ ] Visit cookie house and choose an EU region
* [ ] the TCF banner should pop up, and in your console you should be able to issue gpp commands i.e. `__gpp('ping', (data) => {console.log({data})})`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
