### PR TITLE
Fix CORS middleware hot-swapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.28.0...main)
 
+### Fixed
+
+- Fixed CORS domain update functionality [#4570](https://github.com/ethyca/fides/pull/4570)
+
 ## [2.28.0](https://github.com/ethyca/fides/compare/2.27.0...2.28.0)
 
 ### Added
@@ -40,6 +44,7 @@ The types of changes are:
 - Fixed an issue blocking Salesforce sandbox accounts from refreshing tokens [#4547](https://github.com/ethyca/fides/pull/4547)
 - Fixed DSR zip packages to be unzippable on Windows [#4549](https://github.com/ethyca/fides/pull/4549)
 - Fixed browser compatibility issues with Object.hasOwn [#4568](https://github.com/ethyca/fides/pull/4568)
+
 
 ### Developer Experience
 

--- a/src/fides/api/app_setup.py
+++ b/src/fides/api/app_setup.py
@@ -4,16 +4,14 @@ Contains utility functions that set up the application webserver.
 # pylint: disable=too-many-branches
 from logging import DEBUG
 from os.path import dirname, join
-from typing import List, Optional, Pattern
+from typing import List
 
 from fastapi import APIRouter, FastAPI
 from loguru import logger
-from pydantic import AnyUrl
 from redis.exceptions import RedisError, ResponseError
 from slowapi.errors import RateLimitExceeded  # type: ignore
 from slowapi.extension import _rate_limit_exceeded_handler  # type: ignore
 from slowapi.middleware import SlowAPIMiddleware  # type: ignore
-from starlette.middleware.cors import CORSMiddleware
 
 import fides
 from fides.api.api.deps import get_api_session

--- a/src/fides/api/app_setup.py
+++ b/src/fides/api/app_setup.py
@@ -77,8 +77,6 @@ PRIVACY_EXPERIENCE_CONFIGS_PATH = join(
 
 
 def create_fides_app(
-    cors_origins: List[AnyUrl] = CONFIG.security.cors_origins,
-    cors_origin_regex: Optional[Pattern] = CONFIG.security.cors_origin_regex,
     routers: List = ROUTERS,
     app_version: str = VERSION,
     security_env: str = CONFIG.security.env,
@@ -95,16 +93,6 @@ def create_fides_app(
     for handler in ExceptionHandlers.get_handlers():
         fastapi_app.add_exception_handler(FunctionalityNotConfigured, handler)
     fastapi_app.add_middleware(SlowAPIMiddleware)
-
-    if cors_origins or cors_origin_regex:
-        fastapi_app.add_middleware(
-            CORSMiddleware,
-            allow_origins=[str(origin) for origin in cors_origins],
-            allow_origin_regex=cors_origin_regex,
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
-        )
 
     for router in routers:
         fastapi_app.include_router(router)

--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -2,9 +2,11 @@
 """Logic related to sanitizing and validating user application input."""
 from html import escape
 from re import compile as regex
-from typing import Generator
+from typing import Any, Generator
 
 from nh3 import clean
+from pydantic import AnyUrl, BaseConfig
+from pydantic.fields import ModelField
 
 
 class SafeStr(str):
@@ -112,7 +114,6 @@ class PhoneNumber(str):
 class GPPMechanismConsentValue(str):
     """
     Allowable consent values for GPP Mechanism Mappings.
-
     """
 
     @classmethod
@@ -124,4 +125,25 @@ class GPPMechanismConsentValue(str):
         pattern = regex(r"^\d+$")
         if not isinstance(value, str) or not pattern.search(value):
             raise ValueError("GPP Mechanism consent value must be a string of digits.")
+        return value
+
+
+class URLOrigin(AnyUrl):
+    """
+    A URL origin value. See https://developer.mozilla.org/en-US/docs/Glossary/Origin.
+
+    We perform the basic URL validation, but also prevent URLs with paths,
+    as paths are not part of an origin.
+    """
+
+    @classmethod
+    def __get_validators__(cls) -> Generator:
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Any, field: ModelField, config: BaseConfig) -> AnyUrl:
+        value = super().validate(value, field, config)
+        if value.path:
+            raise ValueError("URL origin values cannot contain a path.")
+
         return value

--- a/src/fides/api/schemas/application_config.py
+++ b/src/fides/api/schemas/application_config.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import AnyUrl, Extra, Field, root_validator, validator
+from pydantic import Extra, Field, root_validator, validator
 
+from fides.api.custom_types import URLOrigin
 from fides.api.schemas.base_class import FidesSchema
 from fides.api.schemas.messaging.messaging import MessagingServiceType
 
@@ -80,7 +81,7 @@ class SecurityApplicationConfig(FidesSchema):
     # for advanced usage of non-URLs, e.g. wildcards (`*`), the related
     # `cors_origin_regex` property should be used.
     # this is explicitly _not_ accessible via API - it must be used with care.
-    cors_origins: Optional[List[AnyUrl]] = Field(
+    cors_origins: Optional[List[URLOrigin]] = Field(
         default=None,
         description="A list of client addresses allowed to communicate with the Fides webserver.",
     )

--- a/src/fides/api/util/cors_middleware_utils.py
+++ b/src/fides/api/util/cors_middleware_utils.py
@@ -1,0 +1,33 @@
+from typing import Iterable, Optional
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+
+def update_cors_middleware(
+    app: FastAPI, allow_origins: Iterable[str], allow_origin_regex: str
+) -> CORSMiddleware:
+    """
+    Update the CORSMiddleware of the running app with the provided origin parameters.
+
+    Returns the _old_ middleware instance that is no longer being used.
+    """
+    existing_middleware = find_cors_middleware(app)
+    app.user_middleware.remove(existing_middleware)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allow_origins,
+        allow_origin_regex=allow_origin_regex,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    return existing_middleware
+
+
+def find_cors_middleware(app: FastAPI) -> Optional[CORSMiddleware]:
+    """Utility function to find the (first) cors middleware of the provided FastAPI app"""
+    for mw in app.user_middleware:
+        if mw.cls is CORSMiddleware:
+            return mw
+    return None

--- a/src/fides/api/util/cors_middleware_utils.py
+++ b/src/fides/api/util/cors_middleware_utils.py
@@ -1,19 +1,23 @@
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional, Pattern
 
 from fastapi import FastAPI
+from fastapi.middleware import Middleware
 from fastapi.middleware.cors import CORSMiddleware
 
 
 def update_cors_middleware(
-    app: FastAPI, allow_origins: Iterable[str], allow_origin_regex: str
-) -> CORSMiddleware:
+    app: FastAPI,
+    allow_origins: Iterable[str],
+    allow_origin_regex: Optional[Pattern[Any]],
+) -> Optional[Middleware]:
     """
     Update the CORSMiddleware of the running app with the provided origin parameters.
 
     Returns the _old_ middleware instance that is no longer being used.
     """
     existing_middleware = find_cors_middleware(app)
-    app.user_middleware.remove(existing_middleware)
+    if existing_middleware:
+        app.user_middleware.remove(existing_middleware)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=allow_origins,
@@ -25,7 +29,7 @@ def update_cors_middleware(
     return existing_middleware
 
 
-def find_cors_middleware(app: FastAPI) -> Optional[CORSMiddleware]:
+def find_cors_middleware(app: FastAPI) -> Optional[Middleware]:
     """Utility function to find the (first) cors middleware of the provided FastAPI app"""
     for mw in app.user_middleware:
         if mw.cls is CORSMiddleware:

--- a/src/fides/api/util/cors_middleware_utils.py
+++ b/src/fides/api/util/cors_middleware_utils.py
@@ -9,11 +9,9 @@ def update_cors_middleware(
     app: FastAPI,
     allow_origins: Iterable[str],
     allow_origin_regex: Optional[Pattern[Any]],
-) -> Optional[Middleware]:
+) -> None:
     """
-    Update the CORSMiddleware of the running app with the provided origin parameters.
-
-    Returns the _old_ middleware instance that is no longer being used.
+    Update the CORSMiddleware of the provided app with the provided origin parameters.
     """
     existing_middleware = find_cors_middleware(app)
     if existing_middleware:
@@ -26,7 +24,6 @@ def update_cors_middleware(
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    return existing_middleware
 
 
 def find_cors_middleware(app: FastAPI) -> Optional[Middleware]:

--- a/src/fides/config/config_proxy.py
+++ b/src/fides/config/config_proxy.py
@@ -5,10 +5,11 @@ from typing import Any, List, Optional
 from fastapi.applications import FastAPI
 from pydantic import AnyUrl
 from sqlalchemy.orm import Session
-from starlette.middleware.cors import CORSMiddleware
 
 from fides.api.models.application_config import ApplicationConfig
 from fides.api.schemas.storage.storage import StorageType
+from fides.api.util.cors_middleware_utils import update_cors_middleware
+from fides.config import CONFIG
 
 
 class ConfigProxyBase:
@@ -131,14 +132,12 @@ class ConfigProxy:
         Util function that loads the current CORS domains from
         `ConfigProxy` into the  `CORSMiddleware` at runtime.
         """
-        for mw in app.user_middleware:
-            if mw.cls is CORSMiddleware:
-                current_config_proxy_domains = (
-                    self.security.cors_origins
-                    if self.security.cors_origins is not None
-                    else []
-                )
 
-                mw.options["allow_origins"] = [
-                    str(domain) for domain in current_config_proxy_domains
-                ]
+        current_config_proxy_domains = (
+            self.security.cors_origins if self.security.cors_origins is not None else []
+        )
+        update_cors_middleware(
+            app,
+            current_config_proxy_domains,
+            CONFIG.security.cors_origin_regex,
+        )

--- a/src/fides/config/security_settings.py
+++ b/src/fides/config/security_settings.py
@@ -4,10 +4,11 @@
 from typing import Dict, List, Optional, Pattern, Tuple, Union
 
 import validators
-from pydantic import AnyUrl, Field, validator
+from pydantic import Field, validator
 from slowapi.wrappers import parse_many  # type: ignore
 
 from fides.api.cryptography.cryptographic_util import generate_salt, hash_with_salt
+from fides.api.custom_types import URLOrigin
 from fides.api.oauth.roles import OWNER
 from fides.common.api.scope_registry import SCOPE_REGISTRY
 
@@ -30,7 +31,7 @@ class SecuritySettings(FidesSettings):
     app_encryption_key: str = Field(
         default="", description="The key used to sign Fides API access tokens."
     )
-    cors_origins: List[AnyUrl] = Field(
+    cors_origins: List[URLOrigin] = Field(
         default_factory=list,
         description="A list of client addresses allowed to communicate with the Fides webserver.",
     )

--- a/tests/ctl/core/config/test_security_settings.py
+++ b/tests/ctl/core/config/test_security_settings.py
@@ -34,6 +34,17 @@ class TestSecuirtySettings:
 
         assert settings.cors_origins == urls
 
+    def test_validate_cors_origins_urls_with_paths(self):
+        with pytest.raises(ValueError) as e:
+            SecuritySettings(cors_origins=["http://test.com/"])
+
+        assert "URL origin values cannot contain a path." in str(e)
+
+        with pytest.raises(ValueError) as e:
+            SecuritySettings(cors_origins=["http://test.com/123/456"])
+
+        assert "URL origin values cannot contain a path." in str(e)
+
     def test_assemble_root_access_token_none(self):
         settings = SecuritySettings(oauth_root_client_secret="")
 

--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -4,32 +4,41 @@ from typing import Any, Generator
 
 import pytest
 from sqlalchemy.orm import Session
-from starlette.middleware.cors import CORSMiddleware
 from starlette.testclient import TestClient
 
 from fides.api.main import app
 from fides.api.models.application_config import ApplicationConfig
 from fides.api.oauth.roles import CONTRIBUTOR, OWNER, VIEWER
 from fides.api.schemas.storage.storage import StorageType
+from fides.api.util.cors_middleware_utils import (
+    find_cors_middleware,
+    update_cors_middleware,
+)
 from fides.common.api import scope_registry as scopes
 from fides.common.api.v1 import urn_registry as urls
 
 
 @pytest.fixture(scope="function")
-def cors_middleware() -> Generator:
-    cors_middleware = None
+def original_cors_middleware_origins() -> Generator:
+    """
+    Fixture to be run on any test that updates cors origins.
+    Fixture teardown ensure cors origin middleware is reset to its original state.
 
-    for mw in app.user_middleware:
-        if mw.cls is CORSMiddleware:
-            cors_middleware = mw
+    The fixture also yields the cors middleware original allow_origins values.
+    """
 
-    assert cors_middleware is not None
+    original_cors_middleware = find_cors_middleware(app)
 
-    initial_cors_domains = [*cors_middleware.options["allow_origins"]]
+    assert original_cors_middleware is not None
 
-    yield cors_middleware, initial_cors_domains
+    yield original_cors_middleware.options["allow_origins"]
 
-    cors_middleware.options["allow_origins"] = initial_cors_domains
+    # on teardown - find the new cors middleware, remove it, and add back in the original
+    update_cors_middleware(
+        app,
+        original_cors_middleware.options["allow_origins"],
+        original_cors_middleware.options["allow_origin_regex"],
+    )
 
 
 class TestPatchApplicationConfig:
@@ -304,9 +313,9 @@ class TestPatchApplicationConfig:
         self,
         api_client: TestClient,
         generate_auth_header,
+        original_cors_middleware_origins,
         url,
         payload,
-        cors_middleware,
         db: Session,
     ):
         auth_header = generate_auth_header([scopes.CONFIG_UPDATE])
@@ -317,9 +326,34 @@ class TestPatchApplicationConfig:
         )
         assert response.status_code == 200
 
-        assert set(cors_middleware[0].options["allow_origins"]) == set(
+        current_cors_middleware = find_cors_middleware(api_client.app)
+
+        assert set(current_cors_middleware.options["allow_origins"]) == set(
             payload["security"]["cors_origins"]
         )
+
+        # now ensure that the middleware update was effective by trying
+        # some sample requests with different origins
+
+        # first, try with an original allowed origin, which should no longer be accepted
+        assert len(original_cors_middleware_origins)
+        headers = {
+            **auth_header,
+            "Origin": original_cors_middleware_origins[0],
+            "Access-Control-Request-Method": "PATCH",
+        }
+        response = api_client.options(url, headers=headers)
+        assert response.status_code == 400
+        assert response.text == "Disallowed CORS origin"
+
+        # now try with a new allowed origin, which should be accepted
+        headers = {
+            **auth_header,
+            "Origin": payload["security"]["cors_origins"][0],
+            "Access-Control-Request-Method": "PATCH",
+        }
+        response = api_client.options(url, headers=headers)
+        assert response.status_code == 200
 
     def test_patch_application_config_updates_cors_domains_rejects_non_url(
         self,
@@ -611,12 +645,12 @@ class TestPutApplicationConfig:
         generate_auth_header,
         url,
         payload,
-        cors_middleware,
+        original_cors_middleware_origins,
     ):
         auth_header = generate_auth_header([scopes.CONFIG_UPDATE])
 
         # if we set cors origins values via API, ensure that those are the
-        # `allow_origins` values actually effective on the middleware
+        # `allow_origins` values on the active cors middleware
         response = api_client.put(
             url,
             headers=auth_header,
@@ -624,9 +658,35 @@ class TestPutApplicationConfig:
         )
         assert response.status_code == 200
 
-        assert set(cors_middleware[0].options["allow_origins"]) == set(
-            payload["security"]["cors_origins"]
+        current_cors_middleware = find_cors_middleware(api_client.app)
+        new_cors_origins = payload["security"]["cors_origins"]
+
+        assert set(current_cors_middleware.options["allow_origins"]) == set(
+            new_cors_origins
         )
+
+        # now ensure that the middleware update was effective by trying
+        # some sample requests with different origins
+
+        # first, try with an original allowed origin, which should no longer be accepted
+        assert len(original_cors_middleware_origins)
+        headers = {
+            **auth_header,
+            "Origin": original_cors_middleware_origins[0],
+            "Access-Control-Request-Method": "PUT",
+        }
+        response = api_client.options(url, headers=headers)
+        assert response.status_code == 400
+        assert response.text == "Disallowed CORS origin"
+
+        # now try with a new allowed origin, which should be accepted
+        headers = {
+            **auth_header,
+            "Origin": new_cors_origins[0],
+            "Access-Control-Request-Method": "PUT",
+        }
+        response = api_client.options(url, headers=headers)
+        assert response.status_code == 200
 
         # but then ensure that we can revert back to the original values
         # by PUTing a config that does not have cors origins specified
@@ -637,9 +697,34 @@ class TestPutApplicationConfig:
             json=payload,
         )
         assert response.status_code == 200
-        assert set(cors_middleware[0].options["allow_origins"]) == set(
-            cors_middleware[1]
+
+        current_cors_middleware = find_cors_middleware(api_client.app)
+        assert set(current_cors_middleware.options["allow_origins"]) == set(
+            original_cors_middleware_origins
         )  # assert our cors middleware has been reset to original values
+
+        # now ensure that the middleware update was effective by trying
+        # some sample requests with different origins
+
+        # first, try with an original allowed origin, which should now be accepted
+        assert len(original_cors_middleware_origins)
+        headers = {
+            **auth_header,
+            "Origin": original_cors_middleware_origins[0],
+            "Access-Control-Request-Method": "PUT",
+        }
+        response = api_client.options(url, headers=headers)
+        assert response.status_code == 200
+
+        # now try with a "new" allowed origin, which should no longer be accepted
+        headers = {
+            **auth_header,
+            "Origin": new_cors_origins[0],
+            "Access-Control-Request-Method": "PUT",
+        }
+        response = api_client.options(url, headers=headers)
+        assert response.status_code == 400
+        assert response.text == "Disallowed CORS origin"
 
 
 class TestGetApplicationConfigApiSet:
@@ -914,7 +999,6 @@ class TestDeleteApplicationConfig:
         generate_auth_header,
         url,
         db: Session,
-        cors_middleware,
         payload,
     ):
         auth_header = generate_auth_header([scopes.CONFIG_UPDATE])

--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -355,7 +355,7 @@ class TestPatchApplicationConfig:
         response = api_client.options(url, headers=headers)
         assert response.status_code == 200
 
-    def test_patch_application_config_updates_cors_domains_rejects_non_url(
+    def test_patch_application_config_updates_cors_domains_rejects_invalid_urls(
         self,
         api_client: TestClient,
         generate_auth_header,
@@ -363,11 +363,43 @@ class TestPatchApplicationConfig:
         db: Session,
     ):
         """
-        Ensure non-URL values for cors domains -- specifically `*` --
-        are rejected by API
+        Ensure invalid URL values for cors origin domains are rejected by API.
         """
+
         payload = {"security": {"cors_origins": ["*"]}}
         auth_header = generate_auth_header([scopes.CONFIG_UPDATE])
+        response = api_client.patch(
+            url,
+            headers=auth_header,
+            json=payload,
+        )
+        assert response.status_code == 422
+
+        payload = {"security": {"cors_origins": ["test.com"]}}
+        response = api_client.patch(
+            url,
+            headers=auth_header,
+            json=payload,
+        )
+        assert response.status_code == 422
+
+        payload = {"security": {"cors_origins": ["test"]}}
+        response = api_client.patch(
+            url,
+            headers=auth_header,
+            json=payload,
+        )
+        assert response.status_code == 422
+
+        payload = {"security": {"cors_origins": ["http://test.com/"]}}
+        response = api_client.patch(
+            url,
+            headers=auth_header,
+            json=payload,
+        )
+        assert response.status_code == 422
+
+        payload = {"security": {"cors_origins": ["http://test.com/123/456"]}}
         response = api_client.patch(
             url,
             headers=auth_header,


### PR DESCRIPTION
Closes [PROD-1419](https://ethyca.atlassian.net/browse/PROD-1419)


https://www.loom.com/share/c38df34b38194d76aa9b91ae9c32ba33

### Description Of Changes

Fixes the broken CORS `allow_origins` update functionality. Basically, before we were trying to mutate the `allow_origins` attribute on the existing `CORSMiddleware` instance "in-place", which wasn't effective in actually updating middleware's functionality, as it requires some reinitialization.

To fix this, we can instead _remove_ the existing `CORSMiddleware` instance and _add_ a new `CORSMiddleware` instance (with the updated `allows_origins` values) using the proper fastAPI app method.

Some additional notes:
- as before, the complete set of `cors_origins` specified via API (i.e. via admin UI) will be the complete set of `allow_origins` in the server's CORS middleware. So any `cors_origins` set via "traditional" config mechanisms (i.e. fides.toml or env var) will be ignored. that being said, the `cors_origin_regex` (a different property) can _only_ be set via "traditional" config mechanisms, and is not settable via API - as a security best practice. the `cors_origin_regex` set via traditional config mechanisms is still used/respected with this change, as it has always been.
- there's not much precedent for doing an operation like this that i can find - either the previous implementation or the new one proposed here, i.e. 'replacing' an existing middleware on a running app. from what i can tell, i don't see any major risk, but there's some inherent risk in not following a well established paradigm/precedent

### Code Changes

* [x] properly _remove_ and _replace_ any existing CORS middleware with an updated CORS middleware that's got its `allow_origins` values determined by config proxy, i.e. it prefers any API-set values and falls back to "traditional" config set values
* [x] remove the addition of a CORS middleware based purely on "traditional" config values that was part of the core app setup, as it's no longer needed. 
    * we don't need this because we now properly initialize the CORS middleware based on the config proxy (which falls back to the "traditional" config values if needed) in the `run_database_startup` startup hook, which comes a bit later in the startup sequence, once we've got a db session to work with (which the config proxy needs)
* [x] update automated tests to actually evaluate the cors middleware functionality, i.e. closer to a real "integration" test!
    * these rewritten tests were (expectedly) failing with the previous app code, i.e. they expose the previous bug 👍 

### Steps to Confirm

* see loom and associated jira ticket for steps for repro'ing locally. i can lend a hand if needed!

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated


[PROD-1419]: https://ethyca.atlassian.net/browse/PROD-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ