### PR TITLE
Fix fides-js-demo page so fides_embed=true works

### DIFF
--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -59,7 +59,7 @@
 
       <div id="render-embed-here"></div>
       <script>
-        if (window.fides_overrides && window.fides_overrides.fides_embed) {
+        if (window.Fides.options.fidesEmbed) {
           /** NOTE: normally you would add <div id="fides-embed-container"></div> directly to
            * your page instead of doing this dynamically as we're doing here. For the purposes
            * of this demo, we're adding it dynamically after a delay to allow for simulating


### PR DESCRIPTION
### Code Changes

* [ ] update if statement to ensure fides-embed-container is rendered on the fides-js-demo page when fides_embed=true 

### Steps to Confirm

* [ ] add GVL systems 
* [ ] enable notice and experiences 
* [ ] nav to the demo page http://localhost:3001/fides-js-demo.html?geolocation=eea&fides_embed=true
* [ ] verify the embedded overlays are shown 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!

### UAT 
<img width="1633" alt="Screenshot 2024-05-23 at 6 20 56 PM" src="https://github.com/ethyca/fides/assets/101993653/243a8fee-a5f4-41c3-8083-85ed21e14c5b">
