### PR TITLE
Allow banner to show notice information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The types of changes are:
 - Add AWS Tags in the meta field for Fides system when using `fides generate` [#4998](https://github.com/ethyca/fides/pull/4998)
 - Added access and erasure support for Checkr integration [#5121](https://github.com/ethyca/fides/pull/5121)
 - Added support for special characters in SaaS request payloads [#5099](https://github.com/ethyca/fides/pull/5099)
+- Added support for displaying notices served in the Consent Banner [#5125](https://github.com/ethyca/fides/pull/5125)
+- Added ability to choose whether to use Opt In/Out buttons or Acknowledge button in the Consent Banner [#5125](https://github.com/ethyca/fides/pull/5125)
 
 ### Changed
 - Moving Privacy Center endpoint logging behind debug flag [#5103](https://github.com/ethyca/fides/pull/5103)

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -210,7 +210,7 @@ describe("Privacy experiences", () => {
             dismissable: true,
             name: "Test experience name",
             layer1_button_options: "opt_in_opt_out",
-            layer1_notices: false,
+            show_layer1_notices: false,
             privacy_notice_ids: ["pri_b1244715-2adb-499f-abb2-e86b6c0040c2"],
             regions: ["fr"],
             translations: [
@@ -262,7 +262,7 @@ describe("Privacy experiences", () => {
       });
 
       it("shows option to display privacy notices in banner and updates preview when clicked", () => {
-        cy.getByTestId("input-layer1_notices").should("not.be.visible");
+        cy.getByTestId("input-show_layer1_notices").should("not.be.visible");
         cy.selectOption("input-component", "Banner and modal");
         cy.getByTestId("add-privacy-notice").click();
         cy.getByTestId("select-privacy-notice").click();
@@ -271,7 +271,7 @@ describe("Privacy experiences", () => {
           .first()
           .as("SelectedPrivacyNotice")
           .click();
-        cy.getByTestId("input-layer1_notices").click();
+        cy.getByTestId("input-show_layer1_notices").click();
         cy.get("#preview-container")
           .find("#fides-banner")
           .find("#fides-banner-notices")

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -209,6 +209,7 @@ describe("Privacy experiences", () => {
             disabled: true,
             dismissable: true,
             name: "Test experience name",
+            layer1_button_options: "opt_in_opt_out",
             layer1_notices: false,
             privacy_notice_ids: ["pri_b1244715-2adb-499f-abb2-e86b6c0040c2"],
             regions: ["fr"],

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -207,6 +207,7 @@ describe("Privacy experiences", () => {
             disabled: true,
             dismissable: true,
             name: "Test experience name",
+            notices_in_banner: false,
             privacy_notice_ids: ["pri_b1244715-2adb-499f-abb2-e86b6c0040c2"],
             regions: ["fr"],
             translations: [

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -209,7 +209,7 @@ describe("Privacy experiences", () => {
             disabled: true,
             dismissable: true,
             name: "Test experience name",
-            notices_in_banner: false,
+            layer1_notices: false,
             privacy_notice_ids: ["pri_b1244715-2adb-499f-abb2-e86b6c0040c2"],
             regions: ["fr"],
             translations: [
@@ -261,7 +261,7 @@ describe("Privacy experiences", () => {
       });
 
       it("shows option to display privacy notices in banner and updates preview when clicked", () => {
-        cy.getByTestId("input-notices_in_banner").should("not.be.visible");
+        cy.getByTestId("input-layer1_notices").should("not.be.visible");
         cy.selectOption("input-component", "Banner and modal");
         cy.getByTestId("add-privacy-notice").click();
         cy.getByTestId("select-privacy-notice").click();
@@ -270,7 +270,7 @@ describe("Privacy experiences", () => {
           .first()
           .as("SelectedPrivacyNotice")
           .click();
-        cy.getByTestId("input-notices_in_banner").click();
+        cy.getByTestId("input-layer1_notices").click();
         cy.get("#preview-container")
           .find("#fides-banner")
           .find("#fides-banner-notices")

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -258,6 +258,23 @@ describe("Privacy experiences", () => {
         cy.get(`#${PREVIEW_CONTAINER_ID}`).should("be.visible");
       });
 
+      it("shows option to display privacy notices in banner and updates preview when clicked", () => {
+        cy.getByTestId("input-notices_in_banner").should("not.be.visible");
+        cy.selectOption("input-component", "Banner and modal");
+        cy.getByTestId("add-privacy-notice").click();
+        cy.getByTestId("select-privacy-notice").click();
+        cy.get(".select-privacy-notice__menu")
+          .find(".select-privacy-notice__option")
+          .first()
+          .as("SelectedPrivacyNotice")
+          .click();
+        cy.getByTestId("input-notices_in_banner").click();
+        cy.get("#preview-container")
+          .find("#fides-banner")
+          .find("#fides-banner-notices")
+          .contains("Essential");
+      });
+
       it("allows editing experience text and shows updated text in the preview", () => {
         cy.selectOption("input-component", "Banner and modal");
         cy.getByTestId("add-privacy-notice").click();

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -79,19 +79,21 @@ describe("Privacy experiences", () => {
     cy.getByTestId("empty-state");
   });
 
-  it("can copy a JS script tag", () => {
-    cy.visit(PRIVACY_EXPERIENCE_ROUTE);
-    cy.getByTestId("js-tag-btn").click();
-    cy.getByTestId("copy-js-tag-modal");
-    // Have to use a "real click" in order for Cypress to properly inspect
-    // the window's clipboard https://github.com/cypress-io/cypress/issues/18198
-    cy.getByTestId("clipboard-btn").realClick();
-    cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        expect(text).to.contain("<script src=");
+  if (Cypress.isBrowser({ family: "chromium" })) {
+    it("can copy a JS script tag", () => {
+      cy.visit(PRIVACY_EXPERIENCE_ROUTE);
+      cy.getByTestId("js-tag-btn").click();
+      cy.getByTestId("copy-js-tag-modal");
+      // Have to use a "real click" in order for Cypress to properly inspect
+      // the window's clipboard https://github.com/cypress-io/cypress/issues/18198
+      cy.getByTestId("clipboard-btn").first().realClick();
+      cy.window().then((win) => {
+        win.navigator.clipboard.readText().then((text) => {
+          expect(text).to.contain("<script src=");
+        });
       });
     });
-  });
+  }
 
   describe("table", () => {
     beforeEach(() => {

--- a/clients/admin-ui/cypress/fixtures/privacy-experiences/experienceConfig.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-experiences/experienceConfig.json
@@ -2,6 +2,7 @@
   "name": "Example modal experience",
   "disabled": true,
   "dismissable": true,
+  "notices_in_banner": false,
   "allow_language_selection": false,
   "auto_detect_language": true,
   "regions": ["us_ca", "us_co", "us_ct", "us_ut", "us_va"],

--- a/clients/admin-ui/cypress/fixtures/privacy-experiences/experienceConfig.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-experiences/experienceConfig.json
@@ -2,7 +2,7 @@
   "name": "Example modal experience",
   "disabled": true,
   "dismissable": true,
-  "layer1_notices": false,
+  "show_layer1_notices": false,
   "layer1_button_options": "opt_in_opt_out",
   "allow_language_selection": false,
   "auto_detect_language": true,

--- a/clients/admin-ui/cypress/fixtures/privacy-experiences/experienceConfig.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-experiences/experienceConfig.json
@@ -3,6 +3,7 @@
   "disabled": true,
   "dismissable": true,
   "layer1_notices": false,
+  "layer1_button_options": "opt_in_opt_out",
   "allow_language_selection": false,
   "auto_detect_language": true,
   "regions": ["us_ca", "us_co", "us_ct", "us_ut", "us_va"],

--- a/clients/admin-ui/cypress/fixtures/privacy-experiences/experienceConfig.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-experiences/experienceConfig.json
@@ -2,7 +2,7 @@
   "name": "Example modal experience",
   "disabled": true,
   "dismissable": true,
-  "notices_in_banner": false,
+  "layer1_notices": false,
   "allow_language_selection": false,
   "auto_detect_language": true,
   "regions": ["us_ca", "us_co", "us_ct", "us_ut", "us_va"],

--- a/clients/admin-ui/src/features/common/ScrollableList.tsx
+++ b/clients/admin-ui/src/features/common/ScrollableList.tsx
@@ -51,13 +51,14 @@ const ScrollableListItem = <T extends unknown>({
         borderColor="gray.200"
         _hover={onRowClick ? { bgColor: "gray.100" } : undefined}
         bgColor="white"
+        position="relative"
       >
-        {draggable ? (
+        {draggable && (
           <DragHandleIcon
             onPointerDown={(e) => dragControls.start(e)}
             cursor="grab"
           />
-        ) : null}
+        )}
         <Flex
           direction="row"
           gap={2}
@@ -83,7 +84,7 @@ const ScrollableListItem = <T extends unknown>({
             {label}
           </Text>
         </Flex>
-        {onDeleteItem ? (
+        {onDeleteItem && (
           <IconButton
             aria-label="Delete"
             onClick={() => onDeleteItem(item)}
@@ -91,12 +92,12 @@ const ScrollableListItem = <T extends unknown>({
             size="xs"
             variant="outline"
             bgColor="white"
+            pos="absolute"
+            right={2}
             visibility="hidden"
-            alignSelf="end"
-            mb={2}
             _groupHover={{ visibility: "visible" }}
           />
-        ) : null}
+        )}
       </Flex>
     </Reorder.Item>
   );

--- a/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
@@ -101,7 +101,10 @@ const ConfigurePrivacyExperience = ({
   const allPrivacyNotices = useAppSelector(selectAllPrivacyNotices);
 
   const initialValues = passedInExperience
-    ? transformConfigResponseToCreate(passedInExperience)
+    ? {
+        ...defaultInitialValues,
+        ...transformConfigResponseToCreate(passedInExperience),
+      }
     : defaultInitialValues;
 
   const handleSubmit = async (values: ExperienceConfigCreate) => {

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -134,8 +134,8 @@ const Preview = ({
         baseConfig.options.fidesLocale = values.translations[0].language;
       }
     }
-    baseConfig.experience.experience_config.notices_in_banner =
-      !!values.privacy_notice_ids?.length && !!values.notices_in_banner;
+    baseConfig.experience.experience_config.layer1_notices =
+      !!values.privacy_notice_ids?.length && !!values.layer1_notices;
     baseConfig.options.preventDismissal = !values.dismissable;
     if (
       window.Fides &&

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -6,10 +6,8 @@ import React, { useEffect, useMemo, useState } from "react";
 
 import { PREVIEW_CONTAINER_ID } from "~/constants";
 import { getErrorMessage } from "~/features/common/helpers";
-import {
-  Layer1ButtonOption,
-  TranslationWithLanguageName,
-} from "~/features/privacy-experience/form/helpers";
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/constants";
+import { TranslationWithLanguageName } from "~/features/privacy-experience/form/helpers";
 import {
   buildBaseConfig,
   translationOrDefault,

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -134,6 +134,8 @@ const Preview = ({
         baseConfig.options.fidesLocale = values.translations[0].language;
       }
     }
+    baseConfig.experience.experience_config.notices_in_banner =
+      !!values.privacy_notice_ids?.length && !!values.notices_in_banner;
     baseConfig.options.preventDismissal = !values.dismissable;
     if (
       window.Fides &&

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -135,8 +135,8 @@ const Preview = ({
         baseConfig.options.fidesLocale = values.translations[0].language;
       }
     }
-    baseConfig.experience.experience_config.layer1_notices =
-      !!values.privacy_notice_ids?.length && !!values.layer1_notices;
+    baseConfig.experience.experience_config.show_layer1_notices =
+      !!values.privacy_notice_ids?.length && !!values.show_layer1_notices;
     baseConfig.experience.experience_config.layer1_button_options =
       (values.component === ComponentType.BANNER_AND_MODAL &&
         values.layer1_button_options) ||

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -6,7 +6,10 @@ import React, { useEffect, useMemo, useState } from "react";
 
 import { PREVIEW_CONTAINER_ID } from "~/constants";
 import { getErrorMessage } from "~/features/common/helpers";
-import { TranslationWithLanguageName } from "~/features/privacy-experience/form/helpers";
+import {
+  Layer1ButtonOption,
+  TranslationWithLanguageName,
+} from "~/features/privacy-experience/form/helpers";
 import {
   buildBaseConfig,
   translationOrDefault,
@@ -139,7 +142,7 @@ const Preview = ({
     baseConfig.experience.experience_config.layer1_button_options =
       (values.component === ComponentType.BANNER_AND_MODAL &&
         values.layer1_button_options) ||
-      "opt_in_opt_out"; // TODO: Enum
+      Layer1ButtonOption.OPT_IN_OPT_OUT;
     baseConfig.options.preventDismissal = !values.dismissable;
     if (
       window.Fides &&

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -253,6 +253,51 @@ const Preview = ({
               width: 70% !important;
               margin: auto;
             }
+            div#fides-banner {
+              padding: 24px;
+              width: 100%;
+            }
+
+            div#fides-banner-description {
+              margin-bottom: 0px;
+            }
+
+            div#fides-banner-inner div#fides-button-group {
+              flex-direction: column;
+              align-items: flex-start;
+              gap: 12px;
+              padding-top: 24px;
+            }
+
+            .fides-banner-button-group {
+              flex-direction: column;
+              width: 100%;
+            }
+
+            button.fides-banner-button {
+              margin: 0px;
+              width: 100%;
+            }
+
+            div#fides-banner-inner-container {
+              display: flex;
+              flex-direction: column;
+              max-height: 50vh;
+              overflow-y: auto;
+              scrollbar-gutter: stable;
+            }
+
+            div#fides-privacy-policy-link {
+              order: 1;
+              width: 100%;
+            }
+            .fides-modal-footer {
+              max-width: 100%;
+            }
+            .fides-banner-secondary-actions {
+              flex-direction: column-reverse;
+              gap: 12px;
+            }
             `}</style>
       ) : (
         <style>{`

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -136,6 +136,10 @@ const Preview = ({
     }
     baseConfig.experience.experience_config.layer1_notices =
       !!values.privacy_notice_ids?.length && !!values.layer1_notices;
+    baseConfig.experience.experience_config.layer1_button_options =
+      (values.component === ComponentType.BANNER_AND_MODAL &&
+        values.layer1_button_options) ||
+      "opt_in_opt_out"; // TODO: Enum
     baseConfig.options.preventDismissal = !values.dismissable;
     if (
       window.Fides &&

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -255,8 +255,8 @@ export const PrivacyExperienceForm = ({
           <Collapse in={!!values.privacy_notice_ids?.length} animateOpacity>
             <Box p="1px">
               <CustomSwitch
-                name="layer1_notices"
-                id="layer1_notices"
+                name="show_layer1_notices"
+                id="show_layer1_notices"
                 label="Add privacy notices to banner"
                 variant="stacked"
               />

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -228,6 +228,16 @@ export const PrivacyExperienceForm = ({
             draggable
             baseTestId="privacy-notice"
           />
+          <Collapse in={!!values.privacy_notice_ids?.length} animateOpacity>
+            <Box p="1px">
+              <CustomSwitch
+                name="notices_in_banner"
+                id="notices_in_banner"
+                label="Add privacy notices to banner"
+                variant="stacked"
+              />
+            </Box>
+          </Collapse>
           <Divider />
         </>
       ) : null}

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -67,11 +67,11 @@ const componentTypeOptions: SelectProps["options"] = [
 const buttonLayoutOptions: SelectProps["options"] = [
   {
     label: "Opt In/Opt Out",
-    value: "opt_in_opt_out",
+    value: "opt_in_opt_out", // TODO: enum
   },
   {
     label: "Acknowledge",
-    value: "acknowledge",
+    value: "acknowledge", // TODO: enum
   },
 ];
 

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -231,8 +231,8 @@ export const PrivacyExperienceForm = ({
           <Collapse in={!!values.privacy_notice_ids?.length} animateOpacity>
             <Box p="1px">
               <CustomSwitch
-                name="notices_in_banner"
-                id="notices_in_banner"
+                name="layer1_notices"
+                id="layer1_notices"
                 label="Add privacy notices to banner"
                 variant="stacked"
               />

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -18,6 +18,7 @@ import {
   CustomSelect,
   CustomSwitch,
   CustomTextInput,
+  SelectProps,
 } from "~/features/common/form/inputs";
 import BackButton from "~/features/common/nav/v2/BackButton";
 import { PRIVACY_EXPERIENCE_ROUTE } from "~/features/common/nav/v2/routes";
@@ -48,7 +49,7 @@ import {
   SupportedLanguage,
 } from "~/types/api";
 
-const componentTypeOptions = [
+const componentTypeOptions: SelectProps["options"] = [
   {
     label: "Banner and modal",
     value: ComponentType.BANNER_AND_MODAL,
@@ -60,6 +61,17 @@ const componentTypeOptions = [
   {
     label: "Privacy center",
     value: ComponentType.PRIVACY_CENTER,
+  },
+];
+
+const buttonLayoutOptions: SelectProps["options"] = [
+  {
+    label: "Opt In/Opt Out",
+    value: "opt_in_opt_out",
+  },
+  {
+    label: "Acknowledge",
+    value: "acknowledge",
   },
 ];
 
@@ -170,7 +182,7 @@ export const PrivacyExperienceForm = ({
         isRequired
         variant="stacked"
       />
-      {values.component !== ComponentType.TCF_OVERLAY ? (
+      {values.component !== ComponentType.TCF_OVERLAY && (
         <CustomSelect
           name="component"
           id="component"
@@ -180,11 +192,9 @@ export const PrivacyExperienceForm = ({
           isDisabled={!!values.component}
           isRequired
         />
-      ) : null}
+      )}
       <Collapse
-        in={
-          values.component && values.component !== ComponentType.PRIVACY_CENTER
-        }
+        in={values.component !== ComponentType.PRIVACY_CENTER}
         animateOpacity
       >
         <Box p="1px">
@@ -195,6 +205,19 @@ export const PrivacyExperienceForm = ({
             variant="stacked"
           />
         </Box>
+      </Collapse>
+      <Collapse
+        in={values.component === ComponentType.BANNER_AND_MODAL}
+        animateOpacity
+      >
+        <CustomSelect
+          name="layer1_button_options"
+          id="layer1_button_options"
+          options={buttonLayoutOptions}
+          label="Banner options"
+          variant="stacked"
+          isDisabled={values.component !== ComponentType.BANNER_AND_MODAL}
+        />
       </Collapse>
       <ScrollableList
         label="Associated properties"

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -28,10 +28,8 @@ import {
   selectLocationsRegulations,
   useGetLocationsRegulationsQuery,
 } from "~/features/locations/locations.slice";
-import {
-  getSelectedRegionIds,
-  Layer1ButtonOption,
-} from "~/features/privacy-experience/form/helpers";
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/constants";
+import { getSelectedRegionIds } from "~/features/privacy-experience/form/helpers";
 import { selectAllLanguages } from "~/features/privacy-experience/language.slice";
 import {
   selectPage as selectNoticePage,

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -28,7 +28,10 @@ import {
   selectLocationsRegulations,
   useGetLocationsRegulationsQuery,
 } from "~/features/locations/locations.slice";
-import { getSelectedRegionIds } from "~/features/privacy-experience/form/helpers";
+import {
+  getSelectedRegionIds,
+  Layer1ButtonOption,
+} from "~/features/privacy-experience/form/helpers";
 import { selectAllLanguages } from "~/features/privacy-experience/language.slice";
 import {
   selectPage as selectNoticePage,
@@ -67,11 +70,11 @@ const componentTypeOptions: SelectProps["options"] = [
 const buttonLayoutOptions: SelectProps["options"] = [
   {
     label: "Opt In/Opt Out",
-    value: "opt_in_opt_out", // TODO: enum
+    value: Layer1ButtonOption.OPT_IN_OPT_OUT,
   },
   {
     label: "Acknowledge",
-    value: "acknowledge", // TODO: enum
+    value: Layer1ButtonOption.ACKNOWLEDGE,
   },
 ];
 

--- a/clients/admin-ui/src/features/privacy-experience/form/constants.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/constants.tsx
@@ -1,0 +1,5 @@
+export enum Layer1ButtonOption {
+  // defines the buttons to show in the layer 1 banner
+  ACKNOWLEDGE = "acknowledge",
+  OPT_IN_OPT_OUT = "opt_in_opt_out",
+}

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -22,6 +22,12 @@ export const getSelectedRegionIds = (
     ?.filter((loc) => loc.selected)
     .map((loc) => loc.id as PrivacyNoticeRegion) ?? [];
 
+export enum Layer1ButtonOption {
+  // defines the buttons to show in the layer 1 banner
+  ACKNOWLEDGE = "acknowledge", // show acknowledge button
+  OPT_IN_OPT_OUT = "opt_in_opt_out", // show opt in and opt out buttons
+}
+
 export const defaultTranslations: ExperienceTranslationCreate[] = [
   {
     language: SupportedLanguage.EN,
@@ -42,7 +48,7 @@ export const defaultInitialValues: Omit<ExperienceConfigCreate, "component"> = {
   dismissable: true,
   allow_language_selection: false,
   layer1_notices: false,
-  layer1_button_options: "opt_in_opt_out", // TODO: enum
+  layer1_button_options: Layer1ButtonOption.OPT_IN_OPT_OUT,
   regions: [],
   translations: defaultTranslations,
   auto_detect_language: true,

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -43,7 +43,7 @@ export const defaultInitialValues: Omit<ExperienceConfigCreate, "component"> = {
   disabled: false,
   dismissable: true,
   allow_language_selection: false,
-  layer1_notices: false,
+  show_layer1_notices: false,
   layer1_button_options: Layer1ButtonOption.OPT_IN_OPT_OUT,
   regions: [],
   translations: defaultTranslations,

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -42,7 +42,7 @@ export const defaultInitialValues: Omit<ExperienceConfigCreate, "component"> = {
   dismissable: true,
   allow_language_selection: false,
   layer1_notices: false,
-  layer1_button_options: "opt_in_opt_out",
+  layer1_button_options: "opt_in_opt_out", // TODO: enum
   regions: [],
   translations: defaultTranslations,
   auto_detect_language: true,

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -10,6 +10,8 @@ import {
   SupportedLanguage,
 } from "~/types/api";
 
+import { Layer1ButtonOption } from "./constants";
+
 interface LocationOrLocationGroup {
   selected?: boolean;
   id: string;
@@ -21,12 +23,6 @@ export const getSelectedRegionIds = (
   allLocations
     ?.filter((loc) => loc.selected)
     .map((loc) => loc.id as PrivacyNoticeRegion) ?? [];
-
-export enum Layer1ButtonOption {
-  // defines the buttons to show in the layer 1 banner
-  ACKNOWLEDGE = "acknowledge", // show acknowledge button
-  OPT_IN_OPT_OUT = "opt_in_opt_out", // show opt in and opt out buttons
-}
 
 export const defaultTranslations: ExperienceTranslationCreate[] = [
   {

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -41,6 +41,7 @@ export const defaultInitialValues: Omit<ExperienceConfigCreate, "component"> = {
   disabled: false,
   dismissable: true,
   allow_language_selection: false,
+  notices_in_banner: false,
   regions: [],
   translations: defaultTranslations,
   auto_detect_language: true,

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -42,6 +42,7 @@ export const defaultInitialValues: Omit<ExperienceConfigCreate, "component"> = {
   dismissable: true,
   allow_language_selection: false,
   layer1_notices: false,
+  layer1_button_options: "opt_in_opt_out",
   regions: [],
   translations: defaultTranslations,
   auto_detect_language: true,

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -41,7 +41,7 @@ export const defaultInitialValues: Omit<ExperienceConfigCreate, "component"> = {
   disabled: false,
   dismissable: true,
   allow_language_selection: false,
-  notices_in_banner: false,
+  layer1_notices: false,
   regions: [],
   translations: defaultTranslations,
   auto_detect_language: true,

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -1,6 +1,7 @@
 /* eslint-disable*/
 
 import { PREVIEW_CONTAINER_ID } from "~/constants";
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/helpers";
 import {
   ExperienceConfigCreate,
   ExperienceTranslation,
@@ -67,7 +68,7 @@ export const buildBaseConfig = (
       is_default: true,
       dismissable: experienceConfig.dismissable,
       layer1_notices: false,
-      layer1_button_options: "opt_in_opt_out", // TODO: enum
+      layer1_button_options: Layer1ButtonOption.OPT_IN_OPT_OUT,
       allow_language_selection: true,
       auto_detect_language: true,
       language: "en",

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -67,7 +67,7 @@ export const buildBaseConfig = (
       is_default: true,
       dismissable: experienceConfig.dismissable,
       layer1_notices: false,
-      layer1_button_options: "opt_in_opt_out",
+      layer1_button_options: "opt_in_opt_out", // TODO: enum
       allow_language_selection: true,
       auto_detect_language: true,
       language: "en",

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -1,7 +1,7 @@
 /* eslint-disable*/
 
 import { PREVIEW_CONTAINER_ID } from "~/constants";
-import { Layer1ButtonOption } from "~/features/privacy-experience/form/helpers";
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/constants";
 import {
   ExperienceConfigCreate,
   ExperienceTranslation,

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -66,7 +66,7 @@ export const buildBaseConfig = (
       disabled: false,
       is_default: true,
       dismissable: experienceConfig.dismissable,
-      notices_in_banner: false,
+      layer1_notices: false,
       allow_language_selection: true,
       auto_detect_language: true,
       language: "en",

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -67,6 +67,7 @@ export const buildBaseConfig = (
       is_default: true,
       dismissable: experienceConfig.dismissable,
       layer1_notices: false,
+      layer1_button_options: "opt_in_opt_out",
       allow_language_selection: true,
       auto_detect_language: true,
       language: "en",

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -66,6 +66,7 @@ export const buildBaseConfig = (
       disabled: false,
       is_default: true,
       dismissable: experienceConfig.dismissable,
+      notices_in_banner: false,
       allow_language_selection: true,
       auto_detect_language: true,
       language: "en",

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -67,7 +67,7 @@ export const buildBaseConfig = (
       disabled: false,
       is_default: true,
       dismissable: experienceConfig.dismissable,
-      layer1_notices: false,
+      show_layer1_notices: false,
       layer1_button_options: Layer1ButtonOption.OPT_IN_OPT_OUT,
       allow_language_selection: true,
       auto_detect_language: true,

--- a/clients/admin-ui/src/types/api/models/ConsentMethod.ts
+++ b/clients/admin-ui/src/types/api/models/ConsentMethod.ts
@@ -13,4 +13,5 @@ export enum ConsentMethod {
   DISMISS = "dismiss",
   GPC = "gpc",
   INDIVIDUAL_NOTICE = "individual_notice",
+  ACKNOWLEDGE = "acknowledge",
 }

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
@@ -17,6 +17,7 @@ export type ExperienceConfigCreate = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
+  layer1_button_options?: string; // TODO: Enum
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions?: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/helpers";
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationCreate } from "./ExperienceTranslationCreate";
 import type { MinimalProperty } from "./MinimalProperty";
@@ -17,7 +18,7 @@ export type ExperienceConfigCreate = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
-  layer1_button_options?: string; // TODO: Enum
+  layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions?: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
@@ -17,7 +17,7 @@ export type ExperienceConfigCreate = {
   name: string;
   disabled?: boolean;
   dismissable?: boolean;
-  layer1_notices?: boolean;
+  show_layer1_notices?: boolean;
   layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
@@ -16,6 +16,7 @@ export type ExperienceConfigCreate = {
   name: string;
   disabled?: boolean;
   dismissable?: boolean;
+  notices_in_banner?: boolean;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions?: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
@@ -16,7 +16,7 @@ export type ExperienceConfigCreate = {
   name: string;
   disabled?: boolean;
   dismissable?: boolean;
-  notices_in_banner?: boolean;
+  layer1_notices?: boolean;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions?: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { Layer1ButtonOption } from "~/features/privacy-experience/form/helpers";
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/constants";
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationCreate } from "./ExperienceTranslationCreate";
 import type { MinimalProperty } from "./MinimalProperty";

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/helpers";
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationResponse } from "./ExperienceTranslationResponse";
 import type { MinimalProperty } from "./MinimalProperty";
@@ -16,7 +17,7 @@ export type ExperienceConfigResponse = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
-  layer1_button_options?: string; // TODO: Enum
+  layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
@@ -15,7 +15,7 @@ export type ExperienceConfigResponse = {
   name: string;
   disabled?: boolean;
   dismissable?: boolean;
-  notices_in_banner?: boolean;
+  layer1_notices?: boolean;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
@@ -15,6 +15,7 @@ export type ExperienceConfigResponse = {
   name: string;
   disabled?: boolean;
   dismissable?: boolean;
+  notices_in_banner?: boolean;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
@@ -16,7 +16,7 @@ export type ExperienceConfigResponse = {
   name: string;
   disabled?: boolean;
   dismissable?: boolean;
-  layer1_notices?: boolean;
+  show_layer1_notices?: boolean;
   layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { Layer1ButtonOption } from "~/features/privacy-experience/form/helpers";
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/constants";
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationResponse } from "./ExperienceTranslationResponse";
 import type { MinimalProperty } from "./MinimalProperty";

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponse.ts
@@ -16,6 +16,7 @@ export type ExperienceConfigResponse = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
+  layer1_button_options?: string; // TODO: Enum
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -73,6 +73,7 @@ export type ExperienceConfigResponseNoNotices = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
+  layer1_button_options?: string; // TODO: Enum
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/helpers";
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationResponse } from "./ExperienceTranslationResponse";
 import type { MinimalProperty } from "./MinimalProperty";
@@ -73,7 +74,7 @@ export type ExperienceConfigResponseNoNotices = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
-  layer1_button_options?: string; // TODO: Enum
+  layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -73,7 +73,7 @@ export type ExperienceConfigResponseNoNotices = {
   name: string;
   disabled?: boolean;
   dismissable?: boolean;
-  layer1_notices?: boolean;
+  show_layer1_notices?: boolean;
   layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { Layer1ButtonOption } from "~/features/privacy-experience/form/helpers";
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/constants";
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationResponse } from "./ExperienceTranslationResponse";
 import type { MinimalProperty } from "./MinimalProperty";

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -72,6 +72,7 @@ export type ExperienceConfigResponseNoNotices = {
   name: string;
   disabled?: boolean;
   dismissable?: boolean;
+  notices_in_banner?: boolean;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -72,7 +72,7 @@ export type ExperienceConfigResponseNoNotices = {
   name: string;
   disabled?: boolean;
   dismissable?: boolean;
-  notices_in_banner?: boolean;
+  layer1_notices?: boolean;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/helpers";
 import type { ExperienceTranslation } from "./ExperienceTranslation";
 import type { MinimalProperty } from "./MinimalProperty";
 import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
@@ -21,7 +22,7 @@ export type ExperienceConfigUpdate = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
-  layer1_button_options?: string; // TODO: Enum
+  layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
@@ -21,6 +21,7 @@ export type ExperienceConfigUpdate = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
+  layer1_button_options?: string; // TODO: Enum
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
@@ -20,7 +20,7 @@ export type ExperienceConfigUpdate = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
-  notices_in_banner?: boolean;
+  layer1_notices?: boolean;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
@@ -21,7 +21,7 @@ export type ExperienceConfigUpdate = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
-  layer1_notices?: boolean;
+  show_layer1_notices?: boolean;
   layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
@@ -20,6 +20,7 @@ export type ExperienceConfigUpdate = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
+  notices_in_banner?: boolean;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigUpdate.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { Layer1ButtonOption } from "~/features/privacy-experience/form/helpers";
+import { Layer1ButtonOption } from "~/features/privacy-experience/form/constants";
 import type { ExperienceTranslation } from "./ExperienceTranslation";
 import type { MinimalProperty } from "./MinimalProperty";
 import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";

--- a/clients/fides-js/__tests__/__fixtures__/mock_experience.json
+++ b/clients/fides-js/__tests__/__fixtures__/mock_experience.json
@@ -14,6 +14,7 @@
     "disabled": false,
     "is_default": true,
     "dismissable": true,
+    "notices_in_banner": false,
     "allow_language_selection": true,
     "auto_detect_language": true,
     "language": "en",

--- a/clients/fides-js/__tests__/__fixtures__/mock_experience.json
+++ b/clients/fides-js/__tests__/__fixtures__/mock_experience.json
@@ -15,6 +15,7 @@
     "is_default": true,
     "dismissable": true,
     "layer1_notices": false,
+    "layer1_button_options": "opt_in_opt_out",
     "allow_language_selection": true,
     "auto_detect_language": true,
     "language": "en",

--- a/clients/fides-js/__tests__/__fixtures__/mock_experience.json
+++ b/clients/fides-js/__tests__/__fixtures__/mock_experience.json
@@ -14,7 +14,7 @@
     "disabled": false,
     "is_default": true,
     "dismissable": true,
-    "layer1_notices": false,
+    "show_layer1_notices": false,
     "layer1_button_options": "opt_in_opt_out",
     "allow_language_selection": true,
     "auto_detect_language": true,

--- a/clients/fides-js/__tests__/__fixtures__/mock_experience.json
+++ b/clients/fides-js/__tests__/__fixtures__/mock_experience.json
@@ -14,7 +14,7 @@
     "disabled": false,
     "is_default": true,
     "dismissable": true,
-    "notices_in_banner": false,
+    "layer1_notices": false,
     "allow_language_selection": true,
     "auto_detect_language": true,
     "language": "en",

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -862,8 +862,12 @@ describe("i18n-utils", () => {
       "component" | "experience_config" | "privacy_notices" | "gvl"
     > & {
       component: string;
-      experience_config: Omit<ExperienceConfig, "component"> & {
+      experience_config: Omit<
+        ExperienceConfig,
+        "component" | "layer1_button_options"
+      > & {
         component: string;
+        layer1_button_options: string;
       };
       privacy_notices: Array<
         Omit<

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -121,7 +121,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
                   }
                 />
                 {!!window.Fides?.experience?.experience_config
-                  ?.notices_in_banner &&
+                  ?.layer1_notices &&
                   !!privacyNotices?.length && (
                     <div
                       id="fides-banner-notices"

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -102,7 +102,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
                   }
                 />
                 {!!window.Fides?.experience?.experience_config
-                  ?.layer1_notices &&
+                  ?.show_layer1_notices &&
                   !!privacyNotices?.length && (
                     <div
                       id="fides-banner-notices"

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -1,15 +1,11 @@
 import { h, FunctionComponent, ComponentChildren, VNode } from "preact";
-import { useState, useEffect } from "preact/hooks";
+import { useEffect } from "preact/hooks";
 import { getConsentContext } from "../lib/consent-context";
 import { GpcStatus } from "../lib/consent-types";
 import CloseButton from "./CloseButton";
 import { GpcBadge } from "./GpcBadge";
 import ExperienceDescription from "./ExperienceDescription";
 import { I18n, messageExists } from "../lib/i18n";
-
-interface ButtonGroupProps {
-  isMobile: boolean;
-}
 
 interface BannerProps {
   i18n: I18n;
@@ -23,7 +19,7 @@ interface BannerProps {
    * */
   children?: ComponentChildren;
   onVendorPageClick?: () => void;
-  renderButtonGroup: (props: ButtonGroupProps) => VNode;
+  renderButtonGroup: () => VNode;
   className?: string;
   isEmbedded: boolean;
 }
@@ -40,21 +36,6 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
   className,
   isEmbedded,
 }) => {
-  const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth < 768);
-    };
-
-    window.addEventListener("resize", handleResize);
-
-    // Cleanup the event listener on component unmount
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-
   const showGpcBadge = getConsentContext().globalPrivacyControl;
 
   useEffect(() => {
@@ -140,9 +121,8 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
               </div>
             </div>
             {children}
-            {!isMobile && renderButtonGroup({ isMobile })}
+            {renderButtonGroup()}
           </div>
-          {isMobile && renderButtonGroup({ isMobile })}
         </div>
       </div>
     </div>

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -111,9 +111,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
                       {privacyNotices.map((notice, i) => (
                         <span>
                           <strong>{notice.name}</strong>
-                          {i < privacyNotices.length - 1 &&
-                            (privacyNotices.length > 2 ? ", " : " ")}
-                          {i === privacyNotices.length - 2 && "& "}
+                          {i < privacyNotices.length - 1 && ", "}
                         </span>
                       ))}
                     </div>

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -83,6 +83,8 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
     .filter((c) => typeof c === "string")
     .join(" ");
 
+  const privacyNotices = window.Fides?.experience?.privacy_notices;
+
   return (
     <div id="fides-banner-container" className={containerClassName}>
       <div id="fides-banner">
@@ -118,6 +120,23 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
                     window.Fides?.options?.allowHTMLDescription
                   }
                 />
+                {!!window.Fides?.experience?.experience_config
+                  ?.notices_in_banner &&
+                  !!privacyNotices?.length && (
+                    <div
+                      id="fides-banner-notices"
+                      className="fides-banner-notices"
+                    >
+                      {privacyNotices.map((notice, i) => (
+                        <span>
+                          <strong>{notice.name}</strong>
+                          {i < privacyNotices.length - 1 &&
+                            (privacyNotices.length > 2 ? ", " : " ")}
+                          {i === privacyNotices.length - 2 && "& "}
+                        </span>
+                      ))}
+                    </div>
+                  )}
               </div>
             </div>
             {children}

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -11,6 +11,7 @@ import {
 import PrivacyPolicyLink from "./PrivacyPolicyLink";
 import { DEFAULT_LOCALE, I18n, Locale } from "../lib/i18n";
 import LanguageSelector from "../components/LanguageSelector";
+import { useMediaQuery } from "../lib/hooks/useMediaQuery";
 
 interface ConsentButtonProps {
   i18n: I18n;
@@ -19,7 +20,6 @@ interface ConsentButtonProps {
   firstButton?: VNode;
   onAcceptAll: () => void;
   onRejectAll: () => void;
-  isMobile: boolean;
   options: FidesInitOptions;
   saveOnly?: boolean;
   isInModal?: boolean;
@@ -32,12 +32,12 @@ export const ConsentButtons = ({
   firstButton,
   onAcceptAll,
   onRejectAll,
-  isMobile,
   saveOnly = false,
   options,
   isInModal,
   isTCF,
 }: ConsentButtonProps) => {
+  const isMobile = useMediaQuery("(max-width: 768px)");
   const includeLanguageSelector = i18n.availableLanguages?.length > 1;
   return (
     <div id="fides-button-group">
@@ -106,7 +106,6 @@ interface NoticeConsentButtonProps {
   isAcknowledge: boolean;
   options: FidesInitOptions;
   isInModal?: boolean;
-  isMobile: boolean;
   saveOnly?: boolean;
 }
 
@@ -118,7 +117,6 @@ export const NoticeConsentButtons = ({
   enabledKeys,
   isInModal,
   isAcknowledge,
-  isMobile,
   saveOnly = false,
   options,
 }: NoticeConsentButtonProps) => {
@@ -182,7 +180,6 @@ export const NoticeConsentButtons = ({
           />
         ) : undefined
       }
-      isMobile={isMobile}
       saveOnly={saveOnly}
       options={options}
     />

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -132,6 +132,13 @@ export const NoticeConsentButtons = ({
     );
   };
 
+  const handleAcknowledgeNotices = () => {
+    onSave(
+      ConsentMethod.ACKNOWLEDGE,
+      notices.map((n) => n.notice_key)
+    );
+  };
+
   const handleRejectAll = () => {
     onSave(
       ConsentMethod.REJECT,
@@ -151,7 +158,7 @@ export const NoticeConsentButtons = ({
         <Button
           buttonType={ButtonType.PRIMARY}
           label={i18n.t("exp.acknowledge_button_label")}
-          onClick={handleAcceptAll}
+          onClick={handleAcknowledgeNotices}
           className="fides-acknowledge-button"
         />
       );

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -17,11 +17,11 @@ interface ConsentButtonProps {
   i18n: I18n;
   availableLocales?: Locale[];
   onManagePreferencesClick?: () => void;
-  firstButton?: VNode;
+  renderFirstButton?: () => VNode | null;
   onAcceptAll: () => void;
   onRejectAll: () => void;
   options: FidesInitOptions;
-  saveOnly?: boolean;
+  hideOptInOut?: boolean;
   isInModal?: boolean;
   isTCF?: boolean;
 }
@@ -29,10 +29,10 @@ export const ConsentButtons = ({
   i18n,
   availableLocales = [DEFAULT_LOCALE],
   onManagePreferencesClick,
-  firstButton,
+  renderFirstButton,
   onAcceptAll,
   onRejectAll,
-  saveOnly = false,
+  hideOptInOut = false,
   options,
   isInModal,
   isTCF,
@@ -48,8 +48,8 @@ export const ConsentButtons = ({
             : "fides-banner-button-group fides-banner-primary-actions"
         }
       >
-        {firstButton}
-        {!saveOnly && (
+        {!!renderFirstButton && renderFirstButton()}
+        {!hideOptInOut && (
           <Fragment>
             <Button
               buttonType={ButtonType.PRIMARY}
@@ -106,7 +106,7 @@ interface NoticeConsentButtonProps {
   isAcknowledge: boolean;
   options: FidesInitOptions;
   isInModal?: boolean;
-  saveOnly?: boolean;
+  hideOptInOut?: boolean;
 }
 
 export const NoticeConsentButtons = ({
@@ -117,7 +117,7 @@ export const NoticeConsentButtons = ({
   enabledKeys,
   isInModal,
   isAcknowledge,
-  saveOnly = false,
+  hideOptInOut = false,
   options,
 }: NoticeConsentButtonProps) => {
   if (!experience.experience_config || !experience.privacy_notices) {
@@ -145,22 +145,29 @@ export const NoticeConsentButtons = ({
     onSave(ConsentMethod.SAVE, enabledKeys);
   };
 
-  if (isAcknowledge) {
-    return (
-      <div
-        className={`fides-acknowledge-button-container ${
-          isInModal ? "" : "fides-banner-acknowledge"
-        }`}
-      >
+  const renderFirstButton = () => {
+    if (isAcknowledge) {
+      return (
         <Button
           buttonType={ButtonType.PRIMARY}
           label={i18n.t("exp.acknowledge_button_label")}
           onClick={handleAcceptAll}
           className="fides-acknowledge-button"
         />
-      </div>
-    );
-  }
+      );
+    }
+    if (isInModal) {
+      return (
+        <Button
+          buttonType={hideOptInOut ? ButtonType.PRIMARY : ButtonType.SECONDARY}
+          label={i18n.t("exp.save_button_label")}
+          onClick={handleSave}
+          className="fides-save-button"
+        />
+      );
+    }
+    return null;
+  };
 
   return (
     <ConsentButtons
@@ -170,17 +177,8 @@ export const NoticeConsentButtons = ({
       onAcceptAll={handleAcceptAll}
       onRejectAll={handleRejectAll}
       isInModal={isInModal}
-      firstButton={
-        isInModal ? (
-          <Button
-            buttonType={saveOnly ? ButtonType.PRIMARY : ButtonType.SECONDARY}
-            label={i18n.t("exp.save_button_label")}
-            onClick={handleSave}
-            className="fides-save-button"
-          />
-        ) : undefined
-      }
-      saveOnly={saveOnly}
+      renderFirstButton={renderFirstButton}
+      hideOptInOut={hideOptInOut}
       options={options}
     />
   );

--- a/clients/fides-js/src/components/LanguageSelector.tsx
+++ b/clients/fides-js/src/components/LanguageSelector.tsx
@@ -19,7 +19,7 @@ interface LanguageSelectorProps {
   i18n: I18n;
   availableLocales: Locale[];
   options: FidesInitOptions;
-  isTCF: boolean;
+  isTCF?: boolean;
 }
 
 const LanguageSelector = ({

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -257,17 +257,6 @@ div#fides-button-group {
   z-index: 5;
 }
 
-div.fides-acknowledge-button-container {
-  margin-inline: var(--fides-overlay-padding);
-  margin-bottom: var(--fides-overlay-padding);
-  display: flex;
-  justify-content: end;
-}
-
-div.fides-banner-acknowledge .fides-banner-button {
-  max-width: 168px;
-}
-
 button.fides-banner-button {
   font-size: var(--fides-overlay-font-size-buttons);
   display: inline-block;
@@ -321,6 +310,10 @@ button.fides-banner-button.fides-banner-button-tertiary {
   font-weight: 500;
   font-size: var(--fides-overlay-font-size-body);
   line-height: 1.25em;
+}
+
+button.fides-banner-button.fides-acknowledge-button {
+  min-width: 160px;
 }
 
 /** Modal */

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -244,6 +244,10 @@ div#fides-banner-description {
   flex: 1;
 }
 
+div#fides-banner-notices {
+  margin-top: 16px;
+}
+
 div#fides-button-group {
   margin-top: 8px;
   margin-bottom: var(--fides-overlay-padding);

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -481,7 +481,7 @@ div#fides-consent-content .fides-modal-description {
 }
 
 /* Responsive overlay */
-@media (max-width: 48em) {
+@media (max-width: 768px) {
   div.fides-modal-content,
   div#fides-consent-content {
     width: 100% !important;
@@ -1099,6 +1099,10 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
     div#fides-button-group
     .fides-banner-button-group {
     padding-left: 0;
+  }
+  .fides-banner-secondary-actions {
+    flex-direction: column-reverse;
+    gap: 12px;
   }
 }
 /* TCF should always be full width and not floating */

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -247,6 +247,8 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
 
   const isDismissable = !!experience.experience_config?.dismissable;
 
+  const isSaveOnly = privacyNoticeItems.length === 1;
+
   return (
     <Overlay
       options={options}
@@ -263,36 +265,44 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
         onClose,
         onSave,
         onManagePreferencesClick,
-      }) => (
-        <ConsentBanner
-          bannerIsOpen={isOpen}
-          dismissable={isDismissable}
-          onOpen={dispatchOpenBannerEvent}
-          onClose={() => {
-            onClose();
-            handleDismiss();
-          }}
-          i18n={i18n}
-          isEmbedded={isEmbedded}
-          renderButtonGroup={() => (
-            <NoticeConsentButtons
-              experience={experience}
-              i18n={i18n}
-              onManagePreferencesClick={onManagePreferencesClick}
-              enabledKeys={draftEnabledNoticeKeys}
-              onSave={(
-                consentMethod: ConsentMethod,
-                keys: Array<PrivacyNotice["notice_key"]>
-              ) => {
-                handleUpdatePreferences(consentMethod, keys);
-                onSave();
-              }}
-              isAcknowledge={isAllNoticeOnly}
-              options={options}
-            />
-          )}
-        />
-      )}
+      }) => {
+        const isAcknowledge =
+          isAllNoticeOnly ||
+          experience.experience_config?.layer1_button_options === "acknowledge"; // TODO: enum
+        return (
+          <ConsentBanner
+            bannerIsOpen={isOpen}
+            dismissable={isDismissable}
+            onOpen={dispatchOpenBannerEvent}
+            onClose={() => {
+              onClose();
+              handleDismiss();
+            }}
+            i18n={i18n}
+            isEmbedded={isEmbedded}
+            renderButtonGroup={() => (
+              <NoticeConsentButtons
+                experience={experience}
+                i18n={i18n}
+                onManagePreferencesClick={
+                  !isAcknowledge ? onManagePreferencesClick : undefined
+                }
+                enabledKeys={draftEnabledNoticeKeys}
+                onSave={(
+                  consentMethod: ConsentMethod,
+                  keys: Array<PrivacyNotice["notice_key"]>
+                ) => {
+                  handleUpdatePreferences(consentMethod, keys);
+                  onSave();
+                }}
+                isAcknowledge={isAcknowledge}
+                hideOptInOut={isAcknowledge}
+                options={options}
+              />
+            )}
+          />
+        );
+      }}
       renderModalContent={() => (
         <div>
           <div className="fides-modal-notices">
@@ -322,7 +332,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
           }}
           isInModal
           isAcknowledge={isAllNoticeOnly}
-          saveOnly={privacyNoticeItems.length === 1}
+          hideOptInOut={isSaveOnly || isAllNoticeOnly}
           options={options}
         />
       )}

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -284,9 +284,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
               <NoticeConsentButtons
                 experience={experience}
                 i18n={i18n}
-                onManagePreferencesClick={
-                  !isAcknowledge ? onManagePreferencesClick : undefined
-                }
+                onManagePreferencesClick={onManagePreferencesClick}
                 enabledKeys={draftEnabledNoticeKeys}
                 onSave={(
                   consentMethod: ConsentMethod,

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -274,7 +274,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
           }}
           i18n={i18n}
           isEmbedded={isEmbedded}
-          renderButtonGroup={({ isMobile }) => (
+          renderButtonGroup={() => (
             <NoticeConsentButtons
               experience={experience}
               i18n={i18n}
@@ -288,7 +288,6 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
                 onSave();
               }}
               isAcknowledge={isAllNoticeOnly}
-              isMobile={isMobile}
               options={options}
             />
           )}
@@ -309,7 +308,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
           </div>
         </div>
       )}
-      renderModalFooter={({ onClose, isMobile }) => (
+      renderModalFooter={({ onClose }) => (
         <NoticeConsentButtons
           experience={experience}
           i18n={i18n}
@@ -323,7 +322,6 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
           }}
           isInModal
           isAcknowledge={isAllNoticeOnly}
-          isMobile={isMobile}
           saveOnly={privacyNoticeItems.length === 1}
           options={options}
         />

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -9,6 +9,7 @@ import {
   ConsentMechanism,
   ConsentMethod,
   FidesCookie,
+  Layer1ButtonOption,
   PrivacyNotice,
   PrivacyNoticeTranslation,
   PrivacyNoticeWithPreference,
@@ -268,7 +269,8 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
       }) => {
         const isAcknowledge =
           isAllNoticeOnly ||
-          experience.experience_config?.layer1_button_options === "acknowledge"; // TODO: enum
+          experience.experience_config?.layer1_button_options ===
+            Layer1ButtonOption.ACKNOWLEDGE;
         return (
           <ConsentBanner
             bannerIsOpen={isOpen}

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -15,7 +15,7 @@ interface TcfConsentButtonProps {
   options: FidesInitOptions;
   onManagePreferencesClick?: () => void;
   onSave: (consentMethod: ConsentMethod, keys: EnabledIds) => void;
-  firstButton?: VNode;
+  renderFirstButton?: () => VNode;
   isInModal?: boolean;
 }
 
@@ -31,7 +31,7 @@ export const TcfConsentButtons = ({
   i18n,
   onManagePreferencesClick,
   onSave,
-  firstButton,
+  renderFirstButton,
   isInModal,
   options,
 }: TcfConsentButtonProps) => {
@@ -77,7 +77,7 @@ export const TcfConsentButtons = ({
       onManagePreferencesClick={onManagePreferencesClick}
       onAcceptAll={handleAcceptAll}
       onRejectAll={handleRejectAll}
-      firstButton={firstButton}
+      renderFirstButton={renderFirstButton}
       isInModal={isInModal}
       options={options}
       isTCF

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -16,7 +16,6 @@ interface TcfConsentButtonProps {
   onManagePreferencesClick?: () => void;
   onSave: (consentMethod: ConsentMethod, keys: EnabledIds) => void;
   firstButton?: VNode;
-  isMobile: boolean;
   isInModal?: boolean;
 }
 
@@ -33,7 +32,6 @@ export const TcfConsentButtons = ({
   onManagePreferencesClick,
   onSave,
   firstButton,
-  isMobile,
   isInModal,
   options,
 }: TcfConsentButtonProps) => {
@@ -80,7 +78,6 @@ export const TcfConsentButtons = ({
       onAcceptAll={handleAcceptAll}
       onRejectAll={handleRejectAll}
       firstButton={firstButton}
-      isMobile={isMobile}
       isInModal={isInModal}
       options={options}
       isTCF

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -406,14 +406,14 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
             experience={experience}
             i18n={i18n}
             onSave={onSave}
-            firstButton={
+            renderFirstButton={() => (
               <Button
                 buttonType={ButtonType.SECONDARY}
                 label={i18n.t("exp.save_button_label")}
                 onClick={() => onSave(ConsentMethod.SAVE, draftIds)}
                 className="fides-save-button"
               />
-            }
+            )}
             isInModal
             options={options}
           />

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -358,7 +358,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
               handleDismiss();
             }}
             onVendorPageClick={goToVendorTab}
-            renderButtonGroup={({ isMobile }) => (
+            renderButtonGroup={() => (
               <TcfConsentButtons
                 experience={experience}
                 i18n={i18n}
@@ -367,7 +367,6 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
                   handleUpdateAllPreferences(consentMethod, keys);
                   onSave();
                 }}
-                isMobile={isMobile}
                 options={options}
               />
             )}
@@ -397,7 +396,7 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
           onTabChange={setActiveTabIndex}
         />
       )}
-      renderModalFooter={({ onClose, isMobile }) => {
+      renderModalFooter={({ onClose }) => {
         const onSave = (consentMethod: ConsentMethod, keys: EnabledIds) => {
           handleUpdateAllPreferences(consentMethod, keys);
           onClose();
@@ -415,7 +414,6 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
                 className="fides-save-button"
               />
             }
-            isMobile={isMobile}
             isInModal
             options={options}
           />

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -430,7 +430,7 @@ export type ExperienceConfig = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
-  layer1_button_options?: string; // TODO: Enum
+  layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   modal_link_label?: string;

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -429,6 +429,7 @@ export type ExperienceConfig = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
+  notices_in_banner?: boolean;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   modal_link_label?: string;

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -429,7 +429,7 @@ export type ExperienceConfig = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
-  layer1_notices?: boolean;
+  show_layer1_notices?: boolean;
   layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -430,6 +430,7 @@ export type ExperienceConfig = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
+  layer1_button_options?: string; // TODO: Enum
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   modal_link_label?: string;

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -720,6 +720,7 @@ export enum ConsentMethod {
   DISMISS = "dismiss",
   GPC = "gpc",
   INDIVIDUAL_NOTICE = "individual_notice",
+  ACKNOWLEDGE = "acknowledge",
 }
 
 export type PrivacyPreferencesRequest = {

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -429,7 +429,7 @@ export type ExperienceConfig = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
-  notices_in_banner?: boolean;
+  layer1_notices?: boolean;
   allow_language_selection?: boolean;
   auto_detect_language?: boolean;
   modal_link_label?: string;

--- a/clients/fides-js/src/lib/hooks/useConsentServed.ts
+++ b/clients/fides-js/src/lib/hooks/useConsentServed.ts
@@ -47,7 +47,9 @@ export const useConsentServed = ({
       // 4) BANNER when notices_in_banner is true
       if (
         !event.detail.extraDetails ||
-        (event.detail.extraDetails.servingComponent === ServingComponent.BANNER && !privacyExperience?.experience_config?.notices_in_banner)
+        (event.detail.extraDetails.servingComponent ===
+          ServingComponent.BANNER &&
+          !privacyExperience?.experience_config?.notices_in_banner)
       ) {
         return;
       }

--- a/clients/fides-js/src/lib/hooks/useConsentServed.ts
+++ b/clients/fides-js/src/lib/hooks/useConsentServed.ts
@@ -44,12 +44,12 @@ export const useConsentServed = ({
       // 1) MODAL
       // 2) TCF_OVERLAY
       // 3) TCF_BANNER
-      // 4) BANNER when layer1_notices is true
+      // 4) BANNER when show_layer1_notices is true
       if (
         !event.detail.extraDetails ||
         (event.detail.extraDetails.servingComponent ===
           ServingComponent.BANNER &&
-          !privacyExperience?.experience_config?.layer1_notices)
+          !privacyExperience?.experience_config?.show_layer1_notices)
       ) {
         return;
       }

--- a/clients/fides-js/src/lib/hooks/useConsentServed.ts
+++ b/clients/fides-js/src/lib/hooks/useConsentServed.ts
@@ -44,12 +44,12 @@ export const useConsentServed = ({
       // 1) MODAL
       // 2) TCF_OVERLAY
       // 3) TCF_BANNER
-      // 4) BANNER when notices_in_banner is true
+      // 4) BANNER when layer1_notices is true
       if (
         !event.detail.extraDetails ||
         (event.detail.extraDetails.servingComponent ===
           ServingComponent.BANNER &&
-          !privacyExperience?.experience_config?.notices_in_banner)
+          !privacyExperience?.experience_config?.layer1_notices)
       ) {
         return;
       }

--- a/clients/fides-js/src/lib/hooks/useConsentServed.ts
+++ b/clients/fides-js/src/lib/hooks/useConsentServed.ts
@@ -39,13 +39,15 @@ export const useConsentServed = ({
       }
 
       // Disable the notices-served API if the serving component is a regular
-      // banner (or unknown!). This means we trigger the API for:
+      // banner (or unknown!) unless the option for displaying notices in the
+      // banner has been set. This means we trigger the API for:
       // 1) MODAL
       // 2) TCF_OVERLAY
       // 3) TCF_BANNER
+      // 4) BANNER when notices_in_banner is true
       if (
         !event.detail.extraDetails ||
-        event.detail.extraDetails.servingComponent === ServingComponent.BANNER
+        (event.detail.extraDetails.servingComponent === ServingComponent.BANNER && !privacyExperience?.experience_config?.notices_in_banner)
       ) {
         return;
       }

--- a/clients/fides-js/src/lib/hooks/useMediaQuery.ts
+++ b/clients/fides-js/src/lib/hooks/useMediaQuery.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "preact/hooks";
+
+export const useMediaQuery = (query: string) => {
+  const [matches, setMatches] = useState<boolean>(false);
+  useEffect(() => {
+    const matchQueryList = window.matchMedia(query);
+    setMatches(matchQueryList.matches);
+    function handleChange(e: MediaQueryListEvent) {
+      setMatches(e.matches);
+    }
+    matchQueryList.addEventListener("change", handleChange);
+    return () => {
+      matchQueryList.removeEventListener("change", handleChange);
+    };
+  }, [query]);
+  return matches;
+};

--- a/clients/fides-js/src/lib/hooks/useMediaQuery.ts
+++ b/clients/fides-js/src/lib/hooks/useMediaQuery.ts
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "preact/hooks";
 
+/**
+ * This React hook listens for matches to a CSS media query. It allows the rendering of components based on whether the query matches or not. The media query string can be any valid CSS media query, for example '(prefers-color-scheme: dark)'.
+ * @param query - The CSS media query string to match against the viewport.
+ * @example const isMobile = useMediaQuery('(max-width: 768px)');
+ * @returns A boolean value indicating whether the media query matches the current viewport.
+ */
 export const useMediaQuery = (query: string) => {
   const [matches, setMatches] = useState<boolean>(false);
   useEffect(() => {

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -2269,6 +2269,25 @@ describe("Consent overlay", () => {
       });
     });
 
+    it("can be sent from the banner if notices_in_banner is true", () => {
+      const noticeOnlyNotices = buildMockNotices().map((notice) => ({
+        ...notice,
+        ...{ consent_mechanism: ConsentMechanism.NOTICE_ONLY },
+      }));
+      cy.fixture("consent/fidesjs_options_banner_modal.json").then((config) => {
+      stubConfig({
+        experience: {
+          privacy_notices: noticeOnlyNotices,
+          experience_config: {...config.experience.experience_config, notices_in_banner: true}
+        },
+      });
+    });
+      cy.get("@FidesUIShown").should("have.been.calledOnce");
+      cy.wait("@patchNoticesServed").then((interception) => {
+        expect(interception.request.body.serving_component).to.eql("banner");
+      });
+    });
+
     it("can set acknowledge mode to true", () => {
       const noticeOnlyNotices = buildMockNotices().map((notice) => ({
         ...notice,

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -2275,13 +2275,16 @@ describe("Consent overlay", () => {
         ...{ consent_mechanism: ConsentMechanism.NOTICE_ONLY },
       }));
       cy.fixture("consent/fidesjs_options_banner_modal.json").then((config) => {
-      stubConfig({
-        experience: {
-          privacy_notices: noticeOnlyNotices,
-          experience_config: {...config.experience.experience_config, notices_in_banner: true}
-        },
+        stubConfig({
+          experience: {
+            privacy_notices: noticeOnlyNotices,
+            experience_config: {
+              ...config.experience.experience_config,
+              notices_in_banner: true,
+            },
+          },
+        });
       });
-    });
       cy.get("@FidesUIShown").should("have.been.calledOnce");
       cy.wait("@patchNoticesServed").then((interception) => {
         expect(interception.request.body.serving_component).to.eql("banner");

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -2269,7 +2269,7 @@ describe("Consent overlay", () => {
       });
     });
 
-    it("can be sent from the banner if layer1_notices is true", () => {
+    it("can be sent from the banner if show_layer1_notices is true", () => {
       const noticeOnlyNotices = buildMockNotices().map((notice) => ({
         ...notice,
         ...{ consent_mechanism: ConsentMechanism.NOTICE_ONLY },
@@ -2280,7 +2280,7 @@ describe("Consent overlay", () => {
             privacy_notices: noticeOnlyNotices,
             experience_config: {
               ...config.experience.experience_config,
-              layer1_notices: true,
+              show_layer1_notices: true,
             },
           },
         });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -2269,7 +2269,7 @@ describe("Consent overlay", () => {
       });
     });
 
-    it("can be sent from the banner if notices_in_banner is true", () => {
+    it("can be sent from the banner if layer1_notices is true", () => {
       const noticeOnlyNotices = buildMockNotices().map((notice) => ({
         ...notice,
         ...{ consent_mechanism: ConsentMechanism.NOTICE_ONLY },
@@ -2280,7 +2280,7 @@ describe("Consent overlay", () => {
             privacy_notices: noticeOnlyNotices,
             experience_config: {
               ...config.experience.experience_config,
-              notices_in_banner: true,
+              layer1_notices: true,
             },
           },
         });

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
@@ -58,7 +58,7 @@
         ],
         "language": "en",
         "dismissable": true,
-        "notices_in_banner": false,
+        "layer1_notices": false,
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
@@ -58,6 +58,7 @@
         ],
         "language": "en",
         "dismissable": true,
+        "notices_in_banner": false,
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
@@ -58,7 +58,7 @@
         ],
         "language": "en",
         "dismissable": true,
-        "layer1_notices": false,
+        "show_layer1_notices": false,
         "layer1_button_options": "opt_in_opt_out",
         "allow_language_selection": true,
         "auto_detect_language": true,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal.json
@@ -59,6 +59,7 @@
         "language": "en",
         "dismissable": true,
         "layer1_notices": false,
+        "layer1_button_options": "opt_in_opt_out",
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
@@ -57,7 +57,7 @@
         ],
         "language": "en",
         "dismissable": true,
-        "notices_in_banner": false,
+        "layer1_notices": false,
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
@@ -57,7 +57,7 @@
         ],
         "language": "en",
         "dismissable": true,
-        "layer1_notices": false,
+        "show_layer1_notices": false,
         "layer1_button_options": "opt_in_opt_out",
         "allow_language_selection": true,
         "auto_detect_language": true,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
@@ -57,6 +57,7 @@
         ],
         "language": "en",
         "dismissable": true,
+        "notices_in_banner": false,
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_banner_modal_notice_only.json
@@ -58,6 +58,7 @@
         "language": "en",
         "dismissable": true,
         "layer1_notices": false,
+        "layer1_button_options": "opt_in_opt_out",
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_gpp.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_gpp.json
@@ -50,7 +50,7 @@
         ],
         "language": "en",
         "dismissable": true,
-        "layer1_notices": false,
+        "show_layer1_notices": false,
         "layer1_button_options": "opt_in_opt_out",
         "allow_language_selection": true,
         "auto_detect_language": true,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_gpp.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_gpp.json
@@ -51,6 +51,7 @@
         "language": "en",
         "dismissable": true,
         "layer1_notices": false,
+        "layer1_button_options": "opt_in_opt_out",
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_gpp.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_gpp.json
@@ -50,6 +50,7 @@
         ],
         "language": "en",
         "dismissable": true,
+        "notices_in_banner": false,
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_gpp.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_gpp.json
@@ -50,7 +50,7 @@
         ],
         "language": "en",
         "dismissable": true,
-        "notices_in_banner": false,
+        "layer1_notices": false,
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
@@ -58,7 +58,7 @@
         ],
         "language": "en",
         "dismissable": true,
-        "notices_in_banner": false,
+        "layer1_notices": false,
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
@@ -58,6 +58,7 @@
         ],
         "language": "en",
         "dismissable": true,
+        "notices_in_banner": false,
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
@@ -58,7 +58,7 @@
         ],
         "language": "en",
         "dismissable": true,
-        "layer1_notices": false,
+        "show_layer1_notices": false,
         "layer1_button_options": "opt_in_opt_out",
         "allow_language_selection": true,
         "auto_detect_language": true,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_privacy_center.json
@@ -59,6 +59,7 @@
         "language": "en",
         "dismissable": true,
         "layer1_notices": false,
+        "layer1_button_options": "opt_in_opt_out",
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -67,6 +67,7 @@
         "language": "en",
         "dismissable": true,
         "layer1_notices": false,
+        "layer1_button_options": "opt_in_opt_out",
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -66,7 +66,7 @@
         ],
         "language": "en",
         "dismissable": true,
-        "notices_in_banner": false,
+        "layer1_notices": false,
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -66,6 +66,7 @@
         ],
         "language": "en",
         "dismissable": true,
+        "notices_in_banner": false,
         "allow_language_selection": true,
         "auto_detect_language": true,
         "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
+++ b/clients/privacy-center/cypress/fixtures/consent/experience_tcf.json
@@ -66,7 +66,7 @@
         ],
         "language": "en",
         "dismissable": true,
-        "layer1_notices": false,
+        "show_layer1_notices": false,
         "layer1_button_options": "opt_in_opt_out",
         "allow_language_selection": true,
         "auto_detect_language": true,

--- a/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
@@ -71,6 +71,7 @@
       "language": "en",
       "dismissable": true,
       "layer1_notices": false,
+      "layer1_button_options": "opt_in_opt_out",
       "allow_language_selection": true,
       "auto_detect_language": true,
       "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
@@ -70,7 +70,7 @@
       ],
       "language": "en",
       "dismissable": true,
-      "layer1_notices": false,
+      "show_layer1_notices": false,
       "layer1_button_options": "opt_in_opt_out",
       "allow_language_selection": true,
       "auto_detect_language": true,

--- a/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
@@ -70,7 +70,7 @@
       ],
       "language": "en",
       "dismissable": true,
-      "notices_in_banner": false,
+      "layer1_notices": false,
       "allow_language_selection": true,
       "auto_detect_language": true,
       "disabled": false,

--- a/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
+++ b/clients/privacy-center/cypress/fixtures/consent/fidesjs_options_banner_modal.json
@@ -70,6 +70,7 @@
       ],
       "language": "en",
       "dismissable": true,
+      "notices_in_banner": false,
       "allow_language_selection": true,
       "auto_detect_language": true,
       "disabled": false,

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -66,6 +66,7 @@
             disabled: false,
             is_default: true,
             dismissable: true,
+            notices_in_banner: false,
             allow_language_selection: true,
             auto_detect_language: true,
             language: "en",

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -66,7 +66,7 @@
             disabled: false,
             is_default: true,
             dismissable: true,
-            notices_in_banner: false,
+            layer1_notices: false,
             allow_language_selection: true,
             auto_detect_language: true,
             language: "en",

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -66,7 +66,7 @@
             disabled: false,
             is_default: true,
             dismissable: true,
-            layer1_notices: false,
+            show_layer1_notices: false,
             layer1_button_options: "opt_in_opt_out",
             allow_language_selection: true,
             auto_detect_language: true,

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -67,6 +67,7 @@
             is_default: true,
             dismissable: true,
             layer1_notices: false,
+            layer1_button_options: "opt_in_opt_out",
             allow_language_selection: true,
             auto_detect_language: true,
             language: "en",

--- a/clients/privacy-center/types/api/models/ConsentMethod.ts
+++ b/clients/privacy-center/types/api/models/ConsentMethod.ts
@@ -13,4 +13,5 @@ export enum ConsentMethod {
   DISMISS = "dismiss",
   GPC = "gpc",
   INDIVIDUAL_NOTICE = "individual_notice",
+  ACKNOWLEDGE = "acknowledge",
 }

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import { Layer1ButtonOption } from "../../index";
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationResponse } from "./ExperienceTranslationResponse";
 import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
@@ -15,7 +16,7 @@ export type ExperienceConfigResponse = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
-  layer1_button_options?: string; // TODO: Enum
+  layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   regions: Array<PrivacyNoticeRegion>;
   id: string;

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
@@ -14,6 +14,7 @@ export type ExperienceConfigResponse = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
+  notices_in_banner?: boolean;
   allow_language_selection?: boolean;
   regions: Array<PrivacyNoticeRegion>;
   id: string;

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
@@ -15,6 +15,7 @@ export type ExperienceConfigResponse = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
+  layer1_button_options?: string; // TODO: Enum
   allow_language_selection?: boolean;
   regions: Array<PrivacyNoticeRegion>;
   id: string;

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
@@ -15,7 +15,7 @@ export type ExperienceConfigResponse = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
-  layer1_notices?: boolean;
+  show_layer1_notices?: boolean;
   layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponse.ts
@@ -14,7 +14,7 @@ export type ExperienceConfigResponse = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
-  notices_in_banner?: boolean;
+  layer1_notices?: boolean;
   allow_language_selection?: boolean;
   regions: Array<PrivacyNoticeRegion>;
   id: string;

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import { Layer1ButtonOption } from "../../index";
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationResponse } from "./ExperienceTranslationResponse";
 import type { PrivacyNoticeRegion } from "./PrivacyNoticeRegion";
@@ -69,7 +70,7 @@ export type ExperienceConfigResponseNoNotices = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
-  layer1_button_options?: string; // TODO: Enum
+  layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   regions: Array<PrivacyNoticeRegion>;
   id: string;

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -68,6 +68,7 @@ export type ExperienceConfigResponseNoNotices = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
+  notices_in_banner?: boolean;
   allow_language_selection?: boolean;
   regions: Array<PrivacyNoticeRegion>;
   id: string;

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -68,7 +68,7 @@ export type ExperienceConfigResponseNoNotices = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
-  notices_in_banner?: boolean;
+  layer1_notices?: boolean;
   allow_language_selection?: boolean;
   regions: Array<PrivacyNoticeRegion>;
   id: string;

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -69,6 +69,7 @@ export type ExperienceConfigResponseNoNotices = {
   disabled?: boolean;
   dismissable?: boolean;
   layer1_notices?: boolean;
+  layer1_button_options?: string; // TODO: Enum
   allow_language_selection?: boolean;
   regions: Array<PrivacyNoticeRegion>;
   id: string;

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -69,7 +69,7 @@ export type ExperienceConfigResponseNoNotices = {
   name?: string;
   disabled?: boolean;
   dismissable?: boolean;
-  layer1_notices?: boolean;
+  show_layer1_notices?: boolean;
   layer1_button_options?: Layer1ButtonOption;
   allow_language_selection?: boolean;
   regions: Array<PrivacyNoticeRegion>;

--- a/clients/privacy-center/types/index.ts
+++ b/clients/privacy-center/types/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 export enum PrivacyRequestStatus {
   APPROVED = "approved",
   COMPLETE = "complete",
@@ -11,4 +9,10 @@ export enum PrivacyRequestStatus {
   PENDING = "pending",
   IDENTITY_UNVERIFIED = "identity_unverified",
   REQUIRES_INPUT = "requires_input",
+}
+
+export enum Layer1ButtonOption {
+  // defines the buttons to show in the layer 1 banner
+  ACKNOWLEDGE = "acknowledge", // show acknowledge button
+  OPT_IN_OPT_OUT = "opt_in_opt_out", // show opt in and opt out buttons
 }

--- a/src/fides/api/models/privacy_preference.py
+++ b/src/fides/api/models/privacy_preference.py
@@ -57,6 +57,7 @@ class ConsentMethod(Enum):
     dismiss = "dismiss"
     gpc = "gpc"
     individual_notice = "individual_notice"
+    acknowledge = "acknowledge"
 
 
 class ServingComponent(Enum):


### PR DESCRIPTION
Closes [PROD-2427](https://ethyca.atlassian.net/browse/PROD-2427) and [PROD-2386](https://ethyca.atlassian.net/browse/PROD-2386)

### Description Of Changes

Update experience form with option for including notices in the banner & update banner to accommodate.

### Code Changes

* Added support for new experience config props `show_layer1_notices` and `layer1_button_options`
* Added notices toggle in UI of Privacy Experience form and dropdown to select Acknowledge button.
* Added list of notices in FidesJS if toggle is on, as well as display/save correct button if Acknowledge button is selected.
* Update rules for calling notices served API
--
* Fixed unrelated UI issue where the delete button for Notices wasn't able to be clicked because of layout issues
* Fixed unrelated failing FF Cypress test due to `realClick` being unavailable for that browser

---

![CleanShot 2024-07-30 at 12 16 20@2x](https://github.com/user-attachments/assets/00de4589-564e-425e-acdd-0c85f07f85c3)

---

![CleanShot 2024-07-30 at 12 17 16@2x](https://github.com/user-attachments/assets/4cb320aa-5612-4fb0-aeb8-1a65df2598e5)

---

### Steps to Confirm

* Visit Privacy Experiences in Admin UI
* Click an experience that has banners
* Add Notices if there aren't any on the experience
* toggle the new switch "Allow banner to show notice information"
* Notice the Preview window shows the notices in a list on the banner
* Click to open Banner Options menu
* Select Acknowledge option
* Notice the Preview window shows the acknowledge button in place of Opt In/Opt Out buttons

- [x] NOTE: saving will not work until related BE is done.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`


[PROD-2427]: https://ethyca.atlassian.net/browse/PROD-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PROD-2386]: https://ethyca.atlassian.net/browse/PROD-2386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ