### PR TITLE
Update Cookie House to support for additional locations (Canada, Quebec, EEA) and a "property_id" override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,11 +45,7 @@ The types of changes are:
 
 ### Developer Experience
 - Added new script to allow recompiling of fides-js when the code changes [#4744](https://github.com/ethyca/fides/pull/4744)
-
-
-### Developer Experience
-- Added new script to allow recompiling of fides-js when the code changes [#4744](https://github.com/ethyca/fides/pull/4744)
-
+- Update Cookie House to support for additional locations (Canada, Quebec, EEA) and a "property_id" override [#4750](https://github.com/ethyca/fides/pull/4750)
 
 ## [2.32.0](https://github.com/ethyca/fides/compare/2.31.1...2.32.0)
 

--- a/clients/sample-app/src/components/GeolocationSelect/index.tsx
+++ b/clients/sample-app/src/components/GeolocationSelect/index.tsx
@@ -18,6 +18,9 @@ const geolocationOptions: GeolocationOption[] = [
   { value: "US-CA", label: "California", flag: "us-ca" },
   { value: "US-VA", label: "Virginia", flag: "us" },
   { value: "US-NY", label: "New York", flag: "us" },
+  { value: "CA", label: "Canada", flag: "ca" },
+  { value: "CA-QC", label: "Quebec", flag: "ca-qc" },
+  { value: "EEA", label: "EEA", flag: "eu" },
   { value: "FR-IDG", label: "Paris", flag: "fr" },
   { value: "DE-HE", label: "Frankfurt", flag: "de" },
 ];

--- a/clients/sample-app/src/components/Home/index.tsx
+++ b/clients/sample-app/src/components/Home/index.tsx
@@ -63,9 +63,7 @@ const Home = ({ privacyCenterUrl, products }: Props) => {
       </main>
       <footer className={css.footer}>
         <div>
-          <a href={privacyCenterUrl}>
-            Privacy Center
-          </a>
+          <a href={privacyCenterUrl}>Privacy Center</a>
         </div>
         <div>
           <button type="button" className={css.modalLink} id="fides-modal-link">

--- a/clients/sample-app/src/pages/index.tsx
+++ b/clients/sample-app/src/pages/index.tsx
@@ -49,13 +49,17 @@ export const getServerSideProps: GetServerSideProps<Props> = async () => {
 const IndexPage = ({ gtmContainerId, privacyCenterUrl, products }: Props) => {
   // Load the fides.js script from the Fides Privacy Center, assumed to be
   // running at http://localhost:3001
-  let fidesScriptTagUrl = `${privacyCenterUrl}/fides.js`;
+  const fidesScriptTagUrl = new URL(`${privacyCenterUrl}/fides.js`);
   const router = useRouter();
-  const { geolocation } = router.query;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { geolocation, property_id } = router.query;
 
-  // If a `?geolocation=` query param exists, pass that along to the fides.js fetch
-  if (geolocation) {
-    fidesScriptTagUrl += `?geolocation=${geolocation}`;
+  // If `geolocation=` or `property_id` query params exists, pass those along to the fides.js fetch
+  if (geolocation && typeof geolocation === "string") {
+    fidesScriptTagUrl.searchParams.append("geolocation", geolocation);
+  }
+  if (typeof property_id === "string") {
+    fidesScriptTagUrl.searchParams.append("property_id", property_id);
   }
 
   return (
@@ -73,7 +77,7 @@ const IndexPage = ({ gtmContainerId, privacyCenterUrl, products }: Props) => {
       <Script
         id="fides-js"
         strategy="beforeInteractive"
-        src={fidesScriptTagUrl}
+        src={fidesScriptTagUrl.href}
         onReady={() => {
           // Enable the GTM integration, if GTM is configured
           if (gtmContainerId) {


### PR DESCRIPTION
Related to PROD-1862

### Description Of Changes

This is a small update to the Cookie House sample app for demo purposes. It allows selecting a few extra locations (Canada, Quebec, EEA) and also lets you add a `property_id=` query param to the URL, which'll get passed along to the `fides.js` script include. Combined, you can use this to demo a lot more advanced consent experiences 👍 

### Code Changes

* [X] Add Canada, Quebec, and EEA options to the GeolocationSelect component
* [X] Add `property_id` to supported query params for fides.js script tag

### Steps to Confirm

* [X] Run `nox -s "fides_env(test)"` to bring up the `fides deploy` sample project
* [X] Try out the Cookie House and inspect the network tab to confirm that the `geolocation` and `property_id` params are passed along to `fides.js` script tag

![image](https://github.com/ethyca/fides/assets/1834295/b472e43c-ea7f-41f2-b224-f715d2fb7c63)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
