### PR TITLE
Support new "All" GPP approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fidesplus/compare/2.49.0...main)
 
+### Added
+- Added support for GPP national string to be used alongside state-by-state using a new approach option [#5480](https://github.com/ethyca/fides/pull/5480)
+
 
 ## [2.49.0](https://github.com/ethyca/fidesplus/compare/2.48.2...2.49.0)
 

--- a/clients/admin-ui/src/features/consent-settings/GppConfiguration.tsx
+++ b/clients/admin-ui/src/features/consent-settings/GppConfiguration.tsx
@@ -61,6 +61,12 @@ const GppConfiguration = () => {
                     tooltip:
                       "When state-by-state is selected, Fides will only present consent to consumers and save their preferences if they are located in a state that is supported by the GPP. The consent options presented to consumers will vary depending on the regulations in each state.",
                   },
+                  {
+                    label: "Enable US National and State-by-State notices",
+                    value: GPPUSApproach.ALL,
+                    tooltip:
+                      "When enabled, Fides can be configured to serve the National and U.S. state notices. This mode is intended to provide consent coverage to U.S. states with new privacy laws where GPP support lags behind the effective date of state laws.",
+                  },
                 ]}
               />
             </Section>

--- a/clients/admin-ui/src/pages/settings/consent.tsx
+++ b/clients/admin-ui/src/pages/settings/consent.tsx
@@ -301,6 +301,7 @@ const ConsentConfigPage: NextPage = () => {
                     disabled={!dirty || !isValid}
                     loading={isSubmitting}
                     data-testid="save-btn"
+                    className="self-start"
                   >
                     Save
                   </Button>

--- a/clients/admin-ui/src/types/api/models/GPPUSApproach.ts
+++ b/clients/admin-ui/src/types/api/models/GPPUSApproach.ts
@@ -5,4 +5,5 @@
 export enum GPPUSApproach {
   NATIONAL = "national",
   STATE = "state",
+  ALL = "all",
 }

--- a/clients/fides-js/__tests__/lib/gpp/us-notices.ts
+++ b/clients/fides-js/__tests__/lib/gpp/us-notices.ts
@@ -681,4 +681,116 @@ describe("setGppOptOutsFromCookieAndExperience", () => {
     expect(cmpApi.getSection("usnatv1")).toBe(null);
     expect(cmpApi.getSection("usnyv1")).toBe(null);
   });
+
+  it("can use US gpp fields when gpp is set to all", () => {
+    const cmpApi = new CmpApi(1, 1);
+    const cookie = mockFidesCookie({
+      consent: {
+        data_sales_and_sharing: false,
+        targeted_advertising: false,
+        sensitive_personal_data_sharing: false,
+        known_child_sensitive_data_consents: false,
+        personal_data_consents: false,
+      },
+    });
+    const notices = [
+      DATA_SALES_SHARING_NOTICE,
+      TARGETED_ADVERTISING_NOTICE,
+      SENSITIVE_PERSONAL_SHARING_NOTICE,
+      KNOWN_CHILD_SENSITIVE_NOTICE,
+      PERSONAL_DATA_NOTICE,
+    ];
+    const experience = mockPrivacyExperience({
+      region: "us_mt", // Set to a non-supported state
+      privacy_notices: notices,
+      gpp_settings: {
+        enabled: true,
+        us_approach: GPPUSApproach.ALL, // Set to all
+        mspa_covered_transactions: true,
+        mspa_opt_out_option_mode: true,
+        mspa_service_provider_mode: false,
+        enable_tcfeu_string: true,
+      },
+    });
+    setGppOptOutsFromCookieAndExperience({
+      cmpApi,
+      cookie,
+      experience,
+    });
+    const section = cmpApi.getSection("usnatv1");
+    expect(section).toEqual({
+      Version: 1,
+      SharingNotice: 0,
+      SaleOptOutNotice: 0,
+      SharingOptOutNotice: 0,
+      TargetedAdvertisingOptOutNotice: 0,
+      SensitiveDataProcessingOptOutNotice: 0,
+      SensitiveDataLimitUseNotice: 0,
+      SaleOptOut: 1,
+      SharingOptOut: 1,
+      TargetedAdvertisingOptOut: 1,
+      SensitiveDataProcessing: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      KnownChildSensitiveDataConsents: [1, 1],
+      PersonalDataConsents: 1,
+      MspaCoveredTransaction: 1,
+      MspaOptOutOptionMode: 1,
+      MspaServiceProviderMode: 2,
+      GpcSegmentType: 1,
+      Gpc: false,
+    });
+    expect(cmpApi.getGppString()).toEqual("DBABLA~BAAVVVVVVWA.QA");
+  });
+
+  it("can use state gpp fields when gpp is set to all", () => {
+    const cmpApi = new CmpApi(1, 1);
+    const cookie = mockFidesCookie({
+      consent: {
+        data_sales_and_sharing: false,
+        targeted_advertising: false,
+        sensitive_personal_data_sharing: false,
+        known_child_sensitive_data_consents: false,
+        personal_data_consents: false,
+      },
+    });
+    const notices = [
+      DATA_SALES_SHARING_NOTICE,
+      TARGETED_ADVERTISING_NOTICE,
+      SENSITIVE_PERSONAL_SHARING_NOTICE,
+      KNOWN_CHILD_SENSITIVE_NOTICE,
+      PERSONAL_DATA_NOTICE,
+    ];
+    const experience = mockPrivacyExperience({
+      region: "us_ut", // Set to a supported state
+      privacy_notices: notices,
+      gpp_settings: {
+        enabled: true,
+        us_approach: GPPUSApproach.ALL, // Set to all
+        mspa_covered_transactions: true,
+        mspa_opt_out_option_mode: true,
+        mspa_service_provider_mode: false,
+        enable_tcfeu_string: true,
+      },
+    });
+    setGppOptOutsFromCookieAndExperience({
+      cmpApi,
+      cookie,
+      experience,
+    });
+    const section = cmpApi.getSection("usutv1");
+    expect(section).toEqual({
+      Version: 1,
+      SharingNotice: 0,
+      SaleOptOutNotice: 0,
+      TargetedAdvertisingOptOutNotice: 0,
+      SensitiveDataProcessingOptOutNotice: 0,
+      SaleOptOut: 0,
+      TargetedAdvertisingOptOut: 0,
+      SensitiveDataProcessing: [0, 0, 0, 0, 0, 0, 0, 0],
+      KnownChildSensitiveDataConsents: 0,
+      MspaCoveredTransaction: 1,
+      MspaOptOutOptionMode: 1,
+      MspaServiceProviderMode: 2,
+    });
+    expect(cmpApi.getGppString()).toEqual("DBABFg~BAAAAAWA");
+  });
 });

--- a/clients/fides-js/src/fides-ext-gpp.ts
+++ b/clients/fides-js/src/fides-ext-gpp.ts
@@ -115,10 +115,19 @@ const getSupportedApis = () => {
       if (window.Fides.options.tcfEnabled && gppSettings.enable_tcfeu_string) {
         supportedApis.push(`${TcfEuV2.ID}:${TcfEuV2.NAME}`);
       }
-      if (gppSettings.us_approach === GPPUSApproach.NATIONAL) {
+      fidesDebugger("GPP settings", gppSettings);
+      if (
+        gppSettings.us_approach === GPPUSApproach.NATIONAL ||
+        gppSettings.us_approach === GPPUSApproach.ALL
+      ) {
+        fidesDebugger("setting US National");
         supportedApis.push(`${UsNatV1.ID}:${UsNatV1.NAME}`);
       }
-      if (gppSettings.us_approach === GPPUSApproach.STATE) {
+      if (
+        gppSettings.us_approach === GPPUSApproach.STATE ||
+        gppSettings.us_approach === GPPUSApproach.ALL
+      ) {
+        fidesDebugger("setting US State");
         // TODO: include the states based off of locations/regulations.
         // For now, hard code all of them. https://ethyca.atlassian.net/browse/PROD-1595
         [UsCaV1, UsCoV1, UsCtV1, UsUtV1, UsVaV1].forEach((state) => {

--- a/clients/fides-js/src/lib/gpp/types.ts
+++ b/clients/fides-js/src/lib/gpp/types.ts
@@ -15,6 +15,7 @@ export type GppFunction = (
 export enum GPPUSApproach {
   NATIONAL = "national",
   STATE = "state",
+  ALL = "all",
 }
 
 export type GPPSettings = {

--- a/clients/fides-js/src/lib/gpp/us-notices.ts
+++ b/clients/fides-js/src/lib/gpp/us-notices.ts
@@ -85,11 +85,17 @@ export const setGppNoticesProvidedFromExperience = ({
     gpp_settings: gppSettings,
   } = experience;
   const usApproach = gppSettings?.us_approach;
-  const gppRegion = deriveGppFieldRegion({
+  let gppRegion = deriveGppFieldRegion({
     experienceRegion,
     usApproach,
   });
-  const gppSection = FIDES_REGION_TO_GPP_SECTION[gppRegion];
+  let gppSection = FIDES_REGION_TO_GPP_SECTION[gppRegion];
+
+  if (!gppSection && usApproach === GPPUSApproach.ALL) {
+    // if we're using the "all" approach, and the user's state isn't supported yet, we should default to national.
+    gppRegion = US_NATIONAL_REGION;
+    gppSection = FIDES_REGION_TO_GPP_SECTION[gppRegion];
+  }
 
   if (
     !gppSection ||
@@ -142,11 +148,17 @@ export const setGppOptOutsFromCookieAndExperience = ({
     gpp_settings: gppSettings,
   } = experience;
   const usApproach = gppSettings?.us_approach;
-  const gppRegion = deriveGppFieldRegion({
+  let gppRegion = deriveGppFieldRegion({
     experienceRegion,
     usApproach,
   });
-  const gppSection = FIDES_REGION_TO_GPP_SECTION[gppRegion];
+  let gppSection = FIDES_REGION_TO_GPP_SECTION[gppRegion];
+
+  if (!gppSection && usApproach === GPPUSApproach.ALL) {
+    // if we're using the all approach, and the current state isn't supported, we should default to national
+    gppRegion = US_NATIONAL_REGION;
+    gppSection = FIDES_REGION_TO_GPP_SECTION[gppRegion];
+  }
 
   if (
     !gppSection ||

--- a/clients/privacy-center/types/api/models/GPPUSApproach.ts
+++ b/clients/privacy-center/types/api/models/GPPUSApproach.ts
@@ -5,4 +5,5 @@
 export enum GPPUSApproach {
   NATIONAL = "national",
   STATE = "state",
+  ALL = "all",
 }


### PR DESCRIPTION
Closes [HJ-167](https://ethyca.atlassian.net/browse/HJ-167), [HJ-84](https://ethyca.atlassian.net/browse/HJ-84)

### Description Of Changes

- Under “Settings > Consent” IN the US GPP section, I can choose a third option: “Enable US National and State-by-State notices”
- Fides allows users to configure both the national and state notices simultaneously.
- The CMP includes the national section as a parsed and applicable section when a user visits from a location with an experience configured to display the national section.
- The CMP still includes the appropriate state section as a parsed and applicable section when a user visits from a state with an experience configured to display that state section. 

### Code Changes

* Adds new configuration option to set the approach to `GPPUSApproach.ALL` on consent settings page
* Fixes button size on consent settings page (HJ-84)
* Updates `fides-js/src/fides-ext-gpp.ts` and `fides-js/src/lib/gpp/us-notices.ts` to support the new `GPPUSApproach.ALL` option appropriately
* Adds unit tests

### Steps to Confirm

1. Visit the Consent Settings page in Admin UI (`/settings/consent`)
2. Ensure that the GPP status is "Enabled"
3. In the **GPP U.S.** section, select the new, 3rd option "Enable US National and State-by-State notices"
4. Notice the [Save] button at the bottom of the screen is no longer taking up the entire width of the page. Click it to save the option selected.
5. Visit the Notices page (`/consent/privacy-notices`)
6. Notice that both US State and US National notices are available
7. Ensure that a state-by-state targeted advertising notice and a national targeted advertising notice are enabled
8. Visit the Experience page (`/consent/privacy-experience`)
9. Assign the state-by-state targeted advertising notice to a privacy experience with the locations of CA, UT, CO, VA, CT
10. Assign the national targeted advertising notices to a privacy experience with the locations of MT, TX, IA, OR, WA
11. Visit the cookie house from Colorado and inspect the GPP API in the browser console to make sure that the parsed section is CO (uscov1), and the CO section number is listed in the applicableSections property `__gpp('ping', (data) => {console.log(data)})`
12. Visit the cookie house from MT and inspect the GPP API in the browser console to make sure that the parsed section is USNAT (usnatv1), and the USNAT section number is listed in the applicableSections property
13. Visit the Privacy Center demo page and load Fides.js with the gpp=true param from a location that is not configured in either experience and make sure the applicableSections value is [-1] (eg. `/fides-js-demo.html?geolocation=us-id&gpp=true` for Idaho).

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[HJ-167]: https://ethyca.atlassian.net/browse/HJ-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HJ-84]: https://ethyca.atlassian.net/browse/HJ-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ