### PR TITLE
Remove unused index

### DIFF
--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -1499,7 +1499,6 @@ class ConsentRequest(IdentityVerificationMixin, Base):
 
     property_id = Column(
         String,
-        index=True,
         nullable=True,
     )
     provided_identity_id = Column(


### PR DESCRIPTION
### Description Of Changes

Removing `index=True` for the `property_id` field of `ConsentRequest` to prevent the index from being added during Alembic autogenerate

### Steps to Confirm

* [ ] Start fides `nox -s dev`
* [ ] Shell into fides `nox -s shell`
* [ ] Navigate to `src/fides/api/alembic/` and run `alembic revision --autogenerate -m "testing"`
* [ ] Verify the generated Alembic file doesn't have any migrations

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
