### PR TITLE
Fix text reflow on Privacy Center when user hovers

### DIFF
--- a/clients/privacy-center/components/Card.tsx
+++ b/clients/privacy-center/components/Card.tsx
@@ -42,6 +42,8 @@ const Card = ({ title, iconPath, description, onClick }: CardProps) => (
         "0px 10px 15px -3px rgba(0, 0, 0, 0.1), 0px 4px 6px -2px rgba(0, 0, 0, 0.05)",
       outline: "none",
     }}
+    border="1px solid"
+    borderColor="transparent"
   >
     <Image alt={description} boxSize="32px" src={iconPath} />
     <Text


### PR DESCRIPTION
### Description Of Changes

When a user hovers or focuses any of the buttons in the Privacy Center, the inner content size of the buttons changes due to the addition of borders since we use `box-size: border-box`. Adding a transparent border that is always present prevents this text reflow.

#### Before

https://github.com/user-attachments/assets/7f762bad-0b09-4193-b0a7-f7264d4cddd5

#### After

https://github.com/user-attachments/assets/05176603-0c9e-48bd-b49a-013e769ce1dc

### Code Changes

* [ ] Add transparent 1px border to all Cards on Privacy Center.

### Steps to Confirm

* [ ] Take Zola's text on their privacy center page and hover each of the buttons. You should see no text reflow happen.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
