### PR TITLE
Data catalog item detail trays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Added
 - Added a read-only consent category cell to Action Center aggregate system results table [#5737](https://github.com/ethyca/fides/pull/5737)
+- Added detail trays to items in data catalog view [#5729](https://github.com/ethyca/fides/pull/5729)
 
 ### Changed
 - Added frequency field to DataHubSchema integration config [#5716](https://github.com/ethyca/fides/pull/5716)

--- a/clients/admin-ui/cypress/e2e/data-catalog.cy.ts
+++ b/clients/admin-ui/cypress/e2e/data-catalog.cy.ts
@@ -29,15 +29,6 @@ describe("data catalog", () => {
         "BigQuery System",
       );
     });
-
-    it("should be able to navigate to system details via the overflow menu", () => {
-      cy.getByTestId("row-bigquery_system").within(() => {
-        cy.getByTestId("system-actions-menu").click();
-        cy.getByTestId("view-system-details").click({ force: true });
-        cy.url().should("include", "/systems/configure/bigquery_system");
-      });
-    });
-
     it("should be able to add a data use", () => {
       cy.getByTestId("row-bigquery_system-col-data-uses").within(() => {
         cy.getByTestId("taxonomy-add-btn").click();
@@ -58,6 +49,29 @@ describe("data catalog", () => {
       cy.getByTestId("row-dynamo_system-col-name").click();
       cy.wait("@getEmptyAvailableDatabases");
       cy.url().should("not.include", "/projects");
+    });
+
+    describe("system detail drawer", () => {
+      it("should be able to navigate to system details via the detail drawer", () => {
+        cy.getByTestId("row-bigquery_system").within(() => {
+          cy.getByTestId("system-actions-menu").click();
+          cy.getByTestId("view-system-details").click({ force: true });
+        });
+        cy.getByTestId("system-details").should("be.visible");
+        cy.getByTestId("edit-system-btn").click();
+        cy.url().should("include", "/systems/configure/bigquery_system");
+      });
+
+      it("should be able to add data uses via the detail drawer", () => {
+        cy.getByTestId("row-bigquery_system").within(() => {
+          cy.getByTestId("system-actions-menu").click();
+          cy.getByTestId("view-system-details").click({ force: true });
+        });
+        cy.getByTestId("system-details").within(() => {
+          cy.getByTestId("taxonomy-add-btn").click();
+          cy.get(".select-wrapper").should("be.visible");
+        });
+      });
     });
   });
 
@@ -91,6 +105,16 @@ describe("data catalog", () => {
         "/projects/bigquery_monitor.prj-bigquery-111111",
       );
     });
+
+    it("should be able to view details in the drawer", () => {
+      cy.getByTestId(
+        "row-bigquery_monitor.prj-bigquery-111111-col-actions",
+      ).within(() => {
+        cy.getByTestId("actions-menu").click();
+        cy.getByTestId("view-resource-details").click({ force: true });
+      });
+      cy.getByTestId("resource-details").should("be.visible");
+    });
   });
 
   describe("resource tables", () => {
@@ -117,8 +141,8 @@ describe("data catalog", () => {
       );
       cy.getByTestId("row-monitor.project.dataset.table_2-col-actions").within(
         () => {
-          cy.getByTestId("resource-actions-menu").click();
-          cy.getByTestId("hide-action").click({ force: true });
+          cy.getByTestId("actions-menu").click();
+          cy.getByTestId("hide-resource").click({ force: true });
           cy.wait("@ignoreResource");
         },
       );
@@ -128,6 +152,30 @@ describe("data catalog", () => {
           cy.wait("@promoteResource");
         },
       );
+    });
+
+    describe("resource detail drawer", () => {
+      it("should be able to view resource details", () => {
+        cy.getByTestId("row-monitor.project.dataset.table_1").within(() => {
+          cy.getByTestId("actions-menu").click();
+          cy.getByTestId("view-resource-details").click({ force: true });
+        });
+        cy.getByTestId("resource-details")
+          .should("be.visible")
+          .within(() => {
+            // don't edit categories unless resource has the right status
+            cy.getByTestId("edit-category-cell").should("not.exist");
+          });
+      });
+      it("should be able to edit data categories where applicable", () => {
+        cy.getByTestId("row-monitor.project.dataset.table_3").within(() => {
+          cy.getByTestId("actions-menu").click();
+          cy.getByTestId("view-resource-details").click({ force: true });
+        });
+        cy.getByTestId("resource-details").within(() => {
+          cy.getByTestId("user-classification-system").should("exist");
+        });
+      });
     });
   });
 });

--- a/clients/admin-ui/cypress/fixtures/data-catalog/catalog-tables.json
+++ b/clients/admin-ui/cypress/fixtures/data-catalog/catalog-tables.json
@@ -13,7 +13,8 @@
     {
       "urn": "monitor.project.dataset.table_3",
       "name": "table_3",
-      "diff_status": "classification_addition"
+      "diff_status": "classification_addition",
+      "user_assigned_data_categories": ["system"]
     },
     {
       "urn": "monitor.project.dataset.table_4",

--- a/clients/admin-ui/src/features/common/copy/components.tsx
+++ b/clients/admin-ui/src/features/common/copy/components.tsx
@@ -1,6 +1,7 @@
 import {
   Code,
   Heading,
+  HeadingProps,
   Link,
   OrderedList,
   Table,
@@ -15,8 +16,11 @@ import {
 } from "fidesui";
 import { ReactNode } from "react";
 
-export const InfoHeading = ({ text }: { text: string }) => (
-  <Heading fontSize="sm" mt={4} mb={1}>
+export const InfoHeading = ({
+  text,
+  ...props
+}: { text: string } & HeadingProps) => (
+  <Heading fontSize="sm" mt={4} mb={1} {...props}>
     {text}
   </Heading>
 );

--- a/clients/admin-ui/src/features/data-catalog/CatalogResourceActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-catalog/CatalogResourceActionsCell.tsx
@@ -1,15 +1,7 @@
-import {
-  AntButton,
-  AntButton as Button,
-  Flex,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
-  MoreIcon,
-} from "fidesui";
+import { AntButton as Button, Flex, Spacer } from "fidesui";
 
 import { useAlert } from "~/features/common/hooks";
+import CatalogResourceOverflowMenu from "~/features/data-catalog/staged-resources/CatalogResourceOverflowMenu";
 import {
   CatalogResourceStatus,
   getCatalogResourceStatus,
@@ -23,8 +15,10 @@ import { StagedResourceAPIResponse } from "~/types/api";
 
 const CatalogResourceActionsCell = ({
   resource,
+  onDetailClick,
 }: {
   resource: StagedResourceAPIResponse;
+  onDetailClick?: () => void;
 }) => {
   const { successAlert } = useAlert();
   const status = getCatalogResourceStatus(resource);
@@ -88,24 +82,11 @@ const CatalogResourceActionsCell = ({
           Approve
         </Button>
       )}
-      <Menu>
-        <MenuButton
-          as={AntButton}
-          size="small"
-          // Chakra is expecting the Chakra "type" prop, i.e. HTML type,
-          // but Ant buttons use "type" for styling
-          // @ts-ignore
-          type="text"
-          className="max-w-4"
-          icon={<MoreIcon transform="rotate(90deg)" ml={2} />}
-          data-testid="resource-actions-menu"
-        />
-        <MenuList>
-          <MenuItem onClick={hideResource} data-testid="hide-action">
-            Hide
-          </MenuItem>
-        </MenuList>
-      </Menu>
+      <Spacer />
+      <CatalogResourceOverflowMenu
+        onHideClick={hideResource}
+        onDetailClick={onDetailClick}
+      />
     </Flex>
   );
 };

--- a/clients/admin-ui/src/features/data-catalog/CatalogStatusBadgeCell.tsx
+++ b/clients/admin-ui/src/features/data-catalog/CatalogStatusBadgeCell.tsx
@@ -6,6 +6,7 @@ const STATUS_COLOR_MAP: Record<CatalogResourceStatus, string> = {
   [CatalogResourceStatus.APPROVED]: "green",
   [CatalogResourceStatus.IN_REVIEW]: "yellow",
   [CatalogResourceStatus.CLASSIFYING]: "blue",
+  [CatalogResourceStatus.NONE]: "gray",
 };
 
 const CatalogStatusBadgeCell = ({

--- a/clients/admin-ui/src/features/data-catalog/datasets/CatalogDatasetDetailDrawer.tsx
+++ b/clients/admin-ui/src/features/data-catalog/datasets/CatalogDatasetDetailDrawer.tsx
@@ -1,0 +1,39 @@
+import {
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+} from "fidesui";
+
+import { InfoHeading, InfoText } from "~/features/common/copy/components";
+import { StagedResourceAPIResponse } from "~/types/api";
+
+const CatalogDatasetDetailDrawer = ({
+  dataset,
+  onClose,
+}: {
+  dataset?: StagedResourceAPIResponse;
+  onClose: () => void;
+}) => (
+  <Drawer isOpen={!!dataset} onClose={onClose} size="md">
+    <DrawerOverlay />
+    <DrawerContent>
+      <DrawerHeader>{dataset?.name || dataset?.urn}</DrawerHeader>
+      <DrawerCloseButton />
+      <DrawerBody>
+        <InfoHeading text="Title" mt={0} />
+        <InfoText>{dataset?.name ?? dataset?.urn}</InfoText>
+        {dataset?.description && (
+          <>
+            <InfoHeading text="Description" />
+            <InfoText>{dataset?.description}</InfoText>
+          </>
+        )}
+      </DrawerBody>
+    </DrawerContent>
+  </Drawer>
+);
+
+export default CatalogDatasetDetailDrawer;

--- a/clients/admin-ui/src/features/data-catalog/datasets/useCatalogDatasetColumns.tsx
+++ b/clients/admin-ui/src/features/data-catalog/datasets/useCatalogDatasetColumns.tsx
@@ -1,6 +1,14 @@
 /* eslint-disable react/no-unstable-nested-components */
 
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import {
+  AntButton as Button,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  MoreIcon,
+} from "fidesui";
 import { useMemo } from "react";
 
 import { DefaultCell } from "~/features/common/table/v2";
@@ -12,7 +20,38 @@ import { StagedResourceAPIResponse } from "~/types/api";
 
 const columnHelper = createColumnHelper<StagedResourceAPIResponse>();
 
-const useCatalogDatasetColumns = () => {
+const CatalogDatasetActionsCell = ({
+  onDetailClick,
+}: {
+  onDetailClick?: () => void;
+}) => {
+  return (
+    <Menu>
+      <MenuButton
+        as={Button}
+        size="small"
+        // @ts-ignore: Ant type, not Chakra type
+        type="text"
+        icon={<MoreIcon transform="rotate(90deg)" />}
+        className="w-6 gap-0"
+        data-testid="dataset-actions"
+      />
+      <MenuList>
+        <MenuItem data-testid="view-dataset-details" onClick={onDetailClick}>
+          View details
+        </MenuItem>
+      </MenuList>
+    </Menu>
+  );
+};
+
+interface CatalogDatasetColumnsParams {
+  onDetailClick: (dataset: StagedResourceAPIResponse) => void;
+}
+
+const useCatalogDatasetColumns = ({
+  onDetailClick,
+}: CatalogDatasetColumnsParams) => {
   const columns: ColumnDef<StagedResourceAPIResponse, any>[] = useMemo(
     () => [
       columnHelper.accessor((row) => row.name, {
@@ -41,8 +80,20 @@ const useCatalogDatasetColumns = () => {
         cell: (props) => <RelativeTimestampCell time={props.getValue()} />,
         header: "Updated",
       }),
+      columnHelper.display({
+        id: "actions",
+        cell: ({ row }) => (
+          <CatalogDatasetActionsCell
+            onDetailClick={() => onDetailClick(row.original)}
+          />
+        ),
+        size: 25,
+        meta: {
+          disableRowClick: true,
+        },
+      }),
     ],
-    [],
+    [onDetailClick],
   );
 
   return columns;

--- a/clients/admin-ui/src/features/data-catalog/projects/CatalogProjectsTable.tsx
+++ b/clients/admin-ui/src/features/data-catalog/projects/CatalogProjectsTable.tsx
@@ -24,6 +24,8 @@ import { RelativeTimestampCell } from "~/features/common/table/v2/cells";
 import CatalogResourceNameCell from "~/features/data-catalog/CatalogResourceNameCell";
 import CatalogStatusBadgeCell from "~/features/data-catalog/CatalogStatusBadgeCell";
 import { useGetCatalogProjectsQuery } from "~/features/data-catalog/data-catalog.slice";
+import CatalogResourceDetailDrawer from "~/features/data-catalog/staged-resources/CatalogResourceDetailDrawer";
+import CatalogResourceOverflowMenu from "~/features/data-catalog/staged-resources/CatalogResourceOverflowMenu";
 import { getCatalogResourceStatus } from "~/features/data-catalog/utils";
 import { StagedResourceAPIResponse } from "~/types/api";
 
@@ -103,6 +105,10 @@ const CatalogProjectsTable = ({
     setTotalPages(totalPages);
   }, [totalPages, setTotalPages]);
 
+  const [detailResource, setDetailResource] = useState<
+    StagedResourceAPIResponse | undefined
+  >(undefined);
+
   const columns: ColumnDef<StagedResourceAPIResponse, any>[] = useMemo(
     () => [
       columnHelper.accessor((row) => row.name, {
@@ -139,6 +145,18 @@ const CatalogProjectsTable = ({
           cellProps: {
             borderRight: "none",
           },
+        },
+      }),
+      columnHelper.display({
+        id: "actions",
+        cell: ({ row }) => (
+          <CatalogResourceOverflowMenu
+            onDetailClick={() => setDetailResource(row.original)}
+          />
+        ),
+        size: 25,
+        meta: {
+          disableRowClick: true,
         },
       }),
     ],
@@ -183,6 +201,10 @@ const CatalogProjectsTable = ({
         isNextPageDisabled={isNextPageDisabled}
         startRange={startRange}
         endRange={endRange}
+      />
+      <CatalogResourceDetailDrawer
+        resource={detailResource}
+        onClose={() => setDetailResource(undefined)}
       />
     </>
   );

--- a/clients/admin-ui/src/features/data-catalog/staged-resources/CatalogResourceDetailDrawer.tsx
+++ b/clients/admin-ui/src/features/data-catalog/staged-resources/CatalogResourceDetailDrawer.tsx
@@ -1,0 +1,62 @@
+import {
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+} from "fidesui";
+
+import { InfoHeading, InfoText } from "~/features/common/copy/components";
+import {
+  CatalogResourceStatus,
+  getCatalogResourceStatus,
+} from "~/features/data-catalog/utils";
+import EditCategoryCell from "~/features/data-discovery-and-detection/tables/cells/EditCategoryCell";
+import { StagedResourceType } from "~/features/data-discovery-and-detection/types/StagedResourceType";
+import { findResourceType } from "~/features/data-discovery-and-detection/utils/findResourceType";
+import { StagedResourceAPIResponse } from "~/types/api";
+
+const CatalogResourceDetailDrawer = ({
+  resource,
+  onClose,
+}: {
+  resource?: StagedResourceAPIResponse;
+  onClose: () => void;
+}) => {
+  const resourceType = findResourceType(resource);
+  const status = getCatalogResourceStatus(resource);
+
+  const showDataCategories =
+    (resourceType === StagedResourceType.FIELD ||
+      resourceType === StagedResourceType.TABLE) &&
+    status === CatalogResourceStatus.IN_REVIEW;
+
+  return (
+    <Drawer isOpen={!!resource} onClose={onClose} size="md">
+      <DrawerOverlay />
+      <DrawerContent data-testid="resource-details">
+        <DrawerHeader>{resource?.name || resource?.urn}</DrawerHeader>
+        <DrawerCloseButton />
+        <DrawerBody>
+          <InfoHeading text="Title" mt={0} />
+          <InfoText>{resource?.name ?? resource?.urn}</InfoText>
+          {resource?.description && (
+            <>
+              <InfoHeading text="Description" />
+              <InfoText>{resource?.description}</InfoText>
+            </>
+          )}
+          {showDataCategories && (
+            <>
+              <InfoHeading text="Data categories" />
+              <EditCategoryCell resource={resource!} />
+            </>
+          )}
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default CatalogResourceDetailDrawer;

--- a/clients/admin-ui/src/features/data-catalog/staged-resources/CatalogResourceOverflowMenu.tsx
+++ b/clients/admin-ui/src/features/data-catalog/staged-resources/CatalogResourceOverflowMenu.tsx
@@ -1,0 +1,42 @@
+import {
+  AntButton as Button,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  MoreIcon,
+} from "fidesui";
+
+const CatalogResourceOverflowMenu = ({
+  onHideClick,
+  onDetailClick,
+}: {
+  onHideClick?: () => void;
+  onDetailClick?: () => void;
+}) => (
+  <Menu>
+    <MenuButton
+      as={Button}
+      size="small"
+      // @ts-ignore: Ant type, not Chakra type
+      type="text"
+      icon={<MoreIcon transform="rotate(90deg)" />}
+      className="w-6 gap-0"
+      data-testid="actions-menu"
+    />
+    <MenuList>
+      {onDetailClick && (
+        <MenuItem onClick={onDetailClick} data-testid="view-resource-details">
+          View details
+        </MenuItem>
+      )}
+      {onHideClick && (
+        <MenuItem onClick={onHideClick} data-testid="hide-resource">
+          Hide
+        </MenuItem>
+      )}
+    </MenuList>
+  </Menu>
+);
+
+export default CatalogResourceOverflowMenu;

--- a/clients/admin-ui/src/features/data-catalog/staged-resources/CatalogResourcesTable.tsx
+++ b/clients/admin-ui/src/features/data-catalog/staged-resources/CatalogResourcesTable.tsx
@@ -16,6 +16,7 @@ import {
   useServerSidePagination,
 } from "~/features/common/table/v2";
 import EmptyCatalogTableNotice from "~/features/data-catalog/datasets/EmptyCatalogTableNotice";
+import CatalogResourceDetailDrawer from "~/features/data-catalog/staged-resources/CatalogResourceDetailDrawer";
 import useCatalogResourceColumns from "~/features/data-catalog/useCatalogResourceColumns";
 import { useGetMonitorResultsQuery } from "~/features/data-discovery-and-detection/discovery-detection.slice";
 import { SearchInput } from "~/features/data-discovery-and-detection/SearchInput";
@@ -95,9 +96,13 @@ const CatalogResourcesTable = ({
     setTotalPages(totalPages);
   }, [totalPages, setTotalPages]);
 
+  const [detailResource, setDetailResource] = useState<
+    StagedResourceAPIResponse | undefined
+  >(undefined);
+
   const type = findResourceType(data[0] ?? StagedResourceType.NONE);
 
-  const columns = useCatalogResourceColumns(type);
+  const columns = useCatalogResourceColumns(type, setDetailResource);
 
   const tableInstance = useReactTable<StagedResourceAPIResponse>({
     getCoreRowModel: getCoreRowModel(),
@@ -139,6 +144,10 @@ const CatalogResourcesTable = ({
         isNextPageDisabled={isNextPageDisabled}
         startRange={startRange}
         endRange={endRange}
+      />
+      <CatalogResourceDetailDrawer
+        resource={detailResource}
+        onClose={() => setDetailResource(undefined)}
       />
     </>
   );

--- a/clients/admin-ui/src/features/data-catalog/systems/CatalogSystemDetailDrawer.tsx
+++ b/clients/admin-ui/src/features/data-catalog/systems/CatalogSystemDetailDrawer.tsx
@@ -1,0 +1,53 @@
+import {
+  AntButton as Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+} from "fidesui";
+
+import { InfoHeading, InfoText } from "~/features/common/copy/components";
+import EditDataUseCell from "~/features/data-catalog/systems/EditDataUseCell";
+import { SystemResponse, SystemWithMonitorKeys } from "~/types/api";
+
+const CatalogSystemDetailDrawer = ({
+  system,
+  onEdit,
+  onClose,
+}: {
+  system?: SystemWithMonitorKeys;
+  onEdit: () => void;
+  onClose: () => void;
+}) => {
+  return (
+    <Drawer isOpen={!!system} onClose={onClose} size="md">
+      <DrawerOverlay />
+      <DrawerContent data-testid="system-details">
+        <DrawerHeader>{system?.name || system?.fides_key}</DrawerHeader>
+        <DrawerCloseButton />
+        <DrawerBody>
+          <InfoHeading text="Title" mt={0} />
+          <InfoText>{system?.name ?? system?.fides_key}</InfoText>
+          {system?.description && (
+            <>
+              <InfoHeading text="Description" />
+              <InfoText>{system?.description}</InfoText>
+            </>
+          )}
+          <InfoHeading text="Data uses" />
+          <EditDataUseCell system={system as SystemResponse} />
+        </DrawerBody>
+        <DrawerFooter>
+          <Button onClick={onEdit} data-testid="edit-system-btn">
+            Edit system
+          </Button>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default CatalogSystemDetailDrawer;

--- a/clients/admin-ui/src/features/data-catalog/systems/CatalogSystemsTable.tsx
+++ b/clients/admin-ui/src/features/data-catalog/systems/CatalogSystemsTable.tsx
@@ -12,7 +12,10 @@ import {
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 
-import { DATA_CATALOG_ROUTE } from "~/features/common/nav/v2/routes";
+import {
+  DATA_CATALOG_ROUTE,
+  EDIT_SYSTEM_ROUTE,
+} from "~/features/common/nav/v2/routes";
 import {
   DefaultCell,
   DefaultHeaderCell,
@@ -24,6 +27,7 @@ import {
 import { getQueryParamsFromArray } from "~/features/common/utils";
 import { useGetCatalogSystemsQuery } from "~/features/data-catalog/data-catalog.slice";
 import EmptyCatalogTableNotice from "~/features/data-catalog/datasets/EmptyCatalogTableNotice";
+import CatalogSystemDetailDrawer from "~/features/data-catalog/systems/CatalogSystemDetailDrawer";
 import EditDataUseCell from "~/features/data-catalog/systems/EditDataUseCell";
 import SystemActionsCell from "~/features/data-catalog/systems/SystemActionCell";
 import { useLazyGetAvailableDatabasesByConnectionQuery } from "~/features/data-discovery-and-detection/discovery-detection.slice";
@@ -78,6 +82,15 @@ const CatalogSystemsTable = () => {
     setTotalPages(totalPages);
   }, [totalPages, setTotalPages]);
 
+  const [detailSystemKey, setDetailSystemKey] = useState<string | undefined>(
+    undefined,
+  );
+
+  // force a re-render when the table fetches again (e.g. on data use updates)
+  const detailsToView = useMemo(() => {
+    return data.find((s) => s.fides_key === detailSystemKey);
+  }, [data, detailSystemKey]);
+
   const handleRowClicked = async (row: SystemWithMonitorKeys) => {
     // if there are projects, go to project view; otherwise go to datasets view
     const projectsResponse = await getProjects({
@@ -124,7 +137,7 @@ const CatalogSystemsTable = () => {
         cell: (props) => (
           <SystemActionsCell
             onDetailClick={() =>
-              router.push(`/systems/configure/${props.row.original.fides_key}`)
+              setDetailSystemKey(props.row.original.fides_key)
             }
           />
         ),
@@ -138,7 +151,7 @@ const CatalogSystemsTable = () => {
         },
       }),
     ],
-    [router],
+    [],
   );
 
   const tableInstance = useReactTable<SystemWithMonitorKeys>({
@@ -178,6 +191,16 @@ const CatalogSystemsTable = () => {
         isNextPageDisabled={isNextPageDisabled}
         startRange={startRange}
         endRange={endRange}
+      />
+      <CatalogSystemDetailDrawer
+        system={detailsToView}
+        onClose={() => setDetailSystemKey(undefined)}
+        onEdit={() =>
+          router.push({
+            pathname: EDIT_SYSTEM_ROUTE,
+            query: { id: detailSystemKey },
+          })
+        }
       />
     </>
   );

--- a/clients/admin-ui/src/features/data-catalog/useCatalogResourceColumns.tsx
+++ b/clients/admin-ui/src/features/data-catalog/useCatalogResourceColumns.tsx
@@ -13,7 +13,10 @@ import { StagedResourceAPIResponse } from "~/types/api";
 
 const columnHelper = createColumnHelper<StagedResourceAPIResponse>();
 
-const useCatalogResourceColumns = (type: StagedResourceType) => {
+const useCatalogResourceColumns = (
+  type: StagedResourceType,
+  onDetailClick: (resource: StagedResourceAPIResponse) => void,
+) => {
   const defaultColumns: ColumnDef<StagedResourceAPIResponse, any>[] = [];
 
   if (!type) {
@@ -58,7 +61,10 @@ const useCatalogResourceColumns = (type: StagedResourceType) => {
       columnHelper.display({
         id: "actions",
         cell: ({ row }) => (
-          <CatalogResourceActionsCell resource={row.original} />
+          <CatalogResourceActionsCell
+            resource={row.original}
+            onDetailClick={() => onDetailClick(row.original)}
+          />
         ),
         header: "Actions",
         meta: {
@@ -112,7 +118,10 @@ const useCatalogResourceColumns = (type: StagedResourceType) => {
       columnHelper.display({
         id: "actions",
         cell: ({ row }) => (
-          <CatalogResourceActionsCell resource={row.original} />
+          <CatalogResourceActionsCell
+            resource={row.original}
+            onDetailClick={() => onDetailClick(row.original)}
+          />
         ),
         header: "Actions",
         meta: {

--- a/clients/admin-ui/src/features/data-catalog/utils.ts
+++ b/clients/admin-ui/src/features/data-catalog/utils.ts
@@ -5,11 +5,15 @@ export enum CatalogResourceStatus {
   IN_REVIEW = "In review",
   APPROVED = "Approved",
   CLASSIFYING = "Classifying",
+  NONE = "None",
 }
 
 export const getCatalogResourceStatus = (
-  resource: StagedResourceAPIResponse,
+  resource: StagedResourceAPIResponse | undefined,
 ) => {
+  if (!resource) {
+    return CatalogResourceStatus.APPROVED;
+  }
   const resourceSchemaChanged =
     resource.diff_status === DiffStatus.ADDITION ||
     resource.diff_status === DiffStatus.REMOVAL;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/EditCategoryCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/EditCategoryCell.tsx
@@ -64,7 +64,7 @@ const EditCategoryCell = ({ resource }: EditCategoryCellProps) => {
     !isAdding && !!bestClassifiedCategory && !userCategories.length;
 
   return (
-    <TaxonomyCellContainer>
+    <TaxonomyCellContainer data-testid="edit-category-cell">
       {noCategories && (
         <>
           <TaxonomyBadge data-testid="no-classifications">None</TaxonomyBadge>

--- a/clients/admin-ui/src/pages/data-catalog/[systemId]/projects/[projectUrn]/index.tsx
+++ b/clients/admin-ui/src/pages/data-catalog/[systemId]/projects/[projectUrn]/index.tsx
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-table";
 import { Icons } from "fidesui";
 import { useRouter } from "next/router";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import Layout from "~/features/common/Layout";
 import { DATA_CATALOG_ROUTE } from "~/features/common/nav/v2/routes";
@@ -17,6 +17,7 @@ import {
   TableSkeletonLoader,
   useServerSidePagination,
 } from "~/features/common/table/v2";
+import CatalogDatasetDetailDrawer from "~/features/data-catalog/datasets/CatalogDatasetDetailDrawer";
 import EmptyCatalogTableNotice from "~/features/data-catalog/datasets/EmptyCatalogTableNotice";
 import useCatalogDatasetColumns from "~/features/data-catalog/datasets/useCatalogDatasetColumns";
 import { getProjectName } from "~/features/data-catalog/utils/urnParsing";
@@ -36,6 +37,10 @@ const CatalogDatasetView = () => {
   const { query, push } = useRouter();
   const systemKey = query.systemId as string;
   const projectUrn = query.projectUrn as string;
+
+  const [detailsToView, setDetailsToView] = useState<
+    StagedResourceAPIResponse | undefined
+  >(undefined);
 
   const { data: system, isLoading: systemIsLoading } =
     useGetSystemByFidesKeyQuery(systemKey);
@@ -74,7 +79,9 @@ const CatalogDatasetView = () => {
     setTotalPages(totalPages);
   }, [totalPages, setTotalPages]);
 
-  const columns = useCatalogDatasetColumns();
+  const columns = useCatalogDatasetColumns({
+    onDetailClick: (dataset) => setDetailsToView(dataset),
+  });
 
   const tableInstance = useReactTable<StagedResourceAPIResponse>({
     getCoreRowModel: getCoreRowModel(),
@@ -123,6 +130,10 @@ const CatalogDatasetView = () => {
             isNextPageDisabled={isNextPageDisabled}
             startRange={startRange}
             endRange={endRange}
+          />
+          <CatalogDatasetDetailDrawer
+            dataset={detailsToView}
+            onClose={() => setDetailsToView(undefined)}
           />
         </>
       )}

--- a/clients/admin-ui/src/pages/data-catalog/[systemId]/resources/index.tsx
+++ b/clients/admin-ui/src/pages/data-catalog/[systemId]/resources/index.tsx
@@ -5,7 +5,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useRouter } from "next/router";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import Layout from "~/features/common/Layout";
 import { DATA_CATALOG_ROUTE } from "~/features/common/nav/v2/routes";
@@ -17,6 +17,7 @@ import {
   useServerSidePagination,
 } from "~/features/common/table/v2";
 import { useGetCatalogDatasetsQuery } from "~/features/data-catalog/data-catalog.slice";
+import CatalogDatasetDetailDrawer from "~/features/data-catalog/datasets/CatalogDatasetDetailDrawer";
 import EmptyCatalogTableNotice from "~/features/data-catalog/datasets/EmptyCatalogTableNotice";
 import useCatalogDatasetColumns from "~/features/data-catalog/datasets/useCatalogDatasetColumns";
 import { useGetSystemByFidesKeyQuery } from "~/features/system";
@@ -72,7 +73,13 @@ const CatalogDatasetViewNoProjects = () => {
     setTotalPages(totalPages);
   }, [totalPages, setTotalPages]);
 
-  const columns = useCatalogDatasetColumns();
+  const [detailsToView, setDetailsToView] = useState<
+    StagedResourceAPIResponse | undefined
+  >(undefined);
+
+  const columns = useCatalogDatasetColumns({
+    onDetailClick: (dataset) => setDetailsToView(dataset),
+  });
 
   const tableInstance = useReactTable<StagedResourceAPIResponse>({
     getCoreRowModel: getCoreRowModel(),
@@ -117,6 +124,10 @@ const CatalogDatasetViewNoProjects = () => {
             isNextPageDisabled={isNextPageDisabled}
             startRange={startRange}
             endRange={endRange}
+          />
+          <CatalogDatasetDetailDrawer
+            dataset={detailsToView}
+            onClose={() => setDetailsToView(undefined)}
           />
         </>
       )}


### PR DESCRIPTION
Closes HA-410

### Description Of Changes

Adds detail trays to items at all levels of the new data catalog view.

### Steps to Confirm

Test with both BQ and a non-database-layer system.

1. Create systems with integrations with and without a database layer (e.g. BigQuery and DynamoDB)
2. For each system, create and run a monitor
3. Go to data catalog view
4. Check all resources have a "View details" option in the table "actions" cell overflow menu
5. For systems, should be able to edit data uses and go to full edit system form
6. For tables and fields with "In Review" status, should be able to edit data categories

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
