### PR TITLE
fix Days Left badge color when warning

### DIFF
--- a/clients/admin-ui/src/features/privacy-requests/cells.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/cells.tsx
@@ -97,7 +97,7 @@ export const RequestDaysLeftCell = ({
   } else if (percentage >= 75) {
     colorScheme = "success";
   } else if (percentage >= 25) {
-    colorScheme = "warn";
+    colorScheme = "warning";
   }
 
   return (


### PR DESCRIPTION
### Description Of Changes

https://ethyca.atlassian.net/browse/LJ-461

### Code Changes

* update color scheme name for days left warning badge

### Steps to Confirm

1.  make sure your config set to require manual DSR approval `FIDES__EXECUTION__REQUIRE_MANUAL_REQUEST_APPROVAL="true"`
2. update line 92 in fides/clients/admin-ui/src/features/privacy-requests/cells.tsx to `const percentage = 25;` so that you see the warning tag when you create new DSRs 
3. submit an access request 
4. verify the colors are now correct/visible

<img width="1423" alt="Screenshot 2025-03-06 at 8 17 04 AM" src="https://github.com/user-attachments/assets/bc6c2cbc-ccd3-4ec5-b9d5-15efafbe31d8" />

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
