### PR TITLE
fix missing classname on body with updated test

### DIFF
--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -165,8 +165,9 @@ const Overlay: FunctionComponent<Props> = ({
   }, [experience, handleOpenModal, options.fidesEmbed]);
 
   useEffect(() => {
+    document.body.classList.add("fides-overlay-modal-link-shown");
     // If empty string is explicitly set, do not attempt to bind the modal link to the click handler.
-    // developers using `Fides.showModal();` can use this to prevent polling for the modal link.
+    // developers using `Fides.showModal();` can use this to prevent polling for the modal link. Developers should always be able to rely on the .fides-overlay-modal-link-shown classname to show their custom modal link.
     if (!modalLinkIsDisabled) {
       if (modalLink) {
         fidesDebugger(
@@ -175,7 +176,6 @@ const Overlay: FunctionComponent<Props> = ({
         modalLinkRef.current = modalLink;
         modalLinkRef.current.addEventListener("click", window.Fides.showModal);
         // show the modal link in the DOM
-        document.body.classList.add("fides-overlay-modal-link-shown");
         modalLinkRef.current.classList.add("fides-modal-link-shown");
       } else {
         fidesDebugger(`Searching for Modal link element #${modalLinkId}...`);

--- a/clients/privacy-center/cypress/e2e/show-modal.cy.ts
+++ b/clients/privacy-center/cypress/e2e/show-modal.cy.ts
@@ -35,6 +35,7 @@ describe("Fides.showModal", () => {
       });
 
       it("Should not show modal link in favor of showModal", () => {
+        cy.get("body").should("have.class", "fides-overlay-modal-link-shown");
         cy.get("#fides-modal-link").should("not.be.visible");
         cy.waitUntilFidesInitialized().then(() => {
           cy.window().its("Fides").invoke("showModal");


### PR DESCRIPTION
Closes [LJ-383]

### Description Of Changes

Changes during the Headless implementation made it so that the .fides-overlay-modal-link-shown classname we add to the <body> tag is reliant on the modalLinkId being found on the page, which potentially breaks the support for a custom link + Fides.showModal() implementation some customers may be using (as seen in this example: https://ethyca.com/docs/dev-docs/js/reference/interfaces/Fides#examples-2)

### Code Changes

* move the setting of `.fides-overlay-modal-link-shown` outside of checks for the `modalLinkId` being present and found.
* Update existing Cypress test to validate this change and help prevent future missteps.

### Steps to Confirm

1.  Edit line 107 of the `fides-js-demo.html` file in the privacy center to be `button.classList.add("my-custom-class");` instead of the standard ID.
2. Run Privacy center and visit the page with a valid Experience configured.
3. After the page has successfully loaded, open the Elements inspector in the browser devtools and ensure that the `<body>` tag has `fides-overlay-modal-link-shown` classname applied.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-383]: https://ethyca.atlassian.net/browse/LJ-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ