### PR TITLE
Fix password manager auto complete

### DIFF
--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -549,6 +549,7 @@ export const CustomTextInput = ({
   isRequired = false,
   inputRightElement,
   size,
+  autoComplete,
   ...props
 }: CustomInputProps & StringField) => {
   const [initialField, meta] = useField(props);
@@ -561,6 +562,7 @@ export const CustomTextInput = ({
   const innerInput = (
     <TextInput
       {...field}
+      autoComplete={autoComplete}
       isDisabled={disabled}
       data-testid={`input-${field.name}`}
       placeholder={placeholder}

--- a/clients/admin-ui/src/pages/login.tsx
+++ b/clients/admin-ui/src/pages/login.tsx
@@ -260,6 +260,9 @@ const Login: NextPage = () => {
                         <CustomTextInput
                           name="password"
                           label={isFromInvite ? "Set new password" : "Password"}
+                          autoComplete={
+                            isFromInvite ? "new-password" : "current-password"
+                          }
                           type="password"
                           variant="stacked"
                           size="md"


### PR DESCRIPTION
### Description Of Changes

I added the `autocomplete` attribute to the password input field on the login for so that password managers got the correct hint for whether to show a "new password" form fill or an "existing password" form fill.

https://developer.1password.com/docs/web/compatible-website-design/#password-change-and-reset-forms
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete

**Before:**
<img width="870" alt="image" src="https://github.com/user-attachments/assets/299f3911-607e-4f59-8171-509c7a10a662">

**After:**
<img width="870" alt="image" src="https://github.com/user-attachments/assets/4e0bbdf3-de58-451c-9b88-a92a777b3cd9">

### Code Changes

* [ ] Added `autocomplete` to password input on login page.
* [ ] Passed `autocomplete` field to `CustomTextInput` component.

### Steps to Confirm

* [ ] Add a new user and check that the new password field comes up on 1Password.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
