### PR TITLE
LJ-309: allow privacy notices to be assigned to TCF components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Changed
 - Added frequency field to DataHubSchema integration config [#5716](https://github.com/ethyca/fides/pull/5716)
+- Exposes privacy notice picker for TCF components [#5730](https://github.com/ethyca/fides/pull/5730)
 
 ### Fixed
 - Fixed `fides annotate dataset` command enters incorrect value on the `direction` field. [#5727](https://github.com/ethyca/fides/pull/5727)

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -266,7 +266,7 @@ describe("Privacy experiences", () => {
       });
 
       it("shows option to display privacy notices in banner and updates preview when clicked", () => {
-        cy.getByTestId("input-show_layer1_notices").should("not.be.visible");
+        cy.getByTestId("input-show_layer1_notices").should("not.exist");
         cy.getByTestId("controlled-select-component").antSelect(
           "Banner and modal",
         );
@@ -277,6 +277,16 @@ describe("Privacy experiences", () => {
           .find("#fides-banner")
           .find("#fides-banner-notices")
           .contains("Essential");
+      });
+
+      it("does not show option to display privacy notices in modal preview when clicked", () => {
+        cy.getByTestId("input-show_layer1_notices").should("not.exist");
+        cy.getByTestId("controlled-select-component").antSelect(
+            "Modal",
+        );
+        cy.getByTestId("add-privacy-notice").click();
+        cy.getByTestId("select-privacy-notice").antSelect(0);
+        cy.getByTestId("input-show_layer1_notices").should("not.exist");
       });
 
       it("allows editing experience text and shows updated text in the preview", () => {

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -281,9 +281,7 @@ describe("Privacy experiences", () => {
 
       it("does not show option to display privacy notices in modal preview when clicked", () => {
         cy.getByTestId("input-show_layer1_notices").should("not.exist");
-        cy.getByTestId("controlled-select-component").antSelect(
-            "Modal",
-        );
+        cy.getByTestId("controlled-select-component").antSelect("Modal");
         cy.getByTestId("add-privacy-notice").click();
         cy.getByTestId("select-privacy-notice").antSelect(0);
         cy.getByTestId("input-show_layer1_notices").should("not.exist");

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -229,22 +229,22 @@ export const PrivacyExperienceForm = ({
         baseTestId="property"
       />
       <Divider />
-      {values.component !== ComponentType.TCF_OVERLAY ? (
+      <Heading fontSize="md" fontWeight="semibold">
+        Privacy notices
+      </Heading>
+      <ScrollableList
+        addButtonLabel="Add privacy notice"
+        allItems={filterNoticesForOnlyParentNotices().map((n) => n.id)}
+        values={values.privacy_notice_ids ?? []}
+        setValues={(newValues) =>
+          setFieldValue("privacy_notice_ids", newValues)
+        }
+        getItemLabel={getPrivacyNoticeName}
+        draggable
+        baseTestId="privacy-notice"
+      />
+      {values.component === ComponentType.BANNER_AND_MODAL ? (
         <>
-          <Heading fontSize="md" fontWeight="semibold">
-            Privacy notices
-          </Heading>
-          <ScrollableList
-            addButtonLabel="Add privacy notice"
-            allItems={filterNoticesForOnlyParentNotices().map((n) => n.id)}
-            values={values.privacy_notice_ids ?? []}
-            setValues={(newValues) =>
-              setFieldValue("privacy_notice_ids", newValues)
-            }
-            getItemLabel={getPrivacyNoticeName}
-            draggable
-            baseTestId="privacy-notice"
-          />
           <Collapse in={!!values.privacy_notice_ids?.length} animateOpacity>
             <Box p="1px">
               <CustomSwitch


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/LJ-309

### Description Of Changes

Exposes privacy notice picker to add privacy notices to TCF components

### Code Changes

* [ ] Expose privacy notice picker for TCF components
* [ ] Adjust `Add privacy notices to banner` toggle to only display for `banner_and_modal` components

### Steps to Confirm
Please test alongside https://github.com/ethyca/fidesplus/pull/1836

1.  Run `nox -s "build(slim)" "dev(slim)" -- dev` on https://github.com/ethyca/fidesplus/pull/1836 branch
2. Run this PR within `/clients/admin-ui` with `turbo run dev`
3. Update a TCF experience with notices, confirm it's saved correctly

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
