### PR TITLE
D & D Icon Key tooltip

### DIFF
--- a/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
@@ -295,6 +295,7 @@ export const FidesTableV2 = <T,>({
       borderBottomWidth="1px"
       borderRightWidth="1px"
       borderLeftWidth="1px"
+      zIndex={0}
     >
       <Table
         variant="unstyled"

--- a/clients/admin-ui/src/features/data-discovery-and-detection/IconKeyTip.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/IconKeyTip.tsx
@@ -1,0 +1,53 @@
+import {
+  HStack,
+  IconButton,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  PopoverProps,
+  PopoverTrigger,
+  QuestionIcon,
+  SimpleGrid,
+  Text,
+} from "fidesui";
+
+import { ResourceChangeTypeIcons } from "~/features/data-discovery-and-detection/tables/ResultStatusCell";
+import { ResourceChangeType } from "~/features/data-discovery-and-detection/types/ResourceChangeType";
+
+export const IconKeyTip = ({ ...props }: PopoverProps) => (
+  <Popover {...props} trigger="hover" placement="top">
+    <PopoverTrigger>
+      <IconButton
+        aria-label="Help"
+        icon={<QuestionIcon />}
+        variant="ghost"
+        size="xs"
+        _hover={{ bg: "transparent" }}
+        fontSize="md"
+        color="gray.400"
+      />
+    </PopoverTrigger>
+    <PopoverContent bg="black" width="auto">
+      <PopoverArrow bg="black" />
+      <PopoverBody>
+        <Text as="h4" fontSize="xs" color="white" fontWeight="600" mb={2}>
+          Activity Legend:
+        </Text>
+        <SimpleGrid columns={2} spacingX={4} spacingY={2}>
+          {ResourceChangeTypeIcons.map(({ icon: Icon, label, color, type }) => (
+            <HStack key={label}>
+              <Icon
+                color={color}
+                boxSize={type === ResourceChangeType.CLASSIFICATION ? 3 : 2}
+              />
+              <Text fontSize="xs" color="white">
+                {label}
+              </Text>
+            </HStack>
+          ))}
+        </SimpleGrid>
+      </PopoverBody>
+    </PopoverContent>
+  </Popover>
+);

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/ActivityTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/ActivityTable.tsx
@@ -22,6 +22,7 @@ import {
 } from "~/features/common/table/v2";
 import { RelativeTimestampCell } from "~/features/common/table/v2/cells";
 import { useGetMonitorResultsQuery } from "~/features/data-discovery-and-detection/discovery-detection.slice";
+import { IconKeyTip } from "~/features/data-discovery-and-detection/IconKeyTip";
 import ResultStatusCell from "~/features/data-discovery-and-detection/tables/ResultStatusCell";
 import getResourceRowName from "~/features/data-discovery-and-detection/utils/getResourceRowName";
 import { Database, DiffStatus, StagedResource } from "~/types/api";
@@ -177,6 +178,7 @@ const ActivityTable = ({
           <Box w={400} flexShrink={0}>
             <SearchInput value={searchQuery} onChange={setSearchQuery} />
           </Box>
+          <IconKeyTip />
         </Flex>
       </TableActionBar>
       <FidesTableV2

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DetectionResultTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DetectionResultTable.tsx
@@ -21,6 +21,7 @@ import {
 import { useGetMonitorResultsQuery } from "~/features/data-discovery-and-detection/discovery-detection.slice";
 import useDetectionResultColumns from "~/features/data-discovery-and-detection/hooks/useDetectionResultColumns";
 import useDiscoveryRoutes from "~/features/data-discovery-and-detection/hooks/useDiscoveryRoutes";
+import { IconKeyTip } from "~/features/data-discovery-and-detection/IconKeyTip";
 import { DiscoveryMonitorItem } from "~/features/data-discovery-and-detection/types/DiscoveryMonitorItem";
 import { StagedResourceType } from "~/features/data-discovery-and-detection/types/StagedResourceType";
 import { findResourceType } from "~/features/data-discovery-and-detection/utils/findResourceType";
@@ -168,11 +169,18 @@ const DetectionResultTable = ({ resourceUrn }: MonitorResultTableProps) => {
           alignItems="center"
           justifyContent="space-between"
           width="full"
+          gap={6}
         >
-          <Box w={400} flexShrink={0}>
+          <Box w={400}>
             <SearchInput value={searchQuery} onChange={setSearchQuery} />
           </Box>
-          <Flex direction="row" alignItems="center">
+          <IconKeyTip />
+          <Flex
+            direction="row"
+            alignItems="center"
+            flexGrow={1}
+            justifyContent="flex-end"
+          >
             <Switch
               size="sm"
               isChecked={isShowingFullSchema}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryResultTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryResultTable.tsx
@@ -21,6 +21,7 @@ import {
 import { useGetMonitorResultsQuery } from "~/features/data-discovery-and-detection/discovery-detection.slice";
 import useDiscoveryResultColumns from "~/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns";
 import useDiscoveryRoutes from "~/features/data-discovery-and-detection/hooks/useDiscoveryRoutes";
+import { IconKeyTip } from "~/features/data-discovery-and-detection/IconKeyTip";
 import DiscoveryFieldBulkActions from "~/features/data-discovery-and-detection/tables/DiscoveryFieldBulkActions";
 import DiscoveryTableBulkActions from "~/features/data-discovery-and-detection/tables/DiscoveryTableBulkActions";
 import { DiscoveryMonitorItem } from "~/features/data-discovery-and-detection/types/DiscoveryMonitorItem";
@@ -161,6 +162,7 @@ const DiscoveryResultTable = ({ resourceUrn }: MonitorResultTableProps) => {
           <Box w={400} flexShrink={0}>
             <SearchInput value={searchQuery} onChange={setSearchQuery} />
           </Box>
+          <IconKeyTip />
           {!!selectedUrns.length && (
             <Flex align="center">
               {resourceType === StagedResourceType.TABLE && (

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/ResultStatusCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/ResultStatusCell.tsx
@@ -8,55 +8,51 @@ import { ResourceChangeType } from "~/features/data-discovery-and-detection/type
 import findResourceChangeType from "~/features/data-discovery-and-detection/utils/findResourceChangeType";
 import { StagedResource } from "~/types/api";
 
+export const ResourceChangeTypeIcons = [
+  {
+    type: ResourceChangeType.CHANGE,
+    icon: CircleIcon,
+    color: "blue.400",
+    label: "Change detected",
+  },
+  {
+    type: ResourceChangeType.ADDITION,
+    icon: RightUpArrowIcon,
+    color: "green.400",
+    label: "Addition detected",
+  },
+  {
+    type: ResourceChangeType.CLASSIFICATION,
+    icon: TagIcon,
+    color: "orange.400",
+    label: "Classification detected",
+  },
+  {
+    type: ResourceChangeType.REMOVAL,
+    icon: RightDownArrowIcon,
+    color: "red.400",
+    label: "Removal detected",
+  },
+];
+
 const getResourceChangeIcon = (changeType: ResourceChangeType) => {
-  switch (changeType) {
-    case ResourceChangeType.ADDITION:
-      return (
-        <Tooltip label="Addition">
-          <RightUpArrowIcon
-            color="green.400"
-            boxSize={2}
-            mr={2}
-            data-testid="add-icon"
-          />
-        </Tooltip>
-      );
-    case ResourceChangeType.REMOVAL:
-      return (
-        <Tooltip label="Removal">
-          <RightDownArrowIcon
-            color="red.400"
-            boxSize={2}
-            mr={2}
-            data-testid="remove-icon"
-          />
-        </Tooltip>
-      );
-    case ResourceChangeType.CLASSIFICATION:
-      return (
-        <Tooltip label="Classification">
-          <TagIcon
-            color="orange.400"
-            boxSize={3}
-            mr={2}
-            data-testid="classify-icon"
-          />
-        </Tooltip>
-      );
-    case ResourceChangeType.CHANGE:
-      return (
-        <Tooltip label="Update">
-          <CircleIcon
-            color="blue.400"
-            boxSize={2}
-            mr={2}
-            data-testid="change-icon"
-          />
-        </Tooltip>
-      );
-    default:
-      return null;
+  const iconConfig = ResourceChangeTypeIcons.find(
+    (icon) => icon.type === changeType
+  );
+  if (iconConfig) {
+    const { icon: Icon, color } = iconConfig;
+    return (
+      <Tooltip label={changeType}>
+        <Icon
+          color={color}
+          boxSize={changeType === ResourceChangeType.CLASSIFICATION ? 3 : 2}
+          mr={2}
+          data-testid={`${changeType.toLowerCase()}-icon`}
+        />
+      </Tooltip>
+    );
   }
+  return null;
 };
 
 const ResultStatusCell = ({


### PR DESCRIPTION
Closes [PROD-2326](https://ethyca.atlassian.net/browse/PROD-2326)

### Description Of Changes

Provides users a key for the activity icons on each activity page to help understand their status.

![CleanShot 2024-07-30 at 18 25 11@2x](https://github.com/user-attachments/assets/7bb47476-5c59-4cae-9f29-64cbc6450b54)

### Code Changes

* Converts icons to an array of properties for looping and re-use.

### Steps to Confirm

* Visit all 3 Data and Discovery pages and note the key at the top of each.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`


[PROD-2326]: https://ethyca.atlassian.net/browse/PROD-2326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ