### PR TITLE
PROD-2230: Fix table cell formatting for vendors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ The types of changes are:
 - Fixed validations for privacy declaration taxonomy labels when creating/updating a System [#4982](https://github.com/ethyca/fides/pull/4982)
 - Allow property-specific messaging to work with non-custom templates [#4986](https://github.com/ethyca/fides/pull/4986)
 - Fixed an issue where config object was being passed twice to `fides.js` output [#5010](https://github.com/ethyca/fides/pull/5010)
-- Disabling Fides initializtion now also disables GPP initialization [#5010](https://github.com/ethyca/fides/pull/5010)
+- Disabling Fides initialization now also disables GPP initialization [#5010](https://github.com/ethyca/fides/pull/5010)
+- Fixes Vendor table formatting [#5013](https://github.com/ethyca/fides/pull/5013)
 
 ## [2.38.1](https://github.com/ethyca/fides/compare/2.38.0...2.38.1)
 

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -94,6 +94,38 @@ export const BadgeCell = ({
   </BadgeCellContainer>
 );
 
+export const BadgeCellCount = ({
+  count,
+  singSuffix,
+  plSuffix,
+  ...badgeProps
+}: {
+  count: number;
+  singSuffix?: string;
+  plSuffix?: string;
+} & BadgeProps) => {
+  // Expanded case, list every value as a badge
+  let badge = null;
+  if (count === 1) {
+    badge = (
+      <FidesBadge {...badgeProps}>
+        {count}
+        {singSuffix ? ` ${singSuffix}` : null}
+      </FidesBadge>
+    );
+  }
+  // Collapsed case, summarize the values in one badge
+  else {
+    badge = (
+      <FidesBadge {...badgeProps}>
+        {count}
+        {plSuffix ? ` ${plSuffix}` : null}
+      </FidesBadge>
+    );
+  }
+  return <BadgeCellContainer>{badge}</BadgeCellContainer>;
+};
+
 export const GroupCountBadgeCell = ({
   value,
   suffix,

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -104,7 +104,7 @@ export const BadgeCellCount = ({
   singSuffix?: string;
   plSuffix?: string;
 } & BadgeProps) => {
-  // Expanded case, list every value as a badge
+  // If count is 1, display count with singular suffix
   let badge = null;
   if (count === 1) {
     badge = (
@@ -114,7 +114,7 @@ export const BadgeCellCount = ({
       </FidesBadge>
     );
   }
-  // Collapsed case, summarize the values in one badge
+  // If count is 0 or > 1, display count with plural suffix
   else {
     badge = (
       <FidesBadge {...badgeProps}>

--- a/clients/admin-ui/src/features/common/table/v2/index.ts
+++ b/clients/admin-ui/src/features/common/table/v2/index.ts
@@ -1,5 +1,6 @@
 export {
   BadgeCell,
+  BadgeCellCount,
   DefaultCell,
   DefaultHeaderCell,
   GroupCountBadgeCell,

--- a/clients/admin-ui/src/features/configure-consent/ConsentManagementTable.tsx
+++ b/clients/admin-ui/src/features/configure-consent/ConsentManagementTable.tsx
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-table";
 import { useFeatures } from "common/features";
 import {
-  BadgeCell,
+  BadgeCellCount,
   DefaultCell,
   DefaultHeaderCell,
   FidesTableV2,
@@ -163,33 +163,55 @@ export const ConsentManagementTable = () => {
       columnHelper.accessor((row) => row.data_uses, {
         id: "tcf_purpose",
         cell: (props) => (
-          <BadgeCell suffix="purposes" value={props.getValue()} />
+          <BadgeCellCount
+            plSuffix="purposes"
+            singSuffix="purpose"
+            count={props.getValue()}
+          />
         ),
         header: (props) => <DefaultHeaderCell value="TCF purpose" {...props} />,
       }),
       columnHelper.accessor((row) => row.data_uses, {
         id: "data_uses",
         cell: (props) => (
-          <BadgeCell suffix="data uses" value={props.getValue()} />
+          <BadgeCellCount
+            plSuffix="data uses"
+            singSuffix="data use"
+            count={props.getValue()}
+          />
         ),
         header: (props) => <DefaultHeaderCell value="Data use" {...props} />,
       }),
       columnHelper.accessor((row) => row.legal_bases, {
         id: "legal_bases",
-        cell: (props) => <BadgeCell suffix="bases" value={props.getValue()} />,
+        cell: (props) => (
+          <BadgeCellCount
+            plSuffix="bases"
+            singSuffix="basis"
+            count={props.getValue()}
+          />
+        ),
         header: (props) => <DefaultHeaderCell value="Legal basis" {...props} />,
       }),
       columnHelper.accessor((row) => row.consent_categories, {
         id: "consent_categories",
         cell: (props) => (
-          <BadgeCell suffix="Categories" value={props.getValue()} />
+          <BadgeCellCount
+            plSuffix="categories"
+            singSuffix="category"
+            count={props.getValue()}
+          />
         ),
         header: (props) => <DefaultHeaderCell value="Categories" {...props} />,
       }),
       columnHelper.accessor((row) => row.cookies, {
         id: "cookies",
         cell: (props) => (
-          <BadgeCell suffix="Cookies" value={props.getValue()} />
+          <BadgeCellCount
+            plSuffix="cookies"
+            singSuffix="cookie"
+            count={props.getValue()}
+          />
         ),
         header: (props) => <DefaultHeaderCell value="Cookies" {...props} />,
       }),

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -786,7 +786,7 @@ export const DatamapReportTable = () => {
         id: COLUMN_IDS.RESPONSIBILITY,
         cell: (props) => (
           <GroupCountBadgeCell
-            suffix="responsibilitlies"
+            suffix="responsibilities"
             value={props.getValue()}
             {...props}
           />


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-2230

### Description Of Changes

Adds new re-usable component to display badges in table cells where we only have count (number) to work with, instead of the value names.


### Code Changes

* [ ] Update vendor table to use new component.

### Steps to Confirm

* [ ] Nav to http://localhost:3000/consent/configure
* [ ] Configure some vendors
* [ ] Confirm that table counts display correctly for all use cases:
<img width="1238" alt="Screenshot 2024-06-20 at 5 51 55 PM" src="https://github.com/ethyca/fides/assets/7697292/273e03fe-0b3b-4abe-98e0-c57d458aef77">


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
