### PR TITLE
PROD-2529 Fix wrong system count on datamap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ The types of changes are:
 - Fixed Admin UI issue where banner would disappear in Experience Preview with GPC enabled [#5131](https://github.com/ethyca/fides/pull/5131)
 - Fixed not being able to edit a monitor from scheduled to not scheduled [#5114](https://github.com/ethyca/fides/pull/5114)
 - Migrating missing Fideslang 2.0 data categories [#5073](https://github.com/ethyca/fides/pull/5073)
+- Fixed wrong system count on Datamap page [#5151](https://github.com/ethyca/fides/pull/5151)
+
 
 ## [2.41.0](https://github.com/ethyca/fides/compare/2.40.0...2.41.0)
 

--- a/clients/admin-ui/src/features/datamap/SettingsBar.tsx
+++ b/clients/admin-ui/src/features/datamap/SettingsBar.tsx
@@ -1,5 +1,6 @@
 import { Button, Flex, Tag, Text, useDisclosure } from "fidesui";
-import React, { useContext } from "react";
+import { uniq } from "lodash";
+import React, { useContext, useMemo } from "react";
 
 import { useFeatures } from "~/features/common/features";
 import QuestionTooltip from "~/features/common/QuestionTooltip";
@@ -28,11 +29,19 @@ const SettingsBar = () => {
   const { tableInstance } = useContext(DatamapTableContext);
   const { systemsCount: totalSystemsCount, dictionaryService: compassEnabled } =
     useFeatures();
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const rows = tableInstance?.getRowModel().rows || [];
+  const uniqueSystemKeysFromFilteredRows = useMemo(
+    () => uniq(rows?.map((row) => row.original["system.fides_key"])),
+    [rows],
+  );
+
   if (!tableInstance) {
     return null;
   }
 
-  const filteredSystemsCount = tableInstance.getRowModel().rows.length || 0;
+  const filteredSystemsCount = uniqueSystemKeysFromFilteredRows.length;
   const totalFiltersApplied = tableInstance.getState().columnFilters.length;
 
   return (

--- a/clients/admin-ui/src/features/datamap/SettingsBar.tsx
+++ b/clients/admin-ui/src/features/datamap/SettingsBar.tsx
@@ -30,12 +30,11 @@ const SettingsBar = () => {
   const { systemsCount: totalSystemsCount, dictionaryService: compassEnabled } =
     useFeatures();
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const rows = tableInstance?.getRowModel().rows || [];
-  const uniqueSystemKeysFromFilteredRows = useMemo(
-    () => uniq(rows?.map((row) => row.original["system.fides_key"])),
-    [rows],
-  );
+  const rowModel = tableInstance?.getRowModel();
+  const uniqueSystemKeysFromFilteredRows = useMemo(() => {
+    const rows = rowModel?.rows || [];
+    return uniq(rows?.map((row) => row.original["system.fides_key"]));
+  }, [rowModel]);
 
   if (!tableInstance) {
     return null;


### PR DESCRIPTION
### Description Of Changes

Fix wrong system count on Datamap page


### Code Changes

* [ ] Filter rows by unique system fides id before counting

### Steps to Confirm
* [ ] Have a system with multiple Data Categories
* [ ] Go to Datamap
* [ ] Check that the filtered system count is correct and isn't higher than the total number of systems

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
