### PR TITLE
Fix TCF overlay issues on mobile sized screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The types of changes are:
 - Fixed not being able to edit a monitor from scheduled to not scheduled [#5114](https://github.com/ethyca/fides/pull/5114)
 - Migrating missing Fideslang 2.0 data categories [#5073](https://github.com/ethyca/fides/pull/5073)
 - Fixed wrong system count on Datamap page [#5151](https://github.com/ethyca/fides/pull/5151)
+- Fixes some responsive styling issues in the consent banner on mobile sized screens [#5157](https://github.com/ethyca/fides/pull/5157)
 
 
 ## [2.41.0](https://github.com/ethyca/fides/compare/2.40.0...2.41.0)

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "preact/hooks";
 
 import { getConsentContext } from "../lib/consent-context";
 import { GpcStatus } from "../lib/consent-types";
+import { useMediaQuery } from "../lib/hooks/useMediaQuery";
 import { I18n, messageExists } from "../lib/i18n";
 import CloseButton from "./CloseButton";
 import ExperienceDescription from "./ExperienceDescription";
@@ -37,6 +38,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
   className,
   isEmbedded,
 }) => {
+  const isMobile = useMediaQuery("(max-width: 768px)");
   const showGpcBadge = getConsentContext().globalPrivacyControl;
 
   useEffect(() => {
@@ -120,8 +122,9 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
               </div>
             </div>
             {children}
-            {renderButtonGroup()}
+            {!isMobile && renderButtonGroup()}
           </div>
+          {isMobile && renderButtonGroup()}
         </div>
       </div>
     </div>

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -1096,7 +1096,6 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
     padding-left: 0;
   }
   .fides-banner-secondary-actions {
-    flex-direction: column-reverse;
     gap: 12px;
   }
 }

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -537,7 +537,7 @@ div#fides-banner-inner .fides-privacy-policy {
 }
 
 div#fides-banner-inner .fides-privacy-policy,
-button.fides-banner-button.fides-manage-preferences-button,
+button.fides-banner-button.fides-banner-button-tertiary,
 div.fides-i18n-pseudo-button {
   margin: 0;
   line-height: 1;
@@ -1098,6 +1098,18 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
   .fides-banner-secondary-actions {
     gap: 12px;
   }
+
+  /* ordering needs to be specific for mobile to work well and
+  varies from the desktop ordering beyond simple `column-reverse` */
+  .fides-banner-secondary-actions .fides-manage-preferences-button {
+    order: 0;
+  }
+  .fides-banner-secondary-actions #fides-privacy-policy-link {
+    order: 1;
+  }
+  .fides-banner-secondary-actions .fides-i18n-menu {
+    order: 2;
+  }
 }
 /* TCF should always be full width and not floating */
 .fides-tcf-banner-container {
@@ -1111,6 +1123,11 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
 }
 .fides-tcf-banner-container #fides-privacy-policy-link {
   margin: auto;
+}
+@media screen and (max-width: 768px) {
+  .fides-tcf-banner-container #fides-banner {
+    padding: 24px;
+  }
 }
 
 /* Paging */


### PR DESCRIPTION
### Description Of Changes

Fixes a newly introduced issue with overlay banner layout, specifically with the positioning of the buttons.

Includes some added polish for noticed issues while testing the mobile version.


### Code Changes

* Reverts and HTML ordering change made [in a recent commit](https://github.com/ethyca/fides/pull/5125/files#diff-ae153e26075500c4b8af65798b4e815786cb27a5f50304e1877e7265c3ad6939L124-L126)
* Fixes some styling issues relating to the banner buttons and layout.

### Steps to Confirm

* Visit TCF enabled experience in the demo site (eg. http://localhost:3001/fides-js-demo.html?geolocation=eea)
* Verify user can scroll the content but the buttons remain sticky at the bottom
* Verify the "Manage Preferences" button has similar size as other buttons
* Verify order of buttons to ensure Privacy Policy link appears below Manage Preferences and above language switcher

![TCF banner overlay on mobile sized screen](https://github.com/user-attachments/assets/5e58526c-ae66-48b9-b7d5-54b055e5cf16)


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`
