### PR TITLE
PROD-2648: Remove unused parameter in Snap integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Changed
 - Removed unused `username` parameter from the Delighted integration configuration [#5220](https://github.com/ethyca/fides/pull/5220)
+- Removed unused `ad_account_id` parameter from the Snap integration configuration [#5229](https://github.com/ethyca/fides/pull/5220)
 
 ### Developer Experience
 - Sourcemaps are now working for fides-js in debug mode [#5222](https://github.com/ethyca/fides/pull/5222)
@@ -31,7 +32,6 @@ The types of changes are:
 - Added success toast on muting/ignoring resources in D&D tables [#5214](https://github.com/ethyca/fides/pull/5214)
 - Added "data type" column to fields and subfields on D&D tables [#5218](https://github.com/ethyca/fides/pull/5218)
 - Added support for navigating and editing nested fields in the Datasets page [#5216](https://github.com/ethyca/fides/pull/5216)
-
 
 ### Fixed
 - Ignore `404` errors on Oracle Responsys deletions [#5203](https://github.com/ethyca/fides/pull/5203)

--- a/data/saas/config/snap_config.yml
+++ b/data/saas/config/snap_config.yml
@@ -3,7 +3,7 @@ saas_config:
   name: Snap
   type: snap
   description: A sample schema representing the Snap integration for Fides
-  version: 0.1.1
+  version: 0.1.2
 
   connector_params:
     - name: domain
@@ -15,8 +15,6 @@ saas_config:
     - name: client_secret
       label: Snap client secret key
       sensitive: true
-    - name: ad_account_id
-      label: Ad account ID
     - name: redirect_uri
       label: Redirect URL
       description: The Fides URL to which users will be redirected upon successful authentication

--- a/tests/fixtures/saas/snap_fixtures.py
+++ b/tests/fixtures/saas/snap_fixtures.py
@@ -20,8 +20,6 @@ def snap_secrets(saas_config) -> Dict[str, Any]:
         or secrets["snap_client_id"],
         "client_secret": pydash.get(saas_config, "snap.client_secret")
         or secrets["snap_client_secret"],
-        "ad_account_id": pydash.get(saas_config, "snap.ad_account_id")
-        or secrets["ad_account_id"],
         "redirect_uri": pydash.get(saas_config, "snap.redirect_uri")
         or secrets["redirect_uri"],
         "access_token": pydash.get(saas_config, "snap.access_token")


### PR DESCRIPTION
Closes PROD-2648

### Description Of Changes

Removes an unused parameter in the Snap connector. `ad_account_id` is collected as configuration, but it's never used in the integration or its overrides.


### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
