### PR TITLE
Fixing datamap Cypress test

### DIFF
--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -118,10 +118,16 @@ describe("Data map report table", () => {
       cy.getByTestId("save-button").click();
 
       cy.getByTestId("row-0-col-system_undeclared_data_categories").contains(
-        "2 system undeclared data categories",
+        "User Contact Email",
+      );
+      cy.getByTestId("row-0-col-system_undeclared_data_categories").contains(
+        "Cookie ID",
       );
       cy.getByTestId("row-0-col-data_use_undeclared_data_categories").contains(
-        "2 data use undeclared data categories",
+        "User Contact Email",
+      );
+      cy.getByTestId("row-0-col-data_use_undeclared_data_categories").contains(
+        "Cookie ID",
       );
     });
   });


### PR DESCRIPTION
### Description Of Changes

Updating a Cypress test for the datamap report table now that the undeclared data category columns use the new `BadgeCellExpandable` component

### Code Changes

* Updated test

### Steps to Confirm

1.  Cypress tests should pass

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
