### PR TITLE
PROD-2796: ignore 400 errors on Talkable's person endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.45.2...main)
 
+### Fixed
+- Ignore `400` errors from Talkable's `person` endpoint. [#5317](https://github.com/ethyca/fides/pull/5317)
+
 ## [2.45.2](https://github.com/ethyca/fides/compare/2.45.1...2.45.2)
 
 ### Fixed

--- a/data/saas/config/talkable_config.yml
+++ b/data/saas/config/talkable_config.yml
@@ -3,7 +3,7 @@ saas_config:
   name: Talkable
   type: talkable
   description: A sample schema representing the talkable connector for Fides
-  version: 0.1.0
+  version: 0.1.1
 
   connector_params:
     - name: domain
@@ -43,6 +43,7 @@ saas_config:
             - name: site_slug
               value: <site_slug>
           data_path: result.person
+          ignore_errors: [400]
           param_values:
             - name: email
               identity: email


### PR DESCRIPTION
Closes PROD-2796

### Description Of Changes

Ignores `400` errors thrown by Talkable when a person is not found. 

```
{
  'action_type': 'access',
  'system_key': 'talkable',
  'connection_key': 'talkable_api', 
  'collection': 'person', 
  'privacy_request_id': 'pri_[REDACTED]', 
  'method': 'GET', 
  'url': 'https://www.talkable.com/api/v2/people/[REDACTED]/personal_data?site_slug=[REDACTED]', 
  'response': '{"ok":false,"error_message":"No person found by `person_slug`."}', 
  'status_code': 400, 'error_group': 'ClientSideError'
}
```

Ideally we'd only ignore the `400`s when the error message matches that case, but for now, we'll ignore all `400` errors. We can implement that when https://github.com/ethyca/fides/pull/5211 is merged.

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
