### PR TITLE
Fix Capitalization in Privacy Center Error Toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The types of changes are:
 ### Changed
 - Set default ports for local development of client projects (:3001 for privacy center and :3000 for admin-ui) [#4912](https://github.com/ethyca/fides/pull/4912)
 - Update privacy center port to :3001 for nox [#4918](https://github.com/ethyca/fides/pull/4918)
+- Update Privacy Center toast text for consistent capitalization [#4936](https://github.com/ethyca/fides/pull/4936)
 
 ## [2.37.0](https://github.com/ethyca/fides/compare/2.36.0...2.37.0)
 

--- a/clients/privacy-center/common/toast-options.ts
+++ b/clients/privacy-center/common/toast-options.ts
@@ -11,7 +11,7 @@ export const ErrorToastOptions: UseToastOptions = {
 };
 
 export const ConfigErrorToastOptions: UseToastOptions = {
-  title: "An error occurred while retrieving the Privacy Center Config",
+  title: "An error occurred while retrieving the Privacy Center config",
   ...ErrorToastOptions,
 };
 


### PR DESCRIPTION
### Description Of Changes

This PR fixes some wonky capitalization that's been on my mind for a while. 

Original:
![Take control of your data](https://github.com/ethyca/fides/assets/39230492/fa6fa8c6-c93c-4780-95da-417ea3376f69)

Updated: 
![image](https://github.com/ethyca/fides/assets/39230492/93060acd-de14-437e-8bf1-7c8ed66afdf3)


### Code Changes

* Change toast text from `An error occurred while retrieving the Privacy Center Config` to `An error occurred while retrieving the Privacy Center config`

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
