### PR TITLE
revert disabling pooling on celery worker tasks (branched off `2.51.1`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 
 ### Added
 - New page in the Cookie House sample app to demonstrate the use of embedding the FidesJS SDK on the page [#5564](https://github.com/ethyca/fides/pull/5564)
+- Adding `dsr_testing_tools_enabled` security setting [#5573](https://github.com/ethyca/fides/pull/5573)
 
 ### Fixed
 - Fixing quickstart.py script [#5585](https://github.com/ethyca/fides/pull/5585)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The types of changes are:
 - Updating dataset PUT to allow deleting all datasets [#5524](https://github.com/ethyca/fides/pull/5524)
 - Adds support for fides_key generation when parent_key is provided in Taxonomy create endpoints [#5542](https://github.com/ethyca/fides/pull/5542)
 - An integration will no longer re-enable after saving the connection form [#5555](https://github.com/ethyca/fides/pull/5555)
+- Fixed positioning of Fides brand link in privacy center [#5572](https://github.com/ethyca/fides/pull/5572)
 
 ### Removed
 - Removed unnecessary debug logging from the load_file config helper [#5544](https://github.com/ethyca/fides/pull/5544)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,20 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fides/compare/2.51.0...main)
+## [Unreleased](https://github.com/ethyca/fides/compare/2.51.1...main)
 
+### Added
+- New page in the Cookie House sample app to demonstrate the use of embedding the FidesJS SDK on the page [#5564](https://github.com/ethyca/fides/pull/5564)
 
+### Fixed
+- Fixing quickstart.py script [#5585](https://github.com/ethyca/fides/pull/5585)
 
+## [2.51.1](https://github.com/ethyca/fides/compare/2.51.0...2.51.1)
 
+### Fixed
+- SaaS integrations using `oauth_client_credentials` now properly update their access token when editing the secrets. [#5548](https://github.com/ethyca/fides/pull/5548)
+- Saas integrations using `oauth_client_credentials` now properly refresh their access token when the current token expires [#5569](https://github.com/ethyca/fides/pull/5569)
+- Adding `dsr_testing_tools_enabled` security setting [#5573](https://github.com/ethyca/fides/pull/5573)
 
 ## [2.51.0](https://github.com/ethyca/fides/compare/2.50.0...2.51.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ The types of changes are:
 
 ### Added
 - New page in the Cookie House sample app to demonstrate the use of embedding the FidesJS SDK on the page [#5564](https://github.com/ethyca/fides/pull/5564)
-- Adding `dsr_testing_tools_enabled` security setting [#5573](https://github.com/ethyca/fides/pull/5573)
 
 ### Fixed
 - Fixing quickstart.py script [#5585](https://github.com/ethyca/fides/pull/5585)

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -522,11 +522,13 @@ export const ConnectorParametersForm = ({
                     {testButtonLabel}
                   </Button>
                 ) : null}
-                {isPlusEnabled && !_.isEmpty(initialDatasets) && (
-                  <Button onClick={() => onTestDatasetsClick()}>
-                    Test datasets
-                  </Button>
-                )}
+                {isPlusEnabled &&
+                  SystemType.DATABASE === connectionOption.type &&
+                  !_.isEmpty(initialDatasets) && (
+                    <Button onClick={() => onTestDatasetsClick()}>
+                      Test datasets
+                    </Button>
+                  )}
                 {connectionOption.authorization_required && !authorized ? (
                   <Button
                     loading={isAuthorizing}

--- a/clients/privacy-center/components/BrandLink.tsx
+++ b/clients/privacy-center/components/BrandLink.tsx
@@ -1,16 +1,32 @@
 import { EthycaLogo, Link, LinkProps } from "fidesui";
 
-const BrandLink = (props: LinkProps) => (
-  <Link
-    fontSize="8px"
-    color="gray.400"
-    isExternal
-    textDecoration="none"
-    _hover={{ textDecoration: "none" }}
-    {...props}
-  >
-    Powered by <EthycaLogo color="minos.500" h="20px" w="31px" />
-  </Link>
-);
+import { useSettings } from "~/features/common/settings.slice";
+
+const BrandLink = ({
+  position = "absolute",
+  right = 6,
+  ...props
+}: LinkProps) => {
+  const { SHOW_BRAND_LINK } = useSettings();
+
+  if (!SHOW_BRAND_LINK) {
+    return null;
+  }
+
+  return (
+    <Link
+      fontSize="8px"
+      color="gray.400"
+      isExternal
+      position={position}
+      right={right}
+      textDecoration="none"
+      _hover={{ textDecoration: "none" }}
+      {...props}
+    >
+      Powered by <EthycaLogo color="minos.500" h="20px" w="31px" />
+    </Link>
+  );
+};
 
 export default BrandLink;

--- a/clients/privacy-center/components/Layout.tsx
+++ b/clients/privacy-center/components/Layout.tsx
@@ -2,16 +2,13 @@ import { Flex } from "fidesui";
 import Head from "next/head";
 import React, { ReactNode } from "react";
 
-import BrandLink from "~/components/BrandLink";
 import Logo from "~/components/Logo";
 import { useConfig } from "~/features/common/config.slice";
-import { useSettings } from "~/features/common/settings.slice";
 import { useStyles } from "~/features/common/styles.slice";
 
 const Layout = ({ children }: { children: ReactNode }) => {
   const config = useConfig();
   const styles = useStyles();
-  const { SHOW_BRAND_LINK } = useSettings();
   return (
     <>
       <Head>
@@ -32,17 +29,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
           <Logo src={config.logo_path ?? ""} href={config.logo_url ?? ""} />
         </Flex>
       </header>
-      <div>
-        {children}
-        {SHOW_BRAND_LINK && (
-          <BrandLink
-            position="absolute"
-            bottom={16}
-            right={6}
-            href="https://fid.es/powered"
-          />
-        )}
-      </div>
+      <div>{children}</div>
     </>
   );
 };

--- a/clients/privacy-center/components/consent/ConfigDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/ConfigDrivenConsent.tsx
@@ -14,6 +14,7 @@ import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { inspectForBrowserIdentities } from "~/common/browser-identities";
 import { useLocalStorage } from "~/common/hooks";
 import { ErrorToastOptions, SuccessToastOptions } from "~/common/toast-options";
+import BrandLink from "~/components/BrandLink";
 import { useConfig } from "~/features/common/config.slice";
 import {
   changeConsent,
@@ -209,6 +210,7 @@ const ConfigDrivenConsent = ({
         cancelLabel="Cancel"
         saveLabel="Save"
       />
+      <BrandLink bottom={0} />
     </Stack>
   );
 };

--- a/clients/privacy-center/components/consent/notice-driven/NoticeDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/notice-driven/NoticeDrivenConsent.tsx
@@ -25,6 +25,7 @@ import { inspectForBrowserIdentities } from "~/common/browser-identities";
 import { useLocalStorage } from "~/common/hooks";
 import useI18n from "~/common/hooks/useI18n";
 import { ErrorToastOptions, SuccessToastOptions } from "~/common/toast-options";
+import BrandLink from "~/components/BrandLink";
 import { useProperty } from "~/features/common/property.slice";
 import {
   selectPrivacyExperience,
@@ -400,7 +401,10 @@ const NoticeDrivenConsent = ({ base64Cookie }: { base64Cookie: boolean }) => {
         onCancel={handleCancel}
         justifyContent="center"
       />
-      <PrivacyPolicyLink alignSelf="center" experience={experience} />
+      <Stack flexDirection="row" alignItems="center">
+        <PrivacyPolicyLink experience={experience} />
+        <BrandLink />
+      </Stack>
     </Box>
   );
 };

--- a/clients/privacy-center/pages/index.tsx
+++ b/clients/privacy-center/pages/index.tsx
@@ -13,6 +13,7 @@ import React, { useEffect, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { ConfigErrorToastOptions } from "~/common/toast-options";
+import BrandLink from "~/components/BrandLink";
 import ConsentCard from "~/components/consent/ConsentCard";
 import {
   ConsentRequestModal,
@@ -25,7 +26,10 @@ import {
 } from "~/components/modals/privacy-request-modal/PrivacyRequestModal";
 import PrivacyCard from "~/components/PrivacyCard";
 import { useConfig } from "~/features/common/config.slice";
-import { selectIsNoticeDriven } from "~/features/common/settings.slice";
+import {
+  selectIsNoticeDriven,
+  useSettings,
+} from "~/features/common/settings.slice";
 import {
   clearLocation,
   selectPrivacyExperience,
@@ -67,6 +71,10 @@ const Home: NextPage = () => {
   } = useConsentRequestModal();
   let isConsentModalOpen = isConsentModalOpenConst;
   const getIdVerificationConfigQuery = useGetIdVerificationConfigQuery();
+
+  const { SHOW_BRAND_LINK } = useSettings();
+  const showPrivacyPolicyLink =
+    !!config.privacy_policy_url && !!config.privacy_policy_url_text;
 
   // Subscribe to experiences just to see if there are any notices.
   // The subscription automatically handles skipping if overlay is not enabled
@@ -214,19 +222,25 @@ const Home: NextPage = () => {
             {paragraph}
           </Text>
         ))}
-        {config.privacy_policy_url && config.privacy_policy_url_text ? (
-          <Link
-            fontSize={["small", "medium"]}
-            fontWeight="medium"
-            textAlign="center"
-            textDecoration="underline"
-            color="gray.600"
-            href={config.privacy_policy_url}
-            isExternal
-          >
-            {config.privacy_policy_url_text}
-          </Link>
-        ) : null}
+
+        {(SHOW_BRAND_LINK || showPrivacyPolicyLink) && (
+          <Stack flexDirection="row">
+            {showPrivacyPolicyLink && (
+              <Link
+                fontSize={["small", "medium"]}
+                fontWeight="medium"
+                textAlign="center"
+                textDecoration="underline"
+                color="gray.600"
+                href={config.privacy_policy_url!}
+                isExternal
+              >
+                {config.privacy_policy_url_text}
+              </Link>
+            )}
+            <BrandLink />
+          </Stack>
+        )}
       </Stack>
       <PrivacyRequestModal
         isOpen={isPrivacyModalOpen}

--- a/src/fides/api/api/v1/endpoints/dataset_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/dataset_endpoints.py
@@ -21,6 +21,7 @@ from starlette.status import (
     HTTP_200_OK,
     HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
+    HTTP_403_FORBIDDEN,
     HTTP_404_NOT_FOUND,
     HTTP_415_UNSUPPORTED_MEDIA_TYPE,
     HTTP_422_UNPROCESSABLE_ENTITY,
@@ -82,6 +83,7 @@ from fides.common.api.v1.urn_registry import (
     V1_URL_PREFIX,
     YAML_DATASETS,
 )
+from fides.config import CONFIG
 
 from fides.api.models.sql_models import (  # type: ignore[attr-defined] # isort: skip
     Dataset as CtlDataset,
@@ -856,6 +858,13 @@ def test_connection_datasets(
     fides_key: FidesKey,
     unlabeled_identities: UnlabeledIdentities,
 ) -> Dict[str, Any]:
+
+    if not CONFIG.security.dsr_testing_tools_enabled:
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail="DSR testing tools are not enabled.",
+        )
+
     dataset_config = DatasetConfig.filter(
         db=db,
         conditions=(

--- a/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
@@ -2,6 +2,7 @@
 
 import csv
 import io
+import json
 from collections import defaultdict
 from datetime import datetime
 from typing import (
@@ -148,6 +149,7 @@ from fides.api.util.endpoint_utils import validate_start_and_end_filters
 from fides.api.util.enums import ColumnSort
 from fides.api.util.fuzzy_search_utils import get_decrypted_identities_automaton
 from fides.api.util.logger import Pii
+from fides.api.util.storage_util import storage_json_encoder
 from fides.common.api.scope_registry import (
     PRIVACY_REQUEST_CALLBACK_RESUME,
     PRIVACY_REQUEST_CREATE,
@@ -2657,8 +2659,13 @@ def get_test_privacy_request_results(
         )
         privacy_request.save(db=db)
 
+    # Escape datetime and ObjectId values
+    raw_data = privacy_request.get_raw_access_results()
+    escaped_json = json.dumps(raw_data, indent=2, default=storage_json_encoder)
+    escaped_data = json.loads(escaped_json)
+
     return {
         "privacy_request_id": privacy_request.id,
         "status": privacy_request.status,
-        "results": privacy_request.get_raw_access_results(),
+        "results": escaped_data,
     }

--- a/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
@@ -2662,10 +2662,14 @@ def get_test_privacy_request_results(
     # Escape datetime and ObjectId values
     raw_data = privacy_request.get_raw_access_results()
     escaped_json = json.dumps(raw_data, indent=2, default=storage_json_encoder)
-    escaped_data = json.loads(escaped_json)
+    results = json.loads(escaped_json)
 
     return {
         "privacy_request_id": privacy_request.id,
         "status": privacy_request.status,
-        "results": escaped_data,
+        "results": (
+            results
+            if CONFIG.security.dsr_testing_tools_enabled
+            else "DSR testing tools are not enabled, results will not be shown."
+        ),
     }

--- a/src/fides/api/api/v1/endpoints/system.py
+++ b/src/fides/api/api/v1/endpoints/system.py
@@ -19,7 +19,11 @@ from starlette.status import HTTP_200_OK, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUN
 
 from fides.api.api import deps
 from fides.api.api.v1.endpoints.saas_config_endpoints import instantiate_connection
-from fides.api.db.crud import get_resource, get_resource_with_custom_fields
+from fides.api.db.crud import (
+    get_resource,
+    get_resource_with_custom_fields,
+    list_resource,
+)
 from fides.api.db.ctl_session import get_async_db
 from fides.api.db.system import (
     create_system,
@@ -396,6 +400,20 @@ async def ls(  # pylint: disable=invalid-name
     Otherwise all Systems will be returned (this may be a slow operation if there are many systems,
     so using the pagination parameters is recommended).
     """
+    if not (
+        size
+        or page
+        or search
+        or data_uses
+        or data_categories
+        or data_subjects
+        or dnd_relevant
+        or show_hidden
+    ):
+        # if no advanced parameters are passed, we return a very basic list of all System resources
+        # to maintain backward compatibility of the original API, which backs some important client usages, e.g. the fides CLI
+
+        return await list_resource(System, db)
 
     query = select(System)
 
@@ -446,19 +464,6 @@ async def ls(  # pylint: disable=invalid-name
 
     # Add a distinct so we only get one row per system
     duplicates_removed = filtered_query.distinct(System.id)
-
-    if not (
-        size
-        or page
-        or search
-        or data_uses
-        or data_categories
-        or data_subjects
-        or dnd_relevant
-        or show_hidden
-    ):
-        result = await db.execute(duplicates_removed)
-        return result.scalars().all()
 
     return await async_paginate(db, duplicates_removed, pagination_params)
 

--- a/src/fides/api/models/connectionconfig.py
+++ b/src/fides/api/models/connectionconfig.py
@@ -220,10 +220,13 @@ class ConnectionConfig(Base):
             return False
 
         # hard-coding to avoid cyclic dependency
-        if authentication.strategy != "oauth2_authorization_code":
+        if authentication.strategy not in [
+            "oauth2_authorization_code",
+            "oauth2_client_credentials",
+        ]:
             return False
 
-        return bool(self.secrets and self.secrets.get("access_token"))
+        return bool(self.secrets and "access_token" in self.secrets.keys())
 
     @property
     def name_or_key(self) -> str:

--- a/src/fides/api/schemas/privacy_request.py
+++ b/src/fides/api/schemas/privacy_request.py
@@ -401,4 +401,4 @@ class FilteredPrivacyRequestResults(FidesSchema):
 
     privacy_request_id: str
     status: PrivacyRequestStatus
-    results: Dict[str, Any]
+    results: Union[Dict[str, Any], str]

--- a/src/fides/api/service/authentication/authentication_strategy_oauth2_client_credentials.py
+++ b/src/fides/api/service/authentication/authentication_strategy_oauth2_client_credentials.py
@@ -33,3 +33,22 @@ class OAuth2ClientCredentialsAuthenticationStrategy(OAuth2AuthenticationStrategy
         # add access_token to request
         request.headers["Authorization"] = "Bearer " + access_token
         return request
+
+    def _refresh_token(self, connection_config: ConnectionConfig) -> str:
+        """
+        Persists and returns a refreshed access_token if the token is close to expiring.
+        Otherwise just returns the existing access_token.
+
+        For the Client Credentials OAuth flow we reuse the access request to get a new token.
+        """
+
+        expires_at = connection_config.secrets.get("expires_at")  # type: ignore
+        if self._close_to_expiration(expires_at, connection_config):
+            refresh_response = self._call_token_request(
+                "refresh", self.token_request, connection_config
+            )
+            return self._validate_and_store_response(
+                refresh_response, connection_config
+            )
+
+        return connection_config.secrets.get("access_token")  # type: ignore

--- a/src/fides/api/tasks/__init__.py
+++ b/src/fides/api/tasks/__init__.py
@@ -64,10 +64,11 @@ class DatabaseTask(Task):  # pylint: disable=W0223
         if self._task_engine is None:
             self._task_engine = get_db_engine(
                 config=CONFIG,
+                pool_size=CONFIG.database.task_engine_pool_size,
+                max_overflow=CONFIG.database.task_engine_max_overflow,
                 keepalives_idle=CONFIG.database.task_engine_keepalives_idle,
                 keepalives_interval=CONFIG.database.task_engine_keepalives_interval,
                 keepalives_count=CONFIG.database.task_engine_keepalives_count,
-                disable_pooling=True,
             )
 
         # same for the sessionmaker

--- a/src/fides/config/security_settings.py
+++ b/src/fides/config/security_settings.py
@@ -123,6 +123,10 @@ class SecuritySettings(FidesSettings):
         default=False,
         description="If set to True, the user interface will display a download button for subject requests.",
     )
+    dsr_testing_tools_enabled: bool = Field(
+        default=False,
+        description="If set to True, contributor and owner roles will be able to run test privacy requests.",
+    )
     subject_request_download_link_ttl_seconds: int = Field(
         default=432000,
         description="The number of seconds that a pre-signed download URL when using S3 storage will be valid. The default is equal to 5 days.",

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -1669,9 +1669,9 @@ class TestSystemList:
         "vendor_deleted_date, expected_systems_count, show_deleted",
         [
             (datetime.now() - timedelta(days=1), 1, True),
-            (datetime.now() - timedelta(days=1), 0, None),
-            (datetime.now() + timedelta(days=1), 1, None),
-            (None, 1, None),
+            (datetime.now() - timedelta(days=1), 0, False),
+            (datetime.now() + timedelta(days=1), 1, False),
+            (None, 1, False),
         ],
     )
     def test_vendor_deleted_systems(
@@ -1691,13 +1691,13 @@ class TestSystemList:
             url=test_config.cli.server_url,
             headers=test_config.user.auth_header,
             resource_type="system",
-            query_params={"show_deleted": True} if show_deleted else {},
+            query_params={"show_deleted": show_deleted, "size": 50},
         )
 
         assert result.status_code == 200
         result_json = result.json()
 
-        assert len(result_json) == expected_systems_count
+        assert len(result_json["items"]) == expected_systems_count
 
 
 @pytest.mark.unit

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -3403,6 +3403,22 @@ def subject_request_download_ui_enabled():
 
 
 @pytest.fixture(scope="function")
+def dsr_testing_tools_enabled():
+    original_value = CONFIG.security.dsr_testing_tools_enabled
+    CONFIG.security.dsr_testing_tools_enabled = True
+    yield
+    CONFIG.security.dsr_testing_tools_enabled = original_value
+
+
+@pytest.fixture(scope="function")
+def dsr_testing_tools_disabled():
+    original_value = CONFIG.security.dsr_testing_tools_enabled
+    CONFIG.security.dsr_testing_tools_enabled = False
+    yield
+    CONFIG.security.dsr_testing_tools_enabled = original_value
+
+
+@pytest.fixture(scope="function")
 def system_with_no_uses(db: Session) -> Generator[System, None, None]:
     system = System.create(
         db=db,

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -8364,8 +8364,7 @@ class TestGetAccessResults:
         assert response.status_code == 403
 
 
-@pytest.mark.integration_external
-@pytest.mark.integration_postgres
+@pytest.mark.integration
 class TestPrivacyRequestFilteredResults:
     @pytest.fixture(scope="function")
     def default_access_policy(self, db) -> None:
@@ -8427,20 +8426,62 @@ class TestPrivacyRequestFilteredResults:
         )
         assert response.status_code == expected_status
 
+    @pytest.mark.integration_postgres
     @pytest.mark.usefixtures("default_access_policy", "postgres_integration_db")
-    def test_filtered_results(
+    def test_filtered_results_postgres(
         self,
         connection_config,
-        dataset_config,
+        postgres_example_test_dataset_config,
         api_client: TestClient,
         generate_auth_header,
     ) -> None:
-        dataset_url = get_connection_dataset_url(connection_config, dataset_config)
+        dataset_url = get_connection_dataset_url(
+            connection_config, postgres_example_test_dataset_config
+        )
         auth_header = generate_auth_header(scopes=[DATASET_TEST])
         response = api_client.post(
             dataset_url + "/test",
             headers=auth_header,
             json={"email": "jane@example.com"},
+        )
+        assert response.status_code == HTTP_200_OK
+
+        privacy_request_id = response.json()["privacy_request_id"]
+        url = V1_URL_PREFIX + PRIVACY_REQUEST_FILTERED_RESULTS.format(
+            privacy_request_id=privacy_request_id
+        )
+        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_READ_ACCESS_RESULTS])
+        response = api_client.get(
+            url,
+            headers=auth_header,
+        )
+        assert response.status_code == HTTP_200_OK
+        assert set(response.json().keys()) == {
+            "privacy_request_id",
+            "status",
+            "results",
+        }
+
+    @pytest.mark.integration_mongo
+    @pytest.mark.usefixtures("default_access_policy")
+    def test_filtered_results_mongo(
+        self,
+        mongo_connection_config,
+        mongo_dataset_config,
+        api_client: TestClient,
+        generate_auth_header,
+    ) -> None:
+        dataset_url = get_connection_dataset_url(
+            mongo_connection_config, mongo_dataset_config
+        )
+        auth_header = generate_auth_header(scopes=[DATASET_TEST])
+        response = api_client.post(
+            dataset_url + "/test",
+            headers=auth_header,
+            json={
+                "email": "employee-1@example.com",
+                "postgres_example_test_dataset:customer:id": 1,
+            },
         )
         assert response.status_code == HTTP_200_OK
 

--- a/tests/ops/service/authentication/test_authentication_strategy_oauth2_client_credentials.py
+++ b/tests/ops/service/authentication/test_authentication_strategy_oauth2_client_credentials.py
@@ -40,23 +40,7 @@ def oauth2_client_credentials_configuration() -> (
                 {"name": "client_secret", "value": "<client_secret>"},
                 {"name": "grant_type", "value": "client_credentials"},
             ],
-        },
-        "refresh_request": {
-            "method": "POST",
-            "path": "/oauth/token",
-            "headers": [
-                {
-                    "name": "Content-Type",
-                    "value": "application/x-www-form-urlencoded",
-                }
-            ],
-            "query_params": [
-                {"name": "client_id", "value": "<client_id>"},
-                {"name": "client_secret", "value": "<client_secret>"},
-                {"name": "grant_type", "value": "refresh_token"},
-                {"name": "refresh_token", "value": "<refresh_token>"},
-            ],
-        },
+        }
     }
 
 
@@ -69,7 +53,6 @@ def oauth2_client_credentials_connection_config(
         "client_id": "client",
         "client_secret": "secret",
         "access_token": "access",
-        "refresh_token": "refresh",
     }
     saas_config = {
         "fides_key": "oauth2_client_credentials_connector",
@@ -249,7 +232,6 @@ class TestAddAuthentication:
                     "client_id": "client",
                     "client_secret": "secret",
                     "access_token": "new_access",
-                    "refresh_token": "refresh",
                     "expires_at": 0,
                 }
             },
@@ -327,7 +309,6 @@ class TestAccessTokenRequest:
         expires_in = 7200
         mock_send().json.return_value = {
             "access_token": "new_access",
-            "refresh_token": "new_refresh",
             "expires_in": expires_in,
         }
 
@@ -347,7 +328,6 @@ class TestAccessTokenRequest:
                     "client_id": "client",
                     "client_secret": "secret",
                     "access_token": "new_access",
-                    "refresh_token": "new_refresh",
                     "expires_at": int(datetime.utcnow().timestamp()) + expires_in,
                 }
             },
@@ -376,7 +356,6 @@ class TestAccessTokenRequest:
         # mock the json response from calling the access token request
         mock_send().json.return_value = {
             "access_token": "new_access",
-            "refresh_token": "new_refresh",
         }
 
         oauth2_client_credentials_configuration["expires_in"] = 3600
@@ -396,7 +375,6 @@ class TestAccessTokenRequest:
                     "client_id": "client",
                     "client_secret": "secret",
                     "access_token": "new_access",
-                    "refresh_token": "new_refresh",
                     "expires_at": int(datetime.utcnow().timestamp())
                     + oauth2_client_credentials_configuration["expires_in"],
                 }

--- a/tests/ops/tasks/test_database_task.py
+++ b/tests/ops/tasks/test_database_task.py
@@ -42,21 +42,6 @@ class TestDatabaseTask:
         mock_maker.side_effect = OperationalError("connection failed", None, None)
         return mock_maker
 
-    @pytest.mark.parametrize(
-        "config_fixture", [None, "mock_config_changed_db_engine_settings"]
-    )
-    def test_get_task_session(self, config_fixture, request):
-        if config_fixture is not None:
-            request.getfixturevalue(
-                config_fixture
-            )  # used to invoke config fixture if provided
-        pool_size = CONFIG.database.task_engine_pool_size
-        max_overflow = CONFIG.database.task_engine_max_overflow
-        t = DatabaseTask()
-        session: Session = t.get_new_session()
-        engine: Engine = session.get_bind()
-        assert isinstance(engine.pool, NullPool)
-
     def test_retry_on_operational_error(self, recovering_session_maker):
         """Test that session creation retries on OperationalError"""
 


### PR DESCRIPTION
Closes HJ-311

### Description Of Changes

Cherry picking the commit from https://github.com/ethyca/fides/pull/5592 into a branch off `2.51.1` to prep a prerelease image and potential hotfix

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
