### PR TITLE
Adding hashes to system tab URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.50.0...main)
 
+### Changed
+- Adding hashes to system tab URLs [#5535](https://github.com/ethyca/fides/pull/5535)
 
 ### Developer Experience
 - Migrated remaining instances of Chakra's Select component to use Ant's Select component [#5502](https://github.com/ethyca/fides/pull/5502)
-
-
 
 ## [2.50.0](https://github.com/ethyca/fides/compare/2.49.1...2.50.0)
 
@@ -57,9 +57,6 @@ The types of changes are:
 - Fixed issue with long-running privacy request tasks losing their connection to the database [#5500](https://github.com/ethyca/fides/pull/5500)
 - Fixed missing "Manage privacy preferences" button label option in TCF experience translations [#5528](https://github.com/ethyca/fides/pull/5528)
 - Fixed privacy center not fetching the correct experience when using custom property paths  [#5532](https://github.com/ethyca/fides/pull/5532)
-
-### Docs
-- Added docs for PrivacyNoticeRegion type [#5488](https://github.com/ethyca/fides/pull/5488)
 
 ### Security
  - Password Policy is now Enforced in Accept Invite API [CVE-2024-52008](https://github.com/ethyca/fides/security/advisories/GHSA-v7vm-rhmg-8j2r)

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -123,7 +123,11 @@ describe("System management with Plus features", () => {
       cy.wait("@getDictSystem");
       cy.getByTestId("input-dpo").should("have.value", "DPO@anzu.io");
       cy.getByTestId("tab-Data uses").click();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
       cy.getByTestId("tab-Information").click();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
       cy.getByTestId("tab-Data uses").click();
       cy.getByTestId("confirmation-modal").should("not.exist");
     });

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -123,11 +123,7 @@ describe("System management with Plus features", () => {
       cy.wait("@getDictSystem");
       cy.getByTestId("input-dpo").should("have.value", "DPO@anzu.io");
       cy.getByTestId("tab-Data uses").click();
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(500);
       cy.getByTestId("tab-Information").click();
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(500);
       cy.getByTestId("tab-Data uses").click();
       cy.getByTestId("confirmation-modal").should("not.exist");
     });
@@ -470,15 +466,23 @@ describe("System management with Plus features", () => {
       cy.visit(`${SYSTEM_ROUTE}/configure/demo_analytics_system#information`);
       cy.location("hash").should("eq", "#information");
 
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
       cy.getByTestId("tab-Data uses").click();
       cy.location("hash").should("eq", "#data-uses");
 
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
       cy.getByTestId("tab-Data flow").click();
       cy.location("hash").should("eq", "#data-flow");
 
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
       cy.getByTestId("tab-Integrations").click();
       cy.location("hash").should("eq", "#integrations");
 
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
       cy.getByTestId("tab-History").click();
       cy.location("hash").should("eq", "#history");
     });

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -460,4 +460,36 @@ describe("System management with Plus features", () => {
       });
     });
   });
+
+  describe("tab navigation", () => {
+    it("updates URL hash when switching tabs", () => {
+      cy.visit(`${SYSTEM_ROUTE}/configure/demo_analytics_system#information`);
+      cy.location("hash").should("eq", "#information");
+
+      cy.getByTestId("tab-Data uses").click();
+      cy.location("hash").should("eq", "#data-uses");
+
+      cy.getByTestId("tab-Data flow").click();
+      cy.location("hash").should("eq", "#data-flow");
+
+      cy.getByTestId("tab-Integrations").click();
+      cy.location("hash").should("eq", "#integrations");
+
+      cy.getByTestId("tab-History").click();
+      cy.location("hash").should("eq", "#history");
+    });
+
+    it("loads correct tab directly based on URL hash", () => {
+      // Visit page with specific hash
+      cy.visit(`${SYSTEM_ROUTE}/configure/demo_analytics_system#data-uses`);
+
+      // Verify correct tab is active
+      cy.getByTestId("tab-Data uses").should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+      cy.location("hash").should("eq", "#data-uses");
+    });
+  });
 });

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -123,8 +123,10 @@ describe("System management with Plus features", () => {
       cy.wait("@getDictSystem");
       cy.getByTestId("input-dpo").should("have.value", "DPO@anzu.io");
       cy.getByTestId("tab-Data uses").click();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(500);
       cy.getByTestId("tab-Information").click();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(500);
       cy.getByTestId("tab-Data uses").click();
       cy.getByTestId("confirmation-modal").should("not.exist");

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -123,7 +123,9 @@ describe("System management with Plus features", () => {
       cy.wait("@getDictSystem");
       cy.getByTestId("input-dpo").should("have.value", "DPO@anzu.io");
       cy.getByTestId("tab-Data uses").click();
+      cy.wait(500);
       cy.getByTestId("tab-Information").click();
+      cy.wait(500);
       cy.getByTestId("tab-Data uses").click();
       cy.getByTestId("confirmation-modal").should("not.exist");
     });

--- a/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
+++ b/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
@@ -187,9 +187,12 @@ const useSystemFormTabs = ({
   const { attemptAction } = useIsAnyFormDirty();
 
   const onTabChange = useCallback(
-    (index: number) => {
-      attemptAction().then((modalConfirmed: boolean) => {
+    async (index: number) => {
+      try {
+        const modalConfirmed = await attemptAction();
+
         if (modalConfirmed) {
+          // Handle status first if it exists
           const { status } = router.query;
           if (status) {
             if (status === "succeeded") {
@@ -199,13 +202,16 @@ const useSystemFormTabs = ({
             }
           }
 
-          // Handle tab change and URL update
+          // Update local state first
           setTabIndex(index);
+
+          // Then update URL
           const tab = getTabFromIndex(index);
           if (tab) {
             const newQuery = { ...router.query };
             delete newQuery.status;
-            router.replace(
+
+            await router.replace(
               {
                 pathname: router.pathname,
                 query: newQuery,
@@ -216,7 +222,9 @@ const useSystemFormTabs = ({
             );
           }
         }
-      });
+      } catch (error) {
+        console.error("Error changing tabs:", error);
+      }
     },
     [attemptAction, router, toast],
   );

--- a/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
+++ b/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
@@ -100,12 +100,12 @@ const useSystemFormTabs = ({
   const router = useRouter();
 
   // Get initial tab index based on URL hash
-  const getInitialTabIndex = useCallback((): number => {
+  const getInitialTabIndex = (): number => {
     const hash: string = router.asPath.split("#")[1];
     return hash
       ? (getTabFromHash(hash)?.index ?? SYSTEM_TABS.INFORMATION.index)
       : SYSTEM_TABS.INFORMATION.index;
-  }, [router.asPath]);
+  };
 
   const [tabIndex, setTabIndex] = useState(getInitialTabIndex());
 

--- a/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
+++ b/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
@@ -188,7 +188,7 @@ const useSystemFormTabs = ({
 
   const onTabChange = useCallback(
     (index: number) => {
-      attemptAction().then((modalConfirmed: boolean) => {
+      attemptAction().then(async (modalConfirmed: boolean) => {
         if (modalConfirmed) {
           const { status } = router.query;
           if (status) {
@@ -209,7 +209,7 @@ const useSystemFormTabs = ({
               const newQuery = { ...router.query };
               delete newQuery.status;
 
-              router.replace(
+              await router.replace(
                 {
                   pathname: router.pathname,
                   query: newQuery,

--- a/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
+++ b/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
@@ -13,7 +13,11 @@ import {
 } from "~/features/common/hooks/useIsAnyFormDirty";
 import { useSystemOrDatamapRoute } from "~/features/common/hooks/useSystemOrDatamapRoute";
 import { INTEGRATION_MANAGEMENT_ROUTE } from "~/features/common/nav/v2/routes";
-import { DEFAULT_TOAST_PARAMS } from "~/features/common/toast";
+import {
+  DEFAULT_TOAST_PARAMS,
+  errorToastParams,
+  successToastParams,
+} from "~/features/common/toast";
 import ToastLink from "~/features/common/ToastLink";
 import ConnectionForm from "~/features/datastore-connections/system_portal_config/ConnectionForm";
 import { ConsentAutomationForm } from "~/features/datastore-connections/system_portal_config/ConsentAutomationForm";
@@ -30,6 +34,38 @@ import {
 } from "~/features/system/system.slice";
 import SystemInformationForm from "~/features/system/SystemInformationForm";
 import { SystemResponse } from "~/types/api";
+
+const SYSTEM_TABS = {
+  INFORMATION: {
+    index: 0,
+    hash: "#information",
+  },
+  DATA_USES: {
+    index: 1,
+    hash: "#data-uses",
+  },
+  DATA_FLOW: {
+    index: 2,
+    hash: "#data-flow",
+  },
+  INTEGRATIONS: {
+    index: 3,
+    hash: "#integrations",
+  },
+  HISTORY: {
+    index: 4,
+    hash: "#history",
+  },
+} as const;
+
+const getTabFromHash = (hash: string) => {
+  const normalizedHash = hash.startsWith("#") ? hash : `#${hash}`;
+  return Object.values(SYSTEM_TABS).find((tab) => tab.hash === normalizedHash);
+};
+
+const getTabFromIndex = (index: number) => {
+  return Object.values(SYSTEM_TABS).find((tab) => tab.index === index);
+};
 
 // The toast doesn't seem to handle next links well, so use buttons with onClick
 // handlers instead
@@ -56,16 +92,25 @@ const ToastMessage = ({
 
 const useSystemFormTabs = ({
   isCreate,
-  initialTabIndex,
 }: {
   initialTabIndex?: number;
   /** If true, then some editing features will not be enabled */
   isCreate?: boolean;
 }) => {
-  const [tabIndex, setTabIndex] = useState(initialTabIndex);
+  const router = useRouter();
+
+  // Get initial tab index based on URL hash
+  const getInitialTabIndex = useCallback((): number => {
+    const hash: string = router.asPath.split("#")[1];
+    return hash
+      ? (getTabFromHash(hash)?.index ?? SYSTEM_TABS.INFORMATION.index)
+      : SYSTEM_TABS.INFORMATION.index;
+  }, [router.asPath]);
+
+  const [tabIndex, setTabIndex] = useState(getInitialTabIndex());
+
   const [showSaveMessage, setShowSaveMessage] = useState(false);
   const { systemOrDatamapRoute } = useSystemOrDatamapRoute();
-  const router = useRouter();
   const toast = useToast();
   const dispatch = useAppDispatch();
   const activeSystem = useAppSelector(selectActiveSystem) as SystemResponse;
@@ -145,12 +190,43 @@ const useSystemFormTabs = ({
     (index: number) => {
       attemptAction().then((modalConfirmed: boolean) => {
         if (modalConfirmed) {
+          const { status } = router.query;
+          if (status) {
+            if (status === "succeeded") {
+              toast(successToastParams(`Integration successfully authorized.`));
+            } else {
+              toast(errorToastParams(`Failed to authorize integration.`));
+            }
+          }
+
+          // Handle tab change and URL update
           setTabIndex(index);
+          const tab = getTabFromIndex(index);
+          if (tab) {
+            const newQuery = { ...router.query };
+            delete newQuery.status;
+            router.replace(
+              {
+                pathname: router.pathname,
+                query: newQuery,
+                hash: tab.hash,
+              },
+              undefined,
+              { shallow: true },
+            );
+          }
         }
       });
     },
-    [attemptAction],
+    [attemptAction, router, toast],
   );
+
+  useEffect(() => {
+    const { status } = router.query;
+    if (status) {
+      onTabChange(SYSTEM_TABS.INTEGRATIONS.index);
+    }
+  }, [router.query, onTabChange]);
 
   const showNewIntegrationNotice = hasPlus && dataDiscoveryAndDetection;
 

--- a/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
+++ b/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
@@ -187,12 +187,9 @@ const useSystemFormTabs = ({
   const { attemptAction } = useIsAnyFormDirty();
 
   const onTabChange = useCallback(
-    async (index: number) => {
-      try {
-        const modalConfirmed = await attemptAction();
-
+    (index: number) => {
+      attemptAction().then((modalConfirmed: boolean) => {
         if (modalConfirmed) {
-          // Handle status first if it exists
           const { status } = router.query;
           if (status) {
             if (status === "succeeded") {
@@ -205,26 +202,26 @@ const useSystemFormTabs = ({
           // Update local state first
           setTabIndex(index);
 
-          // Then update URL
-          const tab = getTabFromIndex(index);
-          if (tab) {
-            const newQuery = { ...router.query };
-            delete newQuery.status;
+          // Update URL if router is ready
+          if (router.isReady) {
+            const tab = getTabFromIndex(index);
+            if (tab) {
+              const newQuery = { ...router.query };
+              delete newQuery.status;
 
-            await router.replace(
-              {
-                pathname: router.pathname,
-                query: newQuery,
-                hash: tab.hash,
-              },
-              undefined,
-              { shallow: true },
-            );
+              router.replace(
+                {
+                  pathname: router.pathname,
+                  query: newQuery,
+                  hash: tab.hash,
+                },
+                undefined,
+                { shallow: true },
+              );
+            }
           }
         }
-      } catch (error) {
-        console.error("Error changing tabs:", error);
-      }
+      });
     },
     [attemptAction, router, toast],
   );

--- a/clients/admin-ui/src/pages/systems/configure/[id].tsx
+++ b/clients/admin-ui/src/pages/systems/configure/[id].tsx
@@ -1,7 +1,7 @@
-import { AntButton as Button, Box, Text, useToast, VStack } from "fidesui";
+import { AntButton as Button, Box, Text, VStack } from "fidesui";
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import DataTabsContent from "~/features/common/DataTabsContent";
@@ -16,7 +16,6 @@ import {
   SYSTEM_ROUTE,
 } from "~/features/common/nav/v2/routes";
 import PageHeader from "~/features/common/PageHeader";
-import { errorToastParams, successToastParams } from "~/features/common/toast";
 import { useGetAllDictionaryEntriesQuery } from "~/features/plus/plus.slice";
 import {
   setActiveSystem,
@@ -29,13 +28,9 @@ import {
 import GVLNotice from "~/features/system/GVLNotice";
 import useSystemFormTabs from "~/features/system/hooks/useSystemFormTabs";
 
-const INTEGRATION_TAB_INDEX = 3; // this needs to be updated if the order of the tabs changes
-
 const ConfigureSystem: NextPage = () => {
-  const toast = useToast();
   const router = useRouter();
   const dispatch = useAppDispatch();
-  const [initialTabIndex, setInitialTabIndex] = useState(0);
 
   let systemId = "";
   if (router.query.id) {
@@ -70,33 +65,8 @@ const ConfigureSystem: NextPage = () => {
     }
   }, [system, dispatch, isTCFEnabled]);
 
-  useEffect(() => {
-    const { status } = router.query;
-
-    if (status) {
-      if (status === "succeeded") {
-        toast(successToastParams(`Integration successfully authorized.`));
-      } else {
-        toast(errorToastParams(`Failed to authorize integration.`));
-      }
-      // create a new url without the status query param
-      const newQuery = { ...router.query };
-      delete newQuery.status;
-      const newUrl = {
-        pathname: router.pathname,
-        query: newQuery,
-      };
-
-      // replace the current history entry
-      router.replace(newUrl, undefined, { shallow: true });
-
-      setInitialTabIndex(INTEGRATION_TAB_INDEX);
-    }
-  }, [router, toast]);
-
   const { tabData, tabIndex, onTabChange } = useSystemFormTabs({
     isCreate: false,
-    initialTabIndex,
   });
 
   if ((isLoading || isDictionaryLoading) && !dictionaryError) {

--- a/clients/admin-ui/src/pages/systems/index.tsx
+++ b/clients/admin-ui/src/pages/systems/index.tsx
@@ -129,6 +129,7 @@ const Systems: NextPage = () => {
         query: {
           id: system.fides_key,
         },
+        hash: "#information",
       });
     },
     [dispatch, router],


### PR DESCRIPTION
Closes [LA-167](https://ethyca.atlassian.net/browse/LA-167)

### Description Of Changes

Adds URL "fragments" for the different tabs in the system page. This allows us to deep-link into specific tabs. It also allows us to navigate back to a specific system tab if needed.

### Code Changes

* Moved some logic away from the systems page and into `useSystemFormTabs.tsx`

### Steps to Confirm

1.  Navigate between the different tabs in the system page, verify the URL updates
2. Copy one of the URLs and verify you can navigate directly to that tab by following the URL
![tabs](https://github.com/user-attachments/assets/2d89aceb-2efa-4123-a7cd-e1f8f6e00dfe)

### Pre-Merge Checklist
* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LA-167]: https://ethyca.atlassian.net/browse/LA-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ