### PR TITLE
LA-16 SSO-Modal-Unexpected-Saves

### DIFF
--- a/clients/admin-ui/src/features/openid-authentication/SSOProviderForm.tsx
+++ b/clients/admin-ui/src/features/openid-authentication/SSOProviderForm.tsx
@@ -206,7 +206,7 @@ const SSOProviderForm = ({
             {values.provider === "custom" && renderCustomProviderExtraFields()}
             <Box textAlign="right">
               <Button
-                htmlType="submit"
+                htmlType="button"
                 data-testid="cancel-btn"
                 className="mr-3"
                 onClick={onClose}


### PR DESCRIPTION
### Description Of Changes

Fix bug where the SSO Provider form is saved when clicking cancel.


### Code Changes

* [ ] Change cancel button type from _submit_ to _button_

### Steps to Confirm

* [ ] Add a new SSO Provider in this screen in admin ui: /settings/organization (it doens't need to be real info)
* [ ] Edit the sso provider, fill the Client ID and Client Secret fields again
* [ ] Open the browser's dev tools and the network tab
* [ ] Click the cancel button on the modal
* [ ] Check that no network requests were made after clicking the cancel button


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
