### PR TITLE
fix button sizes on modal

### DIFF
--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -452,6 +452,10 @@ div#fides-consent-content .fides-modal-description {
   margin-inline: var(--fides-overlay-padding);
 }
 
+.fides-modal-primary-actions .fides-banner-button {
+  flex: 1;
+}
+
 .fides-banner-secondary-actions {
   justify-content: space-between;
 }


### PR DESCRIPTION
### Description Of Changes

Previous button fix, caused a regression on the modal buttons specifically. This update restores the previous style that was removed, but only for those specific buttons.


### Code Changes

* Added `flex: 1` to modal buttons only

### Steps to Confirm

* Visit TCF enabled experience in the demo site in mobile (eg. http://localhost:3001/fides-js-demo.html?geolocation=eea)
* Open the modal
* The buttons at the bottom should span the entire row

![CleanShot 2024-08-07 at 10 04 30@2x](https://github.com/user-attachments/assets/d551f9e4-b77c-478b-b7c8-cb71f754cd0b)