### PR TITLE
Search for both email and user_id to get a segment_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The types of changes are:
 ### Added
 - Added multiple language translations support for privacy center consent page [#4785](https://github.com/ethyca/fides/pull/4785)
 
+### Changed
+- Included searching by `email` for the Segment integration [#4851](https://github.com/ethyca/fides/pull/4851)
+
 ## [2.35.0](https://github.com/ethyca/fides/compare/2.34.0...2.35.0)
 
 ### Added

--- a/data/saas/config/segment_config.yml
+++ b/data/saas/config/segment_config.yml
@@ -44,35 +44,34 @@ saas_config:
     - name: segment_user
       requests:
         read:
-          method: GET
-          path: /v1/spaces/<namespace_id>/collections/users/profiles/user_id:<user_id>/metadata
-          param_values:
-            - name: namespace_id
-              connector_param: namespace_id
-            - name: user_id
-              identity: email
-          client_config:
-            protocol: https
-            host: <personas_domain>
-            authentication:
-              strategy: basic
-              configuration:
-                username: <access_secret>
-        read:
-          method: GET
-          path: /v1/spaces/<namespace_id>/collections/users/profiles/email:<user_id>/metadata
-          param_values:
-            - name: namespace_id
-              connector_param: namespace_id
-            - name: user_id
-              identity: email
-          client_config:
-            protocol: https
-            host: <personas_domain>
-            authentication:
-              strategy: basic
-              configuration:
-                username: <access_secret>
+          - method: GET
+            path: /v1/spaces/<namespace_id>/collections/users/profiles/user_id:<user_id>/metadata
+            param_values:
+              - name: namespace_id
+                connector_param: namespace_id
+              - name: user_id
+                identity: email
+            client_config:
+              protocol: https
+              host: <personas_domain>
+              authentication:
+                strategy: basic
+                configuration:
+                  username: <access_secret>
+          - method: GET
+            path: /v1/spaces/<namespace_id>/collections/users/profiles/email:<email>/metadata
+            param_values:
+              - name: namespace_id
+                connector_param: namespace_id
+              - name: email
+                identity: email
+            client_config:
+              protocol: https
+              host: <personas_domain>
+              authentication:
+                strategy: basic
+                configuration:
+                  username: <access_secret>
     - name: track_events
       requests:
         read:

--- a/data/saas/config/segment_config.yml
+++ b/data/saas/config/segment_config.yml
@@ -4,7 +4,7 @@ saas_config:
   type: segment
   description: A sample schema representing the Segment connector for Fides
   user_guide: https://docs.ethyca.com/user-guides/integrations/saas-integrations/segment
-  version: 0.0.3
+  version: 0.0.4
 
   connector_params:
     - name: domain
@@ -46,6 +46,21 @@ saas_config:
         read:
           method: GET
           path: /v1/spaces/<namespace_id>/collections/users/profiles/user_id:<user_id>/metadata
+          param_values:
+            - name: namespace_id
+              connector_param: namespace_id
+            - name: user_id
+              identity: email
+          client_config:
+            protocol: https
+            host: <personas_domain>
+            authentication:
+              strategy: basic
+              configuration:
+                username: <access_secret>
+        read:
+          method: GET
+          path: /v1/spaces/<namespace_id>/collections/users/profiles/email:<user_id>/metadata
           param_values:
             - name: namespace_id
               connector_param: namespace_id


### PR DESCRIPTION
Closes INTS-294

### Description Of Changes

Includes the option to also collect the segment ID via `email` instead of the `user_id`

I'm unclear if there is any issue with running dual read requests, assuming the returned values are consolidated if (as in our test case) the segment_id is returned for both


### Code Changes

* [ ] add a read request that also queries the email attribute of a segment user profile

### Steps to Confirm

* [ ] validate the test postman request also returns when querying by email

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
