### PR TITLE
Remove 'Add a vendor' from consent configuration page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The types of changes are:
 - `fides.js` now sets `supportsOOB` to `false` [#4516](https://github.com/ethyca/fides/pull/4516)
 - Save consent method ("accept", "reject", "save", etc.) to `fides_consent` cookie as extra metadata [#4529](https://github.com/ethyca/fides/pull/4529)
 - Change vendor add modal on consent configuration screen to use new vendor selector [#4532](https://github.com/ethyca/fides/pull/4532)
+- Remove vendor add modal [#4535](https://github.com/ethyca/fides/pull/4535)
 
 ## [2.26.0](https://github.com/ethyca/fides/compare/2.25.0...main)
 

--- a/clients/admin-ui/cypress/e2e/consent-configuration.cy.ts
+++ b/clients/admin-ui/cypress/e2e/consent-configuration.cy.ts
@@ -113,7 +113,7 @@ describe("Consent configuration", () => {
     });
   });
 
-  describe("adding a vendor", () => {
+  describe.skip("adding a vendor", () => {
     beforeEach(() => {
       stubSystemCrud();
       stubTaxonomyEntities();

--- a/clients/admin-ui/src/features/configure-consent/AddVendor.tsx
+++ b/clients/admin-ui/src/features/configure-consent/AddVendor.tsx
@@ -229,14 +229,6 @@ const AddVendor = ({
       <Box mr={2}>
         <AddMultipleVendors onCancel={modal.onOpen} />
       </Box>
-      <Button
-        onClick={modal.onOpen}
-        data-testid="add-vendor-btn"
-        size="sm"
-        colorScheme="primary"
-      >
-        Add vendor
-      </Button>
       <Formik
         initialValues={initialValues}
         enableReinitialize


### PR DESCRIPTION
### Description Of Changes

Temporarily (re-)removes the "Add a vendor" button from the consent configuration screen (will be added back with work for [PROD-1549](https://ethyca.atlassian.net/browse/PROD-1549?atlOrigin=eyJpIjoiMGUwOWI0NjQ3MTk2NGEzNWIxMzQzN2U0MTc4YTc0MGYiLCJwIjoiaiJ9)).

### Code Changes

* [ ] Removed button
* [ ] Skipped tests dependent on button

### Steps to confirm

* [ ] Go to consent configuration page
* [ ] Should be no "Add a vendor" button

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`


[PROD-1549]: https://ethyca.atlassian.net/browse/PROD-1549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ