### PR TITLE
experience + notice data migration via clearing of experience (config) data

### DIFF
--- a/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data_clear_experience_configs.py
+++ b/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data_clear_experience_configs.py
@@ -1,0 +1,186 @@
+"""translation data
+
+Revision ID: 14acee6f5459
+Revises: a1e23b70f2b2
+Create Date: 2024-01-09 21:17:13.115020
+
+"""
+
+import uuid
+
+import pandas as pd
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+
+revision = "14acee6f5459"
+down_revision = "a1e23b70f2b2"
+branch_labels = None
+depends_on = None
+
+
+def generate_record_id(prefix):
+    return prefix + "_" + str(uuid.uuid4())
+
+
+def remove_existing_experience_data(bind):
+    """
+    We remove any existing PrivacyExperience and PrivacyExperienceConfig records,
+    to allow for a "clean-slate" in creation of _new_ PrivacyExperienceConfigs based on the
+    "out of the box" templates.
+
+    This means that any existing user-edited data on PrivacyExperienceConfig records will need to be
+    _manually_ re-added to the post-migration state. It will not be migrated as part of the automatic migration.
+    """
+
+    def drop_fk_constraint(bind):
+        """
+        Drops FK constraint between PrivacyExperienceConfigHistory and PrivacyExperienceConfig,
+        to allow us to delete PrivacyExperienceConfigs without removing their associated history records
+
+        NOTE: should we just remove the column altogether? will we want to keep it around in the "new" model,
+        given that our PrivacyExperienceConfigHistory records will now be pointing to ExperienceTranslation records?
+        On the other hand, it could be useful to help in performing manual reconciliation steps post-migration.
+        """
+        op.drop_constraint(
+            "privacyexperienceconfighistory_experience_config_id_fkey",
+            "privacyexperienceconfighistory",
+            type_="foreignkey",
+        )
+
+    def delete_experiences(bind):
+        """
+        Delete all PrivacyExperience records.
+
+        These records will be effectively re-created as a result of the "out of the box" creation
+        of 'new-style' PrivacyExperienceConfig records post-migration.
+        """
+        bind.execute(
+            text(
+                """
+                DELETE FROM privacyexperience;
+                """
+            )
+        )
+
+    def delete_experience_configs(bind):
+        """
+        Delete all PrivacyExperienceConfig records.
+
+        These records will be effectively re-created via the server's "out of the box" creation
+        of the updated PrivacyExperienceConfig records, post-migration.
+        """
+        bind.execute(
+            text(
+                """
+                DELETE FROM privacyexperienceconfig;
+                """
+            )
+        )
+
+    drop_fk_constraint(bind)
+    delete_experiences(bind)
+    delete_experience_configs(bind)
+
+
+def migrate_notices(bind):
+    """
+    Migrates existing PrivacyNotice records to the new, translation-based data model.
+
+    Notice keys are not impacted. Most existing notice data is moved onto a linked NoticeTranslation record,
+    which is assumed to be english-language as a default. If the existing notice text/content is _not_ english-language,
+    then users will need to *manually* adjust the language on the created translation record.
+
+    The existing PrivacyNoticeHistory records are adjusted to point to the associated NoticeTranslation record,
+    as is expected in the new data model.
+    """
+
+    get_notices_query = text(
+        """SELECT id from privacynotice;
+         """
+    )
+
+    create_notice_translation_query = text(
+        """
+        INSERT INTO noticetranslation (id, privacy_notice_id, language, title, description, created_at, updated_at)
+        SELECT :record_id, :original_notice_id, :language, name, description, created_at, updated_at
+        FROM privacynotice
+        WHERE id = :original_notice_id
+        """
+    )
+    for res in bind.execute(get_notices_query):
+        # Create a Notice Translation for each notice, setting to english as a default
+        bind.execute(
+            create_notice_translation_query,
+            {
+                "record_id": generate_record_id("pri"),
+                "language": "en",
+                "original_notice_id": res["id"],
+            },
+        )
+
+    # Add a FK from the Notice History back to the Notice Translation
+    link_notice_history_to_translation_id = text(
+        """
+        UPDATE privacynoticehistory
+        SET translation_id = noticetranslation.id, title = privacynoticehistory.name
+        FROM noticetranslation
+        WHERE noticetranslation.privacy_notice_id = privacynoticehistory.privacy_notice_id;
+    """
+    )
+
+    bind.execute(link_notice_history_to_translation_id)
+
+
+def downward_migrate_notices(bind):
+    """
+    Back-migration of PrivacyNotice data.
+
+    Moves data in existing NoticeTranslation records back to the associated PrivacyNotice records,
+    to match the old data model.
+    # NOTE: this won't work "well" if multiple translations are present. Should we even attempt it?
+
+    The existing PrivacyNoticeHistory records are adjusted to point back to the associated PrivacyNotice records,
+    rather than the NoticeTranslation records, as is expected in the old data model.
+
+    # TODO: should we attempt to back-migrate region data from the ExperienceConfig records to the PrivacyNotice records? Feels dicey...
+    """
+
+    noticetranslation_data_to_notice_query = text(
+        """
+        UPDATE privacynotice
+        SET name = noticetranslation.title, description = noticetranslation.description,
+        FROM noticetranslation
+        WHERE noticetranslation.privacy_notice_id = privacynotice.id
+        """
+    )
+    bind.execute(noticetranslation_data_to_notice_query)
+
+    # Update the FK from the Notice History back to the Notice record
+    link_notice_history_to_notice = text(
+        """
+        UPDATE privacynoticehistory
+        SET privacy_notice_id = noticetranslation.privacy_notice_id
+        FROM noticetranslation
+        WHERE noticetranslation.id = privacynoticehistory.translation_id;
+    """
+    )
+
+    bind.execute(link_notice_history_to_notice)
+
+
+def upgrade():
+    bind = op.get_bind()
+
+    remove_existing_experience_data(bind)
+
+    migrate_notices(bind)
+
+
+def downgrade():
+    # Downgrade will _not_ attempt to recreate PrivacyExperienceConfig recrords,
+    # as that should be handled by the (old) server's OOB loading behavior
+    bind = op.get_bind()
+
+    downward_migrate_notices(bind)

--- a/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data_clear_experience_configs.py
+++ b/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data_clear_experience_configs.py
@@ -63,7 +63,6 @@ def remove_existing_experience_data(bind):
             )
         )
 
-    drop_fk_constraint(bind)
     delete_experiences(bind)
     delete_experience_configs(bind)
 

--- a/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data_clear_experience_configs.py
+++ b/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data_clear_experience_configs.py
@@ -107,7 +107,7 @@ def migrate_notices(bind):
     link_notice_history_to_translation_id = text(
         """
         UPDATE privacynoticehistory
-        SET translation_id = noticetranslation.id, title = privacynoticehistory.name, language = "en"
+        SET translation_id = noticetranslation.id, title = privacynoticehistory.name, language = 'en'
         FROM noticetranslation
         WHERE noticetranslation.privacy_notice_id = privacynoticehistory.privacy_notice_id;
         """

--- a/src/fides/api/alembic/migrations/versions/a1e23b70f2b2_add_notice_and_exp_translations.py
+++ b/src/fides/api/alembic/migrations/versions/a1e23b70f2b2_add_notice_and_exp_translations.py
@@ -5,6 +5,7 @@ Revises: 68cb26f3492d
 Create Date: 2024-02-01 21:49:20.792733
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
@@ -208,7 +209,9 @@ def upgrade():
     )
     op.add_column(
         "privacyexperienceconfighistory",
-        sa.Column("language", sa.String(), nullable=False),
+        sa.Column(
+            "language", sa.String(), server_default="en", nullable=False
+        ),  # set "en" as a server default for existing values ... TODO: maybe make temporarily nullable and set english 'manually' instead ??
     )
     op.add_column(
         "privacyexperienceconfighistory", sa.Column("name", sa.String(), nullable=True)
@@ -270,10 +273,16 @@ def upgrade():
         nullable=True,
     )
     op.add_column(
-        "privacynoticehistory", sa.Column("language", sa.String(), nullable=False)
+        "privacynoticehistory",
+        sa.Column(
+            "language", sa.String(), server_default="en", nullable=False
+        ),  # set "en" as a server default for existing values ... TODO: maybe make temporarily nullable and set english 'manually' instead ??
     )
     op.add_column(
-        "privacynoticehistory", sa.Column("title", sa.String(), nullable=False)
+        "privacynoticehistory",
+        sa.Column(
+            "title", sa.String(), nullable=True
+        ),  # temporarily nullable  for existing values
     )
     op.add_column(
         "privacynoticehistory", sa.Column("translation_id", sa.String(), nullable=True)

--- a/src/fides/api/alembic/migrations/versions/a1e23b70f2b2_add_notice_and_exp_translations.py
+++ b/src/fides/api/alembic/migrations/versions/a1e23b70f2b2_add_notice_and_exp_translations.py
@@ -210,8 +210,8 @@ def upgrade():
     op.add_column(
         "privacyexperienceconfighistory",
         sa.Column(
-            "language", sa.String(), server_default="en", nullable=False
-        ),  # set "en" as a server default for existing values ... TODO: maybe make temporarily nullable and set english 'manually' instead ??
+            "language", sa.String(), nullable=True
+        ),  # temporarily nullable for existing values
     )
     op.add_column(
         "privacyexperienceconfighistory", sa.Column("name", sa.String(), nullable=True)
@@ -266,6 +266,13 @@ def upgrade():
         ["custom_asset_id"],
         ["id"],
     )
+    # drop FK constraint between PrivacyExperienceConfigHistory and PrivacyExperienceConfig,
+    # to allow us to delete PrivacyExperienceConfigs without removing their associated history records
+    op.drop_constraint(
+        "privacyexperienceconfighistory_experience_config_id_fkey",
+        "privacyexperienceconfighistory",
+        type_="foreignkey",
+    )
     op.alter_column(
         "privacynotice",
         "regions",
@@ -275,14 +282,14 @@ def upgrade():
     op.add_column(
         "privacynoticehistory",
         sa.Column(
-            "language", sa.String(), server_default="en", nullable=False
-        ),  # set "en" as a server default for existing values ... TODO: maybe make temporarily nullable and set english 'manually' instead ??
+            "language", sa.String(), nullable=True
+        ),  # temporarily nullable for existing values
     )
     op.add_column(
         "privacynoticehistory",
         sa.Column(
             "title", sa.String(), nullable=True
-        ),  # temporarily nullable  for existing values
+        ),  # temporarily nullable for existing values
     )
     op.add_column(
         "privacynoticehistory", sa.Column("translation_id", sa.String(), nullable=True)


### PR DESCRIPTION
Closes [PROD-1614](https://ethyca.atlassian.net/browse/PROD-1614)

### Description Of Changes

Trying out a simplified auto-migration approach that deletes all PrivacyExperienceConfig (and PrivacyExperience) records and relies on records being re-created from OOB (out of the box) server logic post-migration. This implies that we'd need execute some sort of manual migration to propagate any "manual" changes to `PrivacyExperienceConfig` records made by existing users on top of the default records.

`PrivacyNotice`s and their data are effectively auto-migrated to the new translation-based data model (a much simpler auto-migration). 


### Code Changes

* [x] some tweaks to existing schema migration to get things working (needs some review)
* [x] rough draft of a simplified data migration with approach described above. 

### Steps to Confirm

* [x]  manual testing with OOB records:
    1. [x] build and run fidesplus `main`: `nox -s "build(slim)" "dev(slim)" -- dev`
    2. [x] after server has successfully booted up, tear it down, but DO NOT wipe the DB/teardown volumes.
    3. [x] checkout (or branch off) `consent_multitranslation_plus` in fidesplus and update `requirements.txt` to point to the commit at the HEAD of the branch PR'd here
    4. [x] re-run fidesplus server with e.g. ` nox -s "build(slim)" "dev(slim)" -- dev`
    5. [x] the migrations on this branch should have run (includes data migration), and the _new_ OOB server loading logic should have also executed. This leaves us with:
        - migrated `PrivacyNotice` (and `NoticeTranslation`) records; updated `PrivacyNoticeHistory` records.
        - net-new `PrivacyExperienceConfig` and `PrivacyExperience` records. 
        - a mix of old and new `PrivacyExperienceConfigHistory` records. The old ones point at the now nonexistent old-style `PrivacyExperienceConfig` records. The new ones point at the new `ExperienceTranslation` records.

here's the privacy experience configs i'm left with after these steps. they look basically as i'd expect, but attaching a screenshot so we can see concretely how these records look: 
<img width="918" alt="image" src="https://github.com/ethyca/fides/assets/9750285/9c5de4e2-eb6f-4f71-abec-c3852b8c361f">


* [x] manual testing with _edits_ to OOB records, mimicking real-world user edits. perform the same steps above, but between steps 1 and 2, make some manual changes, e.g.:
    * [x] update `PrivacyNotice` fields without changing the record keys or making new records. These should still be pointed to by the new `PrivacyExperienceConfig`s post-migration.
    * [x] try making net-new `PrivacyNotice` records. these will _not_ be pointed to by new `PrivacyExperienceConfig` records automatically, but they should be able to be pointed to via some manual updates post-migration
    * [ ] try deleting `PrivacyNotice` records. What happens here? ❓ 
    * [x] try editing `PrivacyExperienceConfig` records. the edits _will not_ persist across the migration, but ensure migration doesn't fail. establish a path for holding onto the edits (just via history records?) and re-applying them "manually" post-mgiration. 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated


[PROD-1614]: https://ethyca.atlassian.net/browse/PROD-1614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ