### PR TITLE
Fix Preview when Adding Languages to Experience Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The types of changes are:
 - Ignore `400` errors from Talkable's `person` endpoint. [#5317](https://github.com/ethyca/fides/pull/5317)
 - Fix Email Connector logs so they use configuration key instead of name [#5286](https://github.com/ethyca/fides/pull/5286)
 - Updated Responsys and Firebase Auth integrations to allow multiple identities [#5318](https://github.com/ethyca/fides/pull/5318)
+- Fix issues with cached or `window.fides_overrides` languages in the Minimal TCF banner [#5306](https://github.com/ethyca/fides/pull/5306)
+- Fix issue with fides-js where the experience was incorrectly initialized as an empty object which appeared valid, when `undefined` was expected [#5309](https://github.com/ethyca/fides/pull/5309)
+- Fix issue where newly added languages in Admin-UI were not being rendered in the preview [#5316](https://github.com/ethyca/fides/pull/5316)
 
 ### Added
 - Added support for hierarchical notices in Privacy Center [#5291](https://github.com/ethyca/fides/pull/5291)
@@ -28,6 +31,10 @@ The types of changes are:
 
 ### Changed
 - Updated privacy notices to support notice hierarchies [#5272](https://github.com/ethyca/fides/pull/5272)
+
+### Developer Experience
+- Initialized Ant Design and Tailwindcss in Admin-UI to prepare for Design System migration [#5308](https://github.com/ethyca/fides/pull/5308)
+
 
 ## [2.45.2](https://github.com/ethyca/fides/compare/2.45.1...2.45.2)
 
@@ -63,14 +70,11 @@ The types of changes are:
 
 ### Developer Experience
 - Added performance mark timings to debug logs for fides.js [#5245](https://github.com/ethyca/fides/pull/5245)
-- Initialized Ant Design and Tailwindcss in Admin-UI to prepare for Design System migration [#5308](https://github.com/ethyca/fides/pull/5308)
 
 ### Fixed
 - Fix wording in tooltip for Yotpo Reviews [#5274](https://github.com/ethyca/fides/pull/5274)
 - Hardcode ConnectionConfigurationResponse.secrets [#5283](https://github.com/ethyca/fides/pull/5283)
 - Fix Fides.shouldShouldShowExperience() to return false for modal-only experiences [#5281](https://github.com/ethyca/fides/pull/5281)
-- Fix issues with cached or `window.fides_overrides` languages in the Minimal TCF banner [#5306](https://github.com/ethyca/fides/pull/5306)
-- Fix issue with fides-js where the experience was incorrectly initialized as an empty object which appeared valid, when `undefined` was expected [#5309](https://github.com/ethyca/fides/pull/5309)
 
 
 ## [2.44.0](https://github.com/ethyca/fides/compare/2.43.1...2.44.0)

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -126,10 +126,14 @@ const Preview = ({
     );
     if (values.translations?.length) {
       if (currentTranslation) {
+        baseConfig.experience.available_locales = [currentTranslation.language];
         baseConfig.experience.experience_config.translations[0] =
           translationOrDefault(currentTranslation);
         baseConfig.options.fidesLocale = currentTranslation.language;
       } else if (values.translations) {
+        baseConfig.experience.available_locales = [
+          values.translations[0].language,
+        ];
         baseConfig.experience.experience_config.translations[0] =
           translationOrDefault(values.translations[0]);
         baseConfig.options.fidesLocale = values.translations[0].language;

--- a/clients/fides-js/src/components/ConsentContent.tsx
+++ b/clients/fides-js/src/components/ConsentContent.tsx
@@ -14,7 +14,7 @@ export interface ConsentContentProps {
   renderModalFooter: () => VNode | null;
 }
 
-const ConsentModal = ({
+const ConsentContent = ({
   titleProps,
   className,
   renderModalFooter,
@@ -64,4 +64,4 @@ const ConsentModal = ({
   );
 };
 
-export default ConsentModal;
+export default ConsentContent;


### PR DESCRIPTION
Closes [PROD-2715](https://ethyca.atlassian.net/browse/PROD-2715)

### Description Of Changes

When we're adding languages in the Admin UI to an Experience Config, we should see them on the preview until they're saved, the preview just had the exp.title, exp.description, etc. because the new language wasn't included in the `available_locales` list.

This update ensures that the `available_locales` list always includes the currently edited language locale.


### Code Changes

* As we're updating/determining the language to display, also update the `available_locales` list with that language's locale.
* Cleaned up changelog where some items were added in the wrong release

### Steps to Confirm

* In Admin UI, edit an experience with an available preview (non-TCF).
* Add a new language to the experience
* When the language defaults load into the form, those defaults should immediately be displayed in the Preview
Note: For better context, watch the Loom on the [original bug report](https://ethyca.atlassian.net/browse/PROD-2715) in Jira 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

[PROD-2715]: https://ethyca.atlassian.net/browse/PROD-2715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ