### PR TITLE
Fix "download" button icon placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The types of changes are:
 - Fixed a bug where D&D tables were rendering stale data [#5372](https://github.com/ethyca/fides/pull/5372)
 - Fixed issue where multiple login redirects could end up losing login return path [#5389](https://github.com/ethyca/fides/pull/5389)
 - Fixed issue where Dataset with nested fields was unable to edit Categories [#5383](https://github.com/ethyca/fides/pull/5383)
+- Fixed a visual bug where the "download" icon was off-center in some buttons [#5409](https://github.com/ethyca/fides/pull/5409)
 
 ### Developer Experience
 - Fix warning messages from slowapi and docker [#5385](https://github.com/ethyca/fides/pull/5385)

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -476,8 +476,7 @@ export const DatamapReportTable = () => {
                   data-testid="export-btn"
                   size="small"
                   onClick={onExportReportOpen}
-                  icon={<DownloadLightIcon ml="1px" />}
-                  className="size-6"
+                  icon={<DownloadLightIcon ml="1.5px" />}
                 />
                 <Menu placement="bottom-end">
                   <MenuButton

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -476,7 +476,8 @@ export const DatamapReportTable = () => {
                   data-testid="export-btn"
                   size="small"
                   onClick={onExportReportOpen}
-                  icon={<DownloadLightIcon />}
+                  icon={<DownloadLightIcon ml="1px" />}
+                  className="size-6"
                 />
                 <Menu placement="bottom-end">
                   <MenuButton

--- a/clients/admin-ui/src/features/privacy-requests/RequestTable.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestTable.tsx
@@ -147,8 +147,7 @@ export const RequestTable = ({ ...props }: BoxProps): JSX.Element => {
             aria-label="Export report"
             data-testid="export-btn"
             size="small"
-            icon={<DownloadLightIcon ml="1px" />}
-            className="size-6"
+            icon={<DownloadLightIcon ml="1.5px" />}
             onClick={handleExport}
           />
         </HStack>

--- a/clients/admin-ui/src/features/privacy-requests/RequestTable.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestTable.tsx
@@ -147,7 +147,8 @@ export const RequestTable = ({ ...props }: BoxProps): JSX.Element => {
             aria-label="Export report"
             data-testid="export-btn"
             size="small"
-            icon={<DownloadLightIcon />}
+            icon={<DownloadLightIcon ml="1px" />}
+            className="size-6"
             onClick={handleExport}
           />
         </HStack>


### PR DESCRIPTION
Closes HJ-74

### Description Of Changes

Fixes icon placement on "download" buttons on datamap report table and privacy request table so it's no longer off-center.

Before:

![Screenshot 2024-10-23 at 01 35 42](https://github.com/user-attachments/assets/d99bfe81-e0d3-4409-90e2-6392c6ca40f6)

After:

![Screenshot 2024-10-23 at 01 35 54](https://github.com/user-attachments/assets/3ee77aec-e46b-4734-8667-7fcb6891c9ed)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`