### PR TITLE
PROD-2134: Adds validation for taxonomy labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The types of changes are:
 - Fixed "add" icons on some buttons being wrong size [#4975](https://github.com/ethyca/fides/pull/4975)
 - Masked "Keyfile credentials" input on integration config form [#4971](https://github.com/ethyca/fides/pull/4971)
 - Fixed ability to update consent preferences after they've previously been set [#4984](https://github.com/ethyca/fides/pull/4984)
+- Fixed validations for privacy declaration taxonomy labels when creating/updating a System [#4982](https://github.com/ethyca/fides/pull/4982)
 
 ## [2.38.0](https://github.com/ethyca/fides/compare/2.37.0...2.38.0)
 

--- a/src/fides/api/alembic/migrations/versions/a3c173391603_add_property_id_to_privacy_request_model.py
+++ b/src/fides/api/alembic/migrations/versions/a3c173391603_add_property_id_to_privacy_request_model.py
@@ -6,9 +6,8 @@ Create Date: 2024-06-04 17:40:35.230801
 
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a3c173391603"

--- a/src/fides/api/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/consent_request_endpoints.py
@@ -41,7 +41,7 @@ from fides.api.models.privacy_request import (
 )
 from fides.api.models.property import Property
 from fides.api.oauth.utils import verify_oauth_client
-from fides.api.schemas.messaging.messaging import MessagingMethod, MessagingActionType
+from fides.api.schemas.messaging.messaging import MessagingActionType, MessagingMethod
 from fides.api.schemas.privacy_request import BulkPostPrivacyRequests
 from fides.api.schemas.privacy_request import Consent as ConsentSchema
 from fides.api.schemas.privacy_request import (
@@ -56,9 +56,7 @@ from fides.api.schemas.privacy_request import (
 )
 from fides.api.schemas.redis_cache import Identity
 from fides.api.service._verification import send_verification_code_to_user
-from fides.api.service.messaging.message_dispatch_service import (
-    message_send_enabled,
-)
+from fides.api.service.messaging.message_dispatch_service import message_send_enabled
 from fides.api.util.api_router import APIRouter
 from fides.api.util.consent_util import (
     get_or_create_fides_user_device_id_provided_identity,

--- a/src/fides/api/schemas/connection_configuration/__init__.py
+++ b/src/fides/api/schemas/connection_configuration/__init__.py
@@ -87,7 +87,8 @@ from fides.api.schemas.connection_configuration.connection_secrets_saas import (
     SaaSSchemaFactory as SaaSSchemaFactory,
 )
 from fides.api.schemas.connection_configuration.connection_secrets_scylla import (
-    ScyllaSchema, ScyllaDocsSchema,
+    ScyllaDocsSchema,
+    ScyllaSchema,
 )
 from fides.api.schemas.connection_configuration.connection_secrets_snowflake import (
     SnowflakeDocsSchema as SnowflakeDocsSchema,
@@ -175,5 +176,5 @@ connection_secrets_schemas = Union[
     FidesDocsSchema,
     SovrnDocsSchema,
     DynamoDBDocsSchema,
-    ScyllaDocsSchema
+    ScyllaDocsSchema,
 ]

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -83,7 +83,7 @@ def fixture_inactive_data_category(db: Session) -> typing.Generator:
     """
     Fixture that yields an inactive data category and then deletes it for each test run.
     """
-    fides_key = "foo"
+    fides_key = "inactive_data_category"
     data_category = DataCategoryModel.create(
         db=db,
         data={
@@ -102,7 +102,7 @@ def fixture_inactive_data_use(db: Session) -> typing.Generator:
     """
     Fixture that yields an inactive data category and then deletes it for each test run.
     """
-    fides_key = "foo"
+    fides_key = "inactive_data_use"
     data_use = DataUseModel.create(
         db=db,
         data={
@@ -121,7 +121,7 @@ def fixture_inactive_data_subject(db: Session) -> typing.Generator:
     """
     Fixture that yields an inactive data category and then deletes it for each test run.
     """
-    fides_key = "foo"
+    fides_key = "inactive_data_subject"
     data_subject = DataSubjectModel.create(
         db=db,
         data={

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -88,6 +88,7 @@ def fixture_inactive_data_category(db: Session) -> typing.Generator:
         db=db,
         data={
             "fides_key": fides_key,
+            "name": "Inactive Category",
             "active": False,
         },
     )
@@ -107,6 +108,7 @@ def fixture_inactive_data_use(db: Session) -> typing.Generator:
         db=db,
         data={
             "fides_key": fides_key,
+            "name": "Inactive Use",
             "active": False,
         },
     )
@@ -126,6 +128,7 @@ def fixture_inactive_data_subject(db: Session) -> typing.Generator:
         db=db,
         data={
             "fides_key": fides_key,
+            "name": "Inactive Subject",
             "active": False,
         },
     )
@@ -1651,7 +1654,9 @@ class TestSystemUpdate:
         db,
     ):
         auth_header = generate_role_header(roles=[OWNER])
-        system_update_request_body.privacy_declarations[0].data_use = inactive_data_use.fides_key
+        system_update_request_body.privacy_declarations[0].data_use = (
+            inactive_data_use.fides_key
+        )
         result = _api.update(
             url=test_config.cli.server_url,
             headers=auth_header,

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -78,7 +78,7 @@ def get_existing_key(test_config: FidesConfig, resource_type: str) -> int:
     ).json()[-1]["fides_key"]
 
 
-@pytest.fixture(scope="function", name="data_category")
+@pytest.fixture(scope="function", name="inactive_data_category")
 def fixture_inactive_data_category(db: Session) -> typing.Generator:
     """
     Fixture that yields an inactive data category and then deletes it for each test run.
@@ -97,10 +97,10 @@ def fixture_inactive_data_category(db: Session) -> typing.Generator:
     data_category.delete(db)
 
 
-@pytest.fixture(scope="function", name="data_use")
+@pytest.fixture(scope="function", name="inactive_data_use")
 def fixture_inactive_data_use(db: Session) -> typing.Generator:
     """
-    Fixture that yields an inactive data category and then deletes it for each test run.
+    Fixture that yields an inactive data use and then deletes it for each test run.
     """
     fides_key = "inactive_data_use"
     data_use = DataUseModel.create(
@@ -116,10 +116,10 @@ def fixture_inactive_data_use(db: Session) -> typing.Generator:
     data_use.delete(db)
 
 
-@pytest.fixture(scope="function", name="data_subject")
+@pytest.fixture(scope="function", name="inactive_data_subject")
 def fixture_inactive_data_subject(db: Session) -> typing.Generator:
     """
-    Fixture that yields an inactive data category and then deletes it for each test run.
+    Fixture that yields an inactive data subject and then deletes it for each test run.
     """
     fides_key = "inactive_data_subject"
     data_subject = DataSubjectModel.create(
@@ -753,7 +753,7 @@ class TestSystemCreate:
         assert not System.all(db)  # ensure our system wasn't created
 
     def test_system_create_inactive_data_category(
-        self, test_config, data_category, db, generate_auth_header
+        self, test_config, inactive_data_category, db, generate_auth_header
     ):
         auth_header = generate_auth_header(scopes=[SYSTEM_CREATE])
 
@@ -771,7 +771,7 @@ class TestSystemCreate:
                             "data_categories": [
                                 "user.name.first",
                                 "user.name.last",
-                                data_category.fides_key,
+                                inactive_data_category.fides_key,
                             ],
                             "data_use": "marketing",
                         }
@@ -782,13 +782,13 @@ class TestSystemCreate:
 
         assert result.status_code == HTTP_400_BAD_REQUEST
         assert result.json() == {
-            "detail": f"Invalid privacy declaration referencing inactive DataCategory {data_category.fides_key}"
+            "detail": f"Invalid privacy declaration referencing inactive DataCategory {inactive_data_category.fides_key}"
         }
 
         assert not System.all(db)  # ensure our system wasn't created
 
     def test_system_create_inactive_data_use(
-        self, test_config, data_use, db, generate_auth_header
+        self, test_config, inactive_data_use, db, generate_auth_header
     ):
         auth_header = generate_auth_header(scopes=[SYSTEM_CREATE])
 
@@ -807,7 +807,7 @@ class TestSystemCreate:
                                 "user.name.first",
                                 "user.name.last",
                             ],
-                            "data_use": data_use.fides_key,
+                            "data_use": inactive_data_use.fides_key,
                         }
                     ],
                 }
@@ -816,13 +816,13 @@ class TestSystemCreate:
 
         assert result.status_code == HTTP_400_BAD_REQUEST
         assert result.json() == {
-            "detail": f"Invalid privacy declaration referencing inactive DataUse {data_use.fides_key}"
+            "detail": f"Invalid privacy declaration referencing inactive DataUse {inactive_data_use.fides_key}"
         }
 
         assert not System.all(db)  # ensure our system wasn't created
 
     def test_system_create_inactive_data_subject(
-        self, test_config, data_subject, db, generate_auth_header
+        self, test_config, inactive_data_subject, db, generate_auth_header
     ):
         auth_header = generate_auth_header(scopes=[SYSTEM_CREATE])
 
@@ -842,7 +842,7 @@ class TestSystemCreate:
                                 "user.name.last",
                             ],
                             "data_use": "marketing",
-                            "data_subjects": [data_subject.fides_key],
+                            "data_subjects": [inactive_data_subject.fides_key],
                         }
                     ],
                 }
@@ -851,7 +851,7 @@ class TestSystemCreate:
 
         assert result.status_code == HTTP_400_BAD_REQUEST
         assert result.json() == {
-            "detail": f"Invalid privacy declaration referencing inactive DataSubject {data_subject.fides_key}"
+            "detail": f"Invalid privacy declaration referencing inactive DataSubject {inactive_data_subject.fides_key}"
         }
 
         assert not System.all(db)  # ensure our system wasn't created
@@ -1646,12 +1646,12 @@ class TestSystemUpdate:
         system,
         test_config,
         system_update_request_body,
-        data_use,
+        inactive_data_use,
         generate_role_header,
         db,
     ):
         auth_header = generate_role_header(roles=[OWNER])
-        system_update_request_body.privacy_declarations[0].data_use = data_use.fides_key
+        system_update_request_body.privacy_declarations[0].data_use = inactive_data_use.fides_key
         result = _api.update(
             url=test_config.cli.server_url,
             headers=auth_header,
@@ -1660,7 +1660,7 @@ class TestSystemUpdate:
         )
         assert result.status_code == HTTP_400_BAD_REQUEST
         assert result.json() == {
-            "detail": f"Invalid privacy declaration referencing inactive DataUse {data_use.fides_key}"
+            "detail": f"Invalid privacy declaration referencing inactive DataUse {inactive_data_use.fides_key}"
         }
         # assert the system's privacy declaration has not been updated
         db.refresh(system)
@@ -1671,13 +1671,13 @@ class TestSystemUpdate:
         system,
         test_config,
         system_update_request_body,
-        data_category,
+        inactive_data_category,
         generate_role_header,
         db,
     ):
         auth_header = generate_role_header(roles=[OWNER])
         system_update_request_body.privacy_declarations[0].data_categories = [
-            data_category.fides_key
+            inactive_data_category.fides_key
         ]
         result = _api.update(
             url=test_config.cli.server_url,
@@ -1687,7 +1687,7 @@ class TestSystemUpdate:
         )
         assert result.status_code == HTTP_400_BAD_REQUEST
         assert result.json() == {
-            "detail": f"Invalid privacy declaration referencing inactive DataCategory {data_category.fides_key}"
+            "detail": f"Invalid privacy declaration referencing inactive DataCategory {inactive_data_category.fides_key}"
         }
         # assert the system's privacy declaration has not been updated
         db.refresh(system)
@@ -1700,13 +1700,13 @@ class TestSystemUpdate:
         system,
         test_config,
         system_update_request_body,
-        data_subject,
+        inactive_data_subject,
         generate_role_header,
         db,
     ):
         auth_header = generate_role_header(roles=[OWNER])
         system_update_request_body.privacy_declarations[0].data_subjects = [
-            data_subject.fides_key
+            inactive_data_subject.fides_key
         ]
         result = _api.update(
             url=test_config.cli.server_url,
@@ -1716,7 +1716,7 @@ class TestSystemUpdate:
         )
         assert result.status_code == HTTP_400_BAD_REQUEST
         assert result.json() == {
-            "detail": f"Invalid privacy declaration referencing inactive DataSubject {data_subject.fides_key}"
+            "detail": f"Invalid privacy declaration referencing inactive DataSubject {inactive_data_subject.fides_key}"
         }
         # assert the system's privacy declaration has not been updated
         db.refresh(system)

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -13,6 +13,7 @@ from fideslang import DEFAULT_TAXONOMY, model_list, models, parse
 from fideslang.models import PrivacyDeclaration as PrivacyDeclarationSchema
 from fideslang.models import System as SystemSchema
 from pytest import MonkeyPatch
+from sqlalchemy.orm import Session
 from starlette.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
@@ -24,14 +25,17 @@ from starlette.status import (
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
 from starlette.testclient import TestClient
-from sqlalchemy.orm import Session
 
 from fides.api.api.v1.endpoints import health
 from fides.api.db.crud import get_resource
 from fides.api.db.system import create_system
 from fides.api.models.connectionconfig import ConnectionConfig
 from fides.api.models.datasetconfig import DatasetConfig
-from fides.api.models.sql_models import Dataset, PrivacyDeclaration, System, DataCategory as DataCategoryModel, DataUse as DataUseModel, DataSubject as DataSubjectModel
+from fides.api.models.sql_models import DataCategory as DataCategoryModel
+from fides.api.models.sql_models import Dataset
+from fides.api.models.sql_models import DataSubject as DataSubjectModel
+from fides.api.models.sql_models import DataUse as DataUseModel
+from fides.api.models.sql_models import PrivacyDeclaration, System
 from fides.api.models.system_history import SystemHistory
 from fides.api.models.tcf_purpose_overrides import TCFPurposeOverride
 from fides.api.oauth.roles import OWNER, VIEWER
@@ -515,22 +519,23 @@ class TestSystemCreate:
             ],
         )
 
-
     @pytest.fixture(scope="function", name="data_category")
     def fixture_inactive_data_category(self, db: Session) -> typing.Generator:
         """
         Fixture that yields an inactive data category and then deletes it for each test run.
         """
         fides_key = "foo"
-        data_category = DataCategoryModel.create(db=db, data={
-            "fides_key": fides_key,
-            "active": False,
-        })
+        data_category = DataCategoryModel.create(
+            db=db,
+            data={
+                "fides_key": fides_key,
+                "active": False,
+            },
+        )
 
         yield data_category
 
         data_category.delete(db)
-
 
     @pytest.fixture(scope="function", name="data_use")
     def fixture_inactive_data_use(self, db: Session) -> typing.Generator:
@@ -538,10 +543,13 @@ class TestSystemCreate:
         Fixture that yields an inactive data category and then deletes it for each test run.
         """
         fides_key = "foo"
-        data_use = DataUseModel.create(db=db, data={
-            "fides_key": fides_key,
-            "active": False,
-        })
+        data_use = DataUseModel.create(
+            db=db,
+            data={
+                "fides_key": fides_key,
+                "active": False,
+            },
+        )
 
         yield data_use
 
@@ -553,10 +561,13 @@ class TestSystemCreate:
         Fixture that yields an inactive data category and then deletes it for each test run.
         """
         fides_key = "foo"
-        data_subject = DataSubjectModel.create(db=db, data={
-            "fides_key": fides_key,
-            "active": False,
-        })
+        data_subject = DataSubjectModel.create(
+            db=db,
+            data={
+                "fides_key": fides_key,
+                "active": False,
+            },
+        )
 
         yield data_subject
 
@@ -841,7 +852,6 @@ class TestSystemCreate:
         }
 
         assert not System.all(db)  # ensure our system wasn't created
-
 
     async def test_system_create(
         self, generate_auth_header, db, test_config, system_create_request_body


### PR DESCRIPTION
Closes PROD-2134

### Description Of Changes

When creating or updating a `System`, we now validate that it references `DataUses`, `DataCategories`, and `DataSubjects` that both exist and have their `active` attribute set to `True`.

### Code Changes

* Updated the `validate_privacy_declarations` method to add validation for `DataCategories` and `DataSubjects` and to update the validation for `DataUses`
* Added relevant unit tests

### Steps to Confirm

#### Testing for invalid taxonomy labels

1. Go to the `POST api/v1/system` endpoint in the Swagger UI, or alternatively make the request from Postman
2. Use an invalid category for a privacy declaration in the request body, see example JSON below (invalid category is ` "user.contact.company_website"`):
```
{
    "system_type": "Third Party",
    "fides_key": "salesforce_system",
    "name": "Salesforce",
    "description": "Salesforce operates as a business development and lead generation tool (Salesforce Interaction Studio and Salesforce Sales Cloud), it is also used for customer operations (support) personnel management and ticket management for customers (Salesforce Service Cloud)!",
    "dataset_references": [],
    "tags": [
        "Customer-SM"
    ],
    "processes_personal_data": true,
    "exempt_from_privacy_regulations": false,
    "privacy_declarations": [
        {
            "name": "Marketing Campaigns",
            "data_categories": [
                "user.contact",
                "user.contact.company_website"
            ],
            "data_use": "marketing",
            "data_subjects": [
                "visitor"
            ],
            "dataset_references": [
                "saas_salesforce"
            ],
            "egress": null,
            "ingress": null,
            "features": [],
            "flexible_legal_basis_for_processing": false,
            "legal_basis_for_processing": "Consent",
            "impact_assessment_location": null,
            "retention_period": "No retention or erasure policy",
            "processes_special_category_data": false,
            "special_category_legal_basis": null,
            "data_shared_with_third_parties": false,
            "third_parties": null,
            "shared_categories": [],
            "cookies": [],
            "id": "pri_b688c9e9-59f1-44f7-a16b-33681bd3725b"
        }
    ],
    "vendor_id": null,
    "ingress": [
        {
            "fides_key": "platform_system",
            "type": "system",
            "data_categories": []
        },
        {
            "fides_key": "hubspot_system",
            "type": "system",
            "data_categories": []
        }
    ],
    "egress": [
        {
            "fides_key": "de_snowflake",
            "type": "system",
            "data_categories": []
        },
        {
            "fides_key": "outreach_system",
            "type": "system",
            "data_categories": null
        },
        {
            "fides_key": "hubspot_system",
            "type": "system",
            "data_categories": null
        }
    ],
    "meta": null,
    "fidesctl_meta": null,
    "organization_fides_key": "default_organization",
    "dpa_progress": null,
    "previous_vendor_id": null,
    "cookies": [],
    "uses_cookies": false,
    "cookie_refresh": false,
    "uses_non_cookie_access": false,
    "uses_profiling": false,
    "does_international_transfers": true,
    "legal_basis_for_transfers": [],
    "requires_data_protection_assessments": false,
    "legal_name": null,
    "legal_address": "",
    "responsibility": [
        "Controller"
    ],
    "dpo": "",
    "data_security_practices": "",
    "administrating_department": "Business Systems and Sales & Success Teams"
}

```
3. Should receive a 400 response with message
```
{
  "detail": "Invalid privacy declaration referencing unknown DataCategory user.contact.company_website"
}
```

The same can be done for invalid data uses and data subjects.

#### Testing for disabled taxonomy labels


1. In the Admin UI, create the "user.contact.company_website" Data Category and mark it as disabled using the toggle button
2. Go to the `POST api/v1/system` endpoint in the Swagger UI, or alternatively make the request from Postman
3. Use the disabled category `"user.contact.company_website"` for a privacy declaration in the request body, see example JSON below:
```
{
    "system_type": "Third Party",
    "fides_key": "salesforce_system",
    "name": "Salesforce",
    "description": "Salesforce operates as a business development and lead generation tool (Salesforce Interaction Studio and Salesforce Sales Cloud), it is also used for customer operations (support) personnel management and ticket management for customers (Salesforce Service Cloud)!",
    "dataset_references": [],
    "tags": [
        "Customer-SM"
    ],
    "processes_personal_data": true,
    "exempt_from_privacy_regulations": false,
    "privacy_declarations": [
        {
            "name": "Marketing Campaigns",
            "data_categories": [
                "user.contact",
                "user.contact.company_website"
            ],
            "data_use": "marketing",
            "data_subjects": [
                "visitor"
            ],
            "dataset_references": [
                "saas_salesforce"
            ],
            "egress": null,
            "ingress": null,
            "features": [],
            "flexible_legal_basis_for_processing": false,
            "legal_basis_for_processing": "Consent",
            "impact_assessment_location": null,
            "retention_period": "No retention or erasure policy",
            "processes_special_category_data": false,
            "special_category_legal_basis": null,
            "data_shared_with_third_parties": false,
            "third_parties": null,
            "shared_categories": [],
            "cookies": [],
            "id": "pri_b688c9e9-59f1-44f7-a16b-33681bd3725b"
        }
    ],
    "vendor_id": null,
    "ingress": [
        {
            "fides_key": "platform_system",
            "type": "system",
            "data_categories": []
        },
        {
            "fides_key": "hubspot_system",
            "type": "system",
            "data_categories": []
        }
    ],
    "egress": [
        {
            "fides_key": "de_snowflake",
            "type": "system",
            "data_categories": []
        },
        {
            "fides_key": "outreach_system",
            "type": "system",
            "data_categories": null
        },
        {
            "fides_key": "hubspot_system",
            "type": "system",
            "data_categories": null
        }
    ],
    "meta": null,
    "fidesctl_meta": null,
    "organization_fides_key": "default_organization",
    "dpa_progress": null,
    "previous_vendor_id": null,
    "cookies": [],
    "uses_cookies": false,
    "cookie_refresh": false,
    "uses_non_cookie_access": false,
    "uses_profiling": false,
    "does_international_transfers": true,
    "legal_basis_for_transfers": [],
    "requires_data_protection_assessments": false,
    "legal_name": null,
    "legal_address": "",
    "responsibility": [
        "Controller"
    ],
    "dpo": "",
    "data_security_practices": "",
    "administrating_department": "Business Systems and Sales & Success Teams"
}

```
4. Should receive a 400 response with message
```
{
  "detail": "Invalid privacy declaration referencing inactive DataCategory user.contact.company_website"
}
```
5. If you enable the created Data Category, you should be able to re-trigger the request and have it succeed. 


The same can be done for disabled data uses and data subjects.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
