### PR TITLE
HJ-124 - Moving TestBigQueryQueryConfig to its own file

### DIFF
--- a/tests/ops/service/connectors/test_bigquery_queryconfig.py
+++ b/tests/ops/service/connectors/test_bigquery_queryconfig.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Generator, Set
+from typing import Generator
 
 import pytest
 from fideslang.models import Dataset, MaskingStrategies

--- a/tests/ops/service/connectors/test_queryconfig.py
+++ b/tests/ops/service/connectors/test_queryconfig.py
@@ -1,10 +1,9 @@
 from datetime import datetime, timezone
-from typing import Any, Dict, Generator, Set
+from typing import Any, Dict, Set
 
 import pytest
 from boto3.dynamodb.types import TypeDeserializer
-from fideslang.models import Dataset, MaskingStrategies
-from pydantic import ValidationError
+from fideslang.models import Dataset
 
 from fides.api.common_exceptions import MissingNamespaceSchemaException
 from fides.api.graph.config import (
@@ -17,17 +16,12 @@ from fides.api.graph.config import (
 from fides.api.graph.execution import ExecutionNode
 from fides.api.graph.graph import DatasetGraph, Edge
 from fides.api.graph.traversal import Traversal, TraversalNode
-from fides.api.models.datasetconfig import DatasetConfig, convert_dataset_to_graph
+from fides.api.models.datasetconfig import convert_dataset_to_graph
 from fides.api.models.privacy_request import PrivacyRequest
 from fides.api.schemas.masking.masking_configuration import HashMaskingConfiguration
 from fides.api.schemas.masking.masking_secrets import MaskingSecretCache, SecretType
-from fides.api.schemas.namespace_meta.bigquery_namespace_meta import (
-    BigQueryNamespaceMeta,
-)
 from fides.api.schemas.namespace_meta.namespace_meta import NamespaceMeta
-from fides.api.service.connectors import BigQueryConnector
 from fides.api.service.connectors.query_config import (
-    BigQueryQueryConfig,
     DynamoDBQueryConfig,
     MongoQueryConfig,
     SQLQueryConfig,


### PR DESCRIPTION
Closes #HJ-124

### Description Of Changes

Moving TestBigQueryQueryConfig to its own file


### Code Changes

* [ ] Added `tests/ops/service/connectors/test_bigquery_queryconfig.py` with all the tests

### Steps to Confirm

* [ ] _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
