### PR TITLE
Refactoring ConsentableItem to simplify Pydantic v2 migration

### DIFF
--- a/src/fides/api/models/consent_automation.py
+++ b/src/fides/api/models/consent_automation.py
@@ -82,7 +82,7 @@ def link_consentable_items_to_consent_automation(
     ) -> List[ConsentableItem]:
         processed_items = []
         for item_data in items_data:
-            external_id = str(item_data["id"])
+            external_id = str(item_data["external_id"])
             item_type = item_data["type"]
 
             key = (item_type, external_id)

--- a/tests/ops/models/test_consent_automation.py
+++ b/tests/ops/models/test_consent_automation.py
@@ -10,12 +10,12 @@ class TestConsentAutomation:
         consentable_items = [
             {
                 "type": "Channel",
-                "id": 1,
+                "external_id": 1,
                 "name": "Marketing channel (email)",
                 "children": [
                     {
                         "type": "Message type",
-                        "id": 1,
+                        "external_id": 1,
                         "name": "Weekly Ads",
                     }
                 ],
@@ -42,12 +42,12 @@ class TestConsentAutomation:
         consentable_items = [
             {
                 "type": "Channel",
-                "id": 1,
+                "external_id": 1,
                 "name": "Marketing channel (email)",
                 "children": [
                     {
                         "type": "Message type",
-                        "id": 1,
+                        "external_id": 1,
                         "name": "Weekly Ads",
                     }
                 ],
@@ -100,12 +100,12 @@ class TestConsentAutomation:
         consentable_items = [
             {
                 "type": "Channel",
-                "id": 1,
+                "external_id": 1,
                 "name": "Marketing channel (email)",
                 "children": [
                     {
                         "type": "Message type",
-                        "id": 1,
+                        "external_id": 1,
                         "name": "Weekly Ads",
                     }
                 ],
@@ -154,12 +154,12 @@ class TestConsentAutomation:
         consentable_items = [
             {
                 "type": "Channel",
-                "id": 1,
+                "external_id": 1,
                 "name": "Marketing channel (email)",
                 "children": [
                     {
                         "type": "Message type",
-                        "id": 1,
+                        "external_id": 1,
                         "name": "Weekly Ads",
                     }
                 ],
@@ -198,12 +198,12 @@ class TestConsentAutomation:
         consentable_items = [
             {
                 "type": "Channel",
-                "id": 1,
+                "external_id": 1,
                 "name": "Marketing channel (email)",
                 "children": [
                     {
                         "type": "Message type",
-                        "id": 1,
+                        "external_id": 1,
                         "name": "Weekly Ads",
                     }
                 ],

--- a/tests/ops/schemas/test_consentable_item_schema.py
+++ b/tests/ops/schemas/test_consentable_item_schema.py
@@ -6,34 +6,42 @@ class TestConsentableItemUtils:
         api_values = [
             ConsentableItem(
                 type="Channel",
-                id="1",
+                external_id="1",
                 name="Email",
                 children=[
-                    ConsentableItem(type="MessageType", id="1", name="Welcome"),
-                    ConsentableItem(type="MessageType", id="2", name="Promotional"),
+                    ConsentableItem(
+                        type="MessageType", external_id="1", name="Welcome"
+                    ),
+                    ConsentableItem(
+                        type="MessageType", external_id="2", name="Promotional"
+                    ),
                 ],
             )
         ]
         db_values = [
             ConsentableItem(
                 type="Channel",
-                id="2",
+                external_id="2",
                 name="SMS",
                 children=[
-                    ConsentableItem(type="MessageType", id="1", name="Welcome"),
-                    ConsentableItem(type="MessageType", id="2", name="Transactional"),
+                    ConsentableItem(
+                        type="MessageType", external_id="1", name="Welcome"
+                    ),
+                    ConsentableItem(
+                        type="MessageType", external_id="2", name="Transactional"
+                    ),
                 ],
             )
         ]
         assert merge_consentable_items(api_values, db_values) == [
             ConsentableItem(
-                id="1",
+                external_id="1",
                 type="Channel",
                 name="Email",
                 notice_id=None,
                 children=[
                     ConsentableItem(
-                        id="1",
+                        external_id="1",
                         type="MessageType",
                         name="Welcome",
                         notice_id=None,
@@ -41,7 +49,7 @@ class TestConsentableItemUtils:
                         unmapped=True,
                     ),
                     ConsentableItem(
-                        id="2",
+                        external_id="2",
                         type="MessageType",
                         name="Promotional",
                         notice_id=None,
@@ -57,40 +65,46 @@ class TestConsentableItemUtils:
         api_values = [
             ConsentableItem(
                 type="Channel",
-                id="1",
+                external_id="1",
                 name="Marketing",
                 children=[
-                    ConsentableItem(type="MessageType", id="1", name="Newsletter"),
-                    ConsentableItem(type="MessageType", id="3", name="Promotional"),
+                    ConsentableItem(
+                        type="MessageType", external_id="1", name="Newsletter"
+                    ),
+                    ConsentableItem(
+                        type="MessageType", external_id="3", name="Promotional"
+                    ),
                 ],
             )
         ]
         db_values = [
             ConsentableItem(
                 type="Channel",
-                id="1",
+                external_id="1",
                 notice_id="notice_123",
                 name="Marketing",
                 children=[
                     ConsentableItem(
                         type="MessageType",
-                        id="1",
+                        external_id="1",
                         name="Newsletter",
                         notice_id="notice_456",
                     ),
-                    ConsentableItem(type="MessageType", id="3", name="Transactional"),
+                    ConsentableItem(
+                        type="MessageType", external_id="3", name="Transactional"
+                    ),
                 ],
             )
         ]
         assert merge_consentable_items(api_values, db_values) == [
             ConsentableItem(
-                id="1",
+                external_id="1",
                 type="Channel",
                 name="Marketing",
                 notice_id="notice_123",
                 children=[
                     ConsentableItem(
-                        id="1",
+                        external_id="1",
                         type="MessageType",
                         name="Newsletter",
                         notice_id="notice_456",
@@ -98,7 +112,7 @@ class TestConsentableItemUtils:
                         unmapped=False,
                     ),
                     ConsentableItem(
-                        id="3",
+                        external_id="3",
                         type="MessageType",
                         name="Promotional",
                         notice_id=None,
@@ -114,20 +128,22 @@ class TestConsentableItemUtils:
         api_values = [
             ConsentableItem(
                 type="Channel",
-                id="1",
+                external_id="1",
                 name="Email",
-                children=[ConsentableItem(type="MessageType", id="1", name="Welcome")],
+                children=[
+                    ConsentableItem(type="MessageType", external_id="1", name="Welcome")
+                ],
             )
         ]
         assert merge_consentable_items(api_values, []) == [
             ConsentableItem(
-                id="1",
+                external_id="1",
                 type="Channel",
                 name="Email",
                 notice_id=None,
                 children=[
                     ConsentableItem(
-                        id="1",
+                        external_id="1",
                         type="MessageType",
                         name="Welcome",
                         notice_id=None,
@@ -143,20 +159,22 @@ class TestConsentableItemUtils:
         api_values = [
             ConsentableItem(
                 type="Channel",
-                id="1",
+                external_id="1",
                 name="Email",
-                children=[ConsentableItem(type="MessageType", id="1", name="Welcome")],
+                children=[
+                    ConsentableItem(type="MessageType", external_id="1", name="Welcome")
+                ],
             )
         ]
         assert merge_consentable_items(api_values, None) == [
             ConsentableItem(
-                id="1",
+                external_id="1",
                 type="Channel",
                 name="Email",
                 notice_id=None,
                 children=[
                     ConsentableItem(
-                        id="1",
+                        external_id="1",
                         type="MessageType",
                         name="Welcome",
                         notice_id=None,
@@ -170,18 +188,18 @@ class TestConsentableItemUtils:
 
     def test_merge_consentable_items_multiple_items(self):
         api_values = [
-            ConsentableItem(type="Channel", id="1", name="Email"),
-            ConsentableItem(type="Channel", id="2", name="SMS"),
-            ConsentableItem(type="Channel", id="3", name="Push"),
+            ConsentableItem(type="Channel", external_id="1", name="Email"),
+            ConsentableItem(type="Channel", external_id="2", name="SMS"),
+            ConsentableItem(type="Channel", external_id="3", name="Push"),
         ]
         db_values = [
-            ConsentableItem(type="Channel", id="1", name="Email"),
-            ConsentableItem(type="Channel", id="3", name="Push"),
-            ConsentableItem(type="Channel", id="4", name="Web"),
+            ConsentableItem(type="Channel", external_id="1", name="Email"),
+            ConsentableItem(type="Channel", external_id="3", name="Push"),
+            ConsentableItem(type="Channel", external_id="4", name="Web"),
         ]
         assert merge_consentable_items(api_values, db_values) == [
             ConsentableItem(
-                id="1",
+                external_id="1",
                 type="Channel",
                 name="Email",
                 notice_id=None,
@@ -189,7 +207,7 @@ class TestConsentableItemUtils:
                 unmapped=False,
             ),
             ConsentableItem(
-                id="2",
+                external_id="2",
                 type="Channel",
                 name="SMS",
                 notice_id=None,
@@ -197,7 +215,7 @@ class TestConsentableItemUtils:
                 unmapped=True,
             ),
             ConsentableItem(
-                id="3",
+                external_id="3",
                 type="Channel",
                 name="Push",
                 notice_id=None,


### PR DESCRIPTION
### Description Of Changes

Updating the `ConsentableItem` schema to use `external_id` instead of `id` to remove the need for a custom `from_orm` function. Using `external_id` allows us to just map the SQLAlchemy model's `external_id` to the Pydantic model's `external_id` without needing to map `external_id` to `id`.

### Code Changes

* [ ] Updating `ConsentableItem` and removing the custom `from_orm`

### Steps to Confirm

* [ ] Tests should pass

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met