### PR TITLE
LJ-386 Fix privacy request receipt notifications

### DIFF
--- a/src/fides/api/service/messaging/message_dispatch_service.py
+++ b/src/fides/api/service/messaging/message_dispatch_service.py
@@ -65,12 +65,12 @@ def dispatch_message_task(
     schema = FidesopsMessage.model_validate(message_meta)
     with self.get_new_session() as db:
         dispatch_message(
-            db,
-            schema.action_type,
-            Identity.model_validate(to_identity),
-            service_type,
-            schema.body_params,
-            property_id,
+            db=db,
+            action_type=schema.action_type,
+            to_identity=Identity.model_validate(to_identity),
+            service_type=service_type,
+            message_body_params=schema.body_params,
+            property_id=property_id,
         )
 
 
@@ -136,6 +136,7 @@ def message_send_enabled(
     property_specific_messaging_enabled = ConfigProxy(
         db
     ).notifications.enable_property_specific_messaging
+
     if property_specific_messaging_enabled:
         # Only email messaging method is supported when property-specific messaging is enabled.
         service_type = get_email_messaging_config_service_type(db=db)

--- a/src/fides/service/messaging/messaging_service.py
+++ b/src/fides/service/messaging/messaging_service.py
@@ -181,13 +181,15 @@ class MessagingService:
                 if policy.get_rules_for_action(action_type=ActionType(action_type)):
                     request_types.add(action_type)
 
+            request_types_list = list(request_types)
+
             dispatch_message_task.apply_async(
                 queue=MESSAGING_QUEUE_NAME,
                 kwargs={
                     "message_meta": FidesopsMessage(
                         action_type=MessagingActionType.PRIVACY_REQUEST_RECEIPT,
                         body_params=RequestReceiptBodyParams(
-                            request_types=request_types
+                            request_types=request_types_list
                         ),
                     ).model_dump(mode="json"),
                     "service_type": self.config.notifications.notification_service_type,
@@ -299,12 +301,14 @@ def send_privacy_request_receipt_message_to_user(
         if policy.get_rules_for_action(action_type=ActionType(action_type)):
             request_types.add(action_type)
 
+    request_types_list = list(request_types)
+
     dispatch_message_task.apply_async(
         queue=MESSAGING_QUEUE_NAME,
         kwargs={
             "message_meta": FidesopsMessage(
                 action_type=MessagingActionType.PRIVACY_REQUEST_RECEIPT,
-                body_params=RequestReceiptBodyParams(request_types=request_types),
+                body_params=RequestReceiptBodyParams(request_types=request_types_list),
             ).model_dump(mode="json"),
             "service_type": service_type,
             "to_identity": to_identity.labeled_dict(),


### PR DESCRIPTION
Closes [LJ-386](https://ethyca.atlassian.net/browse/LJ-386)

### Description Of Changes

Fixed cryptic error when processing a DSR if `send_request_receipt_notification` was set to `true`. The cause of the error was using `Set` in the type of `RequestReceiptBodyParams` , because `Set` is not JSON serializable. 

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
