### PR TITLE
fix language switcher with queryParams + e2e tests

### DIFF
--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -1,7 +1,7 @@
 import "../fides.css";
 
 import { Fragment, FunctionComponent, h } from "preact";
-import { useCallback, useMemo, useState } from "preact/hooks";
+import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 
 import { getConsentContext } from "../../lib/consent-context";
 import {
@@ -72,7 +72,13 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
     return [];
   };
 
-  const { currentLocale } = useI18n();
+  const { currentLocale, setCurrentLocale } = useI18n();
+
+  useEffect(() => {
+    if (!currentLocale && i18n.locale) {
+      setCurrentLocale(i18n.locale);
+    }
+  }, [currentLocale, i18n.locale, setCurrentLocale]);
 
   /**
    * Determine which ExperienceConfig translation is being used based on the

--- a/clients/fides-js/src/lib/i18n/i18n-context.tsx
+++ b/clients/fides-js/src/lib/i18n/i18n-context.tsx
@@ -1,17 +1,15 @@
 import { createContext, h, FunctionComponent } from "preact";
 import { useContext, useState, useMemo, StateUpdater } from "preact/hooks";
-import { i18n } from "./index";
 
 interface I18nContextProps {
-  currentLocale: string;
-  setCurrentLocale: StateUpdater<string>;
+  currentLocale: string | null;
+  setCurrentLocale: StateUpdater<string | null>;
 }
 
 const I18nContext = createContext<I18nContextProps>({} as I18nContextProps);
 
 export const I18nProvider: FunctionComponent = ({ children }) => {
-  const { locale } = i18n;
-  const [currentLocale, setCurrentLocale] = useState(locale);
+  const [currentLocale, setCurrentLocale] = useState<string | null>(null);
 
   const value: I18nContextProps = useMemo(
     () => ({ currentLocale, setCurrentLocale }),

--- a/clients/fides-js/src/lib/i18n/i18n-context.tsx
+++ b/clients/fides-js/src/lib/i18n/i18n-context.tsx
@@ -2,14 +2,14 @@ import { createContext, h, FunctionComponent } from "preact";
 import { useContext, useState, useMemo, StateUpdater } from "preact/hooks";
 
 interface I18nContextProps {
-  currentLocale: string | null;
-  setCurrentLocale: StateUpdater<string | null>;
+  currentLocale: string | undefined;
+  setCurrentLocale: StateUpdater<string | undefined>;
 }
 
 const I18nContext = createContext<I18nContextProps>({} as I18nContextProps);
 
 export const I18nProvider: FunctionComponent = ({ children }) => {
-  const [currentLocale, setCurrentLocale] = useState<string | null>(null);
+  const [currentLocale, setCurrentLocale] = useState<string>();
 
   const value: I18nContextProps = useMemo(
     () => ({ currentLocale, setCurrentLocale }),

--- a/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
@@ -5,6 +5,7 @@ import {
   PrivacyExperience,
   PrivacyNotice,
 } from "fides-js";
+import { Locale } from "~/../fides-js/src/lib/i18n";
 import { TEST_OVERRIDE_WINDOW_PATH } from "~/cypress/support/constants";
 import { stubConfig } from "../support/stubs";
 
@@ -402,6 +403,14 @@ describe("Consent i18n", () => {
    *
    **********************************************************/
   describe("when localizing banner_and_modal components", () => {
+    const testBannerLanguageMenu = (locale: Locale) => {
+      cy.get("#fides-banner").within(() => {
+        cy.getByTestId(`fides-i18n-option-${locale}`).should(
+          "have.attr",
+          "aria-pressed"
+        );
+      });
+    };
     // Reusable assertions to test that the banner component localizes correctly
     const testBannerLocalization = (t: TestBannerTranslations) => {
       /**
@@ -700,6 +709,22 @@ describe("Consent i18n", () => {
       });
     });
 
+    describe(`when ?fides_locale override param is set to an available locale (${SPANISH_LOCALE})`, () => {
+      it(`ignores browser locale and localizes in the override locale (${SPANISH_LOCALE})`, () => {
+        // Visit the demo site in English, but expect Spanish translations when fides_locale override is set
+        visitDemoWithI18n({
+          navigatorLanguage: ENGLISH_LOCALE,
+          globalPrivacyControl: true,
+          fixture: "experience_banner_modal.json",
+          queryParams: { fides_locale: SPANISH_LOCALE },
+        });
+        testBannerLanguageMenu(SPANISH_LOCALE);
+        testBannerLocalization(SPANISH_BANNER);
+        openAndTestModalLocalization(SPANISH_MODAL);
+        testModalNoticesLocalization(SPANISH_NOTICES);
+      });
+    });
+
     describe("when user selects their own locale", () => {
       it(`localizes in the user selected locale (${SPANISH_LOCALE})`, () => {
         // Visit the demo site in English, but expect Spanish translations when the user selects
@@ -711,24 +736,26 @@ describe("Consent i18n", () => {
         cy.get("#fides-banner").should("be.visible");
         cy.getByTestId(`fides-i18n-option-${SPANISH_LOCALE}`).focus();
         cy.get(`.fides-i18n-menu`).focused().click();
+        testBannerLanguageMenu(SPANISH_LOCALE);
         testBannerLocalization(SPANISH_BANNER);
         openAndTestModalLocalization(SPANISH_MODAL);
         testModalNoticesLocalization(SPANISH_NOTICES);
       });
-    });
-
-    describe(`when ?fides_locale override param is set to an available locale (${SPANISH_LOCALE})`, () => {
-      it(`ignores browser locale and localizes in the override locale (${SPANISH_LOCALE})`, () => {
-        // Visit the demo site in English, but expect Spanish translations when fides_locale override is set
+      it(`ignores query params and localizes in the user selected locale (${ENGLISH_LOCALE})`, () => {
+        // Visit the demo site in English, but expect Spanish translations when the user selects
         visitDemoWithI18n({
           navigatorLanguage: ENGLISH_LOCALE,
           globalPrivacyControl: true,
           fixture: "experience_banner_modal.json",
           queryParams: { fides_locale: SPANISH_LOCALE },
         });
-        testBannerLocalization(SPANISH_BANNER);
-        openAndTestModalLocalization(SPANISH_MODAL);
-        testModalNoticesLocalization(SPANISH_NOTICES);
+        cy.get("#fides-banner").should("be.visible");
+        cy.getByTestId(`fides-i18n-option-${ENGLISH_LOCALE}`).focus();
+        cy.get(`.fides-i18n-menu`).focused().click();
+        testBannerLanguageMenu(ENGLISH_LOCALE);
+        testBannerLocalization(ENGLISH_BANNER);
+        openAndTestModalLocalization(ENGLISH_MODAL);
+        testModalNoticesLocalization(ENGLISH_NOTICES);
       });
     });
 

--- a/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
@@ -742,7 +742,7 @@ describe("Consent i18n", () => {
         testModalNoticesLocalization(SPANISH_NOTICES);
       });
       it(`ignores query params and localizes in the user selected locale (${ENGLISH_LOCALE})`, () => {
-        // Visit the demo site in English, but expect Spanish translations when the user selects
+        // Override the demo site in Spanish, but expect English translations when the user selects
         visitDemoWithI18n({
           navigatorLanguage: ENGLISH_LOCALE,
           globalPrivacyControl: true,


### PR DESCRIPTION
Closes [PROD-1888](https://ethyca.atlassian.net/browse/PROD-1888)

### Description Of Changes

i18n context was being initialized prior to the overrides taking effect. Changed to initialize as `null` and then use the override value once it was ready.

### Code Changes

* [x] Initialize i18n context with null
* [x] update i18n context value once overrides were available in the first plausible React component that could access the hook to do so (`NoticeOverlay.tsx`).
* [x] Add e2e tests to Cypress that verify the correct menu item is currently active to help catch this issue earlier.

### Steps to Confirm

* [ ] Add `fides_locale` query string (eg. `?fides_locale=es`) to the url of the fides test page: `/fides-js-components-demo.html?fides_locale=es`
* [ ] use the language picker in the banner to change language to English
* [ ] strings should switch to English

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded(https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Follow up ticket created https://ethyca.atlassian.net/browse/PROD-1892


[PROD-1888]: https://ethyca.atlassian.net/browse/PROD-1888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ