### PR TITLE
update fides-no-scroll so it works in all browsers 

### DIFF
--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -458,7 +458,7 @@ div#fides-consent-content .fides-modal-description {
 }
 
 .fides-no-scroll {
-  overflow-y: hidden;
+  overflow: hidden;
 }
 
 /* Responsive overlay */


### PR DESCRIPTION
### Description Of Changes

update fides-no-scroll so it works in all browsers (especially safari)

### Code Changes

* [ ] update `overflow-y: hidden` to `overflow: hidden`

### Steps to Confirm

* [ ] ensure a banner will show on the on the [fides.js demo page](http://localhost:3001/fides-js-demo.html?geolocation=eeA) by adding systems with data uses and enabling notices and experiences
* [ ] add `fides-no-scroll` to the body element on the fides.js demo page
* [ ] verify you cannot scroll 
* [ ] verify when exiting the banner you can scroll
* [ ] test this in safari, firefox, chrome, and edge

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
