### PR TITLE
Improve Data uses row interactions

### DIFF
--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
@@ -42,7 +42,11 @@ const PrivacyDeclarationRow = ({
       >
         <Box px={6} py={4} data-testid={`row-${declaration.data_use}`}>
           <HStack>
-            <LinkOverlay onClick={() => handleEdit(declaration)}>
+            <LinkOverlay
+              onClick={() => handleEdit(declaration)}
+              role="button"
+              tabIndex={0}
+            >
               <Text>{title || declaration.data_use}</Text>
             </LinkOverlay>
             <Spacer />

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
@@ -34,52 +34,56 @@ const PrivacyDeclarationRow = ({
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <>
-      <Box px={6} py={4} data-testid={`row-${declaration.data_use}`}>
-        <HStack>
-          <LinkBox
-            onClick={() => handleEdit(declaration)}
-            w="100%"
-            h="100%"
-            cursor="pointer"
-          >
-            <LinkOverlay>
+      <LinkBox
+        w="100%"
+        h="100%"
+        cursor="pointer"
+        _hover={{ backgroundColor: "gray.50" }}
+      >
+        <Box px={6} py={4} data-testid={`row-${declaration.data_use}`}>
+          <HStack>
+            <LinkOverlay onClick={() => handleEdit(declaration)}>
               <Text>{title || declaration.data_use}</Text>
             </LinkOverlay>
-          </LinkBox>
-          <Spacer />
-          {handleDelete ? (
-            <>
-              <IconButton
-                aria-label="delete-declaration"
-                variant="outline"
-                zIndex={2}
-                size="sm"
-                onClick={onOpen}
-                data-testid="delete-btn"
-              >
-                <DeleteIcon />
-              </IconButton>
-              <ConfirmationModal
-                isOpen={isOpen}
-                onClose={onClose}
-                onConfirm={() => handleDelete(declaration)}
-                title="Delete data use declaration"
-                message={
-                  <Text>
-                    You are about to delete the data use declaration{" "}
-                    <Text color="complimentary.500" as="span" fontWeight="bold">
-                      {title || declaration.data_use}
+            <Spacer />
+            {handleDelete ? (
+              <>
+                <IconButton
+                  aria-label="delete-declaration"
+                  variant="outline"
+                  zIndex={2}
+                  size="sm"
+                  onClick={onOpen}
+                  data-testid="delete-btn"
+                >
+                  <DeleteIcon />
+                </IconButton>
+                <ConfirmationModal
+                  isOpen={isOpen}
+                  onClose={onClose}
+                  onConfirm={() => handleDelete(declaration)}
+                  title="Delete data use declaration"
+                  message={
+                    <Text>
+                      You are about to delete the data use declaration{" "}
+                      <Text
+                        color="complimentary.500"
+                        as="span"
+                        fontWeight="bold"
+                      >
+                        {title || declaration.data_use}
+                      </Text>
+                      , including all its cookies. Are you sure you want to
+                      continue?
                     </Text>
-                    , including all its cookies. Are you sure you want to
-                    continue?
-                  </Text>
-                }
-                isCentered
-              />
-            </>
-          ) : null}
-        </HStack>
-      </Box>
+                  }
+                  isCentered
+                />
+              </>
+            ) : null}
+          </HStack>
+        </Box>
+      </LinkBox>
       <Divider />
     </>
   );


### PR DESCRIPTION
### Description Of Changes

- Row hover color
- Expand clickable row area, used to only be able to click on the label's content area.

**Before**
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/e6535317-770c-4540-9453-df9d37ba4c3e">

**After**
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/22a827dc-1ea9-4a1a-8e4b-d8cc3240a800">





### Code Changes

* [ ] Updated Data uses tab on systems configure page.

### Steps to Confirm

* [ ] Go configure a system with data uses, hover the row, click on the row but not on the label for the row.
* [ ] Click the trashcan icon.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
