### PR TITLE
LJ-421: Bump validators version to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,6 @@ tinycss2==1.2.1
 toml==0.10.2
 twilio==7.15.0
 typing-extensions==4.12.2
-validators==0.20.0
+validators==0.34.0
 versioneer==0.19
 fideslang==3.0.9


### PR DESCRIPTION
Closes LJ-421

### Description Of Changes

_Write some things here about the changes and any potential caveats_

### Code Changes

* Bumps `validators` dependency version from `0.20.0` to `0.34.0` (latest)
* No functional changes

### Steps to Confirm

n/a

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
