### PR TITLE
update drop statement depending on db version

### DIFF
--- a/src/fides/api/alembic/migrations/versions/fd52d5f08c17_system_dictionary_data_migration.py
+++ b/src/fides/api/alembic/migrations/versions/fd52d5f08c17_system_dictionary_data_migration.py
@@ -5,6 +5,7 @@ Revises: 39397820a0d5
 Create Date: 2023-08-04 14:14:32.421414
 
 """
+
 import json
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -349,7 +350,6 @@ def privacy_declaration_additive_migration(bind: Connection):
 
 def upgrade():
     bind: Connection = op.get_bind()
-    bind.execute(text("DROP AGGREGATE IF EXISTS array_accum(anyarray);"))
 
     result = bind.execute("SHOW server_version;")  # 12.16 (Debian 12.16-1.pgdg120+1)
     version = result.fetchone()[0]
@@ -358,6 +358,7 @@ def upgrade():
     # Add a new function to be able to combine potentially multiple arrays of different sizes alongside null values
     # into a single array
     if major_version >= 14:
+        bind.execute(text("DROP AGGREGATE IF EXISTS array_accum(anycompatiblearray);"))
         bind.execute(
             text(
                 """
@@ -371,6 +372,7 @@ def upgrade():
             )
         )
     else:
+        bind.execute(text("DROP AGGREGATE IF EXISTS array_accum(anyarray);"))
         bind.execute(
             text(
                 """


### PR DESCRIPTION
Closes n/a

### Description Of Changes

a little while back, we [adjusted](https://github.com/ethyca/fides/commit/7bef8b4ea8761049b1148654370e96e0dbe7a7ea) our db migration that creates the `array_accum` aggregate function to differ its syntax depending on db version, due to a change in postgres typing in version 14.

what we forgot to do was update a corresponding `DROP AGGREGATE IF EXISTS` statement to have the appropriate syntax for the version in question! the practical effect here is _very, very_ narrow - the only real scenario this would come up in is when the function actually already exists when we run this migration. that basically only happens if we've downgraded and are re-upgrading, OR if we are invoking the `db/reset` API endpoint/command!

we did hit this on a cloud (internal) env when trying to invoke that API call to reset the app's db. i think the proposed fix here will allow `db/reset` to run successfully on postgres >= 14 🤞 

### Code Changes

* [x] update migration to conditionally change the `DROP AGGREGATE IF EXISTS` command syntax depending on postgres version, to align with the corresponding `CREATE AGGREGATE` commands we run!

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
