### PR TITLE
Fides Experience form fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The types of changes are:
 
 ### Fixed
 - Fixed typo in the BigQuery integration description [#5120](https://github.com/ethyca/fides/pull/5120)
+- Fixed default values of Experience config toggles [#5123](https://github.com/ethyca/fides/pull/5123)
 
 ## [2.41.0](https://github.com/ethyca/fides/compare/2.40.0...2.41.0)
 

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -201,8 +201,10 @@ describe("Privacy experiences", () => {
           const { body } = interception.request;
           expect(body).to.eql({
             allow_language_selection: false,
+            auto_detect_language: true,
             component: "banner_and_modal",
             disabled: true,
+            dismissable: true,
             name: "Test experience name",
             privacy_notice_ids: ["pri_b1244715-2adb-499f-abb2-e86b6c0040c2"],
             regions: ["fr"],

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -39,9 +39,11 @@ export const defaultTranslations: ExperienceTranslationCreate[] = [
 export const defaultInitialValues: Omit<ExperienceConfigCreate, "component"> = {
   name: "",
   disabled: false,
+  dismissable: true,
   allow_language_selection: false,
   regions: [],
   translations: defaultTranslations,
+  auto_detect_language: true,
 };
 // utility type to pass as a prop to the translation form
 export type TranslationWithLanguageName = ExperienceTranslation &


### PR DESCRIPTION
Closes [PROD-2008](https://ethyca.atlassian.net/browse/PROD-2008)

### Description Of Changes

Backend defaults weren't reflected in the Frontend. These fields weren't being passed at all if not set, which caused the backend to apply its defaults. Since backend defaults are set to "true" on both of these fields, it was a mismatched experience.

Setting these to default to "true" on the Frontend now to match BE defaults. User can turn them off without issue during initial save.


### Code Changes

* Set defaults to true for the 2 fields causing problems

### Steps to Confirm

 1. log in to fides plus 
 1. click on the experiences 
 1. click on create new experience 
 1. complete the following fields 
    - name
    - experience type (banner and modal)
    - add a privacy notice (data sales and sharing)
    - note that "allow users to dismiss" and "auto detect language" are now on by default. 
 1. click save
    - user is now at the main experience screen showing all experiences
 1. click the newly created experience to edit it

observe that the "allow users to dismiss" and "auto detect language" are in the correct state. Repeating the steps above and opting to turn off those 2 should reflect them as off here as well.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[PROD-2008]: https://ethyca.atlassian.net/browse/PROD-2008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ