### PR TITLE
DSR 3.0 Improve External DB Connection Management

### DIFF
--- a/tests/ops/task/test_execute_request_tasks.py
+++ b/tests/ops/task/test_execute_request_tasks.py
@@ -25,6 +25,7 @@ from fides.api.task.create_request_tasks import (
     persist_new_access_request_tasks,
 )
 from fides.api.task.execute_request_tasks import (
+    _collect_task_resources,
     can_run_task_body,
     create_graph_task,
     run_prerequisite_task_checks,
@@ -102,8 +103,9 @@ class TestCreateGraphTask:
         request_task = privacy_request.access_tasks.filter(
             RequestTask.collection_address == "postgres_example_test_dataset:address"
         ).first()
+        resources = _collect_task_resources(db, request_task)
 
-        graph_task = create_graph_task(db, request_task)
+        graph_task = create_graph_task(db, request_task, resources)
 
         assert graph_task.request_task == request_task
         assert graph_task.key == CollectionAddress.from_string(
@@ -133,8 +135,10 @@ class TestCreateGraphTask:
         request_task.collection["name"] = None
         request_task.save(db)
 
+        resources = _collect_task_resources(db, request_task)
+
         with pytest.raises(ResumeTaskException):
-            create_graph_task(db, request_task)
+            create_graph_task(db, request_task, resources)
 
         db.refresh(request_task)
 

--- a/tests/ops/task/test_task_resources.py
+++ b/tests/ops/task/test_task_resources.py
@@ -1,4 +1,3 @@
-from fides.api.task.execute_request_tasks import _collect_task_resources
 from fides.api.task.graph_task import EMPTY_REQUEST_TASK
 from fides.api.task.task_resources import TaskResources
 
@@ -51,14 +50,3 @@ class TestTaskResources:
             "manual_example:filing-cabinet": 2,
             "manual_example:storage-unit": 3,
         }
-
-    def test_collect_task_resources(self, db, privacy_request, policy, request_task):
-        collected = _collect_task_resources(db, request_task)
-
-        expected = TaskResources(privacy_request, policy, [], request_task, db)
-
-        assert collected.privacy_request_task == expected.privacy_request_task
-        assert collected.request == expected.request
-        assert collected.policy == expected.policy
-        assert collected.session == expected.session
-        assert collected.connection_configs == expected.connection_configs


### PR DESCRIPTION
Closes #PROD-1881

❗ Dependent on https://github.com/ethyca/fides/pull/4760

### Description Of Changes

Improve external db connection management

### Code Changes

* [ ] Fix a regression in DSR 2.0 and apply same fix to DSR 3.0 that closes a connection after it's been used by using TaskResources as a context manager

### Steps to Confirm

- In your toml file, toggle DSR 3.0 to on and task_always_eager to True (to test celery)
 ```
[execution]
use_dsr_3_0 = true
```
```
[celery]
task_always_eager = true
```

-  nox -s dev -- shell postgres mongodb worker
- In another terminal, cd /fides/clients
 - turbo run dev
-  Setup postgres connector
- http://localhost:3001/add-systems
- Click Add a System
- Add system name: `postgres_example_test_dataset`
- Click Integrations
- Integration type: PostgreSQL
- Add credentials for local postgres example container running in docker (these aren't private secrets, these are for the example postgres database, docker/docker-compose.integration-postgres.yml). Test connection
![image](https://github.com/ethyca/fides/assets/9755598/ea310fba-8172-40ac-b57b-4dd593b3f028)
-  Upload postgres_example_test_dataset.yml and click Save
- In a separate terminal, start watching the number of connections in your postgres external database:
```bash
PGPASSWORD=postgres watch 'psql -h localhost -p 6432 -U postgres -d postgres_example -c "SELECT sum(numbackends) FROM pg_stat_database"'
```
- Rapidly make this request in a separate terminal - monitored connections should stay around 2-3, instead of quickly maxing out when it gets to 100 
```bash
- curl -X 'POST' \
  'http://localhost:8080/api/v1/privacy-request' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '[
  {
    "identity": {
      "email": "customer-1@example.com"
    },
    "policy_key": "default_access_policy"
  }
]'
```


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
