### PR TITLE
include autofix for VS code users

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,14 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "./clients/node_modules/typescript/lib",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
+  "[javascript, typescript, typescriptreact]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
+  },
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
   }


### PR DESCRIPTION
Uses filetype specific settings to avoid potential conflicts with the Python side of things.