### PR TITLE
Added FidesUpdating event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Added
 - Added erasure support for OpenWeb [#4735](https://github.com/ethyca/fides/pull/4735)
+- Added FidesUpdating event [#4816](https://github.com/ethyca/fides/pull/4816)
 
 ### Fixed
 - Fixed bug prevented adding new privacy center translations [#4786](https://github.com/ethyca/fides/pull/4786)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,6 @@ The types of changes are:
 ### Changed
 - Removed the Celery startup banner from the Fides worker logs [#4814](https://github.com/ethyca/fides/pull/4814)
 
-### Fixed
-- Fixed bug prevented adding new privacy center translations [#4786](https://github.com/ethyca/fides/pull/4786)
-- Fixed bug where Privacy Policy links would be shown without a configured URL [#4801](https://github.com/ethyca/fides/pull/4801)
-
 ## [2.34.0](https://github.com/ethyca/fides/compare/2.33.1...2.34.0)
 
 ### Added

--- a/clients/fides-js/docs/interfaces/FidesEvent.md
+++ b/clients/fides-js/docs/interfaces/FidesEvent.md
@@ -31,17 +31,16 @@ defaults - have been set on the `Fides` global object.
 
 - `FidesUpdating`: Dispatched when a user action (e.g. accepting all, saving
 changes, applying GPC) has started updating the user's consent preferences.
-This event is dispatched immediately once the changes are saved to the
-`Fides` object and `fides_consent` cookie on the user's device, but before
-these changes are saved to the Fides API. To wait until the changes are fully
+This event is dispatched immediately once the changes are made, but before
+they are saved to the `Fides` object, `fides_consent` cookie on the user's
+device, and the Fides API. To wait until the changes are fully
 applied, use the `FidesUpdated` event instead.
 
 - `FidesUpdated`: Dispatched when a user action (e.g. accepting all, saving
 changes, applying GPC) has finished updating the user's consent preferences.
 This event is dispatched once the changes are fully saved to the `Fides`
-object and `fides_consent` cookie on the user's device and has been saved to
-the Fides API, but before these changes are saved to the Fides API. To
-receive an event sooner before the API calls are made, use the
+object, `fides_consent` cookie on the user's device, and the Fides API. To
+receive an event that fires before these changes are saved, use the
 `FidesUpdating` event instead.
 
 - `FidesUIShown`: Dispatched whenever a FidesJS UI component is rendered and

--- a/clients/fides-js/docs/interfaces/FidesEvent.md
+++ b/clients/fides-js/docs/interfaces/FidesEvent.md
@@ -29,12 +29,20 @@ the browser, see the MDN docs:
 current user's consent preferences - either previously saved or applicable
 defaults - have been set on the `Fides` global object.
 
-- `FidesUpdating`: Dispatched whenever the current user's consent preferences
-are about to be saved.
+- `FidesUpdating`: Dispatched when a user action (e.g. accepting all, saving
+changes, applying GPC) has started updating the user's consent preferences.
+This event is dispatched immediately once the changes are saved to the
+`Fides` object and `fides_consent` cookie on the user's device, but before
+these changes are saved to the Fides API. To wait until the changes are fully
+applied, use the `FidesUpdated` event instead.
 
-- `FidesUpdated`: Dispatched whenever the current user's consent preferences
-are updated on the `Fides` global object due to a user action (e.g. accepting
-all, applying GPC).
+- `FidesUpdated`: Dispatched when a user action (e.g. accepting all, saving
+changes, applying GPC) has finished updating the user's consent preferences.
+This event is dispatched once the changes are fully saved to the `Fides`
+object and `fides_consent` cookie on the user's device and has been saved to
+the Fides API, but before these changes are saved to the Fides API. To
+receive an event sooner before the API calls are made, use the
+`FidesUpdating` event instead.
 
 - `FidesUIShown`: Dispatched whenever a FidesJS UI component is rendered and
 shown to the current user (banner, modal, etc.). The specific component shown

--- a/clients/fides-js/docs/interfaces/FidesEvent.md
+++ b/clients/fides-js/docs/interfaces/FidesEvent.md
@@ -29,9 +29,12 @@ the browser, see the MDN docs:
 current user's consent preferences - either previously saved or applicable
 defaults - have been set on the `Fides` global object.
 
+- `FidesUpdating`: Dispatched whenever the current user's consent preferences
+are about to be saved.
+
 - `FidesUpdated`: Dispatched whenever the current user's consent preferences
 are updated on the `Fides` global object due to a user action (e.g. accepting
-all, applying GPC). The
+all, applying GPC).
 
 - `FidesUIShown`: Dispatched whenever a FidesJS UI component is rendered and
 shown to the current user (banner, modal, etc.). The specific component shown

--- a/clients/fides-js/docs/interfaces/FidesOptions.md
+++ b/clients/fides-js/docs/interfaces/FidesOptions.md
@@ -40,15 +40,27 @@ order of precedence:
 
 ### Properties
 
+- [fides\_clear\_cookie](FidesOptions.md#fides_clear_cookie)
 - [fides\_disable\_banner](FidesOptions.md#fides_disable_banner)
 - [fides\_disable\_save\_api](FidesOptions.md#fides_disable_save_api)
 - [fides\_embed](FidesOptions.md#fides_embed)
 - [fides\_locale](FidesOptions.md#fides_locale)
 - [fides\_string](FidesOptions.md#fides_string)
 - [fides\_tcf\_gdpr\_applies](FidesOptions.md#fides_tcf_gdpr_applies)
-- [fides\_clear\_cookie](FidesOptions.md#fides_clear_cookie)
 
 ## Properties
+
+### fides\_clear\_cookie
+
+• **fides\_clear\_cookie**: `boolean`
+
+When `true`, deletes the `fides_consent` cookie when FidesJS is
+initialized, to clear any previously saved consent preferences from the
+user's device.
+
+Defaults to `false`.
+
+___
 
 ### fides\_disable\_banner
 
@@ -150,13 +162,3 @@ overriden at the page-level as needed. Only applicable to a TCF experience.
 For more details, see the [TCF CMP API technical specification](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-does-the-gdprapplies-value-mean)  * 
 
 Defaults to `true`.
-
-___
-
-### fides\_clear\_cookie
-
-• **fides\_clear\_cookie**: `boolean`
-
-When `true`, shows fides.js overlay UI on load. This deletes the fides_consent cookie as if no preferences have been saved on reload.
-
-Defaults to `false`.

--- a/clients/fides-js/src/docs/fides-event.ts
+++ b/clients/fides-js/src/docs/fides-event.ts
@@ -10,6 +10,7 @@
  */
 export type FidesEventType =
   | "FidesInitialized"
+  | "FidesUpdating"
   | "FidesUpdated"
   | "FidesUIShown"
   | "FidesUIChanged"
@@ -43,10 +44,13 @@ export type FidesEventType =
  * - `FidesInitialized`: Dispatched when initialization is complete and the
  * current user's consent preferences - either previously saved or applicable
  * defaults - have been set on the `Fides` global object.
+ * 
+ * - `FidesUpdating`: Dispatched whenever the current user's consent preferences
+ * are about to be saved.
  *
  * - `FidesUpdated`: Dispatched whenever the current user's consent preferences
  * are updated on the `Fides` global object due to a user action (e.g. accepting
- * all, applying GPC). The
+ * all, applying GPC).
  *
  * - `FidesUIShown`: Dispatched whenever a FidesJS UI component is rendered and
  * shown to the current user (banner, modal, etc.). The specific component shown

--- a/clients/fides-js/src/docs/fides-event.ts
+++ b/clients/fides-js/src/docs/fides-event.ts
@@ -47,17 +47,16 @@ export type FidesEventType =
  * 
  * - `FidesUpdating`: Dispatched when a user action (e.g. accepting all, saving
  * changes, applying GPC) has started updating the user's consent preferences.
- * This event is dispatched immediately once the changes are saved to the
- * `Fides` object and `fides_consent` cookie on the user's device, but before
- * these changes are saved to the Fides API. To wait until the changes are fully
+ * This event is dispatched immediately once the changes are made, but before
+ * they are saved to the `Fides` object, `fides_consent` cookie on the user's
+ * device, and the Fides API. To wait until the changes are fully
  * applied, use the `FidesUpdated` event instead.
  *
  * - `FidesUpdated`: Dispatched when a user action (e.g. accepting all, saving
  * changes, applying GPC) has finished updating the user's consent preferences.
  * This event is dispatched once the changes are fully saved to the `Fides`
- * object and `fides_consent` cookie on the user's device and has been saved to
- * the Fides API, but before these changes are saved to the Fides API. To
- * receive an event sooner before the API calls are made, use the
+ * object, `fides_consent` cookie on the user's device, and the Fides API. To
+ * receive an event that fires before these changes are saved, use the
  * `FidesUpdating` event instead.
  * 
  * - `FidesUIShown`: Dispatched whenever a FidesJS UI component is rendered and

--- a/clients/fides-js/src/docs/fides-event.ts
+++ b/clients/fides-js/src/docs/fides-event.ts
@@ -45,13 +45,21 @@ export type FidesEventType =
  * current user's consent preferences - either previously saved or applicable
  * defaults - have been set on the `Fides` global object.
  * 
- * - `FidesUpdating`: Dispatched whenever the current user's consent preferences
- * are about to be saved.
+ * - `FidesUpdating`: Dispatched when a user action (e.g. accepting all, saving
+ * changes, applying GPC) has started updating the user's consent preferences.
+ * This event is dispatched immediately once the changes are saved to the
+ * `Fides` object and `fides_consent` cookie on the user's device, but before
+ * these changes are saved to the Fides API. To wait until the changes are fully
+ * applied, use the `FidesUpdated` event instead.
  *
- * - `FidesUpdated`: Dispatched whenever the current user's consent preferences
- * are updated on the `Fides` global object due to a user action (e.g. accepting
- * all, applying GPC).
- *
+ * - `FidesUpdated`: Dispatched when a user action (e.g. accepting all, saving
+ * changes, applying GPC) has finished updating the user's consent preferences.
+ * This event is dispatched once the changes are fully saved to the `Fides`
+ * object and `fides_consent` cookie on the user's device and has been saved to
+ * the Fides API, but before these changes are saved to the Fides API. To
+ * receive an event sooner before the API calls are made, use the
+ * `FidesUpdating` event instead.
+ * 
  * - `FidesUIShown`: Dispatched whenever a FidesJS UI component is rendered and
  * shown to the current user (banner, modal, etc.). The specific component shown
  * can be obtained from the `detail.extraDetails.servingComponent` property on

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -36,6 +36,15 @@
  */
 export interface FidesOptions {
   /**
+   * When `true`, deletes the `fides_consent` cookie when FidesJS is
+   * initialized, to clear any previously saved consent preferences from the
+   * user's device.
+   * 
+   * Defaults to `false`.
+  */
+  fides_clear_cookie: boolean;
+
+  /**
    * When `true`, disable the FidesJS banner from being shown.
    * 
    * Defaults to `false`.
@@ -127,12 +136,4 @@ export interface FidesOptions {
    * Defaults to `true`.
    */
   fides_tcf_gdpr_applies: boolean;
-
-  /**
-   * When `true`, shows fides.js overlay UI on load. This deletes the fides_consent cookie as if no preferences have been saved on reload.
-   * 
-   * Defaults to `false`.
-  */
-
-  fides_clear_cookie: boolean;
 };

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -12,7 +12,6 @@ declare global {
  */
 interface FidesVariable {
   consent: NoticeConsent;
-  extraDetails?: FidesEventExtraDetails;
 }
 
 // Helper function to push the Fides variable to the GTM data layer from a FidesEvent
@@ -27,7 +26,6 @@ const pushFidesVariableToGTM = (fidesEvent: {
   // Construct the Fides variable that will be pushed to GTM
   const Fides: FidesVariable = {
     consent: fidesEvent.detail.consent,
-    extraDetails: fidesEvent.detail.extraDetails,
   };
 
   // Push to the GTM dataLayer

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -1,4 +1,4 @@
-import { FidesEventDetail, FidesEventExtraDetails } from "../lib/events";
+import { FidesEventDetail } from "../lib/events";
 import { NoticeConsent } from "../lib/consent-types";
 
 declare global {

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -1,4 +1,4 @@
-import { FidesEventDetail } from "../lib/events";
+import { FidesEventDetail, FidesEventExtraDetails } from "../lib/events";
 import { NoticeConsent } from "../lib/consent-types";
 
 declare global {
@@ -12,6 +12,7 @@ declare global {
  */
 interface FidesVariable {
   consent: NoticeConsent;
+  extraDetails?: FidesEventExtraDetails;
 }
 
 // Helper function to push the Fides variable to the GTM data layer from a FidesEvent
@@ -26,6 +27,7 @@ const pushFidesVariableToGTM = (fidesEvent: {
   // Construct the Fides variable that will be pushed to GTM
   const Fides: FidesVariable = {
     consent: fidesEvent.detail.consent,
+    extraDetails: fidesEvent.detail.extraDetails,
   };
 
   // Push to the GTM dataLayer
@@ -40,6 +42,9 @@ const pushFidesVariableToGTM = (fidesEvent: {
 export const gtm = () => {
   // Listen for Fides events and cross-publish them to GTM
   window.addEventListener("FidesInitialized", (event) =>
+    pushFidesVariableToGTM(event)
+  );
+  window.addEventListener("FidesUpdating", (event) =>
     pushFidesVariableToGTM(event)
   );
   window.addEventListener("FidesUpdated", (event) =>

--- a/clients/fides-js/src/lib/events.ts
+++ b/clients/fides-js/src/lib/events.ts
@@ -4,13 +4,7 @@ import type { FidesEventType } from "../docs";
 
 // Bonus points: update the WindowEventMap interface with our custom event types
 declare global {
-  interface WindowEventMap {
-    FidesInitialized: FidesEvent;
-    FidesUpdated: FidesEvent;
-    FidesUIShown: FidesEvent;
-    FidesUIChanged: FidesEvent;
-    FidesModalClosed: FidesEvent;
-  }
+  interface WindowEventMap extends Record<FidesEventType, FidesEvent> {}
 }
 
 /**

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -58,11 +58,12 @@ async function savePreferencesApi(
 /**
  * Updates the user's consent preferences, going through the following steps:
  * 1. Update the cookie object based on new preferences
- * 2. Update the window.Fides object
- * 3. Save preferences to the `fides_consent` cookie in the browser
- * 4. Save preferences to Fides API or a custom function (`savePreferencesFn`)
- * 5. Remove any cookies from notices that were opted-out from the browser
- * 6. Dispatch a "FidesUpdated" event
+ * 2. Dispatch a "FidesUpdating" event with the new preferences
+ * 3. Update the window.Fides object
+ * 4. Save preferences to the `fides_consent` cookie in the browser
+ * 5. Save preferences to Fides API or a custom function (`savePreferencesFn`)
+ * 6. Remove any cookies from notices that were opted-out from the browser
+ * 7. Dispatch a "FidesUpdated" event
  */
 export const updateConsentPreferences = async ({
   consentPreferencesToSave,
@@ -96,7 +97,7 @@ export const updateConsentPreferences = async ({
   Object.assign(cookie, updatedCookie);
   Object.assign(cookie.fides_meta, extraDetails); // save extra details to meta (i.e. consentMethod)
 
-  // 2. Dispatch a "FidesUpdating" event with the new cookie
+  // 2. Dispatch a "FidesUpdating" event with the new preferences
   dispatchFidesEvent("FidesUpdating", cookie, options.debug, extraDetails);
 
   // 3. Update the window.Fides object

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -96,18 +96,21 @@ export const updateConsentPreferences = async ({
   Object.assign(cookie, updatedCookie);
   Object.assign(cookie.fides_meta, extraDetails); // save extra details to meta (i.e. consentMethod)
 
-  // 2. Update the window.Fides object
+  // 2. Dispatch a "FidesUpdating" event with the new cookie
+  dispatchFidesEvent("FidesUpdating", cookie, options.debug, extraDetails);
+  
+  // 3. Update the window.Fides object
   debugLog(options.debug, "Updating window.Fides");
   window.Fides.consent = cookie.consent;
   window.Fides.fides_string = cookie.fides_string;
   window.Fides.tcf_consent = cookie.tcf_consent;
 
-  // 3. Save preferences to the cookie in the browser
+  // 4. Save preferences to the cookie in the browser
   debugLog(options.debug, "Saving preferences to cookie");
   saveFidesCookie(cookie, options.base64Cookie);
   window.Fides.saved_consent = cookie.consent;
 
-  // 4. Save preferences to API (if not disabled)
+  // 5. Save preferences to API (if not disabled)
   if (!options.fidesDisableSaveApi) {
     try {
       await savePreferencesApi(
@@ -130,7 +133,7 @@ export const updateConsentPreferences = async ({
     }
   }
 
-  // 5. Remove cookies associated with notices that were opted-out from the browser
+  // 6. Remove cookies associated with notices that were opted-out from the browser
   if (consentPreferencesToSave) {
     consentPreferencesToSave
       .filter(
@@ -142,6 +145,6 @@ export const updateConsentPreferences = async ({
       });
   }
 
-  // 6. Dispatch a "FidesUpdated" event
+  // 7. Dispatch a "FidesUpdated" event
   dispatchFidesEvent("FidesUpdated", cookie, options.debug, extraDetails);
 };

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -98,7 +98,7 @@ export const updateConsentPreferences = async ({
 
   // 2. Dispatch a "FidesUpdating" event with the new cookie
   dispatchFidesEvent("FidesUpdating", cookie, options.debug, extraDetails);
-  
+
   // 3. Update the window.Fides object
   debugLog(options.debug, "Updating window.Fides");
   window.Fides.consent = cookie.consent;

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -2893,6 +2893,15 @@ describe("Fides-js TCF", () => {
       cy.wait("@patchPrivacyPreference").then((interception) => {
         expect(interception.request.body.method).to.eql(ConsentMethod.ACCEPT);
       });
+      // Both FidesUpdating & FidesUpdated should include the fides_string
+      cy.get("@FidesUpdating")
+        .should("have.been.calledOnce")
+        .its("lastCall.args.0.detail.fides_string")
+        .then((fidesString) => {
+          const parts = fidesString.split(",");
+          expect(parts.length).to.eql(2);
+          expect(parts[1]).to.eql(acceptAllAcString);
+        });
       cy.get("@FidesUpdated")
         .should("have.been.calledOnce")
         .its("lastCall.args.0.detail.fides_string")

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -1629,7 +1629,7 @@ describe("Consent overlay", () => {
 
     // NOTE: See definition of cy.visitConsentDemo in commands.ts for where we
     // register listeners for these window events
-    it("emits a FidesInitialized but not a FidesUpdated event when initialized", () => {
+    it("emits a FidesInitialized but not any other events when initialized", () => {
       cy.window()
         .its("Fides")
         .its("consent")
@@ -1646,12 +1646,14 @@ describe("Consent overlay", () => {
           [PRIVACY_NOTICE_KEY_2]: true,
           [PRIVACY_NOTICE_KEY_3]: true,
         });
+      cy.get("@FidesUpdating").should("not.have.been.called");
       cy.get("@FidesUpdated").should("not.have.been.called");
+      cy.get("@FidesUIShown").should("not.have.been.called");
       cy.get("@FidesUIChanged").should("not.have.been.called");
     });
 
     describe("when preferences are changed / saved", () => {
-      it("emits a FidesUpdated event when reject all is clicked", () => {
+      it("emits FidesUpdating -> FidesUpdated events when reject all is clicked", () => {
         cy.contains("button", "Opt out of all").should("be.visible").click();
         cy.get("@FidesUIChanged").should("not.have.been.called");
         cy.get("@FidesInitialized")
@@ -1663,8 +1665,17 @@ describe("Consent overlay", () => {
             [PRIVACY_NOTICE_KEY_2]: true,
             [PRIVACY_NOTICE_KEY_3]: true,
           });
+        cy.get("@FidesUpdating")
+          // Updating event, when the user rejects all
+          .should("have.been.calledOnce")
+          .its("firstCall.args.0.detail.consent")
+          .should("deep.equal", {
+            [PRIVACY_NOTICE_KEY_1]: false,
+            [PRIVACY_NOTICE_KEY_2]: true,
+            [PRIVACY_NOTICE_KEY_3]: false,
+          });
         cy.get("@FidesUpdated")
-          // Update event, when the user rejects all
+          // Updated event, when the preferences have finished updating
           .should("have.been.calledOnce")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
@@ -1679,7 +1690,7 @@ describe("Consent overlay", () => {
           });
       });
 
-      it("emits a FidesUpdated event when accept all is clicked", () => {
+      it("emits FidesUpdating -> FidesUpdated events when accept all is clicked", () => {
         cy.contains("button", "Opt in to all").should("be.visible").click();
         cy.get("@FidesUIChanged").should("not.have.been.called");
         cy.get("@FidesInitialized")
@@ -1691,8 +1702,17 @@ describe("Consent overlay", () => {
             [PRIVACY_NOTICE_KEY_2]: true,
             [PRIVACY_NOTICE_KEY_3]: true,
           });
+        cy.get("@FidesUpdating")
+          // Updating event, when the user accepts all
+          .should("have.been.calledOnce")
+          .its("firstCall.args.0.detail.consent")
+          .should("deep.equal", {
+            [PRIVACY_NOTICE_KEY_1]: true,
+            [PRIVACY_NOTICE_KEY_2]: true,
+            [PRIVACY_NOTICE_KEY_3]: true,
+          });
         cy.get("@FidesUpdated")
-          // Update event, when the user accepts all
+          // Updated event, when the preferences have finished updating
           .should("have.been.calledOnce")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
@@ -1707,13 +1727,10 @@ describe("Consent overlay", () => {
           });
       });
 
-      it("emits a FidesUIChanged event when preferences are changed and a FidesUpdated event when preferences are saved", () => {
+      it("emits a FidesUIChanged event when preferences are changed and FidesUpdating -> FidesUpdated events when preferences are saved", () => {
         cy.contains("button", "Manage preferences")
           .should("be.visible")
           .click();
-        cy.getByTestId("toggle-Advertising").click();
-        cy.getByTestId("consent-modal").contains("Save").click();
-        cy.get("@FidesUIChanged").should("have.been.calledOnce");
         cy.get("@FidesInitialized")
           // First event, before the user saved preferences
           .should("have.been.calledOnce")
@@ -1724,8 +1741,26 @@ describe("Consent overlay", () => {
             [PRIVACY_NOTICE_KEY_3]: true,
           });
 
+        // Toggle the notice, but don't save yet
+        cy.getByTestId("toggle-Advertising").click();
+        cy.get("@FidesUIChanged").should("have.been.calledOnce");
+        cy.get("@FidesUpdating").should("not.have.been.called");
+        cy.get("@FidesUpdated").should("not.have.been.called");
+
+        // Save the changes
+        cy.getByTestId("consent-modal").contains("Save").click();
+        cy.get("@FidesUIChanged").should("have.been.calledOnce"); // still only once
+        cy.get("@FidesUpdating")
+          // Updating event, when the user saved preferences and opted-in to the first notice
+          .should("have.been.calledOnce")
+          .its("firstCall.args.0.detail.consent")
+          .should("deep.equal", {
+            [PRIVACY_NOTICE_KEY_1]: true,
+            [PRIVACY_NOTICE_KEY_2]: true,
+            [PRIVACY_NOTICE_KEY_3]: true,
+          });
         cy.get("@FidesUpdated")
-          // Update event, when the user saved preferences and opted-in to the first notice
+          // Updated event, when the preferences have finished updating
           .should("have.been.calledOnce")
           .its("firstCall.args.0.detail.consent")
           .should("deep.equal", {
@@ -1744,7 +1779,7 @@ describe("Consent overlay", () => {
     it("pushes events to the GTM integration", () => {
       cy.contains("button", "Opt in to all").should("be.visible").click();
       cy.get("@dataLayerPush")
-        .should("have.been.calledTwice")
+        .should("have.been.calledThrice")
         // First call should be from initialization, before the user accepts all
         .its("firstCall.args.0")
         .should("deep.equal", {
@@ -1760,6 +1795,19 @@ describe("Consent overlay", () => {
       cy.get("@dataLayerPush")
         // Second call is when the user accepts all
         .its("secondCall.args.0")
+        .should("deep.equal", {
+          event: "FidesUpdating",
+          Fides: {
+            consent: {
+              [PRIVACY_NOTICE_KEY_1]: true,
+              [PRIVACY_NOTICE_KEY_2]: true,
+              [PRIVACY_NOTICE_KEY_3]: true,
+            },
+          },
+        });
+      cy.get("@dataLayerPush")
+        // Third call is when the preferences finish updating
+        .its("thirdCall.args.0")
         .should("deep.equal", {
           event: "FidesUpdated",
           Fides: {

--- a/clients/privacy-center/cypress/support/commands.ts
+++ b/clients/privacy-center/cypress/support/commands.ts
@@ -90,6 +90,7 @@ Cypress.Commands.add(
           "FidesInitialized",
           cy.stub().as("FidesInitialized")
         );
+        win.addEventListener("FidesUpdating", cy.stub().as("FidesUpdating"));
         win.addEventListener("FidesUpdated", cy.stub().as("FidesUpdated"));
         win.addEventListener("FidesUIShown", cy.stub().as("FidesUIShown"));
         win.addEventListener("FidesUIChanged", cy.stub().as("FidesUIChanged"));


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1965

### Description Of Changes

Adds a new `FidesUpdating` even that fires (almost) immediately after the user has updated their consent. This allows page code to react to the change sooner than `FidesUpdated` as that will potentially make a network request to save the preferences before firing.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`
