### PR TITLE
Remove extra delete icon from domains page buttons

### DIFF
--- a/clients/admin-ui/src/pages/settings/domains.tsx
+++ b/clients/admin-ui/src/pages/settings/domains.tsx
@@ -212,14 +212,12 @@ const CORSConfigurationPage: NextPage = () => {
 
                                 <Button
                                   aria-label="delete-domain"
-                                  className="z-[2] ml-8"
+                                  className="z-[2] ml-4"
                                   icon={<DeleteIcon />}
                                   onClick={() => {
                                     arrayHelpers.remove(index);
                                   }}
-                                >
-                                  <DeleteIcon />
-                                </Button>
+                                />
                               </Flex>
                             ),
                           )}


### PR DESCRIPTION
Closes HJ-238

### Description Of Changes

Removes an extra "Delete" icon from buttons on the "Domains" page that was accidentally left in during the button migration.  Also narrows margin slightly.

Before:
![Screenshot 2024-11-19 at 01 22 29](https://github.com/user-attachments/assets/7e1fcb95-0b84-4b0e-98c5-ab39d51970ca)

After:
![Screenshot 2024-11-19 at 01 25 34](https://github.com/user-attachments/assets/9de559f9-e59e-402e-a5c9-adc3de313138)

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
