### PR TITLE
Adding Fides.showModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The types of changes are:
 - Support temporary credentials in AWS generate + scan features [#4607](https://github.com/ethyca/fides/pull/4603), [#4608](https://github.com/ethyca/fides/pull/4608)
 - Add ability to store and read Fides cookie in Base64 format [#4556](https://github.com/ethyca/fides/pull/4556)
 - Structured logging for SaaS connector requests [#4594](https://github.com/ethyca/fides/pull/4594)
+- Added Fides.showModal() to fides.js to allow programmatic opening of consent modals [#4617](https://github.com/ethyca/fides/pull/4617)
 
 ### Fixed
 

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -20,7 +20,7 @@ import ConsentModal from "./ConsentModal";
 import { useHasMounted } from "../lib/hooks";
 import { dispatchFidesEvent } from "../lib/events";
 import ConsentContent from "./ConsentContent";
-import { showModal as defaultShowModal } from "../fides";
+import { defaultShowModal } from "../fides";
 
 interface RenderBannerProps {
   isOpen: boolean;
@@ -109,15 +109,9 @@ const Overlay: FunctionComponent<Props> = ({
     return () => clearTimeout(delayBanner);
   }, [setBannerIsOpen]);
 
-  const showModal = () => {
-    if (!modalLinkRef.current) {
-      document.body.classList.add("fides-overlay-modal-link-shown");
-    }
-    handleOpenModal();
-  };
-
   useEffect(() => {
-    window.Fides.showModal = showModal;
+    window.Fides.showModal = handleOpenModal;
+    document.body.classList.add("fides-overlay-modal-link-shown");
     // use a delay to ensure that link exists in the DOM
     const delayModalLinkBinding = setTimeout(() => {
       const modalLinkId = options.modalLinkId || "fides-modal-link";
@@ -128,11 +122,9 @@ const Overlay: FunctionComponent<Props> = ({
           "Modal link element found, updating it to show and trigger modal on click."
         );
         modalLinkRef.current = modalLinkEl;
-        // Update modal link to trigger modal on click
-        const modalLink = modalLinkEl;
-        modalLink.addEventListener("click", window.Fides.showModal);
+        modalLinkRef.current.addEventListener("click", window.Fides.showModal);
         // Update to show the pre-existing modal link in the DOM
-        modalLink.classList.add("fides-modal-link-shown");
+        modalLinkRef.current.classList.add("fides-modal-link-shown");
       } else {
         debugLog(options.debug, "Modal link element not found.");
       }

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -14,7 +14,7 @@ import ConsentModal from "./ConsentModal";
 import { useHasMounted } from "../lib/hooks";
 import { dispatchFidesEvent } from "../lib/events";
 import ConsentContent from "./ConsentContent";
-import { showModal as defaultShowModal } from "~/fides";
+import { showModal as defaultShowModal } from "../fides";
 
 interface RenderBannerProps {
   isOpen: boolean;

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -77,6 +77,7 @@ const Overlay: FunctionComponent<Props> = ({
 
   const handleOpenModal = useCallback(() => {
     if (instance) {
+      setBannerIsOpen(false);
       instance.show();
       onOpen();
     }
@@ -104,9 +105,8 @@ const Overlay: FunctionComponent<Props> = ({
 
   const showModal = () => {
     if (!isModalLinkFound) {
-      document.body.classList.add("fides-modal-link-shown");
+      document.body.classList.add("fides-overlay-modal-link-shown");
     }
-    setBannerIsOpen(false);
     handleOpenModal();
   };
 
@@ -124,7 +124,7 @@ const Overlay: FunctionComponent<Props> = ({
         setIsModalLinkFound(true);
         // Update modal link to trigger modal on click
         const modalLink = modalLinkEl;
-        modalLink.onclick = window.Fides.showModal;
+        modalLink.addEventListener("click", window.Fides.showModal);
         // Update to show the pre-existing modal link in the DOM
         modalLink.classList.add("fides-modal-link-shown");
       } else {
@@ -133,6 +133,11 @@ const Overlay: FunctionComponent<Props> = ({
     }, delayModalLinkMilliseconds);
     return () => {
       clearTimeout(delayModalLinkBinding);
+      const modalLinkId = options.modalLinkId || "fides-modal-link";
+      const modalLinkEl = document.getElementById(modalLinkId);
+      if (modalLinkEl) {
+        modalLinkEl.removeEventListener("click", window.Fides.showModal);
+      }
       window.Fides.showModal = defaultShowModal;
     };
   }, [options.modalLinkId, options.debug, handleOpenModal]);
@@ -148,7 +153,6 @@ const Overlay: FunctionComponent<Props> = ({
 
   const handleManagePreferencesClick = (): void => {
     handleOpenModal();
-    setBannerIsOpen(false);
   };
 
   if (!hasMounted) {

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -1,5 +1,11 @@
 import { h, FunctionComponent, VNode } from "preact";
-import { useEffect, useState, useCallback, useMemo } from "preact/hooks";
+import {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+} from "preact/hooks";
 import {
   FidesCookie,
   FidesOptions,
@@ -54,7 +60,7 @@ const Overlay: FunctionComponent<Props> = ({
   const delayModalLinkMilliseconds = 200;
   const hasMounted = useHasMounted();
   const [bannerIsOpen, setBannerIsOpen] = useState(false);
-  const [isModalLinkFound, setIsModalLinkFound] = useState(false);
+  const modalLinkRef = useRef<HTMLElement | null>(null);
 
   const dispatchCloseEvent = useCallback(
     ({ saved = false }: { saved?: boolean }) => {
@@ -104,7 +110,7 @@ const Overlay: FunctionComponent<Props> = ({
   }, [setBannerIsOpen]);
 
   const showModal = () => {
-    if (!isModalLinkFound) {
+    if (!modalLinkRef.current) {
       document.body.classList.add("fides-overlay-modal-link-shown");
     }
     handleOpenModal();
@@ -121,7 +127,7 @@ const Overlay: FunctionComponent<Props> = ({
           options.debug,
           "Modal link element found, updating it to show and trigger modal on click."
         );
-        setIsModalLinkFound(true);
+        modalLinkRef.current = modalLinkEl;
         // Update modal link to trigger modal on click
         const modalLink = modalLinkEl;
         modalLink.addEventListener("click", window.Fides.showModal);
@@ -133,10 +139,11 @@ const Overlay: FunctionComponent<Props> = ({
     }, delayModalLinkMilliseconds);
     return () => {
       clearTimeout(delayModalLinkBinding);
-      const modalLinkId = options.modalLinkId || "fides-modal-link";
-      const modalLinkEl = document.getElementById(modalLinkId);
-      if (modalLinkEl) {
-        modalLinkEl.removeEventListener("click", window.Fides.showModal);
+      if (modalLinkRef.current) {
+        modalLinkRef.current.removeEventListener(
+          "click",
+          window.Fides.showModal
+        );
       }
       window.Fides.showModal = defaultShowModal;
     };

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -69,7 +69,7 @@ import {
 } from "./lib/initialize";
 import type { Fides } from "./lib/initialize";
 import { dispatchFidesEvent } from "./lib/events";
-import { debugLog, FidesCookie } from "./fides";
+import { debugLog, FidesCookie, showModal } from "./fides";
 import { renderOverlay } from "./lib/tcf/renderOverlay";
 import type { GppFunction } from "./lib/gpp/types";
 import { makeStub } from "./lib/tcf/stub";
@@ -243,6 +243,7 @@ _Fides = {
   initialized: false,
   meta,
   shopify,
+  showModal,
 };
 
 if (typeof window !== "undefined") {

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -69,7 +69,7 @@ import {
 } from "./lib/initialize";
 import type { Fides } from "./lib/initialize";
 import { dispatchFidesEvent } from "./lib/events";
-import { debugLog, FidesCookie, showModal } from "./fides";
+import { debugLog, FidesCookie, defaultShowModal } from "./fides";
 import { renderOverlay } from "./lib/tcf/renderOverlay";
 import type { GppFunction } from "./lib/gpp/types";
 import { makeStub } from "./lib/tcf/stub";
@@ -243,7 +243,7 @@ _Fides = {
   initialized: false,
   meta,
   shopify,
-  showModal,
+  showModal: defaultShowModal,
 };
 
 if (typeof window !== "undefined") {

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -74,6 +74,7 @@ import type { Fides } from "./lib/initialize";
 
 import { renderOverlay } from "./lib/renderOverlay";
 import { customGetConsentPreferences } from "./services/external/preferences";
+import { debugLog } from "./lib/consent-utils";
 
 declare global {
   interface Window {
@@ -161,6 +162,13 @@ const init = async (config: FidesConfig) => {
   dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
 };
 
+export const showModal = () => {
+  debugLog(
+    window.Fides.options.debug,
+    "The current experience does not support displaying a modal."
+  );
+};
+
 // The global Fides object; this is bound to window.Fides if available
 _Fides = {
   consent: {},
@@ -198,6 +206,7 @@ _Fides = {
   initialized: false,
   meta,
   shopify,
+  showModal,
 };
 
 if (typeof window !== "undefined") {

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -162,7 +162,7 @@ const init = async (config: FidesConfig) => {
   dispatchFidesEvent("FidesInitialized", cookie, config.options.debug);
 };
 
-export const showModal = () => {
+export const defaultShowModal = () => {
   debugLog(
     window.Fides.options.debug,
     "The current experience does not support displaying a modal."
@@ -206,7 +206,7 @@ _Fides = {
   initialized: false,
   meta,
   shopify,
-  showModal,
+  showModal: defaultShowModal,
 };
 
 if (typeof window !== "undefined") {

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -62,6 +62,7 @@ export type Fides = {
   initialized: boolean;
   meta: typeof meta;
   shopify: typeof shopify;
+  showModal: () => void;
 };
 
 const retrieveEffectiveRegionString = async (

--- a/clients/privacy-center/cypress/e2e/show-modal.cy.ts
+++ b/clients/privacy-center/cypress/e2e/show-modal.cy.ts
@@ -1,0 +1,59 @@
+import { stubConfig } from "../support/stubs";
+
+describe("Fides.showModal", () => {
+  describe("Overlay enabled", () => {
+    beforeEach(() => {
+      stubConfig({
+        options: {
+          isOverlayEnabled: true,
+        },
+        experience: {
+          show_banner: false,
+        },
+      });
+    });
+
+    it("Should add 'fides-overlay-modal-link-shown' class to body", () => {
+      cy.get("body").should("have.class", "fides-overlay-modal-link-shown");
+    });
+
+    it("Should allow showModal", () => {
+      cy.waitUntilFidesInitialized().then(() => {
+        cy.window().then((win) => {
+          win.Fides.showModal();
+          cy.wait(1000);
+          cy.get("@FidesUIShown").should("have.been.calledOnce");
+          cy.get(".fides-modal-content").should("be.visible");
+        });
+      });
+    });
+  });
+
+  describe("Overlay disabled", () => {
+    beforeEach(() => {
+      stubConfig({
+        options: {
+          isOverlayEnabled: false,
+        },
+        experience: {
+          show_banner: false,
+        },
+      });
+    });
+
+    it("Should not add 'fides-overlay-modal-link-shown' class to body", () => {
+      cy.get("body").should("not.have.class", "fides-overlay-modal-link-shown");
+    });
+
+    it("Should not allow showModal", () => {
+      cy.waitUntilFidesInitialized().then(() => {
+        cy.window().then((win) => {
+          win.Fides.showModal();
+          cy.wait(1000);
+          cy.get("@FidesUIShown").should("not.have.been.called");
+          cy.get(".fides-modal-content").should("not.exist");
+        });
+      });
+    });
+  });
+});

--- a/clients/privacy-center/cypress/e2e/show-modal.cy.ts
+++ b/clients/privacy-center/cypress/e2e/show-modal.cy.ts
@@ -18,14 +18,11 @@ describe("Fides.showModal", () => {
     });
 
     it("Should allow showModal", () => {
-      cy.waitUntilFidesInitialized().then(() => {
-        cy.window().then((win) => {
-          win.Fides.showModal();
-          cy.wait(1000);
-          cy.get("@FidesUIShown").should("have.been.calledOnce");
-          cy.get(".fides-modal-content").should("be.visible");
-        });
-      });
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(100);
+      cy.window().its("Fides").invoke("showModal");
+      cy.get("@FidesUIShown").should("have.been.calledOnce");
+      cy.get(".fides-modal-content").should("be.visible");
     });
   });
 
@@ -46,14 +43,11 @@ describe("Fides.showModal", () => {
     });
 
     it("Should not allow showModal", () => {
-      cy.waitUntilFidesInitialized().then(() => {
-        cy.window().then((win) => {
-          win.Fides.showModal();
-          cy.wait(1000);
-          cy.get("@FidesUIShown").should("not.have.been.called");
-          cy.get(".fides-modal-content").should("not.exist");
-        });
-      });
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(100);
+      cy.window().its("Fides").invoke("showModal");
+      cy.get("@FidesUIShown").should("not.have.been.called");
+      cy.get(".fides-modal-content").should("not.exist");
     });
   });
 });


### PR DESCRIPTION
Closes [PROD-1689](https://ethyca.atlassian.net/browse/PROD-1689)

### Description Of Changes

Adds `Fides.showModal` to be able to manually trigger the modal if supported by the current experience configuration.

### Steps to Confirm

* [ ] Start the fides server
* [ ] Navigate to the `clients` directory and run `turbo run dev`
* [ ] Navigate to http://localhost:3001/fides-js-demo.html?geolocation=us-ca
* [ ] Run `window.Fides.showModal` in the console, verify the console appears

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated


[PROD-1689]: https://ethyca.atlassian.net/browse/PROD-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ