### PR TITLE
improve safety of async `create_resource` crud operation

### DIFF
--- a/src/fides/api/db/crud.py
+++ b/src/fides/api/db/crud.py
@@ -36,11 +36,12 @@ async def create_resource(
     with log.contextualize(
         sql_model=sql_model.__name__, fides_key=resource_dict["fides_key"]
     ):
-        try:
-            await get_resource(sql_model, resource_dict["fides_key"], async_session)
-        except errors.NotFoundError:
-            pass
-        else:
+
+        existing_resource = await get_resource(
+            sql_model, resource_dict["fides_key"], async_session, raise_not_found=False
+        )
+
+        if existing_resource is not None:
             already_exists_error = errors.AlreadyExistsError(
                 sql_model.__name__, resource_dict["fides_key"]
             )


### PR DESCRIPTION
Closes n/a

### Description Of Changes

Our `create_resource` crud function, used as a general function to create DB resources/records with an async DB session, had been executing a `get_resource` and expecting (and catching) a `NotFoundError`. I found that in practice, the underlying exception that was thrown -- even though it was caught and handled within this function -- would cause unexpected async/session problems when used in endpoints/contexts that open other async sessions. Namely, it seemed to be closing the async session that i used to populate another resource.

We already have a version of `get_resource` that _doesn't_ throw a `NotFoundError`, and so I can't see any good reason why our `create_resource` function shouldn't use that version, and avoid the unnecessary exception handling. I've confirmed that this does indeed resolve the bewildering async issues i'd noticed on this [code block](https://github.com/ethyca/fidesplus/pull/1430/files#diff-1a98d1963d8cd96338d01397667283be621ae1998949102cdfa9171ac11100b1R554-R568) before this fix was made.

In general, this feels like a good QOL update with no downside that I can see.

### Code Changes

* [x] specify `raise_if_not_found=False` when calling `get_resource` within `create_resource`

### Steps to Confirm

* [x] i don't know in exactly which scenarios this is causing problems, but i confirmed that it does resolve the issue linked to above on my in-progress fidesplus PR

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
