### PR TITLE
update pr template and changelog to have some flags/tags

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,8 @@ _Write some things here about the changes and any potential caveats_
 * [ ] Issue requirements met
 * [ ] All CI pipelines succeeded
 * [ ] `CHANGELOG.md` updated
+  * [ ] Add a `migration` tag if your change includes a DB migration
+  * [ ] Add a `high-risk` tag if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
 * Followup issues:
   * [ ] Followup issues created (include link)
   * [ ] No followup issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+Changes can also be flagged with various tags for tracking purposes. The tags should be put in brackets and back ticks, e.g. "[`migration`, `high-risk`]" at the end of the changelog entry. The possible tags are:
+- `high-risk`, to indicate that a change is a "high-risk" change that could potentially lead to unanticipated regressions or degradations
+- `migration`, to indicate that a given change includes a DB migration
+
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.52.0...main)
 
 ### Added
@@ -29,7 +33,7 @@ The types of changes are:
 - Added event based communication example to the Cookie House sample app [#5597](https://github.com/ethyca/fides/pull/5597)
 - Added new erasure tests for BigQuery Enterprise [#5554](https://github.com/ethyca/fides/pull/5554)
 - Added new `has_next` parameter for the `link` pagination strategy [#5596](https://github.com/ethyca/fides/pull/5596)
-- Added a `DBCache` model for database-backed caching [#5613](https://github.com/ethyca/fides/pull/5613)
+- Added a `DBCache` model for database-backed caching [#5613](https://github.com/ethyca/fides/pull/5613) [`migration`]
 - Adds "reclassify" button to discovery result tables [#5574](https://github.com/ethyca/fides/pull/5574)
 - Added support for exporting datamaps with column renaming, reordering and visibility options [#5543](https://github.com/ethyca/fides/pull/5543)
 
@@ -98,7 +102,7 @@ The types of changes are:
 - Allow hiding systems via a `hidden` parameter and add two flags on the `/system` api endpoint; `show_hidden` and `dnd_relevant`, to display only systems with integrations [#5484](https://github.com/ethyca/fides/pull/5484)
 - The CMP override `fides_privacy_policy_url` will now apply even if the `fides_override_language` doesn't match [#5515](https://github.com/ethyca/fides/pull/5515)
 - Updated POST taxonomy endpoints to handle creating resources without specifying fides_key [#5468](https://github.com/ethyca/fides/pull/5468)
-- Disabled connection pooling for task workers and added retries and keep-alive configurations for database connections [#5448](https://github.com/ethyca/fides/pull/5448)
+- Disabled connection pooling for task workers and added retries and keep-alive configurations for database connections [#5448](https://github.com/ethyca/fides/pull/5448) [`high-risk`]
 - Added timeout handling in the UI for async discovery monitor-related queries [#5519](https://github.com/ethyca/fides/pull/5519)
 
 ### Developer Experience


### PR DESCRIPTION
Partially closes [HJ-351](https://ethyca.atlassian.net/browse/HJ-351)

### Description Of Changes

Updates to the PR template and the Changelog to include 'tags' that flag high-risk (and migration) changes.

Also adds a few sample tags to existing changelog entries as an example

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
