### PR TITLE
PROD-1356 Fix overlapping/floating buttons in integrations screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.32.0...main)
 
+### Fixed
+
+- Fixed responsive issues with the buttons on the integration screen [#4729](https://github.com/ethyca/fides/pull/4729)
+
+
 ## [2.32.0](https://github.com/ethyca/fides/compare/2.31.1...2.32.0)
 
 ### Added

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionForm.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Spacer, useDisclosure } from "@fidesui/react";
+import { Box, Button, Flex, Stack, useDisclosure } from "@fidesui/react";
 import Restrict from "common/Restrict";
 import ConnectionListDropdown, {
   useConnectionListDropDown,
@@ -63,33 +63,36 @@ const ConnectionForm = ({ connectionConfig, systemFidesKey }: Props) => {
   return (
     <Box id="con-wrapper" px={6}>
       <Flex py={5}>
-        <ConnectionListDropdown
-          list={dropDownOptions}
-          label="Integration type"
-          selectedValue={selectedConnectionOption}
-          onChange={setSelectedConnectionOption}
-          disabled={connectionConfig && connectionConfig !== null}
-        />
-        <Spacer />
-        {!connectionConfig && orphanedConnectionConfigs.length > 0 ? (
-          <OrphanedConnectionModal
-            connectionConfigs={orphanedConnectionConfigs}
-            systemFidesKey={systemFidesKey}
+        <Stack direction={{ base: "column", lg: "row" }}>
+          <ConnectionListDropdown
+            list={dropDownOptions}
+            label="Integration type"
+            selectedValue={selectedConnectionOption}
+            onChange={setSelectedConnectionOption}
+            disabled={connectionConfig && connectionConfig !== null}
           />
-        ) : null}
-        <Restrict scopes={[ScopeRegistryEnum.CONNECTOR_TEMPLATE_REGISTER]}>
-          <Button
-            variant="outline"
-            type="submit"
-            minWidth="auto"
-            data-testid="upload-btn"
-            size="sm"
-            onClick={uploadTemplateModal.onOpen}
-            marginLeft={2}
-          >
-            Upload integration
-          </Button>
-        </Restrict>
+          {!connectionConfig && orphanedConnectionConfigs.length > 0 ? (
+            <OrphanedConnectionModal
+              connectionConfigs={orphanedConnectionConfigs}
+              systemFidesKey={systemFidesKey}
+            />
+          ) : null}
+
+          <Restrict scopes={[ScopeRegistryEnum.CONNECTOR_TEMPLATE_REGISTER]}>
+            <Button
+              variant="outline"
+              type="submit"
+              minWidth="auto"
+              data-testid="upload-btn"
+              size="sm"
+              onClick={uploadTemplateModal.onOpen}
+              marginLeft={2}
+            >
+              Upload integration
+            </Button>
+          </Restrict>
+        </Stack>
+
         <ConnectorTemplateUploadModal
           isOpen={uploadTemplateModal.isOpen}
           onClose={uploadTemplateModal.onClose}


### PR DESCRIPTION

### Description Of Changes

The buttons on the integration screen would sometimes overlap or leave big gaps that shouldn't happen. 
The buttons should display horizontally and in smaller screen they should stack vertically.

### Code Changes

* [x] Removed spacer
* [x] Added Stack element configured to stack vertically on smaller screens and horizontally on larger screens 

### Before changes screenshots
![Screen Shot 2024-03-19 at 12 49 08](https://github.com/ethyca/fides/assets/4809430/df8a38af-e25b-44a1-86a6-5f3f4419c706)
![Captura de pantalla 2024-03-19 a la(s) 11 40 20 a  m](https://github.com/ethyca/fides/assets/4809430/991cf403-1903-4fd1-beeb-2f95a8aff228)

### After changes screenshots
![Screen Shot 2024-03-19 at 13 12 36](https://github.com/ethyca/fides/assets/4809430/6fca2ce0-5ea8-4f98-9341-25f7aaf1b93c)
![Screen Shot 2024-03-19 at 13 12 43](https://github.com/ethyca/fides/assets/4809430/1b2eda3d-d7fc-4d4f-a971-a15f42ca8103)


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
