### PR TITLE
Action center: Bulk add/ignore system UI

### DIFF
--- a/clients/admin-ui/cypress/e2e/action-center.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center.cy.ts
@@ -207,8 +207,42 @@ describe("Action center", () => {
         "10 assets from Google Tag Manager have been ignored and will not appear in future scans.",
       );
     });
+    it("shouldn't allow bulk add when uncategorized system is selected", () => {
+      cy.getByTestId("row-0-col-select").find("label").click();
+      cy.getByTestId("selected-count").should("contain", "1 selected");
+      cy.getByTestId("bulk-actions-menu").click();
+      cy.getByTestId("bulk-add").should("be.disabled");
+    });
+    it("should bulk add results from categorized systems", () => {
+      cy.getByTestId("bulk-actions-menu").should("be.disabled");
+      cy.getByTestId("row-1-col-select").find("label").click();
+      cy.getByTestId("row-2-col-select").find("label").click();
+      cy.getByTestId("selected-count").should("contain", "2 selected");
+      cy.getByTestId("bulk-actions-menu").should("not.be.disabled");
+      cy.getByTestId("bulk-actions-menu").click();
+      cy.getByTestId("bulk-add").click();
+      cy.wait("@addMonitorResultSystem");
+      cy.getByTestId("success-alert").should(
+        "contain",
+        "16 assets have been added to the system inventory.",
+      );
+    });
+    it("should bulk ignore results from all systems", () => {
+      cy.getByTestId("row-0-col-select").find("label").click();
+      cy.getByTestId("row-1-col-select").find("label").click();
+      cy.getByTestId("row-2-col-select").find("label").click();
+      cy.getByTestId("selected-count").should("contain", "3 selected");
+      cy.getByTestId("bulk-actions-menu").should("not.be.disabled");
+      cy.getByTestId("bulk-actions-menu").click();
+      cy.getByTestId("bulk-ignore").click();
+      cy.wait("@ignoreMonitorResultSystem");
+      cy.getByTestId("success-alert").should(
+        "contain",
+        "124 assets have been ignored and will not appear in future scans.",
+      );
+    });
     it("should navigate to table view on row click", () => {
-      cy.getByTestId("row-1").click();
+      cy.getByTestId("row-1-col-system_name").click();
       cy.url().should(
         "contain",
         "system_key-8fe42cdb-af2e-4b9e-9b38-f75673180b88",

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -1,4 +1,5 @@
 import { baseApi } from "~/features/common/api.slice";
+import { getQueryParamsFromArray } from "~/features/common/utils";
 import { Page_StagedResourceAPIResponse_ } from "~/types/api";
 import { PaginationQueryParams } from "~/types/common/PaginationQueryParams";
 
@@ -6,6 +7,11 @@ import {
   MonitorSummaryPaginatedResponse,
   MonitorSystemAggregatePaginatedResponse,
 } from "./types";
+
+interface MonitorResultSystemQueryParams {
+  monitor_config_key: string;
+  resolved_system_ids: string[];
+}
 
 const actionCenterApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
@@ -56,30 +62,36 @@ const actionCenterApi = baseApi.injectEndpoints({
       }),
       providesTags: () => ["Discovery Monitor Results"],
     }),
-    addMonitorResultSystem: build.mutation<
+    addMonitorResultSystems: build.mutation<
       any,
-      { monitor_config_key?: string; resolved_system_id?: string }
+      MonitorResultSystemQueryParams
     >({
-      query: (params) => ({
-        method: "POST",
-        url: `/plus/discovery-monitor/${params.monitor_config_key}/promote`,
-        params: {
-          resolved_system_id: params.resolved_system_id,
-        },
-      }),
+      query: ({ monitor_config_key, resolved_system_ids }) => {
+        const params = getQueryParamsFromArray(
+          resolved_system_ids,
+          "resolved_system_ids",
+        );
+        return {
+          method: "POST",
+          url: `/plus/discovery-monitor/${monitor_config_key}/promote?${params}`,
+        };
+      },
       invalidatesTags: ["Discovery Monitor Results"],
     }),
-    ignoreMonitorResultSystem: build.mutation<
+    ignoreMonitorResultSystems: build.mutation<
       any,
-      { monitor_config_key?: string; resolved_system_id?: string }
+      MonitorResultSystemQueryParams
     >({
-      query: (params) => ({
-        method: "POST",
-        url: `/plus/discovery-monitor/${params.monitor_config_key}/mute`,
-        params: {
-          resolved_system_id: params.resolved_system_id,
-        },
-      }),
+      query: ({ monitor_config_key, resolved_system_ids }) => {
+        const params = getQueryParamsFromArray(
+          resolved_system_ids,
+          "resolved_system_ids",
+        );
+        return {
+          method: "POST",
+          url: `/plus/discovery-monitor/${monitor_config_key}/mute?${params}`,
+        };
+      },
       invalidatesTags: ["Discovery Monitor Results"],
     }),
     addMonitorResultAssets: build.mutation<any, { urnList?: string[] }>({
@@ -133,8 +145,8 @@ export const {
   useGetAggregateMonitorResultsQuery,
   useGetDiscoveredSystemAggregateQuery,
   useGetDiscoveredAssetsQuery,
-  useAddMonitorResultSystemMutation,
-  useIgnoreMonitorResultSystemMutation,
+  useAddMonitorResultSystemsMutation,
+  useIgnoreMonitorResultSystemsMutation,
   useAddMonitorResultAssetsMutation,
   useIgnoreMonitorResultAssetsMutation,
   useUpdateAssetsSystemMutation,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
@@ -34,9 +34,6 @@ export const useDiscoveredSystemAggregateColumns = (monitorId: string) => {
       maxSize: 40,
       meta: {
         disableRowClick: true,
-        cellProps: {
-          borderRight: "none",
-        },
       },
     }),
     columnHelper.accessor((row) => row.name, {
@@ -47,9 +44,6 @@ export const useDiscoveredSystemAggregateColumns = (monitorId: string) => {
       header: "System",
       meta: {
         width: "auto",
-        cellProps: {
-          borderLeft: "none",
-        },
       },
     }),
     columnHelper.accessor((row) => row.total_updates, {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
@@ -1,6 +1,9 @@
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 
-import { DefaultCell } from "~/features/common/table/v2";
+import {
+  DefaultCell,
+  IndeterminateCheckboxCell,
+} from "~/features/common/table/v2";
 import DiscoveredSystemDataUseCell from "~/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemDataUseCell";
 
 import { DiscoveredSystemActionsCell } from "../tables/cells/DiscoveredSystemAggregateActionsCell";
@@ -11,6 +14,31 @@ export const useDiscoveredSystemAggregateColumns = (monitorId: string) => {
   const columnHelper = createColumnHelper<MonitorSystemAggregate>();
 
   const columns: ColumnDef<MonitorSystemAggregate, any>[] = [
+    columnHelper.display({
+      id: "select",
+      cell: ({ row }) => (
+        <IndeterminateCheckboxCell
+          isChecked={row.getIsSelected()}
+          onChange={row.getToggleSelectedHandler()}
+          dataTestId={`select-${row.original.name || row.id}`}
+        />
+      ),
+      header: ({ table }) => (
+        <IndeterminateCheckboxCell
+          isChecked={table.getIsAllPageRowsSelected()}
+          isIndeterminate={table.getIsSomeRowsSelected()}
+          onChange={table.getToggleAllRowsSelectedHandler()}
+          dataTestId="select-all-rows"
+        />
+      ),
+      maxSize: 40,
+      meta: {
+        disableRowClick: true,
+        cellProps: {
+          borderRight: "none",
+        },
+      },
+    }),
     columnHelper.accessor((row) => row.name, {
       id: "system_name",
       cell: (props) => (
@@ -19,6 +47,9 @@ export const useDiscoveredSystemAggregateColumns = (monitorId: string) => {
       header: "System",
       meta: {
         width: "auto",
+        cellProps: {
+          borderLeft: "none",
+        },
       },
     }),
     columnHelper.accessor((row) => row.total_updates, {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
@@ -36,7 +36,7 @@ import {
 } from "~/features/common/table/v2";
 import {
   useAddMonitorResultAssetsMutation,
-  useAddMonitorResultSystemMutation,
+  useAddMonitorResultSystemsMutation,
   useGetDiscoveredAssetsQuery,
   useIgnoreMonitorResultAssetsMutation,
   useUpdateAssetsSystemMutation,
@@ -66,8 +66,8 @@ export const DiscoveredAssetsTable = ({
     useAddMonitorResultAssetsMutation();
   const [ignoreMonitorResultAssetsMutation, { isLoading: isIgnoringResults }] =
     useIgnoreMonitorResultAssetsMutation();
-  const [addMonitorResultSystemMutation, { isLoading: isAddingAllResults }] =
-    useAddMonitorResultSystemMutation();
+  const [addMonitorResultSystemsMutation, { isLoading: isAddingAllResults }] =
+    useAddMonitorResultSystemsMutation();
   const [updateAssetsSystemMutation, { isLoading: isBulkUpdatingSystem }] =
     useUpdateAssetsSystemMutation();
 
@@ -187,9 +187,9 @@ export const DiscoveredAssetsTable = ({
 
   const handleAddAll = async () => {
     const assetCount = data?.items.length || 0;
-    const result = await addMonitorResultSystemMutation({
+    const result = await addMonitorResultSystemsMutation({
       monitor_config_key: monitorId,
-      resolved_system_id: systemId,
+      resolved_system_ids: [systemId],
     });
 
     if (isErrorResult(result)) {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemAggregateActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemAggregateActionsCell.tsx
@@ -9,8 +9,8 @@ import { useAlert } from "~/features/common/hooks";
 import { UNCATEGORIZED_SEGMENT } from "~/features/common/nav/v2/routes";
 
 import {
-  useAddMonitorResultSystemMutation,
-  useIgnoreMonitorResultSystemMutation,
+  useAddMonitorResultSystemsMutation,
+  useIgnoreMonitorResultSystemsMutation,
 } from "../../action-center.slice";
 import { MonitorSystemAggregate } from "../../types";
 
@@ -23,10 +23,10 @@ export const DiscoveredSystemActionsCell = ({
   monitorId,
   system,
 }: DiscoveredSystemActionsCellProps) => {
-  const [addMonitorResultSystemMutation, { isLoading: isAddingResults }] =
-    useAddMonitorResultSystemMutation();
-  const [ignoreMonitorResultSystemMutation, { isLoading: isIgnoringResults }] =
-    useIgnoreMonitorResultSystemMutation();
+  const [addMonitorResultSystemsMutation, { isLoading: isAddingResults }] =
+    useAddMonitorResultSystemsMutation();
+  const [ignoreMonitorResultSystemsMutation, { isLoading: isIgnoringResults }] =
+    useIgnoreMonitorResultSystemsMutation();
 
   const { successAlert, errorAlert } = useAlert();
 
@@ -40,16 +40,16 @@ export const DiscoveredSystemActionsCell = ({
   } = system;
 
   const handleAdd = async () => {
-    const result = await addMonitorResultSystemMutation({
+    const result = await addMonitorResultSystemsMutation({
       monitor_config_key: monitorId,
-      resolved_system_id: resolvedSystemId,
+      resolved_system_ids: [resolvedSystemId],
     });
     if (isErrorResult(result)) {
       errorAlert(getErrorMessage(result.error));
     } else {
       successAlert(
         !systemKey
-          ? `${systemName} and ${totalUpdates}assets have been added to the system inventory. ${systemName} is now configured for consent.`
+          ? `${systemName} and ${totalUpdates} assets have been added to the system inventory. ${systemName} is now configured for consent.`
           : `${totalUpdates} assets from ${systemName} have been added to the system inventory.`,
         `Confirmed`,
       );
@@ -57,9 +57,9 @@ export const DiscoveredSystemActionsCell = ({
   };
 
   const handleIgnore = async () => {
-    const result = await ignoreMonitorResultSystemMutation({
+    const result = await ignoreMonitorResultSystemsMutation({
       monitor_config_key: monitorId,
-      resolved_system_id: resolvedSystemId || UNCATEGORIZED_SEGMENT,
+      resolved_system_ids: [resolvedSystemId || UNCATEGORIZED_SEGMENT],
     });
     if (isErrorResult(result)) {
       errorAlert(getErrorMessage(result.error));


### PR DESCRIPTION
Closes HA-403

### Description Of Changes

Adds row selection and bulk actions menu to aggregate system results table to enable bulk adding/ignoring resources by system.

![Screenshot 2025-02-06 at 16 40 48](https://github.com/user-attachments/assets/571cd7cd-daa8-4fd1-a683-c11b0fde5343)

### Code Changes

* Changes to add/ignore queries to accept a list of system IDs instead of a single one

### Steps to Confirm

1. Run Fidesplus backend on [this branch](https://github.com/ethyca/fidesplus/pull/1832).
2. View aggregate system results table
3. Should be able to individually add and ignore systems from the table row
4. Select "Uncategorized assets" and some other rows, then click "Actions" menu
5. "Add" option should be disabled with tooltip; should be able to click "Ignore" to ignore all selected
6. Select some systems not including "Uncategorized", then click "Actions" menu
7. Should be able to click "Add" to add all selected

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
