### PR TITLE
Fix location display on privacy notice form

### DIFF
--- a/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
@@ -237,6 +237,14 @@ describe("Privacy notices", () => {
         cy.getSelectValueContainer("input-consent_mechanism").contains(
           "Notice only"
         );
+        cy.getByTestId("notice-locations").within(() => {
+          cy.get(".notice-locations--is-disabled");
+          cy.get(".notice-locations__value-container").should(
+            "contain",
+            "United States"
+          );
+        });
+        cy.getByTestId("notice-locations");
         cy.getByTestId("input-has_gpc_flag").within(() => {
           cy.get("span").should("not.have.attr", "data-checked");
         });

--- a/clients/admin-ui/cypress/fixtures/privacy-notices/notice.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-notices/notice.json
@@ -17,5 +17,6 @@
       "title": "English Title",
       "description": "This is a description in English"
     }
-  ]
+  ],
+  "configured_regions": ["us", "us_ca"]
 }

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -67,7 +67,7 @@ const PrivacyNoticeLocationDisplay = ({
       ) : null}
       {tooltip ? <QuestionTooltip label={tooltip} /> : null}
     </Flex>
-    <Box w="100%">
+    <Box w="100%" data-testid="notice-locations">
       <Select
         chakraStyles={{
           ...SELECT_STYLES,
@@ -80,6 +80,7 @@ const PrivacyNoticeLocationDisplay = ({
             display: "none",
           }),
         }}
+        classNamePrefix="notice-locations"
         size="sm"
         isMulti
         isDisabled

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -1,4 +1,14 @@
-import { Button, ButtonGroup, Stack, useToast } from "@fidesui/react";
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Flex,
+  FormLabel,
+  Stack,
+  useToast,
+  VStack,
+} from "@fidesui/react";
+import { Select } from "chakra-react-select";
 import { Form, Formik } from "formik";
 import { useRouter } from "next/router";
 import { useMemo } from "react";
@@ -9,17 +19,23 @@ import {
   CustomSelect,
   CustomSwitch,
   CustomTextInput,
+  SELECT_STYLES,
 } from "~/features/common/form/inputs";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { PRIVACY_NOTICES_ROUTE } from "~/features/common/nav/v2/routes";
-import { PRIVACY_NOTICE_REGION_OPTIONS } from "~/features/common/privacy-notice-regions";
+import { PRIVACY_NOTICE_REGION_RECORD } from "~/features/common/privacy-notice-regions";
+import QuestionTooltip from "~/features/common/QuestionTooltip";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
 import {
   selectEnabledDataUseOptions,
   useGetAllDataUsesQuery,
 } from "~/features/data-use/data-use.slice";
 import PrivacyNoticeTranslationForm from "~/features/privacy-notices/PrivacyNoticeTranslationForm";
-import { PrivacyNoticeCreation, PrivacyNoticeResponse } from "~/types/api";
+import {
+  PrivacyNoticeCreation,
+  PrivacyNoticeRegion,
+  PrivacyNoticeResponseWithRegions,
+} from "~/types/api";
 
 import {
   CONSENT_MECHANISM_OPTIONS,
@@ -33,10 +49,56 @@ import {
   usePostPrivacyNoticeMutation,
 } from "./privacy-notices.slice";
 
+const PrivacyNoticeLocationDisplay = ({
+  regions,
+  label,
+  tooltip,
+}: {
+  regions?: PrivacyNoticeRegion[];
+  label: string;
+  tooltip: string;
+}) => (
+  <VStack align="start">
+    <Flex align="start">
+      {label ? (
+        <FormLabel htmlFor="regions" fontSize="xs" my={0} mr={1}>
+          {label}
+        </FormLabel>
+      ) : null}
+      {tooltip ? <QuestionTooltip label={tooltip} /> : null}
+    </Flex>
+    <Box w="100%">
+      <Select
+        chakraStyles={{
+          ...SELECT_STYLES,
+          dropdownIndicator: (provided) => ({
+            ...provided,
+            display: "none",
+          }),
+          multiValueRemove: (provided) => ({
+            ...provided,
+            display: "none",
+          }),
+        }}
+        size="sm"
+        isMulti
+        isDisabled
+        placeholder="No locations assigned"
+        value={
+          regions?.map((r) => ({
+            label: PRIVACY_NOTICE_REGION_RECORD[r],
+            value: r,
+          })) ?? []
+        }
+      />
+    </Box>
+  </VStack>
+);
+
 const PrivacyNoticeForm = ({
   privacyNotice: passedInPrivacyNotice,
 }: {
-  privacyNotice?: PrivacyNoticeResponse;
+  privacyNotice?: PrivacyNoticeResponseWithRegions;
 }) => {
   const router = useRouter();
   const toast = useToast();
@@ -110,18 +172,11 @@ const PrivacyNoticeForm = ({
                   variant="stacked"
                 />
                 <NoticeKeyField isEditing={isEditing} />
-                {passedInPrivacyNotice ? (
-                  <CustomSelect
-                    name="regions"
-                    label="Locations where consent notice is shown to visitors"
-                    tooltip="Add locations to this privacy notice by configuring the corresponding privacy experience"
-                    options={PRIVACY_NOTICE_REGION_OPTIONS}
-                    variant="stacked"
-                    placeholder="No locations assigned"
-                    isDisabled
-                    isMulti
-                  />
-                ) : null}
+                <PrivacyNoticeLocationDisplay
+                  regions={passedInPrivacyNotice?.configured_regions}
+                  label="Locations where consent notice is shown to visitors"
+                  tooltip="To configure locations, change the privacy experiences where this notice is shown"
+                />
                 <CustomSwitch
                   name="has_gpc_flag"
                   label="Configure whether this notice conforms to the Global Privacy Control"

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticesTable.tsx
@@ -140,13 +140,16 @@ export const PrivacyNoticesTable = () => {
         }),
         columnHelper.accessor((row) => row.configured_regions, {
           id: "regions",
-          cell: (props) => (
-            <GroupCountBadgeCell
-              suffix="Locations"
-              value={getRegions(props.getValue())}
-              {...props}
-            />
-          ),
+          cell: (props) =>
+            getRegions(props.getValue())?.length ? (
+              <GroupCountBadgeCell
+                suffix="Locations"
+                value={getRegions(props.getValue())}
+                {...props}
+              />
+            ) : (
+              <DefaultCell value="Unassigned" />
+            ),
           header: (props) => <DefaultHeaderCell value="Locations" {...props} />,
           meta: {
             displayText: "Locations",

--- a/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
+++ b/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
@@ -8,6 +8,7 @@ import {
   PrivacyNoticeCreation,
   PrivacyNoticeRegion,
   PrivacyNoticeResponse,
+  PrivacyNoticeResponseWithRegions,
   PrivacyNoticeUpdate,
 } from "~/types/api";
 
@@ -76,14 +77,16 @@ const privacyNoticesApi = baseApi.injectEndpoints({
       }),
       invalidatesTags: () => ["Privacy Notices"],
     }),
-    getPrivacyNoticeById: build.query<PrivacyNoticeResponse, string>({
-      query: (id) => ({
-        url: `privacy-notice/${id}`,
-      }),
-      providesTags: (result, error, arg) => [
-        { type: "Privacy Notices", id: arg },
-      ],
-    }),
+    getPrivacyNoticeById: build.query<PrivacyNoticeResponseWithRegions, string>(
+      {
+        query: (id) => ({
+          url: `privacy-notice/${id}`,
+        }),
+        providesTags: (result, error, arg) => [
+          { type: "Privacy Notices", id: arg },
+        ],
+      }
+    ),
     postPrivacyNotice: build.mutation<
       PrivacyNoticeResponse[],
       PrivacyNoticeCreation


### PR DESCRIPTION
Closes #1457

### Description Of Changes

Populates disabled/uninteractable "locations" field on privacy notice form.

### Code Changes

* [ ] Update query in privacy notice slice so it knows it returns a PrivacyNoticeResponseWithRegions
* [ ] Extract location field into separate component in PrivacyNoticeForm
* [ ] Add new checks to Cypress tests

### Steps to Confirm

Run backend on fidesplus branch `consent_multitranslation_plus`.  In `.fides/fides.toml`, make sure translations are enabled:

```
[consent]
enable_translations = true
```

* [ ] Create a new privacy notice
* [ ] On form, should show disabled input for locations, with placeholder stating "no locations assigned"
* [ ] Add multiple translations
* [ ] Save new privacy notice
* [ ] In table, "Locations" column on new privacy notice should show "Unassigned"
* [ ] Edit an existing privacy notice that's assigned to an experience with locations
* [ ] On form, should show disabled input for locations, populated with the appropriate locations for the experience

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
