### PR TITLE
Fix stale items rendering on D&D tables

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/utils/getResourceRowName.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/utils/getResourceRowName.ts
@@ -1,6 +1,6 @@
 import { StagedResource } from "~/types/api";
 
 const getResourceRowName = (row: StagedResource) =>
-  `${row.monitor_config_id}-${row.name ?? row.urn}`;
+  `${row.monitor_config_id}-${row.urn}`;
 
 export default getResourceRowName;


### PR DESCRIPTION
Closes HJ-40

### Description Of Changes

Updates the key generation helper method on D&D tables to use the item URN instead of just the name to prevent name collisions from causing visual bugs.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
