### PR TITLE
Convert `rem` to base font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Updated `DBCache` model so setting cache value always updates the updated_at field [#5669](https://github.com/ethyca/fides/pull/5669)
 - Changed sizes of buttons in table headers [#5654](https://github.com/ethyca/fides/pull/5654)
 - Adds new config for max number of rows in DSR download through Admin-UI [#5671](https://github.com/ethyca/fides/pull/5671)
+- Added CSS variable to FidesJS: `--fides-base-font-size: 16px` for better consistency. Overriding this variable with "1rem" will mimic legacy behavior. [#5673](https://github.com/ethyca/fides/pull/5673) https://github.com/ethyca/fides/labels/high-risk
 
 ### Fixed
 - Fixed issue where the custom report "reset" button was not working as expected [#5649](https://github.com/ethyca/fides/pull/5649)

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -56,11 +56,11 @@
 
   /* Everything else */
   --fides-overlay-font-family: Inter, sans-serif;
-  --8px: 0.5rem;
-  --12px: 0.75rem;
-  --14px: 0.875rem;
-  --15px: 0.9375rem;
-  --16px: 1rem;
+  --fides-base-font-size: 1rem;
+  --8px: calc(var(--fides-base-font-size) * 0.5);
+  --12px: calc(var(--fides-base-font-size) * 0.75);
+  --14px: calc(var(--fides-base-font-size) * 0.875);
+  --16px: calc(var(--fides-base-font-size) * 1);
   --fides-overlay-font-size-body-xs: var(--8px);
   --fides-overlay-font-size-body-small: var(--12px);
   --fides-overlay-font-size-body: var(--14px);
@@ -115,9 +115,7 @@ div#fides-overlay-wrapper * {
   font-family: var(--fides-overlay-font-family);
   font-size: var(--fides-overlay-font-size-body);
   white-space: pre-line;
-
-  /* CSS reset values, adapted from https://www.joshwcomeau.com/css/custom-css-reset/ */
-  line-height: calc(1em + 0.4rem);
+  line-height: 1.4em;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -737,7 +735,7 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
   display: inline-block;
   min-width: 8px;
   height: 8px;
-  margin-right: calc(0.5rem + 2px);
+  margin-right: calc(calc(var(--fides-base-font-size) * 0.5) + 2px);
   content: "";
   transition: transform 0.12s ease-in-out;
   transform: translateY(-2px) rotate(135deg);
@@ -1065,7 +1063,7 @@ div#fides-overlay-wrapper .fides-i18n-pseudo-button {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  max-height: 7rem;
+  max-height: calc(var(--fides-base-font-size) * 7);
   transition: height 0.5s;
 }
 
@@ -1079,7 +1077,7 @@ div#fides-overlay-wrapper .fides-i18n-pseudo-button {
 
 .fides-i18n-menu:hover .fides-i18n-popover,
 .fides-i18n-menu:focus-within .fides-i18n-popover {
-  min-width: 9rem;
+  min-width: calc(var(--fides-base-font-size) * 9);
   height: auto;
   border: 1px solid var(--fides-overlay-primary-color);
   background-color: var(--fides-overlay-background-dark-color);
@@ -1095,7 +1093,7 @@ button.fides-banner-button.fides-menu-item {
   width: 100%;
   text-align: left;
   margin: 0;
-  padding-left: 1.5rem;
+  padding-left: calc(var(--fides-base-font-size) * 1.5);
 }
 
 button.fides-banner-button.fides-menu-item[aria-pressed="true"] {
@@ -1106,8 +1104,8 @@ button.fides-banner-button.fides-menu-item[aria-pressed="true"] {
 button.fides-banner-button.fides-menu-item[aria-pressed="true"]::before {
   content: "\2713";
   display: inline-block;
-  margin-right: 0.25rem;
-  margin-left: -1rem;
+  margin-right: calc(var(--fides-base-font-size) * 0.25);
+  margin-left: calc(var(--fides-base-font-size) * -1);
 }
 
 button.fides-banner-button.fides-menu-item:not([aria-pressed="true"]):hover {

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -56,7 +56,7 @@
 
   /* Everything else */
   --fides-overlay-font-family: Inter, sans-serif;
-  --fides-base-font-size: 1rem;
+  --fides-base-font-size: 16px;
   --8px: calc(var(--fides-base-font-size) * 0.5);
   --12px: calc(var(--fides-base-font-size) * 0.75);
   --14px: calc(var(--fides-base-font-size) * 0.875);

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -735,7 +735,7 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
   display: inline-block;
   min-width: 8px;
   height: 8px;
-  margin-right: calc(calc(var(--fides-base-font-size) * 0.5) + 2px);
+  margin-right: calc(var(--8px) + 2px); /* half font size + border width */
   content: "";
   transition: transform 0.12s ease-in-out;
   transform: translateY(-2px) rotate(135deg);


### PR DESCRIPTION
Closes [HJ-382]

### Description Of Changes

Provides a single css var for customers to use to override the font sizes.

This allows for customers to "opt in" to accessibility compliance by setting this as "1rem" while avoiding the footgun probability that most are hard coding an HTML font size anyway which has the potential to cause sizing issues with fides.js out of the box.

### Code Changes

* Adds a new `--fides-base-font-size`
* Converts all instances of the use of `rem` to calculate from the base size instead.


### Steps to Confirm

1. Visit the fidej.js component demo page (http://localhost:3001/fides-js-components-demo.html)
2. Font sizes should remain exactly how they have always been.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [x] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[HJ-382]: https://ethyca.atlassian.net/browse/HJ-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ