### PR TITLE
Set Redshift to prefer SSL in generate as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The types of changes are:
 ### Added
 - Added multiple language translations support for privacy center consent page [#4785](https://github.com/ethyca/fides/pull/4785)
 
+### Changed
+- Sets `sslmode` to prefer for Redshift connections when generating datasets [#4849](https://github.com/ethyca/fides/pull/4849)
+
 ## [2.35.0](https://github.com/ethyca/fides/compare/2.34.0...2.35.0)
 
 ### Added

--- a/src/fides/core/utils.py
+++ b/src/fides/core/utils.py
@@ -4,7 +4,7 @@ from hashlib import sha1
 from os import getenv
 from os.path import isfile
 from pathlib import Path
-from typing import Dict, Iterator, List
+from typing import Any, Dict, Iterator, List
 
 import sqlalchemy
 import toml
@@ -36,7 +36,11 @@ def get_db_engine(connection_string: str) -> Engine:
     """
 
     # Pymssql doesn't support this arg
-    connect_args = {"connect_timeout": 10} if "pymssql" not in connection_string else {}
+    connect_args: Dict[str, Any] = (
+        {"connect_timeout": 10} if "pymssql" not in connection_string else {}
+    )
+    if "redshift" in connection_string:
+        connect_args["sslmode"] = "prefer"
     try:
         engine = sqlalchemy.create_engine(connection_string, connect_args=connect_args)
     except Exception as err:


### PR DESCRIPTION
Closes FIDES-665

### Description Of Changes

* Follow on from #4790, sets Redshift SSL to prefer


### Code Changes

* [ ] If the connection string is like redshift, sets `sslmode` to "prefer" instead of "verify-full"

### Steps to Confirm

* [ ] This resolved the issue in #4790

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
