### PR TITLE
Support Accept/Reject All with minimal TCF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The types of changes are:
 - Add ability to edit dataset YAML from dataset view [#5262](https://github.com/ethyca/fides/pull/5262)
 - Added support for "in progress" status in classification [#5248](https://github.com/ethyca/fides/pull/5248)
 - Clarify GCP service account permissions when setting up Google Cloud SQL for Postgres in Admin-UI [#5245](https://github.com/ethyca/fides/pull/5266)
+- Support minimal GVL in minimal TCF response allowing Accept/Reject from banner before full GVL is loaded [#5298](https://github.com/ethyca/fides/pull/5298)
 
 ### Changed
 - Validate no path in `server_host` var for CLI config; if there is one then take only up until the first forward slash

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -15,7 +15,7 @@ const GZIP_SIZE_ERROR_KB = 45; // fail build if bundle size exceeds this
 const GZIP_SIZE_WARN_KB = 35; // log a warning if bundle size exceeds this
 
 // TCF
-const GZIP_SIZE_TCF_ERROR_KB = 85;
+const GZIP_SIZE_TCF_ERROR_KB = 86;
 const GZIP_SIZE_TCF_WARN_KB = 75;
 
 const preactAliases = {

--- a/clients/fides-js/src/components/Button.tsx
+++ b/clients/fides-js/src/components/Button.tsx
@@ -29,6 +29,7 @@ const Button: FunctionComponent<ButtonProps> = ({
     onClick={onClick}
     data-testid={`${label}-btn`}
     disabled={disabled || loading}
+    style={{ cursor: disabled || loading ? "not-allowed" : "pointer" }}
   >
     {label || ""}
     {loading && <Spinner />}

--- a/clients/fides-js/src/components/Button.tsx
+++ b/clients/fides-js/src/components/Button.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, h } from "preact";
 
 import { ButtonType } from "../lib/consent-types";
+import { Spinner } from "./Spinner";
 
 interface ButtonProps {
   buttonType: ButtonType;
@@ -9,6 +10,7 @@ interface ButtonProps {
   onClick?: () => void;
   className?: string;
   disabled?: boolean;
+  loading?: boolean;
 }
 
 const Button: FunctionComponent<ButtonProps> = ({
@@ -18,6 +20,7 @@ const Button: FunctionComponent<ButtonProps> = ({
   onClick,
   className = "",
   disabled,
+  loading,
 }) => (
   <button
     type="button"
@@ -25,9 +28,10 @@ const Button: FunctionComponent<ButtonProps> = ({
     className={`fides-banner-button fides-banner-button-${buttonType.valueOf()} ${className}`}
     onClick={onClick}
     data-testid={`${label}-btn`}
-    disabled={disabled}
+    disabled={disabled || loading}
   >
     {label || ""}
+    {loading && <Spinner />}
   </button>
 );
 

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -25,7 +25,8 @@ interface ConsentButtonProps {
   hideOptInOut?: boolean;
   isInModal?: boolean;
   isTCF?: boolean;
-  disableAll?: boolean;
+  isMinimalTCF?: boolean;
+  isGVLLoading?: boolean;
 }
 export const ConsentButtons = ({
   availableLocales = [DEFAULT_LOCALE],
@@ -37,7 +38,8 @@ export const ConsentButtons = ({
   options,
   isInModal,
   isTCF,
-  disableAll,
+  isMinimalTCF,
+  isGVLLoading,
 }: ConsentButtonProps) => {
   const { i18n } = useI18n();
   const isMobile = useMediaQuery("(max-width: 768px)");
@@ -63,7 +65,7 @@ export const ConsentButtons = ({
                 label={i18n.t("exp.privacy_preferences_link_label")}
                 onClick={onManagePreferencesClick}
                 className="fides-manage-preferences-button"
-                disabled={disableAll}
+                loading={isMinimalTCF || isGVLLoading}
               />
             )}
             <Button
@@ -71,14 +73,14 @@ export const ConsentButtons = ({
               label={i18n.t("exp.reject_button_label")}
               onClick={onRejectAll}
               className="fides-reject-all-button"
-              disabled={disableAll}
+              loading={isGVLLoading}
             />
             <Button
               buttonType={ButtonType.PRIMARY}
               label={i18n.t("exp.accept_button_label")}
               onClick={onAcceptAll}
               className="fides-accept-all-button"
-              disabled={disableAll}
+              loading={isGVLLoading}
             />
           </Fragment>
         )}

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -1,4 +1,5 @@
 import { Fragment, h, VNode } from "preact";
+import { useEffect, useState } from "preact/hooks";
 
 import {
   ButtonType,
@@ -41,12 +42,28 @@ export const ConsentButtons = ({
   isMinimalTCF,
   isGVLLoading,
 }: ConsentButtonProps) => {
+  const [isLoadingModal, setIsLoadingModal] = useState<boolean>(false);
   const { i18n } = useI18n();
   const isMobile = useMediaQuery("(max-width: 768px)");
   const includeLanguageSelector = i18n.availableLanguages?.length > 1;
   const includePrivacyPolicyLink =
     messageExists(i18n, "exp.privacy_policy_link_label") &&
     messageExists(i18n, "exp.privacy_policy_url");
+  const handleManagePreferencesClick = () => {
+    const isReady = !isTCF || !isMinimalTCF;
+    setIsLoadingModal(!isReady);
+    if (onManagePreferencesClick && isReady) {
+      onManagePreferencesClick();
+    }
+  };
+
+  useEffect(() => {
+    if (isLoadingModal && !isMinimalTCF) {
+      handleManagePreferencesClick();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoadingModal, isMinimalTCF]);
+
   return (
     <div id="fides-button-group">
       <div
@@ -63,9 +80,9 @@ export const ConsentButtons = ({
               <Button
                 buttonType={ButtonType.SECONDARY}
                 label={i18n.t("exp.privacy_preferences_link_label")}
-                onClick={onManagePreferencesClick}
+                onClick={handleManagePreferencesClick}
                 className="fides-manage-preferences-button"
-                loading={isMinimalTCF || isGVLLoading}
+                loading={isLoadingModal}
               />
             )}
             <Button

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -249,27 +249,10 @@ const Overlay: FunctionComponent<Props> = ({
             onManagePreferencesClick: handleManagePreferencesClick,
           })
         : null}
-      {!!renderModalContent &&
-        !!renderModalFooter &&
-        (options.fidesEmbed ? (
-          bannerIsOpen ? null : (
-            <ConsentContent
-              titleProps={attributes.title}
-              renderModalFooter={() =>
-                renderModalFooter({
-                  onClose: handleCloseModalAfterSave,
-                  isMobile: false,
-                })
-              }
-            >
-              {renderModalContent()}
-            </ConsentContent>
-          )
-        ) : (
-          <ConsentModal
-            attributes={attributes}
-            dismissable={experience.experience_config.dismissable}
-            onVendorPageClick={onVendorPageClick}
+      {options.fidesEmbed ? (
+        bannerIsOpen || !renderModalContent || !renderModalFooter ? null : (
+          <ConsentContent
+            titleProps={attributes.title}
             renderModalFooter={() =>
               renderModalFooter({
                 onClose: handleCloseModalAfterSave,
@@ -278,8 +261,32 @@ const Overlay: FunctionComponent<Props> = ({
             }
           >
             {renderModalContent()}
-          </ConsentModal>
-        ))}
+          </ConsentContent>
+        )
+      ) : (
+        /* If the modal is not going to be embedded, we at least need to instantiate the wrapper
+         * before the footer and content are available so that it can be opened while those render.
+         * Otherwise a race condition can cause problems with the following scenario:
+         * button click too early -> button has spinner -> experience loads -> modal opener called.
+         * This scenario exists today for TCF Minimal experience where banner appears before
+         * full experience (and therefore the modal) is ready.
+         */
+        <ConsentModal
+          attributes={attributes}
+          dismissable={experience.experience_config.dismissable}
+          onVendorPageClick={onVendorPageClick}
+          renderModalFooter={() =>
+            renderModalFooter
+              ? renderModalFooter({
+                  onClose: handleCloseModalAfterSave,
+                  isMobile: false,
+                })
+              : null
+          }
+        >
+          {renderModalContent && renderModalContent()}
+        </ConsentModal>
+      )}
     </div>
   );
 };

--- a/clients/fides-js/src/components/Spinner.tsx
+++ b/clients/fides-js/src/components/Spinner.tsx
@@ -1,0 +1,3 @@
+import { h } from "preact";
+
+export const Spinner = () => <div className="fides-spinner" />;

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -245,9 +245,10 @@ div#fides-button-group {
 
 button.fides-banner-button {
   font-size: var(--fides-overlay-font-size-buttons);
-  display: inline-block;
+  display: flex;
   cursor: pointer;
-  text-align: center;
+  align-items: center;
+  justify-content: center;
   margin: 0;
   margin-top: 4px;
   padding: var(--fides-overlay-button-padding);
@@ -305,6 +306,29 @@ button.fides-banner-button.fides-banner-button-tertiary {
 
 button.fides-banner-button.fides-acknowledge-button {
   min-width: 160px;
+}
+
+.fides-spinner {
+  border: 2px solid transparent;
+  border-top: 2px solid;
+  border-right: 2px solid;
+  border-top-color: var(--fides-overlay-primary-color);
+  border-right-color: var(--fides-overlay-primary-color);
+  border-radius: 50%;
+  width: 1em;
+  height: 1em;
+  animation: spin 1s linear infinite;
+  margin-left: 8px;
+}
+
+.fides-banner-button-primary .fides-spinner {
+  border-top-color: var(--fides-overlay-primary-button-text-color);
+  border-right-color: var(--fides-overlay-primary-button-text-color);
+}
+
+.fides-banner-button-secondary .fides-spinner {
+  border-top-color: var(--fides-overlay-secondary-button-border-color);
+  border-right-color: var(--fides-overlay-secondary-button-border-color);
 }
 
 /** Modal */

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -37,6 +37,8 @@ export const TcfConsentButtons = ({
     return null;
   }
 
+  const isGVLLoading = Object.keys(experience.gvl || {}).length === 0;
+
   const handleAcceptAll = () => {
     let allIds: EnabledIds;
     if (!experience.minimal_tcf) {
@@ -108,7 +110,7 @@ export const TcfConsentButtons = ({
       options={options}
       isTCF
       isMinimalTCF={experience.minimal_tcf}
-      isGVLLoading={!experience.gvl}
+      isGVLLoading={isGVLLoading}
     />
   );
 };

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -38,10 +38,11 @@ export const TcfConsentButtons = ({
   }
 
   const handleAcceptAll = () => {
+    let allIds: EnabledIds;
     if (!experience.minimal_tcf) {
       // eslint-disable-next-line no-param-reassign
       experience = experience as PrivacyExperience;
-      const allIds: EnabledIds = {
+      allIds = {
         purposesConsent: getAllIds(experience.tcf_purpose_consents),
         purposesLegint: getAllIds(experience.tcf_purpose_legitimate_interests),
         specialPurposes: getAllIds(experience.tcf_special_purposes),
@@ -56,22 +57,44 @@ export const TcfConsentButtons = ({
           ...(experience.tcf_system_legitimate_interests || []),
         ]),
       };
-      onSave(ConsentMethod.ACCEPT, allIds);
+    } else {
+      // eslint-disable-next-line no-param-reassign
+      experience = experience as PrivacyExperienceMinimal;
+      allIds = {
+        purposesConsent:
+          experience.tcf_purpose_consent_ids?.map((id) => `${id}`) || [],
+        purposesLegint:
+          experience.tcf_purpose_legitimate_interest_ids?.map(
+            (id) => `${id}`,
+          ) || [],
+        specialPurposes:
+          experience.tcf_special_purpose_ids?.map((id) => `${id}`) || [],
+        features: experience.tcf_feature_ids?.map((id) => `${id}`) || [],
+        specialFeatures:
+          experience.tcf_special_feature_ids?.map((id) => `${id}`) || [],
+        vendorsConsent: [
+          ...(experience.tcf_vendor_consent_ids || []),
+          ...(experience.tcf_system_consent_ids || []),
+        ],
+        vendorsLegint: [
+          ...(experience.tcf_vendor_legitimate_interest_ids || []),
+          ...(experience.tcf_system_legitimate_interest_ids || []),
+        ],
+      };
     }
+    onSave(ConsentMethod.ACCEPT, allIds);
   };
   const handleRejectAll = () => {
-    if (!experience.minimal_tcf) {
-      const emptyIds: EnabledIds = {
-        purposesConsent: [],
-        purposesLegint: [],
-        specialPurposes: [],
-        features: [],
-        specialFeatures: [],
-        vendorsConsent: [],
-        vendorsLegint: [],
-      };
-      onSave(ConsentMethod.REJECT, emptyIds);
-    }
+    const emptyIds: EnabledIds = {
+      purposesConsent: [],
+      purposesLegint: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      vendorsConsent: [],
+      vendorsLegint: [],
+    };
+    onSave(ConsentMethod.REJECT, emptyIds);
   };
 
   return (
@@ -84,7 +107,8 @@ export const TcfConsentButtons = ({
       isInModal={isInModal}
       options={options}
       isTCF
-      disableAll={experience.minimal_tcf}
+      isMinimalTCF={experience.minimal_tcf}
+      isGVLLoading={!experience.gvl}
     />
   );
 };

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -24,11 +24,12 @@ import {
 import { useI18n } from "../../lib/i18n/i18n-context";
 import { updateConsentPreferences } from "../../lib/preferences";
 import { useGvl } from "../../lib/tcf/gvl-context";
-import type { EnabledIds } from "../../lib/tcf/types";
+import type { EnabledIds, TcfSavePreferences } from "../../lib/tcf/types";
 import {
   buildTcfEntitiesFromCookieAndFidesString as buildUserPrefs,
   constructTCFNoticesServedProps,
   createTcfSavePayload,
+  createTcfSavePayloadFromMinExp,
   getEnabledIds,
   getGVLPurposeList,
   updateCookie,
@@ -245,17 +246,25 @@ export const TcfOverlay = ({
 
   const handleUpdateAllPreferences = useCallback(
     (consentMethod: ConsentMethod, enabledIds: EnabledIds) => {
-      if (!experience) {
+      if (!experience && !experienceMinimal) {
         return;
       }
-      const tcf = createTcfSavePayload({
-        experience,
-        enabledIds,
-      });
+      let tcf: TcfSavePreferences;
+      if (experienceMinimal.minimal_tcf) {
+        tcf = createTcfSavePayloadFromMinExp({
+          experienceMinimal,
+          enabledIds,
+        });
+      } else {
+        tcf = createTcfSavePayload({
+          experience: experience as PrivacyExperience,
+          enabledIds,
+        });
+      }
       updateConsentPreferences({
         consentPreferencesToSave: [],
         privacyExperienceConfigHistoryId,
-        experience,
+        experience: experience || experienceMinimal,
         consentMethod,
         options,
         userLocationString: fidesRegionString,
@@ -264,13 +273,19 @@ export const TcfOverlay = ({
         tcf,
         servedNoticeHistoryId,
         updateCookie: (oldCookie) =>
-          updateCookie(oldCookie, tcf, enabledIds, experience),
+          updateCookie(
+            oldCookie,
+            tcf,
+            enabledIds,
+            experience || experienceMinimal,
+          ),
       });
       setDraftIds(enabledIds);
     },
     [
       cookie,
       experience,
+      experienceMinimal,
       fidesRegionString,
       options,
       privacyExperienceConfigHistoryId,

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -252,7 +252,7 @@ export const TcfOverlay = ({
       let tcf: TcfSavePreferences;
       if (!experience && experienceMinimal?.minimal_tcf) {
         tcf = createTcfSavePayloadFromMinExp({
-          experienceMinimal,
+          experience: experienceMinimal,
           enabledIds,
         });
       } else {

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -250,7 +250,7 @@ export const TcfOverlay = ({
         return;
       }
       let tcf: TcfSavePreferences;
-      if (experienceMinimal.minimal_tcf) {
+      if (!experience && experienceMinimal?.minimal_tcf) {
         tcf = createTcfSavePayloadFromMinExp({
           experienceMinimal,
           enabledIds,

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -218,7 +218,7 @@ export type FidesApiOptions = {
     consentMethod: ConsentMethod,
     consent: NoticeConsent,
     fides_string: string | undefined,
-    experience: PrivacyExperience,
+    experience: PrivacyExperience | PrivacyExperienceMinimal,
   ) => Promise<void>;
   /**
    * Intake a custom function that is used to override users' saved preferences.
@@ -436,7 +436,12 @@ interface ExperienceConfigMinimal
 export interface PrivacyExperienceMinimal
   extends Pick<
     PrivacyExperience,
-    "id" | "available_locales" | "gpp_settings" | "vendor_count" | "minimal_tcf"
+    | "id"
+    | "available_locales"
+    | "gpp_settings"
+    | "vendor_count"
+    | "minimal_tcf"
+    | "gvl"
   > {
   experience_config: ExperienceConfigMinimal;
   vendor_count?: number;

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -5,6 +5,7 @@ import {
   FidesCookie,
   FidesInitOptions,
   PrivacyExperience,
+  PrivacyExperienceMinimal,
   PrivacyPreferencesRequest,
   SaveConsentPreference,
   UserConsentPreference,
@@ -20,7 +21,7 @@ import { TcfSavePreferences } from "./tcf/types";
 async function savePreferencesApi(
   options: FidesInitOptions,
   cookie: FidesCookie,
-  experience: PrivacyExperience,
+  experience: PrivacyExperience | PrivacyExperienceMinimal,
   consentMethod: ConsentMethod,
   privacyExperienceConfigHistoryId?: string,
   consentPreferencesToSave?: Array<SaveConsentPreference>,
@@ -82,7 +83,7 @@ export const updateConsentPreferences = async ({
 }: {
   consentPreferencesToSave?: Array<SaveConsentPreference>;
   privacyExperienceConfigHistoryId?: string;
-  experience: PrivacyExperience;
+  experience: PrivacyExperience | PrivacyExperienceMinimal;
   consentMethod: ConsentMethod;
   options: FidesInitOptions;
   userLocationString?: string;

--- a/clients/fides-js/src/lib/tcf/utils.ts
+++ b/clients/fides-js/src/lib/tcf/utils.ts
@@ -272,20 +272,18 @@ const transformTcfIdsToTcfSave = (enabledIds: string[]): TcfSave[] | null => {
   }) as TcfSave[];
 };
 
+interface TcfSavePayloadProps<T> {
+  experience: T;
+  enabledIds: EnabledIds;
+}
+
 /**
  * Creates a TCF save payload based on the user's enabled IDs.
  */
 export const createTcfSavePayload = ({
   experience,
   enabledIds,
-}: {
-  experience: PrivacyExperience;
-  enabledIds: EnabledIds;
-}): TcfSavePreferences => {
-  const {
-    tcf_system_consents: consentSystems,
-    tcf_system_legitimate_interests: legintSystems,
-  } = experience;
+}: TcfSavePayloadProps<PrivacyExperience>): TcfSavePreferences => {
   // Because systems were combined with vendors to make the UI easier to work with,
   // we need to separate them out now (the backend treats them as separate entities).
   const enabledConsentSystemIds: string[] = [];
@@ -293,14 +291,16 @@ export const createTcfSavePayload = ({
   const enabledLegintSystemIds: string[] = [];
   const enabledLegintVendorIds: string[] = [];
   enabledIds.vendorsConsent.forEach((id) => {
-    if (consentSystems?.map((s) => s.id).includes(id)) {
+    if (experience.tcf_system_consents?.map((s) => s.id).includes(id)) {
       enabledConsentSystemIds.push(id);
     } else {
       enabledConsentVendorIds.push(id);
     }
   });
   enabledIds.vendorsLegint.forEach((id) => {
-    if (legintSystems?.map((s) => s.id).includes(id)) {
+    if (
+      experience.tcf_system_legitimate_interests?.map((s) => s.id).includes(id)
+    ) {
       enabledLegintSystemIds.push(id);
     } else {
       enabledLegintVendorIds.push(id);
@@ -340,12 +340,9 @@ export const createTcfSavePayload = ({
 };
 
 export const createTcfSavePayloadFromMinExp = ({
-  experienceMinimal,
+  experience,
   enabledIds,
-}: {
-  experienceMinimal: PrivacyExperienceMinimal;
-  enabledIds: EnabledIds;
-}) => {
+}: TcfSavePayloadProps<PrivacyExperienceMinimal>) => {
   // Because systems were combined with vendors to make the UI easier to work with,
   // we need to separate them out now (the backend treats them as separate entities).
   const enabledConsentSystemIds: string[] = [];
@@ -353,14 +350,14 @@ export const createTcfSavePayloadFromMinExp = ({
   const enabledLegintSystemIds: string[] = [];
   const enabledLegintVendorIds: string[] = [];
   enabledIds.vendorsConsent.forEach((id) => {
-    if (experienceMinimal.tcf_system_consent_ids?.includes(id)) {
+    if (experience.tcf_system_consent_ids?.includes(id)) {
       enabledConsentSystemIds.push(id);
     } else {
       enabledConsentVendorIds.push(id);
     }
   });
   enabledIds.vendorsLegint.forEach((id) => {
-    if (experienceMinimal.tcf_system_legitimate_interest_ids?.includes(id)) {
+    if (experience.tcf_system_legitimate_interest_ids?.includes(id)) {
       enabledLegintSystemIds.push(id);
     } else {
       enabledLegintVendorIds.push(id);

--- a/clients/fides-js/src/lib/tcf/utils.ts
+++ b/clients/fides-js/src/lib/tcf/utils.ts
@@ -261,8 +261,12 @@ const transformTcfIdsToTcfSave = (enabledIds: string[]): TcfSave[] | null => {
   }
   return enabledIds.map((id) => {
     const preference = transformConsentToFidesUserPreference(true);
+    let updatedId: string | number = id;
+    if (!Number.isNaN(parseInt(id, 10))) {
+      updatedId = parseInt(id, 10);
+    }
     return {
-      id,
+      id: updatedId,
       preference,
     };
   }) as TcfSave[];

--- a/clients/fides-js/src/lib/tcf/vendors.ts
+++ b/clients/fides-js/src/lib/tcf/vendors.ts
@@ -63,17 +63,14 @@ export const uniqueGvlVendorIds = (experience: PrivacyExperience): number[] => {
 export const uniqueGvlVendorIdsFromMinimal = (
   experienceMinimal: PrivacyExperienceMinimal,
 ): number[] => {
-  const tcfVendorConsentIds = experienceMinimal.tcf_vendor_consent_ids || [];
-  const tcfVendorLegitimateInterestIds =
-    experienceMinimal.tcf_vendor_legitimate_interest_ids || [];
   const combinedIds = [
-    ...tcfVendorConsentIds,
-    ...tcfVendorLegitimateInterestIds,
+    ...(experienceMinimal.tcf_vendor_consent_ids || []),
+    ...(experienceMinimal.tcf_vendor_legitimate_interest_ids || []),
   ];
   // creating a set automatically removes duplicates
   const uniqueCombinedSet = new Set(combinedIds);
 
-  const gvlIds = Array.from(uniqueCombinedSet).filter((uid) =>
+  const gvlIds = [...uniqueCombinedSet].filter((uid) =>
     vendorGvlEntry(uid, experienceMinimal.gvl),
   );
   // Return [2,4] as numbers

--- a/clients/fides-js/src/lib/tcf/vendors.ts
+++ b/clients/fides-js/src/lib/tcf/vendors.ts
@@ -1,4 +1,4 @@
-import { PrivacyExperience } from "../consent-types";
+import { PrivacyExperience, PrivacyExperienceMinimal } from "../consent-types";
 import {
   GVLJson,
   TCFVendorConsentRecord,
@@ -53,10 +53,29 @@ export const vendorIsAc = (vendorId: TCFVendorRelationships["id"]) =>
 export const uniqueGvlVendorIds = (experience: PrivacyExperience): number[] => {
   const { tcf_vendor_relationships: vendors = [] } = experience;
 
-  // Filter to just i.e. [gvl.2, gvl.4]
   const gvlIds = vendors
     .map((v) => v.id)
     .filter((uid) => vendorGvlEntry(uid, experience.gvl));
+  // Return [2,4] as numbers
+  return gvlIds.map((uid) => +decodeVendorId(uid).id);
+};
+
+export const uniqueGvlVendorIdsFromMinimal = (
+  experienceMinimal: PrivacyExperienceMinimal,
+): number[] => {
+  const tcfVendorConsentIds = experienceMinimal.tcf_vendor_consent_ids || [];
+  const tcfVendorLegitimateInterestIds =
+    experienceMinimal.tcf_vendor_legitimate_interest_ids || [];
+  const combinedIds = [
+    ...tcfVendorConsentIds,
+    ...tcfVendorLegitimateInterestIds,
+  ];
+  // creating a set automatically removes duplicates
+  const uniqueCombinedSet = new Set(combinedIds);
+
+  const gvlIds = Array.from(uniqueCombinedSet).filter((uid) =>
+    vendorGvlEntry(uid, experienceMinimal.gvl),
+  );
   // Return [2,4] as numbers
   return gvlIds.map((uid) => +decodeVendorId(uid).id);
 };

--- a/clients/fides-js/src/services/api.ts
+++ b/clients/fides-js/src/services/api.ts
@@ -87,7 +87,7 @@ export const fetchExperience = async <T = PrivacyExperience>({
     systems_applicable: "true",
     exclude_gvl_languages: "true", // backwards compatibility for TCF optimization work
     include_meta: "true",
-    ...(!requestMinimalTCF && { include_gvl: "true" }),
+    include_gvl: "true",
     ...(requestMinimalTCF && { minimal_tcf: "true" }),
     ...(propertyId && { property_id: propertyId }),
   };

--- a/clients/fides-js/src/services/api.ts
+++ b/clients/fides-js/src/services/api.ts
@@ -197,7 +197,7 @@ export const patchUserPreference = async (
   preferences: PrivacyPreferencesRequest,
   options: FidesInitOptions,
   cookie: FidesCookie,
-  experience: PrivacyExperience,
+  experience: PrivacyExperience | PrivacyExperienceMinimal,
 ): Promise<void> => {
   debugLog(options.debug, "Saving user consent preference...", preferences);
   if (options.apiOptions?.savePreferencesFn) {


### PR DESCRIPTION
Closes [PROD-2777](https://ethyca.atlassian.net/browse/PROD-2777)

### Description Of Changes

Today, the “minimal” TCF banner can display the banner but the “Accept All” and “Reject All” actions are not enabled until the “full” experience is loaded. This can take several seconds to do on a low-speed connection, which creates a window where users can see a banner but are unable to opt-in.

These changes are set up for handling a new scenario in which a minimal version of `experience.gvl` is provided as part of the minimal TCF experience response.

If no GVL is included, we'll at least show some spinners during the loading of the full experience to not appear "broken" during that time.


### Code Changes

* [x] New Spinner component (very small, css only)
* [x] Show spinner on the Modal button (Manage Preferences) while the full experience finishes loading
* [x] Show spinner on Accept/Reject buttons if the gvl object is not included with the minimal experience (for backwards compatibility mostly)
* [x] Update/create several of the utilites that support "Accept All" from the full experience to also support it from the minimal experience, which only supplies IDs
* [x] Remove any blockers from letting users Accept/Reject all from the minimal experience

### Steps to Confirm

1. visit the Fides.JS demo site with TCF enabled (eg. http://localhost:3001/fides-js-demo.html?geolocation=eea)
2. In browser's dev tools, enable throttling in the Network tab to mimic a slow network
3. Clear any existing cookie and reload the page
  * If the response is slow enough with the throttling, you should see a spinner on the Manage Preferences button until the full experience has loaded
  * If the backend task for including a minimal gvl isn't finished yet, you should see a spinner on all 3 buttons while the full experience loads
  * If you attempt to click Accept All or Reject all before the full experience has loaded (the spinner is still spinning), it should work as expected and close the banner. This behavior should be exactly the same as clicking the respective buttons after the full experience loads. (Cookie set with same fides_string, payload for saving the preference api should be the same, CMP Validator should report the same)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`


[PROD-2777]: https://ethyca.atlassian.net/browse/PROD-2777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ