### PR TITLE
Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The types of changes are:
 - Added multiple language translations support for privacy center consent page [#4785](https://github.com/ethyca/fides/pull/4785)
 - Added ability to export the contents of datamap report [#1545](https://ethyca.atlassian.net/browse/PROD-1545)
 
+### Fixed
+- Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions [#4850](https://github.com/ethyca/fides/pull/4850)
+
 ## [2.35.0](https://github.com/ethyca/fides/compare/2.34.0...2.35.0)
 
 ### Added

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -238,10 +238,6 @@ div#fides-banner-description {
   flex: 1;
 }
 
-div.fides-html-description {
-  white-space: normal;
-}
-
 div#fides-button-group {
   margin-top: 8px;
   margin-bottom: var(--fides-overlay-padding);

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -289,16 +289,9 @@ describe("Consent overlay", () => {
             options: Partial<FidesInitOptions> = {}
           ) => {
             const HTMLDescription = `
-            <p>
-              This test is overriding the <pre>experience_config.description</pre> with
-              an <strong>HTML</strong> description, which is used to allow users to configure
-              banners with <a href='https://example.com'>clickable links</a> and...
-            </p>
-            <p>
-              ...multiple paragraphs with ease. However, it's not enabled by default unless
-              the <pre>options.allowHTMLDescription</pre> flag is <pre>true</pre> to reduce
-              the likelihood of XSS attacks.
-            </p>
+            This test is overriding the <pre>experience_config.description</pre> with a <strong>HTML</strong> description, which is used to allow users to configure banners with <a href='https://example.com'>clickable links</a> and...
+
+            ...multiple paragraphs with ease. However, it's not enabled by default unless the <pre>options.allowHTMLDescription</pre> flag is <pre>true</pre> to reduce the likelihood of XSS attacks.
             `;
             cy.fixture("consent/fidesjs_options_banner_modal.json").then(
               (config) => {


### PR DESCRIPTION
### Description Of Changes

This removes a tiny little CSS override when using HTML descriptions in FidesJS components. The net result is that, by default, FidesJS is going to treat whitespace as significant when provided by the Admin UI forms, which is just more intuitive for end-users: we implicitly want to write paragraphs of text with newlines, etc.

This'll make it easier to support a real rich text editor in the future, too, by not rendering our plaintext/richtext descriptions with slightly different CSS rules. 

FYI: I was the one that put this CSS rule there in the first place, because I thought (incorrectly!) that this would be a safer default for HTML descriptions, but that's just hogwash and I see the error of my ways now.

I checked to ensure that all existing usage of HTML descriptions is unaffected by this change, so let's do this now before it would actually break something!

### Code Changes

* [X] Remove extra `.fides-html-description` CSS

### Steps to Confirm

Run the Cypress tests to take a look at how we style the same example HTML description with/without HTML support enabled...

| Plaintext | Richtext |
|---|---|
| ![image](https://github.com/ethyca/fides/assets/1834295/e1b39242-1610-43e9-9626-830458192ec8) | ![image](https://github.com/ethyca/fides/assets/1834295/1092200d-847e-40c3-9562-a1b05eef3eb4) |

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [X] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [X] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
