### PR TITLE
configure logger on worker initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,13 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fides/compare/2.30.0...main)
+## [Unreleased](https://github.com/ethyca/fides/compare/2.30.1...main)
+
+## [2.30.1](https://github.com/ethyca/fides/compare/2.30.0...2.30.1)
+
+### Fixed
+- Configure logger correctly on worker initialization [#4624](https://github.com/ethyca/fides/pull/4624)
+
 
 ## [2.30.0](https://github.com/ethyca/fides/compare/2.29.0...2.30.0)
 

--- a/src/fides/api/tasks/__init__.py
+++ b/src/fides/api/tasks/__init__.py
@@ -5,6 +5,8 @@ from loguru import logger
 from sqlalchemy.orm import Session
 
 from fides.api.db.session import get_db_engine, get_db_session
+from fides.api.util.logger import create_handler_dicts
+from fides.api.util.logger import setup as setup_logging
 from fides.config import CONFIG, FidesConfig
 
 MESSAGING_QUEUE_NAME = "fidesops.messaging"
@@ -44,6 +46,11 @@ def _create_celery(config: FidesConfig = CONFIG) -> Celery:
     """
     Returns a configured version of the Celery application
     """
+    setup_logging(config)
+    logger.bind(api_config=CONFIG.logging.json()).debug(
+        "Logger configuration options in use"
+    )
+
     app = Celery(__name__)
 
     celery_config: Dict[str, Any] = {


### PR DESCRIPTION
### Description Of Changes

Without this change, we don't configure the loguru logger on the worker app/process. This means that even though we may have set e.g. `logging.serialization = json` on the worker container, it wouldn't actually impact the log behavior on the worker in any way.

With this change, before booting up the celery worker app, we now invoke the same `setup()` logging function that's invoked when creating our fides fast API app (i.e. within `create_fides_app`). This ensures consistent logging configuration across both our server and worker apps 👍 

### Code Changes

* [x] invoke `fides.api.util.logger.setup` within the `_create_celery` helper function that's invoked as part of the worker runtime bootstrap, i.e. within `fides.api.worker.start_worker`

### Steps to Confirm

* [x] set `logging.serialization = "json"` and `celery.task_always_eager = false` in your app config (i.e. in `fides.toml`)
* [x] run `nox -s dev -- worker` in fides (OSS)
* [x] create/enable a bogus system with a bogus integration (connector) that will be run on an access request (i used "braze")
* [x] run privacy center and admin UI by running `turbo run dev` in the `clients` dir
* [x] submit an access request for an arbitrary email, wait to see logs come through on the worker container (you can tail logs with `docker logs -f fides-worker-1`
* [x] ensure logs are serialized as JSON and have the additional (structured) metadata they should have (added in https://github.com/ethyca/fides/pull/4594)
   * example: 
```
{"text": "2024-02-20 20:58:04.084 | ERROR    |  - Connector request failed. | {'action_type': 'access', 'system_key': 'asdf', 'connection_key': 'asdf_braze_api', 'collection': 'subscription_groups', 'privacy_request_id': 'pri_b0a1b442-4a6a-4589-8a12-f9a991ef9b2f', 'error_group': 'NetworkError', 'error_details': 'Timeout occurred connecting to https://asdf.com.', 'status_code': None}\n", "record": {"elapsed": {"repr": "0:03:29.848315", "seconds": 209.848315}, "exception": null, "extra": {"action_type": "access", "system_key": "asdf", "connection_key": "asdf_braze_api", "collection": "subscription_groups", "privacy_request_id": "pri_b0a1b442-4a6a-4589-8a12-f9a991ef9b2f", "error_group": "NetworkError", "error_details": "Timeout occurred connecting to https://asdf.com.", "status_code": null}, "file": {"name": "authenticated_client.py", "path": "/fides/src/fides/api/service/connectors/saas/authenticated_client.py"}, "function": "result", "level": {"icon": "❌", "name": "ERROR", "no": 40}, "line": 138, "message": "Connector request failed.", "module": "authenticated_client", "name": "fides.api.service.connectors.saas.authenticated_client", "process": {"id": 22, "name": "ForkPoolWorker-2"}, "thread": {"id": 281473068298720, "name": "ThreadPoolExecutor-0_0"}, "time": {"repr": "2024-02-20 20:58:04.084453+00:00", "timestamp": 1708462684.084453}}}
```

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
