### PR TITLE
FIX: separate urn with non-nested-pattern for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Fixed
 - Fixed a bug where D&D tables were rendering stale data [#5372](https://github.com/ethyca/fides/pull/5372)
+- Fixed issue where Dataset with nested fields was unable to edit Categories [#5383](https://github.com/ethyca/fides/pull/5383)
 
 
 ## [2.47.0](https://github.com/ethyca/fidesplus/compare/2.46.2...2.47.0)

--- a/clients/admin-ui/src/features/common/Breadcrumbs.tsx
+++ b/clients/admin-ui/src/features/common/Breadcrumbs.tsx
@@ -54,6 +54,10 @@ const Breadcrumbs = ({
     {breadcrumbs.map((breadcumbItem, index) => {
       const isLast = index + 1 === breadcrumbs.length;
 
+      if (!breadcumbItem.title) {
+        return null;
+      }
+
       return (
         <BreadcrumbItem
           {...normalItemStyles}

--- a/clients/admin-ui/src/features/dataset/EditCollectionDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditCollectionDrawer.tsx
@@ -1,5 +1,6 @@
 import { errorToastParams, successToastParams } from "common/toast";
 import { ConfirmationModal, Text, useDisclosure, useToast } from "fidesui";
+import { useMemo } from "react";
 
 import EditDrawer, {
   EditDrawerFooter,
@@ -19,8 +20,8 @@ import {
 const DESCRIPTION =
   "Collections are an array of objects that describe the Dataset's collections. Provide additional context to this collection by filling out the fields below.";
 interface Props {
-  dataset?: Dataset;
-  collection?: DatasetCollection;
+  dataset: Dataset;
+  collection: DatasetCollection;
   isOpen: boolean;
   onClose: () => void;
 }
@@ -30,7 +31,11 @@ const EditCollectionDrawer = ({
   isOpen,
   onClose,
 }: Props) => {
-  const collectionIndex = dataset?.collections.indexOf(collection!);
+  const collectionIndex = useMemo(
+    () => dataset?.collections.indexOf(collection),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
   const [updateDataset] = useUpdateDatasetMutation();
   const toast = useToast();
   const {
@@ -42,7 +47,7 @@ const EditCollectionDrawer = ({
   const handleSubmit = async (
     values: Pick<DatasetCollection, "description" | "data_categories">,
   ) => {
-    const updatedCollection = { ...collection!, ...values };
+    const updatedCollection = { ...collection, ...values };
     const updatedDataset = getUpdatedDatasetFromCollection(
       dataset!,
       updatedCollection,
@@ -92,7 +97,7 @@ const EditCollectionDrawer = ({
         }
       >
         <EditCollectionOrFieldForm
-          values={collection!}
+          values={collection}
           onSubmit={handleSubmit}
           dataType="collection"
           showDataCategories={false}

--- a/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
+++ b/clients/admin-ui/src/features/dataset/EditFieldDrawer.tsx
@@ -7,6 +7,7 @@ import EditDrawer, {
 } from "~/features/common/EditDrawer";
 import { Dataset, DatasetField } from "~/types/api";
 
+import { URN_SEPARATOR } from "./constants";
 import { useUpdateDatasetMutation } from "./dataset.slice";
 import EditCollectionOrFieldForm, {
   FORM_ID,
@@ -47,7 +48,9 @@ const EditFieldDrawer = ({
     const pathToField = getDatasetPath({
       dataset: dataset!,
       collectionName,
-      subfieldUrn: subfieldUrn ? `${subfieldUrn}.${field?.name}` : field?.name,
+      subfieldUrn: subfieldUrn
+        ? `${subfieldUrn}${URN_SEPARATOR}${field?.name}`
+        : field?.name,
     });
 
     const updatedField = { ...field!, ...values };

--- a/clients/admin-ui/src/features/dataset/constants.ts
+++ b/clients/admin-ui/src/features/dataset/constants.ts
@@ -29,3 +29,5 @@ export const FIELD = {
       "Arrays of Data Category resources, identified by fides_key, that apply to this field.",
   },
 };
+
+export const URN_SEPARATOR = "/";

--- a/clients/admin-ui/src/features/dataset/helpers.ts
+++ b/clients/admin-ui/src/features/dataset/helpers.ts
@@ -2,6 +2,8 @@ import { get } from "lodash";
 
 import { Dataset, DatasetCollection, DatasetField } from "~/types/api";
 
+import { URN_SEPARATOR } from "./constants";
+
 /**
  * Because there is only one /dataset endpoint which handles dataset, collection,
  * and field modifications, and always takes a whole dataset object, it is convenient
@@ -97,7 +99,7 @@ export const getDatasetPath = ({
     return path;
   }
 
-  const subfieldParts = subfieldUrn.split(".");
+  const subfieldParts = subfieldUrn.split(URN_SEPARATOR);
   subfieldParts.forEach((subfieldName) => {
     const field: DatasetField = get(dataset, path);
     const subfieldIndex = field.fields!.findIndex(

--- a/clients/admin-ui/src/pages/dataset/[datasetId]/[collectionName]/[subfieldUrn].tsx
+++ b/clients/admin-ui/src/pages/dataset/[datasetId]/[collectionName]/[subfieldUrn].tsx
@@ -46,6 +46,7 @@ import {
   useGetDatasetByKeyQuery,
   useUpdateDatasetMutation,
 } from "~/features/dataset";
+import { URN_SEPARATOR } from "~/features/dataset/constants";
 import DatasetBreadcrumbs from "~/features/dataset/DatasetBreadcrumbs";
 import EditFieldDrawer from "~/features/dataset/EditFieldDrawer";
 import { getDatasetPath } from "~/features/dataset/helpers";
@@ -94,7 +95,7 @@ const FieldsDetailPage: NextPage = () => {
       const pathToField = getDatasetPath({
         dataset: dataset!,
         collectionName,
-        subfieldUrn: `${subfieldUrn}.${field.name}`,
+        subfieldUrn: `${subfieldUrn}${URN_SEPARATOR}${field?.name}`,
       });
 
       const updatedDataset = cloneDeep(dataset!);
@@ -119,7 +120,7 @@ const FieldsDetailPage: NextPage = () => {
       const pathToField = getDatasetPath({
         dataset: dataset!,
         collectionName,
-        subfieldUrn: `${subfieldUrn}.${field.name}`,
+        subfieldUrn: `${subfieldUrn}${URN_SEPARATOR}${field?.name}`,
       });
 
       const updatedDataset = cloneDeep(dataset!);

--- a/clients/admin-ui/src/pages/dataset/[datasetId]/[collectionName]/[subfieldUrn].tsx
+++ b/clients/admin-ui/src/pages/dataset/[datasetId]/[collectionName]/[subfieldUrn].tsx
@@ -260,46 +260,48 @@ const FieldsDetailPage: NextPage = () => {
     DatasetField | undefined
   >();
 
+  const breadcrumbs = useMemo(() => {
+    return [
+      {
+        title: "All datasets",
+        icon: <DatabaseIcon boxSize={4} />,
+        link: DATASET_ROUTE,
+      },
+      {
+        title: datasetId,
+        link: {
+          pathname: DATASET_DETAIL_ROUTE,
+          query: { datasetId },
+        },
+        icon: <DatasetIcon boxSize={5} />,
+      },
+      {
+        title: collectionName,
+        icon: <TableIcon boxSize={5} />,
+        link: {
+          pathname: DATASET_COLLECTION_DETAIL_ROUTE,
+          query: { datasetId, collectionName },
+        },
+      },
+      ...subfieldParts.map((subFieldName, index) => ({
+        title: subFieldName,
+        link: {
+          pathname: DATASET_COLLECTION_SUBFIELD_DETAIL_ROUTE,
+          query: {
+            datasetId,
+            collectionName,
+            subfieldUrn: subfieldParts.slice(0, index + 1).join("."),
+          },
+        },
+        icon: <FieldIcon boxSize={5} />,
+      })),
+    ];
+  }, [datasetId, collectionName, subfieldParts]);
+
   return (
     <Layout title={`Dataset - ${datasetId}`} mainProps={{ paddingTop: 0 }}>
       <PageHeader breadcrumbs={[{ title: "Datasets" }]}>
-        <DatasetBreadcrumbs
-          breadcrumbs={[
-            {
-              title: "All datasets",
-              icon: <DatabaseIcon boxSize={4} />,
-              link: DATASET_ROUTE,
-            },
-            {
-              title: datasetId,
-              link: {
-                pathname: DATASET_DETAIL_ROUTE,
-                query: { datasetId },
-              },
-              icon: <DatasetIcon boxSize={5} />,
-            },
-            {
-              title: collectionName,
-              icon: <TableIcon boxSize={5} />,
-              link: {
-                pathname: DATASET_COLLECTION_DETAIL_ROUTE,
-                query: { datasetId, collectionName },
-              },
-            },
-            ...subfieldParts.map((subFieldName, index) => ({
-              title: subFieldName,
-              link: {
-                pathname: DATASET_COLLECTION_SUBFIELD_DETAIL_ROUTE,
-                query: {
-                  datasetId,
-                  collectionName,
-                  subfieldUrn: subfieldParts.slice(0, index + 1).join("."),
-                },
-              },
-              icon: <FieldIcon boxSize={5} />,
-            })),
-          ]}
-        />
+        <DatasetBreadcrumbs breadcrumbs={breadcrumbs} />
       </PageHeader>
 
       {isLoading ? (

--- a/clients/admin-ui/src/pages/dataset/[datasetId]/[collectionName]/[subfieldUrn].tsx
+++ b/clients/admin-ui/src/pages/dataset/[datasetId]/[collectionName]/[subfieldUrn].tsx
@@ -207,6 +207,7 @@ const FieldsDetailPage: NextPage = () => {
           <DefaultHeaderCell value="Data categories" {...props} />
         ),
         size: 300,
+        meta: { disableRowClick: true },
       }),
 
       columnHelper.display({

--- a/clients/admin-ui/src/pages/dataset/[datasetId]/[collectionName]/index.tsx
+++ b/clients/admin-ui/src/pages/dataset/[datasetId]/[collectionName]/index.tsx
@@ -194,6 +194,7 @@ const FieldsDetailPage: NextPage = () => {
           <DefaultHeaderCell value="Data categories" {...props} />
         ),
         size: 300,
+        meta: { disableRowClick: true },
       }),
 
       columnHelper.display({

--- a/clients/admin-ui/src/pages/dataset/[datasetId]/[collectionName]/index.tsx
+++ b/clients/admin-ui/src/pages/dataset/[datasetId]/[collectionName]/index.tsx
@@ -248,30 +248,32 @@ const FieldsDetailPage: NextPage = () => {
     DatasetField | undefined
   >();
 
+  const breadcrumbs = useMemo(() => {
+    return [
+      {
+        title: "All datasets",
+        icon: <DatabaseIcon boxSize={4} />,
+        link: DATASET_ROUTE,
+      },
+      {
+        title: datasetId,
+        link: {
+          pathname: DATASET_DETAIL_ROUTE,
+          query: { datasetId },
+        },
+        icon: <DatasetIcon boxSize={5} />,
+      },
+      {
+        title: collectionName,
+        icon: <TableIcon boxSize={5} />,
+      },
+    ];
+  }, [datasetId, collectionName]);
+
   return (
     <Layout title={`Dataset - ${datasetId}`} mainProps={{ paddingTop: 0 }}>
       <PageHeader breadcrumbs={[{ title: "Datasets" }]}>
-        <DatasetBreadcrumbs
-          breadcrumbs={[
-            {
-              title: "All datasets",
-              icon: <DatabaseIcon boxSize={4} />,
-              link: DATASET_ROUTE,
-            },
-            {
-              title: datasetId,
-              link: {
-                pathname: DATASET_DETAIL_ROUTE,
-                query: { datasetId },
-              },
-              icon: <DatasetIcon boxSize={5} />,
-            },
-            {
-              title: collectionName,
-              icon: <TableIcon boxSize={5} />,
-            },
-          ]}
-        />
+        <DatasetBreadcrumbs breadcrumbs={breadcrumbs} />
       </PageHeader>
 
       {isLoading ? (

--- a/clients/admin-ui/src/pages/dataset/[datasetId]/index.tsx
+++ b/clients/admin-ui/src/pages/dataset/[datasetId]/index.tsx
@@ -136,22 +136,24 @@ const DatasetDetailPage: NextPage = () => {
     });
   };
 
+  const breadcrumbs = useMemo(() => {
+    return [
+      {
+        title: "All datasets",
+        icon: <DatabaseIcon boxSize={4} />,
+        link: DATASET_ROUTE,
+      },
+      {
+        title: datasetId,
+        icon: <DatasetIcon boxSize={5} />,
+      },
+    ];
+  }, [datasetId]);
+
   return (
     <Layout title={`Dataset - ${datasetId}`} mainProps={{ paddingTop: 0 }}>
       <PageHeader breadcrumbs={[{ title: "Datasets" }]}>
-        <DatasetBreadcrumbs
-          breadcrumbs={[
-            {
-              title: "All datasets",
-              icon: <DatabaseIcon boxSize={4} />,
-              link: DATASET_ROUTE,
-            },
-            {
-              title: datasetId,
-              icon: <DatasetIcon boxSize={5} />,
-            },
-          ]}
-        />
+        <DatasetBreadcrumbs breadcrumbs={breadcrumbs} />
       </PageHeader>
 
       {isLoading ? (

--- a/clients/admin-ui/src/pages/dataset/[datasetId]/index.tsx
+++ b/clients/admin-ui/src/pages/dataset/[datasetId]/index.tsx
@@ -176,12 +176,14 @@ const DatasetDetailPage: NextPage = () => {
         </Box>
       )}
 
-      <EditCollectionDrawer
-        dataset={dataset!}
-        collection={selectedCollectionForEditing}
-        isOpen={isEditingCollection}
-        onClose={() => setIsEditingCollection(false)}
-      />
+      {dataset && selectedCollectionForEditing && (
+        <EditCollectionDrawer
+          dataset={dataset}
+          collection={selectedCollectionForEditing}
+          isOpen={isEditingCollection}
+          onClose={() => setIsEditingCollection(false)}
+        />
+      )}
     </Layout>
   );
 };


### PR DESCRIPTION
Closes HJ-36

### Description Of Changes

This is a bit of a bandaid fix to handle nested fields on the frontend. We are specifying something other than `.` used in nested field names for the URN so that we can distinguish those. More robust fixes are happening on both the BE and FE in separate tickets.


### Code Changes

* Specify a non-period separator for FE logic
* Apply some best practices to the Edit drawer and Breadcrumbs to avoid race conditions during E2E testing and for optimization in general.

### Steps to Confirm

* In Fides Plus Admin UI, visit the Manage datasets page (eg. http://localhost:3000/dataset)
* **If the dataset `example_dataset_issue_hj36` exists**
1. Click it
2. Click `example_table`
3. Ensure that you can still add/remove Categories from the "Can save data category changes" fields.
4. Click through to the nested field `example_nested_field`
5. The field `example_failure_nested_field.1` with description "Fail to save data category changes on nested field with '.' in name" should now be able to add/remove categories.
6. Click "edit" on the same `example_failure_nested_field.1` row and make sure you can still "Save"
* **If the dataset `example_dataset_issue_hj36` does not exist**
1. Click "+ Add Dataset" button
2. Click "Upload a Dataset YML"
3. Paste the following into the editor:
```
- fides_key: example_dataset_issue_hj36
  organization_fides_key: default_organization
  tags: null
  name: example_dataset_issue_hj36
  description: Minimal dataset reproducing issue (HJ-36)
  meta: null
  data_categories: null
  fides_meta: null
  collections:
    - name: example_table
      description: null
      data_categories: null
      fields:
        - name: example_nested_field
          description: null
          data_categories: null
          fides_meta: null
          fields:
            - name: example_success_nested_field
              description: Can save data category changes on nested field
              data_categories:
                - user.device
              fides_meta: null
              fields: []
            - name: example_failure_nested_field.1
              description: >-
                Fail to save data category changes on nested field with '.' in
                name
              data_categories:
                - user.location
                - system
              fides_meta: null
              fields: []
        - name: example_success_field
          description: Can save data category changes
          data_categories:
            - user.device
          fides_meta: null
          fields: null
        - name: example_success_field.1
          description: Can save data category changes
          data_categories:
            - user.device
          fides_meta: null
          fields: null
      fides_meta: null
```
4. Click "Create dataset" button
5. Proceed to follow steps 1-6 above for the `example_dataset_issue_hj36` dataset

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
