### PR TITLE
Fixing privacy request received message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The types of changes are:
 - Fixed deletion of ConnectionConfigs that have related MonitorConfigs [#5478](https://github.com/ethyca/fides/pull/5478)
 - Fixed extra delete icon on Domains page [#5513](https://github.com/ethyca/fides/pull/5513)
 - Fixed incorrect display names on some D&D resources [#5498](https://github.com/ethyca/fides/pull/5498)
+- Fixing issue where "privacy request received" emails would not be sent if the request had custom identities [#5518](https://github.com/ethyca/fides/pull/5518)
 
 ### Changed
 - Allow hiding systems via a `hidden` parameter and add two flags on the `/system` api endpoint; `show_hidden` and `dnd_relevant`, to display only systems with integrations [#5484](https://github.com/ethyca/fides/pull/5484)

--- a/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
@@ -297,7 +297,7 @@ def _send_privacy_request_receipt_message_to_user(
                 body_params=RequestReceiptBodyParams(request_types=request_types),
             ).model_dump(mode="json"),
             "service_type": service_type,
-            "to_identity": to_identity.model_dump(mode="json"),
+            "to_identity": to_identity.labeled_dict(),
             "property_id": property_id,
         },
     )


### PR DESCRIPTION
Closes [LA-156](https://ethyca.atlassian.net/browse/LA-156)

### Description Of Changes

Fixing issue where custom identities were not being passed in correctly to the `dispatch_message_task`.

### Steps to Confirm

1. Add a custom identity to the Privacy Center
```
"identity_inputs": {
  "email": "required",
  "stack_overflow_id": { "label": "Stack Overflow ID" }
},
```
2. Configure a messaging provider
3. Set `FIDES__NOTIFICATIONS__SEND_REQUEST_RECEIPT_NOTIFICATION=true`
4. Submit a privacy request
5. You should receive a `Your privacy request has been received` email

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LA-156]: https://ethyca.atlassian.net/browse/LA-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ