### PR TITLE
Handle a mismatch in translations between experience & GVL translations

### DIFF
--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -200,16 +200,14 @@ describe("i18n-utils", () => {
     describe("when loading from a tcf_overlay experience", () => {
       it("reads all messages from gvl_translations API response and loads into the i18n catalog", () => {
         // Mock out a partial response for a tcf_overlay including translations
-        const mockExpWithGVLTranslations = JSON.parse(
-          JSON.stringify(mockExperience)
-        );
-        mockExpWithGVLTranslations.experience_config.component = "tcf_overlay";
-        mockExpWithGVLTranslations.gvl_translations = mockGVLTranslationsJSON;
+        const mockExpWithGVL = JSON.parse(JSON.stringify(mockExperience));
+        mockExpWithGVL.experience_config.component = "tcf_overlay";
+        mockExpWithGVL.gvl_translations = mockGVLTranslationsJSON;
 
         // Load all the translations
         const updatedLocales = loadMessagesFromExperience(
           mockI18n,
-          mockExpWithGVLTranslations
+          mockExpWithGVL
         );
 
         // First, confirm that the "regular" experience_config translations are loaded
@@ -323,34 +321,31 @@ describe("i18n-utils", () => {
 
       it("handles a mismatch between the experience_config and gvl_translations APIs by returning only locales available in both", () => {
         // Mock out a partial response for a tcf_overlay including translations
-        const mockExpWithGVLTranslations = JSON.parse(
-          JSON.stringify(mockExperience)
-        );
-        mockExpWithGVLTranslations.experience_config.component = "tcf_overlay";
-        mockExpWithGVLTranslations.gvl_translations = mockGVLTranslationsJSON;
+        const mockExpWithGVL = JSON.parse(JSON.stringify(mockExperience));
+        mockExpWithGVL.experience_config.component = "tcf_overlay";
+        mockExpWithGVL.gvl_translations = mockGVLTranslationsJSON;
 
         // Replace "es" with "es-MX" in the experience_config.translations to force a mismatch
-        mockExpWithGVLTranslations.experience_config.translations[1].language =
-          "es-MX";
+        mockExpWithGVL.experience_config.translations[1].language = "es-MX";
 
         // Confirm our test setup shows a mismatch between experience_config & gvl_translations
         expect(
-          mockExpWithGVLTranslations.experience_config.translations.map(
+          mockExpWithGVL.experience_config.translations.map(
             (e: any) => e.language
           )
         ).toEqual(["en", "es-MX"]);
-        expect(
-          Object.keys(mockExpWithGVLTranslations.gvl_translations)
-        ).toEqual(["en", "es"]);
+        expect(Object.keys(mockExpWithGVL.gvl_translations)).toEqual([
+          "en",
+          "es",
+        ]);
 
         // Load all the translations
         const updatedLocales = loadMessagesFromExperience(
           mockI18n,
-          mockExpWithGVLTranslations
+          mockExpWithGVL
         );
 
         // Confirm that only the overlapping locales are loaded
-        const EXPECTED_NUM_TRANSLATIONS = 1;
         expect(updatedLocales).toEqual(["en"]);
         const [, loadedMessagesEn] = mockI18n.load.mock.calls[0];
         expect(loadedMessagesEn).toMatchObject({

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -330,11 +330,14 @@ describe("i18n-utils", () => {
         mockExpWithGVLTranslations.gvl_translations = mockGVLTranslationsJSON;
 
         // Replace "es" with "es-MX" in the experience_config.translations to force a mismatch
-        mockExpWithGVLTranslations.experience_config.translations[1].language = "es-MX";
+        mockExpWithGVLTranslations.experience_config.translations[1].language =
+          "es-MX";
 
         // Confirm our test setup shows a mismatch between experience_config & gvl_translations
         expect(
-          mockExpWithGVLTranslations.experience_config.translations.map((e: any) => e.language)
+          mockExpWithGVLTranslations.experience_config.translations.map(
+            (e: any) => e.language
+          )
         ).toEqual(["en", "es-MX"]);
         expect(
           Object.keys(mockExpWithGVLTranslations.gvl_translations)
@@ -353,8 +356,11 @@ describe("i18n-utils", () => {
         expect(loadedMessagesEn).toMatchObject({
           "exp.accept_button_label": "Accept Test",
           "exp.acknowledge_button_label": "Acknowledge Test",
-          "exp.tcf.purposes.1.name": "Store and/or access information on a device",
-          "exp.tcf.purposes.1.description": expect.stringMatching(/^Cookies, device or similar/),
+          "exp.tcf.purposes.1.name":
+            "Store and/or access information on a device",
+          "exp.tcf.purposes.1.description": expect.stringMatching(
+            /^Cookies, device or similar/
+          ),
         });
       });
     });

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -107,7 +107,7 @@ function extractMessagesFromGVLTranslations(
   // itself is not available in most languages
   const extracted: Record<Locale, Messages> = {};
   locales.forEach((locale) => {
-    // TODO (PROD-1811): prefer a case-insensitive locale match
+    // DEFER (PROD-1811): prefer a case-insensitive locale match
     const gvlTranslation = gvl_translations[locale] as any;
     if (gvlTranslation) {
       const messages: Messages = {};


### PR DESCRIPTION
Closes PROD-1811

### Description Of Changes

_Write some things here about the changes and any potential caveats_


### Code Changes

* [X] Fix `extractMessagesFromGVLTranslations` to be more defensive when using external API data!
* [X] Narrow available locales to only those that exist in both experience & GVL translations
* [ ] Add "fallback" support to allow special cases like `es-MX` in the experience which should be OK with `es` in the GVL...?

### Steps to Confirm

* [ ] Configure a TCF experience with translations that don't exist in the GVL translations (e.g. `es-MX`) and check that the TCF experience doesn't crash!

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
