### PR TITLE
Allow `-` in BQ partition clause operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Changed
 - Improved dataset validation for namespace metadata and dataset reachability [#5744](https://github.com/ethyca/fides/pull/5744)
 
+### Fixed
+- Fixed BQ partition clause validation to allow `-` characters in operands [#5796](https://github.com/ethyca/fides/pull/5796)
+
 ### Docs
 - Removed version pins in LDFLAGS & CFLAGS for local MSSQL builds [#5760](https://github.com/ethyca/fides/pull/5760)
 

--- a/src/fides/api/graph/config.py
+++ b/src/fides/api/graph/config.py
@@ -431,7 +431,7 @@ class MaskingTruncation:
 
 
 # for now, we only support BQ partitioning, so the clause pattern we expect is BQ-specific
-BIGQUERY_PARTITION_CLAUSE_PATTERN = r"^`(?P<field_1>[a-zA-Z0-9_]*)` ([<|>][=]?) (?P<operand_1>[a-zA-Z0-9_\s(),\.\"\']*)(\sAND `(?P<field_2>[a-zA-Z0-9_]*)` ([<|>][=]?) (?P<operand_2>[a-zA-Z0-9_\s(),\.\"\']*))?$"
+BIGQUERY_PARTITION_CLAUSE_PATTERN = r"^`(?P<field_1>[a-zA-Z0-9_]*)` ([<|>][=]?) (?P<operand_1>[a-zA-Z0-9_\s(),\.\"\'\-]*)(\sAND `(?P<field_2>[a-zA-Z0-9_]*)` ([<|>][=]?) (?P<operand_2>[a-zA-Z0-9_\s(),\.\"\'\-]*))?$"
 # protected keywords that are _not_ allowed in the operands, to avoid any potential malicious execution.
 PROHIBITED_KEYWORDS = [
     "UNION",

--- a/tests/ops/graph/test_config.py
+++ b/tests/ops/graph/test_config.py
@@ -406,6 +406,13 @@ class TestCollection:
             ),
             (
                 [
+                    "`_pt` > TIMESTAMP(''2020-01-01'') AND `_pt` <= CURRENT_TIMESTAMP()",
+                    "`_pt` > TIMESTAMP(''2019-01-01'') AND `_pt` <= TIMESTAMP(''2019-01-01'')",
+                ],
+                None,
+            ),
+            (
+                [
                     "`created` > 4 OR 1 = 1",  # comparison operators after an OR are not permitted
                     "`created` > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2000 DAY) AND `created` <= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1000 DAY)",
                 ],

--- a/tests/ops/models/test_datasetconfig.py
+++ b/tests/ops/models/test_datasetconfig.py
@@ -85,6 +85,13 @@ def test_convert_dataset_to_graph_no_collections(example_datasets):
         ),
         (
             [
+                "`_pt` > TIMESTAMP(''2020-01-01'') AND `_pt` <= CURRENT_TIMESTAMP()",
+                "`_pt` > TIMESTAMP(''2019-01-01'') AND `_pt` <= TIMESTAMP(''2019-01-01'')",
+            ],
+            None,
+        ),
+        (
+            [
                 "`created` > 4 OR 1 = 1",  # comparison operators after an OR are not permitted
                 "`created` > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2000 DAY) AND `created` <= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1000 DAY)",
             ],


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/LJ-424

### Description Of Changes

Our initial/existing partitioning support (https://github.com/ethyca/fides/pull/5325) incorrectly prohibits `-` as a character in the "operand"s or "value expressions". This can cause problems, specifically when trying to reference specific timestamps in the partitioning clause (e.g. `TIMESTAMP("2019-01-01")`), which is a somewhat common use case.

This PR updates the validation regex to allow `-` characters in the operands.

### Code Changes

* update validation regex to allow `-` characters in the operand
* add test coverage for this use case

### Steps to Confirm

1.  didn't do any manual confirmation (yet), but the unit test should be solid 👍 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
