### PR TITLE
Remove engine reuse

### DIFF
--- a/src/fides/api/schemas/saas/strategy_configuration.py
+++ b/src/fides/api/schemas/saas/strategy_configuration.py
@@ -63,6 +63,7 @@ class LinkPaginationConfiguration(StrategyConfiguration):
     source: LinkSource
     rel: Optional[str] = None
     path: Optional[str] = None
+    has_next: Optional[str] = None
 
     @model_validator(mode="before")
     @classmethod

--- a/src/fides/api/service/pagination/pagination_strategy_link.py
+++ b/src/fides/api/service/pagination/pagination_strategy_link.py
@@ -23,6 +23,7 @@ class LinkPaginationStrategy(PaginationStrategy):
         self.source = configuration.source
         self.rel = configuration.rel
         self.path = configuration.path
+        self.has_next = configuration.has_next
 
     def get_next_request(
         self,
@@ -39,6 +40,12 @@ class LinkPaginationStrategy(PaginationStrategy):
         )
         if not response_data:
             return None
+
+        if self.has_next:
+            has_next = pydash.get(response.json(), self.has_next)
+            logger.info(f"The {self.has_next} field has a value of {has_next}")
+            if str(has_next).lower() != "true":
+                return None
 
         # read the next_link from the correct location based on the source value
         next_link = None

--- a/src/fides/api/task/execute_request_tasks.py
+++ b/src/fides/api/task/execute_request_tasks.py
@@ -193,7 +193,6 @@ def queue_downstream_tasks_with_retries(
     privacy_request_proceed: bool,
 ) -> None:
     with database_task.get_new_session() as session:
-        logger.info(f"Session ID - queue_downstream_tasks_with_retries: {id(session)}")
         privacy_request, request_task = get_privacy_request_and_task(
             session, privacy_request_id, privacy_request_task_id
         )
@@ -262,7 +261,6 @@ def run_access_node(
     """Run an individual task in the access graph for DSR 3.0 and queue downstream nodes
     upon completion if applicable"""
     with self.get_new_session() as session:
-        logger.info(f"Session ID - Start of run_access_node: {id(session)}")
         privacy_request, request_task, upstream_results = run_prerequisite_task_checks(
             session, privacy_request_id, privacy_request_task_id
         )

--- a/src/fides/api/tasks/__init__.py
+++ b/src/fides/api/tasks/__init__.py
@@ -65,6 +65,7 @@ class DatabaseTask(Task):  # pylint: disable=W0223
             keepalives_count=CONFIG.database.task_engine_keepalives_count,
             disable_pooling=True,
         )
+        logger.info(f"Engine ID: {id(engine)}")
 
         return get_db_session(
             config=CONFIG,

--- a/src/fides/api/tasks/__init__.py
+++ b/src/fides/api/tasks/__init__.py
@@ -2,6 +2,7 @@ from typing import Any, ContextManager, Dict, List, Optional
 
 from celery import Celery, Task
 from loguru import logger
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 from tenacity import (
@@ -54,30 +55,21 @@ class DatabaseTask(Task):  # pylint: disable=W0223
     )
     def get_new_session(self) -> ContextManager[Session]:
         """
-        Creates a new Session to be used for each task invocation.
-
-        The new Sessions will reuse a shared `Engine` and `sessionmaker`
-        across invocations, so as to reuse db connection resources.
+        Creates a new Session using a new Engine.
         """
-        # only one engine will be instantiated in a given task scope, i.e
-        # once per celery process.
-        if self._task_engine is None:
-            self._task_engine = get_db_engine(
-                config=CONFIG,
-                keepalives_idle=CONFIG.database.task_engine_keepalives_idle,
-                keepalives_interval=CONFIG.database.task_engine_keepalives_interval,
-                keepalives_count=CONFIG.database.task_engine_keepalives_count,
-                disable_pooling=True,
-            )
 
-        # same for the sessionmaker
-        if self._sessionmaker is None:
-            self._sessionmaker = get_db_session(config=CONFIG, engine=self._task_engine)
+        engine: Engine = get_db_engine(
+            config=CONFIG,
+            keepalives_idle=CONFIG.database.task_engine_keepalives_idle,
+            keepalives_interval=CONFIG.database.task_engine_keepalives_interval,
+            keepalives_count=CONFIG.database.task_engine_keepalives_count,
+            disable_pooling=True,
+        )
 
-        # but a new session is instantiated each time the method is invoked
-        # to prevent session overlap when requests are executing concurrently
-        # when in task_always_eager mode (i.e. without proper workers)
-        return self._sessionmaker()
+        return get_db_session(
+            config=CONFIG,
+            engine=engine,
+        )()
 
 
 def _create_celery(config: FidesConfig = CONFIG) -> Celery:

--- a/tests/ops/service/pagination/test_pagination_strategy_link.py
+++ b/tests/ops/service/pagination/test_pagination_strategy_link.py
@@ -49,6 +49,42 @@ def response_with_empty_string_link():
     return response
 
 
+@pytest.fixture(scope="function")
+def response_with_has_next_conditional_true():
+    response = Response()
+    response._content = bytes(
+        json.dumps(
+            {
+                "customers": [{"id": 1}, {"id": 2}, {"id": 3}],
+                "links": {
+                    "next": "https://domain.com/customers?page=def",
+                    "hasNext": True,
+                },
+            }
+        ),
+        "utf-8",
+    )
+    return response
+
+
+@pytest.fixture(scope="function")
+def response_with_has_next_conditional_false():
+    response = Response()
+    response._content = bytes(
+        json.dumps(
+            {
+                "customers": [{"id": 1}, {"id": 2}, {"id": 3}],
+                "links": {
+                    "next": "https://domain.com/customers?page=abc",
+                    "hasNext": False,
+                },
+            }
+        ),
+        "utf-8",
+    )
+    return response
+
+
 def test_link_in_headers(response_with_header_link):
     config = LinkPaginationConfiguration(source="headers", rel="next")
     request_params: SaaSRequestParams = SaaSRequestParams(
@@ -128,6 +164,50 @@ def test_link_in_body_empty_string(response_with_empty_string_link):
     paginator = LinkPaginationStrategy(config)
     next_request: Optional[SaaSRequestParams] = paginator.get_next_request(
         request_params, {}, response_with_empty_string_link, "customers"
+    )
+    assert next_request is None
+
+
+## TODO: Tests for when the link exists but there is a conditional boolean that checks if there is a next page
+def test_link_in_body_with_conditional_boolean_true(
+    response_with_has_next_conditional_true,
+):
+    config = LinkPaginationConfiguration(
+        source="body", path="links.next", has_next="links.hasNext"
+    )
+    request_params: SaaSRequestParams = SaaSRequestParams(
+        method=HTTPMethod.GET,
+        path="/customers",
+        query_params={"page": "abc"},
+    )
+
+    paginator = LinkPaginationStrategy(config)
+    next_request: Optional[SaaSRequestParams] = paginator.get_next_request(
+        request_params, {}, response_with_has_next_conditional_true, "customers"
+    )
+
+    assert next_request == SaaSRequestParams(
+        method=HTTPMethod.GET,
+        path="/customers",
+        query_params={"page": "def"},
+    )
+
+
+def test_link_in_body_with_conditional_boolean_false(
+    response_with_has_next_conditional_false,
+):
+    config = LinkPaginationConfiguration(
+        source="body", path="links.next", has_next="links.hasNext"
+    )
+    request_params: SaaSRequestParams = SaaSRequestParams(
+        method=HTTPMethod.GET,
+        path="/customers",
+        query_params={"page": "abc"},
+    )
+
+    paginator = LinkPaginationStrategy(config)
+    next_request: Optional[SaaSRequestParams] = paginator.get_next_request(
+        request_params, {}, response_with_has_next_conditional_false, "customers"
     )
     assert next_request is None
 


### PR DESCRIPTION
Closes [LA-180](https://ethyca.atlassian.net/browse/LA-180)

### Description Of Changes

### Code Changes

* Updating `DatabaseTask.get_new_session` to use a new `Engine` when creating a new `Session`

### Steps to Confirm

1.  Tests should pass

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LA-180]: https://ethyca.atlassian.net/browse/LA-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ