### PR TITLE
Address Firefox overflow issue on Data Categories column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The types of changes are:
 - Fixed column resize jank on all tables in Admin UI [#5340](https://github.com/ethyca/fides/pull/5340)
 - Better handling of empty storage secrets in aws_util [#5347](https://github.com/ethyca/fides/pull/5347)
 - Fix SSO Provider form saving when clicking the cancel button with a fully filled form [#5365](https://github.com/ethyca/fides/pull/5365)
+- Fix bleedover of Data Categories into next column on Data map reporting [#5369](https://github.com/ethyca/fides/pull/5369)
 
 
 ### Removed

--- a/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
@@ -64,7 +64,7 @@ export const FidesCell = <T,>({
           ? cell.column.columnDef.meta.width
           : "unset"
       }
-      overflowX={
+      overflow={
         cell.column.columnDef.meta?.overflow
           ? cell.column.columnDef.meta?.overflow
           : "auto"

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTableColumns.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTableColumns.tsx
@@ -203,6 +203,7 @@ export const getDatamapReportColumns = ({
         showHeaderMenu: true,
         showHeaderMenuWrapOption: true,
         width: "auto",
+        overflow: "hidden",
       },
     }),
     columnHelper.accessor((row) => row.data_subjects, {


### PR DESCRIPTION
Closes HJ-37

### Code Changes

* change `overflowX` to `overflow` for Firefox support
* pass along the "hidden" value to the overflow attribute

### Steps to Confirm

* [ ] Visit Data Map Report page using Firefox browser (https://fides-plus-rc.fides-staging.ethyca.com/reporting/datamap)
* [ ] Grab the resizer bar in the header of the Data Categories column and reduce the width of the column
* [ ] Notice the content is no longer bleeding over into the other column

![CleanShot 2024-10-11 at 15 48 54@2x](https://github.com/user-attachments/assets/5c8a528f-d785-4c5d-a6ee-47c3477390a6)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`