### PR TITLE
Docker Compose - Change privacy center port to 3001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Changed
 - Set default ports for local development of client projects (:3001 for privacy center and :3000 for admin-ui) [#4912](https://github.com/ethyca/fides/pull/4912)
+- Update privacy center port to :3001 for nox [#4918](https://github.com/ethyca/fides/pull/4918)
 
 
 ## [2.37.0](https://github.com/ethyca/fides/compare/2.36.0...2.37.0)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,9 +62,9 @@ services:
     image: ethyca/fides:local-pc
     command: npm run dev-pc
     expose:
-      - 3000
+      - 3001
     ports:
-      - "3001:3000"
+      - "3001:3001"
     volumes:
       - type: bind
         source: .


### PR DESCRIPTION
Closes PROD-2120

### Description Of Changes

Following up on #4912, we need to also add the new port to the Docker Compose file, so it works in Nox. Currently `nox -s pc` expects it to be exposed on port `3000`, which leads to a network error when trying to access it via `http://localhost:3001`.

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* Run `nox -s pc` and confirm that `http://localhost:3001` properly serves the privacy center.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
