### PR TITLE
PROD-2219-FE-add-system-names-to-new-data-map-reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The types of changes are:
 - Replaces typescript-cookie with js-cookie [#5022](https://github.com/ethyca/fides/pull/5022)
 - Updated pymongo version to 4.7.3 [#5019](https://github.com/ethyca/fides/pull/5019)
 - Upgraded Datamap instance of `react-table` to v8 [#5024](https://github.com/ethyca/fides/pull/5024)
+- Update name of Ingress/Egress columns in Datamap Report to Sources/Destinations [#5045](https://github.com/ethyca/fides/pull/5045)
 
 ### Removed
 - Removed the `fetch` polyfill from FidesJS [#5026](https://github.com/ethyca/fides/pull/5026)

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -102,13 +102,13 @@ enum COLUMN_IDS {
   DESCRIPTION = "description",
   DOES_INTERNATIONAL_TRANSFERS = "does_international_transfers",
   DPA_LOCATION = "dpa_location",
-  EGRESS = "egress",
+  DESTINATIONS = "egress",
   EXEMPT_FROM_PRIVACY_REGULATIONS = "exempt_from_privacy_regulations",
   FEATURES = "features",
   FIDES_KEY = "fides_key",
   FLEXIBLE_LEGAL_BASIS_FOR_PROCESSING = "flexible_legal_basis_for_processing",
   IMPACT_ASSESSMENT_LOCATION = "impact_assessment_location",
-  INGRESS = "ingress",
+  SOURCES = "ingress",
   JOINT_CONTROLLER_INFO = "joint_controller_info",
   LEGAL_BASIS_FOR_PROFILING = "legal_basis_for_profiling",
   LEGAL_BASIS_FOR_TRANSFERS = "legal_basis_for_transfers",
@@ -594,17 +594,19 @@ export const DatamapReportTable = () => {
         },
       }),
       columnHelper.accessor((row) => row.egress, {
-        id: COLUMN_IDS.EGRESS,
+        id: COLUMN_IDS.DESTINATIONS,
         cell: (props) => (
           <GroupCountBadgeCell
-            suffix="egress"
+            suffix="destinations"
             value={props.getValue()}
             {...props}
           />
         ),
-        header: (props) => <DefaultHeaderCell value="Egress" {...props} />,
+        header: (props) => (
+          <DefaultHeaderCell value="Destinations" {...props} />
+        ),
         meta: {
-          displayText: "Egress",
+          displayText: "Destinations",
           showHeaderMenu: true,
         },
       }),
@@ -668,17 +670,17 @@ export const DatamapReportTable = () => {
         },
       }),
       columnHelper.accessor((row) => row.ingress, {
-        id: COLUMN_IDS.INGRESS,
+        id: COLUMN_IDS.SOURCES,
         cell: (props) => (
           <GroupCountBadgeCell
-            suffix="ingress"
+            suffix="sources"
             value={props.getValue()}
             {...props}
           />
         ),
-        header: (props) => <DefaultHeaderCell value="Ingress" {...props} />,
+        header: (props) => <DefaultHeaderCell value="Sources" {...props} />,
         meta: {
-          displayText: "Ingress",
+          displayText: "Sources",
           showHeaderMenu: true,
         },
       }),


### PR DESCRIPTION
### Description Of Changes

In the datamap report, rename columns Ingress and Egress to Sources and Destinations.


### Code Changes

* [ ] Rename Column Names
* [ ] Rename badge group suffix
* [ ] Rename COLUMNS_IDS enum key

Intentionally didn't update enum key value or row.ingress/row.egress because the api endpoint still return the property as ingress/egress.

### Steps to Confirm

* [ ] Login fides admin
* [ ] Go to Data Inventory > Reporting
* [ ] Check column names are now Sources and Destinations
* [ ] Click on Edit Columns, check that the column names are now Sources and Destinations

### Screenshots
Updated column names in table
<img width="1280" alt="Captura de pantalla 2024-07-01 a la(s) 1 30 19 p  m" src="https://github.com/ethyca/fides/assets/4809430/62cd5002-fa68-4772-afb9-19d2fbdcaf73">

Updated column names in Edit columns modal
<img width="996" alt="Captura de pantalla 2024-07-01 a la(s) 1 30 34 p  m" src="https://github.com/ethyca/fides/assets/4809430/2d4e5da1-33e7-4b21-aa15-c00fc57351d2">


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`