### PR TITLE
Add "all activity" breadcrumb to D&D tables

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/DiscoveryMonitorBreadcrumbs.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/DiscoveryMonitorBreadcrumbs.tsx
@@ -32,6 +32,10 @@ const DiscoveryMonitorBreadcrumbs = ({
   }
 
   if (resourceUrn) {
+    breadcrumbItems.push({
+      title: "All activity",
+      href: parentLink,
+    });
     const urnParts = resourceUrn.split(".");
     urnParts.forEach((urnPart, index) => {
       // don't render anything at the monitor level because there's no view for it


### PR DESCRIPTION
Closes HJ-389

### Description Of Changes

Adds an "all activity" breadcrumb linking to the respective root page to both detection and discovery result tables.

### Steps to Confirm

1. Visit detection result tables and check breadcrumb links back to /data-discovery/detection
2. Visit discovery result tables and check breadcrumb links back to /data-discovery/discovery

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [x] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
