### PR TITLE
Hide empty history rows

### DIFF
--- a/clients/admin-ui/src/features/system/history/SystemHistoryTable.tsx
+++ b/clients/admin-ui/src/features/system/history/SystemHistoryTable.tsx
@@ -128,6 +128,7 @@ const SystemHistoryTable = ({ system }: Props) => {
                 </Tr>
               );
             }
+            return null;
           })}
         </Tbody>
       </Table>

--- a/clients/admin-ui/src/features/system/history/SystemHistoryTable.tsx
+++ b/clients/admin-ui/src/features/system/history/SystemHistoryTable.tsx
@@ -108,24 +108,26 @@ const SystemHistoryTable = ({ system }: Props) => {
         <Tbody>
           {systemHistories.map((history, index) => {
             const description = describeSystemChange(history);
-            return (
-              <Tr
-                // eslint-disable-next-line react/no-array-index-key
-                key={index}
-                onClick={() => openModal(history)}
-                style={{ cursor: "pointer" }}
-              >
-                <Td
-                  pt="10px"
-                  pb="10px"
-                  pl="16px"
-                  fontSize="12px"
-                  border="1px solid #E2E8F0"
+            if (description) {
+              return (
+                <Tr
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={index}
+                  onClick={() => openModal(history)}
+                  style={{ cursor: "pointer" }}
                 >
-                  {description}
-                </Td>
-              </Tr>
-            );
+                  <Td
+                    pt="10px"
+                    pb="10px"
+                    pl="16px"
+                    fontSize="12px"
+                    border="1px solid #E2E8F0"
+                  >
+                    {description}
+                  </Td>
+                </Tr>
+              );
+            }
           })}
         </Tbody>
       </Table>


### PR DESCRIPTION
Closes # https://ethyca.atlassian.net/browse/PROD-1580

### Description Of Changes

This is a frontend half measure to hide empty rows in the system history tab. The backend still needs to be fixed https://ethyca.atlassian.net/browse/PROD-1567. 

### Code Changes

* [ ] added if statement to not show empty table rows

### Steps to Confirm

* [ ] create a custom field on systems
* [ ] create a new system with a POST to http://localhost:8080/api/v1/system with the body
``` 
{
  "fides_key": "123456",
  "name": "test 123",
  "dpo": null,
  "legal_address": null,
  "privacy_declarations": [],
  "system_type": "SaaS"
}
```
* [ ] nav to the new system in the ui and update only the custom field 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
