### PR TITLE
remove leading slash in dsr zip report filenames

### DIFF
--- a/src/fides/api/service/privacy_request/dsr_package/dsr_report_builder.py
+++ b/src/fides/api/service/privacy_request/dsr_package/dsr_report_builder.py
@@ -99,7 +99,7 @@ class DsrReportBuilder:
 
         # generate dataset index page
         self._add_file(
-            f"/data/{dataset_name}/index.html",
+            f"data/{dataset_name}/index.html",
             self._populate_template(
                 "templates/dataset_index.html",
                 dataset_name,
@@ -116,7 +116,7 @@ class DsrReportBuilder:
         for index, item in enumerate(rows, 1):
             detail_url = f"{index}.html"
             self._add_file(
-                f"/data/{dataset_name}/{collection_name}/{index}.html",
+                f"data/{dataset_name}/{collection_name}/{index}.html",
                 self._populate_template(
                     "templates/item.html",
                     f"{collection_name} (item #{index})",
@@ -128,7 +128,7 @@ class DsrReportBuilder:
 
         # generate detail index page
         self._add_file(
-            f"/data/{dataset_name}/{collection_name}/index.html",
+            f"data/{dataset_name}/{collection_name}/index.html",
             self._populate_template(
                 "templates/collection_index.html",
                 collection_name,
@@ -145,11 +145,11 @@ class DsrReportBuilder:
         try:
             # all the css for the pages is in main.css
             self._add_file(
-                "/data/main.css",
+                "data/main.css",
                 self._populate_template("templates/main.css"),
             )
             self._add_file(
-                "/data/back.svg",
+                "data/back.svg",
                 Path(os.path.join(DSR_DIRECTORY, "assets/back.svg")).read_text(
                     encoding="utf-8"
                 ),
@@ -170,7 +170,7 @@ class DsrReportBuilder:
 
             # create the main index once all the datasets have been added
             self._add_file(
-                "/welcome.html",
+                "welcome.html",
                 self._populate_template(
                     "templates/welcome.html", "DSR Report", None, self.main_links
                 ),

--- a/tests/ops/service/test_storage_uploader_service.py
+++ b/tests/ops/service/test_storage_uploader_service.py
@@ -439,22 +439,22 @@ class TestWriteToInMemoryBuffer:
 
         zipfile = ZipFile(buff)
         assert zipfile.namelist() == [
-            "/data/main.css",
-            "/data/back.svg",
-            "/data/mongo/address/1.html",
-            "/data/mongo/address/2.html",
-            "/data/mongo/address/index.html",
-            "/data/mongo/foobar/1.html",
-            "/data/mongo/foobar/index.html",
-            "/data/mongo/index.html",
-            "/data/mysql/customer/1.html",
-            "/data/mysql/customer/2.html",
-            "/data/mysql/customer/index.html",
-            "/data/mysql/index.html",
-            "/data/manual/filing_cabinet/1.html",
-            "/data/manual/filing_cabinet/index.html",
-            "/data/manual/index.html",
-            "/welcome.html",
+            "data/main.css",
+            "data/back.svg",
+            "data/mongo/address/1.html",
+            "data/mongo/address/2.html",
+            "data/mongo/address/index.html",
+            "data/mongo/foobar/1.html",
+            "data/mongo/foobar/index.html",
+            "data/mongo/index.html",
+            "data/mysql/customer/1.html",
+            "data/mysql/customer/2.html",
+            "data/mysql/customer/index.html",
+            "data/mysql/index.html",
+            "data/manual/filing_cabinet/1.html",
+            "data/manual/filing_cabinet/index.html",
+            "data/manual/index.html",
+            "welcome.html",
         ]
 
     def test_not_implemented(self, data, privacy_request):


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1470

### Description Of Changes

leading slashes in the constituent filenames were causing problems when unzipping the DSR report/package .zip on windows (when using the native windows zip utility to unzip). as far as i can tell, the leading slashes are unnecessary (and unintentional) - it gets stripped anyway automatically when unzipping on macOS (see below)

unzipping the old .zip package on macOS - note that absolute path (leading slash) is stripped anyway, which makes me think that we never intentionally included this, nor will it have any impact. 

```
→ unzip  ../fides_uploads/pri_65ab2ecd-b325-4d14-a392-76c337473d34.zip
Archive:  ../fides_uploads/pri_65ab2ecd-b325-4d14-a392-76c337473d34.zip
warning:  stripped absolute path spec from /data/main.css
 extracting: data/main.css
warning:  stripped absolute path spec from /data/back.svg
 extracting: data/back.svg
warning:  stripped absolute path spec from /welcome.html
 extracting: welcome.html
```

### Code Changes

* [x] update file names/paths in the DSR report builder to no longer include a leading slash

### Steps to Confirm

* [x] new DSR zip package outputs can be unzipped natively on windows (i.e. not using 7-zip! that always worked)
* [x] new DSR zip package outputs still work well on mac OS


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
