### PR TITLE
Add missing install python 3.10

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -284,6 +284,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          cache: "pip"
+
       - name: Install Nox
         run: pip install nox>=2022
 
@@ -339,6 +345,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          cache: "pip"
 
       - name: Install Nox
         run: pip install nox>=2022
@@ -425,6 +437,12 @@ jobs:
 
       - name: Load image
         run: docker load --input /tmp/python-${{ matrix.python_version }}.tar
+
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          cache: "pip"
 
       - name: Install Nox
         run: pip install nox>=2022

--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -26,11 +26,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set Up Python
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-          cache: "pip"
+          python-version: "3.10"
 
       - name: Install Nox
         run: pip install nox>=2022

--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -26,10 +26,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.10
+      - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          cache: "pip"
 
       - name: Install Nox
         run: pip install nox>=2022

--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -15,6 +15,7 @@ env:
   # Docker auth with read-only permissions.
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_RO_TOKEN: ${{ secrets.DOCKER_RO_TOKEN }}
+  DEFAULT_PYTHON_VERSION: "3.10.13"
 
 jobs:
   Cypress-E2E:
@@ -26,10 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.10
+      - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          cache: "pip"
 
       - name: Install Nox
         run: pip install nox>=2022

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -11,6 +11,7 @@ env:
   # Docker auth with read-write (publish) permissions. Set as env in workflow root as auth is required in multiple jobs.
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+  DEFAULT_PYTHON_VERSION: "3.10.13"
 
 jobs:
   ParseTags:

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -71,6 +71,12 @@ jobs:
         with:
           fetch-depth: 0 # This is required to properly tag images
 
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          cache: "pip"
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -103,7 +109,6 @@ jobs:
       - name: Push Fides prerelease Tags
         if: needs.ParseTags.outputs.alpha_tag == 'true' || needs.ParseTags.outputs.beta_tag == 'true'
         run: nox -s "push(${{ matrix.application }},prerelease)" -- git_tag
-
 
   NotifyRedeploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -19,9 +19,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - name: Set Up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          cache: "pip"
 
       - name: Echo the Release Tag
         run: echo ${{ env.TAG }}
@@ -31,7 +33,7 @@ jobs:
 
       - name: Install Docs Requirements
         run: pip install -r docs/fides/requirements.txt
-        
+
       - name: Install fides
         run: pip install -e ./[all]
 

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -10,6 +10,7 @@ on:
 env:
   TAG: ${{ github.event.release.tag_name }}
   PROD_PUBLISH: true
+  DEFAULT_PYTHON_VERSION: "3.10.13"
 
 jobs:
   publish_docs:


### PR DESCRIPTION
### Description Of Changes

Fix failing CI jobs that are missing the specific python version install.

### Code Changes

* Add missing python install steps in different workflows
* Add missing env variables for default python version

### Steps to Confirm

1.  CI fully passed

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
