### PR TITLE
PROD-1593- replace object.hasown with object.keys().includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The types of changes are:
 
 - Fixed an issue blocking Salesforce sandbox accounts from refreshing tokens [#4547](https://github.com/ethyca/fides/pull/4547)
 - Fixed DSR zip packages to be unzippable on Windows [#4549](https://github.com/ethyca/fides/pull/4549)
+- Fixed browser compatibility issues with Object.hasOwn [#4568](https://github.com/ethyca/fides/pull/4568)
 
 ### Developer Experience
 

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -225,7 +225,7 @@ export const updateExperienceFromCookieConsentNotices = ({
   // DEFER (PROD-1568) - instead of updating experience here, push this logic into UI
   const noticesWithConsent: PrivacyNoticeWithPreference[] | undefined =
     experience.privacy_notices?.map((notice) => {
-      const preference = Object.hasOwn(cookie.consent, notice.notice_key)
+      const preference = Object.keys(cookie.consent).includes(notice.notice_key)
         ? transformConsentToFidesUserPreference(
             Boolean(cookie.consent[notice.notice_key]),
             notice.consent_mechanism

--- a/clients/fides-js/src/lib/shared-consent-utils.ts
+++ b/clients/fides-js/src/lib/shared-consent-utils.ts
@@ -15,7 +15,7 @@ import {
 export const noticeHasConsentInCookie = (
   notice: PrivacyNoticeWithPreference,
   cookie: FidesCookie
-): boolean => Boolean(Object.hasOwn(cookie.consent, notice.notice_key));
+): boolean => Boolean(Object.keys(cookie.consent).includes(notice.notice_key));
 /**
  * Convert a user consent preference into true/false
  */

--- a/clients/fides-js/src/lib/tcf/utils.ts
+++ b/clients/fides-js/src/lib/tcf/utils.ts
@@ -36,7 +36,8 @@ export const buildTcfEntitiesFromCookieAndFidesString = (
     const cookieConsent = cookie.tcf_consent[cookieKey] ?? {};
     // @ts-ignore the array map should ensure we will get the right record type
     tcfEntities[experienceKey] = experience[experienceKey]?.map((item) => {
-      const preference = Object.hasOwn(cookieConsent, item.id)
+      // Object.keys converts keys to strings, so we coerce id to string here
+      const preference = Object.keys(cookieConsent).includes(item.id as string)
         ? transformConsentToFidesUserPreference(
             Boolean(cookieConsent[item.id]),
             ConsentMechanism.OPT_IN


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1593

### Description Of Changes

Addresses older Safari browser compatibility issues with using Object.hasOwn()

### Code Changes

* [ ] Replace occurrences of object.hasown with object.keys().includes

### Steps to Confirm

* [ ] Test no regressions with PC and fides-js consent functionality (both TCF and non-TCF)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
