### PR TITLE
Fix duplicate data-testid on system tabs

### DIFF
--- a/clients/admin-ui/src/pages/systems/configure/[id].tsx
+++ b/clients/admin-ui/src/pages/systems/configure/[id].tsx
@@ -151,7 +151,6 @@ const ConfigureSystem: NextPage = () => {
         <VStack alignItems="stretch" flex="1" gap="18px" maxWidth="70vw">
           <DataTabsContent
             data={tabData}
-            data-testid="system-tabs"
             index={tabIndex}
             isLazy
             isManual


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

A Plus Cypress test was failing due to finding two elements with data-testid `system-tabs`, this fixes by removing it from the TabContent element (that testid was newly introduced by #4922 and is not being used).

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
