### PR TITLE
Segment Integration: user_id over email

### DIFF
--- a/data/saas/config/segment_config.yml
+++ b/data/saas/config/segment_config.yml
@@ -166,7 +166,10 @@ saas_config:
       - name: workspace_name
         connector_param: workspace
       - name: user_id
-        identity: email
+        references:
+          - dataset: <instance_fides_key>
+            field: traits.user_id
+            direction: from
     body: |
       {
         "regulation_type": "Suppress_With_Delete",

--- a/data/saas/dataset/segment_dataset.yml
+++ b/data/saas/dataset/segment_dataset.yml
@@ -7,8 +7,6 @@ dataset:
         fields:
           - name: segment_id
             data_categories: [user.unique_id]
-            fidesops_meta:
-              primary_key: True
       - name: track_events
         fields:
           - name: external_ids
@@ -25,7 +23,7 @@ dataset:
             fields:
               - name: name
                 data_categories: [user.name]
-                fidesops_meta:
+                fides_meta:
                   data_type: string
               - name: version
                 data_categories: [system.operations]
@@ -57,19 +55,19 @@ dataset:
             fields:
               - name: city
                 data_categories: [user.contact.address.city]
-                fidesops_meta:
+                fides_meta:
                   data_type: string
               - name: country
                 data_categories: [user.contact.address.country]
-                fidesops_meta:
+                fides_meta:
                   data_type: string
               - name: postalCode
                 data_categories: [user.contact.address.postal_code]
-                fidesops_meta:
+                fides_meta:
                   data_type: string
               - name: state
                 data_categories: [user.contact.address.state]
-                fidesops_meta:
+                fides_meta:
                   data_type: string
           - name: age
             data_categories: [user.demographic.age_range]
@@ -81,41 +79,53 @@ dataset:
             data_categories: [user]
           - name: email
             data_categories: [user.contact.email]
-            fidesops_meta:
+            fides_meta:
               data_type: string
           - name: firstName
             data_categories: [user.name]
-            fidesops_meta:
+            fides_meta:
+              data_type: string
+          - name: first_name
+            data_categories: [user.name]
+            fides_meta:
               data_type: string
           - name: gender
             data_categories: [user.demographic.gender]
-            fidesops_meta:
+            fides_meta:
               data_type: string
           - name: id
             data_categories: [user.unique_id]
           - name: industry
             data_categories: [system.operations]
           - name: lastName
+          - name: last_name
+            data_categories: [user.name]
+            fides_meta:
+              data_type: string
           - name: name
             data_categories: [user.name]
-            fidesops_meta:
+            fides_meta:
               data_type: string
           - name: phone
             data_categories: [user.contact.phone_number]
-            fidesops_meta:
+            fides_meta:
               data_type: string
           - name: subscriptionStatus
           - name: title
             data_categories: [user.name]
-            fidesops_meta:
+            fides_meta:
               data_type: string
           - name: username
             data_categories: [user.name]
-            fidesops_meta:
+            fides_meta:
               data_type: string
           - name: website
             data_categories: [user]
-            fidesops_meta:
+            fides_meta:
+              data_type: string
+          - name: user_id
+            data_categories: [user.unique_id]
+            fides_meta:
               data_type: string
       - name: external_ids
         fields:


### PR DESCRIPTION
Closes [FIDES-746](https://ethyca.atlassian.net/browse/FIDES-746)

### Description Of Changes

It's been determined that the email cannot be used as the identity unless it is also the user_id. For this we need to infer the user_id from either traits or external_ids


### Code Changes

* [ ] Update the data_protection_Request to use the user_id instead of the identity email

### Steps to Confirm

* [ ] Validate the erasure completes with our test data

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
