### PR TITLE
Privacy Center port updates for Cypress tests

### DIFF
--- a/.github/workflows/frontend_checks.yml
+++ b/.github/workflows/frontend_checks.yml
@@ -83,7 +83,7 @@ jobs:
           working-directory: clients/${{ matrix.clients }}
           install: false
           start: npm run cy:start
-          wait-on: "http://localhost:3000"
+          wait-on: "http://localhost:${{ matrix.clients === 'privacy-center' ? 3001 : 3000 }}"
           wait-on-timeout: 180
 
       - uses: actions/upload-artifact@v3
@@ -123,4 +123,3 @@ jobs:
           working-directory: clients/${{ matrix.clients }}
           install: false
           component: true
-

--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -11,7 +11,7 @@
     "dist/**"
   ],
   "scripts": {
-    "dev": "NODE_ENV=production rollup --watch -c",
+    "dev": "NODE_ENV=development rollup --watch -c",
     "build": "NODE_ENV=production rollup -c",
     "build:windows": "set NODE_ENV=production && rollup -c",
     "postbuild": "npm run docs:generate",

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable import/no-extraneous-dependencies */
 import alias from "@rollup/plugin-alias";
 import copy from "rollup-plugin-copy";
@@ -61,22 +62,19 @@ const fidesScriptPlugins = ({ name, gzipWarnSizeKb, gzipErrorSizeKb }) => [
       // Add a defensive check to fail the build if our bundle size starts getting too big!
       (options, bundle, { gzipSize, fileName }) => {
         const gzipSizeKb = Number(gzipSize.replace(" KB", ""));
-        if (gzipSizeKb > gzipErrorSizeKb) {
+        if (gzipSizeKb > gzipErrorSizeKb && !IS_DEV) {
           console.error(
             `❌ ERROR: ${fileName} build failed! Gzipped size (${gzipSize}) exceeded maximum size (${gzipErrorSizeKb} KB)!`,
             `If you must, update GZIP_SIZE_* constants in clients/fides-js/rollup.config.mjs.`,
             `Open bundle-size-stats/${name}-stats.html to visualize the (non-gzipped) bundle size.`
           );
           process.exit(1);
-        } else if (gzipSizeKb > gzipWarnSizeKb) {
+        } else if (gzipSizeKb > gzipWarnSizeKb && !IS_DEV) {
           console.warn(
             `️🚨 WARN: ${fileName} build is getting large! Gzipped size (${gzipSize}) exceeded warning size (${gzipWarnSizeKb} KB)!`,
             `If you must, update GZIP_SIZE_* constants in clients/fides-js/rollup.config.mjs.`,
             `Open bundle-size-stats/${name}-stats.html to visualize the (non-gzipped) bundle size.`
           );
-          if (IS_DEV) {
-            process.exit(1);
-          }
         } else {
           console.log(
             `✅ ${fileName} gzipped size passed maximum size checks (${gzipSize} < ${gzipErrorSizeKb} KB)`

--- a/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
+++ b/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
@@ -21,7 +21,7 @@ export interface PrivacyCenterSettings {
   IS_PREFETCH_ENABLED: boolean | false; // (optional) whether we should pre-fetch geolocation and experience server-side
   OVERLAY_PARENT_ID: string | null; // (optional) ID of the parent DOM element where the overlay should be inserted
   MODAL_LINK_ID: string | null; // (optional) ID of the DOM element that should trigger the consent modal
-  PRIVACY_CENTER_URL: string; // e.g. http://localhost:3000
+  PRIVACY_CENTER_URL: string; // e.g. http://localhost:3001
   FIDES_EMBED: boolean | false; // (optional) Whether we should "embed" the fides.js overlay UI (ie. “Layer 2”) into a web page
   FIDES_DISABLE_SAVE_API: boolean | false; // (optional) Whether we should disable saving consent preferences to the Fides API
   FIDES_DISABLE_BANNER: boolean | false; // (optional) Whether we should disable showing the banner

--- a/clients/privacy-center/cypress.config.ts
+++ b/clients/privacy-center/cypress.config.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 
 export default defineConfig({
   e2e: {
-    baseUrl: "http://localhost:3000",
+    baseUrl: "http://localhost:3001",
     experimentalRunAllSpecs: true,
     // Only keep videos from failures
     // Copied from https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests

--- a/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
@@ -204,9 +204,9 @@
     "isOverlayEnabled": true,
     "isGeolocationEnabled": false,
     "geolocationApiUrl": "",
-    "privacyCenterUrl": "http://localhost:3000",
+    "privacyCenterUrl": "http://localhost:3001",
     "fidesApiUrl": "http://localhost:8080/api/v1",
     "fidesTcfGdprApplies": true,
-    "fidesJsBaseUrl": "http://localhost:3000"
+    "fidesJsBaseUrl": "http://localhost:3001"
   }
 }

--- a/clients/privacy-center/package.json
+++ b/clients/privacy-center/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf .turbo node_modules",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "cy:start": "export NODE_ENV=test && npm run build && npm run start",
+    "cy:start": "export NODE_ENV=test && npm run build && next start -p 3001",
     "analyze": "cross-env ANALYZE=true next build",
     "analyze:server": "cross-env BUNDLE_ANALYZE=server next build",
     "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build",

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -6,7 +6,7 @@
 
     <!--
       Pass along any params to the fides.js script. For example, visiting
-      http://localhost:3000/fides-js-demo.html?geolocation=fr-id
+      http://localhost:3001/fides-js-demo.html?geolocation=fr-id
       will pass a geolocation query param to fides.js
     -->
     <script>
@@ -196,7 +196,7 @@
           geolocationApiUrl: "",
           overlayParentId: null,
           modalLinkId: null,
-          privacyCenterUrl: "http://localhost:3000",
+          privacyCenterUrl: "http://localhost:3001",
           fidesApiUrl: "http://localhost:8080/api/v1",
           fidesPrimaryColor: "#008000",
         },

--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -6,7 +6,7 @@
 
     <!--
       Pass along any params to the fides.js script. For example, visiting
-      http://localhost:3000/fides-js-demo.html?geolocation=fr-id
+      http://localhost:3001/fides-js-demo.html?geolocation=fr-id
       will pass a geolocation query param to fides.js
     -->
     <script>


### PR DESCRIPTION
### Description Of Changes

We recently updated Privacy Center development mode to run on port 3001. This could sometimes conflict with Cypress settings so these updates push it even further to start Cypress runs on that same port.


### Code Changes

* Cypress config changed to port `3001`
* `cy:start` script to start server on `3001`
* get dev mode working as intended for local rollup to make local testing easier

### Steps to Confirm

* run `npm run cy:start`
* then run `npm cy:run`
* Everything should be visiting `localhost:3001`
* Viewing the Source of `fides.js` should result in expanded (not-minified) view

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Update `CHANGELOG.md`
