### PR TITLE
Apply any updated state to the overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The types of changes are:
 ### Fixed
 - Fixed a bug where D&D tables were rendering stale data [#5372](https://github.com/ethyca/fides/pull/5372)
 - Fixed issue where Dataset with nested fields was unable to edit Categories [#5383](https://github.com/ethyca/fides/pull/5383)
+- Fixed racecondition where GPP being updated after FidesJS initialization caused Privacy Notices to be in the wrong state [#5384](https://github.com/ethyca/fides/pull/5384)
 
 
 ## [2.47.0](https://github.com/ethyca/fidesplus/compare/2.46.2...2.47.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The types of changes are:
 ### Fixed
 - Fixed a bug where D&D tables were rendering stale data [#5372](https://github.com/ethyca/fides/pull/5372)
 - Fixed issue where Dataset with nested fields was unable to edit Categories [#5383](https://github.com/ethyca/fides/pull/5383)
-- Fixed racecondition where GPP being updated after FidesJS initialization caused Privacy Notices to be in the wrong state [#5384](https://github.com/ethyca/fides/pull/5384)
+- Fixed racecondition where GPC being updated after FidesJS initialization caused Privacy Notices to be in the wrong state [#5384](https://github.com/ethyca/fides/pull/5384)
 
 
 ## [2.47.0](https://github.com/ethyca/fidesplus/compare/2.46.2...2.47.0)

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -9,6 +9,7 @@ import {
   ConsentMethod,
   FidesCookie,
   Layer1ButtonOption,
+  NoticeConsent,
   PrivacyNotice,
   PrivacyNoticeTranslation,
   PrivacyNoticeWithPreference,
@@ -58,7 +59,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
 
   // TODO (PROD-1792): restore useMemo here but ensure that saved changes are respected
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const initialEnabledNoticeKeys = () => {
+  const initialEnabledNoticeKeys = (consent?: NoticeConsent) => {
     if (experience.privacy_notices) {
       // ensure we have most up-to-date cookie vals
       // TODO (PROD-1792): we should be able to replace parsedCookie with savedConsent
@@ -67,7 +68,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
         const val = resolveConsentValue(
           notice,
           getConsentContext(),
-          parsedCookie?.consent,
+          consent || parsedCookie?.consent,
         );
         return val ? (notice.notice_key as PrivacyNotice["notice_key"]) : "";
       });
@@ -123,6 +124,11 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   const [draftEnabledNoticeKeys, setDraftEnabledNoticeKeys] = useState<
     Array<string>
   >(initialEnabledNoticeKeys());
+
+  window.addEventListener("FidesUpdating", (event) => {
+    // If GPP is being applied after initialization, we need to update the initial overlay to reflect the new state. This is especially important for Firefox browsers (Gecko) because GPP gets applied rather late due to how it handles queuing the `setTimeout` on the last step of our `initialize` function.
+    setDraftEnabledNoticeKeys(initialEnabledNoticeKeys(event.detail.consent));
+  });
 
   const isAllNoticeOnly = privacyNoticeItems.every(
     (n) => n.notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY,

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -126,7 +126,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   >(initialEnabledNoticeKeys());
 
   window.addEventListener("FidesUpdating", (event) => {
-    // If GPP is being applied after initialization, we need to update the initial overlay to reflect the new state. This is especially important for Firefox browsers (Gecko) because GPP gets applied rather late due to how it handles queuing the `setTimeout` on the last step of our `initialize` function.
+    // If GPC is being applied after initialization, we need to update the initial overlay to reflect the new state. This is especially important for Firefox browsers (Gecko) because GPC gets applied rather late due to how it handles queuing the `setTimeout` on the last step of our `initialize` function.
     setDraftEnabledNoticeKeys(initialEnabledNoticeKeys(event.detail.consent));
   });
 

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -143,7 +143,9 @@ export const updateConsentPreferences = async ({
           preference.consentPreference === UserConsentPreference.OPT_OUT,
       )
       .forEach((preference) => {
-        removeCookiesFromBrowser(preference.notice.cookies);
+        if (preference.notice?.cookies) {
+          removeCookiesFromBrowser(preference.notice.cookies);
+        }
       });
   }
 

--- a/clients/privacy-center/components/consent/notice-driven/NoticeDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/notice-driven/NoticeDrivenConsent.tsx
@@ -303,9 +303,11 @@ const NoticeDrivenConsent = ({ base64Cookie }: { base64Cookie: boolean }) => {
         noticePreference.notice
       ) {
         // DEFER (PROD-2737) remove type casting
-        removeCookiesFromBrowser(
-          noticePreference.notice.cookies as FidesJSCookies[],
-        );
+        if (noticePreference.notice.cookies) {
+          removeCookiesFromBrowser(
+            noticePreference.notice.cookies as FidesJSCookies[],
+          );
+        }
       }
     });
     router.push("/");

--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -177,6 +177,14 @@
       } else {
         window.addEventListener("FidesInitialized", onInitialized);
       }
+      window.addEventListener("FidesUpdated", () => {
+        console.log("Fides has been updated");
+        document.getElementById("consent-json").textContent = JSON.stringify(
+          Fides.consent,
+          null,
+          2,
+        );
+      });
 
       window.addEventListener("FidesUIShown", () => {
         // Log event timing


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

If GPP (browser's "Do Not Track") is being applied after Fides initialization, we need to update the initial overlay to reflect the new state.

This is especially important for Firefox browsers (Gecko) because—not only does FF make it easy to enable GPP—GPP gets applied rather late due to how Gecko handles queuing the `setTimeout` on the [last step](https://github.com/ethyca/fides/blob/main/clients/fides-js/src/lib/initialize.ts#L461) of our `initialize` function.

### Code Changes

* Add an event watch for `FidesUpdating` and use that to update the Overlay's notices as applicable

### Steps to Confirm

* Enable [GPP in Firefox](https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature).
* Using Firefox now, visit demo page of (or create) an Experience with config:
  * Modal only
  * GPP enabled for U.S. National
  * Location in the united states
  * "Data Sales, Sharing, and Targeted Advertising (GPP - US National)" privacy notice enabled
  * pass U.S. geolocation to the browser if necessary
* Click the Manage Privacy link to open the browser
* Ensure that the privacy policy is "Applied" via GPP and not "Overriden"
![CleanShot 2024-10-15 at 17 46 55@2x](https://github.com/user-attachments/assets/33b07fe5-a20b-417e-9ba4-14548859f7b2)


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
