### PR TITLE
add "headless" to consent types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Changed
 - Added frequency field to DataHubSchema integration config [#5716](https://github.com/ethyca/fides/pull/5716)
+- Added initial support for upcoming "headless" CMP experience type [#5731](https://github.com/ethyca/fides/pull/5731)
 
 ### Fixed
 - Fixed `fides annotate dataset` command enters incorrect value on the `direction` field. [#5727](https://github.com/ethyca/fides/pull/5727)

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -643,6 +643,7 @@ export enum ComponentType {
   MODAL = "modal",
   PRIVACY_CENTER = "privacy_center",
   TCF_OVERLAY = "tcf_overlay",
+  HEADLESS = "headless",
 }
 
 export enum BannerEnabled {

--- a/src/fides/api/models/privacy_experience.py
+++ b/src/fides/api/models/privacy_experience.py
@@ -36,6 +36,7 @@ class ComponentType(Enum):
     modal = "modal"
     privacy_center = "privacy_center"
     tcf_overlay = "tcf_overlay"  # TCF Banner + modal combined
+    headless = "headless"
 
 
 class Layer1ButtonOption(Enum):
@@ -51,6 +52,7 @@ class Layer1ButtonOption(Enum):
 FidesJSUXTypes: List[ComponentType] = [
     ComponentType.banner_and_modal,
     ComponentType.modal,
+    ComponentType.headless,
 ]
 
 # Fides JS Overlay Types - there should only be one of these defined per region + property
@@ -58,6 +60,7 @@ FidesJSOverlayTypes: List[ComponentType] = [
     ComponentType.banner_and_modal,
     ComponentType.modal,
     ComponentType.tcf_overlay,
+    ComponentType.headless,
 ]
 
 


### PR DESCRIPTION
Prep work needed to be able to update the Experience form with "headless" as an option