### PR TITLE
 ignore checking CLI with FE CI changes

### DIFF
--- a/.github/workflows/cli_checks.yml
+++ b/.github/workflows/cli_checks.yml
@@ -10,6 +10,7 @@ on:
       - "**.md"
       - "clients/**"
       - ".vscode/**"
+      - ".github/workflows/frontend_checks.yml"
   push:
     branches:
       - "main"


### PR DESCRIPTION
### Description Of Changes
While working on FE CI stuff, the CLI checks keep firing off just because I'm updating the github actions for FE. This change is to stop that madness.

### Code Changes

* Ignore FE github yml's