### PR TITLE
Fix Fides brand link position on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The types of changes are:
 - Updating dataset PUT to allow deleting all datasets [#5524](https://github.com/ethyca/fides/pull/5524)
 - Adds support for fides_key generation when parent_key is provided in Taxonomy create endpoints [#5542](https://github.com/ethyca/fides/pull/5542)
 - An integration will no longer re-enable after saving the connection form [#5555](https://github.com/ethyca/fides/pull/5555)
+- Fixed positioning of Fides brand link in privacy center [#5572](https://github.com/ethyca/fides/pull/5572)
 
 ### Removed
 - Removed unnecessary debug logging from the load_file config helper [#5544](https://github.com/ethyca/fides/pull/5544)

--- a/clients/privacy-center/components/BrandLink.tsx
+++ b/clients/privacy-center/components/BrandLink.tsx
@@ -1,16 +1,32 @@
 import { EthycaLogo, Link, LinkProps } from "fidesui";
 
-const BrandLink = (props: LinkProps) => (
-  <Link
-    fontSize="8px"
-    color="gray.400"
-    isExternal
-    textDecoration="none"
-    _hover={{ textDecoration: "none" }}
-    {...props}
-  >
-    Powered by <EthycaLogo color="minos.500" h="20px" w="31px" />
-  </Link>
-);
+import { useSettings } from "~/features/common/settings.slice";
+
+const BrandLink = ({
+  position = "absolute",
+  right = 6,
+  ...props
+}: LinkProps) => {
+  const { SHOW_BRAND_LINK } = useSettings();
+
+  if (!SHOW_BRAND_LINK) {
+    return null;
+  }
+
+  return (
+    <Link
+      fontSize="8px"
+      color="gray.400"
+      isExternal
+      position={position}
+      right={right}
+      textDecoration="none"
+      _hover={{ textDecoration: "none" }}
+      {...props}
+    >
+      Powered by <EthycaLogo color="minos.500" h="20px" w="31px" />
+    </Link>
+  );
+};
 
 export default BrandLink;

--- a/clients/privacy-center/components/Layout.tsx
+++ b/clients/privacy-center/components/Layout.tsx
@@ -2,16 +2,13 @@ import { Flex } from "fidesui";
 import Head from "next/head";
 import React, { ReactNode } from "react";
 
-import BrandLink from "~/components/BrandLink";
 import Logo from "~/components/Logo";
 import { useConfig } from "~/features/common/config.slice";
-import { useSettings } from "~/features/common/settings.slice";
 import { useStyles } from "~/features/common/styles.slice";
 
 const Layout = ({ children }: { children: ReactNode }) => {
   const config = useConfig();
   const styles = useStyles();
-  const { SHOW_BRAND_LINK } = useSettings();
   return (
     <>
       <Head>
@@ -32,17 +29,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
           <Logo src={config.logo_path ?? ""} href={config.logo_url ?? ""} />
         </Flex>
       </header>
-      <div>
-        {children}
-        {SHOW_BRAND_LINK && (
-          <BrandLink
-            position="absolute"
-            bottom={16}
-            right={6}
-            href="https://fid.es/powered"
-          />
-        )}
-      </div>
+      <div>{children}</div>
     </>
   );
 };

--- a/clients/privacy-center/components/consent/ConfigDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/ConfigDrivenConsent.tsx
@@ -14,6 +14,7 @@ import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { inspectForBrowserIdentities } from "~/common/browser-identities";
 import { useLocalStorage } from "~/common/hooks";
 import { ErrorToastOptions, SuccessToastOptions } from "~/common/toast-options";
+import BrandLink from "~/components/BrandLink";
 import { useConfig } from "~/features/common/config.slice";
 import {
   changeConsent,
@@ -209,6 +210,7 @@ const ConfigDrivenConsent = ({
         cancelLabel="Cancel"
         saveLabel="Save"
       />
+      <BrandLink bottom={0} />
     </Stack>
   );
 };

--- a/clients/privacy-center/components/consent/notice-driven/NoticeDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/notice-driven/NoticeDrivenConsent.tsx
@@ -25,6 +25,7 @@ import { inspectForBrowserIdentities } from "~/common/browser-identities";
 import { useLocalStorage } from "~/common/hooks";
 import useI18n from "~/common/hooks/useI18n";
 import { ErrorToastOptions, SuccessToastOptions } from "~/common/toast-options";
+import BrandLink from "~/components/BrandLink";
 import { useProperty } from "~/features/common/property.slice";
 import {
   selectPrivacyExperience,
@@ -400,7 +401,10 @@ const NoticeDrivenConsent = ({ base64Cookie }: { base64Cookie: boolean }) => {
         onCancel={handleCancel}
         justifyContent="center"
       />
-      <PrivacyPolicyLink alignSelf="center" experience={experience} />
+      <Stack flexDirection="row" alignItems="center">
+        <PrivacyPolicyLink experience={experience} />
+        <BrandLink />
+      </Stack>
     </Box>
   );
 };

--- a/clients/privacy-center/pages/index.tsx
+++ b/clients/privacy-center/pages/index.tsx
@@ -13,6 +13,7 @@ import React, { useEffect, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { ConfigErrorToastOptions } from "~/common/toast-options";
+import BrandLink from "~/components/BrandLink";
 import ConsentCard from "~/components/consent/ConsentCard";
 import {
   ConsentRequestModal,
@@ -25,7 +26,10 @@ import {
 } from "~/components/modals/privacy-request-modal/PrivacyRequestModal";
 import PrivacyCard from "~/components/PrivacyCard";
 import { useConfig } from "~/features/common/config.slice";
-import { selectIsNoticeDriven } from "~/features/common/settings.slice";
+import {
+  selectIsNoticeDriven,
+  useSettings,
+} from "~/features/common/settings.slice";
 import {
   clearLocation,
   selectPrivacyExperience,
@@ -67,6 +71,10 @@ const Home: NextPage = () => {
   } = useConsentRequestModal();
   let isConsentModalOpen = isConsentModalOpenConst;
   const getIdVerificationConfigQuery = useGetIdVerificationConfigQuery();
+
+  const { SHOW_BRAND_LINK } = useSettings();
+  const showPrivacyPolicyLink =
+    !!config.privacy_policy_url && !!config.privacy_policy_url_text;
 
   // Subscribe to experiences just to see if there are any notices.
   // The subscription automatically handles skipping if overlay is not enabled
@@ -214,19 +222,25 @@ const Home: NextPage = () => {
             {paragraph}
           </Text>
         ))}
-        {config.privacy_policy_url && config.privacy_policy_url_text ? (
-          <Link
-            fontSize={["small", "medium"]}
-            fontWeight="medium"
-            textAlign="center"
-            textDecoration="underline"
-            color="gray.600"
-            href={config.privacy_policy_url}
-            isExternal
-          >
-            {config.privacy_policy_url_text}
-          </Link>
-        ) : null}
+
+        {(SHOW_BRAND_LINK || showPrivacyPolicyLink) && (
+          <Stack flexDirection="row">
+            {showPrivacyPolicyLink && (
+              <Link
+                fontSize={["small", "medium"]}
+                fontWeight="medium"
+                textAlign="center"
+                textDecoration="underline"
+                color="gray.600"
+                href={config.privacy_policy_url!}
+                isExternal
+              >
+                {config.privacy_policy_url_text}
+              </Link>
+            )}
+            <BrandLink />
+          </Stack>
+        )}
       </Stack>
       <PrivacyRequestModal
         isOpen={isPrivacyModalOpen}


### PR DESCRIPTION
Closes HJ-299

### Description Of Changes

Fixes Fides brand link sometimes overlapping page content on small screens.  Issue was caused by absolute positioning offsetting from the bottom, but the location of the bottom of the container is positioned differently depending on whether a privacy policy link is present.

![Screenshot 2024-12-06 at 11 41 36](https://github.com/user-attachments/assets/9cb61237-d949-4f9e-aee3-a7002a1fa980)

To fix, removes the BrandLink component from the universal Layout (calculating vertical position is tricky since it varies depending on page size and contents) and puts it in page content along with the privacy policy link when present.

### Code Changes

* Moved BrandLink from Layout component to be part of page content on all pages
* Refactors to BrandLink to move commonly-used props inside the component

### Steps to Confirm

1.  View privacy center homepage and consent page at all screen sizes
2. Make sure "powered by Ethyca" link is positioned correctly and doesn't overlap page content

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
