### PR TITLE
attempt to only label GVL vendors from compass as such

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 
 ### Fixed
 - Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions [#4850](https://github.com/ethyca/fides/pull/4850)
+- Ensure only GVL vendors from Compass are labeled as such [#4857](https://github.com/ethyca/fides/pull/4857)
 
 
 ## [2.35.0](https://github.com/ethyca/fides/compare/2.34.0...2.35.0)

--- a/clients/admin-ui/src/features/common/helpers.ts
+++ b/clients/admin-ui/src/features/common/helpers.ts
@@ -168,6 +168,13 @@ export const vendorSourceLabels = {
     label: "AC",
     fullName: "Google Additional Consent List",
   },
+  // this is just a generic placeholder/fallback for now
+  // TODO: update this to a proper vendor source once we've
+  // finalized what we are labeling non-GVL/AC compass vendors
+  [VendorSources.COMPASS]: {
+    label: "",
+    fullName: "",
+  },
 };
 
 export const extractVendorSource = (vendorId: string) => {

--- a/clients/admin-ui/src/features/common/helpers.ts
+++ b/clients/admin-ui/src/features/common/helpers.ts
@@ -152,6 +152,11 @@ export const enumToOptions = (e: { [s: number]: string }) =>
 export enum VendorSources {
   GVL = "gvl",
   AC = "gacp",
+
+  // this is just a generic placeholder/fallback for now
+  // TODO: update this to a proper vendor source once we've
+  // finalized what we are labeling non-GVL/AC compass vendors
+  COMPASS = "compass",
 }
 
 export const vendorSourceLabels = {
@@ -170,7 +175,8 @@ export const extractVendorSource = (vendorId: string) => {
   if (source === VendorSources.AC) {
     return VendorSources.AC;
   }
-  else if (source === VendorSources.GVL) {
+  if (source === VendorSources.GVL) {
     return  VendorSources.GVL
   }
+  return VendorSources.COMPASS
 };

--- a/clients/admin-ui/src/features/common/helpers.ts
+++ b/clients/admin-ui/src/features/common/helpers.ts
@@ -170,5 +170,7 @@ export const extractVendorSource = (vendorId: string) => {
   if (source === VendorSources.AC) {
     return VendorSources.AC;
   }
-  return VendorSources.GVL;
+  else if (source === VendorSources.GVL) {
+    return  VendorSources.GVL
+  }
 };

--- a/clients/admin-ui/src/features/common/helpers.ts
+++ b/clients/admin-ui/src/features/common/helpers.ts
@@ -176,7 +176,7 @@ export const extractVendorSource = (vendorId: string) => {
     return VendorSources.AC;
   }
   if (source === VendorSources.GVL) {
-    return  VendorSources.GVL
+    return VendorSources.GVL;
   }
-  return VendorSources.COMPASS
+  return VendorSources.COMPASS;
 };

--- a/clients/admin-ui/src/features/system/add-multiple-systems/MultipleSystemsFilterModal.tsx
+++ b/clients/admin-ui/src/features/system/add-multiple-systems/MultipleSystemsFilterModal.tsx
@@ -66,6 +66,7 @@ type FilterState = {
 const initialFilterState: FilterState = {
   GVL: false,
   AC: false,
+  COMPASS: false,
 };
 
 const MultipleSystemsFilterModal = <T,>({


### PR DESCRIPTION
Closes [PROD-2019](https://ethyca.atlassian.net/browse/PROD-2019)

### Description Of Changes

Updates our determination of vendor source in the FE to more strictly check for a `gvl.` prefix in the `vendor_id`, rather than assuming any non-AC vendors are GVL vendors.


### Code Changes

* [x] tweak logic in `extractVendorSource`

### Steps to Confirm

* [x] locally things _seemed_ good on some smoke testing, but it wasn't a comprehensive check to make sure i didn't break something...
* [ ] i could use some more discerning eyes from a code and functionality perspective!

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated


[PROD-2019]: https://ethyca.atlassian.net/browse/PROD-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ