### PR TITLE
Ignore invalid three-character country codes for FidesJS geolocation (e.g. "USA")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The types of changes are:
 ### Fixed
 - Remove the extra 'white-space: normal' CSS for FidesJS HTML descriptions [#4850](https://github.com/ethyca/fides/pull/4850)
 - Fixed data map report to display second level names from the taxonomy as primary (bold) label [#4856](https://github.com/ethyca/fides/pull/4856)
+- Ignore invalid three-character country codes for FidesJS geolocation (e.g. "USA") [#4877](https://github.com/ethyca/fides/pull/4877)
 
 ### Developer Experience
 - Update typedoc-plugin-markdown to 4.0.0 [#4870](https://github.com/ethyca/fides/pull/4870)

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -195,10 +195,6 @@ div#fides-banner-inner-container {
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-column-gap: 60px;
-
-  .fides-acknowledge-button-container {
-    margin-bottom: 0px;
-  }
 }
 
 div#fides-banner-inner-description {

--- a/clients/fides-js/src/lib/consent-constants.ts
+++ b/clients/fides-js/src/lib/consent-constants.ts
@@ -6,11 +6,18 @@ import {
 } from "./consent-types";
 import { LOCALE_REGEX } from "./i18n/i18n-constants";
 
-// Regex to validate an ISO-3166 location string, which must:
-// 1) Start with a 2-3 letter country code (e.g. "US", "USA", "EEA")
-// 2) Optionally end with a 1-3 alphanumeric character region code (e.g. "CA", "123", "X")
-// 3) Separated by a dash (e.g. "US-CA")
-export const VALID_ISO_3166_LOCATION_REGEX = /^[a-z]{2,3}(-[a-z0-9]{1,3})?$/i;
+/**
+ * Regex to validate a [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code:
+ * 1. Starts with a 2 letter country code (e.g. "US", "GB") (see [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2))
+ * 2. (Optional) Ends with a 1-3 alphanumeric character region code (e.g. "CA", "123", "X") (see [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2))
+ * 3. Country & region codes must be separated by a hyphen (e.g. "US-CA")
+ *
+ * Fides also supports a special `EEA` geolocation code to denote the European
+ * Economic Area; this is not part of ISO 3166-2, but is supported for
+ * convenience.
+ */
+export const VALID_ISO_3166_LOCATION_REGEX =
+  /^(?:([a-z]{2})(-[a-z0-9]{1,3})?|(eea))$/i;
 
 /**
  * Define the mapping of a FidesOption (e.g. "fides_locale") to a

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -101,8 +101,6 @@ export const constructFidesRegionString = (
   if (geoLocation.country && geoLocation.region) {
     return `${geoLocation.country.toLowerCase()}_${geoLocation.region.toLowerCase()}`;
   }
-  // DEFER: return geoLocation.country when BE supports filtering by just country
-  // see https://github.com/ethyca/fides/issues/3300
   debugLog(
     debug,
     "cannot construct user location from provided geoLocation params..."

--- a/clients/privacy-center/__tests__/common/geolocation.test.ts
+++ b/clients/privacy-center/__tests__/common/geolocation.test.ts
@@ -155,7 +155,7 @@ describe("getGeolocation", () => {
 
     it("supports the special 'EEA' code in geolocation query param", async () => {
       const req = createRequest({
-        url: "https://privacy.example.com/fides.js?geolocation=EEA"
+        url: "https://privacy.example.com/fides.js?geolocation=EEA",
       });
       const geolocation = await lookupGeolocation(req);
       expect(geolocation).toEqual({

--- a/clients/privacy-center/__tests__/common/geolocation.test.ts
+++ b/clients/privacy-center/__tests__/common/geolocation.test.ts
@@ -183,11 +183,10 @@ describe("getGeolocation", () => {
     });
 
     it("ignores invalid three-character country codes in geolocation query param", async () => {
-      let req, geolocation;
-      req = createRequest({
+      let req = createRequest({
         url: "https://privacy.example.com/fides.js?geolocation=USA",
       });
-      geolocation = await lookupGeolocation(req);
+      let geolocation = await lookupGeolocation(req);
       expect(geolocation).toBeNull();
 
       // Test again including a (seemingly valid!) region

--- a/clients/privacy-center/__tests__/common/geolocation.test.ts
+++ b/clients/privacy-center/__tests__/common/geolocation.test.ts
@@ -71,13 +71,23 @@ describe("getGeolocation", () => {
     });
 
     it("ignores invalid three-character country geolocation headers", async () => {
-      const req = createRequest({
+      let req = createRequest({
         url: "https://privacy.example.com/fides.js",
         headers: {
           "CloudFront-Viewer-Country": "USA",
         },
       });
-      const geolocation = await lookupGeolocation(req);
+      let geolocation = await lookupGeolocation(req);
+      expect(geolocation).toBeNull();
+
+      // Test again including a (seemingly valid!) region
+      req = createRequest({
+        url: "https://privacy.example.com/fides.js",
+        headers: {
+          "CloudFront-Viewer-Country": "USA-NY",
+        },
+      });
+      geolocation = await lookupGeolocation(req);
       expect(geolocation).toBeNull();
     });
 
@@ -173,10 +183,18 @@ describe("getGeolocation", () => {
     });
 
     it("ignores invalid three-character country codes in geolocation query param", async () => {
-      const req = createRequest({
+      let req, geolocation;
+      req = createRequest({
         url: "https://privacy.example.com/fides.js?geolocation=USA",
       });
-      const geolocation = await lookupGeolocation(req);
+      geolocation = await lookupGeolocation(req);
+      expect(geolocation).toBeNull();
+
+      // Test again including a (seemingly valid!) region
+      req = createRequest({
+        url: "https://privacy.example.com/fides.js?geolocation=USA-NY",
+      });
+      geolocation = await lookupGeolocation(req);
       expect(geolocation).toBeNull();
     });
 

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -11,8 +11,7 @@ import { UserGeolocation } from "fides-js";
  * Economic Area; this is not part of ISO 3166-2, but is supported for
  * convenience.
  */
-// TODO: EEA
- const VALID_ISO_3166_LOCATION_REGEX = /^[a-z]{2}(-[a-z0-9]{1,3})?$/i;
+ const VALID_ISO_3166_LOCATION_REGEX = /^(?:([a-z]{2})(-[a-z0-9]{1,3})?|(eea))$/i;
 
 // Regex to validate a standalone ISO-3166-2 region code, which must be a 1-3
 // alphanumeric character region code (e.g. "CA", "123", "X")

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -1,11 +1,18 @@
 import type { NextApiRequest } from "next";
 import { UserGeolocation } from "fides-js";
 
-// Regex to validate an ISO-3166 location string, which must:
-// 1) Start with a 2-3 letter country code (e.g. "US", "USA", "EEA")
-// 2) Optionally end with a 1-3 alphanumeric character region code (e.g. "CA", "123", "X")
-// 3) Separated by a dash (e.g. "US-CA")
-const VALID_ISO_3166_LOCATION_REGEX = /^[a-z]{2,3}(-[a-z0-9]{1,3})?$/i;
+/**
+ * Regex to validate a [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code:
+ * 1. Starts with a 2 letter country code (e.g. "US", "GB") (see [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2))
+ * 2. (Optional) Ends with a 1-3 alphanumeric character region code (e.g. "CA", "123", "X") (see [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2))
+ * 3. Country & region codes must be separated by a hyphen (e.g. "US-CA")
+ * 
+ * Fides also supports a special `EEA` geolocation code to denote the European
+ * Economic Area; this is not part of ISO 3166-2, but is supported for
+ * convenience.
+ */
+// TODO: EEA
+ const VALID_ISO_3166_LOCATION_REGEX = /^[a-z]{2}(-[a-z0-9]{1,3})?$/i;
 
 // Regex to validate a standalone ISO-3166-2 region code, which must be a 1-3
 // alphanumeric character region code (e.g. "CA", "123", "X")

--- a/clients/privacy-center/common/geolocation.ts
+++ b/clients/privacy-center/common/geolocation.ts
@@ -6,12 +6,13 @@ import { UserGeolocation } from "fides-js";
  * 1. Starts with a 2 letter country code (e.g. "US", "GB") (see [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2))
  * 2. (Optional) Ends with a 1-3 alphanumeric character region code (e.g. "CA", "123", "X") (see [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2))
  * 3. Country & region codes must be separated by a hyphen (e.g. "US-CA")
- * 
+ *
  * Fides also supports a special `EEA` geolocation code to denote the European
  * Economic Area; this is not part of ISO 3166-2, but is supported for
  * convenience.
  */
- const VALID_ISO_3166_LOCATION_REGEX = /^(?:([a-z]{2})(-[a-z0-9]{1,3})?|(eea))$/i;
+const VALID_ISO_3166_LOCATION_REGEX =
+  /^(?:([a-z]{2})(-[a-z0-9]{1,3})?|(eea))$/i;
 
 // Regex to validate a standalone ISO-3166-2 region code, which must be a 1-3
 // alphanumeric character region code (e.g. "CA", "123", "X")

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -41,7 +41,7 @@ let autoRefresh: boolean = true;
  *           1. Starts with a 2 letter country code (e.g. "US", "GB") (see [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2))
  *           2. (Optional) Ends with a 1-3 alphanumeric character region code (e.g. "CA", "123", "X") (see [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2))
  *           3. Country & region codes must be separated by a hyphen (e.g. "US-CA")
- * 
+ *
  *           Fides also supports a special `EEA` geolocation code to denote the European Economic Area; this is not part of ISO 3166-2, but is supported for convenience.
  *         schema:
  *           type: string

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -36,7 +36,13 @@ let autoRefresh: boolean = true;
  *       - in: query
  *         name: geolocation
  *         required: false
- *         description: Geolocation string to inject into the bundle (e.g. "US-CA"), containing ISO 3166 country code (e.g. "US") and optional region code (e.g. "CA"), separated by a "-"
+ *         description: |
+ *           Override FidesJS to use a specific geolocation by providing a valid [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code:
+ *           1. Starts with a 2 letter country code (e.g. "US", "GB") (see [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2))
+ *           2. (Optional) Ends with a 1-3 alphanumeric character region code (e.g. "CA", "123", "X") (see [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2))
+ *           3. Country & region codes must be separated by a hyphen (e.g. "US-CA")
+ * 
+ *           Fides also supports a special `EEA` geolocation code to denote the European Economic Area; this is not part of ISO 3166-2, but is supported for convenience.
  *         schema:
  *           type: string
  *         example: US-CA
@@ -52,6 +58,7 @@ let autoRefresh: boolean = true;
  *         description: Signals fides.js to use the latest custom-fides.css (if available)
  *         schema:
  *           type: boolean
+ *         example: FDS-A0B1C2
  *       - in: query
  *         name: gpp
  *         required: false

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -52,13 +52,13 @@ let autoRefresh: boolean = true;
  *         description: Optional identifier used to filter for experiences associated with the given property. If omitted, returns all experiences not associated with any properties.
  *         schema:
  *           type: string
+ *         example: FDS-A0B1C2
  *       - in: query
  *         name: refresh
  *         required: false
  *         description: Signals fides.js to use the latest custom-fides.css (if available)
  *         schema:
  *           type: boolean
- *         example: FDS-A0B1C2
  *       - in: query
  *         name: gpp
  *         required: false


### PR DESCRIPTION
Closes PROD-2063

### Description Of Changes

This makes FidesJS and the Privacy Center slightly more defensive against invalid ISO 3166-2 codes that must use two-character country codes (e.g. `US` vs `USA`). Technically there are [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) codes that are three letter codes, but these are meant for other purposes (like passports) and aren't used along with the ISO 3166-2 subdivisions, etc.

More importantly, the Fides API expects only two-letter country codes compliant with [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), so this ensures that FidesJS & Privacy Center code will match the validation used in the API 👍 

However, we do support a special-case `EEA` location code, so this ensures that is still considered valid!

### Code Changes

* [X] Update Privacy Center and FidesJS validation regexes for geolocations
* [X] Update tests for 2-letter, 3-letter, and `EEA` codes
* [X] Update docs

### Steps to Confirm

* [X] Run all unit tests in `fides-js` and `privacy-center` projects
* [X] Locally, test that the privacy center's `/fides.js?geolocation=USA` route does not return a `geolocation` object in the generated bundle 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
