### PR TITLE
Remove click outside and esc dismissal

### DIFF
--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -1,5 +1,5 @@
 import { h, FunctionComponent, ComponentChildren, VNode } from "preact";
-import { useState, useEffect, useRef } from "preact/hooks";
+import { useState, useEffect } from "preact/hooks";
 import { getConsentContext } from "../lib/consent-context";
 import { ExperienceConfig } from "../lib/consent-types";
 import CloseButton from "./CloseButton";
@@ -35,8 +35,6 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
   renderButtonGroup,
   className,
 }) => {
-  const ref = useRef<HTMLDivElement>(null);
-
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
   useEffect(() => {
@@ -51,34 +49,6 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
       window.removeEventListener("resize", handleResize);
     };
   }, []);
-
-  // add listeners for ESC and clicking outside of component
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
-        onClose();
-      }
-    };
-
-    const handleEsc = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-
-    if (bannerIsOpen && !window.Fides?.options?.preventDismissal) {
-      window.addEventListener("mousedown", handleClickOutside);
-      window.addEventListener("keydown", handleEsc);
-    } else {
-      window.removeEventListener("mousedown", handleClickOutside);
-      window.removeEventListener("keydown", handleEsc);
-    }
-
-    return () => {
-      window.removeEventListener("mousedown", handleClickOutside);
-      window.removeEventListener("keydown", handleEsc);
-    };
-  }, [onClose, bannerIsOpen, ref]);
 
   const showGpcBadge = getConsentContext().globalPrivacyControl;
 
@@ -101,7 +71,6 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
       className={`fides-banner fides-banner-bottom 
         ${bannerIsOpen ? "" : "fides-banner-hidden"} 
         ${className || ""}`}
-      ref={ref}
     >
       <div id="fides-banner">
         <div id="fides-banner-inner">

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -66,12 +66,9 @@ const Overlay: FunctionComponent<Props> = ({
 
   const { instance, attributes } = useA11yDialog({
     id: "fides-modal",
-    role: window.Fides.options.preventDismissal ? "alertdialog" : "dialog",
+    role: "alertdialog",
     title: experience?.experience_config?.title || "",
     onClose: () => {
-      dispatchCloseEvent({ saved: false });
-    },
-    onEsc: () => {
       dispatchCloseEvent({ saved: false });
     },
   });

--- a/clients/fides-js/src/lib/a11y-dialog.tsx
+++ b/clients/fides-js/src/lib/a11y-dialog.tsx
@@ -6,7 +6,7 @@
 import A11yDialogLib from "a11y-dialog";
 import { useCallback, useEffect, useState } from "preact/hooks";
 
-const useA11yDialogInstance = (onEsc?: () => void) => {
+const useA11yDialogInstance = () => {
   const [instance, setInstance] = useState<A11yDialogLib | null>(null);
   const container = useCallback((node: Element) => {
     if (node !== null) {
@@ -15,19 +15,8 @@ const useA11yDialogInstance = (onEsc?: () => void) => {
         .on("show", () => {
           document.documentElement.style.overflowY = "hidden";
         })
-        .on("hide", (_: Element, event?: Event) => {
+        .on("hide", () => {
           document.documentElement.style.overflowY = "";
-
-          // a11y-dialog natively supports dismissing a dialog by pressing ESC
-          // but it doesn't allow any custom functions to be associated
-          // with an ESC press, so we have to do this manually
-          if (
-            onEsc &&
-            event instanceof KeyboardEvent &&
-            event.key === "Escape"
-          ) {
-            onEsc();
-          }
         });
       setInstance(dialog);
     }
@@ -40,10 +29,9 @@ interface Props {
   id: string;
   title: string;
   onClose?: () => void;
-  onEsc?: () => void;
 }
-export const useA11yDialog = ({ role, id, onClose, onEsc }: Props) => {
-  const { instance, container: ref } = useA11yDialogInstance(onEsc);
+export const useA11yDialog = ({ role, id, onClose }: Props) => {
+  const { instance, container: ref } = useA11yDialogInstance();
   const isAlertDialog = role === "alertdialog";
   const titleId = `${id}-title`;
 

--- a/clients/privacy-center/cypress/e2e/banner-overlay-dismissal.cy.ts
+++ b/clients/privacy-center/cypress/e2e/banner-overlay-dismissal.cy.ts
@@ -67,18 +67,18 @@ describe("Banner and modal dismissal", () => {
             assertDismissCalled();
           });
 
-          it("should dismiss the banner by clicking outside", () => {
+          it("should not dismiss the banner by clicking outside", () => {
             cy.get("#fides-banner").should("be.visible");
             cy.get("h1").click(); // click outside
-            cy.get("#fides-banner").should("not.be.visible");
-            assertDismissCalled();
+            cy.get("#fides-banner").should("be.visible");
+            cy.get("@FidesUpdated").should("not.have.been.called");
           });
 
-          it("should dismiss the banner by hitting ESC", () => {
+          it("should not dismiss the banner by hitting ESC", () => {
             cy.get("#fides-banner").should("be.visible");
             cy.get("body").type("{esc}");
-            cy.get("#fides-banner").should("not.be.visible");
-            assertDismissCalled();
+            cy.get("#fides-banner").should("be.visible");
+            cy.get("@FidesUpdated").should("not.have.been.called");
           });
         });
 
@@ -92,22 +92,22 @@ describe("Banner and modal dismissal", () => {
             assertDismissCalled();
           });
 
-          it("should dismiss the modal by clicking outside", () => {
+          it("should not dismiss the modal by clicking outside", () => {
             cy.get("#fides-banner").should("be.visible");
             cy.getByTestId("Manage preferences-btn").click();
             cy.get(".fides-modal-content").should("be.visible");
             cy.get(".fides-modal-overlay").click({ force: true });
-            cy.get(".fides-modal-content").should("not.be.visible");
-            assertDismissCalled();
+            cy.get(".fides-modal-content").should("be.visible");
+            cy.get("@FidesUpdated").should("not.have.been.called");
           });
 
-          it("should dismiss the modal by hitting ESC", () => {
+          it("should not dismiss the modal by hitting ESC", () => {
             cy.get("#fides-banner").should("be.visible");
             cy.getByTestId("Manage preferences-btn").click();
             cy.get(".fides-modal-content").should("be.visible");
             cy.get("body").type("{esc}");
-            cy.get(".fides-modal-content").should("not.be.visible");
-            assertDismissCalled();
+            cy.get(".fides-modal-content").should("be.visible");
+            cy.get("@FidesUpdated").should("not.have.been.called");
           });
         });
       } else {


### PR DESCRIPTION
Closes # https://ethyca.atlassian.net/browse/PROD-1650

### Description Of Changes

The "x" button will now be all that allows a user to dismiss consent banner and modal.


### Code Changes

* [ ] removed the "click outside" and "esc" listeners 

### Steps to Confirm

* [ ] run fidesplus `nox -s "build(slim)" "dev(slim)" -- dev`
* [ ] run fides with `FIDES_PRIVACY_CENTER__PREVENT_DISMISSAL=false turbo run dev`
* [ ] nav to http://localhost:3000/fides-js-demo.html
* [ ] add systems and turn on privacy notices 
* [ ] confirm in the cookie house app the banner cannot be dismissed unless the user clicks the x 
* [ ] confirm the modal cannot be dismissed unless the user clicks the x 


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
