### PR TITLE
PROD-2821-Consent-automation-accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The types of changes are:
 - Fix issues with cached or `window.fides_overrides` languages in the Minimal TCF banner [#5306](https://github.com/ethyca/fides/pull/5306)
 - Fix issue with fides-js where the experience was incorrectly initialized as an empty object which appeared valid, when `undefined` was expected [#5309](https://github.com/ethyca/fides/pull/5309)
 - Fix issue where newly added languages in Admin-UI were not being rendered in the preview [#5316](https://github.com/ethyca/fides/pull/5316)
+- Fix bug where consent automation accordion shows for integrations that don't support consent automation [#5330](https://github.com/ethyca/fides/pull/5330)
+
 
 ### Added
 - Added support for hierarchical notices in Privacy Center [#5291](https://github.com/ethyca/fides/pull/5291)

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConsentAutomationForm.tsx
@@ -207,7 +207,7 @@ export const ConsentAutomationForm = ({
     );
   }
 
-  if (!consentableItems || !notices) {
+  if (!consentableItems || !consentableItems.length || !notices) {
     return null;
   }
 


### PR DESCRIPTION
### Description Of Changes

Fix bug where Consent Automation Accordion shows up on integrations without support for consent automation.

### Code Changes
* [ ] Check for when consentableItems array is empty

### Steps to Confirm
* [ ] Go to systems, select a system that has an integration that is not Iterable
* [ ] Go to integrations tab and check that the Consent automation accordion is not visible

* [ ] Go to systems, select a system that has an Iterable integration or create a system with an Iterable integration
* [ ] Go to integrations tab and check that the Consent automation accordion is visible


### Screenshots
Iterable Integration
![Screen Shot 2024-09-25 at 14 47 37](https://github.com/user-attachments/assets/7d0401d0-96ab-4e7f-b147-9760726f5e1d)

HubSpot Integration
![Screen Shot 2024-09-25 at 14 47 45](https://github.com/user-attachments/assets/6042eefa-864a-468c-b779-9d05e63d61a7)



### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`