### PR TITLE
Fix misalignment of "powered by" brand link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The types of changes are:
 
 ### Fixed
 - Use BlueConic Profile API correctly. [#5487](https://github.com/ethyca/fides/pull/5487)
+- Fixed a bug where branding link was sometimes misaligned [#5496](https://github.com/ethyca/fides/pull/5496)
 
 ## [2.49.0](https://github.com/ethyca/fidesplus/compare/2.48.2...2.49.0)
 

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -111,7 +111,7 @@ export const ConsentButtons = ({
             : "fides-banner-button-group fides-banner-secondary-actions"
         }${includeLanguageSelector ? " fides-button-group-i18n" : ""}${
           includePrivacyPolicyLink ? " fides-button-group-privacy-policy" : ""
-        }`}
+        }${includeBrandLink ? " fides-button-group-brand" : ""}`}
       >
         {includeLanguageSelector && (
           <LanguageSelector

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -79,6 +79,10 @@
   --fides-overlay-banner-offset: 48px;
   --fides-banner-font-size-title: var(--16px);
   --fides-overlay-language-loading-indicator-speed: 5s;
+  --fides-overlay-modal-secondary-button-group-height: calc(
+    var(--fides-overlay-font-size-body) +
+      (var(--fides-overlay-link-v-padding) * 2)
+  );
 }
 
 @keyframes spin {
@@ -479,6 +483,10 @@ div#fides-consent-content .fides-modal-description {
 
 .fides-modal-secondary-actions {
   justify-content: center;
+}
+
+.fides-modal-container .fides-button-group-brand {
+  min-height: var(--fides-overlay-modal-secondary-button-group-height);
 }
 
 .fides-modal-secondary-actions .fides-brand {
@@ -1022,10 +1030,7 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
 }
 
 .fides-modal-container .fides-button-group-i18n {
-  min-height: calc(
-    var(--fides-overlay-font-size-body) +
-      (var(--fides-overlay-link-v-padding) * 2)
-  );
+  min-height: var(--fides-overlay-modal-secondary-button-group-height);
 }
 
 div.fides-i18n-pseudo-button {


### PR DESCRIPTION
Closes HJ-201

### Description Of Changes

Fixes a bug where the "powered by" brand link was misaligned when the consent modal didn't have a language picker or privacy policy link.

Before:
![Screenshot 2024-11-14 at 15 24 14](https://github.com/user-attachments/assets/b63a4f95-275f-48e7-87c8-b923e583835e)

After:

![Screenshot 2024-11-14 at 15 25 24](https://github.com/user-attachments/assets/0be8ff4d-e1c5-4826-b01c-c459f7b9b7c8)

With language picker and privacy policy link:

![Screenshot 2024-11-14 at 15 27 20](https://github.com/user-attachments/assets/8c444c7c-90f1-4506-82e3-9370fa5736e8)


### Code Changes

* Add a new classname to the modal secondary button group and enforce a min-height (as we do for the language picker) when showFidesBrandLink is true

### Steps to Confirm

1. View the consent modal for an experience with a 

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
