### PR TITLE
LA-171: adds column for action type in event logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.50.0...main)
 
+### Added
+- Added new column for Action Type in privacy request event logs [#5546](https://github.com/ethyca/fides/pull/5546)
+
 ### Changed
 - Adding hashes to system tab URLs [#5535](https://github.com/ethyca/fides/pull/5535)
 

--- a/clients/admin-ui/src/features/privacy-requests/events-and-logs/EventLog.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/events-and-logs/EventLog.tsx
@@ -11,11 +11,28 @@ import {
   Tr,
 } from "fidesui";
 import { ExecutionLog, ExecutionLogStatus } from "privacy-requests/types";
+import {ActionType} from "~/types/api";
 
 type EventDetailsProps = {
   eventLogs: ExecutionLog[];
   openErrorPanel: (message: string) => void;
 };
+
+
+const actionTypeToLabel = (actionType: string) => {
+  switch (actionType) {
+    case ActionType.ACCESS:
+      return "Data Retrieval";
+    case ActionType.ERASURE:
+      return "Data Deletion";
+    case ActionType.CONSENT:
+      return "Consent";
+    case ActionType.UPDATE:
+      return "Data Update";
+    default:
+      return actionType;
+  }
+}
 
 const EventLog = ({ eventLogs, openErrorPanel }: EventDetailsProps) => {
   const tableItems = eventLogs?.map((detail) => (
@@ -38,6 +55,11 @@ const EventLog = ({ eventLogs, openErrorPanel }: EventDetailsProps) => {
       <Td>
         <Text color="gray.600" fontSize="xs" lineHeight="4" fontWeight="medium">
           {formatDate(detail.updated_at)}
+        </Text>
+      </Td>
+      <Td>
+        <Text color="gray.600" fontSize="xs" lineHeight="4" fontWeight="medium">
+          {actionTypeToLabel(detail.action_type)}
         </Text>
       </Td>
       <Td>
@@ -77,6 +99,16 @@ const EventLog = ({ eventLogs, openErrorPanel }: EventDetailsProps) => {
                   fontWeight="medium"
                 >
                   Time
+                </Text>
+              </Th>
+              <Th>
+                <Text
+                  color="black"
+                  fontSize="xs"
+                  lineHeight="4"
+                  fontWeight="medium"
+                >
+                  Action Type
                 </Text>
               </Th>
               <Th>

--- a/clients/admin-ui/src/features/privacy-requests/events-and-logs/EventLog.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/events-and-logs/EventLog.tsx
@@ -11,6 +11,7 @@ import {
   Tr,
 } from "fidesui";
 import { ExecutionLog, ExecutionLogStatus } from "privacy-requests/types";
+
 import { ActionType } from "~/types/api";
 
 type EventDetailsProps = {

--- a/clients/admin-ui/src/features/privacy-requests/events-and-logs/EventLog.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/events-and-logs/EventLog.tsx
@@ -11,13 +11,12 @@ import {
   Tr,
 } from "fidesui";
 import { ExecutionLog, ExecutionLogStatus } from "privacy-requests/types";
-import {ActionType} from "~/types/api";
+import { ActionType } from "~/types/api";
 
 type EventDetailsProps = {
   eventLogs: ExecutionLog[];
   openErrorPanel: (message: string) => void;
 };
-
 
 const actionTypeToLabel = (actionType: string) => {
   switch (actionType) {
@@ -32,7 +31,7 @@ const actionTypeToLabel = (actionType: string) => {
     default:
       return actionType;
   }
-}
+};
 
 const EventLog = ({ eventLogs, openErrorPanel }: EventDetailsProps) => {
   const tableItems = eventLogs?.map((detail) => (


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/LA-171

### Description Of Changes

Adds column for action type in event logs of privacy requests. Helps distinguish data retrieval vs data deletion as part of an erasure request

### Code Changes

* Add column for action type

### Steps to Confirm

1. Create a deletion request in the privacy center
2. Nav to admin-UI and see that there is a new column for "Action Type"
<img width="1189" alt="Screenshot 2024-11-27 at 4 28 04 PM" src="https://github.com/user-attachments/assets/1929049d-57d0-40c2-b1af-2aa49b69d50e">


### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
