### PR TITLE
Updating Paramiko to 3.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ openpyxl==3.0.9
 networkx==3.1
 packaging==23.0
 pandas==1.4.3
-paramiko==3.4.0
+paramiko==3.4.1
 passlib[bcrypt]==1.7.4
 plotly==5.13.1
 pyinstrument==4.5.1


### PR DESCRIPTION
Closes [LA-117](https://ethyca.atlassian.net/browse/LA-117)

### Description Of Changes

Updating Paramiko from `3.4.0` to `3.4.1` to get rid of `Deprecation Warning for TripleDES Algorithm`. The removal of this warning is mentioned in the 3.4.1 release logs for Paramiko https://www.paramiko.org/changelog.html.


### Code Changes

* [ ] Bumping Paramiko version in requirements.txt

### Steps to Confirm

* [ ] Tests should pass

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`
