### PR TITLE
AWS temporary cred test coverage, UI + test cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The types of changes are:
 
 - Add enum and registry of supported languages [#4592](https://github.com/ethyca/fides/pull/4592)
 - Access and erasure support for Talkable [#4589](https://github.com/ethyca/fides/pull/4589)
+- Support temporary credentials in AWS generate + scan features [#4607](https://github.com/ethyca/fides/pull/4603), [#4608](https://github.com/ethyca/fides/pull/4608)
 
 ### Fixed
 

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
@@ -142,6 +142,7 @@ const AuthenticateAwsForm = () => {
                     // content instead of just a string label. The message would be:
                     // "You can find more information about creating access keys and secrets on AWS docs here."
                     tooltip="The Access Key ID created by the cloud hosting provider."
+                    isRequired
                   />
                   <CustomTextInput
                     type="password"
@@ -159,12 +160,12 @@ const AuthenticateAwsForm = () => {
                     tooltip="The session token when using temporary credentials."
                   />
                   <CustomSelect
-                    isRequired
                     name="region_name"
                     label="AWS Region"
                     // "You can learn more about regions in AWS docs here."
                     tooltip="The geographic region of the cloud hosting provider you would like to scan."
                     options={AWS_REGION_OPTIONS}
+                    isRequired
                   />
                 </Stack>
               </>

--- a/tests/ctl/cli/test_utils.py
+++ b/tests/ctl/cli/test_utils.py
@@ -211,6 +211,7 @@ class TestHandleAWSCredentialsOptions:
                 fides_config=test_config,
                 access_key_id=input_access_key_id,
                 secret_access_key=input_access_key,
+                session_token=None,
                 region=input_region,
                 credentials_id=input_credentials_id,
             )
@@ -229,6 +230,7 @@ class TestHandleAWSCredentialsOptions:
                 fides_config=test_config,
                 access_key_id=input_access_key_id,
                 secret_access_key=input_access_key,
+                session_token=None,
                 region=input_region,
                 credentials_id=input_credentials_id,
             )
@@ -237,7 +239,7 @@ class TestHandleAWSCredentialsOptions:
         self,
         test_config: FidesConfig,
     ) -> None:
-        "Check for an exception if credentials dont exist"
+        "Verify credentials specified in config dict"
         input_access_key = ""
         input_access_key_id = ""
         input_region = ""
@@ -246,6 +248,7 @@ class TestHandleAWSCredentialsOptions:
             fides_config=test_config,
             access_key_id=input_access_key_id,
             secret_access_key=input_access_key,
+            session_token=None,
             region=input_region,
             credentials_id=input_credentials_id,
         )
@@ -254,13 +257,14 @@ class TestHandleAWSCredentialsOptions:
             "aws_access_key_id": "redacted_id_override_in_tests",
             "aws_secret_access_key": "redacted_override_in_tests",
             "region_name": "us-east-1",
+            "aws_session_token": None,
         }
 
     def test_returns_input_dict(
         self,
         test_config: FidesConfig,
     ) -> None:
-        "Check for an exception if credentials dont exist"
+        "Verify credentials specified directly as an input args"
         input_access_key = "access_key"
         input_access_key_id = "access_key_id"
         input_region = "us-east-1"
@@ -269,6 +273,7 @@ class TestHandleAWSCredentialsOptions:
             fides_config=test_config,
             access_key_id=input_access_key_id,
             secret_access_key=input_access_key,
+            session_token=None,
             region=input_region,
             credentials_id=input_credentials_id,
         )
@@ -276,6 +281,32 @@ class TestHandleAWSCredentialsOptions:
             "aws_access_key_id": input_access_key_id,
             "aws_secret_access_key": input_access_key,
             "region_name": input_region,
+            "aws_session_token": None,
+        }
+
+    def test_session_token_temporary_credentials(
+        self,
+        test_config: FidesConfig,
+    ) -> None:
+        "Verify AWS temporary credential support, i.e. passing a session token"
+        input_access_key = "access_key"
+        input_access_key_id = "access_key_id"
+        input_region = "us-east-1"
+        session_token = "session_token"
+        input_credentials_id = ""
+        aws_config = utils.handle_aws_credentials_options(
+            fides_config=test_config,
+            access_key_id=input_access_key_id,
+            secret_access_key=input_access_key,
+            session_token=session_token,
+            region=input_region,
+            credentials_id=input_credentials_id,
+        )
+        assert aws_config == {
+            "aws_access_key_id": input_access_key_id,
+            "aws_secret_access_key": input_access_key,
+            "region_name": input_region,
+            "aws_session_token": session_token,
         }
 
 


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/issues/4607

### Description Of Changes

- Provides test coverage for functionality added in https://github.com/ethyca/fides/pull/4603
- Fixes tests accidentally broken y https://github.com/ethyca/fides/pull/4603
- Small UI addition to finish up what was started in https://github.com/ethyca/fides/pull/4603


### Code Changes

* [x] test updates
* [x] UI updates 

### Steps to Confirm

* [x] UI form looks good in server running locally
* [x] already manually tested new functionality original PR

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
