### PR TITLE
LA-56 Only trigger dataset save if values have changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The types of changes are:
 
 ### Fixed
 - Fixing quickstart.py script [#5585](https://github.com/ethyca/fides/pull/5585)
+- Removed unnecessary toast when no updates to datasets have been made [#5612](https://github.com/ethyca/fides/pull/5612)
 
 ### Changed
 - Adjusted Ant's Select component colors and icon [#5594](https://github.com/ethyca/fides/pull/5594)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The types of changes are:
 
 ### Fixed
 - Fixing quickstart.py script [#5585](https://github.com/ethyca/fides/pull/5585)
-- Removed unnecessary toast when no updates to datasets have been made [#5612](https://github.com/ethyca/fides/pull/5612)
+- Removed unnecessary double notification when updating database integrations [#5612](https://github.com/ethyca/fides/pull/5612)
 
 ### Changed
 - Adjusted Ant's Select component colors and icon [#5594](https://github.com/ethyca/fides/pull/5594)

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -12,7 +12,6 @@ import {
   DatastoreConnectionSecretsResponse,
 } from "datastore-connections/types";
 import { Box, Flex, Spacer, useToast, UseToastOptions } from "fidesui";
-import { isEqual } from "lodash";
 import router from "next/router";
 import { useMemo, useState } from "react";
 
@@ -291,14 +290,14 @@ export const useConnectorForm = ({
         }
       }
 
-      const hasDatasetArrayChanged = !isEqual(values.dataset, initialDatasets);
       if (
         connectionConfig &&
         values.dataset &&
-        hasDatasetArrayChanged &&
         connectionOption.type === SystemType.DATABASE
       ) {
-        await patchConnectionDatasetConfig(values, connectionConfig.key);
+        await patchConnectionDatasetConfig(values, connectionConfig.key, {
+          showSuccessAlert: false,
+        });
       }
 
       successAlert(

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -12,6 +12,7 @@ import {
   DatastoreConnectionSecretsResponse,
 } from "datastore-connections/types";
 import { Box, Flex, Spacer, useToast, UseToastOptions } from "fidesui";
+import { isEqual } from "lodash";
 import router from "next/router";
 import { useMemo, useState } from "react";
 
@@ -290,9 +291,11 @@ export const useConnectorForm = ({
         }
       }
 
+      const hasDatasetArrayChanged = !isEqual(values.dataset, initialDatasets);
       if (
         connectionConfig &&
         values.dataset &&
+        hasDatasetArrayChanged &&
         connectionOption.type === SystemType.DATABASE
       ) {
         await patchConnectionDatasetConfig(values, connectionConfig.key);

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/useDatasetConfigField.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/useDatasetConfigField.tsx
@@ -50,6 +50,7 @@ export const useDatasetConfigField = ({
   const patchConnectionDatasetConfig = async (
     values: ConnectionConfigFormValues,
     connectionConfigKey: string,
+    { showSuccessAlert = true }: { showSuccessAlert?: boolean } = {},
   ) => {
     const newDatasetPairs: DatasetConfigCtlDataset[] =
       values.dataset?.map((datasetKey) => ({
@@ -65,7 +66,7 @@ export const useDatasetConfigField = ({
     const payload = await putDatasetConfig(params).unwrap();
     if (payload.failed?.length > 0) {
       errorAlert(payload.failed[0].message);
-    } else {
+    } else if (showSuccessAlert) {
       successAlert("Dataset successfully updated!");
     }
   };


### PR DESCRIPTION
### Code Changes

* Added option to patchConnectionDatasetConfig to show/hide success alert (default: true)
* Use option to hide alert when updating datasets from integration screen

### Steps to Confirm

1. Create a system, or open the system page for an existing system 
2. Go to the Integrations tab of the system page 
3. Add a database integration and save it
5. Only one toast should show up saying "Integration successfully added!"
6. Now hit save again 
7. Only one toast should show up saying "Integration successfully updated!"


### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
