### PR TITLE
Always cookies in preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The types of changes are:
 - Fixed typo in the BigQuery integration description [#5120](https://github.com/ethyca/fides/pull/5120)
 - Fixed default values of Experience config toggles [#5123](https://github.com/ethyca/fides/pull/5123)
 - Skip indexing Custom Privacy Request Field array values [#5127](https://github.com/ethyca/fides/pull/5127)
+- Fixed Admin UI issue where banner would dissapear in Experience Preview with GPC enabled [#5131](https://github.com/ethyca/fides/pull/5131)
 
 ### Fixed
 - Fixed not being able to edit a monitor from scheduled to not scheduled [#5114](https://github.com/ethyca/fides/pull/5114)

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -5,6 +5,7 @@ import {
   stubTranslationConfig,
 } from "cypress/support/stubs";
 
+import { PREVIEW_CONTAINER_ID } from "~/constants";
 import { PRIVACY_EXPERIENCE_ROUTE } from "~/features/common/nav/v2/routes";
 import { RoleRegistryEnum } from "~/types/api";
 
@@ -253,7 +254,7 @@ describe("Privacy experiences", () => {
           .first()
           .click();
         cy.getByTestId("no-preview-notice").should("not.exist");
-        cy.get("#preview-container").should("be.visible");
+        cy.get(`#${PREVIEW_CONTAINER_ID}`).should("be.visible");
       });
 
       it("allows editing experience text and shows updated text in the preview", () => {
@@ -269,7 +270,7 @@ describe("Privacy experiences", () => {
           .clear()
           .type("Edited title");
         cy.getByTestId("save-btn").click();
-        cy.get("#preview-container")
+        cy.get(`#${PREVIEW_CONTAINER_ID}`)
           .find("#fides-banner")
           .contains("Edited title");
       });
@@ -288,7 +289,7 @@ describe("Privacy experiences", () => {
           "have.value",
           "Example modal experience"
         );
-        cy.get("#preview-container").contains(
+        cy.get(`#${PREVIEW_CONTAINER_ID}`).contains(
           "Manage your consent preferences"
         );
       });
@@ -317,7 +318,7 @@ describe("Privacy experiences", () => {
 
       it("shows the preview for the translation currently being edited", () => {
         cy.getByTestId("language-row-fr").click();
-        cy.get("#preview-container").contains(
+        cy.get(`#${PREVIEW_CONTAINER_ID}`).contains(
           "Gestion du consentement et des préférences"
         );
       });
@@ -329,7 +330,7 @@ describe("Privacy experiences", () => {
           .type("Some other title");
         cy.getByTestId("cancel-btn").click();
         cy.getByTestId("warning-modal-confirm-btn").click();
-        cy.get("#preview-container").contains(
+        cy.get(`#${PREVIEW_CONTAINER_ID}`).contains(
           "Manage your consent preferences"
         );
       });
@@ -340,7 +341,7 @@ describe("Privacy experiences", () => {
         cy.getByTestId("save-btn").click();
         cy.getByTestId("warning-modal-confirm-btn").click();
         cy.getByTestId("language-row-fr").contains("(Default)");
-        cy.get("#preview-container").contains(
+        cy.get(`#${PREVIEW_CONTAINER_ID}`).contains(
           "Gestion du consentement et des préférences"
         );
       });

--- a/clients/admin-ui/src/constants.ts
+++ b/clients/admin-ui/src/constants.ts
@@ -137,3 +137,5 @@ export const LOGIN_ROUTE = "/login";
 export const CONNECTION_ROUTE = "/connection";
 export const CONNECTION_TYPE_ROUTE = "/connection_type";
 export const CONNECTOR_TEMPLATE = "/connector_template";
+
+export const PREVIEW_CONTAINER_ID = "preview-container";

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -263,7 +263,6 @@ const Preview = ({
             values.component !== ComponentType.TCF_OVERLAY &&
             values.component !== ComponentType.PRIVACY_CENTER
           ) {
-            console.log(baseConfig);
             window.Fides?.init(baseConfig as any);
           }
         }}

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -4,6 +4,7 @@ import { useFormikContext } from "formik";
 import Script from "next/script";
 import React, { useEffect, useMemo, useState } from "react";
 
+import { PREVIEW_CONTAINER_ID } from "~/constants";
 import { getErrorMessage } from "~/features/common/helpers";
 import { TranslationWithLanguageName } from "~/features/privacy-experience/form/helpers";
 import {
@@ -186,7 +187,7 @@ const Preview = ({
         div#fides-overlay {
           z-index: 5000 !important;
         }
-        div#preview-container {
+        div#${PREVIEW_CONTAINER_ID} {
           padding-top: 45px;
           margin: auto !important;
           pointer-events: none;
@@ -236,7 +237,7 @@ const Preview = ({
       ) : null}
       {isMobilePreview ? (
         <style>{`
-            div#preview-container {
+            div#${PREVIEW_CONTAINER_ID} {
               width: 70% !important;
             }
             div.fides-modal-button-group {
@@ -262,11 +263,12 @@ const Preview = ({
             values.component !== ComponentType.TCF_OVERLAY &&
             values.component !== ComponentType.PRIVACY_CENTER
           ) {
+            console.log(baseConfig);
             window.Fides?.init(baseConfig as any);
           }
         }}
       />
-      <div id="preview-container" />
+      <div id={PREVIEW_CONTAINER_ID} />
     </Flex>
   );
 };

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -1,5 +1,6 @@
 /* eslint-disable*/
 
+import { PREVIEW_CONTAINER_ID } from "~/constants";
 import {
   ExperienceConfigCreate,
   ExperienceTranslation,
@@ -41,7 +42,7 @@ export const buildBaseConfig = (
     isGeolocationEnabled: false,
     isOverlayEnabled: true,
     isPrefetchEnabled: false,
-    overlayParentId: "preview-container",
+    overlayParentId: PREVIEW_CONTAINER_ID,
     modalLinkId: null,
     privacyCenterUrl: "http://localhost:3000",
     fidesApiUrl: "http://localhost:8080/api/v1",

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -52,6 +52,7 @@ export const buildBaseConfig = (
     fidesJsBaseUrl: "",
     base64Cookie: false,
     fidesLocale: experienceConfig.translations?.[0]?.language,
+    fidesClearCookie: true,
   },
   experience: {
     id: "pri_111",


### PR DESCRIPTION
Closes [PROD-2474](https://ethyca.atlassian.net/browse/PROD-2474)

### Description Of Changes

If the user's browser is set to ask sites not to track (GPC), we automatically set a cookie and do not display the banner anymore. This is causing an issue in the Admin UI preview mode where the banner preview was disappearing if a user had GPC enabled.

By always clearing cookies in preview mode, we ensure GPC doesn't cause the banner to be removed from the preview.

### Code Changes

* Update preview container ID to be a constant
* Update preview config to include `fidesClearCookie: true`

### Steps to Confirm

* Enable GPC in the browser.
* Visit a non-TCF, Banner and Modal experience in Admin UI
* If the banner appears, notice that a cookie is set (you can see it set in browser dev tools)
* Reload the page or navigate away and come back

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[PROD-2474]: https://ethyca.atlassian.net/browse/PROD-2474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ