### PR TITLE
Restore CORS domain regex to domains page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The types of changes are:
 - Disable editing of data use declaration name and type after creation [#4731](https://github.com/ethyca/fides/pull/4731)
 - Cleaned up table borders [#4733](https://github.com/ethyca/fides/pull/4733)
 - Initialization issues with ExperienceNotices (#4723)[https://github.com/ethyca/fides/pull/4723]
+- Re-add CORS origin regex field to admin UI (#4742)[https://github.com/ethyca/fides/pull/4742]
 
 ## [2.32.0](https://github.com/ethyca/fides/compare/2.31.1...2.32.0)
 

--- a/clients/admin-ui/cypress/e2e/domains.cy.ts
+++ b/clients/admin-ui/cypress/e2e/domains.cy.ts
@@ -11,6 +11,7 @@ const API_SET_CONFIG = {
 const CONFIG_SET_CONFIG = {
   security: {
     cors_origins: ["http://localhost"],
+    cors_origin_regex: "https://.*\\.example\\.com",
   },
 };
 
@@ -76,6 +77,11 @@ describe("Domains page", () => {
             "http://localhost"
           );
         });
+
+        cy.getByTestId("input-config_cors_origin_regex").should(
+          "have.value",
+          "https://.*\\.example\\.com"
+        );
       });
     });
 
@@ -100,6 +106,7 @@ describe("Domains page", () => {
 
         cy.getByTestId("config-set-domains-form").within(() => {
           cy.getByTestId("input-config_cors_origins[0]").should("not.exist");
+          cy.getByTestId("input-config_cors_origin_regex").should("not.exist");
           cy.contains("No advanced domain settings configured.");
         });
       });

--- a/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -514,8 +514,8 @@ export type CORSOrigins = Pick<SecurityApplicationConfig, "cors_origins">;
  * be consistent!
  */
 export type CORSOriginsSettings = {
-  configSet: Pick<SecurityApplicationConfig, "cors_origins">;
-  apiSet: Pick<SecurityApplicationConfig, "cors_origins">;
+  configSet: SecurityApplicationConfig & { cors_origin_regex?: string };
+  apiSet: SecurityApplicationConfig;
 };
 
 export const selectCORSOrigins: (state: RootState) => CORSOriginsSettings =
@@ -535,6 +535,7 @@ export const selectCORSOrigins: (state: RootState) => CORSOriginsSettings =
       const currentCORSOriginSettings: CORSOriginsSettings = {
         configSet: {
           cors_origins: configSetConfig?.security?.cors_origins || [],
+          cors_origin_regex: configSetConfig?.security?.cors_origin_regex,
         },
         apiSet: {
           cors_origins: apiSetConfig?.security?.cors_origins || [],

--- a/clients/admin-ui/src/pages/management/domains.tsx
+++ b/clients/admin-ui/src/pages/management/domains.tsx
@@ -45,7 +45,9 @@ const CORSConfigurationPage: NextPage = () => {
   const currentSettings = useAppSelector(selectCORSOrigins);
   const apiSettings = currentSettings.apiSet;
   const configSettings = currentSettings.configSet;
-  const hasConfigSettings: boolean = !!configSettings.cors_origins?.length;
+  const hasConfigSettings: boolean = !!(
+    configSettings.cors_origins?.length || configSettings.cors_origin_regex
+  );
   const applicationConfig = useAppSelector(selectApplicationConfig());
   const [putConfigSettingsTrigger, { isLoading: isLoadingPutMutation }] =
     usePutConfigurationSettingsMutation();
@@ -280,6 +282,16 @@ const CORSConfigurationPage: NextPage = () => {
                     isPassword={false}
                   />
                 ))}
+                {configSettings.cors_origin_regex ? (
+                  <TextInput
+                    data-testid="input-config_cors_origin_regex"
+                    key="cors_origin_regex"
+                    marginY={3}
+                    value={configSettings.cors_origin_regex}
+                    isDisabled
+                    isPassword={false}
+                  />
+                ) : undefined}
                 {!hasConfigSettings ? (
                   <Text fontSize="xs" color="gray.500">
                     No advanced domain settings configured.


### PR DESCRIPTION
Closes #PROD-1829

### Description Of Changes

The display for CORS origin regex on domains page was [incorrectly removed](https://github.com/ethyca/fides/pull/4576/files#diff-f1e807941f25cb9ef3e43bcae355506ec80fe430bfd4dbb26aaa12418fe00f4e) as part of the Consent 3.0 release, this restores it.

![Screenshot 2024-03-25 at 13 36 32](https://github.com/ethyca/fides/assets/6394496/d0e89ca1-e501-4610-9892-a814f283cf8c)

### Code Changes

* [ ] Re-add removed code to display CORS origin regex in UI, as well as tests
* [ ] Small refactor to related types

### Steps to Confirm

In .fides/fides.toml under `[security]`, add a value for `cors_origin_regex`, e.g.:

`cors_origin_regex = "http://localhost:[0-9][0-9][0-9][0-9]"`

* [ ] Navigate to `/management/domains`
* [ ] Should see disabled input showing your regex value

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
