### PR TITLE
Fix search input width on D&D tables

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/SearchInput.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/SearchInput.tsx
@@ -29,7 +29,7 @@ export const SearchInput = ({ value, onChange }: SearchInputProps) => {
   };
 
   return (
-    <AntSpace.Compact className="w-[400px]">
+    <AntSpace.Compact className="w-96">
       <AntInput
         value={currentInput}
         placeholder="Search..."

--- a/clients/admin-ui/src/features/data-discovery-and-detection/SearchInput.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/SearchInput.tsx
@@ -29,7 +29,7 @@ export const SearchInput = ({ value, onChange }: SearchInputProps) => {
   };
 
   return (
-    <AntSpace.Compact>
+    <AntSpace.Compact className="w-[400px]">
       <AntInput
         value={currentInput}
         placeholder="Search..."

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/ActivityTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/ActivityTable.tsx
@@ -186,7 +186,7 @@ const ActivityTable = ({
     <>
       <TableActionBar>
         <Flex gap={6} align="center">
-          <Box w={400} flexShrink={0}>
+          <Box flexShrink={0}>
             <SearchInput value={searchQuery} onChange={setSearchQuery} />
           </Box>
           <IconLegendTooltip />

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DetectionResultTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DetectionResultTable.tsx
@@ -182,7 +182,7 @@ const DetectionResultTable = ({ resourceUrn }: MonitorResultTableProps) => {
           width="full"
         >
           <Flex gap={6} align="center">
-            <Box w={400} flexShrink={0}>
+            <Box flexShrink={0}>
               <SearchInput value={searchQuery} onChange={setSearchQuery} />
             </Box>
             <IconLegendTooltip />

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryResultTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryResultTable.tsx
@@ -182,7 +182,7 @@ const DiscoveryResultTable = ({ resourceUrn }: MonitorResultTableProps) => {
       />
       <TableActionBar>
         <Flex gap={6} align="center">
-          <Box w={400} flexShrink={0}>
+          <Box flexShrink={0}>
             <SearchInput value={searchQuery} onChange={setSearchQuery} />
           </Box>
           <IconLegendTooltip />


### PR DESCRIPTION
Closes HJ-35

### Description Of Changes

Restores width of search input to stop the icon legend tooltip from floating awkwardly off to the side. 

![Screenshot 2024-10-16 at 14 30 43](https://github.com/user-attachments/assets/1af632cb-a44a-45ad-a1bd-e31687b7e553)
![Screenshot 2024-10-16 at 14 31 01](https://github.com/user-attachments/assets/ebfc1d53-6af8-4373-9d99-9ab5ad9e1ab9)



### Pre-Merge Checklist

* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
