### PR TITLE
Update changelog for release 2.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,28 +15,33 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fides/compare/2.35.0...main)
+## [Unreleased](https://github.com/ethyca/fides/compare/2.35.1...main)
 
 ### Added
-- Added access and erasure support for Marigold Engage by Sailthru integration [#4826](https://github.com/ethyca/fides/pull/4826)
 - Added multiple language translations support for privacy center consent page [#4785](https://github.com/ethyca/fides/pull/4785)
 - Added ability to export the contents of datamap report [#1545](https://ethyca.atlassian.net/browse/PROD-1545)
 - Added state persistence across sessions to the datamap report table [#4853](https://github.com/ethyca/fides/pull/4853)
-- Update fides_disable_save_api option in FidesJS SDK to disable both privacy-preferences & notice-served APIs [#4860](https://github.com/ethyca/fides/pull/4860)
 
 ### Fixed
 - Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions [#4850](https://github.com/ethyca/fides/pull/4850)
-- Ensure only GVL vendors from Compass are labeled as such [#4857](https://github.com/ethyca/fides/pull/4857)
 - Fixed data map report to display second level names from the taxonomy as primary (bold) label [#4856](https://github.com/ethyca/fides/pull/4856)
-- Fix handling of some ISO-3166 geolocation edge cases in Privacy Center /fides.js endpoint [#4858](https://github.com/ethyca/fides/pull/4858)
+
+## [2.35.1](https://github.com/ethyca/fides/compare/2.35.0...2.35.1)
+
+### Added
+- Added access and erasure support for Marigold Engage by Sailthru integration [#4826](https://github.com/ethyca/fides/pull/4826)
+- Update fides_disable_save_api option in FidesJS SDK to disable both privacy-preferences & notice-served APIs [#4860](https://github.com/ethyca/fides/pull/4860)
+
+### Fixed
 - Fixing issue where privacy requests not approved before upgrading to 2.34 couldn't be processed [#4855](https://github.com/ethyca/fides/pull/4855)
+- Ensure only GVL vendors from Compass are labeled as such [#4857](https://github.com/ethyca/fides/pull/4857)
+- Fix handling of some ISO-3166 geolocation edge cases in Privacy Center /fides.js endpoint [#4858](https://github.com/ethyca/fides/pull/4858)
 
 ### Changed
-- Included searching by `email` for the Segment integration [#4851](https://github.com/ethyca/fides/pull/4851)
 - Hydrates GTM datalayer to match supported FidesEvent Properties [#4847](https://github.com/ethyca/fides/pull/4847)
-
-### Changed
+- Allows a SaaS integration request to process HTTP 204 No Content without erroring trying to unwrap the response. [#4834](https://github.com/ethyca/fides/pull/4834)
 - Sets `sslmode` to prefer for Redshift connections when generating datasets [#4849](https://github.com/ethyca/fides/pull/4849)
+- Included searching by `email` for the Segment integration [#4851](https://github.com/ethyca/fides/pull/4851)
 
 ## [2.35.0](https://github.com/ethyca/fides/compare/2.34.0...2.35.0)
 


### PR DESCRIPTION
### Steps to Confirm

* [ ] check everything is included 
* [Marigold/Sailthru integration](https://github.com/ethyca/fides/pull/4826)
* [Stuck DSRs](https://github.com/ethyca/fides/pull/4855)
* [Update FidesJS' GTM integration](https://github.com/ethyca/fides/pull/4847)
* [Allow 204 error for integrations](https://github.com/ethyca/fides/pull/4834)
* [Redshift SSL part 2](https://github.com/ethyca/fides/pull/4849)
* [Segment integration to use email](https://github.com/ethyca/fides/pull/4851)
* [edit compass/nonGVL vendors](https://github.com/ethyca/fides/pull/4857)
* [geolocation edge cases in Privacy Center](https://github.com/ethyca/fides/pull/4858)
* [fides.js disable save option](https://github.com/ethyca/fides/pull/4860)
* [ ] check spelling and formatting 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
