### PR TITLE
Apply updated taxonomy labels and patterns to other columns in the data map report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The types of changes are:
 
 ### Changed
 - Added a security setting that must be set to true to enable the access request download feature [#5451](https://github.com/ethyca/fides/pull/5451)
+- Updated look/feel of all badges in the Data map report [#5464](https://github.com/ethyca/fides/pull/5464)
 
 ### Developer Experience
 - Added Carbon Icons to FidesUI [#5416](https://github.com/ethyca/fides/pull/5416)

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTableColumns.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTableColumns.tsx
@@ -77,7 +77,12 @@ const getCustomFieldColumns = (
         // Conditionally render the Group cell if we have more than one value.
         // Alternatively, could check the customField type
         Array.isArray(props.getValue()) ? (
-          <GroupCountBadgeCell value={props.getValue()} ignoreZero {...props} />
+          <GroupCountBadgeCell
+            value={props.getValue()}
+            ignoreZero
+            badgeProps={{ variant: "outline" }}
+            {...props}
+          />
         ) : (
           <DefaultCell value={props.getValue() as string} />
         ),
@@ -185,6 +190,7 @@ export const getDatamapReportColumns = ({
                 ? map(value, getDataSubjectDisplayName)
                 : getDataSubjectDisplayName(value || "")
             }
+            badgeProps={{ variant: "outline" }}
             {...props}
           />
         );
@@ -230,6 +236,7 @@ export const getDatamapReportColumns = ({
           suffix="data stewards"
           ignoreZero
           value={props.getValue()}
+          badgeProps={{ variant: "outline" }}
           {...props}
         />
       ),
@@ -253,6 +260,7 @@ export const getDatamapReportColumns = ({
           suffix="destinations"
           ignoreZero
           value={props.getValue()}
+          badgeProps={{ variant: "outline" }}
           {...props}
         />
       ),
@@ -270,6 +278,7 @@ export const getDatamapReportColumns = ({
           suffix="features"
           ignoreZero
           value={props.getValue()}
+          badgeProps={{ variant: "outline" }}
           {...props}
         />
       ),
@@ -293,6 +302,7 @@ export const getDatamapReportColumns = ({
           suffix="sources"
           ignoreZero
           value={props.getValue()}
+          badgeProps={{ variant: "outline" }}
           {...props}
         />
       ),
@@ -310,6 +320,7 @@ export const getDatamapReportColumns = ({
           suffix="profiles"
           ignoreZero
           value={props.getValue()}
+          badgeProps={{ variant: "outline" }}
           {...props}
         />
       ),
@@ -324,6 +335,7 @@ export const getDatamapReportColumns = ({
           suffix="transfers"
           ignoreZero
           value={props.getValue()}
+          badgeProps={{ variant: "outline" }}
           {...props}
         />
       ),
@@ -353,6 +365,7 @@ export const getDatamapReportColumns = ({
           suffix="responsibilities"
           ignoreZero
           value={props.getValue()}
+          badgeProps={{ variant: "outline" }}
           {...props}
         />
       ),
@@ -370,6 +383,7 @@ export const getDatamapReportColumns = ({
           suffix="shared categories"
           ignoreZero
           value={props.getValue()}
+          badgeProps={{ variant: "outline" }}
           {...props}
         />
       ),
@@ -414,6 +428,7 @@ export const getDatamapReportColumns = ({
                 ? map(value, getDataCategoryDisplayName)
                 : getDataCategoryDisplayName(value || "")
             }
+            badgeProps={{ variant: "outline" }}
             {...props}
           />
         );
@@ -436,6 +451,7 @@ export const getDatamapReportColumns = ({
                 ? map(value, getDataCategoryDisplayName)
                 : getDataCategoryDisplayName(value || "")
             }
+            badgeProps={{ variant: "outline" }}
             {...props}
           />
         );
@@ -451,6 +467,7 @@ export const getDatamapReportColumns = ({
           ignoreZero
           suffix="cookies"
           value={props.getValue()}
+          badgeProps={{ variant: "outline" }}
           {...props}
         />
       ),

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTableColumns.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTableColumns.tsx
@@ -242,6 +242,7 @@ export const getDatamapReportColumns = ({
       ),
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.declaration_name, {
@@ -266,6 +267,7 @@ export const getDatamapReportColumns = ({
       ),
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.exempt_from_privacy_regulations, {
@@ -284,6 +286,7 @@ export const getDatamapReportColumns = ({
       ),
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.fides_key, {
@@ -308,6 +311,7 @@ export const getDatamapReportColumns = ({
       ),
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.joint_controller_info, {
@@ -326,6 +330,7 @@ export const getDatamapReportColumns = ({
       ),
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.legal_basis_for_transfers, {
@@ -341,6 +346,7 @@ export const getDatamapReportColumns = ({
       ),
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.legitimate_interest_disclosure_url, {
@@ -371,6 +377,7 @@ export const getDatamapReportColumns = ({
       ),
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.retention_period, {
@@ -389,6 +396,7 @@ export const getDatamapReportColumns = ({
       ),
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.special_category_legal_basis, {
@@ -406,6 +414,7 @@ export const getDatamapReportColumns = ({
       ),
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.third_country_safeguards, {
@@ -435,6 +444,7 @@ export const getDatamapReportColumns = ({
       },
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.data_use_undeclared_data_categories, {
@@ -458,6 +468,7 @@ export const getDatamapReportColumns = ({
       },
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.cookies, {
@@ -473,6 +484,7 @@ export const getDatamapReportColumns = ({
       ),
       meta: {
         showHeaderMenu: !isRenaming,
+        width: "auto",
       },
     }),
     columnHelper.accessor((row) => row.uses_cookies, {


### PR DESCRIPTION
Closes [HJ-39](https://ethyca.atlassian.net/browse/HJ-39)

### Description Of Changes

Any column in Data map report that uses a badge should have the newer badge look/feel

### Code Changes

* Add `badgeProps={{ variant: "outline" }}` to each column using the `GroupCountBadgeCell` component as the cell renderer

### Steps to Confirm
Create a system that populates each of the following columns in the Data map report

* Data use
* Data category
* Data subjects
* Data Stewards (can this even be done?
* Destinations
* Features
* Sources
* Legal Basis for profiling
* Legal Basis for transfers
* Responsibilities
* Shared Categories
* System Dependencies
* System Undeclared data categories
* Data use undeclared categories
* Cookies

Ensure all of those columns have the new, consistent looking badge.

Note: Data use and Data category columns already have this new look/feel, so you can reference those for consistency with the update to all of the other columns for this story.

![CleanShot 2024-11-05 at 14 05 21@2x](https://github.com/user-attachments/assets/61ebfee3-7bde-47f1-8643-8cf7f1630d4f)


### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`


[HJ-39]: https://ethyca.atlassian.net/browse/HJ-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ