### PR TITLE
Rename MinimalPrivacyExperience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 
 ### Changed
 - Adds new var to track fides js overlay types [#4869](https://github.com/ethyca/fides/pull/4869)
+- Rename MinimalPrivacyExperience class and usages [#4889](https://github.com/ethyca/fides/pull/4889)
 
 ### Fixed
 - Fixed an issue with the Iterate connector returning at least one param_value references an invalid field for the 'update' request of user [#4528](https://github.com/ethyca/fides/pull/4528)

--- a/clients/admin-ui/src/features/properties/PropertyForm.tsx
+++ b/clients/admin-ui/src/features/properties/PropertyForm.tsx
@@ -19,7 +19,11 @@ import {
   selectPageSize,
   useGetAllExperienceConfigsQuery,
 } from "~/features/privacy-experience/privacy-experience.slice";
-import { MinimalPrivacyExperienceConfig, Property, PropertyType } from "~/types/api";
+import {
+  MinimalPrivacyExperienceConfig,
+  Property,
+  PropertyType,
+} from "~/types/api";
 
 import DeletePropertyModal from "./DeletePropertyModal";
 

--- a/clients/admin-ui/src/features/properties/PropertyForm.tsx
+++ b/clients/admin-ui/src/features/properties/PropertyForm.tsx
@@ -19,7 +19,7 @@ import {
   selectPageSize,
   useGetAllExperienceConfigsQuery,
 } from "~/features/privacy-experience/privacy-experience.slice";
-import { MinimalPrivacyExperience, Property, PropertyType } from "~/types/api";
+import { MinimalPrivacyExperienceConfig, Property, PropertyType } from "~/types/api";
 
 import DeletePropertyModal from "./DeletePropertyModal";
 
@@ -32,7 +32,7 @@ export interface FormValues {
   id?: string;
   name: string;
   type: PropertyType;
-  experiences: Array<MinimalPrivacyExperience>;
+  experiences: Array<MinimalPrivacyExperienceConfig>;
 }
 
 const ExperiencesFormSection = () => {

--- a/clients/admin-ui/src/types/api/index.ts
+++ b/clients/admin-ui/src/types/api/index.ts
@@ -214,7 +214,7 @@ export type { MessagingServiceSecretsMailchimpTransactionalDocs } from "./models
 export { MessagingServiceType } from "./models/MessagingServiceType";
 export type { MessagingTemplateRequest } from "./models/MessagingTemplateRequest";
 export type { MessagingTemplateResponse } from "./models/MessagingTemplateResponse";
-export type { MinimalPrivacyExperience } from "./models/MinimalPrivacyExperience";
+export type { MinimalPrivacyExperienceConfig } from "./models/MinimalPrivacyExperienceConfig";
 export type { MinimalProperty } from "./models/MinimalProperty";
 export type { MongoDBDocsSchema } from "./models/MongoDBDocsSchema";
 export type { MonitorExecution } from "./models/MonitorExecution";

--- a/clients/admin-ui/src/types/api/models/MinimalPrivacyExperienceConfig.ts
+++ b/clients/admin-ui/src/types/api/models/MinimalPrivacyExperienceConfig.ts
@@ -6,7 +6,7 @@
  * Minimal representation of a privacy experience, contains enough information
  * to select experiences by name in the UI and an ID to link the selections in the database.
  */
-export type MinimalPrivacyExperience = {
+export type MinimalPrivacyExperienceConfig = {
   id: string;
   name: string;
 };

--- a/clients/admin-ui/src/types/api/models/MinimalPrivacyExperienceConfig.ts
+++ b/clients/admin-ui/src/types/api/models/MinimalPrivacyExperienceConfig.ts
@@ -3,8 +3,8 @@
 /* eslint-disable */
 
 /**
- * Minimal representation of a privacy experience, contains enough information
- * to select experiences by name in the UI and an ID to link the selections in the database.
+ * Minimal representation of a privacy experience config, contains enough information
+ * to select experience configs by name in the UI and an ID to link the selections in the database.
  */
 export type MinimalPrivacyExperienceConfig = {
   id: string;

--- a/clients/admin-ui/src/types/api/models/Property.ts
+++ b/clients/admin-ui/src/types/api/models/Property.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { MinimalPrivacyExperience } from "./MinimalPrivacyExperience";
+import type { MinimalPrivacyExperienceConfig } from "./MinimalPrivacyExperienceConfig";
 import type { PropertyType } from "./PropertyType";
 
 /**
@@ -12,5 +12,5 @@ export type Property = {
   name: string;
   type: PropertyType;
   id?: string;
-  experiences: Array<MinimalPrivacyExperience>;
+  experiences: Array<MinimalPrivacyExperienceConfig>;
 };

--- a/src/fides/api/schemas/property.py
+++ b/src/fides/api/schemas/property.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from fides.api.schemas.base_class import FidesSchema
 
 
-class MinimalPrivacyExperience(FidesSchema):
+class MinimalPrivacyExperienceConfig(FidesSchema):
     """
     Minimal representation of a privacy experience, contains enough information
     to select experiences by name in the UI and an ID to link the selections in the database.
@@ -28,4 +28,4 @@ class Property(FidesSchema):
     name: str
     type: PropertyType
     id: Optional[str] = None
-    experiences: List[MinimalPrivacyExperience]
+    experiences: List[MinimalPrivacyExperienceConfig]

--- a/src/fides/api/schemas/property.py
+++ b/src/fides/api/schemas/property.py
@@ -6,8 +6,8 @@ from fides.api.schemas.base_class import FidesSchema
 
 class MinimalPrivacyExperienceConfig(FidesSchema):
     """
-    Minimal representation of a privacy experience, contains enough information
-    to select experiences by name in the UI and an ID to link the selections in the database.
+    Minimal representation of a privacy experience config, contains enough information
+    to select experience configs by name in the UI and an ID to link the selections in the database.
     """
 
     id: str


### PR DESCRIPTION
Closes unticketed - see https://github.com/ethyca/fidesplus/pull/1416#discussion_r1597017358

### Description Of Changes

Rename `MinimalPrivacyExperience` to `MinimalPrivacyExperienceConfig` to better reflect content.

After this is in main, I will update https://github.com/ethyca/fidesplus/pull/1416 with this new name change and point it to the beta tag so that we can merge this in.


### Code Changes

* [ ] Renaming change on fides BE and Admin-UI.

### Steps to Confirm

* [ ] Ensure no regressions

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
