### PR TITLE
FIx privacy center paths

### DIFF
--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -276,7 +276,7 @@ export const loadPrivacyCenterEnvironment = async ({
   if (settings.CUSTOM_PROPERTIES && customPropertyPath) {
     const result = await getPropertyFromUrl({
       customPropertyPath,
-      fidesApiUrl: settings.FIDES_API_URL,
+      fidesApiUrl: settings.SERVER_SIDE_FIDES_API_URL || settings.FIDES_API_URL,
     });
     if (result) {
       property = result;


### PR DESCRIPTION
### Description Of Changes

Fixprivacy center custom paths not working in production because it's using the wrong url to connect within docker.
