### PR TITLE
Hide buttons to add child labels for Data Subjects

### DIFF
--- a/clients/admin-ui/src/features/taxonomy/components/TaxonomyInteractiveTree.tsx
+++ b/clients/admin-ui/src/features/taxonomy/components/TaxonomyInteractiveTree.tsx
@@ -68,6 +68,7 @@ const TaxonomyInteractiveTree = ({
         taxonomyItem: {
           fides_key: TAXONOMY_ROOT_NODE_ID,
         },
+        taxonomyType,
         onTaxonomyItemClick: null,
         onAddButtonClick,
         hasChildren: taxonomyItems.length !== 0,
@@ -90,6 +91,7 @@ const TaxonomyInteractiveTree = ({
       position: { x: 0, y: 0 },
       data: {
         label,
+        taxonomyType,
         taxonomyItem,
         onTaxonomyItemClick,
         onAddButtonClick,

--- a/clients/admin-ui/src/features/taxonomy/components/TaxonomyTreeNode.tsx
+++ b/clients/admin-ui/src/features/taxonomy/components/TaxonomyTreeNode.tsx
@@ -6,7 +6,7 @@ import {
 } from "fidesui";
 import { useCallback, useContext, useEffect } from "react";
 
-import { TAXONOMY_ROOT_NODE_ID } from "../constants";
+import { CoreTaxonomiesEnum, TAXONOMY_ROOT_NODE_ID } from "../constants";
 import {
   TaxonomyTreeHoverContext,
   TreeNodeHoverStatus,
@@ -20,6 +20,7 @@ export type TaxonomyTreeNodeType = Node<
   {
     label: string;
     taxonomyItem?: TaxonomyEntity;
+    taxonomyType: CoreTaxonomiesEnum;
     onTaxonomyItemClick: (taxonomyItem: TaxonomyEntity) => void | null;
     onAddButtonClick: (taxonomyItem: TaxonomyEntity | undefined) => void;
     hasChildren: boolean;
@@ -38,6 +39,7 @@ const TaxonomyTreeNode = ({
     TaxonomyTreeHoverContext,
   );
   const {
+    taxonomyType,
     taxonomyItem,
     onAddButtonClick,
     onTaxonomyItemClick,
@@ -89,6 +91,10 @@ const TaxonomyTreeNode = ({
   }, [nodeHoverStatus]);
 
   const isRootNode = taxonomyItem?.fides_key === TAXONOMY_ROOT_NODE_ID;
+  const isDataSubjectNode = taxonomyType === CoreTaxonomiesEnum.DATA_SUBJECTS;
+
+  // Data subjects don't support child nodes, so we only show the add button for root node
+  const shouldDisplayAddChildButton = !isDataSubjectNode || isRootNode;
 
   return (
     <div
@@ -122,17 +128,19 @@ const TaxonomyTreeNode = ({
         />
       )}
 
-      <div className={styles["add-button-container"]}>
-        <Button
-          type="default"
-          className={`${styles["add-button"]} ${nodeHoverStatus === TreeNodeHoverStatus.ACTIVE_HOVER ? styles["add-button--visible"] : ""}`}
-          icon={<Icons.Add size={20} />}
-          onClick={() => onAddButtonClick?.(taxonomyItem)}
-          size="middle"
-          data-testid="taxonomy-add-child-label-button"
-          aria-label={`Add child label to ${label}`}
-        />
-      </div>
+      {shouldDisplayAddChildButton && (
+        <div className={styles["add-button-container"]}>
+          <Button
+            type="default"
+            className={`${styles["add-button"]} ${nodeHoverStatus === TreeNodeHoverStatus.ACTIVE_HOVER ? styles["add-button--visible"] : ""}`}
+            icon={<Icons.Add size={20} />}
+            onClick={() => onAddButtonClick?.(taxonomyItem)}
+            size="middle"
+            data-testid="taxonomy-add-child-label-button"
+            aria-label={`Add child label to ${label}`}
+          />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION

### Description Of Changes

Data Subjects don't support parent_keys, so we shouldn't allow creating child labels. Hide the buttons to add a new label, except for the root node.

### Code Changes

* Hide the buttons to add a new Data Subject label, except for the root node.

### Steps to Confirm

1.  Go to Taxonomy page
2. Select Data Subject
3. Hover over the labels and confirm the Add button is not there
4. Hover over the root label "Data Subject" and confirm the add button is there and you're able to create a new label

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
