### PR TITLE
show banner title and description input for banner and modal experien…

### DIFF
--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
@@ -214,7 +214,8 @@ const PrivacyExperienceTranslationForm = ({
         isRequired
         variant="stacked"
       />
-      {(values.component === ComponentType.BANNER_AND_MODAL || values.component === ComponentType.TCF_OVERLAY) && (
+      {(values.component === ComponentType.BANNER_AND_MODAL ||
+        values.component === ComponentType.TCF_OVERLAY) && (
         <>
           <CustomTextInput
             name={`translations.${translationIndex}.banner_title`}

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceTranslationForm.tsx
@@ -214,25 +214,24 @@ const PrivacyExperienceTranslationForm = ({
         isRequired
         variant="stacked"
       />
-      {values.component === ComponentType.BANNER_AND_MODAL ||
-        (values.component === ComponentType.TCF_OVERLAY && (
-          <>
-            <CustomTextInput
-              name={`translations.${translationIndex}.banner_title`}
-              id={`translations.${translationIndex}.banner_title`}
-              label="Banner title (optional)"
-              tooltip="A separate title for the banner (defaults to main title)"
-              variant="stacked"
-            />
-            <CustomTextArea
-              name={`translations.${translationIndex}.banner_description`}
-              id={`translations.${translationIndex}.banner_description`}
-              label="Banner description (optional)"
-              tooltip="A separate description for the banner (defaults to main description)"
-              variant="stacked"
-            />
-          </>
-        ))}
+      {(values.component === ComponentType.BANNER_AND_MODAL || values.component === ComponentType.TCF_OVERLAY) && (
+        <>
+          <CustomTextInput
+            name={`translations.${translationIndex}.banner_title`}
+            id={`translations.${translationIndex}.banner_title`}
+            label="Banner title (optional)"
+            tooltip="A separate title for the banner (defaults to main title)"
+            variant="stacked"
+          />
+          <CustomTextArea
+            name={`translations.${translationIndex}.banner_description`}
+            id={`translations.${translationIndex}.banner_description`}
+            label="Banner description (optional)"
+            tooltip="A separate description for the banner (defaults to main description)"
+            variant="stacked"
+          />
+        </>
+      )}
       <CustomTextInput
         name={`translations.${translationIndex}.accept_button_label`}
         id={`translations.${translationIndex}.accept_button_label`}


### PR DESCRIPTION
Closes [PROD-2014](https://ethyca.atlassian.net/browse/PROD-2014)

### Description Of Changes

Show banner title and description input for banner and modal experience configs

### Code Changes

* [ ] fix conditional 

### Steps to Confirm

in the admin ui
* [ ] add systems with data uses
* [ ] enable notices 
* [ ] enable a banner and modal experience 
* [ ] click to edit the banner and modal experience 
* [ ] click on a language like English 
* [ ] verify the banner title and banner description input fields show 
* [ ] change the title and description 
* [ ] verify the preview is correct showing the new banner title/description and different modal title/description 
in the fides.js preview 
* [ ] add the geolocation query param to match the experience you updated 
* [ ] verify the overlays are correct showing the new banner title/description and different modal title/description 


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated

<img width="1582" alt="Screenshot 2024-05-15 at 1 23 44 PM" src="https://github.com/ethyca/fides/assets/101993653/2c392b06-bb87-4d20-89dd-d2f069f4b122">
<img width="1337" alt="Screenshot 2024-05-15 at 1 24 27 PM" src="https://github.com/ethyca/fides/assets/101993653/8d78d5b5-63a6-4402-a8e9-30f3a3742d67">
<img width="939" alt="Screenshot 2024-05-15 at 1 24 32 PM" src="https://github.com/ethyca/fides/assets/101993653/f991c1d8-974b-4061-abb7-fff4eed905b9">

[PROD-2014]: https://ethyca.atlassian.net/browse/PROD-2014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ