### PR TITLE
Fixing field_data_categories property

### DIFF
--- a/src/fides/api/models/sql_models.py
+++ b/src/fides/api/models/sql_models.py
@@ -278,7 +278,8 @@ class Dataset(Base, FidesBase):
         for collection in self.collections:
             dataset_collection = FideslangDatasetCollection(**collection)
             for field in dataset_collection.fields:
-                data_categories.update(field.data_categories)
+                if field.data_categories is not None:
+                    data_categories.update(field.data_categories)
         return data_categories
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1232,6 +1232,7 @@ def system_with_undeclared_data_categories(db: Session) -> System:
                             "name": "email",
                             "data_categories": ["user.contact.email"],
                         },
+                        {"name": "first_name"},
                     ],
                 }
             ],
@@ -1266,6 +1267,7 @@ def privacy_declaration_with_dataset_references(db: Session) -> System:
                             "name": "email",
                             "data_categories": ["user.contact.email"],
                         },
+                        {"name": "first_name"},
                     ],
                 }
             ],

--- a/tests/ctl/core/test_dataset.py
+++ b/tests/ctl/core/test_dataset.py
@@ -357,6 +357,33 @@ def test_unsupported_dialect_error() -> None:
         _dataset.generate_dataset_db(test_url, "test_file.yml", False)
 
 
+@pytest.mark.unit
+def test_field_data_categories(db) -> None:
+    """
+    Verify that field_data_categories works for fields with and without data categories.
+    """
+
+    ctl_dataset = CtlDataset.create_from_dataset_dict(
+        db,
+        {
+            "fides_key": f"dataset_key-f{uuid4()}",
+            "collections": [
+                {
+                    "name": "customer",
+                    "fields": [
+                        {
+                            "name": "email",
+                            "data_categories": ["user.contact.email"],
+                        },
+                        {"name": "first_name"},
+                    ],
+                }
+            ],
+        },
+    )
+    assert ctl_dataset.field_data_categories
+
+
 # Generate Dataset Database Integration Tests
 
 # These URLs are for the databases in the docker-compose.integration-tests.yml file


### PR DESCRIPTION
Closes [PROD-1998](https://ethyca.atlassian.net/browse/PROD-1998)

### Description Of Changes

Fixes a bug caused by accessing `None` valued `field.data_categories` on the `Dataset` model. 

### Code Changes

* [ ] Code fix + test updates

### Steps to Confirm

* [ ] Tests should all pass, the verification of the endpoint needs fidesplus

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`


[PROD-1998]: https://ethyca.atlassian.net/browse/PROD-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ