### PR TITLE
Remove plotly (unused package) to reduce fides image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Developer Experience
 - Moved non-prod Admin UI dependencies to devDependencies [#5832](https://github.com/ethyca/fides/pull/5832)
 - Prevent Admin UI and Privacy Center from starting when running `nox -s dev` with datastore params [#5843](https://github.com/ethyca/fides/pull/5843)
+- Remove plotly (unused package) to reduce fides image size [#5852](https://github.com/ethyca/fides/pull/5852)
 
 ## [2.56.1](https://github.com/ethyca/fides/compare/2.56.0...2.56.1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ module = [
   "okta.*",
   "pandas.*",
   "pg8000.*",
-  "plotly.*",
   "pydash.*",
   "pygtrie.*",
   "pymongo.*",

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,6 @@ packaging==23.0
 pandas==1.4.3
 paramiko==3.4.1
 passlib[bcrypt]==1.7.4
-plotly==5.13.1
 pyinstrument==4.5.1
 psycopg2-binary==2.9.6
 pydantic==2.7.1


### PR DESCRIPTION
Unticketed chore

### Description Of Changes

plotly is the largest single site-package in the final fides image but appears to unused in the source code. I think it may not be needed after this PR: https://github.com/ethyca/fides/pull/1571

![Screenshot 2025-03-06 at 08 42 03](https://github.com/user-attachments/assets/f913f67a-7cc9-413b-80df-a761aae52523)

### Code Changes

* Removes plotly package

### Steps to Confirm

1.  CI passes

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
