### PR TITLE
LA-168: adds support for taxonomy creation specifying a parent key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,19 +17,15 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.50.0...main)
 
-<<<<<<< HEAD
-### Fixed
-- Adds support for fides_key generation when parent_key is provided in Taxonomy create endpoints [#5542](https://github.com/ethyca/fides/pull/5542)
-=======
 ### Changed
 - Adding hashes to system tab URLs [#5535](https://github.com/ethyca/fides/pull/5535)
->>>>>>> f1865030d52eabe84e650a576c9f0449d24d90a3
 
 ### Developer Experience
 - Migrated remaining instances of Chakra's Select component to use Ant's Select component [#5502](https://github.com/ethyca/fides/pull/5502)
 
 ### Fixed
 - Updating dataset PUT to allow deleting all datasets [#5524](https://github.com/ethyca/fides/pull/5524)
+- Adds support for fides_key generation when parent_key is provided in Taxonomy create endpoints [#5542](https://github.com/ethyca/fides/pull/5542)
 
 ## [2.50.0](https://github.com/ethyca/fides/compare/2.49.1...2.50.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.50.0...main)
 
+### Fixed
+- Adds support for fides_key generation when parent_key is provided in Taxonomy create endpoints [#5542](https://github.com/ethyca/fides/pull/5542)
 
 ### Developer Experience
 - Migrated remaining instances of Chakra's Select component to use Ant's Select component [#5502](https://github.com/ethyca/fides/pull/5502)

--- a/src/fides/api/api/v1/endpoints/generic_overrides.py
+++ b/src/fides/api/api/v1/endpoints/generic_overrides.py
@@ -124,29 +124,36 @@ async def create_data_use(
     """
     Create a data use. Updates existing data use if data use with name already exists and is disabled.
     """
-    if data_use.fides_key is None:
-        disabled_resource_with_name = (
-            db.query(DataUseDbModel)
-            .filter(
-                DataUseDbModel.active.is_(False),
-                DataUseDbModel.name == data_use.name,
+    try:
+        if data_use.fides_key is None:
+            disabled_resource_with_name = (
+                db.query(DataUseDbModel)
+                .filter(
+                    DataUseDbModel.active.is_(False),
+                    DataUseDbModel.name == data_use.name,
+                )
+                .first()
             )
-            .first()
-        )
-        data_use.fides_key = get_key_from_data(
-            {"key": data_use.fides_key, "name": data_use.name}, DataUse.__name__
-        )
-        if disabled_resource_with_name:
-            data_use.active = True
-            return disabled_resource_with_name.update(db, data=data_use.model_dump(mode="json"))  # type: ignore[union-attr]
-        try:
+            data_use.fides_key = get_key_from_data(
+                {"key": data_use.fides_key, "name": data_use.name}, DataUse.__name__
+            )
+            if data_use.parent_key:
+                data_use.fides_key = f"{data_use.parent_key}.{data_use.fides_key}"
+            if disabled_resource_with_name:
+                data_use.active = True
+                return disabled_resource_with_name.update(db, data=data_use.model_dump(mode="json"))  # type: ignore[union-attr]
             return DataUseDbModel.create(db=db, data=data_use.model_dump(mode="json"))  # type: ignore[union-attr]
-        except KeyOrNameAlreadyExists:
-            raise HTTPException(
-                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Data use with key {data_use.fides_key} or name {data_use.name} already exists.",
-            )
-    return DataUseDbModel.create(db=db, data=data_use.model_dump(mode="json"))
+        return DataUseDbModel.create(db=db, data=data_use.model_dump(mode="json"))
+    except KeyOrNameAlreadyExists:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Data use with key {data_use.fides_key} or name {data_use.name} already exists.",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Error creating data use: {e}",
+        )
 
 
 @data_category_router.post(
@@ -164,30 +171,42 @@ async def create_data_category(
     Create a data category
     """
 
-    if data_category.fides_key is None:
-        disabled_resource_with_name = (
-            db.query(DataCategoryDbModel)
-            .filter(
-                DataCategoryDbModel.active.is_(False),
-                DataCategoryDbModel.name == data_category.name,
+    try:
+        if data_category.fides_key is None:
+            disabled_resource_with_name = (
+                db.query(DataCategoryDbModel)
+                .filter(
+                    DataCategoryDbModel.active.is_(False),
+                    DataCategoryDbModel.name == data_category.name,
+                )
+                .first()
             )
-            .first()
-        )
-        data_category.fides_key = get_key_from_data(
-            {"key": data_category.fides_key, "name": data_category.name},
-            DataCategory.__name__,
-        )
-        if disabled_resource_with_name:
-            data_category.active = True
-            return disabled_resource_with_name.update(db, data=data_category.model_dump(mode="json"))  # type: ignore[union-attr]
-        try:
+            data_category.fides_key = get_key_from_data(
+                {"key": data_category.fides_key, "name": data_category.name},
+                DataCategory.__name__,
+            )
+            if data_category.parent_key:
+                data_category.fides_key = (
+                    f"{data_category.parent_key}.{data_category.fides_key}"
+                )
+            if disabled_resource_with_name:
+                data_category.active = True
+                return disabled_resource_with_name.update(db, data=data_category.model_dump(mode="json"))  # type: ignore[union-attr]
             return DataCategoryDbModel.create(db=db, data=data_category.model_dump(mode="json"))  # type: ignore[union-attr]
-        except KeyOrNameAlreadyExists:
-            raise HTTPException(
-                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Data category with key {data_category.fides_key} or name {data_category.name} already exists.",
-            )
-    return DataCategoryDbModel.create(db=db, data=data_category.model_dump(mode="json"))
+
+        return DataCategoryDbModel.create(
+            db=db, data=data_category.model_dump(mode="json")
+        )
+    except KeyOrNameAlreadyExists:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Data category with key {data_category.fides_key} or name {data_category.name} already exists.",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Error creating data category: {e}",
+        )
 
 
 @data_subject_router.post(
@@ -205,30 +224,37 @@ async def create_data_subject(
     Create a data subject
     """
 
-    if data_subject.fides_key is None:
-        disabled_resource_with_name = (
-            db.query(DataSubjectDbModel)
-            .filter(
-                DataSubjectDbModel.active.is_(False),
-                DataSubjectDbModel.name == data_subject.name,
+    try:
+        if data_subject.fides_key is None:
+            disabled_resource_with_name = (
+                db.query(DataSubjectDbModel)
+                .filter(
+                    DataSubjectDbModel.active.is_(False),
+                    DataSubjectDbModel.name == data_subject.name,
+                )
+                .first()
             )
-            .first()
-        )
-        data_subject.fides_key = get_key_from_data(
-            {"key": data_subject.fides_key, "name": data_subject.name},
-            DataSubject.__name__,
-        )
-        if disabled_resource_with_name:
-            data_subject.active = True
-            return disabled_resource_with_name.update(db, data=data_subject.model_dump(mode="json"))  # type: ignore[union-attr]
-        try:
+            data_subject.fides_key = get_key_from_data(
+                {"key": data_subject.fides_key, "name": data_subject.name},
+                DataSubject.__name__,
+            )
+            if disabled_resource_with_name:
+                data_subject.active = True
+                return disabled_resource_with_name.update(db, data=data_subject.model_dump(mode="json"))  # type: ignore[union-attr]
             return DataSubjectDbModel.create(db=db, data=data_subject.model_dump(mode="json"))  # type: ignore[union-attr]
-        except KeyOrNameAlreadyExists:
-            raise HTTPException(
-                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Data subject with key {data_subject.fides_key} or name {data_subject.name} already exists.",
-            )
-    return DataSubjectDbModel.create(db=db, data=data_subject.model_dump(mode="json"))
+        return DataSubjectDbModel.create(
+            db=db, data=data_subject.model_dump(mode="json")
+        )
+    except KeyOrNameAlreadyExists:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Data subject with key {data_subject.fides_key} or name {data_subject.name} already exists.",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Error creating data subject: {e}",
+        )
 
 
 GENERIC_OVERRIDES_ROUTER = APIRouter()

--- a/src/fides/api/schemas/taxonomy_extensions.py
+++ b/src/fides/api/schemas/taxonomy_extensions.py
@@ -8,6 +8,7 @@ from fideslang.models import DataCategory as BaseDataCategory
 from fideslang.models import DataSubject as BaseDataSubject
 from fideslang.models import DataSubjectRights
 from fideslang.models import DataUse as BaseDataUse
+from fideslang.models import DefaultModel
 from fideslang.validation import FidesKey
 from pydantic import BaseModel, Field
 
@@ -28,12 +29,11 @@ class DataSubject(BaseDataSubject):
     active: bool = active_field
 
 
-class TaxonomyCreateBase(BaseModel):
+class TaxonomyCreateBase(DefaultModel, BaseModel):
     name: Optional[str] = None
     description: str
     active: bool = True
     fides_key: Optional[FidesKey] = None
-    is_default: bool = False
     tags: Optional[List[str]] = None
     organization_fides_key: Optional[FidesKey] = "default_organization"
 

--- a/tests/ops/api/v1/endpoints/test_taxonomy_overrides.py
+++ b/tests/ops/api/v1/endpoints/test_taxonomy_overrides.py
@@ -69,7 +69,7 @@ class TestCreateDataUse:
         response = api_client.post(url, headers=auth_header, json=payload)
         assert 403 == response.status_code
 
-    def test_create_data_use_with_fides_key(
+    def test_create_data_use_with_fides_key_and_parent_key(
         self,
         db: Session,
         api_client: TestClient,
@@ -78,14 +78,15 @@ class TestCreateDataUse:
         generate_auth_header,
     ):
         auth_header = generate_auth_header([DATA_USE_CREATE])
-        payload["fides_key"] = "test_data_use"
+        payload["fides_key"] = "analytics.test_data_use"
+        payload["parent_key"] = "analytics"
         response = api_client.post(url, headers=auth_header, json=payload)
 
         assert 201 == response.status_code
         response_body = json.loads(response.text)
 
-        assert response_body["fides_key"] == "test_data_use"
-        data_use = db.query(DataUse).filter_by(fides_key="test_data_use")[0]
+        assert response_body["fides_key"] == "analytics.test_data_use"
+        data_use = db.query(DataUse).filter_by(fides_key="analytics.test_data_use")[0]
         data_use.delete(db)
 
     def test_create_data_use_with_no_fides_key(
@@ -104,6 +105,25 @@ class TestCreateDataUse:
 
         assert response_body["fides_key"] == "test_data_use"
         data_use = db.query(DataUse).filter_by(fides_key="test_data_use")[0]
+        data_use.delete(db)
+
+    def test_create_data_use_with_no_fides_key_and_has_parent_key(
+        self,
+        db: Session,
+        api_client: TestClient,
+        payload,
+        url,
+        generate_auth_header,
+    ):
+        auth_header = generate_auth_header([DATA_USE_CREATE])
+        payload["parent_key"] = "analytics"
+        response = api_client.post(url, headers=auth_header, json=payload)
+
+        assert 201 == response.status_code
+        response_body = json.loads(response.text)
+
+        assert response_body["fides_key"] == "analytics.test_data_use"
+        data_use = db.query(DataUse).filter_by(fides_key="analytics.test_data_use")[0]
         data_use.delete(db)
 
     def test_create_data_use_with_conflicting_key(

--- a/tests/ops/api/v1/endpoints/test_taxonomy_overrides.py
+++ b/tests/ops/api/v1/endpoints/test_taxonomy_overrides.py
@@ -89,6 +89,21 @@ class TestCreateDataUse:
         data_use = db.query(DataUse).filter_by(fides_key="analytics.test_data_use")[0]
         data_use.delete(db)
 
+    def test_create_data_use_with_fides_key_and_non_matching_parent_key(
+        self,
+        db: Session,
+        api_client: TestClient,
+        payload,
+        url,
+        generate_auth_header,
+    ):
+        payload["fides_key"] = "analytics.test_data_use"
+        payload["parent_key"] = "invalid_parent"
+        auth_header = generate_auth_header([DATA_USE_CREATE])
+        response = api_client.post(url, headers=auth_header, json=payload)
+
+        assert 422 == response.status_code
+
     def test_create_data_use_with_no_fides_key(
         self,
         db: Session,


### PR DESCRIPTION
Closes https://github.com/ethyca/fides/pull/new/LA-168

### Description Of Changes

Adds support for taxonomy creation specifying a parent key while not specifying a fides key.

If parent_key is provided, fides_key must contain that parent_key. e.g. parent_key = `user`, and fides_key must start with `user.`

If parent_key is not provided, fides_key is generated as usual, with no prefix.

### Code Changes

* Updates data category and data use create endpoints to support fides_key generation when parent key is provided.

### Steps to Confirm

1. Use `http://localhost:8080/docs#/DataCategory/Create_api_v1_data_category_post` with the following req body:
```
{
    "version_deprecated": null,
    "replaced_by": null,
    "organization_fides_key": "default_organization",
    "tags": null,
    "name": "new user key",
    "description": "Records of the location of a user.",
    "parent_key": "user",
    "active": true
}
```

Confirm 201 status code.

2. Use `http://localhost:8080/docs#/DataCategory/Create_api_v1_data_category_post` with the following req body:
```
{
    "version_deprecated": null,
    "replaced_by": null,
    "organization_fides_key": "default_organization",
    "tags": null,
    "name": "new key",
     "fides_key": "user.new_key"
    "description": "Records of the location of a user.",
    "parent_key": "user",
    "active": true
}
```

Confirm 201 status code. 

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
