### PR TITLE
HJ-20 remove requirement in fides and fideslang to not have datacategories on subfields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ types-defusedxml==0.7.0.20240218
 expandvars==0.9.0
 fastapi[all]==0.111.0
 fastapi-pagination[sqlalchemy]==0.12.25
-fideslang==3.0.7
 fideslog==1.2.10
 firebase-admin==5.3.0
 GitPython==3.1.41
@@ -71,3 +70,4 @@ twilio==7.15.0
 typing-extensions==4.12.2
 validators==0.20.0
 versioneer==0.19
+fideslang @ git+https://github.com/ethyca/fideslang@e290bfb320ef8e6637ab011848b48f629cf42b1e

--- a/src/fides/api/graph/config.py
+++ b/src/fides/api/graph/config.py
@@ -338,22 +338,6 @@ class ObjectField(Field):
 
     fields: Dict[str, Field]
 
-    @field_validator("data_categories")
-    @classmethod
-    def validate_data_categories(
-        cls, value: Optional[List[FidesKey]]
-    ) -> Optional[List[FidesKey]]:
-        """To prevent mismatches between data categories on an ObjectField and a nested ScalarField, only
-        allow data categories to be defined on the individual fields.
-
-        This shouldn't be hit unless an ObjectField is declared directly.
-        """
-        if value:
-            raise ValueError(
-                "ObjectFields cannot be given data_categories; annotate the sub-fields instead."
-            )
-        return value
-
     def cast(self, value: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Cast the input value into the form represented by data_type."""
 


### PR DESCRIPTION
Closes #HJ-20

### Description Of Changes
remove the validator on subfields not having data categories


### Code Changes

* [ ] remove the pydantic validator step about subfield data categories

### Steps to Confirm

* [ ] add a new dataset via upload that has data categories on subfields, such as
```
dataset:
- fides_key: example_dataset_issue_hj36
  organization_fides_key: default_organization
  name: example_dataset_issue_hj36
  description: Minimal dataset reproducing issue (HJ-36)
  collections:
    - name: example_table
      fields:
        - name: example_success_field
          description: Can save data category changes
          data_categories:
            - user.device
        - name: example_success_field
          description: Can save data category changes
          data_categories:
            - user.device
        - name: example_nested_field
          data_categories:
            - user.device
          fields:
            - name: example_success_nested_field
              description: Can save data category changes on nested field
              data_categories:
                - user.device
              fields: []
```
* [ ] verify that the dataset uploaded

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
