### PR TITLE
PROD-1653 Disable editing of type of data use and name after it has b…

### DIFF
--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
@@ -116,6 +116,8 @@ export const PrivacyDeclarationFormComponents = ({
   privacyDeclarationId?: string;
   lockedForGVL?: boolean;
 }) => {
+  const isEditing = !!privacyDeclarationId;
+
   const legalBasisForProcessingOptions = useMemo(
     () =>
       (
@@ -161,7 +163,7 @@ export const PrivacyDeclarationFormComponents = ({
           label="Declaration name (optional)"
           name="name"
           tooltip="Would you like to append anything to the system name?"
-          disabled={lockedForGVL}
+          disabled={isEditing || lockedForGVL}
           variant="stacked"
         />
         <CustomSelect
@@ -175,7 +177,7 @@ export const PrivacyDeclarationFormComponents = ({
           tooltip="For which business purposes is this data processed?"
           variant="stacked"
           isRequired
-          isDisabled={!!privacyDeclarationId || lockedForGVL}
+          isDisabled={isEditing || lockedForGVL}
         />
         <CustomSelect
           name="data_categories"
@@ -453,12 +455,14 @@ export const PrivacyDeclarationForm = ({
   initialValues: passedInInitialValues,
   ...dataProps
 }: Props & DataProps) => {
+  const privacyDeclarationId = passedInInitialValues?.id;
+
   const { handleSubmit, initialValues } = usePrivacyDeclarationForm({
     onSubmit,
     onCancel,
     initialValues: passedInInitialValues,
     allDataUses: dataProps.allDataUses,
-    privacyDeclarationId: passedInInitialValues?.id,
+    privacyDeclarationId,
   });
 
   const lockedForGVL = useAppSelector(selectLockedForGVL);
@@ -477,6 +481,7 @@ export const PrivacyDeclarationForm = ({
             <PrivacyDeclarationFormComponents
               values={values}
               lockedForGVL={lockedForGVL}
+              privacyDeclarationId={privacyDeclarationId}
               {...dataProps}
             />
             <Flex w="100%">


### PR DESCRIPTION

### Description Of Changes

After creation of a data use declaration, don't allow to edit the data use type or the declaration name.

### Code Changes

* [ ] Pass privacyDeclarationId prop that was missing
* [ ] Disable field is we're editing an already created data use declaration



### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
