### PR TITLE
PROD-1798 Remove unneeded complexity with fidesjs components preview mode logic

### DIFF
--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -39,7 +39,7 @@ const fidesScriptPlugins = ({ name, gzipWarnSizeKb, gzipErrorSizeKb }) => [
     minify: !IS_DEV,
   }),
   copy({
-    // Automatically add the built script to the privacy center's static files for bundling:
+    // Automatically add the built script to the privacy center's and admin ui's static files for bundling:
     targets: [
       {
         src: `dist/${name}.js`,

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -99,13 +99,6 @@ const Overlay: FunctionComponent<Props> = ({
     }
   }, [instance, onOpen]);
 
-  const handleCloseModal = useCallback(() => {
-    if (instance) {
-      instance.hide();
-      onDismiss();
-    }
-  }, [instance, onDismiss]);
-
   const handleCloseModalAfterSave = useCallback(() => {
     if (instance && !options.fidesEmbed) {
       instance.hide();
@@ -130,35 +123,12 @@ const Overlay: FunctionComponent<Props> = ({
 
   useEffect(() => {
     const delayBanner = setTimeout(() => {
-      if (!options.fidesPreviewMode) {
-        if (showBanner) {
-          setBannerIsOpen(true);
-        }
-      } else if (options.fidesPreviewComponent === "modal") {
-        // close banner, open modal
-        handleOpenModal();
-      } else if (options.fidesPreviewComponent === "banner") {
-        // close modal, open banner
-        handleCloseModal();
+      if (showBanner) {
         setBannerIsOpen(true);
-      } else {
-        debugLog(
-          options.debug,
-          "Preview component is not supported",
-          options.fidesPreviewComponent
-        );
       }
     }, delayBannerMilliseconds);
     return () => clearTimeout(delayBanner);
-  }, [
-    showBanner,
-    setBannerIsOpen,
-    options.fidesPreviewMode,
-    options.fidesPreviewComponent,
-    options.debug,
-    handleOpenModal,
-    handleCloseModal,
-  ]);
+  }, [showBanner, setBannerIsOpen]);
 
   useEffect(() => {
     window.Fides.showModal = handleOpenModal;


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1798

### Description Of Changes

Since preview mode no longer needs to be interactive, we can remove complexity in core fidesjs that was causing a bug with being able to close the modal / banner.


### Code Changes

* [ ] Revert some overlay code in core fides-js

### Steps to Confirm

* [ ] Run privacy center
* [ ] Navigate to `http://localhost:3001/fides-js-components-demo.html`
* [ ] Confirm the banner / modal can be closed

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
