### PR TITLE
update tests to use the router version of fides.js

### DIFF
--- a/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
@@ -1215,7 +1215,9 @@ describe("Consent i18n", () => {
               ".fides-disclosure-visible .fides-tcf-purpose-vendor-list"
             ).contains(t.stacked_purpose_example);
           }
-          cy.get(".fides-notice-toggle-title").contains(title).click();
+          cy.get(".fides-notice-toggle-title")
+            .contains(title)
+            .click({ force: true });
         });
       });
     };

--- a/clients/privacy-center/cypress/support/commands.ts
+++ b/clients/privacy-center/cypress/support/commands.ts
@@ -60,7 +60,7 @@ Cypress.Commands.add(
   "visitConsentDemo",
   (
     options?: FidesConfig,
-    queryParams?: Cypress.VisitOptions["qs"],
+    queryParams?: Cypress.VisitOptions["qs"] | null,
     windowParams?: any
   ) => {
     const visitOptions: Partial<VisitOptions> = {
@@ -192,7 +192,7 @@ declare global {
        */
       visitConsentDemo(
         options?: FidesConfig,
-        queryParams?: Cypress.VisitOptions["qs"],
+        queryParams?: Cypress.VisitOptions["qs"] | null,
         windowParams?: any
       ): Chainable<any>;
       /**

--- a/clients/privacy-center/cypress/support/stubs.ts
+++ b/clients/privacy-center/cypress/support/stubs.ts
@@ -60,7 +60,7 @@ export const stubConfig = (
   { consent, experience, geolocation, options }: Partial<FidesConfigTesting>,
   mockGeolocationApiResp?: any,
   mockExperienceApiResp?: any,
-  demoPageQueryParams?: Cypress.VisitOptions["qs"],
+  demoPageQueryParams?: Cypress.VisitOptions["qs"] | null,
   demoPageWindowParams?: any
 ) => {
   cy.fixture("consent/fidesjs_options_banner_modal.json").then((config) => {

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -134,11 +134,15 @@ export default async function handler(
     }
   }
 
+  // These query params are used for testing purposes only, and should not be used
+  // in production. They allow for the config to be injected by the test framework
+  // and delay the initialization of fides.js until the test framework is ready.
   const { e2e: e2eQuery, tcf: tcfQuery } = req.query;
 
   // We determine server-side whether or not to send the TCF bundle, which is based
   // on whether or not the experience is marked as TCF. This means for TCF, we *must*
-  // be able to prefetch the experience.
+  // be able to prefetch the experience. This can also be forced via query param for
+  // internal testing when we know the experience will be injected by the test framework.
   const tcfEnabled =
     tcfQuery === "true" ||
     (experience

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -5,14 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- TODO: (#1953) use the NextJS router version of `/fides.js` insetad of direct files for more accurate testing -->
     <!--
-      We use the fides*.js file directly so that we can dynamically inject options.
-      We read fidesConfig.options to determine which fides*.js bundle to use.
+      Pass along any params to the fides.js script. For example, visiting
+      http://localhost:3000/fides-js-demo.html?geolocation=fr-id
+      will pass a geolocation query param to fides.js
     -->
     <script>
       (function () {
-        var src = window.fidesConfig?.options?.tcfEnabled
-          ? "./lib/fides-tcf.js"
-          : "./lib/fides.js";
+        const tcfEnabled = window.fidesConfig?.options?.tcfEnabled;
+        const VALID_ISO_3166_LOCATION_REGEX = /^\w{2,3}(-\w{2,3})?$/;
+        const params = new URLSearchParams(window.location.search);
+        const geolocation = params.get("geolocation");
+        if (!VALID_ISO_3166_LOCATION_REGEX.test(geolocation)) {
+          params.delete("geolocation");
+        }
+        const src = `/fides.js?e2e=true${tcfEnabled ? "&tcf=true" : ""}${
+          !!params.size ? `&${params.toString()}` : ""
+        }`;
+
         document.write('<script src="' + src + '"><\/script>');
       })();
       (function () {


### PR DESCRIPTION
Closes [PROD-1953](https://ethyca.atlassian.net/browse/PROD-1953)

### Description Of Changes

Up until now, all of the end-to-end tests in Cypress have been loading either `fides.js` or `fides-tcf.js` directly. Since this doesn't exactly match the end-user experience it's better to load `fides.js` from the NextJS route where the correct file gets loaded along with a lot of other bundling logic that we're missing out on testing.

The changes in this PR implements similar logic to the demo page set up for testing, attempting to be true to the original implementation, with the difference being that we're now utilizing the NextJS route.


### Code Changes

* Pass some new params to the fides.js route to signal ignoring the default config and auto-init behavior, in favor of the Cypress e2e configs (fixtures).

### Steps to Confirm

* Privacy Center Cypress tests are still passing.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`


[PROD-1953]: https://ethyca.atlassian.net/browse/PROD-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ