### PR TITLE
PROD-2644 Improve logging and error visibility for TraversalErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The types of changes are:
 - Validate no path in `server_host` var for CLI config; if there is one then take only up until the first forward slash
 - Update the Datamap report's Data categories column to support better expand/collapse behavior [#5265](https://github.com/ethyca/fides/pull/5265)
 - Rename/refactor Privacy Notice Properties to support performance improvements [#5259](https://github.com/ethyca/fides/pull/5259)
+- Improved logging and error visibility for TraversalErrors [#5263](https://github.com/ethyca/fides/pull/5263)
 
 ### Developer Experience
 - Added performance mark timings to debug logs for fides.js [#5245](https://github.com/ethyca/fides/pull/5245)

--- a/src/fides/api/common_exceptions.py
+++ b/src/fides/api/common_exceptions.py
@@ -25,6 +25,14 @@ class TraversalError(FidesopsException):
     """Fidesops error with the names of all nodes that could not be reached."""
 
 
+class UnreachableNodesError(TraversalError):
+    """Fidesops error with the names of all nodes that could not be reached."""
+
+
+class UnreachableEdgesError(TraversalError):
+    """Fidesops error with the names of all edges that could not be reached."""
+
+
 class ValidationError(FidesopsException):
     """Data does not pass validation."""
 

--- a/src/fides/api/common_exceptions.py
+++ b/src/fides/api/common_exceptions.py
@@ -22,15 +22,15 @@ class FidesopsException(Exception):
 
 
 class TraversalError(FidesopsException):
-    """Fidesops error with the names of all nodes that could not be reached."""
+    """Error with the names of all nodes that could not be reached."""
 
 
 class UnreachableNodesError(TraversalError):
-    """Fidesops error with the names of all nodes that could not be reached."""
+    """Error with the names of all nodes that could not be reached, inherits from TraversalError."""
 
 
 class UnreachableEdgesError(TraversalError):
-    """Fidesops error with the names of all edges that could not be reached."""
+    """Error with the names of all edges that could not be reached, inherits from TraversalError."""
 
 
 class ValidationError(FidesopsException):

--- a/src/fides/api/graph/traversal.py
+++ b/src/fides/api/graph/traversal.py
@@ -7,7 +7,11 @@ import pydash.collections
 from fideslang.validation import FidesKey
 from loguru import logger
 
-from fides.api.common_exceptions import TraversalError
+from fides.api.common_exceptions import (
+    TraversalError,
+    UnreachableEdgesError,
+    UnreachableNodesError,
+)
 from fides.api.graph.config import (
     ROOT_COLLECTION_ADDRESS,
     TERMINATOR_ADDRESS,
@@ -378,7 +382,6 @@ class Traversal:
                 raise TraversalError(
                     f"""Node could not be reached given the specified ordering:
                     [{','.join([str(tn.address) for tn in running_node_queue.data])}]""",
-                    [str(tn.address) for tn in running_node_queue.data],
                 )
 
         # Remove nodes that have custom request fields, since we don't care if these are reachable or not.
@@ -397,7 +400,7 @@ class Traversal:
                 "Some nodes were not reachable: {}",
                 ",".join([str(x) for x in remaining_node_keys]),
             )
-            raise TraversalError(
+            raise UnreachableNodesError(
                 f"Some nodes were not reachable: {','.join([str(x) for x in remaining_node_keys])}",
                 [key.value for key in remaining_node_keys],
             )
@@ -408,7 +411,7 @@ class Traversal:
                 "Some edges were not reachable: {}",
                 ",".join([str(x) for x in remaining_edges]),
             )
-            raise TraversalError(
+            raise UnreachableEdgesError(
                 f"Some edges were not reachable: {','.join([str(x) for x in remaining_edges])}",
                 [f"{edge}" for edge in remaining_edges],
             )

--- a/src/fides/api/graph/traversal.py
+++ b/src/fides/api/graph/traversal.py
@@ -377,7 +377,8 @@ class Traversal:
                 )
                 raise TraversalError(
                     f"""Node could not be reached given the specified ordering:
-                    [{','.join([str(tn.address) for tn in running_node_queue.data])}]"""
+                    [{','.join([str(tn.address) for tn in running_node_queue.data])}]""",
+                    [str(tn.address) for tn in running_node_queue.data],
                 )
 
         # Remove nodes that have custom request fields, since we don't care if these are reachable or not.

--- a/src/fides/api/graph/traversal.py
+++ b/src/fides/api/graph/traversal.py
@@ -397,7 +397,8 @@ class Traversal:
                 ",".join([str(x) for x in remaining_node_keys]),
             )
             raise TraversalError(
-                f"Some nodes were not reachable: {','.join([str(x) for x in remaining_node_keys])}"
+                f"Some nodes were not reachable: {','.join([str(x) for x in remaining_node_keys])}",
+                [key.value for key in remaining_node_keys],
             )
 
         # error if there are edges that have not been visited
@@ -407,7 +408,8 @@ class Traversal:
                 ",".join([str(x) for x in remaining_edges]),
             )
             raise TraversalError(
-                f"Some edges were not reachable: {','.join([str(x) for x in remaining_edges])}"
+                f"Some edges were not reachable: {','.join([str(x) for x in remaining_edges])}",
+                [f"{edge}" for edge in remaining_edges],
             )
 
         end_nodes = [

--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -1281,6 +1281,29 @@ class PrivacyRequest(
         """Fetched the same filtered access results we uploaded to the user"""
         return self.filtered_final_upload or {}
 
+    def add_error_execution_log(
+        self,
+        db: Session,
+        connection_key: str,
+        dataset_name: str,
+        collection_name: str,
+        message: str,
+        action_type: ActionType,
+    ) -> ExecutionLog:
+        execution_log = ExecutionLog.create(
+            db=db,
+            data={
+                "privacy_request_id": self.id,
+                "connection_key": connection_key,
+                "dataset_name": dataset_name,
+                "collection_name": collection_name,
+                "status": ExecutionLogStatus.error,
+                "message": message,
+                "action_type": action_type,
+            }
+        )
+        return execution_log
+
 
 class PrivacyRequestError(Base):
     """The DB ORM model to track PrivacyRequests error message status."""

--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -1285,8 +1285,8 @@ class PrivacyRequest(
         self,
         db: Session,
         connection_key: Optional[str],
-        dataset_name: str,
-        collection_name: str,
+        dataset_name: Optional[str],
+        collection_name: Optional[str],
         message: str,
         action_type: ActionType,
     ) -> ExecutionLog:

--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -1284,7 +1284,7 @@ class PrivacyRequest(
     def add_error_execution_log(
         self,
         db: Session,
-        connection_key: str,
+        connection_key: Optional[str],
         dataset_name: str,
         collection_name: str,
         message: str,

--- a/src/fides/api/models/privacy_request.py
+++ b/src/fides/api/models/privacy_request.py
@@ -1300,7 +1300,7 @@ class PrivacyRequest(
                 "status": ExecutionLogStatus.error,
                 "message": message,
                 "action_type": action_type,
-            }
+            },
         )
         return execution_log
 

--- a/src/fides/api/task/create_request_tasks.py
+++ b/src/fides/api/task/create_request_tasks.py
@@ -485,15 +485,17 @@ def run_access_request(
                 privacy_request.id,
                 err,
             )
-            errors = ", ".join(err.errors)
-            privacy_request.add_error_execution_log(
-                session,
-                connection_key=errors,
-                dataset_name=errors,
-                collection_name=errors,
-                message=f"{err}",
-                action_type=ActionType.access,
-            )
+            for error in err.errors:
+                dataset, collection = error.split(":")
+                privacy_request.add_error_execution_log(
+                    session,
+                    connection_key=None,
+                    dataset_name=dataset,
+                    collection_name=collection,
+                    message=f"Node {error} is not reachable.",
+                    action_type=ActionType.access,
+                )
+
             privacy_request.error_processing(session)
             raise err
 

--- a/src/fides/api/task/create_request_tasks.py
+++ b/src/fides/api/task/create_request_tasks.py
@@ -7,11 +7,7 @@ from loguru import logger
 from networkx import NetworkXNoCycle
 from sqlalchemy.orm import Query, Session
 
-from fides.api.common_exceptions import (
-    TraversalError,
-    UnreachableEdgesError,
-    UnreachableNodesError,
-)
+from fides.api.common_exceptions import TraversalError
 from fides.api.graph.config import (
     ROOT_COLLECTION_ADDRESS,
     TERMINATOR_ADDRESS,
@@ -19,7 +15,12 @@ from fides.api.graph.config import (
     FieldAddress,
 )
 from fides.api.graph.graph import DatasetGraph
-from fides.api.graph.traversal import ARTIFICIAL_NODES, Traversal, TraversalNode
+from fides.api.graph.traversal import (
+    ARTIFICIAL_NODES,
+    Traversal,
+    TraversalNode,
+    log_traversal_error_and_update_privacy_request,
+)
 from fides.api.models.connectionconfig import ConnectionConfig
 from fides.api.models.policy import Policy
 from fides.api.models.privacy_request import (
@@ -484,44 +485,9 @@ def run_access_request(
                 )
             )
         except TraversalError as err:
-            logger.error(
-                "TraversalError encountered for privacy request {}. Error: {}",
-                privacy_request.id,
-                err,
+            log_traversal_error_and_update_privacy_request(
+                privacy_request, session, err
             )
-            # For generic TraversalErrors, we log a generic error execution log
-            if not isinstance(err, UnreachableNodesError) and not isinstance(
-                err, UnreachableEdgesError
-            ):
-                privacy_request.add_error_execution_log(
-                    session,
-                    connection_key=None,
-                    dataset_name=None,
-                    collection_name=None,
-                    message=str(err),
-                    action_type=ActionType.access,
-                )
-
-            # For specific ones, we iterate over each error in the list
-            for error in err.errors:
-                dataset, collection = (
-                    error.split(":")
-                    if isinstance(
-                        err, UnreachableNodesError
-                    )  # For unreachable nodes, we can get the dataset and collection from the node
-                    else (None, None)  # But not for edges
-                )
-                message = f"{'Node' if isinstance(err, UnreachableNodesError) else 'Edge'} {error} is not reachable"
-                privacy_request.add_error_execution_log(
-                    session,
-                    connection_key=None,
-                    dataset_name=dataset,
-                    collection_name=collection,
-                    message=message,
-                    action_type=ActionType.access,
-                )
-
-            privacy_request.error_processing(session)
             raise err
 
     for task in ready_tasks:

--- a/src/fides/api/task/deprecated_graph_task.py
+++ b/src/fides/api/task/deprecated_graph_task.py
@@ -118,15 +118,16 @@ def run_access_request_deprecated(
             privacy_request.id,
             err,
         )
-        errors = ", ".join(err.errors)
-        privacy_request.add_error_execution_log(
-            session,
-            connection_key=errors,
-            dataset_name=errors,
-            collection_name=errors,
-            message=f"{err}",
-            action_type=ActionType.access,
-        )
+        for error in err.errors:
+            dataset, collection = error.split(":")
+            privacy_request.add_error_execution_log(
+                session,
+                connection_key=None,
+                dataset_name=dataset,
+                collection_name=collection,
+                message=f"Node {error} is not reachable.",
+                action_type=ActionType.access,
+            )
         privacy_request.error_processing(session)
         raise err
 

--- a/src/fides/api/task/deprecated_graph_task.py
+++ b/src/fides/api/task/deprecated_graph_task.py
@@ -5,8 +5,8 @@ import dask
 from dask import delayed  # type: ignore[attr-defined]
 from dask.core import getcycle
 from dask.threaded import get
-from sqlalchemy.orm import Session
 from loguru import logger
+from sqlalchemy.orm import Session
 
 from fides.api.common_exceptions import TraversalError
 from fides.api.graph.config import (

--- a/src/fides/cli/commands/ungrouped.py
+++ b/src/fides/cli/commands/ungrouped.py
@@ -150,7 +150,6 @@ def init(ctx: click.Context, fides_dir: str, opt_in: bool) -> None:
 @click.command()
 @click.pass_context
 @with_analytics
-@with_server_health_check
 def status(ctx: click.Context) -> None:
     """
     Check Fides server availability.
@@ -183,7 +182,6 @@ def webserver(ctx: click.Context, port: int = 8080) -> None:
 @click.command()
 @click.pass_context
 @with_analytics
-@with_server_health_check
 def worker(ctx: click.Context) -> None:
     """
     Start a Celery worker for the Fides webserver.

--- a/tests/ops/task/test_deprecated_graph_task.py
+++ b/tests/ops/task/test_deprecated_graph_task.py
@@ -1,0 +1,57 @@
+import pytest
+
+from fides.api.common_exceptions import TraversalError
+from fides.api.graph.graph import DatasetGraph
+from fides.api.models.privacy_request import (
+    ExecutionLog,
+    ExecutionLogStatus,
+    PrivacyRequestStatus,
+)
+from fides.api.task.deprecated_graph_task import run_access_request_deprecated
+
+
+class TestDeprecatedGraphTasks:
+    def test_run_access_request_deprecated_with_unreachable_nodes(
+        self,
+        db,
+        privacy_request,
+        policy,
+        dataset_graph_with_unreachable_collections: DatasetGraph,
+    ):
+        with pytest.raises(TraversalError) as err:
+            run_access_request_deprecated(
+                privacy_request,
+                policy,
+                dataset_graph_with_unreachable_collections,
+                [],
+                {"email": "customer-4@example.com"},
+                db,
+            )
+
+        assert "Some nodes were not reachable:" in str(err.value)
+        assert "dataset_with_unreachable_collections:login" in str(err.value)
+        assert "dataset_with_unreachable_collections:report" in str(err.value)
+
+        db.refresh(privacy_request)
+        privacy_request.status == PrivacyRequestStatus.error
+
+        # We expect two error logs, one per unreachable collection
+        error_logs = privacy_request.execution_logs.filter(
+            ExecutionLog.status == ExecutionLogStatus.error
+        )
+        assert error_logs.count() == 2
+        error_logs = sorted(
+            error_logs, key=lambda execution_log: execution_log.collection_name
+        )
+        assert error_logs[0].dataset_name == "dataset_with_unreachable_collections"
+        assert error_logs[0].collection_name == "login"
+        assert (
+            error_logs[0].message
+            == "Node dataset_with_unreachable_collections:login is not reachable"
+        )
+        assert error_logs[1].dataset_name == "dataset_with_unreachable_collections"
+        assert error_logs[1].collection_name == "report"
+        assert (
+            error_logs[1].message
+            == "Node dataset_with_unreachable_collections:report is not reachable"
+        )


### PR DESCRIPTION
Closes [PROD-2644](https://ethyca.atlassian.net/browse/PROD-2644)

### Description Of Changes

When a `TraversalError` is raised as part of running an access or erasure request the logged error does not include the privacy request id, making it hard to find, and the UI shows the request in an error state but provides no information on what the error actually was. This PR adds a log that includes the privacy request id, and also creates an `ExecutionLog` instance so the error can be surfaced in the UI.


### Code Changes

* Created two specific error classes `UnreachableNodeError` and `UnreachableEdgeError` that inherit from `TraversalError`, and throw those instead when we have an unreachable node or edge, respectively. 
* Catch all `TraversalErrors` in both `run_access_request` and `run_access_request_deprecated` , log the error _including the id of the privacy request_ , create the necessary `ExecutionLog` instances, and raise the error again.
* Unrelated to the ticket but had to remove the `with_server_health_check` decorator from both the `worker` and `status` commands, they were mistakenly added in a recent PR.

### Steps to Confirm

#### Setup
* Start up Fides with the postgres integration, i.e `nox -s dev -- postgres`
* Create two datasets that have no identities and no references, such as
```yaml
    fides_key: prod-2644-example
    name: Example PROD-2644
    description: Example to reproduce PROD-2644
    collections:
      - name: address
        fields:
          - name: city
            data_categories: [user.contact.address.city]
          - name: house
            data_categories: [user.contact.address.street]
```
and
```yaml
    fides_key: prod-2644-example-2
    name: Example PROD-2644 2
    description: Second example to reproduce PROD-2644
    collections:
      - name: login
        fields:
          - name: id
            data_categories: [user.unique_id]
          - name: customer_id
            data_categories: [user.unique_id]
      - name: report
        fields:
          - name: id
            data_categories: [user.unique_id]
          - name: email
            data_categories: [user.contact.email]
```
* Add two different Postgres integrations to connect to the postgres DB running on port 6432
*  For each integration, go to the integration details, and choose one of the datasets you just created (e.g `prod-2644-example`) from the `Dataset` dropdown. You should have two integrations, each linked to a different dataset

#### DSR 2.0
* From the Privacy Center or the Swagger API , create a Privacy Request. 
* In the Admin UI, open the created privacy request: it should be in `error` status, and there should be an Error log in the `Activity Timeline` section (see screenshots below)

<img width="1728" alt="Screenshot 2024-09-11 at 11 19 14 AM" src="https://github.com/user-attachments/assets/b22ed7a8-4868-45da-8146-faafa3ab8f63">
<img width="1728" alt="Screenshot 2024-09-11 at 11 19 22 AM" src="https://github.com/user-attachments/assets/bb90f17b-e4e2-4c53-9089-51ecf65e6585">
<img width="1725" alt="Screenshot 2024-09-11 at 11 19 29 AM" src="https://github.com/user-attachments/assets/eb28a8a0-386a-41f4-b462-c2c54ba9f53c">

You should also see the log in the fides container, e.g 
`2024-09-06 13:57:08 2024-09-06 16:57:08.400 | ERROR    | fides.api.task.deprecated_graph_task:run_access_request_deprecated:116 - TraversalError encountered for privacy request pri_83ace5f2-e4f7-4c2b-9ce3-fb989cddb214. Error: Some nodes were not reachable:  prod-2644-example:address`

#### DSR 3.0
* Stop your fides server
* Open the `fides.toml` file, and replace the following two lines:
   * in the `[execution]` section, change `use_dsr_3_0=false` to `use_dsr_3_0=true`
   * in the `[celery]` section, change `task_always_eager = true` to `task_always_eager = false`
* Run the server with `nox -s dev -- shell postgres worker`
* Make sure the integrations and datasets you created in the Setup section still exist. 
* Repeat the same steps as for DSR 2.0 -- you may need to manually approve the request from the Admin UI, and wait a bit for the task to run in the worker. 


#### Other error cases
When the error is not for unreachable nodes, but rather a more generic `TraversalError` (e.g there's a cycle) then the error's shown a bit differently in the UI

<img width="1539" alt="Screenshot 2024-09-12 at 2 30 02 PM" src="https://github.com/user-attachments/assets/e4c2cbf1-a298-40d0-be28-e4c3f8142ca1">
<img width="1310" alt="Screenshot 2024-09-12 at 2 30 13 PM" src="https://github.com/user-attachments/assets/689c3438-0adf-4cd2-8ff5-90ef7c9778d0">


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!


[PROD-2644]: https://ethyca.atlassian.net/browse/PROD-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ