### PR TITLE
Include `gpp` in fides-js docs

### DIFF
--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -55,7 +55,7 @@ let autoRefresh: boolean = true;
  *       - in: query
  *         name: gpp
  *         required: false
- *         description: Forces the GPP extension to be included in the bundle if the experience has GPP enabled
+ *         description: Forces the GPP extension to be included in the bundle, even if the experience does not have GPP enabled
  *         schema:
  *           type: boolean
  *       - in: header

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -52,6 +52,12 @@ let autoRefresh: boolean = true;
  *         description: Signals fides.js to use the latest custom-fides.css (if available)
  *         schema:
  *           type: boolean
+ *       - in: query
+ *         name: gpp
+ *         required: false
+ *         description: Forces the GPP extension to be included in the bundle if the experience has GPP enabled
+ *         schema:
+ *           type: boolean
  *       - in: header
  *         name: CloudFront-Viewer-Country
  *         required: false


### PR DESCRIPTION
Closes [PROD-2026](https://ethyca.atlassian.net/browse/PROD-2026)

### Description Of Changes

Document support for `gpp` query param in fides.js api docs

### Steps to Confirm

See the update on http://localhost:3000/docs

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met


[PROD-2026]: https://ethyca.atlassian.net/browse/PROD-2026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ