### PR TITLE
[draft] mysql DSR support for D&D datasets 

### DIFF
--- a/src/fides/api/schemas/connection_configuration/connection_secrets_mysql.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_mysql.py
@@ -31,7 +31,8 @@ class MySQLSchema(ConnectionConfigSecretsSchema):
         description="The password used to authenticate and access the database.",
         json_schema_extra={"sensitive": True},
     )
-    dbname: str = Field(
+    dbname: Optional[str] = Field(
+        default=None,
         title="Database",
         description="The name of the specific database within the database server that you want to connect to.",
     )
@@ -41,7 +42,7 @@ class MySQLSchema(ConnectionConfigSecretsSchema):
         description="Indicates whether an SSH tunnel is required for the connection. Enable this option if your MySQL server is behind a firewall and requires SSH tunneling for remote connections.",
     )
 
-    _required_components: ClassVar[List[str]] = ["host", "dbname"]
+    _required_components: ClassVar[List[str]] = ["host"]
 
 
 class MySQLDocsSchema(MySQLSchema, NoValidationSchema):


### PR DESCRIPTION
Closes [<issue>]

### Description Of Changes

- [x] remove `dbname` as a required field
- [ ] support namespace meta set on dataset via D&D 

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
