### PR TITLE
Issues Seeding Data due to Import Issues with Multilang models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.32.0...main)
 
+### Fixed
+- Initialization issues with ExperienceNotices (#4723)[https://github.com/ethyca/fides/pull/4723]
+
 ## [2.32.0](https://github.com/ethyca/fides/compare/2.31.1...2.32.0)
 
 ### Added

--- a/src/fides/api/db/base.py
+++ b/src/fides/api/db/base.py
@@ -10,6 +10,7 @@ from fides.api.models.connectionconfig import ConnectionConfig
 from fides.api.models.custom_asset import CustomAsset
 from fides.api.models.custom_connector_template import CustomConnectorTemplate
 from fides.api.models.datasetconfig import DatasetConfig
+from fides.api.models.experience_notices import ExperienceNotices
 from fides.api.models.fides_cloud import FidesCloud
 from fides.api.models.fides_user import FidesUser
 from fides.api.models.fides_user_permissions import FidesUserPermissions
@@ -20,7 +21,6 @@ from fides.api.models.messaging_template import MessagingTemplate
 from fides.api.models.policy import Policy, Rule, RuleTarget
 from fides.api.models.privacy_experience import (
     ExperienceConfigTemplate,
-    ExperienceNotices,
     ExperienceTranslation,
     PrivacyExperience,
     PrivacyExperienceConfig,

--- a/src/fides/api/models/experience_notices.py
+++ b/src/fides/api/models/experience_notices.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlalchemy import Column, ForeignKey, String
+
+from fides.api.db.base_class import Base
+
+
+class ExperienceNotices(Base):
+    """
+    A many-to-many table that links Privacy Notices to shared Privacy Experience Configs.
+    """
+
+    def generate_uuid(self) -> str:
+        """
+        Generates a uuid with a prefix based on the tablename to be used as the
+        record's ID value
+        """
+        try:
+            prefix = f"{self.current_column.table.name[:3]}_"  # type: ignore
+        except AttributeError:
+            prefix = ""
+        uuid = str(uuid4())
+        return f"{prefix}{uuid}"
+
+    # Overrides Base.id so this is not a primary key.
+    # Instead, we have a composite PK of notice_id and experience_config_id
+    id = Column(String(255), default=generate_uuid)
+
+    notice_id = Column(
+        String,
+        ForeignKey("privacynotice.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+        primary_key=True,
+    )
+    experience_config_id = Column(
+        String,
+        ForeignKey("privacyexperienceconfig.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+        primary_key=True,
+    )

--- a/src/fides/api/models/privacy_experience.py
+++ b/src/fides/api/models/privacy_experience.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Type
-from uuid import uuid4
 
 from sqlalchemy import Boolean, Column
 from sqlalchemy import Enum as EnumColumn
@@ -22,43 +21,6 @@ from fides.api.models.location_regulation_selections import PrivacyNoticeRegion
 from fides.api.models.privacy_notice import PrivacyNotice
 from fides.api.models.property import Property
 from fides.api.schemas.language import SupportedLanguage
-
-
-class ExperienceNotices(Base):
-    """
-    A many-to-many table that links Privacy Notices to shared Privacy Experience Configs.
-    """
-
-    def generate_uuid(self) -> str:
-        """
-        Generates a uuid with a prefix based on the tablename to be used as the
-        record's ID value
-        """
-        try:
-            prefix = f"{self.current_column.table.name[:3]}_"  # type: ignore
-        except AttributeError:
-            prefix = ""
-        uuid = str(uuid4())
-        return f"{prefix}{uuid}"
-
-    # Overrides Base.id so this is not a primary key.
-    # Instead, we have a composite PK of notice_id and experience_config_id
-    id = Column(String(255), default=generate_uuid)
-
-    notice_id = Column(
-        String,
-        ForeignKey("privacynotice.id", ondelete="CASCADE"),
-        index=True,
-        nullable=False,
-        primary_key=True,
-    )
-    experience_config_id = Column(
-        String,
-        ForeignKey("privacyexperienceconfig.id", ondelete="CASCADE"),
-        index=True,
-        nullable=False,
-        primary_key=True,
-    )
 
 
 class ComponentType(Enum):
@@ -209,7 +171,7 @@ class PrivacyExperienceConfig(PrivacyExperienceConfigBase, Base):
     privacy_notices: RelationshipProperty[List[PrivacyNotice]] = relationship(
         "PrivacyNotice",
         secondary="experiencenotices",
-        back_populates="experience_configs",
+        backref="experience_configs",
         lazy="selectin",
     )
 

--- a/src/fides/api/models/privacy_notice.py
+++ b/src/fides/api/models/privacy_notice.py
@@ -20,6 +20,7 @@ from fides.api.models import (
     dry_update_data,
     update_if_modified,
 )
+from fides.api.models.experience_notices import ExperienceNotices
 from fides.api.models.location_regulation_selections import (
     DeprecatedNoticeRegion,
     PrivacyNoticeRegion,
@@ -153,15 +154,6 @@ class PrivacyNotice(PrivacyNoticeBase, Base):
         order_by="NoticeTranslation.created_at",
     )
 
-    # Forward declaration to avoid circular import errors
-    PrivacyExperienceConfig = "PrivacyExperienceConfig"
-
-    experience_configs = relationship(
-        PrivacyExperienceConfig,
-        secondary="experiencenotices",
-        back_populates="privacy_notices",
-    )
-
     @hybridproperty
     def default_preference(self) -> UserConsentPreference:
         """Returns the user's default consent preference given the consent
@@ -212,10 +204,7 @@ class PrivacyNotice(PrivacyNoticeBase, Base):
     @property
     def configured_regions(self) -> List[PrivacyNoticeRegion]:
         """Convenience property to look up which regions are using these Notices."""
-        from fides.api.models.privacy_experience import (
-            ExperienceNotices,
-            PrivacyExperience,
-        )
+        from fides.api.models.privacy_experience import PrivacyExperience
 
         db = Session.object_session(self)
         configured_regions = (

--- a/tests/ops/models/test_privacy_notice.py
+++ b/tests/ops/models/test_privacy_notice.py
@@ -4,11 +4,11 @@ from fideslang.validation import FidesValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from fides.api.models.experience_notices import ExperienceNotices
 from fides.api.models.location_regulation_selections import (
     DeprecatedNoticeRegion,
     PrivacyNoticeRegion,
 )
-from fides.api.models.privacy_experience import ExperienceNotices
 from fides.api.models.privacy_notice import (
     ConsentMechanism,
     EnforcementLevel,


### PR DESCRIPTION
Closes #PROD-1839

### Description Of Changes

Running `nox -s dev -- shell postgres`  fails when the postgres setup script runs due to the way we've defined some of our new multitranslation models:

```shell
sqlalchemy.exc.InvalidRequestError: When initializing mapper mapped class PrivacyNotice->privacynotice, expression 'experiencenotices' failed to locate a name ("name 'experiencenotices' is not defined"). If this is a class name, consider adding this relationship() to the <class 'fides.api.models.privacy_notice.PrivacyNotice'> class after both dependent classes have been defined.
no custom setup logic found for postgres, skipping
```

You can get around this by importing in the ExperienceNotices model early into that script, but instead let's try to define these models more properly. I don't know if anyone else has hit this because `nox - fides_env(test)` works fine for me, if the imports are done in a certain order it would work. 

### Code Changes

* [ ] Move the ExperienceNotices many-to-many model into its own file (ExperienceNotices link Notices to Privacy Experience Configs)
* [ ] Define the `ExperienceConfig.privacy_notices` relationship on one side (ExperienceConfigs) instead of both sides

### Steps to Confirm

* [ ] `nox -s dev -- shell postgres` should work as expected with postgres example database seeded
* [ ] Unit tests should pass here and in fidesplus

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
