### PR TITLE
Fixing privacy request detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 ### Fixed
 - Fixed select dropdowns being cut off by edges of modal forms [#4757](https://github.com/ethyca/fides/pull/4757)
 - Changed "allow user to dismiss" toggle to show on config form for TCF experience [#4755](https://github.com/ethyca/fides/pull/4755)
+- Fixed issue when loading the privacy request detail page [#4775](https://github.com/ethyca/fides/pull/4775)
 
 ### Developer Experience
 - Build a `fides-types.d.ts` type declaration file to include alongside our FidesJS developer docs [#4772](https://github.com/ethyca/fides/pull/4772)

--- a/clients/admin-ui/cypress/e2e/privacy-requests.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-requests.cy.ts
@@ -106,6 +106,7 @@ describe("Privacy Requests", () => {
         cy.contains("Request ID").parent().contains(/pri_/);
         cy.getByTestId("request-status-badge").contains("New");
       });
+      cy.getByTestId("pii-toggle").click();
     });
 
     it("allows approving a new request", () => {

--- a/clients/admin-ui/cypress/fixtures/privacy-requests/list.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-requests/list.json
@@ -13,6 +13,12 @@
       "status": "pending",
       "external_id": null,
       "identity": { "phone_number": null, "email": "cypress-user@ethyca.com" },
+      "custom_privacy_request_fields": {
+        "account_id": { "label": "Account ID", "value": 1 },
+        "user_id": { "label": "User ID", "value": "123" },
+        "subscription_ids": { "label": "Subscription IDs", "value": [1, 2, 3] },
+        "loyalty_ids": { "label": "Loyalty IDs", "value": ["abc", "def"] }
+      },
       "policy": {
         "name": "default_access_policy",
         "key": "default_access_policy",

--- a/clients/admin-ui/src/features/common/PII.tsx
+++ b/clients/admin-ui/src/features/common/PII.tsx
@@ -1,10 +1,10 @@
 type PIIProps = {
-  data: string;
+  data: string | number;
   revealPII: boolean;
 };
 
 const PII = ({ data, revealPII }: PIIProps) => {
-  const pii = revealPII ? data : data.replace(/./g, "*");
+  const pii = revealPII ? data : String(data).replace(/./g, "*");
   return (
     // eslint-disable-next-line react/jsx-no-useless-fragment
     <>{pii}</>

--- a/clients/admin-ui/src/features/common/PIIToggle.tsx
+++ b/clients/admin-ui/src/features/common/PIIToggle.tsx
@@ -16,6 +16,7 @@ const PIIToggle = ({ revealPII, onChange }: PIIToggleProps) => {
 
   return (
     <Switch
+      data-testid="pii-toggle"
       colorScheme="secondary"
       isChecked={revealPII}
       onChange={handleToggle}


### PR DESCRIPTION
Closes [PROD-1925](https://ethyca.atlassian.net/browse/PROD-1925)

### Description Of Changes

Fixing an issue with the `PII` component where it would not render if it received a `number` type as the `data` prop.

### Code Changes

* [ ] Updated `PII` component
* [ ] Updated Cypress tests/fixtures to test custom privacy request field details rendering

### Steps to Confirm

* [ ] Send the following payload to fides
```
curl -X 'POST' \
  'http://localhost:8080/api/v1/privacy-request/authenticated' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer REDACTED\
  -H 'Content-Type: application/json' \
  -d '[
    {
        "external_id": "abc1234561",
        "identity": {
            "email": "testuser@example.com"
        },
        "custom_privacy_request_fields": {
            "userIDs": {
                "label": "User IDs",
                "value": 1234
            },
            "analyticsIDs": {
                "label": "Analytics IDs",
                "value": "abcd"
            }
        },
        "policy_key": "default_erasure_policy"
    }
]'
```
* [ ] In the Admin UI, navigate to the request management page and click to view the details of the new request
* [ ] The page should render correctly

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`

[PROD-1925]: https://ethyca.atlassian.net/browse/PROD-1925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ