### PR TITLE
include `name` in timeout retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 - Fixed the OAuth2 configuration for the Snap integration [#5158](https://github.com/ethyca/fides/pull/5158)
 - Fixes a Marigold Sailthru error when a user does not exist [#5145](https://github.com/ethyca/fides/pull/5145)
 - Fixed malformed HTML issue on switch components [#5166](https://github.com/ethyca/fides/pull/5166)
+- Fixed a timing issue with tcf/gpp locator iframe naming [#5173](https://github.com/ethyca/fides/pull/5173)
 
 ## [2.42.1](https://github.com/ethyca/fides/compare/2.42.0...2.42.1)
 

--- a/clients/fides-js/src/lib/cmp-stubs.ts
+++ b/clients/fides-js/src/lib/cmp-stubs.ts
@@ -17,7 +17,7 @@ export const addFrame = (name: IabFrameName) => {
       iframe.name = name;
       window.document.body.appendChild(iframe);
     } else {
-      setTimeout(addFrame, 5);
+      setTimeout(() => addFrame(name), 5);
     }
   }
 };


### PR DESCRIPTION
Closes [FIDES-1135](https://ethyca.atlassian.net/browse/FIDES-1135)

### Description Of Changes

Include passed in `name` when retrying after timeout is set. Otherwise the iframe name gets added as `undefined`.

### Steps to Confirm

* load demo page with tcf experience (eg. http://localhost:3001/fides-js-demo.html?geolocation=eea)
* find the iframe using the following in the browser console ```document.getElementsByName("__tcfapiLocator")```
* validate that the console responds with a single iframe

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`


[FIDES-1135]: https://ethyca.atlassian.net/browse/FIDES-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ