### PR TITLE
PROD-1941 Fix bug that prevented adding new privacy center translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.34.0...main)
 
+### Fixed
+- Fixed bug prevented adding new privacy center translations [#4786](https://github.com/ethyca/fides/pull/4786)
+
+
 ## [2.34.0](https://github.com/ethyca/fides/compare/2.33.1...2.34.0)
 
 ### Added

--- a/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
@@ -21,7 +21,6 @@ import {
   defaultInitialValues,
   findLanguageDisplayName,
   transformConfigResponseToCreate,
-  transformTranslationResponseToCreate,
   TranslationWithLanguageName,
 } from "~/features/privacy-experience/form/helpers";
 import {
@@ -44,7 +43,6 @@ import {
   ExperienceConfigCreate,
   ExperienceConfigResponse,
   ExperienceTranslation,
-  ExperienceTranslationResponse,
   SupportedLanguage,
 } from "~/types/api";
 import { isErrorResult } from "~/types/errors";
@@ -63,7 +61,7 @@ const translationSchema = (requirePreferencesLink: boolean) =>
     is_default: Yup.boolean(),
     privacy_preferences_link_label: requirePreferencesLink
       ? Yup.string().required().label("Privacy preferences link label")
-      : Yup.string().label("Privacy preferences link label"),
+      : Yup.string().nullable().label("Privacy preferences link label"),
   });
 
 const validationSchema = Yup.object().shape({
@@ -164,14 +162,14 @@ const ConfigurePrivacyExperience = ({
       setUsingOOBValues(true);
     }
 
-    return availableTranslation
-      ? transformTranslationResponseToCreate(
-          availableTranslation as ExperienceTranslationResponse
-        )
-      : {
-          language,
-          is_default: false,
-        };
+    console.log("availableTranslation", availableTranslation);
+
+    return (
+      availableTranslation ?? {
+        language,
+        is_default: false,
+      }
+    );
   };
 
   const handleExitTranslationForm = () => {

--- a/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
@@ -161,9 +161,6 @@ const ConfigurePrivacyExperience = ({
     if (availableTranslation) {
       setUsingOOBValues(true);
     }
-
-    console.log("availableTranslation", availableTranslation);
-
     return (
       availableTranslation ?? {
         language,

--- a/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
@@ -21,6 +21,7 @@ import {
   defaultInitialValues,
   findLanguageDisplayName,
   transformConfigResponseToCreate,
+  transformTranslationResponseToCreate,
   TranslationWithLanguageName,
 } from "~/features/privacy-experience/form/helpers";
 import {
@@ -43,6 +44,7 @@ import {
   ExperienceConfigCreate,
   ExperienceConfigResponse,
   ExperienceTranslation,
+  ExperienceTranslationResponse,
   SupportedLanguage,
 } from "~/types/api";
 import { isErrorResult } from "~/types/errors";
@@ -161,12 +163,15 @@ const ConfigurePrivacyExperience = ({
     if (availableTranslation) {
       setUsingOOBValues(true);
     }
-    return (
-      availableTranslation ?? {
-        language,
-        is_default: false,
-      }
-    );
+
+    return availableTranslation
+      ? transformTranslationResponseToCreate(
+          availableTranslation as ExperienceTranslationResponse
+        )
+      : {
+          language,
+          is_default: false,
+        };
   };
 
   const handleExitTranslationForm = () => {


### PR DESCRIPTION
### Description Of Changes

Fix bug that prevented adding new translation for privacy center


### Code Changes
Investigated the problem a bit, and notices that there was a form validator error about some field being null.
<img width="1484" alt="Captura de pantalla 2024-04-11 a la(s) 11 42 45 a  m" src="https://github.com/ethyca/fides/assets/4809430/c0a5e3cd-59db-4303-9287-263fde621c20">

The problem is that the privacy center experience don't have a need for this field, but the validator stills checks for it. Added nullable option to the validator to account for this use case. 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`
