### PR TITLE
Updating hash migration status check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The types of changes are:
 ### Developer Experience
 - Migrate toggle switches from Chakra to Ant Design [#5323](https://github.com/ethyca/fides/pull/5323)
 
+### Fixed
+- Updating the hash migration status check query to use the available indexes [#5336](https://github.com/ethyca/fides/pull/5336)
+
 ## [2.46.0](https://github.com/ethyca/fides/compare/2.45.2...2.46.0)
 
 ### Fixed

--- a/src/fides/api/migrations/hash_migration_job.py
+++ b/src/fides/api/migrations/hash_migration_job.py
@@ -68,7 +68,7 @@ def is_migrated(db: Session, model: type[FidesBase]) -> bool:
     """
 
     query = text(
-        f"SELECT EXISTS (SELECT 1 FROM {model.__tablename__} WHERE is_hash_migrated = false)"
+        f"SELECT EXISTS (SELECT 1 FROM {model.__tablename__} WHERE is_hash_migrated IS FALSE)"
     )
     result = db.execute(query).scalar()
     return not result


### PR DESCRIPTION
Closes [PROD-2828](https://ethyca.atlassian.net/browse/PROD-2828)

### Description Of Changes

Updates the hash migration status check query to use the `is_hash_migrated IS FALSE` clause instead of `is_hash_migrated = FALSE`. The indexes for this query are created with `IS FALSE` so the status check queries were running an inefficient sequential scan on the entire table instead of an optimized index scan.

### Steps to Confirm

* [ ] This is tricky to test on a dev environment but as long as the server starts up it means the query still ran and the intended behavior is still preserved.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`


[PROD-2828]: https://ethyca.atlassian.net/browse/PROD-2828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ