### PR TITLE
update changelog for 2.48.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fidesplus/compare/2.48.1...main)
 
+### Added
+- Added DataHub integration config [#5401](https://github.com/ethyca/fides/pull/5401)
+- Added keepalive settings to the Redshift integration [#5433](https://github.com/ethyca/fides/pull/5433)
 
+### Developer Experience
+- Added Carbon Icons to FidesUI [#5416](https://github.com/ethyca/fides/pull/5416)
 
 ## [2.48.1](https://github.com/ethyca/fidesplus/compare/2.48.0...2.48.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fidesplus/compare/2.48.0...main)
 
-### Added
-- Added DataHub integration config [#5401](https://github.com/ethyca/fides/pull/5401)
-- Added keepalive settings to the Redshift integration [#5433](https://github.com/ethyca/fides/pull/5433)
 
-### Developer Experience
-- Added Carbon Icons to FidesUI [#5416](https://github.com/ethyca/fides/pull/5416)
+
+## [2.48.1](https://github.com/ethyca/fidesplus/compare/2.48.0...2.48.1)
 
 ### Fixed
  - API router sanitizer being too aggressive with NextJS Catch-all Segments [#5438](https://github.com/ethyca/fides/pull/5438)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fidesplus/compare/2.48.0...main)
+## [Unreleased](https://github.com/ethyca/fidesplus/compare/2.48.1...main)
 
 
 


### PR DESCRIPTION
### Code Changes

* [ ] created new entry in changelog for 2.48.1 release

### Steps to Confirm

* [ ] check the 2.48.1 contains everything included in the release 
* [ ] spelling and formatting 


- API router sanitizer being too aggressive with NextJS Catch-all Segments
https://github.com/ethyca/fides/pull/5438
- Fix BigQuery `partitioning` queries to properly support multiple identity clauses 
https://github.com/ethyca/fides/pull/5432

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
