### PR TITLE
HJ-300 - Adds fail-fast: false to Safe-Tests build strategy

### DIFF
--- a/noxfiles/setup_tests_nox.py
+++ b/noxfiles/setup_tests_nox.py
@@ -95,7 +95,6 @@ def pytest_ctl(session: Session, mark: str, coverage_arg: str) -> None:
             "pytest",
             coverage_arg,
             "tests/ctl/",
-            "-x",
             "-m",
             mark,
         )

--- a/tests/ctl/api/test_seed.py
+++ b/tests/ctl/api/test_seed.py
@@ -85,7 +85,6 @@ def parent_server_config_password_only():
 class TestFilterDataCategories:
     def test_filter_data_categories_excluded(self) -> None:
         """Test that the filter method works as intended"""
-        assert False  # Intentional failure to test CI/CD
         excluded_data_categories = [
             "user.financial",
             "user.payment",


### PR DESCRIPTION
Closes #HJ-300

### Description Of Changes

Adds fail-fast: false to Safe-Tests build strategy

### Code Changes

Adds fail-fast: false to Safe-Tests build strategy to `backend_checks.yml`

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
