### PR TITLE
Prevent multiple login redirects at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The types of changes are:
 
 ### Fixed
 - Fixed a bug where D&D tables were rendering stale data [#5372](https://github.com/ethyca/fides/pull/5372)
+- Fixed issue where multiple login redirects could end up losing login return path [#5389](https://github.com/ethyca/fides/pull/5389)
 
 ### Developer Experience
 - Fix warning messages from slowapi and docker [#5385](https://github.com/ethyca/fides/pull/5385)

--- a/clients/admin-ui/src/features/auth/ProtectedRoute.tsx
+++ b/clients/admin-ui/src/features/auth/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { LOGIN_ROUTE, VERIFY_AUTH_INTERVAL } from "~/constants";
@@ -23,6 +23,7 @@ const useProtectedRoute = (redirectUrl: string) => {
   });
   const plusQuery = useGetHealthQuery();
   const nav = useNav({ path: router.pathname });
+  const [redirectFrom, setRedirectFrom] = useState<string | undefined>();
 
   if (!token || !userId || permissionsQuery.isError) {
     // Reset the user information in redux only if we have stale information
@@ -33,10 +34,20 @@ const useProtectedRoute = (redirectUrl: string) => {
       const query = REDIRECT_IGNORES.includes(window.location.pathname)
         ? undefined
         : { redirect: window.location.pathname };
-      router.push({
-        pathname: redirectUrl,
-        query,
-      });
+      if (
+        redirectFrom !== window.location.pathname &&
+        window.location.pathname !== redirectUrl
+      ) {
+        setRedirectFrom(window.location.pathname);
+        router
+          .push({
+            pathname: redirectUrl,
+            query,
+          })
+          .then(() => {
+            setRedirectFrom(undefined);
+          });
+      }
     }
     return { authenticated: false, hasAccess: false };
   }


### PR DESCRIPTION
Closes [HJ-77](https://ethyca.atlassian.net/browse/HJ-77)

### Description Of Changes

Cypress tests have been failing occasionally in the Auth tests, specifically relating to the login redirects.

After some investigation, it has been determined this is caused by a race condition where we are sometimes telling the NextJS router to redirect to `/login` multiple times resulting in the error: `"Abort fetching component for route: ..."`

It turns out NextJS sends that error when given too many `router.push` commands at once.


### Code Changes

* Take advantage of `useState` to track redirects to prevent duplicating a redirect already in progress. ([credit](https://github.com/vercel/next.js/discussions/39040#discussioncomment-3289472))
* Also checks to see if a redirect is looping on itself, making sure the "from" and the "to" are not the same thing.

### Steps to Confirm

* The `auth.cy.ts` tests should now pass 100% of the time
* To manually confirm changes, you can mimic the test:
1. Visit the user management page while logged out of Admin UI (`/user-management`)
2. You should be redirected to the `/login` screen
3. You should not see any console errors like "Abort fetching component for route..." (which was common to see even outside of E2E tests before this fix)
4. The query param in the URL should be `?redirect=%2Fuser-management` (this would get lost sometimes before this fix)
5. After logging in, you should land on the User management page and not the home

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[HJ-77]: https://ethyca.atlassian.net/browse/HJ-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ