### PR TITLE
Add Docker Hub auth to rate-limited CI workflows

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -15,6 +15,9 @@ on:
 env:
   IMAGE: ethyca/fides:local
   DEFAULT_PYTHON_VERSION: "3.10.13"
+  # Docker auth with read-only permissions.
+  DOCKER_USER: ${{ secrets.DOCKER_USER }}
+  DOCKER_RO_TOKEN: ${{ secrets.DOCKER_RO_TOKEN }}
 
 jobs:
   ###############
@@ -143,6 +146,12 @@ jobs:
       - name: Install Nox
         run: pip install nox>=2022
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_RO_TOKEN }}
+
       - name: Run Performance Tests
         run: nox -s performance_tests
 
@@ -178,8 +187,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_RO_TOKEN }}
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_RO_TOKEN }}
 
       - name: Run test suite
         run: nox -s check_container_startup
@@ -218,6 +227,12 @@ jobs:
 
       - name: Install Nox
         run: pip install nox>=2022
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_RO_TOKEN }}
 
       - name: Run test suite
         run: nox -s "${{ matrix.test_selection }}"
@@ -262,6 +277,12 @@ jobs:
       - name: Install Nox
         run: pip install nox>=2022
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_RO_TOKEN }}
+
       - name: Run test suite
         run: nox -s "pytest(${{ matrix.test_selection }})"
 
@@ -302,6 +323,12 @@ jobs:
       - name: Install Nox
         run: pip install nox>=2022
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_RO_TOKEN }}
+
       - name: Run external test suite
         run: nox -s "pytest(ctl-external)"
         env:
@@ -341,6 +368,12 @@ jobs:
 
       - name: Install Nox
         run: pip install nox>=2022
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_RO_TOKEN }}
 
       - name: Integration Tests (External)
         env:
@@ -418,6 +451,12 @@ jobs:
           method: jwt
           role: ${{ secrets.VAULT_ROLE }}
           exportToken: True
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_RO_TOKEN }}
 
       - name: SaaS Connector Tests
         env:

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -175,6 +175,12 @@ jobs:
       - name: Install Nox
         run: pip install nox>=2022
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_RO_TOKEN }}
+
       - name: Run test suite
         run: nox -s check_container_startup
 
@@ -192,6 +198,8 @@ jobs:
     timeout-minutes: 15
     continue-on-error: true
     steps:
+
+
       - name: Download container
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -198,8 +198,6 @@ jobs:
     timeout-minutes: 15
     continue-on-error: true
     steps:
-
-
       - name: Download container
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -11,6 +11,10 @@ on:
 
 env:
   CI: true
+  env:
+  # Docker auth with read-only permissions.
+  DOCKER_USER: ${{ secrets.DOCKER_USER }}
+  DOCKER_RO_TOKEN: ${{ secrets.DOCKER_RO_TOKEN }}
 
 jobs:
   Cypress-E2E:
@@ -33,8 +37,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_RO_TOKEN }}
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_RO_TOKEN }}
 
       - name: Start test environment in the background
         run: nox -s "fides_env(test)" -- keep_alive

--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_RO_TOKEN }}
+
       - name: Start test environment in the background
         run: nox -s "fides_env(test)" -- keep_alive
 

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -8,7 +8,8 @@ on:
       - "*"
 
 env:
-  DOCKER_USER: ethycaci
+  # Docker auth with read-write (publish) permissions. Set as env in workflow root as auth is required in multiple jobs.
+  DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
 jobs:
@@ -71,7 +72,7 @@ jobs:
           fetch-depth: 0 # This is required to properly tag images
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_USER }}
           password: ${{ env.DOCKER_TOKEN }}


### PR DESCRIPTION
Closes OPS-772

### Description Of Changes

* Add Docker Hub auth to Cypress E2E Tests workflow
* Add Docker Hub auth to Backend Code Checks workflow
* Removes hardcoded Docker username in Publish Docker Images workflow and upgrades action to latest (v3)


### Code Changes

* Adding Docker Hub auth for a premium user will increase the rate limit to 5000/day instead of the 100/6 hours for unauth'd Docker users. 

### Steps to Confirm

* Run currently failing CI jobs for modified workflows and ensure they pass.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
