### PR TITLE
Fix cached translation issues with Minimal TCF experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The types of changes are:
 - Fix wording in tooltip for Yotpo Reviews [#5274](https://github.com/ethyca/fides/pull/5274)
 - Hardcode ConnectionConfigurationResponse.secrets [#5283](https://github.com/ethyca/fides/pull/5283)
 - Fix Fides.shouldShouldShowExperience() to return false for modal-only experiences [#5281](https://github.com/ethyca/fides/pull/5281)
+- Fix issues with cached or `window.fides_overrides` languages in the Minimal TCF banner [#5306](https://github.com/ethyca/fides/pull/5306)
 
 
 ## [2.44.0](https://github.com/ethyca/fides/compare/2.43.1...2.44.0)

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -531,7 +531,20 @@ describe("i18n-utils", () => {
       const mockOptions: Partial<FidesInitOptions> = {
         fidesLocale: "fr",
       };
-      expect(detectUserLocale(mockNavigator, mockOptions)).toEqual("fr");
+      expect(detectUserLocale(mockNavigator, mockOptions.fidesLocale)).toEqual(
+        "fr",
+      );
+    });
+
+    it("returns the browser locale if locale is provided but undefined", () => {
+      const mockOptions: Partial<FidesInitOptions> = {};
+      expect(detectUserLocale(mockNavigator, mockOptions.fidesLocale)).toEqual(
+        "es",
+      );
+    });
+
+    it("returns the default locale if provided and browser locale is missing", () => {
+      expect(detectUserLocale({}, undefined, "fr")).toEqual("fr");
     });
   });
 

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -189,6 +189,17 @@ describe("i18n-utils", () => {
       );
       expect(mockI18n.activate).toHaveBeenCalledWith("es");
     });
+
+    it("handles i18n initialization when translation isn't available (yet)", () => {
+      const mockNavigator: Partial<Navigator> = {
+        language: "fr",
+      };
+      const mockExpMinimalCached = JSON.parse(JSON.stringify(mockExperience));
+      mockExpMinimalCached.experience_config.translations.splice(0, 1);
+      mockExpMinimalCached.available_locales.push("fr");
+      initializeI18n(mockI18n, mockNavigator, mockExpMinimalCached);
+      expect(mockI18n.setDefaultLocale).toHaveBeenCalledWith("es");
+    });
   });
 
   describe("loadMessagesFromFiles", () => {

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -107,33 +107,29 @@ export const TcfOverlay = ({
   const [experience, setExperience] = useState<PrivacyExperience>();
 
   useEffect(() => {
-    // We need to separately track if the experience and GVL translations are loading
-    // since they are loaded asynchronously and we need to know when *both* are done
-    // in order to set the i18n loading state.
-    let isExperienceLoading = false;
     let isGVLLangLoading = false;
 
-    if (!!userlocale && userlocale !== minExperienceLocale) {
+    if (!!userlocale && bestLocale !== minExperienceLocale) {
       // The minimal experience translation is different from the user's language.
       // This occurs when the customer has set their overrides on the window object
       // which isn't available to us until the experience is fetched or when the
       // browser has cached the experience from a previous userLocale. In these cases,
       // we'll get the translations for the banner from the full experience.
+      debugLog(
+        options.debug,
+        `Best locale does not match minimal experience locale (${minExperienceLocale})\nLoading translations from full experience = ${bestLocale}`,
+      );
       setIsI18nLoading(true);
     }
-    if (!!userlocale && userlocale !== DEFAULT_LOCALE) {
+    if (!!userlocale && bestLocale !== DEFAULT_LOCALE) {
       // We can only get English GVL translations from the experience.
       // If the user's locale is not English, we need to load them from the api.
-      setIsI18nLoading(true);
+      // This only affects the modal.
       isGVLLangLoading = true;
       loadGVLTranslations(bestLocale).then(() => {
         isGVLLangLoading = false;
-        if (!isExperienceLoading) {
-          setIsI18nLoading(false);
-        }
       });
     }
-    isExperienceLoading = true;
     fetchExperience({
       userLocationString: fidesRegionString,
       fidesApiUrl: options.fidesApiUrl,
@@ -149,7 +145,6 @@ export const TcfOverlay = ({
 
         setExperience(fullExperience);
         loadMessagesFromExperience(i18n, fullExperience);
-        isExperienceLoading = false;
         if (!userlocale || userlocale === defaultLocale) {
           // English (default) GVL translations are part of the full experience, so we load them here.
           loadGVLMessagesFromExperience(i18n, fullExperience);

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -145,7 +145,7 @@ export const TcfOverlay = ({
 
         setExperience(fullExperience);
         loadMessagesFromExperience(i18n, fullExperience);
-        if (!userlocale || userlocale === defaultLocale) {
+        if (!userlocale || bestLocale === defaultLocale) {
           // English (default) GVL translations are part of the full experience, so we load them here.
           loadGVLMessagesFromExperience(i18n, fullExperience);
         } else {

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -425,7 +425,7 @@ interface ExperienceConfigTranslationMinimal
   privacy_experience_config_history_id: string;
 }
 
-interface ExperienceConfigMinimal
+export interface ExperienceConfigMinimal
   extends Pick<
     ExperienceConfig,
     "component" | "auto_detect_language" | "dismissable"

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -317,11 +317,11 @@ export function getCurrentLocale(i18n: I18n): Locale {
  */
 export function detectUserLocale(
   navigator: Partial<Navigator>,
-  options?: Partial<FidesInitOptions>,
+  fidesLocaleOverride?: string | undefined,
+  defaultLocale: Locale = DEFAULT_LOCALE,
 ): Locale {
   const browserLocale = navigator?.language;
-  const fidesLocaleOverride = options?.fidesLocale;
-  return fidesLocaleOverride || browserLocale || DEFAULT_LOCALE;
+  return fidesLocaleOverride || browserLocale || defaultLocale;
 }
 
 /**
@@ -526,14 +526,18 @@ export function initializeI18n(
   );
 
   // Detect the user's locale, unless it's been *explicitly* disabled in the experience config
-  let userLocale = i18n.getDefaultLocale();
+  let userLocale = defaultLocale;
   if (experience.experience_config?.auto_detect_language === false) {
     debugLog(
       options?.debug,
       "Auto-detection of Fides i18n user locale disabled!",
     );
   } else {
-    userLocale = detectUserLocale(navigator, options);
+    userLocale = detectUserLocale(
+      navigator,
+      options?.fidesLocale,
+      defaultLocale,
+    );
     debugLog(options?.debug, `Detected Fides i18n user locale = ${userLocale}`);
   }
 

--- a/clients/fides-js/src/lib/initOverlay.ts
+++ b/clients/fides-js/src/lib/initOverlay.ts
@@ -38,7 +38,7 @@ export const initOverlay = async ({
     try {
       debugLog(
         options.debug,
-        "Rendering Fides overlay CSS & HTML into the DOM...",
+        "Injecting Fides overlay CSS & HTML into the DOM...",
       );
 
       // If this function is called multiple times (e.g. due to calling

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -234,7 +234,7 @@ export default async function handler(
       options,
     },
     options: {
-      debug: environment.settings.DEBUG,
+      debug: environment.settings.DEBUG || req.query.debug === "true",
       geolocationApiUrl: environment.settings.GEOLOCATION_API_URL,
       isGeolocationEnabled: environment.settings.IS_GEOLOCATION_ENABLED,
       isOverlayEnabled: environment.settings.IS_OVERLAY_ENABLED,
@@ -338,7 +338,8 @@ export default async function handler(
     // Allow CORS since this is a static file we do not need to lock down
     .setHeader("Access-Control-Allow-Origin", "*")
     .setHeader("Cache-Control", stringify(cacheHeaders))
-    .setHeader("Vary", LOCATION_HEADERS)
+    // Ignore cache if user's geolocation or language changes
+    .setHeader("Vary", [...LOCATION_HEADERS, "Accept-Language"])
     .send(script);
 }
 


### PR DESCRIPTION
Closes [PROD-2764](https://ethyca.atlassian.net/browse/PROD-2764)

### Description Of Changes

When the fides.js script gets cached, but a user changes their browser's language, we get into a weird state with multiple languages (especially after the GVL languages load correctly).

### Code Changes

* Update fides.js response headers to include `Accept_Language` in the `Vary` to instruct caches to reset when language changes
* Address a few inconsistencies left over from when we switched to Minimal TCF
* Determine if Minimal TCF Experience translation matches the user's locale (in the case of caching or `window.fides_overrides.fides_locale`) and load the available translation until full TCF Experience is ready with the correct language.

### Steps to Confirm

1. Throttle network in browser dev tools to help see when things are loading slower
2. Load demo page with TCF enabled (eg. http://localhost:3001/fides-js-demo.html?geolocation=eea)
3. Everything should load normally. Do not open the modal or save anything. We don't want to set a cookie yet.
4. Change browser's preferred language in browser settings to something other than English that is available on your configured TCF experience (eg. French)
5. Make sure "Disable Cache" is not active in your browser's network tab while throttling
6. reload the page (not a hard reload, we want to test the browser cache)
7. Page should load with the selected language in-spite of fides.js having been cached already (it should ignore the cache with the browser setting change).
8. Revert browser to english. You can clear cookies and cache now.
9. Update `fides-js-demo.html`:
Replace:
```
// window.fides_overrides = {
//   fides_embed: true,
// };
```
With:
```
window.fides_overrides = {
  fides_locale: "fr",
};
```
10. Reload the page now
11. Since the server isn't aware of the page's `window` setting, it will first load the English banner and the language picker's globe icon should immediately start spinning to indicate a language is loading. Once the full experience loads, it should replace English with the configured language of French. This is just an edge case we need to handle gracefully.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`


[PROD-2764]: https://ethyca.atlassian.net/browse/PROD-2764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ