### PR TITLE
Ant Select minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The types of changes are:
 ### Fixed
 - Fixing quickstart.py script [#5585](https://github.com/ethyca/fides/pull/5585)
 
+### Changed
+- Adjusted Ant's Select component colors and icon [#5594](https://github.com/ethyca/fides/pull/5594)
+
 ## [2.51.1](https://github.com/ethyca/fides/compare/2.51.0...2.51.1)
 
 ### Fixed

--- a/clients/admin-ui/src/theme/ant.ts
+++ b/clients/admin-ui/src/theme/ant.ts
@@ -51,7 +51,7 @@ export const antTheme: AntThemeConfig = {
       bodyBg: palette.FIDESUI_NEUTRAL_50,
     },
     Select: {
-      optionActiveBg: palette.FIDESUI_SANDSTONE,
+      optionActiveBg: palette.FIDESUI_NEUTRAL_50,
     },
     Tooltip: {
       colorBgSpotlight: palette.FIDESUI_MINOS,

--- a/clients/fidesui/src/hoc/CustomSelect.tsx
+++ b/clients/fidesui/src/hoc/CustomSelect.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from "@carbon/icons-react";
+import { Checkmark, ChevronDown } from "@carbon/icons-react";
 import { Flex, Select, SelectProps, Typography } from "antd/lib";
 import { BaseOptionType, DefaultOptionType } from "antd/lib/select";
 import React from "react";
@@ -37,6 +37,7 @@ const withCustomProps = (WrappedComponent: typeof Select) => {
     optionRender = optionDescriptionRender,
     className = "w-full",
     suffixIcon = <ChevronDown />,
+    menuItemSelectedIcon = <Checkmark />,
     ...props
   }: SelectProps<ValueType, OptionType>) => {
     const customProps = {
@@ -44,6 +45,7 @@ const withCustomProps = (WrappedComponent: typeof Select) => {
       optionRender,
       className,
       suffixIcon,
+      menuItemSelectedIcon,
       "data-testid": `select${props.id ? `-${props.id}` : ""}`,
       ...props,
     };


### PR DESCRIPTION
Closes [HJ-312](https://ethyca.atlassian.net/browse/HJ-312)

### Description Of Changes

- Ant Select component’s hover color is still “Sandstone” but should be “Neutral 50”
- For multiselect/tags mode, the checkmark should be the Carbon icon and not Ant Icon.

### Steps to Confirm

1. In AdminUI, Open any select and hover the options. Hover color should be "Neutral 50" aka "#fafafa" which is slightly lighter than a selected option.
2. Open a "tag" mode select (like the Responsibility field when creating a new System) and make a selection. Note that the check icon is slightly different from Ant's default

**OLD**
<img width="516" alt="old" src="https://github.com/user-attachments/assets/d680694b-5aa4-4a17-bd17-694491f8a22d" />

**NEW**
<img width="516" alt="new" src="https://github.com/user-attachments/assets/a51345c5-da3c-47bd-92a9-ce66e9139f3a" />



### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[HJ-312]: https://ethyca.atlassian.net/browse/HJ-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ