### PR TITLE
ensure that action buttons are displayed for empty results

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns.tsx
@@ -62,7 +62,7 @@ const useDiscoveryResultColumns = ({
       columnHelper.display({
         id: "action",
         cell: (props) =>
-          props.row.original.diff_status === DiffStatus.MONITORED ? (
+          props.row.original.diff_status !== DiffStatus.MUTED ? (
             <DiscoveryItemActions resource={props.row.original} />
           ) : (
             <DefaultCell value="--" />


### PR DESCRIPTION
Closes [PROD-2505](https://ethyca.atlassian.net/browse/PROD-2505)

Requires BE changes from https://github.com/ethyca/fidesplus/pull/1556 to be effective

### Description Of Changes

This tweak on the FE allows "empty" schemas to be shown in discovery results and acted upon.


### Code Changes

* [x] show actions on discovery results if the row's diff status _isn't_ `muted`, rather than only on `monitored` rows

### Steps to Confirm

* [x] manually tested with BE branch and actions are showing in the column, see second row in below screenshot:
<img width="1231" alt="image" src="https://github.com/user-attachments/assets/51dc2d78-5e4d-4882-aa33-e3670c939d2c">



### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!


[PROD-2505]: https://ethyca.atlassian.net/browse/PROD-2505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ