### PR TITLE
Translation Data Migration - Duplicate Privacy Notice History records

### DIFF
--- a/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data.py
+++ b/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data.py
@@ -858,7 +858,8 @@ def migrate_notices(bind):
             SELECT :record_id, name, description, origin, consent_mechanism, data_uses, :new_version, disabled, enforcement_level, has_gpc_flag, internal_description, notice_key, gpp_field_mapping, framework, :language, title, translation_id, privacy_notice_id
             FROM privacynoticehistory
             WHERE version = :current_version AND
-            privacy_notice_id = :privacy_notice_id
+            privacy_notice_id = :privacy_notice_id 
+            ORDER BY created_at DESC LIMIT 1
         """
         )
         bind.execute(


### PR DESCRIPTION
Closes #PROD-1834

### Description Of Changes

On RC environment, data migration hit the following error:

```sql
[SQL:
            INSERT INTO privacynoticehistory (id, name, description, origin, consent_mechanism, data_uses, version, disabled, enforcement_level, has_gpc_flag, internal_description, notice_key, gpp_field_mapping, framework, language, title, translation_id, privacy_notice_id)
            SELECT %(record_id)s, name, description, origin, consent_mechanism, data_uses, %(new_version)s, disabled, enforcement_level, has_gpc_flag, internal_description, notice_key, gpp_field_mapping, framework, %(language)s, title, translation_id, privacy_notice_id
            FROM privacynoticehistory
            WHERE version = %(current_version)s AND
            privacy_notice_id = %(privacy_notice_id)s
        ]
[parameters: {'record_id': 'pri_46f39301-f80c-4684-92fb-0a7dcfcd508b', 'new_version': 16.0, 'language': 'en', 'current_version': 15.0, 'privacy_notice_id': 'pri_153cc90b-7257-402c-9eab-4a6751e9d482'}]
(Background on this error at: https://sqlalche.me/e/14/gkpj)
2024-03-14 18:47:17.670 | ERROR    |  - (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "privacynoticehistory_pkey"
DETAIL:  Key (id)=(pri_46f39301-f80c-4684-92fb-0a7dcfcd508b) already exists.
```

- The cause is an unexpected data state where we have two historical records saved for the same privacy notice with the same version.


### Code Changes

* [ ] Only select the most recently created privacy notice history record with the highest version number prior to cloning and bumping the version number 

### Steps to Confirm

* [ ] checkout a Fides commit prior to the multitranslation merge, like `0863408d79954b4cbe268efe4f6fe8baf813c113`
* [ ] nox -s dev -- shell
* [ ] Create a duplicate privacy notice history record with the same version as another historical record, for the same privacy notice id
```sql
INSERT INTO privacynoticehistory (id, name, description, origin, consent_mechanism, data_uses, version, disabled, enforcement_level, has_gpc_flag, internal_description, notice_key, regions, displayed_in_privacy_center, displayed_in_overlay, displayed_in_api, gpp_field_mapping, framework, privacy_notice_id)
SELECT '12345', name, description, origin, consent_mechanism, data_uses, 2, disabled, enforcement_level, has_gpc_flag, internal_description, notice_key, regions, displayed_in_privacy_center, displayed_in_overlay, displayed_in_api, gpp_field_mapping, framework, privacy_notice_id
FROM privacynoticehistory
WHERE version = 2 AND
privacy_notice_id = 'pri_fb0a6a21-3a61-4ae5-9be5-cc855c054491';
```
* [ ] git checkout main 
* [ ] Migration should fail with above error
* [ ] git checkout translation_migration_duplication_privacy_notice_history_versions
* [ ] Migration should succeed

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
