### PR TITLE
Switch to anyascii for unicode transliteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,16 +28,17 @@ The types of changes are:
 ### Changed
 
 - Redesigned nav bar for the admin UI [#4548](https://github.com/ethyca/fides/pull/4548)
+- No longer generate the `vendors_disclosed` section of the TC string in `fides.js` [#4553](https://github.com/ethyca/fides/pull/4553)
+- Changed consent management vendor add flow [#4550](https://github.com/ethyca/fides/pull/4550)
 
 ### Fixed
 
 - Fixed an issue blocking Salesforce sandbox accounts from refreshing tokens [#4547](https://github.com/ethyca/fides/pull/4547)
 - Fixed DSR zip packages to be unzippable on Windows [#4549](https://github.com/ethyca/fides/pull/4549)
 
-### Changed
+### Developer Experience
 
-- No longer generate the `vendors_disclosed` section of the TC string in `fides.js` [#4553](https://github.com/ethyca/fides/pull/4553)
-- Changed consent management vendor add flow [#4550](https://github.com/ethyca/fides/pull/4550)
+- Switch to anyascii for unicode transliteration [#4550](https://github.com/ethyca/fides/pull/4564)
 
 ## [2.27.0](https://github.com/ethyca/fides/compare/2.26.0...2.27.0)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic==1.8.1
+anyascii==0.3.2
 anyio==3.7.1
 APScheduler==3.9.1.post1
 asyncpg==0.27.0
@@ -57,6 +58,5 @@ sshtunnel==0.4.0
 toml==0.10.2
 twilio==7.15.0
 typing_extensions==4.5.0 # pinned to work around https://github.com/pydantic/pydantic/issues/5821
-Unidecode==1.3.4
 validators==0.20.0
 versioneer==0.19

--- a/src/fides/api/util/text.py
+++ b/src/fides/api/util/text.py
@@ -1,6 +1,6 @@
 import re
 
-from anyascii import anyascii
+from anyascii import anyascii # type: ignore
 
 
 def to_snake_case(text: str) -> str:

--- a/src/fides/api/util/text.py
+++ b/src/fides/api/util/text.py
@@ -1,6 +1,6 @@
 import re
 
-import unidecode
+from anyascii import anyascii
 
 
 def to_snake_case(text: str) -> str:
@@ -14,7 +14,7 @@ def to_snake_case(text: str) -> str:
         "foo-bar" -> "foo_bar"
         "foo*bar" -> "foobar"
     """
-    text = unidecode.unidecode(text).lower().strip()
+    text = anyascii(text).lower().strip()
     text = re.sub(r"[^\w\s-]", "", text)
     text = re.sub(r"[\s-]+", "_", text)
     text = re.sub(r"^-+|-+$", "", text)


### PR DESCRIPTION
### Description Of Changes

This is a tiny change to swap out a library used in the `to_snake_case` utility function to `anyascii` which has a safer license.

### Code Changes

* [X] Replace `unidecode` with `anyascii`

### Steps to Confirm

n/a

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [X] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [X] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [X] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated