### PR TITLE
Update `getDataDisplayName` to accept levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 
 ### Fixed
 - Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions [#4850](https://github.com/ethyca/fides/pull/4850)
+- Fixed data map report to display second level names from the taxonomy as primary (bold) label [#4856](https://github.com/ethyca/fides/pull/4856)
 
 
 ## [2.35.0](https://github.com/ethyca/fides/compare/2.34.0...2.35.0)

--- a/clients/admin-ui/src/features/common/hooks/useTaxonomies.test.ts
+++ b/clients/admin-ui/src/features/common/hooks/useTaxonomies.test.ts
@@ -42,7 +42,9 @@ describe("Fides Language Helper Hook", () => {
         ReactDomServer.renderToStaticMarkup(
           getDataCategoryDisplayName("system.authentication")
         )
-      ).toBe("<span><strong>System Data:</strong> Authentication Data</span>");
+      ).toBe(
+        "<span><strong>Authentication Data:</strong> Authentication Data</span>"
+      );
     });
     it("returns the key if it can't find the data category", () => {
       expect(getDataCategoryDisplayName("invalidkey")).toBe("invalidkey");

--- a/clients/admin-ui/src/features/common/hooks/useTaxonomies.test.ts
+++ b/clients/admin-ui/src/features/common/hooks/useTaxonomies.test.ts
@@ -30,21 +30,24 @@ describe("Fides Language Helper Hook", () => {
   });
 
   describe("getDataCategoryDisplayName ", () => {
-    it("returns just the data use name in bold if it's a top-level name", () => {
+    it("returns just the data use name in bold if it's a top-level or secondary-level name", () => {
       expect(
         ReactDomServer.renderToStaticMarkup(
           getDataCategoryDisplayName("system")
         )
       ).toBe("<strong>System Data</strong>");
-    });
-    it("returns the top-level parent name in bold and the name if it's a child data category", () => {
       expect(
         ReactDomServer.renderToStaticMarkup(
           getDataCategoryDisplayName("system.authentication")
         )
-      ).toBe(
-        "<span><strong>Authentication Data:</strong> Authentication Data</span>"
-      );
+      ).toBe("<strong>Authentication Data</strong>");
+    });
+    it("returns the top-level parent name in bold and the name if it's a child data category", () => {
+      expect(
+        ReactDomServer.renderToStaticMarkup(
+          getDataCategoryDisplayName("system.authentication.user")
+        )
+      ).toBe("<span><strong>Authentication Data:</strong> User</span>");
     });
     it("returns the key if it can't find the data category", () => {
       expect(getDataCategoryDisplayName("invalidkey")).toBe("invalidkey");
@@ -94,6 +97,11 @@ jest.mock("~/features/taxonomy", () => ({
       fides_key: "system.authentication",
       name: "Authentication Data",
       parent_key: "system",
+    },
+    {
+      fides_key: "system.authentication.user",
+      name: "User",
+      parent_key: "system.authentication",
     },
   ]),
 }));

--- a/clients/admin-ui/src/features/common/hooks/useTaxonomies.tsx
+++ b/clients/admin-ui/src/features/common/hooks/useTaxonomies.tsx
@@ -19,7 +19,11 @@ import {
 const useTaxonomies = () => {
   const { dataUses, dataCategories, dataSubjects, isLoading } = useData();
 
-  const getTopLevelKey = (fidesLangKey: string) => fidesLangKey.split(".")[0];
+  const getPrimaryKey = (fidesLangKey: string, level = 1) => {
+    const delimiter = ".";
+    const tokens = fidesLangKey.split(delimiter).slice(0, level);
+    return tokens.join(delimiter);
+  };
 
   /**
    * getDataDisplayName
@@ -34,7 +38,8 @@ const useTaxonomies = () => {
           parent_key?: string;
           name?: string;
         }
-      | undefined
+      | undefined,
+    primaryLevel = 1
   ): string | ReactNode => {
     const data = getDataFunction(fidesLangKey);
     if (!data) {
@@ -44,38 +49,42 @@ const useTaxonomies = () => {
 
     const isChild = !!data?.parent_key;
     if (!isChild) {
-      return <strong>{data.name}</strong>;
+      // must include a key since this function is used as an iterator
+      return <strong key={fidesLangKey}>{data.name}</strong>;
     }
 
-    const topLevelData = getDataFunction(getTopLevelKey(fidesLangKey));
+    const primaryLevelData = getDataFunction(
+      getPrimaryKey(fidesLangKey, primaryLevel)
+    );
     return (
-      <span>
-        <strong>{topLevelData?.name}:</strong> {data.name}
+      // must include a key since this function is used as an iterator
+      <span key={fidesLangKey}>
+        <strong>{primaryLevelData?.name}:</strong> {data.name}
       </span>
     );
   };
 
-  /* 
-    Data Uses 
+  /*
+    Data Uses
   */
   const getDataUses = () => dataUses;
   const getDataUseByKey = (dataUseKey: string) =>
     find(dataUses, { fides_key: dataUseKey });
 
   const getDataUseDisplayName = (dataUseKey: string): ReactNode =>
-    getDataDisplayName(dataUseKey, getDataUseByKey);
+    getDataDisplayName(dataUseKey, getDataUseByKey, 1);
 
-  /* 
-    Data Categories 
+  /*
+    Data Categories
   */
   const getDataCategories = () => dataCategories;
   const getDataCategoryByKey = (dataCategoryKey: string) =>
     find(dataCategories, { fides_key: dataCategoryKey });
   const getDataCategoryDisplayName = (dataCategoryKey: string): ReactNode =>
-    getDataDisplayName(dataCategoryKey, getDataCategoryByKey);
+    getDataDisplayName(dataCategoryKey, getDataCategoryByKey, 2);
 
-  /* 
-    Data Subjects 
+  /*
+    Data Subjects
   */
   const getDataSubjects = () => dataSubjects;
   const getDataSubjectByKey = (dataSubjectKey: string) =>

--- a/clients/admin-ui/src/features/common/hooks/useTaxonomies.tsx
+++ b/clients/admin-ui/src/features/common/hooks/useTaxonomies.tsx
@@ -47,15 +47,17 @@ const useTaxonomies = () => {
       return fidesLangKey;
     }
 
-    const isChild = !!data?.parent_key;
-    if (!isChild) {
+    const primaryLevelData = getDataFunction(
+      getPrimaryKey(fidesLangKey, primaryLevel)
+    );
+
+    const isChild = !!data.parent_key;
+
+    if (!isChild || primaryLevelData?.name === data.name) {
       // must include a key since this function is used as an iterator
       return <strong key={fidesLangKey}>{data.name}</strong>;
     }
 
-    const primaryLevelData = getDataFunction(
-      getPrimaryKey(fidesLangKey, primaryLevel)
-    );
     return (
       // must include a key since this function is used as an iterator
       <span key={fidesLangKey}>


### PR DESCRIPTION
Closes [PROD-1991](https://ethyca.atlassian.net/browse/PROD-1991)

### Description Of Changes

Update `getDataDisplayName` utility to accept a level to return the primary label. This way we can pass a level 2 to when retrieving categories.

### Steps to Confirm

* Visit Data Map Report table page `/reporting/datamap`
* Expand the Categories column so that all the badges are broken out individually rather than combined
* Note that before this fix, nearly all of them used a generic "User Data" label and now with this fix those primary, bold labels display the secondary level instead.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`


[PROD-1991]: https://ethyca.atlassian.net/browse/PROD-1991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ