### PR TITLE
Fix crashing integrations after pydantic update

### DIFF
--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -236,7 +236,7 @@ export const ConnectorParametersForm = ({
       ).map((action) => action.toString());
 
       // @ts-ignore
-      initialValues.secrets = connectionConfig.secrets ?? {};
+      initialValues.secrets = connectionConfig.secrets ? _.cloneDeep(connectionConfig.secrets) : {};
 
       // check if we need we need to pre-process any secrets values
       // we currently only need to do this for Fides dataset references
@@ -245,8 +245,10 @@ export const ConnectorParametersForm = ({
         Object.entries(secretsSchema.properties).forEach(([key, schema]) => {
           if (schema.allOf?.[0].$ref === FIDES_DATASET_REFERENCE) {
             const datasetReference = initialValues.secrets[key];
-            initialValues.secrets[key] =
-              `${datasetReference.dataset}.${datasetReference.field}`;
+            if (datasetReference) {
+              initialValues.secrets[key] =
+                `${datasetReference.dataset}.${datasetReference.field}`;
+            }
           }
         });
       }

--- a/clients/admin-ui/src/types/api/models/ConnectionConfigurationResponse.ts
+++ b/clients/admin-ui/src/types/api/models/ConnectionConfigurationResponse.ts
@@ -22,7 +22,7 @@ export type ConnectionConfigurationResponse = {
   last_test_timestamp?: string | null;
   last_test_succeeded?: boolean | null;
   saas_config?: SaaSConfigBase | null;
-  secrets?: null;
+  secrets?: any;
   authorized?: boolean | null;
   enabled_actions?: Array<ActionType> | null;
 };


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

After the Pydantic update, integrations that contain a FidesDatasetReference field as part of their secrets are causing the frontend to crash


### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
