### PR TITLE
remove rewrites from NextJS config

### DIFF
--- a/clients/admin-ui/next.config.js
+++ b/clients/admin-ui/next.config.js
@@ -17,31 +17,6 @@ const nextConfig = {
      */
     proxyTimeout: 120000,
   },
-  async rewrites() {
-    // The tests run without a server. Rewrites cause Next to continually try to connect,
-    // which spams the logs with "ECONNREFUSED".
-    if (process.env.NODE_ENV === "test") {
-      return [];
-    }
-
-    // these paths are unnecessarily complicated due to our backend being
-    // picky about trailing slashes https://github.com/ethyca/fides/issues/690
-    return [
-      {
-        source: `/api/v1/:path`,
-        destination: `${process.env.NEXT_PUBLIC_FIDESCTL_API_SERVER}/api/v1/:path/`,
-      },
-      {
-        source: `/api/v1/:first/:second*`,
-        destination: `${process.env.NEXT_PUBLIC_FIDESCTL_API_SERVER}/api/v1/:first/:second*`,
-      },
-      // The /health path does not live under /api/v1
-      {
-        source: `/health`,
-        destination: `${process.env.NEXT_PUBLIC_FIDESCTL_API_SERVER}/health`,
-      },
-    ];
-  },
   images: {
     loader: "custom",
   },


### PR DESCRIPTION
### Description Of Changes

The `next export` command is being deprecated in favor of `output: "export"` which is not compatible with rewrites.

Since Admin UI gets run from a static export (see the script for `npm run prod-export` in the `package.json` file for reference), these rewrites are likely no longer being used or respected anyway.

Removing these entirely for now to make sure that the assumption that they are already ignored is true before attempting to upgrade NextJS.

### Code Changes

* remove `rewrites()` section of `next.config.js`

### Steps to Confirm

* existing Cypress smoke tests should sniff this out pretty quickly

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
