### PR TITLE
LA-174: Adds max rows limit config to privacy req csv download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Changed "Reclassify" D&D button to show in an overflow menu when row actions are overcrowded [#5655](https://github.com/ethyca/fides/pull/5655)
 - Removed primary key requirements for BigQuery and Postgres erasures [#5591](https://github.com/ethyca/fides/pull/5591)
 - Updated `DBCache` model so setting cache value always updates the updated_at field [#5669](https://github.com/ethyca/fides/pull/5669)
+- Adds new config for max number of rows in DSR download through Admin-UI [#5671](https://github.com/ethyca/fides/pull/5671)
 
 ### Fixed
 - Fixed issue where the custom report "reset" button was not working as expected [#5649](https://github.com/ethyca/fides/pull/5649)

--- a/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -110,8 +110,12 @@ export const requestCSVDownload = async ({
       },
     },
   )
-    .then((response) => {
+    .then(async (response) => {
       if (!response.ok) {
+        if (response.status === 400) {
+          const errorData = await response.json();
+          throw new Error(errorData.detail || "Bad request error");
+        }
         throw new Error("Got a bad response from the server");
       }
       return response.blob();

--- a/src/fides/config/admin_ui_settings.py
+++ b/src/fides/config/admin_ui_settings.py
@@ -17,4 +17,8 @@ class AdminUISettings(FidesSettings):
     url: SerializeAsAny[Optional[AnyHttpUrlStringRemovesSlash]] = Field(
         default=None, description="The base URL for the Admin UI."
     )
+    max_privacy_request_download_rows: int = Field(
+        default=100000,
+        description="The maximum number of rows permitted to be returned in a privacy request report download",
+    )
     model_config = SettingsConfigDict(env_prefix="FIDES__ADMIN_UI__")

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -3499,6 +3499,14 @@ def allow_custom_privacy_request_fields_in_request_execution_disabled():
 
 
 @pytest.fixture(scope="function")
+def set_max_privacy_request_download_rows():
+    original_value = CONFIG.admin_ui.max_privacy_request_download_rows
+    CONFIG.admin_ui.max_privacy_request_download_rows = 1
+    yield
+    CONFIG.admin_ui.max_privacy_request_download_rows = original_value
+
+
+@pytest.fixture(scope="function")
 def subject_request_download_ui_enabled():
     original_value = CONFIG.security.subject_request_download_ui_enabled
     CONFIG.security.subject_request_download_ui_enabled = True

--- a/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_endpoints.py
@@ -1951,6 +1951,19 @@ class TestGetPrivacyRequests:
 
         privacy_request.delete(db)
 
+    def test_get_privacy_requests_csv_format_max_rows_limit(
+        self,
+        db,
+        generate_auth_header,
+        api_client,
+        url,
+        privacy_requests,
+        set_max_privacy_request_download_rows,
+    ):
+        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_READ])
+        response = api_client.get(url + f"?download_csv=True", headers=auth_header)
+        assert 400 == response.status_code
+
     def test_get_requires_input_privacy_request_resume_info(
         self, db, privacy_request, generate_auth_header, api_client, url
     ):


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/LA-174

### Description Of Changes

This PR adds a new config var to limit n number of rows for DSR downloads, `FIDES__ADMIN_UI__MAX_PRIVACY_REQUEST_DOWNLOAD_ROWS`. This is similar to what we already have in place for consent reporting download. The default limit is set at 100,000 for now.

### Code Changes

* Adds new config `FIDES__ADMIN_UI__MAX_PRIVACY_REQUEST_DOWNLOAD_ROWS`
* updates DSR download endpoint to throw 400 if request is > this max
* updates admin-ui code to surface this err in a user-friendly way
* adds new unit test for this behavior

### Steps to Confirm

1.  Set `FIDES__ADMIN_UI__MAX_PRIVACY_REQUEST_DOWNLOAD_ROWS=1`
2. In Privacy center, make 2 privacy requests (access and erasure)
3. In The privacy request manager, attempt to download those requests
4. Confirm you are unable to download and that a user-friendly message appears with clear instructions.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
