### PR TITLE
remove dismissal for esc and clicking outside overlay

### DIFF
--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -52,34 +52,6 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
     };
   }, []);
 
-  // add listeners for ESC and clicking outside of component
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
-        onClose();
-      }
-    };
-
-    const handleEsc = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-
-    if (bannerIsOpen && !window.Fides?.options?.preventDismissal) {
-      window.addEventListener("mousedown", handleClickOutside);
-      window.addEventListener("keydown", handleEsc);
-    } else {
-      window.removeEventListener("mousedown", handleClickOutside);
-      window.removeEventListener("keydown", handleEsc);
-    }
-
-    return () => {
-      window.removeEventListener("mousedown", handleClickOutside);
-      window.removeEventListener("keydown", handleEsc);
-    };
-  }, [onClose, bannerIsOpen, ref]);
-
   const showGpcBadge = getConsentContext().globalPrivacyControl;
 
   useEffect(() => {


### PR DESCRIPTION
Closes # https://ethyca.atlassian.net/browse/PROD-1650

### Description Of Changes

The "x" button will now be all that allows a user to dismiss consent banner and modal.


### Code Changes

* [ ] removed the "click outside" and "esc" listeners 

### Steps to Confirm

* [ ] run `nox -s fides_env` against fides tag `2.29.1a0`
* [ ] add systems and turn on privacy notices 
* [ ] confirm in the cookie house app the banner cannot be dismissed unless the user clicks the x 
* [ ] confirm the modal cannot be dismissed unless the user clicks the x 


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
