### PR TITLE
FE Admin UI update - New field to accept this value

### DIFF
--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
@@ -296,7 +296,7 @@ const PrivacyExperienceTranslationForm = ({
           variant="stacked"
         />
       ) : null}
-      {!!formConfig.modal_link_label?.included && (
+      {formConfig.modal_link_label?.included && (
         <CustomTextInput
           name={`translations.${translationIndex}.modal_link_label`}
           id={`translations.${translationIndex}.modal_link_label`}

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
@@ -296,10 +296,10 @@ const PrivacyExperienceTranslationForm = ({
           variant="stacked"
         />
       ) : null}
-      {!!formConfig.trigger_link_label?.included && (
+      {!!formConfig.modal_link_label?.included && (
         <CustomTextInput
-          name={`translations.${translationIndex}.trigger_link_label`}
-          id={`translations.${translationIndex}.trigger_link_label`}
+          name={`translations.${translationIndex}.modal_link_label`}
+          id={`translations.${translationIndex}.modal_link_label`}
           label="Trigger Link Label (optional)"
           tooltip="Include text here if you would like the Fides CMP to manage the copy of the button that is included on your site to open the CMP."
           variant="stacked"

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
@@ -182,7 +182,7 @@ const PrivacyExperienceTranslationForm = ({
           : "Edit experience text"}
       </Heading>
       {isOOB ? <OOBTranslationNotice languageName={translation.name} /> : null}
-      {translationsEnabled ? (
+      {translationsEnabled && (
         <>
           <CustomSwitch
             name={`translations.${translationIndex}.is_default`}
@@ -204,7 +204,7 @@ const PrivacyExperienceTranslationForm = ({
             handleConfirm={() => setNewDefaultTranslation(translationIndex)}
           />
         </>
-      ) : null}
+      )}
 
       <CustomTextInput
         name={`translations.${translationIndex}.title`}
@@ -221,24 +221,24 @@ const PrivacyExperienceTranslationForm = ({
         variant="stacked"
       />
       {values.component === ComponentType.BANNER_AND_MODAL ||
-      values.component === ComponentType.TCF_OVERLAY ? (
-        <>
-          <CustomTextInput
-            name={`translations.${translationIndex}.banner_title`}
-            id={`translations.${translationIndex}.banner_title`}
-            label="Banner title (optional)"
-            tooltip="A separate title for the banner (defaults to main title)"
-            variant="stacked"
-          />
-          <CustomTextArea
-            name={`translations.${translationIndex}.banner_description`}
-            id={`translations.${translationIndex}.banner_description`}
-            label="Banner description (optional)"
-            tooltip="A separate description for the banner (defaults to main description)"
-            variant="stacked"
-          />
-        </>
-      ) : null}
+        (values.component === ComponentType.TCF_OVERLAY && (
+          <>
+            <CustomTextInput
+              name={`translations.${translationIndex}.banner_title`}
+              id={`translations.${translationIndex}.banner_title`}
+              label="Banner title (optional)"
+              tooltip="A separate title for the banner (defaults to main title)"
+              variant="stacked"
+            />
+            <CustomTextArea
+              name={`translations.${translationIndex}.banner_description`}
+              id={`translations.${translationIndex}.banner_description`}
+              label="Banner description (optional)"
+              tooltip="A separate description for the banner (defaults to main description)"
+              variant="stacked"
+            />
+          </>
+        ))}
       <CustomTextInput
         name={`translations.${translationIndex}.accept_button_label`}
         id={`translations.${translationIndex}.accept_button_label`}
@@ -253,7 +253,7 @@ const PrivacyExperienceTranslationForm = ({
         isRequired
         variant="stacked"
       />
-      {formConfig.privacy_preferences_link_label?.included ? (
+      {formConfig.privacy_preferences_link_label?.included && (
         <CustomTextInput
           name={`translations.${translationIndex}.privacy_preferences_link_label`}
           id={`translations.${translationIndex}.privacy_preferences_link_label`}
@@ -261,8 +261,8 @@ const PrivacyExperienceTranslationForm = ({
           variant="stacked"
           isRequired={formConfig.privacy_preferences_link_label?.required}
         />
-      ) : null}
-      {formConfig.save_button_label?.included ? (
+      )}
+      {formConfig.save_button_label?.included && (
         <CustomTextInput
           name={`translations.${translationIndex}.save_button_label`}
           id={`translations.${translationIndex}.save_button_label`}
@@ -270,8 +270,8 @@ const PrivacyExperienceTranslationForm = ({
           variant="stacked"
           isRequired={formConfig.save_button_label.required}
         />
-      ) : null}
-      {formConfig.acknowledge_button_label?.included ? (
+      )}
+      {formConfig.acknowledge_button_label?.included && (
         <CustomTextInput
           name={`translations.${translationIndex}.acknowledge_button_label`}
           id={`translations.${translationIndex}.acknowledge_button_label`}
@@ -279,23 +279,23 @@ const PrivacyExperienceTranslationForm = ({
           variant="stacked"
           isRequired={formConfig.acknowledge_button_label.required}
         />
-      ) : null}
-      {formConfig.privacy_policy_link_label?.included ? (
+      )}
+      {formConfig.privacy_policy_link_label?.included && (
         <CustomTextInput
           name={`translations.${translationIndex}.privacy_policy_link_label`}
           id={`translations.${translationIndex}.privacy_policy_link_label`}
           label="Privacy policy link label (optional)"
           variant="stacked"
         />
-      ) : null}
-      {formConfig.privacy_policy_url?.included ? (
+      )}
+      {formConfig.privacy_policy_url?.included && (
         <CustomTextInput
           name={`translations.${translationIndex}.privacy_policy_url`}
           id={`translations.${translationIndex}.privacy_policy_url`}
           label="Privacy policy link URL (optional)"
           variant="stacked"
         />
-      ) : null}
+      )}
       {formConfig.modal_link_label?.included && (
         <CustomTextInput
           name={`translations.${translationIndex}.modal_link_label`}

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
@@ -296,6 +296,15 @@ const PrivacyExperienceTranslationForm = ({
           variant="stacked"
         />
       ) : null}
+      {!!formConfig.trigger_link_label?.included && (
+        <CustomTextInput
+          name={`translations.${translationIndex}.trigger_link_label`}
+          id={`translations.${translationIndex}.trigger_link_label`}
+          label="Trigger Link Label (optional)"
+          tooltip="Include text here if you would like the Fides CMP to manage the copy of the button that is included on your site to open the CMP."
+          variant="stacked"
+        />
+      )}
     </PrivacyExperienceConfigColumnLayout>
   );
 };

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -121,6 +121,7 @@ export const getTranslationFormFields = (
       reject_button_label: { included: true, required: true },
       privacy_policy_link_label: { included: true },
       privacy_policy_url: { included: true },
+      trigger_link_label: { included: true },
     };
   }
   if (component === ComponentType.MODAL) {
@@ -134,6 +135,7 @@ export const getTranslationFormFields = (
       privacy_policy_link_label: { included: true },
       privacy_policy_url: { included: true },
       privacy_preferences_link_label: { included: true },
+      trigger_link_label: { included: true },
     };
   }
 
@@ -150,6 +152,7 @@ export const getTranslationFormFields = (
       privacy_policy_link_label: { included: true },
       privacy_policy_url: { included: true },
       privacy_preferences_link_label: { included: true, required: true },
+      trigger_link_label: { included: true },
     };
   }
   // For TCF overlay / default
@@ -163,5 +166,6 @@ export const getTranslationFormFields = (
     privacy_policy_link_label: { included: true },
     privacy_policy_url: { included: true },
     privacy_preferences_link_label: { included: true, required: true },
+    trigger_link_label: { included: true },
   };
 };

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -121,7 +121,7 @@ export const getTranslationFormFields = (
       reject_button_label: { included: true, required: true },
       privacy_policy_link_label: { included: true },
       privacy_policy_url: { included: true },
-      trigger_link_label: { included: true },
+      modal_link_label: { included: true },
     };
   }
   if (component === ComponentType.MODAL) {
@@ -135,7 +135,7 @@ export const getTranslationFormFields = (
       privacy_policy_link_label: { included: true },
       privacy_policy_url: { included: true },
       privacy_preferences_link_label: { included: true },
-      trigger_link_label: { included: true },
+      modal_link_label: { included: true },
     };
   }
 
@@ -152,7 +152,7 @@ export const getTranslationFormFields = (
       privacy_policy_link_label: { included: true },
       privacy_policy_url: { included: true },
       privacy_preferences_link_label: { included: true, required: true },
-      trigger_link_label: { included: true },
+      modal_link_label: { included: true },
     };
   }
   // For TCF overlay / default
@@ -166,6 +166,6 @@ export const getTranslationFormFields = (
     privacy_policy_link_label: { included: true },
     privacy_policy_url: { included: true },
     privacy_preferences_link_label: { included: true, required: true },
-    trigger_link_label: { included: true },
+    modal_link_label: { included: true },
   };
 };

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -16,7 +16,7 @@ const defaultTranslation: ExperienceTranslation = {
   description: "Description",
   privacy_policy_link_label: "",
   privacy_policy_url: "",
-  trigger_link_label: "",
+  modal_link_label: "",
   privacy_preferences_link_label: "Privacy preferences",
   reject_button_label: "Reject All",
   save_button_label: "Save",

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -16,6 +16,7 @@ const defaultTranslation: ExperienceTranslation = {
   description: "Description",
   privacy_policy_link_label: "",
   privacy_policy_url: "",
+  trigger_link_label: "",
   privacy_preferences_link_label: "Privacy preferences",
   reject_button_label: "Reject All",
   save_button_label: "Save",
@@ -78,7 +79,9 @@ export const buildBaseConfig = (
   },
 });
 
-// fill in any empty strings in a translation with the defaults above
+/**
+ * fill in any empty strings in a translation with the defaults from `buildBaseConfig`
+ */
 export const translationOrDefault = (
   translation: ExperienceTranslation
 ): ExperienceTranslation => {

--- a/clients/admin-ui/src/features/privacy-experience/privacy-experience.slice.ts
+++ b/clients/admin-ui/src/features/privacy-experience/privacy-experience.slice.ts
@@ -38,7 +38,7 @@ type ExperienceConfigOptionalFields =
   | "banner_description"
   | "privacy_policy_link_label"
   | "privacy_policy_url"
-  | "trigger_link_label";
+  | "modal_link_label";
 export type ExperienceConfigUpdateParams = Omit<
   Partial<ExperienceConfigUpdate>,
   ExperienceConfigOptionalFields
@@ -48,7 +48,7 @@ export type ExperienceConfigUpdateParams = Omit<
   banner_description?: string | null;
   privacy_policy_link_label?: string | null;
   privacy_policy_url?: string | null;
-  trigger_link_label?: string | null;
+  modal_link_label?: string | null;
 };
 type ExperienceConfigEnableDisableParams = ExperienceConfigDisabledUpdate & {
   id: string;
@@ -61,7 +61,7 @@ export type ExperienceConfigCreateParams = Omit<
   banner_description?: string | null;
   privacy_policy_link_label?: string | null;
   privacy_policy_url?: string | null;
-  trigger_link_label?: string | null;
+  modal_link_label?: string | null;
 };
 
 const privacyExperienceConfigApi = baseApi.injectEndpoints({

--- a/clients/admin-ui/src/features/privacy-experience/privacy-experience.slice.ts
+++ b/clients/admin-ui/src/features/privacy-experience/privacy-experience.slice.ts
@@ -37,7 +37,8 @@ type ExperienceConfigOptionalFields =
   | "banner_title"
   | "banner_description"
   | "privacy_policy_link_label"
-  | "privacy_policy_url";
+  | "privacy_policy_url"
+  | "trigger_link_label";
 export type ExperienceConfigUpdateParams = Omit<
   Partial<ExperienceConfigUpdate>,
   ExperienceConfigOptionalFields
@@ -47,6 +48,7 @@ export type ExperienceConfigUpdateParams = Omit<
   banner_description?: string | null;
   privacy_policy_link_label?: string | null;
   privacy_policy_url?: string | null;
+  trigger_link_label?: string | null;
 };
 type ExperienceConfigEnableDisableParams = ExperienceConfigDisabledUpdate & {
   id: string;
@@ -59,6 +61,7 @@ export type ExperienceConfigCreateParams = Omit<
   banner_description?: string | null;
   privacy_policy_link_label?: string | null;
   privacy_policy_url?: string | null;
+  trigger_link_label?: string | null;
 };
 
 const privacyExperienceConfigApi = baseApi.injectEndpoints({

--- a/clients/admin-ui/src/types/api/models/ExperienceTranslation.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceTranslation.ts
@@ -57,4 +57,8 @@ export type ExperienceTranslation = {
    * Overall description - used for banner as well if applicable.  HTML descriptions are supported so links can be included.
    */
   description?: string;
+  /**
+   * Custom link/button trigger label
+   */
+  trigger_link_label?: string;
 };

--- a/clients/admin-ui/src/types/api/models/ExperienceTranslation.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceTranslation.ts
@@ -60,5 +60,5 @@ export type ExperienceTranslation = {
   /**
    * Custom link/button trigger label
    */
-  trigger_link_label?: string;
+  modal_link_label?: string;
 };

--- a/clients/admin-ui/src/types/api/models/ExperienceTranslationCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceTranslationCreate.ts
@@ -51,4 +51,8 @@ export type ExperienceTranslationCreate = {
    */
   banner_description?: string;
   description: string;
+  /**
+   * Custom link/button trigger label
+   */
+  trigger_link_label?: string;
 };

--- a/clients/admin-ui/src/types/api/models/ExperienceTranslationCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceTranslationCreate.ts
@@ -54,5 +54,5 @@ export type ExperienceTranslationCreate = {
   /**
    * Custom link/button trigger label
    */
-  trigger_link_label?: string;
+  modal_link_label?: string;
 };

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -59,6 +59,7 @@ export const ConsentButtons = ({
                 data-testid={`fides-i18n-option-${lang.locale}`}
                 onClick={() => handleLocaleSelect(lang.locale)}
                 isActive={currentLocale === lang.locale}
+                title={lang.label_en}
               >
                 {lang.label_original}
               </MenuItem>

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -59,7 +59,6 @@ export const ConsentButtons = ({
                 data-testid={`fides-i18n-option-${lang.locale}`}
                 onClick={() => handleLocaleSelect(lang.locale)}
                 isActive={currentLocale === lang.locale}
-                title={lang.label_en}
               >
                 {lang.label_original}
               </MenuItem>

--- a/clients/fides-js/src/lib/i18n/locales/index.ts
+++ b/clients/fides-js/src/lib/i18n/locales/index.ts
@@ -7,6 +7,7 @@ import type { Locale, Messages, Language } from "..";
  * NOTE: This process isn't automatic. To add a new static locale, follow these steps:
  * 1) Add the static import of the new ./{locale}/messages.json file
  * 2) Add the locale to the LOCALES object below
+ * 3) Add the locale to the LOCALE_LANGUAGE_MAP object below
  */
 import ar from "./ar/messages.json";
 import bg from "./bg/messages.json";

--- a/clients/fides-js/src/lib/i18n/locales/index.ts
+++ b/clients/fides-js/src/lib/i18n/locales/index.ts
@@ -6,7 +6,7 @@ import type { Locale, Messages, Language } from "..";
  *
  * NOTE: This process isn't automatic. To add a new static locale, follow these steps:
  * 1) Add the static import of the new ./{locale}/messages.json file
- * 2) Add the locale to the LOCALES object below
+ * 2) Add the locale to the STATIC_MESSAGES object below
  * 3) Add the locale to the LOCALE_LANGUAGE_MAP object below
  */
 import ar from "./ar/messages.json";

--- a/clients/fides-js/src/lib/tcf/i18n/locales/index.ts
+++ b/clients/fides-js/src/lib/tcf/i18n/locales/index.ts
@@ -6,7 +6,7 @@ import type { Locale, Messages } from "../../../i18n";
  *
  * NOTE: This process isn't automatic. To add a new static locale, follow these steps:
  * 1) Add the static import of the new ./{locale}/messages-tcf.json file
- * 2) Add the locale to the LOCALES object below
+ * 2) Add the locale to the STATIC_MESSAGES_TCF object below
  */
 import ar from "./ar/messages-tcf.json";
 import bg from "./bg/messages-tcf.json";


### PR DESCRIPTION
Closes [PROD-1709](https://ethyca.atlassian.net/browse/PROD-1709)

### Description Of Changes

Adds new field to the translation form for Trigger Link Label. This allows users to set the language of the link that opens the Fides modal on their site.


### Code Changes

* [x] adds new `trigger_link_label` to the type definitions of `ExperienceTranslationCreate` and `ExperienceTranslation` schema.
* [x] adds new `trigger_link_label` to form inclusions
* [x] adds new field to the Admin UI translation form (WIP. Not hooked up to BE yet) 

### Steps to Confirm

* [ ] Open an experience in Admin UI
* [ ] Select a language from the sidebar
* [ ] Scroll to the bottom and add a new label to the Trigger Link Label field

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met


[PROD-1709]: https://ethyca.atlassian.net/browse/PROD-1709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ