### PR TITLE
HJ-319 Add cache-clearing methods to DBCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.52.0...main)
 
+### Added
+- Added cache-clearing methods to the `DBCache` model to allow deleting cache entries [#5629](https://github.com/ethyca/fides/pull/5629)
+
 
 
 ## [2.52.0](https://github.com/ethyca/fides/compare/2.51.2...2.52.0)

--- a/src/fides/api/models/db_cache.py
+++ b/src/fides/api/models/db_cache.py
@@ -87,3 +87,41 @@ class DBCache(Base):
         db.commit()
         db.refresh(db_cache_entry)
         return db_cache_entry
+
+    @classmethod
+    def delete_cache_entry(
+        cls,
+        db: Session,
+        namespace: DBCacheNamespace,
+        cache_key: str,
+    ) -> None:
+        """
+        Deletes the cache entry for the given cache_key
+        """
+        db.query(cls).filter(
+            cls.namespace == namespace.value, cls.cache_key == cache_key
+        ).delete()
+        db.commit()
+
+    @classmethod
+    def clear_cache_for_namespace(
+        cls,
+        db: Session,
+        namespace: DBCacheNamespace,
+    ) -> None:
+        """
+        Deletes all cache entries for the given namespace
+        """
+        db.query(cls).filter(cls.namespace == namespace.value).delete()
+        db.commit()
+
+    @classmethod
+    def clear_cache(
+        cls,
+        db: Session,
+    ) -> None:
+        """
+        Deletes all cache entries
+        """
+        db.query(cls).delete()
+        db.commit()

--- a/tests/ops/models/test_dbcache.py
+++ b/tests/ops/models/test_dbcache.py
@@ -1,4 +1,12 @@
+from enum import Enum
+
 from fides.api.models.db_cache import DBCache, DBCacheNamespace
+
+
+# enum used to test extra namespaces since right now DBCacheNamespace only has one value
+# this can be removed once more namespaces are added
+class TestDbCacheNamespace(Enum):
+    TEST_NAMESPACE = "test-namespace"
 
 
 class TestDBCacheModel:
@@ -51,3 +59,179 @@ class TestDBCacheModel:
             db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "some-key"
         )
         assert updated_value.decode() == "value 2"
+
+    def test_delete_cache_entry(self, db):
+        # Add two entries
+        DBCache.set_cache_value(
+            db,
+            DBCacheNamespace.LIST_PRIVACY_EXPERIENCE,
+            "some-key",
+            "value 1".encode(),
+        )
+        DBCache.set_cache_value(
+            db,
+            DBCacheNamespace.LIST_PRIVACY_EXPERIENCE,
+            "some-key-2",
+            "value 2".encode(),
+        )
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "some-key"
+            ).decode()
+            == "value 1"
+        )
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "some-key-2"
+            ).decode()
+            == "value 2"
+        )
+
+        # Delete the first entry
+        DBCache.delete_cache_entry(
+            db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "some-key"
+        )
+
+        # Check the first entry was deleted
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "some-key"
+            )
+            is None
+        )
+
+        # Check the second entry still exists
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "some-key-2"
+            ).decode()
+            == "value 2"
+        )
+
+    def test_clear_cache_for_namespace(self, db):
+        # Add three entries, two belonging to namespace LIST_PRIVACY_EXPERIENCE and one to another namespace
+        DBCache.set_cache_value(
+            db,
+            DBCacheNamespace.LIST_PRIVACY_EXPERIENCE,
+            "key-1",
+            "value 1".encode(),
+        )
+        DBCache.set_cache_value(
+            db,
+            DBCacheNamespace.LIST_PRIVACY_EXPERIENCE,
+            "key-2",
+            "value 2".encode(),
+        )
+        DBCache.set_cache_value(
+            db,
+            TestDbCacheNamespace.TEST_NAMESPACE,
+            "key-1",
+            "value 3".encode(),
+        )
+
+        # Check all entries exist
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "key-1"
+            ).decode()
+            == "value 1"
+        )
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "key-2"
+            ).decode()
+            == "value 2"
+        )
+        assert (
+            DBCache.get_cache_value(
+                db, TestDbCacheNamespace.TEST_NAMESPACE, "key-1"
+            ).decode()
+            == "value 3"
+        )
+
+        # Clear the cache for LIST_PRIVACY_EXPERIENCE namespace
+        DBCache.clear_cache_for_namespace(db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE)
+
+        # Check the entries belonging to LIST_PRIVACY_EXPERIENCE were deleted
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "key-1"
+            )
+            is None
+        )
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "key-2"
+            )
+            is None
+        )
+
+        # Check the entry belonging to another namespace still exists
+        assert (
+            DBCache.get_cache_value(
+                db, TestDbCacheNamespace.TEST_NAMESPACE, "key-1"
+            ).decode()
+            == "value 3"
+        )
+
+    def test_clear_cache(self, db):
+        # Add three entries, two belonging to namespace LIST_PRIVACY_EXPERIENCE and one to another namespace
+        DBCache.set_cache_value(
+            db,
+            DBCacheNamespace.LIST_PRIVACY_EXPERIENCE,
+            "key-1",
+            "value 1".encode(),
+        )
+        DBCache.set_cache_value(
+            db,
+            DBCacheNamespace.LIST_PRIVACY_EXPERIENCE,
+            "key-2",
+            "value 2".encode(),
+        )
+        DBCache.set_cache_value(
+            db,
+            TestDbCacheNamespace.TEST_NAMESPACE,
+            "key-1",
+            "value 3".encode(),
+        )
+
+        # Check all entries exist
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "key-1"
+            ).decode()
+            == "value 1"
+        )
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "key-2"
+            ).decode()
+            == "value 2"
+        )
+        assert (
+            DBCache.get_cache_value(
+                db, TestDbCacheNamespace.TEST_NAMESPACE, "key-1"
+            ).decode()
+            == "value 3"
+        )
+
+        # Clear the cache
+        DBCache.clear_cache(db)
+
+        # Check all entries were deleted
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "key-1"
+            )
+            is None
+        )
+        assert (
+            DBCache.get_cache_value(
+                db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "key-2"
+            )
+            is None
+        )
+        assert (
+            DBCache.get_cache_value(db, TestDbCacheNamespace.TEST_NAMESPACE, "key-1")
+            is None
+        )


### PR DESCRIPTION
Relates to [HJ-319](https://ethyca.atlassian.net/browse/HJ-319)

### Description Of Changes

Adds some methods to `DBCache` that allow deleting a cached entry, deleting all cached entries for a given namespace, and deleting all entries. 

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[HJ-319]: https://ethyca.atlassian.net/browse/HJ-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ