### PR TITLE
Update "consent notice" to say "privacy notice"

### DIFF
--- a/clients/admin-ui/src/features/datamap/constants.ts
+++ b/clients/admin-ui/src/features/datamap/constants.ts
@@ -62,17 +62,6 @@ COLUMN_NAME_MAP[
 COLUMN_NAME_MAP[SYSTEM_PRIVACY_DECLARATION_NAME] = "Processing Activity";
 COLUMN_NAME_MAP[SYSTEM_INGRESS] = "Source Systems";
 COLUMN_NAME_MAP[SYSTEM_EGRESS] = "Destination Systems";
-// COLUMN_NAME_MAP[] = 'Data Steward'; #  needs to be added in backend
-// COLUMN_NAME_MAP[] = 'Geography'; # needs to be added in backend
-// COLUMN_NAME_MAP[] = 'Tags'; # couldn't find it
-// COLUMN_NAME_MAP[] = 'Third Party Categories'; #new
-// COLUMN_NAME_MAP[] = 'Data Protection [Impact] Assessment (DPA/DPIA)'; #new
-// COLUMN_NAME_MAP[] = 'Legal basis for International Transfer'; #new;
-// COLUMN_NAME_MAP[] = 'Cookies'; #new;
-// COLUMN_NAME_MAP[] = 'Consent Notice'; #new;
-// COLUMN_NAME_MAP[] = 'Legal Name & Address'; #new;
-// COLUMN_NAME_MAP[] = 'Privacy Policy'; #new;
-// COLUMN_NAME_MAP[] = 'Data Protection Officer (DPO)'; #new;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export enum DATAMAP_LOCAL_STORAGE_KEYS {

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -178,7 +178,7 @@ const PrivacyNoticeForm = ({
                 <NoticeKeyField isEditing={isEditing} />
                 <PrivacyNoticeLocationDisplay
                   regions={passedInPrivacyNotice?.configured_regions}
-                  label="Locations where consent notice is shown to visitors"
+                  label="Locations where privacy notice is shown to visitors"
                   tooltip="To configure locations, change the privacy experiences where this notice is shown"
                 />
                 <CustomSwitch

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeTranslationForm.tsx
@@ -45,7 +45,7 @@ const NoticeFormFields = ({ index }: { index: number }) => (
     <CustomTextInput
       autoFocus={index !== 0}
       name={`translations.${index}.title`}
-      label="Title of consent notice as displayed to user"
+      label="Title of privacy notice as displayed to user"
       variant="stacked"
     />
     <CustomTextArea

--- a/clients/admin-ui/src/home/constants.ts
+++ b/clients/admin-ui/src/home/constants.ts
@@ -71,7 +71,7 @@ export const MODULE_CARD_ITEMS: ModuleCardConfig[] = [
   {
     color: "green",
     description:
-      "Manage consent notices and experiences for all domains in your organization",
+      "Manage privacy notices and experiences for all domains in your organization",
     href: `${CONFIGURE_CONSENT_ROUTE}`,
     key: ModuleCardKeys.CONFIGURE_CONSENT,
     name: "Manage consent",


### PR DESCRIPTION
Closes #[PROD-1945](https://ethyca.atlassian.net/browse/PROD-1945)

### Description Of Changes

Copy update changing "consent notice" to "privacy notice" throughout the app. 


### Code Changes

* [ ] copy changes to privacy notice form and home page 

### Steps to Confirm

* [ ] verify copy change (see before/after pics) 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!

### Before
<img width="1345" alt="Screenshot 2024-05-24 at 7 11 05 AM" src="https://github.com/ethyca/fides/assets/101993653/4c2be21b-b8f4-4990-97e7-a3cb8db5b880">
<img width="958" alt="Screenshot 2024-05-24 at 8 00 58 AM" src="https://github.com/ethyca/fides/assets/101993653/cb8579bc-f9f4-4e4b-87a6-a6d3e68ff289">
