### PR TITLE
versioning support for Fides

### DIFF
--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "admin-ui",
   "private": true,
+  "version": "2.48.0",
   "scripts": {
     "analyze": "cross-env ANALYZE=true next build",
     "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build",
@@ -26,7 +27,8 @@
     "start": "next start",
     "test": "jest --watchAll",
     "test:ci": "npm run typecheck && jest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "version": "npm version --allow-same-version=true --no-git-tag-version"
   },
   "dependencies": {
     "@ant-design/cssinjs": "^1.21.0",
@@ -42,7 +44,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "dayjs": "^1.11.13",
-    "fides-js": "^0.0.1",
+    "fides-js": "^2",
     "fidesui": "*",
     "file-saver": "^2.0.5",
     "formik": "^2.4.6",

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -403,3 +403,12 @@ Decode a Notice Consent string into a user's consent preferences. See [FidesOpti
 const decoded = Fides.decodeNoticeConsentString("eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9");
 console.log(decoded); // {data_sales_and_sharing: false, analytics: true}
 ```
+
+***
+
+### version?
+
+> `optional` **version**: `string`
+
+Returns the current version of FidesJS. This can be useful for debugging
+purposes, or for checking the version of FidesJS that is currently running.

--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -46,6 +46,7 @@
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
+    "@rollup/plugin-replace": "^6.0.1",
     "@rollup/plugin-strip": "^3.0.4",
     "@types/base-64": "^1.0.2",
     "@types/jest": "^29.5.12",

--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fides-js",
-  "version": "0.0.1",
+  "version": "2.48.0",
   "description": "FidesJS: JavaScript SDK for Fides",
   "license": "Apache-2.0",
   "main": "./dist/fides.js",
@@ -23,7 +23,8 @@
     "lint:fix": "eslint . --fix",
     "test": "jest --watchAll",
     "test:ci": "jest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "version": "npm version --allow-same-version=true --no-git-tag-version"
   },
   "repository": {
     "type": "git",

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -9,6 +9,8 @@ import postcss from "rollup-plugin-postcss";
 import commonjs from "@rollup/plugin-commonjs";
 import { visualizer } from "rollup-plugin-visualizer";
 import strip from "@rollup/plugin-strip";
+import replace from "@rollup/plugin-replace";
+import pkg from "./package.json" assert { type: "json" };
 
 const NAME = "fides";
 const IS_DEV = process.env.NODE_ENV === "development";
@@ -26,6 +28,19 @@ const GZIP_SIZE_HEADLESS_WARN_KB = 20;
 // GPP
 const GZIP_SIZE_GPP_ERROR_KB = 40;
 const GZIP_SIZE_GPP_WARN_KB = 25;
+let PACKAGE_VERSION = "0.0.0";
+
+try {
+  PACKAGE_VERSION = pkg.version;
+  if (!PACKAGE_VERSION) {
+    throw new Error("No version found in package.json");
+  }
+  console.log(
+    `Starting FidesJS build and tagging with current version (Fides.version=${PACKAGE_VERSION})...`,
+  );
+} catch (e) {
+  console.error("🚨 Failed to get package version, defaulting to 0.0.0");
+}
 
 const preactAliases = {
   entries: [
@@ -100,6 +115,11 @@ const fidesScriptPlugins = ({ name, gzipWarnSizeKb, gzipErrorSizeKb }) => [
   }),
   visualizer({
     filename: `bundle-size-stats/${name}-stats.html`,
+  }),
+  replace({
+    __FIDES_JS_VERSION_NUMBER__: PACKAGE_VERSION,
+    preventAssignment: true,
+    include: ["src/fides.ts", "src/fides-tcf.ts"],
   }),
 ];
 

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -301,6 +301,12 @@ export interface Fides {
   };
 
   /**
+   * Returns the current version of FidesJS. This can be useful for debugging
+   * purposes, or for checking the version of FidesJS that is currently running.
+   */
+  version?: string;
+
+  /**
    * NOTE: The properties below are all marked @internal, despite being exported
    * on the global Fides object. This is because they are mostly implementation
    * details and internals that we probably *should* be hiding, to avoid

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -75,6 +75,7 @@ declare global {
 const updateWindowFides = (fidesGlobal: FidesGlobal) => {
   if (typeof window !== "undefined") {
     window.Fides = fidesGlobal;
+    window.Fides.version = "__FIDES_JS_VERSION_NUMBER__";
   }
 };
 

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -63,6 +63,7 @@ declare global {
 const updateWindowFides = (fidesGlobal: FidesGlobal) => {
   if (typeof window !== "undefined") {
     window.Fides = fidesGlobal;
+    window.Fides.version = "__FIDES_JS_VERSION_NUMBER__";
   }
 };
 

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -23,6 +23,7 @@
       }
     },
     "admin-ui": {
+      "version": "2.48.0",
       "dependencies": {
         "@ant-design/cssinjs": "^1.21.0",
         "@date-fns/tz": "^1.2.0",
@@ -37,7 +38,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "dayjs": "^1.11.13",
-        "fides-js": "^0.0.1",
+        "fides-js": "^2",
         "fidesui": "*",
         "file-saver": "^2.0.5",
         "formik": "^2.4.6",
@@ -146,7 +147,7 @@
       }
     },
     "fides-js": {
-      "version": "0.0.1",
+      "version": "2.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@iabgpp/cmpapi": "file:./src/lib/gpp/modules/cmpapi",
@@ -24157,7 +24158,7 @@
       }
     },
     "privacy-center": {
-      "version": "2.13.0",
+      "version": "2.48.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -24166,7 +24167,7 @@
         "@reduxjs/toolkit": "^2.6.0",
         "@types/react-dom": "^19.0.4",
         "cache-control-parser": "^2.0.4",
-        "fides-js": "*",
+        "fides-js": "^2",
         "fidesui": "*",
         "formik": "^2.2.9",
         "framer-motion": "12.4.7",

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -164,6 +164,7 @@
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
+        "@rollup/plugin-replace": "^6.0.1",
         "@rollup/plugin-strip": "^3.0.4",
         "@types/base-64": "^1.0.2",
         "@types/jest": "^29.5.12",
@@ -4207,6 +4208,28 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.1.tgz",
+      "integrity": "sha512-2sPh9b73dj5IxuMmDAsQWVFT7mR+yoHweBaXG2W/R8vQ+IWZlnaI7BR7J6EguVQUp1hd8Z7XuozpDjEKQAAC2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {

--- a/clients/privacy-center/package.json
+++ b/clients/privacy-center/package.json
@@ -1,6 +1,6 @@
 {
   "name": "privacy-center",
-  "version": "2.13.0",
+  "version": "2.48.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",
@@ -22,7 +22,8 @@
     "analyze": "cross-env ANALYZE=true next build",
     "analyze:server": "cross-env BUNDLE_ANALYZE=server next build",
     "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build",
-    "openapi:generate": "openapi --input http://localhost:8080/openapi.json --output ./types/api --exportCore false --exportServices false --indent 2 && prettier --write ."
+    "openapi:generate": "openapi --input http://localhost:8080/openapi.json --output ./types/api --exportCore false --exportServices false --indent 2 && prettier --write .",
+    "version": "npm version --allow-same-version=true --no-git-tag-version"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -32,7 +33,7 @@
     "@reduxjs/toolkit": "^2.6.0",
     "@types/react-dom": "^19.0.4",
     "cache-control-parser": "^2.0.4",
-    "fides-js": "*",
+    "fides-js": "^2",
     "fidesui": "*",
     "formik": "^2.2.9",
     "framer-motion": "12.4.7",

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -21,6 +21,8 @@ import { getPrivacyCenterEnvironmentCached } from "~/app/server-utils";
 import { LOCATION_HEADERS, lookupGeolocation } from "~/common/geolocation";
 import { safeLookupPropertyId } from "~/common/property-id";
 
+import * as npmPackage from "../../package.json";
+
 // one hour, how long until the custom-fides.css is refreshed
 const CUSTOM_FIDES_CSS_TTL_MS = 3600 * 1000;
 
@@ -110,6 +112,7 @@ export default async function handler(
   const environment = await getPrivacyCenterEnvironmentCached({
     skipGeolocation: true,
   });
+  const { version } = npmPackage;
 
   let options: ConsentOption[] = [];
   if (environment.config?.consent?.page.consentOptions) {
@@ -330,6 +333,7 @@ export default async function handler(
       : ""
   }
   window.Fides.config = ${fidesConfigJSON};
+  window.Fides.version = "${version}";
   ${skipInitialization ? "" : `window.Fides.init();`}
   ${
     environment.settings.DEBUG && skipInitialization

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -333,7 +333,6 @@ export default async function handler(
       : ""
   }
   window.Fides.config = ${fidesConfigJSON};
-  window.Fides.version = "${version}";
   ${skipInitialization ? "" : `window.Fides.init();`}
   ${
     environment.settings.DEBUG && skipInitialization

--- a/clients/privacy-center/pages/api/health.ts
+++ b/clients/privacy-center/pages/api/health.ts
@@ -1,0 +1,16 @@
+/* eslint-disable jsdoc/no-missing-syntax */
+import * as fidesJSPackage from "fides-js/package.json";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import * as privacyCenterPackage from "../../package.json";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    res.status(200).json({
+      core_fides_version: fidesJSPackage.version,
+      privacy_center_version: privacyCenterPackage.version,
+    });
+  } catch (error) {
+    res.status(500).json({ error: "failed to get health check" });
+  }
+}

--- a/clients/turbo.json
+++ b/clients/turbo.json
@@ -74,6 +74,9 @@
     },
     "openapi:generate-dictionary": {
       "dependsOn": []
+    },
+    "version": {
+      "dependsOn": []
     }
   }
 }


### PR DESCRIPTION
Closes [#HJ-30](https://ethyca.atlassian.net/browse/HJ-30)

### Description Of Changes

* Provides manual script for updating the version of all of our projects.
* Updates FidesJS to pull from the package.json version as part of the `window.Fides` object
* Aligns all versions to the current version for future release support
* Adds new `/api/health` endpoint to the Privacy Center with FidesJS and Privacy Center versions as response, similar to other `../health` endpoints.

### Steps to Confirm

* Run `turbo version -- 2.48.1` from the `/clients` directory
* Note that all versions have been updated
* Run FidesJS demo from Privacy Center
* Run `Fides.version` from the console log
* Note that the new version `2.48.1` is returned
* Visit `http://localhost:3001/api/health` and notice that `2.48.1` is returned

### Pre-Merge Checklist

* [x] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
* [x] Update window.Fides documentation
* [ ] Update Release notes and inform release manager(s) of the new step
