### PR TITLE
fix deleteCookie script on demo page to include `Path`

### DIFF
--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -26,7 +26,7 @@
       })();
       var deleteCookie = function () {
         document.cookie =
-          "fides_consent=;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+          "fides_consent=;Path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
         location.reload();
       };
     </script>

--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -24,7 +24,7 @@
       })();
       var deleteCookie = function () {
         document.cookie =
-          "fides_consent=;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+          "fides_consent=;Path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
         location.reload();
       };
     </script>


### PR DESCRIPTION
On the demo page, Firefox wasn't removing the cookie when clicking the "Delete cookie and reload" button. This fix specifies the `Path` to ensure that we are deleting the correct cookie.