### PR TITLE
Move system 'Assets' tab to be before 'History'

### DIFF
--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -493,7 +493,7 @@ describe("System management with Plus features", () => {
     });
   });
 
-  describe("tab navigation", () => {
+  describe.only("tab navigation", () => {
     it("updates URL hash when switching tabs", () => {
       cy.visit(`${SYSTEM_ROUTE}/configure/demo_analytics_system#information`);
       cy.location("hash").should("eq", "#information");
@@ -515,7 +515,12 @@ describe("System management with Plus features", () => {
 
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(500);
-      cy.getByTestId("tab-History").click();
+      cy.getByTestId("tab-Assets").click({ force: true });
+      cy.location("hash").should("eq", "#assets");
+
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
+      cy.getByTestId("tab-History").click({ force: true });
       cy.location("hash").should("eq", "#history");
     });
 

--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -493,7 +493,7 @@ describe("System management with Plus features", () => {
     });
   });
 
-  describe.only("tab navigation", () => {
+  describe("tab navigation", () => {
     it("updates URL hash when switching tabs", () => {
       cy.visit(`${SYSTEM_ROUTE}/configure/demo_analytics_system#information`);
       cy.location("hash").should("eq", "#information");

--- a/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
+++ b/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
@@ -56,8 +56,12 @@ const SYSTEM_TABS = {
     index: 3,
     hash: "#integrations",
   },
-  HISTORY: {
+  ASSETS: {
     index: 4,
+    hash: "#assets",
+  },
+  HISTORY: {
+    index: 5,
     hash: "#history",
   },
 } as const;
@@ -350,6 +354,16 @@ const useSystemFormTabs = ({
     },
   ];
 
+  if (isPlusEnabled && webMonitor) {
+    tabData.push({
+      label: "Assets",
+      content: activeSystem ? (
+        <SystemAssetsTable system={activeSystem} />
+      ) : null,
+      isDisabled: !activeSystem,
+    });
+  }
+
   if (isPlusEnabled) {
     tabData.push({
       label: "History",
@@ -364,16 +378,6 @@ const useSystemFormTabs = ({
           </Box>
           <SystemHistoryTable system={activeSystem} />
         </Box>
-      ) : null,
-      isDisabled: !activeSystem,
-    });
-  }
-
-  if (isPlusEnabled && webMonitor) {
-    tabData.push({
-      label: "Assets",
-      content: activeSystem ? (
-        <SystemAssetsTable system={activeSystem} />
       ) : null,
       isDisabled: !activeSystem,
     });

--- a/clients/fidesui/src/hoc/CustomTag.tsx
+++ b/clients/fidesui/src/hoc/CustomTag.tsx
@@ -86,6 +86,7 @@ const withCustomProps = (WrappedComponent: typeof Tag) => {
           <Icons.CloseLarge size={10} />
         </button>
       ) : undefined,
+      ...props,
       children: (
         <>
           {hasSparkle && <SparkleIcon />}
@@ -98,7 +99,6 @@ const withCustomProps = (WrappedComponent: typeof Tag) => {
           )}
         </>
       ),
-      ...props,
     };
 
     return onClick ? (


### PR DESCRIPTION
Closes unticketed

### Description Of Changes

Moves "Assets" to be before "History" in the system form tabs; also fixes a bug in the new Ant tags where icons weren't showing up correctly.

### Steps to Confirm

1.  View a system details page
2. "Assets" should be before "History"
3. Clicking any tab should append the appropriate hash to the URL
4. Should be able to navigate to tabs by adding the appropriate hash

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
