### PR TITLE
add virtual env step to readme quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,15 @@ In order to get started quickly with Fides, a sample project is bundled within t
 
 You can easily download and install Fides using `pip`. Run the following command to get started:
 
+> :blue_book: Good Idea
+>
+> We highly recommend installing into a virtual environment such as venv, and we include those steps below as well as on our [docs site](https://ethyca.com/docs/dev-docs/cli/fides-cloud/connecting-cli-to-fides-cloud#create-and-use-a-new-python-virtual-environment)
+
 ```sh
+mkdir ~/fides
+cd ~/fides
+python3 -m venv venv
+source venv/bin/activate
 pip install ethyca-fides
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,16 +29,19 @@ In order to get started quickly with Fides, a sample project is bundled within t
 
 #### Download and install Fides
 
-You can easily download and install Fides using `pip`. Run the following command to get started:
-
 > [!TIP]
-> We highly recommend installing into a virtual environment such as venv, and we include those steps below as well as on our [docs site](https://ethyca.com/docs/dev-docs/cli/fides-cloud/connecting-cli-to-fides-cloud#create-and-use-a-new-python-virtual-environment)
+> We highly recommend setting up a Python virtual environment such as `venv` to install Fides into. For example:
+> 
+> ```sh
+> mkdir ~/fides
+> cd ~/fides
+> python3 -m venv venv
+> source venv/bin/activate
+> ```
 
-```sh
-mkdir ~/fides
-cd ~/fides
-python3 -m venv venv
-source venv/bin/activate
+Once your virtual environment is ready, you can easily download and install Fides using `pip`. Run the following command to get started:
+
+```
 pip install ethyca-fides
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ In order to get started quickly with Fides, a sample project is bundled within t
 
 You can easily download and install Fides using `pip`. Run the following command to get started:
 
-> :blue_book: Good Idea
->
+> [!TIP]
 > We highly recommend installing into a virtual environment such as venv, and we include those steps below as well as on our [docs site](https://ethyca.com/docs/dev-docs/cli/fides-cloud/connecting-cli-to-fides-cloud#create-and-use-a-new-python-virtual-environment)
 
 ```sh


### PR DESCRIPTION
Closes n/a

### Description Of Changes

Taking some lessons learned and being more explicit about using a virtual environment when installing fides locally

View the formatted output here -> https://github.com/ethyca/fides/blob/d99cb8b236aa5a793273fb18a862b83840b6a1ef/README.md#download-and-install-fides

### Code Changes

* [ ] Adds steps for using a virtual env when doing the quickstart

### Steps to Confirm

* [ ] Run the quickstart

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
