### PR TITLE
PROD-1889: hard-code inactive toggle color to grey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The types of changes are:
 ### Changed
 - Changed the Stripe integration for `Cards` to delete instead of update due to possible issues of a past expiration date [#4768](https://github.com/ethyca/fides/pull/4768)
 - Changed display of Data Uses, Categories and Subjects to user friendly names in the Data map report [#4774](https://github.com/ethyca/fides/pull/4774)
+- Update active disabled Fides.js toggle color to light grey [#4778](https://github.com/ethyca/fides/pull/4778)
 
 ### Fixed
 - Fixed select dropdowns being cut off by edges of modal forms [#4757](https://github.com/ethyca/fides/pull/4757)

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -38,7 +38,6 @@
   --fides-overlay-link-font-color: var(--fides-overlay-font-color-dark);
   /* Switches */
   --fides-overlay-primary-active-color: var(--fides-overlay-primary-color);
-  --fides-overlay-primary-active-disabled-color: #bda4f7;
   --fides-overlay-inactive-color: #e2e8f0;
   --fides-overlay-inactive-font-color: #a0aec0;
   --fides-overlay-disabled-color: #e1e7ee;
@@ -580,7 +579,7 @@ div.fides-i18n-pseudo-button {
   background-color: var(--fides-overlay-disabled-color);
 }
 .fides-toggle .fides-toggle-input:disabled:checked + .fides-toggle-display {
-  background-color: var(--fides-overlay-primary-active-disabled-color);
+  background-color: var(--fides-overlay-disabled-color);
 }
 
 /* Focus ring when using keyboard */

--- a/clients/fides-js/src/lib/consent.ts
+++ b/clients/fides-js/src/lib/consent.ts
@@ -70,18 +70,9 @@ export const initOverlay = async ({
           ColorFormat.HEX,
           1
         );
-        const lightestPrimaryColor: string = generateLighterColor(
-          options.fidesPrimaryColor,
-          ColorFormat.HEX,
-          2
-        );
         document.documentElement.style.setProperty(
           "--fides-overlay-primary-button-background-hover-color",
           lighterPrimaryColor
-        );
-        document.documentElement.style.setProperty(
-          "--fides-overlay-primary-active-disabled-color",
-          lightestPrimaryColor
         );
       }
 


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1889

### Description Of Changes

Hard-code inactive toggle color to light grey


### Code Changes

* [x] Update background-color of active (but disabled) toggles to grey instead of using primary color variant

### Steps to Confirm

* [ ] In `/clients/privacy-center` run `turbo run dev`
* [ ] Nav to http://localhost:3000/fides-js-components-demo.html
* [ ] See disabled toggle color is light grey:
<img width="769" alt="Screenshot 2024-04-07 at 11 09 01 AM" src="https://github.com/ethyca/fides/assets/7697292/5b422ed3-3675-4827-a679-178389d56272">


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
