### PR TITLE
Remove "Customize appearance" button from experience config 

### DIFF
--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -169,14 +169,6 @@ export const PrivacyExperienceForm = ({
           />
         </Box>
       </Collapse>
-      <Button
-        onClick={() => setEditingStyle(true)}
-        size="sm"
-        variant="outline"
-        rightIcon={<ArrowForwardIcon />}
-      >
-        Customize appearance
-      </Button>
       <Divider />
       <Heading fontSize="md" fontWeight="semibold">
         Privacy notices

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -1,5 +1,4 @@
 import {
-  ArrowForwardIcon,
   Box,
   Button,
   ButtonGroup,


### PR DESCRIPTION
Closes #[PROD-1778](https://ethyca.atlassian.net/browse/PROD-1778)

### Description Of Changes

Remove "Customize appearance" button from experience config 

### Steps to Confirm

* [ ] run plus branch [consent_multitranslation_plus](https://github.com/ethyca/fidesplus/pull/1299) with `nox -s "build(slim)" "dev(slim)" -- dev`
* [ ] run this branch with `cd client && turbo run dev`
* [ ] nav to Experiences 
* [ ] click an experience row 
* [ ] verify the "Customize appearance" button in not visible

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated


[PROD-1778]: https://ethyca.atlassian.net/browse/PROD-1778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ