### PR TITLE
avoid 0 as falsey bug in monitor config db property method

### DIFF
--- a/src/fides/api/models/detection_discovery.py
+++ b/src/fides/api/models/detection_discovery.py
@@ -92,7 +92,7 @@ class MonitorConfig(Base):
         """Derives the `execution_start_date`"""
         if (
             not self.monitor_execution_trigger
-            or self.monitor_execution_trigger.get("start_date", None) is not None
+            or self.monitor_execution_trigger.get("start_date", None) is None
         ):
             return None
         return self.monitor_execution_trigger.get("start_date")
@@ -102,7 +102,7 @@ class MonitorConfig(Base):
         """Derives the `execution_frequency`"""
         if (
             not self.monitor_execution_trigger
-            or self.monitor_execution_trigger.get("hour", None) is not None
+            or self.monitor_execution_trigger.get("hour", None) is None
         ):
             return None
         if self.monitor_execution_trigger.get("day", None) is not None:

--- a/src/fides/api/models/detection_discovery.py
+++ b/src/fides/api/models/detection_discovery.py
@@ -92,7 +92,7 @@ class MonitorConfig(Base):
         """Derives the `execution_start_date`"""
         if (
             not self.monitor_execution_trigger
-            or not self.monitor_execution_trigger.get("start_date")
+            or self.monitor_execution_trigger.get("start_date", None) is not None
         ):
             return None
         return self.monitor_execution_trigger.get("start_date")
@@ -102,7 +102,7 @@ class MonitorConfig(Base):
         """Derives the `execution_frequency`"""
         if (
             not self.monitor_execution_trigger
-            or not self.monitor_execution_trigger.get("hour")
+            or self.monitor_execution_trigger.get("hour", None) is not None
         ):
             return None
         if self.monitor_execution_trigger.get("day", None) is not None:

--- a/tests/ops/models/test_detection_discovery.py
+++ b/tests/ops/models/test_detection_discovery.py
@@ -279,7 +279,7 @@ class TestMonitorConfigModel:
                 {
                     "start_date": SAMPLE_START_DATE,
                     "timezone": str(timezone.utc),
-                    "hour": 12,
+                    "hour": 0,
                     "minute": 42,
                     "second": 5,
                 },
@@ -290,7 +290,7 @@ class TestMonitorConfigModel:
                     "start_date": SAMPLE_START_DATE,
                     "timezone": str(timezone.utc),
                     "day_of_week": 0,  # sample start day is a Tuesday (day 0 in cron)
-                    "hour": 12,
+                    "hour": 0,
                     "minute": 42,
                     "second": 5,
                 },
@@ -301,7 +301,7 @@ class TestMonitorConfigModel:
                     "start_date": SAMPLE_START_DATE,
                     "timezone": str(timezone.utc),
                     "day": 20,
-                    "hour": 12,
+                    "hour": 0,
                     "minute": 42,
                     "second": 5,
                 },

--- a/tests/ops/models/test_detection_discovery.py
+++ b/tests/ops/models/test_detection_discovery.py
@@ -160,7 +160,7 @@ class TestStagedResourceModel:
         }
 
 
-SAMPLE_START_DATE = datetime(2024, 5, 20, 12, 42, 5, 17137, tzinfo=timezone.utc)
+SAMPLE_START_DATE = datetime(2024, 5, 20, 0, 42, 5, 17137, tzinfo=timezone.utc)
 
 
 class TestMonitorConfigModel:
@@ -212,7 +212,7 @@ class TestMonitorConfigModel:
                 {
                     "start_date": SAMPLE_START_DATE,
                     "timezone": str(timezone.utc),
-                    "hour": 12,
+                    "hour": 0,
                     "minute": 42,
                     "second": 5,
                 },
@@ -223,7 +223,7 @@ class TestMonitorConfigModel:
                     "start_date": SAMPLE_START_DATE,
                     "timezone": str(timezone.utc),
                     "day_of_week": 0,  # sample start day is a Monday (day 0 in cron)
-                    "hour": 12,
+                    "hour": 0,
                     "minute": 42,
                     "second": 5,
                 },
@@ -234,7 +234,7 @@ class TestMonitorConfigModel:
                     "start_date": SAMPLE_START_DATE,
                     "timezone": str(timezone.utc),
                     "day": 20,
-                    "hour": 12,
+                    "hour": 0,
                     "minute": 42,
                     "second": 5,
                 },


### PR DESCRIPTION
Closes n/a

Found by @jpople in testing.

If the `hour` in the `monitor_execution_trigger` is `0`, then we were accidentally treating it as unset.

### Description Of Changes

- Fix the falsey value check to check explicitly for `None`


### Code Changes

* [x] Fix the falsey value check to check explicitly for `None`

### Steps to Confirm

* [x] updated automated test to cover this edge case, which should be sufficient 👍 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
