### PR TITLE
LA-170: Remove unnecessary load_file debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The types of changes are:
 ### Developer Experience
 - Migrated remaining instances of Chakra's Select component to use Ant's Select component [#5502](https://github.com/ethyca/fides/pull/5502)
 
+### Removed
+- Removed unnecessary debug logging from the load_file config helper [#5544](https://github.com/ethyca/fides/pull/5544)
 
 
 ## [2.50.0](https://github.com/ethyca/fides/compare/2.49.1...2.50.0)

--- a/src/fides/config/helpers.py
+++ b/src/fides/config/helpers.py
@@ -42,7 +42,6 @@ def load_file(file_names: Union[List[Path], List[str]]) -> str:
         for file_name in file_names:
             possible_location = os.path.join(dir_str, file_name)
             if possible_location and os.path.isfile(possible_location):
-                logger.debug("Loading file {} from {}", file_name, dir_str)
                 return possible_location
 
     raise FileNotFoundError

--- a/src/fides/config/helpers.py
+++ b/src/fides/config/helpers.py
@@ -7,7 +7,6 @@ from re import compile as regex
 from typing import Any, Dict, List, Union
 
 from click import echo
-from loguru import logger
 from toml import dump, load
 
 DEFAULT_CONFIG_PATH = ".fides/fides.toml"


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/LA-170

### Description Of Changes

Remove unnecessary load_file debug logs

### Code Changes

* Remove log line

### Steps to Confirm

1.  run `nox -s dev`
2. Confirm no log lines like the following: 
```
fides  | 2024-11-26 16:22:10.859 | DEBUG    | fides.config.helpers:load_file:45 - Loading file /fides/src/fides/api/models/../../data/location/locations.yml from /fides/.fides/fides.toml
fides  | 2024-11-26 16:22:11.300 | DEBUG    | fides.config.helpers:load_file:45 - Loading file /fides/src/fides/api/models/../../data/location/locations.yml from /fides/.fides/fides.toml
fides  | 2024-11-26 16:22:11.425 | DEBUG    | fides.config.helpers:load_file:45 - Loading file /fides/src/fides/api/schemas/../../data/language/languages.yml from /fides/.fides/fides.toml
```

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
