### PR TITLE
Rerun SaaS tests on failure

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,6 +11,7 @@ pytest-asyncio==0.19.0
 pytest-cov==4.0.0
 pytest-env==0.6.2
 pytest-mock==3.14.0
+pytest-rerunfailures==14.0
 pytest==7.2.2
 requests-mock==1.10.0
 setuptools>=64.0.2

--- a/noxfiles/setup_tests_nox.py
+++ b/noxfiles/setup_tests_nox.py
@@ -246,6 +246,8 @@ def pytest_ops(
             CI_ARGS_EXEC,
             CONTAINER_NAME,
             "pytest",
+            "--reruns",
+            "3",
             coverage_arg,
             OPS_TEST_DIR,
             "-m",


### PR DESCRIPTION
### Description Of Changes

Adding the `pytest-rerunfailures` plugin to `dev-requirements.txt`. This plugin introduces a `--reruns` flag that allows us to rerun failed tests up to `n` times before considering them a failure. We've implemented this to mitigate false positives that frequently occur due to data in the third-party APIs we're integrating with not settling in time for our tests.

### Code Changes

* [ ] Updated the `nox -s "pytest(ops-saas)"` command to use `--reruns 3`

### Steps to Confirm

* [ ] Verify the `External-SaaS-Connectors` backend check passes in the CI pipeline

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`