### PR TITLE
Canadian Mulitranslation Data Migration Adjustments

### DIFF
--- a/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data.py
+++ b/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data.py
@@ -449,10 +449,10 @@ def determine_needed_experience_configs(bind):
         component_mappings = NOTICES_TO_EXPERIENCE_CONFIG.get(notice_key, [])
         if component_mappings:
             for component_mapping in component_mappings:
-                if component_mapping.get(ComponentType.Overlay) in [
+                if component_mapping.get(ComponentType.Overlay) in {
                     DefaultExperienceConfigTypes.CANADA_BANNER_MODAL,
                     DefaultExperienceConfigTypes.QUEBEC_BANNER_MODAL,
-                ]:
+                }:
                     # If this is a Canadian/Quebec Banner and Modal, skip updating regions, and just use OOB
                     regions_to_add = set()
                 else:

--- a/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data.py
+++ b/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data.py
@@ -18,7 +18,6 @@ from sqlalchemy import text
 from sqlalchemy.engine import ResultProxy
 
 # revision identifiers, used by Alembic.
-from sqlalchemy.exc import InvalidRequestError
 
 revision = "14acee6f5459"
 down_revision = "0c65325843bd"

--- a/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data.py
+++ b/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data.py
@@ -18,6 +18,7 @@ from sqlalchemy import text
 from sqlalchemy.engine import ResultProxy
 
 # revision identifiers, used by Alembic.
+from sqlalchemy.exc import InvalidRequestError
 
 revision = "14acee6f5459"
 down_revision = "0c65325843bd"
@@ -108,7 +109,6 @@ EXPERIENCE_CONFIG_DEFAULTS = [
             "ca_nu",
             "ca_on",
             "ca_pe",
-            "ca_qc",
             "ca_sk",
             "ca_yt",
         ],
@@ -117,8 +117,22 @@ EXPERIENCE_CONFIG_DEFAULTS = [
         "auto_detect_language": True,
         "dismissable": True,
         "disabled": True,
-        "privacy_notice_keys": ["essential", "functional", "analytics", "marketing"],
+        "privacy_notice_keys": ["marketing"],
         "origin": "pri-694e-02bd-4afe-81b3-2a2ban-modal",
+    },
+    {
+        "id": "pri-d9ed6-25e7-4953-8977-772ban-modal-config",
+        "name": "Quebec Banner + Modal",
+        "regions": [
+            "ca_qc",
+        ],
+        "component": "banner_and_modal",
+        "allow_language_selection": False,
+        "auto_detect_language": True,
+        "dismissable": True,
+        "disabled": True,
+        "privacy_notice_keys": ["essential", "analytics", "marketing"],
+        "origin": "pri-d9ed6-25e7-4953-8977-772ban-modal",
     },
     {
         "id": "d7c3ce0a-a3b3-43ff-bf6f-3d8-tcf-over-config",
@@ -189,6 +203,7 @@ class DefaultExperienceConfigTypes(Enum):
     US_MODAL = "pri-76b8-cc52-11ee-9eaa-8ef97a-modal-config"
     US_PRIVACY_CENTER = "pri-27d4-cc53-11ee-9eaa-8ef97a04-pri-config"
     CANADA_BANNER_MODAL = "pri-694e-02bd-4afe-81b3-2a2ban-modal-config"
+    QUEBEC_BANNER_MODAL = "pri-d9ed6-25e7-4953-8977-772ban-modal-config"
 
 
 class ComponentType(Enum):
@@ -214,6 +229,10 @@ CANADA_MAPPING = {
     ComponentType.Overlay: DefaultExperienceConfigTypes.CANADA_BANNER_MODAL,
 }
 
+QUEBEC_MAPPING = {
+    ComponentType.Overlay: DefaultExperienceConfigTypes.QUEBEC_BANNER_MODAL,
+}
+
 # this map contains the biggest _assumption_ about the migration -
 # these are the notices that will be associated with our new OOB experience configs.
 # any existing notices besides these will remain "orphaned" post-migration.
@@ -221,10 +240,10 @@ CANADA_MAPPING = {
 # will be used to infer the regions associated with the post-migration experience
 # configs to which they map.
 NOTICES_TO_EXPERIENCE_CONFIG = {
-    "marketing": [EEA_MAPPING, CANADA_MAPPING],
-    "functional": [EEA_MAPPING, CANADA_MAPPING],
-    "essential": [EEA_MAPPING, CANADA_MAPPING],
-    "analytics": [EEA_MAPPING, CANADA_MAPPING],
+    "marketing": [EEA_MAPPING, CANADA_MAPPING, QUEBEC_MAPPING],
+    "functional": [EEA_MAPPING],
+    "essential": [EEA_MAPPING, QUEBEC_MAPPING],
+    "analytics": [EEA_MAPPING, QUEBEC_MAPPING],
     "data_sales_and_sharing": [US_MAPPING],
 }
 
@@ -321,12 +340,13 @@ def load_default_experience_configs():
 
         # the reconciled experience config will have its regions populated by existing notices that are
         # associated with this experience config. so in most cases, we start "fresh" with an empty set.
-        # the TCF experience and Canada banner modal experience are exceptions:
+        # the TCF experience and Canada/Quebec banner modal experiences are exceptions:
         # their regions are not derived from existing notices (TCF is not linked to notices; Canada experience config is net-new),
         # so we hardcode their regions to the config defaults.
         if experience_config_type not in (
             DefaultExperienceConfigTypes.EEA_TCF_OVERLAY,
             DefaultExperienceConfigTypes.CANADA_BANNER_MODAL,
+            DefaultExperienceConfigTypes.QUEBEC_BANNER_MODAL,
         ):
             experience_config["regions"] = set()
         else:
@@ -430,11 +450,11 @@ def determine_needed_experience_configs(bind):
         component_mappings = NOTICES_TO_EXPERIENCE_CONFIG.get(notice_key, [])
         if component_mappings:
             for component_mapping in component_mappings:
-                if (
-                    component_mapping.get(ComponentType.Overlay)
-                    == DefaultExperienceConfigTypes.CANADA_BANNER_MODAL
-                ):
-                    # If this is a Canadian Banner and Modal, skip updating regions, and just use OOB
+                if component_mapping.get(ComponentType.Overlay) in [
+                    DefaultExperienceConfigTypes.CANADA_BANNER_MODAL,
+                    DefaultExperienceConfigTypes.QUEBEC_BANNER_MODAL,
+                ]:
+                    # If this is a Canadian/Quebec Banner and Modal, skip updating regions, and just use OOB
                     regions_to_add = set()
                 else:
                     regions_to_add = set(existing_notice["regions"]).copy()
@@ -503,6 +523,8 @@ def determine_needed_experience_configs(bind):
                 configs.append(reconciled_experience_config_map.get(us_config_id))
             if canada_config_id := CANADA_MAPPING.get(component):
                 configs.append(reconciled_experience_config_map.get(canada_config_id))
+            if quebec_config_id := QUEBEC_MAPPING.get(component):
+                configs.append(reconciled_experience_config_map.get(quebec_config_id))
             for config in configs:
                 if config:
                     config["accept_button_label"] = eec["accept_button_label"]

--- a/src/fides/api/alembic/migrations/versions/32497f08e227_translation_cleanup.py
+++ b/src/fides/api/alembic/migrations/versions/32497f08e227_translation_cleanup.py
@@ -7,10 +7,11 @@ Revises: 14acee6f5459
 Create Date: 2024-03-05 17:08:07.093568
 
 """
-from loguru import logger
 from datetime import datetime
+
 import sqlalchemy as sa
 from alembic import op
+from loguru import logger
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/alembic/migrations/versions/a1e23b70f2b2_add_notice_and_exp_translations.py
+++ b/src/fides/api/alembic/migrations/versions/a1e23b70f2b2_add_notice_and_exp_translations.py
@@ -6,9 +6,10 @@ Create Date: 2024-02-01 21:49:20.792733
 
 """
 from datetime import datetime
-from loguru import logger
+
 import sqlalchemy as sa
 from alembic import op
+from loguru import logger
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/service/saas_request/override_implementations/oracle_responsys_request_overrides.py
+++ b/src/fides/api/service/saas_request/override_implementations/oracle_responsys_request_overrides.py
@@ -1,6 +1,6 @@
+import json
 from typing import Any, Dict, List
 
-import json
 import pydash
 
 from fides.api.common_exceptions import FidesopsException

--- a/tests/fixtures/saas/oracle_responsys_fixtures.py
+++ b/tests/fixtures/saas/oracle_responsys_fixtures.py
@@ -1,9 +1,9 @@
-from requests import post
 from typing import Any, Dict, Generator
 
 import pydash
-import requests
 import pytest
+import requests
+from requests import post
 
 from tests.ops.integration_tests.saas.connector_runner import (
     ConnectorRunner,


### PR DESCRIPTION
Closes #PROD-1785

### Description Of Changes

We are making adjustments to our out of the box Canadian Experience Configs and the data migration needs to take that into account:

```yaml
# Canada banner and modal
- id: pri-694e-02bd-4afe-81b3-2a2ban-modal
  name: "Canada Banner + Modal"
  regions:
    - ca_ab
    - ca_bc
    - ca_mb
    - ca_nb
    - ca_nl
    - ca_ns
    - ca_nt
    - ca_nu
    - ca_on
    - ca_pe
    - ca_sk
    - ca_yt
  component: banner_and_modal
  allow_language_selection: false
  auto_detect_language: true
  dismissable: true
  disabled: true
  privacy_notice_keys:
    - marketing


# Quebec banner and modal
- id: pri-d9ed6-25e7-4953-8977-772ban-modal
  name: "Quebec Banner + Modal"
  regions:
    - ca_qc
  component: banner_and_modal
  allow_language_selection: false
  auto_detect_language: true
  dismissable: true
  disabled: true
  privacy_notice_keys:
    - essential
    - marketing
    - analytics
```


### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
