### PR TITLE
PROD-1410: Pass property id when fides.js intializes

### DIFF
--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -363,6 +363,7 @@ export const initialize = async ({
         fidesApiUrl: options.fidesApiUrl,
         apiOptions: options.apiOptions,
         requestMinimalTCF: false,
+        propertyId,
       });
     }
 

--- a/clients/fides-js/src/services/api.ts
+++ b/clients/fides-js/src/services/api.ts
@@ -26,7 +26,7 @@ interface FetchExperienceOptions {
   userLanguageString?: string;
   fidesApiUrl: string;
   apiOptions?: FidesApiOptions | null;
-  propertyId?: string | null;
+  propertyId: string | null | undefined;
   requestMinimalTCF?: boolean;
 }
 


### PR DESCRIPTION
Closes [PROD-1410]

### Description Of Changes

If you call `Fides.init()` it doesn't seem to pass property ids specified in the config. This PR should fix that.


### Code Changes

* [ ] Passed property id to initialization function.

### Steps to Confirm

* [ ] Not sure

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
