### PR TITLE
Fix "enable/disable" toggle in privacy experience table

### DIFF
--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -116,7 +116,7 @@ describe("Privacy experiences", () => {
 
     describe("enabling and disabling", () => {
       beforeEach(() => {
-        cy.intercept("PATCH", "/api/v1/experience-config/*", {
+        cy.intercept("PATCH", "/api/v1/experience-config/*/limited_update", {
           fixture: "privacy-experiences/experienceConfig.json",
         }).as("patchExperience");
       });
@@ -132,7 +132,7 @@ describe("Privacy experiences", () => {
         cy.wait("@patchExperience").then((interception) => {
           const { body, url } = interception.request;
           expect(url).to.contain(DISABLED_EXPERIENCE_ID);
-          expect(body).to.eql({ regions: ["us_ca"], disabled: false });
+          expect(body).to.eql({ disabled: false });
         });
         // redux should requery after invalidation
         cy.wait("@getExperiences");
@@ -151,7 +151,7 @@ describe("Privacy experiences", () => {
         cy.wait("@patchExperience").then((interception) => {
           const { body, url } = interception.request;
           expect(url).to.contain(EXPERIENCE_ID);
-          expect(body).to.eql({ regions: [], disabled: true });
+          expect(body).to.eql({ disabled: true });
         });
         // redux should requery after invalidation
         cy.wait("@getExperiences");

--- a/clients/admin-ui/src/features/privacy-experience/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/cells.tsx
@@ -7,7 +7,7 @@ import { EnableCell, MultiTagCell } from "~/features/common/table/";
 import { ExperienceConfigResponse } from "~/types/api";
 
 import { COMPONENT_MAP } from "./constants";
-import { usePatchExperienceConfigMutation } from "./privacy-experience.slice";
+import { useLimitedPatchExperienceConfigMutation } from "./privacy-experience.slice";
 
 export const ComponentCell = ({
   value,
@@ -25,17 +25,13 @@ export const LocationCell = ({
 export const EnablePrivacyExperienceCell = (
   cellProps: CellProps<ExperienceConfigResponse, boolean>
 ) => {
-  const [patchExperienceMutationTrigger] = usePatchExperienceConfigMutation();
+  const [limitedPatchExperienceMutationTrigger] =
+    useLimitedPatchExperienceConfigMutation();
 
   const { row } = cellProps;
   const onToggle = async (toggle: boolean) =>
-    patchExperienceMutationTrigger({
+    limitedPatchExperienceMutationTrigger({
       id: row.original.id,
-      regions: row.original.regions,
-      translations: row.original.translations,
-      privacy_notice_ids: row.original.privacy_notices?.map(
-        (notice) => notice.id
-      ),
       disabled: !toggle,
     });
 

--- a/clients/admin-ui/src/features/privacy-experience/privacy-experience.slice.ts
+++ b/clients/admin-ui/src/features/privacy-experience/privacy-experience.slice.ts
@@ -4,6 +4,7 @@ import type { RootState } from "~/app/store";
 import { baseApi } from "~/features/common/api.slice";
 import {
   ExperienceConfigCreate,
+  ExperienceConfigDisabledUpdate,
   ExperienceConfigListViewResponse,
   ExperienceConfigResponse,
   ExperienceConfigUpdate,
@@ -46,6 +47,9 @@ export type ExperienceConfigUpdateParams = Omit<
   privacy_policy_link_label?: string | null;
   privacy_policy_url?: string | null;
 };
+type ExperienceConfigEnableDisableParams = ExperienceConfigDisabledUpdate & {
+  id: string;
+};
 export type ExperienceConfigCreateParams = Omit<
   Partial<ExperienceConfigCreate>,
   ExperienceConfigOptionalFields
@@ -82,6 +86,17 @@ const privacyExperienceConfigApi = baseApi.injectEndpoints({
       },
       invalidatesTags: () => ["Privacy Experience Configs"],
     }),
+    limitedPatchExperienceConfig: build.mutation<
+      ExperienceConfigResponse,
+      ExperienceConfigEnableDisableParams
+    >({
+      query: ({ id, disabled }) => ({
+        method: "PATCH",
+        url: `experience-config/${id}/limited_update`,
+        body: { disabled },
+      }),
+      invalidatesTags: () => ["Privacy Experience Configs"],
+    }),
     getExperienceConfigById: build.query<ExperienceConfigResponse, string>({
       query: (id) => ({
         url: `experience-config/${id}`,
@@ -107,6 +122,7 @@ const privacyExperienceConfigApi = baseApi.injectEndpoints({
 export const {
   useGetAllExperienceConfigsQuery,
   usePatchExperienceConfigMutation,
+  useLimitedPatchExperienceConfigMutation,
   useGetExperienceConfigByIdQuery,
   usePostExperienceConfigMutation,
 } = privacyExperienceConfigApi;


### PR DESCRIPTION
### Description Of Changes

Updates the toggle switch in privacy experience table to use the `experience-config/{id}/limited_update` endpoint, rather than the generic PATCH endpoint which requires more fields.

### Code Changes

* Add new Redux query for `/limited_update` endpoint
* Change EnablePrivacyExperienceCell to use new query

### Steps to Confirm

* [ ] Navigate to `/privacy-experience` main table with experiences configured
* [ ] Enable and disable experiences; should see no errors

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
