### PR TITLE
Fix handling of some ISO-3166 geolocation edge cases in Privacy Center /fides.js endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 
 ### Fixed
 - Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions [#4850](https://github.com/ethyca/fides/pull/4850)
+- Fix handling of some ISO-3166 geolocation edge cases in Privacy Center /fides.js endpoint [#4858](https://github.com/ethyca/fides/pull/4858)
 
 
 ## [2.35.0](https://github.com/ethyca/fides/compare/2.34.0...2.35.0)

--- a/clients/fides-js/src/lib/consent-constants.ts
+++ b/clients/fides-js/src/lib/consent-constants.ts
@@ -6,11 +6,11 @@ import {
 } from "./consent-types";
 import { LOCALE_REGEX } from "./i18n/i18n-constants";
 
-// Regex to validate a location string, which must:
-// 1) Start with a 2-3 character country code (e.g. "US")
-// 2) Optionally end with a 2-3 character region code (e.g. "CA")
+// Regex to validate an ISO-3166 location string, which must:
+// 1) Start with a 2-3 letter country code (e.g. "US", "USA", "EEA")
+// 2) Optionally end with a 1-3 alphanumeric character region code (e.g. "CA", "123", "X")
 // 3) Separated by a dash (e.g. "US-CA")
-export const VALID_ISO_3166_LOCATION_REGEX = /^\w{2,3}(-\w{2,3})?$/;
+export const VALID_ISO_3166_LOCATION_REGEX = /^[a-z]{2,3}(-[a-z0-9]{1,3})?$/i;
 
 /**
  * Define the mapping of a FidesOption (e.g. "fides_locale") to a

--- a/clients/privacy-center/__tests__/common/geolocation.test.ts
+++ b/clients/privacy-center/__tests__/common/geolocation.test.ts
@@ -81,23 +81,25 @@ describe("getGeolocation", () => {
         { input: { country: "TR", region: "09" }, expected: "TR-09" },
         { input: { country: "BF", region: "03" }, expected: "BF-03" },
         { input: { country: "CZ", region: "321" }, expected: "CZ-321" },
-      ]
-      return Promise.all(tests.map(async value => {
-        const { input, expected } = value;
-        const req = createRequest({
-          url: "https://privacy.example.com/fides.js",
-          headers: {
-            "CloudFront-Viewer-Country": input.country,
-            "CloudFront-Viewer-Country-Region": input.region,
-          },
-        });
-        const geolocation = await lookupGeolocation(req);
-        expect(geolocation).toEqual({
-          country: input.country,
-          region: input.region,
-          location: expected,
-        });
-      }));
+      ];
+      return Promise.all(
+        tests.map(async (value) => {
+          const { input, expected } = value;
+          const req = createRequest({
+            url: "https://privacy.example.com/fides.js",
+            headers: {
+              "CloudFront-Viewer-Country": input.country,
+              "CloudFront-Viewer-Country-Region": input.region,
+            },
+          });
+          const geolocation = await lookupGeolocation(req);
+          expect(geolocation).toEqual({
+            country: input.country,
+            region: input.region,
+            location: expected,
+          });
+        })
+      );
     });
   });
 
@@ -148,27 +150,53 @@ describe("getGeolocation", () => {
 
     it("handles various ISO-3166 edge cases (numeric regions, single-character codes, etc.)", async () => {
       const tests = [
-        { input: "US", expected: { location: "US", country: "US", region: undefined } },
-        { input: "us", expected: { location: "us", country: "us", region: undefined } },
-        { input: "SE-O", expected: { location: "SE-O", country: "SE", region: "O" } },
-        { input: "gb-eng", expected: { location: "gb-eng", country: "gb", region: "eng" } },
-        { input: "RU-PRI", expected: { location: "RU-PRI", country: "RU", region: "PRI" } },
-        { input: "TR-09", expected: { location: "TR-09", country: "TR", region: "09" } },
-        { input: "BF-03", expected: { location: "BF-03", country: "BF", region: "03" } },
-        { input: "CZ-321", expected: { location: "CZ-321", country: "CZ", region: "321" } },
-      ]
-      return Promise.all(tests.map(async value => {
-        const { input, expected } = value;
-        const req = createRequest({
-          url: `https://privacy.example.com/fides.js?geolocation=${input}`,
-        });
-        const geolocation = await lookupGeolocation(req);
-        expect(geolocation).toEqual({
-          country: expected.country,
-          region: expected.region,
-          location: expected.location,
-        });
-      }));
+        {
+          input: "US",
+          expected: { location: "US", country: "US", region: undefined },
+        },
+        {
+          input: "us",
+          expected: { location: "us", country: "us", region: undefined },
+        },
+        {
+          input: "SE-O",
+          expected: { location: "SE-O", country: "SE", region: "O" },
+        },
+        {
+          input: "gb-eng",
+          expected: { location: "gb-eng", country: "gb", region: "eng" },
+        },
+        {
+          input: "RU-PRI",
+          expected: { location: "RU-PRI", country: "RU", region: "PRI" },
+        },
+        {
+          input: "TR-09",
+          expected: { location: "TR-09", country: "TR", region: "09" },
+        },
+        {
+          input: "BF-03",
+          expected: { location: "BF-03", country: "BF", region: "03" },
+        },
+        {
+          input: "CZ-321",
+          expected: { location: "CZ-321", country: "CZ", region: "321" },
+        },
+      ];
+      return Promise.all(
+        tests.map(async (value) => {
+          const { input, expected } = value;
+          const req = createRequest({
+            url: `https://privacy.example.com/fides.js?geolocation=${input}`,
+          });
+          const geolocation = await lookupGeolocation(req);
+          expect(geolocation).toEqual({
+            country: expected.country,
+            region: expected.region,
+            location: expected.location,
+          });
+        })
+      );
     });
   });
 

--- a/clients/privacy-center/__tests__/common/geolocation.test.ts
+++ b/clients/privacy-center/__tests__/common/geolocation.test.ts
@@ -45,7 +45,7 @@ describe("getGeolocation", () => {
       expect(geolocation).toBeNull();
     });
 
-    it("handles invalid geolocation headers", async () => {
+    it("ignores invalid geolocation headers", async () => {
       const req = createRequest({
         url: "https://privacy.example.com/fides.js",
         headers: {

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -1,11 +1,15 @@
 import type { NextApiRequest } from "next";
 import { UserGeolocation } from "fides-js";
 
-// Regex to validate a location string, which must:
+// Regex to validate an ISO-3166 location string, which must:
 // 1) Start with a 2-3 character country code (e.g. "US")
-// 2) Optionally end with a 2-3 character region code (e.g. "CA")
+// 2) Optionally end with a 1-3 character region code (e.g. "CA")
 // 3) Separated by a dash (e.g. "US-CA")
-const VALID_ISO_3166_LOCATION_REGEX = /^\w{2,3}(-\w{2,3})?$/;
+const VALID_ISO_3166_LOCATION_REGEX = /^\w{2,3}(-\w{1,3})?$/;
+
+// Regex to validate a standalone ISO-3166-2 region code, which must be a 1-3
+// character code (e.g. "CA")
+const VALID_ISO_3166_2_REGION_REGEX = /^\w{1,3}?$/;
 
 // Constants for the supported CloudFront geolocation headers
 // (see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/adding-cloudfront-headers.html#cloudfront-headers-viewer-location)
@@ -50,7 +54,12 @@ export const lookupGeolocation = async (
     geolocation = country;
     if (typeof req.headers[CLOUDFRONT_HEADER_REGION] === "string") {
       [region] = req.headers[CLOUDFRONT_HEADER_REGION].split(",");
-      geolocation = `${country}-${region}`;
+      // Check if the region header is expected; otherwise discard as optional
+      if (VALID_ISO_3166_2_REGION_REGEX.test(region)) {
+        geolocation = `${country}-${region}`;
+      } else {
+        region = undefined;
+      }
     }
     if (VALID_ISO_3166_LOCATION_REGEX.test(geolocation)) {
       return {

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -54,7 +54,7 @@ export const lookupGeolocation = async (
     geolocation = country;
     if (typeof req.headers[CLOUDFRONT_HEADER_REGION] === "string") {
       [region] = req.headers[CLOUDFRONT_HEADER_REGION].split(",");
-      // Check if the region header is expected; otherwise discard as optional
+      // Check if the region header is valid; otherwise discard (it's optional!)
       if (VALID_ISO_3166_2_REGION_REGEX.test(region)) {
         geolocation = `${country}-${region}`;
       } else {

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -2,14 +2,14 @@ import type { NextApiRequest } from "next";
 import { UserGeolocation } from "fides-js";
 
 // Regex to validate an ISO-3166 location string, which must:
-// 1) Start with a 2-3 character country code (e.g. "US")
-// 2) Optionally end with a 1-3 character region code (e.g. "CA")
+// 1) Start with a 2-3 letter country code (e.g. "US", "USA", "EEA")
+// 2) Optionally end with a 1-3 alphanumeric character region code (e.g. "CA", "123", "X")
 // 3) Separated by a dash (e.g. "US-CA")
-const VALID_ISO_3166_LOCATION_REGEX = /^\w{2,3}(-\w{1,3})?$/;
+const VALID_ISO_3166_LOCATION_REGEX = /^[a-z]{2,3}(-[a-z0-9]{1,3})?$/i;
 
 // Regex to validate a standalone ISO-3166-2 region code, which must be a 1-3
-// character code (e.g. "CA")
-const VALID_ISO_3166_2_REGION_REGEX = /^\w{1,3}?$/;
+// alphanumeric character region code (e.g. "CA", "123", "X")
+const VALID_ISO_3166_2_REGION_REGEX = /^[a-z0-9]{1,3}?$/i;
 
 // Constants for the supported CloudFront geolocation headers
 // (see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/adding-cloudfront-headers.html#cloudfront-headers-viewer-location)

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -12,12 +12,8 @@
     <script>
       (function () {
         const tcfEnabled = window.fidesConfig?.options?.tcfEnabled;
-        const VALID_ISO_3166_LOCATION_REGEX = /^\w{2,3}(-\w{2,3})?$/;
         const params = new URLSearchParams(window.location.search);
         const geolocation = params.get("geolocation");
-        if (!VALID_ISO_3166_LOCATION_REGEX.test(geolocation)) {
-          params.delete("geolocation");
-        }
         const src = `/fides.js?e2e=true${tcfEnabled ? "&tcf=true" : ""}${
           !!params.size ? `&${params.toString()}` : ""
         }`;

--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -11,12 +11,8 @@
     -->
     <script>
       (function () {
-        const VALID_ISO_3166_LOCATION_REGEX = /^\w{2,3}(-\w{2,3})?$/;
         const params = new URLSearchParams(window.location.search);
         const geolocation = params.get("geolocation");
-        if (!VALID_ISO_3166_LOCATION_REGEX.test(geolocation)) {
-          params.delete("geolocation");
-        }
         const src = `/fides.js${!!params.size ? `?${params.toString()}` : ""}`;
 
         document.write('<script src="' + src + '"><\/script>');


### PR DESCRIPTION
Closes PROD-2015

### Description Of Changes

This fixes a subtle error where the Privacy Center would consider some valid ISO-3166 codes as invalid if they had single-character regions; for example, `SE-O` would be rejected. The fix here is trivial (accept 1-3 characters!) but this PR also adds additional test coverage for confidence, and also adds an extra defensive check to fallback to just the country header if an invalid CloudFront region header is detected.

### Code Changes

* [X] Update geolocation unit tests
* [X] Fix ISO-3166 regex in `geolocation.ts`
* [X] Discard invalid CloudFront region headers and fallback to country-only

### Steps to Confirm

* [X] Run test suite 👍 

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
