### PR TITLE
Expand/Collapse Data Categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 
 ### Changed
 - Validate no path in `server_host` var for CLI config; if there is one then take only up until the first forward slash
+- Update the Datamap report's Data categories column to support better expand/collapse behavior [#5265](https://github.com/ethyca/fides/pull/5265)
 
 
 ## [2.44.0](https://github.com/ethyca/fides/compare/2.43.1...2.44.0)

--- a/clients/admin-ui/__tests__/features/dataset-helpers.test.tsx
+++ b/clients/admin-ui/__tests__/features/dataset-helpers.test.tsx
@@ -50,7 +50,7 @@ describe("dataset helpers", () => {
       const newField = { ...originalField, ...{ name: newName } };
       const collection = mockDatasetCollection({
         fields: [
-          mockDatasetCollection(),
+          mockDatasetCollection() as any,
           mockDatasetCollection(),
           mockDatasetCollection({ fields: [originalField] }),
         ],

--- a/clients/admin-ui/__tests__/test-utils.tsx
+++ b/clients/admin-ui/__tests__/test-utils.tsx
@@ -1,7 +1,7 @@
 // test-utils.jsx
 import { Store } from "@reduxjs/toolkit";
 import { render as rtlRender, RenderOptions } from "@testing-library/react";
-import React from "react";
+import React, { ReactNode } from "react";
 import { Provider } from "react-redux";
 
 import { makeStore, RootState } from "~/app/store";
@@ -19,7 +19,7 @@ function render(
     ...renderOptions
   }: CustomRenderOptions = {},
 ) {
-  const Wrapper = ({ children }) => (
+  const Wrapper = ({ children }: { children: ReactNode }) => (
     <Provider store={customStore}>{children}</Provider>
   );
   return rtlRender(ui, { wrapper: Wrapper, ...renderOptions });

--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -64,11 +64,11 @@ describe("Minimal datamap report table", () => {
     cy.getByTestId("column-system_pokemon_party").contains("Pokemon party");
     cy.getByTestId("column-privacy_declaration_color").contains("Color");
 
-    // Pokemon party is multi-select, so we should have a menu to allow grouping/displaying all
+    // Pokemon party is multi-select, so we should have a menu to allow expanding/collapsing all
     cy.getByTestId("row-0-col-system_pokemon_party").contains("3");
     cy.getByTestId("system_pokemon_party-header-menu").click();
     cy.getByTestId("system_pokemon_party-header-menu-list").within(() => {
-      cy.get("button").contains("Display all").click();
+      cy.get("button").contains("Expand all").click();
     });
     ["eevee", "pikachu", "articuno"].forEach((pokemon) => {
       cy.getByTestId("row-0-col-system_pokemon_party").contains(pokemon);
@@ -133,7 +133,7 @@ describe("Minimal datamap report table", () => {
       cy.getByTestId(
         "system_undeclared_data_categories-header-menu-list",
       ).within(() => {
-        cy.get("button").contains("Display all").click();
+        cy.get("button").contains("Expand all").click();
       });
       ["User Contact Email", "Cookie ID"].forEach((pokemon) => {
         cy.getByTestId("row-0-col-system_undeclared_data_categories").contains(
@@ -145,7 +145,7 @@ describe("Minimal datamap report table", () => {
       cy.getByTestId(
         "data_use_undeclared_data_categories-header-menu-list",
       ).within(() => {
-        cy.get("button").contains("Display all").click();
+        cy.get("button").contains("Expand all").click();
       });
       ["User Contact Email", "Cookie ID"].forEach((pokemon) => {
         cy.getByTestId(

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -25,7 +25,8 @@
     "openapi:generate-dictionary": "openapi --input http://localhost:8081/openapi.json --output ./src/types/dictionary-api --exportCore false --exportServices false --indent 2",
     "start": "next start",
     "test": "jest --watchAll",
-    "test:ci": "jest"
+    "test:ci": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@fontsource/inter": "^4.5.15",

--- a/clients/admin-ui/src/features/common/hooks/useLocalStorage.ts
+++ b/clients/admin-ui/src/features/common/hooks/useLocalStorage.ts
@@ -6,13 +6,13 @@ Design taken from: https://usehooks.com/useLocalStorage/
 
 // eslint-disable-next-line import/prefer-default-export
 export function useLocalStorage<T = string>(
-  key: string,
+  key: string | undefined,
   initialValue: T,
 ): [T, Dispatch<SetStateAction<T>>] {
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
   const [storedValue, setStoredValue] = useState<T>(() => {
-    if (typeof window === "undefined") {
+    if (typeof window === "undefined" || !key) {
       return initialValue;
     }
     try {
@@ -37,7 +37,7 @@ export function useLocalStorage<T = string>(
       // Save state
       setStoredValue(valueToStore);
       // Save to local storage
-      if (typeof window !== "undefined") {
+      if (typeof window !== "undefined" && !!key) {
         window.localStorage.setItem(key, JSON.stringify(valueToStore));
       }
     } catch (error) {

--- a/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
@@ -74,8 +74,8 @@ export const FidesCell = <T,>({
         },
         ...getTableTHandTDStyles(cell.column.id),
         // Fancy CSS memoization magic https://tanstack.com/table/v8/docs/framework/react/examples/column-resizing-performant
-        maxWidth: `calc(var(--header-${cell.column.id}-size) * 1px)`,
-        minWidth: `calc(var(--header-${cell.column.id}-size) * 1px)`,
+        maxWidth: `calc(var(--col-${cell.column.id}-size) * 1px)`,
+        minWidth: `calc(var(--col-${cell.column.id}-size) * 1px)`,
         "&:hover": {
           backgroundColor: hasCellClickEnabled ? "gray.50" : undefined,
           cursor: hasCellClickEnabled ? "pointer" : undefined,

--- a/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
@@ -6,13 +6,15 @@ import { getTableTHandTDStyles } from "~/features/common/table/v2/util";
 export type FidesCellProps<T> = {
   cell: Cell<T, unknown>;
   onRowClick?: (row: T, e: React.MouseEvent<HTMLTableCellElement>) => void;
-  isDisplayAll: boolean;
+  isExpandAll: boolean;
+  isWrapped?: boolean;
 };
 
 export const FidesCell = <T,>({
   cell,
   onRowClick,
-  isDisplayAll,
+  isExpandAll,
+  isWrapped,
 }: FidesCellProps<T>) => {
   const isTableGrouped = cell.getContext().table.getState().grouping.length > 0;
   const groupedColumnId = isTableGrouped
@@ -104,7 +106,8 @@ export const FidesCell = <T,>({
       {!cell.getIsPlaceholder() || isFirstRowOfGroupedRows
         ? flexRender(cell.column.columnDef.cell, {
             ...cell.getContext(),
-            isDisplayAll,
+            isExpandAll,
+            isWrapped,
           })
         : null}
     </Td>

--- a/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
@@ -3,7 +3,7 @@ import { Td } from "fidesui";
 
 import { getTableTHandTDStyles } from "~/features/common/table/v2/util";
 
-type FidesCellProps<T> = {
+export type FidesCellProps<T> = {
   cell: Cell<T, unknown>;
   onRowClick?: (row: T, e: React.MouseEvent<HTMLTableCellElement>) => void;
   isDisplayAll: boolean;

--- a/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
@@ -3,18 +3,22 @@ import { Td } from "fidesui";
 
 import { getTableTHandTDStyles } from "~/features/common/table/v2/util";
 
-export type FidesCellProps<T> = {
+export interface FidesCellState {
+  isExpanded?: boolean;
+  isWrapped?: boolean;
+  version?: number;
+}
+
+export interface FidesCellProps<T> {
   cell: Cell<T, unknown>;
   onRowClick?: (row: T, e: React.MouseEvent<HTMLTableCellElement>) => void;
-  isExpandAll: boolean;
-  isWrapped?: boolean;
-};
+  cellState?: FidesCellState;
+}
 
 export const FidesCell = <T,>({
   cell,
   onRowClick,
-  isExpandAll,
-  isWrapped,
+  cellState,
 }: FidesCellProps<T>) => {
   const isTableGrouped = cell.getContext().table.getState().grouping.length > 0;
   const groupedColumnId = isTableGrouped
@@ -106,8 +110,7 @@ export const FidesCell = <T,>({
       {!cell.getIsPlaceholder() || isFirstRowOfGroupedRows
         ? flexRender(cell.column.columnDef.cell, {
             ...cell.getContext(),
-            isExpandAll,
-            isWrapped,
+            cellState,
           })
         : null}
     </Td>

--- a/clients/admin-ui/src/features/common/table/v2/FidesRow.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesRow.tsx
@@ -1,7 +1,12 @@
 import { Row } from "@tanstack/react-table";
 import { Tooltip, Tr } from "fidesui";
 
-import { FidesCell } from "~/features/common/table/v2/FidesCell";
+import {
+  FidesCell,
+  FidesCellState,
+} from "~/features/common/table/v2/FidesCell";
+
+import { columnExpandedVersion } from "./util";
 
 type Props<T> = {
   row: Row<T>;
@@ -29,15 +34,25 @@ export const FidesRow = <T,>({
       data-testid={`row-${row.id}`}
       backgroundColor={row.getCanSelect() ? undefined : "gray.50"}
     >
-      {row.getVisibleCells().map((cell) => (
-        <FidesCell
-          key={cell.id}
-          cell={cell}
-          onRowClick={onRowClick}
-          isExpandAll={!!expandedColumns.find((c) => c === cell.column.id)}
-          isWrapped={!!wrappedColumns.find((c) => c === cell.column.id)}
-        />
-      ))}
+      {row.getVisibleCells().map((cell) => {
+        const expansionVersion = columnExpandedVersion(
+          cell.column.id,
+          expandedColumns,
+        );
+        const cellState: FidesCellState = {
+          isExpanded: !!expansionVersion && expansionVersion > 0,
+          isWrapped: !!wrappedColumns.find((c) => c === cell.column.id),
+          version: expansionVersion,
+        };
+        return (
+          <FidesCell
+            key={cell.id}
+            cell={cell}
+            onRowClick={onRowClick}
+            cellState={cellState}
+          />
+        );
+      })}
     </Tr>
   );
   if (renderRowTooltipLabel) {

--- a/clients/admin-ui/src/features/common/table/v2/FidesRow.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesRow.tsx
@@ -7,14 +7,16 @@ type Props<T> = {
   row: Row<T>;
   onRowClick?: (row: T, e: React.MouseEvent<HTMLTableCellElement>) => void;
   renderRowTooltipLabel?: (row: Row<T>) => string | undefined;
-  displayAllColumns: string[];
+  expandedColumns: string[];
+  wrappedColumns: string[];
 };
 
 export const FidesRow = <T,>({
   row,
   renderRowTooltipLabel,
   onRowClick,
-  displayAllColumns,
+  expandedColumns,
+  wrappedColumns,
 }: Props<T>) => {
   if (row.getIsGrouped()) {
     return null;
@@ -32,7 +34,8 @@ export const FidesRow = <T,>({
           key={cell.id}
           cell={cell}
           onRowClick={onRowClick}
-          isDisplayAll={!!displayAllColumns.find((c) => c === cell.column.id)}
+          isExpandAll={!!expandedColumns.find((c) => c === cell.column.id)}
+          isWrapped={!!wrappedColumns.find((c) => c === cell.column.id)}
         />
       ))}
     </Tr>

--- a/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
@@ -41,7 +41,6 @@ import {
   columnExpandedVersion,
   getTableTHandTDStyles,
 } from "~/features/common/table/v2/util";
-import { DATAMAP_LOCAL_STORAGE_KEYS } from "~/features/datamap/constants";
 
 /*
   This was throwing a false positive for unused parameters.
@@ -211,7 +210,7 @@ const HeaderContent = <T,>({
   );
 };
 
-type Props<T> = {
+type FidesTableProps<T> = {
   tableInstance: TableInstance<T>;
   rowActionBar?: ReactNode;
   footer?: ReactNode;
@@ -226,6 +225,8 @@ type Props<T> = {
   overflow?: "auto" | "visible" | "hidden";
   enableSorting?: boolean;
   onSort?: (columnSort: ColumnSort) => void;
+  columnExpandStorageKey?: string;
+  columnWrapStorageKey?: string;
 };
 
 const TableBody = <T,>({
@@ -237,7 +238,7 @@ const TableBody = <T,>({
   expandedColumns,
   wrappedColumns,
   emptyTableNotice,
-}: Omit<Props<T>, "footer" | "enableSorting" | "onSort"> & {
+}: Omit<FidesTableProps<T>, "footer" | "enableSorting" | "onSort"> & {
   expandedColumns: string[];
   wrappedColumns: string[];
 }) => {
@@ -296,14 +297,16 @@ export const FidesTableV2 = <T,>({
   overflow = "auto",
   onSort,
   enableSorting = !!onSort,
-}: Props<T>) => {
+  columnExpandStorageKey,
+  columnWrapStorageKey,
+}: FidesTableProps<T>) => {
   const [colExpandVersion, setColExpandVersion] = useState<number>(1);
   const [expandedColumns, setExpandedColumns] = useLocalStorage<string[]>(
-    DATAMAP_LOCAL_STORAGE_KEYS.COLUMN_EXPANSION_STATE,
+    columnExpandStorageKey,
     [],
   );
   const [wrappedColumns, setWrappedColumns] = useLocalStorage<string[]>(
-    DATAMAP_LOCAL_STORAGE_KEYS.WRAPPING_COLUMNS,
+    columnWrapStorageKey,
     [],
   );
 

--- a/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesTable.tsx
@@ -286,8 +286,18 @@ export const FidesTableV2 = <T,>({
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < headers.length; i++) {
       const header = headers[i]!;
-      colSizes[`--header-${header.id}-size`] = header.getSize();
-      colSizes[`--col-${header.column.id}-size`] = header.column.getSize();
+      const columnHasBeenResized =
+        !!tableInstance.getState().columnSizing?.[header.id];
+      const customInitialWidth = header.column.columnDef.meta?.width;
+      const columnIsAuto = customInitialWidth === "auto";
+      if (columnHasBeenResized || !columnIsAuto) {
+        let currentSize = header.getSize() || header.column.getSize();
+        if (customInitialWidth && !columnIsAuto) {
+          currentSize = parseInt(customInitialWidth, 10);
+        }
+        colSizes[`--header-${header.id}-size`] = currentSize;
+        colSizes[`--col-${header.column.id}-size`] = currentSize;
+      }
     }
     return colSizes;
     // Disabling since the example docs do
@@ -342,9 +352,9 @@ export const FidesTableV2 = <T,>({
                   }}
                   colSpan={header.colSpan}
                   data-testid={`column-${header.id}`}
-                  style={{
+                  sx={{
                     padding: 0,
-                    width: header.column.columnDef.meta?.width || "unset",
+                    width: `calc(var(--header-${header.id}-size) * 1px)`,
                     overflowX: "auto",
                   }}
                   textTransform="unset"

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -26,6 +26,8 @@ import { errorToastParams } from "~/features/common/toast";
 import { formatDate, sentenceCase } from "~/features/common/utils";
 import { RTKResult } from "~/types/errors";
 
+import { FidesCellProps } from "./FidesCell";
+
 export const DefaultCell = ({
   value,
   ...chakraStyleProps
@@ -148,16 +150,17 @@ export const BadgeCellCount = ({
 };
 
 type BadgeCellExpandableValues = { label: string | ReactNode; key: string }[];
-export const BadgeCellExpandable = ({
+export const BadgeCellExpandable = <T,>({
   values,
-  isDisplayAll,
+  cellProps,
   ...badgeProps
 }: {
   values: BadgeCellExpandableValues | undefined;
-  isDisplayAll?: boolean;
+  cellProps?: Omit<FidesCellProps<T>, "onRowClick">;
 } & BadgeProps) => {
-  const displayThreshold = 2;
-  const [isCollapsed, setIsCollapsed] = useState(!isDisplayAll);
+  const { isDisplayAll } = cellProps || {};
+  const displayThreshold = 2; // Number of badges to display when collapsed
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(!isDisplayAll);
   const [displayValues, setDisplayValues] = useState<
     BadgeCellExpandableValues | undefined
   >(!isDisplayAll ? values?.slice(0, displayThreshold) : values);
@@ -185,6 +188,11 @@ export const BadgeCellExpandable = ({
         gap={1.5}
         pt={2}
         pb={2}
+        onClick={(e) => {
+          e.stopPropagation();
+          setIsCollapsed(!isCollapsed);
+        }}
+        cursor="pointer"
       >
         {displayValues.map((value) => (
           <FidesBadge key={value.key} data-testid={value.key} {...badgeProps}>
@@ -196,7 +204,7 @@ export const BadgeCellExpandable = ({
             variant="link"
             size="xs"
             fontWeight={400}
-            onClick={() => setIsCollapsed(!isCollapsed)}
+            onClick={() => setIsCollapsed(false)}
           >
             +{values.length - displayThreshold} more
           </Button>

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -214,6 +214,7 @@ export const BadgeCellExpandable = <T,>({
             size="xs"
             fontWeight={400}
             onClick={() => setIsCollapsed(false)}
+            display="inline-block" // prevents squishing the button on column resize
           >
             +{values.length - displayThreshold} more
           </Button>

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -198,10 +198,12 @@ export const BadgeCellExpandable = <T,>({
         pt={2}
         pb={2}
         onClick={(e) => {
-          e.stopPropagation();
-          setIsCollapsed(!isCollapsed);
+          if (!isCollapsed) {
+            e.stopPropagation();
+            setIsCollapsed(true);
+          }
         }}
-        cursor="pointer"
+        cursor={isCollapsed ? undefined : "pointer"}
       >
         {displayValues.map((value) => (
           <FidesBadge key={value.key} data-testid={value.key} {...badgeProps}>

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -218,14 +218,18 @@ export const GroupCountBadgeCell = ({
   value,
   suffix,
   isDisplayAll,
+  ignoreZero,
 }: {
   value: string[] | string | ReactNode | ReactNode[] | undefined;
   suffix?: string;
   isDisplayAll?: boolean;
+  ignoreZero?: boolean;
 }) => {
   let badges = null;
   if (!value) {
-    return <FidesBadge>0{suffix ? ` ${suffix}` : ""}</FidesBadge>;
+    return ignoreZero ? null : (
+      <FidesBadge>0{suffix ? ` ${suffix}` : ""}</FidesBadge>
+    );
   }
   if (Array.isArray(value)) {
     // If there's only one value, always display it

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -158,16 +158,21 @@ export const BadgeCellExpandable = <T,>({
   values: BadgeCellExpandableValues | undefined;
   cellProps?: Omit<FidesCellProps<T>, "onRowClick">;
 } & BadgeProps) => {
-  const { isDisplayAll } = cellProps || {};
+  const { isExpandAll, isWrapped } = cellProps || {};
   const displayThreshold = 2; // Number of badges to display when collapsed
-  const [isCollapsed, setIsCollapsed] = useState<boolean>(!isDisplayAll);
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(!isExpandAll);
+  const [isWrappedState, setIsWrappedState] = useState<boolean>(!!isWrapped);
   const [displayValues, setDisplayValues] = useState<
     BadgeCellExpandableValues | undefined
-  >(!isDisplayAll ? values?.slice(0, displayThreshold) : values);
+  >(!isExpandAll ? values?.slice(0, displayThreshold) : values);
 
   useEffect(() => {
-    setIsCollapsed(!isDisplayAll);
-  }, [isDisplayAll]);
+    setIsCollapsed(!isExpandAll);
+  }, [isExpandAll]);
+
+  useEffect(() => {
+    setIsWrappedState(!!isWrapped);
+  }, [isWrapped]);
 
   useEffect(() => {
     if (values?.length) {
@@ -184,7 +189,8 @@ export const BadgeCellExpandable = <T,>({
     return (
       <Flex
         alignItems={isCollapsed ? "center" : "flex-start"}
-        flexDirection={isCollapsed ? "row" : "column"}
+        flexDirection={isCollapsed || isWrappedState ? "row" : "column"}
+        flexWrap={isWrappedState ? "wrap" : "nowrap"}
         gap={1.5}
         pt={2}
         pb={2}
@@ -211,18 +217,18 @@ export const BadgeCellExpandable = <T,>({
         )}
       </Flex>
     );
-  }, [displayValues, isCollapsed, values, badgeProps]);
+  }, [displayValues, isCollapsed, isWrappedState, values, badgeProps]);
 };
 
 export const GroupCountBadgeCell = ({
   value,
   suffix,
-  isDisplayAll,
+  isExpandAll,
   ignoreZero,
 }: {
   value: string[] | string | ReactNode | ReactNode[] | undefined;
   suffix?: string;
-  isDisplayAll?: boolean;
+  isExpandAll?: boolean;
   ignoreZero?: boolean;
 }) => {
   let badges = null;
@@ -237,7 +243,7 @@ export const GroupCountBadgeCell = ({
       badges = <FidesBadge>{value}</FidesBadge>;
     }
     // Expanded case, list every value as a badge
-    else if (isDisplayAll && value.length > 0) {
+    else if (isExpandAll && value.length > 0) {
       badges = value.map((d, i) => (
         <Box key={d?.toString() || i} mr={2}>
           <FidesBadge>{d}</FidesBadge>

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -57,6 +57,11 @@ const FidesBadge = ({ children, ...props }: BadgeProps) => (
     color="gray.600"
     px={2}
     py={1}
+    boxShadow={
+      props.variant === "outline"
+        ? "inset 0 0 0px 1px var(--chakra-colors-gray-100)"
+        : undefined
+    }
     {...props}
   >
     {children}
@@ -231,42 +236,44 @@ export const GroupCountBadgeCell = ({
   suffix,
   cellState,
   ignoreZero,
+  badgeProps,
 }: {
   value: string[] | string | ReactNode | ReactNode[] | undefined;
   suffix?: string;
   cellState?: FidesCellState;
   ignoreZero?: boolean;
+  badgeProps?: BadgeProps;
 }) => {
   let badges = null;
   if (!value) {
     return ignoreZero ? null : (
-      <FidesBadge>0{suffix ? ` ${suffix}` : ""}</FidesBadge>
+      <FidesBadge {...badgeProps}>0{suffix ? ` ${suffix}` : ""}</FidesBadge>
     );
   }
   if (Array.isArray(value)) {
     // If there's only one value, always display it
     if (value.length === 1) {
-      badges = <FidesBadge>{value}</FidesBadge>;
+      badges = <FidesBadge {...badgeProps}>{value}</FidesBadge>;
     }
     // Expanded case, list every value as a badge
     else if (cellState?.isExpanded && value.length > 0) {
       badges = value.map((d, i) => (
         <Box key={d?.toString() || i} mr={2}>
-          <FidesBadge>{d}</FidesBadge>
+          <FidesBadge {...badgeProps}>{d}</FidesBadge>
         </Box>
       ));
     }
     // Collapsed case, summarize the values in one badge
     else {
       badges = (
-        <FidesBadge>
+        <FidesBadge {...badgeProps}>
           {value.length}
           {suffix ? ` ${suffix}` : null}
         </FidesBadge>
       );
     }
   } else {
-    badges = <FidesBadge>{value}</FidesBadge>;
+    badges = <FidesBadge {...badgeProps}>{value}</FidesBadge>;
   }
 
   return (

--- a/clients/admin-ui/src/features/common/table/v2/util.ts
+++ b/clients/admin-ui/src/features/common/table/v2/util.ts
@@ -1,5 +1,7 @@
 import { theme } from "fidesui";
 
+export const COLUMN_VERSION_DELIMITER = "::";
+
 export const getTableTHandTDStyles = (cellId: string) =>
   cellId === "select"
     ? { padding: "0px" }
@@ -10,3 +12,13 @@ export const getTableTHandTDStyles = (cellId: string) =>
         paddingBottom: "0px",
         borderRadius: "0px",
       };
+
+export const columnExpandedVersion = (
+  columnId: string,
+  expandedColumns: string[],
+) => {
+  const expandedColumn = expandedColumns.find((c) => c.startsWith(columnId));
+  return expandedColumn
+    ? parseInt(expandedColumn.split(COLUMN_VERSION_DELIMITER)[1], 10)
+    : undefined;
+};

--- a/clients/admin-ui/src/features/datamap/constants.ts
+++ b/clients/admin-ui/src/features/datamap/constants.ts
@@ -68,7 +68,7 @@ export enum DATAMAP_LOCAL_STORAGE_KEYS {
   COLUMN_ORDER = "datamap-column-order",
   TABLE_GROUPING = "datamap-table-grouping",
   TABLE_STATE = "datamap-report-table-state",
-  DISPLAY_ALL_COLUMNS = "datamap-display-all-columns",
+  COLUMN_EXPANSION_STATE = "datamap-column-expansion-state",
   SORTING_STATE = "datamap-sorting-state",
   WRAPPING_COLUMNS = "datamap-wrapping-columns",
 }

--- a/clients/admin-ui/src/features/datamap/constants.ts
+++ b/clients/admin-ui/src/features/datamap/constants.ts
@@ -70,4 +70,5 @@ export enum DATAMAP_LOCAL_STORAGE_KEYS {
   TABLE_STATE = "datamap-report-table-state",
   DISPLAY_ALL_COLUMNS = "datamap-display-all-columns",
   SORTING_STATE = "datamap-sorting-state",
+  WRAPPING_COLUMNS = "datamap-wrapping-columns",
 }

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -388,6 +388,7 @@ export const DatamapReportTable = () => {
                   ? map(value, getDataUseDisplayName)
                   : getDataUseDisplayName(value || "")
               }
+              badgeProps={{ variant: "outline" }}
               {...props}
             />
           );
@@ -419,7 +420,6 @@ export const DatamapReportTable = () => {
             <BadgeCellExpandable
               values={values}
               cellProps={props as any}
-              boxShadow="inset 0 0 0px 1px var(--chakra-colors-gray-100)"
               variant="outline"
             />
           );

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -37,6 +37,7 @@ import { useAppSelector } from "~/app/hooks";
 import { useLocalStorage } from "~/features/common/hooks/useLocalStorage";
 import useTaxonomies from "~/features/common/hooks/useTaxonomies";
 import { DownloadLightIcon } from "~/features/common/Icon";
+import { BadgeCellExpandable } from "~/features/common/table/v2/cells";
 import { getQueryParamsFromArray } from "~/features/common/utils";
 import {
   DATAMAP_LOCAL_STORAGE_KEYS,
@@ -395,17 +396,26 @@ export const DatamapReportTable = () => {
       columnHelper.accessor((row) => row.data_categories, {
         id: COLUMN_IDS.DATA_CATEGORY,
         cell: (props) => {
-          const value = props.getValue();
-
+          const cellValues = props.getValue();
+          if (!cellValues || cellValues.length === 0) {
+            return null;
+          }
+          const values = isArray(cellValues)
+            ? cellValues.map((value) => {
+                return { label: getDataCategoryDisplayName(value), key: value };
+              })
+            : [
+                {
+                  label: getDataCategoryDisplayName(cellValues),
+                  key: cellValues,
+                },
+              ];
           return (
-            <GroupCountBadgeCell
-              suffix="data categories"
-              value={
-                isArray(value)
-                  ? map(value, getDataCategoryDisplayName)
-                  : getDataCategoryDisplayName(value || "")
-              }
-              {...props}
+            <BadgeCellExpandable
+              values={values}
+              cellProps={props as any}
+              boxShadow="inset 0 0 0px 1px var(--chakra-colors-gray-100)"
+              variant="outline"
             />
           );
         },

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -1201,7 +1201,13 @@ export const DatamapReportTable = () => {
         </Flex>
       </TableActionBar>
 
-      <FidesTableV2<DatamapReport> tableInstance={tableInstance} />
+      <FidesTableV2<DatamapReport>
+        tableInstance={tableInstance}
+        columnExpandStorageKey={
+          DATAMAP_LOCAL_STORAGE_KEYS.COLUMN_EXPANSION_STATE
+        }
+        columnWrapStorageKey={DATAMAP_LOCAL_STORAGE_KEYS.WRAPPING_COLUMNS}
+      />
       <PaginationBar
         totalRows={totalRows || 0}
         pageSizes={PAGE_SIZES}

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -389,6 +389,7 @@ export const DatamapReportTable = () => {
         header: (props) => <DefaultHeaderCell value="Data use" {...props} />,
         meta: {
           displayText: "Data use",
+          width: "auto",
         },
       }),
       columnHelper.accessor((row) => row.data_categories, {
@@ -414,6 +415,7 @@ export const DatamapReportTable = () => {
         meta: {
           displayText: "Data categories",
           showHeaderMenu: true,
+          width: "auto",
         },
       }),
       columnHelper.accessor((row) => row.data_subjects, {

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -430,6 +430,7 @@ export const DatamapReportTable = () => {
         meta: {
           displayText: "Data categories",
           showHeaderMenu: true,
+          showHeaderMenuWrapOption: true,
           width: "auto",
         },
       }),

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -342,7 +342,11 @@ export const DatamapReportTable = () => {
           // Conditionally render the Group cell if we have more than one value.
           // Alternatively, could check the customField type
           Array.isArray(props.getValue()) ? (
-            <GroupCountBadgeCell value={props.getValue()} {...props} />
+            <GroupCountBadgeCell
+              value={props.getValue()}
+              ignoreZero
+              {...props}
+            />
           ) : (
             <DefaultCell value={props.getValue() as string} />
           ),
@@ -378,6 +382,7 @@ export const DatamapReportTable = () => {
           return (
             <GroupCountBadgeCell
               suffix="data uses"
+              ignoreZero
               value={
                 isArray(value)
                   ? map(value, getDataUseDisplayName)
@@ -436,6 +441,7 @@ export const DatamapReportTable = () => {
           return (
             <GroupCountBadgeCell
               suffix="data subjects"
+              ignoreZero
               value={
                 isArray(value)
                   ? map(value, getDataSubjectDisplayName)
@@ -564,6 +570,7 @@ export const DatamapReportTable = () => {
         cell: (props) => (
           <GroupCountBadgeCell
             suffix="data stewards"
+            ignoreZero
             value={props.getValue()}
             {...props}
           />
@@ -611,6 +618,7 @@ export const DatamapReportTable = () => {
         cell: (props) => (
           <GroupCountBadgeCell
             suffix="destinations"
+            ignoreZero
             value={props.getValue()}
             {...props}
           />
@@ -641,6 +649,7 @@ export const DatamapReportTable = () => {
         cell: (props) => (
           <GroupCountBadgeCell
             suffix="features"
+            ignoreZero
             value={props.getValue()}
             {...props}
           />
@@ -687,6 +696,7 @@ export const DatamapReportTable = () => {
         cell: (props) => (
           <GroupCountBadgeCell
             suffix="sources"
+            ignoreZero
             value={props.getValue()}
             {...props}
           />
@@ -712,6 +722,7 @@ export const DatamapReportTable = () => {
         cell: (props) => (
           <GroupCountBadgeCell
             suffix="profiles"
+            ignoreZero
             value={props.getValue()}
             {...props}
           />
@@ -729,6 +740,7 @@ export const DatamapReportTable = () => {
         cell: (props) => (
           <GroupCountBadgeCell
             suffix="transfers"
+            ignoreZero
             value={props.getValue()}
             {...props}
           />
@@ -802,6 +814,7 @@ export const DatamapReportTable = () => {
         cell: (props) => (
           <GroupCountBadgeCell
             suffix="responsibilities"
+            ignoreZero
             value={props.getValue()}
             {...props}
           />
@@ -829,6 +842,7 @@ export const DatamapReportTable = () => {
         cell: (props) => (
           <GroupCountBadgeCell
             suffix="shared categories"
+            ignoreZero
             value={props.getValue()}
             {...props}
           />
@@ -856,6 +870,7 @@ export const DatamapReportTable = () => {
         cell: (props) => (
           <GroupCountBadgeCell
             suffix="dependencies"
+            ignoreZero
             value={props.getValue()}
             {...props}
           />
@@ -895,6 +910,7 @@ export const DatamapReportTable = () => {
 
           return (
             <GroupCountBadgeCell
+              ignoreZero
               suffix="system undeclared data categories"
               value={
                 isArray(value)
@@ -923,6 +939,7 @@ export const DatamapReportTable = () => {
 
           return (
             <GroupCountBadgeCell
+              ignoreZero
               suffix="data use undeclared data categories"
               value={
                 isArray(value)
@@ -948,6 +965,7 @@ export const DatamapReportTable = () => {
         id: COLUMN_IDS.COOKIES,
         cell: (props) => (
           <GroupCountBadgeCell
+            ignoreZero
             suffix="cookies"
             value={props.getValue()}
             {...props}

--- a/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
@@ -154,7 +154,7 @@ const MonitorConfigTab = ({
               suffix="Projects"
               value={props.getValue()}
               {...props}
-              isDisplayAll
+              isExpandAll
             />
           ),
         header: (props) => <DefaultHeaderCell value="Scope" {...props} />,

--- a/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
@@ -154,7 +154,7 @@ const MonitorConfigTab = ({
               suffix="Projects"
               value={props.getValue()}
               {...props}
-              isExpandAll
+              cellState={{ isExpanded: true }}
             />
           ),
         header: (props) => <DefaultHeaderCell value="Scope" {...props} />,

--- a/clients/admin-ui/src/features/privacy-requests/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/cells.tsx
@@ -120,5 +120,5 @@ export const RequestActionTypeCell = ({ value }: { value: Rule[] }) => {
   const actionTypes = getActionTypesFromRules(value).map((actionType) =>
     SubjectRequestActionTypeMap.get(actionType),
   );
-  return <GroupCountBadgeCell value={actionTypes} isDisplayAll />;
+  return <GroupCountBadgeCell value={actionTypes} isExpandAll />;
 };

--- a/clients/admin-ui/src/features/privacy-requests/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/cells.tsx
@@ -120,5 +120,7 @@ export const RequestActionTypeCell = ({ value }: { value: Rule[] }) => {
   const actionTypes = getActionTypesFromRules(value).map((actionType) =>
     SubjectRequestActionTypeMap.get(actionType),
   );
-  return <GroupCountBadgeCell value={actionTypes} isExpandAll />;
+  return (
+    <GroupCountBadgeCell value={actionTypes} cellState={{ isExpanded: true }} />
+  );
 };


### PR DESCRIPTION
Closes PROD-2677

### Description Of Changes

On the Datamap Reporting table
* New overflow indicator that represents how many categories are hidden after displaying the first 2
* Update badge styles for Data uses and Data categories columns
* User can expand each cell individually by clicking the overflow indicator
* User can collapse each cell individually by clicking anywhere in the cell
* Update the header menu:
  * Rename options to "Expand all" and "Collapse all"
  * Reorder so that "Expand all" is first
  * add a "Wrap results" checkbox option
* Update all badges in this table to be hidden if there are 0 results
* Adjust table column resize handle to be more user friendly

### Steps to Confirm

* Visit Datamap report page in Admin UI `/reporting/datamap`
* Ensure that Data categories are collapsed by default (may need to visit in incognito window in case expand/collapse has been saved in Local Storage already for you)
* Expand a couple of individual cells by clicking the overflow indicator (eg. "+5 more")
* Open the header menu of the Data categories column
  * Click "Collapse all" to ensure the individual cells you expanded above are collapsed again
  * Click "Expand all" and ensure that all badges appear in this column and are stacked by default
  * Click "Wrap results" checkbox to see that all expanded badges are now wrapping within the cell space rather than stacked
* Drag the column resizer to change width of the Data categories column and ensure badges wrap to the cell width as expected
* Open the column options again, uncheck "Wrap results", and ensure the badges are now stacked within each cell
* Play around with Expand/Collapse/Wrap in various combinations of those states to ensure resulting behavior is expected.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
