### PR TITLE
Use CheckboxTree for data map filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The types of changes are:
 - Added ability to export the contents of datamap report [#1545](https://ethyca.atlassian.net/browse/PROD-1545)
 - Added state persistence across sessions to the datamap report table [#4853](https://github.com/ethyca/fides/pull/4853)
 
+### Changed
+- Changed filters on the data map report table to use checkbox collapsible tree view [#4864](https://github.com/ethyca/fides/pull/4864)
+
 ### Fixed
 - Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions [#4850](https://github.com/ethyca/fides/pull/4850)
 - Fixed data map report to display second level names from the taxonomy as primary (bold) label [#4856](https://github.com/ethyca/fides/pull/4856)

--- a/clients/admin-ui/__tests__/features/common-utils.test.ts
+++ b/clients/admin-ui/__tests__/features/common-utils.test.ts
@@ -1,4 +1,7 @@
-import { getFileNameFromContentDisposition } from "~/features/common/utils";
+import {
+  getFileNameFromContentDisposition,
+  getQueryParamsFromArray,
+} from "~/features/common/utils";
 
 describe("common utils", () => {
   describe(getFileNameFromContentDisposition.name, () => {
@@ -10,6 +13,18 @@ describe("common utils", () => {
       const contentDisposition = "attachment; filename=something-special.csv";
       expect(getFileNameFromContentDisposition(contentDisposition)).toEqual(
         "something-special.csv"
+      );
+    });
+  });
+  describe(getQueryParamsFromArray.name, () => {
+    it("should return undefined when strings is empty", () => {
+      expect(getQueryParamsFromArray([], "test")).toBeUndefined();
+    });
+    it("should return query params from strings", () => {
+      const strings = ["a", "b", "c"];
+      const queryParam = "test";
+      expect(getQueryParamsFromArray(strings, queryParam)).toEqual(
+        "test=a&test=b&test=c"
       );
     });
   });

--- a/clients/admin-ui/__tests__/features/common-utils.test.ts
+++ b/clients/admin-ui/__tests__/features/common-utils.test.ts
@@ -21,9 +21,9 @@ describe("common utils", () => {
       expect(getQueryParamsFromArray([], "test")).toBeUndefined();
     });
     it("should return query params from strings", () => {
-      const strings = ["a", "b", "c"];
+      const valueList = ["a", "b", "c"];
       const queryParam = "test";
-      expect(getQueryParamsFromArray(strings, queryParam)).toEqual(
+      expect(getQueryParamsFromArray(valueList, queryParam)).toEqual(
         "test=a&test=b&test=c"
       );
     });

--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -165,6 +165,34 @@ describe("Minimal datamap report table", () => {
     });
   });
 
+  describe("Filtering", () => {
+    it("should filter the table by making a selection", () => {
+      cy.getByTestId("filter-multiple-systems-btn").click();
+      cy.getByTestId("datamap-report-filter-modal").should("be.visible");
+      cy.getByTestId("filter-modal-accordion-button").eq(1).click();
+      cy.getByTestId("filter-modal-checkbox-tree-categories").should(
+        "be.visible"
+      );
+      cy.getByTestId("filter-modal-checkbox-tree-categories")
+        .find("input")
+        .first()
+        .click({ force: true });
+      cy.getByTestId("datamap-report-filter-modal-continue-btn").click();
+      cy.get("@getDatamapMinimal")
+        .its("request.url")
+        .should("include", "data_categories=custom");
+      cy.getByTestId("datamap-report-filter-modal").should("not.exist");
+
+      // should clear the filters
+      cy.getByTestId("filter-multiple-systems-btn").click();
+      cy.getByTestId("datamap-report-filter-modal-cancel-btn").click();
+      cy.getByTestId("datamap-report-filter-modal").should("not.exist");
+      cy.wait("@getDatamapMinimal")
+        .its("request.url")
+        .should("not.include", "data_categories=custom");
+    });
+  });
+
   describe("Exporting", () => {
     it("should open the export modal", () => {
       cy.getByTestId("export-btn").click();

--- a/clients/admin-ui/src/features/common/CheckboxTree.tsx
+++ b/clients/admin-ui/src/features/common/CheckboxTree.tsx
@@ -8,10 +8,10 @@
  */
 
 import {
-  ArrowDownLineIcon,
-  ArrowUpLineIcon,
   Box,
+  BoxProps,
   Checkbox,
+  ChevronDownIcon,
   IconButton,
 } from "@fidesui/react";
 import { Fragment, ReactNode, useEffect, useState } from "react";
@@ -115,16 +115,11 @@ const CheckboxItem = ({
           <IconButton
             data-testid={`expand-${label}`}
             aria-label={isExpanded ? "collapse" : "expand"}
-            icon={
-              isExpanded ? (
-                <ArrowUpLineIcon boxSize={5} />
-              ) : (
-                <ArrowDownLineIcon boxSize={5} />
-              )
-            }
+            icon={<ChevronDownIcon boxSize={5} />}
             variant="ghost"
             onClick={() => onExpanded(node)}
             size="sm"
+            style={{ transform: isExpanded ? "rotate(180deg)" : "" }}
           />
         ) : null}
       </Box>
@@ -133,13 +128,18 @@ const CheckboxItem = ({
   );
 };
 
-interface CheckboxTreeProps {
+interface CheckboxTreeProps extends BoxProps {
   nodes: TreeNode[];
   selected: string[];
   onSelected: (newSelected: string[]) => void;
 }
 
-const CheckboxTree = ({ nodes, selected, onSelected }: CheckboxTreeProps) => {
+const CheckboxTree = ({
+  nodes,
+  selected,
+  onSelected,
+  ...props
+}: CheckboxTreeProps) => {
   const [checked, setChecked] = useState<string[]>([]);
   const [expanded, setExpanded] = useState<string[]>([]);
 
@@ -236,7 +236,7 @@ const CheckboxTree = ({ nodes, selected, onSelected }: CheckboxTreeProps) => {
   };
 
   return (
-    <Box>
+    <Box {...props}>
       {nodes.map((child) => (
         <Box key={child.value}>{createTree(child)}</Box>
       ))}

--- a/clients/admin-ui/src/features/common/CheckboxTree.tsx
+++ b/clients/admin-ui/src/features/common/CheckboxTree.tsx
@@ -98,6 +98,7 @@ const CheckboxItem = ({
         justifyContent="space-between"
         _hover={{ backgroundColor: "gray.100", cursor: "pointer" }}
         onClick={() => onExpanded(node)}
+        minHeight={8}
       >
         <Checkbox
           colorScheme="complimentary"

--- a/clients/admin-ui/src/features/common/modals/FilterModal.tsx
+++ b/clients/admin-ui/src/features/common/modals/FilterModal.tsx
@@ -15,6 +15,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  ModalProps,
   SimpleGrid,
   Text,
 } from "@fidesui/react";
@@ -167,19 +168,17 @@ export const FilterSection = ({ heading, children }: FilterSectionProps) => (
   </Box>
 );
 
-interface FilterModalProps {
-  isOpen: boolean;
-  onClose: () => void;
+export interface FilterModalProps extends ModalProps {
   resetFilters: () => void;
 }
-
-export const FilterModal: React.FC<FilterModalProps> = ({
+export const FilterModal = ({
+  resetFilters,
   isOpen,
   onClose,
   children,
-  resetFilters,
-}) => (
-  <Modal isOpen={isOpen} onClose={onClose} isCentered size="2xl">
+  ...props
+}: FilterModalProps): JSX.Element => (
+  <Modal isOpen={isOpen} onClose={onClose} isCentered size="2xl" {...props}>
     <ModalOverlay />
     <ModalContent>
       <ModalHeader>Filters</ModalHeader>

--- a/clients/admin-ui/src/features/common/table/v2/filters/GlobalFilterV2.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/filters/GlobalFilterV2.tsx
@@ -36,6 +36,7 @@ export const GlobalFilterV2 = ({
         onClear={onClear}
         search={value || ""}
         placeholder={placeholder}
+        data-testid="global-text-filter"
       />
     </Box>
   );

--- a/clients/admin-ui/src/features/common/utils.ts
+++ b/clients/admin-ui/src/features/common/utils.ts
@@ -48,12 +48,24 @@ export const getFileNameFromContentDisposition = (
   return match ? match[1] : defaultName;
 };
 
+/**
+ * Constructs a query string from an array of values.
+ *
+ * @param valueList - An array of string values to be included in the query string.
+ * @param queryParam - The name of the query parameter.
+ * @returns A query string where each value from the array is assigned to the query parameter.
+ * If the array is empty, the function returns undefined.
+ *
+ * @example
+ * getQueryParamsFromArray(['1', '2', '3'], 'id');
+ * // returns 'id=1&id=2&id=3'
+ */
 export const getQueryParamsFromArray = (
-  strings: string[],
+  valueList: string[],
   queryParam: string
 ) => {
-  if (strings.length > 0) {
-    return `${queryParam}=${strings.join(`&${queryParam}=`)}`;
+  if (valueList.length > 0) {
+    return `${queryParam}=${valueList.join(`&${queryParam}=`)}`;
   }
   return undefined;
 };

--- a/clients/admin-ui/src/features/common/utils.ts
+++ b/clients/admin-ui/src/features/common/utils.ts
@@ -47,3 +47,13 @@ export const getFileNameFromContentDisposition = (
   const match = contentDisposition.match(/filename=(.+)/);
   return match ? match[1] : defaultName;
 };
+
+export const getQueryParamsFromArray = (
+  strings: string[],
+  queryParam: string
+) => {
+  if (strings.length > 0) {
+    return `${queryParam}=${strings.join(`&${queryParam}=`)}`;
+  }
+  return undefined;
+};

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -38,7 +38,7 @@ import { useAppSelector } from "~/app/hooks";
 import { useLocalStorage } from "~/features/common/hooks/useLocalStorage";
 import useTaxonomies from "~/features/common/hooks/useTaxonomies";
 import { DownloadLightIcon } from "~/features/common/Icon";
-import { getQueryParamsFromList } from "~/features/common/modals/FilterModal";
+import { getQueryParamsFromArray } from "~/features/common/utils";
 import {
   DATAMAP_LOCAL_STORAGE_KEYS,
   ExportFormat,
@@ -50,7 +50,7 @@ import {
 import ReportExportModal from "~/features/datamap/modals/ReportExportModal";
 import {
   DatamapReportFilterModal,
-  useDatamapReportFilters,
+  DatamapReportFilterSelections,
 } from "~/features/datamap/reporting/DatamapReportFilterModal";
 import {
   selectAllCustomFieldDefinitions,
@@ -223,17 +223,10 @@ export const DatamapReportTable = () => {
   } = useServerSidePagination();
 
   const {
-    isOpen,
-    onClose,
-    onOpen,
-    resetFilters,
-    dataUseOptions,
-    onDataUseChange,
-    dataCategoriesOptions,
-    onDataCategoriesChange,
-    dataSubjectOptions,
-    onDataSubjectChange,
-  } = useDatamapReportFilters();
+    isOpen: isFilterModalOpen,
+    onClose: onFilterModalClose,
+    onOpen: onFilterModalOpen,
+  } = useDisclosure();
 
   const {
     getDataUseDisplayName,
@@ -242,20 +235,12 @@ export const DatamapReportTable = () => {
     isLoading: isLoadingFidesLang,
   } = useTaxonomies();
 
-  const selectedDataUseFilters = useMemo(
-    () => getQueryParamsFromList(dataUseOptions, "data_uses"),
-    [dataUseOptions]
-  );
-
-  const selectedDataCategoriesFilters = useMemo(
-    () => getQueryParamsFromList(dataCategoriesOptions, "data_categories"),
-    [dataCategoriesOptions]
-  );
-
-  const selectedDataSubjectFilters = useMemo(
-    () => getQueryParamsFromList(dataSubjectOptions, "data_subjects"),
-    [dataSubjectOptions]
-  );
+  const [selectedDataUseFilters, setSelectedDataUseFilters] =
+    useState<string>();
+  const [selectedDataCategoriesFilters, setSelectedDataCategoriesFilters] =
+    useState<string>();
+  const [selectedDataSubjectFilters, setSelectedDataSubjectFilters] =
+    useState<string>();
 
   const [groupChangeStarted, setGroupChangeStarted] = useState<boolean>(false);
   const [globalFilter, setGlobalFilter] = useState<string>("");
@@ -1076,6 +1061,18 @@ export const DatamapReportTable = () => {
     return <TableSkeletonLoader rowHeight={36} numRows={15} />;
   }
 
+  const handleFilterChange = (newFilters: DatamapReportFilterSelections) => {
+    setSelectedDataUseFilters(
+      getQueryParamsFromArray(newFilters.dataUses, "data_uses")
+    );
+    setSelectedDataCategoriesFilters(
+      getQueryParamsFromArray(newFilters.dataCategories, "data_categories")
+    );
+    setSelectedDataSubjectFilters(
+      getQueryParamsFromArray(newFilters.dataSubjects, "data_subjects")
+    );
+  };
+
   return (
     <Flex flex={1} direction="column" overflow="auto">
       <Heading
@@ -1087,15 +1084,9 @@ export const DatamapReportTable = () => {
         Data map report
       </Heading>
       <DatamapReportFilterModal
-        isOpen={isOpen}
-        onClose={onClose}
-        resetFilters={resetFilters}
-        dataUseOptions={dataUseOptions}
-        onDataUseChange={onDataUseChange}
-        dataCategoriesOptions={dataCategoriesOptions}
-        onDataCategoriesChange={onDataCategoriesChange}
-        dataSubjectOptions={dataSubjectOptions}
-        onDataSubjectChange={onDataSubjectChange}
+        isOpen={isFilterModalOpen}
+        onClose={onFilterModalClose}
+        onFilterChange={handleFilterChange}
       />
       <ColumnSettingsModal<DatamapReport>
         isOpen={isColumnSettingsOpen}
@@ -1168,7 +1159,7 @@ export const DatamapReportTable = () => {
             data-testid="filter-multiple-systems-btn"
             size="xs"
             variant="outline"
-            onClick={onOpen}
+            onClick={onFilterModalOpen}
           >
             Filter
           </Button>


### PR DESCRIPTION
Closes [PROD-1916](https://ethyca.atlassian.net/browse/PROD-1916)

### Description Of Changes

Update the filters on the table to apply a modified version of the hierarchy component that we are using on the dataset page. 

### Code Changes

* New `DatamapReportFilterModal` which reduces a lot of over-engineered complexity and implements the `CheckboxTree` component
* Update old `getQueryParamsFromList` as new `getQueryParamsFromArray` utility
* Update checkbox tree to have animated caret similar to accordion.
* Unit test and e2e test

### Steps to Confirm

* visit Data Map Report `/reporting/datamap`
* click the "Filter" button in the top bar
* expand one of the 3 categories
* Note the new style for checking boxes uses our existing tree component rather than just a flat list of check boxes within each of the 3 main sections
* Expand/collapse and click around.
* When desired filter is selected, click the "Done" button. This will apply the filter to the table.
* Open the filter modal again using the "Filter" button.
* Click the "Reset filters" button which will clear all filters.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[PROD-1916]: https://ethyca.atlassian.net/browse/PROD-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ