### PR TITLE
PROD-2473 Update `GET /dataset` endpoint to support `exclude_saas_datasets` and `only_unlinked_datasets` params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 - Added support for displaying notices served in the Consent Banner [#5125](https://github.com/ethyca/fides/pull/5125)
 - Added ability to choose whether to use Opt In/Out buttons or Acknowledge button in the Consent Banner [#5125](https://github.com/ethyca/fides/pull/5125)
 - Add "status" field to detection & discovery tables [#5141](https://github.com/ethyca/fides/pull/5141)
+- Added optional filters `exclude_saas_datasets` and `only_unlinked_datasets` to the list datasets endpoint [#5132](https://github.com/ethyca/fides/pull/5132)
 
 ### Changed
 - Moving Privacy Center endpoint logging behind debug flag [#5103](https://github.com/ethyca/fides/pull/5103)

--- a/src/fides/api/api/v1/endpoints/dataset_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/dataset_endpoints.py
@@ -591,6 +591,7 @@ def get_ctl_datasets(
     only_unlinked_datasets: bool = False,
 ) -> List[Dataset]:
     """
+    Deprecated. Use `GET /datasets` instead.
     Returns all CTL datasets .
     """
 

--- a/src/fides/api/api/v1/endpoints/dataset_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/dataset_endpoints.py
@@ -584,6 +584,7 @@ def delete_dataset(
     f"/filter{DATASETS}",
     dependencies=[Security(verify_oauth_client, scopes=[DATASET_READ])],
     response_model=List[Dataset],
+    deprecated=True,
 )
 def get_ctl_datasets(
     db: Session = Depends(deps.get_db),

--- a/src/fides/api/api/v1/endpoints/generic_overrides.py
+++ b/src/fides/api/api/v1/endpoints/generic_overrides.py
@@ -46,7 +46,7 @@ async def list_dataset_paginated(
     """
     Get a list of all of the Datasets.
     If any pagination parameters (size or page) are provided, then the response will be paginated
-    & provided filters (search, data_categories) will be applied.
+    & provided filters (search, data_categories, exclude_saas_datasets, only_unlinked_datasets) will be applied.
     Otherwise all Datasets will be returned (this may be a slow operation if there are many datasets,
     so using the pagination parameters is recommended).
     """

--- a/src/fides/api/api/v1/endpoints/generic_overrides.py
+++ b/src/fides/api/api/v1/endpoints/generic_overrides.py
@@ -4,11 +4,13 @@ from fastapi import APIRouter, Depends, Query, Security
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.async_sqlalchemy import paginate as async_paginate
 from fideslang.models import Dataset
+from sqlalchemy import and_, not_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.expression import select
 
 from fides.api.db.crud import list_resource
 from fides.api.db.ctl_session import get_async_db
+from fides.api.models.connectionconfig import ConnectionConfig, ConnectionType
 from fides.api.oauth.utils import verify_oauth_client
 from fides.api.schemas.filter_params import FilterParams
 from fides.api.util.filter_utils import apply_filters_to_query
@@ -37,6 +39,7 @@ async def list_dataset_paginated(
     page: Optional[int] = Query(None, ge=1),
     search: Optional[str] = Query(None),
     data_categories: Optional[List[str]] = Query(None),
+    exclude_saas_datasets: Optional[bool] = Query(False),
 ) -> Union[Page[Dataset], List[Dataset]]:
     """
     Get a list of all of the Datasets.
@@ -45,19 +48,31 @@ async def list_dataset_paginated(
     Otherwise all Datasets will be returned (this may be a slow operation if there are many datasets,
     so using the pagination parameters is recommended).
     """
-    if page or size:
-        query = select(CtlDataset)
-        filter_params = FilterParams(search=search, data_categories=data_categories)
-        filtered_query = apply_filters_to_query(
-            query=query,
-            search_model=CtlDataset,
-            taxonomy_model=CtlDataset,
-            filter_params=filter_params,
-        )
-        pagination_params = Params(page=page or 1, size=size or 50)
-        return await async_paginate(db, filtered_query, pagination_params)
+    if not page and not size:
+        return await list_resource(CtlDataset, db)
 
-    return await list_resource(CtlDataset, db)
+    query = select(CtlDataset)
+    # Add filters for search and data categories
+    filter_params = FilterParams(search=search, data_categories=data_categories)
+    filtered_query = apply_filters_to_query(
+        query=query,
+        search_model=CtlDataset,
+        taxonomy_model=CtlDataset,
+        filter_params=filter_params,
+    )
+
+    # If applicable, remove saas config datasets
+    if exclude_saas_datasets:
+        saas_subquery = (
+            select([ConnectionConfig.saas_config["fides_key"].astext])
+            .select_from(ConnectionConfig)  # type: ignore[arg-type]
+            .where(ConnectionConfig.saas_config.is_not(None))  # type: ignore[attr-defined]
+        )
+        filtered_query = filtered_query.where(not_(CtlDataset.fides_key.in_(saas_subquery)))
+
+    pagination_params = Params(page=page or 1, size=size or 50)
+    return await async_paginate(db, filtered_query, pagination_params)
+
 
 
 GENERIC_OVERRIDES_ROUTER = APIRouter()

--- a/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
@@ -2001,7 +2001,7 @@ class TestListDataset:
         api_client: TestClient,
         generate_auth_header,
         ctl_dataset,
-        saas_ctl_dataset,
+        secondary_sendgrid_instance,
     ):
         auth_header = generate_auth_header(scopes=[DATASET_READ])
         response = api_client.get(f"{V1_URL_PREFIX}/dataset", headers=auth_header)
@@ -2013,14 +2013,14 @@ class TestListDataset:
 
         sorted_items = sorted(response_json, key=lambda x: x["fides_key"])
         assert sorted_items[0]["fides_key"] == ctl_dataset.fides_key
-        assert sorted_items[1]["fides_key"] == saas_ctl_dataset.fides_key
+        assert sorted_items[1]["fides_key"] == secondary_sendgrid_instance[1].fides_key
 
     def test_list_dataset_with_pagination(
         self,
         api_client: TestClient,
         generate_auth_header,
         ctl_dataset,
-        saas_ctl_dataset,
+        secondary_sendgrid_instance,
     ):
         auth_header = generate_auth_header(scopes=[DATASET_READ])
         response = api_client.get(
@@ -2035,7 +2035,25 @@ class TestListDataset:
 
         assert len(sorted_items) == 2
         assert sorted_items[0]["fides_key"] == ctl_dataset.fides_key
-        assert sorted_items[1]["fides_key"] == saas_ctl_dataset.fides_key
+        assert sorted_items[1]["fides_key"] == secondary_sendgrid_instance[1].fides_key
+
+    def test_list_dataset_with_pagination_exclude_saas(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        ctl_dataset,
+        secondary_sendgrid_instance,
+    ):
+        auth_header = generate_auth_header(scopes=[DATASET_READ])
+        response = api_client.get(
+            f"{V1_URL_PREFIX}/dataset?page=1&size=5&exclude_saas_datasets=True", headers=auth_header
+        )
+
+        assert response.status_code == 200
+        response_json = response.json()
+
+        assert response_json["total"] == 1
+        assert response_json["items"][0]["fides_key"] == ctl_dataset.fides_key
 
     def test_list_dataset_with_pagination_default_page(
         self,

--- a/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
@@ -2055,6 +2055,25 @@ class TestListDataset:
         assert response_json["total"] == 1
         assert response_json["items"][0]["fides_key"] == ctl_dataset.fides_key
 
+    def test_list_dataset_with_pagination_only_unlinked_datasets(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        unlinked_dataset,
+        linked_dataset
+    ):
+        auth_header = generate_auth_header(scopes=[DATASET_READ])
+        response = api_client.get(
+            f"{V1_URL_PREFIX}/dataset?page=1&size=5&only_unlinked_datasets=True", headers=auth_header
+        )
+
+        assert response.status_code == 200
+        response_json = response.json()
+
+        assert response_json["total"] == 1
+        assert response_json["items"][0]["fides_key"] == unlinked_dataset.fides_key
+
+
     def test_list_dataset_with_pagination_default_page(
         self,
         api_client: TestClient,

--- a/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
@@ -2046,7 +2046,8 @@ class TestListDataset:
     ):
         auth_header = generate_auth_header(scopes=[DATASET_READ])
         response = api_client.get(
-            f"{V1_URL_PREFIX}/dataset?page=1&size=5&exclude_saas_datasets=True", headers=auth_header
+            f"{V1_URL_PREFIX}/dataset?page=1&size=5&exclude_saas_datasets=True",
+            headers=auth_header,
         )
 
         assert response.status_code == 200
@@ -2060,11 +2061,12 @@ class TestListDataset:
         api_client: TestClient,
         generate_auth_header,
         unlinked_dataset,
-        linked_dataset
+        linked_dataset,
     ):
         auth_header = generate_auth_header(scopes=[DATASET_READ])
         response = api_client.get(
-            f"{V1_URL_PREFIX}/dataset?page=1&size=5&only_unlinked_datasets=True", headers=auth_header
+            f"{V1_URL_PREFIX}/dataset?page=1&size=5&only_unlinked_datasets=True",
+            headers=auth_header,
         )
 
         assert response.status_code == 200
@@ -2072,7 +2074,6 @@ class TestListDataset:
 
         assert response_json["total"] == 1
         assert response_json["items"][0]["fides_key"] == unlinked_dataset.fides_key
-
 
     def test_list_dataset_with_pagination_default_page(
         self,

--- a/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_dataset_endpoints.py
@@ -2015,6 +2015,42 @@ class TestListDataset:
         assert sorted_items[0]["fides_key"] == ctl_dataset.fides_key
         assert sorted_items[1]["fides_key"] == secondary_sendgrid_instance[1].fides_key
 
+    def test_list_dataset_no_pagination_exclude_saas(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        ctl_dataset,
+        secondary_sendgrid_instance,
+    ):
+        auth_header = generate_auth_header(scopes=[DATASET_READ])
+        response = api_client.get(
+            f"{V1_URL_PREFIX}/dataset?exclude_saas_datasets=True",
+            headers=auth_header,
+        )
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert len(response_json) == 1
+        assert response_json[0]["fides_key"] == ctl_dataset.fides_key
+
+    def test_list_dataset_no_pagination_only_unlinked_datasets(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        unlinked_dataset,
+        linked_dataset,
+    ):
+        auth_header = generate_auth_header(scopes=[DATASET_READ])
+        response = api_client.get(
+            f"{V1_URL_PREFIX}/dataset?only_unlinked_datasets=True",
+            headers=auth_header,
+        )
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert len(response_json) == 1
+        assert response_json[0]["fides_key"] == unlinked_dataset.fides_key
+
     def test_list_dataset_with_pagination(
         self,
         api_client: TestClient,


### PR DESCRIPTION
Closes [PROD-2473](https://ethyca.atlassian.net/browse/PROD-2473)

### Description Of Changes
Added two query params `exclude_saas_datasets` and `only_unlinked_datasets` to the `GET /datasets` endpoint to match those in `GET /filters/datasets`. 

### Code Changes

* Updated `list_dataset_paginated` to add the two new filter options,  `exclude_saas_datasets` and `only_unlinked_datasets`
* Added relevant unit tests
* Added comment to docstring for `GET /filter/datasets` endpoint

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!


[PROD-2473]: https://ethyca.atlassian.net/browse/PROD-2473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ