### PR TITLE
FIDES-1429: Safari < 14 support

### DIFF
--- a/clients/fides-js/src/lib/hooks/useMediaQuery.ts
+++ b/clients/fides-js/src/lib/hooks/useMediaQuery.ts
@@ -14,9 +14,20 @@ export const useMediaQuery = (query: string) => {
     function handleChange(e: MediaQueryListEvent) {
       setMatches(e.matches);
     }
-    matchQueryList.addEventListener("change", handleChange);
+
+    if (matchQueryList.addEventListener) {
+      matchQueryList.addEventListener("change", handleChange);
+    } else {
+      // Supports Safari < 14
+      matchQueryList.addListener(handleChange);
+    }
     return () => {
-      matchQueryList.removeEventListener("change", handleChange);
+      if (matchQueryList.removeEventListener) {
+        matchQueryList.removeEventListener("change", handleChange);
+      } else {
+        // Supports Safari < 14
+        matchQueryList.removeListener(handleChange);
+      }
     };
   }, [query]);
   return matches;

--- a/clients/fides-js/src/lib/hooks/useMediaQuery.ts
+++ b/clients/fides-js/src/lib/hooks/useMediaQuery.ts
@@ -18,14 +18,15 @@ export const useMediaQuery = (query: string) => {
     if (matchQueryList.addEventListener) {
       matchQueryList.addEventListener("change", handleChange);
     } else {
-      // Supports Safari < 14
+      // Older browser and test automation supportSafari < 14
       matchQueryList.addListener(handleChange);
     }
+
     return () => {
       if (matchQueryList.removeEventListener) {
         matchQueryList.removeEventListener("change", handleChange);
       } else {
-        // Supports Safari < 14
+        // Older browser and test automation support
         matchQueryList.removeListener(handleChange);
       }
     };


### PR DESCRIPTION

Closes [FIDES-1429]

### Description Of Changes

The method we're using for media queries only became available as of Safari 14. Applied the work around mentioned in the stackoverflow post below to use an API that is available in Safari 13 when necessary.

https://stackoverflow.com/questions/62693995/addeventlistener-is-not-a-function-for-matchmedia-in-safari-browser/75517985#75517985



### Code Changes

* [ ] Add a fallback for media query event methods that works for Safari < 14

### Steps to Confirm

* [ ] Use browserstack to confirm that Safari < 14 allows the script to work.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!


[FIDES-1429]: https://ethyca.atlassian.net/browse/FIDES-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ