### PR TITLE
PROD-2722, PROD-2761

### DIFF
--- a/src/fides/api/schemas/connection_configuration/connection_secrets_base_aws.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_base_aws.py
@@ -14,7 +14,6 @@ class BaseAWSSchema(ConnectionConfigSecretsSchema):
     auth_method: AWSAuthMethod = Field(
         title="Authentication Method",
         description="Determines which type of authentication method to use for connecting to Amazon Web Services. Currently accepted values are: `secret_keys` or `automatic`.",
-        default=AWSAuthMethod.SECRET_KEYS,
     )
 
     aws_access_key_id: Optional[str] = Field(

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_dynamodb.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_dynamodb.py
@@ -16,7 +16,9 @@ class DynamoDBSchema(BaseAWSSchema):
         description="The AWS region where your DynamoDB table is located (ex. us-west-2).",
     )
 
-    _required_components: ClassVar[List[str]] = ["region_name"]
+    _required_components: ClassVar[List[str]] = BaseAWSSchema._required_components + [
+        "region_name"
+    ]
 
 
 class DynamoDBDocsSchema(DynamoDBSchema, NoValidationSchema):

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_s3.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_s3.py
@@ -1,5 +1,3 @@
-from typing import ClassVar, List
-
 from fides.api.schemas.base_class import NoValidationSchema
 from fides.api.schemas.connection_configuration.connection_secrets_base_aws import (
     BaseAWSSchema,
@@ -8,8 +6,6 @@ from fides.api.schemas.connection_configuration.connection_secrets_base_aws impo
 
 class S3Schema(BaseAWSSchema):
     """Schema to validate the secrets needed to connect to Amazon S3"""
-
-    _required_components: ClassVar[List[str]] = BaseAWSSchema._required_components
 
 
 class S3DocsSchema(S3Schema, NoValidationSchema):

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_s3.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_s3.py
@@ -1,3 +1,5 @@
+from typing import ClassVar, List
+
 from fides.api.schemas.base_class import NoValidationSchema
 from fides.api.schemas.connection_configuration.connection_secrets_base_aws import (
     BaseAWSSchema,
@@ -6,6 +8,8 @@ from fides.api.schemas.connection_configuration.connection_secrets_base_aws impo
 
 class S3Schema(BaseAWSSchema):
     """Schema to validate the secrets needed to connect to Amazon S3"""
+
+    _required_components: ClassVar[List[str]] = BaseAWSSchema._required_components
 
 
 class S3DocsSchema(S3Schema, NoValidationSchema):

--- a/src/fides/api/util/aws_util.py
+++ b/src/fides/api/util/aws_util.py
@@ -34,11 +34,13 @@ def get_aws_session(
             region_name=storage_secrets.get("region_name"),  # type: ignore
         )
     elif auth_method == AWSAuthMethod.AUTOMATIC.value:
-        session = Session()
+        session = Session(
+            region_name=storage_secrets.get("region_name"),  # type: ignore
+        )
         logger.info("Successfully created automatic session")
     else:
-        logger.error("Auth method not supported for S3: {}", auth_method)
-        raise ValueError(f"Auth method not supported for S3: {auth_method}")
+        logger.error("AWS auth method not supported: {}", auth_method)
+        raise ValueError(f"AWS auth method not supported: {auth_method}")
 
     # Check that credentials are valid
     sts_client = session.client("sts")
@@ -57,6 +59,7 @@ def get_aws_session(
                 aws_access_key_id=temp_credentials["AccessKeyId"],
                 aws_secret_access_key=temp_credentials["SecretAccessKey"],
                 aws_session_token=temp_credentials["SessionToken"],
+                region_name=storage_secrets.get("region_name"),  # type: ignore
             )
         except ClientError as error:
             logger.exception(

--- a/src/fides/api/util/aws_util.py
+++ b/src/fides/api/util/aws_util.py
@@ -19,7 +19,6 @@ def get_aws_session(
     If an `assume_role_arn` is provided, the secrets will be used to
     assume that role and return a Session instantiated with that role.
     """
-    sts_client = None
     if auth_method == AWSAuthMethod.SECRET_KEYS.value:
         if storage_secrets is None:
             err_msg = "Storage secrets not found for S3 storage."

--- a/src/fides/api/util/connection_type.py
+++ b/src/fides/api/util/connection_type.py
@@ -181,6 +181,11 @@ def get_connection_type_secret_schema(*, connection_type: str) -> dict[str, Any]
     }
     if schema.get("additionalProperties"):
         schema.pop("additionalProperties")
+
+    # set an empty array for the 'required' key, if there are no required fields on the schema
+    # this helps the FE, which is expecting _some_ value here, even if it's an empty list
+    if "required" not in schema:
+        schema["required"] = []
     return schema
 
 

--- a/tests/ops/util/test_connection_type.py
+++ b/tests/ops/util/test_connection_type.py
@@ -317,10 +317,6 @@ def test_get_connection_type_secret_schemas_aws():
     dynamodb_required = dynamo_db_schema["required"]
     assert "region_name" in dynamodb_required
     assert "auth_method" in dynamodb_required
-    assert (
-        dynamo_db_schema["properties"]["auth_method"]["default"]
-        == AWSAuthMethod.SECRET_KEYS.value
-    )
 
     s3_secret_schema = get_connection_type_secret_schema(connection_type="s3")
     s3_required = s3_secret_schema["required"]


### PR DESCRIPTION
Closes [PROD-2722](https://ethyca.atlassian.net/browse/PROD-2722), [PROD-2761](https://ethyca.atlassian.net/browse/PROD-2761)

### Description Of Changes

- fix PROD-2722: remove default value for the `auth_method` field on the base AWS connection secret type, so it's now correctly populated as a `required` field
    - implement a fallback so that UI doesn't crash if there aren't any `required` fields inferred by the pydantic secrets schema
- fix PROD-2761: set the `region_name` arg in all of our AWS sessions that we instantiate within  our base `get_aws_session` utility function

### Code Changes

* [x] remove default value for the `auth_method` field on the base AWS connection secret type so that it shows up as `required`
* [x] implement a fallback so that UI doesn't crash if there aren't any `required` fields inferred by the pydantic secrets schema
* [x] set the `region_name` arg in all of our AWS sessions that we instantiate within  our base `get_aws_session` utility function 

### Steps to Confirm

* [x] spin up fidesplus pointed at this commit and ensure that the s3 integration page loads successfully
![image](https://github.com/user-attachments/assets/e0eaa6de-a4b0-4501-9fd9-1f61d7065c9e)

* [x] test assume role workflow with dynamodb monitor - connection test works! (trust me that secret keys + an assume role ARN are configured here! 😄)
![image](https://github.com/user-attachments/assets/2f826cc0-a234-4a45-92f0-3aeac0264bfe)


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!


[PROD-2722]: https://ethyca.atlassian.net/browse/PROD-2722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PROD-2761]: https://ethyca.atlassian.net/browse/PROD-2761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ