### PR TITLE
PROD-1755: Fix bug where closing consent overlay via "x" sometimes overrides saved preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The types of changes are:
 ### Changed
 - Update when GPP API reports signal status: ready [#4635](https://github.com/ethyca/fides/pull/4635)
 
+### Fixed
+- Fix issue where "x" button on Fides.js components overwrites saved preferences [#4649](https://github.com/ethyca/fides/pull/4649)
+
 
 ## [2.30.1](https://github.com/ethyca/fides/compare/2.30.0...2.30.1)
 

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -2,7 +2,8 @@ import { h, FunctionComponent, Fragment } from "preact";
 import { useState, useCallback, useMemo } from "preact/hooks";
 import {
   ConsentMechanism,
-  ConsentMethod, FidesCookie,
+  ConsentMethod,
+  FidesCookie,
   PrivacyNotice,
   SaveConsentPreference,
   ServingComponent,
@@ -18,7 +19,10 @@ import { NoticeConsentButtons } from "../ConsentButtons";
 import NoticeToggles from "./NoticeToggles";
 import { OverlayProps } from "../types";
 import { useConsentServed } from "../../lib/hooks";
-import {getFidesConsentCookie, updateCookieFromNoticePreferences} from "../../lib/cookie";
+import {
+  getFidesConsentCookie,
+  updateCookieFromNoticePreferences,
+} from "../../lib/cookie";
 import PrivacyPolicyLink from "../PrivacyPolicyLink";
 import { dispatchFidesEvent } from "../../lib/events";
 import { resolveConsentValue } from "../../lib/consent-value";
@@ -36,12 +40,16 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
       // ensure we have most up-to-date cookie vals
       const parsedCookie: FidesCookie | undefined = getFidesConsentCookie();
       return experience.privacy_notices.map((notice) => {
-        const val = resolveConsentValue(notice, getConsentContext(), parsedCookie?.consent);
+        const val = resolveConsentValue(
+          notice,
+          getConsentContext(),
+          parsedCookie?.consent
+        );
         return val ? (notice.notice_key as PrivacyNotice["notice_key"]) : "";
       });
     }
     return [];
-  }
+  };
 
   const [draftEnabledNoticeKeys, setDraftEnabledNoticeKeys] = useState<
     Array<PrivacyNotice["notice_key"]>

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -2,7 +2,7 @@ import { h, FunctionComponent, Fragment } from "preact";
 import { useState, useCallback, useMemo } from "preact/hooks";
 import {
   ConsentMechanism,
-  ConsentMethod,
+  ConsentMethod, FidesCookie,
   PrivacyNotice,
   SaveConsentPreference,
   ServingComponent,
@@ -18,7 +18,7 @@ import { NoticeConsentButtons } from "../ConsentButtons";
 import NoticeToggles from "./NoticeToggles";
 import { OverlayProps } from "../types";
 import { useConsentServed } from "../../lib/hooks";
-import { updateCookieFromNoticePreferences } from "../../lib/cookie";
+import {getFidesConsentCookie, updateCookieFromNoticePreferences} from "../../lib/cookie";
 import PrivacyPolicyLink from "../PrivacyPolicyLink";
 import { dispatchFidesEvent } from "../../lib/events";
 import { resolveConsentValue } from "../../lib/consent-value";
@@ -31,19 +31,21 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   fidesRegionString,
   cookie,
 }) => {
-  const initialEnabledNoticeKeys = useMemo(() => {
+  const initialEnabledNoticeKeys = () => {
     if (experience.privacy_notices) {
+      // ensure we have most up-to-date cookie vals
+      const parsedCookie: FidesCookie | undefined = getFidesConsentCookie();
       return experience.privacy_notices.map((notice) => {
-        const val = resolveConsentValue(notice, getConsentContext(), cookie);
+        const val = resolveConsentValue(notice, getConsentContext(), parsedCookie?.consent);
         return val ? (notice.notice_key as PrivacyNotice["notice_key"]) : "";
       });
     }
     return [];
-  }, [cookie, experience]);
+  }
 
   const [draftEnabledNoticeKeys, setDraftEnabledNoticeKeys] = useState<
     Array<PrivacyNotice["notice_key"]>
-  >(initialEnabledNoticeKeys);
+  >(initialEnabledNoticeKeys());
 
   const privacyNotices = useMemo(
     () => experience.privacy_notices ?? [],
@@ -124,7 +126,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   }, [cookie, options.debug]);
 
   const handleDismiss = useCallback(() => {
-    handleUpdatePreferences(ConsentMethod.DISMISS, initialEnabledNoticeKeys);
+    handleUpdatePreferences(ConsentMethod.DISMISS, initialEnabledNoticeKeys());
   }, [handleUpdatePreferences, initialEnabledNoticeKeys]);
 
   if (!experience.experience_config) {

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -225,7 +225,7 @@ export const shouldResurfaceConsent = (
   // If not every notice has previous user consent, we need to resurface consent
   return Boolean(
     !experience.privacy_notices?.every((notice) =>
-      noticeHasConsentInCookie(notice, cookie)
+      noticeHasConsentInCookie(notice, cookie.consent)
     )
   );
 };

--- a/clients/fides-js/src/lib/consent-value.ts
+++ b/clients/fides-js/src/lib/consent-value.ts
@@ -1,7 +1,7 @@
 import { ConsentContext } from "./consent-context";
 import {
   ConsentMechanism,
-  ConsentValue,
+  ConsentValue, CookieKeyConsent,
   FidesCookie,
   PrivacyNoticeWithPreference,
 } from "./consent-types";
@@ -32,15 +32,15 @@ export const resolveLegacyConsentValue = (
 export const resolveConsentValue = (
   notice: PrivacyNoticeWithPreference,
   context: ConsentContext,
-  cookie: FidesCookie
+  consent: CookieKeyConsent | undefined
 ): boolean => {
   if (notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY) {
     return true;
   }
-  const preferenceExistsInCookie = noticeHasConsentInCookie(notice, cookie);
   // Note about GPC - consent has already applied to the cookie at this point, so we can trust preference there
-  if (preferenceExistsInCookie) {
-    return !!cookie.consent[notice.notice_key];
+  if (consent && noticeHasConsentInCookie(notice, consent)) {
+    return !!consent[notice.notice_key];
   }
+
   return transformUserPreferenceToBoolean(notice.default_preference);
 };

--- a/clients/fides-js/src/lib/consent-value.ts
+++ b/clients/fides-js/src/lib/consent-value.ts
@@ -1,8 +1,8 @@
 import { ConsentContext } from "./consent-context";
 import {
   ConsentMechanism,
-  ConsentValue, CookieKeyConsent,
-  FidesCookie,
+  ConsentValue,
+  CookieKeyConsent,
   PrivacyNoticeWithPreference,
 } from "./consent-types";
 import {

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -114,7 +114,7 @@ const automaticallyApplyGPCPreferences = ({
   let gpcApplied = false;
   const consentPreferencesToSave = effectiveExperience.privacy_notices.map(
     (notice) => {
-      const hasPriorConsent = noticeHasConsentInCookie(notice, cookie);
+      const hasPriorConsent = noticeHasConsentInCookie(notice, cookie.consent);
       // only apply GPC for notices that do not have prior consent
       if (
         notice.has_gpc_flag &&
@@ -130,7 +130,7 @@ const automaticallyApplyGPCPreferences = ({
       return new SaveConsentPreference(
         notice,
         transformConsentToFidesUserPreference(
-          resolveConsentValue(notice, context, cookie),
+          resolveConsentValue(notice, context, cookie.consent),
           notice.consent_mechanism
         )
       );

--- a/clients/fides-js/src/lib/shared-consent-utils.ts
+++ b/clients/fides-js/src/lib/shared-consent-utils.ts
@@ -1,6 +1,5 @@
 import {
-  ConsentMechanism,
-  FidesCookie,
+  ConsentMechanism, CookieKeyConsent,
   PrivacyNoticeWithPreference,
   UserConsentPreference,
 } from "./consent-types";
@@ -14,8 +13,8 @@ import {
  */
 export const noticeHasConsentInCookie = (
   notice: PrivacyNoticeWithPreference,
-  cookie: FidesCookie
-): boolean => Boolean(Object.keys(cookie.consent).includes(notice.notice_key));
+  consent: CookieKeyConsent
+): boolean => Boolean(Object.keys(consent).includes(notice.notice_key));
 /**
  * Convert a user consent preference into true/false
  */

--- a/clients/fides-js/src/lib/shared-consent-utils.ts
+++ b/clients/fides-js/src/lib/shared-consent-utils.ts
@@ -1,5 +1,6 @@
 import {
-  ConsentMechanism, CookieKeyConsent,
+  ConsentMechanism,
+  CookieKeyConsent,
   PrivacyNoticeWithPreference,
   UserConsentPreference,
 } from "./consent-types";

--- a/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
@@ -53,7 +53,10 @@ export const resolveConsentValue = (
   const gpcEnabled =
     !!notice.has_gpc_flag &&
     context.globalPrivacyControl === true &&
-    !noticeHasConsentInCookie(notice as PrivacyNoticeWithPreference, cookie.consent);
+    !noticeHasConsentInCookie(
+      notice as PrivacyNoticeWithPreference,
+      cookie.consent
+    );
   if (gpcEnabled) {
     return UserConsentPreference.OPT_OUT;
   }

--- a/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/NoticeDrivenConsent.tsx
@@ -53,13 +53,13 @@ export const resolveConsentValue = (
   const gpcEnabled =
     !!notice.has_gpc_flag &&
     context.globalPrivacyControl === true &&
-    !noticeHasConsentInCookie(notice as PrivacyNoticeWithPreference, cookie);
+    !noticeHasConsentInCookie(notice as PrivacyNoticeWithPreference, cookie.consent);
   if (gpcEnabled) {
     return UserConsentPreference.OPT_OUT;
   }
   const preferenceExistsInCookie = noticeHasConsentInCookie(
     notice as PrivacyNoticeWithPreference,
-    cookie
+    cookie.consent
   );
   if (preferenceExistsInCookie) {
     return transformConsentToFidesUserPreference(


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1755

### Description Of Changes

This addresses a bug where closing consent overlay via "x" sometimes overrides saved preferences. The issue was two-fold, in the code that determined what preferences to save when the "x" was clicked:

1. We wrapped code in a useMemo, which means it only ran once, and could not update once the user saved prefs on the banner/modal 
2. We were relying on the `cookie` variable, which doesn't actually get updated when the user saved prefs on the banner/modal 

So the fix was to remove the useMemo wrapper, and instead use a plain old fn, in addition to retrieving the fides consent cookie when this fn is called on modal / banner dismissal. 


### Code Changes

* [ ] Update core fides.js to use most up-to-date cookie when calculating consent prefs to save

### Steps to Confirm

* [ ] In `/clients/privacy-center`, run `turbo run dev`
* [ ] Nav to http://localhost:3000/fides-js-components-demo.html
* [ ] Click "Accept" on the banner
* [ ] Click "Manage Consent" link on page
* [ ] "x" out of modal
* [ ] Click "Manage Consent" link on page
* [ ] Confirm that all prefs are still all toggled on
* [ ] Click "Manage Consent" link on page
* [ ] Toggle one notice off, click "save"
* [ ] Click "Manage Consent" link on page
* [ ] "x" out of modal
* [ ] Click "Manage Consent" link on page
* [ ] Confirm that the prefs did not change, and the one notice is still toggled off

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
