### PR TITLE
Regulated toggle bug

### DIFF
--- a/clients/admin-ui/cypress/e2e/locations.cy.ts
+++ b/clients/admin-ui/cypress/e2e/locations.cy.ts
@@ -81,6 +81,15 @@ describe("Locations", () => {
         cy.getByTestId("Venezuela-checkbox").should("not.exist");
       });
 
+      // Toggle "regulated" in Africa which has no regulations
+      cy.getByTestId("picker-card-Africa").within(() => {
+        cy.getByTestId("Eritrea-checkbox");
+        cy.getByTestId("regulated-toggle").click();
+        cy.getByTestId("Eritrea-checkbox").should("not.exist");
+        cy.getByTestId("regulated-toggle").click();
+        cy.getByTestId("Eritrea-checkbox");
+      });
+
       // North America should have stayed the same through all this
       cy.getByTestId("picker-card-North America").within(() => {
         assertIsChecked("Canada-checkbox", "unchecked");
@@ -196,6 +205,10 @@ describe("Locations", () => {
         expect(body.regulations).to.eql([]);
         // Check locations
         expect(body.locations).to.eql([
+          {
+            id: "er",
+            selected: false,
+          },
           {
             id: "fr",
             selected: true,

--- a/clients/admin-ui/cypress/fixtures/locations/list.json
+++ b/clients/admin-ui/cypress/fixtures/locations/list.json
@@ -1,6 +1,14 @@
 {
   "locations": [
     {
+      "id": "er",
+      "selected": false,
+      "name": "Eritrea",
+      "continent": "Africa",
+      "belongs_to": [],
+      "regulation": []
+    },
+    {
       "id": "fr",
       "selected": true,
       "name": "France",

--- a/clients/admin-ui/src/features/locations/LocationPickerCard.tsx
+++ b/clients/admin-ui/src/features/locations/LocationPickerCard.tsx
@@ -114,7 +114,8 @@ const LocationPickerCard = ({
     handleChange(Array.from(newSelected));
   };
 
-  if (filteredLocations.length === 0) {
+  // Do not render the card if search ends up with no results
+  if (filteredLocations.length === 0 && search) {
     return null;
   }
 


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1561

### Description Of Changes

Fixes bug where toggling "regulated" on a continent that has no regulated subregions would make the whole card disappear


### Code Changes

* [x] Only make cards disappear on search
* [x] Add cypress test for this case

### Steps to Confirm

* [ ] See bug report

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
