### PR TITLE
fix mysql service in integration-tests compose

### DIFF
--- a/docker-compose.integration-tests.yml
+++ b/docker-compose.integration-tests.yml
@@ -25,7 +25,7 @@ services:
   mysql-test:
     image: mysql:8
     platform: linux/amd64
-    command: --default-authentication-plugin=mysql_native_password
+    command: --mysql-native-password=ON
     restart: always
     environment:
       - MYSQL_HOST=mysql_example


### PR DESCRIPTION
### Description Of Changes

Follow up to https://github.com/ethyca/fides/pull/4852, missed another reference we had.

### Code Changes

* [x] update deprecated command arg in `docker-compose.integration-tests.yml`

### Steps to Confirm

* [x] CI should pass

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
