### PR TITLE
Fix action column width on D&D tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Docs
 - Removed version pins in LDFLAGS & CFLAGS for local MSSQL builds [#5760](https://github.com/ethyca/fides/pull/5760)
 
+### Fixed
+- Fixed bug with D&D table column widths [#5813](https://github.com/ethyca/fides/pull/5813)
+
 ## [2.55.4](https://github.com/ethyca/fides/compare/2.55.3...2.55.4)
 
 ### Added

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsColumns.tsx
@@ -37,6 +37,7 @@ export const useDiscoveredAssetsColumns = () => {
       id: "name",
       cell: (props) => <DefaultCell value={props.getValue()} />,
       header: "Asset",
+      size: 300,
     }),
     columnHelper.accessor((row) => row.resource_type, {
       id: "resource_type",
@@ -53,9 +54,9 @@ export const useDiscoveredAssetsColumns = () => {
           />
         ),
       header: "System",
+      size: 200,
       meta: {
         noPadding: true,
-        width: "auto",
       },
     }),
     columnHelper.display({
@@ -64,8 +65,8 @@ export const useDiscoveredAssetsColumns = () => {
         <DiscoveredAssetDataUseCell asset={props.row.original} />
       ),
       header: "Categories of consent",
+      size: 400,
       meta: {
-        width: "auto",
         disableRowClick: true,
       },
     }),
@@ -106,7 +107,6 @@ export const useDiscoveredAssetsColumns = () => {
       ),
       header: "Actions",
       meta: {
-        width: "auto",
         disableRowClick: true,
       },
     }),

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
@@ -42,9 +42,7 @@ export const useDiscoveredSystemAggregateColumns = (monitorId: string) => {
         <DiscoveredSystemStatusCell system={props.row.original} />
       ),
       header: "System",
-      meta: {
-        width: "auto",
-      },
+      size: 300,
     }),
     columnHelper.accessor((row) => row.total_updates, {
       id: "total_updates",
@@ -58,8 +56,8 @@ export const useDiscoveredSystemAggregateColumns = (monitorId: string) => {
         <DiscoveredSystemDataUseCell system={props.row.original} />
       ),
       header: "Categories of consent",
+      size: 400,
       meta: {
-        width: "auto",
         disableRowClick: true,
       },
     }),
@@ -99,7 +97,6 @@ export const useDiscoveredSystemAggregateColumns = (monitorId: string) => {
       ),
       header: "Actions",
       meta: {
-        width: "auto",
         disableRowClick: true,
       },
     }),

--- a/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDetectionResultColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDetectionResultColumns.tsx
@@ -12,6 +12,9 @@ import { StagedResourceType } from "~/features/data-discovery-and-detection/type
 
 import findProjectFromUrn from "../utils/findProjectFromUrn";
 
+const NAME_COLUMN_SIZE = 300;
+const ACTION_COLUMN_SIZE = 200;
+
 const useDetectionResultColumns = ({
   resourceType,
   changeTypeOverride,
@@ -38,6 +41,7 @@ const useDetectionResultColumns = ({
           />
         ),
         header: (props) => <DefaultHeaderCell value="Name" {...props} />,
+        size: NAME_COLUMN_SIZE,
       }),
       columnHelper.accessor((row) => row.urn, {
         id: "project",
@@ -85,8 +89,8 @@ const useDetectionResultColumns = ({
           />
         ),
         header: "Actions",
+        size: ACTION_COLUMN_SIZE,
         meta: {
-          width: "auto",
           disableRowClick: true,
         },
       }),
@@ -105,6 +109,7 @@ const useDetectionResultColumns = ({
           />
         ),
         header: (props) => <DefaultHeaderCell value="Table name" {...props} />,
+        size: NAME_COLUMN_SIZE,
       }),
       columnHelper.accessor((row) => row.description, {
         id: "description",
@@ -142,8 +147,8 @@ const useDetectionResultColumns = ({
           <DetectionItemActionsCell resource={props.row.original} />
         ),
         header: "Actions",
+        size: ACTION_COLUMN_SIZE,
         meta: {
-          width: "auto",
           disableRowClick: true,
         },
       }),
@@ -162,6 +167,7 @@ const useDetectionResultColumns = ({
           />
         ),
         header: (props) => <DefaultHeaderCell value="Field name" {...props} />,
+        size: NAME_COLUMN_SIZE,
       }),
       columnHelper.accessor((row) => row.source_data_type, {
         id: "data-type",
@@ -204,8 +210,8 @@ const useDetectionResultColumns = ({
           <DetectionItemActionsCell resource={props.row.original} />
         ),
         header: "Actions",
+        size: ACTION_COLUMN_SIZE,
         meta: {
-          width: "auto",
           disableRowClick: true,
         },
       }),

--- a/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDetectionResultColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDetectionResultColumns.tsx
@@ -85,7 +85,10 @@ const useDetectionResultColumns = ({
           />
         ),
         header: "Actions",
-        size: 180,
+        meta: {
+          width: "auto",
+          disableRowClick: true,
+        },
       }),
     ];
     return { columns };
@@ -139,6 +142,10 @@ const useDetectionResultColumns = ({
           <DetectionItemActionsCell resource={props.row.original} />
         ),
         header: "Actions",
+        meta: {
+          width: "auto",
+          disableRowClick: true,
+        },
       }),
     ];
     return { columns };
@@ -197,6 +204,10 @@ const useDetectionResultColumns = ({
           <DetectionItemActionsCell resource={props.row.original} />
         ),
         header: "Actions",
+        meta: {
+          width: "auto",
+          disableRowClick: true,
+        },
       }),
     ];
     return { columns };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns.tsx
@@ -76,6 +76,7 @@ const useDiscoveryResultColumns = ({
         header: "Actions",
         meta: {
           width: "auto",
+          disableRowClick: true,
         },
       }),
     ];
@@ -141,6 +142,7 @@ const useDiscoveryResultColumns = ({
         header: "Actions",
         meta: {
           width: "auto",
+          disableRowClick: true,
         },
       }),
     ];
@@ -201,6 +203,7 @@ const useDiscoveryResultColumns = ({
         header: "Actions",
         meta: {
           width: "auto",
+          disableRowClick: true,
         },
       }),
     ];

--- a/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns.tsx
@@ -17,6 +17,9 @@ import DiscoveryItemActionsCell from "../tables/cells/DiscoveryItemActionsCell";
 import EditCategoryCell from "../tables/cells/EditCategoryCell";
 import ResultStatusCell from "../tables/cells/ResultStatusCell";
 
+const NAME_COLUMN_SIZE = 300;
+const ACTION_COLUMN_SIZE = 220;
+
 const useDiscoveryResultColumns = ({
   resourceType,
 }: {
@@ -37,6 +40,7 @@ const useDiscoveryResultColumns = ({
           />
         ),
         header: (props) => <DefaultHeaderCell value="Name" {...props} />,
+        size: NAME_COLUMN_SIZE,
       }),
       columnHelper.accessor((row) => row.urn, {
         id: "project",
@@ -74,8 +78,8 @@ const useDiscoveryResultColumns = ({
             <DefaultCell value="--" />
           ),
         header: "Actions",
+        size: ACTION_COLUMN_SIZE,
         meta: {
-          width: "auto",
           disableRowClick: true,
         },
       }),
@@ -108,6 +112,7 @@ const useDiscoveryResultColumns = ({
         id: "tables",
         cell: (props) => <ResultStatusCell result={props.row.original} />,
         header: (props) => <DefaultHeaderCell value="Table name" {...props} />,
+        size: NAME_COLUMN_SIZE,
       }),
       columnHelper.accessor((row) => row.description, {
         id: "description",
@@ -140,8 +145,8 @@ const useDiscoveryResultColumns = ({
           <DiscoveryItemActionsCell resource={props.row.original} />
         ),
         header: "Actions",
+        size: ACTION_COLUMN_SIZE,
         meta: {
-          width: "auto",
           disableRowClick: true,
         },
       }),
@@ -155,6 +160,7 @@ const useDiscoveryResultColumns = ({
         id: "name",
         cell: (props) => <ResultStatusCell result={props.row.original} />,
         header: (props) => <DefaultHeaderCell value="Field name" {...props} />,
+        size: NAME_COLUMN_SIZE,
       }),
       columnHelper.accessor((row) => row.source_data_type, {
         id: "data-type",
@@ -201,8 +207,8 @@ const useDiscoveryResultColumns = ({
           <DiscoveryItemActionsCell resource={props.row.original} />
         ),
         header: "Actions",
+        size: ACTION_COLUMN_SIZE,
         meta: {
-          width: "auto",
           disableRowClick: true,
         },
       }),

--- a/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/hooks/useDiscoveryResultColumns.tsx
@@ -18,7 +18,7 @@ import EditCategoryCell from "../tables/cells/EditCategoryCell";
 import ResultStatusCell from "../tables/cells/ResultStatusCell";
 
 const NAME_COLUMN_SIZE = 300;
-const ACTION_COLUMN_SIZE = 220;
+const ACTION_COLUMN_SIZE = 235;
 
 const useDiscoveryResultColumns = ({
   resourceType,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DetectionItemActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DetectionItemActionsCell.tsx
@@ -62,7 +62,7 @@ const DetectionItemActionsCell = ({
     childDiffHasChanges;
 
   return (
-    <HStack width="fit-content">
+    <HStack>
       {showStartMonitoringAction && (
         <ActionButton
           title="Monitor"

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DetectionItemActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DetectionItemActionsCell.tsx
@@ -62,7 +62,7 @@ const DetectionItemActionsCell = ({
     childDiffHasChanges;
 
   return (
-    <HStack onClick={(e) => e.stopPropagation()}>
+    <HStack width="fit-content">
       {showStartMonitoringAction && (
         <ActionButton
           title="Monitor"

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DiscoveryItemActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DiscoveryItemActionsCell.tsx
@@ -104,7 +104,7 @@ const DiscoveryItemActionsCell = ({ resource }: DiscoveryItemActionsProps) => {
   };
 
   return (
-    <HStack gap={2} width="fit-content">
+    <HStack gap={2}>
       {showPromoteAction && (
         <ActionButton
           title="Confirm"

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DiscoveryItemActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DiscoveryItemActionsCell.tsx
@@ -104,7 +104,7 @@ const DiscoveryItemActionsCell = ({ resource }: DiscoveryItemActionsProps) => {
   };
 
   return (
-    <HStack onClick={(e) => e.stopPropagation()} gap={2}>
+    <HStack gap={2} width="fit-content">
       {showPromoteAction && (
         <ActionButton
           title="Confirm"


### PR DESCRIPTION
Closes HA-179

### Description Of Changes

Fixes a bug where D&D action buttons were sometimes cut off at certain screen sizes and after resizing other columns.

https://github.com/user-attachments/assets/1206a8f2-170f-4279-bb03-7a1302044c40

### Code Changes

* Changes all "Actions" columns in D&D tables to have width `auto`
* Also removes stopPropagation calls to move to updated `disableRowClick`pattern

### Steps to Confirm

1. Populate the D&D tables with some items
2. On both detection tables and discovery tables, make sure action buttons are visible and don't get cut off when resizing

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
