### PR TITLE
PROD-1782: Allows approver to view user management table so they can reset their own password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.42.1...main)
 
 ### Added
-- Added support for mapping a system's inegration's consentable items to privacy notices [#5156](https://github.com/ethyca/fides/pull/5156)
+- Added support for mapping a system's integration's consentable items to privacy notices [#5156](https://github.com/ethyca/fides/pull/5156)
 - Added support for SSO Login with multiple providers (Fides Plus feature) [#5134](https://github.com/ethyca/fides/pull/5134)
 - Added current version to the window.Fides object [#5173](https://github.com/ethyca/fides/pull/5173)
+- Adds user_read scope to approver role so that they can update their own password [#5178](https://github.com/ethyca/fides/pull/5178)
 
 ### Fixed
 - Fixed the OAuth2 configuration for the Snap integration [#5158](https://github.com/ethyca/fides/pull/5158)

--- a/src/fides/api/oauth/roles.py
+++ b/src/fides/api/oauth/roles.py
@@ -76,6 +76,7 @@ approver_scopes = [
     PRIVACY_REQUEST_CALLBACK_RESUME,
     PRIVACY_REQUEST_UPLOAD_DATA,
     PRIVACY_REQUEST_VIEW_DATA,
+    USER_READ,  # allows approver to view user management table and update their own password
 ]
 
 


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-1782

### Description Of Changes

Adds a scope to the approver role so that they can view the user management section of the Admin-UI. We already have appropriate checks in place so that the approver cannot delete other users or change other users' info.

### Code Changes

* [ ] Update scope for approvers

### Steps to Confirm

* [ ] Create an approver user
* [ ] Confirm they can change their own password 
* [ ] Confirm they cannot make any changes to other users' info

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
