### PR TITLE
add extras require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
     license="Apache License 2.0",
     install_requires=install_requires,
     dev_requires=dev_requires,
+    extras_require=extras,
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Closes PROD-1558

### Description Of Changes

I missed an important piece of the move of `pymssql` to optioanl-requirements that was leading to CI failures on fidesplus!

Basically, we weren't actually including the extra/optional dependencies in our package at all 😮. i'm almost positive this was the cause of the fidesplus CI [failures](https://github.com/ethyca/fidesplus/actions/runs/7733467792/job/21085607087), even while pulling in `[all]` of the latest RC tagged packages...`[all]` wasn't even doing anything!

the tarballs from the rc0 package (https://pypi.org/project/ethyca-fides/2.29.0rc0/#files) and the new alpha tag built off this branch (https://test.pypi.org/project/ethyca-fides/2.28.1a4/#files) tell the difference. within `src/ethyca_fides.egg-info/requires.txt`, the alpha tagged package (i.e. with the fix on this branch) has the following section, while the rc package does not: 
```
[all]
pymssql==2.2.8

[mssql]
pymssql==2.2.8
```


### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
