### PR TITLE
LJ-435 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Developer Experience
 - Moved non-prod Admin UI dependencies to devDependencies [#5832](https://github.com/ethyca/fides/pull/5832)
 
+### Fixed
+- Fixed usage of stale DB sessions when running privacy requests [#5834](https://github.com/ethyca/fides/pull/5834)
+
 ## [2.56.0](https://github.com/ethyca/fides/compare/2.55.4...2.56.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Developer Experience
 - Moved non-prod Admin UI dependencies to devDependencies [#5832](https://github.com/ethyca/fides/pull/5832)
 
-
 ## [2.56.1](https://github.com/ethyca/fides/compare/2.56.0...2.56.1)
 
 ### Changed

--- a/src/fides/api/api/deps.py
+++ b/src/fides/api/api/deps.py
@@ -10,10 +10,6 @@ from fides.api.util.cache import get_cache as get_redis_connection
 from fides.config import CONFIG, FidesConfig
 from fides.config import get_config as get_app_config
 from fides.config.config_proxy import ConfigProxy
-from fides.service.dataset.dataset_config_service import DatasetConfigService
-from fides.service.dataset.dataset_service import DatasetService
-from fides.service.messaging.messaging_service import MessagingService
-from fides.service.privacy_request.privacy_request_service import PrivacyRequestService
 
 _engine = None
 
@@ -70,27 +66,3 @@ def get_cache() -> Generator:
             "Application redis cache required, but it is currently disabled! Please update your application configuration to enable integration with a Redis cache."
         )
     yield get_redis_connection()
-
-
-def get_messaging_service(
-    db: Session = Depends(get_db),
-    config: FidesConfig = Depends(get_config),
-    config_proxy: ConfigProxy = Depends(get_config_proxy),
-) -> MessagingService:
-    return MessagingService(db, config, config_proxy)
-
-
-def get_privacy_request_service(
-    db: Session = Depends(get_db),
-    config_proxy: ConfigProxy = Depends(get_config_proxy),
-    messaging_service: MessagingService = Depends(get_messaging_service),
-) -> PrivacyRequestService:
-    return PrivacyRequestService(db, config_proxy, messaging_service)
-
-
-def get_dataset_service(db: Session = Depends(get_db)) -> DatasetService:
-    return DatasetService(db)
-
-
-def get_dataset_config_service(db: Session = Depends(get_db)) -> DatasetConfigService:
-    return DatasetConfigService(db)

--- a/src/fides/api/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/consent_request_endpoints.py
@@ -21,7 +21,7 @@ from starlette.status import (
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
 
-from fides.api.api.deps import get_config_proxy, get_db, get_messaging_service
+from fides.api.api.deps import get_config_proxy, get_db
 from fides.api.common_exceptions import (
     IdentityVerificationException,
     RedisNotConfigured,
@@ -50,6 +50,7 @@ from fides.api.schemas.privacy_request import (
     VerificationCode,
 )
 from fides.api.schemas.redis_cache import Identity
+from fides.api.service.deps import get_messaging_service
 from fides.api.util.api_router import APIRouter
 from fides.api.util.consent_util import (
     get_or_create_fides_user_device_id_provided_identity,

--- a/src/fides/api/api/v1/endpoints/dataset_config_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/dataset_config_endpoints.py
@@ -38,6 +38,7 @@ from fides.api.schemas.dataset import (
 )
 from fides.api.schemas.privacy_request import TestPrivacyRequest
 from fides.api.schemas.redis_cache import DatasetTestRequest
+from fides.api.service.deps import get_dataset_config_service
 from fides.api.util.api_router import APIRouter
 from fides.common.api.scope_registry import (
     DATASET_CREATE_OR_UPDATE,
@@ -93,9 +94,7 @@ def _get_connection_config(
 )
 def validate_dataset(
     dataset: FideslangDataset,
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
 ) -> ValidateDatasetResponse:
     """
@@ -134,9 +133,7 @@ def validate_dataset(
 def put_dataset_configs(
     dataset_pairs: Annotated[List[DatasetConfigCtlDataset], Field(max_length=50)],  # type: ignore
     db: Session = Depends(deps.get_db),
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
 ) -> BulkPutDataset:
     """
@@ -185,9 +182,7 @@ def put_dataset_configs(
 )
 def patch_dataset_configs(
     dataset_pairs: Annotated[List[DatasetConfigCtlDataset], Field(max_length=50)],  # type: ignore
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
 ) -> BulkPutDataset:
     """
@@ -223,9 +218,7 @@ def patch_dataset_configs(
 )
 def patch_datasets(
     datasets: Annotated[List[FideslangDataset], Field(max_length=50)],  # type: ignore
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
 ) -> BulkPutDataset:
     """
@@ -257,9 +250,7 @@ def patch_datasets(
 )
 async def patch_yaml_datasets(
     request: Request,
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
 ) -> BulkPutDataset:
     """
@@ -547,9 +538,7 @@ def dataset_reachability(
     *,
     db: Session = Depends(deps.get_db),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     dataset_key: FidesKey,
     policy_key: Optional[FidesKey] = None,
 ) -> Dict[str, Any]:
@@ -595,9 +584,7 @@ def dataset_reachability(
 def test_connection_datasets(
     *,
     db: Session = Depends(deps.get_db),
-    dataset_config_service: DatasetConfigService = Depends(
-        deps.get_dataset_config_service
-    ),
+    dataset_config_service: DatasetConfigService = Depends(get_dataset_config_service),
     connection_config: ConnectionConfig = Depends(_get_connection_config),
     dataset_key: FidesKey,
     test_request: DatasetTestRequest,

--- a/src/fides/api/api/v1/endpoints/generic_overrides.py
+++ b/src/fides/api/api/v1/endpoints/generic_overrides.py
@@ -17,7 +17,7 @@ from starlette.status import (
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
 
-from fides.api.api.deps import get_dataset_service, get_db
+from fides.api.api.deps import get_db
 from fides.api.common_exceptions import KeyOrNameAlreadyExists, ValidationError
 from fides.api.db.base_class import get_key_from_data
 from fides.api.db.crud import list_resource_query
@@ -34,6 +34,7 @@ from fides.api.schemas.taxonomy_extensions import (
     DataUse,
     DataUseCreateOrUpdate,
 )
+from fides.api.service.deps import get_dataset_service
 from fides.api.util.api_router import APIRouter
 from fides.api.util.errors import FidesError, ForbiddenIsDefaultTaxonomyError
 from fides.api.util.filter_utils import apply_filters_to_query

--- a/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
@@ -41,7 +41,6 @@ from starlette.status import (
 )
 
 from fides.api.api import deps
-from fides.api.api.deps import get_privacy_request_service
 from fides.api.api.v1.endpoints.dataset_config_endpoints import _get_connection_config
 from fides.api.api.v1.endpoints.manual_webhook_endpoints import (
     get_access_manual_webhook_or_404,
@@ -109,6 +108,7 @@ from fides.api.schemas.privacy_request import (
     ReviewPrivacyRequestIds,
     VerificationCode,
 )
+from fides.api.service.deps import get_messaging_service, get_privacy_request_service
 from fides.api.service.messaging.message_dispatch_service import EMAIL_JOIN_STRING
 from fides.api.task.execute_request_tasks import log_task_queued, queue_request_task
 from fides.api.task.filter_results import filter_data_categories
@@ -214,7 +214,7 @@ def get_privacy_request_or_error(
 def create_privacy_request(
     *,
     privacy_request_service: PrivacyRequestService = Depends(
-        deps.get_privacy_request_service
+        get_privacy_request_service
     ),
     data: Annotated[List[PrivacyRequestCreate], Field(max_length=50)],  # type: ignore
 ) -> BulkPostPrivacyRequests:
@@ -1232,7 +1232,7 @@ def restart_privacy_request_from_failure(
     *,
     db: Session = Depends(deps.get_db),
     privacy_request_service: PrivacyRequestService = Depends(
-        deps.get_privacy_request_service
+        get_privacy_request_service
     ),
 ) -> PrivacyRequestResponse:
     """Restart a privacy request from failure"""
@@ -1279,7 +1279,7 @@ def verify_identification_code(
     *,
     db: Session = Depends(deps.get_db),
     config_proxy: ConfigProxy = Depends(deps.get_config_proxy),
-    messaging_service: MessagingService = Depends(deps.get_messaging_service),
+    messaging_service: MessagingService = Depends(get_messaging_service),
     provided_code: VerificationCode,
 ) -> PrivacyRequestResponse:
     """Verify the supplied identity verification code.
@@ -1339,7 +1339,7 @@ def approve_privacy_request(
         scopes=[PRIVACY_REQUEST_REVIEW],
     ),
     privacy_request_service: PrivacyRequestService = Depends(
-        deps.get_privacy_request_service
+        get_privacy_request_service
     ),
     privacy_requests: ReviewPrivacyRequestIds,
 ) -> BulkReviewResponse:
@@ -1362,7 +1362,7 @@ def deny_privacy_request(
         scopes=[PRIVACY_REQUEST_REVIEW],
     ),
     privacy_request_service: PrivacyRequestService = Depends(
-        deps.get_privacy_request_service
+        get_privacy_request_service
     ),
     privacy_requests: DenyPrivacyRequests,
 ) -> BulkReviewResponse:
@@ -1399,7 +1399,7 @@ def mark_privacy_request_pre_approve_eligible(
     *,
     db: Session = Depends(deps.get_db),
     privacy_request_service: PrivacyRequestService = Depends(
-        deps.get_privacy_request_service
+        get_privacy_request_service
     ),
     webhook: PreApprovalWebhook = Security(
         verify_callback_oauth_pre_approval_webhook, scopes=[PRIVACY_REQUEST_REVIEW]

--- a/src/fides/api/service/deps.py
+++ b/src/fides/api/service/deps.py
@@ -1,0 +1,34 @@
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from fides.api.api.deps import get_config, get_config_proxy, get_db
+from fides.config import FidesConfig
+from fides.config.config_proxy import ConfigProxy
+from fides.service.dataset.dataset_config_service import DatasetConfigService
+from fides.service.dataset.dataset_service import DatasetService
+from fides.service.messaging.messaging_service import MessagingService
+from fides.service.privacy_request.privacy_request_service import PrivacyRequestService
+
+
+def get_messaging_service(
+    db: Session = Depends(get_db),
+    config: FidesConfig = Depends(get_config),
+    config_proxy: ConfigProxy = Depends(get_config_proxy),
+) -> MessagingService:
+    return MessagingService(db, config, config_proxy)
+
+
+def get_privacy_request_service(
+    db: Session = Depends(get_db),
+    config_proxy: ConfigProxy = Depends(get_config_proxy),
+    messaging_service: MessagingService = Depends(get_messaging_service),
+) -> PrivacyRequestService:
+    return PrivacyRequestService(db, config_proxy, messaging_service)
+
+
+def get_dataset_service(db: Session = Depends(get_db)) -> DatasetService:
+    return DatasetService(db)
+
+
+def get_dataset_config_service(db: Session = Depends(get_db)) -> DatasetConfigService:
+    return DatasetConfigService(db)

--- a/src/fides/api/task/graph_task.py
+++ b/src/fides/api/task/graph_task.py
@@ -551,7 +551,7 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
         return output
 
     def get_connection_config(self) -> ConnectionConfig:
-        """ "
+        """
         Retrieves the connection configuration for the current connector.
         This method attempts to fetch the connection configuration from the database
         using the connector's configuration ID. If the configuration is found in the
@@ -576,8 +576,6 @@ class GraphTask(ABC):  # pylint: disable=too-many-instance-attributes
 
     def skip_if_disabled(self) -> None:
         """Skip execution for the given collection if it is attached to a disabled ConnectionConfig."""
-        # connection_config: ConnectionConfig = self.connector.configuration
-
         connection_config: ConnectionConfig = self.get_connection_config()
 
         if connection_config.disabled:

--- a/tests/ops/service/privacy_request/test_postgres_privacy_requests.py
+++ b/tests/ops/service/privacy_request/test_postgres_privacy_requests.py
@@ -451,7 +451,7 @@ def test_create_and_process_access_request_postgres_with_disabled_integration(
         task_timeout=PRIVACY_REQUEST_TASK_TIMEOUT_EXTERNAL,
     )
 
-    first, *rest = pr.execution_logs
+    first, *rest = pr.execution_logs.order_by("created_at")
 
     assert first.dataset_name == "Dataset reference validation"
     assert first.status == ExecutionLogStatus.complete


### PR DESCRIPTION
Closes [LJ-453](https://ethyca.atlassian.net/browse/LJ-453)

### Description Of Changes

Because some privacy requests can take very long to process (e.g 40min) , by the time some access tasks complete, the database session they were using has been closed and so we get SSL / transaction errors when they try to update their own status. Since they throw before they can save their status in the DB, these tasks get re-processed indefinitely when re-submitting the request.  

This PR fixes this by using a brand new DB session every time `GrpahTask.update_status` gets called. 

### Code Changes
- Moved `get_messaging_service`, `get_privacy_request_service`, `get_dataset_service` and `get_dataset_config_service` from `src/fides/api/api/deps.py` into their own file `src/fides/api/service/deps.py` to avoid circular imports
- Updated `GraphTask` methods `update_status` and `log_end` to use new DB sessions

### Steps to Confirm

1. Update your fides.toml to run DSR 3.0 by setting use_dsr_3_0 = true under [execution]
2. Create a System (or choose an existing one) and link an integration of your choosing to it (e.g Postgres )
3. Create a Dataset for that integration and link it to the integration
4. Run a DSR
5. Privacy Request should run OK
6. Change the credentials for the integration so that they are wrong (i.e integration will fail)
7. Run another DSR
8. Privacy Request should show in errored status as expected, with the Activity Timeline showing correctly
9. Update your fides.toml back to DSR 2.0 , and re-run steps 2-8


### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-453]: https://ethyca.atlassian.net/browse/LJ-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ