### PR TITLE
Send property id and also override path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The types of changes are:
 - Added BigQuery Enterprise access request integration test [#5504](https://github.com/ethyca/fides/pull/5504)
 - Added MD5 email hashing for Segment's Right to Forget endpoint requests [#5514](https://github.com/ethyca/fides/pull/5514)
 - Added loading state to the toggle switches on the Privacy experiences page [#5529](https://github.com/ethyca/fides/pull/5529)
+- Added new env variable to set a privacy center to default to a specific property  [#5532](https://github.com/ethyca/fides/pull/5532)
 
 ### Changed
 - Allow hiding systems via a `hidden` parameter and add two flags on the `/system` api endpoint; `show_hidden` and `dnd_relevant`, to display only systems with integrations [#5484](https://github.com/ethyca/fides/pull/5484)
@@ -53,6 +54,7 @@ The types of changes are:
 - Fixing issue where "privacy request received" emails would not be sent if the request had custom identities [#5518](https://github.com/ethyca/fides/pull/5518)
 - Fixed issue with long-running privacy request tasks losing their connection to the database [#5500](https://github.com/ethyca/fides/pull/5500)
 - Fixed missing "Manage privacy preferences" button label option in TCF experience translations [#5528](https://github.com/ethyca/fides/pull/5528)
+- Fixed privacy center not fetching the correct experience when using custom property paths  [#5532](https://github.com/ethyca/fides/pull/5532)
 
 ### Docs
 - Added docs for PrivacyNoticeRegion type [#5488](https://github.com/ethyca/fides/pull/5488)

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -285,7 +285,7 @@ export const loadServerSettings = (): PrivacyCenterServerSettings => {
 // eslint-disable-next-line no-underscore-dangle,@typescript-eslint/naming-convention
 
 export const loadPrivacyCenterEnvironment = async ({
-  customPropertyPath = undefined,
+  customPropertyPath = "p2",
 }: { customPropertyPath?: string } = {}): Promise<PrivacyCenterEnvironment> => {
   if (typeof window !== "undefined") {
     throw new Error(

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -285,7 +285,7 @@ export const loadServerSettings = (): PrivacyCenterServerSettings => {
 // eslint-disable-next-line no-underscore-dangle,@typescript-eslint/naming-convention
 
 export const loadPrivacyCenterEnvironment = async ({
-  customPropertyPath = "p2",
+  customPropertyPath,
 }: { customPropertyPath?: string } = {}): Promise<PrivacyCenterEnvironment> => {
   if (typeof window !== "undefined") {
     throw new Error(
@@ -302,6 +302,14 @@ export const loadPrivacyCenterEnvironment = async ({
   if (settings.CUSTOM_PROPERTIES && customPropertyPath) {
     const result = await getPropertyFromUrl({
       customPropertyPath,
+      fidesApiUrl: settings.SERVER_SIDE_FIDES_API_URL || settings.FIDES_API_URL,
+    });
+    if (result) {
+      property = result;
+    }
+  } else if (settings.FIDES_PRIVACY_CENTER__ROOT_PROPERTY_PATH) {
+    const result = await getPropertyFromUrl({
+      customPropertyPath: settings.FIDES_PRIVACY_CENTER__ROOT_PROPERTY_PATH,
       fidesApiUrl: settings.SERVER_SIDE_FIDES_API_URL || settings.FIDES_API_URL,
     });
     if (result) {

--- a/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
+++ b/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
@@ -13,6 +13,7 @@ export interface PrivacyCenterSettings {
   CONFIG_JSON_URL: string; // e.g. file:///app/config/config.json
   SHOW_BRAND_LINK: boolean; // whether to render the Ethyca brand link
   CUSTOM_PROPERTIES: boolean; // (optional) (default: true) enables the use of a single privacy center instance to serve different properties on different paths with custom configs
+  FIDES_PRIVACY_CENTER__ROOT_PROPERTY_PATH: string | null; // (optional) setting this will fetch a property when navigating the root ("/") path.
 
   // Fides.js options
   DEBUG: boolean; // whether console logs are enabled for consent components

--- a/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
+++ b/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
@@ -16,7 +16,9 @@ const loadEnvironmentVariables = () => {
       "file:///app/config/config.css",
     SHOW_BRAND_LINK:
       process.env.FIDES_PRIVACY_CENTER__SHOW_BRAND_LINK === "true" || false,
-    CUSTOM_PROPERTIES: process.env.CUSTOM_PROPERTIES === "true" || true,
+    CUSTOM_PROPERTIES: process.env.CUSTOM_PROPERTIES !== "false", // default: true
+    FIDES_PRIVACY_CENTER__ROOT_PROPERTY_PATH:
+      process.env.FIDES_PRIVACY_CENTER__ROOT_PROPERTY_PATH || null,
 
     // Overlay options
     DEBUG: process.env.FIDES_PRIVACY_CENTER__DEBUG

--- a/clients/privacy-center/features/common/property.slice.ts
+++ b/clients/privacy-center/features/common/property.slice.ts
@@ -27,7 +27,8 @@ export const propertySlice = createSlice({
 });
 
 const selectProperty = (state: RootState) => state.property;
-
+export const selectPropertyId = (state: RootState) =>
+  state.property?.property?.id;
 export const { reducer } = propertySlice;
 export const { loadProperty } = propertySlice.actions;
 export const useProperty = (): Property | undefined => {

--- a/clients/privacy-center/features/consent/consent.slice.ts
+++ b/clients/privacy-center/features/consent/consent.slice.ts
@@ -17,9 +17,11 @@ import {
   PrivacyExperienceResponse,
   PrivacyNoticeRegion,
   PrivacyPreferencesRequest,
+  Property,
   RecordConsentServedRequest,
 } from "~/types/api";
 
+import { selectPropertyId } from "../common/property.slice";
 import { selectSettings } from "../common/settings.slice";
 import { FidesKeyToConsent } from "./types";
 
@@ -73,7 +75,7 @@ export const consentApi = baseApi.injectEndpoints({
     }),
     getPrivacyExperience: build.query<
       PagePrivacyExperienceResponse,
-      { region: PrivacyNoticeRegion }
+      { region: PrivacyNoticeRegion; property_id: Property["id"] }
     >({
       query: (payload) => ({
         url: "privacy-experience/",
@@ -236,7 +238,6 @@ export const selectUserRegion = createSelector(
           settings.GEOLOCATION_API_URL,
         )(RootState)?.data;
       }
-
       return constructFidesRegionString(geolocation) as PrivacyNoticeRegion;
     }
     return undefined;
@@ -244,13 +245,19 @@ export const selectUserRegion = createSelector(
 );
 
 export const selectPrivacyExperience = createSelector(
-  [(RootState) => RootState, selectUserRegion, selectFidesUserDeviceId],
-  (RootState, region) => {
+  [
+    (RootState) => RootState,
+    selectUserRegion,
+    selectFidesUserDeviceId,
+    selectPropertyId,
+  ],
+  (RootState, region, _deviceId, propertyId) => {
     if (!region) {
       return undefined;
     }
     return consentApi.endpoints.getPrivacyExperience.select({
       region,
-    })(RootState)?.data?.items[0];
+      property_id: propertyId,
+    })(RootState).data?.items[0];
   },
 );

--- a/clients/privacy-center/features/consent/hooks.ts
+++ b/clients/privacy-center/features/consent/hooks.ts
@@ -5,6 +5,7 @@ import {
 } from "~/features/common/settings.slice";
 import { PrivacyNoticeRegion } from "~/types/api";
 
+import { selectPropertyId } from "../common/property.slice";
 import {
   selectUserRegion,
   useGetPrivacyExperienceQuery,
@@ -26,7 +27,6 @@ import {
  */
 export const useSubscribeToPrivacyExperienceQuery = () => {
   const { IS_GEOLOCATION_ENABLED, GEOLOCATION_API_URL } = useSettings();
-
   const skipFetchExperience = !useAppSelector(selectIsNoticeDriven);
   const skipFetchGeolocation =
     skipFetchExperience || !IS_GEOLOCATION_ENABLED || !GEOLOCATION_API_URL;
@@ -36,9 +36,11 @@ export const useSubscribeToPrivacyExperienceQuery = () => {
   });
 
   const region = useAppSelector(selectUserRegion);
+  const propertyId = useAppSelector(selectPropertyId);
   const params = {
     // Casting should be safe because we skip in the hook below if region does not exist
     region: region as PrivacyNoticeRegion,
+    property_id: propertyId,
   };
   useGetPrivacyExperienceQuery(params, {
     skip: !region || skipFetchExperience,


### PR DESCRIPTION
### Description Of Changes

Fetch correct experience when a privacy center property is being use. Add env variable to override use a specific property for the root domain (when no property paths are used).

### Code Changes

* If property_id is available, send it as a paramater to the fetch experience function
* Add env variable to override use a specific property 

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues