### PR TITLE
add option for GB country

### DIFF
--- a/clients/admin-ui/src/features/common/privacy-notice-regions.ts
+++ b/clients/admin-ui/src/features/common/privacy-notice-regions.ts
@@ -85,6 +85,7 @@ export const PRIVACY_NOTICE_REGION_RECORD: Record<PrivacyNoticeRegion, string> =
     [PrivacyNoticeRegion.SK]: "Slovakia (EU)",
     [PrivacyNoticeRegion.FI]: "Finland (EU)",
     [PrivacyNoticeRegion.SE]: "Sweden (EU)",
+    [PrivacyNoticeRegion.GB]: "Great Britain",
     [PrivacyNoticeRegion.GB_ENG]: "England",
     [PrivacyNoticeRegion.GB_SCT]: "Scotland",
     [PrivacyNoticeRegion.GB_WLS]: "Wales",

--- a/clients/admin-ui/src/types/api/models/PrivacyNoticeRegion.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyNoticeRegion.ts
@@ -85,6 +85,7 @@ export enum PrivacyNoticeRegion {
   SK = "sk",
   FI = "fi",
   SE = "se",
+  GB = "gb",
   GB_ENG = "gb_eng",
   GB_SCT = "gb_sct",
   GB_WLS = "gb_wls",

--- a/clients/privacy-center/types/api/models/PrivacyNoticeRegion.ts
+++ b/clients/privacy-center/types/api/models/PrivacyNoticeRegion.ts
@@ -85,6 +85,7 @@ export enum PrivacyNoticeRegion {
   SK = "sk",
   FI = "fi",
   SE = "se",
+  GB = "gb",
   GB_ENG = "gb_eng",
   GB_SCT = "gb_sct",
   GB_WLS = "gb_wls",

--- a/src/fides/api/models/privacy_notice.py
+++ b/src/fides/api/models/privacy_notice.py
@@ -119,6 +119,7 @@ PrivacyNoticeRegion = Enum(
         ("sk", "sk"),  # slovakia
         ("fi", "fi"),  # finland
         ("se", "se"),  # sweden
+        ("gb", "gb"),  # great britain
         ("gb_eng", "gb_eng"),  # england
         ("gb_sct", "gb_sct"),  # scotland
         ("gb_wls", "gb_wls"),  # wales

--- a/src/fides/api/util/consent_util.py
+++ b/src/fides/api/util/consent_util.py
@@ -661,6 +661,7 @@ EEA_COUNTRIES: List[PrivacyNoticeRegion] = [
     PrivacyNoticeRegion.sk,
     PrivacyNoticeRegion.fi,
     PrivacyNoticeRegion.se,
+    PrivacyNoticeRegion.gb,
     PrivacyNoticeRegion.gb_eng,
     PrivacyNoticeRegion.gb_sct,
     PrivacyNoticeRegion.gb_wls,


### PR DESCRIPTION
Closes FIDES-454

### Description Of Changes

* include `gb` as a country


### Code Changes

* [ ] add GB as an option in all required locations

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
