### PR TITLE
Replace Yotpo Loyalty with Yotpo Reviews in description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The types of changes are:
 - Update the Datamap report's Data categories column to support better expand/collapse behavior [#5265](https://github.com/ethyca/fides/pull/5265)
 - Rename/refactor Privacy Notice Properties to support performance improvements [#5259](https://github.com/ethyca/fides/pull/5259)
 
+### Fixed
+- Fix wording in tooltip for Yotpo Reviews [#5274](https://github.com/ethyca/fides/pull/5274)
+
 
 ## [2.44.0](https://github.com/ethyca/fides/compare/2.43.1...2.44.0)
 

--- a/data/saas/config/yotpo_reviews_config.yml
+++ b/data/saas/config/yotpo_reviews_config.yml
@@ -4,12 +4,12 @@ saas_config:
   type: yotpo_reviews
   description: A sample schema representing the Yotpo Reviews integration for Fides
   user_guide: https://docs.ethyca.com/user-guides/integrations/saas-integrations/yotpo-reviews
-  version: 0.1.3
+  version: 0.1.4
 
   connector_params:
     - name: domain
       default_value: api.yotpo.com
-      description: The URL for your Yotpo Loyalty instance
+      description: The URL for your Yotpo Reviews instance
     - name: store_id
       label: Store ID
       description: Your Yotpo Store ID, previously referred to as "app key"


### PR DESCRIPTION
Closes PROD-2738

### Description Of Changes

Yotpo Reviews `domain` tooltip erroneously refers to Yotpo Loyalty.

### Code Changes

* Edit wording on Yotpo Reviews integration tooltip

### Steps to Confirm

* [ ] go to create an integration of type Yotpo Reviews, check all tooltips for references to Yotpo Loyalty.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
