### PR TITLE
fix mysql integration: pin 9, remove command

### DIFF
--- a/docker-compose.integration-tests.yml
+++ b/docker-compose.integration-tests.yml
@@ -23,9 +23,8 @@ services:
       - "0.0.0.0:6432:5432"
 
   mysql-test:
-    image: mysql:8
+    image: mysql:9
     platform: linux/amd64
-    command: --mysql-native-password=ON
     restart: always
     environment:
       - MYSQL_HOST=mysql_example

--- a/docker-compose.integration-tests.yml
+++ b/docker-compose.integration-tests.yml
@@ -22,21 +22,6 @@ services:
     ports:
       - "0.0.0.0:6432:5432"
 
-  mysql-test:
-    image: mysql:9
-    platform: linux/amd64
-    restart: always
-    environment:
-      - MYSQL_HOST=mysql_example
-      - MYSQL_DATABASE=mysql_example
-      - MYSQL_ROOT_PASSWORD=example
-      - MYSQL_USER=mysql_user
-      - MYSQL_PASSWORD=mysql_pw
-    expose:
-      - 3306
-    ports:
-      - "3306:3306"
-
   sqlserver-test:
     image: mcr.microsoft.com/azure-sql-edge:latest # Equivalent to SQL Server 2016
     environment:
@@ -46,3 +31,5 @@ services:
       - 1433
     ports:
       - "0.0.0.0:1433:1433"
+
+  # mysql integration test config lives at `docker/docker-compose.integration-mysql.yml`

--- a/docker/docker-compose.integration-mysql.yml
+++ b/docker/docker-compose.integration-mysql.yml
@@ -1,8 +1,7 @@
 services:
   mysql_example:
-    image: mysql
+    image: mysql:9
     platform: linux/amd64
-    command: --mysql-native-password=ON
     restart: always
     environment:
       - MYSQL_HOST=mysql_example

--- a/docker/docker-compose.integration-mysql.yml
+++ b/docker/docker-compose.integration-mysql.yml
@@ -1,6 +1,6 @@
 services:
   mysql_example:
-    image: mysql:9
+    image: mysql
     platform: linux/amd64
     restart: always
     environment:

--- a/docker/docker-compose.integration-mysql.yml
+++ b/docker/docker-compose.integration-mysql.yml
@@ -1,6 +1,6 @@
 services:
   mysql_example:
-    image: mysql
+    image: mysql:latest
     platform: linux/amd64
     restart: always
     environment:


### PR DESCRIPTION
prereq for PROD-2083

### Description Of Changes
removes command calling naive plugin, changes image to mysql:9 instead of 8


### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
