### PR TITLE
Remove Celery Startup Banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The types of changes are:
 - Fixed bug prevented adding new privacy center translations [#4786](https://github.com/ethyca/fides/pull/4786)
 - Fixed bug where Privacy Policy links would be shown without a configured URL [#4801](https://github.com/ethyca/fides/pull/4801)
 
+### Changed
+- Removed the Celery startup banner from the Fides worker logs [#4814](https://github.com/ethyca/fides/pull/4814)
+
 
 ## [2.34.0](https://github.com/ethyca/fides/compare/2.33.1...2.34.0)
 

--- a/src/fides/api/worker/__init__.py
+++ b/src/fides/api/worker/__init__.py
@@ -1,10 +1,10 @@
 import json
 
+from typing import Any
 from celery import VERSION_BANNER
 from celery.apps.worker import Worker
 from celery.signals import celeryd_after_setup
 from loguru import logger
-from typing import Any
 
 from fides.api.service.saas_request.override_implementations import *
 from fides.api.tasks import MESSAGING_QUEUE_NAME, celery_app

--- a/src/fides/api/worker/__init__.py
+++ b/src/fides/api/worker/__init__.py
@@ -40,7 +40,7 @@ def log_celery_setup(sender: str, instance: Worker, **kwargs: Any) -> None:
 
     logger.bind(
         celery_details=celery_details
-    ).info(f"Celery connection setup complete")
+    ).info("Celery connection setup complete")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/fides/api/worker/__init__.py
+++ b/src/fides/api/worker/__init__.py
@@ -1,3 +1,8 @@
+import json
+
+from celery import VERSION_BANNER
+from celery.apps.worker import Worker
+from celery.signals import celeryd_after_setup
 from loguru import logger
 
 from fides.api.service.saas_request.override_implementations import *
@@ -9,12 +14,31 @@ def start_worker() -> None:
     default_queue_name = celery_app.conf.get("task_default_queue", "celery")
     celery_app.worker_main(
         argv=[
+            "--quiet",  # Disable Celery startup banner
             "worker",
             "--loglevel=info",
             "--concurrency=2",
             f"--queues={default_queue_name},{MESSAGING_QUEUE_NAME}",
         ]
     )
+
+
+@celeryd_after_setup.connect
+def log_celery_setup(sender: str, instance: Worker, **kwargs) -> None:
+    """In lieu of the Celery banner, print the connection details"""
+    app = instance.app
+    concurrency = str(instance.concurrency)
+    celery_details = {
+        "hostname": instance.hostname,
+        "version": VERSION_BANNER,
+        "app": "{0}:{1:#x}".format(app.main or "__main__", id(app)),
+        "transport": app.connection().as_uri(),
+        "results": app.backend.as_uri(),
+        "concurrency": concurrency,
+        "queues": "|".join(str(queue) for queue in app.amqp.queues.keys()),
+    }
+
+    logger.info(f"Celery connection details | {json.dumps(celery_details)}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/fides/api/worker/__init__.py
+++ b/src/fides/api/worker/__init__.py
@@ -28,14 +28,13 @@ def start_worker() -> None:
 def log_celery_setup(sender: str, instance: Worker, **kwargs: Any) -> None:
     """In lieu of the Celery banner, print the connection details"""
     app = instance.app
-    concurrency = str(instance.concurrency)
     celery_details = {
         "hostname": instance.hostname,
         "version": VERSION_BANNER,
         "app": "{0}:{1:#x}".format(app.main or "__main__", id(app)),
         "transport": app.connection().as_uri(),
         "results": app.backend.as_uri(),
-        "concurrency": concurrency,
+        "concurrency": str(instance.concurrency),
         "queues": "|".join(str(queue) for queue in app.amqp.queues.keys()),
     }
 

--- a/src/fides/api/worker/__init__.py
+++ b/src/fides/api/worker/__init__.py
@@ -39,7 +39,9 @@ def log_celery_setup(sender: str, instance: Worker, **kwargs: Any) -> None:
         "queues": "|".join(str(queue) for queue in app.amqp.queues.keys()),
     }
 
-    logger.info(f"Celery connection details | {json.dumps(celery_details)}")
+    logger.bind(
+        celery_details=celery_details
+    ).info(f"Celery connection setup complete")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/fides/api/worker/__init__.py
+++ b/src/fides/api/worker/__init__.py
@@ -4,6 +4,7 @@ from celery import VERSION_BANNER
 from celery.apps.worker import Worker
 from celery.signals import celeryd_after_setup
 from loguru import logger
+from typing import Any
 
 from fides.api.service.saas_request.override_implementations import *
 from fides.api.tasks import MESSAGING_QUEUE_NAME, celery_app
@@ -24,7 +25,7 @@ def start_worker() -> None:
 
 
 @celeryd_after_setup.connect
-def log_celery_setup(sender: str, instance: Worker, **kwargs) -> None:
+def log_celery_setup(sender: str, instance: Worker, **kwargs: Any) -> None:
     """In lieu of the Celery banner, print the connection details"""
     app = instance.app
     concurrency = str(instance.concurrency)


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

The Celery startup banner that gets displayed on the workers is bulky and doesn't serialize well into logging systems, as it spans multiple lines. This PR removes the banner by setting the `--quiet` flag on the worker command. It then listens for the 
setup complete signal and prints a log message that contains most of the same info as the banner.

Derived from https://blog.sneawo.com/blog/2021/06/17/how-to-replace-celery-banner-with-one-log-line/


### Code Changes

* Pass `--quiet` to the Celery worker command
* Create a function that listens for the setup complete signal to log information

### Steps to Confirm

* In the `fides.toml`, set `task_always_eager = false`
* Spin up Fides with a worker: `nox -s dev -- shell ui pc worker`
* Review Worker logs and notice that Celery banner doesn't show up
* Submit a DSR and confirm that the worker still works and prints out the normal logs.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
