### PR TITLE
Add JSON debug logging to Privacy Center /fides.js endpoint

### DIFF
--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -37,6 +37,7 @@ export interface PrivacyCenterSettings {
   SERVER_SIDE_FIDES_API_URL: string | null; // e.g. http://fides:8080/api/v1
   CONFIG_CSS_URL: string; // e.g. file:///app/config/config.css
   CONFIG_JSON_URL: string; // e.g. file:///app/config/config.json
+  LOG_LEVEL: string | null; // e.g. "DEBUG", "INFO"
 
   // Fides.js options
   DEBUG: boolean; // whether console logs are enabled for consent components
@@ -314,6 +315,7 @@ export const loadPrivacyCenterEnvironment =
       CONFIG_CSS_URL:
         process.env.FIDES_PRIVACY_CENTER__CONFIG_CSS_URL ||
         "file:///app/config/config.css",
+      LOG_LEVEL: process.env.FIDES_PRIVACY_CENTER__LOG_LEVEL || "INFO",
 
       // Overlay options
       DEBUG: process.env.FIDES_PRIVACY_CENTER__DEBUG

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -142,9 +142,10 @@ const loadConfigFile = async (
         path = urlString.replace("file:", "");
       }
       const file = await fsPromises.readFile(path || url, "utf-8");
-      if (process.env.NODE_ENV === "development") {
-        console.log(`Loaded configuration file: ${urlString}`);
-      }
+      // TODO: switch to debugLog in this file and reduce verbosity
+      // if (process.env.NODE_ENV === "development") {
+      //   console.log(`Loaded configuration file: ${urlString}`);
+      // }
       return file;
     } catch (err: any) {
       // Catch "file not found" errors (ENOENT)
@@ -295,10 +296,10 @@ export const loadPrivacyCenterEnvironment =
       );
     }
     // DEFER: Log a version number here (see https://github.com/ethyca/fides/issues/3171)
-    // TODO: switch to debugLog in this file
-    if (process.env.NODE_ENV === "development") {
-      console.log("Load Privacy Center environment for session...");
-    }
+    // TODO: switch to debugLog in this file and reduce verbosity
+    // if (process.env.NODE_ENV === "development") {
+    //   console.log("Load Privacy Center environment for session...");
+    // }
 
     // Load environment variables
     const settings: PrivacyCenterSettings = {

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -295,6 +295,7 @@ export const loadPrivacyCenterEnvironment =
       );
     }
     // DEFER: Log a version number here (see https://github.com/ethyca/fides/issues/3171)
+    // TODO: switch to debugLog in this file
     if (process.env.NODE_ENV === "development") {
       console.log("Load Privacy Center environment for session...");
     }

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -9,8 +9,8 @@ const VALID_ISO_3166_LOCATION_REGEX = /^\w{2,3}(-\w{2,3})?$/;
 
 // Constants for the supported CloudFront geolocation headers
 // (see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/adding-cloudfront-headers.html#cloudfront-headers-viewer-location)
-const CLOUDFRONT_HEADER_COUNTRY = "cloudfront-viewer-country";
-const CLOUDFRONT_HEADER_REGION = "cloudfront-viewer-country-region";
+export const CLOUDFRONT_HEADER_COUNTRY = "cloudfront-viewer-country";
+export const CLOUDFRONT_HEADER_REGION = "cloudfront-viewer-country-region";
 export const LOCATION_HEADERS = [
   CLOUDFRONT_HEADER_COUNTRY,
   CLOUDFRONT_HEADER_REGION,

--- a/clients/privacy-center/common/logger.ts
+++ b/clients/privacy-center/common/logger.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { PrivacyCenterEnvironment } from "~/app/server-environment";
 import {
   CLOUDFRONT_HEADER_COUNTRY,
   CLOUDFRONT_HEADER_REGION,
@@ -14,7 +15,9 @@ export function debugLog(
   message: string,
   context: { req?: NextApiRequest; res?: NextApiResponse; [key: string]: any }
 ) {
-  if (process.env.NODE_ENV === "development") {
+  // TODO: ensure this LOG_LEVEL env var is forwards-compatible with a real logger
+  // TODO: load this LOG_LEVEL env var through a server-environment helper
+  if (process.env.FIDES_PRIVACY_CENTER__LOG_LEVEL === "DEBUG") {
     // NOTE: in a real JSON logger, we wouldn't stringify this ourselves ;)
     const { req, res, ...other } = context;
     let log: any = {

--- a/clients/privacy-center/common/logger.ts
+++ b/clients/privacy-center/common/logger.ts
@@ -1,6 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import type { PrivacyCenterEnvironment } from "~/app/server-environment";
 import {
   CLOUDFRONT_HEADER_COUNTRY,
   CLOUDFRONT_HEADER_REGION,

--- a/clients/privacy-center/common/logger.ts
+++ b/clients/privacy-center/common/logger.ts
@@ -1,0 +1,56 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import {
+  CLOUDFRONT_HEADER_COUNTRY,
+  CLOUDFRONT_HEADER_REGION,
+} from "~/common/geolocation";
+
+/**
+ * Implements a basic wrapper around the Console module for *semi*-structured
+ * logging from Privacy Center. This is designed to be easily replaced by a real
+ * logger like `pino`.
+ */
+export function debugLog(
+  message: string,
+  context: { req?: NextApiRequest; res?: NextApiResponse; [key: string]: any }
+) {
+  if (process.env.NODE_ENV === "development") {
+    // NOTE: in a real JSON logger, we wouldn't stringify this ourselves ;)
+    const { req, res, ...other } = context;
+    let log: any = {
+      level: 10, // 10 === DEBUG-level log in most frameworks (Pino, Python, etc.)
+      msg: message,
+    };
+    // Add Request context
+    if (req) {
+      log = {
+        ...log,
+        method: req.method,
+        query: req.query,
+        [`headers[${CLOUDFRONT_HEADER_COUNTRY}]`]:
+          req.headers[CLOUDFRONT_HEADER_COUNTRY] || "",
+        [`headers[${CLOUDFRONT_HEADER_REGION}]`]:
+          req.headers[CLOUDFRONT_HEADER_REGION] || "",
+      };
+    }
+    // Add Response context
+    if (res) {
+      log = {
+        ...log,
+        statusCode: res.statusCode,
+      };
+    }
+    // Add custom context
+    if (other) {
+      log = {
+        ...log,
+        ...other,
+      };
+    }
+    // Write the log as a JSON string
+    // eslint-disable-next-line no-console
+    // console.log(JSON.stringify(log));
+    // eslint-disable-next-line no-console
+    console.log(log);
+  }
+}

--- a/clients/privacy-center/common/logger.ts
+++ b/clients/privacy-center/common/logger.ts
@@ -49,8 +49,6 @@ export function debugLog(
     }
     // Write the log as a JSON string
     // eslint-disable-next-line no-console
-    // console.log(JSON.stringify(log));
-    // eslint-disable-next-line no-console
-    console.log(log);
+    console.log(JSON.stringify(log));
   }
 }

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -311,7 +311,7 @@ export default async function handler(
       `/fides.js bundling fides-ext-gpp.js extension (GPP was ${
         forcedGppQuery === "true" ? "forced" : "enabled"
       })...`,
-      { req, res }
+      logContext
     );
     const fidesGPPBuffer = await fsPromises.readFile(
       "public/lib/fides-ext-gpp.js"


### PR DESCRIPTION
### Description Of Changes

TODO: describe me!


### Code Changes

* [X] Add `debugLog` helper to privacy-center project, as a stepping stone towards real JSON loggers like `pino`
* [X] Add debug logging to /fides.js handler that traces the request handling across the ~12 steps
* [ ] Replace all existing usage of the fides-js `debugLog` import with this privacy-center version
* [ ] Update existing debug logs in server-environment.ts to be less verbose

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
