### PR TITLE
Move .env var to before server runs

### DIFF
--- a/clients/privacy-center/cypress/e2e/home.cy.ts
+++ b/clients/privacy-center/cypress/e2e/home.cy.ts
@@ -35,35 +35,26 @@ describe("Home", () => {
     cy.get("body").should("have.css", "background-color", "rgb(255, 99, 71)");
   });
 
-  it(
-    "should show an empty state when notice-driven but there are no notices",
-    {
-      env: {
-        // race condition sometimes picks up env variable *after* the override, so let's be double sure
-        FIDES_PRIVACY_CENTER__IS_OVERLAY_ENABLED: true,
-      },
-    },
-    () => {
-      const geolocationApiUrl = "https://www.example.com/location";
-      const settings = {
-        IS_OVERLAY_ENABLED: true,
-        IS_GEOLOCATION_ENABLED: true,
-        GEOLOCATION_API_URL: geolocationApiUrl,
-      };
-      cy.visit("/");
-      cy.overrideSettings(settings);
-      cy.intercept("GET", geolocationApiUrl, {
-        fixture: "consent/geolocation.json",
-      }).as("getGeolocation");
-      // Will return undefined when there are no relevant privacy notices
-      cy.intercept("GET", `${API_URL}/privacy-experience/*`, {
-        body: undefined,
-      }).as("getExperience");
+  it("should show an empty state when notice-driven but there are no notices", () => {
+    const geolocationApiUrl = "https://www.example.com/location";
+    const settings = {
+      IS_OVERLAY_ENABLED: true,
+      IS_GEOLOCATION_ENABLED: true,
+      GEOLOCATION_API_URL: geolocationApiUrl,
+    };
+    cy.visit("/");
+    cy.overrideSettings(settings);
+    cy.intercept("GET", geolocationApiUrl, {
+      fixture: "consent/geolocation.json",
+    }).as("getGeolocation");
+    // Will return undefined when there are no relevant privacy notices
+    cy.intercept("GET", `${API_URL}/privacy-experience/*`, {
+      body: undefined,
+    }).as("getExperience");
 
-      cy.getByTestId("card").contains("Manage your consent").click();
-      cy.getByTestId("notice-empty-state");
-    }
-  );
+    cy.getByTestId("card").contains("Manage your consent").click();
+    cy.getByTestId("notice-empty-state");
+  });
 
   describe("when handling errors", () => {
     // Allow uncaught exceptions to occur without failing the test

--- a/clients/privacy-center/package.json
+++ b/clients/privacy-center/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf .turbo node_modules",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "cy:start": "export NODE_ENV=test && npm run build && next start -p 3001",
+    "cy:start": "export NODE_ENV=test && FIDES_PRIVACY_CENTER__IS_OVERLAY_ENABLED=true && npm run build && next start -p 3001",
     "analyze": "cross-env ANALYZE=true next build",
     "analyze:server": "cross-env BUNDLE_ANALYZE=server next build",
     "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build",


### PR DESCRIPTION
This environment variable still isn't working correctly in tests because it's read by the Next server, not the client. Setting it in Cypress is never going to work because Cypress relies on the server to already be running.

### Description Of Changes

Force this env variable for all tests, so that developer's machine settings don't cause unexpected failures.

### Code Changes

* move `FIDES_PRIVACY_CENTER__IS_OVERLAY_ENABLED=true` from Cypress config to `package.json` script that runs the cypress start.

### Steps to Confirm

* set `FIDES_PRIVACY_CENTER__IS_OVERLAY_ENABLED=false` in local `privacy-center/.env`
* run `npm run cy:start` and then run `cy:run`
* All tests should pass
