### PR TITLE
Add .syncignore to ignore unnecessary file syncs to volume

### DIFF
--- a/.syncignore
+++ b/.syncignore
@@ -1,0 +1,21 @@
+# Frontend
+**/node_modules
+**/.next
+**/.eslintrc.json
+**/.jest.config.js
+**/jest.config.jest
+**/.prettierignore
+**/.prettierrc.json
+**/__tests__
+**/npm-debug.log
+**/*__mocks__
+
+# Ignore Python-Specific Files
+**/.mypy_cache/
+**/.nox/
+**/.pytest_cache/
+**/__pycache__/
+**/.coverage
+**/*.pyc
+**/*.pyo
+**/*.pyd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,16 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [2.41.0](https://github.com/ethyca/fides/compare/2.40.0...2.41.0)
+## [Unreleased](https://github.com/ethyca/fides/compare/2.41.0...main)
 
-- Add AWS Tags in the meta field for Fides system when using `fides generate` [#4998](https://github.com/ethyca/fides/pull/4998).
+### Added
+- Add AWS Tags in the meta field for Fides system when using `fides generate` [#4998](https://github.com/ethyca/fides/pull/4998)
+
+### Developer Experience
+- Add `.syncignore` to reduce file sync size with new volumes [#5104](https://github.com/ethyca/fides/pull/5104)
+
+
+## [2.41.0](https://github.com/ethyca/fides/compare/2.40.0...2.41.0)
 
 ### Added
 - Added erasure support for Alchemer integration [#4925](https://github.com/ethyca/fides/pull/4925)


### PR DESCRIPTION
Closes n/a

### Description Of Changes

This is a minor dev qol change to reduce build times when dropping volumes. It was noticed that we were moving the entire .nox directory over causing >7GB of data transfer

This will reduce it to <1GB (more could likely be added but this is a good start anyway)

Before:
<img width="788" alt="Screenshot 2024-07-18 at 9 42 37 PM" src="https://github.com/user-attachments/assets/b4dcdc50-ff23-4664-90b9-773f26355345">

After:
<img width="783" alt="Screenshot 2024-07-18 at 9 46 33 PM" src="https://github.com/user-attachments/assets/3bdf928c-d1e1-445b-ab79-e01c02db53b0">


### Code Changes

* [x] Add a `.syncignore` file to the root
* [x] Copy some directories over from `.dockerignore`

### Steps to Confirm

* [ ] Measure the sizes to upload
* [ ] Validate the UI isn't affected when running `nox -s dev`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
