### PR TITLE
Fix: language switcher not working in tcf overlay

### DIFF
--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -1,5 +1,5 @@
 import { Fragment, FunctionComponent, h } from "preact";
-import { useCallback, useMemo, useState } from "preact/hooks";
+import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import ConsentBanner from "../ConsentBanner";
 import PrivacyPolicyLink from "../PrivacyPolicyLink";
 
@@ -47,6 +47,7 @@ import {
   transformConsentToFidesUserPreference,
   transformUserPreferenceToBoolean,
 } from "../../lib/shared-consent-utils";
+import { useI18n } from "../../lib/i18n/i18n-context";
 
 const resolveConsentValueFromTcfModel = (
   model:
@@ -234,6 +235,14 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
 
   const [draftIds, setDraftIds] = useState<EnabledIds>(initialEnabledIds);
 
+  const { currentLocale, setCurrentLocale } = useI18n();
+
+  useEffect(() => {
+    if (!currentLocale && i18n.locale) {
+      setCurrentLocale(i18n.locale);
+    }
+  }, [currentLocale, i18n.locale, setCurrentLocale]);
+
   // Determine which ExperienceConfig history ID should be used for the
   // reporting APIs, based on the selected locale
   const privacyExperienceConfigHistoryId: string | undefined = useMemo(() => {
@@ -245,7 +254,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
       return bestTranslation?.privacy_experience_config_history_id;
     }
     return undefined;
-  }, [experience, i18n]);
+  }, [experience, i18n, currentLocale]);
 
   const { servedNotice } = useConsentServed({
     privacyExperienceConfigHistoryId,

--- a/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
@@ -1487,6 +1487,20 @@ describe("Consent i18n", () => {
         testTcfModalLocalization(modal);
       });
     });
+    describe("when user selects their own locale", () => {
+      it(`localizes in the user selected locale (${SPANISH_LOCALE})`, () => {
+        visitDemoWithI18n({
+          navigatorLanguage: ENGLISH_LOCALE,
+          fixture: "experience_tcf.json",
+          options: { tcfEnabled: true },
+        });
+        cy.get("#fides-banner").should("be.visible");
+        cy.getByTestId(`fides-i18n-option-${SPANISH_LOCALE}`).focus();
+        cy.get(`.fides-i18n-menu`).focused().click();
+        testTcfBannerLocalization(SPANISH_TCF_BANNER);
+        testTcfModalLocalization(SPANISH_TCF_MODAL);
+      });
+    });
   });
 
   describe.skip("when localizing privacy_center components", () => {});


### PR DESCRIPTION
Closes [PROD-1892](https://ethyca.atlassian.net/browse/PROD-1892)

### Description Of Changes

matches Notices Overlay in TCF Overlay for how we watch the locale state from the i18n react context.


### Code Changes

* [x] updates `tcfOverlay.tsx` to include and utilize the `useI18n` hook to set and watch user set locale.
* [x] includes Cypress test for TCF overlay

### Steps to Confirm

* [ ] visit /fides-js-demo.html?geolocation=eea
* [ ] Use the language switcher to change languages
* [ ] ensure all of the text changes (not just the buttons)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met


[PROD-1892]: https://ethyca.atlassian.net/browse/PROD-1892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ