### PR TITLE
ensure `decode_password` function properly handles plaintext but valid base64 passwords 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed column ordering issue in the Data Map report [#5649](https://github.com/ethyca/fides/pull/5649)
 - Fixed issue where the Data Map report filter dialog was missing an Accordion item label [#5649](https://github.com/ethyca/fides/pull/5649)
 - Improved database session management for long running access request tasks [#5667](https://github.com/ethyca/fides/pull/5667)
+- Ensured decode_password function properly handles plaintext but valid base64 passwords [#5698](https://github.com/ethyca/fides/pull/5698)
 
 ## [2.52.0](https://github.com/ethyca/fides/compare/2.51.2...2.52.0)
 

--- a/src/fides/api/cryptography/cryptographic_util.py
+++ b/src/fides/api/cryptography/cryptographic_util.py
@@ -13,7 +13,7 @@ def decode_password(password: str) -> str:
     """
     try:
         return b64_str_to_str(password)
-    except Error:
+    except (Error, UnicodeDecodeError):
         return password
 
 

--- a/tests/lib/test_cryptography_util.py
+++ b/tests/lib/test_cryptography_util.py
@@ -104,7 +104,12 @@ def test_str_to_b64_str() -> None:
     "password, expected",
     [
         ("Testpassword1!", "Testpassword1!"),
+        (
+            "Test_1234",
+            "Test_1234",
+        ),  # this is actually valid base64 (but should be treated as plaintext), so this represents an edge case
         (str_to_b64_str("Testpassword1!"), "Testpassword1!"),
+        (str_to_b64_str("Test_1234"), "Test_1234"),
     ],
 )
 def test_decode_password(password, expected):


### PR DESCRIPTION
Closes [HJ-397]

### Description Of Changes

Handles the `UnicodeDecodeError` that is raised by `decode_password` if it is given a plaintext password that's also valid base64. The exception is caught, and the input string is returned as it was provided, under the assumption that it is a plaintext (and _not_ base64-encoded) password.

See issue description for more details. This impacts some user-related endpoints (e.g. reset password, accept invite) if the user provides a password that also happens to be valid base64. Notably, the utilities also _ignore_ invalid base64 characters like `_`, so a value like  e.g. `Test_1234` is treated as valid base64, since the `_` is ignored and its length of `8` is a multiple of 4.

### Code Changes

* catch and ignore `UnicodeDecodeError` in `decode_password` utility function, assuming input string is a plaintext password

### Steps to Confirm

- [x] confirmed locally that I can (still) create a user and manually set their password to `Test_1234` (i think this was working before, because we send a base64 encoded password in the request from the UI in this workflow)
- [x] confirmed i can now accept a user invite and set my password to `Test_1234`, which i also confirmed was broken before: 
<img width="720" alt="image" src="https://github.com/user-attachments/assets/4e14f296-6a2f-477e-847a-6e49ffe4980e" />
 

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[HJ-397]: https://ethyca.atlassian.net/browse/HJ-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ