### PR TITLE
Fix vendor count in embedded 2nd layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed Bigquery flakey tests. [#5713](https://github.com/ethyca/fides/pull/5713)
 - Fixed breadcrumb navigation issues in data catalog view [#5717](https://github.com/ethyca/fides/pull/5717)
 - Fixed `window.Fides.experience` of FidesJS to be a merged version of the minimal and full experience. [#5726](https://github.com/ethyca/fides/pull/5726)
+- Fixed vendor count template string on FidesJS embedded layer 2 descriptions (#5736)[https://github.com/ethyca/fides/pull/5736]
 
 ## [2.54.0](https://github.com/ethyca/fides/compare/2.53.0...2.54.0)
 

--- a/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
+++ b/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
@@ -263,7 +263,7 @@ export const AddMultipleSystems = ({ redirectRoute }: Props) => {
           successToastParams(
             `Successfully added ${
               vendorIds.length
-            } ${systemText.toLocaleLowerCase()}`,
+            } ${systemText.toLocaleLowerCase()}${vendorIds.length > 1 ? "s" : ""}`,
           ),
         );
       }

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -258,6 +258,7 @@ const Overlay: FunctionComponent<Props> = ({
                 isMobile: false,
               })
             }
+            onVendorPageClick={onVendorPageClick}
           >
             {renderModalContent()}
           </ConsentContent>

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -1526,6 +1526,9 @@ describe("Fides-js TCF", () => {
           stubOptions: { fidesDisableBanner: true },
           demoPageWindowParams: { fides_embed: "true" },
         });
+        cy.getByTestId("fides-modal-description").within(() => {
+          cy.get(".fides-vendor-count").first().should("have.text", "16");
+        });
         checkDefaultExperienceRender();
       });
     });


### PR DESCRIPTION
Closes [LJ-341]

### Description Of Changes

When fides_embed is enabled, the vendor count isn’t being set in place of the __VENDOR_COUNT_LINK__ template string. This happens regardless of whether disable_fides_banner is also true or not.

### Code Changes

* Minor string fix for pluralizing multiple vendors/systems
* Include Vendor click behavior in embedded layer 2, similar to modal, which enables the vendor text check.
* add Cypress test to catch this issue in the future

### Steps to Confirm

1. Create a TCF experience with the default text for description which includes the `__VENDOR_COUNT_LINK__` template string.
2. Visit demo page as normal (http://localhost:3001/fides-js-demo.html?geolocation=eea)
3. Note that the `__VENDOR_COUNT_LINK__` string has been replaced by a vendor count as a button. Clicking that button will open the modal to the Vendors tab. The modal also includes the count/button. This is all existing behavior.
4. Now validate this fix by visiting the demo page with embedded layer 2 enabled (http://localhost:3001/fides-js-demo.html?geolocation=eea&fides_embed=true&fides_disable_banner=true)
5. Note that the `__VENDOR_COUNT_LINK__` string has been replaced by a vendor count as a button. Clicking that button should switch to the Vendors tab.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-341]: https://ethyca.atlassian.net/browse/LJ-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ