### PR TITLE
Hj-298 - Fix tests/ctl/core/test_api.py::TestSystemList::test_vendor_deleted_systems test

### DIFF
--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -1669,9 +1669,9 @@ class TestSystemList:
         "vendor_deleted_date, expected_systems_count, show_deleted",
         [
             (datetime.now() - timedelta(days=1), 1, True),
-            (datetime.now() - timedelta(days=1), 0, None),
-            (datetime.now() + timedelta(days=1), 1, None),
-            (None, 1, None),
+            (datetime.now() - timedelta(days=1), 0, False),
+            (datetime.now() + timedelta(days=1), 1, False),
+            (None, 1, False),
         ],
     )
     def test_vendor_deleted_systems(
@@ -1691,13 +1691,13 @@ class TestSystemList:
             url=test_config.cli.server_url,
             headers=test_config.user.auth_header,
             resource_type="system",
-            query_params={"show_deleted": True} if show_deleted else {},
+            query_params={"show_deleted": show_deleted, "size": 50},
         )
 
         assert result.status_code == 200
         result_json = result.json()
 
-        assert len(result_json) == expected_systems_count
+        assert len(result_json["items"]) == expected_systems_count
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #Hj-298

### Description Of Changes

Fix tests/ctl/core/test_api.py::TestSystemList::test_vendor_deleted_systems test

### Code Changes

* Fix tests/ctl/core/test_api.py::TestSystemList::test_vendor_deleted_systems test

### Steps to Confirm

1.  Run the test locally, or check the CI

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
