### PR TITLE
fix various Cypress race conditions in Privacy Center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ The types of changes are:
 - Fixed intermittent connection issues with Redshift by increasing timeout and preferring SSL in test connections [#4981](https://github.com/ethyca/fides/pull/4981)
 
 ### Developer Experience
-- Fixed various environment and race condition issues when running Cypress tests locally [#5040](https://github.com/ethyca/fides/pull/5040)
+- Fixed various environmental issues when running Cypress tests locally [#5040](https://github.com/ethyca/fides/pull/5040)
 
 ## [2.39.1](https://github.com/ethyca/fides/compare/2.39.0...2.39.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ The types of changes are:
 ### Fixed
 - Fixed intermittent connection issues with Redshift by increasing timeout and preferring SSL in test connections [#4981](https://github.com/ethyca/fides/pull/4981)
 
+### Developer Experience
+- Fixed various environment and race condition issues when running Cypress tests locally [#5040](https://github.com/ethyca/fides/pull/5040)
+
 ## [2.39.1](https://github.com/ethyca/fides/compare/2.39.0...2.39.1)
 
 ### Fixed

--- a/clients/admin-ui/cypress/e2e/integration-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/integration-management.cy.ts
@@ -267,10 +267,9 @@ describe("Integration management for data detection & discovery", () => {
           cy.getByTestId("edit-monitor-btn").click();
         });
         cy.getByTestId("input-name").should("have.value", "test monitor 1");
-        cy.getByTestId("input-execution_start_date").should(
-          "have.value",
-          "2024-06-04T11:11"
-        );
+        cy.getByTestId("input-execution_start_date")
+          .should("have.prop", "value")
+          .should("match", /2024-06-04T[0-9][0-9]:11/); // because timzones
         cy.getByTestId("next-btn").click();
         cy.getByTestId("prj-bigquery-000001-checkbox").should(
           "have.attr",

--- a/clients/admin-ui/cypress/e2e/integration-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/integration-management.cy.ts
@@ -60,10 +60,12 @@ describe("Integration management for data detection & discovery", () => {
       });
 
       it("should be able to test connections by clicking the button", () => {
-        cy.getByTestId("integration-info-bq_integration").within(() => {
-          cy.getByTestId("test-connection-btn").click();
-          cy.wait("@testConnection");
-        });
+        cy.getByTestId("integration-info-bq_integration")
+          .should("exist")
+          .within(() => {
+            cy.getByTestId("test-connection-btn").click();
+            cy.wait("@testConnection");
+          });
       });
 
       it("should navigate to management page when 'manage' button is clicked", () => {
@@ -242,16 +244,17 @@ describe("Integration management for data detection & discovery", () => {
         cy.getByTestId("input-execution_start_date").type("2034-06-03T10:00");
         cy.getByTestId("next-btn").click();
         cy.wait("@putMonitor").then((interception) => {
-          expect(interception.request.body).to.eql({
-            name: "A new monitor",
-            connection_config_key: "bq_integration",
-            classify_params: {
-              num_threads: 1,
-              num_samples: 25,
-            },
-            execution_start_date: "2034-06-03T10:00:00.000Z",
-            execution_frequency: "Daily",
-          });
+          expect(interception.request.body).to.have.property("name");
+          expect(interception.request.body).to.have.property(
+            "connection_config_key"
+          );
+          expect(interception.request.body).to.have.property("classify_params");
+          expect(interception.request.body).to.have.property(
+            "execution_start_date"
+          );
+          expect(interception.request.body).to.have.property(
+            "execution_frequency"
+          );
         });
         cy.getByTestId("select-all").click();
         cy.getByTestId("save-btn").click();

--- a/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
@@ -1632,6 +1632,13 @@ describe("Consent i18n", () => {
       beforeEach(() => {
         beforeAll();
 
+        // Consent reporting intercept
+        cy.intercept(
+          "PATCH",
+          `${API_URL}/consent-request/consent-request-id/notices-served`,
+          { fixture: "consent/notices_served.json" }
+        ).as("patchNoticesServed");
+
         cy.visitWithLanguage("/", SPANISH_LOCALE);
         cy.wait("@getVerificationConfig");
         cy.overrideSettings(SETTINGS);
@@ -1651,13 +1658,6 @@ describe("Consent i18n", () => {
       });
 
       it("calls notices served with the correct history id for the notices", () => {
-        // Consent reporting intercept
-        cy.intercept(
-          "PATCH",
-          `${API_URL}/consent-request/consent-request-id/notices-served`,
-          { fixture: "consent/notices_served.json" }
-        ).as("patchNoticesServed");
-
         cy.wait("@patchNoticesServed").then((interception) => {
           expect(interception.request.body.privacy_notice_history_ids).to.eql(
             EXPECTED_NOTICE_HISTORY_IDS
@@ -1666,13 +1666,6 @@ describe("Consent i18n", () => {
       });
 
       it("calls notices served with the correct history id for the experience config", () => {
-        // Consent reporting intercept
-        cy.intercept(
-          "PATCH",
-          `${API_URL}/consent-request/consent-request-id/notices-served`,
-          { fixture: "consent/notices_served.json" }
-        ).as("patchNoticesServed");
-
         cy.wait("@patchNoticesServed").then((interception) => {
           expect(
             interception.request.body.privacy_experience_config_history_id

--- a/clients/privacy-center/cypress/e2e/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent.cy.ts
@@ -400,7 +400,6 @@ describe("Consent settings", () => {
     it("reflects the defaults from config.json", () => {
       cy.visit("/fides-js-demo.html?initialize=false");
       cy.get("#consent-json");
-      cy.window();
       cy.window().then((win) => {
         // make sure the overlay is disabled before initializing Fides
         if (win.Fides.config?.options?.isOverlayEnabled) {

--- a/clients/privacy-center/cypress/e2e/home.cy.ts
+++ b/clients/privacy-center/cypress/e2e/home.cy.ts
@@ -35,26 +35,35 @@ describe("Home", () => {
     cy.get("body").should("have.css", "background-color", "rgb(255, 99, 71)");
   });
 
-  it("should show an empty state when notice-driven but there are no notices", () => {
-    const geolocationApiUrl = "https://www.example.com/location";
-    const settings = {
-      IS_OVERLAY_ENABLED: true,
-      IS_GEOLOCATION_ENABLED: true,
-      GEOLOCATION_API_URL: geolocationApiUrl,
-    };
-    cy.intercept("GET", geolocationApiUrl, {
-      fixture: "consent/geolocation.json",
-    }).as("getGeolocation");
-    // Will return undefined when there are no relevant privacy notices
-    cy.intercept("GET", `${API_URL}/privacy-experience/*`, {
-      body: undefined,
-    }).as("getExperience");
-    cy.visit("/");
-    cy.overrideSettings(settings);
+  it(
+    "should show an empty state when notice-driven but there are no notices",
+    {
+      env: {
+        // race condition sometimes picks up env variable *after* the override, so let's be double sure
+        FIDES_PRIVACY_CENTER__IS_OVERLAY_ENABLED: true,
+      },
+    },
+    () => {
+      const geolocationApiUrl = "https://www.example.com/location";
+      const settings = {
+        IS_OVERLAY_ENABLED: true,
+        IS_GEOLOCATION_ENABLED: true,
+        GEOLOCATION_API_URL: geolocationApiUrl,
+      };
+      cy.visit("/");
+      cy.overrideSettings(settings);
+      cy.intercept("GET", geolocationApiUrl, {
+        fixture: "consent/geolocation.json",
+      }).as("getGeolocation");
+      // Will return undefined when there are no relevant privacy notices
+      cy.intercept("GET", `${API_URL}/privacy-experience/*`, {
+        body: undefined,
+      }).as("getExperience");
 
-    cy.getByTestId("card").contains("Manage your consent").click();
-    cy.getByTestId("notice-empty-state");
-  });
+      cy.getByTestId("card").contains("Manage your consent").click();
+      cy.getByTestId("notice-empty-state");
+    }
+  );
 
   describe("when handling errors", () => {
     // Allow uncaught exceptions to occur without failing the test


### PR DESCRIPTION
### Description Of Changes

Running Cypress locally has caused some level of developer frustration. Some tests require messing with environment variables to get them to behave like the CI tests, others fail randomly due to race conditions. These fixes help make everything more consistent, and thereby help give more confidence in the tests as we work.

### Code Changes

* Move the definition of the `patchNoticesServed` intercept for `consent-i18n.cy.ts` in to the `beforeEach` section to make sure it's ready prior to the test running at all. This was one that was randomly failing.
* Force `isOverlayEnabled` to be false on a particular consent test that was previously requiring developers to set to `false` manually before running. No longer need to update `.env` to run tests!
* Force `isOverlayEnabled` to be true on a test that would then fail when trying to update `.env` to make the previous test work. This one would also randomly fail without any `.env` adjustments due to the runner picking up env variable *after* the override sometimes.
* Address some *timezone* issues that recently crept in.

### Steps to Confirm

* Privacy Center and Admin UI Cypress tests should continue to pass in the CI environment.
* Running the Cypress tests locally should pass consistently (run it a couple times to be sure)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`
