### PR TITLE
Add padding to gpc label and fix wrapping in firefox

### DIFF
--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -689,7 +689,8 @@ div#fides-banner-inner .fides-privacy-policy {
 .fides-gpc-label {
   font-weight: 600;
   font-size: var(--fides-overlay-font-size-body);
-  text-wrap: nowrap;
+  white-space: nowrap;
+  padding: 0 10px;
 }
 
 .fides-gpc-badge {


### PR DESCRIPTION
Closes # https://ethyca.atlassian.net/browse/PROD-1601

### Description Of Changes

Add padding to gpc label and fix wrapping in firefox


### Code Changes

* [ ] replace text-wrap with white-space since nowrap doesn't work on firefox 
* [ ] add padding between gpc label and on/off toggle in the consent modal 

### Steps to Confirm

* [ ] add systems to the preview env through the consent vendor add flow
* [ ] enable all privacy notices 
* [ ] turn on gpc in your browser
* [ ] nav to cookie house sample app 
* [ ] verify there is space between gpc label and on/off toggle in the modal 
* [ ] verify the "global privacy consent" text and "applied" tag are not wrapped 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

![Screenshot 2024-02-07 at 2 47 12 PM](https://github.com/ethyca/fides/assets/101993653/b11fc13e-8dc2-4ada-b7a7-085c527dc646)