### PR TITLE
LJ-477 Improvements to GraphTask and poll_for_exited_privacy_request_tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Added
 - DB model support for Attachments [#5784](https://github.com/ethyca/fides/pull/5784) https://github.com/ethyca/fides/labels/db-migration
 
+### Fixed
+- Fixed `GraphTask` and `poll_for_exited_privacy_request_tasks` for DSR-processing improvements [#5820](https://github.com/ethyca/fides/pull/5820)
+
 ## [2.56.0](https://github.com/ethyca/fides/compare/2.55.4...2.56.0)
 
 ### Added

--- a/src/fides/api/api/deps.py
+++ b/src/fides/api/api/deps.py
@@ -10,10 +10,6 @@ from fides.api.util.cache import get_cache as get_redis_connection
 from fides.config import CONFIG, FidesConfig
 from fides.config import get_config as get_app_config
 from fides.config.config_proxy import ConfigProxy
-from fides.service.dataset.dataset_config_service import DatasetConfigService
-from fides.service.dataset.dataset_service import DatasetService
-from fides.service.messaging.messaging_service import MessagingService
-from fides.service.privacy_request.privacy_request_service import PrivacyRequestService
 
 _engine = None
 
@@ -70,27 +66,3 @@ def get_cache() -> Generator:
             "Application redis cache required, but it is currently disabled! Please update your application configuration to enable integration with a Redis cache."
         )
     yield get_redis_connection()
-
-
-def get_messaging_service(
-    db: Session = Depends(get_db),
-    config: FidesConfig = Depends(get_config),
-    config_proxy: ConfigProxy = Depends(get_config_proxy),
-) -> MessagingService:
-    return MessagingService(db, config, config_proxy)
-
-
-def get_privacy_request_service(
-    db: Session = Depends(get_db),
-    config_proxy: ConfigProxy = Depends(get_config_proxy),
-    messaging_service: MessagingService = Depends(get_messaging_service),
-) -> PrivacyRequestService:
-    return PrivacyRequestService(db, config_proxy, messaging_service)
-
-
-def get_dataset_service(db: Session = Depends(get_db)) -> DatasetService:
-    return DatasetService(db)
-
-
-def get_dataset_config_service(db: Session = Depends(get_db)) -> DatasetConfigService:
-    return DatasetConfigService(db)

--- a/src/fides/api/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/consent_request_endpoints.py
@@ -21,7 +21,7 @@ from starlette.status import (
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
 
-from fides.api.api.deps import get_config_proxy, get_db, get_messaging_service
+from fides.api.api.deps import get_config_proxy, get_db
 from fides.api.common_exceptions import (
     IdentityVerificationException,
     RedisNotConfigured,
@@ -50,6 +50,7 @@ from fides.api.schemas.privacy_request import (
     VerificationCode,
 )
 from fides.api.schemas.redis_cache import Identity
+from fides.api.service.deps import get_messaging_service
 from fides.api.util.api_router import APIRouter
 from fides.api.util.consent_util import (
     get_or_create_fides_user_device_id_provided_identity,

--- a/src/fides/api/api/v1/endpoints/dataset_config_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/dataset_config_endpoints.py
@@ -38,6 +38,7 @@ from fides.api.schemas.dataset import (
 )
 from fides.api.schemas.privacy_request import TestPrivacyRequest
 from fides.api.schemas.redis_cache import DatasetTestRequest
+from fides.api.service.deps import get_dataset_config_service
 from fides.api.util.api_router import APIRouter
 from fides.common.api.scope_registry import (
     DATASET_CREATE_OR_UPDATE,
@@ -93,9 +94,7 @@ def _get_connection_config(
 )
 def validate_dataset(
     dataset: FideslangDataset,
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
 ) -> ValidateDatasetResponse:
     """
@@ -134,9 +133,7 @@ def validate_dataset(
 def put_dataset_configs(
     dataset_pairs: Annotated[List[DatasetConfigCtlDataset], Field(max_length=50)],  # type: ignore
     db: Session = Depends(deps.get_db),
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
 ) -> BulkPutDataset:
     """
@@ -185,9 +182,7 @@ def put_dataset_configs(
 )
 def patch_dataset_configs(
     dataset_pairs: Annotated[List[DatasetConfigCtlDataset], Field(max_length=50)],  # type: ignore
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
 ) -> BulkPutDataset:
     """
@@ -223,9 +218,7 @@ def patch_dataset_configs(
 )
 def patch_datasets(
     datasets: Annotated[List[FideslangDataset], Field(max_length=50)],  # type: ignore
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
 ) -> BulkPutDataset:
     """
@@ -257,9 +250,7 @@ def patch_datasets(
 )
 async def patch_yaml_datasets(
     request: Request,
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
 ) -> BulkPutDataset:
     """
@@ -547,9 +538,7 @@ def dataset_reachability(
     *,
     db: Session = Depends(deps.get_db),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     dataset_key: FidesKey,
     policy_key: Optional[FidesKey] = None,
 ) -> Dict[str, Any]:
@@ -595,9 +584,7 @@ def dataset_reachability(
 def test_connection_datasets(
     *,
     db: Session = Depends(deps.get_db),
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
     dataset_key: FidesKey,
     test_request: DatasetTestRequest,

--- a/src/fides/api/api/v1/endpoints/generic_overrides.py
+++ b/src/fides/api/api/v1/endpoints/generic_overrides.py
@@ -17,7 +17,7 @@ from starlette.status import (
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
 
-from fides.api.api.deps import get_dataset_service, get_db
+from fides.api.api.deps import get_db
 from fides.api.common_exceptions import KeyOrNameAlreadyExists, ValidationError
 from fides.api.db.base_class import get_key_from_data
 from fides.api.db.crud import list_resource_query
@@ -34,6 +34,7 @@ from fides.api.schemas.taxonomy_extensions import (
     DataUse,
     DataUseCreateOrUpdate,
 )
+from fides.api.service.deps import get_dataset_service
 from fides.api.util.api_router import APIRouter
 from fides.api.util.errors import FidesError, ForbiddenIsDefaultTaxonomyError
 from fides.api.util.filter_utils import apply_filters_to_query

--- a/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
@@ -41,7 +41,6 @@ from starlette.status import (
 )
 
 from fides.api.api import deps
-from fides.api.api.deps import get_privacy_request_service
 from fides.api.api.v1.endpoints.dataset_config_endpoints import _get_connection_config
 from fides.api.api.v1.endpoints.manual_webhook_endpoints import (
     get_access_manual_webhook_or_404,
@@ -109,6 +108,7 @@ from fides.api.schemas.privacy_request import (
     ReviewPrivacyRequestIds,
     VerificationCode,
 )
+from fides.api.service.deps import get_messaging_service, get_privacy_request_service
 from fides.api.service.messaging.message_dispatch_service import EMAIL_JOIN_STRING
 from fides.api.task.execute_request_tasks import log_task_queued, queue_request_task
 from fides.api.task.filter_results import filter_data_categories
@@ -214,7 +214,7 @@ def get_privacy_request_or_error(
 def create_privacy_request(
     *,
     privacy_request_service: PrivacyRequestService = Depends(
-        deps.get_privacy_request_service
+        get_privacy_request_service
     ),
     data: Annotated[List[PrivacyRequestCreate], Field(max_length=50)],  # type: ignore
 ) -> BulkPostPrivacyRequests:
@@ -1232,7 +1232,7 @@ def restart_privacy_request_from_failure(
     *,
     db: Session = Depends(deps.get_db),
     privacy_request_service: PrivacyRequestService = Depends(
-        deps.get_privacy_request_service
+        get_privacy_request_service
     ),
 ) -> PrivacyRequestResponse:
     """Restart a privacy request from failure"""
@@ -1279,7 +1279,7 @@ def verify_identification_code(
     *,
     db: Session = Depends(deps.get_db),
     config_proxy: ConfigProxy = Depends(deps.get_config_proxy),
-    messaging_service: MessagingService = Depends(deps.get_messaging_service),
+    messaging_service: MessagingService = Depends(get_messaging_service),
     provided_code: VerificationCode,
 ) -> PrivacyRequestResponse:
     """Verify the supplied identity verification code.
@@ -1339,7 +1339,7 @@ def approve_privacy_request(
         scopes=[PRIVACY_REQUEST_REVIEW],
     ),
     privacy_request_service: PrivacyRequestService = Depends(
-        deps.get_privacy_request_service
+        get_privacy_request_service
     ),
     privacy_requests: ReviewPrivacyRequestIds,
 ) -> BulkReviewResponse:
@@ -1362,7 +1362,7 @@ def deny_privacy_request(
         scopes=[PRIVACY_REQUEST_REVIEW],
     ),
     privacy_request_service: PrivacyRequestService = Depends(
-        deps.get_privacy_request_service
+        get_privacy_request_service
     ),
     privacy_requests: DenyPrivacyRequests,
 ) -> BulkReviewResponse:
@@ -1399,7 +1399,7 @@ def mark_privacy_request_pre_approve_eligible(
     *,
     db: Session = Depends(deps.get_db),
     privacy_request_service: PrivacyRequestService = Depends(
-        deps.get_privacy_request_service
+        get_privacy_request_service
     ),
     webhook: PreApprovalWebhook = Security(
         verify_callback_oauth_pre_approval_webhook, scopes=[PRIVACY_REQUEST_REVIEW]

--- a/src/fides/api/service/deps.py
+++ b/src/fides/api/service/deps.py
@@ -1,0 +1,39 @@
+"""
+Module to define service dependencies so service classes can be used
+via FastAPI dependency injection.
+"""
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from fides.api.api.deps import get_config, get_config_proxy, get_db
+from fides.config import FidesConfig
+from fides.config.config_proxy import ConfigProxy
+from fides.service.dataset.dataset_config_service import DatasetConfigService
+from fides.service.dataset.dataset_service import DatasetService
+from fides.service.messaging.messaging_service import MessagingService
+from fides.service.privacy_request.privacy_request_service import PrivacyRequestService
+
+
+def get_messaging_service(
+    db: Session = Depends(get_db),
+    config: FidesConfig = Depends(get_config),
+    config_proxy: ConfigProxy = Depends(get_config_proxy),
+) -> MessagingService:
+    return MessagingService(db, config, config_proxy)
+
+
+def get_privacy_request_service(
+    db: Session = Depends(get_db),
+    config_proxy: ConfigProxy = Depends(get_config_proxy),
+    messaging_service: MessagingService = Depends(get_messaging_service),
+) -> PrivacyRequestService:
+    return PrivacyRequestService(db, config_proxy, messaging_service)
+
+
+def get_dataset_service(db: Session = Depends(get_db)) -> DatasetService:
+    return DatasetService(db)
+
+
+def get_dataset_config_service(db: Session = Depends(get_db)) -> DatasetConfigService:
+    return DatasetConfigService(db)

--- a/src/fides/api/service/privacy_request/request_service.py
+++ b/src/fides/api/service/privacy_request/request_service.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, Set
 from httpx import AsyncClient
 from loguru import logger
 from sqlalchemy import text
-from sqlalchemy.orm import Query
 from sqlalchemy.sql.elements import TextClause
 
 from fides.api.common_exceptions import PrivacyRequestNotFound
@@ -224,7 +223,7 @@ def poll_for_exited_privacy_request_tasks(self: DatabaseTask) -> Set[str]:
                 RequestTask.action_type == task_type,
             )
 
-            statuses = set([status for status, in tasks_statuses_query.all()])
+            statuses = set(status for status, in tasks_statuses_query.all())
             all_exited = all(
                 status in EXITED_EXECUTION_LOG_STATUSES for status in statuses
             )

--- a/src/fides/api/service/privacy_request/request_service.py
+++ b/src/fides/api/service/privacy_request/request_service.py
@@ -210,11 +210,14 @@ def poll_for_exited_privacy_request_tasks(self: DatabaseTask) -> Set[str]:
             .order_by(PrivacyRequest.created_at)
         )
 
+        # TODO: With this approach, we're making 3*n queries , where n is the number of in-progress privacy requests.
+        # We could optimize this to just get all the RequestTasks for all in-progress privacy requests in one single
+        # query and then process them in-memory. This could be more efficient.
         def privacy_request_has_errored_tasks(
             privacy_request: PrivacyRequest, task_type: ActionType
         ) -> bool:
-            """Check if a privacy request has all exited all its tasks of the given type,
-            and at least on the tasks has errored.
+            """Check if a privacy request has exited all its tasks of the given type,
+            and at least one of the tasks has errored.
             We specifically only query for the RequestTask.status column to avoid
             querying for the entire RequestTask row.
             """

--- a/src/fides/api/task/graph_task.py
+++ b/src/fides/api/task/graph_task.py
@@ -429,11 +429,13 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
         # stored in self.resources has been closed by the time we get to this point. We need
         # to get a new session to appropriately mark the task as errored.
         with get_db_session() as db:
-            request_task_new_session = db.merge(self.request_task)
             # Update the session in the resources object to the new session
             # and update the request_task reference to the new instance
-            self.resources.session = db
-            self.request_task = request_task_new_session
+            # We only need this for DSR 3.0, i.e if request_task has an id
+            if self.request_task.id:
+                self.resources.session = db
+                request_task_new_session = db.merge(self.request_task)
+                self.request_task = request_task_new_session
 
             if ex:
                 logger.warning(

--- a/src/fides/api/task/graph_task.py
+++ b/src/fides/api/task/graph_task.py
@@ -218,7 +218,6 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
     ):  # cache config, log config, db store config
         super().__init__()
         self.request_task = resources.privacy_request_task
-        self.request_task_id = resources.privacy_request_task.id
         self.execution_node = ExecutionNode(resources.privacy_request_task)
         self.resources = resources
         self.connector: BaseConnector = resources.get_connector(

--- a/src/fides/api/task/graph_task.py
+++ b/src/fides/api/task/graph_task.py
@@ -218,6 +218,7 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
     ):  # cache config, log config, db store config
         super().__init__()
         self.request_task = resources.privacy_request_task
+        self.request_task_id = resources.privacy_request_task.id
         self.execution_node = ExecutionNode(resources.privacy_request_task)
         self.resources = resources
         self.connector: BaseConnector = resources.get_connector(
@@ -384,11 +385,13 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
                 },
             )
 
-            if self.request_task.id:
+            if self.request_task_id:
                 # For DSR 3.0, updating the Request Task status when the ExecutionLog is
                 # created to keep these in sync.
                 # TODO remove conditional above alongside deprecating DSR 2.0
-                self.request_task.update_status(db, status)
+                request_task = RequestTask.get(db, object_id=self.request_task_id)
+                if request_task:
+                    request_task.update_status(db, status)
 
     def log_start(self, action_type: ActionType) -> None:
         """Task start activities"""

--- a/tests/fixtures/mariadb_fixtures.py
+++ b/tests/fixtures/mariadb_fixtures.py
@@ -13,7 +13,7 @@ from fides.api.models.connectionconfig import (
 )
 from fides.api.models.datasetconfig import DatasetConfig
 from fides.api.models.sql_models import Dataset as CtlDataset
-from fides.api.service.connectors import MariaDBConnector
+from fides.api.service.connectors.mariadb_connector import MariaDBConnector
 from fides.config import CONFIG
 
 from .application_fixtures import integration_secrets

--- a/tests/ops/integration_tests/setup_scripts/mariadb_setup.py
+++ b/tests/ops/integration_tests/setup_scripts/mariadb_setup.py
@@ -11,7 +11,7 @@ from fides.api.models.connectionconfig import (
     ConnectionType,
 )
 from fides.api.models.privacy_experience import PrivacyExperienceConfig
-from fides.api.service.connectors.sql_connector import MariaDBConnector
+from fides.api.service.connectors.mariadb_connector import MariaDBConnector
 from fides.config import CONFIG
 
 integration_config = load_toml("tests/ops/integration_test_config.toml")

--- a/tests/ops/integration_tests/setup_scripts/postgres_setup.py
+++ b/tests/ops/integration_tests/setup_scripts/postgres_setup.py
@@ -7,6 +7,7 @@ from sqlalchemy_utils import create_database, database_exists, drop_database
 from toml import load as load_toml
 
 from fides.api.db.session import get_db_engine, get_db_session
+from fides.api.models.asset import Asset
 from fides.api.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,

--- a/tests/ops/integration_tests/setup_scripts/timescale_setup.py
+++ b/tests/ops/integration_tests/setup_scripts/timescale_setup.py
@@ -7,13 +7,14 @@ from sqlalchemy_utils import create_database, database_exists, drop_database
 from toml import load as load_toml
 
 from fides.api.db.session import get_db_engine, get_db_session
+from fides.api.models.asset import Asset
 from fides.api.models.connectionconfig import (
     AccessLevel,
     ConnectionConfig,
     ConnectionType,
 )
 from fides.api.models.privacy_experience import PrivacyExperienceConfig
-from fides.api.service.connectors import TimescaleConnector
+from fides.api.service.connectors.timescale_connector import TimescaleConnector
 from fides.config import CONFIG
 
 integration_config = load_toml("tests/ops/integration_test_config.toml")

--- a/tests/ops/integration_tests/test_external_database_connections.py
+++ b/tests/ops/integration_tests/test_external_database_connections.py
@@ -171,6 +171,7 @@ def test_bigquery_example_data(bigquery_test_engine):
         [
             "address",
             "customer",
+            "customer_profile",
             "employee",
             "login",
             "order_item",

--- a/tests/ops/integration_tests/test_sql_task.py
+++ b/tests/ops/integration_tests/test_sql_task.py
@@ -1091,12 +1091,16 @@ class TestRetryIntegration:
             )
             assert 44 == execution_logs.count()
 
-            visit_logs = execution_logs.filter_by(collection_name="visit")
+            visit_logs = execution_logs.filter_by(collection_name="visit").order_by(
+                "created_at"
+            )
             assert ["in_processing", "retrying", "retrying", "error"] == [
                 el.status.value for el in visit_logs
             ]
 
-            order_item_logs = execution_logs.filter_by(collection_name="order_item")
+            order_item_logs = execution_logs.filter_by(
+                collection_name="order_item"
+            ).order_by("created_at")
             assert ["in_processing", "retrying", "retrying", "error"] == [
                 el.status.value for el in order_item_logs
             ]

--- a/tests/ops/task/test_graph_task.py
+++ b/tests/ops/task/test_graph_task.py
@@ -1025,9 +1025,11 @@ class TestGraphTaskAffectedConsentSystems:
             relevant_preferences=[privacy_preference_history_us_ca_provide],
             relevant_user_identities={"email": "customer-1@example.com"},
         )
-        with pytest.raises(BaseException):
+        with pytest.raises(BaseException) as exc:
             ret = mock_graph_task.consent_request({"email": "customer-1@example.com"})
             assert ret is False
+
+        assert str(exc.value) == "Request failed"
 
         db.refresh(privacy_preference_history)
         db.refresh(privacy_preference_history_us_ca_provide)


### PR DESCRIPTION
Closes [LJ-447](https://ethyca.atlassian.net/browse/LJ-447)

### Description Of Changes

**Issue**: We were seeing a lot of data being transferred from the DB to the fides webserver 

**Explanation**:
We have a recurring task `poll_for_exited_privacy_request_tasks` that checks all in-progress privacy requests to see if they have any errored tasks. This task was inadvertently querying for all fields in the request tasks table (including task results), instead of for just task status. 

At the same time, we have long-running privacy request that has a LOT of request tasks, and since it's stuck in "in progress", all its tasks keep getting polled by the recurring check . This long-running request fails to move to a completed status because of access tasks that take a long time to process: the task processes fine, but when it goes to update its own status in the DB, the DB session it was using has already been closed .

### Code Changes

* Update code in `src/fides/api/task/graph_task.py` to use a new DB session to log updates to the request task status
* Update `poll_for_exited_privacy_request_tasks` to only query for `RequestTask.status` rather than the entire row
* I had to move some service functions from `api.api.deps` to a new file `api.service.deps` so that I could avoid circular imports

### Steps to Confirm

1.  Update your `fides.toml` to run DSR 3.0 by setting `use_dsr_3_0 = true` under `[execution]` 
2. Create a System (or choose an existing one) and link an integration of your choosing to it (e.g Postgres ) 
3. Create a Dataset for that integration and link it to the integration 
4. Run a DSR
5. Privacy Request should run OK 
6. Change the credentials for the integration so that they are wrong (i.e integration will fail)
7. Run another DSR 
8. Privacy Request should show in errored status as expected, with the Activity Timeline showing correctly 
9. Update your `fides.toml` back to DSR 2.0 , and re-run steps 2-8

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-447]: https://ethyca.atlassian.net/browse/LJ-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ