### PR TITLE
Stripe Config Update to match fidesplus

### DIFF
--- a/data/saas/config/stripe_config.yml
+++ b/data/saas/config/stripe_config.yml
@@ -4,7 +4,7 @@ saas_config:
   type: stripe
   user_guide: https://docs.ethyca.com/user-guides/integrations/saas-integrations/stripe
   description: A sample schema representing the Stripe connector for Fides
-  version: 0.0.6
+  version: 0.0.9
 
   connector_params:
     - name: domain

--- a/data/saas/dataset/stripe_dataset.yml
+++ b/data/saas/dataset/stripe_dataset.yml
@@ -67,6 +67,11 @@ dataset:
             data_categories: [user.contact.email]
             fidesops_meta:
               data_type: string
+              masking_strategy_override:
+                strategy: random_string_rewrite
+                configuration:
+                  format_preservation:
+                    suffix: "+masked@ethyca.com"
           - name: invoice_prefix
             data_categories: [system.operations]
           - name: invoice_settings
@@ -89,6 +94,8 @@ dataset:
             data_categories: [user.contact.phone_number]
             fidesops_meta:
               data_type: string
+              masking_strategy_override:
+                strategy: null_rewrite
           - name: preferred_locales
             data_categories: [user]
             fidesops_meta:
@@ -183,6 +190,11 @@ dataset:
                 data_categories: [user.contact.email]
                 fidesops_meta:
                   data_type: string
+                  masking_strategy_override:
+                    strategy: random_string_rewrite
+                    configuration:
+                      format_preservation:
+                        suffix: "+masked@ethyca.com"
               - name: name
                 data_categories: [user.name]
                 fidesops_meta:
@@ -289,6 +301,11 @@ dataset:
             data_categories: [user.contact.email]
             fidesops_meta:
               data_type: string
+              masking_strategy_override:
+                strategy: random_string_rewrite
+                configuration:
+                  format_preservation:
+                    suffix: "+masked@ethyca.com"
           - name: receipt_number
             data_categories: [system.operations]
           - name: receipt_url
@@ -421,6 +438,11 @@ dataset:
                 data_categories: [user.contact.email]
                 fidesops_meta:
                   data_type: string
+                  masking_strategy_override:
+                    strategy: random_string_rewrite
+                    configuration:
+                      format_preservation:
+                        suffix: "+masked@ethyca.com"
               - name: customer_name
                 data_categories: [user.name]
                 fidesops_meta:
@@ -559,6 +581,11 @@ dataset:
             data_categories: [user.contact.email]
             fidesops_meta:
               data_type: string
+              masking_strategy_override:
+                strategy: random_string_rewrite
+                configuration:
+                  format_preservation:
+                    suffix: "+masked@ethyca.com"
           - name: review
             data_categories: [system.operations]
           - name: setup_future_usage
@@ -634,6 +661,10 @@ dataset:
                     data_categories: [user.contact.address.country]
                     fidesops_meta:
                       data_type: string
+                      masking_strategy_override:
+                        strategy: string_rewrite
+                        configuration:
+                          rewrite_value: US
                   - name: line1
                     data_categories: [user.contact.address.street]
                     fidesops_meta:
@@ -654,6 +685,11 @@ dataset:
                 data_categories: [user.contact.email]
                 fidesops_meta:
                   data_type: string
+                  masking_strategy_override:
+                    strategy: random_string_rewrite
+                    configuration:
+                      format_preservation:
+                        suffix: "+masked@ethyca.com"
               - name: name
                 data_categories: [user.name]
                 fidesops_meta:
@@ -734,6 +770,7 @@ dataset:
             data_categories: [user.contact.address.country]
             fidesops_meta:
               data_type: string
+              read_only: True
           - name: currency
             data_categories: [system.operations]
           - name: customer
@@ -1041,6 +1078,11 @@ dataset:
             data_categories: [user.contact.email]
             fidesops_meta:
               data_type: string
+              masking_strategy_override:
+                strategy: random_string_rewrite
+                configuration:
+                  format_preservation:
+                    suffix: "+masked@ethyca.com"
           - name: customer_name
             data_categories: [user.name]
             fidesops_meta:

--- a/data/saas/dataset/stripe_dataset.yml
+++ b/data/saas/dataset/stripe_dataset.yml
@@ -661,10 +661,7 @@ dataset:
                     data_categories: [user.contact.address.country]
                     fidesops_meta:
                       data_type: string
-                      masking_strategy_override:
-                        strategy: string_rewrite
-                        configuration:
-                          rewrite_value: US
+                      read_only: true
                   - name: line1
                     data_categories: [user.contact.address.street]
                     fidesops_meta:

--- a/tests/fixtures/saas/stripe_fixtures.py
+++ b/tests/fixtures/saas/stripe_fixtures.py
@@ -367,13 +367,12 @@ class StripeTestClient:
             headers=self.headers,
         )
 
-    def get_customer(self, email):
+    def get_customer(self, id):
         response = requests.get(
-            url=f"{self.base_url}/v1/customers",
+            url=f"{self.base_url}/v1/customers/{id}",
             headers=self.headers,
-            params={"email": email},
         )
-        customer = response.json()["data"][0]
+        customer = response.json()
         return customer
 
     def get_card(self, customer_id):
@@ -513,7 +512,7 @@ def stripe_create_data(
         stripe_test_client, generate_random_email(), generate_random_phone_number()
     )
 
-    yield
+    yield customer
 
     for data in [customer, random_customer]:
         stripe_test_client.delete_customer(data["customer_id"])


### PR DESCRIPTION
Closes [LJ-66](https://ethyca.atlassian.net/browse/LJ-66)

### Description Of Changes

Stripe and recharge integrations failed on erasure because some fields where not properly mask. The solution is to apply masking overrides.

Relates to: https://github.com/ethyca/fidesplus/pull/1830

### Code Changes

- [x] updated stripe to match fidesplus

### Steps to Confirm

- [x] CI tests passing.
- [ ] Stripe integration working.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-66]: https://ethyca.atlassian.net/browse/LJ-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ