### PR TITLE
UX for experience config form for TCF

### DIFF
--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -39,45 +39,31 @@ declare global {
   }
 }
 
-const NoPreviewNotice = () => (
-  <Flex
-    bgColor="white"
-    borderRadius="md"
-    p={6}
-    boxShadow="md"
-    direction="column"
-    align="center"
-    gap="2"
-    maxW="512px"
-  >
-    <Text fontSize="lg" fontWeight="500" align="center">
-      No privacy notices added
-    </Text>
-    <Text color="gray.500" align="center">
-      To view a preview of this experience, add a privacy notice under
-      &quot;Privacy Notices&quot; to the left.
-    </Text>
-  </Flex>
-);
-
-const TCFExperienceNotice = () => (
-  <Flex
-    bgColor="white"
-    borderRadius="md"
-    p={6}
-    boxShadow="md"
-    direction="column"
-    align="center"
-    gap="2"
-    maxW="512px"
-  >
-    <Text fontSize="lg" fontWeight="500" align="center">
-      TCF preview not available
-    </Text>
-    <Text color="gray.500" align="center">
-      There is no preview available for TCF. You can edit the available settings
-      and languages to the left.
-    </Text>
+const NoPreviewNotice = ({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) => (
+  <Flex h="full" justify="center" align="center">
+    <Flex
+      bgColor="white"
+      borderRadius="md"
+      p={6}
+      boxShadow="md"
+      direction="column"
+      align="center"
+      gap="2"
+      maxW="512px"
+    >
+      <Text fontSize="lg" fontWeight="500" align="center">
+        {title}
+      </Text>
+      <Text color="gray.500" align="center">
+        {description}
+      </Text>
+    </Flex>
   </Flex>
 );
 
@@ -172,17 +158,21 @@ const Preview = ({
 
   if (values.component === ComponentType.TCF_OVERLAY) {
     return (
-      <Flex h="full" justify="center" align="center">
-        <TCFExperienceNotice />
-      </Flex>
+      <NoPreviewNotice
+        title="TCF preview not available"
+        description="There is no preview available for TCF. You can edit the available settings
+      and languages to the left."
+      />
     );
   }
 
   if (!values.privacy_notice_ids?.length) {
     return (
-      <Flex h="full" justify="center" align="center">
-        <NoPreviewNotice />
-      </Flex>
+      <NoPreviewNotice
+        title="No privacy notices added"
+        description='To view a preview of this experience, add a privacy notice under
+      "Privacy Notices" to the left.'
+      />
     );
   }
 

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -60,6 +60,27 @@ const NoPreviewNotice = () => (
   </Flex>
 );
 
+const TCFExperienceNotice = () => (
+  <Flex
+    bgColor="white"
+    borderRadius="md"
+    p={6}
+    boxShadow="md"
+    direction="column"
+    align="center"
+    gap="2"
+    maxW="512px"
+  >
+    <Text fontSize="lg" fontWeight="500" align="center">
+      TCF preview not available
+    </Text>
+    <Text color="gray.500" align="center">
+      There is no preview available for TCF. You can edit the available settings
+      and languages to the left.
+    </Text>
+  </Flex>
+);
+
 const Preview = ({
   allPrivacyNotices,
   initialValues,
@@ -145,6 +166,14 @@ const Preview = ({
   const modal = document.getElementById("fides-modal");
   if (modal) {
     modal.removeAttribute("tabindex");
+  }
+
+  if (values.component === ComponentType.TCF_OVERLAY) {
+    return (
+      <Flex h="full" justify="center" align="center">
+        <TCFExperienceNotice />
+      </Flex>
+    );
   }
 
   if (!values.privacy_notice_ids?.length) {

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -178,20 +178,24 @@ export const PrivacyExperienceForm = ({
         </Box>
       </Collapse>
       <Divider />
-      <Heading fontSize="md" fontWeight="semibold">
-        Privacy notices
-      </Heading>
-      <ScrollableList
-        addButtonLabel="Add privacy notice"
-        allItems={allPrivacyNotices.map((n) => n.id)}
-        values={values.privacy_notice_ids ?? []}
-        setValues={(newValues) =>
-          setFieldValue("privacy_notice_ids", newValues)
-        }
-        getItemLabel={getPrivacyNoticeName}
-        draggable
-      />
-      <Divider />
+      {values.component !== ComponentType.TCF_OVERLAY ? (
+        <>
+          <Heading fontSize="md" fontWeight="semibold">
+            Privacy notices
+          </Heading>
+          <ScrollableList
+            addButtonLabel="Add privacy notice"
+            allItems={allPrivacyNotices.map((n) => n.id)}
+            values={values.privacy_notice_ids ?? []}
+            setValues={(newValues) =>
+              setFieldValue("privacy_notice_ids", newValues)
+            }
+            getItemLabel={getPrivacyNoticeName}
+            draggable
+          />
+          <Divider />
+        </>
+      ) : null}
       <Text as="h2" fontWeight="600">
         Locations & Languages
       </Text>

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -153,30 +153,35 @@ export const PrivacyExperienceForm = ({
         label="Name (internal admin use only)"
         variant="stacked"
       />
-      <CustomSelect
-        name="component"
-        id="component"
-        options={componentTypeOptions}
-        label="Experience Type"
-        variant="stacked"
-        isDisabled={!!values.component}
-        isRequired
-      />
-      <Collapse
-        in={
-          values.component && values.component !== ComponentType.PRIVACY_CENTER
-        }
-        animateOpacity
-      >
-        <Box p="1px">
-          <CustomSwitch
-            name="dismissable"
-            id="dismissable"
-            label="Modal is dismissable"
+      {values.component !== ComponentType.TCF_OVERLAY ? (
+        <>
+          <CustomSelect
+            name="component"
+            id="component"
+            options={componentTypeOptions}
+            label="Experience Type"
             variant="stacked"
+            isDisabled={!!values.component}
+            isRequired
           />
-        </Box>
-      </Collapse>
+          <Collapse
+            in={
+              values.component &&
+              values.component !== ComponentType.PRIVACY_CENTER
+            }
+            animateOpacity
+          >
+            <Box p="1px">
+              <CustomSwitch
+                name="dismissable"
+                id="dismissable"
+                label="Modal is dismissable"
+                variant="stacked"
+              />
+            </Box>
+          </Collapse>
+        </>
+      ) : null}
       <Divider />
       {values.component !== ComponentType.TCF_OVERLAY ? (
         <>

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -71,7 +71,7 @@ export const buildBaseConfig = (
       is_default: true,
       dismissable: experienceConfig.dismissable,
       allow_language_selection: true,
-      auto_detect_language: true,
+      auto_detect_language: false,
       language: "en",
       // in preview mode, we show the first translation in the main window, even when multiple translations are configured
       translations: [buildExperienceTranslation(experienceConfig)],

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -71,7 +71,7 @@ export const buildBaseConfig = (
       is_default: true,
       dismissable: experienceConfig.dismissable,
       allow_language_selection: true,
-      auto_detect_language: false,
+      auto_detect_language: true,
       language: "en",
       // in preview mode, we show the first translation in the main window, even when multiple translations are configured
       translations: [buildExperienceTranslation(experienceConfig)],


### PR DESCRIPTION
Closes PROD-1686

### Description Of Changes

* hide "Experience type" field and privacy notice selector when editing TCF experience
* hide preview, instead show placeholder with notice that preview is now shown for TCF

### Steps to Confirm

* [ ] Navigate to privacy experience table
* [ ] Edit TCF experience
* [ ] Should see no experience type field, nor a list for notices
* [ ] Should see no preview
* [ ] Should see "no preview for TCF" notice in preview box

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
