### PR TITLE
PROD-2409 By default, don't show data categories that are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The types of changes are:
 - Endpoints for listing systems (GET /system) and datasets (GET /dataset) now support optional pagination [#5071](https://github.com/ethyca/fides/pull/5071)
 - Messaging page will now show a notice about using global mode [#5090](https://github.com/ethyca/fides/pull/5090)
 - Changed behavior of project selection modal in discovery monitor form [#5092](https://github.com/ethyca/fides/pull/5092)
+- Data category selector for Discovery results won't show disabled categories [#5102](https://github.com/ethyca/fides/pull/5102)
+
 
 ### Developer Experience
 - Upgrade to React 18 and Chakra 2, including other dependencies [#5036](https://github.com/ethyca/fides/pull/5036)

--- a/clients/admin-ui/cypress/e2e/discovery-detection.cy.ts
+++ b/clients/admin-ui/cypress/e2e/discovery-detection.cy.ts
@@ -346,10 +346,10 @@ describe("discovery and detection", () => {
         cy.url().should("not.contain", "User_geography");
       });
 
-      it("allows classifications to be changed using the dropdown", () => {
+      it.only("allows classifications to be changed using the dropdown", () => {
         cy.intercept("GET", "/api/v1/data_category", [
-          { fides_key: "system" },
-          { fides_key: "user.contact" },
+          { fides_key: "system", active: true },
+          { fides_key: "user.contact", active: true },
         ]);
         cy.intercept("PATCH", "/api/v1/plus/discovery-monitor/*/results").as(
           "patchClassification"

--- a/clients/admin-ui/cypress/e2e/discovery-detection.cy.ts
+++ b/clients/admin-ui/cypress/e2e/discovery-detection.cy.ts
@@ -346,7 +346,7 @@ describe("discovery and detection", () => {
         cy.url().should("not.contain", "User_geography");
       });
 
-      it.only("allows classifications to be changed using the dropdown", () => {
+      it("allows classifications to be changed using the dropdown", () => {
         cy.intercept("GET", "/api/v1/data_category", [
           { fides_key: "system", active: true },
           { fides_key: "user.contact", active: true },

--- a/clients/admin-ui/src/features/common/dropdown/TaxonomySelectDropdown.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/TaxonomySelectDropdown.tsx
@@ -45,13 +45,21 @@ const Option = ({ data, setValue }: OptionProps<TaxonomySelectOption>) => {
 interface TaxonomySelectDropdownProps {
   onChange: (selectedOption: TaxonomySelectOption) => void;
   menuIsOpen?: boolean;
+  showDisabled?: boolean;
 }
 const TaxonomySelectDropdown = ({
   onChange,
   menuIsOpen,
+  showDisabled = false,
 }: TaxonomySelectDropdownProps) => {
   const { getDataCategoryDisplayName, getDataCategories } = useTaxonomies();
-  const dataCategories = getDataCategories();
+
+  const getActiveDataCategories = () =>
+    getDataCategories().filter((c) => c.active);
+
+  const dataCategories = showDisabled
+    ? getDataCategories()
+    : getActiveDataCategories();
 
   const options: Options<TaxonomySelectOption> = dataCategories.map(
     (category) => ({


### PR DESCRIPTION
### Description Of Changes

In the taxonomy picker by default, don't show data categories that are disabled.


### Code Changes

* [ ] Added showDisabled prop to TaxonomySelectDropdown defaulting to false
* [ ] Added filtering in the FE for categories that aren't active

### Steps to Confirm
Need to have D&D setup and some classification results.
* [ ] Log in to admin ui
* [ ] Go to Settings > Taxonomy, and disable a data category
* [ ] Go to data discovery
* [ ] Use the taxonomy picker and check that the data category that is disabled isn't shown as an option

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
