### PR TITLE
Add acknowledge button label to default language form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The types of changes are:
 - Erasure support for Simon Data [#4552](https://github.com/ethyca/fides/pull/4552)
 - Added notice there will be no preview for Privacy Center types in the Experience preview [#4709](https://github.com/ethyca/fides/pull/4709)
 - Removed properties beta flag [#4710](https://github.com/ethyca/fides/pull/4710)
+- Add acknowledge button label to default Experience English form [#4714](https://github.com/ethyca/fides/pull/4714)
+
 
 ### Changed
 - Moved location-targeting from Notices to Experiences [#4576](https://github.com/ethyca/fides/pull/4576)

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -31,6 +31,7 @@ export const defaultTranslations: ExperienceTranslationCreate[] = [
     accept_button_label: "Accept",
     reject_button_label: "Reject",
     save_button_label: "Save",
+    acknowledge_button_label: "Ok",
     privacy_preferences_link_label: "Privacy Preferences",
   },
 ];


### PR DESCRIPTION
### Steps to Confirm

* [ ] run fidesplus on the main branch with `nox -s "build(slim)" "dev(slim)" -- dev`
* [ ] run this fide branch with `cd clients && turbo run dev`
* [ ] nav to Experience page
* [ ] click create new experience 
* [ ] click English
* [ ] verify "Acknowledge" button label is populated with OK

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
