### PR TITLE
Fix creation of new root level labels

### DIFF
--- a/clients/admin-ui/src/pages/taxonomy/index.tsx
+++ b/clients/admin-ui/src/pages/taxonomy/index.tsx
@@ -21,7 +21,10 @@ import PageHeader from "~/features/common/PageHeader";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
 import TaxonomyEditDrawer from "~/features/taxonomy/components/TaxonomyEditDrawer";
 import TaxonomyInteractiveTree from "~/features/taxonomy/components/TaxonomyInteractiveTree";
-import { CoreTaxonomiesEnum } from "~/features/taxonomy/constants";
+import {
+  CoreTaxonomiesEnum,
+  TAXONOMY_ROOT_NODE_ID,
+} from "~/features/taxonomy/constants";
 import useTaxonomySlices from "~/features/taxonomy/hooks/useTaxonomySlices";
 import { TaxonomyEntity } from "~/features/taxonomy/types";
 
@@ -67,9 +70,11 @@ const TaxonomyPage: NextPage = () => {
         return;
       }
 
+      const isChildOfRoot = draftNewItem?.parent_key === TAXONOMY_ROOT_NODE_ID;
       const newItem = {
         ...draftNewItem,
         name: labelName,
+        parent_key: isChildOfRoot ? null : draftNewItem.parent_key,
       };
 
       const result = await createTrigger(newItem);


### PR DESCRIPTION
### Description Of Changes

Fix creation of root level new labels. 

### Code Changes

* Use null as parent_key instead of root when creating root-level labels

### Steps to Confirm

1.  Go to Taxonomy
2. Try create a label from the top level (Data Categories, Data Uses, Data Subjects)

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
