### PR TITLE
Add Peacock Colors and Extension Recommendation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,7 @@ dmypy.json
 
 # VSCode
 .vscode/*
+!.vscode/extensions.json
 !.vscode/launch.json
 !.vscode/settings.json
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["johnpapa.vscode-peacock"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,25 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "./clients/node_modules/typescript/lib",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "typescript.preferences.importModuleSpecifier": "non-relative"
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#dfc1ee",
+    "activityBar.background": "#dfc1ee",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#af8530",
+    "activityBarBadge.foreground": "#15202b",
+    "commandCenter.border": "#15202b99",
+    "sash.hoverBorder": "#dfc1ee",
+    "statusBar.background": "#cb99e3",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#b771d8",
+    "statusBarItem.remoteBackground": "#cb99e3",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#cb99e3",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#cb99e399",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.color": "#cb99e3"
 }


### PR DESCRIPTION
### Description Of Changes

This PR adds settings color the top and bottom bars on VSCode so that it's easier to tell at a glance which Ethyca Repository you have open in a given editor.

`ethyca/fides`
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/f6a90b75-8bc7-425f-ab58-fa6c4f8037a7">

To use the editor colors install: https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock
If you do not want to see editor colors this change will not impact you if you do not have Peacock installed.

I also added Peacock as a extension recommendation to prompt new developers on the project to install it.

### Code Changes

None. 

### Steps to Confirm

1. Install https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock
2. Check that the window border colors change.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
