### PR TITLE
Fix FidesJS to not attempt to load GVL translations for regular banner/modal components

### DIFF
--- a/clients/fides-js/__tests__/__fixtures__/mock_experience.json
+++ b/clients/fides-js/__tests__/__fixtures__/mock_experience.json
@@ -128,5 +128,7 @@
         }
       ]
     }
-  ]
+  ],
+  "gvl": {},
+  "gvl_translations": {}
 }

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -634,7 +634,7 @@ describe("i18n-utils", () => {
      */
     type MockPrivacyExperience = Omit<
       PrivacyExperience,
-      "component" | "experience_config" | "privacy_notices"
+      "component" | "experience_config" | "privacy_notices" | "gvl"
     > & {
       component: string;
       experience_config: Omit<ExperienceConfig, "component"> & {

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
@@ -141,7 +141,9 @@
             }
           ]
         }
-      ]
+      ],
+      "gvl": {},
+      "gvl_translations": {}
     }
   ],
   "total": 1,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
@@ -81,7 +81,9 @@
             }
           ]
         }
-      ]
+      ],
+      "gvl": {},
+      "gvl_translations": {}
     }
   ],
   "total": 1,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
@@ -141,7 +141,9 @@
             }
           ]
         }
-      ]
+      ],
+      "gvl": {},
+      "gvl_translations": {}
     }
   ],
   "total": 1,

--- a/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
@@ -154,7 +154,9 @@
           }
         ]
       }
-    ]
+    ],
+    "gvl": {},
+    "gvl_translations": {}
   },
   "geolocation": {
     "country": "US",


### PR DESCRIPTION
Closes PROD-1824

### Description Of Changes

Fixes a silly bug where I was attempting to load GVL translations for a non-TCF banner, which led to _all_ translations being discarded and the modal rendering like this:
![image](https://github.com/ethyca/fides/assets/1834295/5e6706a3-5cff-44e4-8be3-ebed4d999940)

### Code Changes

* [X] Only attempt to load GVL translations when a TCF overlay
* [X] Fix tests to include empty objects for GVL

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
