### PR TITLE
Apply Black=24.3.0 Formatting Changes

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,7 @@
 """
 This file aggregates nox commands for various development tasks.
 """
+
 import platform
 import shutil
 import sys

--- a/noxfiles/ci_nox.py
+++ b/noxfiles/ci_nox.py
@@ -1,4 +1,5 @@
 """Contains the nox sessions used during CI checks."""
+
 from functools import partial
 from typing import Callable, Dict
 

--- a/noxfiles/constants_nox.py
+++ b/noxfiles/constants_nox.py
@@ -1,4 +1,5 @@
 """Define constants to be used across the noxfiles."""
+
 from os import getcwd, getenv
 
 # Files

--- a/noxfiles/dev_nox.py
+++ b/noxfiles/dev_nox.py
@@ -1,4 +1,5 @@
 """Contains the nox sessions for running development environments."""
+
 import time
 from pathlib import Path
 from typing import Literal

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -1,4 +1,5 @@
 """Contains the nox sessions for docker-related tasks."""
+
 from typing import Callable, Dict, List, Optional, Tuple
 
 import nox

--- a/noxfiles/docs_nox.py
+++ b/noxfiles/docs_nox.py
@@ -1,4 +1,5 @@
 """Contains the nox sessions for developing docs."""
+
 import nox
 
 from constants_nox import CI_ARGS

--- a/noxfiles/run_infrastructure.py
+++ b/noxfiles/run_infrastructure.py
@@ -2,6 +2,7 @@
 This file invokes a command used to setup infrastructure for use in testing Fidesops
 and related workflows.
 """
+
 # pylint: disable=inconsistent-return-statements
 import argparse
 import subprocess

--- a/noxfiles/utils_nox.py
+++ b/noxfiles/utils_nox.py
@@ -1,4 +1,5 @@
 """Contains various utility-related nox sessions."""
+
 from pathlib import Path
 
 import nox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ ignore_missing_imports = true
 ## Black ##
 ###########
 [tool.black]
-py39 = true
+target-version = ["py39"]
 line-length = 88
 include = '\.pyi?$'
 exclude = '''

--- a/scripts/create_test_data.py
+++ b/scripts/create_test_data.py
@@ -1,4 +1,5 @@
 """Script to create test data for the Admin UI"""
+
 import asyncio
 import string
 from datetime import datetime, timedelta

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1,6 +1,7 @@
 """
 This module handles generating documentation from code.
 """
+
 import json
 import sys
 

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -1,6 +1,7 @@
 """
 A five-step fidesops quickstart
 """
+
 import json
 import os
 import time

--- a/src/fides/__init__.py
+++ b/src/fides/__init__.py
@@ -1,4 +1,5 @@
 """The root module for the Fides package."""
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/src/fides/api/alembic/migrations/versions/0210948a8147_initial.py
+++ b/src/fides/api/alembic/migrations/versions/0210948a8147_initial.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2021-10-29 11:51:19.265141
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/021d288d0ce3_add_consent_request.py
+++ b/src/fides/api/alembic/migrations/versions/021d288d0ce3_add_consent_request.py
@@ -5,6 +5,7 @@ Revises: a0e6feb5bdc8
 Create Date: 2022-09-17 01:26:43.187484
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/07014ff34eb2_add_mariadb.py
+++ b/src/fides/api/alembic/migrations/versions/07014ff34eb2_add_mariadb.py
@@ -5,6 +5,7 @@ Revises: f3841942d90c
 Create Date: 2022-01-27 19:18:11.899734
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/093bb28a8270_add_plus_system_history_table.py
+++ b/src/fides/api/alembic/migrations/versions/093bb28a8270_add_plus_system_history_table.py
@@ -5,6 +5,7 @@ Revises: 3038667ba898
 Create Date: 2023-08-18 23:48:22.934916
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/0c65325843bd_add_location_groups_column.py
+++ b/src/fides/api/alembic/migrations/versions/0c65325843bd_add_location_groups_column.py
@@ -5,6 +5,7 @@ Revises: a1e23b70f2b2
 Create Date: 2024-02-21 19:56:39.228072
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/144d9b85c712_update_consent_mechanism.py
+++ b/src/fides/api/alembic/migrations/versions/144d9b85c712_update_consent_mechanism.py
@@ -5,6 +5,7 @@ Revises: 8188ddbf8cae
 Create Date: 2023-04-12 14:57:07.532660
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data.py
+++ b/src/fides/api/alembic/migrations/versions/14acee6f5459_translation_data.py
@@ -326,9 +326,9 @@ def load_default_experience_configs():
             experience_config["regions"] = set(experience_config["regions"])
 
         experience_config["privacy_notices"] = set()
-        experience_config[
-            "needs_migration"
-        ] = False  # indicator whether the record requires migration, or we can default to the template values
+        experience_config["needs_migration"] = (
+            False  # indicator whether the record requires migration, or we can default to the template values
+        )
         _reconciled_experience_config_map[experience_config_type] = experience_config
         experience_config["needs_migration"] = False
     return _reconciled_experience_config_map, _raw_experience_config_map

--- a/src/fides/api/alembic/migrations/versions/150f234ef1de_add_fidesctl_meta_to_organization_object.py
+++ b/src/fides/api/alembic/migrations/versions/150f234ef1de_add_fidesctl_meta_to_organization_object.py
@@ -5,6 +5,7 @@ Revises: edcd28ede1f7
 Create Date: 2022-03-07 20:14:00.530408
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/155fd8e51d9d_add_fideslib_models.py
+++ b/src/fides/api/alembic/migrations/versions/155fd8e51d9d_add_fideslib_models.py
@@ -5,6 +5,7 @@ Revises: be432bd23596
 Create Date: 2022-07-09 01:13:23.440193
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/15a3e7483249_make_customfielddefinition_uniqueness_.py
+++ b/src/fides/api/alembic/migrations/versions/15a3e7483249_make_customfielddefinition_uniqueness_.py
@@ -5,6 +5,7 @@ Revises: e92da354691e
 Create Date: 2023-05-02 15:03:56.256982
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.exc import IntegrityError

--- a/src/fides/api/alembic/migrations/versions/1739aa4a4ab7_add_security_policy_link_and_erasure_.py
+++ b/src/fides/api/alembic/migrations/versions/1739aa4a4ab7_add_security_policy_link_and_erasure_.py
@@ -5,6 +5,7 @@ Revises: 4c3693c289d0
 Create Date: 2022-01-28 20:41:20.065432
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/179f2bb623ae_update_table_for_twilio.py
+++ b/src/fides/api/alembic/migrations/versions/179f2bb623ae_update_table_for_twilio.py
@@ -5,6 +5,7 @@ Revises: 8f1a19465239
 Create Date: 2022-10-31 18:19:26.845723
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/192f23f4c968_add_fides_cloud_table.py
+++ b/src/fides/api/alembic/migrations/versions/192f23f4c968_add_fides_cloud_table.py
@@ -5,6 +5,7 @@ Revises: 093bb28a8270
 Create Date: 2023-09-01 17:28:22.099543
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/1af6950f4625_update_flexible_legal_basis_default.py
+++ b/src/fides/api/alembic/migrations/versions/1af6950f4625_update_flexible_legal_basis_default.py
@@ -5,6 +5,7 @@ Revises: 3cc39a6ce32b
 Create Date: 2023-11-15 22:15:38.688530
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/1dfc5a2d30e7_add_saas_config_to_connection_config.py
+++ b/src/fides/api/alembic/migrations/versions/1dfc5a2d30e7_add_saas_config_to_connection_config.py
@@ -5,6 +5,7 @@ Revises: e55a51b354e3
 Create Date: 2022-02-09 23:27:24.742938
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/1ea164cee8bc_fideslang_2_data_migrations.py
+++ b/src/fides/api/alembic/migrations/versions/1ea164cee8bc_fideslang_2_data_migrations.py
@@ -5,6 +5,7 @@ Revises: 708a780b01ba
 Create Date: 2023-09-06 04:09:06.212144
 
 """
+
 import json
 from typing import Dict, List, Optional
 

--- a/src/fides/api/alembic/migrations/versions/1f61c765cd1c_merge_alembic_heads.py
+++ b/src/fides/api/alembic/migrations/versions/1f61c765cd1c_merge_alembic_heads.py
@@ -5,6 +5,7 @@ Revises: 8f84fad4e00b, b72541d79f10
 Create Date: 2022-12-02 17:59:08.490577
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/1ff88b7bd579_add_authorization_request.py
+++ b/src/fides/api/alembic/migrations/versions/1ff88b7bd579_add_authorization_request.py
@@ -5,6 +5,7 @@ Revises: 3a7c5fb119c9
 Create Date: 2022-05-25 04:09:22.149110
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/216cdc7944f1_add_datasetconfig_ctl_datasets_fk.py
+++ b/src/fides/api/alembic/migrations/versions/216cdc7944f1_add_datasetconfig_ctl_datasets_fk.py
@@ -8,6 +8,7 @@ Revises: 2fb48b0e268b
 Create Date: 2022-12-09 22:03:51.097585
 
 """
+
 import json
 import uuid
 from typing import Any, Dict

--- a/src/fides/api/alembic/migrations/versions/25adddf820a3_another_fidesops_remote_merge.py
+++ b/src/fides/api/alembic/migrations/versions/25adddf820a3_another_fidesops_remote_merge.py
@@ -5,6 +5,7 @@ Revises: 7b81d34352e8, 97801300fedd
 Create Date: 2022-08-24 10:40:25.875324
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/2661f31daffb_track_experience_on_preferences.py
+++ b/src/fides/api/alembic/migrations/versions/2661f31daffb_track_experience_on_preferences.py
@@ -5,6 +5,7 @@ Revises: b546ce845e6c
 Create Date: 2023-05-16 20:05:29.478005
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/26934c96ec80_initial_migration.py
+++ b/src/fides/api/alembic/migrations/versions/26934c96ec80_initial_migration.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2021-09-22 04:12:38.479740
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/27fe9da9d0f9_privacy_request_stopped.py
+++ b/src/fides/api/alembic/migrations/versions/27fe9da9d0f9_privacy_request_stopped.py
@@ -5,6 +5,7 @@ Revises: 1ff88b7bd579
 Create Date: 2022-06-06 20:28:08.893135
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/28108b17a99c_add_notifications_for_failed_dsr_.py
+++ b/src/fides/api/alembic/migrations/versions/28108b17a99c_add_notifications_for_failed_dsr_.py
@@ -5,6 +5,7 @@ Revises: 8f1a19465239
 Create Date: 2022-11-07 23:56:14.066374
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/29a7d707163a_adds_first_name_and_last_name_to_user_.py
+++ b/src/fides/api/alembic/migrations/versions/29a7d707163a_adds_first_name_and_last_name_to_user_.py
@@ -5,6 +5,7 @@ Revises: 90070db16d05
 Create Date: 2022-05-05 13:41:28.807920
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/2af81f2b1a6f_add_system_vendor_id.py
+++ b/src/fides/api/alembic/migrations/versions/2af81f2b1a6f_add_system_vendor_id.py
@@ -5,6 +5,7 @@ Revises: b3b407ce2d5f
 Create Date: 2023-11-06 21:46:30.715273
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/2be84e68df32_add_cookie_table.py
+++ b/src/fides/api/alembic/migrations/versions/2be84e68df32_add_cookie_table.py
@@ -5,6 +5,7 @@ Revises: c1885270b3cc
 Create Date: 2023-06-13 23:08:35.011377
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/2f6aa5fe797a_update_messaging_service_type_enum.py
+++ b/src/fides/api/alembic/migrations/versions/2f6aa5fe797a_update_messaging_service_type_enum.py
@@ -5,6 +5,7 @@ Revises: d65bbc647083
 Create Date: 2023-03-03 17:13:21.108111
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/2fb48b0e268b_update_ctl_datasets_fidesctl_meta.py
+++ b/src/fides/api/alembic/migrations/versions/2fb48b0e268b_update_ctl_datasets_fidesctl_meta.py
@@ -5,6 +5,7 @@ Revises: 5b4b9c2d1c93
 Create Date: 2022-12-08 17:49:14.317905
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/3038667ba898_update_system_legal_basis_fields.py
+++ b/src/fides/api/alembic/migrations/versions/3038667ba898_update_system_legal_basis_fields.py
@@ -5,6 +5,7 @@ Revises: 507563f6f8d4
 Create Date: 2023-08-25 14:19:16.798409
 
 """
+
 from typing import Dict
 
 import sqlalchemy as sa

--- a/src/fides/api/alembic/migrations/versions/312aff72b275_migrate_to_usage_of_evaluation_.py
+++ b/src/fides/api/alembic/migrations/versions/312aff72b275_migrate_to_usage_of_evaluation_.py
@@ -5,6 +5,7 @@ Revises: 45c7a349db68
 Create Date: 2021-12-15 15:53:46.484775
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/317e6197c76a_reduce_experience_and_config_duplication.py
+++ b/src/fides/api/alembic/migrations/versions/317e6197c76a_reduce_experience_and_config_duplication.py
@@ -5,6 +5,7 @@ Revises: b8248ce6b8a1
 Create Date: 2023-06-05 23:24:43.174826
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/32497f08e227_translation_cleanup.py
+++ b/src/fides/api/alembic/migrations/versions/32497f08e227_translation_cleanup.py
@@ -7,6 +7,7 @@ Revises: 14acee6f5459
 Create Date: 2024-03-05 17:08:07.093568
 
 """
+
 from datetime import datetime
 
 import sqlalchemy as sa

--- a/src/fides/api/alembic/migrations/versions/327cd266f7b3_update_dataset_depth.py
+++ b/src/fides/api/alembic/migrations/versions/327cd266f7b3_update_dataset_depth.py
@@ -5,6 +5,7 @@ Revises: 26934c96ec80
 Create Date: 2021-09-28 19:58:31.618442
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/3842d1acac5f_adds_fides_device_id_enum.py
+++ b/src/fides/api/alembic/migrations/versions/3842d1acac5f_adds_fides_device_id_enum.py
@@ -5,6 +5,7 @@ Revises: 8342453518cc
 Create Date: 2023-04-21 20:10:01.389078
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/alembic/migrations/versions/392992c7733a_add_ga_client_id_as_a_provided_identity_type.py
+++ b/src/fides/api/alembic/migrations/versions/392992c7733a_add_ga_client_id_as_a_provided_identity_type.py
@@ -5,6 +5,7 @@ Revises: de456534dbda
 Create Date: 2023-01-20 15:33:24.084841
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/39397820a0d5_system_dictionary_schema_migration.py
+++ b/src/fides/api/alembic/migrations/versions/39397820a0d5_system_dictionary_schema_migration.py
@@ -5,6 +5,7 @@ Revises: 3a47ce736a37
 Create Date: 2023-08-03 20:07:46.326248
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/39a23bc016ea_record_consent_preferences.py
+++ b/src/fides/api/alembic/migrations/versions/39a23bc016ea_record_consent_preferences.py
@@ -5,6 +5,7 @@ Revises: a0f219697fa0
 Create Date: 2023-03-28 02:42:13.114938
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/39b209861471_adds_mailchimp_transactional_enum.py
+++ b/src/fides/api/alembic/migrations/versions/39b209861471_adds_mailchimp_transactional_enum.py
@@ -5,6 +5,7 @@ Revises: 9f38dad37628
 Create Date: 2023-03-03 21:57:14.368385
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/3a47ce736a37_adding_host_to_authenticationrequest.py
+++ b/src/fides/api/alembic/migrations/versions/3a47ce736a37_adding_host_to_authenticationrequest.py
@@ -5,6 +5,7 @@ Revises: 5abb65a8cb91
 Create Date: 2023-07-18 03:38:18.238072
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/3a7c5fb119c9_add_manual_connector_type.py
+++ b/src/fides/api/alembic/migrations/versions/3a7c5fb119c9_add_manual_connector_type.py
@@ -5,6 +5,7 @@ Revises: 5078badb90b9
 Create Date: 2022-05-13 19:18:45.400669
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/3c5e1253465d_adds_provided_identity_table_for_.py
+++ b/src/fides/api/alembic/migrations/versions/3c5e1253465d_adds_provided_identity_table_for_.py
@@ -5,6 +5,7 @@ Revises: fc90277bbcde
 Create Date: 2022-07-08 11:53:05.215848
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/3caf11127442_add_connection_key_to_execution_log.py
+++ b/src/fides/api/alembic/migrations/versions/3caf11127442_add_connection_key_to_execution_log.py
@@ -5,6 +5,7 @@ Revises: 1f61c765cd1c
 Create Date: 2022-12-21 13:36:17.859959
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/3cc39a6ce32b_cookie_system_unique_constraint.py
+++ b/src/fides/api/alembic/migrations/versions/3cc39a6ce32b_cookie_system_unique_constraint.py
@@ -5,6 +5,7 @@ Revises: 842790fa918a
 Create Date: 2023-11-07 18:07:42.861201
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/3d9c476d7cea_classification_management.py
+++ b/src/fides/api/alembic/migrations/versions/3d9c476d7cea_classification_management.py
@@ -5,6 +5,7 @@ Revises: 6bd93cb0603d
 Create Date: 2022-09-14 02:21:37.828382
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/451684a726a5_save_privacy_preferences_on_device_id.py
+++ b/src/fides/api/alembic/migrations/versions/451684a726a5_save_privacy_preferences_on_device_id.py
@@ -5,6 +5,7 @@ Revises: 48d9caacebd4
 Create Date: 2023-04-23 16:06:19.788074
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/45c7a349db68_remove_qualifier_lists_from_data_set_.py
+++ b/src/fides/api/alembic/migrations/versions/45c7a349db68_remove_qualifier_lists_from_data_set_.py
@@ -5,6 +5,7 @@ Revises: 732105cd54e3
 Create Date: 2021-10-25 17:59:25.244689
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/48d9caacebd4_create_privacy_declarations_table.py
+++ b/src/fides/api/alembic/migrations/versions/48d9caacebd4_create_privacy_declarations_table.py
@@ -5,6 +5,7 @@ Revises: 3842d1acac5f
 Create Date: 2023-04-20 20:35:05.377471
 
 """
+
 import json
 import uuid
 from collections import defaultdict

--- a/src/fides/api/alembic/migrations/versions/4c3693c289d0_add_optional_contact_information_for_.py
+++ b/src/fides/api/alembic/migrations/versions/4c3693c289d0_add_optional_contact_information_for_.py
@@ -5,6 +5,7 @@ Revises: 7c851d8a102a
 Create Date: 2022-01-21 15:56:53.519486
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/4cb3b5af4160_update_special_purpose_unique_constraint.py
+++ b/src/fides/api/alembic/migrations/versions/4cb3b5af4160_update_special_purpose_unique_constraint.py
@@ -5,6 +5,7 @@ Revises: 8c54e1e5bdc4
 Create Date: 2023-09-27 22:58:43.064996
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/4ced99dabebb_add_location_regulation_selections_table.py
+++ b/src/fides/api/alembic/migrations/versions/4ced99dabebb_add_location_regulation_selections_table.py
@@ -5,6 +5,7 @@ Revises: 548a1ac26771
 Create Date: 2023-12-18 13:50:50.620939
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/4fc34906c389_.py
+++ b/src/fides/api/alembic/migrations/versions/4fc34906c389_.py
@@ -5,6 +5,7 @@ Revises: aaa81d97a6f6, f131a1263a10
 Create Date: 2022-08-17 19:35:33.413593
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/50180bbbb959_automigrate_viewer_role.py
+++ b/src/fides/api/alembic/migrations/versions/50180bbbb959_automigrate_viewer_role.py
@@ -5,6 +5,7 @@ Revises: 68a518a3c050
 Create Date: 2023-03-14 14:26:32.910570
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/507563f6f8d4_added_messaging_template_table.py
+++ b/src/fides/api/alembic/migrations/versions/507563f6f8d4_added_messaging_template_table.py
@@ -5,6 +5,7 @@ Revises: fd52d5f08c17
 Create Date: 2023-08-05 05:30:52.105840
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/5078badb90b9_adds_drp_action_to_policy.py
+++ b/src/fides/api/alembic/migrations/versions/5078badb90b9_adds_drp_action_to_policy.py
@@ -5,6 +5,7 @@ Revises: c98da12d76f8
 Create Date: 2022-05-04 17:22:46.500067
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/50b3736634d2_extend_data_use_with_recipients_and_.py
+++ b/src/fides/api/alembic/migrations/versions/50b3736634d2_extend_data_use_with_recipients_and_.py
@@ -5,6 +5,7 @@ Revises: 1739aa4a4ab7
 Create Date: 2022-02-03 18:03:16.120608
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/52b2cfd1af47_fix_messaging_template_indexes.py
+++ b/src/fides/api/alembic/migrations/versions/52b2cfd1af47_fix_messaging_template_indexes.py
@@ -5,6 +5,7 @@ Revises: f17f92237383
 Create Date: 2023-09-15 21:29:23.060892
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/5307999c0dac_remove_deprecated_data_uses_for_.py
+++ b/src/fides/api/alembic/migrations/versions/5307999c0dac_remove_deprecated_data_uses_for_.py
@@ -5,6 +5,7 @@ Revises: 76c02f99eec1
 Create Date: 2023-06-11 11:15:53.386526
 
 """
+
 from alembic import op
 from loguru import logger
 from sqlalchemy import text

--- a/src/fides/api/alembic/migrations/versions/530fb8533ca4_test.py
+++ b/src/fides/api/alembic/migrations/versions/530fb8533ca4_test.py
@@ -5,6 +5,7 @@ Revises: c9759675b5d3
 Create Date: 2022-04-27 15:47:15.015128
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/54102bba36de_add_attentive_connector.py
+++ b/src/fides/api/alembic/migrations/versions/54102bba36de_add_attentive_connector.py
@@ -5,6 +5,7 @@ Revises: 50180bbbb959
 Create Date: 2023-03-09 22:08:17.480643
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/548a1ac26771_fideslang_3.0_remove_references.py
+++ b/src/fides/api/alembic/migrations/versions/548a1ac26771_fideslang_3.0_remove_references.py
@@ -5,6 +5,7 @@ Revises: 848a8f4125cf
 Create Date: 2023-12-08 22:07:38.617038
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/55bedede956d_requesttask.py
+++ b/src/fides/api/alembic/migrations/versions/55bedede956d_requesttask.py
@@ -5,6 +5,7 @@ Revises: 6cfd59e7920a
 Create Date: 2024-04-04 04:12:25.332952
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/55d61eb8ed12_add_default_policies.py
+++ b/src/fides/api/alembic/migrations/versions/55d61eb8ed12_add_default_policies.py
@@ -5,6 +5,7 @@ Revises: b3b68c87c4a0
 Create Date: 2022-06-13 19:26:24.197262
 
 """
+
 import logging
 
 logging.basicConfig()

--- a/src/fides/api/alembic/migrations/versions/587c53fe3e99_add_audit_log_resource_table.py
+++ b/src/fides/api/alembic/migrations/versions/587c53fe3e99_add_audit_log_resource_table.py
@@ -5,6 +5,7 @@ Revises: 8a71872089e4
 Create Date: 2023-05-18 19:21:33.496435
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/58933b5cc6e8_merge_failed_dsr_and_twilio.py
+++ b/src/fides/api/alembic/migrations/versions/58933b5cc6e8_merge_failed_dsr_and_twilio.py
@@ -5,6 +5,7 @@ Revises: 179f2bb623ae, 28108b17a99c
 Create Date: 2022-11-14 21:26:49.027809
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/5a8cee9c014c_privacy_preferences_v2_data.py
+++ b/src/fides/api/alembic/migrations/versions/5a8cee9c014c_privacy_preferences_v2_data.py
@@ -5,6 +5,7 @@ Revises: f9b28f36b53e
 Create Date: 2023-12-10 20:41:16.804029
 
 """
+
 import json
 from enum import Enum
 from typing import Dict, List, Optional, Set

--- a/src/fides/api/alembic/migrations/versions/5a966cd643d7_fidesops_user_and_client_detail.py
+++ b/src/fides/api/alembic/migrations/versions/5a966cd643d7_fidesops_user_and_client_detail.py
@@ -5,6 +5,7 @@ Revises: 1dfc5a2d30e7
 Create Date: 2022-03-08 22:05:18.352032
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/5abb65a8cb91_add_active_column_taxonomy_elements.py
+++ b/src/fides/api/alembic/migrations/versions/5abb65a8cb91_add_active_column_taxonomy_elements.py
@@ -5,6 +5,7 @@ Revises: 7c562441c589
 Create Date: 2023-07-14 11:08:55.169966
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/5b03859e51b5_update_custom_field_resource_type_enum.py
+++ b/src/fides/api/alembic/migrations/versions/5b03859e51b5_update_custom_field_resource_type_enum.py
@@ -5,6 +5,7 @@ Revises: 451684a726a5
 Create Date: 2023-04-19 19:22:47.566852
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/alembic/migrations/versions/5b4b9c2d1c93_add_system_foreign_key_to_connection_.py
+++ b/src/fides/api/alembic/migrations/versions/5b4b9c2d1c93_add_system_foreign_key_to_connection_.py
@@ -5,6 +5,7 @@ Revises: a08024ba7e2b
 Create Date: 2023-01-13 19:39:11.936347
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/5d62bab40b71_add_application_config_table.py
+++ b/src/fides/api/alembic/migrations/versions/5d62bab40b71_add_application_config_table.py
@@ -5,6 +5,7 @@ Revises: 7fd4601ef88b
 Create Date: 2023-01-27 22:56:33.367379
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/61a922702f4c_add_consent_request_relationship.py
+++ b/src/fides/api/alembic/migrations/versions/61a922702f4c_add_consent_request_relationship.py
@@ -5,6 +5,7 @@ Revises: 5a8cee9c014c
 Create Date: 2024-01-04 22:57:24.155581
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/63b482f5b49b_upgrade_to_fideslang_1_4.py
+++ b/src/fides/api/alembic/migrations/versions/63b482f5b49b_upgrade_to_fideslang_1_4.py
@@ -5,6 +5,7 @@ Revises: deb97d9393f3
 Create Date: 2023-05-26 07:51:25.947974
 
 """
+
 import json
 from typing import Dict, List, Optional
 

--- a/src/fides/api/alembic/migrations/versions/643249f65453_case_insensitive_usernames_delete_.py
+++ b/src/fides/api/alembic/migrations/versions/643249f65453_case_insensitive_usernames_delete_.py
@@ -5,6 +5,7 @@ Revises: 5d62bab40b71
 Create Date: 2023-02-01 22:22:38.055862
 
 """
+
 from alembic import op
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import text

--- a/src/fides/api/alembic/migrations/versions/66df7d9b8103_add_tcf_columns.py
+++ b/src/fides/api/alembic/migrations/versions/66df7d9b8103_add_tcf_columns.py
@@ -7,6 +7,7 @@ Create Date: 2023-08-23 21:12:43.651877
 This is a large migration, but in short, we are expanding our existing tables that let us save preferences against
 privacy notices to allow us to also save preferences against TCF components.  Every TCF attribute gets its own column.
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/671358247251_migrate_meta_vendor.py
+++ b/src/fides/api/alembic/migrations/versions/671358247251_migrate_meta_vendor.py
@@ -5,6 +5,7 @@ Revises: ad2e3f9a6850
 Create Date: 2023-09-13 20:52:58.425483
 
 """
+
 import json
 from typing import Dict, Optional
 

--- a/src/fides/api/alembic/migrations/versions/68a518a3c050_system_managers.py
+++ b/src/fides/api/alembic/migrations/versions/68a518a3c050_system_managers.py
@@ -8,6 +8,7 @@ Revises: 2f6aa5fe797a
 Create Date: 2023-02-23 21:52:56.225405
 
 """
+
 from typing import List
 
 import sqlalchemy as sa

--- a/src/fides/api/alembic/migrations/versions/68cb26f3492d_remove_client_id_constraint.py
+++ b/src/fides/api/alembic/migrations/versions/68cb26f3492d_remove_client_id_constraint.py
@@ -5,6 +5,7 @@ Revises: 956d21f13def
 Create Date: 2024-02-01 18:07:16.757838
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/6b287ff8cde4_penultimate_ops_merge.py
+++ b/src/fides/api/alembic/migrations/versions/6b287ff8cde4_penultimate_ops_merge.py
@@ -5,6 +5,7 @@ Revises: c4df5d585029, cdbd0fa118dd
 Create Date: 2022-10-04 17:38:30.961693
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/6b9885e68cbb_add_plus_system_scans_table.py
+++ b/src/fides/api/alembic/migrations/versions/6b9885e68cbb_add_plus_system_scans_table.py
@@ -5,6 +5,7 @@ Revises: fb6b0150d6e4
 Create Date: 2022-10-24 23:36:51.166480
 
 """
+
 from alembic.op import create_table, drop_table
 from sqlalchemy import JSON, Boolean, Column, DateTime, Integer, String, text
 

--- a/src/fides/api/alembic/migrations/versions/6bd93cb0603d_add_egress_and_ingress_to_systems.py
+++ b/src/fides/api/alembic/migrations/versions/6bd93cb0603d_add_egress_and_ingress_to_systems.py
@@ -5,6 +5,7 @@ Revises: 4fc34906c389
 Create Date: 2022-09-21 00:27:35.164295
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/6cfd59e7920a_new_tables_for_pre_approval_webhooks.py
+++ b/src/fides/api/alembic/migrations/versions/6cfd59e7920a_new_tables_for_pre_approval_webhooks.py
@@ -5,6 +5,7 @@ Revises: d49a767eb49d
 Create Date: 2024-04-15 13:14:39.027682
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/6d6b0b7cbb36_add_privacynotice_tables.py
+++ b/src/fides/api/alembic/migrations/versions/6d6b0b7cbb36_add_privacynotice_tables.py
@@ -5,6 +5,7 @@ Revises: 8615ac51e78b
 Create Date: 2023-03-22 12:09:47.395190
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/6f98e1bd7e4f_another_upstream_merge.py
+++ b/src/fides/api/alembic/migrations/versions/6f98e1bd7e4f_another_upstream_merge.py
@@ -5,6 +5,7 @@ Revises: 6bd93cb0603d, 794e5f5b76ae
 Create Date: 2022-09-22 20:46:34.831732
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/708a780b01ba_add_version_fields_to_default_types.py
+++ b/src/fides/api/alembic/migrations/versions/708a780b01ba_add_version_fields_to_default_types.py
@@ -5,6 +5,7 @@ Revises: 192f23f4c968
 Create Date: 2023-08-17 12:29:04.855626
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.engine import Connection

--- a/src/fides/api/alembic/migrations/versions/7315b9d7fda6_make_connectionconfig_name_optional.py
+++ b/src/fides/api/alembic/migrations/versions/7315b9d7fda6_make_connectionconfig_name_optional.py
@@ -5,6 +5,7 @@ Revises: d2996381c4dd
 Create Date: 2023-06-26 20:39:29.953904
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/732105cd54e3_update_dataset_field_name.py
+++ b/src/fides/api/alembic/migrations/versions/732105cd54e3_update_dataset_field_name.py
@@ -5,6 +5,7 @@ Revises: e576b6a80a49
 Create Date: 2021-10-01 06:48:22.449643
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/76c02f99eec1_move_system_dependencies_to_egress_and_.py
+++ b/src/fides/api/alembic/migrations/versions/76c02f99eec1_move_system_dependencies_to_egress_and_.py
@@ -5,6 +5,7 @@ Revises: e798f37f0c26
 Create Date: 2023-05-10 17:59:14.536666
 
 """
+
 import json
 
 import sqlalchemy as sa

--- a/src/fides/api/alembic/migrations/versions/794e5f5b76ae_merge_unified_with_ctl_and_ops.py
+++ b/src/fides/api/alembic/migrations/versions/794e5f5b76ae_merge_unified_with_ctl_and_ops.py
@@ -5,6 +5,7 @@ Revises: 25adddf820a3, c2f7a29c4780
 Create Date: 2022-09-02 08:41:29.962231
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/7a4f4042091e_manual_webhooks.py
+++ b/src/fides/api/alembic/migrations/versions/7a4f4042091e_manual_webhooks.py
@@ -5,6 +5,7 @@ Revises: d8df7ff7aab4
 Create Date: 2022-09-07 14:10:28.106679
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/7a94527643a1_add_column_for_special_category_to_data_.py
+++ b/src/fides/api/alembic/migrations/versions/7a94527643a1_add_column_for_special_category_to_data_.py
@@ -5,6 +5,7 @@ Revises: 150f234ef1de
 Create Date: 2022-03-18 03:22:23.975102
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/7b81d34352e8_merge_ops_and_ctl_migrations.py
+++ b/src/fides/api/alembic/migrations/versions/7b81d34352e8_merge_ops_and_ctl_migrations.py
@@ -5,6 +5,7 @@ Revises: 4fc34906c389, 7abe778b7082
 Create Date: 2022-08-22 00:41:38.597943
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/7c562441c589_track_notices_served.py
+++ b/src/fides/api/alembic/migrations/versions/7c562441c589_track_notices_served.py
@@ -5,6 +5,7 @@ Revises: 7315b9d7fda6
 Create Date: 2023-07-10 16:42:37.433995
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/7c851d8a102a_add_created_at_and_updated_at.py
+++ b/src/fides/api/alembic/migrations/versions/7c851d8a102a_add_created_at_and_updated_at.py
@@ -5,6 +5,7 @@ Revises: 45c7a349db68
 Create Date: 2021-12-16 12:20:03.801089
 
 """
+
 from alembic import op
 from sqlalchemy import Column, DateTime, text
 

--- a/src/fides/api/alembic/migrations/versions/7e218e880eaf_remove_user_reset_password_scope.py
+++ b/src/fides/api/alembic/migrations/versions/7e218e880eaf_remove_user_reset_password_scope.py
@@ -5,6 +5,7 @@ Revises: d6c6c6555c86
 Create Date: 2023-01-25 19:16:19.950294
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/7f7c2b098f5d_add_name_index_to_ctl_systems.py
+++ b/src/fides/api/alembic/migrations/versions/7f7c2b098f5d_add_name_index_to_ctl_systems.py
@@ -5,6 +5,7 @@ Revises: 1af6950f4625
 Create Date: 2023-11-21 18:52:34.508076
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/7fd4601ef88b_add_is_default_column_to_storage_config.py
+++ b/src/fides/api/alembic/migrations/versions/7fd4601ef88b_add_is_default_column_to_storage_config.py
@@ -5,6 +5,7 @@ Revises: d6c6c6555c86
 Create Date: 2023-01-26 14:13:22.538719
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import text

--- a/src/fides/api/alembic/migrations/versions/81226042d7d4_remove_preferences_for_system_vendor_.py
+++ b/src/fides/api/alembic/migrations/versions/81226042d7d4_remove_preferences_for_system_vendor_.py
@@ -8,6 +8,7 @@ Revises: 81886da90395
 Create Date: 2023-10-02 00:34:46.828946
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/81886da90395_add_legal_basis_dimension.py
+++ b/src/fides/api/alembic/migrations/versions/81886da90395_add_legal_basis_dimension.py
@@ -8,6 +8,7 @@ Revises: 9b98aba5bba8
 Create Date: 2023-09-30 17:39:46.251444
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/8188ddbf8cae_add_privacy_preference_table.py
+++ b/src/fides/api/alembic/migrations/versions/8188ddbf8cae_add_privacy_preference_table.py
@@ -5,6 +5,7 @@ Revises: ff782b0dc07e
 Create Date: 2023-04-11 17:03:07.605408
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/8342453518cc_index_preference_created_and_updated.py
+++ b/src/fides/api/alembic/migrations/versions/8342453518cc_index_preference_created_and_updated.py
@@ -5,6 +5,7 @@ Revises: 144d9b85c712
 Create Date: 2023-04-19 18:33:17.034245
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/842790fa918a_add_compass_system_sync.py
+++ b/src/fides/api/alembic/migrations/versions/842790fa918a_add_compass_system_sync.py
@@ -5,6 +5,7 @@ Revises: 2af81f2b1a6f
 Create Date: 2023-11-07 16:22:01.746436
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/848a8f4125cf_tcf_purpose_overrides.py
+++ b/src/fides/api/alembic/migrations/versions/848a8f4125cf_tcf_purpose_overrides.py
@@ -5,6 +5,7 @@ Revises: 7f7c2b098f5d
 Create Date: 2023-12-02 13:18:55.768697
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/8615ac51e78b_create_custom_connector_template.py
+++ b/src/fides/api/alembic/migrations/versions/8615ac51e78b_create_custom_connector_template.py
@@ -5,6 +5,7 @@ Revises: 39a23bc016ea
 Create Date: 2023-03-20 15:11:52.634508
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/8a71872089e4_add_notice_key_to_notices.py
+++ b/src/fides/api/alembic/migrations/versions/8a71872089e4_add_notice_key_to_notices.py
@@ -5,6 +5,7 @@ Revises: 2661f31daffb
 Create Date: 2023-05-18 19:48:33.268790
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from fideslang.validation import FidesKey, FidesValidationError

--- a/src/fides/api/alembic/migrations/versions/8c54e1e5bdc4_custom_asset_table.py
+++ b/src/fides/api/alembic/migrations/versions/8c54e1e5bdc4_custom_asset_table.py
@@ -5,6 +5,7 @@ Revises: 66df7d9b8103
 Create Date: 2023-09-22 03:10:38.544455
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/8e198eb13802_add_sovrn_consent_connector.py
+++ b/src/fides/api/alembic/migrations/versions/8e198eb13802_add_sovrn_consent_connector.py
@@ -5,6 +5,7 @@ Revises: 643249f65453
 Create Date: 2023-01-27 21:58:23.344582
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/alembic/migrations/versions/8f1a19465239_adds_userregistration_table.py
+++ b/src/fides/api/alembic/migrations/versions/8f1a19465239_adds_userregistration_table.py
@@ -5,6 +5,7 @@ Revises: 6b9885e68cbb
 Create Date: 2022-10-29 00:11:51.449359
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/8f84fad4e00b_add_error_message_tracking.py
+++ b/src/fides/api/alembic/migrations/versions/8f84fad4e00b_add_error_message_tracking.py
@@ -5,6 +5,7 @@ Revises: 58933b5cc6e8
 Create Date: 2022-11-15 01:38:28.531640
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/90070db16d05_add_fidesops_user_permissions.py
+++ b/src/fides/api/alembic/migrations/versions/90070db16d05_add_fidesops_user_permissions.py
@@ -5,6 +5,7 @@ Revises: 530fb8533ca4
 Create Date: 2022-04-27 17:24:31.548916
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/906d7198df28_privacy_request_approve.py
+++ b/src/fides/api/alembic/migrations/versions/906d7198df28_privacy_request_approve.py
@@ -5,6 +5,7 @@ Revises: 5a966cd643d7
 Create Date: 2022-03-11 19:49:26.450054
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/912d801f06c0_audit_log_email_send.py
+++ b/src/fides/api/alembic/migrations/versions/912d801f06c0_audit_log_email_send.py
@@ -5,6 +5,7 @@ Revises: bde646a6f51e
 Create Date: 2022-09-01 16:23:10.905356
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/956d21f13def_update_privacy_notices_for_gpp.py
+++ b/src/fides/api/alembic/migrations/versions/956d21f13def_update_privacy_notices_for_gpp.py
@@ -5,6 +5,7 @@ Revises: 61a922702f4c
 Create Date: 2024-01-10 02:14:24.802051
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/97801300fedd_identity_verification.py
+++ b/src/fides/api/alembic/migrations/versions/97801300fedd_identity_verification.py
@@ -5,6 +5,7 @@ Revises: c61fd9d4f73e
 Create Date: 2022-08-18 19:13:07.393937
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/9b98aba5bba8_remove_consent_settings.py
+++ b/src/fides/api/alembic/migrations/versions/9b98aba5bba8_remove_consent_settings.py
@@ -5,6 +5,7 @@ Revises: 4cb3b5af4160
 Create Date: 2023-10-03 20:26:12.492657
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/9c6f62e4c9da_make_datasetconfig_ctl_datasets_non_nullable.py
+++ b/src/fides/api/alembic/migrations/versions/9c6f62e4c9da_make_datasetconfig_ctl_datasets_non_nullable.py
@@ -5,6 +5,7 @@ Revises: 216cdc7944f1
 Create Date: 2022-12-09 23:56:13.022119
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/9f38dad37628_redo_roles_scopes_mapping.py
+++ b/src/fides/api/alembic/migrations/versions/9f38dad37628_redo_roles_scopes_mapping.py
@@ -5,6 +5,7 @@ Revises: eb1e6ec39b83
 Create Date: 2023-03-03 16:53:03.553992
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/a08024ba7e2b_add_custom_metadata_tables.py
+++ b/src/fides/api/alembic/migrations/versions/a08024ba7e2b_add_custom_metadata_tables.py
@@ -5,6 +5,7 @@ Revises: 3caf11127442
 Create Date: 2023-01-18 16:10:23.832614
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/a0e6feb5bdc8_add_consent.py
+++ b/src/fides/api/alembic/migrations/versions/a0e6feb5bdc8_add_consent.py
@@ -5,6 +5,7 @@ Revises: 7a4f4042091e
 Create Date: 2022-09-12 14:46:05.443579
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/a0f219697fa0_remove_user_scopes.py
+++ b/src/fides/api/alembic/migrations/versions/a0f219697fa0_remove_user_scopes.py
@@ -5,6 +5,7 @@ Revises: 54102bba36de
 Create Date: 2023-03-15 22:25:09.654149
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import text

--- a/src/fides/api/alembic/migrations/versions/a1e23b70f2b2_add_notice_and_exp_translations.py
+++ b/src/fides/api/alembic/migrations/versions/a1e23b70f2b2_add_notice_and_exp_translations.py
@@ -5,6 +5,7 @@ Revises: 26d5976531d6
 Create Date: 2024-02-01 21:49:20.792733
 
 """
+
 from datetime import datetime
 
 import sqlalchemy as sa

--- a/src/fides/api/alembic/migrations/versions/a2b9b156ebaf_data_protection_impact_assessments_.py
+++ b/src/fides/api/alembic/migrations/versions/a2b9b156ebaf_data_protection_impact_assessments_.py
@@ -5,6 +5,7 @@ Revises: adad3be6af08
 Create Date: 2022-04-01 18:42:58.961132
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/aaa81d97a6f6_prepend_tables_with_ctl.py
+++ b/src/fides/api/alembic/migrations/versions/aaa81d97a6f6_prepend_tables_with_ctl.py
@@ -5,6 +5,7 @@ Revises: f53e04e5b7f5
 Create Date: 2022-08-11 09:59:38.709501
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/alembic/migrations/versions/ad2e3f9a6850_adding_custom_privacy_request_field_table.py
+++ b/src/fides/api/alembic/migrations/versions/ad2e3f9a6850_adding_custom_privacy_request_field_table.py
@@ -5,6 +5,7 @@ Revises: 1ea164cee8bc
 Create Date: 2023-09-06 20:09:10.188690
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/adad3be6af08_privacy_notice_attributes.py
+++ b/src/fides/api/alembic/migrations/versions/adad3be6af08_privacy_notice_attributes.py
@@ -5,6 +5,7 @@ Revises: 7a94527643a1
 Create Date: 2022-03-22 19:22:15.248311
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/b3b407ce2d5f_disconnect_privacy_declaration_cookies_.py
+++ b/src/fides/api/alembic/migrations/versions/b3b407ce2d5f_disconnect_privacy_declaration_cookies_.py
@@ -5,6 +5,7 @@ Revises: ddec29f24945
 Create Date: 2023-11-03 18:28:36.416814
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/b3b68c87c4a0_add_connection_config_description.py
+++ b/src/fides/api/alembic/migrations/versions/b3b68c87c4a0_add_connection_config_description.py
@@ -5,6 +5,7 @@ Revises: c3472d75c80e
 Create Date: 2022-06-13 17:24:56.889227
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/b546ce845e6c_split_privacy_experience_table.py
+++ b/src/fides/api/alembic/migrations/versions/b546ce845e6c_split_privacy_experience_table.py
@@ -5,6 +5,7 @@ Revises: fc04e3e637c0
 Create Date: 2023-05-11 16:21:13.825649
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/b72541d79f10_add_fides_connector.py
+++ b/src/fides/api/alembic/migrations/versions/b72541d79f10_add_fides_connector.py
@@ -5,6 +5,7 @@ Revises: 179f2bb623ae
 Create Date: 2022-11-21 14:55:27.767109
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/b8248ce6b8a1_add_privacy_notice_template.py
+++ b/src/fides/api/alembic/migrations/versions/b8248ce6b8a1_add_privacy_notice_template.py
@@ -5,6 +5,7 @@ Revises: 63b482f5b49b
 Create Date: 2023-05-30 14:19:20.629394
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/bab75915670a_add_finished_audit_log.py
+++ b/src/fides/api/alembic/migrations/versions/bab75915670a_add_finished_audit_log.py
@@ -5,6 +5,7 @@ Revises: 3c5e1253465d
 Create Date: 2022-08-04 20:18:29.339116
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/bde646a6f51e_add_execution_timeframe.py
+++ b/src/fides/api/alembic/migrations/versions/bde646a6f51e_add_execution_timeframe.py
@@ -5,6 +5,7 @@ Revises: c2f7a29c4780
 Create Date: 2022-09-01 15:46:47.954354
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/be432bd23596_add_fidesctl_meta_field_to_dataset.py
+++ b/src/fides/api/alembic/migrations/versions/be432bd23596_add_fidesctl_meta_field_to_dataset.py
@@ -5,6 +5,7 @@ Revises: adad3be6af08
 Create Date: 2022-04-01 00:15:07.569104
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/c1885270b3cc_add_html_format_for_storageconfig.py
+++ b/src/fides/api/alembic/migrations/versions/c1885270b3cc_add_html_format_for_storageconfig.py
@@ -5,6 +5,7 @@ Revises: 5307999c0dac
 Create Date: 2023-05-31 21:43:45.404454
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/alembic/migrations/versions/c2f7a29c4780_email_connection_config.py
+++ b/src/fides/api/alembic/migrations/versions/c2f7a29c4780_email_connection_config.py
@@ -3,6 +3,7 @@ Revision ID: c2f7a29c4780
 Revises: 97801300fedd
 Create Date: 2022-08-24 14:02:25.096312
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/c3472d75c80e_connectionconfig_disabled.py
+++ b/src/fides/api/alembic/migrations/versions/c3472d75c80e_connectionconfig_disabled.py
@@ -5,6 +5,7 @@ Revises: 27fe9da9d0f9
 Create Date: 2022-06-08 20:15:28.924262
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/c4df5d585029_data_use_unique_together.py
+++ b/src/fides/api/alembic/migrations/versions/c4df5d585029_data_use_unique_together.py
@@ -5,6 +5,7 @@ Revises: cf88efa1ad89
 Create Date: 2022-09-26 23:12:00.816657
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/c5336b841d70_add_policy_webhooks.py
+++ b/src/fides/api/alembic/migrations/versions/c5336b841d70_add_policy_webhooks.py
@@ -5,6 +5,7 @@ Revises: f206d4e7574d
 Create Date: 2021-11-24 23:20:48.807643
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/c5a218831820_additional_tcf_fields_system.py
+++ b/src/fides/api/alembic/migrations/versions/c5a218831820_additional_tcf_fields_system.py
@@ -5,6 +5,7 @@ Revises: 81226042d7d4
 Create Date: 2023-10-05 15:40:09.294013
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/c61fd9d4f73e_emailconfig.py
+++ b/src/fides/api/alembic/migrations/versions/c61fd9d4f73e_emailconfig.py
@@ -6,6 +6,7 @@ Revises: 7abe778b7082
 Create Date: 2022-08-10 19:29:12.119401
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/alembic/migrations/versions/c7cc36820d4b_rename_user_name_tables_and_indexes.py
+++ b/src/fides/api/alembic/migrations/versions/c7cc36820d4b_rename_user_name_tables_and_indexes.py
@@ -5,6 +5,7 @@ Revises: ed1b00ff963d
 Create Date: 2022-06-25 15:20:20.373137
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/c9759675b5d3_add_user_login_and_password_reset_dates.py
+++ b/src/fides/api/alembic/migrations/versions/c9759675b5d3_add_user_login_and_password_reset_dates.py
@@ -5,6 +5,7 @@ Revises: 906d7198df28
 Create Date: 2022-04-14 13:16:58.940571
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/c98da12d76f8_add_audit_log.py
+++ b/src/fides/api/alembic/migrations/versions/c98da12d76f8_add_audit_log.py
@@ -5,6 +5,7 @@ Revises: 29a7d707163a
 Create Date: 2022-05-04 20:16:39.246537
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/c9ee230fa6da_add_config_set_column_to_application_.py
+++ b/src/fides/api/alembic/migrations/versions/c9ee230fa6da_add_config_set_column_to_application_.py
@@ -5,6 +5,7 @@ Revises: 8e198eb13802
 Create Date: 2023-02-01 15:13:52.133075
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/cdbd0fa118dd_unified_fides_2_merger.py
+++ b/src/fides/api/alembic/migrations/versions/cdbd0fa118dd_unified_fides_2_merger.py
@@ -5,6 +5,7 @@ Revises: 6f98e1bd7e4f, cf88efa1ad89
 Create Date: 2022-09-28 16:27:25.429064
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/cf88efa1ad89_add_timescale_db.py
+++ b/src/fides/api/alembic/migrations/versions/cf88efa1ad89_add_timescale_db.py
@@ -5,6 +5,7 @@ Revises: 021d288d0ce3
 Create Date: 2022-09-14 21:26:43.721397
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/d2996381c4dd_eu_locations_migration.py
+++ b/src/fides/api/alembic/migrations/versions/d2996381c4dd_eu_locations_migration.py
@@ -5,6 +5,7 @@ Revises: 2be84e68df32
 Create Date: 2023-06-20 21:43:45.404454
 
 """
+
 from typing import Dict, List, Optional
 
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/d65bbc647083_adds_gpc_info_to_consent_table.py
+++ b/src/fides/api/alembic/migrations/versions/d65bbc647083_adds_gpc_info_to_consent_table.py
@@ -5,6 +5,7 @@ Revises: c9ee230fa6da
 Create Date: 2023-02-15 13:57:36.159161
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/d65e7e921814_add_privacy_request_status.py
+++ b/src/fides/api/alembic/migrations/versions/d65e7e921814_add_privacy_request_status.py
@@ -5,6 +5,7 @@ Revises: c5336b841d70
 Create Date: 2021-12-02 22:06:16.270442
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/d6c6c6555c86_remove_datasetconfig_dataset.py
+++ b/src/fides/api/alembic/migrations/versions/d6c6c6555c86_remove_datasetconfig_dataset.py
@@ -5,6 +5,7 @@ Revises: 9c6f62e4c9da
 Create Date: 2022-12-20 20:44:32.840423
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/d8df7ff7aab4_add_due_date.py
+++ b/src/fides/api/alembic/migrations/versions/d8df7ff7aab4_add_due_date.py
@@ -5,6 +5,7 @@ Revises: 912d801f06c0
 Create Date: 2022-09-06 15:21:21.181463
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/d8f8bd52754f_add_tags_as_part_of_fideslang_1_1_0.py
+++ b/src/fides/api/alembic/migrations/versions/d8f8bd52754f_add_tags_as_part_of_fideslang_1_1_0.py
@@ -5,6 +5,7 @@ Revises: be432bd23596
 Create Date: 2022-07-07 02:54:13.724757
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/de456534dbda_add_privacyrequest_consent_preferences_.py
+++ b/src/fides/api/alembic/migrations/versions/de456534dbda_add_privacyrequest_consent_preferences_.py
@@ -6,6 +6,7 @@ Revises: 7e218e880eaf
 Create Date: 2023-01-03 22:59:45.144538
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/deb97d9393f3_remove_delivery_mechanism.py
+++ b/src/fides/api/alembic/migrations/versions/deb97d9393f3_remove_delivery_mechanism.py
@@ -5,6 +5,7 @@ Revises: ed46521679fb
 Create Date: 2023-05-25 16:47:16.566034
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/e4023342ebbb_add_modal_link_label_to_experience_.py
+++ b/src/fides/api/alembic/migrations/versions/e4023342ebbb_add_modal_link_label_to_experience_.py
@@ -5,6 +5,7 @@ Revises: 7799269e7078
 Create Date: 2024-04-02 01:16:46.183952
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/e55a51b354e3_add_bigquery.py
+++ b/src/fides/api/alembic/migrations/versions/e55a51b354e3_add_bigquery.py
@@ -5,6 +5,7 @@ Revises: 07014ff34eb2
 Create Date: 2022-02-01 18:02:05.023599
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/e576b6a80a49_add_parent_key_to_dataqualifier.py
+++ b/src/fides/api/alembic/migrations/versions/e576b6a80a49_add_parent_key_to_dataqualifier.py
@@ -5,6 +5,7 @@ Revises: 327cd266f7b3
 Create Date: 2021-10-01 03:16:51.491505
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/e798f37f0c26_add_enabled_actions_to_connectionconfig.py
+++ b/src/fides/api/alembic/migrations/versions/e798f37f0c26_add_enabled_actions_to_connectionconfig.py
@@ -5,6 +5,7 @@ Revises: 317e6197c76a
 Create Date: 2023-05-11 17:54:05.476225
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/e92da354691e_privacy_experiences.py
+++ b/src/fides/api/alembic/migrations/versions/e92da354691e_privacy_experiences.py
@@ -5,6 +5,7 @@ Revises: 5b03859e51b5
 Create Date: 2023-04-24 14:49:37.588144
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/src/fides/api/alembic/migrations/versions/eb1e6ec39b83_add_role_based_permissions.py
+++ b/src/fides/api/alembic/migrations/versions/eb1e6ec39b83_add_role_based_permissions.py
@@ -5,6 +5,7 @@ Revises: d65bbc647083
 Create Date: 2023-02-24 19:27:17.844231
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/ed1b00ff963d_cancel_privacy_request.py
+++ b/src/fides/api/alembic/migrations/versions/ed1b00ff963d_cancel_privacy_request.py
@@ -5,6 +5,7 @@ Revises: 55d61eb8ed12
 Create Date: 2022-06-03 15:45:14.584540
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/ed46521679fb_add_generic_email_connector_types.py
+++ b/src/fides/api/alembic/migrations/versions/ed46521679fb_add_generic_email_connector_types.py
@@ -5,6 +5,7 @@ Revises: 587c53fe3e99
 Create Date: 2023-05-19 23:25:48.711050
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/edcd28ede1f7_add_fidesctl_meta_to_system.py
+++ b/src/fides/api/alembic/migrations/versions/edcd28ede1f7_add_fidesctl_meta_to_system.py
@@ -5,6 +5,7 @@ Revises: 50b3736634d2
 Create Date: 2022-02-17 00:41:41.595166
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/f131a1263a10_add_is_default_to_taxonomy_fields.py
+++ b/src/fides/api/alembic/migrations/versions/f131a1263a10_add_is_default_to_taxonomy_fields.py
@@ -5,6 +5,7 @@ Revises: f53e04e5b7f5
 Create Date: 2022-08-10 16:25:13.754740
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/f17f92237383_disable_inactive_notices.py
+++ b/src/fides/api/alembic/migrations/versions/f17f92237383_disable_inactive_notices.py
@@ -5,6 +5,7 @@ Revises: 671358247251
 Create Date: 2023-09-14 13:35:38.474968
 
 """
+
 import uuid
 from typing import Set
 

--- a/src/fides/api/alembic/migrations/versions/f206d4e7574d_add_redshift_and_snowflake_support.py
+++ b/src/fides/api/alembic/migrations/versions/f206d4e7574d_add_redshift_and_snowflake_support.py
@@ -5,6 +5,7 @@ Revises: 0210948a8147
 Create Date: 2021-11-09 20:41:39.287326
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/alembic/migrations/versions/f3841942d90c_add_mssql.py
+++ b/src/fides/api/alembic/migrations/versions/f3841942d90c_add_mssql.py
@@ -5,6 +5,7 @@ Revises: d65e7e921814
 Create Date: 2021-12-13 22:15:25.043952
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/f396c1f84b0f_add_banner_description_to_experience_.py
+++ b/src/fides/api/alembic/migrations/versions/f396c1f84b0f_add_banner_description_to_experience_.py
@@ -5,6 +5,7 @@ Revises: 4ced99dabebb
 Create Date: 2024-01-02 01:35:41.813279
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/f53e04e5b7f5_merge_heads.py
+++ b/src/fides/api/alembic/migrations/versions/f53e04e5b7f5_merge_heads.py
@@ -5,6 +5,7 @@ Revises: 155fd8e51d9d, d8f8bd52754f
 Create Date: 2022-07-16 02:48:43.622664
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/f9b28f36b53e_privacy_preference_v2.py
+++ b/src/fides/api/alembic/migrations/versions/f9b28f36b53e_privacy_preference_v2.py
@@ -5,6 +5,7 @@ Revises: f396c1f84b0f
 Create Date: 2023-12-13 17:14:00.677493
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/src/fides/api/alembic/migrations/versions/fb6b0150d6e4_final_unified_ctl_merge.py
+++ b/src/fides/api/alembic/migrations/versions/fb6b0150d6e4_final_unified_ctl_merge.py
@@ -5,6 +5,7 @@ Revises: 3d9c476d7cea, 6b287ff8cde4
 Create Date: 2022-10-06 14:56:13.267477
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/fc04e3e637c0_add_dynamodb_to_connector_list.py
+++ b/src/fides/api/alembic/migrations/versions/fc04e3e637c0_add_dynamodb_to_connector_list.py
@@ -5,6 +5,7 @@ Revises: 15a3e7483249
 Create Date: 2023-04-14 10:19:50.681752
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/src/fides/api/alembic/migrations/versions/fc90277bbcde_populate_saas_type_to_saas_config.py
+++ b/src/fides/api/alembic/migrations/versions/fc90277bbcde_populate_saas_type_to_saas_config.py
@@ -5,6 +5,7 @@ Revises: ed1b00ff963d
 Create Date: 2022-07-05 19:20:59.384767
 
 """
+
 import enum
 from typing import List
 

--- a/src/fides/api/alembic/migrations/versions/fdd28c39a679_add_responsibility_role_attribute_for_.py
+++ b/src/fides/api/alembic/migrations/versions/fdd28c39a679_add_responsibility_role_attribute_for_.py
@@ -5,6 +5,7 @@ Revises: 7a94527643a1
 Create Date: 2022-03-21 17:37:23.855761
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/alembic/migrations/versions/ff782b0dc07e_add_replaceable_field_to_custom_connector_template.py
+++ b/src/fides/api/alembic/migrations/versions/ff782b0dc07e_add_replaceable_field_to_custom_connector_template.py
@@ -5,6 +5,7 @@ Revises: 6d6b0b7cbb36
 Create Date: 2023-03-29 23:41:26.164600
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/src/fides/api/api/v1/__init__.py
+++ b/src/fides/api/api/v1/__init__.py
@@ -3,6 +3,7 @@ Define routes for the ctl-related objects.
 
 All routes should get imported here and added to the CTL_ROUTER
 """
+
 from fastapi import APIRouter
 
 from .endpoints.generate import GENERATE_ROUTER

--- a/src/fides/api/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/consent_request_endpoints.py
@@ -477,16 +477,16 @@ def set_consent_preferences(
     )
 
     # Note: This just queues the PrivacyRequest for processing
-    privacy_request_creation_results: Optional[
-        BulkPostPrivacyRequests
-    ] = queue_privacy_request_to_propagate_consent_old_workflow(
-        db,
-        provided_identity,
-        data.policy_key or DEFAULT_CONSENT_POLICY,
-        consent_preferences,
-        consent_request,
-        data.executable_options,
-        data.browser_identity,
+    privacy_request_creation_results: Optional[BulkPostPrivacyRequests] = (
+        queue_privacy_request_to_propagate_consent_old_workflow(
+            db,
+            provided_identity,
+            data.policy_key or DEFAULT_CONSENT_POLICY,
+            consent_preferences,
+            consent_request,
+            data.executable_options,
+            data.browser_identity,
+        )
     )
 
     if privacy_request_creation_results:

--- a/src/fides/api/api/v1/endpoints/dataset_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/dataset_endpoints.py
@@ -298,7 +298,7 @@ def patch_datasets(
     dependencies=[Security(verify_oauth_client, scopes=[DATASET_CREATE_OR_UPDATE])],
     status_code=200,
     response_model=BulkPutDataset,
-    include_in_schema=False  # Not including this path in the schema.
+    include_in_schema=False,  # Not including this path in the schema.
     # Since this yaml function needs to access the request, the open api spec will not be generated correctly.
     # To include this path, extend open api: https://fastapi.tiangolo.com/advanced/extending-openapi/
 )

--- a/src/fides/api/api/v1/endpoints/generate.py
+++ b/src/fides/api/api/v1/endpoints/generate.py
@@ -1,6 +1,7 @@
 """
 Contains all of the endpoints required to manage generating resources.
 """
+
 from enum import Enum
 from typing import Dict, List, Optional, Union
 

--- a/src/fides/api/api/v1/endpoints/generic.py
+++ b/src/fides/api/api/v1/endpoints/generic.py
@@ -2,6 +2,7 @@
 This module generates all of the routers for the boilerplate/generic
 objects that don't require any extra logic.
 """
+
 from fideslang.models import Dataset, Evaluation, Organization, Policy
 
 from fides.api.schemas.taxonomy_extensions import DataCategory, DataSubject, DataUse

--- a/src/fides/api/api/v1/endpoints/identity_verification_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/identity_verification_endpoints.py
@@ -20,7 +20,7 @@ router = APIRouter(tags=["Identity Verification"], prefix=urls.V1_URL_PREFIX)
 def get_id_verification_config(
     *,
     db: Session = Depends(deps.get_db),
-    config_proxy: ConfigProxy = Depends(deps.get_config_proxy)
+    config_proxy: ConfigProxy = Depends(deps.get_config_proxy),
 ) -> IdentityVerificationConfigResponse:
     """Returns id verification config."""
     messaging_config: Optional[MessagingConfig] = db.query(MessagingConfig).first()

--- a/src/fides/api/api/v1/endpoints/oauth_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/oauth_endpoints.py
@@ -225,9 +225,9 @@ def oauth_callback(code: str, state: str, db: Session = Depends(get_db)) -> Resp
     """
 
     # find authentication request by state
-    authentication_request: Optional[
-        AuthenticationRequest
-    ] = AuthenticationRequest.get_by(db, field="state", value=state)
+    authentication_request: Optional[AuthenticationRequest] = (
+        AuthenticationRequest.get_by(db, field="state", value=state)
+    )
     if not authentication_request:
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND,

--- a/src/fides/api/api/v1/endpoints/policy_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/policy_endpoints.py
@@ -259,12 +259,12 @@ def create_or_update_rules(
             storage_destination_key = schema.storage_destination_key
             # storage key doesn't need to be specified, as there is a default to fallback to
             if storage_destination_key:
-                associated_storage_config: Optional[
-                    StorageConfig
-                ] = StorageConfig.get_by(
-                    db=db,
-                    field="key",
-                    value=storage_destination_key,
+                associated_storage_config: Optional[StorageConfig] = (
+                    StorageConfig.get_by(
+                        db=db,
+                        field="key",
+                        value=storage_destination_key,
+                    )
                 )
                 if not associated_storage_config:
                     logger.warning(

--- a/src/fides/api/api/v1/endpoints/policy_webhook_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/policy_webhook_endpoints.py
@@ -432,14 +432,16 @@ def delete_webhook(
     )
     loaded_webhook.delete(db=db)
     return PolicyWebhookDeleteResponse(
-        new_order=[
-            webhook
-            for webhook in getattr(
-                policy, f"{webhook_cls.prefix}_execution_webhooks"
-            ).order_by(webhook_cls.order)
-        ]
-        if reordering
-        else []
+        new_order=(
+            [
+                webhook
+                for webhook in getattr(
+                    policy, f"{webhook_cls.prefix}_execution_webhooks"
+                ).order_by(webhook_cls.order)
+            ]
+            if reordering
+            else []
+        )
     )
 
 

--- a/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
@@ -300,9 +300,9 @@ def privacy_request_csv_download(
 
     f.seek(0)
     response = StreamingResponse(f, media_type="text/csv")
-    response.headers[
-        "Content-Disposition"
-    ] = f"attachment; filename=privacy_requests_download_{datetime.today().strftime('%Y-%m-%d')}.csv"
+    response.headers["Content-Disposition"] = (
+        f"attachment; filename=privacy_requests_download_{datetime.today().strftime('%Y-%m-%d')}.csv"
+    )
     return response
 
 
@@ -912,9 +912,9 @@ def bulk_restart_privacy_request_from_failure(
             )
             continue
 
-        failed_details: Optional[
-            CheckpointActionRequired
-        ] = privacy_request.get_failed_checkpoint_details()
+        failed_details: Optional[CheckpointActionRequired] = (
+            privacy_request.get_failed_checkpoint_details()
+        )
 
         succeeded.append(
             _process_privacy_request_restart(
@@ -951,9 +951,9 @@ def restart_privacy_request_from_failure(
             detail=f"Cannot restart privacy request from failure: privacy request '{privacy_request.id}' status = {privacy_request.status.value}.",  # type: ignore
         )
 
-    failed_details: Optional[
-        CheckpointActionRequired
-    ] = privacy_request.get_failed_checkpoint_details()
+    failed_details: Optional[CheckpointActionRequired] = (
+        privacy_request.get_failed_checkpoint_details()
+    )
 
     return _process_privacy_request_restart(
         privacy_request,
@@ -1030,11 +1030,11 @@ def _send_privacy_request_review_message_to_user(
         kwargs={
             "message_meta": FidesopsMessage(
                 action_type=action_type,
-                body_params=RequestReviewDenyBodyParams(
-                    rejection_reason=rejection_reason
-                )
-                if action_type is MessagingActionType.PRIVACY_REQUEST_REVIEW_DENY
-                else None,
+                body_params=(
+                    RequestReviewDenyBodyParams(rejection_reason=rejection_reason)
+                    if action_type is MessagingActionType.PRIVACY_REQUEST_REVIEW_DENY
+                    else None
+                ),
             ).dict(),
             "service_type": service_type,
             "to_identity": to_identity.dict(),
@@ -1818,9 +1818,9 @@ def requeue_privacy_request(
         )
 
     # Both DSR 2.0 and 3.0 cache checkpoint details
-    checkpoint_details: Optional[
-        CheckpointActionRequired
-    ] = pr.get_failed_checkpoint_details()
+    checkpoint_details: Optional[CheckpointActionRequired] = (
+        pr.get_failed_checkpoint_details()
+    )
     resume_step = checkpoint_details.step if checkpoint_details else None
 
     # DSR 3.0 additionally stores Request Tasks in the application db that can be used to infer

--- a/src/fides/api/api/v1/endpoints/saas_config_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/saas_config_endpoints.py
@@ -270,7 +270,9 @@ def authorize_connection(
     authentication = connection_config.get_saas_config().client_config.authentication  # type: ignore
 
     try:
-        auth_strategy: OAuth2AuthorizationCodeAuthenticationStrategy = AuthenticationStrategy.get_strategy(
+        auth_strategy: (
+            OAuth2AuthorizationCodeAuthenticationStrategy
+        ) = AuthenticationStrategy.get_strategy(
             authentication.strategy, authentication.configuration  # type: ignore
         )
         return auth_strategy.get_authorization_url(db, connection_config, referer)
@@ -303,9 +305,9 @@ def instantiate_connection(
     Looks up the connector type in the SaaS connector registry and, if all required
     fields are provided, persists the associated connection config and dataset to the database.
     """
-    connector_template: Optional[
-        ConnectorTemplate
-    ] = ConnectorRegistry.get_connector_template(saas_connector_type)
+    connector_template: Optional[ConnectorTemplate] = (
+        ConnectorRegistry.get_connector_template(saas_connector_type)
+    )
     if not connector_template:
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND,

--- a/src/fides/api/api/v1/endpoints/storage_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/storage_endpoints.py
@@ -231,9 +231,11 @@ def put_config_secrets(
 
         return TestStatusMessage(
             msg=msg,
-            test_status=ConnectionTestStatus.succeeded
-            if status
-            else ConnectionTestStatus.failed,
+            test_status=(
+                ConnectionTestStatus.succeeded
+                if status
+                else ConnectionTestStatus.failed
+            ),
         )
 
     return TestStatusMessage(msg=msg, test_status=None)
@@ -545,9 +547,11 @@ def put_default_config_secrets(
 
         return TestStatusMessage(
             msg=msg,
-            test_status=ConnectionTestStatus.succeeded
-            if status
-            else ConnectionTestStatus.failed,
+            test_status=(
+                ConnectionTestStatus.succeeded
+                if status
+                else ConnectionTestStatus.failed
+            ),
         )
 
     return TestStatusMessage(msg=msg, test_status=None)

--- a/src/fides/api/api/v1/endpoints/validate.py
+++ b/src/fides/api/api/v1/endpoints/validate.py
@@ -1,6 +1,7 @@
 """
 Contains all of the endpoints required to validate credentials.
 """
+
 from enum import Enum
 from typing import Callable, Dict, Union
 

--- a/src/fides/api/api/v1/endpoints/view.py
+++ b/src/fides/api/api/v1/endpoints/view.py
@@ -1,6 +1,7 @@
 """
 Contains api endpoints for fides web pages
 """
+
 from fastapi import Depends, Security
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/fides/api/app_setup.py
+++ b/src/fides/api/app_setup.py
@@ -1,6 +1,7 @@
 """
 Contains utility functions that set up the application webserver.
 """
+
 # pylint: disable=too-many-branches
 from logging import DEBUG
 from typing import List

--- a/src/fides/api/db/crud.py
+++ b/src/fides/api/db/crud.py
@@ -2,6 +2,7 @@
 Contains all of the generic CRUD endpoints that can be
 generated programmatically for each resource.
 """
+
 from collections import defaultdict
 from typing import Any, Dict, List, Tuple
 
@@ -187,9 +188,9 @@ async def get_resource_with_custom_fields(
 
     for field in custom_fields:
         if field["name"] in resource_dict:
-            resource_dict[
-                field["name"]
-            ] = f"{resource_dict[field['name']]}, {', '.join(field['value'])}"
+            resource_dict[field["name"]] = (
+                f"{resource_dict[field['name']]}, {', '.join(field['value'])}"
+            )
         else:
             resource_dict[field["name"]] = ", ".join(field["value"])
 

--- a/src/fides/api/db/database.py
+++ b/src/fides/api/db/database.py
@@ -1,6 +1,7 @@
 """
 Contains all of the logic related to the database including connections, setup, teardown, etc.
 """
+
 from os import path
 from typing import Literal
 

--- a/src/fides/api/db/seed.py
+++ b/src/fides/api/db/seed.py
@@ -1,6 +1,7 @@
 """
 Provides functions that seed the application with data.
 """
+
 from typing import Dict, List, Optional
 
 from fideslang.default_taxonomy import DEFAULT_TAXONOMY

--- a/src/fides/api/db/system.py
+++ b/src/fides/api/db/system.py
@@ -1,6 +1,7 @@
 """
 Functions for interacting with System objects in the database.
 """
+
 import copy
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
@@ -203,9 +204,9 @@ async def upsert_cookies(
                         "name": cookie_data.name,
                         "path": cookie_data.path,
                         "domain": cookie_data.domain,
-                        "privacy_declaration_id": privacy_declaration.id
-                        if privacy_declaration
-                        else None,
+                        "privacy_declaration_id": (
+                            privacy_declaration.id if privacy_declaration else None
+                        ),
                         "system_id": system.id if system else None,
                     }
                 )

--- a/src/fides/api/db/util.py
+++ b/src/fides/api/db/util.py
@@ -9,8 +9,7 @@ if TYPE_CHECKING:
     T = TypeVar("T")
 
     class EnumColumn(TypeEngine[T]):
-        def __init__(self, enum: Type[T], **kwargs: Any) -> None:
-            ...
+        def __init__(self, enum: Type[T], **kwargs: Any) -> None: ...
 
 else:
     from sqlalchemy import Enum as EnumColumn

--- a/src/fides/api/graph/config.py
+++ b/src/fides/api/graph/config.py
@@ -75,6 +75,7 @@ Field identities:
 
 
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -524,9 +525,9 @@ class Collection(BaseModel):
         def build_field(serialized_field: dict) -> Field:
             """Convert a serialized field on RequestTask.collection.fields into a Scalar Field
             or Object Field"""
-            converted_references: List[
-                Tuple[FieldAddress, Optional[EdgeDirection]]
-            ] = []
+            converted_references: List[Tuple[FieldAddress, Optional[EdgeDirection]]] = (
+                []
+            )
             for reference in serialized_field.pop("references", []):
                 field_address: str = reference[0]
                 edge_direction: Optional[str] = reference[1]

--- a/src/fides/api/graph/execution.py
+++ b/src/fides/api/graph/execution.py
@@ -48,9 +48,9 @@ class ExecutionNode(Contextualizable):  # pylint: disable=too-many-instance-attr
             traversal_details.dataset_connection_key
         )
 
-        self.incoming_edges_by_collection: Dict[
-            CollectionAddress, List[Edge]
-        ] = partition(self.incoming_edges, lambda e: e.f1.collection_address())
+        self.incoming_edges_by_collection: Dict[CollectionAddress, List[Edge]] = (
+            partition(self.incoming_edges, lambda e: e.f1.collection_address())
+        )
 
         # Input should be passed into accessing data in this order
         self.input_keys: List[CollectionAddress] = [

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -1,6 +1,7 @@
 """
 Contains the code that sets up the API.
 """
+
 import os
 import sys
 from datetime import datetime, timezone
@@ -143,9 +144,9 @@ async def prepare_and_log_request(
             endpoint=endpoint,
             status_code=status_code,
             error=error_class or None,
-            extra_data={ExtraData.fides_source.value: fides_source}
-            if fides_source
-            else None,
+            extra_data=(
+                {ExtraData.fides_source.value: fides_source} if fides_source else None
+            ),
         )
     )
 

--- a/src/fides/api/models/location_regulation_selections.py
+++ b/src/fides/api/models/location_regulation_selections.py
@@ -383,15 +383,15 @@ def load_regulations() -> Dict[str, LocationRegulationBase]:
         return regulation_dict
 
 
-locations_by_id: Dict[
-    str, Location
-] = load_locations()  # should only be accessed for read-only access
-location_groups: Dict[
-    str, LocationGroup
-] = load_location_groups()  # should only be accessed for read-only access
-location_group_to_location: Dict[
-    str, Set[str]
-] = load_location_group_to_location()  # should only be accessed for read-only access
+locations_by_id: Dict[str, Location] = (
+    load_locations()
+)  # should only be accessed for read-only access
+location_groups: Dict[str, LocationGroup] = (
+    load_location_groups()
+)  # should only be accessed for read-only access
+location_group_to_location: Dict[str, Set[str]] = (
+    load_location_group_to_location()
+)  # should only be accessed for read-only access
 default_selected_locations: Set[str] = {
     id for id, location in locations_by_id.items() if location.default_selected
 }
@@ -402,9 +402,9 @@ def _load_privacy_notice_regions() -> Dict[str, Union[Location, LocationGroup]]:
     return {**locations_by_id, **location_groups}
 
 
-privacy_notice_regions_by_id: Dict[
-    str, Union[Location, LocationGroup]
-] = _load_privacy_notice_regions()  # should only be accessed for read-only access
+privacy_notice_regions_by_id: Dict[str, Union[Location, LocationGroup]] = (
+    _load_privacy_notice_regions()
+)  # should only be accessed for read-only access
 
 
 # dynamically create an enum based on definitions loaded from YAML
@@ -437,9 +437,9 @@ def filter_regions_by_location(
     """
 
     saved_locations: Set[str] = LocationRegulationSelections.get_selected_locations(db)
-    saved_location_groups: Set[
-        str
-    ] = LocationRegulationSelections.get_selected_location_groups(db)
+    saved_location_groups: Set[str] = (
+        LocationRegulationSelections.get_selected_location_groups(db)
+    )
     multilevel_locations: Set[str] = saved_locations.union(saved_location_groups)
 
     # For backwards-compatibility, if no system-wide locations or location groups are set,

--- a/src/fides/api/models/privacy_experience.py
+++ b/src/fides/api/models/privacy_experience.py
@@ -285,9 +285,9 @@ class PrivacyExperienceConfig(PrivacyExperienceConfigBase, Base):
         config_updated = update_if_modified(self, db=db, data=data)
 
         for translation_data in request_translations:
-            existing_translation: Optional[
-                ExperienceTranslation
-            ] = self.get_translation_by_language(db, translation_data.get("language"))
+            existing_translation: Optional[ExperienceTranslation] = (
+                self.get_translation_by_language(db, translation_data.get("language"))
+            )
             if existing_translation:
                 # Do a patch update of the existing experience translation if applicable
                 translation_updated: bool = update_if_modified(
@@ -565,14 +565,14 @@ def upsert_privacy_experiences_after_config_update(
     Links regions to a PrivacyExperienceConfig by adding or removing PrivacyExperience records.
     """
     current_regions: List[PrivacyNoticeRegion] = experience_config.regions
-    removed_regions: List[
-        PrivacyNoticeRegion
-    ] = [  # Regions that were not in the request, but currently attached to the Config
-        PrivacyNoticeRegion(reg)
-        for reg in {reg.value for reg in current_regions}.difference(
-            {reg.value for reg in regions}
-        )
-    ]
+    removed_regions: List[PrivacyNoticeRegion] = (
+        [  # Regions that were not in the request, but currently attached to the Config
+            PrivacyNoticeRegion(reg)
+            for reg in {reg.value for reg in current_regions}.difference(
+                {reg.value for reg in regions}
+            )
+        ]
+    )
 
     # Delete any PrivacyExperiences whose regions are not in the request
     experience_config.experiences.filter(  # type: ignore[call-arg]
@@ -699,9 +699,9 @@ def delete_experience_config_translations(
 ) -> None:
     """Removes any translations that are currently stored on the PrivacyExperienceConfig
     but not in the update request"""
-    experience_translations: List[
-        ExperienceTranslation
-    ] = privacy_experience_config.translations
+    experience_translations: List[ExperienceTranslation] = (
+        privacy_experience_config.translations
+    )
     translations_to_remove: Set[SupportedLanguage] = set(  # type: ignore[assignment]
         translation.language for translation in experience_translations
     ).difference(

--- a/src/fides/api/models/privacy_notice.py
+++ b/src/fides/api/models/privacy_notice.py
@@ -271,9 +271,9 @@ class PrivacyNotice(PrivacyNoticeBase, Base):
         base_notice_updated: bool = update_if_modified(self, db=db, data=data)
 
         for translation_data in request_translations:
-            existing_translation: Optional[
-                NoticeTranslation
-            ] = self.get_translation_by_language(db, translation_data.get("language"))
+            existing_translation: Optional[NoticeTranslation] = (
+                self.get_translation_by_language(db, translation_data.get("language"))
+            )
 
             if existing_translation:
                 translation: NoticeTranslation = existing_translation

--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -835,9 +835,9 @@ class PrivacyRequest(
         Fetch the collection -> data use map cached for this privacy request
         """
         cache: FidesopsRedis = get_cache()
-        value_dict: Optional[
-            Dict[str, Optional[Dict[str, Set[str]]]]
-        ] = cache.get_encoded_objects_by_prefix(f"DATA_USE_MAP__{self.id}")
+        value_dict: Optional[Dict[str, Optional[Dict[str, Set[str]]]]] = (
+            cache.get_encoded_objects_by_prefix(f"DATA_USE_MAP__{self.id}")
+        )
         return list(value_dict.values())[0] if value_dict else None
 
     def trigger_policy_webhook(
@@ -957,9 +957,7 @@ class PrivacyRequest(
             self.canceled_at = datetime.utcnow()
             self.save(db)
 
-            task_ids: List[
-                str
-            ] = (
+            task_ids: List[str] = (
                 self.get_request_task_celery_task_ids()
             )  # Celery tasks for sub tasks (DSR 3.0 Request Tasks)
             parent_task_id = (
@@ -1179,10 +1177,10 @@ def _get_manual_access_input_from_cache(
     """Get raw manual input uploaded to the privacy request for the given webhook
     from the cache without attempting to coerce into a Pydantic schema"""
     cache: FidesopsRedis = get_cache()
-    cached_results: Optional[
-        Optional[Dict[str, Any]]
-    ] = cache.get_encoded_objects_by_prefix(
-        f"WEBHOOK_MANUAL_ACCESS_INPUT__{privacy_request.id}__{manual_webhook.id}"
+    cached_results: Optional[Optional[Dict[str, Any]]] = (
+        cache.get_encoded_objects_by_prefix(
+            f"WEBHOOK_MANUAL_ACCESS_INPUT__{privacy_request.id}__{manual_webhook.id}"
+        )
     )
     if cached_results:
         return list(cached_results.values())[0]
@@ -1195,10 +1193,10 @@ def _get_manual_erasure_input_from_cache(
     """Get raw manual input uploaded to the privacy request for the given webhook
     from the cache without attempting to coerce into a Pydantic schema"""
     cache: FidesopsRedis = get_cache()
-    cached_results: Optional[
-        Optional[Dict[str, Any]]
-    ] = cache.get_encoded_objects_by_prefix(
-        f"WEBHOOK_MANUAL_ERASURE_INPUT__{privacy_request.id}__{manual_webhook.id}"
+    cached_results: Optional[Optional[Dict[str, Any]]] = (
+        cache.get_encoded_objects_by_prefix(
+            f"WEBHOOK_MANUAL_ERASURE_INPUT__{privacy_request.id}__{manual_webhook.id}"
+        )
     )
     if cached_results:
         return list(cached_results.values())[0]

--- a/src/fides/api/oauth/system_manager_oauth_util.py
+++ b/src/fides/api/oauth/system_manager_oauth_util.py
@@ -139,11 +139,15 @@ def has_system_permissions(
         authorization, db
     )  # Can raise permission errors if issues with client or token
 
-    has_model_level_permissions: bool = has_permissions(  # Token has the correct scope(s) or role(s) associated with the correct scopes
-        token_data, client, security_scopes
+    has_model_level_permissions: bool = (
+        has_permissions(  # Token has the correct scope(s) or role(s) associated with the correct scopes
+            token_data, client, security_scopes
+        )
     )
-    has_system_manager_permissions: bool = _has_scope_as_system_manager(  # Token indicates system manager permissions of the current system(s)
-        token_data, client, security_scopes, system_auth_data.system
+    has_system_manager_permissions: bool = (
+        _has_scope_as_system_manager(  # Token indicates system manager permissions of the current system(s)
+            token_data, client, security_scopes, system_auth_data.system
+        )
     )
 
     has_perms: bool = has_model_level_permissions or has_system_manager_permissions

--- a/src/fides/api/schemas/language.py
+++ b/src/fides/api/schemas/language.py
@@ -31,9 +31,9 @@ def _load_supported_languages() -> Dict[str, Language]:
         return language_dict
 
 
-supported_languages_by_id: Dict[
-    str, Language
-] = _load_supported_languages()  # should only be accessed for read-only access
+supported_languages_by_id: Dict[str, Language] = (
+    _load_supported_languages()
+)  # should only be accessed for read-only access
 
 
 # dynamically create an enum based on definitions loaded from YAML

--- a/src/fides/api/schemas/saas/saas_config.py
+++ b/src/fides/api/schemas/saas/saas_config.py
@@ -105,9 +105,9 @@ class SaaSRequest(BaseModel):
     grouped_inputs: Optional[List[str]] = []
     ignore_errors: Optional[Union[bool, List[int]]] = False
     rate_limit_config: Optional[RateLimitConfig]
-    skip_missing_param_values: Optional[
-        bool
-    ] = False  # Skip instead of raising an exception if placeholders can't be populated in body
+    skip_missing_param_values: Optional[bool] = (
+        False  # Skip instead of raising an exception if placeholders can't be populated in body
+    )
 
     class Config:
         """Populate models with the raw value of enum fields, rather than the enum itself"""

--- a/src/fides/api/service/connectors/consent_email_connector.py
+++ b/src/fides/api/service/connectors/consent_email_connector.py
@@ -152,14 +152,14 @@ class GenericConsentEmailConnector(BaseEmailConnector):
         ):
             return False
 
-        old_workflow_consent_preferences: Optional[
-            Any
-        ] = privacy_request.consent_preferences
-        new_workflow_consent_preferences: List[
-            PrivacyPreferenceHistory
-        ] = filter_privacy_preferences_for_propagation(
-            self.configuration.system,
-            privacy_request.privacy_preferences,  # type: ignore[attr-defined]
+        old_workflow_consent_preferences: Optional[Any] = (
+            privacy_request.consent_preferences
+        )
+        new_workflow_consent_preferences: List[PrivacyPreferenceHistory] = (
+            filter_privacy_preferences_for_propagation(
+                self.configuration.system,
+                privacy_request.privacy_preferences,  # type: ignore[attr-defined]
+            )
         )
         if not (old_workflow_consent_preferences or new_workflow_consent_preferences):
             return False
@@ -217,9 +217,9 @@ class GenericConsentEmailConnector(BaseEmailConnector):
 
         for privacy_request in privacy_requests:
             user_identities: Dict[str, Any] = privacy_request.get_cached_identity_data()
-            filtered_user_identities: Dict[
-                str, Any
-            ] = filter_user_identities_for_connector(self.config, user_identities)
+            filtered_user_identities: Dict[str, Any] = (
+                filter_user_identities_for_connector(self.config, user_identities)
+            )
 
             # Backwards-compatible consent preferences for old workflow
             consent_preference_schemas: List[Consent] = [
@@ -227,10 +227,10 @@ class GenericConsentEmailConnector(BaseEmailConnector):
             ]
 
             # Privacy preferences for new workflow
-            filtered_privacy_preference_records: List[
-                PrivacyPreferenceHistory
-            ] = filter_privacy_preferences_for_propagation(
-                self.configuration.system, privacy_request.privacy_preferences
+            filtered_privacy_preference_records: List[PrivacyPreferenceHistory] = (
+                filter_privacy_preferences_for_propagation(
+                    self.configuration.system, privacy_request.privacy_preferences
+                )
             )
             filtered_privacy_request_schemas: List[
                 MinimalPrivacyPreferenceHistorySchema

--- a/src/fides/api/service/connectors/erasure_email_connector.py
+++ b/src/fides/api/service/connectors/erasure_email_connector.py
@@ -102,9 +102,9 @@ class GenericErasureEmailConnector(BaseEmailConnector):
 
         for privacy_request in privacy_requests:
             user_identities: Dict[str, Any] = privacy_request.get_cached_identity_data()
-            filtered_user_identities: Dict[
-                str, Any
-            ] = filter_user_identities_for_connector(self.config, user_identities)
+            filtered_user_identities: Dict[str, Any] = (
+                filter_user_identities_for_connector(self.config, user_identities)
+            )
             if filtered_user_identities:
                 batched_identities.extend(filtered_user_identities.values())
             else:

--- a/src/fides/api/service/connectors/query_config.py
+++ b/src/fides/api/service/connectors/query_config.py
@@ -135,9 +135,9 @@ class QueryConfig(Generic[T], ABC):
         with null values.
 
         """
-        rule_to_collection_field_paths: Dict[
-            Rule, List[FieldPath]
-        ] = self.build_rule_target_field_paths(policy)
+        rule_to_collection_field_paths: Dict[Rule, List[FieldPath]] = (
+            self.build_rule_target_field_paths(policy)
+        )
 
         value_map: Dict[str, Any] = {}
         for rule, field_paths in rule_to_collection_field_paths.items():

--- a/src/fides/api/service/connectors/saas_connector.py
+++ b/src/fides/api/service/connectors/saas_connector.py
@@ -194,9 +194,9 @@ class SaaSConnector(BaseConnector[AuthenticatedClient], Contextualizable):
         # 2) The complete set of results for a collection is made up of subsets. For example, to retrieve all tickets
         #    we must change a 'status' query param from 'active' to 'pending' and finally 'closed'
         read_requests: List[SaaSRequest] = query_config.get_read_requests_by_identity()
-        delete_request: Optional[
-            SaaSRequest
-        ] = query_config.get_erasure_request_by_action("delete")
+        delete_request: Optional[SaaSRequest] = (
+            query_config.get_erasure_request_by_action("delete")
+        )
 
         if not read_requests:
             # if a delete request is specified for this endpoint without a read request
@@ -511,9 +511,9 @@ class SaaSConnector(BaseConnector[AuthenticatedClient], Contextualizable):
                 f"Skipping consent propagation for node {node.address.value} - no actionable consent preferences to propagate"
             )
 
-        matching_consent_requests: List[
-            SaaSRequest
-        ] = self._get_consent_requests_by_preference(should_opt_in)
+        matching_consent_requests: List[SaaSRequest] = (
+            self._get_consent_requests_by_preference(should_opt_in)
+        )
 
         query_config.action = (
             "opt_in" if should_opt_in else "opt_out"
@@ -622,10 +622,10 @@ class SaaSConnector(BaseConnector[AuthenticatedClient], Contextualizable):
 
         Contains error handling for uncaught exceptions coming out of the override.
         """
-        override_function: Callable[
-            ..., Union[List[Row], int]
-        ] = SaaSRequestOverrideFactory.get_override(
-            override_function_name, SaaSRequestType.READ
+        override_function: Callable[..., Union[List[Row], int]] = (
+            SaaSRequestOverrideFactory.get_override(
+                override_function_name, SaaSRequestType.READ
+            )
         )
         try:
             return override_function(
@@ -662,10 +662,10 @@ class SaaSConnector(BaseConnector[AuthenticatedClient], Contextualizable):
         Includes the necessary data preparations for override input
         and has error handling for uncaught exceptions coming out of the override
         """
-        override_function: Callable[
-            ..., Union[List[Row], int]
-        ] = SaaSRequestOverrideFactory.get_override(
-            override_function_name, SaaSRequestType(query_config.action)
+        override_function: Callable[..., Union[List[Row], int]] = (
+            SaaSRequestOverrideFactory.get_override(
+                override_function_name, SaaSRequestType(query_config.action)
+            )
         )
         try:
             # if using a saas override, we still need to use the core framework
@@ -694,9 +694,9 @@ class SaaSConnector(BaseConnector[AuthenticatedClient], Contextualizable):
 
     def _get_consent_requests_by_preference(self, opt_in: bool) -> List[SaaSRequest]:
         """Helper to either pull out the opt-in requests or the opt out requests that were defined."""
-        consent_requests: Optional[
-            ConsentRequestMap
-        ] = self.saas_config.consent_requests
+        consent_requests: Optional[ConsentRequestMap] = (
+            self.saas_config.consent_requests
+        )
 
         if not consent_requests:
             return []

--- a/src/fides/api/service/connectors/saas_query_config.py
+++ b/src/fides/api/service/connectors/saas_query_config.py
@@ -377,9 +377,9 @@ class SaaSQueryConfig(QueryConfig[SaaSRequestParams]):
         collection_name: str = self.node.address.collection
         collection_values: Dict[str, Row] = {collection_name: row}
         identity_data: Dict[str, Any] = privacy_request.get_cached_identity_data()
-        custom_privacy_request_fields: Dict[
-            str, Any
-        ] = privacy_request.get_cached_custom_privacy_request_fields()
+        custom_privacy_request_fields: Dict[str, Any] = (
+            privacy_request.get_cached_custom_privacy_request_fields()
+        )
 
         # create the source of param values to populate the various placeholders
         # in the path, headers, query_params, and body

--- a/src/fides/api/service/masking/strategy/masking_strategy_aes_encrypt.py
+++ b/src/fides/api/service/masking/strategy/masking_strategy_aes_encrypt.py
@@ -37,9 +37,9 @@ class AesEncryptionMaskingStrategy(MaskingStrategy):
             return None
 
         if self.mode == AesEncryptionMaskingConfiguration.Mode.GCM:
-            masking_meta: Dict[
-                SecretType, MaskingSecretMeta
-            ] = self._build_masking_secret_meta()
+            masking_meta: Dict[SecretType, MaskingSecretMeta] = (
+                self._build_masking_secret_meta()
+            )
             key: bytes | None = SecretsUtil.get_or_generate_secret(
                 request_id, SecretType.key, masking_meta[SecretType.key]
             )
@@ -75,9 +75,9 @@ class AesEncryptionMaskingStrategy(MaskingStrategy):
         return True
 
     def generate_secrets_for_cache(self) -> List[MaskingSecretCache]:
-        masking_meta: Dict[
-            SecretType, MaskingSecretMeta
-        ] = self._build_masking_secret_meta()
+        masking_meta: Dict[SecretType, MaskingSecretMeta] = (
+            self._build_masking_secret_meta()
+        )
         return SecretsUtil.build_masking_secrets_for_cache(masking_meta)
 
     @classmethod

--- a/src/fides/api/service/masking/strategy/masking_strategy_hash.py
+++ b/src/fides/api/service/masking/strategy/masking_strategy_hash.py
@@ -44,9 +44,9 @@ class HashMaskingStrategy(MaskingStrategy):
         if values is None:
             return None
 
-        masking_meta: Dict[
-            SecretType, MaskingSecretMeta
-        ] = self._build_masking_secret_meta()
+        masking_meta: Dict[SecretType, MaskingSecretMeta] = (
+            self._build_masking_secret_meta()
+        )
         salt: str | None = SecretsUtil.get_or_generate_secret(
             request_id,
             SecretType.salt,
@@ -70,9 +70,9 @@ class HashMaskingStrategy(MaskingStrategy):
         return True
 
     def generate_secrets_for_cache(self) -> List[MaskingSecretCache]:
-        masking_meta: Dict[
-            SecretType, MaskingSecretMeta
-        ] = self._build_masking_secret_meta()
+        masking_meta: Dict[SecretType, MaskingSecretMeta] = (
+            self._build_masking_secret_meta()
+        )
         return SecretsUtil.build_masking_secrets_for_cache(masking_meta)
 
     # MR Note - We will need a way to ensure that this does not fall out of date. Given that it

--- a/src/fides/api/service/masking/strategy/masking_strategy_hmac.py
+++ b/src/fides/api/service/masking/strategy/masking_strategy_hmac.py
@@ -43,9 +43,9 @@ class HmacMaskingStrategy(MaskingStrategy):
         if values is None:
             return None
 
-        masking_meta: Dict[
-            SecretType, MaskingSecretMeta
-        ] = self._build_masking_secret_meta()
+        masking_meta: Dict[SecretType, MaskingSecretMeta] = (
+            self._build_masking_secret_meta()
+        )
         key: str | None = SecretsUtil.get_or_generate_secret(
             request_id, SecretType.key, masking_meta[SecretType.key]
         )
@@ -69,9 +69,9 @@ class HmacMaskingStrategy(MaskingStrategy):
         return True
 
     def generate_secrets_for_cache(self) -> List[MaskingSecretCache]:
-        masking_meta: Dict[
-            SecretType, MaskingSecretMeta
-        ] = self._build_masking_secret_meta()
+        masking_meta: Dict[SecretType, MaskingSecretMeta] = (
+            self._build_masking_secret_meta()
+        )
         return SecretsUtil.build_masking_secrets_for_cache(masking_meta)
 
     @classmethod

--- a/src/fides/api/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/service/messaging/message_dispatch_service.py
@@ -199,9 +199,11 @@ def dispatch_message(
     dispatcher(
         messaging_config,
         message,
-        to_identity.email
-        if messaging_method == MessagingMethod.EMAIL
-        else to_identity.phone_number,
+        (
+            to_identity.email
+            if messaging_method == MessagingMethod.EMAIL
+            else to_identity.phone_number
+        ),
     )
 
 

--- a/src/fides/api/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/service/privacy_request/request_runner_service.py
@@ -220,14 +220,14 @@ def upload_access_results(  # pylint: disable=R0912
         storage_destination = rule.get_storage_destination(session)
 
         target_categories: Set[str] = {target.data_category for target in rule.targets}  # type: ignore[attr-defined]
-        filtered_results: Dict[
-            str, List[Dict[str, Optional[Any]]]
-        ] = filter_data_categories(
-            access_result,
-            target_categories,
-            dataset_graph.data_category_field_mapping,
-            rule.key,
-            fides_connector_datasets,
+        filtered_results: Dict[str, List[Dict[str, Optional[Any]]]] = (
+            filter_data_categories(
+                access_result,
+                target_categories,
+                dataset_graph.data_category_field_mapping,
+                rule.key,
+                fides_connector_datasets,
+            )
         )
 
         filtered_results.update(

--- a/src/fides/api/service/privacy_request/request_service.py
+++ b/src/fides/api/service/privacy_request/request_service.py
@@ -83,9 +83,9 @@ def cache_data(
         unique_masking_strategies_by_name.add(strategy_name)
         masking_strategy = MaskingStrategy.get_strategy(strategy_name, configuration)
         if masking_strategy.secrets_required():
-            masking_secrets: List[
-                MaskingSecretCache
-            ] = masking_strategy.generate_secrets_for_cache()
+            masking_secrets: List[MaskingSecretCache] = (
+                masking_strategy.generate_secrets_for_cache()
+            )
             for masking_secret in masking_secrets:
                 privacy_request.cache_masking_secret(masking_secret)
     if drp_request_body:

--- a/src/fides/api/service/saas_request/override_implementations/authentication_strategy_doordash.py
+++ b/src/fides/api/service/saas_request/override_implementations/authentication_strategy_doordash.py
@@ -48,9 +48,9 @@ class DoordashAuthenticationStrategy(AuthenticationStrategy):
         token = jwt.encode(
             {
                 "aud": "doordash",
-                "iss": assign_placeholders(self.developer_id, secrets)
-                if secrets
-                else None,
+                "iss": (
+                    assign_placeholders(self.developer_id, secrets) if secrets else None
+                ),
                 "kid": assign_placeholders(self.key_id, secrets) if secrets else None,
                 "exp": str(math.floor(time.time() + 60)),
                 "iat": str(math.floor(time.time())),

--- a/src/fides/api/service/saas_request/saas_request_override_factory.py
+++ b/src/fides/api/service/saas_request/saas_request_override_factory.py
@@ -29,9 +29,9 @@ class SaaSRequestOverrideFactory:
     user-defined functions that act as overrides to SaaS request execution
     """
 
-    registry: Dict[
-        SaaSRequestType, Dict[str, Callable[..., Union[List[Row], int]]]
-    ] = {}
+    registry: Dict[SaaSRequestType, Dict[str, Callable[..., Union[List[Row], int]]]] = (
+        {}
+    )
     valid_overrides: Dict[SaaSRequestType, str] = {}
 
     # initialize each request type's inner dicts with an empty dict

--- a/src/fides/api/task/create_request_tasks.py
+++ b/src/fides/api/task/create_request_tasks.py
@@ -209,9 +209,11 @@ def base_task_data(
         "collection_address": node.value,
         "dataset_name": node.dataset,
         "collection_name": node.collection,
-        "status": ExecutionLogStatus.complete
-        if node == ROOT_COLLECTION_ADDRESS
-        else ExecutionLogStatus.pending,
+        "status": (
+            ExecutionLogStatus.complete
+            if node == ROOT_COLLECTION_ADDRESS
+            else ExecutionLogStatus.pending
+        ),
         "collection": collection_representation,
         "traversal_details": traversal_details,
     }
@@ -248,9 +250,11 @@ def persist_new_access_request_tasks(
                 **base_task_data(
                     graph, dataset_graph, privacy_request, node, traversal_nodes
                 ),
-                "access_data": json.dumps([traversal.seed_data], cls=CustomJSONEncoder)
-                if node == ROOT_COLLECTION_ADDRESS
-                else [],  # For consistent treatment of nodes, add the seed data to the root node.  Subsequent
+                "access_data": (
+                    json.dumps([traversal.seed_data], cls=CustomJSONEncoder)
+                    if node == ROOT_COLLECTION_ADDRESS
+                    else []
+                ),  # For consistent treatment of nodes, add the seed data to the root node.  Subsequent
                 # tasks will save the data collected on the same field.
                 "action_type": ActionType.access,
             },
@@ -310,12 +314,12 @@ def _get_data_for_erasures(
     """
     # Get the access task of the same name as the erasure task so we can transfer the data
     # collected for masking onto the current erasure task
-    corresponding_access_task: Optional[
-        RequestTask
-    ] = privacy_request.get_existing_request_task(
-        db=session,
-        action_type=ActionType.access,
-        collection_address=request_task.request_task_address,
+    corresponding_access_task: Optional[RequestTask] = (
+        privacy_request.get_existing_request_task(
+            db=session,
+            action_type=ActionType.access,
+            collection_address=request_task.request_task_address,
+        )
     )
     retrieved_task_data: List[Dict] = []
     if (
@@ -382,9 +386,11 @@ def persist_new_consent_request_tasks(
                     graph, dataset_graph, privacy_request, node, traversal_nodes
                 ),
                 # Consent nodes take in identity data from their upstream root node
-                "access_data": json.dumps([identity], cls=CustomJSONEncoder)
-                if node == ROOT_COLLECTION_ADDRESS
-                else [],
+                "access_data": (
+                    json.dumps([identity], cls=CustomJSONEncoder)
+                    if node == ROOT_COLLECTION_ADDRESS
+                    else []
+                ),
                 "action_type": ActionType.consent,
             },
         )

--- a/src/fides/api/task/execute_request_tasks.py
+++ b/src/fides/api/task/execute_request_tasks.py
@@ -219,10 +219,10 @@ def run_access_node(
                 )
                 # Currently, upstream tasks and "input keys" (which are built by data dependencies)
                 # are the same, but they may not be the same in the future.
-                ordered_upstream_tasks: List[
-                    Optional[RequestTask]
-                ] = _order_tasks_by_input_key(
-                    graph_task.execution_node.input_keys, upstream_results
+                ordered_upstream_tasks: List[Optional[RequestTask]] = (
+                    _order_tasks_by_input_key(
+                        graph_task.execution_node.input_keys, upstream_results
+                    )
                 )
                 # Pass in access data dependencies in the same order as the input keys.
                 # If we don't have access data for an upstream node, pass in an empty list

--- a/src/fides/api/task/filter_element_match.py
+++ b/src/fides/api/task/filter_element_match.py
@@ -87,13 +87,13 @@ def _remove_paths_from_row(
 
     {'A': {'B': [{'C': 'D'}]}}
     """
-    desc_path_length: Dict[
-        str, List[int]
-    ] = dict(  # We want to remove elements from the deepest paths first
-        sorted(
-            preserve_indices.items(),
-            key=lambda item: item[0].count("."),
-            reverse=True,
+    desc_path_length: Dict[str, List[int]] = (
+        dict(  # We want to remove elements from the deepest paths first
+            sorted(
+                preserve_indices.items(),
+                key=lambda item: item[0].count("."),
+                reverse=True,
+            )
         )
     )
     for path, preserve_index_list in desc_path_length.items():

--- a/src/fides/api/task/filter_results.py
+++ b/src/fides/api/task/filter_results.py
@@ -188,9 +188,9 @@ def unpack_fides_connector_results(
             # if we get a ValueError, a given CollectionAddress key
             # already exists in the results dict. Handle that here.
             for key, value in rule_results.items():
-                filtered: Optional[
-                    List[Dict[str, Optional[Any]]]
-                ] = filtered_access_results.get(key)
+                filtered: Optional[List[Dict[str, Optional[Any]]]] = (
+                    filtered_access_results.get(key)
+                )
                 if not filtered:
                     filtered_access_results[key] = value  # type: ignore
                 else:

--- a/src/fides/api/task/graph_runners.py
+++ b/src/fides/api/task/graph_runners.py
@@ -34,9 +34,9 @@ def use_dsr_3_0_scheduler(
     """
     use_dsr_3_0 = CONFIG.execution.use_dsr_3_0
 
-    prev_results: Dict[
-        str, Optional[List[Row]]
-    ] = privacy_request.get_raw_access_results()
+    prev_results: Dict[str, Optional[List[Row]]] = (
+        privacy_request.get_raw_access_results()
+    )
     existing_tasks_count: int = privacy_request.get_tasks_by_action(action_type).count()
 
     if prev_results and use_dsr_3_0 and not existing_tasks_count:

--- a/src/fides/api/util/connection_type.py
+++ b/src/fides/api/util/connection_type.py
@@ -205,9 +205,12 @@ def get_connection_types(
                     type=SystemType.email,
                     human_readable=ConnectionType(email_type).human_readable,
                     supported_actions=[
-                        ActionType.consent
-                        if ConnectionType(email_type) in CONSENT_EMAIL_CONNECTOR_TYPES
-                        else ActionType.erasure
+                        (
+                            ActionType.consent
+                            if ConnectionType(email_type)
+                            in CONSENT_EMAIL_CONNECTOR_TYPES
+                            else ActionType.erasure
+                        )
                     ],
                 )
                 for email_type in email_types

--- a/src/fides/api/util/logger.py
+++ b/src/fides/api/util/logger.py
@@ -1,6 +1,7 @@
 """
 Defines the logging format and other helper functions to be used throughout the API server code.
 """
+
 # pylint: disable=eval-used,no-member
 
 from __future__ import annotations

--- a/src/fides/api/util/logger_context_utils.py
+++ b/src/fides/api/util/logger_context_utils.py
@@ -114,17 +114,17 @@ def request_details(
         # assign error group only if error should not be ignored
         if not ignore_error:
             if response.status_code in [401, 403]:
-                details[
-                    LoggerContextKeys.error_group.value
-                ] = ErrorGroup.authentication_error.value
+                details[LoggerContextKeys.error_group.value] = (
+                    ErrorGroup.authentication_error.value
+                )
             elif 400 <= response.status_code < 500:
-                details[
-                    LoggerContextKeys.error_group.value
-                ] = ErrorGroup.client_error.value
+                details[LoggerContextKeys.error_group.value] = (
+                    ErrorGroup.client_error.value
+                )
             elif 500 <= response.status_code:
-                details[
-                    LoggerContextKeys.error_group.value
-                ] = ErrorGroup.server_error.value
+                details[LoggerContextKeys.error_group.value] = (
+                    ErrorGroup.server_error.value
+                )
     return details
 
 
@@ -137,21 +137,21 @@ def connection_exception_details(exception: Exception, url: str) -> Dict[str, An
         LoggerContextKeys.status_code.value: None,
     }
     if isinstance(exception, ConnectTimeout):
-        details[
-            LoggerContextKeys.error_details.value
-        ] = f"Timeout occurred connecting to {url}."
+        details[LoggerContextKeys.error_details.value] = (
+            f"Timeout occurred connecting to {url}."
+        )
     elif isinstance(exception, ReadTimeout):
-        details[
-            LoggerContextKeys.error_details.value
-        ] = f"Timeout occurred waiting for a response from {url}."
+        details[LoggerContextKeys.error_details.value] = (
+            f"Timeout occurred waiting for a response from {url}."
+        )
     elif isinstance(exception, SSLError):
-        details[
-            LoggerContextKeys.error_details.value
-        ] = f"SSL exception occurred connecting to {url}."
+        details[LoggerContextKeys.error_details.value] = (
+            f"SSL exception occurred connecting to {url}."
+        )
     elif isinstance(exception, TooManyRedirects):
-        details[
-            LoggerContextKeys.error_details.value
-        ] = f"Too many redirects occurred connecting to {url}."
+        details[LoggerContextKeys.error_details.value] = (
+            f"Too many redirects occurred connecting to {url}."
+        )
     elif isinstance(exception, ConnectionError):
         details[LoggerContextKeys.error_details.value] = f"Unable to connect to {url}."
     return details

--- a/src/fides/cli/__init__.py
+++ b/src/fides/cli/__init__.py
@@ -1,6 +1,7 @@
 """
 Entrypoint for the Fides command-line.
 """
+
 # pylint: disable=wrong-import-position
 import warnings
 

--- a/src/fides/cli/commands/db.py
+++ b/src/fides/cli/commands/db.py
@@ -1,4 +1,5 @@
 """Contains the db group of the commands for fides."""
+
 import rich_click as click
 
 from fides.cli.options import yes_flag

--- a/src/fides/cli/commands/deploy.py
+++ b/src/fides/cli/commands/deploy.py
@@ -1,4 +1,5 @@
 """Contains all of the deploy group of CLI commands for fides."""
+
 from os import environ
 from subprocess import CalledProcessError
 from typing import Optional

--- a/src/fides/cli/commands/ungrouped.py
+++ b/src/fides/cli/commands/ungrouped.py
@@ -1,4 +1,5 @@
 """Contains all of the ungrouped CLI commands for fides."""
+
 from datetime import datetime, timezone
 from typing import Optional
 

--- a/src/fides/cli/commands/user.py
+++ b/src/fides/cli/commands/user.py
@@ -1,4 +1,5 @@
 """Contains the user command group for the fides CLI."""
+
 import rich_click as click
 
 from fides.cli.options import (

--- a/src/fides/common/utils.py
+++ b/src/fides/common/utils.py
@@ -4,6 +4,7 @@ These utils are designed to be safe to use across Fides, with no potential for c
 These utils should only import from 3rd-party libraries, with zero imports
 from local Fides modules.
 """
+
 import json
 import pprint
 import sys

--- a/src/fides/config/cli_settings.py
+++ b/src/fides/config/cli_settings.py
@@ -1,4 +1,5 @@
 """This module defines the settings for everything related to the CLI."""
+
 from typing import Dict, Optional
 
 from fideslog.sdk.python.utils import FIDESCTL_CLI, generate_client_id

--- a/src/fides/config/create.py
+++ b/src/fides/config/create.py
@@ -1,6 +1,7 @@
 """
 This module auto-generates a documented config from the config source.
 """
+
 import os
 from textwrap import wrap
 from typing import Dict, List, Optional, Set, Tuple

--- a/src/fides/config/helpers.py
+++ b/src/fides/config/helpers.py
@@ -1,4 +1,5 @@
 """This module contains logic related to loading/manipulation/writing the config."""
+
 import os
 from os import environ
 from pathlib import Path

--- a/src/fides/connectors/aws.py
+++ b/src/fides/connectors/aws.py
@@ -1,4 +1,5 @@
 """Module that adds interactions with aws"""
+
 from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Optional
 
@@ -172,12 +173,12 @@ def create_redshift_systems(
             system_type="redshift_cluster",
             organization_fides_key=organization_key,
             fidesctl_meta=SystemMetadata(
-                endpoint_address=cluster["Endpoint"]["Address"]
-                if cluster.get("Endpoint")
-                else None,
-                endpoint_port=cluster["Endpoint"]["Port"]
-                if cluster.get("Endpoint")
-                else None,
+                endpoint_address=(
+                    cluster["Endpoint"]["Address"] if cluster.get("Endpoint") else None
+                ),
+                endpoint_port=(
+                    cluster["Endpoint"]["Port"] if cluster.get("Endpoint") else None
+                ),
                 resource_id=cluster["ClusterNamespaceArn"],
             ),
             privacy_declarations=[],
@@ -223,12 +224,14 @@ def create_rds_systems(
             system_type="rds_instance",
             organization_fides_key=organization_key,
             fidesctl_meta=SystemMetadata(
-                endpoint_address=instance["Endpoint"]["Address"]
-                if instance.get("Endpoint")
-                else None,
-                endpoint_port=instance["Endpoint"]["Port"]
-                if instance.get("Endpoint")
-                else None,
+                endpoint_address=(
+                    instance["Endpoint"]["Address"]
+                    if instance.get("Endpoint")
+                    else None
+                ),
+                endpoint_port=(
+                    instance["Endpoint"]["Port"] if instance.get("Endpoint") else None
+                ),
                 resource_id=instance["DBInstanceArn"],
             ),
             privacy_declarations=[],

--- a/src/fides/connectors/okta.py
+++ b/src/fides/connectors/okta.py
@@ -1,4 +1,5 @@
 """Module that adds interactions with okta"""
+
 import ast
 from functools import update_wrapper
 from typing import Any, Callable, List, Optional

--- a/src/fides/core/annotate_dataset.py
+++ b/src/fides/core/annotate_dataset.py
@@ -1,6 +1,7 @@
 """
 This script is a utility for interactively annotating data categories in the dataset manifest
 """
+
 from typing import List, Union
 
 import click

--- a/src/fides/core/api.py
+++ b/src/fides/core/api.py
@@ -1,4 +1,5 @@
 """A wrapper to make calling the API consistent across fides."""
+
 from typing import Dict, List
 
 import requests

--- a/src/fides/core/dataset.py
+++ b/src/fides/core/dataset.py
@@ -1,4 +1,5 @@
 """Module that adds functionality for generating or scanning datasets."""
+
 from typing import Dict, List, Optional, Tuple
 
 import sqlalchemy

--- a/src/fides/core/evaluate.py
+++ b/src/fides/core/evaluate.py
@@ -1,4 +1,5 @@
 """Module for evaluating policies."""
+
 import uuid
 from typing import Callable, Dict, List, Optional, Set, cast
 
@@ -159,13 +160,17 @@ def compare_rule_to_declaration(
         # any matches return matching declared values as violations
         MatchesEnum.ANY: lambda: matched_declaration_types,
         # all matches return matching declared values as violations if all values match rule values
-        MatchesEnum.ALL: lambda: matched_declaration_types
-        if len(matched_declaration_types) == len(declaration_type_hierarchies)
-        else set(),
+        MatchesEnum.ALL: lambda: (
+            matched_declaration_types
+            if len(matched_declaration_types) == len(declaration_type_hierarchies)
+            else set()
+        ),
         # none matches return mismatched declared values as violations if none of the values matched rule values
-        MatchesEnum.NONE: lambda: mismatched_declaration_types
-        if not any(matched_declaration_types)
-        else set(),
+        MatchesEnum.NONE: lambda: (
+            mismatched_declaration_types
+            if not any(matched_declaration_types)
+            else set()
+        ),
         # other matches return mismatched declared values as violations
         MatchesEnum.OTHER: lambda: mismatched_declaration_types,
     }

--- a/src/fides/core/filters.py
+++ b/src/fides/core/filters.py
@@ -1,4 +1,5 @@
 """Module that adds functionality for resource filtering."""
+
 from typing import Callable, List, Optional
 
 from fideslang.models import Organization, System

--- a/src/fides/core/parse.py
+++ b/src/fides/core/parse.py
@@ -1,4 +1,5 @@
 """This module is responsible for parsing and verifying file, either with or without a server being available."""
+
 from fideslang.manifests import ingest_manifests
 from fideslang.models import Taxonomy
 from fideslang.parse import load_manifests_into_taxonomy

--- a/src/fides/core/pull.py
+++ b/src/fides/core/pull.py
@@ -1,4 +1,5 @@
 """This module handles the logic for syncing remote resource versions into their local file."""
+
 from typing import Dict, List, Optional
 
 import yaml

--- a/src/fides/core/push.py
+++ b/src/fides/core/push.py
@@ -1,4 +1,5 @@
 """This module handles the logic required for pushing manifest files to the server."""
+
 from json import loads
 from pprint import pprint
 from typing import Dict, List, Tuple

--- a/src/fides/core/system.py
+++ b/src/fides/core/system.py
@@ -1,4 +1,5 @@
 """Module that adds functionality for generating or scanning systems."""
+
 import asyncio
 from collections import defaultdict
 from typing import Dict, List, Optional
@@ -385,9 +386,9 @@ def scan_system_aws(
 
     organization = get_organization(
         organization_key=organization_key,
-        manifest_organizations=manifest_taxonomy.organization
-        if manifest_taxonomy
-        else [],
+        manifest_organizations=(
+            manifest_taxonomy.organization if manifest_taxonomy else []
+        ),
         url=url,
         headers=headers,
     )
@@ -435,9 +436,9 @@ def scan_system_okta(
 
     organization = get_organization(
         organization_key=organization_key,
-        manifest_organizations=manifest_taxonomy.organization
-        if manifest_taxonomy
-        else [],
+        manifest_organizations=(
+            manifest_taxonomy.organization if manifest_taxonomy else []
+        ),
         url=url,
         headers=headers,
     )

--- a/src/fides/core/user.py
+++ b/src/fides/core/user.py
@@ -1,4 +1,5 @@
 """Module for interaction with User endpoints/commands."""
+
 import json
 from typing import Dict, List, Tuple
 

--- a/tests/ctl/cli/test_cli.py
+++ b/tests/ctl/cli/test_cli.py
@@ -847,21 +847,21 @@ class TestGenerate:
         os.environ["FIDES__CREDENTIALS__BIGQUERY_1__PROJECT_ID"] = config_data_decoded[
             "project_id"
         ]
-        os.environ[
-            "FIDES__CREDENTIALS__BIGQUERY_1__PRIVATE_KEY_ID"
-        ] = config_data_decoded["private_key_id"]
+        os.environ["FIDES__CREDENTIALS__BIGQUERY_1__PRIVATE_KEY_ID"] = (
+            config_data_decoded["private_key_id"]
+        )
         os.environ["FIDES__CREDENTIALS__BIGQUERY_1__PRIVATE_KEY"] = config_data_decoded[
             "private_key"
         ]
-        os.environ[
-            "FIDES__CREDENTIALS__BIGQUERY_1__CLIENT_EMAIL"
-        ] = config_data_decoded["client_email"]
+        os.environ["FIDES__CREDENTIALS__BIGQUERY_1__CLIENT_EMAIL"] = (
+            config_data_decoded["client_email"]
+        )
         os.environ["FIDES__CREDENTIALS__BIGQUERY_1__CLIENT_ID"] = config_data_decoded[
             "client_id"
         ]
-        os.environ[
-            "FIDES__CREDENTIALS__BIGQUERY_1__CLIENT_X509_CERT_URL"
-        ] = config_data_decoded["client_x509_cert_url"]
+        os.environ["FIDES__CREDENTIALS__BIGQUERY_1__CLIENT_X509_CERT_URL"] = (
+            config_data_decoded["client_x509_cert_url"]
+        )
         dataset_name = "fidesopstest"
         result = test_cli_runner.invoke(
             cli,

--- a/tests/ctl/core/config/test_execution_settings.py
+++ b/tests/ctl/core/config/test_execution_settings.py
@@ -27,13 +27,13 @@ class TestExecutionSettings:
     ):
         kwargs = {}
         if subject_verification_required is not None:
-            kwargs[
-                "subject_identity_verification_required"
-            ] = subject_verification_required
+            kwargs["subject_identity_verification_required"] = (
+                subject_verification_required
+            )
         if disable_consent_verification is not None:
-            kwargs[
-                "disable_consent_identity_verification"
-            ] = disable_consent_verification
+            kwargs["disable_consent_identity_verification"] = (
+                disable_consent_verification
+            )
 
         settings = ExecutionSettings(**kwargs)
         assert settings.disable_consent_identity_verification is expected

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -2009,9 +2009,9 @@ class TestSystemUpdate:
         )
 
         db.refresh(system_multiple_decs)
-        updated_decs: List[
-            PrivacyDeclaration
-        ] = system_multiple_decs.privacy_declarations.copy()
+        updated_decs: List[PrivacyDeclaration] = (
+            system_multiple_decs.privacy_declarations.copy()
+        )
 
         for old_dec_updated in old_decs_updated:
             updated_dec = next(

--- a/tests/fixtures/fides_connector_example_fixtures.py
+++ b/tests/fixtures/fides_connector_example_fixtures.py
@@ -58,12 +58,12 @@ def test_fides_connector_overridden_polling(
     fides_connector_connection_config: Dict[str, str],
     fides_connector_polling_overrides: Tuple[int, int],
 ) -> FidesConnector:
-    fides_connector_connection_config.secrets[
-        "polling_timeout"
-    ] = fides_connector_polling_overrides[0]
-    fides_connector_connection_config.secrets[
-        "polling_interval"
-    ] = fides_connector_polling_overrides[1]
+    fides_connector_connection_config.secrets["polling_timeout"] = (
+        fides_connector_polling_overrides[0]
+    )
+    fides_connector_connection_config.secrets["polling_interval"] = (
+        fides_connector_polling_overrides[1]
+    )
     return FidesConnector(configuration=fides_connector_connection_config)
 
 

--- a/tests/fixtures/postgres_fixtures.py
+++ b/tests/fixtures/postgres_fixtures.py
@@ -312,9 +312,9 @@ def postgres_connection_config_with_schema(
             "description": "Backup postgres data",
         },
     )
-    connection_config.secrets[
-        "db_schema"
-    ] = "backup_schema"  # Matches the second schema created in postgres_example.schema
+    connection_config.secrets["db_schema"] = (
+        "backup_schema"  # Matches the second schema created in postgres_example.schema
+    )
     connection_config.save(db)
     yield connection_config
     connection_config.delete(db)

--- a/tests/fixtures/saas/connection_template_fixtures.py
+++ b/tests/fixtures/saas/connection_template_fixtures.py
@@ -98,9 +98,9 @@ def instantiate_connector(
     """
     Helper to genericize instantiation of a SaaS connector
     """
-    connector_template: Optional[
-        ConnectorTemplate
-    ] = ConnectorRegistry.get_connector_template(connector_type)
+    connector_template: Optional[ConnectorTemplate] = (
+        ConnectorRegistry.get_connector_template(connector_type)
+    )
     template_vals = SaasConnectionTemplateValues(
         key=fides_key,
         description=description,

--- a/tests/ops/api/v1/endpoints/test_storage_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_storage_endpoints.py
@@ -930,9 +930,7 @@ class TestPutDefaultStorageConfig:
         payload,
     ):
         payload["type"] = StorageType.local.value
-        payload[
-            "format"
-        ] = (
+        payload["format"] = (
             ResponseFormat.json.value
         )  # change to JSON because that's what local expects
         auth_header = generate_auth_header([STORAGE_CREATE_OR_UPDATE])
@@ -966,9 +964,7 @@ class TestPutDefaultStorageConfig:
         payload: dict,
     ):
         payload["type"] = StorageType.local.value
-        payload[
-            "format"
-        ] = (
+        payload["format"] = (
             ResponseFormat.json.value
         )  # change to JSON because that's what local expects
         payload["details"] = {
@@ -1027,9 +1023,7 @@ class TestPutDefaultStorageConfig:
     ):
         mock_create_or_update.side_effect = KeyOrNameAlreadyExists("Key already exists")
         payload["type"] = StorageType.local.value
-        payload[
-            "format"
-        ] = (
+        payload["format"] = (
             ResponseFormat.json.value
         )  # change to JSON because that's what local expects
         payload["details"] = {
@@ -1053,9 +1047,7 @@ class TestPutDefaultStorageConfig:
     ):
         mock_create_or_update.side_effect = KeyValidationError()
         payload["type"] = StorageType.local.value
-        payload[
-            "format"
-        ] = (
+        payload["format"] = (
             ResponseFormat.json.value
         )  # change to JSON because that's what local expects
         payload["details"] = {

--- a/tests/ops/api/v1/test_main.py
+++ b/tests/ops/api/v1/test_main.py
@@ -1,4 +1,5 @@
 """Tests for the webserver and its various configurations."""
+
 import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient

--- a/tests/ops/graph/test_graph.py
+++ b/tests/ops/graph/test_graph.py
@@ -63,9 +63,9 @@ def test_retry_decorator(privacy_request, policy, db):
     input_data = {"test": "data"}
     graph: DatasetGraph = integration_db_graph("postgres_example")
     traversal = Traversal(graph, {"email": "X"})
-    traversal_nodes: Dict[
-        CollectionAddress, TraversalNode
-    ] = traversal.traversal_node_dict
+    traversal_nodes: Dict[CollectionAddress, TraversalNode] = (
+        traversal.traversal_node_dict
+    )
     payment_card_node = traversal_nodes[
         CollectionAddress("postgres_example", "payment_card")
     ]

--- a/tests/ops/models/test_custom_connector_template.py
+++ b/tests/ops/models/test_custom_connector_template.py
@@ -24,10 +24,10 @@ class TestCustomConnectorTemplate:
 
         # assert we can retrieve a connector template by key and
         # that the values are the same as what we persisted
-        custom_connector: Optional[
-            CustomConnectorTemplate
-        ] = CustomConnectorTemplate.get_by_key_or_id(
-            db=db, data={"key": "planet_express"}
+        custom_connector: Optional[CustomConnectorTemplate] = (
+            CustomConnectorTemplate.get_by_key_or_id(
+                db=db, data={"key": "planet_express"}
+            )
         )
         assert custom_connector
         assert custom_connector.name == "Planet Express"

--- a/tests/ops/service/connectors/test_saas_connector.py
+++ b/tests/ops/service/connectors/test_saas_connector.py
@@ -337,9 +337,7 @@ class TestSaasConnector:
         )
 
         #  Mock adding a new placeholder to the request body for which we don't have a value
-        connector.endpoints[
-            "data_management"
-        ].requests.update.body = (
+        connector.endpoints["data_management"].requests.update.body = (
             '{\n  "unique_id": "<privacy_request_id>", "email": "<test_val>"\n}\n'
         )
 
@@ -423,14 +421,14 @@ class TestConsentRequests:
             mailchimp_transactional_connection_config
         )
 
-        opt_in_request: List[
-            SaaSRequest
-        ] = connector._get_consent_requests_by_preference(opt_in=True)
+        opt_in_request: List[SaaSRequest] = (
+            connector._get_consent_requests_by_preference(opt_in=True)
+        )
         assert opt_in_request[0].path == "/allowlists/add"
 
-        opt_out_request: List[
-            SaaSRequest
-        ] = connector._get_consent_requests_by_preference(opt_in=False)
+        opt_out_request: List[SaaSRequest] = (
+            connector._get_consent_requests_by_preference(opt_in=False)
+        )
 
         assert opt_out_request[0].path == "/allowlists/delete"
         assert opt_out_request[1].path == "/rejects/add"

--- a/tests/ops/service/connectors/test_saas_queryconfig.py
+++ b/tests/ops/service/connectors/test_saas_queryconfig.py
@@ -208,9 +208,9 @@ class TestSaaSQueryConfig:
         combined_traversal,
         saas_example_connection_config,
     ):
-        saas_config: Optional[
-            SaaSConfig
-        ] = saas_example_connection_config.get_saas_config()
+        saas_config: Optional[SaaSConfig] = (
+            saas_example_connection_config.get_saas_config()
+        )
         saas_config.endpoints[2].requests.update.method = HTTPMethod.POST
         endpoints = saas_config.top_level_endpoint_dict
 
@@ -246,12 +246,10 @@ class TestSaaSQueryConfig:
         combined_traversal,
         saas_example_connection_config,
     ):
-        saas_config: Optional[
-            SaaSConfig
-        ] = saas_example_connection_config.get_saas_config()
-        saas_config.endpoints[
-            2
-        ].requests.update.body = (
+        saas_config: Optional[SaaSConfig] = (
+            saas_example_connection_config.get_saas_config()
+        )
+        saas_config.endpoints[2].requests.update.body = (
             '{"properties": {<masked_object_fields>, "list_id": "<list_id>"}}'
         )
         body_param_value = ParamValue(
@@ -323,9 +321,9 @@ class TestSaaSQueryConfig:
         saas_example_connection_config,
         saas_example_secrets,
     ):
-        saas_config: Optional[
-            SaaSConfig
-        ] = saas_example_connection_config.get_saas_config()
+        saas_config: Optional[SaaSConfig] = (
+            saas_example_connection_config.get_saas_config()
+        )
         endpoints = saas_config.top_level_endpoint_dict
         customer = combined_traversal.traversal_node_dict[
             CollectionAddress(saas_config.fides_key, "customer")
@@ -366,9 +364,9 @@ class TestSaaSQueryConfig:
     ):
         mock_identity_data.return_value = {"email": "test@example.com"}
 
-        saas_config: Optional[
-            SaaSConfig
-        ] = saas_example_connection_config.get_saas_config()
+        saas_config: Optional[SaaSConfig] = (
+            saas_example_connection_config.get_saas_config()
+        )
         endpoints = saas_config.top_level_endpoint_dict
 
         member = combined_traversal.traversal_node_dict[
@@ -414,9 +412,9 @@ class TestSaaSQueryConfig:
     def test_get_masking_request(
         self, combined_traversal, saas_example_connection_config
     ):
-        saas_config: Optional[
-            SaaSConfig
-        ] = saas_example_connection_config.get_saas_config()
+        saas_config: Optional[SaaSConfig] = (
+            saas_example_connection_config.get_saas_config()
+        )
         endpoints = saas_config.top_level_endpoint_dict
 
         member = combined_traversal.traversal_node_dict[
@@ -483,9 +481,9 @@ class TestSaaSQueryConfig:
     def test_list_param_values(
         self, combined_traversal, saas_example_connection_config, policy
     ):
-        saas_config: Optional[
-            SaaSConfig
-        ] = saas_example_connection_config.get_saas_config()
+        saas_config: Optional[SaaSConfig] = (
+            saas_example_connection_config.get_saas_config()
+        )
         endpoints = saas_config.top_level_endpoint_dict
 
         accounts = combined_traversal.traversal_node_dict[
@@ -545,9 +543,9 @@ class TestSaaSQueryConfig:
         more prepared_requests if they are not used by the request
         """
 
-        saas_config: Optional[
-            SaaSConfig
-        ] = saas_example_connection_config.get_saas_config()
+        saas_config: Optional[SaaSConfig] = (
+            saas_example_connection_config.get_saas_config()
+        )
         endpoints = saas_config.top_level_endpoint_dict
 
         mailing_lists = combined_traversal.traversal_node_dict[

--- a/tests/ops/service/privacy_request/test_request_runner_service.py
+++ b/tests/ops/service/privacy_request/test_request_runner_service.py
@@ -362,9 +362,9 @@ def get_privacy_request_results(
         unique_masking_strategies_by_name.add(strategy_name)
         masking_strategy = MaskingStrategy.get_strategy(strategy_name, configuration)
         if masking_strategy.secrets_required():
-            masking_secrets: List[
-                MaskingSecretCache
-            ] = masking_strategy.generate_secrets_for_cache()
+            masking_secrets: List[MaskingSecretCache] = (
+                masking_strategy.generate_secrets_for_cache()
+            )
             for masking_secret in masking_secrets:
                 privacy_request.cache_masking_secret(masking_secret)
 

--- a/tests/ops/util/encryption/test_secrets_util.py
+++ b/tests/ops/util/encryption/test_secrets_util.py
@@ -81,9 +81,9 @@ def test_generate_secret() -> None:
 
 def test_build_masking_secrets_for_cache() -> None:
     # build masking secret meta for all HMAC secrets
-    masking_meta: Dict[
-        SecretType, MaskingSecretMeta
-    ] = HmacMaskingStrategy._build_masking_secret_meta()
+    masking_meta: Dict[SecretType, MaskingSecretMeta] = (
+        HmacMaskingStrategy._build_masking_secret_meta()
+    )
     result: List[MaskingSecretCache] = SecretsUtil.build_masking_secrets_for_cache(
         masking_meta
     )


### PR DESCRIPTION
Closes N/A

### Description Of Changes

Followup to: https://github.com/ethyca/fides/pull/4807

`black` was upgraded here but the corresponding formatting changes were not applied.


### Code Changes

- Run `nox -s static_checks` to apply new formatting fixes
- Remove py39=true from pyproject.toml and replace with "target-version=["py39"] to resolve Invalid config keys detected: 'py39' (in /../fides/pyproject.toml)

### Steps to Confirm

* [ ] N/A - Formatting changes

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
