### PR TITLE
sort comparison in test to ensure consistent comparison

### DIFF
--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -2057,12 +2057,11 @@ class TestSystemUpdate:
         # System level cookies removed
         assert result.json()["cookies"] == []
         # Privacy declaration cookies added
-        assert sorted(result.json()["privacy_declarations"][0]["cookies"]) == sorted(
-            [
+        assert sorted(result.json()["privacy_declarations"][0]["cookies"], key=lambda r: r["name"]) == sorted([
                 {"name": "my_cookie", "path": None, "domain": "example.com"},
                 {"name": "my_other_cookie", "path": None, "domain": None},
-            ]
-        )
+            ], key=lambda r: r["name"])
+
 
         db.refresh(system)
         assert system.name == self.updated_system_name

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -2057,10 +2057,12 @@ class TestSystemUpdate:
         # System level cookies removed
         assert result.json()["cookies"] == []
         # Privacy declaration cookies added
-        assert result.json()["privacy_declarations"][0]["cookies"] == [
-            {"name": "my_cookie", "path": None, "domain": "example.com"},
-            {"name": "my_other_cookie", "path": None, "domain": None},
-        ]
+        assert sorted(result.json()["privacy_declarations"][0]["cookies"]) == sorted(
+            [
+                {"name": "my_cookie", "path": None, "domain": "example.com"},
+                {"name": "my_other_cookie", "path": None, "domain": None},
+            ]
+        )
 
         db.refresh(system)
         assert system.name == self.updated_system_name


### PR DESCRIPTION
unticketed

### Description Of Changes

seems to be at least a flaky test in `main`, i think this should make it more consistent

### Code Changes

* [x] make test more consistent/deterministic

### Steps to Confirm

* [x] CI passing!

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
