### PR TITLE
use FixedLayout to contain the new tables when expanding the columns

### DIFF
--- a/clients/admin-ui/src/pages/consent/privacy-experience/index.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-experience/index.tsx
@@ -1,14 +1,16 @@
 import { Box, Heading, Text } from "@fidesui/react";
 import React from "react";
-import FixedLayout from "~/features/common/FixedLayout";
 
+import FixedLayout from "~/features/common/FixedLayout";
 import { PrivacyExperiencesTable } from "~/features/privacy-experience/PrivacyExperiencesTable";
 
 const PrivacyExperiencePage = () => (
-  <FixedLayout title="Privacy experiences"
+  <FixedLayout
+    title="Privacy experiences"
     mainProps={{
       padding: "24px 40px",
-    }}>
+    }}
+  >
     <Box mb={4} data-testid="privacy-experience-page">
       <Heading fontSize="2xl" fontWeight="semibold" mb={2} data-testid="header">
         Privacy experience
@@ -23,7 +25,7 @@ const PrivacyExperiencePage = () => (
       website, copy the javascript using the button on this page and place it on
       your website.
     </Text>
-    <Box >
+    <Box>
       <PrivacyExperiencesTable />
     </Box>
   </FixedLayout>

--- a/clients/admin-ui/src/pages/consent/privacy-experience/index.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-experience/index.tsx
@@ -1,12 +1,15 @@
 import { Box, Heading, Text } from "@fidesui/react";
 import React from "react";
+import FixedLayout from "~/features/common/FixedLayout";
 
-import Layout from "~/features/common/Layout";
 import { PrivacyExperiencesTable } from "~/features/privacy-experience/PrivacyExperiencesTable";
 
 const PrivacyExperiencePage = () => (
-  <Layout title="Privacy experiences">
-    <Box mb={4}>
+  <FixedLayout title="Privacy experiences"
+    mainProps={{
+      padding: "24px 40px",
+    }}>
+    <Box mb={4} data-testid="privacy-experience-page">
       <Heading fontSize="2xl" fontWeight="semibold" mb={2} data-testid="header">
         Privacy experience
       </Heading>
@@ -20,10 +23,10 @@ const PrivacyExperiencePage = () => (
       website, copy the javascript using the button on this page and place it on
       your website.
     </Text>
-    <Box data-testid="privacy-experience-page">
+    <Box >
       <PrivacyExperiencesTable />
     </Box>
-  </Layout>
+  </FixedLayout>
 );
 
 export default PrivacyExperiencePage;

--- a/clients/admin-ui/src/pages/consent/privacy-notices/index.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/index.tsx
@@ -1,11 +1,14 @@
 import { Box, Heading, Text } from "@fidesui/react";
 import React from "react";
+import FixedLayout from "~/features/common/FixedLayout";
 
-import Layout from "~/features/common/Layout";
 import { PrivacyNoticesTable } from "~/features/privacy-notices/PrivacyNoticesTable";
 
 const PrivacyNoticesPage = () => (
-  <Layout title="Privacy notices">
+  <FixedLayout title="Privacy notices"
+    mainProps={{
+      padding: "24px 40px",
+    }}>
     <Box mb={4}>
       <Heading fontSize="2xl" fontWeight="semibold" mb={2} data-testid="header">
         Manage privacy notices
@@ -19,7 +22,7 @@ const PrivacyNoticesPage = () => (
     <Box data-testid="privacy-notices-page">
       <PrivacyNoticesTable />
     </Box>
-  </Layout>
+  </FixedLayout>
 );
 
 export default PrivacyNoticesPage;

--- a/clients/admin-ui/src/pages/consent/privacy-notices/index.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/index.tsx
@@ -1,14 +1,16 @@
 import { Box, Heading, Text } from "@fidesui/react";
 import React from "react";
-import FixedLayout from "~/features/common/FixedLayout";
 
+import FixedLayout from "~/features/common/FixedLayout";
 import { PrivacyNoticesTable } from "~/features/privacy-notices/PrivacyNoticesTable";
 
 const PrivacyNoticesPage = () => (
-  <FixedLayout title="Privacy notices"
+  <FixedLayout
+    title="Privacy notices"
     mainProps={{
       padding: "24px 40px",
-    }}>
+    }}
+  >
     <Box mb={4}>
       <Heading fontSize="2xl" fontWeight="semibold" mb={2} data-testid="header">
         Manage privacy notices

--- a/clients/admin-ui/src/pages/reporting/datamap/index.tsx
+++ b/clients/admin-ui/src/pages/reporting/datamap/index.tsx
@@ -7,8 +7,7 @@ const DatamapReportingPage = () => (
   <FixedLayout
     title="Datamap Report"
     mainProps={{
-      padding: "40px",
-      paddingRight: "48px",
+      padding: "24px 40px",
     }}
   >
     <DatamapReportTable />


### PR DESCRIPTION
Closes #[1911](https://ethyca.atlassian.net/browse/PROD-1911)

### Description Of Changes

Update the Privacy Experience and Privacy Notice tables to not overflow the page. Update the Data map report table padding to match other pages.  

### Code Changes

* [ ] update table containers to be `FixedLayout` 
* [ ] update the table page padding 

### Steps to Confirm

* [ ] run fides `turbo run dev`
* [ ] run fidesplus `nox -s "build(slim)" "dev(slim)" -- dev`
* [ ] nav to data map reporting table (http://localhost:3001/reporting/datamap) verify the padding matches the other pages 
* [ ] nav to notices table (http://localhost:3001/consent/privacy-notices) expand the columns verify horizontal scroll enables and the table does not overflow from the full page 
* [ ] nav to experiences table (http://localhost:3001/consent/privacy-experience) expand the columns verify horizontal scroll enables and the table does not overflow from the full page 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated