### PR TITLE
Update LDFLAGS & CFLAGS exports in MSSQL local build instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.55.0...main)
 
-
+### Docs
+- Removed version pins in LDFLAGS & CFLAGS for local MSSQL builds  [#TBC](https://github.com/ethyca/fides/pull/TBC)
 
 ## [2.55.0](https://github.com/ethyca/fides/compare/2.54.0...2.55.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.55.0...main)
 
 ### Docs
-- Removed version pins in LDFLAGS & CFLAGS for local MSSQL builds  [#TBC](https://github.com/ethyca/fides/pull/TBC)
+- Removed version pins in LDFLAGS & CFLAGS for local MSSQL builds [#5760](https://github.com/ethyca/fides/pull/5760)
 
 ## [2.55.0](https://github.com/ethyca/fides/compare/2.54.0...2.55.0)
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ brew install freetds openssl
 ```
 2. Add the following to your shell (i.e. `.zshrc`) to ensure your compiler can access the `freetds` and `openssl` libraries, updating the paths & versions to match your local install:
 ```bash
-export LDFLAGS="-L/opt/homebrew/Cellar/freetds/1.3.18/lib -L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
-export CFLAGS="-I/opt/homebrew/Cellar/freetds/1.3.18/include"
+export LDFLAGS="-L/opt/homebrew/opt/freetds/lib -L/opt/homebrew/opt/openssl/lib"
+export CFLAGS="-I/opt/homebrew/opt/freetds/include"
 ```
 3. Reinstall Fides with MSSQL support by including the `all` extra requirement:
 ```bash

--- a/README.md
+++ b/README.md
@@ -135,15 +135,15 @@ By default, running `pip install ethyca-fides` locally will not install the opti
 
 For local development setup on macOS, follow these steps:
 1. Install the required development libraries from Homebrew:
-```bash
+```zsh
 brew install freetds openssl
 ```
 2. Add the following to your shell (i.e. `.zshrc`) to ensure your compiler can access the `freetds` and `openssl` libraries, updating the paths & versions to match your local install:
-```bash
+```zsh
 export LDFLAGS="-L/opt/homebrew/opt/freetds/lib -L/opt/homebrew/opt/openssl/lib"
 export CFLAGS="-I/opt/homebrew/opt/freetds/include"
 ```
 3. Reinstall Fides with MSSQL support by including the `all` extra requirement:
-```bash
-pip install ethyca-fides[all]
+```zsh
+pip install "ethyca-fides[all]"
 ```


### PR DESCRIPTION
Unticketed change (minor docs correction)

### Description Of Changes

* Changes the LDFLAGS and CFLAGS exports used to run build Fides with MSSQL support on macOS
* The new exports use symlinks in their paths so that they don't have to be changed very time the openssl and freetds versions used by homebrew are updated. Homebrew manages these symlinks automatically.
 
### Code Changes

* No code changes

### Steps to Confirm

1. Test the updated build instructions at https://github.com/ethyca/fides/blob/daveqnet/unticketed/update-README/README.md#%EF%B8%8F-advanced-setup-for-microsoft-sql-server-mssql-support

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
