### PR TITLE
Fix D&D resource display names

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/utils/getResourceName.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/utils/getResourceName.ts
@@ -1,22 +1,47 @@
 import { DiscoveryMonitorItem } from "~/features/data-discovery-and-detection/types/DiscoveryMonitorItem";
 
-const TOP_LEVEL_FIELD_URN_PARTS = 5;
+const MAX_NON_NESTED_URN_LENGTH = 5;
+const URN_SEPARATOR = ".";
+/**
+ * Helper method for deriving a resource's display name from its URN
+ */
+const getResourceName = ({
+  name,
+  urn,
+  monitor_config_id,
+  database_name,
+  schema_name,
+  table_name,
+  top_level_field_name,
+}: DiscoveryMonitorItem) => {
+  const splitUrn = urn.split(URN_SEPARATOR);
 
-const getResourceName = (resource: DiscoveryMonitorItem) => {
-  const URN_SEPARATOR = ".";
-  const splitUrn = resource.urn.split(URN_SEPARATOR);
   if (
-    !resource.parent_table_urn ||
-    splitUrn.length === TOP_LEVEL_FIELD_URN_PARTS
+    !table_name ||
+    !top_level_field_name ||
+    splitUrn.length < MAX_NON_NESTED_URN_LENGTH
   ) {
     // use name as-is if it's not a subfield
-    return resource.name;
+    return name;
   }
-  // TODO HJ-162: better handle case where field name contains "."
+  // URN format is "monitor.project?.dataset.table.field.[any number of subfields]"
+  // we want to show all subfield names separated by "."
+  const partsToRemove = [
+    monitor_config_id,
+    database_name,
+    schema_name,
+    table_name,
+    top_level_field_name,
+  ];
 
-  // URN format is "monitor.project.dataset.field.[any number of subfields]"
-  // for a subfield, we want to show all subfield names separated by "."
-  return splitUrn.slice(TOP_LEVEL_FIELD_URN_PARTS).join(URN_SEPARATOR);
+  partsToRemove.forEach((part) => {
+    const index = splitUrn.indexOf(part!);
+    if (index > -1) {
+      splitUrn.splice(index, 1);
+    }
+  });
+
+  return splitUrn.join(URN_SEPARATOR);
 };
 
 export default getResourceName;


### PR DESCRIPTION
Closes #HJ-162

### Description Of Changes

Fixes D&D resource display names to be more generalizable across systems and handle some edge cases better by no longer relying (solely) on URN length.

### Steps to Confirm

To test, have some data in your detection or discovery tables with:
* nested fields (I used BigQuery)
* a system without a database layer (I used DynamoDB)

1. View D&D tables
1. At all levels, non-subfield resource names should display the resource's name as-is
1. Subfields should display all names below the top-level field name, separated by `.`

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
