### PR TITLE
add CUSTOM_OPTIONS_PATH to env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The types of changes are:
 - Fixed select dropdowns being cut off by edges of modal forms [#4757](https://github.com/ethyca/fides/pull/4757)
 - Changed "allow user to dismiss" toggle to show on config form for TCF experience [#4755](https://github.com/ethyca/fides/pull/4755)
 
+### Added
+- Adds CUSTOM_OPTIONS_PATH to Privacy Center env vars [#4769](https://github.com/ethyca/fides/pull/4769)
+
+
 ## [2.33.0](https://github.com/ethyca/fides/compare/2.32.0...2.33.0)
 
 ### Added

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -54,6 +54,7 @@ export interface PrivacyCenterSettings {
   FIDES_STRING: string | null; // (optional) An explicitly passed-in string that supersedes the cookie. Can contain both TC and AC strings
   IS_FORCED_TCF: boolean; // whether to force the privacy center to use the fides-tcf.js bundle
   FIDES_JS_BASE_URL: string; // A base URL to a directory of fides.js scripts
+  CUSTOM_OPTIONS_PATH: string | null; // (optional) A custom path to fetch FidesOptions (e.g. "window.config.overrides"). Defaults to window.fides_overrides
   PREVENT_DISMISSAL: boolean; // whether or not the user is allowed to dismiss the banner/overlay
   ALLOW_HTML_DESCRIPTION: boolean | null; // (optional) whether or not HTML descriptions should be rendered
   BASE_64_COOKIE: boolean; // whether or not to encode cookie as base64 on top of the default JSON string
@@ -84,6 +85,7 @@ export type PrivacyCenterClientSettings = Pick<
   | "FIDES_STRING"
   | "IS_FORCED_TCF"
   | "FIDES_JS_BASE_URL"
+  | "CUSTOM_OPTIONS_PATH"
   | "PREVENT_DISMISSAL"
   | "ALLOW_HTML_DESCRIPTION"
   | "BASE_64_COOKIE"
@@ -352,6 +354,7 @@ export const loadPrivacyCenterEnvironment =
       FIDES_JS_BASE_URL:
         process.env.FIDES_PRIVACY_CENTER__FIDES_JS_BASE_URL ||
         "http://localhost:3000",
+      CUSTOM_OPTIONS_PATH: process.env.FIDES_PRIVACY_CENTER__CUSTOM_OPTIONS_PATH || null,
       PREVENT_DISMISSAL: process.env.FIDES_PRIVACY_CENTER__PREVENT_DISMISSAL
         ? process.env.FIDES_PRIVACY_CENTER__PREVENT_DISMISSAL === "true"
         : false,
@@ -393,6 +396,7 @@ export const loadPrivacyCenterEnvironment =
       FIDES_STRING: settings.FIDES_STRING,
       IS_FORCED_TCF: settings.IS_FORCED_TCF,
       FIDES_JS_BASE_URL: settings.FIDES_JS_BASE_URL,
+      CUSTOM_OPTIONS_PATH: settings.CUSTOM_OPTIONS_PATH,
       PREVENT_DISMISSAL: settings.PREVENT_DISMISSAL,
       ALLOW_HTML_DESCRIPTION: settings.ALLOW_HTML_DESCRIPTION,
       BASE_64_COOKIE: settings.BASE_64_COOKIE,

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -354,7 +354,8 @@ export const loadPrivacyCenterEnvironment =
       FIDES_JS_BASE_URL:
         process.env.FIDES_PRIVACY_CENTER__FIDES_JS_BASE_URL ||
         "http://localhost:3000",
-      CUSTOM_OPTIONS_PATH: process.env.FIDES_PRIVACY_CENTER__CUSTOM_OPTIONS_PATH || null,
+      CUSTOM_OPTIONS_PATH:
+        process.env.FIDES_PRIVACY_CENTER__CUSTOM_OPTIONS_PATH || null,
       PREVENT_DISMISSAL: process.env.FIDES_PRIVACY_CENTER__PREVENT_DISMISSAL
         ? process.env.FIDES_PRIVACY_CENTER__PREVENT_DISMISSAL === "true"
         : false,

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -167,7 +167,7 @@ export default async function handler(
       // Custom API override functions must be passed into custom Fides extensions via Fides.init(...)
       apiOptions: null,
       fidesJsBaseUrl: environment.settings.FIDES_JS_BASE_URL,
-      customOptionsPath: null,
+      customOptionsPath: environment.settings.CUSTOM_OPTIONS_PATH,
       preventDismissal: environment.settings.PREVENT_DISMISSAL,
       allowHTMLDescription: environment.settings.ALLOW_HTML_DESCRIPTION,
       base64Cookie: environment.settings.BASE_64_COOKIE,


### PR DESCRIPTION
Closes Unticketed

### Description Of Changes

Add `CUSTOM_OPTIONS_PATH` to privacy center env vars


### Code Changes

* [ ] Add `CUSTOM_OPTIONS_PATH` to privacy center env vars

### Steps to Confirm

* [ ] Add `FIDES_PRIVACY_CENTER__CUSTOM_OPTIONS_PATH=window.mv.fides_overrides` to .env file
* [ ] Configure privacy experience / notices / systems for a specific geo
* [ ] Add the following in `fides-js-demo.html` above where we load fides.js script:
```
window.mv = {
          fides_overrides: {
            fides_primary_color: "blue"
          }
        }
```
* [ ] See that primary color is reflected in UI

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
