### PR TITLE
Persist the state of the reporting table so that viewers can return to their previous view easily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The types of changes are:
 - Added access and erasure support for Marigold Engage by Sailthru integration [#4826](https://github.com/ethyca/fides/pull/4826)
 - Added multiple language translations support for privacy center consent page [#4785](https://github.com/ethyca/fides/pull/4785)
 - Added ability to export the contents of datamap report [#1545](https://ethyca.atlassian.net/browse/PROD-1545)
+- Added state persistence across sessions to the datamap report table [#4853](https://github.com/ethyca/fides/pull/4853)
 
 ### Fixed
 - Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions [#4850](https://github.com/ethyca/fides/pull/4850)

--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -82,6 +82,19 @@ describe("Minimal datamap report table", () => {
     cy.getByTestId("datamap-report-heading").should("be.visible");
   });
 
+  it("can group by data use", () => {
+    cy.getByTestId("group-by-menu").should("contain.text", "Group by system");
+    cy.getByTestId("group-by-menu").click();
+    cy.getByTestId("group-by-menu-list").within(() => {
+      cy.getByTestId("group-by-data-use-system").click();
+    });
+    cy.getByTestId("group-by-menu").should("contain.text", "Group by data use");
+
+    // should persist the grouping when navigating away
+    cy.reload();
+    cy.getByTestId("group-by-menu").should("contain.text", "Group by data use");
+  });
+
   describe("Undeclared data category columns", () => {
     it("should have the undeclared data columns disabled by default", () => {
       cy.getByTestId("row-0-col-system_undeclared_data_categories").should(
@@ -98,6 +111,15 @@ describe("Minimal datamap report table", () => {
       cy.contains("div", "Data use undeclared data categories").click();
       cy.getByTestId("save-button").click();
 
+      cy.getByTestId("row-0-col-system_undeclared_data_categories").contains(
+        "2 system undeclared data categories"
+      );
+      cy.getByTestId("row-0-col-data_use_undeclared_data_categories").contains(
+        "2 data use undeclared data categories"
+      );
+
+      // should persist the columns when navigating away
+      cy.reload();
       cy.getByTestId("row-0-col-system_undeclared_data_categories").contains(
         "2 system undeclared data categories"
       );
@@ -125,6 +147,17 @@ describe("Minimal datamap report table", () => {
         cy.get("button").contains("Display all").click();
       });
       ["User Contact Email", "Cookie ID"].forEach((pokemon) => {
+        cy.getByTestId(
+          "row-0-col-data_use_undeclared_data_categories"
+        ).contains(pokemon);
+      });
+
+      // should persist the expanded columns when navigating away
+      cy.reload();
+      ["User Contact Email", "Cookie ID"].forEach((pokemon) => {
+        cy.getByTestId("row-0-col-system_undeclared_data_categories").contains(
+          pokemon
+        );
         cy.getByTestId(
           "row-0-col-data_use_undeclared_data_categories"
         ).contains(pokemon);

--- a/clients/admin-ui/src/features/common/hooks/useLocalStorage.ts
+++ b/clients/admin-ui/src/features/common/hooks/useLocalStorage.ts
@@ -1,0 +1,50 @@
+import { Dispatch, SetStateAction, useState } from "react";
+
+/*
+Design taken from: https://usehooks.com/useLocalStorage/
+*/
+
+// eslint-disable-next-line import/prefer-default-export
+export function useLocalStorage<T = string>(
+  key: string,
+  initialValue: T
+): [T, Dispatch<SetStateAction<T>>] {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      // eslint-disable-next-line no-console
+      console.error(error);
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T | ((x: T) => T)) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+  };
+  return [storedValue, setValue];
+}

--- a/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
@@ -22,11 +22,13 @@ import {
   RowData,
   Table as TableInstance,
 } from "@tanstack/react-table";
-import React, { ReactNode, useMemo, useState } from "react";
+import React, { ReactNode, useMemo } from "react";
 
+import { useLocalStorage } from "~/features/common/hooks/useLocalStorage";
 import { DisplayAllIcon, GroupedIcon } from "~/features/common/Icon";
 import { FidesRow } from "~/features/common/table/v2/FidesRow";
 import { getTableTHandTDStyles } from "~/features/common/table/v2/util";
+import { DATAMAP_LOCAL_STORAGE_KEYS } from "~/features/datamap/constants";
 
 /*
   This was throwing a false positive for unused parameters.
@@ -176,7 +178,10 @@ export const FidesTableV2 = <T,>({
   renderRowTooltipLabel,
   emptyTableNotice,
 }: Props<T>) => {
-  const [displayAllColumns, setDisplayAllColumns] = useState<string[]>([]);
+  const [displayAllColumns, setDisplayAllColumns] = useLocalStorage<string[]>(
+    DATAMAP_LOCAL_STORAGE_KEYS.DISPLAY_ALL_COLUMNS,
+    []
+  );
 
   const handleAddDisplayColumn = (id: string) => {
     setDisplayAllColumns([...displayAllColumns, id]);

--- a/clients/admin-ui/src/features/common/table/v2/column-settings/ColumnSettingsModal.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/column-settings/ColumnSettingsModal.tsx
@@ -30,6 +30,7 @@ type ColumnSettingsModalProps<T> = {
   headerText: string;
   prefixColumns: string[];
   tableInstance: TableInstance<T>;
+  onColumnOrderChange: (columns: string[]) => void;
 };
 
 export const ColumnSettingsModal = <T,>({
@@ -38,6 +39,7 @@ export const ColumnSettingsModal = <T,>({
   headerText,
   tableInstance,
   prefixColumns,
+  onColumnOrderChange,
 }: ColumnSettingsModalProps<T>) => {
   const initialColumns = useMemo(
     () =>
@@ -49,7 +51,23 @@ export const ColumnSettingsModal = <T,>({
           displayText: c.columnDef?.meta?.displayText || c.id,
           isVisible:
             tableInstance.getState().columnVisibility[c.id] ?? c.getIsVisible(),
-        })),
+        }))
+        .sort((a, b) => {
+          // columnOrder is not always a complete list. Sorts by columnOrder but leaves the rest alone
+          const { columnOrder } = tableInstance.getState();
+          const aIndex = columnOrder.indexOf(a.id);
+          const bIndex = columnOrder.indexOf(b.id);
+          if (aIndex === -1 && bIndex === -1) {
+            return 0;
+          }
+          if (aIndex === -1) {
+            return 1;
+          }
+          if (bIndex === -1) {
+            return -1;
+          }
+          return aIndex - bIndex;
+        }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
@@ -58,10 +76,11 @@ export const ColumnSettingsModal = <T,>({
   });
 
   const handleSave = useCallback(() => {
-    tableInstance.setColumnOrder([
+    const newColumnOrder: string[] = [
       ...prefixColumns,
       ...columnEditor.columns.map((c) => c.id),
-    ]);
+    ];
+    onColumnOrderChange(newColumnOrder);
     tableInstance.setColumnVisibility(
       columnEditor.columns.reduce(
         (acc: Record<string, boolean>, current: DraggableColumn) => {
@@ -73,7 +92,13 @@ export const ColumnSettingsModal = <T,>({
       )
     );
     onClose();
-  }, [onClose, prefixColumns, tableInstance, columnEditor.columns]);
+  }, [
+    onClose,
+    prefixColumns,
+    tableInstance,
+    columnEditor.columns,
+    onColumnOrderChange,
+  ]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} isCentered size="2xl">

--- a/clients/admin-ui/src/features/datamap/constants.ts
+++ b/clients/admin-ui/src/features/datamap/constants.ts
@@ -73,3 +73,8 @@ COLUMN_NAME_MAP[SYSTEM_EGRESS] = "Destination Systems";
 // COLUMN_NAME_MAP[] = 'Legal Name & Address'; #new;
 // COLUMN_NAME_MAP[] = 'Privacy Policy'; #new;
 // COLUMN_NAME_MAP[] = 'Data Protection Officer (DPO)'; #new;
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export enum DATAMAP_LOCAL_STORAGE_KEYS {
+  TABLE_STATE = "datamap-report-table-state",
+}

--- a/clients/admin-ui/src/features/datamap/constants.ts
+++ b/clients/admin-ui/src/features/datamap/constants.ts
@@ -76,5 +76,8 @@ COLUMN_NAME_MAP[SYSTEM_EGRESS] = "Destination Systems";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export enum DATAMAP_LOCAL_STORAGE_KEYS {
+  GROUP_BY = "datamap-group-by",
+  COLUMN_ORDER = "datamap-column-order",
+  TABLE_GROUPING = "datamap-table-grouping",
   TABLE_STATE = "datamap-report-table-state",
 }

--- a/clients/admin-ui/src/features/datamap/constants.ts
+++ b/clients/admin-ui/src/features/datamap/constants.ts
@@ -80,4 +80,5 @@ export enum DATAMAP_LOCAL_STORAGE_KEYS {
   COLUMN_ORDER = "datamap-column-order",
   TABLE_GROUPING = "datamap-table-grouping",
   TABLE_STATE = "datamap-report-table-state",
+  DISPLAY_ALL_COLUMNS = "datamap-display-all-columns",
 }

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -1129,16 +1129,18 @@ export const DatamapReportTable = () => {
               spinnerPlacement="end"
               isLoading={groupChangeStarted}
               loadingText={`Group by ${getMenuDisplayValue()}`}
+              data-testid="group-by-menu"
             >
               Group by {getMenuDisplayValue()}
             </MenuButton>
-            <MenuList zIndex={11}>
+            <MenuList zIndex={11} data-testid="group-by-menu-list">
               <MenuItemOption
                 onClick={() => {
                   onGroupChange(DATAMAP_GROUPING.SYSTEM_DATA_USE);
                 }}
                 isChecked={DATAMAP_GROUPING.SYSTEM_DATA_USE === groupBy}
                 value={DATAMAP_GROUPING.SYSTEM_DATA_USE}
+                data-testid="group-by-system-data-use"
               >
                 System
               </MenuItemOption>
@@ -1148,6 +1150,7 @@ export const DatamapReportTable = () => {
                 }}
                 isChecked={DATAMAP_GROUPING.DATA_USE_SYSTEM === groupBy}
                 value={DATAMAP_GROUPING.DATA_USE_SYSTEM}
+                data-testid="group-by-data-use-system"
               >
                 Data use
               </MenuItemOption>


### PR DESCRIPTION
Closes [PROD-1907](https://ethyca.atlassian.net/browse/PROD-1907)

### Description Of Changes

This modifies the existing Data Map Reporting page to keep track of the various states in Local Storage in addition to the react state. This will allow the user to reload the page, or close the page and come back to it, and not need to adjust these settings again.

This includes storing

- The overall "Group by" status
- Each column’s “Group/Display” status
- Each column’s width
- Column visibility
- Column order

### Code Changes

* created a new hook `useLocalStorage` in AdminUI client that is a modified version of the one in FidesJS.
* converted or created state management over to local storage for the following:
```
export enum DATAMAP_LOCAL_STORAGE_KEYS {
  GROUP_BY = "datamap-group-by",
  COLUMN_ORDER = "datamap-column-order",
  TABLE_GROUPING = "datamap-table-grouping",
  TABLE_STATE = "datamap-report-table-state",
  DISPLAY_ALL_COLUMNS = "datamap-display-all-columns",
}
```

Some things needed to be updated to accept initialized values from the storage, since many were just using hard coded defaults:

* Column ordering modal now respects column ordering when initializing
* The `tableInstance` is now initialized using the stored state if there is one.

### Steps to Confirm

1. Visit Data map report page in Admin UI at `/reporting/datamap`
2. Resize a column or two
3. Change the "Group by..." to something different than the default (eg. "Data Use")
4. Open the "Edit Columns" modal and hide a few columns as well as reording a few columns
5. Change one or two of the columns to "Display All" from the heading dropdown menu.
6. Now reload the page and ensure that all of the above changes have been remembered 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[PROD-1907]: https://ethyca.atlassian.net/browse/PROD-1907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ