### PR TITLE
Fixing quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ The types of changes are:
 - New page in the Cookie House sample app to demonstrate the use of embedding the FidesJS SDK on the page [#5564](https://github.com/ethyca/fides/pull/5564)
 
 ### Fixed
-- SaaS integrations using `oauth_client_credentials` now properly update their access token when editing the secrets.
-- Saas integrations using `oauth_client_credentials` now properly refresh their access token when the current token expires
+- SaaS integrations using `oauth_client_credentials` now properly update their access token when editing the secrets [#5548](https://github.com/ethyca/fides/pull/5548)
+- Saas integrations using `oauth_client_credentials` now properly refresh their access token when the current token expires [#5569](https://github.com/ethyca/fides/pull/5569)
+- Fixing quickstart.py script [#5585](https://github.com/ethyca/fides/pull/5585)
 
 ## [2.51.0](https://github.com/ethyca/fides/compare/2.50.0...2.51.0)
 

--- a/tests/ops/integration_tests/setup_scripts/postgres_setup.py
+++ b/tests/ops/integration_tests/setup_scripts/postgres_setup.py
@@ -15,6 +15,7 @@ from fides.api.models.connectionconfig import (
 
 # Need to manually import this model because it's used in src/fides/api/models/property.py
 # but that file only imports it conditionally if TYPE_CHECKING is true
+from fides.api.models.detection_discovery import MonitorConfig
 from fides.api.models.experience_notices import ExperienceNotices
 from fides.api.models.privacy_experience import PrivacyExperienceConfig
 from fides.api.service.connectors.sql_connector import PostgreSQLConnector


### PR DESCRIPTION
Closes [LA-206](https://ethyca.atlassian.net/browse/LA-206)

### Description Of Changes

Adding `MonitorConfig` import to `postgres_setup.py` to fix data seeding

### Steps to Confirm

1.  Run `nox -s quickstart` and go through the steps, you should see the access results JSON at the end

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LA-206]: https://ethyca.atlassian.net/browse/LA-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ