### PR TITLE
LA-225 Datamap-report-page-breaks-if-there-are-no-results

### DIFF
--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -224,7 +224,7 @@ export const DatamapReportTable = () => {
   );
 
   useEffect(() => {
-    if (datamapReport) {
+    if (datamapReport?.items?.length) {
       const columnIDs = Object.keys(datamapReport.items[0]);
       setColumnOrder(getColumnOrder(groupBy, columnIDs));
     }


### PR DESCRIPTION
### Description Of Changes

Fix datamap report breaking when no it has no results

### Code Changes

* Check for datamap results length before accessing element

### Steps to Confirm

1.  Delete all systems
2. Go to Datamap Report page
3. Check that it doesn't break when it doesn't have any results

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
