### PR TITLE
Add 'test connection' button to integrations view

### DIFF
--- a/clients/admin-ui/cypress/e2e/integration-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/integration-management.cy.ts
@@ -5,6 +5,12 @@ import { INTEGRATION_MANAGEMENT_ROUTE } from "~/features/common/nav/v2/routes";
 describe("Integration management for data detection & discovery", () => {
   beforeEach(() => {
     cy.login();
+    cy.intercept("GET", "/api/v1/connection/*/test", {
+      statusCode: 200,
+      body: {
+        test_status: "succeeded",
+      },
+    }).as("testConnection");
   });
 
   describe("accessing the page", () => {
@@ -47,6 +53,13 @@ describe("Integration management for data detection & discovery", () => {
       it("should show a list of integrations", () => {
         cy.getByTestId("integration-info-bq_integration").should("exist");
         cy.getByTestId("empty-state").should("not.exist");
+      });
+
+      it("should be able to test connections by clicking the button", () => {
+        cy.getByTestId("integration-info-bq_integration").within(() => {
+          cy.getByTestId("test-connection-btn").click();
+          cy.wait("@testConnection");
+        });
       });
 
       it("should navigate to management page when 'manage' button is clicked", () => {
@@ -132,6 +145,11 @@ describe("Integration management for data detection & discovery", () => {
         fixture: "connectors/bigquery_connection.json",
       }).as("getConnection");
       cy.visit("/integrations/bq_integration");
+    });
+
+    it("can test the connection", () => {
+      cy.getByTestId("test-connection-btn").click();
+      cy.wait("@testConnection");
     });
 
     it("can edit integration with the modal", () => {

--- a/clients/admin-ui/src/features/datastore-connections/useTestConnection.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/useTestConnection.tsx
@@ -1,3 +1,6 @@
+import { useToast } from "fidesui";
+
+import { getErrorMessage } from "~/features/common/helpers";
 import { formatDate } from "~/features/common/utils";
 import { useLazyGetDatastoreConnectionStatusQuery } from "~/features/datastore-connections/datastore-connection.slice";
 import { ConnectionStatusData } from "~/features/integrations/ConnectionStatusNotice";
@@ -11,19 +14,35 @@ const useTestConnection = (
     { data, fulfilledTimeStamp, isLoading: queryIsLoading, isFetching },
   ] = useLazyGetDatastoreConnectionStatusQuery();
 
-  const testConnection = () => {
+  const toast = useToast();
+
+  const testConnection = async () => {
     if (!integration) {
       return;
     }
-    connectionTestTrigger(integration.key);
+    const result = await connectionTestTrigger(integration.key);
+    if (result.isError) {
+      toast({
+        status: "error",
+        description: getErrorMessage(
+          result.error,
+          "Unable to test connection. Please try again."
+        ),
+      });
+    } else if (result.data?.test_status === "succeeded") {
+      toast({ status: "success", description: "Connected successfully" });
+    } else if (result.data?.test_status === "failed") {
+      toast({ status: "warning", description: "Connection test failed" });
+    }
   };
 
   const testData: ConnectionStatusData = {
     timestamp: fulfilledTimeStamp
       ? formatDate(fulfilledTimeStamp)
       : integration?.last_test_timestamp,
-    succeeded:
-      data?.test_status === "succeeded" || integration?.last_test_succeeded,
+    succeeded: data
+      ? data.test_status === "succeeded"
+      : integration?.last_test_succeeded,
   };
 
   const isLoading = queryIsLoading || isFetching;

--- a/clients/admin-ui/src/features/datastore-connections/useTestConnection.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/useTestConnection.tsx
@@ -1,0 +1,38 @@
+import { formatDate } from "~/features/common/utils";
+import { useLazyGetDatastoreConnectionStatusQuery } from "~/features/datastore-connections/datastore-connection.slice";
+import { ConnectionStatusData } from "~/features/integrations/ConnectionStatusNotice";
+import { ConnectionConfigurationResponse } from "~/types/api";
+
+const useTestConnection = (
+  integration: ConnectionConfigurationResponse | undefined
+) => {
+  const [
+    connectionTestTrigger,
+    { data, fulfilledTimeStamp, isLoading: queryIsLoading, isFetching },
+  ] = useLazyGetDatastoreConnectionStatusQuery();
+
+  const testConnection = () => {
+    if (!integration) {
+      return;
+    }
+    connectionTestTrigger(integration.key);
+  };
+
+  const testData: ConnectionStatusData = {
+    timestamp: fulfilledTimeStamp
+      ? formatDate(fulfilledTimeStamp)
+      : integration?.last_test_timestamp,
+    succeeded:
+      data?.test_status === "succeeded" || integration?.last_test_succeeded,
+  };
+
+  const isLoading = queryIsLoading || isFetching;
+
+  return {
+    testConnection,
+    isLoading,
+    testData,
+  };
+};
+
+export default useTestConnection;

--- a/clients/admin-ui/src/features/integrations/ConnectionStatusNotice.tsx
+++ b/clients/admin-ui/src/features/integrations/ConnectionStatusNotice.tsx
@@ -2,18 +2,21 @@ import { CheckCircleIcon, Flex, Text, WarningIcon } from "fidesui";
 
 import { formatDate } from "~/features/common/utils";
 
-const ConnectionStatusNotice = ({
-  timestamp,
-  succeeded,
-}: {
+export type ConnectionStatusData = {
   timestamp?: string;
   succeeded?: boolean;
+};
+
+const ConnectionStatusNotice = ({
+  testData,
+}: {
+  testData: ConnectionStatusData;
 }) => {
-  if (!timestamp) {
+  if (!testData.timestamp) {
     return <Text data-testid="connection-status">Connection not tested</Text>;
   }
-  const testDate = formatDate(timestamp);
-  return succeeded ? (
+  const testDate = formatDate(testData.timestamp);
+  return testData.succeeded ? (
     <Flex color="green.400" align="center" data-testid="connection-status">
       <CheckCircleIcon mr={2} />
       <Text>Last connected {testDate}</Text>

--- a/clients/admin-ui/src/features/integrations/ConnectionStatusNotice.tsx
+++ b/clients/admin-ui/src/features/integrations/ConnectionStatusNotice.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon, Flex, Text, WarningIcon } from "fidesui";
+import { CheckCircleIcon, Flex, Text, WarningTwoIcon } from "fidesui";
 
 import { formatDate } from "~/features/common/utils";
 
@@ -18,12 +18,12 @@ const ConnectionStatusNotice = ({
   const testDate = formatDate(testData.timestamp);
   return testData.succeeded ? (
     <Flex color="green.400" align="center" data-testid="connection-status">
-      <CheckCircleIcon mr={2} />
+      <CheckCircleIcon mr={2} boxSize={4} />
       <Text>Last connected {testDate}</Text>
     </Flex>
   ) : (
     <Flex color="red.400" align="center" data-testid="connection-status">
-      <WarningIcon mr={2} />
+      <WarningTwoIcon mr={2} boxSize={4} />
       <Text>Last connection failed {testDate}</Text>
     </Flex>
   );

--- a/clients/admin-ui/src/features/integrations/IntegrationBox.tsx
+++ b/clients/admin-ui/src/features/integrations/IntegrationBox.tsx
@@ -1,7 +1,8 @@
-import { Box, Button, Flex, Text } from "fidesui";
+import { Box, Button, ButtonGroup, Flex, Text } from "fidesui";
 
 import Tag from "~/features/common/Tag";
 import ConnectionTypeLogo from "~/features/datastore-connections/ConnectionTypeLogo";
+import useTestConnection from "~/features/datastore-connections/useTestConnection";
 import ConnectionStatusNotice from "~/features/integrations/ConnectionStatusNotice";
 import { ConnectionConfigurationResponse } from "~/types/api";
 
@@ -17,51 +18,55 @@ const IntegrationBox = ({
   showTestNotice?: boolean;
   buttonLabel?: string;
   onConfigureClick?: () => void;
-}) => (
-  <Box
-    maxW="760px"
-    borderWidth={1}
-    borderRadius="lg"
-    overflow="hidden"
-    height="114px"
-    padding="12px"
-    marginBottom="24px"
-    data-testid={`integration-info-${integration?.key}`}
-  >
-    <Flex>
-      <ConnectionTypeLogo data={integration ?? ""} boxSize="50px" />
-      <Flex direction="column" flexGrow={1} marginLeft="16px">
-        <Text color="gray.700" fontWeight="semibold">
-          {integration?.name || "(No name)"}
-        </Text>
-        {showTestNotice ? (
-          <ConnectionStatusNotice
-            timestamp={integration?.last_test_timestamp}
-            succeeded={integration?.last_test_succeeded}
-          />
-        ) : (
-          <Text color="gray.700" fontSize="sm" fontWeight="semibold" mt={1}>
-            Data Warehouse
+}) => {
+  const { testConnection, isLoading, testData } =
+    useTestConnection(integration);
+
+  return (
+    <Box
+      maxW="760px"
+      borderWidth={1}
+      borderRadius="lg"
+      overflow="hidden"
+      height="114px"
+      padding="12px"
+      marginBottom="24px"
+      data-testid={`integration-info-${integration?.key}`}
+    >
+      <Flex>
+        <ConnectionTypeLogo data={integration ?? ""} boxSize="50px" />
+        <Flex direction="column" flexGrow={1} marginLeft="16px">
+          <Text color="gray.700" fontWeight="semibold">
+            {integration?.name || "(No name)"}
           </Text>
-        )}
+          {showTestNotice ? (
+            <ConnectionStatusNotice testData={testData} />
+          ) : (
+            <Text color="gray.700" fontSize="sm" fontWeight="semibold" mt={1}>
+              Data Warehouse
+            </Text>
+          )}
+        </Flex>
+        <ButtonGroup size="sm" variant="outline">
+          {showTestNotice && (
+            <Button onClick={testConnection} isLoading={isLoading}>
+              Test connection
+            </Button>
+          )}
+          {onConfigureClick && (
+            <Button onClick={onConfigureClick} data-testid="configure-btn">
+              {buttonLabel}
+            </Button>
+          )}
+        </ButtonGroup>
       </Flex>
-      {onConfigureClick && (
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={onConfigureClick}
-          data-testid="configure-btn"
-        >
-          {buttonLabel}
-        </Button>
-      )}
-    </Flex>
-    <Flex marginTop="16px">
-      {BIGQUERY_TAGS.map((item) => (
-        <Tag key={item}>{item}</Tag>
-      ))}
-    </Flex>
-  </Box>
-);
+      <Flex marginTop="16px">
+        {BIGQUERY_TAGS.map((item) => (
+          <Tag key={item}>{item}</Tag>
+        ))}
+      </Flex>
+    </Box>
+  );
+};
 
 export default IntegrationBox;

--- a/clients/admin-ui/src/features/integrations/IntegrationBox.tsx
+++ b/clients/admin-ui/src/features/integrations/IntegrationBox.tsx
@@ -49,7 +49,11 @@ const IntegrationBox = ({
         </Flex>
         <ButtonGroup size="sm" variant="outline">
           {showTestNotice && (
-            <Button onClick={testConnection} isLoading={isLoading}>
+            <Button
+              onClick={testConnection}
+              isLoading={isLoading}
+              data-testid="test-connection-btn"
+            >
               Test connection
             </Button>
           )}

--- a/clients/admin-ui/src/pages/integrations/[id].tsx
+++ b/clients/admin-ui/src/pages/integrations/[id].tsx
@@ -1,4 +1,12 @@
-import { Box, Button, Flex, Spacer, Spinner, useDisclosure } from "fidesui";
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Flex,
+  Spacer,
+  Spinner,
+  useDisclosure,
+} from "fidesui";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 
@@ -7,6 +15,7 @@ import Layout from "~/features/common/Layout";
 import { INTEGRATION_MANAGEMENT_ROUTE } from "~/features/common/nav/v2/routes";
 import PageHeader from "~/features/common/PageHeader";
 import { useGetDatastoreConnectionByKeyQuery } from "~/features/datastore-connections";
+import useTestConnection from "~/features/datastore-connections/useTestConnection";
 import BigQueryOverview, {
   BigQueryInstructions,
 } from "~/features/integrations/bigqueryOverviewCopy";
@@ -18,9 +27,14 @@ import IntegrationBox from "~/features/integrations/IntegrationBox";
 const IntegrationDetailView: NextPage = () => {
   const { query } = useRouter();
   const id = Array.isArray(query.id) ? query.id[0] : query.id;
-  const { data: connection, isLoading } = useGetDatastoreConnectionByKeyQuery(
-    id ?? ""
-  );
+  const { data: connection, isLoading: integrationIsLoading } =
+    useGetDatastoreConnectionByKeyQuery(id ?? "");
+
+  const {
+    testConnection,
+    isLoading: testIsLoading,
+    testData,
+  } = useTestConnection(connection);
 
   const { onOpen, isOpen, onClose } = useDisclosure();
   const tabs: TabData[] = [
@@ -36,15 +50,17 @@ const IntegrationDetailView: NextPage = () => {
             p={3}
           >
             <Flex flexDirection="column">
-              <ConnectionStatusNotice
-                timestamp={connection?.last_test_timestamp}
-                succeeded={connection?.last_test_succeeded}
-              />
+              <ConnectionStatusNotice testData={testData} />
             </Flex>
             <Spacer />
-            <Button variant="outline" onClick={onOpen} data-testid="manage-btn">
-              Manage connection
-            </Button>
+            <ButtonGroup size="sm" variant="outline">
+              <Button onClick={testConnection} isLoading={testIsLoading}>
+                Test connection
+              </Button>
+              <Button onClick={onOpen} data-testid="manage-btn">
+                Manage
+              </Button>
+            </ButtonGroup>
           </Flex>
           <ConfigureIntegrationModal
             isOpen={isOpen}
@@ -76,7 +92,7 @@ const IntegrationDetailView: NextPage = () => {
         ]}
       >
         <IntegrationBox integration={connection} />
-        {isLoading ? <Spinner /> : <DataTabs data={tabs} isLazy />}
+        {integrationIsLoading ? <Spinner /> : <DataTabs data={tabs} isLazy />}
       </PageHeader>
     </Layout>
   );

--- a/clients/admin-ui/src/pages/integrations/[id].tsx
+++ b/clients/admin-ui/src/pages/integrations/[id].tsx
@@ -54,7 +54,11 @@ const IntegrationDetailView: NextPage = () => {
             </Flex>
             <Spacer />
             <ButtonGroup size="sm" variant="outline">
-              <Button onClick={testConnection} isLoading={testIsLoading}>
+              <Button
+                onClick={testConnection}
+                isLoading={testIsLoading}
+                data-testid="test-connection-btn"
+              >
                 Test connection
               </Button>
               <Button onClick={onOpen} data-testid="manage-btn">


### PR DESCRIPTION
Closes PROD-2129

### Description Of Changes

Add a "test connection" button to the new integrations UI on the list view and also detail view.

![Screenshot 2024-06-06 at 16 19 47](https://github.com/ethyca/fides/assets/6394496/04fcc41f-09a4-4f30-84b5-c6685c2bbb9a)
![Screenshot 2024-06-06 at 16 20 00](https://github.com/ethyca/fides/assets/6394496/f5f02faa-9784-474d-861c-24415965708f)
![Screenshot 2024-06-06 at 16 20 18](https://github.com/ethyca/fides/assets/6394496/599e8580-0522-4800-aaf8-9ac86b2bbfd6)
![Screenshot 2024-06-06 at 16 21 32](https://github.com/ethyca/fides/assets/6394496/0919ce72-33b5-4cdc-a8ab-108cae110e9f)

### Code Changes

* [ ] Add "test connection" buttons to IntegrationBox and integration detail view pages
* [ ] Add new `useTestConnection` hook to control both and provide data and toasts

### Steps to Confirm

* Navigate to `/integrations`
* Create a new BigQuery integration and provide it with credentials
* On integration detail view, click "test connection"; should see success toast and status message should update with current timestamp
* Return to list view and click "test connection"; same thing should happen
* Return to detail view and click "manage"
* Input any incorrect credentials JSON
* Click "test connection" again
* Should show failure toast and change to failure message

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
