### PR TITLE
Render 'Reclassify' button in overflow menu when applicable

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DiscoveryItemActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DiscoveryItemActionsCell.tsx
@@ -1,4 +1,17 @@
-import { CheckIcon, HStack, RepeatIcon, ViewOffIcon } from "fidesui";
+import {
+  AntButton as Button,
+  CheckIcon,
+  Flex,
+  HStack,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  MoreIcon,
+  RepeatIcon,
+  Spacer,
+  ViewOffIcon,
+} from "fidesui";
 
 import { useAlert } from "~/features/common/hooks";
 import { DiscoveryMonitorItem } from "~/features/data-discovery-and-detection/types/DiscoveryMonitorItem";
@@ -54,21 +67,50 @@ const DiscoveryItemActionsCell = ({ resource }: DiscoveryItemActionsProps) => {
   const showMuteAction =
     itemHasClassificationChanges || childItemsHaveClassificationChanges;
 
+  const handlePromote = async () => {
+    await promoteResourceMutation({
+      staged_resource_urn: resource.urn,
+    });
+    successAlert(
+      `These changes have been added to a Fides dataset. To view, navigate to "Manage datasets".`,
+      `Table changes confirmed`,
+    );
+  };
+
+  const handleMute = async () => {
+    await muteResourceMutation({
+      staged_resource_urn: resource.urn,
+    });
+    successAlert(
+      `Ignored changes will not be added to a Fides dataset.`,
+      `${resource.name || "Changes"} ignored`,
+    );
+  };
+
+  const handleReclassify = async () => {
+    await confirmResourceMutation({
+      staged_resource_urn: resource.urn,
+      monitor_config_id: resource.monitor_config_id!,
+      start_classification: true,
+      classify_monitored_resources: true,
+    });
+    successAlert(
+      `Reclassification of ${getResourceName(resource) || "the resource"} has begun.  The results may take some time to appear in the “Data discovery“ tab.`,
+      `Reclassification started`,
+    );
+  };
+
+  // if promote and mute are both shown, show "Reclassify" in an overflow menu
+  // to avoid having too many buttons in the cell
+  const showReclassifyInOverflow = showPromoteAction && showMuteAction;
+
   return (
-    <HStack onClick={(e) => e.stopPropagation()}>
+    <Flex onClick={(e) => e.stopPropagation()} gap={2}>
       {showPromoteAction && (
         <ActionButton
           title="Confirm"
           icon={<CheckIcon />}
-          onClick={async () => {
-            await promoteResourceMutation({
-              staged_resource_urn: resource.urn,
-            });
-            successAlert(
-              `These changes have been added to a Fides dataset. To view, navigate to "Manage datasets".`,
-              `Table changes confirmed`,
-            );
-          }}
+          onClick={handlePromote}
           disabled={anyActionIsLoading}
           loading={promoteIsLoading}
         />
@@ -77,38 +119,40 @@ const DiscoveryItemActionsCell = ({ resource }: DiscoveryItemActionsProps) => {
         <ActionButton
           title="Ignore"
           icon={<ViewOffIcon />}
-          onClick={async () => {
-            await muteResourceMutation({
-              staged_resource_urn: resource.urn,
-            });
-            successAlert(
-              `Ignored changes will not be added to a Fides dataset.`,
-              `${resource.name || "Changes"} ignored`,
-            );
-          }}
+          onClick={handleMute}
           disabled={anyActionIsLoading}
           loading={muteIsLoading}
         />
       )}
-      <ActionButton
-        title="Reclassify"
-        icon={<RepeatIcon />}
-        onClick={async () => {
-          await confirmResourceMutation({
-            staged_resource_urn: resource.urn,
-            monitor_config_id: resource.monitor_config_id!,
-            start_classification: true,
-            classify_monitored_resources: true,
-          });
-          successAlert(
-            `Reclassification of ${getResourceName(resource) || "the resource"} has begun.  The results may take some time to appear in the “Data discovery“ tab.`,
-            `Reclassification started`,
-          );
-        }}
-        disabled={anyActionIsLoading}
-        loading={confirmIsLoading}
-      />
-    </HStack>
+      {!showReclassifyInOverflow && (
+        <ActionButton
+          title="Reclassify"
+          icon={<RepeatIcon />}
+          onClick={handleReclassify}
+          disabled={anyActionIsLoading}
+          loading={confirmIsLoading}
+        />
+      )}
+      <Spacer />
+      {showReclassifyInOverflow && (
+        <Menu>
+          <MenuButton
+            as={Button}
+            size="small"
+            // TS expects Chakra's type prop (HTML type) but we want to assign the Ant type
+            // @ts-ignore
+            type="text"
+            icon={<MoreIcon transform="rotate(90deg)" />}
+            className="w-6 gap-0"
+          />
+          <MenuList>
+            <MenuItem onClick={handleReclassify} icon={<RepeatIcon />}>
+              Reclassify
+            </MenuItem>
+          </MenuList>
+        </Menu>
+      )}
+    </Flex>
   );
 };
 


### PR DESCRIPTION
Closes HJ-341

### Description Of Changes

![Screenshot 2025-01-09 at 03 28 57](https://github.com/user-attachments/assets/011b049c-cca5-4765-9f79-5a49d2512a8d)

Changes discovery item actions cell so "Reclassify" option renders in an overflow menu when both promote and mute actions are available, to keep from overloading the cell with 3 action buttons.
 
### Steps to Confirm

1.  Run a monitor and classify the results
2. View results in discovery table
3. Results should have both "Confirm" and "Ignore" options and "Reclassify" option in kebab menu
4. View a result without one of the other two actions (for example, subfields of a nested field which don't have the "Confirm" action)
5. "Reclassify" should show up as an action button in the cell

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
