### PR TITLE
tweak logic in execution frequency property function to be more robust

### DIFF
--- a/src/fides/api/models/detection_discovery.py
+++ b/src/fides/api/models/detection_discovery.py
@@ -105,9 +105,9 @@ class MonitorConfig(Base):
             or not self.monitor_execution_trigger.get("hour")
         ):
             return None
-        if self.monitor_execution_trigger.get("day"):
+        if self.monitor_execution_trigger.get("day", None) is not None:
             return MonitorFrequency.MONTHLY
-        if self.monitor_execution_trigger.get("day_of_week"):
+        if self.monitor_execution_trigger.get("day_of_week", None) is not None:
             return MonitorFrequency.WEEKLY
         return MonitorFrequency.DAILY
 

--- a/tests/ops/models/test_detection_discovery.py
+++ b/tests/ops/models/test_detection_discovery.py
@@ -160,7 +160,7 @@ class TestStagedResourceModel:
         }
 
 
-SAMPLE_START_DATE = datetime(2024, 5, 14, 12, 42, 5, 17137, tzinfo=timezone.utc)
+SAMPLE_START_DATE = datetime(2024, 5, 20, 12, 42, 5, 17137, tzinfo=timezone.utc)
 
 
 class TestMonitorConfigModel:
@@ -222,7 +222,7 @@ class TestMonitorConfigModel:
                 {
                     "start_date": SAMPLE_START_DATE,
                     "timezone": str(timezone.utc),
-                    "day_of_week": 1,  # sample start day is a Tuesday (day 1 in cron)
+                    "day_of_week": 0,  # sample start day is a Monday (day 0 in cron)
                     "hour": 12,
                     "minute": 42,
                     "second": 5,
@@ -233,7 +233,7 @@ class TestMonitorConfigModel:
                 {
                     "start_date": SAMPLE_START_DATE,
                     "timezone": str(timezone.utc),
-                    "day": 14,
+                    "day": 20,
                     "hour": 12,
                     "minute": 42,
                     "second": 5,
@@ -289,7 +289,7 @@ class TestMonitorConfigModel:
                 {
                     "start_date": SAMPLE_START_DATE,
                     "timezone": str(timezone.utc),
-                    "day_of_week": 1,  # sample start day is a Tuesday (day 1 in cron)
+                    "day_of_week": 0,  # sample start day is a Tuesday (day 0 in cron)
                     "hour": 12,
                     "minute": 42,
                     "second": 5,
@@ -300,7 +300,7 @@ class TestMonitorConfigModel:
                 {
                     "start_date": SAMPLE_START_DATE,
                     "timezone": str(timezone.utc),
-                    "day": 14,
+                    "day": 20,
                     "hour": 12,
                     "minute": 42,
                     "second": 5,


### PR DESCRIPTION
closes n/a

### Description Of Changes

Pesky bug i found in recently merged model-level updates that did not handle falsey `0` values well. This is a simple fix.


### Code Changes

* [x] explicitly check values for null/`None` rather than relying on falsey evaluation of integer value

### Steps to Confirm

* [x] test coverage is sufficient here, i tweaked the test to evaluate the case that was erroring before 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
