### PR TITLE
Bump Python 3.9.x and 3.10.x versions to latest

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   IMAGE: ethyca/fides:local
-  DEFAULT_PYTHON_VERSION: "3.10.13"
+  DEFAULT_PYTHON_VERSION: "3.10.16"
   # Docker auth with read-only permissions.
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_RO_TOKEN: ${{ secrets.DOCKER_RO_TOKEN }}
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: These are the currently supported/tested Python Versions
-        python_version: ["3.9.18", "3.10.13"]
+        python_version: ["3.9.21", "3.10.16"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -209,7 +209,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.9.18", "3.10.13"]
+        python_version: ["3.9.21", "3.10.16"]
         test_selection:
           - "ctl-not-external"
           - "ops-unit-api"
@@ -266,7 +266,7 @@ jobs:
     strategy:
       max-parallel: 1 # This prevents collisions in shared external resources
       matrix:
-        python_version: ["3.9.18", "3.10.13"]
+        python_version: ["3.9.21", "3.10.16"]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # In PRs run with the "unsafe" label, or run on a "push" event to main
@@ -328,7 +328,7 @@ jobs:
     strategy:
       max-parallel: 1 # This prevents collisions in shared external resources
       matrix:
-        python_version: ["3.9.18", "3.10.13"]
+        python_version: ["3.9.21", "3.10.16"]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # In PRs run with the "unsafe" label, or run on a "push" event to main
@@ -427,7 +427,7 @@ jobs:
     strategy:
       max-parallel: 1 # This prevents collisions in shared external resources
       matrix:
-        python_version: ["3.9.18", "3.10.13"]
+        python_version: ["3.9.21", "3.10.16"]
     steps:
       - name: Download container
         uses: actions/download-artifact@v4

--- a/.github/workflows/cli_checks.yml
+++ b/.github/workflows/cli_checks.yml
@@ -17,7 +17,7 @@ on:
       - "release-**"
 
 env:
-  DEFAULT_PYTHON_VERSION: "3.10.13"
+  DEFAULT_PYTHON_VERSION: "3.10.16"
 
 jobs:
   # Basic smoke test of a local install of the fides Python CLI

--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -12,7 +12,7 @@ env:
   # Docker auth with read-only permissions.
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_RO_TOKEN: ${{ secrets.DOCKER_RO_TOKEN }}
-  DEFAULT_PYTHON_VERSION: "3.10.13"
+  DEFAULT_PYTHON_VERSION: "3.10.16"
 
 jobs:
   Cypress-E2E:

--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -11,7 +11,7 @@ env:
   # Docker auth with read-write (publish) permissions. Set as env in workflow root as auth is required in multiple jobs.
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-  DEFAULT_PYTHON_VERSION: "3.10.13"
+  DEFAULT_PYTHON_VERSION: "3.10.16"
 
 jobs:
   ParseTags:

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -10,7 +10,7 @@ on:
 env:
   TAG: ${{ github.event.release.tag_name }}
   PROD_PUBLISH: true
-  DEFAULT_PYTHON_VERSION: "3.10.13"
+  DEFAULT_PYTHON_VERSION: "3.10.16"
 
 jobs:
   publish_docs:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   IMAGE: ethyca/fides:local
-  DEFAULT_PYTHON_VERSION: "3.10.13"
+  DEFAULT_PYTHON_VERSION: "3.10.16"
   # Docker auth with read-only permissions.
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_RO_TOKEN: ${{ secrets.DOCKER_RO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - DB model support for Attachments [#5784](https://github.com/ethyca/fides/pull/5784) https://github.com/ethyca/fides/labels/db-migration
 
 ### Changed
-- Bumped supported Python versions to `3.10.16` and `3.9.21` [#TBC](https://github.com/ethyca/fides/pull/TBC)
+- Bumped supported Python versions to `3.10.16` and `3.9.21` [#5840](https://github.com/ethyca/fides/pull/5840)
 
 ### Developer Experience
 - Moved non-prod Admin UI dependencies to devDependencies [#5832](https://github.com/ethyca/fides/pull/5832)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Added
 - DB model support for Attachments [#5784](https://github.com/ethyca/fides/pull/5784) https://github.com/ethyca/fides/labels/db-migration
 
+### Changed
+- Bumped supported Python versions to `3.10.16` and `3.9.21` [#TBC](https://github.com/ethyca/fides/pull/TBC)
+
 ### Developer Experience
 - Moved non-prod Admin UI dependencies to devDependencies [#5832](https://github.com/ethyca/fides/pull/5832)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # If you update this, also update `DEFAULT_PYTHON_VERSION` in the GitHub workflow files
-ARG PYTHON_VERSION="3.10.13"
+ARG PYTHON_VERSION="3.10.16"
 #########################
 ## Compile Python Deps ##
 #########################

--- a/docs/fides/Dockerfile
+++ b/docs/fides/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.13-slim-bookworm AS build
+FROM python:3.10.16-slim-bookworm AS build
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -31,7 +31,7 @@ COPY . .
 RUN pip install -U pip && pip install . && pip install -r docs/fides/requirements.txt
 
 
-FROM python:3.10.13-slim-bookworm AS docs
+FROM python:3.10.16-slim-bookworm AS docs
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     git \

--- a/tests/ctl/cli/test_cli.py
+++ b/tests/ctl/cli/test_cli.py
@@ -145,7 +145,7 @@ def test_parse(test_config_path: str, test_cli_runner: CliRunner) -> None:
 
 class TestDB:
     @pytest.mark.skip(
-        "This test is timing out only in CI: Safe-Tests (3.10.13, ctl-not-external)"
+        "This test is timing out only in CI: Safe-Tests (3.10.16, ctl-not-external)"
     )
     @pytest.mark.integration
     def test_reset_db(self, test_config_path: str, test_cli_runner: CliRunner) -> None:


### PR DESCRIPTION
Unticketed chore

### Description Of Changes

- Bumps all use of Python `3.10.x` in repo from `3.10.13` to `3.10.16`
- Bumps all use of Python `3.9.x` in repo from `3.9.18` to `3.9.21`
- Latest release versions listed at https://www.python.org/downloads/source/

### Code Changes

* See code diff (very simple version bumps)

### Steps to Confirm

1.  CI passes

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
