### PR TITLE
Fix preview's language picker

### DIFF
--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -126,14 +126,14 @@ const Preview = ({
     );
     if (values.translations?.length) {
       if (currentTranslation) {
-        baseConfig.experience.available_locales = [currentTranslation.language];
+        baseConfig.experience.available_locales = [
+          ...(baseConfig.experience.available_locales || []),
+          currentTranslation.language,
+        ];
         baseConfig.experience.experience_config.translations[0] =
           translationOrDefault(currentTranslation);
         baseConfig.options.fidesLocale = currentTranslation.language;
       } else if (values.translations) {
-        baseConfig.experience.available_locales = [
-          values.translations[0].language,
-        ];
         baseConfig.experience.experience_config.translations[0] =
           translationOrDefault(values.translations[0]);
         baseConfig.options.fidesLocale = values.translations[0].language;


### PR DESCRIPTION
### Description Of Changes

The fix in https://github.com/ethyca/fides/pull/5316 created a new regression where, even though the correct translations are appearing, the language picker stopped appearing.


### Code Changes

* include exising `available_languages` instead of overriding them with a single language.

### Steps to Confirm

* In Admin UI, edit an experience with an available preview (non-TCF).
* Ensure that while changing languages to edit, or adding a new language, does indeed show the language picker.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met