### PR TITLE
Remove sourcemaps from fides-js dist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The types of changes are:
 - Fixed an issue with the Iterate connector returning at least one param_value references an invalid field for the 'update' request of user [#4528](https://github.com/ethyca/fides/pull/4528)
 - Enhanced classification of the dataset used with Twilio [#4872](https://github.com/ethyca/fides/pull/4872)
 - Reduce privacy center logging to not show response size limit when the /fides.js endpoint has a size bigger than 4MB [#4878](https://github.com/ethyca/fides/pull/4878)
+- Fixed an issue where sourcemaps references were unintentionally included in the FidesJS bundle [#4887](https://github.com/ethyca/fides/pull/4887)
 
 ## [2.36.0](https://github.com/ethyca/fides/compare/2.35.1...2.36.0)
 

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -131,7 +131,7 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
         file: `dist/${name}.js`,
         name: isExtension ? undefined : "Fides",
         format: isExtension ? undefined : "umd",
-        sourcemap: true, //IS_DEV,
+        sourcemap: IS_DEV,
       },
     ],
   };

--- a/clients/fides-js/src/fides-ext-gpp.ts
+++ b/clients/fides-js/src/fides-ext-gpp.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 /**
  * Extension for GPP
  *


### PR DESCRIPTION
Closes [PROD-2080](https://ethyca.atlassian.net/browse/PROD-2080)

### Description Of Changes

Only include sourcemaps when in dev mode


### Code Changes

* restore previous change where `IS_DEV` was commented out and `true` was left in

### Steps to Confirm

* build and run Privacy Center
* View source of `fides.js` in browser devTools
* Note the browser warning that the sourcemap can’t be found is now gone

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[PROD-2080]: https://ethyca.atlassian.net/browse/PROD-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ