### PR TITLE
Nested identity query support for BigQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Added
 - DB model support for Web Monitoring [#5616](https://github.com/ethyca/fides/pull/5616) https://github.com/ethyca/fides/labels/db-migration
 - Added support for queue-specific Celery workers [#5761](https://github.com/ethyca/fides/pull/5761)
+- Nested identity query support for BigQuery [#5814](https://github.com/ethyca/fides/pull/5814)
 
 ### Changed
 - Improved dataset validation for namespace metadata and dataset reachability [#5744](https://github.com/ethyca/fides/pull/5744)

--- a/data/dataset/bigquery_example_test_dataset.yml
+++ b/data/dataset/bigquery_example_test_dataset.yml
@@ -260,3 +260,25 @@ dataset:
               data_type: string
           - name: last_visit
             data_categories: [system.operations]
+
+      - name: customer_profile
+        fields:
+          - name: id
+            data_categories: [system.operations]
+          - name: contact_info
+            fides_meta:
+              type: object
+            fields:
+              - name: primary_email
+                data_categories: [user.contact.email]
+                fides_meta:
+                  identity: email
+                  data_type: string
+              - name: phone_number
+                data_categories: [user.contact.phone_number]
+                fides_meta:
+                  data_type: string
+          - name: address
+            data_categories: [user.contact.address]
+            fides_meta:
+              data_type: string

--- a/src/fides/api/service/connectors/query_configs/bigquery_query_config.py
+++ b/src/fides/api/service/connectors/query_configs/bigquery_query_config.py
@@ -236,6 +236,22 @@ class BigQueryQueryConfig(QueryStringWithoutTuplesOverrideQueryConfig):
         on the Node or Graph structure.
 
         This is an override of the base class method that supports nested fields for BigQuery.
+
+        Examples with dot-delimited field names, notice the periods are replaced with underscores in the parameter bindings:
+
+        1. Single value filter:
+           field_list = ["id", "name", "email"]
+           filters = {"user.id": [123]}
+
+           Generates: SELECT id, name, email FROM `project_id.dataset_id.table_name` WHERE (user.id = :user_id)
+           With parameter binding: user_id = 123
+
+        2. Multiple value filter:
+           field_list = ["id", "name", "email"]
+           filters = {"user.status": ["active", "pending"]}
+
+           Generates: SELECT id, name, email FROM `project_id.dataset_id.table_name` WHERE (user.status IN (:user_status_in_stmt_generated_0, :user_status_in_stmt_generated_1))
+           With parameter bindings: user_status_in_stmt_generated_0 = "active", user_status_in_stmt_generated_1 = "pending"
         """
         clauses = []
         query_data = {}

--- a/src/fides/api/service/connectors/query_configs/bigquery_query_config.py
+++ b/src/fides/api/service/connectors/query_configs/bigquery_query_config.py
@@ -228,7 +228,7 @@ class BigQueryQueryConfig(QueryStringWithoutTuplesOverrideQueryConfig):
                 formatted_fields.append(field_path.levels[0])
         return formatted_fields
 
-    def generate_raw_query(
+    def generate_raw_query_without_tuples(
         self, field_list: List[str], filters: Dict[str, List[Any]]
     ) -> Optional[TextClause]:
         """

--- a/tests/ops/service/privacy_request/test_bigquery_privacy_requests.py
+++ b/tests/ops/service/privacy_request/test_bigquery_privacy_requests.py
@@ -78,8 +78,13 @@ def test_create_and_process_access_request_bigquery(
     # this covers access requests against a partitioned table
     visit_partitioned_table_key = "bigquery_example_test_dataset:visit_partitioned"
     assert len(results[visit_partitioned_table_key]) == 1
+    assert results[visit_partitioned_table_key][0]["email"] == customer_email
+
+    customer_profile_table_key = "bigquery_example_test_dataset:customer_profile"
+    assert len(results[customer_profile_table_key]) == 1
     assert (
-        results[visit_partitioned_table_key][0]["email"] == bigquery_resources["email"]
+        results[customer_profile_table_key][0]["contact_info"]["primary_email"]
+        == customer_email
     )
 
     pr.delete(db=db)


### PR DESCRIPTION
Closes [LJ-432](https://ethyca.atlassian.net/browse/LJ-432)

### Description Of Changes

Adding nested identity query support for BigQuery

### Code Changes

* Overriding the base `generate_raw_query_without_tuples` method for `BigQueryQueryConfig`. This allows us to correctly map dot-delimited/nested `input_data` such as
```
{"contact_info.primary_email": ["customer-1@example.com"]}
```

### Steps to Confirm

1.  Run the tests in `tests/ops/service/privacy_request/test_bigquery_privacy_requests.py`

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-432]: https://ethyca.atlassian.net/browse/LJ-432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ