### PR TITLE
Dynamically load GVL translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The types of changes are:
 
 ### Changed
 - Removed PRIVACY_REQUEST_READ scope from Viewer role [#5184](https://github.com/ethyca/fides/pull/5184)
+- Asynchronously load GVL translations in FidesJS instead of blocking UI rendering [#5187](https://github.com/ethyca/fides/pull/5187)
 
 
 ### Developer Experience

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -125,7 +125,7 @@ console.log(Fides.getModalLinkLabel({ disableLocalization: true })); // "Your Pr
 
 Applying the link text to a custom modal link element:
 ```html
-<button class="my-custom-show-modal" id="fides-modal-link-label" onclick="Fides.showModal()" />
+<button class="my-custom-show-modal" id="fides-modal-link-label" onclick="Fides.showModal()"><button>
 <script>
  document.getElementById('fides-modal-link-label').innerText = Fides.getModalLinkLabel();
 </script>

--- a/clients/fides-js/src/components/LanguageSelector.tsx
+++ b/clients/fides-js/src/components/LanguageSelector.tsx
@@ -1,9 +1,6 @@
 import { h } from "preact";
 
-import {
-  FIDES_I18N_ICON,
-  FIDES_OVERLAY_WRAPPER,
-} from "../lib/consent-constants";
+import { FIDES_OVERLAY_WRAPPER } from "../lib/consent-constants";
 import { FidesInitOptions } from "../lib/consent-types";
 import { debugLog } from "../lib/consent-utils";
 import {
@@ -29,19 +26,18 @@ const LanguageSelector = ({
   options,
   isTCF,
 }: LanguageSelectorProps) => {
-  const { currentLocale, setCurrentLocale } = useI18n();
+  const { currentLocale, setCurrentLocale, setIsLoading } = useI18n();
 
   const handleLocaleSelect = async (locale: string) => {
     if (locale !== i18n.locale) {
       if (isTCF) {
-        const icon = document.getElementById(FIDES_I18N_ICON);
-        icon?.style.setProperty("animation-name", "spin");
+        setIsLoading(true);
         const gvlTranslations = await fetchGvlTranslations(
           options.fidesApiUrl,
           [locale],
           options.debug,
         );
-        icon?.style.removeProperty("animation-name");
+        setIsLoading(false);
         if (gvlTranslations && Object.keys(gvlTranslations).length) {
           loadMessagesFromGVLTranslations(
             i18n,

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -14,7 +14,10 @@ import { debugLog } from "../../lib/consent-utils";
 import { transformTcfPreferencesToCookieKeys } from "../../lib/cookie";
 import { dispatchFidesEvent } from "../../lib/events";
 import { useConsentServed } from "../../lib/hooks";
-import { selectBestExperienceConfigTranslation } from "../../lib/i18n";
+import {
+  loadMessagesFromGVLTranslations,
+  selectBestExperienceConfigTranslation,
+} from "../../lib/i18n";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import { updateConsentPreferences } from "../../lib/preferences";
 import {
@@ -37,6 +40,7 @@ import type {
   TCFVendorLegitimateInterestsRecord,
   TCFVendorSave,
 } from "../../lib/tcf/types";
+import { fetchGvlTranslations } from "../../services/api";
 import Button from "../Button";
 import ConsentBanner from "../ConsentBanner";
 import Overlay from "../Overlay";
@@ -229,11 +233,32 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
 
   const { currentLocale, setCurrentLocale } = useI18n();
 
-  useEffect(() => {
-    if (!currentLocale && i18n.locale) {
-      setCurrentLocale(i18n.locale);
+  const { locale, getDefaultLocale } = i18n;
+  const defaultLocale = getDefaultLocale();
+
+  const loadGVLTranslations = async () => {
+    const gvlTranslations = await fetchGvlTranslations(
+      options.fidesApiUrl,
+      [locale],
+      options.debug,
+    );
+    if (gvlTranslations) {
+      loadMessagesFromGVLTranslations(i18n, gvlTranslations, [locale]);
+      debugLog(options.debug, `Fides GVL translations updated to ${locale}`);
     }
-  }, [currentLocale, i18n.locale, setCurrentLocale]);
+    setCurrentLocale(locale);
+  };
+
+  useEffect(() => {
+    if (!currentLocale && locale && defaultLocale) {
+      if (locale !== defaultLocale) {
+        loadGVLTranslations();
+      } else {
+        setCurrentLocale(locale);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentLocale, locale, defaultLocale, setCurrentLocale]);
 
   // Determine which ExperienceConfig history ID should be used for the
   // reporting APIs, based on the selected locale

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -231,20 +231,22 @@ const TcfOverlay: FunctionComponent<OverlayProps> = ({
 
   const [draftIds, setDraftIds] = useState<EnabledIds>(initialEnabledIds);
 
-  const { currentLocale, setCurrentLocale } = useI18n();
+  const { currentLocale, setCurrentLocale, setIsLoading } = useI18n();
 
   const { locale, getDefaultLocale } = i18n;
   const defaultLocale = getDefaultLocale();
 
   const loadGVLTranslations = async () => {
+    setIsLoading(true);
     const gvlTranslations = await fetchGvlTranslations(
       options.fidesApiUrl,
       [locale],
       options.debug,
     );
+    setIsLoading(false);
     if (gvlTranslations) {
       loadMessagesFromGVLTranslations(i18n, gvlTranslations, [locale]);
-      debugLog(options.debug, `Fides GVL translations updated to ${locale}`);
+      debugLog(options.debug, `Fides GVL translations loaded for ${locale}`);
     }
     setCurrentLocale(locale);
   };

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -110,7 +110,7 @@ export interface Fides {
    * @example
    * Applying the link text to a custom modal link element:
    * ```html
-   * <button class="my-custom-show-modal" id="fides-modal-link-label" onclick="Fides.showModal()" />
+   * <button class="my-custom-show-modal" id="fides-modal-link-label" onclick="Fides.showModal()"><button>
    * <script>
    *  document.getElementById('fides-modal-link-label').innerText = Fides.getModalLinkLabel();
    * </script>

--- a/clients/fides-js/src/lib/i18n/i18n-context.tsx
+++ b/clients/fides-js/src/lib/i18n/i18n-context.tsx
@@ -3,23 +3,38 @@ import {
   Dispatch,
   StateUpdater,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "preact/hooks";
 
+import { FIDES_I18N_ICON } from "../consent-constants";
+
 interface I18nContextProps {
   currentLocale: string | undefined;
   setCurrentLocale: Dispatch<StateUpdater<string | undefined>>;
+  isLoading: boolean;
+  setIsLoading: Dispatch<StateUpdater<boolean>>;
 }
 
 const I18nContext = createContext<I18nContextProps>({} as I18nContextProps);
 
 export const I18nProvider: FunctionComponent = ({ children }) => {
   const [currentLocale, setCurrentLocale] = useState<string>();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    const icon = document.getElementById(FIDES_I18N_ICON);
+    if (isLoading) {
+      icon?.style.setProperty("animation-name", "spin");
+    } else {
+      icon?.style.removeProperty("animation-name");
+    }
+  }, [isLoading]);
 
   const value: I18nContextProps = useMemo(
-    () => ({ currentLocale, setCurrentLocale }),
-    [currentLocale],
+    () => ({ currentLocale, setCurrentLocale, isLoading, setIsLoading }),
+    [currentLocale, isLoading],
   );
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
 };

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -1,4 +1,5 @@
 import {
+  ComponentType,
   ExperienceConfig,
   ExperienceConfigTranslation,
   FidesExperienceTranslationOverrides,
@@ -268,6 +269,24 @@ export function loadMessagesFromExperience(
 }
 
 /**
+ *
+ */
+export function loadGVLMessagesFromExperience(
+  i18n: I18n,
+  experience: Partial<PrivacyExperience>,
+) {
+  if (!experience.gvl) {
+    return;
+  }
+  const { locale } = i18n;
+  const gvlTranslations: GVLTranslations = {};
+  gvlTranslations[locale] = experience.gvl;
+  const extracted: Record<Locale, Messages> =
+    extractMessagesFromGVLTranslations(gvlTranslations, [locale]);
+  i18n.load(locale, extracted[locale]);
+}
+
+/**
  * Parse the provided GVLTranslations object and load all translated strings
  * into the message catalog.
  */
@@ -522,6 +541,18 @@ export function initializeI18n(
     i18n.getDefaultLocale(),
   );
   i18n.activate(bestLocale);
+
+  // Now that we've activated the best locale, load the GVL messages if needed.
+  // First load default language messages from the experience's GVL to avoid
+  // delay in rendering the overlay. If a translation is needed, it will be
+  // loaded in the background.
+  if (
+    experience.experience_config?.component === ComponentType.TCF_OVERLAY &&
+    !!experience.gvl
+  ) {
+    loadGVLMessagesFromExperience(i18n, experience);
+  }
+
   debugLog(
     options?.debug,
     `Initialized Fides i18n with best locale match = ${bestLocale}`,

--- a/clients/fides-js/src/lib/initOverlay.ts
+++ b/clients/fides-js/src/lib/initOverlay.ts
@@ -1,12 +1,8 @@
 import { ContainerNode, render } from "preact";
 
 import { OverlayProps } from "../components/types";
-import { fetchGvlTranslations } from "../services/api";
 import { ComponentType } from "./consent-types";
 import { debugLog } from "./consent-utils";
-import { DEFAULT_LOCALE } from "./i18n";
-import { loadMessagesFromGVLTranslations } from "./i18n/i18n-utils";
-import { LOCALE_LANGUAGE_MAP } from "./i18n/locales";
 import { ColorFormat, generateLighterColor } from "./style-utils";
 
 const FIDES_EMBED_CONTAINER_ID = "fides-embed-container";
@@ -37,34 +33,6 @@ export const initOverlay = async ({
   renderOverlay: (props: OverlayProps, parent: ContainerNode) => void;
 }): Promise<void> => {
   debugLog(options.debug, "Initializing Fides consent overlays...");
-
-  if (experience.experience_config?.component === ComponentType.TCF_OVERLAY) {
-    let gvlTranslations = await fetchGvlTranslations(
-      options.fidesApiUrl,
-      [i18n.locale],
-      options.debug,
-    );
-    if (
-      (!gvlTranslations || Object.keys(gvlTranslations).length === 0) &&
-      experience.gvl
-    ) {
-      // if translations API fails or is empty, use the GVL object directly
-      // as a fallback, since it already contains the english version of strings
-      gvlTranslations = {};
-      gvlTranslations[DEFAULT_LOCALE] = experience.gvl;
-      // eslint-disable-next-line no-param-reassign
-      experience.available_locales = [DEFAULT_LOCALE];
-      i18n.setAvailableLanguages(
-        LOCALE_LANGUAGE_MAP.filter((lang) => lang.locale === DEFAULT_LOCALE),
-      );
-      i18n.activate(DEFAULT_LOCALE);
-    }
-    loadMessagesFromGVLTranslations(
-      i18n,
-      gvlTranslations,
-      experience.available_locales || [DEFAULT_LOCALE],
-    );
-  }
 
   async function renderFidesOverlay(): Promise<void> {
     try {

--- a/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-i18n.cy.ts
@@ -1490,8 +1490,10 @@ describe("Consent i18n", () => {
           fixture,
           options: { tcfEnabled: true },
         });
-        cy.wait("@getGvlTranslations");
         testTcfBannerLocalization(banner);
+        if (locale === SPANISH_LOCALE) {
+          cy.wait("@getGvlTranslations");
+        }
         testTcfModalLocalization(modal);
       });
     });
@@ -1501,10 +1503,6 @@ describe("Consent i18n", () => {
           navigatorLanguage: ENGLISH_LOCALE,
           fixture: "experience_tcf.json",
           options: { tcfEnabled: true },
-        });
-        cy.wait("@getGvlTranslations").then((interception) => {
-          const { url } = interception.request;
-          expect(url.split("?")[1]).to.eq(`language=${ENGLISH_LOCALE}`);
         });
         cy.get("#fides-banner").should("be.visible");
         cy.get(
@@ -1540,12 +1538,10 @@ describe("Consent i18n", () => {
           fixture: "experience_tcf.json",
           options: { tcfEnabled: true },
         });
-        cy.wait("@getGvlTranslations");
         cy.get("#fides-banner").should("be.visible");
-        cy.get(".fides-i18n-menu").should("not.exist");
         cy.get(".fides-notice-toggle")
           .first()
-          .contains(/^Selection of personalised(.*)/);
+          .contains(/^Selection of personalised(.*)/); // english fallback
       });
     });
   });
@@ -1758,7 +1754,6 @@ describe("Consent i18n", () => {
           fixture: "experience_tcf.json",
           options: { tcfEnabled: true },
         });
-        cy.wait("@getGvlTranslations");
         cy.get("#fides-modal-link").click();
         cy.getByTestId("records-list-purposes").within(() => {
           cy.get(".fides-toggle:first").contains("Off");
@@ -1788,7 +1783,6 @@ describe("Consent i18n", () => {
           fixture: "experience_tcf.json",
           options: { tcfEnabled: true },
         });
-        cy.wait("@getGvlTranslations");
         cy.get("#fides-modal-link").click();
         cy.getByTestId("records-list-purposes").within(() => {
           cy.get(".fides-toggle:first").contains("Off").should("not.exist");


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

The current implementation ensures that the call to the language API does not block `FidesInitialized`. With these changes, it also doesn't block `FidesUIShown`.

Loads the UI immediately using English for the GVL string and asynchronously loads the resulting translation (if not English) as it becomes available.

On most connections, this is completely transparent to the user. For slower connections the user may see English strings in the banner GVL strings for a brief moment. For non-TCF overlays, these changes have zero effect or need.

![CleanShot 2024-08-13 at 12 43 37@2x](https://github.com/user-attachments/assets/12510c36-fa14-49d7-a747-6f8841642b47)

### Code Changes

* Fix malformed `<button>` in the example documentation
* Use the GVL strings from Experience to pre-populate GVL in the banner.
* load GVL translations after UI is already initialized (moved to the `TFCOverlay` component)
* update globe spinner to be more DRY
* update e2e tests affected by these changes.

### Steps to Confirm

* For non-TCF experiences, nothing should change.
* For TCF experiences (in DEBUG mode for console messages to appear) when visiting with a non-English locale (eg. http://localhost:3001/fides-js-demo.html?geolocation=eea&fides_locale=es):
  * Open browser console and notice that "Rendering Fides overlay CSS & HTML into the DOM..." is logged _before_ "Recieved GVL languages response from Fides API" (the reverse was true, prior to these changes)
  * The text in the right side of the banner is displayed in the appropriate non-english text after loading.
* For TCF experiences from an English locale (eg. http://localhost:3001/fides-js-demo.html?geolocation=eea&fides_locale=en)
  * Open browser console and notice that "Recieved GVL languages response from Fides API" never gets logged (it was redundantly called prior to these changes)


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
