### PR TITLE
PROD-2709 Fix Email Connector logs so they use configuration key instead of name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Fixed
 - Ignore `400` errors from Talkable's `person` endpoint. [#5317](https://github.com/ethyca/fides/pull/5317)
+- Fix Email Connector logs so they use configuration key instead of name [#5286](https://github.com/ethyca/fides/pull/5286)
 
 ## [2.45.2](https://github.com/ethyca/fides/compare/2.45.1...2.45.2)
 
@@ -50,7 +51,6 @@ The types of changes are:
 - Update the Datamap report's Data categories column to support better expand/collapse behavior [#5265](https://github.com/ethyca/fides/pull/5265)
 - Rename/refactor Privacy Notice Properties to support performance improvements [#5259](https://github.com/ethyca/fides/pull/5259)
 - Improved logging and error visibility for TraversalErrors [#5263](https://github.com/ethyca/fides/pull/5263)
-- Fix Email Connector logs so they use configuration key instead of name [#5286](https://github.com/ethyca/fides/pull/5286)
 
 ### Developer Experience
 - Added performance mark timings to debug logs for fides.js [#5245](https://github.com/ethyca/fides/pull/5245)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The types of changes are:
 - Update the Datamap report's Data categories column to support better expand/collapse behavior [#5265](https://github.com/ethyca/fides/pull/5265)
 - Rename/refactor Privacy Notice Properties to support performance improvements [#5259](https://github.com/ethyca/fides/pull/5259)
 - Improved logging and error visibility for TraversalErrors [#5263](https://github.com/ethyca/fides/pull/5263)
+- Fix Email Connector logs so they use configuration key instead of name [#5286](https://github.com/ethyca/fides/pull/5286)
 
 ### Developer Experience
 - Added performance mark timings to debug logs for fides.js [#5245](https://github.com/ethyca/fides/pull/5245)

--- a/src/fides/api/models/connectionconfig.py
+++ b/src/fides/api/models/connectionconfig.py
@@ -203,6 +203,11 @@ class ConnectionConfig(Base):
 
         return bool(self.secrets and self.secrets.get("access_token"))
 
+    @property
+    def name_or_key(self) -> str:
+        """Returns the ConnectionConfig name if it exists, or its key otherwise."""
+        return self.name or self.key
+
     @classmethod
     def create_without_saving(
         cls: Type[ConnectionConfig], db: Session, *, data: dict[str, Any]

--- a/src/fides/api/service/connectors/base_erasure_email_connector.py
+++ b/src/fides/api/service/connectors/base_erasure_email_connector.py
@@ -73,12 +73,12 @@ class BaseErasureEmailConnector(BaseEmailConnector):
             db=db,
             data={
                 "connection_key": self.configuration.key,
-                "dataset_name": self.configuration.name,
-                "collection_name": self.configuration.name,
+                "dataset_name": self.configuration.name or self.configuration.key,
+                "collection_name": self.configuration.name or self.configuration.key,
                 "privacy_request_id": privacy_request.id,
                 "action_type": ActionType.erasure,
                 "status": ExecutionLogStatus.skipped,
-                "message": f"Erasure email skipped for '{self.configuration.name}'",
+                "message": f"Erasure email skipped for '{self.configuration.name or self.configuration.key}'",
             },
         )
 

--- a/src/fides/api/service/connectors/base_erasure_email_connector.py
+++ b/src/fides/api/service/connectors/base_erasure_email_connector.py
@@ -73,12 +73,12 @@ class BaseErasureEmailConnector(BaseEmailConnector):
             db=db,
             data={
                 "connection_key": self.configuration.key,
-                "dataset_name": self.configuration.name or self.configuration.key,
-                "collection_name": self.configuration.name or self.configuration.key,
+                "dataset_name": self.configuration.name_or_key,
+                "collection_name": self.configuration.name_or_key,
                 "privacy_request_id": privacy_request.id,
                 "action_type": ActionType.erasure,
                 "status": ExecutionLogStatus.skipped,
-                "message": f"Erasure email skipped for '{self.configuration.name or self.configuration.key}'",
+                "message": f"Erasure email skipped for '{self.configuration.name_or_key}'",
             },
         )
 

--- a/src/fides/api/service/connectors/consent_email_connector.py
+++ b/src/fides/api/service/connectors/consent_email_connector.py
@@ -306,11 +306,9 @@ class GenericConsentEmailConnector(BaseEmailConnector):
                     db=db,
                     data={
                         "connection_key": self.configuration.key,
-                        "dataset_name": self.configuration.name
-                        or self.configuration.key,
+                        "dataset_name": self.configuration.name_or_key,
                         "privacy_request_id": privacy_request.id,
-                        "collection_name": self.configuration.name
-                        or self.configuration.key,
+                        "collection_name": self.configuration.name_or_key,
                         "action_type": ActionType.consent,
                         "status": ExecutionLogStatus.complete,
                         "message": f"Consent email instructions dispatched for '{self.configuration.name_or_key}'",

--- a/src/fides/api/service/connectors/consent_email_connector.py
+++ b/src/fides/api/service/connectors/consent_email_connector.py
@@ -83,7 +83,7 @@ class GenericConsentEmailConnector(BaseEmailConnector):
         try:
             if not self.config.test_email_address:
                 raise MessageDispatchException(
-                    f"Cannot test connection. No test email defined for {self.configuration.name}"
+                    f"Cannot test connection. No test email defined for {self.configuration.key}"
                 )
 
             logger.info("Starting test connection to {}", self.configuration.key)
@@ -137,7 +137,11 @@ class GenericConsentEmailConnector(BaseEmailConnector):
             )
 
         except MessageDispatchException as exc:
-            logger.info("Email consent connector test failed with exception {}", exc)
+            logger.info(
+                "Email consent connector test for {} failed with exception {}",
+                self.configuration.key,
+                exc,
+            )
             return ConnectionTestStatus.failed
         return ConnectionTestStatus.succeeded
 
@@ -177,12 +181,12 @@ class GenericConsentEmailConnector(BaseEmailConnector):
             db=db,
             data={
                 "connection_key": self.configuration.key,
-                "dataset_name": self.configuration.name,
-                "collection_name": self.configuration.name,
+                "dataset_name": self.configuration.name or self.configuration.key,
+                "collection_name": self.configuration.name or self.configuration.key,
                 "privacy_request_id": privacy_request.id,
                 "action_type": ActionType.consent,
                 "status": ExecutionLogStatus.skipped,
-                "message": f"Consent email skipped for '{self.configuration.name}'",
+                "message": f"Consent email skipped for '{self.configuration.name or self.configuration.key}'",
             },
         )
         for pref in privacy_request.privacy_preferences:  # type: ignore[attr-defined]
@@ -197,12 +201,12 @@ class GenericConsentEmailConnector(BaseEmailConnector):
             db=db,
             data={
                 "connection_key": self.configuration.key,
-                "dataset_name": self.configuration.name,
-                "collection_name": self.configuration.name,
+                "dataset_name": self.configuration.name or self.configuration.key,
+                "collection_name": self.configuration.name or self.configuration.key,
                 "privacy_request_id": privacy_request.id,
                 "action_type": ActionType.consent,
                 "status": ExecutionLogStatus.error,
-                "message": f"Consent email send error for '{self.configuration.name}'",
+                "message": f"Consent email send error for '{self.configuration.name or self.configuration.key}'",
             },
         )
         add_errored_system_status_for_consent_reporting(
@@ -265,13 +269,13 @@ class GenericConsentEmailConnector(BaseEmailConnector):
             logger.info(
                 "Skipping consent email send for connector: '{}'. "
                 "No corresponding user identities found for pending privacy requests.",
-                self.configuration.name,
+                self.configuration.key,
             )
             return
 
         logger.info(
             "Sending batched consent email for connector {}...",
-            self.configuration.name,
+            self.configuration.key,
         )
 
         db = Session.object_session(self.configuration)
@@ -286,7 +290,11 @@ class GenericConsentEmailConnector(BaseEmailConnector):
                 test_mode=False,
             )
         except MessageDispatchException as exc:
-            logger.info("Consent email failed with exception {}", exc)
+            logger.info(
+                "Consent email for connector {} failed with exception {}",
+                self.configuration.key,
+                exc,
+            )
             for privacy_request in privacy_requests:
                 if privacy_request.id not in skipped_privacy_requests:
                     self.add_errored_log(db, privacy_request)
@@ -298,12 +306,14 @@ class GenericConsentEmailConnector(BaseEmailConnector):
                     db=db,
                     data={
                         "connection_key": self.configuration.key,
-                        "dataset_name": self.configuration.name,
+                        "dataset_name": self.configuration.name
+                        or self.configuration.key,
                         "privacy_request_id": privacy_request.id,
-                        "collection_name": self.configuration.name,
+                        "collection_name": self.configuration.name
+                        or self.configuration.key,
                         "action_type": ActionType.consent,
                         "status": ExecutionLogStatus.complete,
-                        "message": f"Consent email instructions dispatched for '{self.configuration.name}'",
+                        "message": f"Consent email instructions dispatched for '{self.configuration.name or self.configuration.key}'",
                     },
                 )
                 add_complete_system_status_for_consent_reporting(

--- a/src/fides/api/service/connectors/consent_email_connector.py
+++ b/src/fides/api/service/connectors/consent_email_connector.py
@@ -181,12 +181,12 @@ class GenericConsentEmailConnector(BaseEmailConnector):
             db=db,
             data={
                 "connection_key": self.configuration.key,
-                "dataset_name": self.configuration.name or self.configuration.key,
-                "collection_name": self.configuration.name or self.configuration.key,
+                "dataset_name": self.configuration.name_or_key,
+                "collection_name": self.configuration.name_or_key,
                 "privacy_request_id": privacy_request.id,
                 "action_type": ActionType.consent,
                 "status": ExecutionLogStatus.skipped,
-                "message": f"Consent email skipped for '{self.configuration.name or self.configuration.key}'",
+                "message": f"Consent email skipped for '{self.configuration.name_or_key}'",
             },
         )
         for pref in privacy_request.privacy_preferences:  # type: ignore[attr-defined]
@@ -201,12 +201,12 @@ class GenericConsentEmailConnector(BaseEmailConnector):
             db=db,
             data={
                 "connection_key": self.configuration.key,
-                "dataset_name": self.configuration.name or self.configuration.key,
-                "collection_name": self.configuration.name or self.configuration.key,
+                "dataset_name": self.configuration.name_or_key,
+                "collection_name": self.configuration.name_or_key,
                 "privacy_request_id": privacy_request.id,
                 "action_type": ActionType.consent,
                 "status": ExecutionLogStatus.error,
-                "message": f"Consent email send error for '{self.configuration.name or self.configuration.key}'",
+                "message": f"Consent email send error for '{self.configuration.name_or_key}'",
             },
         )
         add_errored_system_status_for_consent_reporting(
@@ -313,7 +313,7 @@ class GenericConsentEmailConnector(BaseEmailConnector):
                         or self.configuration.key,
                         "action_type": ActionType.consent,
                         "status": ExecutionLogStatus.complete,
-                        "message": f"Consent email instructions dispatched for '{self.configuration.name or self.configuration.key}'",
+                        "message": f"Consent email instructions dispatched for '{self.configuration.name_or_key}'",
                     },
                 )
                 add_complete_system_status_for_consent_reporting(

--- a/src/fides/api/service/connectors/dynamic_erasure_email_connector.py
+++ b/src/fides/api/service/connectors/dynamic_erasure_email_connector.py
@@ -181,7 +181,7 @@ class DynamicErasureEmailConnector(BaseErasureEmailConnector):
                         "privacy_request_id": privacy_request.id,
                         "action_type": ActionType.erasure,
                         "status": ExecutionLogStatus.complete,
-                        "message": f"Erasure email instructions dispatched for '{self.configuration.name or self.configuration.key}'",
+                        "message": f"Erasure email instructions dispatched for '{self.configuration.name_or_key}'",
                     },
                 )
 
@@ -496,8 +496,8 @@ class DynamicErasureEmailConnector(BaseErasureEmailConnector):
             db=db,
             data={
                 "connection_key": self.configuration.key,
-                "dataset_name": self.configuration.name or self.configuration.key,
-                "collection_name": self.configuration.name or self.configuration.key,
+                "dataset_name": self.configuration.name_or_key,
+                "collection_name": self.configuration.name_or_key,
                 "privacy_request_id": privacy_request.id,
                 "action_type": ActionType.erasure,
                 "status": ExecutionLogStatus.error,

--- a/src/fides/api/service/connectors/dynamic_erasure_email_connector.py
+++ b/src/fides/api/service/connectors/dynamic_erasure_email_connector.py
@@ -174,10 +174,8 @@ class DynamicErasureEmailConnector(BaseErasureEmailConnector):
                     db=db,
                     data={
                         "connection_key": self.configuration.key,
-                        "dataset_name": self.configuration.name
-                        or self.configuration.key,
-                        "collection_name": self.configuration.name
-                        or self.configuration.key,
+                        "dataset_name": self.configuration.name_or_key,
+                        "collection_name": self.configuration.name_or_key,
                         "privacy_request_id": privacy_request.id,
                         "action_type": ActionType.erasure,
                         "status": ExecutionLogStatus.complete,

--- a/src/fides/api/service/connectors/erasure_email_connector.py
+++ b/src/fides/api/service/connectors/erasure_email_connector.py
@@ -118,10 +118,8 @@ class GenericErasureEmailConnector(BaseErasureEmailConnector):
                     db=db,
                     data={
                         "connection_key": self.configuration.key,
-                        "dataset_name": self.configuration.name
-                        or self.configuration.key,
-                        "collection_name": self.configuration.name
-                        or self.configuration.key,
+                        "dataset_name": self.configuration.name_or_key,
+                        "collection_name": self.configuration.name_or_key,
                         "privacy_request_id": privacy_request.id,
                         "action_type": ActionType.erasure,
                         "status": ExecutionLogStatus.complete,

--- a/src/fides/api/service/connectors/erasure_email_connector.py
+++ b/src/fides/api/service/connectors/erasure_email_connector.py
@@ -125,6 +125,6 @@ class GenericErasureEmailConnector(BaseErasureEmailConnector):
                         "privacy_request_id": privacy_request.id,
                         "action_type": ActionType.erasure,
                         "status": ExecutionLogStatus.complete,
-                        "message": f"Erasure email instructions dispatched for '{self.configuration.name or self.configuration.key}'",
+                        "message": f"Erasure email instructions dispatched for '{self.configuration.name_or_key}'",
                     },
                 )

--- a/src/fides/api/service/connectors/erasure_email_connector.py
+++ b/src/fides/api/service/connectors/erasure_email_connector.py
@@ -47,7 +47,7 @@ class GenericErasureEmailConnector(BaseErasureEmailConnector):
         try:
             if not self.config.test_email_address:
                 raise MessageDispatchException(
-                    f"Cannot test connection. No test email defined for {self.configuration.name}"
+                    f"Cannot test connection. No test email defined for {self.configuration.key}"
                 )
             # synchronous for now since failure to send is considered a connection test failure
             send_single_erasure_email(
@@ -58,7 +58,11 @@ class GenericErasureEmailConnector(BaseErasureEmailConnector):
                 test_mode=True,
             )
         except MessageDispatchException as exc:
-            logger.info("Email connector test failed with exception {}", exc)
+            logger.info(
+                "Email connector test for {} failed with exception {}",
+                self.configuration.key,
+                exc,
+            )
             return ConnectionTestStatus.failed
         return ConnectionTestStatus.succeeded
 
@@ -82,13 +86,13 @@ class GenericErasureEmailConnector(BaseErasureEmailConnector):
             logger.info(
                 "Skipping erasure email send for connector: '{}'. "
                 "No corresponding user identities found for pending privacy requests.",
-                self.configuration.name,
+                self.configuration.key,
             )
             return
 
         logger.info(
             "Sending batched erasure email for connector {}...",
-            self.configuration.name,
+            self.configuration.key,
         )
 
         try:
@@ -100,7 +104,11 @@ class GenericErasureEmailConnector(BaseErasureEmailConnector):
                 test_mode=False,
             )
         except MessageDispatchException as exc:
-            logger.info("Erasure email failed with exception {}", exc)
+            logger.info(
+                "Erasure email for connector {} failed with exception {}",
+                self.configuration.key,
+                exc,
+            )
             raise
 
         # create an audit event for each privacy request ID
@@ -110,11 +118,13 @@ class GenericErasureEmailConnector(BaseErasureEmailConnector):
                     db=db,
                     data={
                         "connection_key": self.configuration.key,
-                        "dataset_name": self.configuration.name,
-                        "collection_name": self.configuration.name,
+                        "dataset_name": self.configuration.name
+                        or self.configuration.key,
+                        "collection_name": self.configuration.name
+                        or self.configuration.key,
                         "privacy_request_id": privacy_request.id,
                         "action_type": ActionType.erasure,
                         "status": ExecutionLogStatus.complete,
-                        "message": f"Erasure email instructions dispatched for '{self.configuration.name}'",
+                        "message": f"Erasure email instructions dispatched for '{self.configuration.name or self.configuration.key}'",
                     },
                 )


### PR DESCRIPTION
Closes [PROD-2709](https://ethyca.atlassian.net/browse/PROD-2709)

### Description Of Changes

Adds the `name_or_key` property to `ConnectionConfig`, and updates all email connectors to do two things:
- All logs will log the connection config key, not the name
- All `ExecutionLog` instances created will use the `name_or_key` property instead of just the name 

This is because the `name` is an optional property for the connection config. 

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!


[PROD-2709]: https://ethyca.atlassian.net/browse/PROD-2709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ