### PR TITLE
Fix empty Filters modal

### DIFF
--- a/clients/admin-ui/src/features/datamap/modals/FilterModal.tsx
+++ b/clients/admin-ui/src/features/datamap/modals/FilterModal.tsx
@@ -45,10 +45,7 @@ interface FilterModalProps {
 const FilterModal: React.FC<FilterModalProps> = ({ isOpen, onClose }) => {
   const { tableInstance } = useContext(DatamapTableContext);
 
-  const headerGroups = useMemo(
-    () => tableInstance?.getHeaderGroups() || [],
-    [tableInstance]
-  );
+  const headerGroups = tableInstance?.getHeaderGroups();
 
   const renderHeaderFilter = (
     headers: Header<DatamapRow, unknown>[],


### PR DESCRIPTION
Closes: [PROD-2311](https://ethyca.atlassian.net/browse/PROD-2311)

### Description Of Changes

Memo was not being updated with new table data because it was only monitoring the table instance and not the data. Removing memo since it's really not helping much at all anyway, it's just extracting the data to a variable.


### Code Changes

* Remove memo from the `headerGroups` variable

### Steps to Confirm

* Log out of Admin UI (important step for reproducing!)
* Log in and visit Spatial Datamap `/datamap`
* Click "Filter" button.
* Modal should not be empty.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met


[PROD-2311]: https://ethyca.atlassian.net/browse/PROD-2311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ