### PR TITLE
Pin setuptools version due to error

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,7 @@ pytest-env==0.6.2
 pytest-mock==3.14.0
 pytest==7.2.2
 requests-mock==1.10.0
-setuptools>=64.0.2
+setuptools>=64.0.2,<72.0.0
 sqlalchemy-stubs
 types-paramiko==3.0.0.10
 types-PyYAML==6.0.11


### PR DESCRIPTION
Closes n/a

### Description Of Changes

Started to get this earlier today, pinning to remove latest version temporarily


### Code Changes

* [ ] limit setuptools to `<72.0.0`

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
