### PR TITLE
add timing to debug logs for fides.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.44.0...main)
 
+### Developer Experience
+- Added performance mark timings to debug logs for fides.js [#5245](https://github.com/ethyca/fides/pull/5245)
+
 
 ## [2.44.0](https://github.com/ethyca/fides/compare/2.43.1...2.44.0)
 

--- a/clients/fides-js/src/lib/events.ts
+++ b/clients/fides-js/src/lib/events.ts
@@ -65,7 +65,7 @@ export const dispatchFidesEvent = (
     const event = new CustomEvent(type, {
       detail: { ...cookie, debug, extraDetails: constructedExtraDetails },
     });
-    performance?.mark(type);
+    const perfMark = performance?.mark(type);
     debugLog(
       debug,
       `Dispatching event type ${type} ${
@@ -76,7 +76,7 @@ export const dispatchFidesEvent = (
         constructedExtraDetails
           ? `with extra details ${JSON.stringify(constructedExtraDetails)} `
           : ""
-      }`,
+      } (${perfMark?.startTime?.toFixed(2)}ms)`,
     );
     window.dispatchEvent(event);
   }

--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -177,6 +177,30 @@
       } else {
         window.addEventListener("FidesInitialized", onInitialized);
       }
+
+      window.addEventListener("FidesUIShown", () => {
+        // Log event timing
+        const fidesLoaded = performance
+          .getEntriesByType("resource")
+          .find((entry) => entry.name.includes("fides"));
+        const fidesEvents = performance
+          .getEntriesByType("mark")
+          .filter((entry) => entry.name.includes("Fides"));
+
+        const fidesTiming = {};
+        fidesTiming[
+          `fides.js (${(fidesLoaded.encodedBodySize / 1000).toFixed(2)} kB)`
+        ] = {
+          "Time (ms)": parseFloat(fidesLoaded.responseEnd.toFixed(2)),
+        };
+        fidesEvents.map((entry) => {
+          const name = entry.name;
+          fidesTiming[name] = {
+            "Time (ms)": parseFloat(entry.startTime.toFixed(2)),
+          };
+        });
+        console.table(fidesTiming);
+      });
     })();
   </script>
 </html>


### PR DESCRIPTION
### Description Of Changes

Adds timings to our debug logs for fides.js

![debug timings](https://github.com/user-attachments/assets/e3fdac41-7580-460b-82b9-ec20aa11d06e)

### Steps to Confirm

* Run the demo site with console log open, preferable with an experience (like TCF) where the banner appears (eg. `http://localhost:3001/fides-js-demo.html?geolocation=eea`)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`
