### PR TITLE
Update fides_disable_save_api option in FidesJS SDK to disable both privacy-preferences & notice-served APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 - Added multiple language translations support for privacy center consent page [#4785](https://github.com/ethyca/fides/pull/4785)
 - Added ability to export the contents of datamap report [#1545](https://ethyca.atlassian.net/browse/PROD-1545)
 - Added state persistence across sessions to the datamap report table [#4853](https://github.com/ethyca/fides/pull/4853)
+- Update fides_disable_save_api option in FidesJS SDK to disable both privacy-preferences & notice-served APIs [#4860](https://github.com/ethyca/fides/pull/4860)
 
 ### Fixed
 - Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions [#4850](https://github.com/ethyca/fides/pull/4850)

--- a/clients/fides-js/src/lib/hooks.ts
+++ b/clients/fides-js/src/lib/hooks.ts
@@ -97,15 +97,24 @@ export const useConsentServed = ({
 
   const handleUIEvent = useCallback(
     async (event: FidesEvent) => {
-      // The only time a notices served API call isn't triggered is when
-      // the BANNER is shown or preview mode is enabled. Calls can be triggered for
-      // TCF_BANNER, TCF_OVERLAY, and OVERLAY
+      // Disable the notices-served API if the fides_disable_save_api option is set
+      if (options.fidesDisableSaveApi) {
+        return;
+      }
+
+      // Disable the notices-served API if the serving component is a regular
+      // banner (or unknown!). This means we trigger the API for:
+      // 1) MODAL
+      // 2) TCF_OVERLAY
+      // 3) TCF_BANNER
       if (
         !event.detail.extraDetails ||
         event.detail.extraDetails.servingComponent === ServingComponent.BANNER
       ) {
         return;
       }
+
+      // Construct the notices-served API request and send!
       const request: RecordConsentServedRequest = {
         browser_identity: event.detail.identity,
         privacy_experience_config_history_id:

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -2297,7 +2297,7 @@ describe("Consent overlay", () => {
           privacy_notices: buildMockNotices(),
         },
         options: {
-          fidesDisableSaveApi: false,
+          fidesDisableSaveApi: true,
         },
       });
       cy.waitUntilFidesInitialized().then(() => {

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -1,14 +1,15 @@
 import {
-  ComponentType,
   CONSENT_COOKIE_NAME,
+  ComponentType,
   ConsentMechanism,
   ConsentMethod,
   FidesCookie,
   FidesInitOptions,
+  PrivacyNotice,
+  RecordConsentServedRequest,
   UserConsentPreference,
 } from "fides-js";
 
-import { RecordConsentServedRequest } from "fides-js/src/lib/consent-types";
 import { TEST_OVERRIDE_WINDOW_PATH } from "~/cypress/support/constants";
 
 import {
@@ -2150,40 +2151,44 @@ describe("Consent overlay", () => {
     });
   });
 
-  describe("consent reporting", () => {
+  describe.only("consent reporting", () => {
     const historyId1 = "pri_mock_history_id_1";
     const historyId2 = "pri_mock_history_id_2";
+    const buildMockNotices = (): PrivacyNotice[] => {
+      return [
+        mockPrivacyNotice(
+          {
+            title: "Data Sales and Sharing",
+            id: "pri_notice-data-sales",
+            notice_key: "data_sales_and_sharing",
+          },
+          [
+            mockPrivacyNoticeTranslation({
+              title: "Data Sales and Sharing",
+              privacy_notice_history_id: historyId1,
+            }),
+          ]
+        ),
+        mockPrivacyNotice(
+          {
+            title: "Essential",
+            notice_key: "essential",
+            id: "pri_notice-essential",
+          },
+          [
+            mockPrivacyNoticeTranslation({
+              title: "Essential",
+              privacy_notice_history_id: historyId2,
+            }),
+          ]
+        ),
+      ]
+    };
+
     it("can go through consent reporting flow", () => {
       stubConfig({
         experience: {
-          privacy_notices: [
-            mockPrivacyNotice(
-              {
-                title: "Data Sales and Sharing",
-                id: "pri_notice-mock-1",
-                notice_key: "data_sales_and_sharing",
-              },
-              [
-                mockPrivacyNoticeTranslation({
-                  title: "Data Sales and Sharing",
-                  privacy_notice_history_id: historyId1,
-                }),
-              ]
-            ),
-            mockPrivacyNotice(
-              {
-                title: "Essential",
-                id: "pri_notice-mock-2",
-                notice_key: "essential",
-              },
-              [
-                mockPrivacyNoticeTranslation({
-                  title: "Essential",
-                  privacy_notice_history_id: historyId2,
-                }),
-              ]
-            ),
-          ],
+          privacy_notices: buildMockNotices(),
         },
       });
       cy.get("#fides-modal-link").click();
@@ -2229,38 +2234,16 @@ describe("Consent overlay", () => {
     });
 
     it("can set acknowledge mode to true", () => {
+      const noticeOnlyNotices = buildMockNotices().map(notice => {
+        notice.consent_mechanism
+        return {
+          ...notice,
+          ...{ consent_mechanism: ConsentMechanism.NOTICE_ONLY }
+        }
+      });
       stubConfig({
         experience: {
-          privacy_notices: [
-            mockPrivacyNotice(
-              {
-                title: "Data Sales and Sharing",
-                id: "pri_notice-data-sales",
-                notice_key: "data_sales_and_sharing",
-                consent_mechanism: ConsentMechanism.NOTICE_ONLY,
-              },
-              [
-                mockPrivacyNoticeTranslation({
-                  title: "Data Sales and Sharing",
-                  privacy_notice_history_id: historyId1,
-                }),
-              ]
-            ),
-            mockPrivacyNotice(
-              {
-                title: "Essential",
-                notice_key: "essential",
-                id: "pri_notice-essential",
-                consent_mechanism: ConsentMechanism.NOTICE_ONLY,
-              },
-              [
-                mockPrivacyNoticeTranslation({
-                  title: "Essential",
-                  privacy_notice_history_id: historyId2,
-                }),
-              ]
-            ),
-          ],
+          privacy_notices: noticeOnlyNotices
         },
       });
       cy.get("@FidesUIShown").should("have.been.calledOnce");
@@ -2269,6 +2252,7 @@ describe("Consent overlay", () => {
         expect(interception.request.body.acknowledge_mode).to.eql(true);
       });
     });
+    
     it("can call custom notices served fn instead of Fides API", () => {
       /* eslint-disable @typescript-eslint/no-unused-vars */
       const apiOptions = {
@@ -2279,34 +2263,7 @@ describe("Consent overlay", () => {
       const spyObject = cy.spy(apiOptions, "patchNoticesServedFn");
       stubConfig({
         experience: {
-          privacy_notices: [
-            mockPrivacyNotice(
-              {
-                title: "Data Sales and Sharing",
-                id: "pri_notice-data-sales",
-                notice_key: "data_sales_and_sharing",
-              },
-              [
-                mockPrivacyNoticeTranslation({
-                  title: "Data Sales and Sharing",
-                  privacy_notice_history_id: historyId1,
-                }),
-              ]
-            ),
-            mockPrivacyNotice(
-              {
-                title: "Essential",
-                id: "pri_notice-essential",
-                notice_key: "essential",
-              },
-              [
-                mockPrivacyNoticeTranslation({
-                  title: "Essential",
-                  privacy_notice_history_id: historyId2,
-                }),
-              ]
-            ),
-          ],
+          privacy_notices: buildMockNotices(),
         },
         options: {
           apiOptions,
@@ -2331,6 +2288,50 @@ describe("Consent overlay", () => {
           });
           // check that notices aren't patched to Fides API
           cy.wait("@patchNoticesServed", {
+            requestTimeout: 100,
+          }).then((xhr) => {
+            assert.isNull(xhr?.response?.body);
+          });
+        });
+      });
+    });    
+
+    it("when fides_disable_save_api option is set, disables notices-served & privacy-preferences APIs", () => {
+      stubConfig({
+        experience: {
+          privacy_notices: buildMockNotices(),
+        },
+        options: {
+          fidesDisableSaveApi: false,
+        },
+      });
+      cy.waitUntilFidesInitialized().then(() => {
+        cy.get("@FidesUIShown").should("not.have.been.called");
+        cy.get("#fides-modal-link").click();
+
+        // Check that notices-served API is not called when the modal is shown
+        cy.get("@FidesUIShown").then(() => {
+          cy.on("fail", (error) => {
+            if (error.message.indexOf("Timed out retrying") !== 0) {
+              throw error;
+            }
+          });
+          cy.wait("@patchNoticesServed", {
+            requestTimeout: 100,
+          }).then((xhr) => {
+            assert.isNull(xhr?.response?.body);
+          });
+        });
+
+        // Also, check that privacy-preferences API is not called after saving
+        cy.getByTestId("Save-btn").click();
+        cy.get("@FidesUpdated").then(() => {
+          cy.on("fail", (error) => {
+            if (error.message.indexOf("Timed out retrying") !== 0) {
+              throw error;
+            }
+          });
+          cy.wait("@patchPrivacyPreference", {
             requestTimeout: 100,
           }).then((xhr) => {
             assert.isNull(xhr?.response?.body);

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -2151,39 +2151,37 @@ describe("Consent overlay", () => {
     });
   });
 
-  describe.only("consent reporting", () => {
+  describe("consent reporting APIs (notices-served, privacy-preferences)", () => {
     const historyId1 = "pri_mock_history_id_1";
     const historyId2 = "pri_mock_history_id_2";
-    const buildMockNotices = (): PrivacyNotice[] => {
-      return [
-        mockPrivacyNotice(
-          {
+    const buildMockNotices = (): PrivacyNotice[] => [
+      mockPrivacyNotice(
+        {
+          title: "Data Sales and Sharing",
+          id: "pri_notice-data-sales",
+          notice_key: "data_sales_and_sharing",
+        },
+        [
+          mockPrivacyNoticeTranslation({
             title: "Data Sales and Sharing",
-            id: "pri_notice-data-sales",
-            notice_key: "data_sales_and_sharing",
-          },
-          [
-            mockPrivacyNoticeTranslation({
-              title: "Data Sales and Sharing",
-              privacy_notice_history_id: historyId1,
-            }),
-          ]
-        ),
-        mockPrivacyNotice(
-          {
+            privacy_notice_history_id: historyId1,
+          }),
+        ]
+      ),
+      mockPrivacyNotice(
+        {
+          title: "Essential",
+          notice_key: "essential",
+          id: "pri_notice-essential",
+        },
+        [
+          mockPrivacyNoticeTranslation({
             title: "Essential",
-            notice_key: "essential",
-            id: "pri_notice-essential",
-          },
-          [
-            mockPrivacyNoticeTranslation({
-              title: "Essential",
-              privacy_notice_history_id: historyId2,
-            }),
-          ]
-        ),
-      ]
-    };
+            privacy_notice_history_id: historyId2,
+          }),
+        ]
+      ),
+    ];
 
     it("can go through consent reporting flow", () => {
       stubConfig({
@@ -2234,16 +2232,13 @@ describe("Consent overlay", () => {
     });
 
     it("can set acknowledge mode to true", () => {
-      const noticeOnlyNotices = buildMockNotices().map(notice => {
-        notice.consent_mechanism
-        return {
-          ...notice,
-          ...{ consent_mechanism: ConsentMechanism.NOTICE_ONLY }
-        }
-      });
+      const noticeOnlyNotices = buildMockNotices().map((notice) => ({
+        ...notice,
+        ...{ consent_mechanism: ConsentMechanism.NOTICE_ONLY },
+      }));
       stubConfig({
         experience: {
-          privacy_notices: noticeOnlyNotices
+          privacy_notices: noticeOnlyNotices,
         },
       });
       cy.get("@FidesUIShown").should("have.been.calledOnce");
@@ -2252,7 +2247,7 @@ describe("Consent overlay", () => {
         expect(interception.request.body.acknowledge_mode).to.eql(true);
       });
     });
-    
+
     it("can call custom notices served fn instead of Fides API", () => {
       /* eslint-disable @typescript-eslint/no-unused-vars */
       const apiOptions = {
@@ -2294,7 +2289,7 @@ describe("Consent overlay", () => {
           });
         });
       });
-    });    
+    });
 
     it("when fides_disable_save_api option is set, disables notices-served & privacy-preferences APIs", () => {
       stubConfig({


### PR DESCRIPTION
Closes PROD-2017

### Description Of Changes

This is a small change to make the `fides_disable_save_api` option more consistent; in usage, we expected this to disable all save APIs (both notices-served & privacy-preferences), but as of today only the privacy-preferences API is disabled, which was surprising.

As with a lot of PRs, the majority of the changes here are updating the tests 😄 

### Code Changes

* [X] Update FidesJS to disable calling `notices-served` if `fides_disable_save_api` option is `true`
* [X] Update Cypress tests

### Steps to Confirm

* [X] Run the Cookie House demo locally with `?fides_disable_save_api=true` as a query param
* [X] Check the network tab and observe that `notices-served` and `privacy-preferences` are not called

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
