### PR TITLE
Update FidesJS `fides_embed` option to support embedding both banner & modal components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The types of changes are:
 - Changed the Stripe integration for `Cards` to delete instead of update due to possible issues of a past expiration date [#4768](https://github.com/ethyca/fides/pull/4768)
 - Changed display of Data Uses, Categories and Subjects to user friendly names in the Data map report [#4774](https://github.com/ethyca/fides/pull/4774)
 - Update active disabled Fides.js toggle color to light grey [#4778](https://github.com/ethyca/fides/pull/4778)
+- Update FidesJS fides_embed option to support embedding both banner & modal components [#4782](https://github.com/ethyca/fides/pull/4782)
 
 ### Fixed
 - Fixed select dropdowns being cut off by edges of modal forms [#4757](https://github.com/ethyca/fides/pull/4757)

--- a/clients/fides-js/docs/interfaces/FidesOptions.md
+++ b/clients/fides-js/docs/interfaces/FidesOptions.md
@@ -76,14 +76,12 @@ ___
 When `true`, require FidesJS to "embed" it's UI into a specific `<div>` on
 the page, instead of as an overlay over the `<body>` itself. This is useful
 for creating a dedicated page to manage consent preferences on your site.
+Both the consent modal and the banner will be embedded into the container.
+To only embed the consent modal, set `fides_disable_banner` to `true`.
 
 To use the `fides_embed` option, ensure that a DOM element with
 `id="fides-embed-container"` exists on the page, which FidesJS will then
 use as the parent element to render within.
-
-Before version 2.34 only the consent modal was embedded while the banner was
-not shown at all, but since that version both will be embedded. To get the
-previous behavior also set `fides_disable_banner` to `true`.
 
 NOTE: If you're using a JavaScript framework (e.g. React), ensure that you
 do not re-render the parent `<div>` element, as this could remove the

--- a/clients/fides-js/docs/interfaces/FidesOptions.md
+++ b/clients/fides-js/docs/interfaces/FidesOptions.md
@@ -81,6 +81,10 @@ To use the `fides_embed` option, ensure that a DOM element with
 `id="fides-embed-container"` exists on the page, which FidesJS will then
 use as the parent element to render within.
 
+Before version 2.34 only the consent modal was embedded while the banner was
+not shown at all, but since that version both will be embedded. To get the
+previous behavior also set `fides_disable_banner` to `true`.
+
 NOTE: If you're using a JavaScript framework (e.g. React), ensure that you
 do not re-render the parent `<div>` element, as this could remove the
 FidesJS UI fully from the page!

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -25,6 +25,7 @@ interface BannerProps {
   onVendorPageClick?: () => void;
   renderButtonGroup: (props: ButtonGroupProps) => VNode;
   className?: string;
+  isEmbedded: boolean;
 }
 
 const ConsentBanner: FunctionComponent<BannerProps> = ({
@@ -37,6 +38,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
   onVendorPageClick,
   renderButtonGroup,
   className,
+  isEmbedded,
 }) => {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
@@ -71,13 +73,18 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
     ? i18n.t("exp.banner_description")
     : i18n.t("exp.description");
 
+  const containerClassName = [
+    "fides-banner",
+    "fides-banner-bottom",
+    !bannerIsOpen && "fides-banner-hidden",
+    isEmbedded && "fides-embedded",
+    className,
+  ]
+    .filter((c) => typeof c === "string")
+    .join(" ");
+
   return (
-    <div
-      id="fides-banner-container"
-      className={`fides-banner fides-banner-bottom 
-        ${bannerIsOpen ? "" : "fides-banner-hidden"} 
-        ${className || ""}`}
-    >
+    <div id="fides-banner-container" className={containerClassName}>
       <div id="fides-banner">
         <div id="fides-banner-inner">
           <CloseButton

--- a/clients/fides-js/src/components/ConsentModal.tsx
+++ b/clients/fides-js/src/components/ConsentModal.tsx
@@ -1,4 +1,4 @@
-import { VNode, h } from "preact";
+import { ComponentChildren, VNode, h } from "preact";
 import { HTMLAttributes } from "preact/compat";
 
 import { Attributes } from "../lib/a11y-dialog";
@@ -9,17 +9,17 @@ import ConsentContent from "./ConsentContent";
 
 const ConsentModal = ({
   attributes,
+  children,
   dismissable,
   i18n,
   renderModalFooter,
-  renderModalContent,
 }: {
   attributes: Attributes;
+  children: ComponentChildren;
   dismissable: boolean | undefined;
   i18n: I18n;
   onVendorPageClick?: () => void;
   renderModalFooter: () => VNode;
-  renderModalContent: () => VNode;
 }) => {
   const { container, overlay, dialog, title, closeButton } = attributes;
 
@@ -48,7 +48,7 @@ const ConsentModal = ({
           i18n={i18n}
           renderModalFooter={renderModalFooter}
         >
-          {renderModalContent()}
+          {children}
         </ConsentContent>
       </div>
     </div>

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -113,7 +113,6 @@ const Overlay: FunctionComponent<Props> = ({
   const handleOpenModal = useCallback(() => {
     if (options.fidesEmbed) {
       setBannerIsOpen(false);
-      onOpen();
     } else if (instance) {
       setBannerIsOpen(false);
       instance.show();

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -76,7 +76,7 @@ const Overlay: FunctionComponent<Props> = ({
   const delayBannerMilliseconds = 100;
   const delayModalLinkMilliseconds = 200;
   const hasMounted = useHasMounted();
-  const [bannerIsOpen, setBannerIsOpen] = useState(options.fidesEmbed);
+  const [bannerIsOpen, setBannerIsOpen] = useState(false);
   const modalLinkRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -76,7 +76,16 @@ const Overlay: FunctionComponent<Props> = ({
   const delayBannerMilliseconds = 100;
   const delayModalLinkMilliseconds = 200;
   const hasMounted = useHasMounted();
-  const [bannerIsOpen, setBannerIsOpen] = useState(false);
+
+  const showBanner = useMemo(
+    () =>
+      !options.fidesDisableBanner &&
+      experience.experience_config?.component !== ComponentType.MODAL &&
+      shouldResurfaceConsent(experience, cookie, savedConsent),
+    [cookie, savedConsent, experience, options]
+  );
+
+  const [bannerIsOpen, setBannerIsOpen] = useState(options.fidesEmbed ? showBanner : false);
   const modalLinkRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -133,14 +142,7 @@ const Overlay: FunctionComponent<Props> = ({
     }
   }, [options, onOpen, bannerIsOpen]);
 
-  const showBanner = useMemo(
-    () =>
-      !options.fidesDisableBanner &&
-      experience.experience_config?.component !== ComponentType.MODAL &&
-      shouldResurfaceConsent(experience, cookie, savedConsent),
-    [cookie, savedConsent, experience, options]
-  );
-
+  // The delay is needed for the banner CSS animation
   useEffect(() => {
     const delayBanner = setTimeout(() => {
       if (showBanner) {

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -85,7 +85,9 @@ const Overlay: FunctionComponent<Props> = ({
     [cookie, savedConsent, experience, options]
   );
 
-  const [bannerIsOpen, setBannerIsOpen] = useState(options.fidesEmbed ? showBanner : false);
+  const [bannerIsOpen, setBannerIsOpen] = useState(
+    options.fidesEmbed ? showBanner : false
+  );
   const modalLinkRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -78,7 +78,8 @@ div#fides-overlay {
   position: fixed;
 }
 
-.fides-banner, .fides-modal-container {
+.fides-banner,
+.fides-modal-container {
   font-family: var(--fides-overlay-font-family);
   font-size: var(--fides-overlay-font-size-body);
   white-space: pre-line;

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -74,10 +74,13 @@
 }
 
 div#fides-overlay {
-  font-family: var(--fides-overlay-font-family);
-  font-size: var(--fides-overlay-font-size-body);
   z-index: 1000;
   position: fixed;
+}
+
+.fides-banner, .fides-modal-container {
+  font-family: var(--fides-overlay-font-family);
+  font-size: var(--fides-overlay-font-size-body);
   white-space: pre-line;
 
   /* CSS reset values, adapted from https://www.joshwcomeau.com/css/custom-css-reset/ */
@@ -94,7 +97,7 @@ div#fides-overlay {
   display: inline;
 }
 
-div#fides-banner-container {
+div#fides-banner-container:not(.fides-embedded) {
   position: fixed;
   z-index: 1;
   width: 100%;
@@ -122,6 +125,10 @@ div#fides-banner {
   border-top: 1px solid var(--fides-overlay-primary-color);
 }
 
+.fides-embedded div#fides-banner {
+  border: none;
+}
+
 div#fides-banner-inner {
   width: 100%;
 }
@@ -131,9 +138,16 @@ div#fides-banner-container.fides-banner-bottom {
   left: 0;
 }
 
+div#fides-banner-container.fides-banner-hidden {
+  visibility: hidden;
+}
+
+div#fides-banner-container.fides-banner-hidden.fides-embedded {
+  display: none;
+}
+
 div#fides-banner-container.fides-banner-bottom.fides-banner-hidden {
   transform: translateY(150%);
-  visibility: hidden;
 }
 
 div#fides-banner-container.fides-banner-top {
@@ -143,7 +157,6 @@ div#fides-banner-container.fides-banner-top {
 
 div#fides-banner-container.fides-banner-top.fides-banner-hidden {
   transform: translateY(-150%);
-  visibility: hidden;
 }
 
 div#fides-banner-inner div#fides-button-group {
@@ -463,6 +476,10 @@ div#fides-banner .fides-close-button {
 
 .fides-close-button:hover {
   background: var(--fides-overlay-hover-color);
+}
+
+.fides-embedded .fides-close-button {
+  display: none !important;
 }
 
 .fides-modal-notices {

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -253,7 +253,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
       isUiBlocking={!isDismissable}
       onOpen={dispatchOpenOverlayEvent}
       onDismiss={handleDismiss}
-      renderBanner={({ isOpen, onClose, onSave, onManagePreferencesClick }) => (
+      renderBanner={({ isEmbedded, isOpen, onClose, onSave, onManagePreferencesClick }) => (
         <ConsentBanner
           bannerIsOpen={isOpen}
           dismissable={isDismissable}
@@ -263,6 +263,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
             handleDismiss();
           }}
           i18n={i18n}
+          isEmbedded={isEmbedded}
           renderButtonGroup={({ isMobile }) => (
             <NoticeConsentButtons
               experience={experience}

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -253,7 +253,13 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
       isUiBlocking={!isDismissable}
       onOpen={dispatchOpenOverlayEvent}
       onDismiss={handleDismiss}
-      renderBanner={({ isEmbedded, isOpen, onClose, onSave, onManagePreferencesClick }) => (
+      renderBanner={({
+        isEmbedded,
+        isOpen,
+        onClose,
+        onSave,
+        onManagePreferencesClick,
+      }) => (
         <ConsentBanner
           bannerIsOpen={isOpen}
           dismissable={isDismissable}

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -336,7 +336,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
       isUiBlocking={!isDismissable}
       onOpen={dispatchOpenOverlayEvent}
       onDismiss={handleDismiss}
-      renderBanner={({ isOpen, onClose, onSave, onManagePreferencesClick }) => {
+      renderBanner={({ isEmbedded, isOpen, onClose, onSave, onManagePreferencesClick }) => {
         const goToVendorTab = () => {
           onManagePreferencesClick();
           setActiveTabIndex(2);
@@ -346,6 +346,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
             i18n={i18n}
             dismissable={isDismissable}
             bannerIsOpen={isOpen}
+            isEmbedded={isEmbedded}
             onOpen={dispatchOpenBannerEvent}
             onClose={() => {
               onClose();

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -254,7 +254,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
       return bestTranslation?.privacy_experience_config_history_id;
     }
     return undefined;
-  }, [experience, i18n, currentLocale]);
+  }, [experience, i18n]);
 
   const { servedNotice } = useConsentServed({
     privacyExperienceConfigHistoryId,
@@ -336,7 +336,13 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
       isUiBlocking={!isDismissable}
       onOpen={dispatchOpenOverlayEvent}
       onDismiss={handleDismiss}
-      renderBanner={({ isEmbedded, isOpen, onClose, onSave, onManagePreferencesClick }) => {
+      renderBanner={({
+        isEmbedded,
+        isOpen,
+        onClose,
+        onSave,
+        onManagePreferencesClick,
+      }) => {
         const goToVendorTab = () => {
           onManagePreferencesClick();
           setActiveTabIndex(2);

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -53,15 +53,13 @@ export interface FidesOptions {
    * When `true`, require FidesJS to "embed" it's UI into a specific `<div>` on
    * the page, instead of as an overlay over the `<body>` itself. This is useful
    * for creating a dedicated page to manage consent preferences on your site.
+   * Both the consent modal and the banner will be embedded into the container.
+   * To only embed the consent modal, set `fides_disable_banner` to `true`.
    * 
    * To use the `fides_embed` option, ensure that a DOM element with
    * `id="fides-embed-container"` exists on the page, which FidesJS will then
    * use as the parent element to render within.
-   * 
-   * Before version 2.34 only the consent modal was embedded while the banner was
-   * not shown at all, but since that version both will be embedded. To get the
-   * previous behavior also set `fides_disable_banner` to `true`.
-   * 
+   *
    * NOTE: If you're using a JavaScript framework (e.g. React), ensure that you
    * do not re-render the parent `<div>` element, as this could remove the
    * FidesJS UI fully from the page!

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -58,6 +58,10 @@ export interface FidesOptions {
    * `id="fides-embed-container"` exists on the page, which FidesJS will then
    * use as the parent element to render within.
    * 
+   * Before version 2.34 only the consent modal was embedded while the banner was
+   * not shown at all, but since that version both will be embedded. To get the
+   * previous behavior also set `fides_disable_banner` to `true`.
+   * 
    * NOTE: If you're using a JavaScript framework (e.g. React), ensure that you
    * do not re-render the parent `<div>` element, as this could remove the
    * FidesJS UI fully from the page!


### PR DESCRIPTION
### Description Of Changes

This turned out to be a bit of an adventure. Initially I wanted to allow embedding the banner and the modal in separate containers and after spending some time going in this direction, it turned out to be not possible without a lot of effort refactoring the code which I didn't feel comfortable doing (also time). The issue is that putting the banner and the modal in two different containers would require separating the components "all the way to the top", so to speak, which would mean they'd have entirely separate state and everything.

The approach here is to embed both the banner and the modal in the same `fides-embed-container`. The `bannerIsOpen` state in `Overlay` is used to control if the banner or the modal is shown.

### Code Changes

* [x] `Overlay` component state management
* [x] CSS overrides when the banner is embedded

### Steps to Confirm

The changes can be tested by using the `fides_embed=true` override. The banner will be shown first and it should be replaced with the Layer 2 "modal" when the "Manage preferences" link is clicked. Using `fides_disable_banner=true` will skip the banner and show the modal immediately, which is the previous behavior.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
