### PR TITLE
PROD-2626 Privacy-Request-screen-crashes-when-daysLeft-null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The types of changes are:
 
 ### Fixed
 - Ignore `404` errors on Oracle Responsys deletions [#5203](https://github.com/ethyca/fides/pull/5203)
+- Fix white screen issue when privacy request has null value for daysLeft [#5213](https://github.com/ethyca/fides/pull/5213)
+
 
 ## [2.43.0](https://github.com/ethyca/fides/compare/2.42.1...2.43.0)
 

--- a/clients/admin-ui/src/features/privacy-requests/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/cells.tsx
@@ -75,6 +75,7 @@ export const RequestDaysLeftCell = ({
 }) => {
   if (
     daysLeft === undefined ||
+    daysLeft === null ||
     status === PrivacyRequestStatus.COMPLETE ||
     status === PrivacyRequestStatus.CANCELED ||
     status === PrivacyRequestStatus.DENIED ||


### PR DESCRIPTION
### Description Of Changes

Fix privacy request screen crashes when a PrivacyRequestResponse daysLeft property is null.

![Screen Shot 2024-08-19 at 16 27 47](https://github.com/user-attachments/assets/afd7c6b9-3422-46e1-8daa-bf3d572c5db2)


### Code Changes

* [ ] Change RequestDaysLeftCell to return null if daysLeft is null

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
