### PR TITLE
Do not render nav until we are finished loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.28.0...main)
 
+### Changed
+- Delay rendering the nav until all necessary queries are finished loading [#4571](https://github.com/ethyca/fides/pull/4571)
+
 ## [2.28.0](https://github.com/ethyca/fides/compare/2.27.0...2.28.0)
 
 ### Added

--- a/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
+++ b/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
@@ -37,6 +37,7 @@ const LINK_HOVER_BACKGROUND_COLOR = "#28303F";
 const LINK_ACTIVE_BACKGROUND_COLOR = "#7745F0";
 const LINK_COLOR = "#CBD5E0";
 const NAV_BACKGROUND_COLOR = "#191D27";
+const NAV_WIDTH = "200px";
 
 const FidesLogoHomeLink = () => (
   <Box px={2}>
@@ -144,8 +145,8 @@ export const UnconnectedMainSideNav = ({
   <Box
     p={4}
     pb={0}
-    minWidth="200px"
-    maxWidth="200px"
+    minWidth={NAV_WIDTH}
+    maxWidth={NAV_WIDTH}
     backgroundColor={NAV_BACKGROUND_COLOR}
     height="100%"
     overflow="scroll"
@@ -237,8 +238,8 @@ const MainSideNav = () => {
   if (plusQuery.isLoading) {
     return (
       <Box
-        minWidth="200px"
-        maxWidth="200px"
+        minWidth={NAV_WIDTH}
+        maxWidth={NAV_WIDTH}
         backgroundColor={NAV_BACKGROUND_COLOR}
         height="100%"
       />

--- a/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
+++ b/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
@@ -36,6 +36,7 @@ import { INDEX_ROUTE } from "./routes";
 const LINK_HOVER_BACKGROUND_COLOR = "#28303F";
 const LINK_ACTIVE_BACKGROUND_COLOR = "#7745F0";
 const LINK_COLOR = "#CBD5E0";
+const NAV_BACKGROUND_COLOR = "#191D27";
 
 const FidesLogoHomeLink = () => (
   <Box px={2}>
@@ -145,7 +146,7 @@ export const UnconnectedMainSideNav = ({
     pb={0}
     minWidth="200px"
     maxWidth="200px"
-    backgroundColor="#191D27"
+    backgroundColor={NAV_BACKGROUND_COLOR}
     height="100%"
     overflow="scroll"
   >
@@ -238,7 +239,7 @@ const MainSideNav = () => {
       <Box
         minWidth="200px"
         maxWidth="200px"
-        backgroundColor="#191D27"
+        backgroundColor={NAV_BACKGROUND_COLOR}
         height="100%"
       />
     );

--- a/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
+++ b/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
@@ -27,6 +27,7 @@ import logoImage from "~/../public/logo-white.svg";
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { logout, selectUser, useLogoutMutation } from "~/features/auth";
 import Image from "~/features/common/Image";
+import { useGetHealthQuery } from "~/features/plus/plus.slice";
 
 import { useNav } from "./hooks";
 import { ActiveNav, NavGroup, NavGroupChild } from "./nav-config";
@@ -221,12 +222,28 @@ const MainSideNav = () => {
   const [logoutMutation] = useLogoutMutation();
   const dispatch = useAppDispatch();
   const user = useAppSelector(selectUser);
+  const plusQuery = useGetHealthQuery();
   const username = user ? user.username : "";
 
   const handleLogout = async () => {
     await logoutMutation({});
     dispatch(logout());
   };
+
+  // While we are loading if we have plus, the nav isn't ready to display yet
+  // since otherwise new items can suddenly pop in. So instead, we render an empty
+  // version of the nav during load, so that when the nav does load, it is fully featured.
+  if (plusQuery.isLoading) {
+    return (
+      <Box
+        minWidth="200px"
+        maxWidth="200px"
+        backgroundColor="#191D27"
+        height="100%"
+      />
+    );
+  }
+
   return (
     <UnconnectedMainSideNav
       {...nav}


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1592

### Description Of Changes

The ticket req was to make the management tab in the nav open by default. The reason why it was starting off closed was because, in general, we have the following accordion groups:

1. Overview
2. Data map
3. Privacy requests
4. Consent
5. Management

However, 4. Consent only shows up in plus environments. To figure out if we are in a plus environment, we have to query for it first. During the query time, the nav only sees 4 options, so it says "open 4 accordion tabs" and by the time the plus query says "yes we have plus, render Consent", only the first 4 tabs open up. 

Relatedly, [Michael also commented a while back](https://ethyca.slack.com/archives/C04S7K0T2V7/p1705085365822779):
> Is there any way to delay showing everything until the page is fully ready? I think menu options for plus features pop in a bit later than the other items. I think it might look cleaner if we determine what to display, then once that determination is made, the fully formed nav is made visible.

So, to feed two birds with one scone, we now render a blank nav until the plus query is ready. This makes sure that the management tab will open up, and also that the plus only menu options don't pop in later 🐦🍰🐦 

https://github.com/ethyca/fides/assets/24641006/68c84b45-96db-47e3-8ae7-931dbb7aeced

### Code Changes

* [x] In `MainSideNav`, query for plus health. While that's loading, render an empty nav box

### Steps to Confirm

* [ ] Load the admin-ui. The Management tab should start off open

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

