### PR TITLE
Fix poorly formed HTML for switches

### DIFF
--- a/clients/fides-js/src/components/DataUseToggle.tsx
+++ b/clients/fides-js/src/components/DataUseToggle.tsx
@@ -18,7 +18,7 @@ const DataUseToggle = ({
   includeToggle = true,
 }: {
   noticeKey: string;
-  title?: string;
+  title: string;
   checked: boolean;
   onToggle: (noticeKey: string) => void;
   children?: ComponentChildren;
@@ -75,7 +75,8 @@ const DataUseToggle = ({
           {badge ? <span className="fides-notice-badge">{badge}</span> : null}
           {includeToggle ? (
             <Toggle
-              name={title || ""}
+              label={title}
+              name={noticeKey}
               id={noticeKey}
               checked={checked}
               onChange={onToggle}

--- a/clients/fides-js/src/components/Toggle.tsx
+++ b/clients/fides-js/src/components/Toggle.tsx
@@ -1,6 +1,7 @@
 import { h } from "preact";
 
 const Toggle = ({
+  label,
   name,
   id,
   checked,
@@ -9,6 +10,7 @@ const Toggle = ({
   onLabel,
   offLabel,
 }: {
+  label: string;
   name: string;
   id: string;
   checked: boolean;
@@ -22,7 +24,8 @@ const Toggle = ({
     <div className="fides-toggle" data-testid={`toggle-${name}`}>
       <input
         type="checkbox"
-        aria-label={name}
+        name={name}
+        aria-label={label}
         className="fides-toggle-input"
         onChange={() => {
           onChange(id);

--- a/clients/fides-js/src/components/Toggle.tsx
+++ b/clients/fides-js/src/components/Toggle.tsx
@@ -17,29 +17,22 @@ const Toggle = ({
   onLabel?: string;
   offLabel?: string;
 }) => {
-  const labelId = `toggle-${id}`;
   const labelText = checked ? onLabel : offLabel;
   return (
-    <label
-      className="fides-toggle"
-      htmlFor={name}
-      data-testid={`toggle-${name}`}
-      id={labelId}
-    >
+    <div className="fides-toggle" data-testid={`toggle-${name}`}>
       <input
         type="checkbox"
-        name={name}
+        aria-label={name}
         className="fides-toggle-input"
         onChange={() => {
           onChange(id);
         }}
         checked={checked}
         role="switch"
-        aria-labelledby={labelId}
         disabled={disabled}
       />
       <span className="fides-toggle-display">{labelText}</span>
-    </label>
+    </div>
   );
 };
 

--- a/clients/fides-js/src/components/notices/NoticeToggles.tsx
+++ b/clients/fides-js/src/components/notices/NoticeToggles.tsx
@@ -8,7 +8,7 @@ import { GpcBadge } from "../GpcBadge";
 
 export interface NoticeToggleProps {
   noticeKey: string;
-  title?: string;
+  title: string;
   description?: string;
   checked: boolean;
   disabled: boolean;

--- a/clients/privacy-center/components/consent/ConsentItem.tsx
+++ b/clients/privacy-center/components/consent/ConsentItem.tsx
@@ -80,6 +80,7 @@ const ConsentItem = ({
 
         <Box>
           <Toggle
+            label={name}
             name={id}
             id={id}
             disabled={disabled}

--- a/clients/privacy-center/components/consent/Toggle.tsx
+++ b/clients/privacy-center/components/consent/Toggle.tsx
@@ -15,29 +15,22 @@ const Toggle = ({
   onLabel?: string;
   offLabel?: string;
 }) => {
-  const labelId = `toggle-${id}`;
   const labelText = checked ? onLabel : offLabel;
   return (
-    <label
-      className="fides-toggle"
-      htmlFor={name}
-      data-testid={`toggle-${name}`}
-      id={labelId}
-    >
+    <div className="fides-toggle" data-testid={`toggle-${name}`}>
       <input
         type="checkbox"
-        name={name}
+        aria-label={name}
         className="fides-toggle-input"
         onChange={() => {
           onChange(id);
         }}
         checked={checked}
         role="switch"
-        aria-labelledby={labelId}
         disabled={disabled}
       />
       <span className="fides-toggle-display">{labelText}</span>
-    </label>
+    </div>
   );
 };
 

--- a/clients/privacy-center/components/consent/Toggle.tsx
+++ b/clients/privacy-center/components/consent/Toggle.tsx
@@ -1,4 +1,5 @@
 const Toggle = ({
+  label,
   name,
   id,
   checked,
@@ -7,6 +8,7 @@ const Toggle = ({
   onLabel,
   offLabel,
 }: {
+  label: string;
   name: string;
   id: string;
   checked: boolean;
@@ -20,7 +22,8 @@ const Toggle = ({
     <div className="fides-toggle" data-testid={`toggle-${name}`}>
       <input
         type="checkbox"
-        aria-label={name}
+        name={name}
+        aria-label={label}
         className="fides-toggle-input"
         onChange={() => {
           onChange(id);


### PR DESCRIPTION
Closes [PROD-2394](https://ethyca.atlassian.net/browse/PROD-2394)

### Description Of Changes

Browser was logging issues with poorly formed HTML around the labeling of our switches. This was also causing problems for a11y and made it so screen readers would not be able to deal with the switches correctly.

These changes simplify the labeling and correctly implement the expected a11y support.


### Code Changes

* Convert the switch wrapper from `<label>` to `<div>` and label the input using `aria-label` instead.
* Clean up other useless or incorrect relationships.

### Steps to Confirm

**Privacy Center**
* Visit the privacy center consent page (http://localhost:3001/consent)
* Ensure that functionality and look-and-feel of the switches on this page have not changed
* Right-click and "inspect" the switch and verify that on the `<input ...>` element the `aria-label` matches the human readable name of the section.
* 

**Fides JS**
* Visit the demo page (http://localhost:3001/fides-js-demo.html)
* Open the "manage preferences" modal
* Ensure that functionality and look-and-feel of the switches on the modal have not changed
* Right-click and "inspect" the switch and verify that on the `<input ...>` element the `aria-label` matches the human readable name of the section.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
