### PR TITLE
Setuptools Handling of Dashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,7 @@ COPY --from=built_frontend /fides/clients/admin-ui/out/ /fides/src/fides/ui-buil
 RUN python setup.py sdist
 
 USER root
-RUN pip install dist/ethyca-fides-*.tar.gz
+RUN pip install dist/ethyca_fides-*.tar.gz
 
 # Remove this directory to prevent issues with catch all
 RUN rm -r /fides/src/fides/ui-build


### PR DESCRIPTION
Addresses a new change to `setuptools` described [here](https://github.com/pypa/setuptools/issues/4300), introduced in setuptools `69.3.0`.

### Description Of Changes

As described in https://github.com/pypa/setuptools/issues/4300, setuptools changed to produce built tarballs with `_` instead of `-` in the distribution's naming convention. Our Dockerfile `prod` build (incorrectly) relied on the `-` naming convention for our built distribution of `ethyca-fides`.

We can adjust the expected naming convention to `ethyca_fides`. Per the comments on https://github.com/pypa/setuptools/issues/4300, we _can_ now rely on this naming convention, as it is up to spec.

As mentioned in the issue, [the change in setuptools](https://github.com/pypa/setuptools/pull/4286/files#diff-b9c5224191f52b3ea80acfdc52fce5ea9e840a6a9237d479918bb7e974642f0bR266) was in response to https://peps.python.org/pep-0625/ which mentions
> The name of an sdist should be {distribution}-{version}.tar.gz.
> - distribution is the name of the distribution as defined in [PEP 345](https://peps.python.org/pep-0345/), and normalised as described in [the wheel spec](https://packaging.python.org/en/latest/specifications/binary-distribution-format/) e.g. 'pip', 'flit_core'.

and then the linked [wheel spec](https://packaging.python.org/en/latest/specifications/binary-distribution-format/) mentions [here](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode):
> In distribution names, any run of -_. characters (HYPHEN-MINUS, LOW LINE and FULL STOP) should be replaced with _ (LOW LINE), and uppercase characters should be replaced with corresponding lowercase ones. This is equivalent to regular [name normalization](https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization) followed by replacing - with _. Tools consuming wheels must be prepared to accept . (FULL STOP) and uppercase letters, however, as these were allowed by an earlier version of this specification.


### Code Changes

* [x] update `Dockerfile` to look for `dist/ethyca_fides-*.tar.gz` rather than `dist/ethyca-fides-*.tar.gz`

### Steps to Confirm

* [x] CI jobs relying on the prod image run successfully

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
