### PR TITLE
PROD-2415 : Adding ignore 400 to unsubscribe call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The types of changes are:
 ### Developer Experience
 - Sourcemaps are now working for fides-js in debug mode [#5222](https://github.com/ethyca/fides/pull/5222)
 
+### Fixed
+- Ignoring HTTP 400 error responses from the unsubscribe endpoint for HubSpot [#5237](https://github.com/ethyca/fides/pull/5237)
+
 ## [2.43.1](https://github.com/ethyca/fides/compare/2.43.0...2.43.1)
 
 ### Added

--- a/data/saas/config/hubspot_config.yml
+++ b/data/saas/config/hubspot_config.yml
@@ -4,7 +4,7 @@ saas_config:
   type: hubspot
   description: A sample schema representing the HubSpot connector for Fides
   user_guide: https://docs.ethyca.com/user-guides/integrations/saas-integrations/hubspot
-  version: 0.0.5
+  version: 0.0.6
 
   connector_params:
     - name: domain
@@ -105,6 +105,7 @@ saas_config:
               "legalBasisExplanation": "At users request, we opted them out"
             }
           data_path: subscriptionStatuses
+          ignore-errors: [400]
           param_values:
             - name: email
               identity: email

--- a/data/saas/config/hubspot_config.yml
+++ b/data/saas/config/hubspot_config.yml
@@ -105,7 +105,7 @@ saas_config:
               "legalBasisExplanation": "At users request, we opted them out"
             }
           data_path: subscriptionStatuses
-          ignore-errors: [400]
+          ignore_errors: [400]
           param_values:
             - name: email
               identity: email


### PR DESCRIPTION
Partially Closes [# 2415](https://ethyca.atlassian.net/browse/PROD-2415).

### Description Of Changes
We are adding the 400 Ignore errors for the unsubscribe call.

A PR For expanding the Ignore errors functionality to a postprocessor that checks the error message is on the way, See [PR-5211](https://github.com/ethyca/fides/pull/5211)


### Code Changes

* [ ] Updating hubspot confi.yml

### Steps to Confirm

Attempt to Replicate bug reported on [the Issue](https://ethyca.atlassian.net/browse/PROD-2415)

* [ ] Set up a subscription of Hubspot
* [ ] Remove twice the email subscribed there 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
