### PR TITLE
Bump integration versions for changes in #5054

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.43.0...main)
 
+### Fixed
+- Bumps versions of integrations as required for their changes to take effect [#5207](https://github.com/ethyca/fides/pull/5207)
 
 ## [2.43.0](https://github.com/ethyca/fides/compare/2.42.1...2.43.0)
 

--- a/data/saas/config/adyen_config.yml
+++ b/data/saas/config/adyen_config.yml
@@ -4,7 +4,7 @@ saas_config:
   type: adyen
   description: A sample schema representing the Adyen integrations for Fides
   user_guide: https://docs.ethyca.com/user-guides/integrations/saas-integrations/adyen
-  version: 0.1.0
+  version: 0.1.1
 
   connector_params:
     - name: domain_management

--- a/data/saas/config/appsflyer_config.yml
+++ b/data/saas/config/appsflyer_config.yml
@@ -4,7 +4,7 @@ saas_config:
   type: appsflyer
   description: A sample schema representing the AppsFlyer connector for Fides
   user_guide: https://docs.ethyca.com/user-guides/integrations/saas-integrations/appsflyer
-  version: 0.1.0
+  version: 0.1.1
 
   connector_params:
     - name: domain

--- a/data/saas/config/statsig_enterprise_config.yml
+++ b/data/saas/config/statsig_enterprise_config.yml
@@ -4,7 +4,7 @@ saas_config:
   type: statsig_enterprise
   description: A sample schema representing the Statsig connector for Fides
   user_guide: https://docs.ethyca.com/user-guides/integrations/saas-integrations/statsig-enterprise
-  version: 0.1.0
+  version: 0.1.1
 
   connector_params:
     - name: domain


### PR DESCRIPTION
Closes FIDES-1154

### Description Of Changes

This was found when troubleshooting an error message from a user:

```
Custom SaaS override 'appsflyer_user_read' does not exist. Valid custom SaaS override classes for SaaSRequestType SaaSRequestType.READ are [firebase_auth_user_access, iterate_company_read, marigold_engage_user_read, oracle_responsys_profile_list_recipients_read, oracle_responsys_profile_extension_recipients_read]
```

It appears the custom overrides were removed as part of #5054 but the version were not bumped. Any deployed integration that uses this Fides version will continue to look for the override


### Code Changes

* [x] Bump the impacted integrations versions

### Steps to Confirm

* [ ] We can do this manually today and restart the service, so it can cover the gap in the meantime

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
