### PR TITLE
Adding table size checks to hash migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fides/compare/2.45.1...main)
+## [Unreleased](https://github.com/ethyca/fides/compare/2.45.2...main)
+
+## [2.45.2](https://github.com/ethyca/fides/compare/2.45.1...2.45.2)
+
+### Fixed
+- Updated the hash migration script to only run on tables with less than 1 million rows. [#5310](https://github.com/ethyca/fides/pull/5310)
 
 ## [2.45.1](https://github.com/ethyca/fides/compare/2.45.0...2.45.1)
 

--- a/src/fides/api/alembic/migrations/versions/784f145ec892_add_is_hash_migrated_column.py
+++ b/src/fides/api/alembic/migrations/versions/784f145ec892_add_is_hash_migrated_column.py
@@ -142,6 +142,7 @@ def upgrade():
             "WHERE is_hash_migrated IS false'"
         )
 
+
 def downgrade():
     op.drop_index(
         "idx_servednoticehistory_unmigrated",

--- a/src/fides/api/alembic/migrations/versions/784f145ec892_add_is_hash_migrated_column.py
+++ b/src/fides/api/alembic/migrations/versions/784f145ec892_add_is_hash_migrated_column.py
@@ -8,6 +8,7 @@ Create Date: 2024-09-03 21:04:21.880497
 
 import sqlalchemy as sa
 from alembic import op
+from loguru import logger
 
 # revision identifiers, used by Alembic.
 revision = "784f145ec892"
@@ -21,58 +22,125 @@ def upgrade():
         "currentprivacypreferencev2",
         sa.Column("is_hash_migrated", sa.Boolean(), server_default="f", nullable=False),
     )
-    op.create_index(
-        "idx_currentprivacypreferencev2_unmigrated",
-        "currentprivacypreferencev2",
-        ["is_hash_migrated"],
-        unique=False,
-        postgresql_where=sa.text("is_hash_migrated IS false"),
-    )
     op.add_column(
         "custom_privacy_request_field",
         sa.Column("is_hash_migrated", sa.Boolean(), server_default="f", nullable=False),
-    )
-    op.create_index(
-        "idx_custom_privacy_request_field_unmigrated",
-        "custom_privacy_request_field",
-        ["is_hash_migrated"],
-        unique=False,
-        postgresql_where=sa.text("is_hash_migrated IS false"),
     )
     op.add_column(
         "privacypreferencehistory",
         sa.Column("is_hash_migrated", sa.Boolean(), server_default="f", nullable=False),
     )
-    op.create_index(
-        "idx_privacypreferencehistory_unmigrated",
-        "privacypreferencehistory",
-        ["is_hash_migrated"],
-        unique=False,
-        postgresql_where=sa.text("is_hash_migrated IS false"),
-    )
     op.add_column(
         "providedidentity",
         sa.Column("is_hash_migrated", sa.Boolean(), server_default="f", nullable=False),
     )
-    op.create_index(
-        "idx_providedidentity_unmigrated",
-        "providedidentity",
-        ["is_hash_migrated"],
-        unique=False,
-        postgresql_where=sa.text("is_hash_migrated IS false"),
-    )
     op.add_column(
         "servednoticehistory",
         sa.Column("is_hash_migrated", sa.Boolean(), server_default="f", nullable=False),
-    )
-    op.create_index(
-        "idx_servednoticehistory_unmigrated",
-        "servednoticehistory",
-        ["is_hash_migrated"],
-        unique=False,
-        postgresql_where=sa.text("is_hash_migrated IS false"),
     )
 
+    connection = op.get_bind()
+
+    # only run the index creation if the tables have less than 1 million rows
+    currentprivacypreferencev2_count = connection.execute(
+        sa.text("SELECT COUNT(*) FROM currentprivacypreferencev2")
+    ).scalar()
+    if currentprivacypreferencev2_count < 1000000:
+        op.create_index(
+            "idx_currentprivacypreferencev2_unmigrated",
+            "currentprivacypreferencev2",
+            ["is_hash_migrated"],
+            unique=False,
+            postgresql_where=sa.text("is_hash_migrated IS false"),
+        )
+    else:
+        logger.warning(
+            "The currentprivacypreferencev2 table has more than 1 million rows, "
+            "skipping index creation. Be sure to manually run "
+            "'CREATE INDEX CONCURRENTLY idx_currentprivacypreferencev2_unmigrated "
+            "ON currentprivacypreferencev2 (is_hash_migrated) "
+            "WHERE is_hash_migrated IS false'"
+        )
+
+    custom_privacy_request_field_count = connection.execute(
+        sa.text("SELECT COUNT(*) FROM custom_privacy_request_field")
+    ).scalar()
+    if custom_privacy_request_field_count < 1000000:
+        op.create_index(
+            "idx_custom_privacy_request_field_unmigrated",
+            "custom_privacy_request_field",
+            ["is_hash_migrated"],
+            unique=False,
+            postgresql_where=sa.text("is_hash_migrated IS false"),
+        )
+    else:
+        logger.warning(
+            "The custom_privacy_request_field table has more than 1 million rows, "
+            "skipping index creation. Be sure to manually run "
+            "'CREATE INDEX CONCURRENTLY idx_custom_privacy_request_field_unmigrated "
+            "ON custom_privacy_request_field (is_hash_migrated) "
+            "WHERE is_hash_migrated IS false'"
+        )
+
+    privacypreferencehistory_count = connection.execute(
+        sa.text("SELECT COUNT(*) FROM privacypreferencehistory")
+    ).scalar()
+    if privacypreferencehistory_count < 1000000:
+        op.create_index(
+            "idx_privacypreferencehistory_unmigrated",
+            "privacypreferencehistory",
+            ["is_hash_migrated"],
+            unique=False,
+            postgresql_where=sa.text("is_hash_migrated IS false"),
+        )
+    else:
+        logger.warning(
+            "The privacypreferencehistory table has more than 1 million rows, "
+            "skipping index creation. Be sure to manually run "
+            "'CREATE INDEX CONCURRENTLY idx_privacypreferencehistory_unmigrated "
+            "ON privacypreferencehistory (is_hash_migrated) "
+            "WHERE is_hash_migrated IS false'"
+        )
+
+    providedidentity_count = connection.execute(
+        sa.text("SELECT COUNT(*) FROM providedidentity")
+    ).scalar()
+    if providedidentity_count < 1000000:
+        op.create_index(
+            "idx_providedidentity_unmigrated",
+            "providedidentity",
+            ["is_hash_migrated"],
+            unique=False,
+            postgresql_where=sa.text("is_hash_migrated IS false"),
+        )
+    else:
+        logger.warning(
+            "The providedidentity table has more than 1 million rows, "
+            "skipping index creation. Be sure to manually run "
+            "'CREATE INDEX CONCURRENTLY idx_providedidentity_unmigrated "
+            "ON providedidentity (is_hash_migrated) "
+            "WHERE is_hash_migrated IS false'"
+        )
+
+    servednoticehistory_count = connection.execute(
+        sa.text("SELECT COUNT(*) FROM servednoticehistory")
+    ).scalar()
+    if servednoticehistory_count < 1000000:
+        op.create_index(
+            "idx_servednoticehistory_unmigrated",
+            "servednoticehistory",
+            ["is_hash_migrated"],
+            unique=False,
+            postgresql_where=sa.text("is_hash_migrated IS false"),
+        )
+    else:
+        logger.warning(
+            "The servednoticehistory table has more than 1 million rows, "
+            "skipping index creation. Be sure to manually run "
+            "'CREATE INDEX CONCURRENTLY idx_servednoticehistory_unmigrated "
+            "ON servednoticehistory (is_hash_migrated) "
+            "WHERE is_hash_migrated IS false'"
+        )
 
 def downgrade():
     op.drop_index(


### PR DESCRIPTION
Closes [PROD-2793](https://ethyca.atlassian.net/browse/PROD-2793)

### Description Of Changes

Updating an existing migration to use a table size check before creating the indices. Refer to the corresponding fiesplus PR for the post-migration script.

### Code Changes

* [ ] Updated the hash migration to check the table size

### Steps to Confirm

* [ ] The standard migration should be successful. See the fidesplus PR for instructions on how to test the post-migration script https://github.com/ethyca/fidesplus/pull/1629

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works


[PROD-2793]: https://ethyca.atlassian.net/browse/PROD-2793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ