### PR TITLE
Fixing error when rendering empty datamap report table

### DIFF
--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -74,4 +74,11 @@ describe("Datamap table and spatial view", () => {
       cy.getByTestId("row-0-col-system_pokemon_party").contains(pokemon);
     });
   });
+
+  it("can render empty datamap report", () => {
+    cy.intercept("GET", "/api/v1/plus/datamap/minimal*", {
+      body: { items: [], page: 1, pages: 0, size: 25, total: 0 },
+    }).as("getDatamapMinimalEmpty");
+    cy.getByTestId("datamap-report-heading").should("be.visible");
+  });
 });

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -298,7 +298,7 @@ export const DatamapReportTable = () => {
     // Determine custom field keys by
     // 1. If they aren't in our expected, static, columns
     // 2. If they start with one of the custom field prefixes
-    const datamapKeys = datamapReport
+    const datamapKeys = datamapReport?.items?.length
       ? Object.keys(datamapReport.items[0])
       : [];
     const defaultKeys = Object.values(COLUMN_IDS);
@@ -919,8 +919,13 @@ export const DatamapReportTable = () => {
 
   return (
     <Flex flex={1} direction="column" overflow="auto">
-      <Heading mb={8} fontSize="2xl" fontWeight="semibold">
-        Data Map Report
+      <Heading
+        mb={8}
+        fontSize="2xl"
+        fontWeight="semibold"
+        data-testid="datamap-report-heading"
+      >
+        Data map report
       </Heading>
       <DatamapReportFilterModal
         isOpen={isOpen}


### PR DESCRIPTION
Closes [PROD-1644](https://ethyca.atlassian.net/jira/software/projects/PROD/issues/PROD-1644)

### Description Of Changes

Fixing error when rendering an empty datamap report.

### Code Changes

* [ ] Added null checks when generating custom fields
* [ ] Updated "Data Map Report" to sentence case "Data map report"
* [ ] Added Cypress test

### Steps to Confirm

* [ ] Load an empty datamap table or enter text in the search bar to cause the search to not yield any results

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`


[PROD-1644]: https://ethyca.atlassian.net/browse/PROD-1644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ