### PR TITLE
Make banner title and description nullable, not optional

### DIFF
--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -176,17 +176,18 @@ describe("Privacy experiences", () => {
     });
     interface Props {
       component?: "overlay" | "privacy_center";
+      banner_title?: string;
     }
     /**
      * Helper function to swap out the component type in a stubbed experience
      * @example stubExperience({component: "overlay"})
      */
-    const stubExperience = ({ component }: Props) => {
+    const stubExperience = (overrides: Props) => {
       cy.fixture("privacy-experiences/experienceConfig.json").then(
         (experience) => {
           const updatedExperience = {
             ...experience,
-            component: component ?? experience.component,
+            ...overrides,
           };
           cy.intercept("GET", "/api/v1/experience-config/pri*", {
             body: updatedExperience,
@@ -283,6 +284,14 @@ describe("Privacy experiences", () => {
         // Make sure regions is still ["us_ca"] (unchanged)
         expect(body.regions).to.eql(["us_ca"]);
       });
+    });
+
+    it("can still save when banner title is null", () => {
+      stubExperience({ component: "overlay", banner_title: null });
+      cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/${OVERLAY_EXPERIENCE_ID}`);
+      cy.getByTestId("save-btn").should("be.disabled");
+      cy.selectOption("input-banner_enabled", "Enabled where legally required");
+      cy.getByTestId("save-btn").should("not.be.disabled");
     });
 
     it("can submit an overlay form excluding optional values", () => {

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -76,8 +76,8 @@ const bannerValidationSchema = Yup.object()
     privacy_preferences_link_label: Yup.string()
       .required()
       .label("Privacy preferences link label"),
-    banner_title: Yup.string().optional().label("Banner title"),
-    banner_description: Yup.string().optional().label("Banner description"),
+    banner_title: Yup.string().nullable().label("Banner title"),
+    banner_description: Yup.string().nullable().label("Banner description"),
     privacy_policy_link_label: Yup.string()
       .nullable()
       .label("Privacy policy link label"),


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1566

### Description Of Changes

The new banner title and banner description fields can be null, so the yup schema had to be `nullable` not `optional`


### Code Changes

* [x] `.optional()` --> `.nullable()`
* [x] Cypress test

### Steps to Confirm

* [ ] See bug report steps!

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
