### PR TITLE
Fix- adds back missing option param

### DIFF
--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -269,6 +269,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
               }}
               isAcknowledge={isAllNoticeOnly}
               isMobile={isMobile}
+              options={options}
             />
           )}
         />
@@ -305,6 +306,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
             isAcknowledge={isAllNoticeOnly}
             isMobile={isMobile}
             saveOnly={privacyNoticeItems.length === 1}
+            options={options}
           />
           <PrivacyPolicyLink i18n={i18n} />
         </Fragment>


### PR DESCRIPTION
Closes unticketed

### Description Of Changes

Fix type err in cypress test and on tsx compile.

### Code Changes

* [ ] Adds missing param to `NoticeConsentButtons` component

### Steps to Confirm

* [ ] Run `npx tsc --noEmit ` in clients/fides-js

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
