### PR TITLE
Fix: move cell styles outside of `article`

### DIFF
--- a/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
@@ -54,11 +54,11 @@ export const FidesCell = <T,>({
         article: {
           borderTopWidth: "2x",
           borderTopColor: "red",
-          ...getTableTHandTDStyles(cell.column.id),
-          // Fancy CSS memoization magic https://tanstack.com/table/v8/docs/framework/react/examples/column-resizing-performant
-          maxWidth: `calc(var(--header-${cell.column.id}-size) * 1px)`,
-          minWidth: `calc(var(--header-${cell.column.id}-size) * 1px)`,
         },
+        ...getTableTHandTDStyles(cell.column.id),
+        // Fancy CSS memoization magic https://tanstack.com/table/v8/docs/framework/react/examples/column-resizing-performant
+        maxWidth: `calc(var(--header-${cell.column.id}-size) * 1px)`,
+        minWidth: `calc(var(--header-${cell.column.id}-size) * 1px)`,
       }}
       _first={{
         borderBottomWidth:


### PR DESCRIPTION
### Description Of Changes

Accidentally moved styles into the `article` styles instead of the root element.


### Code Changes

* [x] move the styles to the root

### Steps to Confirm

* [ ] Check table cell padding

### Screenshot of fix
![CleanShot 2024-03-26 at 15 04 13@2x](https://github.com/ethyca/fides/assets/103820/066e7f7a-0879-4f2e-b71a-1bd3fab244b4)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
