### PR TITLE
HJ-166: Use BlueConic Profile API correctly.

### DIFF
--- a/clients/fides-js/src/integrations/blueconic.ts
+++ b/clients/fides-js/src/integrations/blueconic.ts
@@ -4,8 +4,10 @@ declare global {
   interface Window {
     blueConicClient?: {
       profile?: {
-        setConsentedObjectives: (objectives: string[]) => void;
-        setRefusedObjectives: (objectives: string[]) => void;
+        getProfile: () => {
+          setConsentedObjectives: (objectives: string[]) => void;
+          setRefusedObjectives: (objectives: string[]) => void;
+        };
         updateProfile: () => void;
       };
       event?: {
@@ -26,7 +28,7 @@ const configureObjectives = () => {
     return;
   }
 
-  const profile = window.blueConicClient?.profile;
+  const profile = window.blueConicClient?.profile?.getProfile();
   const { consent } = window.Fides;
   const optedIn = MARKETING_CONSENT_KEYS.some((key) => consent[key]);
   if (optedIn) {
@@ -46,7 +48,7 @@ const configureObjectives = () => {
     ]);
   }
 
-  profile.updateProfile();
+  window.blueConicClient.profile.updateProfile();
 };
 
 export const blueconic = (


### PR DESCRIPTION
Closes HJ-166

### Description Of Changes

Uses the BlueConic API correctly.

### Code Changes

* Get profile before using it.

### Steps to Confirm

NA

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
