### PR TITLE
Fix various issues with Consentable Items form

### DIFF
--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
@@ -218,8 +218,7 @@ export const ConsentAutomationForm = ({
           >
             <Text mb={7}>
               Configure the notices that will trigger consent propagation for
-              this integration. A default value can be used to trigger every
-              consent preference or each item can be configured individually.
+              this integration.
             </Text>
             <Formik initialValues={initialValues || {}} onSubmit={handleSubmit}>
               <Form>

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
@@ -95,7 +95,8 @@ export const ConsentAutomationForm = ({
 
   const { data, isLoading: isLoadingConsentableItems } =
     useGetConsentableItemsQuery(connectionKey);
-  const [consentableItemsMutationTrigger] = useUpdateConsentableItemsMutation();
+  const [consentableItemsMutationTrigger, { isLoading: isSubmitting }] =
+    useUpdateConsentableItemsMutation();
 
   const noticePage = useAppSelector(selectNoticePage);
   const noticePageSize = useAppSelector(selectNoticePageSize);
@@ -248,6 +249,9 @@ export const ConsentAutomationForm = ({
                   <Button
                     bg="primary.800"
                     color="white"
+                    isDisabled={isSubmitting}
+                    isLoading={isSubmitting}
+                    loadingText="Submitting"
                     size="sm"
                     variant="solid"
                     type="submit"

--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -450,7 +450,7 @@ const plusApi = baseApi.injectEndpoints({
     }),
     getConsentableItems: build.query<ConsentableItem[], string>({
       query: (connectionKey) => ({
-        url: `plus/${CONNECTION_ROUTE}/${connectionKey}/consentable-items`,
+        url: `plus${CONNECTION_ROUTE}/${connectionKey}/consentable-items`,
       }),
       providesTags: () => ["Consentable Items"],
     }),
@@ -459,7 +459,7 @@ const plusApi = baseApi.injectEndpoints({
       { connectionKey: string; consentableItems: ConsentableItem[] }
     >({
       query: ({ connectionKey, consentableItems }) => ({
-        url: `plus/${CONNECTION_ROUTE}/${connectionKey}/consentable-items`,
+        url: `plus${CONNECTION_ROUTE}/${connectionKey}/consentable-items`,
         method: "PUT",
         body: consentableItems,
       }),


### PR DESCRIPTION
Closes [PROD-2344](https://ethyca.atlassian.net/browse/PROD-2344)

### Description Of Changes

* There was an extra forward-slash in the endpoint URL causing problems
* tie the save button on the Consentable Items form to the `isLoading` flag so we can get the spinner to show up
* remove "default notices" text since we ended up not adding that feature
