### PR TITLE
Preventing completion email from being sent for consent requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The types of changes are:
 ### Fixed
 
 - Fixed CORS domain update functionality [#4570](https://github.com/ethyca/fides/pull/4570)
+- Completion emails are no longer attempted for consent requests [#4578](https://github.com/ethyca/fides/pull/4578)
 
 ## [2.28.0](https://github.com/ethyca/fides/compare/2.27.0...2.28.0)
 

--- a/src/fides/api/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/service/privacy_request/request_runner_service.py
@@ -490,7 +490,11 @@ async def run_privacy_request(
             if not proceed:
                 return
 
-        if ConfigProxy(session).notifications.send_request_completion_notification:
+        if ConfigProxy(
+            session
+        ).notifications.send_request_completion_notification and not policy.get_rules_for_action(
+            action_type=ActionType.consent
+        ):
             try:
                 initiate_privacy_request_completion_email(
                     session, policy, access_result_urls, identity_data


### PR DESCRIPTION
Closes [PROD-1634](https://ethyca.atlassian.net/browse/PROD-1634)

### Description Of Changes

Prevention privacy request completion emails from being sent for consent requests.

### Code Changes

* [ ] Adding a check for consent requests in `request_runner_service.run_privacy_request` before sending privacy request completion emails

### Steps to Confirm


* [ ] set the following values in `fides/.env`
```
FIDES__NOTIFICATIONS__NOTIFICATION_SERVICE_TYPE=mailgun
FIDES__NOTIFICATIONS__SEND_REQUEST_COMPLETION_NOTIFICATION=true
```
* [ ] Set `"executable": true` for the `marketing.advertising` `consentOption` in _src/fides/data/sample_project/privacy_center/config/config.json_
* [ ] Create a messaging config via the API (Postman)
  * [ ] Post Messaging Config
  * [ ] Messaging Config Secrets
* [ ] Submit a consent request
* [ ] Verify the request in the Admin UI, it should go to complete with no errors

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`


[PROD-1634]: https://ethyca.atlassian.net/browse/PROD-1634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ