### PR TITLE
Remove properties flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The types of changes are:
 - Added Locations & Regulations pages to allow a wider selection of locations for consent [#4660](https://github.com/ethyca/fides/pull/4660)
 - Erasure support for Simon Data [#4552](https://github.com/ethyca/fides/pull/4552)
 - Added notice there will be no preview for Privacy Center types in the Experience preview [#4709](https://github.com/ethyca/fides/pull/4709)
+- Removed properties beta flag [#4710](https://github.com/ethyca/fides/pull/4710)
 
 ### Changed
 - Moved location-targeting from Notices to Experiences [#4576](https://github.com/ethyca/fides/pull/4576)

--- a/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
+++ b/clients/admin-ui/src/features/common/nav/v2/nav-config.ts
@@ -99,7 +99,6 @@ export const NAV_CONFIG: NavConfigGroup[] = [
         path: routes.PROPERTIES_ROUTE,
         requiresPlus: true,
         scopes: [ScopeRegistryEnum.PROPERTY_READ],
-        requiresFlag: "properties",
       },
       {
         title: "Vendors",

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -35,11 +35,5 @@
     "development": true,
     "test": true,
     "production": false
-  },
-  "properties": {
-    "description": "Page to view properties",
-    "development": true,
-    "test": true,
-    "production": false
   }
 }


### PR DESCRIPTION
### Steps to Confirm

* [ ] run fidesplus on the main branch with `nox -s "build(slim)" "dev(slim)" -- dev`
* [ ] run this fide branch with `cd clients && turbo run dev` 
* [ ] verify the properties tab in the nav is now visible and accessible 
* [ ] verify the properties flag is no longer on the About Fides page

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
