### PR TITLE
update nav menu as links

### DIFF
--- a/clients/admin-ui/src/features/common/nav/MainSideNav.tsx
+++ b/clients/admin-ui/src/features/common/nav/MainSideNav.tsx
@@ -1,11 +1,4 @@
-import {
-  AntButton,
-  AntMenuProps as MenuProps,
-  Box,
-  Icons,
-  Link,
-  VStack,
-} from "fidesui";
+import { AntButton, Box, Icons, VStack } from "fidesui";
 import palette from "fidesui/src/palette/palette.module.scss";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
@@ -39,8 +32,6 @@ export const UnconnectedMainSideNav = ({
   handleLogout: any;
   username: string;
 }) => {
-  const router = useRouter();
-
   const navMenuItems = groups.map((group) => ({
     key: group.title,
     icon: group.icon,
@@ -49,9 +40,13 @@ export const UnconnectedMainSideNav = ({
       key: child.path,
       // child label needs left margin/padding to align with group title
       label: (
-        <span data-testid={`${child.title}-nav-link`} className="ml-4 pl-0.5">
+        <NextLink
+          href={child.path}
+          data-testid={`${child.title}-nav-link`}
+          className="ml-4 pl-0.5"
+        >
           {child.title}
-        </span>
+        </NextLink>
       ),
     })),
   }));
@@ -74,10 +69,6 @@ export const UnconnectedMainSideNav = ({
   };
 
   const activeKey = getActiveKeyFromUrl();
-
-  const handleMenuItemClick: MenuProps["onClick"] = ({ key: path }) => {
-    router.push(path);
-  };
 
   // When the nav is first loaded, we want to open the toggles that were open when the user last visited
   // the page. This is stored in local storage so that it persists across refreshes.
@@ -132,13 +123,12 @@ export const UnconnectedMainSideNav = ({
         <Box width="100%">
           <Box pb={6}>
             <Box px={2}>
-              <Link as={NextLink} href={INDEX_ROUTE} display="flex">
+              <NextLink href={INDEX_ROUTE}>
                 <Image src={logoImage} alt="Fides Logo" width={116} />
-              </Link>
+              </NextLink>
             </Box>
           </Box>
           <NavMenu
-            onClick={handleMenuItemClick}
             items={navMenuItems}
             selectedKeys={activeKey ? [activeKey] : []}
             onOpenChange={handleOpenChange}

--- a/clients/admin-ui/src/theme/global.scss
+++ b/clients/admin-ui/src/theme/global.scss
@@ -40,17 +40,21 @@ h6 {
 // Custom styles for dark submenus
 .ant-menu-dark .ant-menu-sub {
   // The unselected submenu item should be light gray
-  > .ant-menu-item > .ant-menu-title-content {
+  > .ant-menu-item > .ant-menu-title-content a {
     color: var(--fidesui-neutral-200);
 
-    &:hover {
+    &:hover,
+    &:focus {
       color: var(--fidesui-full-white);
+    }
+    &:focus-visible {
+      text-decoration: underline;
     }
   }
   // The selected submenu item should be dark, because the background is light
   // But using the token "darkItemSelectedColor" also affect the group title,
   // therefore we need this css rule
-  > .ant-menu-item.ant-menu-item-selected > .ant-menu-title-content {
+  > .ant-menu-item.ant-menu-item-selected > .ant-menu-title-content a {
     color: var(--fidesui-minos);
   }
 }


### PR DESCRIPTION
Closes [LJ-374]

### Description Of Changes

Update nav menu to use `NextLink` instead of `onClick` for routing

### Steps to Confirm

1. Main menu can be focusable using keyboard tab key or arrows and pressing the Return key activates the link to navigate.
2. Main menu allows user to Command + Click to open links in new tab
3. Main menu allows user to right click + open in new tab

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-374]: https://ethyca.atlassian.net/browse/LJ-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ