### PR TITLE
[PROD-2588] Support PATCH requests for connection secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 - Added support for SSO Login with multiple providers (Fides Plus feature) [#5134](https://github.com/ethyca/fides/pull/5134)
 - Added current version to the window.Fides object [#5173](https://github.com/ethyca/fides/pull/5173)
 - Adds user_read scope to approver role so that they can update their own password [#5178](https://github.com/ethyca/fides/pull/5178)
+- Added PATCH endpoint for partially updating connection secrets [#5172](https://github.com/ethyca/fides/pull/5172)
 
 ### Fixed
 - Fixed the OAuth2 configuration for the Snap integration [#5158](https://github.com/ethyca/fides/pull/5158)

--- a/src/fides/api/api/v1/endpoints/connection_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/connection_endpoints.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import Depends
 from fastapi.params import Query, Security
@@ -265,12 +265,12 @@ def patch_connection_config_secrets(
     """
     connection_config = get_connection_config_or_error(db, connection_key)
 
-    existing_secrets = connection_config.secrets
+    existing_secrets: Optional[Dict[str, Any]] = connection_config.secrets
 
     # We create the new secrets object by combining the existing secrets with the new secrets.
     patched_secrets = {}
     if existing_secrets:
-        patched_secrets = {**existing_secrets}  # type: ignore[arg-type]
+        patched_secrets = {**existing_secrets}
 
     patched_secrets = {
         **patched_secrets,

--- a/src/fides/api/api/v1/endpoints/connection_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/connection_endpoints.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from fastapi import Depends
 from fastapi.params import Query, Security
@@ -266,9 +266,14 @@ def patch_connection_config_secrets(
     connection_config = get_connection_config_or_error(db, connection_key)
 
     existing_secrets = connection_config.secrets
+
     # We create the new secrets object by combining the existing secrets with the new secrets.
-    patched_secrets: connection_secrets_schemas = {
-        **existing_secrets,  # type: ignore[arg-type]
+    patched_secrets = {}
+    if existing_secrets:
+        patched_secrets = {**existing_secrets}  # type: ignore[arg-type]
+
+    patched_secrets = {
+        **patched_secrets,
         **unvalidated_secrets,
     }
 


### PR DESCRIPTION
Closes [PROD-2588](https://ethyca.atlassian.net/browse/PROD-2588)

### Description Of Changes

Adds a new `PATCH` endpoint for connection secrets so that each field can be updated individually. This supports a UX improvement for the Integrations page. 

### Code Changes

* Added the new endpoint `PATCH /connection/{connection_key}/secret`
* Added relevant unit tests

### Steps to Confirm

* Create an integration, either from the admin UI or from the API 
* Call the PATCH endpoint, e.g from Swagger UI, and update just one field of the connection secret using this new endpoint: For example in a big query integration, you can send the `dataset` field
* Endpoint should return 200 and integration secrets should be updated, only changing the field(s) you sent in the request

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!


[PROD-2588]: https://ethyca.atlassian.net/browse/PROD-2588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ