### PR TITLE
PROD-2002: Adds new var to track fides js overlay types

### DIFF
--- a/src/fides/api/models/privacy_experience.py
+++ b/src/fides/api/models/privacy_experience.py
@@ -44,6 +44,13 @@ FidesJSUXTypes: List[ComponentType] = [
     ComponentType.modal,
 ]
 
+# Fides JS Overlay Types - there should only be one of these defined per region + property
+FidesJSOverlayTypes: List[ComponentType] = [
+    ComponentType.banner_and_modal,
+    ComponentType.modal,
+    ComponentType.tcf_overlay
+]
+
 
 class PrivacyExperienceConfigBase:
     """


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-2002

### Description Of Changes

Adds new type to track fides js overlay types which is needed for fidesplus portion of this work


### Code Changes

* [ ] Adds new var we can use in fidesplus repo

### Steps to Confirm

* [ ] No functionality changes here. Please test fidesplus PR which has been pointed to this feat branch.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
