### PR TITLE
Select from GVL translations using a case-insensitive locale match

### DIFF
--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -325,6 +325,9 @@ describe("i18n-utils", () => {
         mockExpWithGVL.experience_config.component = "tcf_overlay";
         mockExpWithGVL.gvl_translations = mockGVLTranslationsJSON;
 
+        // Modify "en" to be "EN" (uppercased!), which shouldn't be treated as a mismatch!
+        mockExpWithGVL.experience_config.translations[0].language = "EN";
+
         // Replace "es" with "es-MX" in the experience_config.translations to force a mismatch
         mockExpWithGVL.experience_config.translations[1].language = "es-MX";
 
@@ -333,7 +336,7 @@ describe("i18n-utils", () => {
           mockExpWithGVL.experience_config.translations.map(
             (e: any) => e.language
           )
-        ).toEqual(["en", "es-MX"]);
+        ).toEqual(["EN", "es-MX"]);
         expect(Object.keys(mockExpWithGVL.gvl_translations)).toEqual([
           "en",
           "es",
@@ -346,7 +349,7 @@ describe("i18n-utils", () => {
         );
 
         // Confirm that only the overlapping locales are loaded
-        expect(updatedLocales).toEqual(["en"]);
+        expect(updatedLocales).toEqual(["EN"]);
         const [, loadedMessagesEn] = mockI18n.load.mock.calls[0];
         expect(loadedMessagesEn).toMatchObject({
           "exp.accept_button_label": "Accept Test",

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -107,9 +107,14 @@ function extractMessagesFromGVLTranslations(
   // itself is not available in most languages
   const extracted: Record<Locale, Messages> = {};
   locales.forEach((locale) => {
-    // DEFER (PROD-1811): prefer a case-insensitive locale match
-    const gvlTranslation = gvl_translations[locale] as any;
-    if (gvlTranslation) {
+    // Lookup the locale in the GVL using a case-insensitive match
+    const gvlLocaleMatch = Object.keys(gvl_translations).find(
+      (gvlLocale) =>
+        gvlLocale.toLowerCase().replaceAll("_", "-") ===
+        locale.toLowerCase().replaceAll("_", "-")
+    );
+    if (gvlLocaleMatch) {
+      const gvlTranslation = gvl_translations[gvlLocaleMatch] as any;
       const messages: Messages = {};
 
       const recordTypes = [


### PR DESCRIPTION
Closes PROD-1811
### Description Of Changes

This is a small follow-up to #4689 

### Code Changes

* [X] Modify `extractMessagesFromGVLTranslations` to do a case-insensitive match 👍 

### Steps to Confirm

* [X] Unit tests!

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
