### PR TITLE
Remove password from credentials object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The types of changes are:
 
 ### Changed
 - Update when GPP API reports signal status: ready [#4635](https://github.com/ethyca/fides/pull/4635)
+- Modify `fides user login` to not store plaintext password in `~/.fides-credentials` [#4661](https://github.com/ethyca/fides/pull/4661)
 
 ### Fixed
 - Fix issue where "x" button on Fides.js components overwrites saved preferences [#4649](https://github.com/ethyca/fides/pull/4649)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.31.1...main)
 
+### Changed
+- Modify `fides user login` to not store plaintext password in `~/.fides-credentials` [#4661](https://github.com/ethyca/fides/pull/4661)
+
 ### Fixed
 
 - Ignore 404 errors from Delighted and Kustomer when an erasure client is not found [#4593](https://github.com/ethyca/fides/pull/4593)
@@ -30,7 +33,6 @@ The types of changes are:
 
 ### Changed
 - Update when GPP API reports signal status: ready [#4635](https://github.com/ethyca/fides/pull/4635)
-- Modify `fides user login` to not store plaintext password in `~/.fides-credentials` [#4661](https://github.com/ethyca/fides/pull/4661)
 
 ### Fixed
 - Fix issue where "x" button on Fides.js components overwrites saved preferences [#4649](https://github.com/ethyca/fides/pull/4649)

--- a/src/fides/core/user.py
+++ b/src/fides/core/user.py
@@ -1,5 +1,4 @@
 """Module for interaction with User endpoints/commands."""
-
 import json
 from typing import Dict, List, Tuple
 

--- a/src/fides/core/user.py
+++ b/src/fides/core/user.py
@@ -1,4 +1,5 @@
 """Module for interaction with User endpoints/commands."""
+
 import json
 from typing import Dict, List, Tuple
 
@@ -156,7 +157,7 @@ def login_command(username: str, password: str, server_url: str) -> str:
     )
     echo_green(f"Logged in as user: {username}")
     credentials = Credentials(
-        username=username, password=password, user_id=user_id, access_token=access_token
+        username=username, user_id=user_id, access_token=access_token
     )
     credentials_path = get_credentials_path()
     write_credentials_file(credentials, credentials_path)

--- a/src/fides/core/utils.py
+++ b/src/fides/core/utils.py
@@ -26,7 +26,6 @@ class Credentials(BaseModel):
     """
 
     username: str
-    password: str
     user_id: str
     access_token: str
 

--- a/tests/ctl/core/test_user.py
+++ b/tests/ctl/core/test_user.py
@@ -25,7 +25,6 @@ class TestCredentials:
             access_token="some_token",
         )
         assert credentials.username == "test"
-        assert credentials.password == "password"
         assert credentials.user_id == "some_id"
         assert credentials.access_token == "some_token"
 


### PR DESCRIPTION
Fixes issue introduced in #2153

### Description Of Changes

`fides user login` stores the plaintext password to the `~/.fides-credentials` file. This removes the password since it's not actively used anywhere.

### Code Changes

* [x] Remove password from the credentials object.

### Steps to Confirm

* [ ] Use `fides user login` and login with credentials.
* [ ] Open `~/.fides-credentials` and ensure password is not stored

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
