### PR TITLE
Removing unnecessary integration-external mark

### DIFF
--- a/tests/ops/api/v1/endpoints/test_dataset_test_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_dataset_test_endpoints.py
@@ -194,7 +194,6 @@ class TestDatasetReachability:
         assert set(response.json().keys()) == {"reachable", "details"}
 
 
-@pytest.mark.integration_external
 @pytest.mark.integration_postgres
 class TestDatasetTest:
     @pytest.fixture(scope="function")

--- a/tests/ops/api/v1/endpoints/test_dataset_test_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_dataset_test_endpoints.py
@@ -194,6 +194,7 @@ class TestDatasetReachability:
         assert set(response.json().keys()) == {"reachable", "details"}
 
 
+@pytest.mark.integration
 @pytest.mark.integration_postgres
 class TestDatasetTest:
     @pytest.fixture(scope="function")

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -8364,6 +8364,7 @@ class TestGetAccessResults:
         assert response.status_code == 403
 
 
+@pytest.mark.integration
 @pytest.mark.integration_postgres
 class TestPrivacyRequestFilteredResults:
     @pytest.fixture(scope="function")

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -8364,7 +8364,6 @@ class TestGetAccessResults:
         assert response.status_code == 403
 
 
-@pytest.mark.integration_external
 @pytest.mark.integration_postgres
 class TestPrivacyRequestFilteredResults:
     @pytest.fixture(scope="function")

--- a/tests/ops/service/dataset/test_dataset_service.py
+++ b/tests/ops/service/dataset/test_dataset_service.py
@@ -111,6 +111,7 @@ class TestGetIdentitiesAndReferences:
         assert required_identities == expected_required_identities
 
 
+@pytest.mark.integration
 @pytest.mark.integration_postgres
 class TestRunTestAccessRequest:
     """

--- a/tests/ops/service/dataset/test_dataset_service.py
+++ b/tests/ops/service/dataset/test_dataset_service.py
@@ -111,7 +111,6 @@ class TestGetIdentitiesAndReferences:
         assert required_identities == expected_required_identities
 
 
-@pytest.mark.integration_external
 @pytest.mark.integration_postgres
 class TestRunTestAccessRequest:
     @pytest.mark.usefixtures("postgres_integration_db")

--- a/tests/ops/service/dataset/test_dataset_service.py
+++ b/tests/ops/service/dataset/test_dataset_service.py
@@ -113,6 +113,10 @@ class TestGetIdentitiesAndReferences:
 
 @pytest.mark.integration_postgres
 class TestRunTestAccessRequest:
+    """
+    Run test requests against the postgres_example database
+    """
+
     @pytest.mark.usefixtures("postgres_integration_db")
     def test_run_test_access_request(
         self,


### PR DESCRIPTION
### Description Of Changes

Removes the unnecessary `integration-external` Pytest mark from recently added tests

### Steps to Confirm

1.  CI tests should pass

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
