### PR TITLE
Update FidesJS to support localizing CMP UI with configurable, non-English default locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The types of changes are:
 - Added notice there will be no preview for Privacy Center types in the Experience preview [#4709](https://github.com/ethyca/fides/pull/4709)
 - Removed properties beta flag [#4710](https://github.com/ethyca/fides/pull/4710)
 - Add acknowledge button label to default Experience English form [#4714](https://github.com/ethyca/fides/pull/4714)
-
+- Update FidesJS to support localizing CMP UI with configurable, non-English default locales [#4720](https://github.com/ethyca/fides/pull/4720)
 
 ### Changed
 - Moved location-targeting from Notices to Experiences [#4576](https://github.com/ethyca/fides/pull/4576)

--- a/clients/fides-js/__tests__/__fixtures__/mock_experience.json
+++ b/clients/fides-js/__tests__/__fixtures__/mock_experience.json
@@ -51,7 +51,7 @@
         "banner_description": "Descripción del Banner de Prueba",
         "banner_title": "Título del Banner de Prueba",
         "description": "Descripción de la Prueba",
-        "is_default": true,
+        "is_default": false,
         "privacy_policy_link_label": "Política de Privacidad de Prueba",
         "privacy_policy_url": "https://privacy.example.com/es",
         "privacy_preferences_link_label": "Administrar Preferencias de Prueba",

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -32,11 +32,17 @@ import mockGVLTranslationsJSON from "../../__fixtures__/mock_gvl_translations.js
 describe("i18n-utils", () => {
   // Define a mock implementation of the i18n singleton for tests
   let mockCurrentLocale = "";
-  let mockDefaultLocale = DEFAULT_LOCALE; // TODO (PROD-1831): actually code this
+  let mockDefaultLocale = DEFAULT_LOCALE;
   const mockI18n = {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     activate: jest.fn((locale: Locale): void => {
       mockCurrentLocale = locale;
+    }),
+    getDefaultLocale: jest.fn((): Locale  => {
+      return mockDefaultLocale;
+    }),
+    setDefaultLocale: jest.fn((locale: Locale): void  => {
+      mockDefaultLocale = locale;
     }),
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     load: jest.fn((locale: Locale, messages: Messages): void => {}),
@@ -55,6 +61,8 @@ describe("i18n-utils", () => {
     mockI18n.activate.mockClear();
     mockI18n.load.mockClear();
     mockI18n.t.mockClear();
+    mockCurrentLocale = "";
+    mockDefaultLocale = DEFAULT_LOCALE;
   });
 
   describe("initializeI18n", () => {
@@ -930,8 +938,13 @@ describe("i18n module", () => {
     });
 
     describe("locale getter", () => {
-      it("returns the currently active locale", () => {
+      it("allows getting but not setting the currently active locale", () => {
         expect(testI18n.locale).toEqual("en");
+        expect(testI18n.locale).toEqual("en");
+        expect(() => (testI18n as any).locale = "zz").toThrow(TypeError);
+        expect(testI18n.locale).toEqual("en");
+        
+        // Change the actual locale using load & activate
         testI18n.load("zz", { "test.greeting": "Zalloz, Jest!" });
         expect(testI18n.locale).toEqual("en");
         testI18n.activate("zz");
@@ -939,7 +952,7 @@ describe("i18n module", () => {
       });
     });
 
-    describe("defaultLocale", () => {
+    describe("getDefaultLocale & setDefaultLocale methods", () => {
       /**
        * NOTE: Modifying the default locale is *not* supported by LinguiJS, so
        * this would need to be re-implemented carefully! This default locale
@@ -953,9 +966,9 @@ describe("i18n module", () => {
        * a default locale in some scenarios.
        */
       it("allows getting & setting the default locale", () => {
-        expect(testI18n.defaultLocale).toEqual(DEFAULT_LOCALE);
-        testI18n.defaultLocale = "es";
-        expect(testI18n.defaultLocale).toEqual("es");
+        expect(testI18n.getDefaultLocale()).toEqual("en");
+        expect(testI18n.setDefaultLocale("es")).toBeUndefined();
+        expect(testI18n.getDefaultLocale()).toEqual("es");
       });
     });
   });

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -461,6 +461,13 @@ describe("i18n-utils", () => {
       expect(matchAvailableLocales("foo", availableLocales)).toEqual("en");
     });
 
+    it("falls back to a user-specified default language when no match is found", () => {
+      const userDefaultLocale = "fr";
+      const availableLocales = ["en", "es", "fr"];
+      expect(matchAvailableLocales("zh", availableLocales, userDefaultLocale)).toEqual("fr");
+      expect(matchAvailableLocales("foo", availableLocales, userDefaultLocale)).toEqual("fr");
+    });
+
     it("performs a case-insensitive lookup", () => {
       expect(matchAvailableLocales("fr-ca", ["es", "fr-CA"])).toEqual("fr-CA");
       expect(matchAvailableLocales("Fr-Ca", ["es", "fr-CA"])).toEqual("fr-CA");

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -18,6 +18,7 @@ import {
   messageExists,
   setupI18n,
   selectBestExperienceConfigTranslation,
+  areLocalesEqual,
 } from "~/lib/i18n";
 import { loadTcfMessagesFromFiles } from "~/lib/tcf/i18n/tcf-i18n-utils";
 import messagesEn from "~/lib/i18n/locales/en/messages.json";
@@ -38,21 +39,24 @@ describe("i18n-utils", () => {
     activate: jest.fn((locale: Locale): void => {
       mockCurrentLocale = locale;
     }),
-    getDefaultLocale: jest.fn((): Locale => {
-      return mockDefaultLocale;
-    }),
+
+    getDefaultLocale: jest.fn((): Locale => mockDefaultLocale),
+
     setDefaultLocale: jest.fn((locale: Locale): void => {
       mockDefaultLocale = locale;
     }),
+
+    get locale(): Locale {
+      return mockCurrentLocale;
+    },
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     load: jest.fn((locale: Locale, messages: Messages): void => {}),
+
     t: jest.fn(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       (idOrDescriptor: string | MessageDescriptor): string => "mock translate"
     ),
-    get locale(): Locale {
-      return mockCurrentLocale;
-    },
   };
 
   const mockExperience: Partial<PrivacyExperience> = mockExperienceJSON as any;
@@ -522,6 +526,20 @@ describe("i18n-utils", () => {
     });
   });
 
+  describe("areLocalesEqual", () => {
+    it("performs a case-insensitive match and treats underscore- & dash-separated locales as equal", () => {
+      expect(areLocalesEqual("en", "en")).toEqual(true);
+      expect(areLocalesEqual("en", "EN")).toEqual(true);
+      expect(areLocalesEqual("en-US", "en-US")).toEqual(true);
+      expect(areLocalesEqual("en-US", "EN-us")).toEqual(true);
+      expect(areLocalesEqual("en-US", "en_US")).toEqual(true);
+      expect(areLocalesEqual("en-US", "en_us")).toEqual(true);
+      expect(areLocalesEqual("en", "fr")).toEqual(false);
+      expect(areLocalesEqual("en", "en-US")).toEqual(false);
+      expect(areLocalesEqual("fr-CA", "fr-CA-Foo")).toEqual(false);
+    });
+  });
+
   describe("matchAvailableLocales", () => {
     it("returns an exact match when able", () => {
       const availableLocales = ["en", "es", "fr-CA"];
@@ -945,6 +963,7 @@ describe("i18n module", () => {
       it("allows getting but not setting the currently active locale", () => {
         expect(testI18n.locale).toEqual("en");
         expect(testI18n.locale).toEqual("en");
+        // eslint-disable-next-line no-return-assign
         expect(() => ((testI18n as any).locale = "zz")).toThrow(TypeError);
         expect(testI18n.locale).toEqual("en");
 

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   LOCALE_REGEX,
   detectUserLocale,
+  extractDefaultLocaleFromExperienceConfig,
   getCurrentLocale,
   initializeI18n,
   loadMessagesFromExperience,
@@ -418,6 +419,44 @@ describe("i18n-utils", () => {
       });
     });
   });
+
+  describe("extractDefaultLocaleFromExperienceConfig", () => {
+    it("returns the locale of the first 'is_default' translation from experience_config", () => {
+      expect(extractDefaultLocaleFromExperienceConfig(
+        mockExperience.experience_config as ExperienceConfig
+      )).toEqual("en");
+
+      expect(extractDefaultLocaleFromExperienceConfig({
+        translations: [
+          { language: "en", is_default: false },
+          { language: "es", is_default: false },
+          { language: "fr", is_default: true },
+          { language: "zh", is_default: false },
+        ]
+      } as ExperienceConfig)).toEqual("fr");
+
+      // Check for multiple 'is_default' translations
+      expect(extractDefaultLocaleFromExperienceConfig({
+        translations: [
+          { language: "en", is_default: false },
+          { language: "es", is_default: true },
+          { language: "fr", is_default: true },
+          { language: "zh", is_default: false },
+        ]
+      } as ExperienceConfig)).toEqual("es");
+    });
+
+    it("returns undefined if no 'is_default' translations exist in experience_config", () => {
+      expect(extractDefaultLocaleFromExperienceConfig({
+        translations: [
+          { language: "en", is_default: false },
+          { language: "es", is_default: false },
+          { language: "fr", is_default: false },
+          { language: "zh", is_default: false },
+        ]
+      } as ExperienceConfig)).toBeUndefined();
+    });
+  }) 
 
   describe("detectUserLocale", () => {
     const mockNavigator: Partial<Navigator> = {

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -38,10 +38,10 @@ describe("i18n-utils", () => {
     activate: jest.fn((locale: Locale): void => {
       mockCurrentLocale = locale;
     }),
-    getDefaultLocale: jest.fn((): Locale  => {
+    getDefaultLocale: jest.fn((): Locale => {
       return mockDefaultLocale;
     }),
-    setDefaultLocale: jest.fn((locale: Locale): void  => {
+    setDefaultLocale: jest.fn((locale: Locale): void => {
       mockDefaultLocale = locale;
     }),
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -107,9 +107,13 @@ describe("i18n-utils", () => {
     it("activates the first is_default locale in the experience when no better match exists", () => {
       // Make a deep copy of the mock experience using a dirty JSON serialization trick
       // NOTE: This is why lodash exists, but I'm not going to install it just for this! :)
-      const mockExpDifferentDefault = JSON.parse(JSON.stringify(mockExperience));
-      mockExpDifferentDefault.experience_config.translations[0].is_default = false;
-      mockExpDifferentDefault.experience_config.translations[1].is_default = true; // sets "es" to default
+      const mockExpDifferentDefault = JSON.parse(
+        JSON.stringify(mockExperience)
+      );
+      mockExpDifferentDefault.experience_config.translations[0].is_default =
+        false;
+      mockExpDifferentDefault.experience_config.translations[1].is_default =
+        true; // sets "es" to default
 
       const mockNavigator: Partial<Navigator> = {
         language: "fr-CA", // not a match for either en or es
@@ -941,9 +945,9 @@ describe("i18n module", () => {
       it("allows getting but not setting the currently active locale", () => {
         expect(testI18n.locale).toEqual("en");
         expect(testI18n.locale).toEqual("en");
-        expect(() => (testI18n as any).locale = "zz").toThrow(TypeError);
+        expect(() => ((testI18n as any).locale = "zz")).toThrow(TypeError);
         expect(testI18n.locale).toEqual("en");
-        
+
         // Change the actual locale using load & activate
         testI18n.load("zz", { "test.greeting": "Zalloz, Jest!" });
         expect(testI18n.locale).toEqual("en");
@@ -961,7 +965,7 @@ describe("i18n module", () => {
        * fallback behavior in some scenarios when the current locale cannot be
        * used, and in those cases we want the default locale to (sometimes!) not
        * just be English.
-       * 
+       *
        * For example, see selectBestNoticeTranslation() that needs a fallback to
        * a default locale in some scenarios.
        */

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -5,6 +5,7 @@ import {
   PrivacyNoticeWithPreference,
 } from "~/fides";
 import {
+  DEFAULT_LOCALE,
   LOCALE_REGEX,
   detectUserLocale,
   extractDefaultLocaleFromExperience,
@@ -31,6 +32,7 @@ import mockGVLTranslationsJSON from "../../__fixtures__/mock_gvl_translations.js
 describe("i18n-utils", () => {
   // Define a mock implementation of the i18n singleton for tests
   let mockCurrentLocale = "";
+  let mockDefaultLocale = DEFAULT_LOCALE; // TODO (PROD-1831): actually code this
   const mockI18n = {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     activate: jest.fn((locale: Locale): void => {
@@ -572,9 +574,16 @@ describe("i18n-utils", () => {
 
     it("falls back to the default locale if an exact match isn't available", () => {
       mockCurrentLocale = "zh";
+      mockDefaultLocale = "en";
       expect(selectBestNoticeTranslation(mockI18n, mockNotice)).toHaveProperty(
         "language",
         "en"
+      );
+
+      mockDefaultLocale = "es";
+      expect(selectBestNoticeTranslation(mockI18n, mockNotice)).toHaveProperty(
+        "language",
+        "es"
       );
     });
 
@@ -587,6 +596,7 @@ describe("i18n-utils", () => {
         "es",
       ]);
       mockCurrentLocale = "zh";
+      mockDefaultLocale = "en";
       expect(
         selectBestNoticeTranslation(mockI18n, mockNoticeNoEnglish)
       ).toHaveProperty("language", "es");
@@ -628,9 +638,15 @@ describe("i18n-utils", () => {
 
     it("falls back to the default locale if an exact match isn't available", () => {
       mockCurrentLocale = "zh";
+      mockDefaultLocale = "en";
       expect(
         selectBestExperienceConfigTranslation(mockI18n, mockExperienceConfig)
       ).toHaveProperty("language", "en");
+
+      mockDefaultLocale = "es";
+      expect(
+        selectBestExperienceConfigTranslation(mockI18n, mockExperienceConfig)
+      ).toHaveProperty("language", "es");
     });
 
     it("falls back to the first locale if neither exact match nor default locale are available", () => {
@@ -920,6 +936,26 @@ describe("i18n module", () => {
         expect(testI18n.locale).toEqual("en");
         testI18n.activate("zz");
         expect(testI18n.locale).toEqual("zz");
+      });
+    });
+
+    describe("defaultLocale", () => {
+      /**
+       * NOTE: Modifying the default locale is *not* supported by LinguiJS, so
+       * this would need to be re-implemented carefully! This default locale
+       * should typically not be needed for i18n purposes - instead, the current
+       * locale should be used! However, in our application we need to provide
+       * fallback behavior in some scenarios when the current locale cannot be
+       * used, and in those cases we want the default locale to (sometimes!) not
+       * just be English.
+       * 
+       * For example, see selectBestNoticeTranslation() that needs a fallback to
+       * a default locale in some scenarios.
+       */
+      it("allows getting & setting the default locale", () => {
+        expect(testI18n.defaultLocale).toEqual(DEFAULT_LOCALE);
+        testI18n.defaultLocale = "es";
+        expect(testI18n.defaultLocale).toEqual("es");
       });
     });
   });

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -108,7 +108,7 @@ describe("i18n-utils", () => {
       expect(mockI18n.activate).toHaveBeenCalledWith("en");
     });
 
-    it("activates the first is_default locale in the experience when no better match exists", () => {
+    it("changes the fallback default locale based on the first is_default translation in the experience", () => {
       // Make a deep copy of the mock experience using a dirty JSON serialization trick
       // NOTE: This is why lodash exists, but I'm not going to install it just for this! :)
       const mockExpDifferentDefault = JSON.parse(
@@ -126,6 +126,7 @@ describe("i18n-utils", () => {
       initializeI18n(mockI18n, mockNavigator, mockExpDifferentDefault);
       expect(mockI18n.load).toHaveBeenCalledWith("en", messagesEn);
       expect(mockI18n.load).toHaveBeenCalledWith("es", messagesEs);
+      expect(mockI18n.setDefaultLocale).toHaveBeenCalledWith("es");
       expect(mockI18n.activate).toHaveBeenCalledWith("es");
     });
   });

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -64,7 +64,7 @@ function extractMessagesFromExperienceConfig(
   } else {
     // For backwards-compatibility, when "translations" doesn't exist, look for
     // the fields on the ExperienceConfig itself
-    const locale = DEFAULT_LOCALE;
+    const locale = experienceConfig.language || DEFAULT_LOCALE;
     const messages: Messages = {};
     EXPERIENCE_TRANSLATION_FIELDS.forEach((key) => {
       const message = experienceConfig[key];
@@ -437,11 +437,11 @@ export function initializeI18n(
   );
 
   // Extract the default locale from the experience API, or fallback to DEFAULT_LOCALE
-  // TODO
-  // const defaultLocale: Locale = ...
+  const defaultLocale: Locale = extractDefaultLocaleFromExperience(experience) || DEFAULT_LOCALE;
+  debugLog(options?.debug, `Setting Fides i18n default locale = ${defaultLocale}`);
 
   // Detect the user's locale, unless it's been *explicitly* disabled in the experience config
-  let userLocale = DEFAULT_LOCALE;
+  let userLocale = defaultLocale;
   if (experience.experience_config?.auto_detect_language === false) {
     debugLog(
       options?.debug,
@@ -453,11 +453,11 @@ export function initializeI18n(
   }
 
   // Match the user locale to the "best" available locale from the experience API and activate it!
-  const bestLocale = matchAvailableLocales(userLocale, availableLocales);
+  const bestLocale = matchAvailableLocales(userLocale, availableLocales, defaultLocale);
   i18n.activate(bestLocale);
   debugLog(
     options?.debug,
-    `Initialized fides-js i18n with best locale = ${bestLocale}`
+    `Initialized Fides i18n with best locale match = ${bestLocale}`
   );
 }
 

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -80,6 +80,19 @@ function extractMessagesFromExperienceConfig(
 }
 
 /**
+ * Helper function to extract the default locale from an ExperienceConfig API
+ * response. Returns the first matching translation where is_default == true.
+ */
+export function extractDefaultLocaleFromExperienceConfig(
+  experienceConfig: ExperienceConfig
+): Locale | undefined {
+  if (experienceConfig.translations) {
+    const defaultTranslation = experienceConfig.translations.find((translation) => translation.is_default);
+    return defaultTranslation?.language;
+  }
+}
+
+/**
  * Helper function to extract all the translated messages from the "gvl_translations"
  * API response. Returns an object that maps locales -> messages, e.g.
  * {
@@ -164,7 +177,7 @@ export function loadMessagesFromFiles(i18n: I18n): Locale[] {
  * 1) experience.experience_config
  * 2) experience.gvl_translations
  *
- * Returns a list of locales that exist in *both* these sources, discarding any
+ * Returns an object containing  list of locales that exist in *both* these sources, discarding any
  * locales that exist in one but not the other. This is done to encourage only
  * using locales with "full" translation catalogs.
  *

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -470,6 +470,9 @@ export function initializeI18n(
  * LinguiJS once we're ready to upgrade to the real thing!
  */
 export function setupI18n(): I18n {
+  // Default locale; default this to English
+  let defaultLocale: Locale = DEFAULT_LOCALE;
+
   // Currently active locale; default this to English
   let currentLocale: Locale = DEFAULT_LOCALE;
 
@@ -480,6 +483,14 @@ export function setupI18n(): I18n {
   return {
     activate: (locale: Locale): void => {
       currentLocale = locale;
+    },
+
+    getDefaultLocale: (): Locale => {
+      return defaultLocale;
+    },
+
+    setDefaultLocale: (locale: Locale): void => {
+      defaultLocale = locale;
     },
 
     get locale() {

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -80,14 +80,18 @@ function extractMessagesFromExperienceConfig(
 }
 
 /**
- * Helper function to extract the default locale from an ExperienceConfig API
- * response. Returns the first matching translation where is_default == true.
+ * Helper function to extract the default locale from a PrivacyExperience API
+ * response. Returns the first experience_config.translations' locale where the
+ * translation has is_default === true.
  */
-export function extractDefaultLocaleFromExperienceConfig(
-  experienceConfig: ExperienceConfig
+export function extractDefaultLocaleFromExperience(
+  experience: Partial<PrivacyExperience>
 ): Locale | undefined {
-  if (experienceConfig.translations) {
-    const defaultTranslation = experienceConfig.translations.find((translation) => translation.is_default);
+  if (experience?.experience_config?.translations) {
+    const translations = experience.experience_config.translations;
+    const defaultTranslation = translations.find(
+      (translation) => translation.is_default
+    );
     return defaultTranslation?.language;
   }
 }
@@ -281,7 +285,7 @@ export function detectUserLocale(
 export function matchAvailableLocales(
   requestedLocale: Locale,
   availableLocales: Locale[],
-  defaultLocale: Locale = DEFAULT_LOCALE,
+  defaultLocale: Locale = DEFAULT_LOCALE
 ): Locale {
   // 1) Parse the requested locale string using our regex
   const match = requestedLocale.match(LOCALE_REGEX);
@@ -431,6 +435,10 @@ export function initializeI18n(
     options?.debug,
     `Loaded Fides i18n with available locales = ${availableLocales}`
   );
+
+  // Extract the default locale from the experience API, or fallback to DEFAULT_LOCALE
+  // TODO
+  // const defaultLocale: Locale = ...
 
   // Detect the user's locale, unless it's been *explicitly* disabled in the experience config
   let userLocale = DEFAULT_LOCALE;

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -431,8 +431,13 @@ export function selectBestExperienceConfigTranslation(
 /**
  * Initialize the given i18n singleton by:
  * 1) Loading all static messages from locale files
- * 2) Detecting the user's locale
- * 3) Activating the best match for the user's locale
+ * 2) Loading all dynamic messages from experience API
+ * 3) Setting the default locale based on the experience API
+ * 4) Detecting the user's browser locale
+ * 5) Activating the best match for the user's locale based on:
+ *   a) user's browser locale
+ *   b) available locales from the experience API
+ *   c) default locale from the experience API
  */
 export function initializeI18n(
   i18n: I18n,
@@ -451,13 +456,14 @@ export function initializeI18n(
   // Extract the default locale from the experience API, or fallback to DEFAULT_LOCALE
   const defaultLocale: Locale =
     extractDefaultLocaleFromExperience(experience) || DEFAULT_LOCALE;
+  i18n.setDefaultLocale(defaultLocale);
   debugLog(
     options?.debug,
-    `Setting Fides i18n default locale = ${defaultLocale}`
+    `Setting Fides i18n default locale = ${i18n.getDefaultLocale()}`
   );
 
   // Detect the user's locale, unless it's been *explicitly* disabled in the experience config
-  let userLocale = defaultLocale;
+  let userLocale = i18n.getDefaultLocale();
   if (experience.experience_config?.auto_detect_language === false) {
     debugLog(
       options?.debug,
@@ -472,7 +478,7 @@ export function initializeI18n(
   const bestLocale = matchAvailableLocales(
     userLocale,
     availableLocales,
-    defaultLocale
+    i18n.getDefaultLocale()
   );
   i18n.activate(bestLocale);
   debugLog(

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -365,7 +365,7 @@ export function selectBestNoticeTranslation(
 
   // 2) Fallback to default locale, if an exact match isn't found
   const defaultTranslation = notice.translations.find(
-    (e) => e.language === DEFAULT_LOCALE
+    (e) => e.language === i18n.getDefaultLocale()
   );
   if (defaultTranslation) {
     return defaultTranslation;
@@ -406,7 +406,7 @@ export function selectBestExperienceConfigTranslation(
 
   // 2) Fallback to default locale, if an exact match isn't found
   const defaultTranslation = experience.translations.find(
-    (e) => e.language === DEFAULT_LOCALE
+    (e) => e.language === i18n.getDefaultLocale()
   );
   if (defaultTranslation) {
     return defaultTranslation;
@@ -437,8 +437,12 @@ export function initializeI18n(
   );
 
   // Extract the default locale from the experience API, or fallback to DEFAULT_LOCALE
-  const defaultLocale: Locale = extractDefaultLocaleFromExperience(experience) || DEFAULT_LOCALE;
-  debugLog(options?.debug, `Setting Fides i18n default locale = ${defaultLocale}`);
+  const defaultLocale: Locale =
+    extractDefaultLocaleFromExperience(experience) || DEFAULT_LOCALE;
+  debugLog(
+    options?.debug,
+    `Setting Fides i18n default locale = ${defaultLocale}`
+  );
 
   // Detect the user's locale, unless it's been *explicitly* disabled in the experience config
   let userLocale = defaultLocale;
@@ -453,7 +457,11 @@ export function initializeI18n(
   }
 
   // Match the user locale to the "best" available locale from the experience API and activate it!
-  const bestLocale = matchAvailableLocales(userLocale, availableLocales, defaultLocale);
+  const bestLocale = matchAvailableLocales(
+    userLocale,
+    availableLocales,
+    defaultLocale
+  );
   i18n.activate(bestLocale);
   debugLog(
     options?.debug,

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -267,7 +267,8 @@ export function detectUserLocale(
  */
 export function matchAvailableLocales(
   requestedLocale: Locale,
-  availableLocales: Locale[]
+  availableLocales: Locale[],
+  defaultLocale: Locale = DEFAULT_LOCALE,
 ): Locale {
   // 1) Parse the requested locale string using our regex
   const match = requestedLocale.match(LOCALE_REGEX);
@@ -296,7 +297,7 @@ export function matchAvailableLocales(
   }
 
   // 4) Fallback to default locale
-  return DEFAULT_LOCALE;
+  return defaultLocale;
 }
 
 /**

--- a/clients/fides-js/src/lib/i18n/index.ts
+++ b/clients/fides-js/src/lib/i18n/index.ts
@@ -66,7 +66,7 @@ interface I18n {
 
   /**
    * Set the current default locale for this session.
-   * 
+   *
    * WARN: This does not affect the behaviour of t(), load(), or activate()!
    * To change the active locale and get different translations, use
    * activate(). This method should only be used to determine what a

--- a/clients/fides-js/src/lib/i18n/index.ts
+++ b/clients/fides-js/src/lib/i18n/index.ts
@@ -57,6 +57,28 @@ interface I18n {
   activate(locale: Locale): void;
 
   /**
+   * Get the current default locale for this session.
+   *
+   * WARN: LinguiJS does not support getting/setting the default locale, so
+   * use this sparingly!
+   */
+  getDefaultLocale(): Locale;
+
+  /**
+   * Set the current default locale for this session.
+   * 
+   * WARN: This does not affect the behaviour of t(), load(), or activate()!
+   * To change the active locale and get different translations, use
+   * activate(). This method should only be used to determine what a
+   * "fallback" locale should be for the current user's session if the active
+   * locale cannot be used.
+   *
+   * WARN: LinguiJS does not support getting/setting the default locale, so
+   * use this sparingly!
+   */
+  setDefaultLocale(locale: Locale): void;
+
+  /**
    * Get the currently active locale.
    */
   get locale(): Locale;

--- a/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
@@ -339,6 +339,7 @@ const SPANISH_TCF_MODAL: TestTcfModalTranslations = {
  **********************************************************/
 const ENGLISH_LOCALE = "en";
 const SPANISH_LOCALE = "es";
+const FRENCH_LOCALE = "fr-CA";
 const JAPANESE_LOCALE = "ja-JP";
 
 describe("Consent i18n", () => {
@@ -635,83 +636,109 @@ describe("Consent i18n", () => {
           });
         });
       });
+    });
 
-      describe(`when browser language does not match any available locale (${JAPANESE_LOCALE})`, () => {
-        it(`localizes banner_and_modal components in the default locale (${ENGLISH_LOCALE})`, () => {
-          visitDemoWithI18n({
-            navigatorLanguage: JAPANESE_LOCALE,
-            globalPrivacyControl: true,
-            fixture,
-          });
-          testBannerLocalization(ENGLISH_BANNER);
-          openAndTestModalLocalization(ENGLISH_MODAL);
-          testModalNoticesLocalization(ENGLISH_NOTICES);
+    describe(`when browser language does not match any available locale (${JAPANESE_LOCALE})`, () => {
+      it(`localizes banner_and_modal components in the default locale (${ENGLISH_LOCALE})`, () => {
+        visitDemoWithI18n({
+          navigatorLanguage: JAPANESE_LOCALE,
+          globalPrivacyControl: true,
+          fixture,
         });
+        testBannerLocalization(ENGLISH_BANNER);
+        openAndTestModalLocalization(ENGLISH_MODAL);
+        testModalNoticesLocalization(ENGLISH_NOTICES);
+      });
+    });
+
+    describe("when auto_detect_language is false", () => {
+      it(`ignores browser locale (${SPANISH_LOCALE}) and localizes in the default locale (${ENGLISH_LOCALE})`, () => {
+        // Visit the demo site in Spanish, but expect English translations when auto-detection is disabled
+        visitDemoWithI18n({
+          navigatorLanguage: SPANISH_LOCALE,
+          globalPrivacyControl: true,
+          fixture,
+          overrideExperience: (experience) => {
+            /* eslint-disable-next-line no-param-reassign */
+            experience.experience_config!.auto_detect_language = false;
+            return experience;
+          },
+        });
+        testBannerLocalization(ENGLISH_BANNER);
+        openAndTestModalLocalization(ENGLISH_MODAL);
+        testModalNoticesLocalization(ENGLISH_NOTICES);
       });
 
-      describe("when auto_detect_language is false", () => {
-        it(`ignores browser locale and localizes in the default locale (${ENGLISH_LOCALE})`, () => {
-          // Visit the demo site in Spanish, but expect English translations when auto-detection is disabled
+      describe(`when an alternate default locale is specified in the experience (${SPANISH_LOCALE})`, () => {
+        it(`ignores browser locale (${ENGLISH_LOCALE}) and localizes in the default locale from the experience (${SPANISH_LOCALE})`, () => {
+          // Visit the demo site in English, but expect Spanish translations when auto-detection is disabled
           visitDemoWithI18n({
-            navigatorLanguage: SPANISH_LOCALE,
+            navigatorLanguage: ENGLISH_LOCALE,
             globalPrivacyControl: true,
             fixture,
             overrideExperience: (experience) => {
-              /* eslint-disable-next-line no-param-reassign */
+              /* eslint-disable no-param-reassign */
+              // Override the test data to specify Spanish as the default translation for the experience.
+              experience.experience_config!.translations[0].is_default = false;
+              experience.experience_config!.translations[1].is_default = true;
+              // Disable auto-detection
               experience.experience_config!.auto_detect_language = false;
               return experience;
+              /* eslint-enable no-param-reassign */
             },
           });
-          testBannerLocalization(ENGLISH_BANNER);
-          openAndTestModalLocalization(ENGLISH_MODAL);
-          testModalNoticesLocalization(ENGLISH_NOTICES);
-        });
-      });
-
-      // TODO (PROD-1598): enable this test and add other cases as needed!
-      describe.skip("when user selects their own locale", () => {
-        it(`localizes in the user selected locale (${SPANISH_LOCALE})`, () => {
-          // Visit the demo site in English, but expect Spanish translations when the user selects
-          visitDemoWithI18n({
-            navigatorLanguage: ENGLISH_LOCALE,
-            globalPrivacyControl: true,
-            fixture: "experience_banner_modal.json",
-          });
-          // TODO (PROD-1598): select Spanish from banner
           testBannerLocalization(SPANISH_BANNER);
           openAndTestModalLocalization(SPANISH_MODAL);
           testModalNoticesLocalization(SPANISH_NOTICES);
         });
       });
+    });
 
-      describe(`when ?fides_locale override param is set to an available locale (${SPANISH_LOCALE})`, () => {
-        it(`ignores browser locale and localizes in the override locale (${SPANISH_LOCALE})`, () => {
-          // Visit the demo site in English, but expect Spanish translations when fides_locale override is set
-          visitDemoWithI18n({
-            navigatorLanguage: ENGLISH_LOCALE,
-            globalPrivacyControl: true,
-            fixture: "experience_banner_modal.json",
-            queryParams: { fides_locale: SPANISH_LOCALE },
-          });
-          testBannerLocalization(SPANISH_BANNER);
-          openAndTestModalLocalization(SPANISH_MODAL);
-          testModalNoticesLocalization(SPANISH_NOTICES);
+    // TODO (PROD-1598): enable this test and add other cases as needed!
+    describe.skip("when user selects their own locale", () => {
+      it(`localizes in the user selected locale (${SPANISH_LOCALE})`, () => {
+        // Visit the demo site in English, but expect Spanish translations when the user selects
+        visitDemoWithI18n({
+          navigatorLanguage: ENGLISH_LOCALE,
+          globalPrivacyControl: true,
+          fixture: "experience_banner_modal.json",
         });
+        // TODO (PROD-1598): select Spanish from banner
+        testBannerLocalization(SPANISH_BANNER);
+        openAndTestModalLocalization(SPANISH_MODAL);
+        testModalNoticesLocalization(SPANISH_NOTICES);
       });
+    });
 
-      /**
-       * Special-case tests for various edge cases or potential gotchas
-       */
-      describe(`when notices are missing translations that are available in the experience for the correct language (${SPANISH_LOCALE})`, () => {
+    describe(`when ?fides_locale override param is set to an available locale (${SPANISH_LOCALE})`, () => {
+      it(`ignores browser locale and localizes in the override locale (${SPANISH_LOCALE})`, () => {
+        // Visit the demo site in English, but expect Spanish translations when fides_locale override is set
+        visitDemoWithI18n({
+          navigatorLanguage: ENGLISH_LOCALE,
+          globalPrivacyControl: true,
+          fixture: "experience_banner_modal.json",
+          queryParams: { fides_locale: SPANISH_LOCALE },
+        });
+        testBannerLocalization(SPANISH_BANNER);
+        openAndTestModalLocalization(SPANISH_MODAL);
+        testModalNoticesLocalization(SPANISH_NOTICES);
+      });
+    });
+
+    /**
+     * Special-case tests for mismatching translations between notices & experiences
+     */
+    describe.only(`when notices and experience have mismatched translations`, () => {
+      describe(`when notices are missing translations that are available in the experience for the browser locale (${SPANISH_LOCALE})`, () => {
         beforeEach(() => {
-          // Visit the demo in Spanish, but remove all non-English translations from the Advertising notice
+          // Visit the demo in Spanish, but remove the Spanish translations from the Advertising notice
           visitDemoWithI18n({
             navigatorLanguage: SPANISH_LOCALE,
             globalPrivacyControl: true,
             fixture: "experience_banner_modal.json",
             overrideExperience: (experience: any) => {
               /* eslint-disable no-param-reassign */
-              // Modify the first notice (Advertising) and delete all non-English translations
+              // Modify the first notice (Advertising) and remove the Spanish translations
               const testNotices: PrivacyNotice[] = experience.privacy_notices;
               const adsNotice = testNotices[0];
               cy.wrap(adsNotice).should(
@@ -721,7 +748,7 @@ describe("Consent i18n", () => {
               );
               adsNotice.has_gpc_flag = true;
               adsNotice.translations = adsNotice.translations.filter(
-                (e) => e.language === "en"
+                (e) => e.language !== SPANISH_LOCALE
               );
               return experience;
               /* eslint-enable no-param-reassign */
@@ -812,6 +839,60 @@ describe("Consent i18n", () => {
           // TODO (PROD-1598): test that correct history ID used after user changes language
         });
         /* eslint-enable @typescript-eslint/naming-convention */
+      });
+
+      describe(`when an alternate default locale is specified in the experience (${SPANISH_LOCALE})`, () => {
+        describe(`when the experience has translations matching the browser locale (${FRENCH_LOCALE}) but notices are missing translations`, () => {
+          beforeEach(() => {
+            // Visit the demo in French, but remove the French translations from the Advertising notice
+            visitDemoWithI18n({
+              navigatorLanguage: FRENCH_LOCALE,
+              globalPrivacyControl: true,
+              fixture: "experience_banner_modal.json",
+              overrideExperience: (experience: any) => {
+                /* eslint-disable no-param-reassign */
+                // Override the test data to specify Spanish as the default translation for the experience.
+                experience.experience_config!.translations[0].is_default =
+                  false;
+                experience.experience_config!.translations[1].is_default = true;
+                // Modify the first notice (Advertising) and remove the French translations
+                const testNotices: PrivacyNotice[] = experience.privacy_notices;
+                const adsNotice = testNotices[0];
+                cy.wrap(adsNotice).should(
+                  "have.property",
+                  "id",
+                  "pri_notice-advertising-000"
+                );
+                adsNotice.has_gpc_flag = true;
+                adsNotice.translations = adsNotice.translations.filter(
+                  (e) => e.language !== FRENCH_LOCALE
+                );
+                return experience;
+                /* eslint-enable no-param-reassign */
+              },
+            });
+          });
+
+          it(`falls back to showing notices in the alternate default locale (${SPANISH_LOCALE}) and the experience in the correct locale (${FRENCH_LOCALE})`, () => {
+            // Do some _lightweight_ checks for the French localization 🇫🇷
+            cy.get("#fides-banner .fides-banner-title").contains("[banner] Gestion de vos préférences de consentement");
+            cy.get("#fides-banner .fides-manage-preferences-button").click();
+            cy.get("#fides-modal .fides-modal-title").contains("Gestion de vos préférences de consentement");
+
+            // Test the notices are what we expect
+            testModalNoticesLocalization([
+              SPANISH_NOTICES[0], // fallback to Spani🇫🇷sh translation for first (Advertising) notice
+              {
+                title: "Analytique",
+                description: "Ce site Web utilise des témoins et des services analytiques",
+              },
+              {
+                title: "Essentiel",
+                description: "Ce site Web utilise des témoins et des services essentiels",
+              },
+            ]);
+          });
+        });
       });
     });
   });

--- a/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
@@ -728,7 +728,7 @@ describe("Consent i18n", () => {
     /**
      * Special-case tests for mismatching translations between notices & experiences
      */
-    describe.only(`when notices and experience have mismatched translations`, () => {
+    describe(`when notices and experience have mismatched translations`, () => {
       describe(`when notices are missing translations that are available in the experience for the browser locale (${SPANISH_LOCALE})`, () => {
         beforeEach(() => {
           // Visit the demo in Spanish, but remove the Spanish translations from the Advertising notice
@@ -875,20 +875,26 @@ describe("Consent i18n", () => {
 
           it(`falls back to showing notices in the alternate default locale (${SPANISH_LOCALE}) and the experience in the correct locale (${FRENCH_LOCALE})`, () => {
             // Do some _lightweight_ checks for the French localization 🇫🇷
-            cy.get("#fides-banner .fides-banner-title").contains("[banner] Gestion de vos préférences de consentement");
+            cy.get("#fides-banner .fides-banner-title").contains(
+              "[banner] Gestion de vos préférences de consentement"
+            );
             cy.get("#fides-banner .fides-manage-preferences-button").click();
-            cy.get("#fides-modal .fides-modal-title").contains("Gestion de vos préférences de consentement");
+            cy.get("#fides-modal .fides-modal-title").contains(
+              "Gestion de vos préférences de consentement"
+            );
 
             // Test the notices are what we expect
             testModalNoticesLocalization([
               SPANISH_NOTICES[0], // fallback to Spani🇫🇷sh translation for first (Advertising) notice
               {
                 title: "Analytique",
-                description: "Ce site Web utilise des témoins et des services analytiques",
+                description:
+                  "Ce site Web utilise des témoins et des services analytiques",
               },
               {
                 title: "Essentiel",
-                description: "Ce site Web utilise des témoins et des services essentiels",
+                description:
+                  "Ce site Web utilise des témoins et des services essentiels",
               },
             ]);
           });

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
@@ -27,7 +27,7 @@
             "banner_description": "[banner] Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
             "banner_title": "[banner] Administrar sus preferencias de consentimiento",
             "description": "Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
-            "is_default": true,
+            "is_default": false,
             "privacy_policy_link_label": "Política de privacidad",
             "privacy_policy_url": "https://privacy.example.com/",
             "privacy_preferences_link_label": "Administrar preferencias",

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
@@ -35,6 +35,21 @@
             "save_button_label": "Guardar",
             "title": "Administrar sus preferencias de consentimiento",
             "privacy_experience_config_history_id": "pri_exp-history-banner-modal-es-000"
+          },
+          {
+            "language": "fr-CA",
+            "accept_button_label": "Tout activer",
+            "acknowledge_button_label": "OK",
+            "banner_description": "[banner] Nous utilisons des témoins et des méthodes similaires pour reconnaitre les visiteurs et se souvenir de leurs préférences. Nous pouvons également les utiliser pour mesurer l’efficacité des campagnes de publicité, cibler les annonces et analyser le trafic du site. Selon votre emplacement, vous pouvez activer ou désactiver l’utilisation de ces technologies.",
+            "banner_title": "[banner] Gestion de vos préférences de consentement",
+            "description": "Nous utilisons des témoins et des méthodes similaires pour reconnaitre les visiteurs et se souvenir de leurs préférences. Nous pouvons également les utiliser pour mesurer l’efficacité des campagnes de publicité, cibler les annonces et analyser le trafic du site. Selon votre emplacement, vous pouvez activer ou désactiver l’utilisation de ces technologies.",
+            "is_default": false,
+            "privacy_policy_link_label": "Politique de confidentialité",
+            "privacy_preferences_link_label": "Gestion des préférences",
+            "reject_button_label": "Tout désactiver",
+            "save_button_label": "Sauvegarder",
+            "title": "Gestion de vos préférences de consentement",
+            "privacy_experience_config_history_id": "pri_exp-history-banner-modal-fr-ca-000"
           }
         ],
         "language": "en",
@@ -78,6 +93,12 @@
               "title": "Mercadotecnia",
               "description": "Este sitio web usa cookies y servicios de mercadotecnia para presentar anuncios, promociones y ofertas personalizadas relevantes para usted. Estos datos ayudan a optimizar los anuncios, medir la eficacia de las campañas y permitir a los anunciantes llegar a audiencias objetivo específicas.",
               "privacy_notice_history_id": "pri_notice-history-advertising-es-000"
+            },
+            {
+              "language": "fr-CA",
+              "title": "Marketing",
+              "description": "Ce site Web utilise des témoins et des services marketing pour délivrer des publicités personnalisées, des promotions et des offres qui vous correspondent.  Ils aident à optimiser la délivrance de publicités, à mesurer l’efficacité des campagnes publicitaires et permettent aux annonceurs d’atteindre des audiences ciblées spécifiques.",
+              "privacy_notice_history_id": "pri_notice-history-advertising-fr-ca-000"
             }
           ]
         },
@@ -108,6 +129,12 @@
               "title": "Análisis",
               "description": "Este sitio web usa cookies analíticas y servicios para recopilar datos agregados e información estadística. Estos datos nos ayudan a analizar y optimizar el rendimiento del sitio, identificar contenido popular, detectar problemas de navegación y tomar decisiones informadas para mejorar la experiencia del usuario.",
               "privacy_notice_history_id": "pri_notice-history-analytics-es-000"
+            },
+            {
+              "language": "fr-CA",
+              "title": "Analytique",
+              "description": "Ce site Web utilise des témoins et des services analytiques pour collecter des données agrégées et de l’information statistique. Ces données nous aident à analyser et à optimiser la performance des sites, à identifier le contenu préféré, à détecter les problèmes de navigation et à prendre des décisions éclairées pour améliorer l’expérience de l'utilisateur.",
+              "privacy_notice_history_id": "pri_notice-history-analytics-fr-ca-000"
             }
           ]
         },
@@ -138,6 +165,12 @@
               "title": "Esenciales",
               "description": "Este sitio web utiliza cookies esenciales y servicios para habilitar las funciones principales del sitio web y brindar una experiencia de usuario perfecta. Estas cookies y servicios se usan para facilitar características como la navegación, recordar referencias del usuario y garantizar la seguridad del sitio web.",
               "privacy_notice_history_id": "pri_notice-history-essential-es-000"
+            },
+            {
+              "language": "fr-CA",
+              "title": "Essentiel",
+              "description": "Ce site Web utilise des témoins et des services essentiels pour activer les fonctionnalités principales du site et offrir une expérience fluide aux utilisateurs. Ces témoins et services sont utilisés pour faciliter les fonctionnalités comme la navigation, la mémorisation des préférences de l’utilisateur et assurer la sécurité du site.",
+              "privacy_notice_history_id": "pri_notice-history-essential-fr-ca-000"
             }
           ]
         }

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
@@ -27,7 +27,7 @@
             "banner_description": "[banner] Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
             "banner_title": "[banner] Administrar sus preferencias de consentimiento",
             "description": "Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
-            "is_default": true,
+            "is_default": false,
             "privacy_policy_link_label": "Política de privacidad",
             "privacy_policy_url": "https://privacy.example.com/",
             "privacy_preferences_link_label": "Administrar preferencias",

--- a/clients/privacy-center/cypress/fixtures/consent/experience_gpp.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_gpp.json
@@ -35,7 +35,7 @@
             "banner_description": "[banner] Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
             "banner_title": "[banner] Administrar sus preferencias de consentimiento",
             "description": "Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
-            "is_default": true,
+            "is_default": false,
             "privacy_policy_link_label": "Política de privacidad",
             "privacy_policy_url": "https://privacy.example.com/",
             "privacy_preferences_link_label": "Administrar preferencias",

--- a/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
@@ -35,6 +35,21 @@
             "save_button_label": "Guardar",
             "title": "Administrar sus preferencias de consentimiento",
             "privacy_experience_config_history_id": "pri_exp-history-privacy-center-es-000"
+          },
+          {
+            "language": "fr-CA",
+            "accept_button_label": "Tout activer",
+            "acknowledge_button_label": "OK",
+            "banner_description": "[banner] Nous utilisons des témoins et des méthodes similaires pour reconnaitre les visiteurs et se souvenir de leurs préférences. Nous pouvons également les utiliser pour mesurer l’efficacité des campagnes de publicité, cibler les annonces et analyser le trafic du site. Selon votre emplacement, vous pouvez activer ou désactiver l’utilisation de ces technologies.",
+            "banner_title": "[banner] Gestion de vos préférences de consentement",
+            "description": "Nous utilisons des témoins et des méthodes similaires pour reconnaitre les visiteurs et se souvenir de leurs préférences. Nous pouvons également les utiliser pour mesurer l’efficacité des campagnes de publicité, cibler les annonces et analyser le trafic du site. Selon votre emplacement, vous pouvez activer ou désactiver l’utilisation de ces technologies.",
+            "is_default": false,
+            "privacy_policy_link_label": "Politique de confidentialité",
+            "privacy_preferences_link_label": "Gestion des préférences",
+            "reject_button_label": "Tout désactiver",
+            "save_button_label": "Sauvegarder",
+            "title": "Gestion de vos préférences de consentement",
+            "privacy_experience_config_history_id": "pri_exp-history-banner-modal-fr-ca-000"
           }
         ],
         "language": "en",
@@ -78,6 +93,12 @@
               "title": "Mercadotecnia",
               "description": "Este sitio web usa cookies y servicios de mercadotecnia para presentar anuncios, promociones y ofertas personalizadas relevantes para usted. Estos datos ayudan a optimizar los anuncios, medir la eficacia de las campañas y permitir a los anunciantes llegar a audiencias objetivo específicas.",
               "privacy_notice_history_id": "pri_notice-history-advertising-en-000"
+            },
+            {
+              "language": "fr-CA",
+              "title": "Marketing",
+              "description": "Ce site Web utilise des témoins et des services marketing pour délivrer des publicités personnalisées, des promotions et des offres qui vous correspondent.  Ils aident à optimiser la délivrance de publicités, à mesurer l’efficacité des campagnes publicitaires et permettent aux annonceurs d’atteindre des audiences ciblées spécifiques.",
+              "privacy_notice_history_id": "pri_notice-history-advertising-fr-ca-000"
             }
           ]
         },
@@ -108,6 +129,12 @@
               "title": "Análisis",
               "description": "Este sitio web usa cookies analíticas y servicios para recopilar datos agregados e información estadística. Estos datos nos ayudan a analizar y optimizar el rendimiento del sitio, identificar contenido popular, detectar problemas de navegación y tomar decisiones informadas para mejorar la experiencia del usuario.",
               "privacy_notice_history_id": "pri_notice-history-analytics-es-000"
+            },
+            {
+              "language": "fr-CA",
+              "title": "Analytique",
+              "description": "Ce site Web utilise des témoins et des services analytiques pour collecter des données agrégées et de l’information statistique. Ces données nous aident à analyser et à optimiser la performance des sites, à identifier le contenu préféré, à détecter les problèmes de navigation et à prendre des décisions éclairées pour améliorer l’expérience de l'utilisateur.",
+              "privacy_notice_history_id": "pri_notice-history-analytics-fr-ca-000"
             }
           ]
         },
@@ -138,6 +165,12 @@
               "title": "Esenciales",
               "description": "Este sitio web utiliza cookies esenciales y servicios para habilitar las funciones principales del sitio web y brindar una experiencia de usuario perfecta. Estas cookies y servicios se usan para facilitar características como la navegación, recordar referencias del usuario y garantizar la seguridad del sitio web.",
               "privacy_notice_history_id": "pri_notice-history-essential-es-000"
+            },
+            {
+              "language": "fr-CA",
+              "title": "Essentiel",
+              "description": "Ce site Web utilise des témoins et des services essentiels pour activer les fonctionnalités principales du site et offrir une expérience fluide aux utilisateurs. Ces témoins et services sont utilisés pour faciliter les fonctionnalités comme la navigation, la mémorisation des préférences de l’utilisateur et assurer la sécurité du site.",
+              "privacy_notice_history_id": "pri_notice-history-essential-fr-ca-000"
             }
           ]
         }

--- a/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
@@ -27,7 +27,7 @@
             "banner_description": "[banner] Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
             "banner_title": "[banner] Administrar sus preferencias de consentimiento",
             "description": "Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
-            "is_default": true,
+            "is_default": false,
             "privacy_policy_link_label": "Política de privacidad",
             "privacy_policy_url": "https://privacy.example.com/",
             "privacy_preferences_link_label": "Administrar preferencias",

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -43,6 +43,21 @@
             "save_button_label": "Guardar",
             "title": "Administrar sus preferencias de consentimiento",
             "privacy_experience_config_history_id": "pri_exp-history-tcf-overlay-es-00"
+          },
+          {
+            "language": "fr-CA",
+            "accept_button_label": "Tout activer",
+            "acknowledge_button_label": "OK",
+            "banner_description": "[banner] Nous utilisons des témoins et des méthodes similaires pour reconnaitre les visiteurs et se souvenir de leurs préférences. Nous pouvons également les utiliser pour mesurer l’efficacité des campagnes de publicité, cibler les annonces et analyser le trafic du site. Selon votre emplacement, vous pouvez activer ou désactiver l’utilisation de ces technologies.",
+            "banner_title": "[banner] Gestion de vos préférences de consentement",
+            "description": "Nous utilisons des témoins et des méthodes similaires pour reconnaitre les visiteurs et se souvenir de leurs préférences. Nous pouvons également les utiliser pour mesurer l’efficacité des campagnes de publicité, cibler les annonces et analyser le trafic du site. Selon votre emplacement, vous pouvez activer ou désactiver l’utilisation de ces technologies.",
+            "is_default": false,
+            "privacy_policy_link_label": "Politique de confidentialité",
+            "privacy_preferences_link_label": "Gestion des préférences",
+            "reject_button_label": "Tout désactiver",
+            "save_button_label": "Sauvegarder",
+            "title": "Gestion de vos préférences de consentement",
+            "privacy_experience_config_history_id": "pri_exp-history-banner-modal-fr-ca-000"
           }
         ],
         "language": "en",

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -35,7 +35,7 @@
             "banner_description": "[banner] Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
             "banner_title": "[banner] Administrar sus preferencias de consentimiento",
             "description": "Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
-            "is_default": true,
+            "is_default": false,
             "privacy_policy_link_label": "Política de privacidad",
             "privacy_policy_url": "https://privacy.example.com/",
             "privacy_preferences_link_label": "Administrar preferencias",

--- a/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
@@ -40,7 +40,7 @@
           "banner_description": "[banner] Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
           "banner_title": "[banner] Administrar sus preferencias de consentimiento",
           "description": "Usamos cookies y métodos similares para reconocer a los visitantes y recordar sus preferencias. También podemos usarlos para medir la eficacia de campañas publicitarias, dirigir anuncios y analizar el tráfico del sitio. En función de su ubicación, puede optar por participar o no en el uso de estas tecnologías.",
-          "is_default": true,
+          "is_default": false,
           "privacy_policy_link_label": "Política de privacidad",
           "privacy_policy_url": "https://privacy.example.com/",
           "privacy_preferences_link_label": "Administrar preferencias",

--- a/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
@@ -48,6 +48,21 @@
           "save_button_label": "Guardar",
           "title": "Administrar sus preferencias de consentimiento",
           "privacy_experience_config_history_id": "pri_exp-history-banner-modal-es-000"
+        },
+        {
+          "language": "fr-CA",
+          "accept_button_label": "Tout activer",
+          "acknowledge_button_label": "OK",
+          "banner_description": "[banner] Nous utilisons des témoins et des méthodes similaires pour reconnaitre les visiteurs et se souvenir de leurs préférences. Nous pouvons également les utiliser pour mesurer l’efficacité des campagnes de publicité, cibler les annonces et analyser le trafic du site. Selon votre emplacement, vous pouvez activer ou désactiver l’utilisation de ces technologies.",
+          "banner_title": "[banner] Gestion de vos préférences de consentement",
+          "description": "Nous utilisons des témoins et des méthodes similaires pour reconnaitre les visiteurs et se souvenir de leurs préférences. Nous pouvons également les utiliser pour mesurer l’efficacité des campagnes de publicité, cibler les annonces et analyser le trafic du site. Selon votre emplacement, vous pouvez activer ou désactiver l’utilisation de ces technologies.",
+          "is_default": false,
+          "privacy_policy_link_label": "Politique de confidentialité",
+          "privacy_preferences_link_label": "Gestion des préférences",
+          "reject_button_label": "Tout désactiver",
+          "save_button_label": "Sauvegarder",
+          "title": "Gestion de vos préférences de consentement",
+          "privacy_experience_config_history_id": "pri_exp-history-banner-modal-fr-ca-000"
         }
       ],
       "language": "en",
@@ -91,6 +106,12 @@
             "title": "Mercadotecnia",
             "description": "Este sitio web usa cookies y servicios de mercadotecnia para presentar anuncios, promociones y ofertas personalizadas relevantes para usted. Estos datos ayudan a optimizar los anuncios, medir la eficacia de las campañas y permitir a los anunciantes llegar a audiencias objetivo específicas.",
             "privacy_notice_history_id": "pri_notice-history-advertising-es-000"
+          },
+          {
+            "language": "fr-CA",
+            "title": "Marketing",
+            "description": "Ce site Web utilise des témoins et des services marketing pour délivrer des publicités personnalisées, des promotions et des offres qui vous correspondent.  Ils aident à optimiser la délivrance de publicités, à mesurer l’efficacité des campagnes publicitaires et permettent aux annonceurs d’atteindre des audiences ciblées spécifiques.",
+            "privacy_notice_history_id": "pri_notice-history-advertising-fr-ca-000"
           }
         ]
       },
@@ -121,6 +142,12 @@
             "title": "Análisis",
             "description": "Este sitio web usa cookies analíticas y servicios para recopilar datos agregados e información estadística. Estos datos nos ayudan a analizar y optimizar el rendimiento del sitio, identificar contenido popular, detectar problemas de navegación y tomar decisiones informadas para mejorar la experiencia del usuario.",
             "privacy_notice_history_id": "pri_notice-history-analytics-es-000"
+          },
+          {
+            "language": "fr-CA",
+            "title": "Analytique",
+            "description": "Ce site Web utilise des témoins et des services analytiques pour collecter des données agrégées et de l’information statistique. Ces données nous aident à analyser et à optimiser la performance des sites, à identifier le contenu préféré, à détecter les problèmes de navigation et à prendre des décisions éclairées pour améliorer l’expérience de l'utilisateur.",
+            "privacy_notice_history_id": "pri_notice-history-analytics-fr-ca-000"
           }
         ]
       },
@@ -151,6 +178,12 @@
             "title": "Esenciales",
             "description": "Este sitio web utiliza cookies esenciales y servicios para habilitar las funciones principales del sitio web y brindar una experiencia de usuario perfecta. Estas cookies y servicios se usan para facilitar características como la navegación, recordar referencias del usuario y garantizar la seguridad del sitio web.",
             "privacy_notice_history_id": "pri_notice-history-essential-es-000"
+          },
+          {
+            "language": "fr-CA",
+            "title": "Essentiel",
+            "description": "Ce site Web utilise des témoins et des services essentiels pour activer les fonctionnalités principales du site et offrir une expérience fluide aux utilisateurs. Ces témoins et services sont utilisés pour faciliter les fonctionnalités comme la navigation, la mémorisation des préférences de l’utilisateur et assurer la sécurité du site.",
+            "privacy_notice_history_id": "pri_notice-history-essential-fr-ca-000"
           }
         ]
       }


### PR DESCRIPTION
Closes PROD-1831

### Description Of Changes

This fixes a missing gap in the initial implementation of FidesJS localization to support a dynamic, configurable "default locale" set in the Experience configuration. How this works is:
1. During initialization, scan the list of `experience.experience_config.translations` to find which is marked as `is_default`
2. Set the "default locale" in the `i18n` module to use, or fallback to `en` if no API default is provided
3. Use the new "default locale" as the fallback in a few places:
  1. When selecting the active locale for the overall session, the default locale is used when no "better" match exists
  2. When auto-detection is disabled, the default locale will always be used
  3. When the active locale (from the experience) is not available for a notice, the default locale is used if possible

The net result is now what you'd expect: when you set a translation as "default" in the Admin UI, that locale will be used in the FidesJS CMP UI everywhere... unless a better, more specific match is available for the user ;)

### Code Changes

* [X] Update test fixtures to include `is_default: true` and, for good measure, include `fr-CA` as a non-default translation
* [X] Update our `i18n` module to support changing the default locale, so we can rely on `i18n` as the source-of-truth
  * NOTE: Most `i18n` libraries probably won't support this out of the box, so if we do upgrade to something like LinguiJS, react-intl, etc. we'll need to modify them
* [X] Add a new `areLocalesEqual` helper to DRY up existing code for locale comparisons 👍 
* [X] Modify the `initializeI18n` logic to extract the default locale from the experience API
* [X] Modify the `selectBestNoticeTranslation` and `selectBestExperienceConfigTranslation` helpers to fallback to the configurable default locale when no better match exists (instead of English)
* [X] Add unit tests to cover as much as we can
* [X] Add new E2E tests to cover:
  * [X] Specifying an alternate default locale and localizing the CMP to match
  * [X] Specifying an alternate default locale and using that as the fallback for notices when they are missing an exact translation match

### Steps to Confirm

* [ ] Configure a Banner & Modal experience with at least three languages: English, Spanish, and French
* [ ] Disable auto-detect language on the experience
* [ ] Load the CMP UI and check that the experience is rendered in the default language (English)
* [ ] Change the default language to Spanish
* [ ] Load the CMP UI and check that the experience is rendered in the new default language (Spanish)
![image](https://github.com/ethyca/fides/assets/1834295/e3c90bc1-ceb0-4fb8-a3ce-2c22d26c1580)
(this screenshot has auto detect disabled and default locale set to Spanish)

Advanced test to check that mismatched notices also fallback to the default:
* [ ] Re-enable auto-detect language on the experience
* [ ] Load the CMP UI and use `?fides_locale=fr` to change user locale to French, check that the experience is rendered in French
* [ ] Delete the French translation for one of the notices
* [ ] Load the CMP UI in French, check that the experience is rendered in French but the modified notice falls back to Spanish
![image](https://github.com/ethyca/fides/assets/1834295/8e144b5d-cccb-4bb7-b31e-ff19de1d25ca)
(this screenshot has auto detect enabled, browser locale set to French, default locale set to Spanish, but the "Marketing" notice does not have a French translation)

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
