### PR TITLE
PROD-2705 Fix broken dnd pagination

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDetectionResultsFilterTabs.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDetectionResultsFilterTabs.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { ResourceChangeType } from "~/features/data-discovery-and-detection/types/ResourceChangeType";
 import { DiffStatus } from "~/types/api";
@@ -12,25 +12,28 @@ const useDetectionResultsFilterTabs = ({
 }: DetectionResultFiltersTabsProps) => {
   const [filterTabIndex, setFilterTabIndex] = useState(initialFilterTabIndex);
 
-  const filterTabs = [
-    {
-      label: "Action Required",
-      filters: [DiffStatus.ADDITION, DiffStatus.REMOVAL],
-      childFilters: [DiffStatus.ADDITION, DiffStatus.REMOVAL],
-    },
-    {
-      label: "Monitored",
-      filters: [DiffStatus.MONITORED],
-      childFilters: [],
-      changeTypeOverride: ResourceChangeType.MONITORED,
-    },
-    {
-      label: "Unmonitored",
-      filters: [DiffStatus.MUTED],
-      childFilters: [],
-      changeTypeOverride: ResourceChangeType.MUTED,
-    },
-  ];
+  const filterTabs = useMemo(
+    () => [
+      {
+        label: "Action Required",
+        filters: [DiffStatus.ADDITION, DiffStatus.REMOVAL],
+        childFilters: [DiffStatus.ADDITION, DiffStatus.REMOVAL],
+      },
+      {
+        label: "Monitored",
+        filters: [DiffStatus.MONITORED],
+        childFilters: [],
+        changeTypeOverride: ResourceChangeType.MONITORED,
+      },
+      {
+        label: "Unmonitored",
+        filters: [DiffStatus.MUTED],
+        childFilters: [],
+        changeTypeOverride: ResourceChangeType.MUTED,
+      },
+    ],
+    [],
+  );
 
   return {
     filterTabs,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultsFilterTabs.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultsFilterTabs.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { DiffStatus } from "~/types/api";
 
@@ -16,24 +16,27 @@ const useDiscoveryResultsFilterTabs = ({
 }: DiscoveryResultsFilterTabsProps) => {
   const [filterTabIndex, setFilterTabIndex] = useState(initialFilterTabIndex);
 
-  const filterTabs = [
-    {
-      label: "Action Required",
-      filters: [
-        DiffStatus.CLASSIFICATION_ADDITION,
-        DiffStatus.CLASSIFICATION_UPDATE,
-      ],
-      childFilters: [
-        DiffStatus.CLASSIFICATION_ADDITION,
-        DiffStatus.CLASSIFICATION_UPDATE,
-      ],
-    },
-    {
-      label: "Unmonitored",
-      filters: [DiffStatus.MUTED],
-      childFilters: [],
-    },
-  ];
+  const filterTabs = useMemo(
+    () => [
+      {
+        label: "Action Required",
+        filters: [
+          DiffStatus.CLASSIFICATION_ADDITION,
+          DiffStatus.CLASSIFICATION_UPDATE,
+        ],
+        childFilters: [
+          DiffStatus.CLASSIFICATION_ADDITION,
+          DiffStatus.CLASSIFICATION_UPDATE,
+        ],
+      },
+      {
+        label: "Unmonitored",
+        filters: [DiffStatus.MUTED],
+        childFilters: [],
+      },
+    ],
+    [],
+  );
 
   return {
     filterTabs,


### PR DESCRIPTION
### Description Of Changes

Fix broken dnd pagination after adding tab filters.


### Code Changes

* [ ] Added useMemo to get a consistent value for activeDiffFilters and activeChildDiffFilters since those are used as dependencies to reset the pagination

### Steps to Confirm

* [ ] Go to Data Detection Page
* [ ] Check that you can navigate to Page 2
* [ ] Go to Data Discovery Page
* [ ] Check that you can navigate to Page 2

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met