### PR TITLE
Remove accidental back-tick causing errors in cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ brew install freetds openssl
 ```
 2. Add the following to your shell (i.e. `.zshrc`) to ensure your compiler can access the `freetds` and `openssl` libraries, updating the paths & versions to match your local install:
 ```bash
-export LDFLAGS="-L/opt/homebrew/Cellar/freetds/1.3.18/lib -L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"`
+export LDFLAGS="-L/opt/homebrew/Cellar/freetds/1.3.18/lib -L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
 export CFLAGS="-I/opt/homebrew/Cellar/freetds/1.3.18/include"
 ```
 3. Reinstall Fides with MSSQL support by including the `all` extra requirement:

--- a/docs/fides/docs/development/overview.md
+++ b/docs/fides/docs/development/overview.md
@@ -39,7 +39,7 @@ brew install freetds openssl
 Add the following to your run commands (i.e. `.zshrc`), updating any path/versions to match yours
 
 ```bash
-export LDFLAGS="-L/opt/homebrew/Cellar/freetds/1.3.18/lib -L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"`
+export LDFLAGS="-L/opt/homebrew/Cellar/freetds/1.3.18/lib -L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
 export CFLAGS="-I/opt/homebrew/Cellar/freetds/1.3.18/include"
 ```
 


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

Removing incorrectly pasted character from the code samples


### Code Changes

* [x] removes extra `` ` ``

### Steps to Confirm

* [x] see https://ethyca.github.io/fides/development/overview/
* [x] see https://github.com/ethyca/fides/blob/main/README.md

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
