### PR TITLE
fix typo in bigquery monitor copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The types of changes are:
 ### Developer Experience
 - Add `.syncignore` to reduce file sync size with new volumes [#5104](https://github.com/ethyca/fides/pull/5104)
 
+### Fixed
+- Fixed typo in the BigQuery integration description [#5120](https://github.com/ethyca/fides/pull/5120)
+
 ## [2.41.0](https://github.com/ethyca/fides/compare/2.40.0...2.41.0)
 
 ### Added

--- a/clients/admin-ui/src/features/integrations/integration-type-info/bigqueryInfo.tsx
+++ b/clients/admin-ui/src/features/integrations/integration-type-info/bigqueryInfo.tsx
@@ -97,7 +97,7 @@ export const BigQueryOverview = () => (
         <ListItem>bigquery.tables.getData</ListItem>
         <ListItem>bigquery.tables.list</ListItem>
         <ListItem>bigquery.tables.updateData</ListItem>
-        <ListItem>bigquery.projects.get</ListItem>
+        <ListItem>resourcemanager.projects.get</ListItem>
       </InfoUnorderedList>
     </ShowMoreContent>
   </>
@@ -144,7 +144,7 @@ const MONITORED_PROJECT_PERMISSIONS = [
     description: "List all tables in the specified dataset.",
   },
   {
-    permission: "bigquery.projects.get",
+    permission: "resourcemanager.projects.get",
     description: "Retrieve metadata for the specified project.",
   },
 ];


### PR DESCRIPTION
Closes [PROD-2381](https://ethyca.atlassian.net/browse/PROD-2381)

### Description Of Changes

Updates the `bigquery.projects.get` permission to be `resourcemanager.projects.get`, which is the correct google cloud permission.

### Steps to Confirm

* Visit BigQuery integration details page and click both instances of "show more" to reveal the text. Verify that the property name is now correct.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[PROD-2381]: https://ethyca.atlassian.net/browse/PROD-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ