### PR TITLE
Fix cookie update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The types of changes are:
 - Fixed and optimized Database Icon SVGs used in Datamap [#4969](https://github.com/ethyca/fides/pull/4969)
 - Fixed "add" icons on some buttons being wrong size [#4975](https://github.com/ethyca/fides/pull/4975)
 - Masked "Keyfile credentials" input on integration config form [#4971](https://github.com/ethyca/fides/pull/4971)
+- Fixed ability to update consent preferences after they've previously been set [#4984](https://github.com/ethyca/fides/pull/4984)
 
 ## [2.38.0](https://github.com/ethyca/fides/compare/2.37.0...2.38.0)
 

--- a/clients/fides-js/__tests__/lib/cookie.test.ts
+++ b/clients/fides-js/__tests__/lib/cookie.test.ts
@@ -208,6 +208,11 @@ describe("getOrMakeFidesCookie", () => {
 });
 
 describe("saveFidesCookie", () => {
+  beforeEach(() =>
+    mockGetCookie.mockReturnValue(
+      JSON.stringify({ fides_meta: { updatedAt: MOCK_DATE } })
+    )
+  );
   afterEach(() => mockSetCookie.mockClear());
 
   it("updates the updatedAt date", () => {
@@ -288,25 +293,6 @@ describe("saveFidesCookie", () => {
       );
     }
   );
-
-  // DEFER: known issue https://github.com/ethyca/fides/issues/2072
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip.each([
-    {
-      url: "https://privacy.subdomain.example.co.uk",
-      expected: "example.co.uk",
-    },
-  ])("it handles second-level domains ($url)", ({ url, expected }) => {
-    const mockUrl = new URL(url);
-    Object.defineProperty(window, "location", {
-      value: mockUrl,
-      writable: true,
-    });
-    const cookie: FidesCookie = getOrMakeFidesCookie();
-    saveFidesCookie(cookie);
-    expect(mockSetCookie.mock.calls).toHaveLength(1);
-    expect(mockSetCookie.mock.calls[0][2]).toHaveProperty("domain", expected);
-  });
 });
 
 describe("makeConsentDefaultsLegacy", () => {

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -234,8 +234,12 @@ export const saveFidesCookie = (
       CODEC
     );
     if (c) {
-      const cookieString = getCookieByName(CONSENT_COOKIE_NAME);
-      if (cookieString) {
+      const savedCookie = getFidesConsentCookie();
+      // If it's a new cookie, then checking for an existing cookie would be enough. But, if the cookie is being updated then we need to also check if the updatedAt is the same. Otherwise, we would be breaking on the TLD (eg. .com) here.
+      if (
+        savedCookie &&
+        savedCookie.fides_meta.updatedAt === cookie.fides_meta.updatedAt
+      ) {
         break;
       }
     }


### PR DESCRIPTION
Closes [PROD-2196](https://ethyca.atlassian.net/browse/PROD-2196)

### Description Of Changes

Our cookie saving logic wasn't saving updates to the `fides_consent` cookie after it was first created.


### Code Changes

* use the `updatedAt` property to validate the cookie to ensure the domain checking logic doesn't get false positives when updating the cookie in addition to setting a new cookie.
* Additional E2E tests to validate cookie can also be _updated_ on any domain.

### Steps to Confirm

1. Visit https://cookiehouse-plus-rc.fides-staging.ethyca.com/?geolocation=US-CA
2. Delete any existing fides_consent cookie 
3. Open the FidesJS modal and opt-out of “Targeted Advertising” and save changes
4. Inspect the `fides_consent` cookie is created with `false` set for the notice
5. Refresh the page
6. Open the FidesJS modal and change your consent to opt-in of “Targeted Advertising” and save changes
7. Inspect the `fides_consent` cookie has been updated, so `true` is now set for the notice

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

[PROD-2196]: https://ethyca.atlassian.net/browse/PROD-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ