### PR TITLE
HJ-143: Fix ValidationError for datasets with a connection_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The types of changes are:
 - Added Carbon Icons to FidesUI [#5416](https://github.com/ethyca/fides/pull/5416)
 
 ### Fixed
-- Fix ValidationError for datasets with a connection_type [#5447](https://github.com/ethyca/fides/pull/5447)
+- Fixed ValidationError for datasets with a connection_type [#5447](https://github.com/ethyca/fides/pull/5447)
 
 ## [2.48.1](https://github.com/ethyca/fidesplus/compare/2.48.0...2.48.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The types of changes are:
 ### Developer Experience
 - Added Carbon Icons to FidesUI [#5416](https://github.com/ethyca/fides/pull/5416)
 
+### Fixed
+- Fix ValidationError for datasets with a connection_type [#5447](https://github.com/ethyca/fides/pull/5447)
+
 ## [2.48.1](https://github.com/ethyca/fidesplus/compare/2.48.0...2.48.1)
 
 ### Fixed

--- a/src/fides/api/models/connectionconfig.py
+++ b/src/fides/api/models/connectionconfig.py
@@ -30,7 +30,7 @@ class ConnectionTestStatus(enum.Enum):
     skipped = "skipped"
 
 
-class ConnectionType(enum.Enum):
+class ConnectionType(str, enum.Enum):
     """
     Supported types to which we can connect Fides.
     """

--- a/src/fides/api/models/connectionconfig.py
+++ b/src/fides/api/models/connectionconfig.py
@@ -30,7 +30,7 @@ class ConnectionTestStatus(enum.Enum):
     skipped = "skipped"
 
 
-class ConnectionType(str, enum.Enum):
+class ConnectionType(enum.Enum):
     """
     Supported types to which we can connect Fides.
     """

--- a/src/fides/api/schemas/namespace_meta/bigquery_namespace_meta.py
+++ b/src/fides/api/schemas/namespace_meta/bigquery_namespace_meta.py
@@ -1,6 +1,5 @@
 from typing import Literal
 
-from fides.api.models.connectionconfig import ConnectionType
 from fides.api.schemas.namespace_meta.namespace_meta import NamespaceMeta
 
 
@@ -13,6 +12,6 @@ class BigQueryNamespaceMeta(NamespaceMeta):
         dataset_id (str): The ID of the BigQuery dataset.
     """
 
-    connection_type: Literal[ConnectionType.bigquery] = ConnectionType.bigquery
+    connection_type: Literal["bigquery"] = "bigquery"
     project_id: str
     dataset_id: str

--- a/src/fides/api/schemas/namespace_meta/namespace_meta.py
+++ b/src/fides/api/schemas/namespace_meta/namespace_meta.py
@@ -3,8 +3,6 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-from fides.api.models.connectionconfig import ConnectionType
-
 
 class NamespaceMeta(BaseModel, ABC):
-    connection_type: Optional[ConnectionType] = None
+    connection_type: Optional[str] = None

--- a/tests/fixtures/bigquery_fixtures.py
+++ b/tests/fixtures/bigquery_fixtures.py
@@ -137,6 +137,7 @@ def bigquery_example_test_dataset_config_with_namespace_meta(
         "namespace": {
             "project_id": "silken-precinct-284918",
             "dataset_id": "fidesopstest",
+            "connection_type": "bigquery",
         }
     }
     fides_key = bigquery_dataset["fides_key"]
@@ -170,6 +171,7 @@ def bigquery_example_test_dataset_config_with_namespace_and_partitioning_meta(
         "namespace": {
             "project_id": "silken-precinct-284918",
             "dataset_id": "fidesopstest",
+            "connection_type": "bigquery",
         },
     }
     # update customer collection to have a partition

--- a/tests/ops/service/connectors/test_bigquery_queryconfig.py
+++ b/tests/ops/service/connectors/test_bigquery_queryconfig.py
@@ -82,6 +82,14 @@ class TestBigQueryQueryConfig:
                 "SELECT address_id, created, custom_id, email, id, name FROM `cool_project.first_dataset.customer` WHERE (email = :email)",
             ),
             (
+                {
+                    "project_id": "cool_project",
+                    "dataset_id": "first_dataset",
+                    "connection_type": "bigquery",
+                },
+                "SELECT address_id, created, custom_id, email, id, name FROM `cool_project.first_dataset.customer` WHERE (email = :email)",
+            ),
+            (
                 None,
                 "SELECT address_id, created, custom_id, email, id, name FROM `customer` WHERE (email = :email)",
             ),


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

Trying to parse a correct `fides_meta.namespace` field from a BigQuery dataset (i.e with a `connection_type: 'bigquery'`) was raising a Pydantic validation error, because Pydantic was expecting an Enum instance for `connection_type` rather than a string.  We now use the string literal for the type rather than the enum value. 

I've also added a test for this case (this was an oversight on my part when I implemented the original PR) and updated two fixtures to include the `connection_type` as well.  

### Steps to Confirm

If you run the test added in `tests/ops/service/connectors/test_bigquery_queryconfig.py` without the other changes, it should fail with the validation error. Adding the changes to the `BigQueryNameSpaceMeta` should have the test passing. 

**Manual check: ** 
For easier testing with D & D features , pull down this fidesplus branch https://github.com/ethyca/fidesplus/pull/1705

1. Create a bigquery dataset through D & D. Make sure the dataset is reachable, e.g it has an email identity declared on it
2. Link the dataset to a bigquery integration. 
3. Create a privacy request
4. Request should not fail because of a validation error

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] if there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
* [ ] For API changes, the [Postman collection](https://github.com/ethyca/fides/blob/main/docs/fides/docs/development/postman/Fides.postman_collection.json) has been updated
* If there are any database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
