### PR TITLE
set up tests for validating various domains

### DIFF
--- a/clients/privacy-center/cypress/e2e/consent-banner-cookies.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-cookies.cy.ts
@@ -1,0 +1,71 @@
+import { CONSENT_COOKIE_NAME } from "fides-js";
+import { stubConfig } from "~/cypress/support/stubs";
+
+const domains: {
+  domain: string;
+  expected: string;
+}[] = require("../fixtures/domains.json");
+
+/**
+ * This test is for validating our cookie domain logic. We want to ensure that cookies are able to be set on the topmost domain without needing to be the full domain.
+ *
+ * NOTE: the reason we aren't testing for things like `example` or `example.whatever` is because the browser will *always* set the cookie on *anything* you set for those as long as the page can be visited. This is why `localhost` works for example, or `example.localhost`.
+ *
+ * For example, if we are on `subdomain.example.co.uk`, we want to be able to set cookies on `example.co.uk` (but not `co.uk`).
+ *
+ * In order to run this test, you will need to have all of the domains in the `domains.json` set up in your `/etc/hosts` file, for example:
+ * 127.0.0.1 example.co.cr
+ * 127.0.0.1 subdomain.example.co.cr
+ * 127.0.0.1 xyz.subdomain.example.co.cr
+ * ...and so forth (unfortunately, wildcard domains are not supported in `/etc/hosts`), as well as one for `example.co.invalid` to test invalid domains.
+ *
+ * This test will fail if you do not have the domains set up in your `/etc/hosts` file!
+ *
+ * Once you have the domains set up, you can remove the `.skip` below and run the test.
+ */
+
+describe.skip("Consent overlay", () => {
+  describe("when visiting valid domains", () => {
+    Cypress.on("uncaught:exception", () => false);
+    domains.forEach(({ domain, expected }) => {
+      it(`allows cookie for ${domain}`, () => {
+        Cypress.config("baseUrl", `http://${domain}:3001`);
+        cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
+        stubConfig({
+          options: {
+            isOverlayEnabled: true,
+          },
+        });
+        cy.get("div#fides-banner").within(() => {
+          cy.get("button").contains("Opt in to all").click();
+        });
+        cy.getCookie(CONSENT_COOKIE_NAME)
+          .should("exist")
+          .then((cookie) => {
+            // check domain of cookie
+            expect(cookie?.domain).to.eq(expected);
+          });
+      });
+    });
+  });
+  describe("when visiting invalid domains", () => {
+    it(`doesn't allow cookie for example.co.invalid`, () => {
+      Cypress.config("baseUrl", `http://example.co.invalid:3001`);
+      cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
+      stubConfig({
+        options: {
+          isOverlayEnabled: true,
+        },
+      });
+      cy.get("div#fides-banner").within(() => {
+        cy.get("button").contains("Opt in to all").click();
+      });
+      cy.getCookie(CONSENT_COOKIE_NAME)
+        .should("exist")
+        .then((cookie) => {
+          // browser allows this because it assumes it's a localhost domain, which is correct, but the test passes because it's not set to the correct domain `example.co.invalid`
+          expect(cookie?.domain).to.eq(".co.invalid");
+        });
+    });
+  });
+});

--- a/clients/privacy-center/cypress/fixtures/domains.json
+++ b/clients/privacy-center/cypress/fixtures/domains.json
@@ -1,0 +1,23 @@
+[
+  { "domain": "example.co.cr", "expected": ".example.co.cr" },
+  { "domain": "example.co.nz", "expected": ".example.co.nz" },
+  { "domain": "example.co.uk", "expected": ".example.co.uk" },
+  { "domain": "example.co.za", "expected": ".example.co.za" },
+  { "domain": "example.com.au", "expected": ".example.com.au" },
+  { "domain": "example.com.br", "expected": ".example.com.br" },
+  { "domain": "example.com.my", "expected": ".example.com.my" },
+  { "domain": "subdomain.example.co.cr", "expected": ".example.co.cr" },
+  { "domain": "subdomain.example.co.nz", "expected": ".example.co.nz" },
+  { "domain": "subdomain.example.co.uk", "expected": ".example.co.uk" },
+  { "domain": "subdomain.example.co.za", "expected": ".example.co.za" },
+  { "domain": "subdomain.example.com.au", "expected": ".example.com.au" },
+  { "domain": "subdomain.example.com.br", "expected": ".example.com.br" },
+  { "domain": "subdomain.example.com.my", "expected": ".example.com.my" },
+  { "domain": "xyz.subdomain.example.co.cr", "expected": ".example.co.cr" },
+  { "domain": "xyz.subdomain.example.co.nz", "expected": ".example.co.nz" },
+  { "domain": "xyz.subdomain.example.co.uk", "expected": ".example.co.uk" },
+  { "domain": "xyz.subdomain.example.co.za", "expected": ".example.co.za" },
+  { "domain": "xyz.subdomain.example.com.au", "expected": ".example.com.au" },
+  { "domain": "xyz.subdomain.example.com.br", "expected": ".example.com.br" },
+  { "domain": "xyz.subdomain.example.com.my", "expected": ".example.com.my" }
+]


### PR DESCRIPTION
### Description Of Changes

Set up tests and instructions to run against various real world TLDs and validate that our cookie logic is sound. Can only be run locally and manually, but handy to keep around for validating any future changes.

![CleanShot 2024-06-06 at 10 46 01@2x](https://github.com/ethyca/fides/assets/103820/9f8e167c-00ee-40fc-b39b-0c633d8e1b1a)