### PR TITLE
revert to undefined instead of empty object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The types of changes are:
 - Hardcode ConnectionConfigurationResponse.secrets [#5283](https://github.com/ethyca/fides/pull/5283)
 - Fix Fides.shouldShouldShowExperience() to return false for modal-only experiences [#5281](https://github.com/ethyca/fides/pull/5281)
 - Fix issues with cached or `window.fides_overrides` languages in the Minimal TCF banner [#5306](https://github.com/ethyca/fides/pull/5306)
+- Fix issue with fides-js where the experience was incorrectly initialized as an empty object which appeared valid, when `undefined` was expected [#5309](https://github.com/ethyca/fides/pull/5309)
 
 
 ## [2.44.0](https://github.com/ethyca/fides/compare/2.43.1...2.44.0)

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -149,13 +149,21 @@ export default async function handler(
     return;
   }
 
-  // If a geolocation can be determined, "prefetch" the experience from the Fides API immediately.
-  // This allows the bundle to be fully configured server-side, so that the Fides.js bundle can initialize instantly!
-
+  /**
+   * NOTE: initializing `experienc` as an empty object `{}` causes problems specifically
+   * for clients not using prefetch and CDNs as now Fides.js believe that the user
+   * received a valid, albeit empty experience and then does not call the Fides API to
+   * check for experiences.
+   * This is why we initialize `experience` as `undefined`.
+   */
   let experience:
     | PrivacyExperience
     | PrivacyExperienceMinimal
-    | EmptyExperience = {};
+    | EmptyExperience
+    | undefined;
+
+  // If a geolocation can be determined, "prefetch" the experience from the Fides API immediately.
+  // This allows the bundle to be fully configured server-side, so that the Fides.js bundle can initialize instantly!
 
   if (
     geolocation &&

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -150,10 +150,9 @@ export default async function handler(
   }
 
   /**
-   * NOTE: initializing `experienc` as an empty object `{}` causes problems specifically
-   * for clients not using prefetch and CDNs as now Fides.js believe that the user
-   * received a valid, albeit empty experience and then does not call the Fides API to
-   * check for experiences.
+   * NOTE: initializing `experience` as an empty object `{}` causes problems, specifically
+   * for clients not using prefetch and CDNs as Fides.js interprets that as a valid, albeit
+   * empty, experience and then does not make a follow up call to the `privacy-experience` API.
    * This is why we initialize `experience` as `undefined`.
    */
   let experience:


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

In version 2.44 of the Privacy Center, the value of the default experience was set to `{}` (see https://github.com/ethyca/fides/pull/5230/files#diff-ba7bb0c80dbf370b49c211bf0e888dc34cf0f7a713e2b4b685d98b0b46b25014R155-R158).

This causes problems specifically for clients not using prefetch and CDNs as now Fides.js believe that the user received a valid, albeit empty experience and then does not call the Fides API to check for experiences.

Reverting back to `undefined` for that reason.


### Code Changes

* initialize `experience` as `undefined`

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
