### PR TITLE
add supported language model + enum + registry YAML

### DIFF
--- a/src/fides/api/schemas/language.py
+++ b/src/fides/api/schemas/language.py
@@ -1,0 +1,46 @@
+from enum import Enum
+from os.path import dirname, join
+from typing import Dict
+
+import yaml
+from pydantic import BaseModel
+
+from fides.api.util.text import to_snake_case
+from fides.config.helpers import load_file
+
+LANGUAGES_YAML_FILE_PATH = join(
+    dirname(__file__),
+    "../../data",
+    "language",
+    "languages.yml",
+)
+
+
+class Language(BaseModel):
+    id: str
+    name: str
+
+
+def _load_supported_languages() -> Dict[str, Language]:
+    """Loads language dict based on yml file on disk"""
+    with open(load_file([LANGUAGES_YAML_FILE_PATH]), "r", encoding="utf-8") as file:
+        _languages = yaml.safe_load(file).get("languages", [])
+        language_dict = {}
+        for language in _languages:
+            language_dict[language["id"]] = Language.parse_obj(language)
+        return language_dict
+
+
+supported_languages_by_id: Dict[str, Language] = (
+    _load_supported_languages()
+)  # should only be accessed for read-only access
+
+
+# dynamically create an enum based on definitions loaded from YAML
+SupportedLanguage = Enum(  # type: ignore[misc]
+    "SupportedLanguage",
+    {
+        to_snake_case(language.name): language.id
+        for language in supported_languages_by_id.values()
+    },
+)

--- a/src/fides/data/language/languages.yml
+++ b/src/fides/data/language/languages.yml
@@ -1,0 +1,79 @@
+languages:
+- id: ar
+  name: Arabic
+- id: bg
+  name: Bulgarian
+- id: bs
+  name: Bosnian
+- id: ca
+  name: Catalan
+- id: cs
+  name: Czech
+- id: da
+  name: Danish
+- id: de
+  name: German
+- id: el
+  name: Greek
+- id: en
+  name: English
+- id: es
+  name: Spanish
+- id: et
+  name: Estonian
+- id: eu
+  name: Basque
+- id: fi
+  name: Finnish
+- id: fr
+  name: French
+- id: fr-CA
+  name: French (Canada)
+- id: gl
+  name: Galician
+- id: hi-IN
+  name: Hindi (India)
+- id: hr
+  name: Croatian
+- id: hu
+  name: Hungarian
+- id: it
+  name: Italian
+- id: ja
+  name: Japanese
+- id: lt
+  name: Lithuanian
+- id: lv
+  name: Latvian
+- id: mt
+  name: Maltese
+- id: nl
+  name: Dutch
+- id: "no" # needs quotes, `no` literal in YAML is a keyword for False
+  name: Norwegian
+- id: pl
+  name: Polish
+- id: pt-BR
+  name: Portuguese (Brazil)
+- id: pt-PT
+  name: Portuguese (Portugal)
+- id: ro
+  name: Romanian
+- id: ru
+  name: Russian
+- id: sk
+  name: Slovak
+- id: sl
+  name: Slovenian
+- id: sr-Cyrl
+  name: Serbian (Cyrillic)
+- id: sr-Latn
+  name: Serbian (Latin)
+- id: sv
+  name: Swedish
+- id: tr
+  name: Turkish
+- id: uk
+  name: Ukrainian
+- id: zh
+  name: Chinese

--- a/tests/ops/schemas/language/test_language.py
+++ b/tests/ops/schemas/language/test_language.py
@@ -1,0 +1,55 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from fides.api.schemas.language import SupportedLanguage, supported_languages_by_id
+
+
+class TestLanguageSchema:
+
+    def test_languages_by_id(self):
+        # some basic language lookups
+        assert supported_languages_by_id["ar"].name == "Arabic"
+        assert supported_languages_by_id["en"].name == "English"
+        assert supported_languages_by_id["es"].name == "Spanish"
+
+        # norwegian is an edge case because `no` is a YAML keyword for False!
+        assert supported_languages_by_id["no"].name == "Norwegian"
+
+        # assert our language subtypes work
+        assert supported_languages_by_id["pt-BR"].name == "Portuguese (Brazil)"
+        assert supported_languages_by_id["pt-PT"].name == "Portuguese (Portugal)"
+        assert supported_languages_by_id["sr-Cyrl"].name == "Serbian (Cyrillic)"
+        assert supported_languages_by_id["sr-Latn"].name == "Serbian (Latin)"
+
+    def test_language_enum(self):
+        # some basic language lookups
+        assert SupportedLanguage.arabic.value == "ar"
+        assert SupportedLanguage.english.value == "en"
+        assert SupportedLanguage.spanish.value == "es"
+
+        # norwegian is an edge case because `no` is a YAML keyword for False!
+        assert SupportedLanguage.norwegian.value == "no"
+
+        # assert our language subtypes work
+        assert SupportedLanguage.portuguese_brazil.value == "pt-BR"
+        assert SupportedLanguage.portuguese_portugal.value == "pt-PT"
+        assert SupportedLanguage.serbian_cyrillic.value == "sr-Cyrl"
+        assert SupportedLanguage.serbian_latin.value == "sr-Latn"
+
+    def test_language_enum_in_schema(self):
+
+        class SamplePydanticSchema(BaseModel):
+            test_prop: str
+            language: SupportedLanguage
+
+        test_schema_instance = SamplePydanticSchema(test_prop="foo", language="ar")
+        assert test_schema_instance.language == SupportedLanguage.arabic
+
+        test_schema_instance = SamplePydanticSchema(test_prop="foo", language="pt-BR")
+        assert test_schema_instance.language == SupportedLanguage.portuguese_brazil
+
+        # test that specifying an invalid language (e.g. es-MX) throws a validation error
+        with pytest.raises(ValidationError):
+            test_schema_instance = SamplePydanticSchema(
+                test_prop="foo", language="es-MX"
+            )


### PR DESCRIPTION
### Description Of Changes

Defines the `SupportedLanguage` enum (and very-lightweight `Language` pydantic model) for use within the multilanguage epic.

Will be leveraged first by a `GET /languages` endpoint in plus, but also meant to be used more broadly by other notice/experience schemas and models.

### Code Changes

* [x] YAML file enumerating our supported languages (`id` + `name` for each)
* [x] basic API model for a language - just id and name fields, for now
* [x]  dynamically-defined Enum to allow for pydantic model-validation against the supported languages


### Steps to Confirm

* [x] will manually test integration with endpoint functions over in the associated fidesplus PR
* [x] automated test coverage here proves out that the enum is working as we would hope/expect (i think!) 👍 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
