### PR TITLE
Privacy request cache refresh

### DIFF
--- a/src/fides/api/alembic/migrations/versions/ffca47b43275_add_encryption_and_masking_secrets.py
+++ b/src/fides/api/alembic/migrations/versions/ffca47b43275_add_encryption_and_masking_secrets.py
@@ -1,0 +1,41 @@
+"""add encryption and masking secrets to privacy request
+
+Revision ID: ffca47b43275
+Revises: 68cb26f3492d
+Create Date: 2024-02-12 23:06:23.868617
+
+"""
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ffca47b43275"
+down_revision = "68cb26f3492d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "privacyrequest",
+        sa.Column(
+            "encryption",
+            sqlalchemy_utils.types.encrypted.encrypted_type.StringEncryptedType(),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "privacyrequest",
+        sa.Column(
+            "masking_secrets",
+            sqlalchemy_utils.types.encrypted.encrypted_type.StringEncryptedType(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("privacyrequest", "masking_secrets")
+    op.drop_column("privacyrequest", "encryption")

--- a/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
@@ -69,7 +69,6 @@ from fides.api.models.privacy_request import (
 from fides.api.oauth.utils import verify_callback_oauth, verify_oauth_client
 from fides.api.schemas.dataset import CollectionAddressResponse, DryRunDatasetResponse
 from fides.api.schemas.external_https import PrivacyRequestResumeFormat
-from fides.api.schemas.masking.masking_secrets import MaskingSecretCache
 from fides.api.schemas.messaging.messaging import (
     FidesopsMessage,
     MessagingActionType,
@@ -93,7 +92,6 @@ from fides.api.schemas.privacy_request import (
 )
 from fides.api.schemas.redis_cache import Identity
 from fides.api.service._verification import send_verification_code_to_user
-from fides.api.service.masking.strategy.masking_strategy import MaskingStrategy
 from fides.api.service.messaging.message_dispatch_service import (
     EMAIL_JOIN_STRING,
     check_and_dispatch_error_notifications,

--- a/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
@@ -1870,23 +1870,6 @@ def create_privacy_request_func(
     )
 
 
-def create_masking_secrets(policy: Policy) -> Optional[List[MaskingSecretCache]]:
-    """Returns a list of masking secrets for the masking strategies in the given policy."""
-    masking_secrets: List[MaskingSecretCache] = []
-    erasure_rules = policy.get_rules_for_action(action_type=ActionType.erasure)
-    unique_masking_strategies_by_name: Set[str] = set()
-    for rule in erasure_rules:
-        strategy_name: str = rule.masking_strategy["strategy"]  # type: ignore
-        configuration = rule.masking_strategy["configuration"]  # type: ignore
-        if strategy_name in unique_masking_strategies_by_name:
-            continue
-        unique_masking_strategies_by_name.add(strategy_name)
-        masking_strategy = MaskingStrategy.get_strategy(strategy_name, configuration)
-        if masking_strategy.secrets_required():
-            masking_secrets = masking_strategy.generate_secrets_for_cache()
-    return masking_secrets
-
-
 def _create_or_update_custom_fields(
     db: Session,
     privacy_request: PrivacyRequest,

--- a/src/fides/api/models/policy.py
+++ b/src/fides/api/models/policy.py
@@ -1,6 +1,6 @@
 # pylint: disable=E1101
 from enum import Enum as EnumType
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from fideslang.default_taxonomy import DEFAULT_TAXONOMY
 from fideslang.models import DataCategory as FideslangDataCategory
@@ -25,7 +25,9 @@ from fides.api.models.client import ClientDetail
 from fides.api.models.connectionconfig import ConnectionConfig
 from fides.api.models.sql_models import DataCategory  # type: ignore
 from fides.api.models.storage import StorageConfig, get_active_default_storage_config
+from fides.api.schemas.masking.masking_secrets import MaskingSecretCache
 from fides.api.schemas.policy import ActionType, DrpAction
+from fides.api.service.masking.strategy.masking_strategy import MaskingStrategy
 from fides.api.util.data_category import _validate_data_category
 from fides.config import CONFIG
 
@@ -136,6 +138,27 @@ class Policy(Base):
             return self.rules[0].action_type  # type: ignore[attr-defined]
         except IndexError:
             return None
+
+    def create_masking_secrets(self) -> Optional[List[MaskingSecretCache]]:
+        """
+        Returns a list of masking secrets for the masking strategies in the policy.
+        """
+
+        masking_secrets: List[MaskingSecretCache] = []
+        erasure_rules = self.get_rules_for_action(action_type=ActionType.erasure)
+        unique_masking_strategies_by_name: Set[str] = set()
+        for rule in erasure_rules:
+            strategy_name: str = rule.masking_strategy["strategy"]  # type: ignore
+            configuration = rule.masking_strategy["configuration"]  # type: ignore
+            if strategy_name in unique_masking_strategies_by_name:
+                continue
+            unique_masking_strategies_by_name.add(strategy_name)
+            masking_strategy = MaskingStrategy.get_strategy(
+                strategy_name, configuration
+            )
+            if masking_strategy.secrets_required():
+                masking_secrets = masking_strategy.generate_secrets_for_cache()
+        return masking_secrets
 
 
 def _get_ref_from_taxonomy(

--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -523,6 +523,12 @@ class PrivacyRequest(IdentityVerificationMixin, Base):  # pylint: disable=R0904
         prefix = f"id-{self.id}-identity-*"
         cache: FidesopsRedis = get_cache()
         keys = cache.keys(prefix)
+
+        if not keys:
+            identity = self.get_persisted_identity()
+            self.cache_identity(identity)
+            keys = cache.keys(prefix)
+
         return {key.split("-")[-1]: cache.get(key) for key in keys}
 
     def get_cached_custom_privacy_request_fields(self) -> Dict[str, Any]:
@@ -530,6 +536,19 @@ class PrivacyRequest(IdentityVerificationMixin, Base):  # pylint: disable=R0904
         prefix = f"id-{self.id}-custom-privacy-request-field-*"
         cache: FidesopsRedis = get_cache()
         keys = cache.keys(prefix)
+
+        if not keys:
+            custom_privacy_request_fields = (
+                self.get_persisted_custom_privacy_request_fields()
+            )
+            self.cache_custom_privacy_request_fields(
+                {
+                    key: CustomPrivacyRequestFieldSchema(**value)
+                    for key, value in custom_privacy_request_fields.items()
+                }
+            )
+            keys = cache.keys(prefix)
+
         return {key.split("-")[-1]: cache.get(key) for key in keys}
 
     def get_results(self) -> Dict[str, Any]:

--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -580,7 +580,7 @@ class PrivacyRequest(IdentityVerificationMixin, Base):  # pylint: disable=R0904
                         masking_strategy=secret["masking_strategy"],
                         secret_type=SecretType(secret["secret_type"]),
                     )
-                    for secret in self.masking_secrets
+                    for secret in self.masking_secrets or []
                 ]
             )
 

--- a/src/fides/api/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/service/privacy_request/request_runner_service.py
@@ -415,6 +415,8 @@ async def run_privacy_request(
             ) and can_run_checkpoint(
                 request_checkpoint=CurrentStep.erasure, from_checkpoint=resume_step
             ):
+                privacy_request.refresh_cached_masking_secrets()
+
                 # We only need to run the erasure once until masking strategies are handled
                 await run_erasure(
                     privacy_request=privacy_request,

--- a/src/fides/api/service/privacy_request/request_service.py
+++ b/src/fides/api/service/privacy_request/request_service.py
@@ -2,20 +2,17 @@ from __future__ import annotations
 
 from asyncio import sleep
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 from httpx import AsyncClient
 from loguru import logger
 
 from fides.api.common_exceptions import PrivacyRequestNotFound
-from fides.api.models.policy import Policy
 from fides.api.models.privacy_request import PrivacyRequest, PrivacyRequestStatus
 from fides.api.schemas.drp_privacy_request import DrpPrivacyRequestCreate
 from fides.api.schemas.masking.masking_secrets import MaskingSecretCache
-from fides.api.schemas.policy import ActionType
 from fides.api.schemas.privacy_request import PrivacyRequestResponse
 from fides.api.schemas.redis_cache import Identity
-from fides.api.service.masking.strategy.masking_strategy import MaskingStrategy
 from fides.common.api.v1.urn_registry import PRIVACY_REQUESTS, V1_URL_PREFIX
 
 
@@ -44,11 +41,11 @@ def build_required_privacy_request_kwargs(
 
 def cache_data(
     privacy_request: PrivacyRequest,
-    policy: Policy,
     identity: Identity,
-    encryption_key: Optional[str],
-    drp_request_body: Optional[DrpPrivacyRequestCreate],
+    encryption_key: Optional[str] = None,
+    drp_request_body: Optional[DrpPrivacyRequestCreate] = None,
     custom_privacy_request_fields: Optional[Dict[str, Any]] = None,
+    masking_secrets: Optional[List[MaskingSecretCache]] = None,
 ) -> None:
     """Cache privacy request data"""
     # Store identity and encryption key in the cache
@@ -56,24 +53,7 @@ def cache_data(
     privacy_request.cache_identity(identity)
     privacy_request.cache_custom_privacy_request_fields(custom_privacy_request_fields)
     privacy_request.cache_encryption(encryption_key)  # handles None already
-
-    # Store masking secrets in the cache
-    logger.info("Caching masking secrets for privacy request {}", privacy_request.id)
-    erasure_rules = policy.get_rules_for_action(action_type=ActionType.erasure)
-    unique_masking_strategies_by_name: Set[str] = set()
-    for rule in erasure_rules:
-        strategy_name: str = rule.masking_strategy["strategy"]  # type: ignore
-        configuration = rule.masking_strategy["configuration"]  # type: ignore
-        if strategy_name in unique_masking_strategies_by_name:
-            continue
-        unique_masking_strategies_by_name.add(strategy_name)
-        masking_strategy = MaskingStrategy.get_strategy(strategy_name, configuration)
-        if masking_strategy.secrets_required():
-            masking_secrets: List[
-                MaskingSecretCache
-            ] = masking_strategy.generate_secrets_for_cache()
-            for masking_secret in masking_secrets:
-                privacy_request.cache_masking_secret(masking_secret)
+    privacy_request.cache_masking_secrets(masking_secrets)
     if drp_request_body:
         privacy_request.cache_drp_request_body(drp_request_body)
 

--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -230,6 +230,14 @@ def get_masking_secret_cache_key(
     )
 
 
+def get_all_masking_secret_cache_keys_for_privacy_request(
+    privacy_request_id: str,
+) -> List[str]:
+    """Return all the cache keys for this privacy request's masking secrets."""
+    cache: FidesopsRedis = get_cache()
+    return cache.keys(f"id-{privacy_request_id}-masking-secret-*")
+
+
 def get_all_cache_keys_for_privacy_request(privacy_request_id: str) -> List[Any]:
     """Returns all cache keys related to this privacy request's cached identities"""
     cache: FidesopsRedis = get_cache()

--- a/tests/ops/service/test_storage_uploader_service.py
+++ b/tests/ops/service/test_storage_uploader_service.py
@@ -512,7 +512,9 @@ class TestWriteToInMemoryBuffer:
 class TestEncryptResultsPackage:
     def test_no_encryption_keys_set(self):
         data = "test data"
-        ret = encrypt_access_request_results(data, request_id="test-request-id")
+        ret = encrypt_access_request_results(
+            data, privacy_request=PrivacyRequest(id="test-request-id")
+        )
 
         assert ret == data
 
@@ -520,7 +522,7 @@ class TestEncryptResultsPackage:
         key = "abvnfhrke8398398"
         privacy_request.cache_encryption("abvnfhrke8398398")
         data = "test data"
-        ret = encrypt_access_request_results(data, request_id=privacy_request.id)
+        ret = encrypt_access_request_results(data, privacy_request=privacy_request)
         decrypted = decrypt_combined_nonce_and_message(
             ret, key.encode(CONFIG.security.encoding)
         )


### PR DESCRIPTION
Closes [PROD-1605](https://ethyca.atlassian.net/browse/PROD-1605)

### Description Of Changes

Updating cache reads for select values related to privacy request to be refreshed from the database. The `cache_data` function in `request_service.py` is used to cache the following values after a privacy request is created:

| Value | Usage | Stored in database? |
| --- | --- | --- |
| identity | email and phone number identities | yes |
| custom privacy request fields | custom fields from privacy center | yes |
| encryption | used to encrypt DSR package | **no** |
| masking secret | used for masking data | **no** |
| DRP request body | used for local troubleshooting, not read anywhere in the app | **no** |

It is possible for a privacy request to be created, for these values to be cached, and for them to expire before the request is approved. In order prevent these values from being required again on approval, we need to store them to the database. This will allow us to refresh the cache as needed.

### Code Changes

* [ ] Add fallback logic to each of the listed `get_*_from_cache` functions to be able to refresh their values from the database
* [ ] Update the `PrivacyRequest` model to be able to persist `encryption` and `masking_secret` to the database to be able to refresh the cache after the values have expired. The `drp_request_body` value is excluded from this refactor since it is only used for local troubleshooting.

### Steps to Confirm

- [ ] Modify the `.env` file in the root directory of fides repo and add `FIDES__REDIS__DEFAULT_TTL_SECONDS=30`
- [ ] Run `nox -s "fides_env(test)"` and wait for the test environment to start up
- [ ] Open the Privacy Center and submit an access request for jane@example.com
- [ ] Open the Admin UI within 30 seconds and approve the request, and confirm that the access request succeeds
- [ ] Open the Privacy Center and submit a second access request for jane@example.com
- [ ] Wait 60 seconds!
- [ ] Open the Admin UI and approve the second request, and confirm that the access request completes successfully

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated


[PROD-1605]: https://ethyca.atlassian.net/browse/PROD-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ