### PR TITLE
Context test

### DIFF
--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -8,6 +8,7 @@ from enum import Enum as EnumType
 from typing import Any, Dict, List, Optional, Set, Union
 
 from celery.result import AsyncResult
+from fides.api.util.logger_context_utils import Contextualizable
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy import (
@@ -181,7 +182,7 @@ def generate_request_callback_jwe(webhook: PolicyPreWebhook) -> str:
     )
 
 
-class PrivacyRequest(IdentityVerificationMixin, Base):  # pylint: disable=R0904
+class PrivacyRequest(IdentityVerificationMixin, Contextualizable, Base):  # pylint: disable=R0904
     """
     The DB ORM model to describe current and historic PrivacyRequests.
     A privacy request is a database record representing the request's
@@ -949,6 +950,9 @@ class PrivacyRequest(IdentityVerificationMixin, Base):  # pylint: disable=R0904
         PrivacyRequestError.create(
             db=db, data={"message_sent": False, "privacy_request_id": self.id}
         )
+
+    def get_log_context(self):
+        return {"privacy_request_id": self.id}
 
 
 class PrivacyRequestError(Base):

--- a/src/fides/api/util/logger_context_utils.py
+++ b/src/fides/api/util/logger_context_utils.py
@@ -1,4 +1,6 @@
+from abc import abstractmethod
 from enum import Enum
+from functools import wraps
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from requests import PreparedRequest, Response
@@ -9,6 +11,8 @@ from requests.exceptions import (  # pylint: disable=redefined-builtin
     SSLError,
     TooManyRedirects,
 )
+
+from loguru import logger
 
 from fides.api.schemas.policy import ActionType
 from fides.config import CONFIG
@@ -31,6 +35,41 @@ class ErrorGroup(Enum):
     client_error = "Client-side error"
     server_error = "Server-side error"
 
+class Contextualizable:
+    """
+    An abstract base class that defines a contract for classes which can provide 
+    contextual information for logging purposes.
+
+    Subclasses of Contextualizable must implement the get_log_context method, 
+    which should return a dictionary of context information relevant to the object. 
+    This context will be used by the log_context decorator to add additional
+    information to log messages.
+    """
+    @abstractmethod
+    def get_log_context(self):
+        pass
+
+def log_context(_func=None, **additional_context):
+    """
+    A decorator that adds context information to log messages. It extracts context from 
+    the arguments of the decorated function and from any specified additional context. 
+    Optional additional context is provided through keyword arguments.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            context = dict(additional_context)
+            for arg in args:
+                if isinstance(arg, Contextualizable):
+                    context.update(arg.get_log_context())
+            with logger.contextualize(**context):
+                return func(*args, **kwargs)
+        return wrapper
+
+    if _func is None:        
+        return decorator
+    else:
+        return decorator(_func)
 
 def saas_connector_details(
     connector: "SaaSConnector",


### PR DESCRIPTION
### Description Of Changes

Alternate proposal for contextualized logging. Uses a combination of a `Contextualizable` mixin and a `log_context` decorator. The decorator iterates through the arguments of the decorated function and calls `get_log_context` on every argument that implements `Contextualizable`. The `log_context` decorator accepts optional keyword arguments to add additional context outside of the contextualizable arguments.