### PR TITLE
Add Spanish (Mexico) es-MX language code

### DIFF
--- a/src/fides/data/language/languages.yml
+++ b/src/fides/data/language/languages.yml
@@ -19,6 +19,8 @@ languages:
   name: English
 - id: es
   name: Spanish
+- id: es-MX
+  name: Spanish (Mexico)
 - id: et
   name: Estonian
 - id: eu

--- a/tests/ops/integration_tests/saas/connector_runner.py
+++ b/tests/ops/integration_tests/saas/connector_runner.py
@@ -499,6 +499,7 @@ def _process_external_references(
 def generate_random_email() -> str:
     return f"{cryptographic_util.generate_secure_random_string(13)}@email.com"
 
+
 def generate_random_phone_number() -> str:
     """
     Generate a random phone number in the format of E.164, +1112223333

--- a/tests/ops/schemas/language/test_language.py
+++ b/tests/ops/schemas/language/test_language.py
@@ -34,6 +34,7 @@ class TestLanguageSchema:
         assert SupportedLanguage.portuguese_portugal.value == "pt-PT"
         assert SupportedLanguage.serbian_cyrillic.value == "sr-Cyrl"
         assert SupportedLanguage.serbian_latin.value == "sr-Latn"
+        assert SupportedLanguage.spanish_mexico.value == "es-MX"
 
     def test_language_enum_in_schema(self):
         class SamplePydanticSchema(BaseModel):
@@ -46,8 +47,8 @@ class TestLanguageSchema:
         test_schema_instance = SamplePydanticSchema(test_prop="foo", language="pt-BR")
         assert test_schema_instance.language == SupportedLanguage.portuguese_brazil
 
-        # test that specifying an invalid language (e.g. es-MX) throws a validation error
+        # test that specifying an invalid language (e.g. es-ES) throws a validation error
         with pytest.raises(ValidationError):
             test_schema_instance = SamplePydanticSchema(
-                test_prop="foo", language="es-MX"
+                test_prop="foo", language="es-ES"
             )


### PR DESCRIPTION
Closes #PROD-1735 

Partially closes, just continued updates to backend translations 

### Description Of Changes

We currently support language code "es" and are adding additional support for "es-MX" language code.


### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
