### PR TITLE
Fix: remove double line from final row's first column

### DIFF
--- a/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/FidesCell.tsx
@@ -95,8 +95,8 @@ export const FidesCell = <T,>({
       _first={{
         borderBottomWidth:
           (!isTableGrouped && !isLastRowOfPage) ||
-          (isLastRowOfGroupedRows && !isFirstRowOfPage) ||
-          (isFirstRowOfGroupedRows && hasOneSubRow)
+          (isLastRowOfGroupedRows && !isFirstRowOfPage && !isLastRowOfPage) ||
+          (isFirstRowOfGroupedRows && hasOneSubRow && !isLastRowOfPage)
             ? "1px"
             : "0px",
       }}


### PR DESCRIPTION
Closes [#HJ-75](https://ethyca.atlassian.net/browse/HJ-75)

### Description Of Changes

On the bottom of the first column in the reporting view, there’s a double line. Let’s remove that. See ref image below. 

Before:
![with double border](https://github.com/user-attachments/assets/8da1c741-9d19-411e-b46e-2647d57dbec0)

After:
![without double border](https://github.com/user-attachments/assets/89bdf990-7466-4424-9eb7-638784dee147)

### Steps to Confirm

* Visit a populated Data map report page (eg. `http://localhost:3000/reporting/datamap`)
* Scroll to the very bottom
* First column should not have a double border

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
