### PR TITLE
Add Gzip Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.43.1...main)
 
+### Added
 
+- Added Gzip Middleware for responses [#5225](https://github.com/ethyca/fides/pull/5225)
 
 ## [2.43.1](https://github.com/ethyca/fides/compare/2.43.0...2.43.1)
 

--- a/src/fides/api/app_setup.py
+++ b/src/fides/api/app_setup.py
@@ -7,6 +7,7 @@ from logging import DEBUG
 from typing import AsyncGenerator, List
 
 from fastapi import APIRouter, FastAPI
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.routing import APIRoute
 from loguru import logger
 from redis.exceptions import RedisError, ResponseError
@@ -82,6 +83,8 @@ def create_fides_app(
         # Starlette bug causing this to fail mypy
         fastapi_app.add_exception_handler(FunctionalityNotConfigured, handler)  # type: ignore
     fastapi_app.add_middleware(SlowAPIMiddleware)
+    fastapi_app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)  # minimum_size is in bytes
+
 
     for router in routers:
         fastapi_app.include_router(router)

--- a/src/fides/api/app_setup.py
+++ b/src/fides/api/app_setup.py
@@ -83,8 +83,9 @@ def create_fides_app(
         # Starlette bug causing this to fail mypy
         fastapi_app.add_exception_handler(FunctionalityNotConfigured, handler)  # type: ignore
     fastapi_app.add_middleware(SlowAPIMiddleware)
-    fastapi_app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)  # minimum_size is in bytes
-
+    fastapi_app.add_middleware(
+        GZipMiddleware, minimum_size=1000, compresslevel=5
+    )  # minimum_size is in bytes
 
     for router in routers:
         fastapi_app.include_router(router)


### PR DESCRIPTION
Partially Closes #2604

### Description Of Changes

Add Gzip middleware https://fastapi.tiangolo.com/advanced/middleware/#gzipmiddleware specially for compressing responses in Fidesplus Experience Translations. 


### Code Changes

* [ ] Adds Gzip middleware 

### Steps to Confirm

* [ ] Test in Fidesplus - https://github.com/ethyca/fidesplus/pull/1575.  This middleware isn't used for small responses and  without a request header

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
