### PR TITLE
Remove fetch polyfill from FidesJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,11 @@ The types of changes are:
 
 ### Changed
 - Navigation changes. 'Management' was renamed 'Settings'. Properties was moved to Settings section. [#5005](https://github.com/ethyca/fides/pull/5005)
-
-
-### Changed
 - Changed discovery monitor form behavior around execution date/time selection [#5017](https://github.com/ethyca/fides/pull/5017)
 - Changed integration form behavior when errors occur [#5023](https://github.com/ethyca/fides/pull/5023)
+
+### Removed
+- Removed the `fetch` polyfill from FidesJS (#5026)[https://github.com/ethyca/fides/pull/5026]
 
 ### Fixed
 - Fixed intermittent connection issues with Redshift by increasing timeout and preferring SSL in test connections [#4981](https://github.com/ethyca/fides/pull/4981)

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -271,13 +271,6 @@ export default async function handler(
 
   const script = `
   (function () {
-    // This polyfill service adds a fetch polyfill only when needed, depending on browser making the request
-    if (!window.fetch) {
-      var script = document.createElement('script');
-      script.src = 'https://polyfill.io/v3/polyfill.min.js?features=fetch';
-      document.head.appendChild(script);
-    }
-
     // Include generic fides.js script and GPP extension (if enabled)
     ${fidesJS}${fidesGPP}${
     customFidesCss


### PR DESCRIPTION
### Description Of Changes

No need to continue supporting browsers without `fetch` capabilities.
See https://caniuse.com/?search=fetch

### Code Changes

* Remove polyfill that was used to supplement `fetch` when browsers didn't support it.

### Steps to Confirm

* For the scope of this change, we only need to ensure that no regressions occur using your default / standard browser and all pre-existing functionality with the cookie banner is not broken.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
