### PR TITLE
PROD-2701 Fix no monitor button on empty tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The types of changes are:
 ### Fixed
 - Fix bug where Data Detection & Discovery table pagination fails to reset after navigating or searching  [#5234](https://github.com/ethyca/fides/pull/5234)
 - Ignoring HTTP 400 error responses from the unsubscribe endpoint for HubSpot [#5237](https://github.com/ethyca/fides/pull/5237)
+- Fix bug where empty datasets / table wouldn't show a Monitor button  [#5249](https://github.com/ethyca/fides/pull/5249)
 
 ### Security
 - Reduced timing differences in login endpoint [CVE-2024-45052](https://github.com/ethyca/fides/security/advisories/GHSA-2h46-8gf5-fmxv)

--- a/clients/admin-ui/src/features/data-discovery-and-detection/utils/findResourceType.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/utils/findResourceType.ts
@@ -8,7 +8,7 @@ export const findResourceType = (
     return StagedResourceType.NONE;
   }
   if (item.resource_type) {
-    return item.resource_type;
+    return item.resource_type as StagedResourceType;
   }
 
   // Fallback to match the resource type based on the presence of

--- a/clients/admin-ui/src/features/data-discovery-and-detection/utils/findResourceType.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/utils/findResourceType.ts
@@ -7,6 +7,12 @@ export const findResourceType = (
   if (!item) {
     return StagedResourceType.NONE;
   }
+  if (item.resource_type) {
+    return item.resource_type;
+  }
+
+  // Fallback to match the resource type based on the presence of
+  // nested resources.
   if (item.schemas?.length) {
     return StagedResourceType.DATABASE;
   }


### PR DESCRIPTION
### Description Of Changes

Fix no monitor button appearing on empty tables.

The problem was caused because the FE was trying to figure out the resource type based off the nested resource content. This caused a problem with empty tables causing it to think that it was a Field and therefore not showing a Monitor icon. The BE now returns a resource_type so we should use that instead. I still left the other code as a fallback since resource_type is listed as an optional property.

### Code Changes

* [ ] Get resource type from the BE property first, before trying to infer the type based on it's nested resources

### Steps to Confirm

* [ ] Run a DnD monitor with our test BQ
* [ ] Look at the monitor results in the Data Detection / Activity pages
* [ ] Check that we now display a Monitor button for the empty_dataset

### Pre-Merge Checklist
* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`