### PR TITLE
Fix discovery pagination

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultsFilterTabs.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultsFilterTabs.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { DiffStatus } from "~/types/api";
 
@@ -16,29 +16,35 @@ const useDiscoveryResultsFilterTabs = ({
 }: DiscoveryResultsFilterTabsProps) => {
   const [filterTabIndex, setFilterTabIndex] = useState(initialFilterTabIndex);
 
-  const filterTabs = [
-    {
-      label: "Action Required",
-      filters: [
-        DiffStatus.CLASSIFICATION_ADDITION,
-        DiffStatus.CLASSIFICATION_UPDATE,
-      ],
-      childFilters: [
-        DiffStatus.CLASSIFICATION_ADDITION,
-        DiffStatus.CLASSIFICATION_UPDATE,
-      ],
-    },
-    {
-      label: "In progress",
-      filters: [DiffStatus.CLASSIFYING, DiffStatus.CLASSIFICATION_QUEUED],
-      childFilters: [DiffStatus.CLASSIFYING, DiffStatus.CLASSIFICATION_QUEUED],
-    },
-    {
-      label: "Unmonitored",
-      filters: [DiffStatus.MUTED],
-      childFilters: [],
-    },
-  ];
+  const filterTabs = useMemo(
+    () => [
+      {
+        label: "Action Required",
+        filters: [
+          DiffStatus.CLASSIFICATION_ADDITION,
+          DiffStatus.CLASSIFICATION_UPDATE,
+        ],
+        childFilters: [
+          DiffStatus.CLASSIFICATION_ADDITION,
+          DiffStatus.CLASSIFICATION_UPDATE,
+        ],
+      },
+      {
+        label: "In progress",
+        filters: [DiffStatus.CLASSIFYING, DiffStatus.CLASSIFICATION_QUEUED],
+        childFilters: [
+          DiffStatus.CLASSIFYING,
+          DiffStatus.CLASSIFICATION_QUEUED,
+        ],
+      },
+      {
+        label: "Unmonitored",
+        filters: [DiffStatus.MUTED],
+        childFilters: [],
+      },
+    ],
+    [],
+  );
 
   return {
     filterTabs,


### PR DESCRIPTION

### Description Of Changes

Fix discovery pagination. Change was lost due to bad merge.

### Code Changes

* [ ] Fix pagination by making filter array persist and not trigger a change in pagination

### Steps to Confirm

* [ ] Go to discovery results of a large dataset and try to use pagination

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
