### PR TITLE
Right-align bulk action buttons on discovery tables

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryFieldBulkActions.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryFieldBulkActions.tsx
@@ -35,7 +35,6 @@ const DiscoveryFieldBulkActions = ({
       direction="row"
       align="center"
       justify="center"
-      w="full"
       data-testid="bulk-actions-menu"
     >
       <ButtonGroup>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryResultTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryResultTable.tsx
@@ -163,17 +163,13 @@ const DiscoveryResultTable = ({ resourceUrn }: MonitorResultTableProps) => {
             <SearchInput value={searchQuery} onChange={setSearchQuery} />
           </Box>
           <IconLegendTooltip />
-          {!!selectedUrns.length && (
-            <Flex align="center">
-              {resourceType === StagedResourceType.TABLE && (
-                <DiscoveryTableBulkActions selectedUrns={selectedUrns} />
-              )}
-            </Flex>
-          )}
-          {resourceType === StagedResourceType.FIELD && (
-            <DiscoveryFieldBulkActions resourceUrn={resourceUrn!} />
-          )}
         </Flex>
+        {resourceType === StagedResourceType.TABLE && !!selectedUrns.length && (
+          <DiscoveryTableBulkActions selectedUrns={selectedUrns} />
+        )}
+        {resourceType === StagedResourceType.FIELD && (
+          <DiscoveryFieldBulkActions resourceUrn={resourceUrn!} />
+        )}
       </TableActionBar>
       <FidesTableV2
         tableInstance={tableInstance}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryTableBulkActions.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryTableBulkActions.tsx
@@ -39,7 +39,6 @@ const DiscoveryTableBulkActions = ({
       direction="row"
       align="center"
       justify="center"
-      w="full"
       data-testid="bulk-actions-menu"
     >
       <Text


### PR DESCRIPTION
Closes PROD-2591

### Description Of Changes

Right-align bulk table actions menu on table- and field-level discovery results tables.

Old:

![Screenshot 2024-08-12 at 14 57 54](https://github.com/user-attachments/assets/cd7729b2-c0b2-4710-b3ce-8cf05b404d96)
![Screenshot 2024-08-12 at 14 58 01](https://github.com/user-attachments/assets/071283c5-7dfb-4566-8cca-861ae3db1a1a)

New:

![Screenshot 2024-08-12 at 14 58 49](https://github.com/user-attachments/assets/cd78e46a-a3e7-444e-b58b-281769721a57)
![Screenshot 2024-08-12 at 14 58 54](https://github.com/user-attachments/assets/448a5fea-9cff-480e-ba00-0e7b08d7c486)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
