### PR TITLE
Fix Scylla Integration Test

### DIFF
--- a/src/fides/api/service/connectors/scylla_connector.py
+++ b/src/fides/api/service/connectors/scylla_connector.py
@@ -34,7 +34,13 @@ class ScyllaConnector(BaseConnector):
         auth_provider = PlainTextAuthProvider(
             username=config.username, password=config.password
         )
-        cluster = Cluster([config.host], port=config.port, auth_provider=auth_provider)
+        try:
+            cluster = Cluster(
+                [config.host], port=config.port, auth_provider=auth_provider
+            )
+        except cassandra.UnresolvableContactPoints:
+            raise ConnectionException("No host available.")
+
         return cluster
 
     def query_config(self, node: ExecutionNode) -> QueryConfig[Any]:


### PR DESCRIPTION
Closes Unticketed

### Description Of Changes

Fix intermittently failing scylla integration test.


### Code Changes

* [ ] Fixing a test that passes locally and passes sometimes in CI. Failing test does reveal a location where we can have uncaught errors when creating a scylla client.

### Steps to Confirm

* [ ] Just looking for integration test to pass in CI

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
