### PR TITLE
HJ-319 Updated updated_at field of DBCache even when value doesn't change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Updated brand link url [#5656](https://github.com/ethyca/fides/pull/5656)
 - Changed "Reclassify" D&D button to show in an overflow menu when row actions are overcrowded [#5655](https://github.com/ethyca/fides/pull/5655)
 - Removed primary key requirements for BigQuery and Postgres erasures [#5591](https://github.com/ethyca/fides/pull/5591)
+- Updated `DBCache` model so setting cache value always updates the updated_at field [#5669](https://github.com/ethyca/fides/pull/5669)
 
 ### Fixed
 - Fixed issue where the custom report "reset" button was not working as expected [#5649](https://github.com/ethyca/fides/pull/5649)

--- a/src/fides/api/models/db_cache.py
+++ b/src/fides/api/models/db_cache.py
@@ -4,6 +4,7 @@ from typing import ByteString, Optional
 from sqlalchemy import Column, Index, String
 from sqlalchemy.dialects.postgresql import BYTEA
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
 
 from fides.api.db.base_class import Base
 
@@ -78,6 +79,9 @@ class DBCache(Base):
         db_cache_entry = cls.get_cache_entry(db, namespace, cache_key)
         if db_cache_entry:
             db_cache_entry.cache_value = cache_value
+            # We manually flag it as modified so that the update runs even if the cache_value hasn't changed
+            # so the updated_at field of the cache entry gets updated.
+            flag_modified(db_cache_entry, "cache_value")
         else:
             db_cache_entry = cls(
                 namespace=namespace.value, cache_key=cache_key, cache_value=cache_value

--- a/tests/ops/models/test_dbcache.py
+++ b/tests/ops/models/test_dbcache.py
@@ -47,18 +47,31 @@ class TestDBCacheModel:
             ).decode()
             == "value 1"
         )
+        assert cache_value.updated_at is not None
+
+        original_timestamp = cache_value.updated_at
 
         # Update the cache value
         cache_value = DBCache.set_cache_value(
             db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "some-key", "value 2".encode()
         )
         assert cache_value.cache_value.decode() == "value 2"
+        assert cache_value.updated_at > original_timestamp
 
         # Check the value was actually updated
         updated_value = DBCache.get_cache_value(
             db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "some-key"
         )
         assert updated_value.decode() == "value 2"
+
+        previous_timestamp = cache_value.updated_at
+
+        # Updating the value with the same value should still update the timestamp
+        cache_value = DBCache.set_cache_value(
+            db, DBCacheNamespace.LIST_PRIVACY_EXPERIENCE, "some-key", "value 2".encode()
+        )
+        assert cache_value.cache_value.decode() == "value 2"
+        assert cache_value.updated_at > previous_timestamp
 
     def test_delete_cache_entry(self, db):
         # Add two entries


### PR DESCRIPTION
Relates to HJ-319

### Description Of Changes

When `set_cache_value` is called, we want to update the `updated_at` value for that cache entry, even if the value provided is the same as the previous one. 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
