### PR TITLE
revert disabling pooling on celery worker tasks

### DIFF
--- a/src/fides/api/tasks/__init__.py
+++ b/src/fides/api/tasks/__init__.py
@@ -64,10 +64,11 @@ class DatabaseTask(Task):  # pylint: disable=W0223
         if self._task_engine is None:
             self._task_engine = get_db_engine(
                 config=CONFIG,
+                pool_size=CONFIG.database.task_engine_pool_size,
+                max_overflow=CONFIG.database.task_engine_max_overflow,
                 keepalives_idle=CONFIG.database.task_engine_keepalives_idle,
                 keepalives_interval=CONFIG.database.task_engine_keepalives_interval,
                 keepalives_count=CONFIG.database.task_engine_keepalives_count,
-                disable_pooling=True,
             )
 
         # same for the sessionmaker

--- a/tests/ops/tasks/test_database_task.py
+++ b/tests/ops/tasks/test_database_task.py
@@ -42,21 +42,6 @@ class TestDatabaseTask:
         mock_maker.side_effect = OperationalError("connection failed", None, None)
         return mock_maker
 
-    @pytest.mark.parametrize(
-        "config_fixture", [None, "mock_config_changed_db_engine_settings"]
-    )
-    def test_get_task_session(self, config_fixture, request):
-        if config_fixture is not None:
-            request.getfixturevalue(
-                config_fixture
-            )  # used to invoke config fixture if provided
-        pool_size = CONFIG.database.task_engine_pool_size
-        max_overflow = CONFIG.database.task_engine_max_overflow
-        t = DatabaseTask()
-        session: Session = t.get_new_session()
-        engine: Engine = session.get_bind()
-        assert isinstance(engine.pool, NullPool)
-
     def test_retry_on_operational_error(self, recovering_session_maker):
         """Test that session creation retries on OperationalError"""
 


### PR DESCRIPTION
Closes HJ-311

### Description Of Changes

Reverts the disabling of connection pooling on celery worker tasks that was introduced by https://github.com/ethyca/fides/pull/5448/files.

We are suspecting (but are not entirely sure) that this is contributing to some DB performance degradation we are noticing on Fides Cloud

### Code Changes

* [x] do not disable connection pooling when instantiating a DB engine on a worker task

### Steps to Confirm

1. [x] we should smoke test for no obvious regressions
2. [x] once complete, we should build a prerelease image and deploy to fides cloud to see if this is effective in mitigating the performance issue we're noticing

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
