### PR TITLE
Disable GPP stub when `initialize=false` is set until `Fides.init()` is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The types of changes are:
 - New privacy request search to replace existing endpoint [#4987](https://github.com/ethyca/fides/pull/4987)
 - Added new Google Cloud SQL for MySQL Connector [#4949](https://github.com/ethyca/fides/pull/4949)
 - Add new options for integrations for discovery & detection [#5000](https://github.com/ethyca/fides/pull/5000)
+- Add new `FidesInitializing` event for when FidesJS begins initialization [#5010](https://github.com/ethyca/fides/pull/5010)
 
 ### Changed
 - Move new data map reporting table out of beta and remove old table from Data Lineage map. [#4963](https://github.com/ethyca/fides/pull/4963)
@@ -44,6 +45,8 @@ The types of changes are:
 - Masked "Keyfile credentials" input on integration config form [#4971](https://github.com/ethyca/fides/pull/4971)
 - Fixed validations for privacy declaration taxonomy labels when creating/updating a System [#4982](https://github.com/ethyca/fides/pull/4982)
 - Allow property-specific messaging to work with non-custom templates [#4986](https://github.com/ethyca/fides/pull/4986)
+- Fixed an issue where config object was being passed twice to `fides.js` output [#5010](https://github.com/ethyca/fides/pull/5010)
+- Disabling Fides initializtion now also disables GPP initialization [#5010](https://github.com/ethyca/fides/pull/5010)
 
 ## [2.38.1](https://github.com/ethyca/fides/compare/2.38.0...2.38.1)
 

--- a/clients/fides-js/docs/interfaces/FidesEvent.md
+++ b/clients/fides-js/docs/interfaces/FidesEvent.md
@@ -25,6 +25,10 @@ the browser, see the MDN docs:
 
 ### List of FidesEvent Types
 
+- `FidesInitializing`: Dispatched when initialization begins, which happens
+immediately once the FidesJS script is loaded. If `Fides.init()` is called
+multiple times, this event will also be dispatched each time.
+
 - `FidesInitialized`: Dispatched when initialization is complete and the
 current user's consent preferences - either previously saved or applicable
 defaults - have been set on the `Fides` global object.

--- a/clients/fides-js/src/docs/fides-event.ts
+++ b/clients/fides-js/src/docs/fides-event.ts
@@ -5,10 +5,11 @@
  * documentation, since it's mostly just noise there - the list of events on
  * {@link FidesEvent} provides a good reference. But when coding, it's still
  * useful to have this union type around!
- * 
+ *
  * @private
  */
 export type FidesEventType =
+  | "FidesInitializing"
   | "FidesInitialized"
   | "FidesUpdating"
   | "FidesUpdated"
@@ -41,10 +42,14 @@ export type FidesEventType =
  *
  * ### List of FidesEvent Types
  *
+ * - `FidesInitializing`: Dispatched when initialization begins, which happens
+ * immediately once the FidesJS script is loaded. If `Fides.init()` is called
+ * multiple times, this event will also be dispatched each time.
+ *
  * - `FidesInitialized`: Dispatched when initialization is complete and the
  * current user's consent preferences - either previously saved or applicable
  * defaults - have been set on the `Fides` global object.
- * 
+ *
  * - `FidesUpdating`: Dispatched when a user action (e.g. accepting all, saving
  * changes, applying GPC) has started updating the user's consent preferences.
  * This event is dispatched immediately once the changes are made, but before
@@ -58,7 +63,7 @@ export type FidesEventType =
  * object, `fides_consent` cookie on the user's device, and the Fides API. To
  * receive an event that fires before these changes are saved, use the
  * `FidesUpdating` event instead.
- * 
+ *
  * - `FidesUIShown`: Dispatched whenever a FidesJS UI component is rendered and
  * shown to the current user (banner, modal, etc.). The specific component shown
  * can be obtained from the `detail.extraDetails.servingComponent` property on
@@ -107,7 +112,7 @@ export interface FidesEvent extends CustomEvent {
       /**
        * Whether the user should be shown the consent experience. Only available on FidesInitialized events.
        */
-     shouldShowExperience?: boolean;
+      shouldShowExperience?: boolean;
 
       /**
        * What consent method (if any) caused this event.
@@ -115,4 +120,4 @@ export interface FidesEvent extends CustomEvent {
       consentMethod?: "accept" | "reject" | "save" | "dismiss" | "gpc";
     };
   };
-};
+}

--- a/clients/fides-js/src/fides-ext-gpp.ts
+++ b/clients/fides-js/src/fides-ext-gpp.ts
@@ -246,4 +246,8 @@ const initializeGppCmpApi = () => {
     cmpApi.setSignalStatus(SignalStatus.READY);
   });
 };
-initializeGppCmpApi();
+window.addEventListener("FidesInitializing", (event) => {
+  if (event.detail.extraDetails?.gppEnabled) {
+    initializeGppCmpApi();
+  }
+});

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -129,7 +129,9 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
     undefined,
     this.config.options.debug,
     {
-      gppEnabled: this.config.options.gppEnabled,
+      gppEnabled:
+        this.config.options.gppEnabled ||
+        this.config.experience?.gpp_settings?.enabled,
       tcfEnabled: this.config.options.tcfEnabled,
     }
   );

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -124,6 +124,16 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
   this.config = config; // no matter how the config is set, we want to store it on the global object
   updateWindowFides(this);
 
+  dispatchFidesEvent(
+    "FidesInitializing",
+    undefined,
+    this.config.options.debug,
+    {
+      gppEnabled: this.config.options.gppEnabled,
+      tcfEnabled: this.config.options.tcfEnabled,
+    }
+  );
+
   const optionsOverrides: Partial<FidesInitOptionsOverrides> =
     getOverridesByType<Partial<FidesInitOptionsOverrides>>(
       OverrideType.OPTIONS,

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -235,6 +235,7 @@ const _Fides: FidesGlobal = {
     fidesApiUrl: "",
     serverSideFidesApiUrl: "",
     tcfEnabled: true,
+    gppEnabled: false,
     fidesEmbed: false,
     fidesDisableSaveApi: false,
     fidesDisableNoticesServedApi: false,

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -98,7 +98,9 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
     undefined,
     this.config.options.debug,
     {
-      gppEnabled: this.config.options.gppEnabled,
+      gppEnabled:
+        this.config.options.gppEnabled ||
+        this.config.experience?.gpp_settings?.enabled,
       tcfEnabled: this.config.options.tcfEnabled,
     }
   );

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -173,6 +173,7 @@ const _Fides: FidesGlobal = {
     fidesApiUrl: "",
     serverSideFidesApiUrl: "",
     tcfEnabled: false,
+    gppEnabled: false,
     fidesEmbed: false,
     fidesDisableSaveApi: false,
     fidesDisableNoticesServedApi: false,

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -93,6 +93,16 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
 
   this.config = config; // no matter how the config is set, we want to store it on the global object
 
+  dispatchFidesEvent(
+    "FidesInitializing",
+    undefined,
+    this.config.options.debug,
+    {
+      gppEnabled: this.config.options.gppEnabled,
+      tcfEnabled: this.config.options.tcfEnabled,
+    }
+  );
+
   const optionsOverrides: Partial<FidesInitOptionsOverrides> =
     getOverridesByType<Partial<FidesInitOptionsOverrides>>(
       OverrideType.OPTIONS,

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -78,6 +78,9 @@ export interface FidesInitOptions {
   // Whether we should show the TCF modal
   tcfEnabled: boolean;
 
+  // Whether to include the GPP extension
+  gppEnabled: boolean;
+
   // Whether we should "embed" the fides.js overlay UI (ie. “Layer 2”) into a web page instead of as a pop-up
   // overlay, and never render the banner (ie. “Layer 1”).
   fidesEmbed: boolean;

--- a/clients/fides-js/src/lib/events.ts
+++ b/clients/fides-js/src/lib/events.ts
@@ -12,7 +12,10 @@ declare global {
  * events. This is intentionally vague, but constrained to be basic (primitive)
  * values for simplicity.
  */
-export type FidesEventExtraDetails = Record<string, string | number | boolean>;
+export type FidesEventExtraDetails = Record<
+  string,
+  string | number | boolean | undefined
+>;
 
 /**
  * Defines the properties available on event.detail. Currently the FidesCookie
@@ -49,14 +52,14 @@ export type FidesEvent = CustomEvent<FidesEventDetail>;
  */
 export const dispatchFidesEvent = (
   type: FidesEventType,
-  cookie: FidesCookie,
+  cookie: FidesCookie | undefined,
   debug: boolean,
   extraDetails?: FidesEventExtraDetails
 ) => {
   if (typeof window !== "undefined" && typeof CustomEvent !== "undefined") {
     // Extracts consentMethod directly from the cookie instead of having to pass in duplicate data to this method
     const constructedExtraDetails: FidesEventExtraDetails = {
-      consentMethod: cookie.fides_meta.consentMethod,
+      consentMethod: cookie?.fides_meta.consentMethod,
       ...extraDetails,
     };
     const event = new CustomEvent(type, {
@@ -68,7 +71,7 @@ export const dispatchFidesEvent = (
         constructedExtraDetails?.servingComponent
           ? `from ${constructedExtraDetails.servingComponent} `
           : ""
-      }with cookie ${JSON.stringify(cookie)} ${
+      }${cookie ? `with cookie ${JSON.stringify(cookie)} ` : ""}${
         constructedExtraDetails
           ? `with extra details ${JSON.stringify(constructedExtraDetails)} `
           : ""

--- a/clients/privacy-center/cypress/e2e/consent-banner-gpp.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-gpp.cy.ts
@@ -75,7 +75,7 @@ describe("Fides-js GPP extension", () => {
     });
   });
 
-  describe.only("Fides is not initialized", () => {
+  describe("Fides is not initialized", () => {
     beforeEach(() => {
       visitDemoWithGPP({}, { init: false });
     });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -1649,11 +1649,12 @@ describe("Consent overlay", () => {
           isOverlayEnabled: true,
         },
       });
+      cy.get("@FidesInitializing").should("have.been.calledOnce");
     });
 
     // NOTE: See definition of cy.visitConsentDemo in commands.ts for where we
     // register listeners for these window events
-    it("emits a FidesInitialized but not any other events when initialized", () => {
+    it("emits a FidesInitialized but not any subsequent events when initialized", () => {
       cy.window()
         .its("Fides")
         .its("consent")

--- a/clients/privacy-center/cypress/e2e/fides-js.cy.ts
+++ b/clients/privacy-center/cypress/e2e/fides-js.cy.ts
@@ -208,6 +208,11 @@ describe("fides.js API route", () => {
         expect(response.body).not.to.match(/window.Fides.init(fidesConfig)/);
       });
     });
+    it("does not initialize GPP", () => {
+      cy.request("/fides.js?initialize=false&gpp=true").then((response) => {
+        expect(response.body).not.to.match(/window.__gpp/);
+      });
+    });
   });
 });
 

--- a/clients/privacy-center/cypress/e2e/fides-js.cy.ts
+++ b/clients/privacy-center/cypress/e2e/fides-js.cy.ts
@@ -15,10 +15,10 @@ describe("fides.js API route", () => {
         .to.match(/^\s+\(function/, "should be an IIFE")
         .to.match(/\}\)\(\);\s+$/, "should be an IIFE");
       expect(response.body)
-        .to.match(/var fidesConfig = \{/, "should bundle Fides.init")
-        .to.match(/Fides.init\(fidesConfig\);/, "should bundle Fides.init");
+        .to.match(/window.Fides.config = \{/, "should bundle Fides.init")
+        .to.match(/Fides.init\(\);/, "should call Fides.init");
       const matches = response.body.match(
-        /var fidesConfig = (?<json>\{.*?\});/
+        /window.Fides.config = (?<json>\{.*?\});/
       );
       expect(matches).to.have.nested.property("groups.json");
       expect(JSON.parse(matches.groups.json))
@@ -44,9 +44,9 @@ describe("fides.js API route", () => {
   describe("when pre-fetching geolocation", () => {
     it("returns geolocation if provided as a '?geolocation' query param", () => {
       cy.request("/fides.js?geolocation=US-CA").then((response) => {
-        expect(response.body).to.match(/var fidesConfig = \{/);
+        expect(response.body).to.match(/window.Fides.config = \{/);
         const matches = response.body.match(
-          /var fidesConfig = (?<json>\{.*?\});/
+          /window.Fides.config = (?<json>\{.*?\});/
         );
         expect(JSON.parse(matches.groups.json))
           .to.have.nested.property("geolocation")
@@ -66,9 +66,9 @@ describe("fides.js API route", () => {
           "CloudFront-Viewer-Country-Region": "IDF",
         },
       }).then((response) => {
-        expect(response.body).to.match(/var fidesConfig = \{/);
+        expect(response.body).to.match(/window.Fides.config = \{/);
         const matches = response.body.match(
-          /var fidesConfig = (?<json>\{.*?\});/
+          /window.Fides.config = (?<json>\{.*?\});/
         );
         expect(JSON.parse(matches.groups.json))
           .to.have.nested.property("geolocation")

--- a/clients/privacy-center/cypress/e2e/fides-js.cy.ts
+++ b/clients/privacy-center/cypress/e2e/fides-js.cy.ts
@@ -208,11 +208,6 @@ describe("fides.js API route", () => {
         expect(response.body).not.to.match(/window.Fides.init(fidesConfig)/);
       });
     });
-    it("does not initialize GPP", () => {
-      cy.request("/fides.js?initialize=false&gpp=true").then((response) => {
-        expect(response.body).not.to.match(/window.__gpp/);
-      });
-    });
   });
 });
 

--- a/clients/privacy-center/cypress/support/commands.ts
+++ b/clients/privacy-center/cypress/support/commands.ts
@@ -98,6 +98,10 @@ Cypress.Commands.add(
 
         // Add event listeners for Fides.js events
         win.addEventListener(
+          "FidesInitializing",
+          cy.stub().as("FidesInitializing")
+        );
+        win.addEventListener(
           "FidesInitialized",
           cy.stub().as("FidesInitialized")
         );

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -167,11 +167,9 @@ export default async function handler(
     }
   }
 
-  // These query params are used for testing purposes only, and should not be used
-  // in production. They allow for the config to be injected by the test framework
-  // and delay the initialization of fides.js until the test framework is ready.
-  const { e2e: e2eQuery, tcf: tcfQuery } = req.query;
-  const isTestMode = e2eQuery === "true";
+  // This query param is used for testing purposes only, and should not be used
+  // in production.
+  const { tcf: tcfQuery } = req.query;
 
   // We determine server-side whether or not to send the TCF bundle, which is based
   // on whether or not the experience is marked as TCF. This means for TCF, we *must*
@@ -209,6 +207,7 @@ export default async function handler(
       privacyCenterUrl: environment.settings.PRIVACY_CENTER_URL,
       fidesApiUrl: environment.settings.FIDES_API_URL,
       tcfEnabled,
+      gppEnabled,
       serverSideFidesApiUrl:
         environment.settings.SERVER_SIDE_FIDES_API_URL ||
         environment.settings.FIDES_API_URL,
@@ -289,17 +288,13 @@ export default async function handler(
     document.head.append(style);
     `
       : ""
-  }${
-    isTestMode // let end-to-end tests set the config and initialize as needed
-      ? ""
-      : `
-    window.Fides.config = ${fidesConfigJSON};
-    ${skipInitialization ? "" : `window.Fides.init();`}
-    ${
-      environment.settings.DEBUG && skipInitialization
-        ? `console.log("Fides initialization skipped. Call window.Fides.init() manually.");`
-        : ""
-    }`
+  }
+  window.Fides.config = ${fidesConfigJSON};
+  ${skipInitialization ? "" : `window.Fides.init();`}
+  ${
+    environment.settings.DEBUG && skipInitialization
+      ? `console.log("Fides initialization skipped. Call window.Fides.init() manually.");`
+      : ""
   }
   })();
   `;

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -293,12 +293,11 @@ export default async function handler(
     isTestMode // let end-to-end tests set the config and initialize as needed
       ? ""
       : `
-    var fidesConfig = ${fidesConfigJSON};
     window.Fides.config = ${fidesConfigJSON};
-    ${skipInitialization ? "" : `window.Fides.init(fidesConfig);`}
+    ${skipInitialization ? "" : `window.Fides.init();`}
     ${
       environment.settings.DEBUG && skipInitialization
-        ? `console.log("fides.js initialization skipped. Call window.Fides.init() manually.");`
+        ? `console.log("Fides initialization skipped. Call window.Fides.init() manually.");`
         : ""
     }`
   }

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -12,17 +12,17 @@
     <script>
       (function () {
         const tcfEnabled = window.fidesConfig?.options?.tcfEnabled;
+        const gppEnabled =
+          window.fidesConfig?.experience?.gpp_settings?.enabled;
         const params = new URLSearchParams(window.location.search);
         const geolocation = params.get("geolocation");
-        const src = `/fides.js?e2e=true${tcfEnabled ? "&tcf=true" : ""}${
+        const src = `/fides.js?initialize=false${
+          tcfEnabled ? "&tcf=true" : ""
+        }${gppEnabled ? "&gpp=true" : ""}${
           !!params.size ? `&${params.toString()}` : ""
         }`;
 
         document.write('<script src="' + src + '"><\/script>');
-      })();
-      (function () {
-        if (window.fidesConfig?.experience?.gpp_settings?.enabled)
-          document.write('<script src="./lib/fides-ext-gpp.js"><\/script>');
       })();
       var deleteCookie = function () {
         document.cookie =

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -10,11 +10,11 @@
       will pass a geolocation query param to fides.js
     -->
     <script>
+      const params = new URLSearchParams(window.location.search);
       (function () {
         const tcfEnabled = window.fidesConfig?.options?.tcfEnabled;
         const gppEnabled =
           window.fidesConfig?.experience?.gpp_settings?.enabled;
-        const params = new URLSearchParams(window.location.search);
         const geolocation = params.get("geolocation");
         const src = `/fides.js?initialize=false${
           tcfEnabled ? "&tcf=true" : ""
@@ -33,6 +33,7 @@
     <script>
       // Our cypress test suite requires injecting consent options through an obj on window
       // we default to the below for dev purposes
+      const init = params.get("init");
       var fidesConfig = window.fidesConfig || {
         consent: {
           options: [
@@ -201,8 +202,10 @@
           fidesPrimaryColor: "#008000",
         },
       };
-      window.Fides.init(fidesConfig);
-      Fides.gtm();
+      if (init !== "false") {
+        window.Fides.init(fidesConfig);
+        Fides.gtm();
+      }
     </script>
 
     <style>


### PR DESCRIPTION
Closes [PROD-2214](https://ethyca.atlassian.net/browse/PROD-2214)

### Description Of Changes

Initializing GPP without initializing Fides has been known to cause issues, especially in cases where Fides never gets initialized.

* When FidesJS is downloaded with `initialize=false`, ensure that GPP is not initialized at all
* When `Fides.init()` is called, ensure that the GPP stub is initialized promptly and is not delayed by any other blocking logic (e.g. API calls, etc.)

### Code Changes

* eliminated waste on resulting `fides.js` response by not printing config object twice.
* include `gppEnabled` as part of the config options object (similar to existing `tcfEnabled`)
* add new `FidesInitializing` event for benefit of GPP initialization and other similar use cases
* wait for `FidesInitializing` to be dispatched before initializing GPP.
* Add and clean up related Cypress tests

### Steps to Confirm

1. Open browser console
2. visit demo page with GPP enabled but `initialize` set to false (eg. `/fides-js-demo.html?gpp=true&initialize=false`)
3. observe browser console message that Fides was not initialized
4. check if GPP is initialized by attempting to ping it `__gpp('ping', (data) => {console.log(data)})`
5. observe browser console error that `__gpp` does not exist yet.
6. initialize Fides using the browser console `window.Fides.init()`
7. observe browser console debug messages indicating that Fides started normally
8. check if GPP is initialized by attempting to ping it `__gpp('ping', (data) => {console.log(data)})`
9. observe that the ping now displays a response indicating that GPP has been initialized.

![image](https://github.com/ethyca/fides/assets/103820/20bf6a52-5e2d-410d-aa7f-30631bc40c5b)
![image](https://github.com/ethyca/fides/assets/103820/bfc99df6-0250-429d-b5e3-1a8243006e8c)


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [x] documentation complete
* [x] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`

[PROD-2214]: https://ethyca.atlassian.net/browse/PROD-2214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ