### PR TITLE
"activate" default locale during fallback of GVL language error

### DIFF
--- a/clients/fides-js/src/lib/initOverlay.ts
+++ b/clients/fides-js/src/lib/initOverlay.ts
@@ -51,12 +51,14 @@ export const initOverlay = async ({
     ) {
       // if translations API fails or is empty, use the GVL object directly
       // as a fallback, since it already contains the english version of strings
-      gvlTranslations = { en: experience.gvl };
+      gvlTranslations = {};
+      gvlTranslations[DEFAULT_LOCALE] = experience.gvl;
       // eslint-disable-next-line no-param-reassign
-      experience.available_locales = ["en"];
+      experience.available_locales = [DEFAULT_LOCALE];
       i18n.setAvailableLanguages(
-        LOCALE_LANGUAGE_MAP.filter((lang) => lang.locale === "en")
+        LOCALE_LANGUAGE_MAP.filter((lang) => lang.locale === DEFAULT_LOCALE)
       );
+      i18n.activate(DEFAULT_LOCALE);
     }
     loadMessagesFromGVLTranslations(
       i18n,


### PR DESCRIPTION
Closes [PROD-2413](https://ethyca.atlassian.net/browse/PROD-2413)

### Description Of Changes

When GVL languages are not available, the UI should fall back to the default language (English) even when the locale is set to something else.


### Code Changes

* Replace hard-coded instances of default locale with `DEFAULT_LOCALE`
* call `i18n.activate(DEFAULT_LOCALE)` during fallback to fix fallback bug.

### Steps to Confirm

1. visit https://privacy-plus-rc.fides-staging.ethyca.com/fides-js-demo.html?geolocation=eea&fides_locale=fr (or localhost equivalent http://localhost:3001/fides-js-demo.html?geolocation=eea&fides_locale=fr) 
2. Simulate a failed api call by opening dev tools Networks tab, right clicking the gvl/translations and choosing to block that URL. Make sure to update the resulting blocked URL to just use a * wildcard (eg. `https://privacy-plus-rc.fides-staging.ethyca.com/api/v1/privacy-experience/gvl/translations*`)
3. Reload the page
4. Overlay should all be in English and not French

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded


[PROD-2413]: https://ethyca.atlassian.net/browse/PROD-2413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ