### PR TITLE
remove unnecessary ending slash (/) in endpoint URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The types of changes are:
 
 ### Fixed
 - Fixed an issue where the GPP signal status was prematurely set to `ready` in some scenarios [#4957](https://github.com/ethyca/fides/pull/4957)
+- Removed exteraneous `/` from the several endpoint URLs [#4962](https://github.com/ethyca/fides/pull/4962)
 
 ## [2.38.0](https://github.com/ethyca/fides/compare/2.37.0...2.38.0)
 

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -89,7 +89,7 @@ export const stubDatasetCrud = () => {
   );
 
   // Update
-  cy.intercept("PUT", "/api/v1/dataset/*", { fixture: "dataset.json" }).as(
+  cy.intercept("PUT", "/api/v1/dataset*", { fixture: "dataset.json" }).as(
     "putDataset"
   );
 

--- a/clients/admin-ui/src/features/data-subjects/data-subject.slice.ts
+++ b/clients/admin-ui/src/features/data-subjects/data-subject.slice.ts
@@ -7,7 +7,7 @@ import { DataSubject } from "~/types/api";
 const dataSubjectsApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getAllDataSubjects: build.query<DataSubject[], void>({
-      query: () => ({ url: `data_subject/` }),
+      query: () => ({ url: `data_subject` }),
       providesTags: () => ["Data Subjects"],
       transformResponse: (subjects: DataSubject[]) =>
         subjects.sort((a, b) => a.fides_key.localeCompare(b.fides_key)),
@@ -17,7 +17,7 @@ const dataSubjectsApi = baseApi.injectEndpoints({
       Partial<DataSubject> & Pick<DataSubject, "fides_key">
     >({
       query: (dataSubject) => ({
-        url: `data_subject/`,
+        url: `data_subject`,
         params: { resource_type: "data_subject" },
         method: "PUT",
         body: dataSubject,
@@ -26,7 +26,7 @@ const dataSubjectsApi = baseApi.injectEndpoints({
     }),
     createDataSubject: build.mutation<DataSubject, DataSubject>({
       query: (dataSubject) => ({
-        url: `data_subject/`,
+        url: `data_subject`,
         method: "POST",
         body: dataSubject,
       }),

--- a/clients/admin-ui/src/features/data-use/data-use.slice.ts
+++ b/clients/admin-ui/src/features/data-use/data-use.slice.ts
@@ -7,7 +7,7 @@ import { DataUse } from "~/types/api";
 const dataUseApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getAllDataUses: build.query<DataUse[], void>({
-      query: () => ({ url: `data_use/` }),
+      query: () => ({ url: `data_use` }),
       providesTags: () => ["Data Uses"],
       transformResponse: (uses: DataUse[]) =>
         uses.sort((a, b) => a.fides_key.localeCompare(b.fides_key)),
@@ -20,7 +20,7 @@ const dataUseApi = baseApi.injectEndpoints({
       Partial<DataUse> & Pick<DataUse, "fides_key">
     >({
       query: (dataUse) => ({
-        url: `data_use/`,
+        url: `data_use`,
         params: { resource_type: "data_use" },
         method: "PUT",
         body: dataUse,
@@ -29,7 +29,7 @@ const dataUseApi = baseApi.injectEndpoints({
     }),
     createDataUse: build.mutation<DataUse, DataUse>({
       query: (dataUse) => ({
-        url: `data_use/`,
+        url: `data_use`,
         method: "POST",
         body: dataUse,
       }),

--- a/clients/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/admin-ui/src/features/dataset/dataset.slice.ts
@@ -30,7 +30,7 @@ interface DatasetDeleteResponse {
 const datasetApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getAllDatasets: build.query<Dataset[], void>({
-      query: () => ({ url: `dataset/` }),
+      query: () => ({ url: `dataset` }),
       providesTags: () => ["Datasets"],
     }),
     getAllFilteredDatasets: build.query<
@@ -52,7 +52,7 @@ const datasetApi = baseApi.injectEndpoints({
       Partial<Dataset> & Pick<Dataset, "fides_key">
     >({
       query: (dataset) => ({
-        url: `dataset/`,
+        url: `dataset`,
         params: { resource_type: "dataset" },
         method: "PUT",
         body: dataset,
@@ -63,7 +63,7 @@ const datasetApi = baseApi.injectEndpoints({
     // on the backend to do the validation for us
     createDataset: build.mutation<Dataset, Dataset | unknown>({
       query: (dataset) => ({
-        url: `dataset/`,
+        url: `dataset`,
         method: "POST",
         body: dataset,
       }),
@@ -90,7 +90,7 @@ const datasetApi = baseApi.injectEndpoints({
     }),
     generateDataset: build.mutation<GenerateResponse, GenerateRequestPayload>({
       query: (payload) => ({
-        url: `generate/`,
+        url: `generate`,
         method: "POST",
         body: payload,
       }),

--- a/clients/admin-ui/src/features/messaging-templates/messaging-templates.slice.ts
+++ b/clients/admin-ui/src/features/messaging-templates/messaging-templates.slice.ts
@@ -19,7 +19,7 @@ export type BulkPutMessagingTemplateResponse = {
 const messagingTemplatesApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getMessagingTemplates: build.query<MessagingTemplate[], void>({
-      query: () => ({ url: `messaging/templates/` }),
+      query: () => ({ url: `messaging/templates` }),
       providesTags: () => ["Messaging Templates"],
     }),
     updateMessagingTemplates: build.mutation<
@@ -27,7 +27,7 @@ const messagingTemplatesApi = baseApi.injectEndpoints({
       MessagingTemplate[]
     >({
       query: (templates) => ({
-        url: `messaging/templates/`,
+        url: `messaging/templates`,
         method: "PUT",
         body: templates,
       }),

--- a/clients/admin-ui/src/features/organization/organization.slice.ts
+++ b/clients/admin-ui/src/features/organization/organization.slice.ts
@@ -8,7 +8,7 @@ const organizationApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     createOrganization: build.mutation<Organization, Partial<Organization>>({
       query: (body) => ({
-        url: `organization/`,
+        url: `organization`,
         method: "POST",
         body,
       }),
@@ -18,7 +18,7 @@ const organizationApi = baseApi.injectEndpoints({
       Partial<Organization> & Pick<Organization, "fides_key">,
       string
     >({
-      query: (fides_key) => ({ url: `organization/${fides_key}/` }),
+      query: (fides_key) => ({ url: `organization/${fides_key}` }),
       providesTags: ["Organization"],
     }),
     updateOrganization: build.mutation<
@@ -26,7 +26,7 @@ const organizationApi = baseApi.injectEndpoints({
       Partial<Organization> & Pick<Organization, "fides_key">
     >({
       query: ({ ...patch }) => ({
-        url: `organization/`,
+        url: `organization`,
         method: "PUT",
         body: patch,
       }),

--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -70,7 +70,7 @@ const plusApi = baseApi.injectEndpoints({
       ClassifyRequestPayload
     >({
       query: (body) => ({
-        url: `plus/classify/`,
+        url: `plus/classify`,
         method: "POST",
         body,
       }),
@@ -84,7 +84,7 @@ const plusApi = baseApi.injectEndpoints({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         const { resource_type = GenerateTypes.DATASETS, ...body } = payload;
         return {
-          url: `plus/classify/`,
+          url: `plus/classify`,
           method: "PUT",
           params: { resource_type },
           body,
@@ -108,7 +108,7 @@ const plusApi = baseApi.injectEndpoints({
           urlParams.append("fides_keys", key);
         });
         return {
-          url: `plus/classify/?${urlParams.toString()}`,
+          url: `plus/classify?${urlParams.toString()}`,
           method: "GET",
         };
       },

--- a/clients/admin-ui/src/features/privacy-experience/language.slice.ts
+++ b/clients/admin-ui/src/features/privacy-experience/language.slice.ts
@@ -24,7 +24,7 @@ const languageApi = baseApi.injectEndpoints({
     getAllLanguages: build.query<Page_Language_, LanguageQueryParams>({
       query: (params) => ({
         params,
-        url: `/plus/languages/`,
+        url: `/plus/languages`,
       }),
       providesTags: () => ["Languages"],
     }),

--- a/clients/admin-ui/src/features/privacy-experience/privacy-experience.slice.ts
+++ b/clients/admin-ui/src/features/privacy-experience/privacy-experience.slice.ts
@@ -71,7 +71,7 @@ const privacyExperienceConfigApi = baseApi.injectEndpoints({
       ExperienceConfigParams
     >({
       query: (params) => ({
-        url: `experience-config/`,
+        url: `experience-config`,
         params: { ...params, show_disabled: true },
       }),
       providesTags: () => ["Privacy Experience Configs"],
@@ -124,7 +124,7 @@ const privacyExperienceConfigApi = baseApi.injectEndpoints({
     >({
       query: (payload) => ({
         method: "POST",
-        url: `experience-config/`,
+        url: `experience-config`,
         body: payload,
       }),
       invalidatesTags: () => ["Privacy Experience Configs", "Property"],

--- a/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
+++ b/clients/admin-ui/src/features/privacy-notices/privacy-notices.slice.ts
@@ -46,7 +46,7 @@ const privacyNoticesApi = baseApi.injectEndpoints({
       PrivacyNoticesParams
     >({
       query: (params) => ({
-        url: `privacy-notice/`,
+        url: `privacy-notice`,
         params: { ...params, show_disabled: true },
       }),
       providesTags: () => ["Privacy Notices"],
@@ -103,7 +103,7 @@ const privacyNoticesApi = baseApi.injectEndpoints({
     >({
       query: (payload) => ({
         method: "POST",
-        url: `privacy-notice/`,
+        url: `privacy-notice`,
         body: payload,
       }),
       invalidatesTags: () => ["Privacy Notices"],

--- a/clients/admin-ui/src/features/system/system.slice.ts
+++ b/clients/admin-ui/src/features/system/system.slice.ts
@@ -31,7 +31,7 @@ export type ConnectionConfigSecretsRequest = {
 const systemApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getAllSystems: build.query<SystemResponse[], void>({
-      query: () => ({ url: `system/` }),
+      query: () => ({ url: `system` }),
       providesTags: () => ["System"],
       transformResponse: (systems: SystemResponse[]) =>
         systems.sort((a, b) => {
@@ -43,14 +43,14 @@ const systemApi = baseApi.injectEndpoints({
         }),
     }),
     getSystemByFidesKey: build.query<SystemResponse, string>({
-      query: (fides_key) => ({ url: `system/${fides_key}/` }),
+      query: (fides_key) => ({ url: `system/${fides_key}` }),
       providesTags: ["System"],
     }),
     // we accept 'unknown' as well since the user can paste anything in, and we rely
     // on the backend to do the validation for us
     createSystem: build.mutation<SystemResponse, System | unknown>({
       query: (body) => ({
-        url: `system/`,
+        url: `system`,
         method: "POST",
         body,
       }),
@@ -95,7 +95,7 @@ const systemApi = baseApi.injectEndpoints({
       Partial<System> & Pick<System, "fides_key">
     >({
       query: ({ ...patch }) => ({
-        url: `system/`,
+        url: `system`,
         params: { resource_type: "system" },
         method: "PUT",
         body: patch,

--- a/clients/admin-ui/src/features/taxonomy/taxonomy.slice.ts
+++ b/clients/admin-ui/src/features/taxonomy/taxonomy.slice.ts
@@ -7,7 +7,7 @@ import { DataCategory } from "~/types/api";
 const taxonomyApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getAllDataCategories: build.query<DataCategory[], void>({
-      query: () => ({ url: `data_category/` }),
+      query: () => ({ url: `data_category` }),
       providesTags: () => ["Data Categories"],
       transformResponse: (categories: DataCategory[]) =>
         categories.sort((a, b) => a.fides_key.localeCompare(b.fides_key)),
@@ -17,7 +17,7 @@ const taxonomyApi = baseApi.injectEndpoints({
       Partial<DataCategory> & Pick<DataCategory, "fides_key">
     >({
       query: (dataCategory) => ({
-        url: `data_category/`,
+        url: `data_category`,
         params: { resource_type: "data_category" },
         method: "PUT",
         body: dataCategory,
@@ -27,7 +27,7 @@ const taxonomyApi = baseApi.injectEndpoints({
 
     createDataCategory: build.mutation<DataCategory, DataCategory>({
       query: (dataCategory) => ({
-        url: `data_category/`,
+        url: `data_category`,
         method: "POST",
         body: dataCategory,
       }),


### PR DESCRIPTION
Closes [PROD-2178](https://ethyca.atlassian.net/browse/PROD-2178)

### Description Of Changes

Many of our endpoints in Fides Admin UI are pointing at a URL unnecessarily ending with `/` which ends up being redirected in the browser behind the scenes to the same URL without it.

Fixing these URLs in the code is a quick way to optimize our response time!

![image](https://github.com/ethyca/fides/assets/103820/17454e8e-3b73-4e98-853e-86e55a5816d0)


### Steps to Confirm

* Open DevTools to the Network tab
* Visit Fides Admin UI and click around to various pages
* Endpoints should be getting called directly without redirecting

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[PROD-2178]: https://ethyca.atlassian.net/browse/PROD-2178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ