### PR TITLE
Remove focus outline from nav

### DIFF
--- a/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
+++ b/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
@@ -80,7 +80,7 @@ export const NavSideBarLink = ({
             backgroundColor: LINK_ACTIVE_BACKGROUND_COLOR,
           }}
           _focus={{
-            outline: "none"
+            outline: "none",
           }}
           data-testid={`${title}-nav-link`}
         >

--- a/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
+++ b/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
@@ -152,7 +152,7 @@ export const UnconnectedMainSideNav = ({
     maxWidth={NAV_WIDTH}
     backgroundColor={NAV_BACKGROUND_COLOR}
     height="100%"
-    overflow="scroll"
+    overflow="auto"
   >
     <VStack
       as="nav"

--- a/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
+++ b/clients/admin-ui/src/features/common/nav/v2/MainSideNav.tsx
@@ -79,6 +79,9 @@ export const NavSideBarLink = ({
             color: "white",
             backgroundColor: LINK_ACTIVE_BACKGROUND_COLOR,
           }}
+          _focus={{
+            outline: "none"
+          }}
           data-testid={`${title}-nav-link`}
         >
           {title}


### PR DESCRIPTION
### Description Of Changes

The blue outline caused by clicking the side nav was not pretty. This PR removes that focus outline. 


### Steps to Confirm

* [ ] run with `nox -s dev -- ui` 
* [ ] click on the main side nav buttons to verify the blue outline does not appear 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
