### PR TITLE
Table visual fixes

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsColumns.tsx
@@ -30,7 +30,7 @@ export const useDiscoveredAssetsColumns = () => {
           dataTestId="select-all-rows"
         />
       ),
-      maxSize: 25,
+      maxSize: 40,
     }),
     columnHelper.accessor((row) => row.name, {
       id: "name",

--- a/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns.tsx
@@ -101,7 +101,7 @@ const useDiscoveryResultColumns = ({
             dataTestId="select-all-rows"
           />
         ),
-        maxSize: 25,
+        maxSize: 40,
       }),
       columnHelper.accessor((row) => row.name, {
         id: "tables",

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryFieldBulkActions.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryFieldBulkActions.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, Flex, ViewOffIcon } from "fidesui";
+import { AntFlex as Flex, CheckIcon, ViewOffIcon } from "fidesui";
 
 import ActionButton from "~/features/data-discovery-and-detection/ActionButton";
 import {
@@ -31,12 +31,7 @@ const DiscoveryFieldBulkActions = ({
   };
 
   return (
-    <Flex
-      direction="row"
-      align="center"
-      justify="center"
-      data-testid="bulk-actions-menu"
-    >
+    <Flex data-testid="bulk-actions-menu">
       <div className="flex gap-2">
         <ActionButton
           title="Confirm all"
@@ -45,6 +40,7 @@ const DiscoveryFieldBulkActions = ({
           disabled={anyActionIsLoading}
           loading={isPromoteLoading}
           type="primary"
+          size="middle"
         />
         <ActionButton
           title="Ignore all"
@@ -52,6 +48,7 @@ const DiscoveryFieldBulkActions = ({
           onClick={() => handleIgnoreClicked([resourceUrn])}
           disabled={anyActionIsLoading}
           loading={isMuteLoading}
+          size="middle"
         />
       </div>
     </Flex>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryTableBulkActions.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryTableBulkActions.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, Flex, Text, ViewOffIcon } from "fidesui";
+import { AntFlex as Flex, CheckIcon, Text, ViewOffIcon } from "fidesui";
 
 import ActionButton from "~/features/data-discovery-and-detection/ActionButton";
 import {
@@ -35,19 +35,14 @@ const DiscoveryTableBulkActions = ({
   }
 
   return (
-    <Flex
-      direction="row"
-      align="center"
-      justify="center"
-      data-testid="bulk-actions-menu"
-    >
+    <Flex className="items-center" data-testid="bulk-actions-menu">
       <Text
         fontSize="xs"
         fontWeight="semibold"
         minW={16}
-        mr={6}
+        mr={4}
       >{`${selectedUrns.length} selected`}</Text>
-      <div>
+      <Flex className="gap-2">
         <ActionButton
           title="Confirm"
           icon={<CheckIcon />}
@@ -65,7 +60,7 @@ const DiscoveryTableBulkActions = ({
           onClick={() => handleIgnoreClicked(selectedUrns)}
           size="middle"
         />
-      </div>
+      </Flex>
     </Flex>
   );
 };


### PR DESCRIPTION
Closes HJ_390

### Description Of Changes

Small visual tweaks to some table buttons:

* In discovery result table, bulk action buttons at table level now have spacing between them (also drive-by fix to make spacing slightly better)
* In discovery result table, bulk action buttons at field level are correct size
* Fix cell padding on "select" cells in some tables

### Steps to Confirm

1.  Visually check discovery result table/field tables

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
