### PR TITLE
Add Carbon Icons and upgrade Ant Design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The types of changes are:
 ### Fixed
 - Fixed Snowflake DSR integration failing with syntax error [#5417](https://github.com/ethyca/fides/pull/5417)
 
+### Developer Experience
+- Added Carbon Icons to FidesUI [#5416](https://github.com/ethyca/fides/pull/5416)
+
 ## [2.48.0](https://github.com/ethyca/fidesplus/compare/2.47.1...2.48.0)
 
 ### Added

--- a/clients/admin-ui/src/features/common/ClipboardButton.tsx
+++ b/clients/admin-ui/src/features/common/ClipboardButton.tsx
@@ -15,32 +15,16 @@ enum TooltipText {
 
 const useClipboardButton = (copyText: string) => {
   const { onCopy } = useClipboard(copyText);
-
-  const [highlighted, setHighlighted] = useState(false);
   const [tooltipText, setTooltipText] = useState(TooltipText.COPY);
 
-  const handleMouseDown = () => {
+  const handleClick = () => {
     setTooltipText(TooltipText.COPIED);
     onCopy();
-  };
-  const handleMouseUp = () => {
-    setHighlighted(false);
-  };
-
-  const handleMouseEnter = () => {
-    setHighlighted(true);
-  };
-  const handleMouseLeave = () => {
-    setHighlighted(false);
   };
 
   return {
     tooltipText,
-    highlighted,
-    handleMouseDown,
-    handleMouseUp,
-    handleMouseEnter,
-    handleMouseLeave,
+    handleClick,
     setTooltipText,
   };
 };
@@ -54,17 +38,8 @@ interface ClipboardButtonProps
 }
 
 const ClipboardButton = ({ copyText, ...props }: ClipboardButtonProps) => {
-  const {
-    tooltipText,
-    highlighted,
-    handleMouseDown,
-    handleMouseUp,
-    handleMouseEnter,
-    handleMouseLeave,
-    setTooltipText,
-  } = useClipboardButton(copyText);
-
-  const iconColor = !highlighted ? "gray.600" : "complimentary.500";
+  const { tooltipText, handleClick, setTooltipText } =
+    useClipboardButton(copyText);
 
   return (
     <Tooltip
@@ -80,15 +55,11 @@ const ClipboardButton = ({ copyText, ...props }: ClipboardButtonProps) => {
     >
       <Button
         icon={<CopyIcon />}
-        color={iconColor}
         aria-label="copy"
         type="text"
         data-testid="clipboard-btn"
         {...props}
-        onClick={handleMouseDown}
-        onMouseUp={handleMouseUp}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
+        onClick={handleClick}
       />
     </Tooltip>
   );

--- a/clients/fidesui/package.json
+++ b/clients/fidesui/package.json
@@ -12,9 +12,10 @@
     "clean": "rm -rf node_modules"
   },
   "dependencies": {
+    "@carbon/icons-react": "^11.51.0",
     "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
-    "antd": "^5.20.0",
+    "antd": "^5.21.5",
     "chakra-react-select": "^4.7.6",
     "typescript": "^4.9.5"
   },

--- a/clients/fidesui/src/index.ts
+++ b/clients/fidesui/src/index.ts
@@ -33,6 +33,13 @@ export { AddIcon, LinkIcon, QuestionIcon, WarningIcon } from "./icons";
 export * from "./icons";
 /* eslint-enable import/export */
 
+/**
+ * prefixed icons from Carbon Icons
+ * @example <Icons.download size={14} />
+ */
+export * as Icons from "@carbon/icons-react";
+/* end prefixed icons */
+
 export * from "./FidesUIProvider";
 export { extendTheme, theme } from "./FidesUITheme";
 

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -1019,9 +1019,10 @@
     },
     "fidesui": {
       "dependencies": {
+        "@carbon/icons-react": "^11.51.0",
         "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.8.2",
-        "antd": "^5.20.0",
+        "antd": "^5.21.5",
         "chakra-react-select": "^4.7.6",
         "typescript": "^4.9.5"
       },
@@ -1110,9 +1111,9 @@
       }
     },
     "node_modules/@ant-design/cssinjs": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.21.0.tgz",
-      "integrity": "sha512-gIilraPl+9EoKdYxnupxjHB/Q6IHNRjEXszKbDxZdsgv4sAZ9pjkCq8yanDWNvyfjp4leir2OVAJm0vxwKK8YA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.21.1.tgz",
+      "integrity": "sha512-tyWnlK+XH7Bumd0byfbCiZNK43HEubMoCcu9VxwsAwiHdHTgWa+tMN0/yvxa+e8EzuFP1WdUNNPclRpVtD33lg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -1121,7 +1122,7 @@
         "classnames": "^2.3.1",
         "csstype": "^3.1.3",
         "rc-util": "^5.35.0",
-        "stylis": "^4.0.13"
+        "stylis": "^4.3.3"
       },
       "peerDependencies": {
         "react": ">=16.0.0",
@@ -1129,9 +1130,9 @@
       }
     },
     "node_modules/@ant-design/cssinjs-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.0.3.tgz",
-      "integrity": "sha512-BrztZZKuoYcJK8uEH40ylBemf/Mu/QPiDos56g2bv6eUoniQkgQHOCOvA3+pncoFO1TaS8xcUCIqGzDA0I+ZVQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.1.tgz",
+      "integrity": "sha512-2HAiyGGGnM0es40SxdszeQAU5iWp41wBIInq+ONTCKjlSKOrzQfnw4JDtB8IBmqE6tQaEKwmzTP2LGdt5DSwYQ==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/cssinjs": "^1.21.0",
@@ -1155,10 +1156,16 @@
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
       "license": "MIT"
     },
+    "node_modules/@ant-design/cssinjs/node_modules/stylis": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.4.tgz",
+      "integrity": "sha512-osIBl6BGUmSfDkyH2mB7EFvCJntXDrLhKjHTRj/rK6xLH0yuPrHULDRQzKokSOD4VoorhtKpfcfW1GAntu8now==",
+      "license": "MIT"
+    },
     "node_modules/@ant-design/fast-color": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.5.tgz",
-      "integrity": "sha512-kzUEdptM2vbHFn+fGkgKgbfsko5TR9GlGvAj+Xa7pKSXipbsvbqPtxcUGv7vdoPHFCr6JUBZa8Rfs+QJtFZEAw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
+      "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7"
@@ -1168,9 +1175,9 @@
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.4.0.tgz",
-      "integrity": "sha512-QZbWC5xQYexCI5q4/fehSEkchJr5UGtvAJweT743qKUQQGs9IH2DehNLP49DJ3Ii9m9CijD2HN6fNy3WKhIFdA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.5.1.tgz",
+      "integrity": "sha512-0UrM02MA2iDIgvLatWrj6YTCYe0F/cwXvVE0E2SqGrL7PZireQwgEKTKBisWpZyal5eXZLvuM98kju6YtYne8w==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
@@ -1699,9 +1706,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
+      "integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -1779,6 +1786,31 @@
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.2.tgz",
       "integrity": "sha512-NVf/1YycDMs6+FxS0Tb/W8MjJRDQdXF+tBfDtZ5UZeiRUkTmwKc4vmYCKZTyymfJk1gnMsauvZSX/HiV9jOABw==",
       "license": "MIT"
+    },
+    "node_modules/@carbon/icon-helpers": {
+      "version": "10.53.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.53.0.tgz",
+      "integrity": "sha512-5yVbIH3/cYSJBgJ+04l2/zBikxm7IA/CV2MTt04Op3ZwOcSkVbmRNNAWslkamTE/DOHLCTj76GK0Jh6vgXF/UQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.5.0"
+      }
+    },
+    "node_modules/@carbon/icons-react": {
+      "version": "11.51.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons-react/-/icons-react-11.51.0.tgz",
+      "integrity": "sha512-2e5s0TpEokBw8hbpIr/TKbbzM3FFS5MzO7oEQ5J9uSn6Z/j0r+go6d7b+JamqjJFnLRCc0aq3VwsXuy/k3YIWA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@carbon/icon-helpers": "^10.53.0",
+        "@ibm/telemetry-js": "^1.5.0",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
     },
     "node_modules/@chakra-ui/accordion": {
       "version": "2.3.1",
@@ -3741,6 +3773,15 @@
       "resolved": "https://registry.npmjs.org/@iabtechlabtcf/core/-/core-1.5.12.tgz",
       "integrity": "sha512-xm2Q28FXA/1sHY/Xr5YKQ/PEAeEa3BtL5RZLIQ3pk+jtp7dl6YPBpaQokYwXVUijMJPA2q7KLfZRchvV6wmLAg=="
     },
+    "node_modules/@ibm/telemetry-js": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.7.1.tgz",
+      "integrity": "sha512-6S824qKqNr/gGWNkaxQz3c/9Ni5O87CrD289ms3Z/z52oUsHRgB6XYssRrn3wkiIhM9C93en1WJGmFe5nppP0A==",
+      "license": "Apache-2.0",
+      "bin": {
+        "ibmtelemetry": "dist/collect.js"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -5205,12 +5246,12 @@
       }
     },
     "node_modules/@rc-component/color-picker": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-2.0.0.tgz",
-      "integrity": "sha512-52z3XqUwUr0+Br3B8RjN2GfuR1Pk3MZPAVd34WptWFEOyTz7OQmmn8nqgXUBOYwZem8jXp6G3iv+6Dm1+1epJA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-2.0.1.tgz",
+      "integrity": "sha512-WcZYwAThV/b2GISQ8F+7650r5ZZJ043E57aVBFkQ+kSY4C6wdofXgB0hBx+GPGpIU0Z81eETNoDUJMr7oy/P8Q==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/fast-color": "^2.0.1",
+        "@ant-design/fast-color": "^2.0.6",
         "@babel/runtime": "^7.23.6",
         "classnames": "^2.2.6",
         "rc-util": "^5.38.1"
@@ -5301,9 +5342,9 @@
       }
     },
     "node_modules/@rc-component/tour": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.15.0.tgz",
-      "integrity": "sha512-h6hyILDwL+In9GAgRobwRWihLqqsD7Uft3fZGrJ7L4EiyCoxbnNYwzPXDfz7vNDhWeVyvAWQJj9fJCzpI4+b4g==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.15.1.tgz",
+      "integrity": "sha512-Tr2t7J1DKZUpfJuDZWHxyxWpfmj8EZrqSgyMZ+BCdvKZ6r1UDsfU46M/iWAAFBy961Ssfom2kv5f3UcjIL2CmQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
@@ -5321,9 +5362,9 @@
       }
     },
     "node_modules/@rc-component/trigger": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.2.0.tgz",
-      "integrity": "sha512-QarBCji02YE9aRFhZgRZmOpXBj0IZutRippsVBv85sxvG4FGk/vRxwAlkn3MS9zK5mwbETd86mAVg2tKqTkdJA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.2.3.tgz",
+      "integrity": "sha512-X1oFIpKoXAMXNDYCviOmTfuNuYxE4h5laBsyCqVAVMjNHxoF3/uiyA7XdegK1XbCvBbCZ6P6byWrEoDRpKL8+A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
@@ -7484,57 +7525,57 @@
       }
     },
     "node_modules/antd": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.20.0.tgz",
-      "integrity": "sha512-wWCFzbry3hov7k8gqhPR+FzD6EkWlhBbGD9mYOSIDoYRGMRqueTh2+2jfU1voHucmwcxDwzU7iwZDU2+PCXZdA==",
+      "version": "5.21.5",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.21.5.tgz",
+      "integrity": "sha512-g/c8VkdruKDCVA6di9Ow1fG6dLtYJ1IOraPo7vXaY7DoQ56A3HExaFaH0fBEwTYKC0ICeftC4iA5eAjrF6/b9w==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.1.0",
-        "@ant-design/cssinjs": "^1.21.0",
-        "@ant-design/cssinjs-utils": "^1.0.3",
-        "@ant-design/icons": "^5.4.0",
+        "@ant-design/cssinjs": "^1.21.1",
+        "@ant-design/cssinjs-utils": "^1.1.1",
+        "@ant-design/icons": "^5.5.1",
         "@ant-design/react-slick": "~1.1.2",
-        "@babel/runtime": "^7.24.8",
+        "@babel/runtime": "^7.25.6",
         "@ctrl/tinycolor": "^3.6.1",
-        "@rc-component/color-picker": "~2.0.0",
+        "@rc-component/color-picker": "~2.0.1",
         "@rc-component/mutate-observer": "^1.1.0",
         "@rc-component/qrcode": "~1.0.0",
-        "@rc-component/tour": "~1.15.0",
-        "@rc-component/trigger": "^2.2.0",
+        "@rc-component/tour": "~1.15.1",
+        "@rc-component/trigger": "^2.2.3",
         "classnames": "^2.5.1",
         "copy-to-clipboard": "^3.3.3",
         "dayjs": "^1.11.11",
-        "rc-cascader": "~3.27.0",
+        "rc-cascader": "~3.28.2",
         "rc-checkbox": "~3.3.0",
-        "rc-collapse": "~3.7.3",
-        "rc-dialog": "~9.5.2",
+        "rc-collapse": "~3.8.0",
+        "rc-dialog": "~9.6.0",
         "rc-drawer": "~7.2.0",
         "rc-dropdown": "~4.2.0",
-        "rc-field-form": "~2.2.1",
-        "rc-image": "~7.9.0",
-        "rc-input": "~1.6.2",
+        "rc-field-form": "~2.4.0",
+        "rc-image": "~7.11.0",
+        "rc-input": "~1.6.3",
         "rc-input-number": "~9.2.0",
-        "rc-mentions": "~2.15.0",
-        "rc-menu": "~9.14.1",
-        "rc-motion": "^2.9.2",
-        "rc-notification": "~5.6.0",
-        "rc-pagination": "~4.2.0",
-        "rc-picker": "~4.6.11",
+        "rc-mentions": "~2.16.1",
+        "rc-menu": "~9.15.1",
+        "rc-motion": "^2.9.3",
+        "rc-notification": "~5.6.2",
+        "rc-pagination": "~4.3.0",
+        "rc-picker": "~4.6.15",
         "rc-progress": "~4.0.0",
         "rc-rate": "~2.13.0",
         "rc-resize-observer": "^1.4.0",
-        "rc-segmented": "~2.3.0",
-        "rc-select": "~14.15.1",
-        "rc-slider": "~11.1.3",
+        "rc-segmented": "~2.5.0",
+        "rc-select": "~14.15.2",
+        "rc-slider": "~11.1.7",
         "rc-steps": "~6.0.1",
         "rc-switch": "~4.1.0",
-        "rc-table": "~7.45.7",
-        "rc-tabs": "~15.1.1",
-        "rc-textarea": "~1.8.1",
-        "rc-tooltip": "~6.2.0",
-        "rc-tree": "~5.8.8",
-        "rc-tree-select": "~5.22.1",
-        "rc-upload": "~4.6.0",
+        "rc-table": "~7.47.5",
+        "rc-tabs": "~15.3.0",
+        "rc-textarea": "~1.8.2",
+        "rc-tooltip": "~6.2.1",
+        "rc-tree": "~5.9.0",
+        "rc-tree-select": "~5.23.0",
+        "rc-upload": "~4.8.1",
         "rc-util": "^5.43.0",
         "scroll-into-view-if-needed": "^3.1.0",
         "throttle-debounce": "^5.0.2"
@@ -20821,16 +20862,16 @@
       }
     },
     "node_modules/rc-cascader": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.27.0.tgz",
-      "integrity": "sha512-z5uq8VvQadFUBiuZJ7YF5UAUGNkZtdEtcEYiIA94N/Kc2MIKr6lEbN5HyVddvYSgwWlKqnL6pH5bFXFuIK3MNg==",
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.28.2.tgz",
+      "integrity": "sha512-8f+JgM83iLTvjgdkgU7GfI4qY8icXOBP0cGZjOdx2iJAkEe8ucobxDQAVE69UD/c3ehCxZlcgEHeD5hFmypbUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "array-tree-filter": "^2.1.0",
         "classnames": "^2.3.1",
         "rc-select": "~14.15.0",
-        "rc-tree": "~5.8.1",
+        "rc-tree": "~5.9.0",
         "rc-util": "^5.37.0"
       },
       "peerDependencies": {
@@ -20854,9 +20895,9 @@
       }
     },
     "node_modules/rc-collapse": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.7.3.tgz",
-      "integrity": "sha512-60FJcdTRn0X5sELF18TANwtVi7FtModq649H11mYF1jh83DniMoM4MqY627sEKRCTm4+WXfGDcB7hY5oW6xhyw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.8.0.tgz",
+      "integrity": "sha512-YVBkssrKPBG09TGfcWWGj8zJBYD9G3XuTy89t5iUmSXrIXEAnO1M+qjUxRW6b4Qi0+wNWG6MHJF/+US+nmIlzA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -20870,9 +20911,9 @@
       }
     },
     "node_modules/rc-dialog": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.5.2.tgz",
-      "integrity": "sha512-qVUjc8JukG+j/pNaHVSRa2GO2/KbV2thm7yO4hepQ902eGdYK913sGkwg/fh9yhKYV1ql3BKIN2xnud3rEXAPw==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
+      "integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -20920,9 +20961,9 @@
       }
     },
     "node_modules/rc-field-form": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.2.1.tgz",
-      "integrity": "sha512-uoNqDoR7A4tn4QTSqoWPAzrR7ZwOK5I+vuZ/qdcHtbKx+ZjEsTg7QXm2wk/jalDiSksAQmATxL0T5LJkRREdIA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.4.0.tgz",
+      "integrity": "sha512-XZ/lF9iqf9HXApIHQHqzJK5v2w4mkUMsVqAzOyWVzoiwwXEavY6Tpuw7HavgzIoD+huVff4JghSGcgEfX6eycg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
@@ -20938,15 +20979,15 @@
       }
     },
     "node_modules/rc-image": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.9.0.tgz",
-      "integrity": "sha512-l4zqO5E0quuLMCtdKfBgj4Suv8tIS011F5k1zBBlK25iMjjiNHxA0VeTzGFtUZERSA45gvpXDg8/P6qNLjR25g==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.11.0.tgz",
+      "integrity": "sha512-aZkTEZXqeqfPZtnSdNUnKQA0N/3MbgR7nUnZ+/4MfSFWPFHZau4p5r5ShaI0KPEMnNjv4kijSCFq/9wtJpwykw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@rc-component/portal": "^1.0.2",
         "classnames": "^2.2.6",
-        "rc-dialog": "~9.5.2",
+        "rc-dialog": "~9.6.0",
         "rc-motion": "^2.6.2",
         "rc-util": "^5.34.1"
       },
@@ -20956,9 +20997,9 @@
       }
     },
     "node_modules/rc-input": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.6.2.tgz",
-      "integrity": "sha512-nJqsiIv8K88w8pvbUR5savKqBokdSR0zVGPntLApeOKFp8dp6s92l1CzD60yVActpCZAJwlCfRX5rno+QVYV7g==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.6.3.tgz",
+      "integrity": "sha512-wI4NzuqBS8vvKr8cljsvnTUqItMfG1QbJoxovCgL+DX4eVUcHIjVwharwevIxyy7H/jbLryh+K7ysnJr23aWIA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -20988,16 +21029,16 @@
       }
     },
     "node_modules/rc-mentions": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.15.0.tgz",
-      "integrity": "sha512-f5v5i7VdqvBDXbphoqcQWmXDif2Msd2arritVoWybrVDuHE6nQ7XCYsybHbV//WylooK52BFDouFvyaRDtXZEw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.16.1.tgz",
+      "integrity": "sha512-GnhSTGP9Mtv6pqFFGQze44LlrtWOjHNrUUAcsdo9DnNAhN4pwVPEWy4z+2jpjkiGlJ3VoXdvMHcNDQdfI9fEaw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
         "rc-input": "~1.6.0",
-        "rc-menu": "~9.14.0",
+        "rc-menu": "~9.15.1",
         "rc-textarea": "~1.8.0",
         "rc-util": "^5.34.1"
       },
@@ -21007,9 +21048,9 @@
       }
     },
     "node_modules/rc-menu": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.14.1.tgz",
-      "integrity": "sha512-5wlRb3M8S4yGlWhSoEYJ7ZVRElyScdcpUHxgiLxkeig1tEdyKrnED3B2fhpN0Rrpdp9jyhnmZR/Lwq2fH5VvDQ==",
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.15.1.tgz",
+      "integrity": "sha512-UKporqU6LPfHnpPmtP6hdEK4iO5Q+b7BRv/uRpxdIyDGplZy9jwUjsnpev5bs3PQKB0H0n34WAPDfjAfn3kAPA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -21025,9 +21066,9 @@
       }
     },
     "node_modules/rc-motion": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.2.tgz",
-      "integrity": "sha512-fUAhHKLDdkAXIDLH0GYwof3raS58dtNUmzLF2MeiR8o6n4thNpSDQhOqQzWE4WfFZDCi9VEN8n7tiB7czREcyw==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.3.tgz",
+      "integrity": "sha512-rkW47ABVkic7WEB0EKJqzySpvDqwl60/tdkY7hWP7dYnh5pm0SzJpo54oW3TDUGXV5wfxXFmMkxrzRRbotQ0+w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -21040,9 +21081,9 @@
       }
     },
     "node_modules/rc-notification": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.0.tgz",
-      "integrity": "sha512-TGQW5T7waOxLwgJG7fXcw8l7AQiFOjaZ7ISF5PrU526nunHRNcTMuzKihQHaF4E/h/KfOCDk3Mv8eqzbu2e28w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.2.tgz",
+      "integrity": "sha512-Id4IYMoii3zzrG0lB0gD6dPgJx4Iu95Xu0BQrhHIbp7ZnAZbLqdqQ73aIWH0d0UFcElxwaKjnzNovTjo7kXz7g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -21075,9 +21116,9 @@
       }
     },
     "node_modules/rc-pagination": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-4.2.0.tgz",
-      "integrity": "sha512-V6qeANJsT6tmOcZ4XiUmj8JXjRLbkusuufpuoBw2GiAn94fIixYjFLmbruD1Sbhn8fPLDnWawPp4CN37zQorvw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-4.3.0.tgz",
+      "integrity": "sha512-UubEWA0ShnroQ1tDa291Fzw6kj0iOeF26IsUObxYTpimgj4/qPCWVFl18RLZE+0Up1IZg0IK4pMn6nB3mjvB7g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -21090,9 +21131,9 @@
       }
     },
     "node_modules/rc-picker": {
-      "version": "4.6.11",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.6.11.tgz",
-      "integrity": "sha512-PEVH5MMTUrdvTTxCmPndsXiJL7TFLSu8q0cDdZrhdcjn8en3NbuhOFacWqKTvdnfG53RPPhiBssXCUHYyc3R/Q==",
+      "version": "4.6.15",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.6.15.tgz",
+      "integrity": "sha512-OWZ1yrMie+KN2uEUfYCfS4b2Vu6RC1FWwNI0s+qypsc3wRt7g+peuZKVIzXCTaJwyyZruo80+akPg2+GmyiJjw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
@@ -21178,9 +21219,9 @@
       }
     },
     "node_modules/rc-segmented": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.3.0.tgz",
-      "integrity": "sha512-I3FtM5Smua/ESXutFfb8gJ8ZPcvFR+qUgeeGFQHBOvRiRKyAk4aBE5nfqrxXx+h8/vn60DQjOt6i4RNtrbOobg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.5.0.tgz",
+      "integrity": "sha512-B28Fe3J9iUFOhFJET3RoXAPFJ2u47QvLSYcZWC4tFYNGPEjug5LAxEasZlA/PpAxhdOPqGWsGbSj7ftneukJnw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -21194,9 +21235,9 @@
       }
     },
     "node_modules/rc-select": {
-      "version": "14.15.1",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.15.1.tgz",
-      "integrity": "sha512-mGvuwW1RMm1NCSI8ZUoRoLRK51R2Nb+QJnmiAvbDRcjh2//ulCkxeV6ZRFTECPpE1t2DPfyqZMPw90SVJzQ7wQ==",
+      "version": "14.15.2",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.15.2.tgz",
+      "integrity": "sha512-oNoXlaFmpqXYcQDzcPVLrEqS2J9c+/+oJuGrlXeVVX/gVgrbHa5YcyiRUXRydFjyuA7GP3elRuLF7Y3Tfwltlw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -21216,9 +21257,9 @@
       }
     },
     "node_modules/rc-slider": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.5.tgz",
-      "integrity": "sha512-b77H5PbjMKsvkYXAYIkn50QuFX6ICQmCTibDinI9q+BHx65/TV4TeU25+oadhSRzykxs0/vBWeKBwRyySOeWlg==",
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.7.tgz",
+      "integrity": "sha512-ytYbZei81TX7otdC0QvoYD72XSlxvTihNth5OeZ6PMXyEDq/vHdWFulQmfDGyXK1NwKwSlKgpvINOa88uT5g2A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -21267,16 +21308,16 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.45.7",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.45.7.tgz",
-      "integrity": "sha512-wi9LetBL1t1csxyGkMB2p3mCiMt+NDexMlPbXHvQFmBBAsMxrgNSAPwUci2zDLUq9m8QdWc1Nh8suvrpy9mXrg==",
+      "version": "7.47.5",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.47.5.tgz",
+      "integrity": "sha512-fzq+V9j/atbPIcvs3emuclaEoXulwQpIiJA6/7ey52j8+9cJ4P8DGmp4YzfUVDrb3qhgedcVeD6eRgUrokwVEQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/context": "^1.4.0",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.37.0",
+        "rc-util": "^5.41.0",
         "rc-virtual-list": "^3.14.2"
       },
       "engines": {
@@ -21288,15 +21329,15 @@
       }
     },
     "node_modules/rc-tabs": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.1.1.tgz",
-      "integrity": "sha512-Tc7bJvpEdkWIVCUL7yQrMNBJY3j44NcyWS48jF/UKMXuUlzaXK+Z/pEL5LjGcTadtPvVmNqA40yv7hmr+tCOAw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.3.0.tgz",
+      "integrity": "sha512-lzE18r+zppT/jZWOAWS6ntdkDUKHOLJzqMi5UAij1LeKwOaQaupupAoI9Srn73GRzVpmGznkECMRrzkRusC40A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
         "rc-dropdown": "~4.2.0",
-        "rc-menu": "~9.14.0",
+        "rc-menu": "~9.15.1",
         "rc-motion": "^2.6.2",
         "rc-resize-observer": "^1.0.0",
         "rc-util": "^5.34.1"
@@ -21310,9 +21351,9 @@
       }
     },
     "node_modules/rc-textarea": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.8.1.tgz",
-      "integrity": "sha512-bm36N2ZqwZAP60ZQg2OY9mPdqWC+m6UTjHc+CqEZOxb3Ia29BGHazY/s5bI8M4113CkqTzhtFUDNA078ZiOx3Q==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.8.2.tgz",
+      "integrity": "sha512-UFAezAqltyR00a8Lf0IPAyTd29Jj9ee8wt8DqXyDMal7r/Cg/nDt3e1OOv3Th4W6mKaZijjgwuPXhAfVNTN8sw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -21327,9 +21368,9 @@
       }
     },
     "node_modules/rc-tooltip": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.2.0.tgz",
-      "integrity": "sha512-iS/3iOAvtDh9GIx1ulY7EFUXUtktFccNLsARo3NPgLf0QW9oT0w3dA9cYWlhqAKmD+uriEwdWz1kH0Qs4zk2Aw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.2.1.tgz",
+      "integrity": "sha512-rws0duD/3sHHsD905Nex7FvoUGy2UBQRhTkKxeEvr2FB+r21HsOxcDJI0TzyO8NHhnAA8ILr8pfbSBg5Jj5KBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
@@ -21342,9 +21383,9 @@
       }
     },
     "node_modules/rc-tree": {
-      "version": "5.8.8",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.8.8.tgz",
-      "integrity": "sha512-S+mCMWo91m5AJqjz3PdzKilGgbFm7fFJRFiTDOcoRbD7UfMOPnerXwMworiga0O2XIo383UoWuEfeHs1WOltag==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.9.0.tgz",
+      "integrity": "sha512-CPrgOvm9d/9E+izTONKSngNzQdIEjMox2PBufWjS1wf7vxtvmCWzK1SlpHbRY6IaBfJIeZ+88RkcIevf729cRg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -21362,15 +21403,15 @@
       }
     },
     "node_modules/rc-tree-select": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.22.1.tgz",
-      "integrity": "sha512-b8mAK52xEpRgS+b2PTapCt29GoIrO5cO8jB7AfHttFsIJfcnynY9FCtnYzURsKXJkGHbFY6UzSEB2I3TETtdWg==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.23.0.tgz",
+      "integrity": "sha512-aQGi2tFSRw1WbXv0UVXPzHm09E0cSvUVZMLxQtMv3rnZZpNmdRXWrnd9QkLNlVH31F+X5rgghmdSFF3yZW0N9A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
         "rc-select": "~14.15.0",
-        "rc-tree": "~5.8.1",
+        "rc-tree": "~5.9.0",
         "rc-util": "^5.16.1"
       },
       "peerDependencies": {
@@ -21379,9 +21420,9 @@
       }
     },
     "node_modules/rc-upload": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.6.0.tgz",
-      "integrity": "sha512-Zr0DT1NHw/ApxrP7UAoxOtGaVYuzarrrCVr0ld7RiEFsKX07uFhE1EpCBxwL11ruFn89GMcshOKWp+s6FLyAlA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.8.1.tgz",
+      "integrity": "sha512-toEAhwl4hjLAI1u8/CgKWt30BR06ulPa4iGQSMvSXoHzO88gPCslxqV/mnn4gJU7PDoltGIC9Eh+wkeudqgHyw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -21414,9 +21455,9 @@
       "license": "MIT"
     },
     "node_modules/rc-virtual-list": {
-      "version": "3.14.5",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.14.5.tgz",
-      "integrity": "sha512-ZMOnkCLv2wUN8Jz7yI4XiSLa9THlYvf00LuMhb1JlsQCewuU7ydPuHw1rGVPhe9VZYl/5UqODtNd7QKJ2DMGfg==",
+      "version": "3.14.8",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.14.8.tgz",
+      "integrity": "sha512-8D0KfzpRYi6YZvlOWIxiOm9BGt4Wf2hQyEaM6RXlDDiY2NhLheuYI+RA+7ZaZj1lq+XQqy3KHlaeeXQfzI5fGg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",


### PR DESCRIPTION
Supports [HJ-71](https://ethyca.atlassian.net/browse/HJ-71)

### Description Of Changes

Exports [Carbon Icons](https://carbondesignsystem.com/elements/icons/library/) from `fidesui` prefixed as `Icons` to avoid conflicts with other components

Upgrade Ant Design to latest version to benefit from new `variant` property as well as bug fixes.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Update `CHANGELOG.md`


[HJ-71]: https://ethyca.atlassian.net/browse/HJ-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ