### PR TITLE
PROD-2254: User must have delete scope to delete systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The types of changes are:
 - Fixed intermittent connection issues with Redshift by increasing timeout and preferring SSL in test connections [#4981](https://github.com/ethyca/fides/pull/4981)
 - Fixed a bug where system information form was not loading for Viewer users [#5034](https://github.com/ethyca/fides/pull/5034)
 - Fixed viewers being given the option to delete systems [#5035](https://github.com/ethyca/fides/pull/5035)
+- Restrict Delete Systems API endpoint such that user must have "SYSTEM_DELETE" scope [#5037](https://github.com/ethyca/fides/pull/5037)
 
 ## [2.39.0](https://github.com/ethyca/fides/compare/2.38.1...2.39.0)
 

--- a/src/fides/api/api/v1/endpoints/system.py
+++ b/src/fides/api/api/v1/endpoints/system.py
@@ -37,7 +37,6 @@ from fides.api.oauth.system_manager_oauth_util import (
 )
 from fides.api.oauth.utils import (
     get_current_user,
-    verify_oauth_client,
     verify_oauth_client_prod,
 )
 from fides.api.schemas.connection_configuration import connection_secrets_schemas

--- a/src/fides/api/api/v1/endpoints/system.py
+++ b/src/fides/api/api/v1/endpoints/system.py
@@ -33,7 +33,6 @@ from fides.api.models.fides_user import FidesUser
 from fides.api.models.sql_models import System  # type:ignore[attr-defined]
 from fides.api.oauth.system_manager_oauth_util import (
     verify_oauth_client_for_system_from_fides_key,
-    verify_oauth_client_for_system_from_fides_key_cli,
     verify_oauth_client_for_system_from_request_body_cli,
 )
 from fides.api.oauth.utils import get_current_user, verify_oauth_client_prod

--- a/src/fides/api/api/v1/endpoints/system.py
+++ b/src/fides/api/api/v1/endpoints/system.py
@@ -35,7 +35,11 @@ from fides.api.oauth.system_manager_oauth_util import (
     verify_oauth_client_for_system_from_fides_key,
     verify_oauth_client_for_system_from_request_body_cli,
 )
-from fides.api.oauth.utils import get_current_user, verify_oauth_client_prod
+from fides.api.oauth.utils import (
+    get_current_user,
+    verify_oauth_client,
+    verify_oauth_client_prod,
+)
 from fides.api.schemas.connection_configuration import connection_secrets_schemas
 from fides.api.schemas.connection_configuration.connection_config import (
     BulkPutConnectionConfiguration,
@@ -293,6 +297,12 @@ async def upsert(
 
 @SYSTEM_ROUTER.delete(
     "/{fides_key}",
+    dependencies=[
+        Security(
+            verify_oauth_client_prod,
+            scopes=[SYSTEM_DELETE],
+        )
+    ],
     responses={
         status.HTTP_403_FORBIDDEN: {
             "content": {
@@ -310,9 +320,7 @@ async def upsert(
     },
 )
 async def delete(
-    fides_key: str = Security(
-        scopes=[SYSTEM_DELETE],
-    ),  # Security dependency defined here instead of the path operation decorator so we have access to the fides_key
+    fides_key: str,
     # to retrieve the System and also return a value
     db: AsyncSession = Depends(get_async_db),
 ) -> Dict:

--- a/src/fides/api/api/v1/endpoints/system.py
+++ b/src/fides/api/api/v1/endpoints/system.py
@@ -312,7 +312,6 @@ async def upsert(
 )
 async def delete(
     fides_key: str = Security(
-        verify_oauth_client_for_system_from_fides_key_cli,
         scopes=[SYSTEM_DELETE],
     ),  # Security dependency defined here instead of the path operation decorator so we have access to the fides_key
     # to retrieve the System and also return a value

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -2542,9 +2542,7 @@ class TestSystemDelete:
             resource_id=system.fides_key,
             headers=auth_header,
         )
-        assert result.status_code == HTTP_200_OK
-        assert result.json()["message"] == "resource deleted"
-        assert result.json()["resource"]["fides_key"] == system.fides_key
+        assert result.status_code == HTTP_403_FORBIDDEN
 
     def test_delete_system_deletes_connection_config_and_dataset(
         self,

--- a/tests/ops/service/connectors/test_queryconfig.py
+++ b/tests/ops/service/connectors/test_queryconfig.py
@@ -475,7 +475,7 @@ class TestMongoQueryConfig:
                 "birthday": 1,
                 "comments": 1,
                 "customer_id": 1,
-                'customer_uuid': 1,
+                "customer_uuid": 1,
                 "emergency_contacts": 1,
                 "children": 1,
                 "gender": 1,


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-2254

### Description Of Changes

Remove "OR" condition in the security of Delete Systems endpoint such that we only check for users with the "SYSTEM_DELETE" scope explicitly.


### Code Changes

* [ ] Restrict Delete systems API endpoint such that user must have "SYSTEM_DELETE" scope

### Steps to Confirm

* [ ] Log into Admin-UI with viewer scope
* [ ] Confirm that you cannot delete systems

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
