### PR TITLE
public property response schema as a base class

### DIFF
--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -112,6 +112,13 @@ class ConsentConfig(FidesSchema):
 
 
 class PrivacyCenterConfig(FidesSchema):
+    """
+    NOTE: Add to this schema with care. Any fields added to
+    this response schema will be exposed in public-facing
+    (i.e. unauthenticated) API responses. If a field has
+    sensitive information, it should NOT be added to this schema!
+    """
+
     title: str
     description: str
     description_subtext: Optional[List[str]]

--- a/src/fides/api/schemas/property.py
+++ b/src/fides/api/schemas/property.py
@@ -12,6 +12,11 @@ class MinimalPrivacyExperienceConfig(FidesSchema):
     """
     Minimal representation of a privacy experience config, contains enough information
     to select experience configs by name in the UI and an ID to link the selections in the database.
+
+    NOTE: Add to this schema with care. Any fields added to
+    this response schema will be exposed in public-facing
+    (i.e. unauthenticated) API responses. If a field has
+    sensitive information, it should NOT be added to this schema!
     """
 
     id: str

--- a/src/fides/api/schemas/property.py
+++ b/src/fides/api/schemas/property.py
@@ -28,7 +28,20 @@ class MinimalProperty(FidesSchema):
     name: str
 
 
-class Property(FidesSchema):
+class PublicPropertyResponse(FidesSchema):
+    """
+    Schema that represents a `Property` as returned in the
+    public-facing Property APIs.
+
+    NOTE: Add to this schema with care. Any fields added to
+    this response schema will be exposed in public-facing
+    (i.e. unauthenticated) API responses. If a field has
+    sensitive information, it should NOT be added to this schema!
+
+    Any `Property` fields that are sensitive should be added to the
+    appropriate non-public schemas that extend this schema.
+    """
+
     name: str
     type: PropertyType
     id: Optional[str] = None
@@ -38,10 +51,9 @@ class Property(FidesSchema):
     paths: List[str]
 
     @validator("paths", pre=True)
-    def convert_to_list(cls, value: Any) -> Any:
+    def convert_to_list(cls, value: Any) -> Any:  # type: ignore[misc]
         """
         Convert the 'paths' value to a list if it is an iterable of strings.
-
         This validator is necessary because SQLAlchemy returns the 'paths' value
         as an iterable (association proxy) instead of a list. The validator checks
         if the 'paths' value is an iterable (excluding strings) and if all its
@@ -55,3 +67,16 @@ class Property(FidesSchema):
         ):
             return list(value)
         return value
+
+
+class Property(PublicPropertyResponse):
+    """
+    A schema representing the complete `Property` model.
+
+    This schema extends the base `PublicPropertyResponse` schema,
+    which only includes fields that are appropriate to be exposed
+    in public endpoints.
+
+    Any `Property` fields that are sensitive but need to be included in private
+    API responses should be added to this schema.
+    """


### PR DESCRIPTION
### Description Of Changes

To help with https://github.com/ethyca/fidesplus/pull/1432 - this base class will give us a space to add sensitive fields to a `Property` schema while keeping the public API's response model more locked down.


### Code Changes

* [x] make `PublicPropertyResponse` as a baseclass for `Property` (in `fides.api.schemas.property`)

### Steps to Confirm

* [ ] automated tests over in [plus PR](https://github.com/ethyca/fidesplus/pull/1432) should cover us i think?

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
