### PR TITLE
Fix CI pipeline because numpy == 2.0.0 is being installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ joblib==1.3.2
 loguru==0.6.0
 multidimensional_urlencode==0.0.4
 nh3==0.2.15
-numpy==1.26.4
+numpy==1.24.4
 okta==2.7.0
 openpyxl==3.0.9
 networkx==3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ joblib==1.3.2
 loguru==0.6.0
 multidimensional_urlencode==0.0.4
 nh3==0.2.15
+numpy==1.26.4
 okta==2.7.0
 openpyxl==3.0.9
 networkx==3.1


### PR DESCRIPTION
### Description Of Changes

Fixed CI failing because numpy 2.0.0 just got released. Added `numpy==1.26.4` to requirements.txt


### Code Changes

* [ ] Added `numpy==1.26.4` to requirements.txt

### Steps to Confirm

* [ ] Run `nox -s check_install`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
