### PR TITLE
Fix modal preview not being shown/shown in the wrong position

### DIFF
--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -196,19 +196,6 @@ const Preview = ({
         div#fides-banner-container.fides-banner-hidden {
           display: none;
         }
-        ${values.component === ComponentType.BANNER_AND_MODAL ||
-        values.component === ComponentType.MODAL
-          ? `div#fides-modal {
-          display: flex !important;
-          ${
-            values.component === ComponentType.BANNER_AND_MODAL
-              ? "padding-top: 3rem; padding-bottom: 3rem;"
-              : null
-          }
-          justify-content: center;
-          background_color: unset;
-        }`
-          : null}
         .fides-modal-container {
           background-color: unset !important;
           position: static !important;
@@ -229,6 +216,21 @@ const Preview = ({
           width: unset;
         }
       `}</style>
+      {values.component === ComponentType.BANNER_AND_MODAL ||
+      values.component === ComponentType.MODAL ? (
+        <style>
+          {`div#fides-modal {
+          display: flex !important;
+          justify-content: center;
+          background-color: unset;
+          ${
+            values.component === ComponentType.BANNER_AND_MODAL
+              ? "padding-top: 3rem; padding-bottom: 3rem;"
+              : ""
+          }
+        }`}
+        </style>
+      ) : null}
       {isMobilePreview ? (
         <style>{`
             div#preview-container {


### PR DESCRIPTION
Closes PROD-1810

### Description Of Changes

Fix an issue where:
* when creating/editing a "modal" experience, the preview modal would show in the top-right corner and have a modal overlay that prevented interaction elsewhere on the page
* when creating/editing a "banner and modal" experience, only the banner and not the modal would be shown in the preview

Issue was somewhere in Next's build process for production builds, was not occurring in a regular local dev build.

### Code Changes

* [ ] Put CSS styles for modal in separate `<style>` element
* [ ] Fixed typo in `background_color` → `background-color`

### Steps to Confirm
* [ ] Run fidesplus on `consent_multitranslation_plus`
* [ ] Run admin-ui using `turbo run build` and then `turbo run start` (note: *not* `turbo run dev`)
* [ ] Create or edit a "modal" privacy experience
* [ ] Modal should show in preview box, rest of page should be accessible as normal
* [ ] Create or edit a "banner and modal" privacy experience
* [ ] Banner and modal should both show in preview box like this: 

![Screenshot 2024-03-12 at 15 56 22](https://github.com/ethyca/fides/assets/6394496/3ef07e1e-fd0c-40a9-aef9-cb4f9911a84e)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
