### PR TITLE
Oracle Responsys: ignore `404`s on delete endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.43.0...main)
 
+### Fixed
+- Ignore `404` errors on Oracle Responsys deletions [#5203](https://github.com/ethyca/fides/pull/5203)
 
 ## [2.43.0](https://github.com/ethyca/fides/compare/2.42.1...2.43.0)
 

--- a/data/saas/config/oracle_responsys_config.yml
+++ b/data/saas/config/oracle_responsys_config.yml
@@ -3,7 +3,7 @@ saas_config:
   name: Oracle Responsys
   type: oracle_responsys
   description: A sample schema representing the Oracle Responsys connector for Fides
-  version: 0.0.2
+  version: 0.0.3
 
   connector_params:
     - name: domain

--- a/src/fides/api/service/saas_request/override_implementations/oracle_responsys_request_overrides.py
+++ b/src/fides/api/service/saas_request/override_implementations/oracle_responsys_request_overrides.py
@@ -272,7 +272,8 @@ def oracle_responsys_profile_list_recipients_delete(
                 SaaSRequestParams(
                     method=HTTPMethod.DELETE,
                     path=f"/rest/api/v1.3/lists/{list_id}/members/{responsys_id}",
-                )
+                ),
+                [404],
             )
 
             rows_deleted += 1


### PR DESCRIPTION
Closes FIDES-1070

### Description Of Changes

This prevents race conditions when duplicate requests are submitted or the responsys user is deleted outside of Fides


### Code Changes

* [ ] ignore 404s on `oracle_responsys_profile_list_recipients_delete`

### Steps to Confirm

* [ ] submit two erasure requests for the same identity and approve both at the same time. 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
