### PR TITLE
Allow 404 errors for Segment ID/Email not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The types of changes are:
 - Enhanced classification of the dataset used with Twilio [#4872](https://github.com/ethyca/fides/pull/4872)
 - Reduce privacy center logging to not show response size limit when the /fides.js endpoint has a size bigger than 4MB [#4878](https://github.com/ethyca/fides/pull/4878)
 - Fixed an issue where sourcemaps references were unintentionally included in the FidesJS bundle [#4887](https://github.com/ethyca/fides/pull/4887)
+- Handle a 404 response from Segment when a user ID or email is not found [#4902](https://github.com/ethyca/fides/pull/4902)
 
 
 ## [2.36.0](https://github.com/ethyca/fides/compare/2.35.1...2.36.0)

--- a/data/saas/config/segment_config.yml
+++ b/data/saas/config/segment_config.yml
@@ -4,7 +4,7 @@ saas_config:
   type: segment
   description: A sample schema representing the Segment connector for Fides
   user_guide: https://docs.ethyca.com/user-guides/integrations/saas-integrations/segment
-  version: 0.0.4
+  version: 0.0.5
 
   connector_params:
     - name: domain
@@ -51,6 +51,7 @@ saas_config:
                 connector_param: namespace_id
               - name: user_id
                 identity: email
+            ignore_errors: [404]
             client_config:
               protocol: https
               host: <personas_domain>
@@ -65,6 +66,7 @@ saas_config:
                 connector_param: namespace_id
               - name: email
                 identity: email
+            ignore_errors: [404]
             client_config:
               protocol: https
               host: <personas_domain>


### PR DESCRIPTION
Closes FIDES-701

### Description Of Changes

When adding the option for either an ID or an email, we also should have handled the error response of an ID or email not found


### Code Changes

* [ ] Allows a 404 for Segment

### Steps to Confirm

* [ ] The 404 response only occurs when a search doesn'y yield a finding

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
