### PR TITLE
Don't show empty history rows

### DIFF
--- a/clients/admin-ui/src/features/system/history/helpers.tsx
+++ b/clients/admin-ui/src/features/system/history/helpers.tsx
@@ -75,19 +75,16 @@ const categorizeFieldModifications = (
       return;
     }
 
-    // If both values are null or empty, skip
-    if (
-      (_.isNil(beforeValue) || _.isEmpty(beforeValue)) &&
-      (_.isNil(afterValue) || _.isEmpty(afterValue))
-    ) {
+    // If both values are empty string, false, 0, null, undefined; skip
+    if (!beforeValue && !afterValue) {
       return;
     }
 
     // For all other types
     if (!_.isEqual(beforeValue, afterValue)) {
-      if (_.isNil(beforeValue) || _.isEmpty(beforeValue)) {
+      if (!beforeValue) {
         addedFields.push(key);
-      } else if (_.isNil(afterValue) || _.isEmpty(afterValue)) {
+      } else if (!afterValue) {
         removedFields.push(key);
       } else {
         changedFields.push(key);


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1580

### Description Of Changes

Empty history rows will no longer show in System history tab 


### Code Changes

* [ ] changed helper function to check if both before and after values are empty string, false, 0, null, undefined

### Steps to Confirm

* [ ] use the preview env
* [ ] add a custom field
* [ ] create a system 
* [ ] update the system by populating the custom field 
* [ ] check the history tab has no empty rows 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
