### PR TITLE
Fix source-destination save button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The types of changes are:
 
 ### Fixed
  - Fix rendering of subfield names in D&D tables [#5439](https://github.com/ethyca/fides/pull/5439)
+ - Fix "Save" button on system source/destination page not working [#5469](https://github.com/ethyca/fides/pull/5469)
 
 ### Developer Experience
 - Added Carbon Icons to FidesUI [#5416](https://github.com/ethyca/fides/pull/5416)

--- a/clients/admin-ui/src/features/common/system-data-flow/DataFlowAccordionForm.tsx
+++ b/clients/admin-ui/src/features/common/system-data-flow/DataFlowAccordionForm.tsx
@@ -171,6 +171,7 @@ export const DataFlowAccordionForm = ({
                   </Button>
                   <Button
                     type="primary"
+                    htmlType="submit"
                     loading={isSubmitting}
                     disabled={!dirty && assignedDataFlow === initialDataFlows}
                     data-testid="save-btn"


### PR DESCRIPTION
Closes HJ-164

### Description Of Changes

Restores the HTML `submit` type to the "Save" button in the system detail source/destination forms so the form works again (it was accidentally removed in the Ant button migration).

### Steps to Confirm

* [ ] Add a source or destination to a system; on clicking "save" should be saved

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Update `CHANGELOG.md`