### PR TITLE
Fix language picker cut-off in mobile

### DIFF
--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -134,14 +134,14 @@ export const NoticeConsentButtons = ({
   const handleAcceptAll = () => {
     onSave(
       ConsentMethod.ACCEPT,
-      notices.map((n) => n.notice_key)
+      notices.map((n) => n.notice_key),
     );
   };
 
   const handleAcknowledgeNotices = () => {
     onSave(
       ConsentMethod.ACKNOWLEDGE,
-      notices.map((n) => n.notice_key)
+      notices.map((n) => n.notice_key),
     );
   };
 
@@ -150,7 +150,7 @@ export const NoticeConsentButtons = ({
       ConsentMethod.REJECT,
       notices
         .filter((n) => n.consent_mechanism === ConsentMechanism.NOTICE_ONLY)
-        .map((n) => n.notice_key)
+        .map((n) => n.notice_key),
     );
   };
 

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -9,7 +9,7 @@ import {
   PrivacyNotice,
 } from "../lib/consent-types";
 import { useMediaQuery } from "../lib/hooks/useMediaQuery";
-import { DEFAULT_LOCALE, I18n, Locale } from "../lib/i18n";
+import { DEFAULT_LOCALE, I18n, Locale, messageExists } from "../lib/i18n";
 import Button from "./Button";
 import LanguageSelector from "./LanguageSelector";
 import PrivacyPolicyLink from "./PrivacyPolicyLink";
@@ -40,6 +40,9 @@ export const ConsentButtons = ({
 }: ConsentButtonProps) => {
   const isMobile = useMediaQuery("(max-width: 768px)");
   const includeLanguageSelector = i18n.availableLanguages?.length > 1;
+  const includePrivacyPolicyLink =
+    messageExists(i18n, "exp.privacy_policy_link_label") &&
+    messageExists(i18n, "exp.privacy_policy_url");
   return (
     <div id="fides-button-group">
       <div
@@ -72,7 +75,9 @@ export const ConsentButtons = ({
           isInModal
             ? "fides-modal-button-group fides-modal-secondary-actions"
             : "fides-banner-button-group fides-banner-secondary-actions"
-        } ${includeLanguageSelector ? "fides-button-group-i18n" : ""}`}
+        }${includeLanguageSelector ? " fides-button-group-i18n" : ""}${
+          includePrivacyPolicyLink ? " fides-button-group-privacy-policy" : ""
+        }`}
       >
         {includeLanguageSelector && (
           <LanguageSelector
@@ -90,7 +95,7 @@ export const ConsentButtons = ({
             className="fides-manage-preferences-button"
           />
         )}
-        <PrivacyPolicyLink i18n={i18n} />
+        {includePrivacyPolicyLink && <PrivacyPolicyLink i18n={i18n} />}
       </div>
     </div>
   );
@@ -129,14 +134,14 @@ export const NoticeConsentButtons = ({
   const handleAcceptAll = () => {
     onSave(
       ConsentMethod.ACCEPT,
-      notices.map((n) => n.notice_key),
+      notices.map((n) => n.notice_key)
     );
   };
 
   const handleAcknowledgeNotices = () => {
     onSave(
       ConsentMethod.ACKNOWLEDGE,
-      notices.map((n) => n.notice_key),
+      notices.map((n) => n.notice_key)
     );
   };
 
@@ -145,7 +150,7 @@ export const NoticeConsentButtons = ({
       ConsentMethod.REJECT,
       notices
         .filter((n) => n.consent_mechanism === ConsentMechanism.NOTICE_ONLY)
-        .map((n) => n.notice_key),
+        .map((n) => n.notice_key)
     );
   };
 

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -63,6 +63,7 @@
   --fides-overlay-font-size-title: var(--16px);
   --fides-overlay-font-size-buttons: var(--14px);
   --fides-overlay-padding: 24px;
+  --fides-overlay-padding-tcf: 40px;
   --fides-overlay-button-border-radius: 6px;
   --fides-overlay-button-padding: 8px 16px;
   --fides-overlay-link-v-padding: 4px;
@@ -262,7 +263,6 @@ div#fides-button-group {
 button.fides-banner-button {
   font-size: var(--fides-overlay-font-size-buttons);
   display: inline-block;
-  flex: auto;
   cursor: pointer;
   text-align: center;
   margin: 0;
@@ -1119,14 +1119,15 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
   width: 100%;
   border-radius: 0;
   border-width: 1px 0 0 0;
-  padding: 24px 40px 40px 40px;
+  padding: var(--fides-overlay-padding) var(--fides-overlay-padding-tcf)
+    var(--fides-overlay-padding-tcf) var(--fides-overlay-padding-tcf);
 }
 .fides-tcf-banner-container #fides-privacy-policy-link {
   margin: auto;
 }
 @media screen and (max-width: 768px) {
   .fides-tcf-banner-container #fides-banner {
-    padding: 24px;
+    padding: var(--fides-overlay-padding);
   }
 }
 
@@ -1170,6 +1171,7 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
 .fides-modal-container .fides-i18n-menu {
   position: absolute;
   left: var(--fides-overlay-padding);
+  bottom: var(--fides-overlay-padding);
 }
 
 .fides-modal-container .fides-button-group-i18n {
@@ -1177,6 +1179,17 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
     var(--fides-overlay-font-size-body) +
       (var(--fides-overlay-link-v-padding) * 2)
   );
+}
+
+@media screen and (max-width: 768px) {
+  .fides-banner-button-group.fides-button-group-i18n {
+    min-height: 68px;
+  }
+  .fides-i18n-menu {
+    position: absolute;
+    left: var(--fides-overlay-padding);
+    bottom: var(--fides-overlay-padding);
+  }
 }
 
 div.fides-i18n-pseudo-button {

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -1214,12 +1214,6 @@ div#fides-overlay-wrapper .fides-i18n-pseudo-button {
   max-height: 7rem;
   transition: height 0.5s;
 }
-@media screen and (max-width: 768px) {
-  .fides-i18n-popover {
-    bottom: auto;
-    top: 100%;
-  }
-}
 
 .fides-i18n-menu:hover .fides-i18n-pseudo-button {
   background-color: var(--fides-overlay-hover-color);


### PR DESCRIPTION


### Description Of Changes

Language picker menu is being cut off in the mobile view of overlays. Update the positioning of the button and menu to correct this issue and mimic the layout in the modal where language picker and privacy policy link occupy the same space.

### Code Changes

* CSS tweaks to fix button/menu layouts

### Steps to Confirm

* Visit TCF enabled experience in the demo site in mobile (eg. http://localhost:3001/fides-js-demo.html?geolocation=eea)
* Click to open the Language picker
* Verify the menu opens _up_ and is not cut off

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Update `CHANGELOG.md`
