### PR TITLE
consistent casing

### DIFF
--- a/clients/admin-ui/src/features/privacy-requests/RequestTableColumns.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestTableColumns.tsx
@@ -57,7 +57,7 @@ export const getRequestTableColumns = (revealPII = false) => [
         <DefaultCell value={getPII(getValue(), revealPII)} />
       ),
       header: (props) => (
-        <DefaultHeaderCell value="Subject Identity" {...props} />
+        <DefaultHeaderCell value="Subject identity" {...props} />
       ),
       enableSorting: false,
     }
@@ -65,14 +65,14 @@ export const getRequestTableColumns = (revealPII = false) => [
   columnHelper.accessor((row) => row.created_at, {
     id: COLUMN_IDS.TIME_RECIEVED,
     cell: ({ getValue }) => <DefaultCell value={formatDate(getValue())} />,
-    header: (props) => <DefaultHeaderCell value="Time Received" {...props} />,
+    header: (props) => <DefaultHeaderCell value="Time received" {...props} />,
   }),
   columnHelper.accessor((row) => row.reviewer?.username || "", {
     id: COLUMN_IDS.REVIEWER,
     cell: ({ getValue }) => (
       <DefaultCell value={getPII(getValue(), revealPII)} /> // NOTE: this field does not get set when reviewed as root user
     ),
-    header: (props) => <DefaultHeaderCell value="Reviewed By" {...props} />,
+    header: (props) => <DefaultHeaderCell value="Reviewed by" {...props} />,
     enableSorting: false,
   }),
   columnHelper.accessor((row) => row.id, {


### PR DESCRIPTION
Closes [PROD-2227](https://ethyca.atlassian.net/browse/PROD-2227)

### Description Of Changes

The title of the columns should have consistent capitalization. To keep consistency with other table headers and with other titles, buttons, etc. we are only capitalizing the first word.

### Code Changes

* string changes only

### Steps to Confirm

* go to request manager /privacy-requests
* the title of the columns should have consistent capitalization. 


[PROD-2227]: https://ethyca.atlassian.net/browse/PROD-2227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ