### PR TITLE
PROD-2051 notify users of discovery process after selecting resources for monitoring

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/DetectionItemActions.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/DetectionItemActions.tsx
@@ -71,10 +71,10 @@ const DetectionItemAction: React.FC<DetectionItemActionProps> = ({
           icon={<MonitorOnIcon />}
           onClick={async () => {
             setIsProcessingAction(true);
-            // await confirmResourceMutation({
-            //   staged_resource_urn: resource.urn,
-            //   monitor_config_id: resource.monitor_config_id!,
-            // });
+            await confirmResourceMutation({
+              staged_resource_urn: resource.urn,
+              monitor_config_id: resource.monitor_config_id!,
+            });
             successAlert(
               "Data discovery has started. The results may take some time to appear in the “Data discovery“ tab.",
               `${resource.name || "The resource"} is now being monitored.`

--- a/clients/admin-ui/src/features/data-discovery-and-detection/DetectionItemActions.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/DetectionItemActions.tsx
@@ -6,6 +6,7 @@ import {
   ViewOffIcon,
 } from "fidesui";
 import { useState } from "react";
+import { useAlert } from "~/features/common/hooks";
 
 import { DiffStatus, StagedResource } from "~/types/api";
 
@@ -32,6 +33,7 @@ const DetectionItemAction: React.FC<DetectionItemActionProps> = ({
   const [confirmResourceMutation] = useConfirmResourceMutation();
   const [muteResourceMutation] = useMuteResourceMutation();
   const [unmuteResourceMutation] = useUnmuteResourceMutation();
+  const { successAlert } = useAlert();
 
   const [isProcessingAction, setIsProcessingAction] = useState(false);
 
@@ -69,10 +71,14 @@ const DetectionItemAction: React.FC<DetectionItemActionProps> = ({
           icon={<MonitorOnIcon />}
           onClick={async () => {
             setIsProcessingAction(true);
-            await confirmResourceMutation({
-              staged_resource_urn: resource.urn,
-              monitor_config_id: resource.monitor_config_id!,
-            });
+            // await confirmResourceMutation({
+            //   staged_resource_urn: resource.urn,
+            //   monitor_config_id: resource.monitor_config_id!,
+            // });
+            successAlert(
+              "Data discovery has started. The results may take some time to appear in the “Data discovery“ tab.",
+              `${resource.name || "The resource"} is now being monitored.`
+            );
             setIsProcessingAction(false);
           }}
           disabled={isProcessingAction}
@@ -87,6 +93,10 @@ const DetectionItemAction: React.FC<DetectionItemActionProps> = ({
             await unmuteResourceMutation({
               staged_resource_urn: resource.urn,
             });
+            successAlert(
+              "Data discovery has started. The results may take some time to appear in the “Data discovery“ tab.",
+              `${resource.name || "The resource"} is now being monitored.`
+            );
             setIsProcessingAction(false);
           }}
           disabled={isProcessingAction}


### PR DESCRIPTION
### Description Of Changes

After the user takes the action to monitor a resource, we should display a toast indicating that the resource is now monitor and that the results will appear later in the Data Discovery tab.


### Code Changes

* [ ] Add toast with message

### Steps to Confirm

* [ ] Setup a connection and monitor for Data discovery & detection
* [ ] Go to Detection & Discovery > Activity
* [ ] Click on Monitor on a resource
* [ ] You should see the toast appear

Also:
* [ ] Click on Ignore a resource
* [ ] Go to Data detection and toggle "Show full schema" to see ignored resource
* [ ] Click on Monitor on that ignored resource
* [ ] You should see the toast appear




### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
