### PR TITLE
Fix: get the top-level hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The types of changes are:
 ### Fixed
 - Fixed an issue where the test integration action failed for the Zendesk integration [#4929](https://github.com/ethyca/fides/pull/4929)
 
+### Fixed
+- Fixed an issue where the consent cookie could not be set on multi-level root domain (e.g. co.uk, co.jp) [#4935](https://github.com/ethyca/fides/pull/4935)
+
 ## [2.37.0](https://github.com/ethyca/fides/compare/2.36.0...2.37.0)
 
 ### Added

--- a/clients/fides-js/__tests__/lib/cookie.test.ts
+++ b/clients/fides-js/__tests__/lib/cookie.test.ts
@@ -45,8 +45,9 @@ const mockGetCookie = jest.fn((): string | undefined => "mockGetCookie return");
 const mockSetCookie = jest.fn(
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   (name: string, value: string, attributes: object, encoding: object) => {
+    // Simulate that browsers will not write cookies to known top-level public domains like "com" or "co.uk"
     if (
-      ["com", "ca", "org", "uk", "co.uk"].indexOf(
+      ["com", "ca", "org", "uk", "co.uk", "in", "co.in", "jp", "co.jp"].indexOf(
         (attributes as { domain: string }).domain
       ) > -1
     ) {
@@ -260,6 +261,14 @@ describe("saveFidesCookie", () => {
     {
       url: "https://privacy.subdomain.example.co.uk",
       expected: "example.co.uk",
+    },
+    {
+      url: "https://example.co.in",
+      expected: "example.com.in",
+    },
+    {
+      url: "https://example.co.jp",
+      expected: "example.co.jp",
     },
   ])(
     "calculates the root domain from the hostname ($url)",

--- a/clients/fides-js/__tests__/lib/cookie.test.ts
+++ b/clients/fides-js/__tests__/lib/cookie.test.ts
@@ -264,7 +264,7 @@ describe("saveFidesCookie", () => {
     },
     {
       url: "https://example.co.in",
-      expected: "example.com.in",
+      expected: "example.co.in",
     },
     {
       url: "https://example.co.jp",

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -221,7 +221,7 @@ export const saveFidesCookie = (
   for (let i = 1; i < hostname.length + 1; i += 1) {
     // This loop guarantees to get the top-level hostname because that's the smallest one browsers will let you set cookies in. We test a given suffix for whether we are able to set cookies, if not we try the next suffix until we find the one that works.
     topViableDomain = hostname.slice(-i).join(".");
-    setCookie(
+    const c = setCookie(
       CONSENT_COOKIE_NAME,
       encodedCookie,
       {
@@ -233,9 +233,11 @@ export const saveFidesCookie = (
       },
       CODEC
     );
-    const cookieString = getCookieByName(CONSENT_COOKIE_NAME);
-    if (cookieString) {
-      break;
+    if (c) {
+      const cookieString = getCookieByName(CONSENT_COOKIE_NAME);
+      if (cookieString) {
+        break;
+      }
     }
   }
 };

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -218,7 +218,7 @@ export const saveFidesCookie = (
 
   const hostname = window.location.hostname.split(".");
   let topViableDomain = "";
-  for (let i = 1; i < hostname.length; i += 1) {
+  for (let i = 1; i < hostname.length + 1; i += 1) {
     // This loop guarantees to get the top-level hostname because that's the smallest one browsers will let you set cookies in. We test a given suffix for whether we are able to set cookies, if not we try the next suffix until we find the one that works.
     topViableDomain = hostname.slice(-i).join(".");
     setCookie(

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -191,7 +191,7 @@ export const getOrMakeFidesCookie = (
 /**
  * Save the given Fides cookie to the browser using the current root domain.
  *
- * This calculates the root domain by using the last two parts of the hostname:
+ * This calculates the root domain by using the last parts of the hostname:
  *   privacy.example.co.uk -> example.co.uk
  *   privacy.example.com -> example.com
  *   example.com -> example.com
@@ -218,7 +218,7 @@ export const saveFidesCookie = (
 
   const hostname = window.location.hostname.split(".");
   let topViableDomain = "";
-  for (let i = 1; i < hostname.length + 1; i += 1) {
+  for (let i = 1; i <= hostname.length; i += 1) {
     // This loop guarantees to get the top-level hostname because that's the smallest one browsers will let you set cookies in. We test a given suffix for whether we are able to set cookies, if not we try the next suffix until we find the one that works.
     topViableDomain = hostname.slice(-i).join(".");
     const c = setCookie(

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -216,11 +216,11 @@ export const saveFidesCookie = (
     encodedCookie = base64_encode(encodedCookie);
   }
 
-  const hostname = window.location.hostname.split(".");
+  const hostnameParts = window.location.hostname.split(".");
   let topViableDomain = "";
-  for (let i = 1; i <= hostname.length; i += 1) {
+  for (let i = 1; i <= hostnameParts.length; i += 1) {
     // This loop guarantees to get the top-level hostname because that's the smallest one browsers will let you set cookies in. We test a given suffix for whether we are able to set cookies, if not we try the next suffix until we find the one that works.
-    topViableDomain = hostname.slice(-i).join(".");
+    topViableDomain = hostnameParts.slice(-i).join(".");
     const c = setCookie(
       CONSENT_COOKIE_NAME,
       encodedCookie,


### PR DESCRIPTION
Closes [PROD-2027](https://ethyca.atlassian.net/browse/PROD-2027)

### Description Of Changes

IP addresses and top level hostnames that included multiple TLDs (like `co.uk`) were not working for setting a Fides Cookie.

This fix update cookie setter to guarantee highest level domain allowed to set cookie. It relies on browser's own methods to determine viable domain.

### Code Changes

* Loop through parts of hostname backwards until cookie gets set.
* Validate the cookie gets set and stop looping

### Steps to Confirm

* Update `/etc/hosts` on your local machine to include new line:
  ```127.0.0.1 privacy.example.co.uk```
* Fire up privacy center on localhost
* Instead of visiting localhost, visit `http://privacy.example.co.uk:3001/fides-js-demo.html`
* In the banner/modal make a selection that will set the cookie
* Verify that the cookie was set with domain `example.co.uk`
* repeat for the IP address `http://127.0.0.1:3001/fides-js-demo.html` and ensure that works.

(domains like `www.fides.com` and `localhost` should _continue_ working with this enhancement in place)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`


[PROD-2027]: https://ethyca.atlassian.net/browse/PROD-2027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ