### PR TITLE
Change brand link to show in CMP modal and privacy center by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.50.0...main)
 
-
+### Changed
+- Show "powered by" branding link by default [#5534](https://github.com/ethyca/fides/pull/5534)
 
 
 

--- a/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
+++ b/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
@@ -15,7 +15,7 @@ const loadEnvironmentVariables = () => {
       process.env.FIDES_PRIVACY_CENTER__CONFIG_CSS_URL ||
       "file:///app/config/config.css",
     SHOW_BRAND_LINK:
-      process.env.FIDES_PRIVACY_CENTER__SHOW_BRAND_LINK === "true" || false,
+      process.env.FIDES_PRIVACY_CENTER__SHOW_BRAND_LINK === "true" || true,
     CUSTOM_PROPERTIES: process.env.CUSTOM_PROPERTIES === "true" || true,
 
     // Overlay options


### PR DESCRIPTION
Closes HJ-182

### Description Of Changes

Changes Fides brand link in CMP modal and privacy center to be enabled by default rather than dependent on env variable.

### Steps to Confirm

1. Remove `FIDES_PRIVACY_CENTER__SHOW_BRAND_LINK` from your .env
2. Verify "powered by" brand link shows in privacy center
3. Verify "powered by" brand link shows in CMP modal

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
