### PR TITLE
Include fides.js sourcemaps during development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The types of changes are:
 
 ### Developer Experience
 - Add `.syncignore` to reduce file sync size with new volumes [#5104](https://github.com/ethyca/fides/pull/5104)
+- Fix sourcemap generation in development version of FidesJS [#5119](https://github.com/ethyca/fides/pull/5119)
 
 ## [2.41.0](https://github.com/ethyca/fides/compare/2.40.0...2.41.0)
 

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -129,7 +129,7 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
         file: `dist/${name}.js`,
         name: isExtension ? undefined : "Fides",
         format: isExtension ? undefined : "umd",
-        sourcemap: IS_DEV,
+        sourcemap: IS_DEV ? "inline" : false,
       },
     ],
   };

--- a/clients/turbo.json
+++ b/clients/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turbo.build/schema.v1.json",
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],

--- a/clients/turbo.json
+++ b/clients/turbo.json
@@ -14,7 +14,6 @@
       "cache": false
     },
     "dev": {
-      "dependsOn": ["^build"],
       "outputs": [".next/*", "!.next/cache/*"],
       "cache": false,
       "persistent": true


### PR DESCRIPTION
### Description Of Changes

Since sourcemaps don't get copied over to privacy center, the easiest solution is to include them in the scripts inline. This is also beneficial when we add GPP where there's potential for more than one sourcemap to be included.


### Code Changes

* Remove `[^build]` dependency from rollup, since that runs as `production` and conflicts with sourcemap building.
* Change sourcemap option from `true` to `"inline"` in dev mode.
* Point to correct schema version for our version of Turbo (see https://turbo.build/repo/docs/getting-started/editor-integration#older-versions)

### Steps to Confirm

* From `/clients` directory in fides, run `turbo dev`
* In the browser, load the Privacy Center demo page `/fides-js-demo.html`
* Open dev tools to the Source (chrome) or Debugger (firefox) tab
* Notice that the full source is included for debugging

![CleanShot 2024-07-22 at 12 55 14@2x](https://github.com/user-attachments/assets/687f7acc-0ca9-4641-8f25-71cf2b7827b3)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`