### PR TITLE
Fix issue where default language for privacy experience was not being set

### DIFF
--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
@@ -104,6 +104,7 @@ const PrivacyExperienceTranslationForm = ({
     }));
     // move the new default to first in the array
     newTranslations.unshift(newTranslations.splice(newDefaultIndex, 1)[0]);
+    setFieldValue("translations", newTranslations);
     onReturnToMainForm();
   };
 
@@ -168,7 +169,7 @@ const PrivacyExperienceTranslationForm = ({
         name={`translations.${translationIndex}.is_default`}
         id={`translations.${translationIndex}.is_default`}
         label="Default language"
-        disabled={initialTranslation.is_default}
+        isDisabled={initialTranslation.is_default}
         variant="stacked"
       />
       <CustomTextInput


### PR DESCRIPTION
### Description Of Changes

Fix issues with functionality for setting the default translation on a privacy experience.

### Code Changes

* [ ] Call `setFieldValue` inside `setNewDefaultTranslation` (whoops)
* [ ] Fix switch not being disabled when translation is already default

### Steps to Confirm

* [ ] Create or edit a privacy experience with multiple translations
* [ ] Edit the default translation
* [ ] "Default translation" switch should be checked and disabled
* [ ] Edit any non-default translation
* [ ] Set that translation as default, then save changes and confirm in modal
* [ ] That translation should be at the top of the list and listed as default
* [ ] Previous default translation should no longer be default

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
