### PR TITLE
Map notices to consent able items in Admin UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.42.0...main)
 
+### Added
+- Added support for mapping a system's inegration's consentable items to privacy notices [#5156](https://github.com/ethyca/fides/pull/5156)
+
 ### Fixed
 - Fixed the OAuth2 configuration for the Snap integration [#5158](https://github.com/ethyca/fides/pull/5158)
 

--- a/clients/admin-ui/cypress/e2e/system-integrations-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/system-integrations-plus.cy.ts
@@ -79,4 +79,40 @@ describe("System integrations", () => {
       });
     });
   });
+
+  describe("Consent automation", () => {
+    beforeEach(() => {
+      cy.intercept("GET", "/api/v1/system/*", {
+        fixture: "systems/system_active_integration.json",
+      });
+      cy.intercept("GET", "/api/v1/plus/connection/*/consentable-items", {
+        fixture: "connectors/consentable_items.json",
+      });
+      cy.intercept("GET", "/api/v1/privacy-notice*", {
+        fixture: "privacy-notices/list.json",
+      }).as("getNotices");
+      cy.getByTestId("system-fidesctl_system").within(() => {
+        cy.getByTestId("edit-btn").click();
+      });
+      cy.getByTestId("tab-Integrations").click();
+    });
+    it("should render the consent automation accordion panel", () => {
+      cy.getByTestId("accordion-consent-automation").click();
+      cy.getByTestId("accordion-panel-consent-automation").should("exist");
+      cy.getByTestId("consentable-item-label").should("have.length", 5);
+      cy.getByTestId("consentable-item-label-child").should("have.length", 6);
+      cy.getByTestId("consentable-item-select").should("have.length", 11);
+      cy.getByTestId("consentable-item-select")
+        .first()
+        .within(() => {
+          cy.get(".custom-select__input").focus().realPress(" ");
+        });
+      cy.get(".custom-select__menu").first().should("exist");
+      cy.get(".custom-select__menu")
+        .first()
+        .within(() => {
+          cy.get(".custom-select__option").should("have.length", 5);
+        });
+    });
+  });
 });

--- a/clients/admin-ui/cypress/e2e/system-integrations-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/system-integrations-plus.cy.ts
@@ -88,6 +88,9 @@ describe("System integrations", () => {
       cy.intercept("GET", "/api/v1/plus/connection/*/consentable-items", {
         fixture: "connectors/consentable_items.json",
       });
+      cy.intercept("PUT", "/api/v1/plus/connection/*/consentable-items", {
+        fixture: "connectors/consentable_items.json",
+      }).as("putConsentableItems");
       cy.intercept("GET", "/api/v1/privacy-notice*", {
         fixture: "privacy-notices/list.json",
       }).as("getNotices");
@@ -113,6 +116,28 @@ describe("System integrations", () => {
         .within(() => {
           cy.get(".custom-select__option").should("have.length", 5);
         });
+    });
+    it("should save the consent automation settings", () => {
+      cy.getByTestId("accordion-consent-automation").click();
+      cy.getByTestId("consentable-item-select")
+        .first()
+        .within(() => {
+          cy.get(".custom-select__input").focus().realPress(" ");
+        });
+      cy.get(".custom-select__menu")
+        .first()
+        .within(() => {
+          cy.get(".custom-select__option").first().click();
+        });
+      cy.getByTestId("save-consent-automation").click();
+      cy.wait("@putConsentableItems").then((interception) => {
+        cy.fixture("connectors/consentable_items.json").then((expected) => {
+          // eslint-disable-next-line no-param-reassign
+          expected[0].notice_id = "pri_b1244715-2adb-499f-abb2-e86b6c0040c2";
+          expect(interception.request.body).to.deep.equal(expected);
+        });
+      });
+      cy.getByTestId("toast-success-msg").should("exist");
     });
   });
 });

--- a/clients/admin-ui/cypress/fixtures/connectors/connection_types.json
+++ b/clients/admin-ui/cypress/fixtures/connectors/connection_types.json
@@ -84,6 +84,15 @@
       "type": "saas",
       "human_readable": "Shopify",
       "encoded_icon": null
+    },
+    {
+      "identifier": "iterable",
+      "type": "saas",
+      "human_readable": "Iterable",
+      "encoded_icon": null,
+      "authorization_required": false,
+      "user_guide": "https://docs.ethyca.com/user-guides/integrations/saas-integrations/iterable",
+      "supported_actions": ["erasure", "consent"]
     }
   ],
   "total": 10,

--- a/clients/admin-ui/cypress/fixtures/connectors/consentable_items.json
+++ b/clients/admin-ui/cypress/fixtures/connectors/consentable_items.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "34419",
+    "type": "Channel",
+    "name": "Default SMS channel (SMS)",
+    "notice_id": null,
+    "children": [
+      {
+        "id": "40007",
+        "type": "Message type",
+        "name": "Default SMS message type",
+        "notice_id": null,
+        "children": [],
+        "unmapped": true
+      }
+    ],
+    "unmapped": true
+  },
+  {
+    "id": "34415",
+    "type": "Channel",
+    "name": "Default InApp channel (InApp)",
+    "notice_id": null,
+    "children": [
+      {
+        "id": "40003",
+        "type": "Message type",
+        "name": "Default InApp message type",
+        "notice_id": null,
+        "children": [],
+        "unmapped": true
+      }
+    ],
+    "unmapped": true
+  },
+  {
+    "id": "33843",
+    "type": "Channel",
+    "name": "Push Marketing Channel (Push)",
+    "notice_id": null,
+    "children": [
+      {
+        "id": "39240",
+        "type": "Message type",
+        "name": "Push Marketing Message",
+        "notice_id": null,
+        "children": [],
+        "unmapped": true
+      }
+    ],
+    "unmapped": true
+  },
+  {
+    "id": "33842",
+    "type": "Channel",
+    "name": "Transactional Channel (Email)",
+    "notice_id": null,
+    "children": [
+      {
+        "id": "39239",
+        "type": "Message type",
+        "name": "Transactional Message",
+        "notice_id": null,
+        "children": [],
+        "unmapped": true
+      }
+    ],
+    "unmapped": true
+  },
+  {
+    "id": "33841",
+    "type": "Channel",
+    "name": "Marketing Channel (Email)",
+    "notice_id": null,
+    "children": [
+      {
+        "id": "40000",
+        "type": "Message type",
+        "name": "Untitled message type",
+        "notice_id": null,
+        "children": [],
+        "unmapped": true
+      },
+      {
+        "id": "39238",
+        "type": "Message type",
+        "name": "Marketing Message",
+        "notice_id": null,
+        "children": [],
+        "unmapped": true
+      }
+    ],
+    "unmapped": true
+  }
+]

--- a/clients/admin-ui/cypress/fixtures/connectors/consentable_items.json
+++ b/clients/admin-ui/cypress/fixtures/connectors/consentable_items.json
@@ -1,12 +1,12 @@
 [
   {
-    "id": "34419",
+    "external_id": "34419",
     "type": "Channel",
     "name": "Default SMS channel (SMS)",
     "notice_id": null,
     "children": [
       {
-        "id": "40007",
+        "external_id": "40007",
         "type": "Message type",
         "name": "Default SMS message type",
         "notice_id": null,
@@ -17,13 +17,13 @@
     "unmapped": true
   },
   {
-    "id": "34415",
+    "external_id": "34415",
     "type": "Channel",
     "name": "Default InApp channel (InApp)",
     "notice_id": null,
     "children": [
       {
-        "id": "40003",
+        "external_id": "40003",
         "type": "Message type",
         "name": "Default InApp message type",
         "notice_id": null,
@@ -34,13 +34,13 @@
     "unmapped": true
   },
   {
-    "id": "33843",
+    "external_id": "33843",
     "type": "Channel",
     "name": "Push Marketing Channel (Push)",
     "notice_id": null,
     "children": [
       {
-        "id": "39240",
+        "external_id": "39240",
         "type": "Message type",
         "name": "Push Marketing Message",
         "notice_id": null,
@@ -51,13 +51,13 @@
     "unmapped": true
   },
   {
-    "id": "33842",
+    "external_id": "33842",
     "type": "Channel",
     "name": "Transactional Channel (Email)",
     "notice_id": null,
     "children": [
       {
-        "id": "39239",
+        "external_id": "39239",
         "type": "Message type",
         "name": "Transactional Message",
         "notice_id": null,
@@ -68,13 +68,13 @@
     "unmapped": true
   },
   {
-    "id": "33841",
+    "external_id": "33841",
     "type": "Channel",
     "name": "Marketing Channel (Email)",
     "notice_id": null,
     "children": [
       {
-        "id": "40000",
+        "external_id": "40000",
         "type": "Message type",
         "name": "Untitled message type",
         "notice_id": null,
@@ -82,7 +82,7 @@
         "unmapped": true
       },
       {
-        "id": "39238",
+        "external_id": "39238",
         "type": "Message type",
         "name": "Marketing Message",
         "notice_id": null,

--- a/clients/admin-ui/cypress/fixtures/connectors/consentable_items.json
+++ b/clients/admin-ui/cypress/fixtures/connectors/consentable_items.json
@@ -10,7 +10,14 @@
         "type": "Message type",
         "name": "Default SMS message type",
         "notice_id": null,
-        "children": [],
+        "children": {
+          "external_id": "500",
+          "type": "Message type",
+          "name": "Another SMS message type",
+          "notice_id": null,
+          "children": [],
+          "unmapped": true
+        },
         "unmapped": true
       }
     ],

--- a/clients/admin-ui/cypress/fixtures/systems/system_active_integration.json
+++ b/clients/admin-ui/cypress/fixtures/systems/system_active_integration.json
@@ -1,0 +1,70 @@
+{
+  "fides_key": "demo_analytics_system",
+  "organization_fides_key": "default_organization",
+  "tags": ["demo", "analytics"],
+  "name": "Demo Analytics System",
+  "description": "A system used for analyzing customer behaviour.",
+  "meta": null,
+  "fidesctl_meta": null,
+  "dataset_reference": null,
+  "system_type": "Service",
+  "privacy_declarations": [
+    {
+      "name": "Analyze customer behaviour for improvements.",
+      "data_categories": ["user.contact", "user.device.cookie_id"],
+      "data_use": "functional.service.improve",
+      "data_subjects": ["customer"],
+      "dataset_references": ["demo_users_dataset"],
+      "cookies": [],
+      "legal_basis_for_processing": "Consent",
+      "retention_period": "0",
+      "features": [],
+      "processes_special_category_data": true,
+      "special_category_legal_basis": "Explicit Consent",
+      "data_shared_with_third_parties": false,
+      "third_parties": [],
+      "shared_categories": [],
+      "id": "pri_ac9d4dfb-d033-4b06-bc7f-968df8d125ff"
+    }
+  ],
+  "processes_personal_data": true,
+  "exempt_from_privacy_regulations": false,
+  "reason_for_exemption": null,
+  "uses_profiling": true,
+  "legal_basis_for_profiling": "Explicit consent",
+  "does_international_transfers": false,
+  "legal_basis_for_transfers": null,
+  "requires_data_protection_assessments": true,
+  "dpa_location": "https://example.org/analytics_system_data_protection_impact_assessment",
+  "privacy_policy": "https://example.org/privacy_policy",
+  "legal_name": "Example Name",
+  "legal_address": "100 Main St.",
+  "administrating_department": "Engineering",
+  "responsibility": "Controller",
+  "dpo": "Derek P. Officer",
+  "data_security_practices": [],
+  "cookies": [],
+  "connection_configs": {
+    "name": null,
+    "key": "fidesctl_system_iterable_api",
+    "description": "",
+    "connection_type": "saas",
+    "access": "write",
+    "created_at": "2024-08-01T20:38:51.953543+00:00",
+    "updated_at": "2024-08-02T16:07:57.769608+00:00",
+    "disabled": false,
+    "last_test_timestamp": "2024-08-02T16:07:58.452157+00:00",
+    "last_test_succeeded": true,
+    "saas_config": {
+      "fides_key": "fidesctl_system_iterable_api",
+      "name": "Iterable",
+      "type": "iterable"
+    },
+    "secrets": {
+      "api_key": "**********",
+      "domain": "api.iterable.com"
+    },
+    "authorized": false,
+    "enabled_actions": ["erasure"]
+  }
+}

--- a/clients/admin-ui/src/features/common/api.slice.ts
+++ b/clients/admin-ui/src/features/common/api.slice.ts
@@ -22,6 +22,7 @@ export const baseApi = createApi({
     "Classify Instances Datasets",
     "Classify Instances Systems",
     "Connection Type",
+    "Consentable Items",
     "Custom Assets",
     "Custom Field Definition",
     "Custom Fields",

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -260,10 +260,17 @@ export const SelectInput = ({
   onChange,
   isCustomOption,
   textColor,
-}: { fieldName: string; isMulti?: boolean; onChange?: any } & Omit<
-  SelectProps,
-  "label"
->) => {
+  ariaLabel,
+  ariaLabelledby,
+  ariaDescribedby,
+}: {
+  fieldName: string;
+  isMulti?: boolean;
+  onChange?: any;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+  ariaDescribedby?: string;
+} & Omit<SelectProps, "label">) => {
   const [initialField] = useField(fieldName);
   const field = { ...initialField, value: initialField.value ?? "" };
   const selected = isMulti
@@ -380,6 +387,9 @@ export const SelectInput = ({
       isDisabled={isDisabled}
       menuPosition={menuPosition}
       menuPlacement="auto"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
+      aria-describedby={ariaDescribedby}
     />
   );
 };

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
@@ -46,7 +46,7 @@ const ConsentableItemField = ({
   onNoticeChange,
   isChild,
 }: ConsentableItemFieldProps) => {
-  const { id, name } = item;
+  const { external_id: id, name } = item;
   const fieldName = `${id}-notice_id`;
   return (
     <>
@@ -112,13 +112,13 @@ export const ConsentAutomationForm = ({
       (acc, item) => {
         if (item.notice_id) {
           // eslint-disable-next-line no-param-reassign
-          acc[`${item.id}-notice_id`] = item.notice_id;
+          acc[`${item.external_id}-notice_id`] = item.notice_id;
         }
         if (item.children?.length) {
           item.children.forEach((child) => {
             if (child.notice_id) {
               // eslint-disable-next-line no-param-reassign
-              acc[`${child.id}-notice_id`] = child.notice_id;
+              acc[`${child.external_id}-notice_id`] = child.notice_id;
             }
           });
         }
@@ -175,12 +175,16 @@ export const ConsentAutomationForm = ({
     parent?: ConsentableItem,
   ): void => {
     const updatedItems = consentableItems.map((i) => {
-      if (parent ? i.id === parent.id : i.id === value.id) {
+      if (
+        parent
+          ? i.external_id === parent.external_id
+          : i.external_id === value.external_id
+      ) {
         if (parent) {
           return {
             ...i,
             children: i.children?.map((child) => {
-              if (child.id === value.id) {
+              if (child.external_id === value.external_id) {
                 return value;
               }
               return child;
@@ -220,7 +224,7 @@ export const ConsentAutomationForm = ({
               <Form>
                 <SimpleGrid columns={2} spacing={3}>
                   {consentableItems.map((item) => (
-                    <Fragment key={item.id}>
+                    <Fragment key={item.external_id}>
                       <ConsentableItemField
                         item={item}
                         options={noticesOptions}
@@ -230,7 +234,7 @@ export const ConsentAutomationForm = ({
                         <ConsentableItemField
                           item={child}
                           options={noticesOptions}
-                          key={child.id}
+                          key={child.external_id}
                           isChild
                           onNoticeChange={(newValue) =>
                             handleNoticeChange(newValue, item)

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
@@ -1,0 +1,258 @@
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  ArrowDownRightIcon,
+  Box,
+  BoxProps,
+  Button,
+  FormLabel,
+  HStack,
+  SimpleGrid,
+  Skeleton,
+  Text,
+  useToast,
+} from "fidesui";
+import { Form, Formik, FormikValues } from "formik";
+import { Fragment, useEffect, useMemo, useState } from "react";
+
+import { useAppSelector } from "~/app/hooks";
+import { Option, SelectInput } from "~/features/common/form/inputs";
+import { errorToastParams, successToastParams } from "~/features/common/toast";
+import {
+  useGetConsentableItemsQuery,
+  useUpdateConsentableItemsMutation,
+} from "~/features/plus/plus.slice";
+import {
+  selectPage as selectNoticePage,
+  selectPageSize as selectNoticePageSize,
+  useGetAllPrivacyNoticesQuery,
+} from "~/features/privacy-notices/privacy-notices.slice";
+import { ConsentableItem } from "~/types/api/models/ConsentableItem";
+import { isErrorResult } from "~/types/errors";
+
+interface ConsentableItemFieldProps {
+  item: ConsentableItem;
+  options: Option[];
+  onNoticeChange: (newValue: ConsentableItem) => void;
+  isChild?: boolean;
+}
+
+const ConsentableItemField = ({
+  item,
+  options = [],
+  onNoticeChange,
+  isChild,
+}: ConsentableItemFieldProps) => {
+  const { id, name } = item;
+  const fieldName = `${id}-notice_id`;
+  return (
+    <>
+      <HStack flexGrow={1}>
+        {isChild && <ArrowDownRightIcon />}
+        <FormLabel
+          id={`${id}-label`}
+          m={0}
+          fontSize="14px"
+          fontWeight={isChild ? "normal" : "semibold"}
+        >
+          {name}
+        </FormLabel>
+      </HStack>
+      <Box>
+        <SelectInput
+          placeholder="None"
+          size="sm"
+          fieldName={fieldName}
+          options={options}
+          aria-label="Notices"
+          aria-describedby={`${id}-label`}
+          isClearable
+          onChange={(option: Option | undefined) => {
+            const value = option?.value;
+            // eslint-disable-next-line no-param-reassign
+            item = { ...item, notice_id: value };
+            onNoticeChange(item);
+          }}
+        />
+      </Box>
+    </>
+  );
+};
+
+interface ConsentAutomationFormProps extends BoxProps {
+  connectionKey: string;
+}
+
+export const ConsentAutomationForm = ({
+  connectionKey,
+  ...props
+}: ConsentAutomationFormProps) => {
+  const toast = useToast();
+
+  const { data, isLoading: isLoadingConsentableItems } =
+    useGetConsentableItemsQuery(connectionKey);
+  const [consentableItemsMutationTrigger] = useUpdateConsentableItemsMutation();
+
+  const noticePage = useAppSelector(selectNoticePage);
+  const noticePageSize = useAppSelector(selectNoticePageSize);
+  const { data: notices, isLoading: isLoadingNotices } =
+    useGetAllPrivacyNoticesQuery({
+      page: noticePage,
+      size: noticePageSize,
+    });
+
+  const [consentableItems, setConsentableItems] = useState<ConsentableItem[]>();
+  const [noticesOptions, setNoticesOptions] = useState<Option[]>([]);
+  const initialValues = useMemo(() => {
+    return consentableItems?.reduce(
+      (acc, item) => {
+        if (item.notice_id) {
+          // eslint-disable-next-line no-param-reassign
+          acc[`${item.id}-notice_id`] = item.notice_id;
+        }
+        if (item.children?.length) {
+          item.children.forEach((child) => {
+            if (child.notice_id) {
+              // eslint-disable-next-line no-param-reassign
+              acc[`${child.id}-notice_id`] = child.notice_id;
+            }
+          });
+        }
+        return acc;
+      },
+      {} as FormikValues & Record<string, string>,
+    );
+  }, [consentableItems]);
+
+  const handleSubmit = async () => {
+    const result = await consentableItemsMutationTrigger({
+      connectionKey,
+      consentableItems: consentableItems as ConsentableItem[],
+    });
+
+    if (isErrorResult(result)) {
+      toast(errorToastParams("Failed to save consent automation"));
+    } else {
+      toast(successToastParams(`Consent automation has been saved`));
+    }
+  };
+
+  useEffect(() => {
+    if (data) {
+      setConsentableItems(data);
+    }
+  }, [data]);
+
+  useEffect(() => {
+    if (notices) {
+      setNoticesOptions(
+        notices.items.map((notice) => ({
+          label: notice.name,
+          value: notice.id,
+        })),
+      );
+    }
+  }, [notices]);
+
+  if (isLoadingConsentableItems || isLoadingNotices) {
+    return (
+      <Box borderWidth="1px" borderRadius="md" {...props}>
+        <Skeleton height="35px" />
+      </Box>
+    );
+  }
+
+  if (!consentableItems || !notices) {
+    return null;
+  }
+
+  const handleNoticeChange = (
+    value: ConsentableItem,
+    parent?: ConsentableItem,
+  ): void => {
+    const updatedItems = consentableItems.map((i) => {
+      if (parent ? i.id === parent.id : i.id === value.id) {
+        if (parent) {
+          return {
+            ...i,
+            children: i.children?.map((child) => {
+              if (child.id === value.id) {
+                return value;
+              }
+              return child;
+            }),
+          };
+        }
+        return value;
+      }
+      return i;
+    });
+    setConsentableItems(updatedItems);
+  };
+
+  return (
+    <Box borderWidth="1px" borderRadius="md" {...props}>
+      <Accordion allowMultiple>
+        <AccordionItem border="none">
+          <AccordionButton>
+            <Box as="span" flex="1" textAlign="left">
+              <Text as="h2" fontWeight="semibold" fontSize="sm">
+                Consent automation
+              </Text>
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel p={5} fontSize="sm">
+            <Text mb={7}>
+              Configure the notices that will trigger consent propagation for
+              this integration. A default value can be used to trigger every
+              consent preference or each item can be configured individually.
+            </Text>
+            <Formik initialValues={initialValues || {}} onSubmit={handleSubmit}>
+              <Form>
+                <SimpleGrid columns={2} spacing={3}>
+                  {consentableItems.map((item) => (
+                    <Fragment key={item.id}>
+                      <ConsentableItemField
+                        item={item}
+                        options={noticesOptions}
+                        onNoticeChange={handleNoticeChange}
+                      />
+                      {item.children?.map((child) => (
+                        <ConsentableItemField
+                          item={child}
+                          options={noticesOptions}
+                          key={child.id}
+                          isChild
+                          onNoticeChange={(newValue) =>
+                            handleNoticeChange(newValue, item)
+                          }
+                        />
+                      ))}
+                    </Fragment>
+                  ))}
+                </SimpleGrid>
+                <HStack justifyContent="flex-end" mt={3}>
+                  <Button
+                    bg="primary.800"
+                    color="white"
+                    size="sm"
+                    variant="solid"
+                    type="submit"
+                    _active={{ bg: "primary.500" }}
+                    _hover={{ bg: "primary.400" }}
+                  >
+                    Save
+                  </Button>
+                </HStack>
+              </Form>
+            </Formik>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    </Box>
+  );
+};

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
@@ -253,6 +253,7 @@ export const ConsentAutomationForm = ({
                     type="submit"
                     _active={{ bg: "primary.500" }}
                     _hover={{ bg: "primary.400" }}
+                    data-testid="save-consent-automation"
                   >
                     Save
                   </Button>

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
@@ -54,6 +54,7 @@ const ConsentableItemField = ({
         {isChild && <ArrowDownRightIcon />}
         <FormLabel
           id={`${id}-label`}
+          data-testid={`consentable-item-label${isChild ? "-child" : ""}`}
           m={0}
           fontSize="14px"
           fontWeight={isChild ? "normal" : "semibold"}
@@ -61,7 +62,7 @@ const ConsentableItemField = ({
           {name}
         </FormLabel>
       </HStack>
-      <Box>
+      <Box data-testid="consentable-item-select">
         <SelectInput
           placeholder="None"
           size="sm"
@@ -195,7 +196,7 @@ export const ConsentAutomationForm = ({
 
   return (
     <Box borderWidth="1px" borderRadius="md" {...props}>
-      <Accordion allowMultiple>
+      <Accordion allowMultiple data-testid="accordion-consent-automation">
         <AccordionItem border="none">
           <AccordionButton>
             <Box as="span" flex="1" textAlign="left">
@@ -205,7 +206,11 @@ export const ConsentAutomationForm = ({
             </Box>
             <AccordionIcon />
           </AccordionButton>
-          <AccordionPanel p={5} fontSize="sm">
+          <AccordionPanel
+            p={5}
+            fontSize="sm"
+            data-testid="accordion-panel-consent-automation"
+          >
             <Text mb={7}>
               Configure the notices that will trigger consent propagation for
               this integration. A default value can be used to trigger every

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
@@ -67,8 +67,8 @@ const ConsentableItemField = ({
           size="sm"
           fieldName={fieldName}
           options={options}
-          aria-label="Notices"
-          aria-describedby={`${id}-label`}
+          ariaLabel="Notices"
+          ariaDescribedby={`${id}-label`}
           isClearable
           onChange={(option: Option | undefined) => {
             const value = option?.value;

--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -26,6 +26,7 @@ import {
   ClassifySystem,
   CloudConfig,
   ConnectionConfigurationResponse,
+  ConsentableItem,
   CustomAssetType,
   CustomFieldDefinition,
   CustomFieldDefinitionWithId,
@@ -447,6 +448,23 @@ const plusApi = baseApi.injectEndpoints({
       }),
       invalidatesTags: ["TCF Purpose Override"],
     }),
+    getConsentableItems: build.query<ConsentableItem[], string>({
+      query: (connectionKey) => ({
+        url: `plus/${CONNECTION_ROUTE}/${connectionKey}/consentable-items`,
+      }),
+      providesTags: () => ["Consentable Items"],
+    }),
+    updateConsentableItems: build.mutation<
+      ConsentableItem[],
+      { connectionKey: string; consentableItems: ConsentableItem[] }
+    >({
+      query: ({ connectionKey, consentableItems }) => ({
+        url: `plus/${CONNECTION_ROUTE}/${connectionKey}/consentable-items`,
+        method: "PUT",
+        body: consentableItems,
+      }),
+      invalidatesTags: ["Consentable Items"],
+    }),
   }),
 });
 
@@ -486,6 +504,8 @@ export const {
   useCreatePlusSaasConnectionConfigMutation,
   useGetTcfPurposeOverridesQuery,
   usePatchTcfPurposeOverridesMutation,
+  useGetConsentableItemsQuery,
+  useUpdateConsentableItemsMutation,
 } = plusApi;
 
 export const selectHealth: (state: RootState) => HealthCheck | undefined =

--- a/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
+++ b/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
@@ -16,6 +16,7 @@ import { INTEGRATION_MANAGEMENT_ROUTE } from "~/features/common/nav/v2/routes";
 import { DEFAULT_TOAST_PARAMS } from "~/features/common/toast";
 import ToastLink from "~/features/common/ToastLink";
 import ConnectionForm from "~/features/datastore-connections/system_portal_config/ConnectionForm";
+import { ConsentAutomationForm } from "~/features/datastore-connections/system_portal_config/ConsentAutomationForm";
 import {
   setLockedForGVL,
   setSuggestions,
@@ -247,6 +248,12 @@ const useSystemFormTabs = ({
             connectionConfig={activeSystem.connection_configs}
             systemFidesKey={activeSystem.fides_key}
           />
+          {activeSystem.connection_configs?.key && (
+            <ConsentAutomationForm
+              m={6}
+              connectionKey={activeSystem.connection_configs?.key}
+            />
+          )}
         </Box>
       ) : null,
       isDisabled: !activeSystem,

--- a/clients/admin-ui/src/mocks/data.ts
+++ b/clients/admin-ui/src/mocks/data.ts
@@ -4,6 +4,7 @@ import {
   ClassifyCollection,
   ClassifyDataset,
   ClassifyField,
+  ConsentableItem,
   Dataset,
   DatasetCollection,
   DatasetField,
@@ -266,3 +267,99 @@ export const mockClassifyDataset = (
   };
   return Object.assign(initial, partial);
 };
+
+export const mockConsentableItems: ConsentableItem[] = [
+  {
+    id: "34419",
+    type: "Channel",
+    name: "Default SMS channel (SMS)",
+    notice_id: null,
+    children: [
+      {
+        id: "40007",
+        type: "Message type",
+        name: "Default SMS message type",
+        notice_id: null,
+        children: [],
+        unmapped: true,
+      },
+    ],
+    unmapped: true,
+  },
+  {
+    id: "34415",
+    type: "Channel",
+    name: "Default InApp channel (InApp)",
+    notice_id: null,
+    children: [
+      {
+        id: "40003",
+        type: "Message type",
+        name: "Default InApp message type",
+        notice_id: null,
+        children: [],
+        unmapped: true,
+      },
+    ],
+    unmapped: true,
+  },
+  {
+    id: "33843",
+    type: "Channel",
+    name: "Push Marketing Channel (Push)",
+    notice_id: null,
+    children: [
+      {
+        id: "39240",
+        type: "Message type",
+        name: "Push Marketing Message",
+        notice_id: null,
+        children: [],
+        unmapped: true,
+      },
+    ],
+    unmapped: true,
+  },
+  {
+    id: "33842",
+    type: "Channel",
+    name: "Transactional Channel (Email)",
+    notice_id: null,
+    children: [
+      {
+        id: "39239",
+        type: "Message type",
+        name: "Transactional Message",
+        notice_id: null,
+        children: [],
+        unmapped: true,
+      },
+    ],
+    unmapped: true,
+  },
+  {
+    id: "33841",
+    type: "Channel",
+    name: "Marketing Channel (Email)",
+    notice_id: null,
+    children: [
+      {
+        id: "40000",
+        type: "Message type",
+        name: "Untitled message type",
+        notice_id: null,
+        children: [],
+        unmapped: true,
+      },
+      {
+        id: "39238",
+        type: "Message type",
+        name: "Marketing Message",
+        notice_id: null,
+        children: [],
+        unmapped: true,
+      },
+    ],
+    unmapped: true,
+  },
+];

--- a/clients/admin-ui/src/mocks/data.ts
+++ b/clients/admin-ui/src/mocks/data.ts
@@ -270,13 +270,13 @@ export const mockClassifyDataset = (
 
 export const mockConsentableItems: ConsentableItem[] = [
   {
-    id: "34419",
+    external_id: "34419",
     type: "Channel",
     name: "Default SMS channel (SMS)",
     notice_id: null,
     children: [
       {
-        id: "40007",
+        external_id: "40007",
         type: "Message type",
         name: "Default SMS message type",
         notice_id: null,
@@ -287,13 +287,13 @@ export const mockConsentableItems: ConsentableItem[] = [
     unmapped: true,
   },
   {
-    id: "34415",
+    external_id: "34415",
     type: "Channel",
     name: "Default InApp channel (InApp)",
     notice_id: null,
     children: [
       {
-        id: "40003",
+        external_id: "40003",
         type: "Message type",
         name: "Default InApp message type",
         notice_id: null,
@@ -304,13 +304,13 @@ export const mockConsentableItems: ConsentableItem[] = [
     unmapped: true,
   },
   {
-    id: "33843",
+    external_id: "33843",
     type: "Channel",
     name: "Push Marketing Channel (Push)",
     notice_id: null,
     children: [
       {
-        id: "39240",
+        external_id: "39240",
         type: "Message type",
         name: "Push Marketing Message",
         notice_id: null,
@@ -321,13 +321,13 @@ export const mockConsentableItems: ConsentableItem[] = [
     unmapped: true,
   },
   {
-    id: "33842",
+    external_id: "33842",
     type: "Channel",
     name: "Transactional Channel (Email)",
     notice_id: null,
     children: [
       {
-        id: "39239",
+        external_id: "39239",
         type: "Message type",
         name: "Transactional Message",
         notice_id: null,
@@ -338,13 +338,13 @@ export const mockConsentableItems: ConsentableItem[] = [
     unmapped: true,
   },
   {
-    id: "33841",
+    external_id: "33841",
     type: "Channel",
     name: "Marketing Channel (Email)",
     notice_id: null,
     children: [
       {
-        id: "40000",
+        external_id: "40000",
         type: "Message type",
         name: "Untitled message type",
         notice_id: null,
@@ -352,7 +352,7 @@ export const mockConsentableItems: ConsentableItem[] = [
         unmapped: true,
       },
       {
-        id: "39238",
+        external_id: "39238",
         type: "Message type",
         name: "Marketing Message",
         notice_id: null,

--- a/clients/admin-ui/src/types/api/index.ts
+++ b/clients/admin-ui/src/types/api/index.ts
@@ -71,6 +71,7 @@ export { ConnectionTestStatus } from "./models/ConnectionTestStatus";
 export { ConnectionType } from "./models/ConnectionType";
 export type { ConnectorParam } from "./models/ConnectorParam";
 export type { Consent } from "./models/Consent";
+export type { ConsentableItem } from "./models/ConsentableItem";
 export type { ConsentConfigButton } from "./models/ConsentConfigButton";
 export type { ConsentConfigPage } from "./models/ConsentConfigPage";
 export { ConsentMechanism } from "./models/ConsentMechanism";

--- a/clients/admin-ui/src/types/api/models/ConsentableItem.ts
+++ b/clients/admin-ui/src/types/api/models/ConsentableItem.ts
@@ -1,0 +1,11 @@
+/**
+ * 3rd-party consentable item and privacy notice relationships
+ */
+export interface ConsentableItem {
+  id: string;
+  type: string;
+  name: string;
+  notice_id?: string | null;
+  children?: ConsentableItem[];
+  unmapped?: boolean;
+}

--- a/clients/admin-ui/src/types/api/models/ConsentableItem.ts
+++ b/clients/admin-ui/src/types/api/models/ConsentableItem.ts
@@ -2,7 +2,7 @@
  * 3rd-party consentable item and privacy notice relationships
  */
 export interface ConsentableItem {
-  id: string;
+  external_id: string;
   type: string;
   name: string;
   notice_id?: string | null;

--- a/clients/fidesui/src/icons/ArrowDownRight.tsx
+++ b/clients/fidesui/src/icons/ArrowDownRight.tsx
@@ -1,0 +1,11 @@
+import { createIcon } from "@chakra-ui/icon";
+
+export default createIcon({
+  displayName: "ArrowDownRightIcon",
+  viewBox: "0 0 16 16",
+  defaultProps: {
+    width: "16px",
+    height: "16px",
+  },
+  d: "M10.781 7.333 7.205 3.757l.943-.943L13.333 8l-5.185 5.185-.943-.943 3.576-3.576H2.667V3.333H4v4z",
+});

--- a/clients/fidesui/src/icons/index.ts
+++ b/clients/fidesui/src/icons/index.ts
@@ -1,6 +1,7 @@
 // Icons from Fides:
 export { default as AddIcon } from "./Add";
 export { default as ArrowDownLineIcon } from "./ArrowDownLine";
+export { default as ArrowDownRightIcon } from "./ArrowDownRight";
 export { default as ArrowUpLineIcon } from "./ArrowUpLine";
 export { default as CircleHelpIcon } from "./CircleHelp";
 export { default as CloseSolidIcon } from "./CloseSolid";


### PR DESCRIPTION
Closes [PROD-2344](https://ethyca.atlassian.net/browse/PROD-2344)

### Description Of Changes

Adds an accordion panel to the System's Integration tab to allow customers to map each consentable item to a privacy notice for consent automation.


### Code Changes

* Consumes both the Consentable Items API and the Privacy Notices API
* UI for displaying the options to the user for mapping
* Saves changes to the Consentable Items API and displays saved data when returning

### Steps to Confirm

1. In Admin UI of Fides Plus, visit the System Inventory page `/systems`
2. Add a new system and configure the Iterable integration (check with Adrian for credentials)
3. Once added, a new "Consent Automation" accordion button will appear. Click to expand it
4. Verify that the appropriate parent/child relationships exist for Iterable (see screenshot)
5. Make some selections from the list of available Privacy Notices and save
6. Leave the page and return. Expand the Consent Automation panel and ensure the notices selected were saved.

![CleanShot 2024-08-05 at 14 58 16@2x](https://github.com/user-attachments/assets/aaadc781-6e1e-4295-bc39-0b649e237ea1)


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

[PROD-2344]: https://ethyca.atlassian.net/browse/PROD-2344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ