### PR TITLE
add warning note to release checklist to avoid merging release branch

### DIFF
--- a/docs/fides/docs/development/releases.md
+++ b/docs/fides/docs/development/releases.md
@@ -174,6 +174,10 @@ This checklist should be copy/pasted into the final pre-release PR, and checked 
 
 Additionally, there is a robust [Release Process](https://ethyca.atlassian.net/wiki/spaces/EN/pages/2545483802/Release+Process+Fides) page available in Confluence (_internal only_).
 
+
+> [!WARNING]
+> THIS RELEASE BRANCH PULL REQUEST SHOULD NOT BE MERGED! IT IS FOR TRACEABILITY PURPOSES ONLY!
+
 ### Pre-Release Steps
 
 #### General
@@ -214,11 +218,11 @@ Run these from within the test environment shell:
 * [ ] DSR approval succeeds
 * [ ] DSR execution succeeds
 
-### User Permissions 
+### User Permissions
 
 - [ ] Verify user creation
 - [ ] Verify a Viewer can view all systems
-- [ ] Verify a Data Steward can edit systems they are assigned 
+- [ ] Verify a Data Steward can edit systems they are assigned
 
 #### Documentation
 
@@ -245,6 +249,6 @@ When publishing the release, be sure to include the following sections in the re
 * [ ] Smoke test the PyPi & DockerHub releases:
     * [ ] Create a fresh venv with `python3 -m venv 2_12_0_venv`
     * [ ] Activate the venv `source 2_12_0_venv/bin/activate`
-    * [ ] `pip install ethyca-fides` 
+    * [ ] `pip install ethyca-fides`
     * [ ] `fides deploy up`
 * [ ] Announce the release!


### PR DESCRIPTION
### Description Of Changes

Updates the release template/checklist to include a warning to avoid merging release branch into `main`, to help avoid confusion/mistakes moving forward.