### PR TITLE
PROD-2698: clarify permissions needed for GCP

### DIFF
--- a/clients/admin-ui/src/features/integrations/integration-type-info/googleCloudSQLPostgresInfo.tsx
+++ b/clients/admin-ui/src/features/integrations/integration-type-info/googleCloudSQLPostgresInfo.tsx
@@ -50,17 +50,21 @@ export const GoogleCloudSQLPostgresOverview = () => (
         For detection and discovery, Fides requires a user with the SELECT
         permission on the database. If you intend to automate governance for DSR
         or Consent, Fides requires a user with the SELECT, UPDATE, and DELETE
-        The permissions allow Fides to read the schema of, and data stored in
-        tables, and fields as well as write restricted updates based on your
-        policy configurations to tables you specify as part of DSR and Consent
+        permission. The permissions allow Fides to read the schema of, and data
+        stored in tables, and fields as well as write restricted updates based
+        on your policy configurations to tables you specify as part of DSR and
         orchestration. For a complete list of permissions view the Google Cloud
         SQL for Postgres DB documentation.
       </InfoText>
+      <InfoText>
+        The following GCP service account permissions are needed when setting up
+        Google Cloud SQL for Postgres.
+      </InfoText>
       <InfoHeading text="Permissions list" />
       <InfoUnorderedList>
-        <ListItem>GRANT SELECT</ListItem>
-        <ListItem>GRANT UPDATE</ListItem>
-        <ListItem>GRANT DELETE</ListItem>
+        <ListItem>cloudsql.instances.connect</ListItem>
+        <ListItem>cloudsql.instances.get</ListItem>
+        <ListItem>cloudsql.instances.login</ListItem>
       </InfoUnorderedList>
     </ShowMoreContent>
   </>


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/PROD-2698

### Description Of Changes

Update Info text in Admin-UI for Google Cloud SQL for Postgres


### Code Changes

* [ ] update copy

### Steps to Confirm

* [ ] Run plus with detection & discovery enabled, pointed to this branch
* [ ] Create discovery monitor for Google Cloud SQL for postgres
* [ ] Confirm Info text contains the following permissions:
```
cloudsql.instances.connect
cloudsql.instances.get
cloudsql.instances.login
```

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
