### PR TITLE
Add keepalive settings for redshift integration

### DIFF
--- a/src/fides/api/service/connectors/sql_connector.py
+++ b/src/fides/api/service/connectors/sql_connector.py
@@ -501,6 +501,13 @@ class RedshiftConnector(SQLConnector):
         """Returns a SQLAlchemy Engine that can be used to interact with a database"""
         connect_args = {}
         connect_args["sslmode"] = "prefer"
+
+        # keep alive settings to prevent long-running queries from causing a connection close
+        connect_args["keepalives"] = 1
+        connect_args["keepalives_idle"] = 30
+        connect_args["keepalives_interval"] = 5
+        connect_args["keepalives_count"] = 5
+
         if (
             self.configuration.secrets
             and self.configuration.secrets.get("ssh_required", False)

--- a/src/fides/api/service/connectors/sql_connector.py
+++ b/src/fides/api/service/connectors/sql_connector.py
@@ -499,7 +499,7 @@ class RedshiftConnector(SQLConnector):
     # Overrides SQLConnector.create_client
     def create_client(self) -> Engine:
         """Returns a SQLAlchemy Engine that can be used to interact with a database"""
-        connect_args = {}
+        connect_args: Dict[str, Union[int, str]] = {}
         connect_args["sslmode"] = "prefer"
 
         # keep alive settings to prevent long-running queries from causing a connection close


### PR DESCRIPTION
Closes [LA-57](https://ethyca.atlassian.net/browse/LA-57)

### Description Of Changes

Adding keep-alive settings for the Redshift connector. Here is an explanation of the settings:

- keepalives: enable tcp keepalive
- keepalives_idle: seconds before sending first keepalive probe after the connection is idle
- keepalives_interval: seconds between subsequent keepalive probes is no response is received
- keepalives_count: number of failed keepalive probes before declaring a connection dead

### Steps to Confirm

* [ ] Will verify on customer's test/staging environment since we can't reproduce the `(psycopg2.OperationalError) SSL SYSCALL error: EOF detected` error locally

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`

[LA-57]: https://ethyca.atlassian.net/browse/LA-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ