### PR TITLE
Fix menu caret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,11 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - https://github.com/ethyca/fides/labels/high-risk: to indicate that a change is a "high-risk" change that could potentially lead to unanticipated regressions or degradations
 - https://github.com/ethyca/fides/labels/db-migration: to indicate that a given change includes a DB migration
 
-## [Unreleased](https://github.com/ethyca/fides/compare/2.54.0...main)
+## [Unreleased](https://github.com/ethyca/fides/compare/2.55.0...main)
+
+
+
+## [2.55.0](https://github.com/ethyca/fides/compare/2.54.0...2.55.0)
 
 ### Added
 - Added editing support for categories of consent on discovered assets [#5739](https://github.com/ethyca/fides/pull/5739)

--- a/clients/admin-ui/src/features/common/nav/NavMenu.tsx
+++ b/clients/admin-ui/src/features/common/nav/NavMenu.tsx
@@ -1,4 +1,4 @@
-import { AntMenu as Menu, Icons } from "fidesui";
+import { AntMenu as Menu } from "fidesui";
 import { ComponentProps } from "react";
 
 import styles from "./NavMenu.module.scss";
@@ -10,12 +10,6 @@ export const NavMenu = ({ className, ...props }: MenuProps) => (
     mode="inline"
     theme="dark"
     inlineIndent={8}
-    expandIcon={
-      <div>
-        {/* The wrapper div is required otherwise the size of the icon is ignored */}
-        <Icons.ChevronDown size={14} />
-      </div>
-    }
     {...props}
     className={`${styles.menu} ${className}`}
   />

--- a/clients/admin-ui/src/theme/global.scss
+++ b/clients/admin-ui/src/theme/global.scss
@@ -62,6 +62,7 @@ h6 {
     --ant-border-radius: 0px;
 
     // fix missing pixel in the arrow icon
+    // (it's the same width as ant only changing 0.6 to 0.65 here)
     &::before,
     &::after {
       width: calc(calc(var(--ant-font-size) / 7 * 5) * 0.65);

--- a/clients/admin-ui/src/theme/global.scss
+++ b/clients/admin-ui/src/theme/global.scss
@@ -55,8 +55,16 @@ h6 {
   }
 }
 
-// Remove rounding from submenu arrow
-// to better match the style Carbon icons
-.ant-menu-submenu-arrow {
-  --ant-border-radius: 0px;
+.ant-menu {
+  .ant-menu-submenu-arrow {
+    // Remove rounding from submenu arrow
+    // to better match the style Carbon icons
+    --ant-border-radius: 0px;
+
+    // fix missing pixel in the arrow icon
+    &::before,
+    &::after {
+      width: calc(calc(var(--ant-font-size) / 7 * 5) * 0.65);
+    }
+  }
 }

--- a/clients/admin-ui/src/theme/global.scss
+++ b/clients/admin-ui/src/theme/global.scss
@@ -54,3 +54,9 @@ h6 {
     color: var(--fidesui-minos);
   }
 }
+
+// Remove rounding from submenu arrow
+// to better match the style Carbon icons
+.ant-menu-submenu-arrow {
+  --ant-border-radius: 0px;
+}


### PR DESCRIPTION
### Description Of Changes

Fix menu caret to animate and flip when expanding/collapsing menu groups

### Code Changes

* Go back to using ant's default caret icon
* Update ant global styling to remove rounding from ant icon
* Update ant global styling to make arrow lines slightly longer to cover up a missing pixel

### Steps to Confirm

1.  Login to admin ui
2. Check the caret icon on menu groups isn't rounded
3. Check that when expanding a menu item the caret flips with an animation

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
