### PR TITLE
LJ-343 Allow search by default in all Selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added frequency field to DataHubSchema integration config [#5716](https://github.com/ethyca/fides/pull/5716)
 - Added glossary_node field to DataHubSchema integration config [#5734](https://github.com/ethyca/fides/pull/5734)
 - Added initial support for upcoming "headless" CMP experience type [#5731](https://github.com/ethyca/fides/pull/5731)
+- All Select dropdowns will now allow searching to narrow down the options by default [#5738](https://github.com/ethyca/fides/pull/5738)
+
 
 ### Fixed
 - Fixed `fides annotate dataset` command enters incorrect value on the `direction` field. [#5727](https://github.com/ethyca/fides/pull/5727)

--- a/clients/admin-ui/src/features/common/ScrollableList.tsx
+++ b/clients/admin-ui/src/features/common/ScrollableList.tsx
@@ -121,7 +121,6 @@ const ScrollableListAdd = ({
   return isAdding ? (
     <Box w="full">
       <Select
-        showSearch
         labelInValue
         placeholder="Select..."
         filterOption={(input, option) =>

--- a/clients/admin-ui/src/features/common/dropdown/SystemSelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/SystemSelect.tsx
@@ -33,10 +33,7 @@ const dropdownRender = (
 };
 
 interface SystemSelectProps
-  extends Omit<
-    SelectProps,
-    "options" | "showSearch" | "filterOption" | "onSearch"
-  > {
+  extends Omit<SelectProps, "options" | "filterOption" | "onSearch"> {
   onAddSystem?: MouseEventHandler<HTMLButtonElement>;
 }
 
@@ -77,7 +74,6 @@ export const SystemSelect = ({ onAddSystem, ...props }: SystemSelectProps) => {
       }
       data-testid="system-select"
       {...props}
-      showSearch
       filterOption={false}
       options={options}
       onSearch={onSearch}

--- a/clients/admin-ui/src/features/common/dropdown/TaxonomySelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/TaxonomySelect.tsx
@@ -48,7 +48,6 @@ export const TaxonomySelect = ({
     <Select<string, TaxonomySelectOption>
       options={selectOptions}
       autoFocus
-      showSearch
       variant="borderless"
       optionRender={TaxonomyOption}
       dropdownStyle={{ minWidth: "500px" }}

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/SelectDataset.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/SelectDataset.tsx
@@ -36,7 +36,6 @@ const SelectDataset = ({ options }: { options?: Option[] }) => {
             options={options}
             onChange={(v) => setValue(v)}
             mode="multiple"
-            showSearch
             className="w-full"
           />
         </Box>

--- a/clients/admin-ui/src/features/system/VendorSelector.tsx
+++ b/clients/admin-ui/src/features/system/VendorSelector.tsx
@@ -201,7 +201,6 @@ const VendorSelector = ({
         <Box width="100%" className="relative">
           <Select<VendorOption, VendorOption>
             id="vendorName"
-            showSearch
             labelInValue
             autoFocus
             allowClear

--- a/clients/fidesui/src/hoc/CustomSelect.tsx
+++ b/clients/fidesui/src/hoc/CustomSelect.tsx
@@ -36,6 +36,7 @@ const withCustomProps = (WrappedComponent: typeof Select) => {
     placeholder = "Select...",
     optionRender = optionDescriptionRender,
     className = "w-full",
+    showSearch = true,
     suffixIcon,
     menuItemSelectedIcon = <Checkmark />,
     ...props
@@ -44,6 +45,7 @@ const withCustomProps = (WrappedComponent: typeof Select) => {
       placeholder,
       optionRender,
       className,
+      showSearch,
       suffixIcon: props.loading ? undefined : suffixIcon || <ChevronDown />,
       menuItemSelectedIcon,
       "data-testid": `select${props.id ? `-${props.id}` : ""}`,


### PR DESCRIPTION
### Description Of Changes

Change default options for Select component to allow search by default.

### Code Changes

* Set default props to showSearch = true
* Remove showSearch from components since it's no longer needed

### Steps to Confirm

1.  Login to admin ui
2. Go to any system and add a new Data Use
3. Check that all Selects within this modal allow typing to filter the dropdown options

Note: This change applies to all Selects in the product, but specifically this modal has a few Selects that didn't have a showModal prop, so it's a good test for the new default behavior.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
