### PR TITLE
PROD-1538: Adds ability to use base 64 cookie format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The types of changes are:
 
 - Add enum and registry of supported languages [#4592](https://github.com/ethyca/fides/pull/4592)
 - Access and erasure support for Talkable [#4589](https://github.com/ethyca/fides/pull/4589)
+- Add ability to store and read Fides cookie in Base64 format [#4556](https://github.com/ethyca/fides/pull/4556)
 
 ### Fixed
 

--- a/clients/fides-js/__tests__/lib/cookie.test.ts
+++ b/clients/fides-js/__tests__/lib/cookie.test.ts
@@ -224,30 +224,24 @@ describe("saveFidesCookie", () => {
     const cookie: FidesCookie = getOrMakeFidesCookie();
     saveFidesCookie(cookie, false);
     const expectedCookieString = JSON.stringify(cookie);
-    // NOTE: signature of the setCookie fn is: setCookie(name, value, attributes, encoding)
     expect(mockSetCookie.mock.calls).toHaveLength(1);
-    expect(mockSetCookie.mock.calls[0][0]).toEqual("fides_consent"); // name
-    expect(mockSetCookie.mock.calls[0][1]).toEqual(expectedCookieString); // value
-    expect(mockSetCookie.mock.calls[0][2]).toHaveProperty(
-      "domain",
-      "localhost"
-    ); // attributes
-    expect(mockSetCookie.mock.calls[0][2]).toHaveProperty("expires", 365); // attributes
+    const [name, value, attributes] = mockSetCookie.mock.calls[0];
+    expect(name).toEqual("fides_consent");
+    expect(value).toEqual(expectedCookieString);
+    expect(attributes).toHaveProperty("domain", "localhost");
+    expect(attributes).toHaveProperty("expires", 365);
   });
 
   it("sets a base64 cookie", () => {
     const cookie: FidesCookie = getOrMakeFidesCookie();
     saveFidesCookie(cookie, true);
     const expectedCookieString = base64_encode(JSON.stringify(cookie));
-    // NOTE: signature of the setCookie fn is: setCookie(name, value, attributes, encoding)
     expect(mockSetCookie.mock.calls).toHaveLength(1);
-    expect(mockSetCookie.mock.calls[0][0]).toEqual("fides_consent"); // name
-    expect(mockSetCookie.mock.calls[0][1]).toEqual(expectedCookieString); // value
-    expect(mockSetCookie.mock.calls[0][2]).toHaveProperty(
-      "domain",
-      "localhost"
-    ); // attributes
-    expect(mockSetCookie.mock.calls[0][2]).toHaveProperty("expires", 365); // attributes
+    const [name, value, attributes] = mockSetCookie.mock.calls[0];
+    expect(name).toEqual("fides_consent");
+    expect(value).toEqual(expectedCookieString);
+    expect(attributes).toHaveProperty("domain", "localhost");
+    expect(attributes).toHaveProperty("expires", 365);
   });
 
   it.each([

--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -30,6 +30,7 @@
     "@iabtechlabtcf/cmpapi": "^1.5.8",
     "@iabtechlabtcf/core": "^1.5.7",
     "a11y-dialog": "^7.5.2",
+    "base-64": "^1.0.0",
     "preact": "^10.13.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -38,8 +39,10 @@
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^5.0.0",
+    "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
+    "@types/base-64": "^1.0.2",
     "@types/node": "^18.16.3",
     "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.57.0",

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -7,10 +7,11 @@ import filesize from "rollup-plugin-filesize";
 import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import postcss from "rollup-plugin-postcss";
+import commonjs from "@rollup/plugin-commonjs";
 
 const NAME = "fides";
 const IS_DEV = process.env.NODE_ENV === "development";
-const GZIP_SIZE_ERROR_KB = 24; // fail build if bundle size exceeds this
+const GZIP_SIZE_ERROR_KB = 25; // fail build if bundle size exceeds this
 const GZIP_SIZE_WARN_KB = 15; // log a warning if bundle size exceeds this
 
 // TCF
@@ -29,6 +30,7 @@ const preactAliases = {
 const fidesScriptPlugins = ({ name, gzipWarnSizeKb, gzipErrorSizeKb }) => [
   alias(preactAliases),
   nodeResolve(),
+  commonjs(),
   json(),
   postcss({
     minimize: !IS_DEV,
@@ -126,6 +128,7 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
       alias(preactAliases),
       json(),
       nodeResolve(),
+      commonjs(),
       postcss(),
       esbuild(),
     ],

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -233,6 +233,7 @@ _Fides = {
     customOptionsPath: null,
     preventDismissal: false,
     allowHTMLDescription: null,
+    base64Cookie: false,
   },
   fides_meta: {},
   identity: {},

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -188,6 +188,7 @@ _Fides = {
     customOptionsPath: null,
     preventDismissal: false,
     allowHTMLDescription: null,
+    base64Cookie: false,
   },
   fides_meta: {},
   identity: {},

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -97,6 +97,9 @@ export type FidesOptions = {
 
   // Allows providing rich HTML descriptions
   allowHTMLDescription: boolean | null;
+
+  // Encodes cookie as base64 on top of the default JSON string
+  base64Cookie: boolean;
 };
 
 /**

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import { getCookie, removeCookie, setCookie, Types } from "typescript-cookie";
+import { decode as base64_decode, encode as base64_encode } from "base-64";
 
 import { ConsentContext } from "./consent-context";
 import { resolveLegacyConsentValue } from "./consent-value";
@@ -95,6 +96,29 @@ export const getCookieByName = (cookieName: string): string | undefined =>
   getCookie(cookieName, CODEC);
 
 /**
+ * Retrieve and decode fides consent cookie
+ */
+export const getFidesConsentCookie = (
+  debug: boolean = false
+): FidesCookie | undefined => {
+  const cookieString = getCookieByName(CONSENT_COOKIE_NAME);
+  if (!cookieString) {
+    return undefined;
+  }
+  // For safety, always try JSON decoding, and if that fails use BASE64
+  try {
+    return JSON.parse(cookieString);
+  } catch {
+    try {
+      return JSON.parse(base64_decode(cookieString));
+    } catch (e) {
+      debugLog(debug, `Unable to read consent cookie`, e);
+      return undefined;
+    }
+  }
+};
+
+/**
  * Attempt to read, parse, and return the current Fides cookie from the browser.
  * If one doesn't exist, make a new default cookie (including generating a new
  * pseudonymous ID) and return the default values.
@@ -114,31 +138,26 @@ export const getOrMakeFidesCookie = (
   }
 
   // Check for an existing cookie for this device
-  const cookieString = getCookieByName(CONSENT_COOKIE_NAME);
-  if (!cookieString) {
+  let parsedCookie: FidesCookie | undefined = getFidesConsentCookie();
+  if (!parsedCookie) {
     debugLog(
       debug,
       `No existing Fides consent cookie found, returning defaults.`,
-      cookieString
+      parsedCookie
     );
     return defaultCookie;
   }
 
   try {
-    // Parse the cookie and check its format; if it's structured like we
+    // Check format of parsed cookie; if it's structured like we
     // expect, cast it directly. Otherwise, assume it's a previous version of
     // the cookie, which was strictly the consent key/value preferences
-    let parsedCookie: FidesCookie;
-    const parsedJson = JSON.parse(cookieString);
-    if ("consent" in parsedJson && "fides_meta" in parsedJson) {
-      // Matches the expected format, so we can use it as-is
-      parsedCookie = parsedJson;
-    } else {
+    if (!("consent" in parsedCookie && "fides_meta" in parsedCookie)) {
       // Missing the expected format, so we parse it as strictly consent
       // preferences and "wrap" it with the default cookie style
       parsedCookie = {
         ...defaultCookie,
-        consent: parsedJson,
+        consent: parsedCookie,
       };
     }
 
@@ -158,7 +177,6 @@ export const getOrMakeFidesCookie = (
     );
     return parsedCookie;
   } catch (err) {
-    // eslint-disable-next-line no-console
     debugLog(debug, `Unable to read consent cookie: invalid JSON.`, err);
     return defaultCookie;
   }
@@ -177,7 +195,10 @@ export const getOrMakeFidesCookie = (
  *
  * (see https://github.com/ethyca/fides/issues/2072)
  */
-export const saveFidesCookie = (cookie: FidesCookie) => {
+export const saveFidesCookie = (
+  cookie: FidesCookie,
+  base64Cookie: boolean = false
+) => {
   if (typeof document === "undefined") {
     return;
   }
@@ -191,9 +212,14 @@ export const saveFidesCookie = (cookie: FidesCookie) => {
   // Write the cookie to the root domain
   const rootDomain = window.location.hostname.split(".").slice(-2).join(".");
 
+  let encodedCookie: string = JSON.stringify(cookie);
+  if (base64Cookie) {
+    encodedCookie = base64_encode(encodedCookie);
+  }
+
   setCookie(
     CONSENT_COOKIE_NAME,
-    JSON.stringify(cookie),
+    encodedCookie,
     {
       // An explicit path ensures this is always set to the entire domain.
       path: "/",

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -119,7 +119,7 @@ export const updateConsentPreferences = async ({
 
   // 4. Save preferences to the cookie in the browser
   debugLog(options.debug, "Saving preferences to cookie");
-  saveFidesCookie(cookie);
+  saveFidesCookie(cookie, options.base64Cookie);
 
   // 5. Remove cookies associated with notices that were opted-out from the browser
   if (consentPreferencesToSave) {

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -102,6 +102,7 @@
         "@iabtechlabtcf/cmpapi": "^1.5.8",
         "@iabtechlabtcf/core": "^1.5.7",
         "a11y-dialog": "^7.5.2",
+        "base-64": "^1.0.0",
         "preact": "^10.13.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -110,8 +111,10 @@
       },
       "devDependencies": {
         "@rollup/plugin-alias": "^5.0.0",
+        "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
+        "@types/base-64": "^1.0.2",
         "@types/node": "^18.16.3",
         "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
@@ -4110,6 +4113,71 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "25.0.7",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
+      "integrity": "sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "glob": "^8.0.3",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rollup/plugin-json": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.0.0.tgz",
@@ -5030,6 +5098,12 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/base-64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.2.tgz",
+      "integrity": "sha512-uPgKMmM9fmn7I+Zi6YBqctOye4SlJsHKcisjHIMWpb2YKZRc36GpKyNuQ03JcT+oNXg1m7Uv4wU94EVltn8/cw==",
+      "dev": true
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
@@ -6492,6 +6566,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7503,6 +7582,12 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
     },
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.14",
@@ -11985,6 +12070,15 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -15365,12 +15459,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -357,7 +357,7 @@ export const loadPrivacyCenterEnvironment =
         .FIDES_PRIVACY_CENTER__ALLOW_HTML_DESCRIPTION
         ? process.env.FIDES_PRIVACY_CENTER__ALLOW_HTML_DESCRIPTION === "true"
         : null,
-      BASE_64_COOKIE: process.env.BASE_64_COOKIE
+      BASE_64_COOKIE: process.env.FIDES_PRIVACY_CENTER__BASE_64_COOKIE
         ? process.env.FIDES_PRIVACY_CENTER__BASE_64_COOKIE === "true"
         : false,
     };

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -358,7 +358,7 @@ export const loadPrivacyCenterEnvironment =
         ? process.env.FIDES_PRIVACY_CENTER__ALLOW_HTML_DESCRIPTION === "true"
         : null,
       BASE_64_COOKIE: process.env.BASE_64_COOKIE
-        ? process.env.BASE_64_COOKIE === "true"
+        ? process.env.FIDES_PRIVACY_CENTER__BASE_64_COOKIE === "true"
         : false,
     };
 

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -56,6 +56,7 @@ export interface PrivacyCenterSettings {
   FIDES_JS_BASE_URL: string; // A base URL to a directory of fides.js scripts
   PREVENT_DISMISSAL: boolean; // whether or not the user is allowed to dismiss the banner/overlay
   ALLOW_HTML_DESCRIPTION: boolean | null; // (optional) whether or not HTML descriptions should be rendered
+  BASE_64_COOKIE: boolean; // whether or not to encode cookie as base64 on top of the default JSON string
 }
 
 /**
@@ -84,6 +85,7 @@ export type PrivacyCenterClientSettings = Pick<
   | "FIDES_JS_BASE_URL"
   | "PREVENT_DISMISSAL"
   | "ALLOW_HTML_DESCRIPTION"
+  | "BASE_64_COOKIE"
 >;
 
 export type Styles = string;
@@ -355,6 +357,9 @@ export const loadPrivacyCenterEnvironment =
         .FIDES_PRIVACY_CENTER__ALLOW_HTML_DESCRIPTION
         ? process.env.FIDES_PRIVACY_CENTER__ALLOW_HTML_DESCRIPTION === "true"
         : null,
+      BASE_64_COOKIE: process.env.BASE_64_COOKIE
+        ? process.env.BASE_64_COOKIE === "true"
+        : false,
     };
 
     // Load configuration file (if it exists)
@@ -385,6 +390,7 @@ export const loadPrivacyCenterEnvironment =
       FIDES_JS_BASE_URL: settings.FIDES_JS_BASE_URL,
       PREVENT_DISMISSAL: settings.PREVENT_DISMISSAL,
       ALLOW_HTML_DESCRIPTION: settings.ALLOW_HTML_DESCRIPTION,
+      BASE_64_COOKIE: settings.BASE_64_COOKIE,
     };
 
     // For backwards-compatibility, override FIDES_API_URL with the value from the config file if present

--- a/clients/privacy-center/components/consent/ConfigDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/ConfigDrivenConsent.tsx
@@ -27,8 +27,10 @@ import SaveCancel from "./SaveCancel";
 
 const ConfigDrivenConsent = ({
   storePreferences,
+  base64Cookie,
 }: {
   storePreferences: (data: ConsentPreferences) => void;
+  base64Cookie: boolean;
 }) => {
   const config = useConfig();
   const consentOptions = useMemo(
@@ -77,7 +79,7 @@ const ConfigDrivenConsent = ({
       };
     });
     const cookie: FidesCookie = getOrMakeFidesCookie();
-    saveFidesCookie({ ...cookie, consent: newConsent });
+    saveFidesCookie({ ...cookie, consent: newConsent }, base64Cookie);
 
     const executableOptions = consentOptions.map((option) => ({
       data_use: option.fidesDataUseKey,
@@ -104,6 +106,7 @@ const ConfigDrivenConsent = ({
     fidesKeyToConsent,
     updateConsentRequestPreferencesMutationTrigger,
     verificationCode,
+    base64Cookie,
   ]);
 
   const toastError = useCallback(

--- a/clients/privacy-center/components/consent/ConsentToggles.tsx
+++ b/clients/privacy-center/components/consent/ConsentToggles.tsx
@@ -10,12 +10,17 @@ const ConsentToggles = ({
   storePreferences: (data: ConsentPreferences) => void;
 }) => {
   const settings = useSettings();
-  const { IS_OVERLAY_ENABLED } = settings;
+  const { IS_OVERLAY_ENABLED, BASE_64_COOKIE } = settings;
 
   if (IS_OVERLAY_ENABLED) {
-    return <NoticeDrivenConsent />;
+    return <NoticeDrivenConsent base64Cookie={BASE_64_COOKIE} />;
   }
-  return <ConfigDrivenConsent storePreferences={storePreferences} />;
+  return (
+    <ConfigDrivenConsent
+      storePreferences={storePreferences}
+      base64Cookie={BASE_64_COOKIE}
+    />
+  );
 };
 
 export default ConsentToggles;

--- a/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
@@ -72,7 +72,7 @@ export const resolveConsentValue = (
   return notice.default_preference;
 };
 
-const NoticeDrivenConsent = () => {
+const NoticeDrivenConsent = ({ base64Cookie }: { base64Cookie: boolean }) => {
   const router = useRouter();
   const toast = useToast();
   const [consentRequestId] = useLocalStorage("consentRequestId", "");
@@ -254,7 +254,7 @@ const NoticeDrivenConsent = () => {
     window.Fides.consent = consentCookieKey;
     const updatedCookie = { ...cookie, consent: consentCookieKey };
     updatedCookie.fides_meta.consentMethod = ConsentMethod.SAVE; // include the consentMethod as extra metadata
-    saveFidesCookie(updatedCookie);
+    saveFidesCookie(updatedCookie, base64Cookie);
     toast({
       title: "Your consent preferences have been saved",
       ...SuccessToastOptions,

--- a/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
+++ b/clients/privacy-center/components/modals/consent-request-modal/ConsentRequestForm.tsx
@@ -58,6 +58,7 @@ const useConsentRequestForm = ({
   const customPrivacyRequestFields =
     config.consent?.button.custom_privacy_request_fields ?? {};
   const settings = useSettings();
+  const { BASE_64_COOKIE } = settings;
   const toast = useToast();
   const cookie = useMemo(() => getOrMakeFidesCookie(), []);
   const formik = useFormik<FormValues>({
@@ -139,7 +140,7 @@ const useConsentRequestForm = ({
         // After successfully initializing a consent request, save the current
         // cookie with our unique fides_user_device_id, etc.
         try {
-          saveFidesCookie(cookie);
+          saveFidesCookie(cookie, BASE_64_COOKIE);
         } catch (error) {
           handleError({ title: "Could not save consent cookie" });
           return;

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -155,6 +155,7 @@ export default async function handler(
       customOptionsPath: null,
       preventDismissal: environment.settings.PREVENT_DISMISSAL,
       allowHTMLDescription: environment.settings.ALLOW_HTML_DESCRIPTION,
+      base64Cookie: environment.settings.BASE_64_COOKIE,
     },
     experience: experience || undefined,
     geolocation: geolocation || undefined,

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -29,10 +29,12 @@ import ConsentToggles from "~/components/consent/ConsentToggles";
 import { useSubscribeToPrivacyExperienceQuery } from "~/features/consent/hooks";
 import ConsentHeading from "~/components/consent/ConsentHeading";
 import ConsentDescription from "~/components/consent/ConsentDescription";
-import { selectIsNoticeDriven } from "~/features/common/settings.slice";
+import { selectIsNoticeDriven, useSettings } from "~/features/common/settings.slice";
 import { useGetIdVerificationConfigQuery } from "~/features/id-verification";
 
 const Consent: NextPage = () => {
+  const settings = useSettings();
+  const { BASE_64_COOKIE } = settings;
   const [consentRequestId] = useLocalStorage("consentRequestId", "");
   const [verificationCode] = useLocalStorage("verificationCode", "");
   const router = useRouter();
@@ -103,13 +105,14 @@ const Consent: NextPage = () => {
   useEffect(() => {
     const cookie: FidesCookie = getOrMakeFidesCookie();
     if (isNoticeDriven) {
-      saveFidesCookie(cookie);
+      saveFidesCookie(cookie, BASE_64_COOKIE);
     }
   }, [
     consentOptions,
     persistedFidesKeyToConsent,
     consentContext,
     isNoticeDriven,
+    BASE_64_COOKIE,
   ]);
 
   /**

--- a/clients/privacy-center/pages/consent.tsx
+++ b/clients/privacy-center/pages/consent.tsx
@@ -29,7 +29,10 @@ import ConsentToggles from "~/components/consent/ConsentToggles";
 import { useSubscribeToPrivacyExperienceQuery } from "~/features/consent/hooks";
 import ConsentHeading from "~/components/consent/ConsentHeading";
 import ConsentDescription from "~/components/consent/ConsentDescription";
-import { selectIsNoticeDriven, useSettings } from "~/features/common/settings.slice";
+import {
+  selectIsNoticeDriven,
+  useSettings,
+} from "~/features/common/settings.slice";
 import { useGetIdVerificationConfigQuery } from "~/features/id-verification";
 
 const Consent: NextPage = () => {


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1538

### Description Of Changes

Adds ability to use base64 cookie so that we send less data across all client <---> server packets. This is better for both performance and also decreases chance we'll get flagged by OWASP SQL injection rules.

We give our users the option to configure using base64 in a new env var: `FIDES_PRIVACY_CENTER__BASE_64_COOKIE` which defaults to `false`.


### Code Changes

* [ ] Adds new config var for base 64 cookie usage
* [ ] Updates every read / write cookie to handle base64 encoding. Note that with decoding, we always want to try pure JSON first, and if it fails, try base64 decoding. This is because config may have changed, between when the cookie was written and when the cookie was read.
* [ ] Update tests

### Steps to Confirm

* [ ] With `FIDES_PRIVACY_CENTER__BASE_64_COOKIE` set to `true`, in both Privacy center and consent banner, save consent, see cookie is written in base64 format. 
* [ ] Confirm that preferences persist correctly across page loads
* [ ] Additionally, with `FIDES_PRIVACY_CENTER__BASE_64_COOKIE` set to `false`, confirm no new regressions with other ways to set / save consent in PC

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
