### PR TITLE
Add ability to configure "Enforcement Level"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,10 @@ The types of changes are:
 ### Added
 - Adds last_monitored and enabled attributes to MonitorConfig [#4991](https://github.com/ethyca/fides/pull/4991)
 - New messaging page. Allows managing messaging templates for different properties. [#5005](https://github.com/ethyca/fides/pull/5005)
+- Ability to configure "Enforcement Level" for Privacy Notices [#5025](https://github.com/ethyca/fides/pull/5025)
 
 ### Changed
 - Navigation changes. 'Management' was renamed 'Settings'. Properties was moved to Settings section. [#5005](https://github.com/ethyca/fides/pull/5005)
-
-
-### Changed
 - Changed discovery monitor form behavior around execution date/time selection [#5017](https://github.com/ethyca/fides/pull/5017)
 - Changed integration form behavior when errors occur [#5023](https://github.com/ethyca/fides/pull/5023)
 

--- a/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
@@ -238,6 +238,7 @@ describe("Privacy notices", () => {
         cy.getSelectValueContainer("input-consent_mechanism").contains(
           "Notice only"
         );
+
         cy.getByTestId("notice-locations").within(() => {
           cy.get(".notice-locations--is-disabled");
           cy.get(".notice-locations__value-container").should(
@@ -245,7 +246,7 @@ describe("Privacy notices", () => {
             "United States"
           );
         });
-        cy.getByTestId("notice-locations");
+
         cy.getByTestId("input-has_gpc_flag").within(() => {
           cy.get("span").should("not.have.attr", "data-checked");
         });
@@ -254,6 +255,11 @@ describe("Privacy notices", () => {
         notice.data_uses.forEach((dataUse) => {
           cy.getSelectValueContainer("input-data_uses").contains(dataUse);
         });
+
+        // enforcement level
+        cy.getSelectValueContainer("input-enforcement_level").contains(
+          "Not applicable"
+        );
 
         // translations
         cy.getByTestId("input-translations.0.title").should(
@@ -314,7 +320,7 @@ describe("Privacy notices", () => {
       const notice = {
         name: "my notice",
         consent_mechanism: "opt_in",
-        enforcement_level: "system_wide",
+        enforcement_level: "frontend",
         has_gpc_flag: true,
         data_uses: ["analytics"],
         notice_key: "my_notice",

--- a/clients/admin-ui/src/features/common/util.test.ts
+++ b/clients/admin-ui/src/features/common/util.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "@jest/globals";
 import {
   createSelectedMap,
   getKeysFromMap,
+  getOptionsFromMap,
   getPII,
 } from "~/features/common/utils";
 
@@ -65,6 +66,21 @@ describe(getKeysFromMap.name, () => {
   });
   it("should return an empty array when no values are provided", () => {
     const result = getKeysFromMap(MOCK_MAP, undefined);
+    expect(result).toEqual([]);
+  });
+});
+
+describe(getOptionsFromMap.name, () => {
+  it("should return an array of options", () => {
+    const result = getOptionsFromMap(MOCK_MAP);
+    expect(result).toEqual([
+      { label: "value1", value: "key1" },
+      { label: "value2", value: "key2" },
+    ]);
+  });
+  it("should return an empty array when the map is empty", () => {
+    const EMPTY_MOCK_MAP = new Map();
+    const result = getOptionsFromMap(EMPTY_MOCK_MAP);
     expect(result).toEqual([]);
   });
 });

--- a/clients/admin-ui/src/features/common/utils.ts
+++ b/clients/admin-ui/src/features/common/utils.ts
@@ -108,3 +108,11 @@ export const getKeysFromMap = <T = string>(
   Array.from(map)
     .filter(([, value]) => values?.includes(value))
     .map(([key]) => key);
+
+export const getOptionsFromMap = <T = string>(
+  map: Map<T, string>
+): { label: string; value: T }[] =>
+  Array.from(map).map(([key, value]) => ({
+    label: value,
+    value: key,
+  }));

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -41,6 +41,7 @@ import {
 import {
   CONSENT_MECHANISM_OPTIONS,
   defaultInitialValues,
+  ENFORCEMENT_LEVEL_OPTIONS,
   transformPrivacyNoticeResponseToCreation,
   ValidationSchema,
 } from "./form";
@@ -128,7 +129,6 @@ const PrivacyNoticeForm = ({
       const valuesToSubmit = {
         ...values,
         id: passedInPrivacyNotice!.id,
-        enforcement_level: passedInPrivacyNotice!.enforcement_level,
         translations: values.translations ?? [],
       };
       result = await patchNoticesMutationTrigger(valuesToSubmit);
@@ -191,6 +191,13 @@ const PrivacyNoticeForm = ({
                   label="Data use"
                   options={dataUseOptions}
                   isMulti
+                  variant="stacked"
+                />
+                <CustomSelect
+                  name="enforcement_level"
+                  label="Enforcement level"
+                  options={ENFORCEMENT_LEVEL_OPTIONS}
+                  isRequired
                   variant="stacked"
                 />
               </FormSection>

--- a/clients/admin-ui/src/features/privacy-notices/constants.ts
+++ b/clients/admin-ui/src/features/privacy-notices/constants.ts
@@ -1,13 +1,15 @@
+import { ConsentMechanism, EnforcementLevel } from "~/types/api";
+
 export const MECHANISM_MAP = new Map([
-  ["opt_in", "Opt in"],
-  ["notice_only", "Notice only"],
-  ["opt_out", "Opt out"],
+  [ConsentMechanism.OPT_IN, "Opt in"],
+  [ConsentMechanism.NOTICE_ONLY, "Notice only"],
+  [ConsentMechanism.OPT_OUT, "Opt out"],
 ]);
 
 export const ENFORCEMENT_LEVEL_MAP = new Map([
-  ["system_wide", "System wide"],
-  ["frontend", "Front end"],
-  ["not_applicable", "Not applicable"],
+  [EnforcementLevel.SYSTEM_WIDE, "System wide"],
+  [EnforcementLevel.FRONTEND, "Front end"],
+  [EnforcementLevel.NOT_APPLICABLE, "Not applicable"],
 ]);
 
 export const FRAMEWORK_MAP = new Map([

--- a/clients/admin-ui/src/features/privacy-notices/form.ts
+++ b/clients/admin-ui/src/features/privacy-notices/form.ts
@@ -1,5 +1,10 @@
 import * as Yup from "yup";
 
+import { getOptionsFromMap } from "~/features/common/utils";
+import {
+  ENFORCEMENT_LEVEL_MAP,
+  MECHANISM_MAP,
+} from "~/features/privacy-notices/constants";
 import {
   ConsentMechanism,
   EnforcementLevel,
@@ -13,20 +18,11 @@ interface PrivacyNoticeUpdateOrCreate extends PrivacyNoticeCreation {
   id?: string;
 }
 
-export const CONSENT_MECHANISM_OPTIONS = [
-  {
-    label: "Opt in",
-    value: ConsentMechanism.OPT_IN,
-  },
-  {
-    label: "Opt out",
-    value: ConsentMechanism.OPT_OUT,
-  },
-  {
-    label: "Notice only",
-    value: ConsentMechanism.NOTICE_ONLY,
-  },
-];
+export const CONSENT_MECHANISM_OPTIONS = getOptionsFromMap(MECHANISM_MAP);
+
+export const ENFORCEMENT_LEVEL_OPTIONS = getOptionsFromMap(
+  ENFORCEMENT_LEVEL_MAP
+);
 
 export const defaultInitialTranslations: NoticeTranslationCreate[] = [
   {
@@ -40,7 +36,7 @@ export const defaultInitialValues: PrivacyNoticeUpdateOrCreate = {
   name: "",
   consent_mechanism: ConsentMechanism.OPT_IN,
   data_uses: [],
-  enforcement_level: EnforcementLevel.SYSTEM_WIDE,
+  enforcement_level: EnforcementLevel.FRONTEND,
   // When creating, set to disabled to start
   disabled: true,
   translations: defaultInitialTranslations,


### PR DESCRIPTION
Closes [PROD-2206](https://ethyca.atlassian.net/browse/PROD-2206)

### Description Of Changes

The “enforcement level” is what controls the “backend consent propagation” integrations, so we need the ability to enable/edit this in the Admin UI.

Additionally, we were defaulting the enforcement level to “system-wide” but that default has been changed to "frontend"

### Code Changes

* Add ability to configure "Enforcement Level" for Privacy Notices in Admin UI
  * Update Cypress tests to look for new field
  * Add new Options utility and related unit test
  * Update options maps to use same key as our data models to avoid regressions
* change default to "frontend"

### Steps to Confirm

* Log in to Admin UI
* Visit Manage privacy notices
* Click on a notice listed to open the edit form
* Enforcement level should now be a required option
* Change it and save the form
* Reloading the page should retain the saved value selected

![CleanShot 2024-06-26 at 12 27 28@2x](https://github.com/ethyca/fides/assets/103820/3287b475-64e2-4431-9e49-dc5369eb34d6)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[PROD-2206]: https://ethyca.atlassian.net/browse/PROD-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ