### PR TITLE
include manage label in TCF experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The types of changes are:
 - Fixed position of "Integration" button on system detail page [#5497](https://github.com/ethyca/fides/pull/5497)
 - Fixing issue where "privacy request received" emails would not be sent if the request had custom identities [#5518](https://github.com/ethyca/fides/pull/5518)
 - Fixed issue with long-running privacy request tasks losing their connection to the database [#5500](https://github.com/ethyca/fides/pull/5500)
+- Fixed missing "Manage privacy preferences" button label option in TCF experience translations [#5528](https://github.com/ethyca/fides/pull/5528)
 
 ### Docs
 - Added docs for PrivacyNoticeRegion type [#5488](https://github.com/ethyca/fides/pull/5488)

--- a/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/helpers.tsx
@@ -178,6 +178,7 @@ export const getTranslationFormFields = (
       acknowledge_button_label: { included: true, required: true },
       privacy_policy_link_label: { included: true },
       privacy_policy_url: { included: true },
+      privacy_preferences_link_label: { included: true, required: true },
       modal_link_label: { included: true },
     };
   }


### PR DESCRIPTION
Closes [HJ-253](https://ethyca.atlassian.net/browse/HJ-253)

include manage label in TCF experience

### Steps to Confirm

1.  Visit Experience page in Admin UI
2. Click through to a TCF experience
3. Click "English" to open translations
4. Ensure "Manage privacy preferences" button label is an option

![CleanShot 2024-11-21 at 12 36 00@2x](https://github.com/user-attachments/assets/8f6a6e40-58bb-40bb-9295-82ee7963e026)


### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[HJ-253]: https://ethyca.atlassian.net/browse/HJ-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ