### PR TITLE
Action center: Categories of consent cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.54.0...main)
 
+### Added
+- Added a read-only consent category cell to Action Center aggregate system results table [#5737](https://github.com/ethyca/fides/pull/5737)
+
 ### Changed
 - Added frequency field to DataHubSchema integration config [#5716](https://github.com/ethyca/fides/pull/5716)
 - Added initial support for upcoming "headless" CMP experience type [#5731](https://github.com/ethyca/fides/pull/5731)

--- a/clients/admin-ui/cypress/e2e/action-center.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center.cy.ts
@@ -154,11 +154,11 @@ describe("Action center", () => {
       });
       // data use column should be empty for uncategorized assets
       cy.getByTestId("row-0-col-data_use").children().should("have.length", 0);
-      cy.getByTestId("row-1-col-system_name").within(() => {
-        cy.getByTestId("change-icon").should("not.exist"); // existing result
-        cy.contains("Google Tag Manager").should("exist");
-      });
-      // TODO: [HJ-356] data use column should not be empty for other assets
+      // cy.getByTestId("row-1-col-system_name").within(() => {
+      //   cy.getByTestId("change-icon").should("not.exist"); // existing result
+      //   cy.contains("Google Tag Manager").should("exist");
+      // });
+      // data use column should not be empty for other assets
       cy.getByTestId("row-1-col-data_use")
         .children()
         .should("not.have.length", 0);

--- a/clients/admin-ui/cypress/e2e/action-center.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center.cy.ts
@@ -153,7 +153,7 @@ describe("Action center", () => {
         cy.getByTestId("change-icon").should("exist"); // new system
       });
       // data use column should be empty for uncategorized assets
-      cy.getByTestId("row-0-col-data_use").children().should("have.length", 0);
+      cy.getByTestId("row-0-col-data_use").should("be.empty");
       // cy.getByTestId("row-1-col-system_name").within(() => {
       //   cy.getByTestId("change-icon").should("not.exist"); // existing result
       //   cy.contains("Google Tag Manager").should("exist");

--- a/clients/admin-ui/cypress/e2e/action-center.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center.cy.ts
@@ -141,8 +141,7 @@ describe("Action center", () => {
       cy.getByTestId("pagination-btn").should("exist");
       cy.getByTestId("column-system_name").should("exist");
       cy.getByTestId("column-total_updates").should("exist");
-      // TODO: [HJ-356] uncomment when data use column is implemented
-      // cy.getByTestId("column-data_use").should("exist");
+      cy.getByTestId("column-data_use").should("exist");
       cy.getByTestId("column-locations").should("exist");
       cy.getByTestId("column-domains").should("exist");
       cy.getByTestId("column-actions").should("exist");
@@ -153,15 +152,16 @@ describe("Action center", () => {
       cy.getByTestId("row-3-col-system_name").within(() => {
         cy.getByTestId("change-icon").should("exist"); // new system
       });
-      // TODO: [HJ-356] uncomment when data use column is implemented
-      /* // data use column should be empty for uncategorized assets
+      // data use column should be empty for uncategorized assets
       cy.getByTestId("row-0-col-data_use").children().should("have.length", 0);
       cy.getByTestId("row-1-col-system_name").within(() => {
         cy.getByTestId("change-icon").should("not.exist"); // existing result
         cy.contains("Google Tag Manager").should("exist");
-      }); */
+      });
       // TODO: [HJ-356] data use column should not be empty for other assets
-      // cy.getByTestId("row-1-col-data_use").children().should("not.have.length", 0);
+      cy.getByTestId("row-1-col-data_use")
+        .children()
+        .should("not.have.length", 0);
 
       // multiple locations
       cy.getByTestId("row-2-col-locations").should("contain", "2 locations");

--- a/clients/admin-ui/cypress/e2e/action-center.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center.cy.ts
@@ -159,9 +159,7 @@ describe("Action center", () => {
       //   cy.contains("Google Tag Manager").should("exist");
       // });
       // data use column should not be empty for other assets
-      cy.getByTestId("row-1-col-data_use")
-        .children()
-        .should("not.have.length", 0);
+      cy.getByTestId("row-1-col-data_use").children().should("have.length", 1);
 
       // multiple locations
       cy.getByTestId("row-2-col-locations").should("contain", "2 locations");

--- a/clients/admin-ui/cypress/fixtures/detection-discovery/activity-center/system-aggregate-results.json
+++ b/clients/admin-ui/cypress/fixtures/detection-discovery/activity-center/system-aggregate-results.json
@@ -46,6 +46,7 @@
       "vendor_id": "fds.1046",
       "total_updates": 10,
       "locations": ["USA"],
+      "data_uses": ["essential", "collect"],
       "domains": [
         "td.doubleclick.net",
         "www.google.com",

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
@@ -1,6 +1,7 @@
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 
 import { DefaultCell } from "~/features/common/table/v2";
+import DiscoveredSystemDataUseCell from "~/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemDataUseCell";
 
 import { DiscoveredSystemActionsCell } from "../tables/cells/DiscoveredSystemAggregateActionsCell";
 import { DiscoveredSystemStatusCell } from "../tables/cells/DiscoveredSystemAggregateStatusCell";
@@ -26,15 +27,17 @@ export const useDiscoveredSystemAggregateColumns = (monitorId: string) => {
       header: "Assets",
       size: 80,
     }),
-    /*
-    // TODO: [HJ-356] uncomment when monitor supports categories of consent
     columnHelper.display({
       id: "data_use",
+      cell: (props) => (
+        <DiscoveredSystemDataUseCell system={props.row.original} />
+      ),
       header: "Categories of consent",
       meta: {
         width: "auto",
+        disableRowClick: true,
       },
-    }), */
+    }),
     columnHelper.accessor((row) => row.locations, {
       id: "locations",
       cell: (props) => (

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemDataUseCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemDataUseCell.tsx
@@ -18,7 +18,7 @@ const DiscoveredSystemDataUseCell = ({
 
   return (
     <BadgeCellExpandable
-      values={cellValues.length ? cellValues : [{ label: "None", key: "none" }]}
+      values={cellValues}
       bgColor="white"
       borderWidth="1px"
       borderColor="gray.200"

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemDataUseCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemDataUseCell.tsx
@@ -1,0 +1,30 @@
+import useTaxonomies from "~/features/common/hooks/useTaxonomies";
+import { BadgeCellExpandable } from "~/features/common/table/v2/cells";
+import { MonitorSystemAggregate } from "~/features/data-discovery-and-detection/action-center/types";
+import isConsentCategory from "~/features/data-discovery-and-detection/action-center/utils/isConsentCategory";
+
+const DiscoveredSystemDataUseCell = ({
+  system,
+}: {
+  system: MonitorSystemAggregate;
+}) => {
+  const { getDataUseDisplayName } = useTaxonomies();
+  const consentCategories = system.data_uses.filter((use) =>
+    isConsentCategory(use),
+  );
+  const cellValues = consentCategories.map((use) => ({
+    label: getDataUseDisplayName(use),
+    key: use,
+  }));
+
+  return (
+    <BadgeCellExpandable
+      values={cellValues}
+      bgColor="white"
+      borderWidth="1px"
+      borderColor="gray.200"
+    />
+  );
+};
+
+export default DiscoveredSystemDataUseCell;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemDataUseCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemDataUseCell.tsx
@@ -9,9 +9,8 @@ const DiscoveredSystemDataUseCell = ({
   system: MonitorSystemAggregate;
 }) => {
   const { getDataUseDisplayName } = useTaxonomies();
-  const consentCategories = system.data_uses.filter((use) =>
-    isConsentCategory(use),
-  );
+  const consentCategories =
+    system.data_uses?.filter((use) => isConsentCategory(use)) ?? [];
   const cellValues = consentCategories.map((use) => ({
     label: getDataUseDisplayName(use),
     key: use,
@@ -19,7 +18,7 @@ const DiscoveredSystemDataUseCell = ({
 
   return (
     <BadgeCellExpandable
-      values={cellValues}
+      values={cellValues.length ? cellValues : [{ label: "None", key: "none" }]}
       bgColor="white"
       borderWidth="1px"
       borderColor="gray.200"

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/types.d.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/types.d.ts
@@ -20,6 +20,7 @@ export interface MonitorSystemAggregate {
   system_key: string | null; // null when the system is not a known system
   vendor_id: string;
   total_updates: 0;
+  data_uses: string[];
   locations: string[];
   domains: string[];
 }

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/utils/isConsentCategory.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/utils/isConsentCategory.ts
@@ -1,0 +1,14 @@
+export const CONSENT_CATEGORIES = [
+  "essential",
+  "functional.service.improve",
+  "personalize",
+  "analytics",
+  "marketing.advertising.first_party.targeted",
+  "marketing.advertising.third_party.targeted",
+];
+
+const isConsentCategory = (category: string): boolean => {
+  return CONSENT_CATEGORIES.includes(category);
+};
+
+export default isConsentCategory;


### PR DESCRIPTION
Closes HA-356

### Description Of Changes

Adds a read-only consent category cell to the action center aggregate systems table.

![Screenshot 2025-02-05 at 13 17 21](https://github.com/user-attachments/assets/1f794f28-aae0-4730-8d9d-8a6774295264)

### Steps to Confirm

1. Checkout and run the backend from Adam's branch in the fidesplus repo (asachs/HJ-295).
2. Run turbo dev from the clients directory
3. Visit AdminUI's "About" page and enable the new "Website Monitor" feature flag
4. Click the "Action center" left nav item
5. If you receive a message here saying it's disabled, contact Adam to update config.
6. You should see 2 monitors, which are just dummy data from Adam's BE at the moment.
7. Click into a monitor by clicking the row or the "Review" button
8. For aggregate system results that have with data uses, the eligible data uses should show in the "Categories of consent" cell

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
