### PR TITLE
FIDES-1606: Change BlueConic Consent Behavior

### DIFF
--- a/clients/fides-js/__tests__/integrations/blueconic.test.ts
+++ b/clients/fides-js/__tests__/integrations/blueconic.test.ts
@@ -1,5 +1,3 @@
-import { addSyntheticLeadingComment } from "typescript";
-
 import { FidesGlobal } from "../../src/fides";
 import { blueconic } from "../../src/integrations/blueconic";
 import { MARKETING_CONSENT_KEYS } from "../../src/lib/consent-constants";

--- a/clients/fides-js/__tests__/integrations/blueconic.test.ts
+++ b/clients/fides-js/__tests__/integrations/blueconic.test.ts
@@ -35,6 +35,12 @@ const setupFidesWithConsent = (key: string, optInStatus: boolean) => {
   } as any as FidesGlobal;
 };
 
+const setupFidesWithoutConsent = () => {
+  window.Fides = {
+    consent: {},
+  } as any as FidesGlobal;
+};
+
 describe("blueconic", () => {
   afterEach(() => {
     window.blueConicClient = undefined;
@@ -56,6 +62,22 @@ describe("blueconic", () => {
     expect(
       window.blueConicClient?.profile?.updateProfile,
     ).not.toHaveBeenCalled();
+  });
+
+  test("when fides configures no consent, blueconic sets consent for all purposes", () => {
+    const { client, mockProfile } = setupBlueConicClient();
+    setupFidesWithoutConsent();
+
+    blueconic();
+
+    expect(mockProfile.setConsentedObjectives).toHaveBeenCalledWith([
+      "iab_purpose_1",
+      "iab_purpose_2",
+      "iab_purpose_3",
+      "iab_purpose_4",
+    ]);
+    expect(mockProfile.setRefusedObjectives).toHaveBeenCalledWith([]);
+    expect(client.profile.updateProfile).toHaveBeenCalled();
   });
 
   describe.each(MARKETING_CONSENT_KEYS)(

--- a/clients/fides-js/__tests__/integrations/blueconic.test.ts
+++ b/clients/fides-js/__tests__/integrations/blueconic.test.ts
@@ -1,3 +1,5 @@
+import { addSyntheticLeadingComment } from "typescript";
+
 import { FidesGlobal } from "../../src/fides";
 import { blueconic } from "../../src/integrations/blueconic";
 import { MARKETING_CONSENT_KEYS } from "../../src/lib/consent-constants";
@@ -48,8 +50,74 @@ describe("blueconic", () => {
     jest.resetAllMocks();
   });
 
-  test("that other modes are not supported", () => {
-    expect(() => blueconic({ approach: "other mode" as "onetrust" })).toThrow();
+  describe("approaches", () => {
+    test("that other approaches are not supported", () => {
+      expect(() =>
+        blueconic({ approach: "other mode" as "onetrust" }),
+      ).toThrow();
+    });
+
+    describe.each([undefined, "onetrust"] as const)(
+      "onetrust approach",
+      (approach) => {
+        test("when fides configures no consent, blueconic sets consent for all purposes", () => {
+          const { client, mockProfile } = setupBlueConicClient();
+          setupFidesWithoutConsent();
+
+          blueconic({ approach });
+
+          expect(mockProfile.setConsentedObjectives).toHaveBeenCalledWith([
+            "iab_purpose_1",
+            "iab_purpose_2",
+            "iab_purpose_3",
+            "iab_purpose_4",
+          ]);
+          expect(mockProfile.setRefusedObjectives).toHaveBeenCalledWith([]);
+          expect(client.profile.updateProfile).toHaveBeenCalled();
+        });
+
+        describe.each(MARKETING_CONSENT_KEYS)(
+          "when consent is set via the %s key",
+          (key) => {
+            test.each([
+              [
+                "opted in",
+                true,
+                [
+                  "iab_purpose_1",
+                  "iab_purpose_2",
+                  "iab_purpose_3",
+                  "iab_purpose_4",
+                ],
+                [],
+              ],
+              [
+                "opted out",
+                false,
+                ["iab_purpose_1"],
+                ["iab_purpose_2", "iab_purpose_3", "iab_purpose_4"],
+              ],
+            ])(
+              "that a user who has %s gets the correct consented and refused objectives",
+              (_, optInStatus, consented, refused) => {
+                const { client, mockProfile } = setupBlueConicClient();
+                setupFidesWithConsent(key, optInStatus);
+
+                blueconic();
+
+                expect(mockProfile.setConsentedObjectives).toHaveBeenCalledWith(
+                  consented,
+                );
+                expect(mockProfile.setRefusedObjectives).toHaveBeenCalledWith(
+                  refused,
+                );
+                expect(client.profile.updateProfile).toHaveBeenCalled();
+              },
+            );
+          },
+        );
+      },
+    );
   });
 
   test("that nothing happens when blueconic and fides are not initialized", () => {
@@ -63,58 +131,6 @@ describe("blueconic", () => {
       window.blueConicClient?.profile?.updateProfile,
     ).not.toHaveBeenCalled();
   });
-
-  test("when fides configures no consent, blueconic sets consent for all purposes", () => {
-    const { client, mockProfile } = setupBlueConicClient();
-    setupFidesWithoutConsent();
-
-    blueconic();
-
-    expect(mockProfile.setConsentedObjectives).toHaveBeenCalledWith([
-      "iab_purpose_1",
-      "iab_purpose_2",
-      "iab_purpose_3",
-      "iab_purpose_4",
-    ]);
-    expect(mockProfile.setRefusedObjectives).toHaveBeenCalledWith([]);
-    expect(client.profile.updateProfile).toHaveBeenCalled();
-  });
-
-  describe.each(MARKETING_CONSENT_KEYS)(
-    "when consent is set via the %s key",
-    (key) => {
-      test.each([
-        [
-          "opted in",
-          true,
-          ["iab_purpose_1", "iab_purpose_2", "iab_purpose_3", "iab_purpose_4"],
-          [],
-        ],
-        [
-          "opted out",
-          false,
-          ["iab_purpose_1"],
-          ["iab_purpose_2", "iab_purpose_3", "iab_purpose_4"],
-        ],
-      ])(
-        "that a user who has %s gets the correct consented and refused objectives",
-        (_, optInStatus, consented, refused) => {
-          const { client, mockProfile } = setupBlueConicClient();
-          setupFidesWithConsent(key, optInStatus);
-
-          blueconic();
-
-          expect(mockProfile.setConsentedObjectives).toHaveBeenCalledWith(
-            consented,
-          );
-          expect(mockProfile.setRefusedObjectives).toHaveBeenCalledWith(
-            refused,
-          );
-          expect(client.profile.updateProfile).toHaveBeenCalled();
-        },
-      );
-    },
-  );
 
   test.each(["FidesInitialized", "FidesUpdated", "onBlueConicLoaded"])(
     "that %s event can cause objectives to be set",

--- a/clients/fides-js/src/integrations/blueconic.ts
+++ b/clients/fides-js/src/integrations/blueconic.ts
@@ -29,9 +29,12 @@ const configureObjectives = () => {
   }
 
   const profile = window.blueConicClient?.profile?.getProfile();
+
   const { consent } = window.Fides;
+  const hasConsentFlags =
+    consent !== undefined && Object.entries(consent).length > 0;
   const optedIn = MARKETING_CONSENT_KEYS.some((key) => consent[key]);
-  if (optedIn) {
+  if (!hasConsentFlags || optedIn) {
     profile.setConsentedObjectives([
       "iab_purpose_1",
       "iab_purpose_2",

--- a/clients/fides-js/src/integrations/blueconic.ts
+++ b/clients/fides-js/src/integrations/blueconic.ts
@@ -55,7 +55,9 @@ const configureObjectives = () => {
 };
 
 export const blueconic = (
-  { approach }: { approach: "onetrust" } = { approach: "onetrust" },
+  { approach = "onetrust" }: { approach: "onetrust" | undefined } = {
+    approach: "onetrust",
+  },
 ) => {
   if (approach !== "onetrust") {
     throw new Error("Unsupported approach");


### PR DESCRIPTION
Set Consented Objects to all if Fides detects that a user is in a region with no consent preferences.

Closes [FIDES-1606]

### Description Of Changes

Update BlueConic integration to communicate that objectives are consented to when Fides detects that the user is in a state with no consent options.

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[FIDES-1606]: https://ethyca.atlassian.net/browse/FIDES-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ