### PR TITLE
Fix bulk add/ignore assets

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -83,23 +83,29 @@ const actionCenterApi = baseApi.injectEndpoints({
       invalidatesTags: ["Discovery Monitor Results"],
     }),
     addMonitorResultAssets: build.mutation<any, { urnList?: string[] }>({
-      query: (params) => ({
-        method: "POST",
-        url: `/plus/discovery-monitor/promote`,
-        params: {
-          staged_resource_urns: params.urnList,
-        },
-      }),
+      query: (params) => {
+        const queryParams = new URLSearchParams();
+        params.urnList?.forEach((urn) =>
+          queryParams.append("staged_resource_urns", urn),
+        );
+        return {
+          method: "POST",
+          url: `/plus/discovery-monitor/promote?${queryParams}`,
+        };
+      },
       invalidatesTags: ["Discovery Monitor Results"],
     }),
     ignoreMonitorResultAssets: build.mutation<any, { urnList?: string[] }>({
-      query: (params) => ({
-        method: "POST",
-        url: `/plus/discovery-monitor/mute`,
-        params: {
-          staged_resource_urns: params.urnList,
-        },
-      }),
+      query: (params) => {
+        const queryParams = new URLSearchParams();
+        params.urnList?.forEach((urn) =>
+          queryParams.append("staged_resource_urns", urn),
+        );
+        return {
+          method: "POST",
+          url: `/plus/discovery-monitor/mute?${queryParams}`,
+        };
+      },
       invalidatesTags: ["Discovery Monitor Results"],
     }),
     updateAssetsSystem: build.mutation<


### PR DESCRIPTION
Closes [LJ-319]

### Description Of Changes

Params were being passed as comma separated but server is expecting serialized list.

### Code Changes

* generate serialized query string by looping through array first

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-319]: https://ethyca.atlassian.net/browse/LJ-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ