### PR TITLE
Add download UI to data map report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Added
 - Added multiple language translations support for privacy center consent page [#4785](https://github.com/ethyca/fides/pull/4785)
+- Added ability to export the contents of datamap report [#1545](https://ethyca.atlassian.net/browse/PROD-1545)
 
 ## [2.35.0](https://github.com/ethyca/fides/compare/2.34.0...2.35.0)
 

--- a/clients/admin-ui/__tests__/features/common-utils.test.ts
+++ b/clients/admin-ui/__tests__/features/common-utils.test.ts
@@ -1,0 +1,18 @@
+import { getFileNameFromContentDisposition } from "~/features/common/utils";
+
+describe("common utils", () => {
+  describe(getFileNameFromContentDisposition.name, () => {
+    it('should return "export" when contentDisposition is null', () => {
+      expect(getFileNameFromContentDisposition(null)).toEqual("export");
+    });
+
+    it("should return the filename from the contentDisposition header", () => {
+      const contentDisposition = "attachment; filename=something-special.csv";
+      expect(getFileNameFromContentDisposition(contentDisposition)).toEqual(
+        "something-special.csv"
+      );
+    });
+  });
+});
+
+export default undefined;

--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -131,4 +131,18 @@ describe("Minimal datamap report table", () => {
       });
     });
   });
+
+  describe("Exporting", () => {
+    it("should open the export modal", () => {
+      cy.getByTestId("export-btn").click();
+      cy.getByTestId("export-modal").should("be.visible");
+      cy.getByTestId("export-format-select").should("be.visible");
+      cy.getByTestId("export-modal-continue-btn").should(
+        "contain.text",
+        "Download"
+      );
+      cy.getByTestId("export-modal-cancel-btn").click();
+      cy.getByTestId("export-modal").should("not.exist");
+    });
+  });
 });

--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -144,5 +144,8 @@ describe("Minimal datamap report table", () => {
       cy.getByTestId("export-modal-cancel-btn").click();
       cy.getByTestId("export-modal").should("not.exist");
     });
+
+    // ideally we should test the downloads, but it's a bit complex and time consuming so deferring for now
+    it.skip("should download the export file", () => {});
   });
 });

--- a/clients/admin-ui/src/features/common/modals/StandardDialog.tsx
+++ b/clients/admin-ui/src/features/common/modals/StandardDialog.tsx
@@ -1,0 +1,81 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  ModalProps,
+  ThemingProps,
+} from "@fidesui/react";
+
+export interface StandardDialogProps extends ModalProps {
+  heading?: string;
+  cancelButtonText?: string;
+  cancelButtonThemingProps?: ThemingProps<"Button">;
+  continueButtonText?: string;
+  continueButtonThemingProps?: ThemingProps<"Button">;
+  onCancel?: () => void;
+  onConfirm: () => void;
+  isLoading?: boolean;
+  "data-testid"?: string;
+}
+
+const StandardDialog = ({
+  children,
+  heading,
+  onCancel,
+  onConfirm,
+  isLoading,
+  cancelButtonText,
+  cancelButtonThemingProps,
+  continueButtonText,
+  continueButtonThemingProps,
+  "data-testid": testId = "standard-dialog",
+  ...props
+}: StandardDialogProps): JSX.Element => {
+  const { onClose } = props;
+  return (
+    <Modal {...props}>
+      <ModalOverlay />
+      <ModalContent>
+        {heading && <ModalHeader>{heading}</ModalHeader>}
+        <ModalCloseButton />
+        {children && <ModalBody>{children}</ModalBody>}
+        <ModalFooter
+          gap={3}
+          width="100%"
+          sx={{ "& button": { width: "100%" } }}
+        >
+          <Button
+            variant="outline"
+            onClick={() => {
+              if (onCancel) {
+                onCancel();
+              }
+              onClose();
+            }}
+            data-testid={`${testId ? `${testId}-` : ""}cancel-btn`}
+            isDisabled={isLoading}
+            {...cancelButtonThemingProps}
+          >
+            {cancelButtonText || "Cancel"}
+          </Button>
+          <Button
+            colorScheme="primary"
+            onClick={onConfirm}
+            data-testid={`${testId ? `${testId}-` : ""}cancel-btn`}
+            isLoading={isLoading}
+            {...cancelButtonThemingProps}
+          >
+            {continueButtonText || "Continue"}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default StandardDialog;

--- a/clients/admin-ui/src/features/common/modals/StandardDialog.tsx
+++ b/clients/admin-ui/src/features/common/modals/StandardDialog.tsx
@@ -40,7 +40,7 @@ const StandardDialog = ({
   return (
     <Modal closeOnOverlayClick={isLoading} {...props}>
       <ModalOverlay />
-      <ModalContent>
+      <ModalContent data-testid={testId}>
         {heading && <ModalHeader>{heading}</ModalHeader>}
         <ModalCloseButton disabled={isLoading} />
         {children && <ModalBody>{children}</ModalBody>}
@@ -66,7 +66,7 @@ const StandardDialog = ({
           <Button
             colorScheme="primary"
             onClick={onConfirm}
-            data-testid={`${testId ? `${testId}-` : ""}cancel-btn`}
+            data-testid={`${testId ? `${testId}-` : ""}continue-btn`}
             isLoading={isLoading}
             {...cancelButtonThemingProps}
           >

--- a/clients/admin-ui/src/features/common/modals/StandardDialog.tsx
+++ b/clients/admin-ui/src/features/common/modals/StandardDialog.tsx
@@ -38,11 +38,11 @@ const StandardDialog = ({
 }: StandardDialogProps): JSX.Element => {
   const { onClose } = props;
   return (
-    <Modal {...props}>
+    <Modal closeOnOverlayClick={isLoading} {...props}>
       <ModalOverlay />
       <ModalContent>
         {heading && <ModalHeader>{heading}</ModalHeader>}
-        <ModalCloseButton />
+        <ModalCloseButton disabled={isLoading} />
         {children && <ModalBody>{children}</ModalBody>}
         <ModalFooter
           gap={3}

--- a/clients/admin-ui/src/features/common/utils.ts
+++ b/clients/admin-ui/src/features/common/utils.ts
@@ -36,3 +36,13 @@ export const formatDate = (value: string | number | Date): string =>
 
 export const utf8ToB64 = (str: string): string =>
   window.btoa(unescape(encodeURIComponent(str)));
+
+export const getFileNameFromContentDisposition = (
+  contentDisposition: string | null
+) => {
+  if (!contentDisposition) {
+    return "export";
+  }
+  const match = contentDisposition.match(/filename=(.+)/);
+  return match ? match[1] : "export";
+};

--- a/clients/admin-ui/src/features/common/utils.ts
+++ b/clients/admin-ui/src/features/common/utils.ts
@@ -40,9 +40,10 @@ export const utf8ToB64 = (str: string): string =>
 export const getFileNameFromContentDisposition = (
   contentDisposition: string | null
 ) => {
+  const defaultName = "export";
   if (!contentDisposition) {
-    return "export";
+    return defaultName;
   }
   const match = contentDisposition.match(/filename=(.+)/);
-  return match ? match[1] : "export";
+  return match ? match[1] : defaultName;
 };

--- a/clients/admin-ui/src/features/datamap/constants.ts
+++ b/clients/admin-ui/src/features/datamap/constants.ts
@@ -10,6 +10,11 @@ export const ItemTypes = {
   DraggableColumnListItem: "DraggableColumnListItem",
 };
 
+export enum ExportFormat {
+  csv = "csv",
+  xlsx = "xlsx",
+}
+
 export const SYSTEM_FIDES_KEY_COLUMN_ID = "system.fides_key";
 export const SYSTEM_NAME = "system.name";
 export const SYSTEM_PRIVACY_DECLARATION_DATA_USE_NAME =

--- a/clients/admin-ui/src/features/datamap/datamap.slice.ts
+++ b/clients/admin-ui/src/features/datamap/datamap.slice.ts
@@ -156,7 +156,7 @@ const datamapApi = baseApi.injectEndpoints({
                 "application/octet-stream",
             });
             saveAs(blob, filename);
-            return { data: undefined };
+            return { data: undefined }; // once the file is downloaded, we no longer want this to be cached in the browser so we return undefined to RTK Query
           },
         };
       },

--- a/clients/admin-ui/src/features/datamap/modals/ReportExportModal.tsx
+++ b/clients/admin-ui/src/features/datamap/modals/ReportExportModal.tsx
@@ -24,6 +24,7 @@ const ReportExportModal = (props: ReportExportModalProps): JSX.Element => {
       size="xl"
       {...props}
       onConfirm={() => onConfirm(downloadType)}
+      data-testid="export-modal"
     >
       <Flex direction="column" gap={3} pb={3}>
         <Text textAlign="left">
@@ -35,6 +36,7 @@ const ReportExportModal = (props: ReportExportModalProps): JSX.Element => {
           <Select
             value={downloadType}
             onChange={(e) => setDownloadType(e.target.value as ExportFormat)}
+            data-testid="export-format-select"
           >
             <option value={ExportFormat.csv}>CSV</option>
             <option value={ExportFormat.xlsx}>XLSX</option>

--- a/clients/admin-ui/src/features/datamap/modals/ReportExportModal.tsx
+++ b/clients/admin-ui/src/features/datamap/modals/ReportExportModal.tsx
@@ -1,0 +1,48 @@
+import { Flex, FormControl, FormLabel, Select, Text } from "@fidesui/react";
+import { useState } from "react";
+
+import StandardDialog, {
+  StandardDialogProps,
+} from "~/features/common/modals/StandardDialog";
+import { ExportFormat } from "~/features/datamap/constants";
+
+interface ReportExportModalProps
+  extends Omit<StandardDialogProps, "children" | "onConfirm"> {
+  onConfirm: (downloadType: ExportFormat) => void;
+}
+
+const ReportExportModal = (props: ReportExportModalProps): JSX.Element => {
+  const [downloadType, setDownloadType] = useState<ExportFormat>(
+    ExportFormat.csv
+  );
+  const { onConfirm } = props;
+
+  return (
+    <StandardDialog
+      heading="Export report"
+      continueButtonText="Download"
+      size="xl"
+      {...props}
+      onConfirm={() => onConfirm(downloadType)}
+    >
+      <Flex direction="column" gap={3} pb={3}>
+        <Text textAlign="left">
+          Export your data map report using the options below. Depending on the
+          number of rows, the file may take a few minutes to process.
+        </Text>
+        <FormControl>
+          <FormLabel>Choose Format</FormLabel>
+          <Select
+            value={downloadType}
+            onChange={(e) => setDownloadType(e.target.value as ExportFormat)}
+          >
+            <option value={ExportFormat.csv}>CSV</option>
+            <option value={ExportFormat.xlsx}>XLSX</option>
+          </Select>
+        </FormControl>
+      </Flex>
+    </StandardDialog>
+  );
+};
+
+export default ReportExportModal;

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -3,16 +3,12 @@ import {
   Button,
   ChevronDownIcon,
   Flex,
-  FormControl,
-  FormLabel,
   Heading,
   IconButton,
   Menu,
   MenuButton,
   MenuItemOption,
   MenuList,
-  Select,
-  Text,
   useDisclosure,
 } from "@fidesui/react";
 import {
@@ -40,10 +36,10 @@ import { useEffect, useMemo, useState } from "react";
 import { useAppSelector } from "~/app/hooks";
 import useTaxonomies from "~/features/common/hooks/useTaxonomies";
 import { DownloadLightIcon } from "~/features/common/Icon";
-import ConfirmationModal from "~/features/common/modals/ConfirmationModal";
 import { getQueryParamsFromList } from "~/features/common/modals/FilterModal";
 import { ExportFormat } from "~/features/datamap/constants";
 import { useGetMinimalDatamapReportQuery } from "~/features/datamap/datamap.slice";
+import ReportExportModal from "~/features/datamap/modals/ReportExportModal";
 import {
   DatamapReportFilterModal,
   useDatamapReportFilters,
@@ -986,13 +982,19 @@ export const DatamapReportTable = () => {
   } = useDisclosure();
 
   const [isExporting, setIsExporting] = useState<boolean>(false);
-  const [downloadType, setDownloadType] = useState<ExportFormat>(
-    ExportFormat.csv
-  );
 
-  const onExport = () => {
+  const onExport = (downloadType: ExportFormat) => {
     // TASK: Implement export functionality
-    console.log("Export report here!", downloadType);
+    console.log("Export report here!", downloadType, {
+      pageIndex,
+      pageSize,
+      groupBy,
+      search: globalFilter,
+      dataUses: selectedDataUseFilters,
+      dataSubjects: selectedDataSubjectFilters,
+      dataCategories: selectedDataCategoriesFilters,
+    });
+
     setIsExporting(true);
   };
 
@@ -1068,31 +1070,9 @@ export const DatamapReportTable = () => {
         prefixColumns={getPrefixColumns(groupBy)}
         tableInstance={tableInstance}
       />
-      <ConfirmationModal
+      <ReportExportModal
         isOpen={isExportReportOpen}
         onClose={onExportReportClose}
-        title="Export report"
-        continueButtonText="Download"
-        message={
-          <Flex direction="column" gap={3} pb={3}>
-            <Text textAlign="left">
-              Export your data map report using the options below. Depending on
-              the number of rows, the file may take a few minutes to process.
-            </Text>
-            <FormControl>
-              <FormLabel>Choose Format</FormLabel>
-              <Select
-                value={downloadType}
-                onChange={(e) =>
-                  setDownloadType(e.target.value as ExportFormat)
-                }
-              >
-                <option value={ExportFormat.csv}>CSV</option>
-                <option value={ExportFormat.xlsx}>XLSX</option>
-              </Select>
-            </FormControl>
-          </Flex>
-        }
         onConfirm={onExport}
         isLoading={isExporting}
       />

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -3,11 +3,16 @@ import {
   Button,
   ChevronDownIcon,
   Flex,
+  FormControl,
+  FormLabel,
   Heading,
+  IconButton,
   Menu,
   MenuButton,
   MenuItemOption,
   MenuList,
+  Select,
+  Text,
   useDisclosure,
 } from "@fidesui/react";
 import {
@@ -34,7 +39,10 @@ import { useEffect, useMemo, useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import useTaxonomies from "~/features/common/hooks/useTaxonomies";
+import { DownloadLightIcon } from "~/features/common/Icon";
+import ConfirmationModal from "~/features/common/modals/ConfirmationModal";
 import { getQueryParamsFromList } from "~/features/common/modals/FilterModal";
+import { ExportFormat } from "~/features/datamap/constants";
 import { useGetMinimalDatamapReportQuery } from "~/features/datamap/datamap.slice";
 import {
   DatamapReportFilterModal,
@@ -281,9 +289,9 @@ export const DatamapReportTable = () => {
 
     /*
       It's important that `grouping` and `columnOrder` are updated
-      in this `useMemo`. It makes it so grouping and column order 
+      in this `useMemo`. It makes it so grouping and column order
       updates are synced up with when the data changes. Otherwise
-      the table will update the grouping and column order before 
+      the table will update the grouping and column order before
       the correct data loads.
     */
     return {
@@ -971,6 +979,23 @@ export const DatamapReportTable = () => {
     onClose: onColumnSettingsClose,
   } = useDisclosure();
 
+  const {
+    isOpen: isExportReportOpen,
+    onOpen: onExportReportOpen,
+    onClose: onExportReportClose,
+  } = useDisclosure();
+
+  const [isExporting, setIsExporting] = useState<boolean>(false);
+  const [downloadType, setDownloadType] = useState<ExportFormat>(
+    ExportFormat.csv
+  );
+
+  const onExport = () => {
+    // TASK: Implement export functionality
+    console.log("Export report here!", downloadType);
+    setIsExporting(true);
+  };
+
   const tableInstance = useReactTable<DatamapReport>({
     getCoreRowModel: getCoreRowModel(),
     getGroupedRowModel: getGroupedRowModel(),
@@ -1043,19 +1068,46 @@ export const DatamapReportTable = () => {
         prefixColumns={getPrefixColumns(groupBy)}
         tableInstance={tableInstance}
       />
+      <ConfirmationModal
+        isOpen={isExportReportOpen}
+        onClose={onExportReportClose}
+        title="Export report"
+        continueButtonText="Download"
+        message={
+          <Flex direction="column" gap={3} pb={3}>
+            <Text textAlign="left">
+              Export your data map report using the options below. Depending on
+              the number of rows, the file may take a few minutes to process.
+            </Text>
+            <FormControl>
+              <FormLabel>Choose Format</FormLabel>
+              <Select
+                value={downloadType}
+                onChange={(e) =>
+                  setDownloadType(e.target.value as ExportFormat)
+                }
+              >
+                <option value={ExportFormat.csv}>CSV</option>
+                <option value={ExportFormat.xlsx}>XLSX</option>
+              </Select>
+            </FormControl>
+          </Flex>
+        }
+        onConfirm={onExport}
+        isLoading={isExporting}
+      />
       <TableActionBar>
         <GlobalFilterV2
           globalFilter={globalFilter}
           setGlobalFilter={updateGlobalFilter}
           placeholder="System name, Fides key, or ID"
         />
-        <Flex alignItems="center">
+        <Flex alignItems="center" gap={2}>
           <Menu>
             <MenuButton
               as={Button}
               size="xs"
               variant="outline"
-              mr={2}
               rightIcon={<ChevronDownIcon />}
               spinnerPlacement="end"
               isLoading={groupChangeStarted}
@@ -1089,7 +1141,6 @@ export const DatamapReportTable = () => {
             size="xs"
             variant="outline"
             onClick={onColumnSettingsOpen}
-            mr={2}
           >
             Edit columns
           </Button>
@@ -1101,6 +1152,14 @@ export const DatamapReportTable = () => {
           >
             Filter
           </Button>
+          <IconButton
+            aria-label="Export report"
+            data-testid="export-btn"
+            size="xs"
+            variant="outline"
+            onClick={onExportReportOpen}
+            icon={<DownloadLightIcon />}
+          />
         </Flex>
       </TableActionBar>
 

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -38,7 +38,10 @@ import useTaxonomies from "~/features/common/hooks/useTaxonomies";
 import { DownloadLightIcon } from "~/features/common/Icon";
 import { getQueryParamsFromList } from "~/features/common/modals/FilterModal";
 import { ExportFormat } from "~/features/datamap/constants";
-import { useGetMinimalDatamapReportQuery } from "~/features/datamap/datamap.slice";
+import {
+  useExportMinimalDatamapReportMutation,
+  useGetMinimalDatamapReportQuery,
+} from "~/features/datamap/datamap.slice";
 import ReportExportModal from "~/features/datamap/modals/ReportExportModal";
 import {
   DatamapReportFilterModal,
@@ -268,6 +271,11 @@ export const DatamapReportTable = () => {
     dataSubjects: selectedDataSubjectFilters,
     dataCategories: selectedDataCategoriesFilters,
   });
+
+  const [
+    exportMinimalDatamapReport,
+    { isLoading: isExportingReport, isSuccess: isExportReportSuccess },
+  ] = useExportMinimalDatamapReportMutation();
 
   const {
     items: data,
@@ -981,11 +989,8 @@ export const DatamapReportTable = () => {
     onClose: onExportReportClose,
   } = useDisclosure();
 
-  const [isExporting, setIsExporting] = useState<boolean>(false);
-
   const onExport = (downloadType: ExportFormat) => {
-    // TASK: Implement export functionality
-    console.log("Export report here!", downloadType, {
+    exportMinimalDatamapReport({
       pageIndex,
       pageSize,
       groupBy,
@@ -993,9 +998,12 @@ export const DatamapReportTable = () => {
       dataUses: selectedDataUseFilters,
       dataSubjects: selectedDataSubjectFilters,
       dataCategories: selectedDataCategoriesFilters,
+      format: downloadType,
+    }).then(() => {
+      if (isExportReportSuccess) {
+        onExportReportClose();
+      }
     });
-
-    setIsExporting(true);
   };
 
   const tableInstance = useReactTable<DatamapReport>({
@@ -1074,7 +1082,7 @@ export const DatamapReportTable = () => {
         isOpen={isExportReportOpen}
         onClose={onExportReportClose}
         onConfirm={onExport}
-        isLoading={isExporting}
+        isLoading={isExportingReport}
       />
       <TableActionBar>
         <GlobalFilterV2


### PR DESCRIPTION
Closes [PROD-1914](https://ethyca.atlassian.net/browse/PROD-1914)

### Description Of Changes

Export a file that mirrors the criteria of data showing in the UI

### Code Changes

* New button and confirmation modal for downloading the report

### Steps to Confirm

* visit Datamap report page `/reporting/datamap`
* play around with various settings to view the data on the page
* click new export button in top right corner
* export either csv or xlsx
* verify that the data mimics what is on the screen

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded(https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[PROD-1914]: https://ethyca.atlassian.net/browse/PROD-1914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ