### PR TITLE
Merge Full TCF in to `window.Fides.experience` after successful fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed `fides annotate dataset` command enters incorrect value on the `direction` field. [#5727](https://github.com/ethyca/fides/pull/5727)
 - Fixed Bigquery flakey tests. [#5713](https://github.com/ethyca/fides/pull/5713)
 - Fixed breadcrumb navigation issues in data catalog view [#5717](https://github.com/ethyca/fides/pull/5717)
+- Fixed `window.Fides.experience` of FidesJS to be a merged version of the minimal and full experience. [#5726](https://github.com/ethyca/fides/pull/5726)
 
 ## [2.53.0](https://github.com/ethyca/fides/compare/2.53.0...2.54.0)
 

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -152,6 +152,11 @@ export const TcfOverlay = ({
         // include user preferences from the cookie
         const userPrefs = buildUserPrefs(result, cookie);
         const fullExperience: PrivacyExperience = { ...result, ...userPrefs };
+        window.Fides.experience = {
+          ...window.Fides.experience,
+          ...fullExperience,
+        };
+        window.Fides.experience.minimal_tcf = false;
 
         setExperience(fullExperience);
         loadMessagesFromExperience(i18n, fullExperience, translationOverrides);

--- a/clients/privacy-center/cypress/e2e/consent-notices.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-notices.cy.ts
@@ -474,7 +474,9 @@ describe("Privacy notice driven consent", () => {
       cy.wait("@getExperience");
 
       cy.getByTestId("consent-item-pri_notice-advertising-000").click();
+      cy.getByTestId("toggle-Weekly Newsletter").should("be.visible");
       cy.getByTestId("toggle-Weekly Newsletter").getToggle().check();
+      cy.getByTestId("toggle-Monthly Newsletter").should("be.visible");
       cy.getByTestId("toggle-Monthly Newsletter").getToggle().check();
 
       cy.getByTestId("save-btn").click();

--- a/clients/privacy-center/cypress/support/commands.ts
+++ b/clients/privacy-center/cypress/support/commands.ts
@@ -12,7 +12,7 @@ Cypress.Commands.add("getByTestId", (selector, ...args) =>
   cy.get(`[data-testid='${selector}']`, ...args),
 );
 
-Cypress.Commands.add("getToggle", (...args) =>
+Cypress.Commands.add("getToggle", (_, ...args) =>
   cy.get(`input[type="checkbox"]`, ...args),
 );
 
@@ -121,9 +121,6 @@ Cypress.Commands.add(
       visitOptions.qs = queryParams;
     }
     cy.visit("/fides-js-components-demo.html", visitOptions);
-    if (options?.options?.tcfEnabled) {
-      cy.wait("@getPrivacyExperience");
-    }
   },
 );
 


### PR DESCRIPTION
Closes [LJ-322]

### Description Of Changes

Currently, when we have successfully loaded the Full TCF Experience, we replace the experience object in the React environment for use by the CMP.

However, the `window.Fides.experience` object only ever gets the Minimal TCF Experience.

This change **merges** the minimal and full experiences so that all properties from either experience is available and apply that to the `window.Fides.experience` once the fetch is successful.

### Code Changes

* sets `Fides.experience` to merged object of both minimal and full after the successful result.
* Adds Cypress test for the merge
* Updates/fixes some Cypress test configs to help support this as well as tighten up some unrelated testing issues.

### Steps to Confirm

1. Configure a TCF Experience in Admin UI
2. Visit demo page for TCF experience `http://localhost:3001/fides-js-demo.html?geolocation=eea`
3. In browser's dev tools console, run `Fides.experience`. Notice that for most of the properties there exists both an array of IDs as well as the full array of objects.
For example:
`tcf_purpose_consent_ids` (from minimal experience) and `tcf_purpose_consents` (from full experience) both exist.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-322]: https://ethyca.atlassian.net/browse/LJ-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ