### PR TITLE
Make banner width 100% when mobile

### DIFF
--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -950,6 +950,7 @@ div#fides-banner-inner .fides-privacy-policy {
 @media screen and (max-width: 768px) {
   div#fides-banner {
     padding: 24px;
+    width: 100%;
   }
 
   div#fides-banner-description {


### PR DESCRIPTION
### Steps to Confirm

* [ ] run fidesplus on the main branch with nox -s "build(slim)" "dev(slim)" -- dev 
* [ ] run this fide branch with cd clients && turbo run dev
in the admin ui
* [ ] add systems with data uses
* [ ] enable notices 
* [ ] enable a banner and modal experience (not TCF) 
* [ ] verify the banner and modal preview looks good when toggling between mobile and large screen 
* [ ] nav to fides js demo page with the geolocation that will show the experience you enabled ex. http://localhost:3000/fides-js-demo.html?geolocation=us-ca
* [ ] verify the banner looks good at all window sizes 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

## Before 
https://github.com/ethyca/fides/assets/101993653/2eb1471b-7073-4716-9bf5-68b41610b507
## After
https://github.com/ethyca/fides/assets/101993653/9bd64acf-da39-4d4d-842c-272fa6f3b57a