### PR TITLE
Add support for STS-issued AWS Credentials

### DIFF
--- a/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
@@ -149,15 +149,17 @@ const AuthenticateAwsForm = () => {
                     label="Secret"
                     // "You can find more about creating access keys and secrets on AWS docs here."
                     tooltip="The secret associated with the Access Key ID used for authentication."
+                    isRequired
                   />
                   <CustomTextInput
                     type="password"
                     name="aws_session_token"
-                    label="Session Token (if applicable)"
+                    label="Session Token"
                     // "You can find more about creating access keys and secrets on AWS docs here."
-                    tooltip="The session token for temporary credentials."
+                    tooltip="The session token when using temporary credentials."
                   />
                   <CustomSelect
+                    isRequired
                     name="region_name"
                     label="AWS Region"
                     // "You can learn more about regions in AWS docs here."

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
@@ -33,6 +33,7 @@ import ScannerLoading from "./ScannerLoading";
 const initialValues = {
   aws_access_key_id: "",
   aws_secret_access_key: "",
+  aws_session_token: "",
   region_name: "",
 };
 
@@ -49,6 +50,11 @@ const ValidationSchema = Yup.object().shape({
     .trim()
     .matches(/^[^\s]+$/, "Cannot contain spaces")
     .label("Secret"),
+  aws_session_token: Yup.string()
+    .optional()
+    .trim()
+    .matches(/^[^\s]+$/, "Cannot contain spaces")
+    .label("Session Token (for temporary credentials)"),
   region_name: Yup.string().required().label("Default Region"),
 });
 
@@ -143,6 +149,13 @@ const AuthenticateAwsForm = () => {
                     label="Secret"
                     // "You can find more about creating access keys and secrets on AWS docs here."
                     tooltip="The secret associated with the Access Key ID used for authentication."
+                  />
+                  <CustomTextInput
+                    type="password"
+                    name="aws_session_token"
+                    label="Session Token (if applicable)"
+                    // "You can find more about creating access keys and secrets on AWS docs here."
+                    tooltip="The session token for temporary credentials."
                   />
                   <CustomSelect
                     name="region_name"

--- a/clients/admin-ui/src/types/api/models/AWSConfig.ts
+++ b/clients/admin-ui/src/types/api/models/AWSConfig.ts
@@ -9,4 +9,5 @@ export type AWSConfig = {
   region_name: string;
   aws_secret_access_key: string;
   aws_access_key_id: string;
+  aws_session_token?: string;
 };

--- a/src/fides/cli/commands/generate.py
+++ b/src/fides/cli/commands/generate.py
@@ -1,10 +1,12 @@
 """Contains the generate group of CLI commands for fides."""
+
 import rich_click as click
 
 from fides.cli.options import (
     aws_access_key_id_option,
     aws_region_option,
     aws_secret_access_key_option,
+    aws_session_token_option,
     connection_string_option,
     credentials_id_option,
     include_null_flag,
@@ -125,6 +127,7 @@ def generate_dataset_aws(ctx: click.Context) -> None:
 @credentials_id_option
 @aws_access_key_id_option
 @aws_secret_access_key_option
+@aws_session_token_option
 @aws_region_option
 @include_null_flag
 @with_analytics
@@ -135,6 +138,7 @@ def generate_dataset_dynamodb(
     credentials_id: str,
     access_key_id: str,
     secret_access_key: str,
+    session_token: str,
     region: str,
 ) -> None:
     """
@@ -146,6 +150,7 @@ def generate_dataset_dynamodb(
         fides_config=config,
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
+        session_token=session_token,
         region=region,
         credentials_id=credentials_id,
     )
@@ -213,6 +218,7 @@ def generate_system_okta(
 @credentials_id_option
 @aws_access_key_id_option
 @aws_secret_access_key_option
+@aws_session_token_option
 @aws_region_option
 @include_null_flag
 @organization_fides_key_option
@@ -225,6 +231,7 @@ def generate_system_aws(
     credentials_id: str,
     access_key_id: str,
     secret_access_key: str,
+    session_token: str,
     region: str,
 ) -> None:
     """
@@ -236,6 +243,7 @@ def generate_system_aws(
         fides_config=config,
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
+        session_token=session_token,
         region=region,
         credentials_id=credentials_id,
     )

--- a/src/fides/cli/commands/scan.py
+++ b/src/fides/cli/commands/scan.py
@@ -6,6 +6,7 @@ from fides.cli.options import (
     aws_access_key_id_option,
     aws_region_option,
     aws_secret_access_key_option,
+    aws_session_token_option,
     connection_string_option,
     coverage_threshold_option,
     credentials_id_option,
@@ -128,6 +129,7 @@ def scan_system_okta(
 @credentials_id_option
 @aws_access_key_id_option
 @aws_secret_access_key_option
+@aws_session_token_option
 @aws_region_option
 @organization_fides_key_option
 @coverage_threshold_option
@@ -138,6 +140,7 @@ def scan_system_aws(
     credentials_id: str,
     access_key_id: str,
     secret_access_key: str,
+    session_token: str,
     region: str,
     org_key: str,
     coverage_threshold: int,
@@ -152,6 +155,7 @@ def scan_system_aws(
         fides_config=config,
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
+        session_token=session_token,
         region=region,
         credentials_id=credentials_id,
     )

--- a/src/fides/cli/options.py
+++ b/src/fides/cli/options.py
@@ -219,6 +219,18 @@ def aws_secret_access_key_option(command: Callable) -> Callable:
     return command
 
 
+def aws_session_token_option(command: Callable) -> Callable:
+    "Use a session token with temporary access keys to connect to aws. Requires options --access_key_id, --secret_access_key and --region"
+    command = click.option(
+        "--session_token",
+        type=str,
+        help="Connect to AWS using a temporary `Access Key`. _Requires options `--access_key_id`, `--secret_access_key`, `--session_token`, & `--region`._",
+    )(
+        command
+    )  # type: ignore
+    return command
+
+
 def aws_region_option(command: Callable) -> Callable:
     "Use region option to connect to aws. Requires options --access_key_id, access_key and --region"
     command = click.option(

--- a/src/fides/cli/options.py
+++ b/src/fides/cli/options.py
@@ -224,6 +224,7 @@ def aws_session_token_option(command: Callable) -> Callable:
     command = click.option(
         "--session_token",
         type=str,
+        default="",
         help="Connect to AWS using a temporary `Access Key`. _Requires options `--access_key_id`, `--secret_access_key`, `--session_token`, & `--region`._",
     )(
         command

--- a/src/fides/cli/utils.py
+++ b/src/fides/cli/utils.py
@@ -309,6 +309,7 @@ def handle_aws_credentials_options(
     fides_config: FidesConfig,
     access_key_id: str,
     secret_access_key: str,
+    session_token: str,
     region: str,
     credentials_id: str,
 ) -> Optional[AWSConfig]:
@@ -330,6 +331,7 @@ def handle_aws_credentials_options(
         aws_config = AWSConfig(
             aws_access_key_id=access_key_id,
             aws_secret_access_key=secret_access_key,
+            aws_session_token=session_token,
             region_name=region,
         )
     if credentials_id:

--- a/src/fides/connectors/models.py
+++ b/src/fides/connectors/models.py
@@ -14,6 +14,7 @@ class AWSConfig(BaseModel):
     region_name: str
     aws_secret_access_key: str
     aws_access_key_id: str
+    aws_session_token: str
 
 
 class KeyfileCreds(BaseModel):

--- a/src/fides/connectors/models.py
+++ b/src/fides/connectors/models.py
@@ -14,7 +14,7 @@ class AWSConfig(BaseModel):
     region_name: str
     aws_secret_access_key: str
     aws_access_key_id: str
-    aws_session_token: str
+    aws_session_token: Optional[str] = None
 
 
 class KeyfileCreds(BaseModel):


### PR DESCRIPTION
Closes #4596

### Description Of Changes

This change adds an option to pass `session_token` to the CLI, UI, or API when using the system discovery feature for AWS. Long-term credentials only require an `access_key_id` and `secret_access_key`. As it stands today, this means that long-term credentials have to be created to use any system discovery. By adding an option to use `session_token`s, we now allow for temporary credentials that can reflect the principle of least access.


### Code Changes

* [ ] Update Python and React data models to include `aws_session_token`
* [ ] Add `--session_token` as an optional argument to `fides generate` and `fides scan`
* [ ] Add optional session token field to AWS discovery.

### Steps to Confirm

After setting up the dev environment

* [ ] Provision temporary credentials (e.g. `aws sts assume-role ...`)
* [ ] Attempt to use just the `access_key_id` and `secret_access_key`, this should fail.
* [ ] Now try to include the `session_token` argument, this should pass.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
