### PR TITLE
Hide translation interface in notice/experience form when translations aren't enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.32.0...main)
 
+### Changed
+- Updated privacy notice & experience forms to hide translation UI when user doesn't have translation feature [#4728](https://github.com/ethyca/fides/pull/4728)
+
 ## [2.32.0](https://github.com/ethyca/fides/compare/2.31.1...2.32.0)
 
 ### Added

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -1,4 +1,4 @@
-import { stubPlus } from "cypress/support/stubs";
+import { stubPlus, stubTranslationConfig } from "cypress/support/stubs";
 
 import { PRIVACY_EXPERIENCE_ROUTE } from "~/features/common/nav/v2/routes";
 import { RoleRegistryEnum } from "~/types/api";
@@ -190,6 +190,23 @@ describe("Privacy experiences", () => {
         // Make sure regions is still ["us_ca"] (unchanged)
         expect(body.regions).to.eql(["us_ca"]);
       });
+    });
+  });
+
+  describe("translation interface", () => {
+    it("shows the language interface when translations are enabled", () => {
+      stubTranslationConfig(true);
+      cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/new`);
+      cy.wait("@getTranslationConfig");
+      cy.getByTestId("input-auto_detect_language").should("exist");
+    });
+
+    it("shows an edit button instead when translations are disabled", () => {
+      stubTranslationConfig(false);
+      cy.visit(`${PRIVACY_EXPERIENCE_ROUTE}/new`);
+      cy.wait("@getTranslationConfig");
+      cy.getByTestId("input-auto_detect_language").should("not.exist");
+      cy.getByTestId("edit-experience-btn").should("exist");
     });
   });
 });

--- a/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
@@ -3,6 +3,7 @@ import {
   stubPlus,
   stubPrivacyNoticesCrud,
   stubTaxonomyEntities,
+  stubTranslationConfig,
 } from "cypress/support/stubs";
 
 import { PRIVACY_NOTICES_ROUTE } from "~/features/common/nav/v2/routes";
@@ -307,6 +308,7 @@ describe("Privacy notices", () => {
     });
 
     it("can create a new privacy notice", () => {
+      stubTranslationConfig(true);
       cy.visit(`${PRIVACY_NOTICES_ROUTE}/new`);
       cy.getByTestId("new-privacy-notice-page");
       const notice = {
@@ -380,6 +382,23 @@ describe("Privacy notices", () => {
 
       // can still edit the notice key field to be something else
       cy.getByTestId("input-notice_key").clear().type("custom_key");
+    });
+  });
+
+  describe("translation interface", () => {
+    it("shows the translation interface when translations are enabled", () => {
+      stubLanguages();
+      stubTranslationConfig(true);
+      cy.visit(`${PRIVACY_NOTICES_ROUTE}/new`);
+      cy.wait("@getTranslationConfig");
+      cy.getByTestId("add-language-btn").should("exist");
+    });
+
+    it("doesn't show the translation interface when translations are disabled", () => {
+      stubTranslationConfig(false);
+      cy.visit(`${PRIVACY_NOTICES_ROUTE}/new`);
+      cy.wait("@getTranslationConfig");
+      cy.getByTestId("add-language-btn").should("not.exist");
     });
   });
 });

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -247,3 +247,14 @@ export const stubSystemVendors = () => {
     fixture: "systems/system-vendors.json",
   }).as("getSystemVendors");
 };
+
+export const stubTranslationConfig = (enabled: boolean) => {
+  cy.intercept("GET", "/api/v1/config*", {
+    body: {
+      consent: {
+        enable_translations: enabled,
+        enable_oob_translations: enabled,
+      },
+    },
+  }).as("getTranslationConfig");
+};

--- a/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
@@ -37,6 +37,7 @@ import {
 import { PrivacyExperienceForm } from "~/features/privacy-experience/PrivacyExperienceForm";
 import PrivacyExperienceTranslationForm from "~/features/privacy-experience/PrivacyExperienceTranslationForm";
 import { selectAllPrivacyNotices } from "~/features/privacy-notices/privacy-notices.slice";
+import { useGetConfigurationSettingsQuery } from "~/features/privacy-requests";
 import {
   ComponentType,
   ExperienceConfigCreate,
@@ -90,6 +91,11 @@ const ConfigurePrivacyExperience = ({
   const [isMobilePreview, setIsMobilePreview] = useState(false);
 
   const router = useRouter();
+
+  const { data: appConfig } = useGetConfigurationSettingsQuery({
+    api_set: false,
+  });
+  const translationsEnabled = appConfig?.consent?.enable_translations;
 
   const languagePage = useAppSelector(selectLanguagePage);
   const languagePageSize = useAppSelector(selectLanguagePageSize);
@@ -184,12 +190,14 @@ const ConfigurePrivacyExperience = ({
           {translationToEdit ? (
             <PrivacyExperienceTranslationForm
               translation={translationToEdit}
+              translationsEnabled={translationsEnabled}
               isOOB={usingOOBValues}
               onReturnToMainForm={handleExitTranslationForm}
             />
           ) : (
             <PrivacyExperienceForm
               allPrivacyNotices={allPrivacyNotices}
+              translationsEnabled={translationsEnabled}
               onSelectTranslation={handleTranslationSelected}
               onCreateTranslation={handleCreateNewTranslation}
             />

--- a/clients/admin-ui/src/features/privacy-experience/NewJavaScriptTag.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/NewJavaScriptTag.tsx
@@ -43,7 +43,7 @@ const NewJavaScriptTag = ({ property }: Props) => {
   const fidesJsScriptTag = useMemo(() => {
     const script = FIDES_JS_SCRIPT_TEMPLATE.replace(
       PROPERTY_UNIQUE_ID_TEMPLATE,
-      property.id.toString()
+      property.id!.toString()
     );
     if (isFidesCloud && isSuccess && fidesCloudConfig?.privacy_center_url) {
       script.replace(

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowForwardIcon,
   Box,
   Button,
   ButtonGroup,
@@ -81,10 +82,12 @@ export const PrivacyExperienceConfigColumnLayout = ({
 
 export const PrivacyExperienceForm = ({
   allPrivacyNotices,
+  translationsEnabled,
   onSelectTranslation,
   onCreateTranslation,
 }: {
   allPrivacyNotices: LimitedPrivacyNoticeResponseSchema[];
+  translationsEnabled?: boolean;
   onSelectTranslation: (t: ExperienceTranslation) => void;
   onCreateTranslation: (lang: SupportedLanguage) => ExperienceTranslation;
 }) => {
@@ -241,34 +244,48 @@ export const PrivacyExperienceForm = ({
         getItemLabel={(item) => PRIVACY_NOTICE_REGION_RECORD[item]}
         draggable
       />
-      <ScrollableList
-        label="Languages for this experience"
-        addButtonLabel="Add language"
-        values={values.translations ?? []}
-        setValues={(newValues) => setFieldValue("translations", newValues)}
-        idField="language"
-        canDeleteItem={(item) => !item.is_default}
-        allItems={allLanguages
-          .slice()
-          .sort((a, b) => a.name.localeCompare(b.name))
-          .map((lang) => ({
-            language: lang.id as SupportedLanguage,
-            is_default: false,
-          }))}
-        getItemLabel={getTranslationDisplayName}
-        createNewValue={(opt) =>
-          onCreateTranslation(opt.value as SupportedLanguage)
-        }
-        onRowClick={onSelectTranslation}
-        selectOnAdd
-        draggable
-      />
-      <CustomSwitch
-        name="auto_detect_language"
-        id="auto_detect_language"
-        label="Auto detect language"
-        variant="stacked"
-      />
+      {translationsEnabled ? (
+        <>
+          <ScrollableList
+            label="Languages for this experience"
+            addButtonLabel="Add language"
+            values={values.translations ?? []}
+            setValues={(newValues) => setFieldValue("translations", newValues)}
+            idField="language"
+            canDeleteItem={(item) => !item.is_default}
+            allItems={allLanguages
+              .slice()
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((lang) => ({
+                language: lang.id as SupportedLanguage,
+                is_default: false,
+              }))}
+            getItemLabel={getTranslationDisplayName}
+            createNewValue={(opt) =>
+              onCreateTranslation(opt.value as SupportedLanguage)
+            }
+            onRowClick={onSelectTranslation}
+            selectOnAdd
+            draggable
+          />
+          <CustomSwitch
+            name="auto_detect_language"
+            id="auto_detect_language"
+            label="Auto detect language"
+            variant="stacked"
+          />
+        </>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          rightIcon={<ArrowForwardIcon />}
+          onClick={() => onSelectTranslation(values.translations![0])}
+          data-testid="edit-experience-btn"
+        >
+          Edit experience text
+        </Button>
+      )}
     </PrivacyExperienceConfigColumnLayout>
   );
 };

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
@@ -40,10 +40,12 @@ export const OOBTranslationNotice = ({
 
 const PrivacyExperienceTranslationForm = ({
   translation,
+  translationsEnabled,
   isOOB,
   onReturnToMainForm,
 }: {
   translation: TranslationWithLanguageName;
+  translationsEnabled?: boolean;
   isOOB?: boolean;
   onReturnToMainForm: () => void;
 }) => {
@@ -148,46 +150,57 @@ const PrivacyExperienceTranslationForm = ({
     </ButtonGroup>
   );
 
+  let unsavedChangesMessage;
+  if (!translationsEnabled) {
+    unsavedChangesMessage =
+      "You have unsaved changes to this experience text. Discard changes?";
+  } else {
+    unsavedChangesMessage = isEditing
+      ? "You have unsaved changes to this translation. Discard changes?"
+      : "This translation has not been added to your experience.  Discard translation?";
+  }
+
   return (
     <PrivacyExperienceConfigColumnLayout buttonPanel={buttonPanel}>
       <BackButtonNonLink onClick={handleLeaveForm} mt={4} />
       <WarningModal
         isOpen={unsavedChangesIsOpen}
         onClose={onCloseUnsavedChanges}
-        title="Translation not saved"
-        message={
-          <Text>
-            {isEditing
-              ? "You have unsaved changes to this translation. Discard changes?"
-              : "This translation has not been added to your experience.  Discard translation?"}
-          </Text>
-        }
+        title={translationsEnabled ? "Translation not saved" : "Text not saved"}
+        message={<Text>{unsavedChangesMessage}</Text>}
         confirmButtonText="Discard"
         handleConfirm={discardChanges}
       />
-      <WarningModal
-        isOpen={newDefaultIsOpen}
-        onClose={onCloseNewDefault}
-        title="Update default language"
-        message={
-          <Text>
-            Are you sure you want to update the default language of this
-            experience?
-          </Text>
-        }
-        handleConfirm={() => setNewDefaultTranslation(translationIndex)}
-      />
       <Heading fontSize="md" fontWeight="semibold">
-        Edit {translation.name} translation
+        {translationsEnabled
+          ? `Edit ${translation.name} translation`
+          : "Edit experience text"}
       </Heading>
       {isOOB ? <OOBTranslationNotice languageName={translation.name} /> : null}
-      <CustomSwitch
-        name={`translations.${translationIndex}.is_default`}
-        id={`translations.${translationIndex}.is_default`}
-        label="Default language"
-        isDisabled={initialTranslation.is_default}
-        variant="stacked"
-      />
+      {translationsEnabled ? (
+        <>
+          <CustomSwitch
+            name={`translations.${translationIndex}.is_default`}
+            id={`translations.${translationIndex}.is_default`}
+            label="Default language"
+            isDisabled={initialTranslation.is_default}
+            variant="stacked"
+          />
+          <WarningModal
+            isOpen={newDefaultIsOpen}
+            onClose={onCloseNewDefault}
+            title="Update default language"
+            message={
+              <Text>
+                Are you sure you want to update the default language of this
+                experience?
+              </Text>
+            }
+            handleConfirm={() => setNewDefaultTranslation(translationIndex)}
+          />
+        </>
+      ) : null}
+
       <CustomTextInput
         name={`translations.${translationIndex}.title`}
         id={`translations.${translationIndex}.title`}

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeTranslationForm.tsx
@@ -32,12 +32,29 @@ import {
   useGetAllLanguagesQuery,
 } from "~/features/privacy-experience/language.slice";
 import { OOBTranslationNotice } from "~/features/privacy-experience/PrivacyExperienceTranslationForm";
+import { useGetConfigurationSettingsQuery } from "~/features/privacy-requests";
 import {
   NoticeTranslation,
   NoticeTranslationCreate,
   PrivacyNoticeCreation,
   SupportedLanguage,
 } from "~/types/api";
+
+const NoticeFormFields = ({ index }: { index: number }) => (
+  <>
+    <CustomTextInput
+      autoFocus={index !== 0}
+      name={`translations.${index}.title`}
+      label="Title of consent notice as displayed to user"
+      variant="stacked"
+    />
+    <CustomTextArea
+      name={`translations.${index}.description`}
+      label="Privacy notice displayed to the user"
+      variant="stacked"
+    />
+  </>
+);
 
 const TranslationFormBlock = ({
   index,
@@ -51,17 +68,7 @@ const TranslationFormBlock = ({
   <Flex direction="column" gap={6}>
     <Heading size="sm">Edit {name} translation</Heading>
     {isOOB ? <OOBTranslationNotice languageName={name} /> : null}
-    <CustomTextInput
-      autoFocus={index !== 0}
-      name={`translations.${index}.title`}
-      label="Title of consent notice as displayed to user"
-      variant="stacked"
-    />
-    <CustomTextArea
-      name={`translations.${index}.description`}
-      label="Privacy notice displayed to the user"
-      variant="stacked"
-    />
+    <NoticeFormFields index={index} />
   </Flex>
 );
 
@@ -110,6 +117,11 @@ const PrivacyNoticeTranslationForm = ({
     useState<boolean>(false);
   const [translationIsOOB, setTranslationIsOOB] = useState<boolean>(false);
   const [tabIndex, setTabIndex] = useState<number>(0);
+
+  const { data: appConfig } = useGetConfigurationSettingsQuery({
+    api_set: false,
+  });
+  const translationsEnabled = appConfig?.consent?.enable_translations;
 
   const languagePage = useAppSelector(selectPage);
   const languagePageSize = useAppSelector(selectPageSize);
@@ -160,6 +172,14 @@ const PrivacyNoticeTranslationForm = ({
 
   const getLanguageDisplayName = (lang: SupportedLanguage) =>
     allLanguages.find((language) => language.id === lang)?.name ?? lang;
+
+  if (!translationsEnabled) {
+    return (
+      <FormSection title="Notice text">
+        <NoticeFormFields index={0} />
+      </FormSection>
+    );
+  }
 
   return (
     <FormSection title="Localizations">

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
@@ -4,8 +4,8 @@
 
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationCreate } from "./ExperienceTranslationCreate";
+import type { MinimalProperty } from "./MinimalProperty";
 import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
-import type { Property } from "./Property";
 
 /**
  * Schema for creating Experience Configs via the API
@@ -22,5 +22,5 @@ export type ExperienceConfigCreate = {
   component: ComponentType;
   privacy_notice_ids?: Array<string>;
   translations?: Array<ExperienceTranslationCreate>;
-  properties?: Array<Property>;
+  properties?: Array<MinimalProperty>;
 };

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigListViewResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigListViewResponse.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 
 import type { ComponentType } from "./ComponentType";
-import { MinimalProperty } from "./MinimalProperty";
+import type { MinimalProperty } from "./MinimalProperty";
 import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
 
 /**
@@ -13,8 +13,8 @@ export type ExperienceConfigListViewResponse = {
   id: string;
   name: string;
   regions: Array<PrivacyNoticeRegion>;
-  properties: Array<MinimalProperty>;
   component: ComponentType;
   updated_at: string;
   disabled: boolean;
+  properties: Array<MinimalProperty>;
 };

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
@@ -4,6 +4,7 @@
 
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationResponse } from "./ExperienceTranslationResponse";
+import type { MinimalProperty } from "./MinimalProperty";
 import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
 import type { PrivacyNoticeResponse } from "./PrivacyNoticeResponse";
 
@@ -24,4 +25,5 @@ export type ExperienceConfigResponse = {
   component: ComponentType;
   privacy_notices?: Array<PrivacyNoticeResponse>;
   translations?: Array<ExperienceTranslationResponse>;
+  properties?: Array<MinimalProperty>;
 };

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -4,6 +4,7 @@
 
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationResponse } from "./ExperienceTranslationResponse";
+import type { MinimalProperty } from "./MinimalProperty";
 import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
 import type { SupportedLanguage } from "./SupportedLanguage";
 
@@ -75,4 +76,5 @@ export type ExperienceConfigResponseNoNotices = {
   updated_at: string;
   component: ComponentType;
   translations?: Array<ExperienceTranslationResponse>;
+  properties?: Array<MinimalProperty>;
 };

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { ExperienceTranslation } from "./ExperienceTranslation";
+import type { MinimalProperty } from "./MinimalProperty";
 import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
 
 /**
@@ -24,4 +25,5 @@ export type ExperienceConfigUpdate = {
   regions: Array<PrivacyNoticeRegion>;
   translations: Array<ExperienceTranslation>;
   privacy_notice_ids: Array<string>;
+  properties: Array<MinimalProperty>;
 };

--- a/clients/admin-ui/src/types/api/models/MinimalPrivacyExperience.ts
+++ b/clients/admin-ui/src/types/api/models/MinimalPrivacyExperience.ts
@@ -2,6 +2,10 @@
 /* tslint:disable */
 /* eslint-disable */
 
+/**
+ * Minimal representation of a privacy experience, contains enough information
+ * to select experiences by name in the UI and an ID to link the selections in the database.
+ */
 export type MinimalPrivacyExperience = {
   id: string;
   name: string;

--- a/clients/admin-ui/src/types/api/models/MinimalProperty.ts
+++ b/clients/admin-ui/src/types/api/models/MinimalProperty.ts
@@ -2,6 +2,9 @@
 /* tslint:disable */
 /* eslint-disable */
 
+/**
+ * A base template for all other Fides Schemas to inherit from.
+ */
 export type MinimalProperty = {
   id: string;
   name: string;

--- a/clients/admin-ui/src/types/api/models/PrivacyExperienceResponse.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyExperienceResponse.ts
@@ -23,7 +23,8 @@ import type { TCFVendorRelationships } from "./TCFVendorRelationships";
  * Notices are extracted from the shared Experience Config and placed at the top-level here
  * for backwards compatibility, and to reduce nesting due to notice translations.
  *
- * Additionally, the notices on the ExperienceConfig are further filtered.
+ * Additionally, the notices may be a subset of the notices attached to the ExperienceConfig
+ * due to filtering
  */
 export type PrivacyExperienceResponse = {
   id: string;

--- a/clients/admin-ui/src/types/api/models/PrivacyNoticeResponse.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyNoticeResponse.ts
@@ -13,7 +13,7 @@ import type { UserConsentPreference } from "./UserConsentPreference";
 /**
  * An API representation of a PrivacyNotice used for response payloads
  *
- * Overrides fields from PriavcyNotice schema to indicate which ones
+ * Overrides fields from PrivacyNotice schema to indicate which ones
  * are guaranteed to be supplied
  */
 export type PrivacyNoticeResponse = {

--- a/clients/admin-ui/src/types/api/models/Property.ts
+++ b/clients/admin-ui/src/types/api/models/Property.ts
@@ -2,12 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { MinimalPrivacyExperience } from "./MinimalPrivacyExperience";
-import { PropertyType } from "./PropertyType";
+import type { MinimalPrivacyExperience } from "./MinimalPrivacyExperience";
+import type { PropertyType } from "./PropertyType";
 
+/**
+ * A base template for all other Fides Schemas to inherit from.
+ */
 export type Property = {
-  id: string;
   name: string;
   type: PropertyType;
+  id?: string;
   experiences: Array<MinimalPrivacyExperience>;
 };

--- a/clients/admin-ui/src/types/api/models/SupportedLanguage.ts
+++ b/clients/admin-ui/src/types/api/models/SupportedLanguage.ts
@@ -16,6 +16,7 @@ export enum SupportedLanguage {
   EL = "el",
   EN = "en",
   ES = "es",
+  ES_MX = "es-MX",
   ET = "et",
   EU = "eu",
   FI = "fi",


### PR DESCRIPTION
Closes PROD-1820

### Description Of Changes

Removes references to translations in the privacy notice and privacy experience forms when user does not have translations enabled on the backend, replacing them with generic "text editing" forms.

### Code Changes

* [ ] Small refactors to privacy notice form and privacy experience form
* [ ] Re-generate OpenAPI types

### Steps to Confirm

Use fidesplus backend on branch `PROD-1819_surface_translation_config_settings`.

As a control to confirm translation interfaces still work as expected when translations are enabled, have the following in `.fides/fides.toml` in fidesplus:
```toml
[consent]
enable_translations = true
enable_oob_translations = true
```
* [ ] In admin UI, navigate to `/consent/privacy-notices`
* [ ] Edit or create a new privacy notice
* [ ] Should see interface at bottom of form for adding new languages and switching between languages
* [ ] Should be able to make changes to translations and submit notices
* [ ] In admin UI, navigate to `/consent/privacy-experience`
* [ ] Edit or create a new privacy experience
* [ ] Should see scrollable list component with languages; should be able to add new translations and edit existing ones
* [ ] Should be able to make changes to translations and submit experience

Replace `true` with `false` in the config snippet above, then rerun backend.
* [ ] Navigate to `/consent/privacy-notices`
* [ ] Edit or create a new privacy notice
* [ ] Should see form titled "Notice text" and no language selection menu:

![Screenshot 2024-03-19 at 11 14 33](https://github.com/ethyca/fides/assets/6394496/f7fd3bb9-6393-4a4b-a38a-ad2574a79da5)

* [ ] Should be able to make changes to notice text and submit notice
* [ ] Navigate to `/consent/privacy-experience`
* [ ] Edit or create a new privacy experience
* [ ] Should see button labeled "Edit experience text" and no language selection or "auto detect language" switch
* [ ] Inside text edit form, switch to toggle whether language is default should not be present
* [ ] Should be able to make changes to experience text and submit experience

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
