### PR TITLE
HJ-131 Delete monitors before deleting integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The types of changes are:
 ### Added
 - Added support for GPP national string to be used alongside state-by-state using a new approach option [#5480](https://github.com/ethyca/fides/pull/5480)
 
+### Fixed
+- Fixed deletion of ConnectionConfigs that have related MonitorConfigs [#5478](https://github.com/ethyca/fides/pull/5478)
+
 
 ## [2.49.0](https://github.com/ethyca/fidesplus/compare/2.48.2...2.49.0)
 

--- a/src/fides/api/db/base.py
+++ b/src/fides/api/db/base.py
@@ -12,7 +12,7 @@ from fides.api.models.custom_asset import CustomAsset
 from fides.api.models.custom_connector_template import CustomConnectorTemplate
 from fides.api.models.custom_report import CustomReport
 from fides.api.models.datasetconfig import DatasetConfig
-from fides.api.models.detection_discovery import StagedResource
+from fides.api.models.detection_discovery import MonitorConfig, StagedResource
 from fides.api.models.experience_notices import ExperienceNotices
 from fides.api.models.fides_cloud import FidesCloud
 from fides.api.models.fides_user import FidesUser

--- a/src/fides/api/models/detection_discovery.py
+++ b/src/fides/api/models/detection_discovery.py
@@ -114,7 +114,7 @@ class MonitorConfig(Base):
 
     # TODO: many-to-many link to users assigned as data stewards; likely will need a join-table
 
-    connection_config = relationship(ConnectionConfig)
+    connection_config = relationship(ConnectionConfig, back_populates="monitors")
 
     @property
     def connection_config_key(self) -> str:

--- a/src/fides/api/models/detection_discovery.py
+++ b/src/fides/api/models/detection_discovery.py
@@ -114,7 +114,7 @@ class MonitorConfig(Base):
 
     # TODO: many-to-many link to users assigned as data stewards; likely will need a join-table
 
-    connection_config = relationship(ConnectionConfig, back_populates="monitors")
+    connection_config = relationship(ConnectionConfig)
 
     @property
     def connection_config_key(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ from fides.config.config_proxy import ConfigProxy
 from tests.fixtures.application_fixtures import *
 from tests.fixtures.bigquery_fixtures import *
 from tests.fixtures.datahub_fixtures import *
+from tests.fixtures.detection_discovery_fixtures import *
 from tests.fixtures.dynamodb_fixtures import *
 from tests.fixtures.email_fixtures import *
 from tests.fixtures.fides_connector_example_fixtures import *

--- a/tests/fixtures/detection_discovery_fixtures.py
+++ b/tests/fixtures/detection_discovery_fixtures.py
@@ -2,6 +2,7 @@ from typing import Generator
 
 import pytest
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.exc import ObjectDeletedError
 
 from fides.api.models.connectionconfig import ConnectionConfig
 from fides.api.models.detection_discovery import MonitorConfig
@@ -27,45 +28,17 @@ def monitor_config(
         },
     )
     yield mc
-    db.delete(mc)
+    try:
+        db.delete(mc)
+    except ObjectDeletedError:
+        # Object was already deleted, do nothing
+        return
 
 
 @pytest.fixture(scope="function")
-def monitor_config_1_no_deletion(
+def monitor_config_2(
     db: Session, connection_config: ConnectionConfig
 ) -> Generator[MonitorConfig, None, None]:
-    """
-    This fixture creates a monitor config that will NOT be cleaned up after the test,
-    so the test itself should delete the monitor config. If your test does not delete
-    the monitor config, use the `monitor_config` fixture instead.
-    """
-    mc = MonitorConfig.create(
-        db=db,
-        data={
-            "name": "test monitor config 1",
-            "key": "test_monitor_config_1",
-            "connection_config_id": connection_config.id,
-            "classify_params": {
-                "num_samples": 25,
-                "num_threads": 2,
-            },
-            "databases": ["db1", "db2"],
-            "execution_frequency": None,
-            "execution_start_date": None,
-        },
-    )
-    yield mc
-
-
-@pytest.fixture(scope="function")
-def monitor_config_2_no_deletion(
-    db: Session, connection_config: ConnectionConfig
-) -> Generator[MonitorConfig, None, None]:
-    """
-    This fixture creates a monitor config that will NOT be cleaned up after the test,
-    so the test itself should delete the monitor config. If your test does not delete
-    the monitor config, use the `monitor_config` fixture instead.
-    """
     mc = MonitorConfig.create(
         db=db,
         data={
@@ -82,3 +55,8 @@ def monitor_config_2_no_deletion(
         },
     )
     yield mc
+    try:
+        db.delete(mc)
+    except ObjectDeletedError:
+        # Object was already deleted, do nothing
+        return

--- a/tests/fixtures/detection_discovery_fixtures.py
+++ b/tests/fixtures/detection_discovery_fixtures.py
@@ -1,0 +1,84 @@
+import pytest
+from typing import Generator
+
+from sqlalchemy.orm import Session
+
+from fides.api.models.connectionconfig import ConnectionConfig
+from fides.api.models.detection_discovery import MonitorConfig
+
+
+@pytest.fixture(scope="function")
+def monitor_config(
+    db: Session, connection_config: ConnectionConfig
+) -> Generator[MonitorConfig, None, None]:
+    mc = MonitorConfig.create(
+        db=db,
+        data={
+            "name": "test monitor config 1",
+            "key": "test_monitor_config_1",
+            "connection_config_id": connection_config.id,
+            "classify_params": {
+                "num_samples": 25,
+                "num_threads": 2,
+            },
+            "databases": ["db1", "db2"],
+            "execution_frequency": None,
+            "execution_start_date": None,
+        },
+    )
+    yield mc
+    db.delete(mc)
+
+
+@pytest.fixture(scope="function")
+def monitor_config_1_no_deletion(
+    db: Session, connection_config: ConnectionConfig
+) -> Generator[MonitorConfig, None, None]:
+    """
+    This fixture creates a monitor config that will NOT be cleaned up after the test,
+    so the test itself should delete the monitor config. If your test does not delete
+    the monitor config, use the `monitor_config` fixture instead.
+    """
+    mc = MonitorConfig.create(
+        db=db,
+        data={
+            "name": "test monitor config 1",
+            "key": "test_monitor_config_1",
+            "connection_config_id": connection_config.id,
+            "classify_params": {
+                "num_samples": 25,
+                "num_threads": 2,
+            },
+            "databases": ["db1", "db2"],
+            "execution_frequency": None,
+            "execution_start_date": None,
+        },
+    )
+    yield mc
+
+
+@pytest.fixture(scope="function")
+def monitor_config_2_no_deletion(
+    db: Session, connection_config: ConnectionConfig
+) -> Generator[MonitorConfig, None, None]:
+    """
+    This fixture creates a monitor config that will NOT be cleaned up after the test,
+    so the test itself should delete the monitor config. If your test does not delete
+    the monitor config, use the `monitor_config` fixture instead.
+    """
+    mc = MonitorConfig.create(
+        db=db,
+        data={
+            "name": "test monitor config 2",
+            "key": "test_monitor_config_2",
+            "connection_config_id": connection_config.id,
+            "classify_params": {
+                "num_samples": 20,
+                "num_threads": 2,
+            },
+            "databases": ["db1", "db3"],
+            "execution_frequency": None,
+            "execution_start_date": None,
+        },
+    )
+    yield mc

--- a/tests/fixtures/detection_discovery_fixtures.py
+++ b/tests/fixtures/detection_discovery_fixtures.py
@@ -1,6 +1,6 @@
-import pytest
 from typing import Generator
 
+import pytest
 from sqlalchemy.orm import Session
 
 from fides.api.models.connectionconfig import ConnectionConfig

--- a/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
@@ -1372,14 +1372,14 @@ class TestDeleteConnection:
         db: Session,
         generate_role_header,
         connection_config: ConnectionConfig,
-        monitor_config_1_no_deletion: MonitorConfig,
-        monitor_config_2_no_deletion: MonitorConfig,
+        monitor_config: MonitorConfig,
+        monitor_config_2: MonitorConfig,
     ):
         auth_header = generate_role_header(roles=[OWNER])
 
         # Save ids of monitor configs before deletion to use in query
-        id_monitor_config_1 = monitor_config_1_no_deletion.id
-        id_monitor_config_2 = monitor_config_2_no_deletion.id
+        id_monitor_config_1 = monitor_config.id
+        id_monitor_config_2 = monitor_config_2.id
 
         response = api_client.delete(
             f"{V1_URL_PREFIX}{CONNECTIONS}/{connection_config.key}", headers=auth_header

--- a/tests/ops/models/test_detection_discovery.py
+++ b/tests/ops/models/test_detection_discovery.py
@@ -190,34 +190,14 @@ SAMPLE_START_DATE = datetime(2024, 5, 20, 0, 42, 5, 17137, tzinfo=timezone.utc)
 
 
 class TestMonitorConfigModel:
-    @pytest.fixture
-    def create_monitor_config(self, db: Session, connection_config: ConnectionConfig):
-        mc = MonitorConfig.create(
-            db=db,
-            data={
-                "name": "test monitor config 1",
-                "key": "test_monitor_config_1",
-                "connection_config_id": connection_config.id,
-                "classify_params": {
-                    "num_samples": 25,
-                    "num_threads": 2,
-                },
-                "databases": ["db1", "db2"],
-                "execution_frequency": None,
-                "execution_start_date": None,
-            },
-        )
-        yield mc
-        db.delete(mc)
-
     def test_create_monitor_config(
-        self, db: Session, create_monitor_config, connection_config: ConnectionConfig
+        self, db: Session, monitor_config, connection_config: ConnectionConfig
     ) -> None:
         """
         Creation fixture creates the config, this tests that it was created successfully
         and that we can access its attributes as expected.
         """
-        mc: MonitorConfig = MonitorConfig.get(db=db, object_id=create_monitor_config.id)
+        mc: MonitorConfig = MonitorConfig.get(db=db, object_id=monitor_config.id)
         assert mc.name == "test monitor config 1"
         assert mc.key == "test_monitor_config_1"
         assert mc.classify_params == {
@@ -237,11 +217,11 @@ class TestMonitorConfigModel:
         assert mc.excluded_databases == []
 
     def test_update_monitor_config_fails_with_conflicting_dbs(
-        self, db: Session, create_monitor_config, connection_config: ConnectionConfig
+        self, db: Session, monitor_config, connection_config: ConnectionConfig
     ) -> None:
         """ """
         with pytest.raises(ValueError):
-            create_monitor_config.update(
+            monitor_config.update(
                 db=db,
                 data={
                     "name": "updated test monitor config 1",
@@ -388,12 +368,12 @@ class TestMonitorConfigModel:
         self,
         db: Session,
         connection_config: ConnectionConfig,
-        create_monitor_config: MonitorConfig,
+        monitor_config: MonitorConfig,
         monitor_frequency,
         expected_dict,
     ):
         """Tests that execution_trigger logic works as expected during within `update`"""
-        create_monitor_config.update(
+        monitor_config.update(
             db=db,
             data={
                 "name": "updated test monitor config 1",
@@ -407,7 +387,7 @@ class TestMonitorConfigModel:
                 "execution_frequency": monitor_frequency,
             },
         )
-        mc: MonitorConfig = MonitorConfig.get(db=db, object_id=create_monitor_config.id)
+        mc: MonitorConfig = MonitorConfig.get(db=db, object_id=monitor_config.id)
 
         # first ensure update works as expected on a "normal" field
         assert mc.name == "updated test monitor config 1"


### PR DESCRIPTION
Closes  [HJ-131](https://ethyca.atlassian.net/browse/HJ-131)

### Description Of Changes

Before, trying to delete an integration (i.e `ConnectionConfig`) that had a related monitor (i.e `MonitorConfig`) would throw a 500 error. Intended behavior is to cascade the deletion so that all monitors associated to the given `ConnectionConfig` are deleted. 

### Code Changes

- Updated `ConnectionConfig` model to explicitly define its `monitors` reference, and updated the class' `delete` method to iterate over its related `MonitorConfig`s and delete them as well
- Added a test for this case
- Created a `detection_discovery_fixtures.py` file to organize D&D fixtures in one single place

### Steps to Confirm

1. Pull down [this fidesplus branch](https://github.com/ethyca/fidesplus/pull/1717) so that you have all D&D features. 
2. Create an integration, or click on an existing one, e.g a BigQuery integration. 
3. Add a couple (i.e more than 1) monitors to the integration
4. Click `Delete integration`
5. Integration and monitors should both be deleted 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[HJ-131]: https://ethyca.atlassian.net/browse/HJ-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ