### PR TITLE
Revert search/replace issue

### DIFF
--- a/clients/admin-ui/src/features/common/custom-reports/CustomReportCreationModal.tsx
+++ b/clients/admin-ui/src/features/common/custom-reports/CustomReportCreationModal.tsx
@@ -106,8 +106,8 @@ export const CustomReportCreationModal = ({
               <ModalBody>
                 <Text fontSize="sm" color="gray.600" pb={6}>
                   Customize and save your current filter settings for easy
-                  access in the future. This reporting customReport will save
-                  the column layout and currently applied filter settings.
+                  access in the future. This saved report will include the
+                  column layout and currently applied filter settings.
                 </Text>
                 <CustomTextInput
                   id="reportName"


### PR DESCRIPTION
Search and replace for a code name change ended up affecting the body text. This fix reverts that mistake.