### PR TITLE
Add no preview notice for Privacy Center types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The types of changes are:
 - Added property_id query param to fides.js to filter experiences by Property when installed [#4676](https://github.com/ethyca/fides/pull/4676)
 - Added Locations & Regulations pages to allow a wider selection of locations for consent [#4660](https://github.com/ethyca/fides/pull/4660)
 - Erasure support for Simon Data [#4552](https://github.com/ethyca/fides/pull/4552)
+- Added notice there will be not preview for Privacy Center types in the Experience preview [#4709](https://github.com/ethyca/fides/pull/4709)
 
 ### Changed
 - Moved location-targeting from Notices to Experiences [#4576](https://github.com/ethyca/fides/pull/4576)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The types of changes are:
 - Added property_id query param to fides.js to filter experiences by Property when installed [#4676](https://github.com/ethyca/fides/pull/4676)
 - Added Locations & Regulations pages to allow a wider selection of locations for consent [#4660](https://github.com/ethyca/fides/pull/4660)
 - Erasure support for Simon Data [#4552](https://github.com/ethyca/fides/pull/4552)
-- Added notice there will be not preview for Privacy Center types in the Experience preview [#4709](https://github.com/ethyca/fides/pull/4709)
+- Added notice there will be no preview for Privacy Center types in the Experience preview [#4709](https://github.com/ethyca/fides/pull/4709)
 
 ### Changed
 - Moved location-targeting from Notices to Experiences [#4576](https://github.com/ethyca/fides/pull/4576)

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -166,6 +166,16 @@ const Preview = ({
     );
   }
 
+  if (values.component === ComponentType.PRIVACY_CENTER) {
+    return (
+      <NoPreviewNotice
+        title="Privacy center preview not available"
+        description="There is no preview available for privacy center. You can edit the available settings
+      and languages to the left."
+      />
+    );
+  }
+
   if (!values.privacy_notice_ids?.length) {
     return (
       <NoPreviewNotice
@@ -217,17 +227,16 @@ const Preview = ({
         }
       `}</style>
       {values.component === ComponentType.BANNER_AND_MODAL ||
-      values.component === ComponentType.MODAL ? (
+        values.component === ComponentType.MODAL ? (
         <style>
           {`div#fides-modal {
           display: flex !important;
           justify-content: center;
           background-color: unset;
-          ${
-            values.component === ComponentType.BANNER_AND_MODAL
+          ${values.component === ComponentType.BANNER_AND_MODAL
               ? "padding-top: 3rem; padding-bottom: 3rem;"
               : ""
-          }
+            }
         }`}
         </style>
       ) : null}

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -227,16 +227,17 @@ const Preview = ({
         }
       `}</style>
       {values.component === ComponentType.BANNER_AND_MODAL ||
-        values.component === ComponentType.MODAL ? (
+      values.component === ComponentType.MODAL ? (
         <style>
           {`div#fides-modal {
           display: flex !important;
           justify-content: center;
           background-color: unset;
-          ${values.component === ComponentType.BANNER_AND_MODAL
+          ${
+            values.component === ComponentType.BANNER_AND_MODAL
               ? "padding-top: 3rem; padding-bottom: 3rem;"
               : ""
-            }
+          }
         }`}
         </style>
       ) : null}


### PR DESCRIPTION
### Description Of Changes

Add no preview notice for Privacy Center types to the Experience preview window

### Steps to Confirm

* [ ] run fidesplus on the main branch with `nox -s "build(slim)" "dev(slim)" -- dev`
* [ ] run this fide branch with `cd clients && turbo run dev`
* [ ] nav to Experience under Consent
* [ ] chose Privacy Center 
* [ ] verify the notice in the preview window states there are no previews for Privacy Centers

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

## Before
<img width="2547" alt="Screenshot 2024-03-14 at 11 25 42 AM" src="https://github.com/ethyca/fides/assets/101993653/9b51560b-d38c-4b86-80bb-3587c6d95b53">

## After
<img width="2548" alt="Screenshot 2024-03-14 at 11 23 22 AM" src="https://github.com/ethyca/fides/assets/101993653/8e0b9bbb-6356-4039-96c8-63c362aff6a3">
