### PR TITLE
Hide On/Off toggle labels in non-default locales

### DIFF
--- a/clients/fides-js/src/components/DataUseToggle.tsx
+++ b/clients/fides-js/src/components/DataUseToggle.tsx
@@ -11,6 +11,8 @@ const DataUseToggle = ({
   badge,
   gpcBadge,
   disabled,
+  onLabel,
+  offLabel,
   isHeader,
   includeToggle = true,
 }: {
@@ -22,6 +24,8 @@ const DataUseToggle = ({
   badge?: string;
   gpcBadge?: VNode;
   disabled?: boolean;
+  onLabel?: string;
+  offLabel?: string;
   isHeader?: boolean;
   includeToggle?: boolean;
 }) => {
@@ -74,6 +78,8 @@ const DataUseToggle = ({
             checked={checked}
             onChange={onToggle}
             disabled={disabled}
+            onLabel={onLabel}
+            offLabel={offLabel}
           />
         ) : null}
       </div>

--- a/clients/fides-js/src/components/Toggle.tsx
+++ b/clients/fides-js/src/components/Toggle.tsx
@@ -6,19 +6,19 @@ const Toggle = ({
   checked,
   onChange,
   disabled,
+  onLabel,
+  offLabel,
 }: {
   name: string;
   id: string;
   checked: boolean;
   onChange: (noticeKey: string) => void;
   disabled?: boolean;
+  onLabel?: string;
+  offLabel?: string;
 }) => {
   const labelId = `toggle-${id}`;
-  /* TODO (PROD-1754)
-  if (getCurrentLocale(i18n) == DEFAULT_LOCALE) {
-    const label = checked ? "On" : "Off";
-  }
-  */
+  const labelText = checked ? onLabel : offLabel;
   return (
     <label
       className="fides-toggle"
@@ -38,10 +38,7 @@ const Toggle = ({
         aria-labelledby={labelId}
         disabled={disabled}
       />
-      {/* Mark as `hidden` so it will fall back to a regular checkbox if CSS is not available */}
-      <span className="fides-toggle-display" hidden>
-        {checked ? "On" : "Off"}
-      </span>
+      <span className="fides-toggle-display">{labelText}</span>
     </label>
   );
 };

--- a/clients/fides-js/src/components/notices/NoticeToggles.tsx
+++ b/clients/fides-js/src/components/notices/NoticeToggles.tsx
@@ -1,7 +1,7 @@
 import { h } from "preact";
 
 import { GpcStatus } from "../../lib/consent-types";
-import type { I18n } from "../../lib/i18n";
+import { DEFAULT_LOCALE, getCurrentLocale, I18n } from "../../lib/i18n";
 
 import Divider from "../Divider";
 
@@ -39,6 +39,14 @@ export const NoticeToggles = ({
     }
   };
 
+  // Only show the toggle labels ("On"/"Off") in English, since our Toggle components are fixed-width!
+  let toggleOnLabel: string | undefined;
+  let toggleOffLabel: string | undefined;
+  if (getCurrentLocale(i18n) === DEFAULT_LOCALE) {
+    toggleOnLabel = "On";
+    toggleOffLabel = "Off";
+  }
+
   return (
     <div>
       {noticeToggles.map((props, idx) => {
@@ -54,6 +62,8 @@ export const NoticeToggles = ({
               onToggle={handleToggle}
               gpcBadge={<GpcBadge i18n={i18n} status={gpcStatus} />}
               disabled={disabled}
+              onLabel={toggleOnLabel}
+              offLabel={toggleOffLabel}
             >
               {description}
             </DataUseToggle>

--- a/clients/fides-js/src/components/tcf/RecordsList.tsx
+++ b/clients/fides-js/src/components/tcf/RecordsList.tsx
@@ -1,5 +1,6 @@
 import { VNode, h } from "preact";
 import DataUseToggle from "../DataUseToggle";
+import { DEFAULT_LOCALE, getCurrentLocale, I18n } from "../../lib/i18n";
 
 interface Item {
   id: string | number;
@@ -7,6 +8,7 @@ interface Item {
 }
 
 interface Props<T extends Item> {
+  i18n: I18n;
   items: T[];
   title: string;
   enabledIds: string[];
@@ -17,6 +19,7 @@ interface Props<T extends Item> {
 }
 
 const RecordsList = <T extends Item>({
+  i18n,
   items,
   title,
   enabledIds,
@@ -38,6 +41,14 @@ const RecordsList = <T extends Item>({
     }
   };
 
+  // Only show the toggle labels ("On"/"Off") in English, since our Toggle components are fixed-width!
+  let toggleOnLabel: string | undefined;
+  let toggleOffLabel: string | undefined;
+  if (getCurrentLocale(i18n) === DEFAULT_LOCALE) {
+    toggleOnLabel = "On";
+    toggleOffLabel = "Off";
+  }
+
   return (
     <div data-testid={`records-list-${title}`}>
       <div className="fides-record-header">{title}</div>
@@ -51,6 +62,8 @@ const RecordsList = <T extends Item>({
           checked={enabledIds.indexOf(`${item.id}`) !== -1}
           badge={renderBadgeLabel ? renderBadgeLabel(item) : undefined}
           includeToggle={!hideToggles}
+          onLabel={toggleOnLabel}
+          offLabel={toggleOffLabel}
         >
           {renderToggleChild(item)}
         </DataUseToggle>

--- a/clients/fides-js/src/components/tcf/TcfFeatures.tsx
+++ b/clients/fides-js/src/components/tcf/TcfFeatures.tsx
@@ -1,7 +1,8 @@
 import { h } from "preact";
 
-import { TCFFeatureRecord, TCFSpecialFeatureRecord } from "../../lib/tcf/types";
 import { PrivacyExperience } from "../../lib/consent-types";
+import { I18n } from "../../lib/i18n";
+import { TCFFeatureRecord, TCFSpecialFeatureRecord } from "../../lib/tcf/types";
 import type { UpdateEnabledIds } from "./TcfOverlay";
 import RecordsList from "./RecordsList";
 import EmbeddedVendorList from "./EmbeddedVendorList";
@@ -19,12 +20,14 @@ const FeatureChildren = ({ feature }: { feature: TCFFeatureRecord }) => {
 // static.tcf.features
 // static.tcf.special_features
 const TcfFeatures = ({
+  i18n,
   allFeatures,
   allSpecialFeatures,
   enabledFeatureIds,
   enabledSpecialFeatureIds,
   onChange,
 }: {
+  i18n: I18n;
   allFeatures: PrivacyExperience["tcf_features"];
   allSpecialFeatures: PrivacyExperience["tcf_special_features"];
   enabledFeatureIds: string[];
@@ -33,6 +36,7 @@ const TcfFeatures = ({
 }) => (
   <div>
     <RecordsList<TCFFeatureRecord>
+      i18n={i18n}
       title="Features"
       items={allFeatures ?? []}
       enabledIds={enabledFeatureIds}
@@ -43,6 +47,7 @@ const TcfFeatures = ({
       hideToggles
     />
     <RecordsList<TCFSpecialFeatureRecord>
+      i18n={i18n}
       title="Special features"
       items={allSpecialFeatures ?? []}
       enabledIds={enabledSpecialFeatureIds}

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -366,6 +366,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
       }}
       renderModalContent={() => (
         <TcfTabs
+          i18n={i18n}
           experience={experience}
           enabledIds={draftIds}
           onChange={(updatedIds) => {

--- a/clients/fides-js/src/components/tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/tcf/TcfPurposes.tsx
@@ -2,6 +2,9 @@ import { h } from "preact";
 
 import { useMemo, useState } from "preact/hooks";
 import { PrivacyExperience } from "../../lib/consent-types";
+import { I18n } from "../../lib/i18n";
+import { LEGAL_BASIS_OPTIONS } from "../../lib/tcf/constants";
+import { getUniquePurposeRecords, hasLegalBasis } from "../../lib/tcf/purposes";
 import {
   EnabledIds,
   LegalBasisEnum,
@@ -11,9 +14,7 @@ import {
   TCFSpecialPurposeRecord,
 } from "../../lib/tcf/types";
 import { UpdateEnabledIds } from "./TcfOverlay";
-import { getUniquePurposeRecords, hasLegalBasis } from "../../lib/tcf/purposes";
 import RecordsList from "./RecordsList";
-import { LEGAL_BASIS_OPTIONS } from "../../lib/tcf/constants";
 import RadioGroup from "./RadioGroup";
 import EmbeddedVendorList from "./EmbeddedVendorList";
 
@@ -38,6 +39,7 @@ const PurposeDetails = ({ purpose }: { purpose: TCFPurposeRecord }) => {
 };
 
 const TcfPurposes = ({
+  i18n,
   allPurposesConsent = [],
   allPurposesLegint = [],
   allSpecialPurposes,
@@ -46,6 +48,7 @@ const TcfPurposes = ({
   enabledSpecialPurposeIds,
   onChange,
 }: {
+  i18n: I18n;
   allPurposesConsent: TCFPurposeConsentRecord[] | undefined;
   enabledPurposeConsentIds: string[];
   allSpecialPurposes: PrivacyExperience["tcf_special_purposes"];
@@ -113,6 +116,7 @@ const TcfPurposes = ({
         onChange={setActiveLegalBasisOption}
       />
       <RecordsList<PurposeRecord>
+        i18n={i18n}
         title="Purposes"
         items={activeData.purposes}
         enabledIds={activeData.enabledPurposeIds}
@@ -124,6 +128,7 @@ const TcfPurposes = ({
         key={`purpose-record-${activeLegalBasisOption.value}`}
       />
       <RecordsList<TCFSpecialPurposeRecord>
+        i18n={i18n}
         title="Special purposes"
         items={activeData.specialPurposes}
         enabledIds={activeData.enabledSpecialPurposeIds}

--- a/clients/fides-js/src/components/tcf/TcfTabs.tsx
+++ b/clients/fides-js/src/components/tcf/TcfTabs.tsx
@@ -1,23 +1,26 @@
 import { h } from "preact";
 import { useCallback, useRef } from "preact/hooks";
-import TcfPurposes from "./TcfPurposes";
+import { I18n } from "../../lib/i18n";
 import { PrivacyExperience } from "../../lib/consent-types";
+import { EnabledIds } from "../../lib/tcf/types";
+import TcfPurposes from "./TcfPurposes";
 import type { UpdateEnabledIds } from "./TcfOverlay";
 import TcfFeatures from "./TcfFeatures";
 import TcfVendors from "./TcfVendors";
 import InfoBox from "../InfoBox";
-import { EnabledIds } from "../../lib/tcf/types";
 
 const KEY_ARROW_RIGHT = "ArrowRight";
 const KEY_ARROW_LEFT = "ArrowLeft";
 
 const TcfTabs = ({
+  i18n,
   experience,
   enabledIds,
   onChange,
   activeTabIndex,
   onTabChange,
 }: {
+  i18n: I18n;
   experience: PrivacyExperience;
   enabledIds: EnabledIds;
   onChange: (payload: EnabledIds) => void;
@@ -50,6 +53,7 @@ const TcfTabs = ({
             the toggles below.
           </InfoBox>
           <TcfPurposes
+            i18n={i18n}
             allPurposesConsent={experience.tcf_purpose_consents}
             allPurposesLegint={experience.tcf_purpose_legitimate_interests}
             allSpecialPurposes={experience.tcf_special_purposes}
@@ -71,6 +75,7 @@ const TcfTabs = ({
             using the toggles below.
           </InfoBox>
           <TcfFeatures
+            i18n={i18n}
             allFeatures={experience.tcf_features}
             allSpecialFeatures={experience.tcf_special_features}
             enabledFeatureIds={enabledIds.features}
@@ -90,6 +95,7 @@ const TcfTabs = ({
             your rights for each vendor based on the legal basis they assert.
           </InfoBox>
           <TcfVendors
+            i18n={i18n}
             experience={experience}
             enabledVendorConsentIds={enabledIds.vendorsConsent}
             enabledVendorLegintIds={enabledIds.vendorsLegint}

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -1,6 +1,9 @@
 import { Fragment, h } from "preact";
 import { useMemo, useState } from "preact/hooks";
 import { Vendor } from "@iabtechlabtcf/core";
+import { PrivacyExperience } from "../../lib/consent-types";
+import { I18n } from "../../lib/i18n";
+import { LEGAL_BASIS_OPTIONS } from "../../lib/tcf/constants";
 import {
   GvlDataCategories,
   GvlDataDeclarations,
@@ -8,15 +11,13 @@ import {
   EmbeddedPurpose,
   LegalBasisEnum,
 } from "../../lib/tcf/types";
-import { PrivacyExperience } from "../../lib/consent-types";
-import { UpdateEnabledIds } from "./TcfOverlay";
 import {
   transformExperienceToVendorRecords,
   vendorGvlEntry,
 } from "../../lib/tcf/vendors";
+import { UpdateEnabledIds } from "./TcfOverlay";
 import ExternalLink from "../ExternalLink";
 import RecordsList from "./RecordsList";
-import { LEGAL_BASIS_OPTIONS } from "../../lib/tcf/constants";
 import RadioGroup from "./RadioGroup";
 import PagingButtons, { usePaging } from "../PagingButtons";
 
@@ -221,11 +222,13 @@ const ToggleChild = ({
 };
 
 const PagedVendorData = ({
+  i18n,
   experience,
   vendors,
   enabledIds,
   onChange,
 }: {
+  i18n: I18n;
   experience: PrivacyExperience;
   vendors: VendorRecord[];
   enabledIds: string[];
@@ -252,6 +255,7 @@ const PagedVendorData = ({
   return (
     <Fragment>
       <RecordsList<VendorRecord>
+        i18n={i18n}
         title="IAB TCF vendors"
         items={gvlVendors}
         enabledIds={enabledIds}
@@ -264,6 +268,7 @@ const PagedVendorData = ({
         )}
       />
       <RecordsList<VendorRecord>
+        i18n={i18n}
         title="Other vendors"
         items={otherVendors}
         enabledIds={enabledIds}
@@ -278,11 +283,13 @@ const PagedVendorData = ({
 };
 
 const TcfVendors = ({
+  i18n,
   experience,
   enabledVendorConsentIds,
   enabledVendorLegintIds,
   onChange,
 }: {
+  i18n: I18n;
   experience: PrivacyExperience;
   enabledVendorConsentIds: string[];
   enabledVendorLegintIds: string[];
@@ -318,6 +325,7 @@ const TcfVendors = ({
         onChange={setActiveLegalBasisOption}
       />
       <PagedVendorData
+        i18n={i18n}
         experience={experience}
         vendors={filteredVendors}
         enabledIds={

--- a/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
@@ -650,6 +650,78 @@ describe("Consent i18n", () => {
     });
   });
 
+  describe("when localizing the 'On'/'Off' toggle labels", () => {
+    describe(`when in the default locale (${ENGLISH_LOCALE})`, () => {
+      it("shows the 'On'/'Off' toggle labels in banner_and_modal components", () => {
+        visitDemoWithI18n({
+          navigatorLanguage: ENGLISH_LOCALE,
+          fixture: "experience_banner_modal.json",
+        });
+        cy.get("#fides-modal-link").click();
+        cy.get("#fides-modal .fides-modal-notices").within(() => {
+          cy.get(".fides-toggle:first").contains("Off");
+          cy.get(".fides-toggle:first").click();
+          cy.get(".fides-toggle:first").contains("On");
+        });
+      });
+
+      it("shows the 'On'/'Off' toggle labels in tcf_overlay components", () => {
+        visitDemoWithI18n({
+          navigatorLanguage: ENGLISH_LOCALE,
+          fixture: "experience_tcf.json",
+          options: { tcfEnabled: true },
+        });
+        cy.get("#fides-modal-link").click();
+        cy.getByTestId("records-list-Purposes").within(() => {
+          cy.get(".fides-toggle:first").contains("Off");
+          cy.get(".fides-toggle:first").click();
+          cy.get(".fides-toggle:first").contains("On");
+        });
+      });
+    });
+
+    describe(`when in any non-default locale (${SPANISH_LOCALE})`, () => {
+      it("hides the 'On'/'Off' toggle labels in banner_and_modal components", () => {
+        visitDemoWithI18n({
+          navigatorLanguage: SPANISH_LOCALE,
+          fixture: "experience_banner_modal.json",
+        });
+        cy.get("#fides-modal-link").click();
+        cy.get("#fides-modal .fides-modal-notices").within(() => {
+          cy.get(".fides-toggle:first").contains("Off").should("not.exist");
+          cy.get(".fides-toggle:first .fides-toggle-display").should(
+            "be.empty"
+          );
+          cy.get(".fides-toggle:first").click();
+          cy.get(".fides-toggle:first").contains("On").should("not.exist");
+          cy.get(".fides-toggle:first .fides-toggle-display").should(
+            "be.empty"
+          );
+        });
+      });
+
+      it("hides the 'On'/'Off' toggle labels in tcf_overlay components", () => {
+        visitDemoWithI18n({
+          navigatorLanguage: SPANISH_LOCALE,
+          fixture: "experience_tcf.json",
+          options: { tcfEnabled: true },
+        });
+        cy.get("#fides-modal-link").click();
+        cy.getByTestId("records-list-Purposes").within(() => {
+          cy.get(".fides-toggle:first").contains("Off").should("not.exist");
+          cy.get(".fides-toggle:first .fides-toggle-display").should(
+            "be.empty"
+          );
+          cy.get(".fides-toggle:first").click();
+          cy.get(".fides-toggle:first").contains("On").should("not.exist");
+          cy.get(".fides-toggle:first .fides-toggle-display").should(
+            "be.empty"
+          );
+        });
+      });
+    });
+  });
+
   // TODO (PROD-1598): enable this test and add other cases as needed!
   describe.skip("when user selects their own locale", () => {
     it(`localizes in the user selected locale (${SPANISH_LOCALE})`, () => {


### PR DESCRIPTION
Closes PROD-1754

### Description Of Changes

This is a quick change to hide the "On" / "Off" toggle labels in any language other than English - basically, I don't think we can safely design these toggles without assuming they are fixed width, so I don't want us to try supporting anything remotely dynamic 👍

### Code Changes

* [X] Add E2E tests for on/off toggle labels in English/Spanish and banner+modal / TCF
* [X] Update `Toggle` component to take `onLabel` and `offLabel` props from parent component (to keep these Toggles "dumb" and non-`i18n` aware)
* [X] Update `NoticeToggles` and `RecordsList` components to pass down toggle labels only in English
* [X] Start threading the `i18n` prop through the various TCF components (since I'll need to do this for PROD-1683)

### Steps to Confirm

* [ ] View the modal component in English and check for the On/Off toggle labels
* [ ] View the modal component in any non-English language and check the toggle labels are not present
* [ ] View the TCF modal component in English and check for On/Off toggle labels
* [ ] View the TCF modal component in any non-English language and check the toggle labels are not present

Here's a couple quick screenshots for UAT:

| Component | English | Spanish |
|---|---|---|
| Banner + Modal | ![image](https://github.com/ethyca/fides/assets/1834295/89a92848-9657-4313-8001-8bb122d37b89) | ![image](https://github.com/ethyca/fides/assets/1834295/3863233e-cc4b-4b0f-8897-5869f2111bca) |
| TCF Overlay | ![image](https://github.com/ethyca/fides/assets/1834295/71b46c0e-567e-4203-ba72-79836ca09bd1) | ![image](https://github.com/ethyca/fides/assets/1834295/71bca90f-ce51-456a-af6f-f72a45527c52) |

⚠️ NOTE: TCF overlay needs a lot more localization, so only focus on the toggle text in those screenshots!


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
