### PR TITLE
Removing invalid characters from auto-generated integration keys

### DIFF
--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -51,23 +51,7 @@ import {
   ConnectorParametersForm,
   TestConnectionResponse,
 } from "./ConnectorParametersForm";
-
-const generateIntegrationKey = (
-  systemFidesKey: string,
-  connectionOption: ConnectionSystemTypeMap,
-): string => {
-  let integrationKey = systemFidesKey;
-
-  if (!systemFidesKey.includes(connectionOption.identifier)) {
-    integrationKey += `_${connectionOption.identifier}`;
-  }
-
-  if (connectionOption.type === SystemType.SAAS) {
-    integrationKey += "_api";
-  }
-
-  return integrationKey;
-};
+import { generateIntegrationKey } from "./helpers";
 
 /**
  * Only handles creating saas connectors. The BE handler automatically

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/helpers.test.ts
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/helpers.test.ts
@@ -1,4 +1,5 @@
 import { SystemType } from "~/types/api/models/SystemType";
+
 import { generateIntegrationKey } from "./helpers";
 
 describe("generateIntegrationKey", () => {

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/helpers.test.ts
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/helpers.test.ts
@@ -1,0 +1,44 @@
+import { SystemType } from "~/types/api/models/SystemType";
+import { generateIntegrationKey } from "./helpers";
+
+describe("generateIntegrationKey", () => {
+  it("removes special characters except allowed ones", () => {
+    const result = generateIntegrationKey("test.system!@#$%^&*()", {
+      identifier: "test",
+      type: SystemType.DATABASE,
+    });
+    expect(result).toBe("testsystem");
+  });
+
+  it("keeps allowed characters (alphanumeric, hyphen, underscore)", () => {
+    const result = generateIntegrationKey("test-system_123", {
+      identifier: "test",
+      type: SystemType.DATABASE,
+    });
+    expect(result).toBe("test-system_123");
+  });
+
+  it("adds identifier if not present", () => {
+    const result = generateIntegrationKey("system", {
+      identifier: "postgres",
+      type: SystemType.DATABASE,
+    });
+    expect(result).toBe("system_postgres");
+  });
+
+  it("does not add identifier if already present", () => {
+    const result = generateIntegrationKey("system_postgres", {
+      identifier: "postgres",
+      type: SystemType.DATABASE,
+    });
+    expect(result).toBe("system_postgres");
+  });
+
+  it("adds API suffix for SaaS type", () => {
+    const result = generateIntegrationKey("system", {
+      identifier: "salesforce",
+      type: SystemType.SAAS,
+    });
+    expect(result).toBe("system_salesforce_api");
+  });
+});

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/helpers.ts
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/helpers.ts
@@ -1,4 +1,6 @@
 import { ConnectionTypeSecretSchemaResponse } from "~/features/connection-type/types";
+import { ConnectionSystemTypeMap } from "~/types/api/models/ConnectionSystemTypeMap";
+import { SystemType } from "~/types/api/models/SystemType";
 
 /**
  * Fill in default values based off of a schema
@@ -28,4 +30,26 @@ export const fillInDefaults = (
     });
   }
   return filledInValues;
+};
+
+/**
+ *
+ * Auto-generate an integration key based on the system name
+ *
+ */
+export const generateIntegrationKey = (
+  systemFidesKey: string,
+  connectionOption: Pick<ConnectionSystemTypeMap, "identifier" | "type">,
+): string => {
+  let integrationKey = systemFidesKey.replace(/[^A-Za-z0-9\-_]/g, "");
+
+  if (!integrationKey.includes(connectionOption.identifier)) {
+    integrationKey += `_${connectionOption.identifier}`;
+  }
+
+  if (connectionOption.type === SystemType.SAAS) {
+    integrationKey += "_api";
+  }
+
+  return integrationKey;
 };


### PR DESCRIPTION
Closes [LA-149](https://ethyca.atlassian.net/browse/LA-149)

### Description Of Changes

Updates the `generateIntegrationKey` helper function to remove unsupported characters.

### Code Changes

* Remove unsupported characters from system key
* Adds unit tests

### Steps to Confirm

1.  Create a system with a period, for example "Zendesk Inc."
2. Add an integration
3. You should be able to save the integration with no issues

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LA-149]: https://ethyca.atlassian.net/browse/LA-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ