### PR TITLE
Fix Days Left Badge Color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Moved non-prod Admin UI dependencies to devDependencies [#5832](https://github.com/ethyca/fides/pull/5832)
 - Prevent Admin UI and Privacy Center from starting when running `nox -s dev` with datastore params [#5843](https://github.com/ethyca/fides/pull/5843)
 
+### Fixed
+- Corrected the Tag color for some columns of the Privacy requests table. [#5848](https://github.com/ethyca/fides/pull/5848)
+
 ## [2.56.1](https://github.com/ethyca/fides/compare/2.56.0...2.56.1)
 
 ### Changed

--- a/clients/admin-ui/src/features/privacy-requests/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/cells.tsx
@@ -23,7 +23,7 @@ export const statusPropMap: {
   },
   denied: {
     label: "Denied",
-    colorScheme: "warn",
+    colorScheme: "warning",
   },
   canceled: {
     label: "Canceled",
@@ -97,7 +97,7 @@ export const RequestDaysLeftCell = ({
   } else if (percentage >= 75) {
     colorScheme = "success";
   } else if (percentage >= 25) {
-    colorScheme = "warn";
+    colorScheme = "warning";
   }
 
   return (

--- a/clients/admin-ui/src/pages/ant-poc.tsx
+++ b/clients/admin-ui/src/pages/ant-poc.tsx
@@ -232,6 +232,7 @@ const AntPOC: NextPage = () => {
                 <Tag color="nectar">nectar</Tag>
                 <Tag color="error">error</Tag>
                 <Tag color="warning">warning</Tag>
+                <Tag color="caution">caution</Tag>
                 <Tag color="success">success</Tag>
                 <Tag color="info">info</Tag>
                 <Tag color="alert">alert</Tag>


### PR DESCRIPTION
Closes [LJ-461]

### Description Of Changes

"warn" is not a valid Palette color or Ant color, so the color treatment was failing.

### Code Changes

* Updated to use "warning" instead of "warn"
* Added "caution" color to POC for completeness.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-461]: https://ethyca.atlassian.net/browse/LJ-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ