### PR TITLE
Build a `fides-types.d.ts` type declaration file to include alongside our FidesJS developer docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ The types of changes are:
 - Added `getModalLinkLabel` method to global fides object [#4766](https://github.com/ethyca/fides/pull/4766)
 
 ### Fixed
-
 - Fixed select dropdowns being cut off by edges of modal forms [#4757](https://github.com/ethyca/fides/pull/4757)
 - Changed "allow user to dismiss" toggle to show on config form for TCF experience [#4755](https://github.com/ethyca/fides/pull/4755)
+
+### Developer Experience
+- Build a `fides-types.d.ts` type declaration file to include alongside our FidesJS developer docs [#4772](https://github.com/ethyca/fides/pull/4772)
 
 ## [2.33.1](https://github.com/ethyca/fides/compare/2.33.0...2.33.1)
 

--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -77,6 +77,7 @@
   "typedocOptions": {
     "disableSources": true,
     "excludeExternals": true,
+    "excludeInternal": true,
     "excludePrivate": true,
     "githubPages": false,
     "hideBreadcrumbs": true,

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -114,6 +114,9 @@ const SCRIPTS = [
  */
 const rollupOptions = [];
 
+/**
+ * For each of our entrypoint scripts, build .js, .mjs, and .d.ts outputs
+ */
 SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
   const js = {
     input: `src/${name}.ts`,
@@ -162,6 +165,20 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
   };
 
   rollupOptions.push(...[js, mjs, declaration]);
+});
+
+/**
+ * In addition to our regular built outputs (like fides.js!) also generate a
+ * fides-types.d.ts file from  our documented types for external use.
+ */
+rollupOptions.push({
+  input: `src/docs/index.ts`,
+  plugins: [dts()],
+  output: [
+    {
+      file: `dist/fides-types.d.ts`
+    },
+  ]
 });
 
 export default rollupOptions;

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -176,9 +176,9 @@ rollupOptions.push({
   plugins: [dts()],
   output: [
     {
-      file: `dist/fides-types.d.ts`
+      file: `dist/fides-types.d.ts`,
     },
-  ]
+  ],
 });
 
 export default rollupOptions;

--- a/clients/fides-js/src/docs/fides-event.ts
+++ b/clients/fides-js/src/docs/fides-event.ts
@@ -2,8 +2,9 @@
  * Defines the list of FidesEvent names. See {@link FidesEvent} for details on each!
  *
  * NOTE: We mark this type @private to exclude it from the generated SDK
- * documentation, since it's mostly just noise - the list of events on {@link
- * FidesEvent} provides a good reference.
+ * documentation, since it's mostly just noise there - the list of events on
+ * {@link FidesEvent} provides a good reference. But when coding, it's still
+ * useful to have this union type around!
  * 
  * @private
  */

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -97,9 +97,9 @@ export interface FidesOptions {
 
   /**
    * TODO (PROD-1887): Add docs for using this option. Once added, remove the
-   * @private tag and rebuild!
+   * @internal tag and rebuild!
    * 
-   * @private
+   * @internal
    */
   fides_primary_color: string;
 

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -209,7 +209,7 @@ export interface Fides {
   init: (config: any) => Promise<void>;
 
   /**
-   * NOTE: The properties below are all marked @private, despite being exported
+   * NOTE: The properties below are all marked @internal, despite being exported
    * on the global Fides object. This is because they are mostly implementation
    * details and internals that we probably *should* be hiding, to avoid
    * customers getting too comfortable with accessing them.
@@ -217,50 +217,50 @@ export interface Fides {
 
   /**
    * DEFER (PROD-1815): This probably *should* be part of the documented SDK.
-   *
-   * @private
+   * 
+   * @internal
    */
   fides_meta: Record<any, any>;
 
   /**
    * DEFER (PROD-1815): This probably *should* be part of the documented SDK.
    *
-   * @private
+   * @internal
    */
   identity: Record<string, string>;
 
   /**
-   * @private
+   * @internal
    */
   experience?: any;
 
   /**
-   * @private
+   * @internal
    */
   geolocation?: any;
 
   /**
-   * @private
+   * @internal
    */
   options: any;
 
   /**
-   * @private
+   * @internal
    */
   tcf_consent: any;
 
   /**
-   * @private
+   * @internal
    */
   saved_consent: Record<string, boolean>;
 
   /**
-   * @private
+   * @internal
    */
   meta: (options: any) => void;
 
   /**
-   * @private
+   * @internal
    */
   shopify: (options: any) => void;
 }

--- a/clients/fides-js/src/docs/index.ts
+++ b/clients/fides-js/src/docs/index.ts
@@ -41,14 +41,13 @@
  * Therefore, all the types in src/docs should be considered part of FidesJS'
  * *official* developer API, so treat them with care!
  *
- * You can also use the \@private tag to intentionally leave specific
- * properties/comments/etc. undocumented; this can be useful for internal-only
+ * You can also use the tag to intentionally leave specific
+ * properties/comments/etc. undocumented; this can be useful for 
  * types for developers contributing directly to FidesJS, but that shouldn't be
  * included in the generic developer documentation. This comment itself is a
  * good example of that!
- * 
- * @private
  */
+
 export * from "./fides";
 export * from "./fides-event";
 export * from "./fides-options";

--- a/clients/fides-js/src/docs/index.ts
+++ b/clients/fides-js/src/docs/index.ts
@@ -41,13 +41,13 @@
  * Therefore, all the types in src/docs should be considered part of FidesJS'
  * *official* developer API, so treat them with care!
  *
- * You can also use the tag to intentionally leave specific
- * properties/comments/etc. undocumented; this can be useful for 
+ * You can also use the "internal" tag to intentionally leave specific
+ * properties/comments/etc. undocumented; this can be useful for internal-only
  * types for developers contributing directly to FidesJS, but that shouldn't be
- * included in the generic developer documentation. This comment itself is a
- * good example of that!
+ * included in the generic developer documentation.
  */
 
+// Export all the types from files in src/docs directory
 export * from "./fides";
 export * from "./fides-event";
 export * from "./fides-options";

--- a/clients/fides-js/tsconfig.json
+++ b/clients/fides-js/tsconfig.json
@@ -14,6 +14,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
+    "stripInternal": true,
     "target": "es2015",
     "plugins": [{ "name": "typescript-plugin-css-modules" }],
     "baseUrl": "./",


### PR DESCRIPTION
### Description Of Changes

This adds a new `dist/fides-types.d.ts` file to our build outputs in `fides-js` that includes _just_ the documented types that we use to build the developer docs here: https://ethyca.com/docs/dev-docs/js/reference

As a next step, we could host the most recent `fides-types.d.ts` on the docs site so that customer developers could download these and use them! Technically the _right_ thing to do is to publish these on `npm`, but let's not overengineer it too much... yet 😉.

Basically: I can tinker with how to _distribute_ these types next, but first want to get the build reviewed and working.

### Code Changes

* [X] Enable `stripInternal` in the tsconfig to tell Typescript _not_ to emit internal types in any type declarations
* [X] Use `@internal` tag instead of `@private` tag in TSDoc comments to specify types that shouldn't be documented (in either the SDK docs or the type declarations!)

### Steps to Confirm

* [X] Run `turbo build` in the `fides-js` project and check the `dist/fides-types.d.ts` output 👍

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
