### PR TITLE
Remove .only from test suite

### DIFF
--- a/clients/admin-ui/cypress/e2e/discovery-detection.cy.ts
+++ b/clients/admin-ui/cypress/e2e/discovery-detection.cy.ts
@@ -470,7 +470,7 @@ describe("discovery and detection", () => {
     });
   });
 
-  describe.only("without a db layer", () => {
+  describe("without a db layer", () => {
     it("shows resource name for resources that are not subfields", () => {
       cy.intercept("GET", "/api/v1/plus/discovery-monitor/results?*", {
         fixture: "detection-discovery/results/no-db-layer/field-list.json",


### PR DESCRIPTION
Closes unticketed

### Description Of Changes

Removes a .only that was accidentally left in the D&D Cypress test suite.

### Steps to Confirm

1. CI passes

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
