### PR TITLE
FidesJS sourcemaps working correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.43.1...main)
 
+### Developer Experience
+- Sourcemaps are now working for fides-js in debug mode [#5222](https://github.com/ethyca/fides/pull/5222)
+
 
 
 ## [2.43.1](https://github.com/ethyca/fides/compare/2.43.0...2.43.1)

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -127,7 +127,7 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
         file: `dist/${name}.js`,
         name: isExtension ? undefined : "Fides",
         format: isExtension ? undefined : "umd",
-        sourcemap: IS_DEV ? "inline" : false,
+        sourcemap: IS_DEV && !isExtension ? "inline" : false,
       },
     ],
   };

--- a/clients/privacy-center/cypress/e2e/fides-js.cy.ts
+++ b/clients/privacy-center/cypress/e2e/fides-js.cy.ts
@@ -12,7 +12,7 @@ describe("fides.js API route", () => {
       // 2) ...includes a call to Fides.init with a config JSON that...
       // 3) ...is populated with the config.json options
       expect(response.body)
-        .to.match(/^\s+\(function/, "should be an IIFE")
+        .to.match(/^\(function/, "should be an IIFE")
         .to.match(/\}\)\(\);\s+$/, "should be an IIFE");
       expect(response.body)
         .to.match(/window.Fides.config = \{/, "should bundle Fides.init")

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -279,19 +279,17 @@ export default async function handler(
   const { initialize: initializeQuery } = req.query;
   const skipInitialization = initializeQuery === "false";
 
-  const script = `
-  (function () {
-    // Include generic fides.js script and GPP extension (if enabled)
-    ${fidesJS}${fidesGPP}${
-      customFidesCss
-        ? `
-    // Include custom fides.css styles
+  // keep fidesJS on the first line to avoid sourcemap issues!
+  const script = `(function () {${fidesJS}
+  ${fidesGPP}
+  ${
+    customFidesCss
+      ? `// Include custom fides.css styles
     const style = document.createElement('style');
     style.innerHTML = ${JSON.stringify(customFidesCss)};
-    document.head.append(style);
-    `
-        : ""
-    }
+    document.head.append(style);`
+      : ""
+  }
   window.Fides.config = ${fidesConfigJSON};
   ${skipInitialization ? "" : `window.Fides.init();`}
   ${


### PR DESCRIPTION
Sourcemaps for `fides.js` and `fides-tcf.js` are now functional with this change. GPP doesn't work, but since nothing worked before, this is a huge improvement.

Clicking from console logs etc. will take you to the correct source in the browser. Setting breakpoints is now possible.

### Code Changes

* Removes sourcemaps for GPP extension (conflicted with fides.js sourcemap)
* Moves fides.js output to first line to maintain line numbering with source maps

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`
