### PR TITLE
FE fixes related to experience config form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The types of changes are:
 
 ### Fixed
 - Ignore 404 errors from Delighted and Kustomer when an erasure client is not found [#4593](https://github.com/ethyca/fides/pull/4593)
+- Various FE fixes for Admin-UI experience config form [#4707](https://github.com/ethyca/fides/pull/4707)
 
 ## [2.31.0](https://github.com/ethyca/fides/compare/2.30.1...2.31.0)
 

--- a/clients/admin-ui/src/features/common/ScrollableList.tsx
+++ b/clients/admin-ui/src/features/common/ScrollableList.tsx
@@ -22,12 +22,14 @@ const ScrollableListItem = <T extends unknown>({
   draggable,
   onDeleteItem,
   onRowClick,
+  maxH = 10,
 }: {
   item: T;
   label: string;
   draggable?: boolean;
   onDeleteItem?: (item: T) => void;
   onRowClick?: (item: T) => void;
+  maxH?: number;
 }) => {
   const dragControls = useDragControls();
 
@@ -36,7 +38,7 @@ const ScrollableListItem = <T extends unknown>({
       <Flex
         direction="row"
         gap={2}
-        maxH={10}
+        maxH={maxH}
         px={2}
         align="center"
         role="group"
@@ -147,6 +149,7 @@ const ScrollableList = <T extends unknown>({
   selectOnAdd,
   getItemLabel,
   createNewValue,
+  maxHeight = 36,
 }: {
   label?: string;
   tooltip?: string;
@@ -162,6 +165,7 @@ const ScrollableList = <T extends unknown>({
   selectOnAdd?: boolean;
   getItemLabel?: (item: T) => string;
   createNewValue?: (opt: Option) => T;
+  maxHeight?: number;
 }) => {
   const getItemId = (item: T) =>
     item instanceof Object && idField && idField in item
@@ -217,7 +221,6 @@ const ScrollableList = <T extends unknown>({
     borderColor: "gray.200",
     borderRadius: "md",
     w: "full",
-    maxH: 36,
     overflowY: "scroll",
   } as ChakraProps;
 
@@ -239,6 +242,7 @@ const ScrollableList = <T extends unknown>({
             }
             onRowClick={onRowClick}
             draggable
+            maxH={maxHeight}
           />
         ))}
       </Reorder.Group>
@@ -253,6 +257,7 @@ const ScrollableList = <T extends unknown>({
             label={getItemDisplayName(item)}
             onRowClick={onRowClick}
             onDeleteItem={handleDeleteItem}
+            maxH={maxHeight}
           />
         ))}
       </List>

--- a/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
@@ -51,6 +51,10 @@ const translationSchema = (requirePreferencesLink: boolean) =>
     description: Yup.string().required().label("Description"),
     accept_button_label: Yup.string().required().label("Accept button label"),
     reject_button_label: Yup.string().required().label("Reject button label"),
+    save_button_label: Yup.string().required().label("Save button label"),
+    acknowledge_button_label: Yup.string()
+      .required()
+      .label("Acknowledge button label"),
     privacy_policy_url: Yup.string().url().nullable(),
     is_default: Yup.boolean(),
     privacy_preferences_link_label: requirePreferencesLink

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -206,6 +206,7 @@ export const PrivacyExperienceForm = ({
         values={values.properties ?? []}
         setValues={(newValues) => setFieldValue("properties", newValues)}
         draggable
+        maxHeight={100}
       />
       <Divider />
       {values.component !== ComponentType.TCF_OVERLAY ? (

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
@@ -185,7 +185,8 @@ const PrivacyExperienceTranslationForm = ({
         isRequired
         variant="stacked"
       />
-      {values.component === ComponentType.BANNER_AND_MODAL ? (
+      {values.component === ComponentType.BANNER_AND_MODAL ||
+      values.component === ComponentType.TCF_OVERLAY ? (
         <>
           <CustomTextInput
             name={`translations.${translationIndex}.banner_title`}
@@ -231,8 +232,8 @@ const PrivacyExperienceTranslationForm = ({
           name={`translations.${translationIndex}.save_button_label`}
           id={`translations.${translationIndex}.save_button_label`}
           label={`"Save" button label`}
-          isRequired={formConfig.save_button_label.required}
           variant="stacked"
+          isRequired={formConfig.save_button_label.required}
         />
       ) : null}
       {formConfig.acknowledge_button_label?.included ? (
@@ -241,13 +242,14 @@ const PrivacyExperienceTranslationForm = ({
           id={`translations.${translationIndex}.acknowledge_button_label`}
           label={`"Acknowledge" button label`}
           variant="stacked"
+          isRequired={formConfig.acknowledge_button_label.required}
         />
       ) : null}
       {formConfig.privacy_policy_link_label?.included ? (
         <CustomTextInput
           name={`translations.${translationIndex}.privacy_policy_link_label`}
           id={`translations.${translationIndex}.privacy_policy_link_label`}
-          label="Privacy policy link label"
+          label="Privacy policy link label (optional)"
           variant="stacked"
         />
       ) : null}
@@ -255,7 +257,7 @@ const PrivacyExperienceTranslationForm = ({
         <CustomTextInput
           name={`translations.${translationIndex}.privacy_policy_url`}
           id={`translations.${translationIndex}.privacy_policy_url`}
-          label="Privacy policy link URL"
+          label="Privacy policy link URL (optional)"
           variant="stacked"
         />
       ) : null}

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -129,7 +129,7 @@ export const getTranslationFormFields = (
       accept_button_label: { included: true, required: true },
       reject_button_label: { included: true, required: true },
       save_button_label: { included: true, required: true },
-      acknowledge_button_label: { included: true },
+      acknowledge_button_label: { included: true, required: true },
       privacy_policy_link_label: { included: true },
       privacy_policy_url: { included: true },
       privacy_preferences_link_label: { included: true },
@@ -145,19 +145,20 @@ export const getTranslationFormFields = (
       accept_button_label: { included: true, required: true },
       reject_button_label: { included: true, required: true },
       save_button_label: { included: true, required: true },
-      acknowledge_button_label: { included: true },
+      acknowledge_button_label: { included: true, required: true },
       privacy_policy_link_label: { included: true },
       privacy_policy_url: { included: true },
       privacy_preferences_link_label: { included: true, required: true },
     };
   }
+  // For TCF overlay / default
   return {
     title: { included: true, required: true },
     description: { included: true, required: true },
     accept_button_label: { included: true, required: true },
     reject_button_label: { included: true, required: true },
-    save_button_label: { included: true },
-    acknowledge_button_label: { included: true },
+    save_button_label: { included: true, required: true },
+    acknowledge_button_label: { included: true, required: true },
     privacy_policy_link_label: { included: true },
     privacy_policy_url: { included: true },
     privacy_preferences_link_label: { included: true, required: true },


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

Fixes the following from https://ethyca.atlassian.net/wiki/spaces/PM/pages/2957672451/Product+UAT:

* TCF Overlay missing some translation fields: Banner title, Banner description
* Additional translation fields should be required: Save button label, Acknowledge button label
* All optional translation fields should say “(optional)” for consistency: Banner title, Banner description, Privacy policy link label, Privacy policy link URL
* Privacy Experience Config - Long property names overflow from the list container


### Code Changes

* [ ] Preview mode FE changes

### Steps to Confirm

* [ ] See https://ethyca.atlassian.net/wiki/spaces/PM/pages/2957672451/Product+UAT

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
