### PR TITLE
Update the get_cached_identity_data function to support non-JSON-encoded value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 
 ### Fixed
 - Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions [#4850](https://github.com/ethyca/fides/pull/4850)
+- Fixing issue where privacy requests not approved before upgrading to 2.34 couldn't be processed [#4855](https://github.com/ethyca/fides/pull/4855)
 
 
 ## [2.35.0](https://github.com/ethyca/fides/compare/2.34.0...2.35.0)

--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -624,7 +624,10 @@ class PrivacyRequest(
                     # try parsing the value as JSON
                     parsed_value = json.loads(value)
                 except json.JSONDecodeError:
-                    # if parsing as JSON fails, assume it's a string
+                    # if parsing as JSON fails, assume it's a string.
+                    # this is purely for backward compatibility: to ensure
+                    # that identity data stored pre-2.34.0 in the "old" format 
+                    # can still be correctly retrieved from the cache.
                     parsed_value = value
                 result[key.split("-")[-1]] = parsed_value
         return result

--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -626,7 +626,7 @@ class PrivacyRequest(
                 except json.JSONDecodeError:
                     # if parsing as JSON fails, assume it's a string.
                     # this is purely for backward compatibility: to ensure
-                    # that identity data stored pre-2.34.0 in the "old" format 
+                    # that identity data stored pre-2.34.0 in the "old" format
                     # can still be correctly retrieved from the cache.
                     parsed_value = value
                 result[key.split("-")[-1]] = parsed_value

--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -620,7 +620,13 @@ class PrivacyRequest(
         for key in keys:
             value = cache.get(key)
             if value:
-                result[key.split("-")[-1]] = json.loads(value)
+                try:
+                    # try parsing the value as JSON
+                    parsed_value = json.loads(value)
+                except json.JSONDecodeError:
+                    # if parsing as JSON fails, assume it's a string
+                    parsed_value = value
+                result[key.split("-")[-1]] = parsed_value
         return result
 
     def get_cached_custom_privacy_request_fields(self) -> Dict[str, Any]:


### PR DESCRIPTION
Closes [PROD-2009](https://ethyca.atlassian.net/browse/PROD-2009)

### Description Of Changes

This is a fix for a defect that was introduced with the custom identities feature, specifically [this line](https://github.com/ethyca/fides/pull/4764/files#diff-ef7d3e10be42d5a81721075db1647f7a59ad17ab20b273bfcda1edbcbc8ba391R356). Moving forward, we want to make sure that any non-JSON-encoded values in the cache can still be read. There is no data lost between the two caching methods since we're just formatting the values differently. This means the change can be targeted and everything can continue to work as expected as long as `get_cached_identity_data` returns the expected response.

### Code Changes

* [ ] Updated `get_cached_identity_data` and added a test

### Steps to Confirm

* [ ] This one is tricky to verify since it involves queuing a privacy request pre-2.34, upgrading to 2.34 then approving the request. I just wrote a test to make sure we could reproduce the issue reported in prod and verify the fix.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`

[PROD-2009]: https://ethyca.atlassian.net/browse/PROD-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ