### PR TITLE
LA 151 - Allow Special URL reserved characters in the username/ passwords of mongodb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Changed
 - Updated UI colors to new brand. Update logo, homepage cards. [#5668](https://github.com/ethyca/fides/pull/5668)
 
-
+### Fixed
+- Updating mongodb connectors so it can support usernames and password with URL encoded characters [#5682](https://github.com/ethyca/fides/pull/5682)
 
 ## [2.53.0](https://github.com/ethyca/fides/compare/2.52.0...2.53.0)
 

--- a/src/fides/api/service/connectors/mongodb_connector.py
+++ b/src/fides/api/service/connectors/mongodb_connector.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 from loguru import logger
 from pymongo import MongoClient
 from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
-import urllib
+from urllib.parse import quote_plus
 
 from fides.api.common_exceptions import ConnectionException
 from fides.api.graph.execution import ExecutionNode
@@ -35,14 +35,12 @@ class MongoDBConnector(BaseConnector[MongoClient]):
         user_pass: str = ""
         default_auth_db: str = ""
         if config.username and config.password:
-            user_pass = urllib.parse.quote_plus( f"{config.username}:{config.password}@")
-
+            user_pass = ( f"{quote_plus(config.username)}:{quote_plus(config.password)}@")
             if config.defaultauthdb:
                 default_auth_db = f"/{config.defaultauthdb}"
 
         port: str = f":{config.port}" if config.port else ""
         url = f"mongodb://{user_pass}{config.host}{port}{default_auth_db}"
-        logger.info("Built URI: {}", url)
         return url
 
     def create_client(self) -> MongoClient:

--- a/src/fides/api/service/connectors/mongodb_connector.py
+++ b/src/fides/api/service/connectors/mongodb_connector.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 from loguru import logger
 from pymongo import MongoClient
 from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
+import urllib
 
 from fides.api.common_exceptions import ConnectionException
 from fides.api.graph.execution import ExecutionNode
@@ -34,13 +35,14 @@ class MongoDBConnector(BaseConnector[MongoClient]):
         user_pass: str = ""
         default_auth_db: str = ""
         if config.username and config.password:
-            user_pass = f"{config.username}:{config.password}@"
+            user_pass = urllib.parse.quote_plus( f"{config.username}:{config.password}@")
 
             if config.defaultauthdb:
                 default_auth_db = f"/{config.defaultauthdb}"
 
         port: str = f":{config.port}" if config.port else ""
         url = f"mongodb://{user_pass}{config.host}{port}{default_auth_db}"
+        logger.info("Built URI: {}", url)
         return url
 
     def create_client(self) -> MongoClient:

--- a/src/fides/api/service/connectors/mongodb_connector.py
+++ b/src/fides/api/service/connectors/mongodb_connector.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote_plus
 
 from loguru import logger
 from pymongo import MongoClient
 from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
-from urllib.parse import quote_plus
 
 from fides.api.common_exceptions import ConnectionException
 from fides.api.graph.execution import ExecutionNode
@@ -35,7 +35,7 @@ class MongoDBConnector(BaseConnector[MongoClient]):
         user_pass: str = ""
         default_auth_db: str = ""
         if config.username and config.password:
-            user_pass = ( f"{quote_plus(config.username)}:{quote_plus(config.password)}@")
+            user_pass = f"{quote_plus(config.username)}:{quote_plus(config.password)}@"
             if config.defaultauthdb:
                 default_auth_db = f"/{config.defaultauthdb}"
 


### PR DESCRIPTION
Trying to add an integration to mongodb with an user or password with special URL reserved characters was throwing the following error on console 

Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus


_Solution proposed by pymongo docs:_ 

> For username and passwords reserved characters like ':', '/', '+' and '@' must be percent encoded following RFC 2396:

```
  from urllib.parse import quote_plus

            uri = "mongodb://%s:%s@%s" % (
                quote_plus(user), quote_plus(password), host)
            client = MongoClient(uri)

```

### Description Of Changes

We are using quote plus to parse URL reserved characters on the username and password directly, so they can be used as characters in a connection URL

### Code Changes

* updating mongodb connector

### Steps to Confirm

1.  Prepare a mongodb image on the same network as fides dev. This can be done by adding the following code block ton the docker-compose.yml file and then running the command below 
```
  mongodb-test:
    image: mongo:5.0.3
    environment:
      - MONGO_INITDB_DATABASE=mongo_test
      - MONGO_INITDB_ROOT_USERNAME=mongo_user
      - MONGO_INITDB_ROOT_PASSWORD=mongo_pass
    healthcheck:
      interval: 15s
      timeout: 5s
      retries: 5
    ports:
      - "37017:27017"
    volumes:
      - ./mongo_sample.js:/docker-entrypoint-initdb.d/mongo_sample.js:ro
```
` docker compose up mongodb-test `

2. Connect to the mongo-db container and create a new username and password on the test database

`mongosh -u mongo_user -p mongo_pass`

```
db.createUser(
  {
    user: "tester",
    pwd:  "pass%word" ,
    roles: [ { role: "readWrite", db: "test" },
             { role: "read", db: "reporting" } ]
  }
```

Check that the user was created correctly by running the following

```
mongosh -u "tester" \
    --authenticationDatabase "test" -p
```


3. Create a new integration to mongodb by navigating to Data Inventory>Add systems. 
 Integration data should be the following 
    Host: mongodb-test
    Port 27017
    Username: tester
    Password: pass%word
    Default Auth DB: test 
    Datasets: Any
    
4. Press Test Integration. It should show a green passing integration

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] No followup issues
* Database migrations:
  * [ ] No migrations
* Documentation:
  * [ ] No documentation updates required
