### PR TITLE
PROD-1600 Implement experience-config-driven dismissable consent components

### DIFF
--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -13,6 +13,7 @@ interface ButtonGroupProps {
 
 interface BannerProps {
   i18n: I18n;
+  dismissable: boolean | undefined;
   onOpen: () => void;
   onClose: () => void;
   bannerIsOpen: boolean;
@@ -28,6 +29,7 @@ interface BannerProps {
 
 const ConsentBanner: FunctionComponent<BannerProps> = ({
   i18n,
+  dismissable,
   onOpen,
   onClose,
   bannerIsOpen,
@@ -81,7 +83,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
           <CloseButton
             ariaLabel="Close banner"
             onClick={window.Fides.options.fidesPreviewMode ? () => {} : onClose}
-            hidden={window.Fides?.options?.preventDismissal}
+            hidden={window.Fides?.options?.preventDismissal || !dismissable}
           />
           <div
             id="fides-banner-inner-container"

--- a/clients/fides-js/src/components/ConsentModal.tsx
+++ b/clients/fides-js/src/components/ConsentModal.tsx
@@ -8,11 +8,13 @@ import ConsentContent from "./ConsentContent";
 
 const ConsentModal = ({
   attributes,
+  dismissable,
   i18n,
   renderModalFooter,
   renderModalContent,
 }: {
   attributes: Attributes;
+  dismissable: boolean | undefined;
   i18n: I18n;
   onVendorPageClick?: () => void;
   renderModalFooter: () => VNode;
@@ -42,7 +44,7 @@ const ConsentModal = ({
                 ? () => {}
                 : closeButton.onClick
             }
-            hidden={window.Fides.options.preventDismissal}
+            hidden={window.Fides.options.preventDismissal || !dismissable}
           />
         </div>
         <ConsentContent

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -209,6 +209,7 @@ const Overlay: FunctionComponent<Props> = ({
       ) : (
         <ConsentModal
           attributes={attributes}
+          dismissable={experience.experience_config.dismissable}
           i18n={i18n}
           onVendorPageClick={onVendorPageClick}
           renderModalFooter={() =>

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -242,6 +242,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
       renderBanner={({ isOpen, onClose, onSave, onManagePreferencesClick }) => (
         <ConsentBanner
           bannerIsOpen={isOpen}
+          dismissable={experience.experience_config?.dismissable}
           onOpen={dispatchOpenBannerEvent}
           onClose={() => {
             onClose();

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -332,6 +332,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
         return (
           <ConsentBanner
             i18n={i18n}
+            dismissable={experience.experience_config?.dismissable}
             bannerIsOpen={isOpen}
             onOpen={dispatchOpenBannerEvent}
             onClose={() => {

--- a/clients/privacy-center/cypress/e2e/banner-overlay-dismissal.cy.ts
+++ b/clients/privacy-center/cypress/e2e/banner-overlay-dismissal.cy.ts
@@ -32,7 +32,9 @@ describe("Banner and modal dismissal", () => {
   // Test all combinations of TCF enabled/disabled and prevent dismissal enabled/disabled
   interface TestCaseOptions {
     tcfEnabled: boolean;
+    // this comes from the env var "PREVENT_DISMISSAL", and should take precedence over the below
     preventDismissal: boolean;
+    // this comes from the experience config
     dismissable: boolean;
     expectation: Expectation;
   }

--- a/clients/privacy-center/cypress/e2e/banner-overlay-dismissal.cy.ts
+++ b/clients/privacy-center/cypress/e2e/banner-overlay-dismissal.cy.ts
@@ -24,151 +24,212 @@ describe("Banner and modal dismissal", () => {
 
     cy.wait("@patchPrivacyPreference");
   }
+  enum Expectation {
+    DISMISSABLE,
+    NOT_DISMISSABLE,
+  }
 
   // Test all combinations of TCF enabled/disabled and prevent dismissal enabled/disabled
   interface TestCaseOptions {
     tcfEnabled: boolean;
     preventDismissal: boolean;
+    dismissable: boolean;
+    expectation: Expectation;
   }
 
   const testCases: TestCaseOptions[] = [
-    { tcfEnabled: false, preventDismissal: false },
-    { tcfEnabled: false, preventDismissal: true },
-    { tcfEnabled: true, preventDismissal: false },
-    { tcfEnabled: true, preventDismissal: true },
+    {
+      tcfEnabled: false,
+      preventDismissal: false,
+      dismissable: true,
+      expectation: Expectation.DISMISSABLE,
+    },
+    {
+      tcfEnabled: false,
+      preventDismissal: true,
+      dismissable: true,
+      expectation: Expectation.NOT_DISMISSABLE,
+    },
+    {
+      tcfEnabled: false,
+      preventDismissal: false,
+      dismissable: false,
+      expectation: Expectation.NOT_DISMISSABLE,
+    },
+    {
+      tcfEnabled: false,
+      preventDismissal: true,
+      dismissable: false,
+      expectation: Expectation.NOT_DISMISSABLE,
+    },
+    {
+      tcfEnabled: true,
+      preventDismissal: false,
+      dismissable: true,
+      expectation: Expectation.DISMISSABLE,
+    },
+    {
+      tcfEnabled: true,
+      preventDismissal: true,
+      dismissable: true,
+      expectation: Expectation.NOT_DISMISSABLE,
+    },
+    {
+      tcfEnabled: true,
+      preventDismissal: false,
+      dismissable: false,
+      expectation: Expectation.NOT_DISMISSABLE,
+    },
+    {
+      tcfEnabled: true,
+      preventDismissal: true,
+      dismissable: false,
+      expectation: Expectation.NOT_DISMISSABLE,
+    },
   ];
 
-  testCases.forEach(({ tcfEnabled, preventDismissal }) => {
-    describe(`when tcfEnabled is ${tcfEnabled} and preventDismissal is ${preventDismissal}`, () => {
-      beforeEach(() => {
-        if (!tcfEnabled) {
-          stubConfig({
-            options: { tcfEnabled, preventDismissal },
+  testCases.forEach(
+    ({ tcfEnabled, preventDismissal, dismissable, expectation }) => {
+      describe(`when tcfEnabled is ${tcfEnabled} and preventDismissal is ${preventDismissal} and dismissable is ${dismissable}`, () => {
+        beforeEach(() => {
+          if (!tcfEnabled) {
+            cy.fixture("consent/fidesjs_options_banner_modal.json").then(
+              (config) => {
+                const experienceItem = config.experience;
+                experienceItem.experience_config.dismissable = dismissable;
+                stubConfig({
+                  options: { tcfEnabled, preventDismissal },
+                  experience: experienceItem,
+                });
+              }
+            );
+          } else {
+            cy.fixture("consent/experience_tcf.json").then((experience) => {
+              const experienceItem = experience.items[0];
+              experienceItem.experience_config.dismissable = dismissable;
+              stubConfig({
+                options: { tcfEnabled, preventDismissal },
+                experience: experienceItem,
+              });
+            });
+          }
+        });
+
+        if (expectation === Expectation.DISMISSABLE) {
+          /**
+           * Tests for when dismissal is allowed
+           */
+          describe("when using the banner", () => {
+            it("should dismiss the banner by clicking the x", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("#fides-banner .fides-close-button").click();
+              cy.get("@FidesUpdated").should("have.been.called");
+              cy.get("#fides-banner").should("not.be.visible");
+              assertDismissCalled();
+            });
+
+            it("should not dismiss the banner by clicking outside", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("h1").click(); // click outside
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("@FidesUpdated").should("not.have.been.called");
+            });
+
+            it("should not dismiss the banner by hitting ESC", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("body").type("{esc}");
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("@FidesUpdated").should("not.have.been.called");
+            });
+          });
+
+          describe("when using the modal", () => {
+            it("should dismiss the modal by clicking the x", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.getByTestId("Manage preferences-btn").click();
+              cy.get(".fides-modal-content").should("be.visible");
+              cy.get(".fides-modal-content .fides-close-button").click();
+              cy.get(".fides-modal-content").should("not.be.visible");
+              assertDismissCalled();
+            });
+
+            it("should not dismiss the modal by clicking outside", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.getByTestId("Manage preferences-btn").click();
+              cy.get(".fides-modal-content").should("be.visible");
+              cy.get(".fides-modal-overlay").click({ force: true });
+              cy.get(".fides-modal-content").should("be.visible");
+              cy.get("@FidesUpdated").should("not.have.been.called");
+            });
+
+            it("should not dismiss the modal by hitting ESC", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.getByTestId("Manage preferences-btn").click();
+              cy.get(".fides-modal-content").should("be.visible");
+              cy.get("body").type("{esc}");
+              cy.get(".fides-modal-content").should("be.visible");
+              cy.get("@FidesUpdated").should("not.have.been.called");
+            });
           });
         } else {
-          cy.fixture("consent/experience_tcf.json").then((experience) => {
-            stubConfig({
-              options: { tcfEnabled, preventDismissal },
-              experience: experience.items[0],
+          /**
+           * Tests for the special case, when dismissal is prevented
+           */
+          describe("when using the banner", () => {
+            it("should not show the x button", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("#fides-banner .fides-close-button").should(
+                "not.be.visible"
+              );
+              cy.get("@FidesUpdated").should("not.have.been.called");
+            });
+
+            it("should not dismiss the banner by clicking outside", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("h1").click({ force: true }); // click outside
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("@FidesUpdated").should("not.have.been.called");
+            });
+
+            it("should not dismiss the banner by hitting ESC", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("body").type("{esc}");
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("@FidesUpdated").should("not.have.been.called");
+            });
+          });
+
+          describe("when using the modal", () => {
+            it("should not show the x button", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.getByTestId("Manage preferences-btn").click();
+              cy.get(".fides-modal-content").should("be.visible");
+              cy.get(".fides-modal-content .fides-close-button").should(
+                "not.be.visible"
+              );
+              cy.get("@FidesUpdated").should("not.have.been.called");
+            });
+
+            it("should not dismiss the modal by clicking outside", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.getByTestId("Manage preferences-btn").click();
+              cy.get(".fides-modal-content").should("be.visible");
+              cy.get(".fides-modal-overlay").click({ force: true });
+              cy.get(".fides-modal-content").should("be.visible");
+              cy.get("@FidesUpdated").should("not.have.been.called");
+            });
+
+            it("should not dismiss the modal by hitting ESC", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.getByTestId("Manage preferences-btn").click();
+              cy.get(".fides-modal-content").should("be.visible");
+              cy.get("body").type("{esc}");
+              cy.get(".fides-modal-content").should("be.visible");
+              cy.get("@FidesUpdated").should("not.have.been.called");
             });
           });
         }
       });
-
-      if (!preventDismissal) {
-        /**
-         * Tests for the default case, when dismissal is allowed
-         */
-        describe("when using the banner", () => {
-          it("should dismiss the banner by clicking the x", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.get("#fides-banner .fides-close-button").click();
-            cy.get("@FidesUpdated").should("have.been.called");
-            cy.get("#fides-banner").should("not.be.visible");
-            assertDismissCalled();
-          });
-
-          it("should not dismiss the banner by clicking outside", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.get("h1").click(); // click outside
-            cy.get("#fides-banner").should("be.visible");
-            cy.get("@FidesUpdated").should("not.have.been.called");
-          });
-
-          it("should not dismiss the banner by hitting ESC", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.get("body").type("{esc}");
-            cy.get("#fides-banner").should("be.visible");
-            cy.get("@FidesUpdated").should("not.have.been.called");
-          });
-        });
-
-        describe("when using the modal", () => {
-          it("should dismiss the modal by clicking the x", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.getByTestId("Manage preferences-btn").click();
-            cy.get(".fides-modal-content").should("be.visible");
-            cy.get(".fides-modal-content .fides-close-button").click();
-            cy.get(".fides-modal-content").should("not.be.visible");
-            assertDismissCalled();
-          });
-
-          it("should not dismiss the modal by clicking outside", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.getByTestId("Manage preferences-btn").click();
-            cy.get(".fides-modal-content").should("be.visible");
-            cy.get(".fides-modal-overlay").click({ force: true });
-            cy.get(".fides-modal-content").should("be.visible");
-            cy.get("@FidesUpdated").should("not.have.been.called");
-          });
-
-          it("should not dismiss the modal by hitting ESC", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.getByTestId("Manage preferences-btn").click();
-            cy.get(".fides-modal-content").should("be.visible");
-            cy.get("body").type("{esc}");
-            cy.get(".fides-modal-content").should("be.visible");
-            cy.get("@FidesUpdated").should("not.have.been.called");
-          });
-        });
-      } else {
-        /**
-         * Tests for the special case, when dismissal is prevented
-         */
-        describe("when using the banner", () => {
-          it("should not show the x button", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.get("#fides-banner .fides-close-button").should(
-              "not.be.visible"
-            );
-            cy.get("@FidesUpdated").should("not.have.been.called");
-          });
-
-          it("should not dismiss the banner by clicking outside", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.get("h1").click({ force: true }); // click outside
-            cy.get("#fides-banner").should("be.visible");
-            cy.get("@FidesUpdated").should("not.have.been.called");
-          });
-
-          it("should not dismiss the banner by hitting ESC", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.get("body").type("{esc}");
-            cy.get("#fides-banner").should("be.visible");
-            cy.get("@FidesUpdated").should("not.have.been.called");
-          });
-        });
-
-        describe("when using the modal", () => {
-          it("should not show the x button", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.getByTestId("Manage preferences-btn").click();
-            cy.get(".fides-modal-content").should("be.visible");
-            cy.get(".fides-modal-content .fides-close-button").should(
-              "not.be.visible"
-            );
-            cy.get("@FidesUpdated").should("not.have.been.called");
-          });
-
-          it("should not dismiss the modal by clicking outside", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.getByTestId("Manage preferences-btn").click();
-            cy.get(".fides-modal-content").should("be.visible");
-            cy.get(".fides-modal-overlay").click({ force: true });
-            cy.get(".fides-modal-content").should("be.visible");
-            cy.get("@FidesUpdated").should("not.have.been.called");
-          });
-
-          it("should not dismiss the modal by hitting ESC", () => {
-            cy.get("#fides-banner").should("be.visible");
-            cy.getByTestId("Manage preferences-btn").click();
-            cy.get(".fides-modal-content").should("be.visible");
-            cy.get("body").type("{esc}");
-            cy.get(".fides-modal-content").should("be.visible");
-            cy.get("@FidesUpdated").should("not.have.been.called");
-          });
-        });
-      }
-    });
-  });
+    }
+  );
 });

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -49,7 +49,7 @@
             component: "banner_and_modal",
             disabled: false,
             is_default: true,
-            dismissable: true,
+            dismissable: false,
             allow_language_selection: true,
             auto_detect_language: true,
             language: "en",

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -49,7 +49,7 @@
             component: "banner_and_modal",
             disabled: false,
             is_default: true,
-            dismissable: false,
+            dismissable: true,
             allow_language_selection: true,
             auto_detect_language: true,
             language: "en",


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1600

### Description Of Changes

Allows consent banner / modal to be dismissable based on both the `PREVENT_DISMISSAL` env var and the `experience_config.dismissable` option.

This change prefers the `PREVENT_DISMISSAL` env var, so if that's set to "true", we respect that over any other setting, and do not show the "x". With any other case, we look at the `experience_config.dismissable` option to determine whether or not to show the "x".


### Code Changes

* [ ] Adds a check for `experience_config.dismissable` when determining whether or not to show the "x" button on the banner / modal, for both TCF and non-TCF
* [ ] Adds e2e test cases

### Steps to Confirm

* [ ] Run e2e tests
* [ ] If you wish to test, change the dismissable toggle in admin-ui as part of an experience config, and see that "x" button respects that setting. See cypress test for details on expectations.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
