### PR TITLE
revert AddModal refactor

### DIFF
--- a/clients/admin-ui/src/features/common/EditDrawer.tsx
+++ b/clients/admin-ui/src/features/common/EditDrawer.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  ButtonGroup,
   CloseIcon,
   Drawer,
   DrawerBody,
@@ -34,6 +35,7 @@ export const EditDrawerHeader = ({ title }: { title: string }) => (
 
 export const EditDrawerFooter = ({
   onDelete,
+  onEditYaml,
   formId,
   isSaving,
 }: {
@@ -44,6 +46,7 @@ export const EditDrawerFooter = ({
   formId?: string;
   isSaving?: boolean;
   onDelete?: () => void;
+  onEditYaml?: () => void;
 } & Pick<Props, "onClose">) => (
   <DrawerFooter justifyContent="space-between">
     {onDelete ? (
@@ -56,17 +59,22 @@ export const EditDrawerFooter = ({
         data-testid="delete-btn"
       />
     ) : null}
-
-    <Button
-      type="submit"
-      colorScheme="primary"
-      size="sm"
-      data-testid="save-btn"
-      form={formId}
-      isLoading={isSaving}
-    >
-      Save
-    </Button>
+    <ButtonGroup size="sm">
+      {onEditYaml && (
+        <Button variant="outline" onClick={onEditYaml}>
+          Edit YAML
+        </Button>
+      )}
+      <Button
+        type="submit"
+        colorScheme="primary"
+        data-testid="save-btn"
+        form={formId}
+        isLoading={isSaving}
+      >
+        Save
+      </Button>
+    </ButtonGroup>
   </DrawerFooter>
 );
 

--- a/clients/admin-ui/src/features/dataset/EditDatasetDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditDatasetDrawer.tsx
@@ -1,5 +1,6 @@
 import { ConfirmationModal, Text, useDisclosure, useToast } from "fidesui";
 import { useRouter } from "next/router";
+import { useState } from "react";
 
 import EditDrawer, {
   EditDrawerFooter,
@@ -7,6 +8,7 @@ import EditDrawer, {
 } from "~/features/common/EditDrawer";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
+import YamlEditorModal from "~/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/YamlEditorModal";
 import { Dataset } from "~/types/api";
 
 import {
@@ -24,7 +26,7 @@ interface Props {
   onClose: () => void;
 }
 const EditDatasetDrawer = ({ dataset, isOpen, onClose }: Props) => {
-  const [updateDataset] = useUpdateDatasetMutation();
+  const [updateDataset, { isLoading }] = useUpdateDatasetMutation();
   const [deleteDataset] = useDeleteDatasetMutation();
   const router = useRouter();
   const toast = useToast();
@@ -33,6 +35,15 @@ const EditDatasetDrawer = ({ dataset, isOpen, onClose }: Props) => {
     onOpen: onDeleteOpen,
     onClose: onDeleteClose,
   } = useDisclosure();
+  const {
+    isOpen: yamlIsOpen,
+    onOpen: onYamlOpen,
+    onClose: onYamlClose,
+  } = useDisclosure();
+
+  const [datasetYaml, setDatasetYaml] = useState<Dataset | undefined>(
+    undefined,
+  );
 
   const handleSubmit = async (values: Partial<Dataset>) => {
     const updatedDataset = { ...dataset!, ...values };
@@ -75,10 +86,21 @@ const EditDatasetDrawer = ({ dataset, isOpen, onClose }: Props) => {
           <EditDrawerFooter
             onClose={onClose}
             onDelete={onDeleteOpen}
+            onEditYaml={() => onYamlOpen()}
             formId={FORM_ID}
           />
         }
       >
+        <YamlEditorModal
+          isOpen={yamlIsOpen}
+          onClose={onYamlClose}
+          onChange={setDatasetYaml}
+          onSubmit={() => handleSubmit(datasetYaml!)}
+          title="Edit dataset YAML"
+          isLoading={isLoading}
+          isDatasetSelected={false}
+          dataset={dataset}
+        />
         <EditDatasetForm values={dataset!} onSubmit={handleSubmit} />
       </EditDrawer>
       <ConfirmationModal

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/YamlEditor.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/YamlEditor.tsx
@@ -12,6 +12,7 @@ type YamlEditorFormProps = {
   data: Dataset[];
   isSubmitting: boolean;
   onChange: (value: Dataset) => void;
+  onSubmit?: () => void;
   isLoading?: boolean;
   onCancel?: () => void;
   disabled?: boolean;
@@ -21,6 +22,7 @@ const YamlEditor = ({
   data = [],
   isSubmitting = false,
   onCancel,
+  onSubmit,
   disabled,
   isLoading,
   onChange,
@@ -64,7 +66,12 @@ const YamlEditor = ({
       setIsTouched(true);
       validate(value as string);
       setIsEmptyState(!value || value.trim() === "");
-      onChange(yaml.load(value || "", { json: true }) as Dataset);
+      const yamlDoc = yaml.load(value || "", { json: true });
+      if (Array.isArray(yamlDoc)) {
+        onChange(yamlDoc[0] as Dataset);
+      } else {
+        onChange(yamlDoc as Dataset);
+      }
       checkForOverWrittenKeys();
     } catch (error) {
       if (isYamlException(error)) {
@@ -73,6 +80,11 @@ const YamlEditor = ({
         errorAlert("Could not parse the supplied YAML");
       }
     }
+  };
+
+  const handleSubmit = () => {
+    onSubmit?.();
+    onCancel?.();
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -132,7 +144,7 @@ const YamlEditor = ({
             ) : null}
             <Button
               colorScheme="primary"
-              onClick={onCancel}
+              onClick={handleSubmit}
               data-testid="continue-btn"
               isDisabled={
                 disabled || isEmptyState || !!yamlError || isSubmitting

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/YamlEditorModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/YamlEditorModal.tsx
@@ -16,6 +16,7 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onChange: (value: Dataset) => void;
+  onSubmit?: () => void;
   title?: string;
   isLoading?: boolean;
   returnFocusOnClose?: boolean;
@@ -31,6 +32,7 @@ const YamlEditorModal = ({
   isDatasetSelected,
   dataset,
   onChange,
+  onSubmit,
 }: Props) => (
   <Modal
     isOpen={isOpen}
@@ -48,6 +50,7 @@ const YamlEditorModal = ({
         <Box data-testid="yaml-editor-section">
           <YamlEditor
             data={dataset ? [dataset] : []}
+            onSubmit={onSubmit}
             isSubmitting={false}
             disabled={isDatasetSelected}
             onChange={onChange}


### PR DESCRIPTION
Closes PROD-2661

### Description Of Changes

Allows users to edit dataset YAML from the "Manage datasets" view in the admin UI.

https://github.com/user-attachments/assets/847a0471-bc46-4f0e-b407-421d332acaa4

### Code Changes

* [ ] Changes to YamlEditor and YamlEditorModal components to broaden use case

### Steps to Confirm

* [ ] Visit "Manage datasets" view
* [ ] If necessary, create a dataset
* [ ] Click "Edit"
* [ ] In side drawer, click "Edit YAML"
* [ ] Make changes to YAML meta and save; should see changes applied
* [ ] YAML should show appropriate error when invalid

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
