### PR TITLE
Fix typo RDS MySQL Schema

### DIFF
--- a/src/fides/api/schemas/connection_configuration/connection_secrets_rds_mysql.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_rds_mysql.py
@@ -11,7 +11,7 @@ class RDSMySQLSchema(BaseAWSSchema):
     Schema to validate the secrets needed to connect to a RDS MySQL Database
     """
 
-    db_sername: str = Field(
+    db_username: str = Field(
         default="fides_service_user",
         title="Username",
         description="The user account used to authenticate and access the databases.",

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -1356,7 +1356,7 @@ class TestGetConnectionSecretSchema:
                     "title": "Region",
                     "type": "string",
                 },
-                "db_sername": {
+                "db_username": {
                     "default": "fides_service_user",
                     "description": "The user account used to "
                     "authenticate and access the "


### PR DESCRIPTION
Fix typo RDS MySQL Schema


### Code Changes

* [ ] src/fides/api/schemas/connection_configuration/connection_secrets_rds_mysql.py
* [ ] tests/ops/api/v1/endpoints/test_connection_template_endpoints.py

