### PR TITLE
Visual fixes for monitor table

### DIFF
--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -20,6 +20,7 @@ import { ChangeEvent, ReactNode } from "react";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import ConfirmationModal from "~/features/common/modals/ConfirmationModal";
 import { errorToastParams } from "~/features/common/toast";
+import { sentenceCase } from "~/features/common/utils";
 import { RTKResult } from "~/types/errors";
 
 export const DefaultCell = ({
@@ -63,13 +64,12 @@ export const RelativeTimestampCell = ({
   if (!time) {
     return <DefaultCell value="N/A" />;
   }
-  return (
-    <DefaultCell
-      value={formatDistance(new Date(time), new Date(), {
-        addSuffix: true,
-      })}
-    />
-  );
+
+  const timestamp = formatDistance(new Date(time), new Date(), {
+    addSuffix: true,
+  });
+
+  return <DefaultCell value={sentenceCase(timestamp)} />;
 };
 
 export const BadgeCellContainer = ({ children }: { children: ReactNode }) => (

--- a/clients/admin-ui/src/features/data-discovery-and-detection/ActionButton.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/ActionButton.tsx
@@ -23,7 +23,7 @@ const ActionButton = ({
     data-testid={`action-${title}`}
   >
     {icon}
-    <Text marginLeft={1} fontWeight="semibold" fontSize={12}>
+    <Text marginLeft={icon && 1} fontWeight="semibold" fontSize={12}>
       {title}
     </Text>
   </Button>


### PR DESCRIPTION
### Description Of Changes

* Changes "last scanned" timestamp to use sentence case
* Removes asymmetrical padding on "Scan" action button that was left from when that component always expected an icon

Before:  
![Screenshot 2024-07-19 at 12 40 20](https://github.com/user-attachments/assets/f487c179-27cf-4b06-9bba-5be6d1d35588)

After:
![Screenshot 2024-07-19 at 12 39 42](https://github.com/user-attachments/assets/d8b94181-bf4e-4349-8555-e29efc641528)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
