### PR TITLE
CLI Issues: YAML Cannot Find Constructors for FidesKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The types of changes are:
 ### Fixed
 - Fixed bug with unescaped table names in mysql queries [#5072](https://github.com/ethyca/fides/pull/5072/)
 - Fixed bug with unresponsive messaging ui [#5081](https://github.com/ethyca/fides/pull/5081/)
+- Fixed FidesKey constructor bugs in CLI [#5113](https://github.com/ethyca/fides/pull/5113)
 
 
 ## [2.40.0](https://github.com/ethyca/fides/compare/2.39.2...2.40.0)

--- a/src/fides/core/annotate_dataset.py
+++ b/src/fides/core/annotate_dataset.py
@@ -82,7 +82,7 @@ def get_data_categories_annotation(
                 dataset_member, valid_categories
             )
 
-    return [str(FidesKey(value)) for value in user_response]
+    return [str(FidesKey(value)) for value in user_response]  # type: ignore
 
 
 def annotate_dataset(

--- a/src/fides/core/annotate_dataset.py
+++ b/src/fides/core/annotate_dataset.py
@@ -82,7 +82,7 @@ def get_data_categories_annotation(
                 dataset_member, valid_categories
             )
 
-    return [FidesKey(value) for value in user_response]
+    return [str(FidesKey(value)) for value in user_response]
 
 
 def annotate_dataset(

--- a/src/fides/core/dataset.py
+++ b/src/fides/core/dataset.py
@@ -140,9 +140,9 @@ def make_dataset_key_unique(
     to avoid naming collisions.
     """
 
-    dataset.fides_key = FidesKey(
+    dataset.fides_key = str(FidesKey(
         generate_unique_fides_key(dataset.fides_key, database_host, database_name)
-    )
+    ))
     dataset.meta = {"database_host": database_host, "database_name": database_name}
     return dataset
 

--- a/src/fides/core/dataset.py
+++ b/src/fides/core/dataset.py
@@ -140,9 +140,11 @@ def make_dataset_key_unique(
     to avoid naming collisions.
     """
 
-    dataset.fides_key = str(FidesKey(
-        generate_unique_fides_key(dataset.fides_key, database_host, database_name)
-    ))
+    dataset.fides_key = str(
+        FidesKey(
+            generate_unique_fides_key(dataset.fides_key, database_host, database_name)
+        )
+    )
     dataset.meta = {"database_host": database_host, "database_name": database_name}
     return dataset
 

--- a/src/fides/core/dataset.py
+++ b/src/fides/core/dataset.py
@@ -140,7 +140,7 @@ def make_dataset_key_unique(
     to avoid naming collisions.
     """
 
-    dataset.fides_key = str(
+    dataset.fides_key = str(  # type: ignore
         FidesKey(
             generate_unique_fides_key(dataset.fides_key, database_host, database_name)
         )

--- a/tests/ctl/cli/test_cli.py
+++ b/tests/ctl/cli/test_cli.py
@@ -1,11 +1,12 @@
 # pylint: disable=missing-docstring, redefined-outer-name
 import os
-import yaml
 from base64 import b64decode
 from json import dump, loads
 from typing import Generator
 
+import click
 import pytest
+import yaml
 from click.testing import CliRunner
 from git.repo import Repo
 from py._path.local import LocalPath
@@ -216,6 +217,61 @@ class TestPull:
         os.remove(test_file)
         print(result.output)
         assert result.exit_code == 0
+
+
+@pytest.mark.integration
+class TestAnnotate:
+
+    def test_annotate(
+        self,
+        test_config_path: str,
+        test_cli_runner: CliRunner,
+    ) -> None:
+        """
+        Test annotating dataset allowing you to interactively annotate the dataset with data categories
+        """
+        with open(
+            "tests/ctl/data/dataset_missing_categories.yml", "r"
+        ) as current_dataset_yml:
+            dataset_yml = yaml.safe_load(current_dataset_yml)
+            # Confirm starting state, that the first field has no data categories
+            assert (
+                "data_categories"
+                not in dataset_yml["dataset"][0]["collections"][0]["fields"][0]
+            )
+
+        result = test_cli_runner.invoke(
+            cli,
+            [
+                "-f",
+                test_config_path,
+                "annotate",
+                "dataset",
+                "tests/ctl/data/dataset_missing_categories.yml",
+            ],
+            input="user\n",
+        )
+        print(result.output)
+        with open("tests/ctl/data/dataset_missing_categories.yml", "r") as dataset_yml:
+            # Helps assert that the data category was output correctly
+            dataset_yml = yaml.safe_load(dataset_yml)
+            assert dataset_yml["dataset"][0]["collections"][0]["fields"][0][
+                "data_categories"
+            ] == ["user"]
+
+            # Now remove the data category that was written by annotate dataset
+            del dataset_yml["dataset"][0]["collections"][0]["fields"][0][
+                "data_categories"
+            ]
+
+        with open(
+            "tests/ctl/data/dataset_missing_categories.yml", "w"
+        ) as current_dataset_yml:
+            # Restore the original contents to the file
+            yaml.safe_dump(dataset_yml, current_dataset_yml)
+
+        assert result.exit_code == 0
+        print(result.output)
 
 
 @pytest.mark.integration

--- a/tests/ctl/cli/test_cli.py
+++ b/tests/ctl/cli/test_cli.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring, redefined-outer-name
 import os
+import yaml
 from base64 import b64decode
 from json import dump, loads
 from typing import Generator
@@ -665,6 +666,12 @@ class TestGenerate:
         )
         print(result.output)
         assert result.exit_code == 0
+
+        with open(tmp_file, "r") as dataset_yml:
+            # Helps assert that the file was output correctly, namely, fides_keys were serialized as strings
+            # and not a FidesKey python object
+            dataset = yaml.safe_load(dataset_yml).get("dataset", [])
+            assert isinstance(dataset[0]["fides_key"], str)
 
     @pytest.mark.integration
     def test_generate_dataset_db_with_credentials_id(

--- a/tests/ctl/data/dataset_missing_categories.yml
+++ b/tests/ctl/data/dataset_missing_categories.yml
@@ -1,0 +1,13 @@
+dataset:
+- collections:
+  - description: Organization information
+    fields:
+    - name: city
+    - data_categories:
+      - account.contact.state
+      name: state
+    name: organization
+  description: Sample dataset to be annotated
+  fides_key: test_missing_data_categories
+  name: Sample Dataset
+  organization_fides_key: default_organization


### PR DESCRIPTION
Closes #2423

### Description Of Changes


`fides generate` and `fides annotate` dataset commands are running into issues due to pyyaml not being able to find a constructor for the FidesKey tag.  FidesKeys are `ConstrainedStr` underneath and have been successfully dumped as strings in the past.  The commands appear to pass, but then data like this is written to the yaml file:

```yaml
dataset:
- fides_key: !!python/object/new:fideslang.validation.FidesKey
  - public_a5735113d5
  organization_fides_key: default_organization
  name: public
```

### Code Changes

* [ ] Manually converting the FidesKeys in strings as a quick fix.  This issue is not present in the Pydantic v2 work that is going out next release, potentially because how a FidesKey is constructed has changed.
* [ ] Improving test coverage

### Steps to Confirm

#### Fides Generate

* [ ] `nox -s dev -- shell`
* [ ] `fides generate dataset db  --connection-string postgresql+psycopg2://postgres:fides@fides-db:5432/fides .fides/test.yml` (this generates a dataset from the locally running application db.  No real secrets here, these are all public)
* [ ] Confirm the generated dataset looks as expected, no double explanation points like above
```yaml
dataset:
- fides_key: public_a5735113d5
  organization_fides_key: default_organization
  name: public
```

#### Fides Annotate
- Open your .fides/db_dataset.yml
- Remove a data category from an existing field
- Run `fides annotate dataset .fides/db_dataset.yml` to annotate your dataset interactively
- When prompted, enter a data category
- Verify the data category looks as expected, no double exclamation points in the file
```  - name: accessmanualwebhook
    description: A table to record manual steps within data subject execution
    data_categories: []
    fields:
    - name: connection_config_id
      description: The identifier of the system to locate this data within
      data_categories: [system.operations]
    - name: created_at
```




### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
