### PR TITLE
Improve API error messages when using `is_default` field on taxonomy resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The types of changes are:
 - Use the `user_id` from a Segment Trait instead of an `email` when deleting a user in Segment [#5004](https://github.com/ethyca/fides/pull/5004)
 - Moves some endpoints for property-specific messaging from OSS -> plus [#5069](https://github.com/ethyca/fides/pull/5069)
 - Text changes in monitor config table and form [#5142](https://github.com/ethyca/fides/pull/5142)
+-  Improve API error messages when using is_default field on taxonomy resources [#5147](https://github.com/ethyca/fides/pull/5147)
 
 ### Developer Experience
 - Add `.syncignore` to reduce file sync size with new volumes [#5104](https://github.com/ethyca/fides/pull/5104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ The types of changes are:
 - Use the `user_id` from a Segment Trait instead of an `email` when deleting a user in Segment [#5004](https://github.com/ethyca/fides/pull/5004)
 - Moves some endpoints for property-specific messaging from OSS -> plus [#5069](https://github.com/ethyca/fides/pull/5069)
 - Text changes in monitor config table and form [#5142](https://github.com/ethyca/fides/pull/5142)
--  Improve API error messages when using is_default field on taxonomy resources [#5147](https://github.com/ethyca/fides/pull/5147)
+- Improve API error messages when using is_default field on taxonomy resources [#5147](https://github.com/ethyca/fides/pull/5147)
 
 ### Developer Experience
 - Add `.syncignore` to reduce file sync size with new volumes [#5104](https://github.com/ethyca/fides/pull/5104)

--- a/src/fides/api/api/v1/endpoints/router_factory.py
+++ b/src/fides/api/api/v1/endpoints/router_factory.py
@@ -145,7 +145,9 @@ def create_router_factory(fides_model: FidesModelType, model_type: str) -> APIRo
         if isinstance(resource, Dataset):
             await validate_data_categories(resource, db)
         if isinstance(sql_model, ModelWithDefaultField) and resource.is_default:
-            raise errors.ForbiddenIsDefaultTaxonomyError(model_type, resource.fides_key, action="create")
+            raise errors.ForbiddenIsDefaultTaxonomyError(
+                model_type, resource.fides_key, action="create"
+            )
         return await create_resource(sql_model, resource.dict(), db)
 
     return router

--- a/src/fides/api/api/v1/endpoints/router_factory.py
+++ b/src/fides/api/api/v1/endpoints/router_factory.py
@@ -145,7 +145,7 @@ def create_router_factory(fides_model: FidesModelType, model_type: str) -> APIRo
         if isinstance(resource, Dataset):
             await validate_data_categories(resource, db)
         if isinstance(sql_model, ModelWithDefaultField) and resource.is_default:
-            raise errors.ForbiddenError(model_type, resource.fides_key)
+            raise errors.ForbiddenIsDefaultTaxonomyError(model_type, resource.fides_key, action="create")
         return await create_resource(sql_model, resource.dict(), db)
 
     return router

--- a/src/fides/api/util/endpoint_utils.py
+++ b/src/fides/api/util/endpoint_utils.py
@@ -78,7 +78,7 @@ async def forbid_if_editing_is_default(
             raise errors.ForbiddenIsDefaultTaxonomyError(
                 sql_model.__name__,
                 fides_key,
-                error_message="cannot modify 'is_default' field on an existing resource"
+                error_message="cannot modify 'is_default' field on an existing resource",
             )
 
 

--- a/src/fides/api/util/endpoint_utils.py
+++ b/src/fides/api/util/endpoint_utils.py
@@ -75,7 +75,11 @@ async def forbid_if_editing_is_default(
         ), "Provided Payload is not the right type!"
 
         if resource.is_default != payload.is_default:
-            raise errors.ForbiddenError(sql_model.__name__, fides_key)
+            raise errors.ForbiddenIsDefaultTaxonomyError(
+                sql_model.__name__,
+                fides_key,
+                error_message="cannot modify 'is_default' field on an existing resource"
+            )
 
 
 async def forbid_if_default(
@@ -88,7 +92,7 @@ async def forbid_if_default(
     if isinstance(sql_model, ModelWithDefaultField):
         resource = await get_resource(sql_model, fides_key, async_session)
         if resource.is_default:
-            raise errors.ForbiddenError(sql_model.__name__, fides_key)
+            raise errors.ForbiddenIsDefaultTaxonomyError(sql_model.__name__, fides_key)
 
 
 async def forbid_if_editing_any_is_default(
@@ -109,14 +113,18 @@ async def forbid_if_editing_any_is_default(
             if existing_resources.get(resource["fides_key"]) is None:
                 # new resource is being upserted
                 if resource["is_default"]:
-                    raise errors.ForbiddenError(
-                        sql_model.__name__, resource["fides_key"]
+                    raise errors.ForbiddenIsDefaultTaxonomyError(
+                        sql_model.__name__, resource["fides_key"], action="create"
                     )
             elif (
                 resource["is_default"]
                 != existing_resources[resource["fides_key"]].is_default
             ):
-                raise errors.ForbiddenError(sql_model.__name__, resource["fides_key"])
+                raise errors.ForbiddenIsDefaultTaxonomyError(
+                    sql_model.__name__,
+                    resource["fides_key"],
+                    error_message="cannot modify 'is_default' field on an existing resource",
+                )
 
 
 def validate_start_and_end_filters(

--- a/src/fides/api/util/errors.py
+++ b/src/fides/api/util/errors.py
@@ -98,11 +98,11 @@ class ForbiddenIsDefaultTaxonomyError(ForbiddenError):
         action: str = "modify",
         error_message: str = None,
     ) -> None:
-        error = error_message or f"cannot {action} a resource where 'is_default' is true"
+        error = (
+            error_message or f"cannot {action} a resource where 'is_default' is true"
+        )
         super().__init__(
-            resource_type=resource_type,
-            fides_key=fides_key,
-            error_message=error
+            resource_type=resource_type, fides_key=fides_key, error_message=error
         )
 
 

--- a/src/fides/api/util/errors.py
+++ b/src/fides/api/util/errors.py
@@ -72,13 +72,38 @@ class ForbiddenError(HTTPException):
     To be raised when a user cannot modify an entity.
     """
 
-    def __init__(self, resource_type: str, fides_key: str) -> None:
+    def __init__(
+        self,
+        resource_type: str,
+        fides_key: str,
+        error_message: str = "user does not have permission to modify",
+    ) -> None:
         detail = {
-            "error": "user does not have permission to modify",
+            "error": error_message,
             "resource_type": resource_type,
             "fides_key": fides_key,
         }
         super().__init__(status.HTTP_403_FORBIDDEN, detail=detail)
+
+
+class ForbiddenIsDefaultTaxonomyError(ForbiddenError):
+    """
+    To be raised when a user cannot modify a resource from the default Fideslang taxonomy (`is_default` is True)
+    """
+
+    def __init__(
+        self,
+        resource_type: str,
+        fides_key: str,
+        action: str = "modify",
+        error_message: str = None,
+    ) -> None:
+        error = error_message or f"cannot {action} a resource where 'is_default' is true"
+        super().__init__(
+            resource_type=resource_type,
+            fides_key=fides_key,
+            error_message=error
+        )
 
 
 def get_full_exception_name(exception: Exception) -> str:

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -2938,8 +2938,6 @@ class TestDefaultTaxonomyCrud:
             resource_id=resource.fides_key,
             headers=test_config.user.auth_header,
         )
-        print(f"result object: {result}")
-        print(f"result json: {result.json()}")
         assert result.status_code == 403
         assert (
             "cannot modify a resource where 'is_default' is true"

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -2941,7 +2941,10 @@ class TestDefaultTaxonomyCrud:
         print(f"result object: {result}")
         print(f"result json: {result.json()}")
         assert result.status_code == 403
-        assert "cannot modify a resource where 'is_default' is true" in result.json()["detail"]["error"]
+        assert (
+            "cannot modify a resource where 'is_default' is true"
+            in result.json()["detail"]["error"]
+        )
 
     @pytest.mark.parametrize("endpoint", TAXONOMY_ENDPOINTS)
     def test_api_can_update_default(
@@ -2990,7 +2993,10 @@ class TestDefaultTaxonomyCrud:
             headers=test_config.user.auth_header,
         )
         assert result.status_code == 403
-        assert "cannot create a resource where 'is_default' is true" in result.json()["detail"]["error"]
+        assert (
+            "cannot create a resource where 'is_default' is true"
+            in result.json()["detail"]["error"]
+        )
 
         _api.delete(
             url=test_config.cli.server_url,
@@ -3016,7 +3022,10 @@ class TestDefaultTaxonomyCrud:
             resources=[manifest.dict()],
         )
         assert result.status_code == 403
-        assert "cannot create a resource where 'is_default' is true" in result.json()["detail"]["error"]
+        assert (
+            "cannot create a resource where 'is_default' is true"
+            in result.json()["detail"]["error"]
+        )
 
         _api.delete(
             url=test_config.cli.server_url,
@@ -3048,7 +3057,10 @@ class TestDefaultTaxonomyCrud:
             json_resource=manifest.json(exclude_none=True),
         )
         assert result.status_code == 403
-        assert "cannot modify 'is_default' field on an existing resource" in result.json()["detail"]["error"]
+        assert (
+            "cannot modify 'is_default' field on an existing resource"
+            in result.json()["detail"]["error"]
+        )
 
     @pytest.mark.parametrize("endpoint", TAXONOMY_ENDPOINTS)
     def test_api_cannot_upsert_is_default(
@@ -3077,7 +3089,10 @@ class TestDefaultTaxonomyCrud:
             resources=[manifest.dict(), second_item.dict()],
         )
         assert result.status_code == 403
-        assert "cannot modify 'is_default' field on an existing resource" in result.json()["detail"]["error"]
+        assert (
+            "cannot modify 'is_default' field on an existing resource"
+            in result.json()["detail"]["error"]
+        )
 
         _api.delete(
             url=test_config.cli.server_url,

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -2938,7 +2938,10 @@ class TestDefaultTaxonomyCrud:
             resource_id=resource.fides_key,
             headers=test_config.user.auth_header,
         )
+        print(f"result object: {result}")
+        print(f"result json: {result.json()}")
         assert result.status_code == 403
+        assert "cannot modify a resource where 'is_default' is true" in result.json()["detail"]["error"]
 
     @pytest.mark.parametrize("endpoint", TAXONOMY_ENDPOINTS)
     def test_api_can_update_default(
@@ -2987,6 +2990,7 @@ class TestDefaultTaxonomyCrud:
             headers=test_config.user.auth_header,
         )
         assert result.status_code == 403
+        assert "cannot create a resource where 'is_default' is true" in result.json()["detail"]["error"]
 
         _api.delete(
             url=test_config.cli.server_url,
@@ -3012,6 +3016,7 @@ class TestDefaultTaxonomyCrud:
             resources=[manifest.dict()],
         )
         assert result.status_code == 403
+        assert "cannot create a resource where 'is_default' is true" in result.json()["detail"]["error"]
 
         _api.delete(
             url=test_config.cli.server_url,
@@ -3043,6 +3048,7 @@ class TestDefaultTaxonomyCrud:
             json_resource=manifest.json(exclude_none=True),
         )
         assert result.status_code == 403
+        assert "cannot modify 'is_default' field on an existing resource" in result.json()["detail"]["error"]
 
     @pytest.mark.parametrize("endpoint", TAXONOMY_ENDPOINTS)
     def test_api_cannot_upsert_is_default(
@@ -3071,6 +3077,7 @@ class TestDefaultTaxonomyCrud:
             resources=[manifest.dict(), second_item.dict()],
         )
         assert result.status_code == 403
+        assert "cannot modify 'is_default' field on an existing resource" in result.json()["detail"]["error"]
 
         _api.delete(
             url=test_config.cli.server_url,


### PR DESCRIPTION
### Description Of Changes

Today we throw a generic 403 error for a variety of edits which make it _look_ like the user is lacking sufficient permissions, but in reality it is that they are forbidden from editing the `is_default` field on a resource (e.g. `DataUse`, `DataCategory`).

#### Current Error Message
For example, we had a user report this unexpected error: they called the `/api/v1/data_category/upsert` API with this body:
```
[
    {
        "version_added": "2.0.0",
        "is_default": true,
        "fides_key": "user.unique_id.my_custom_category",
        "organization_fides_key": "default_organization",
        "name": "custom data category",
        "description": "description for custom data category",
        "parent_key": "user.unique_id",
        "active": true
    }
]
```

Which returns this error:
```
{ 'detail': { 'error': 'user does not have permission to modify',
              'fides_key': 'user.unique_id.my_custom_category',
              'resource_type': 'DataCategory'}}
```

#### New Error Message
As you can see above, the message is confusing - the error actually isn't that the user is lacking permission, it's that the user is trying to create a resource with `is_default: true`, which we never allow.

With this change, the error looks like this instead:
```
{ 'detail': { 'error': "cannot create a resource where 'is_default' is true",
              'fides_key': 'user.unique_id.my_custom_category',
              'resource_type': 'DataCategory'}}
```

There are some slight variations on those messages for deleting/editing/etc.

### Code Changes

* [X] Added a `ForbiddenIsDefaultTaxonomyError` error type with more user-friendly error messages
* [X] Updated `test_api.py` integration tests to assert on better error messages
* [X] Use the `ForbiddenIsDefaultTaxonomyError` error in the various code paths that were throwing generic 403s due to `is_default` rejections

### Steps to Confirm

* [X] Run integration tests

### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* Documentation:
  * ~[ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)~
  * ~[ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)~
  * ~[ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry~
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* ~[ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated~
* If there are any database migrations:
  * ~[ ] Ensure that your downrev is up to date with the latest revision on `main`~
  * ~[ ] Ensure that your `downgrade()` migration is correct and works~
    * ~[ ] If a downgrade migration is not possible for this change, please call this out in the PR description!~
