### PR TITLE
Remove location and regulation beta flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.31.1...main)
 
+### Changed
+- Removed location and regulation beta flag [#4660](https://github.com/ethyca/fides/pull/4660)
+
 ## [2.31.0](https://github.com/ethyca/fides/compare/2.30.1...2.31.0)
 
 ### Added

--- a/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
@@ -158,7 +158,6 @@ export const NAV_CONFIG: NavConfigGroup[] = [
           ScopeRegistryEnum.LOCATION_UPDATE,
         ],
         requiresPlus: true,
-        requiresFlag: "locationRegulationConfiguration",
       },
       {
         title: "Regulations",
@@ -168,7 +167,6 @@ export const NAV_CONFIG: NavConfigGroup[] = [
           ScopeRegistryEnum.LOCATION_UPDATE,
         ],
         requiresPlus: true,
-        requiresFlag: "locationRegulationConfiguration",
       },
       {
         title: "Taxonomy",

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -30,12 +30,6 @@
     "test": true,
     "production": false
   },
-  "locationRegulationConfiguration": {
-    "description": "Page to configure locations and regulations",
-    "development": true,
-    "test": true,
-    "production": false
-  },
   "datamapReportingPage": {
     "description": "Page to view datamap reports",
     "development": true,


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1747

### Description Of Changes

Remove location and regulation beta flag so that the location page and the regulation 

### Steps to Confirm

* [ ] look at beta flags page under management and verify the flag no longer exists 
* [ ] verify regulations and locations show in nav and can be access by an Owner and Contributor user role 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
