### PR TITLE
HA-481: improve CORS origin handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ module = [
   "sqlalchemy.future.*",
   "twilio.*",
   "uvicorn.*",
-  "validators.*",
 ]
 ignore_missing_imports = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,5 @@ tinycss2==1.2.1
 toml==0.10.2
 twilio==7.15.0
 typing-extensions==4.12.2
-validators==0.20.0
 versioneer==0.19
 fideslang==3.0.9

--- a/src/fides/config/security_settings.py
+++ b/src/fides/config/security_settings.py
@@ -3,7 +3,6 @@
 # pylint: disable=C0115,C0116, E0213
 from typing import List, Optional, Pattern, Tuple, Union
 
-import validators
 from pydantic import Field, SerializeAsAny, ValidationInfo, field_validator
 from pydantic_settings import SettingsConfigDict
 from slowapi.wrappers import parse_many  # type: ignore

--- a/src/fides/config/security_settings.py
+++ b/src/fides/config/security_settings.py
@@ -177,21 +177,10 @@ class SecuritySettings(FidesSettings):
     @classmethod
     def assemble_cors_origins(cls, v: Union[str, List[str]]) -> Union[List[str], str]:
         """Return a list of valid origins for CORS requests"""
-
-        def validate(values: List[str]) -> None:
-            for value in values:
-                if value != "*":
-                    if not validators.url(value):
-                        raise ValueError(f"{value} is not a valid url")
-
         if isinstance(v, str) and not v.startswith("["):
             values = [i.strip() for i in v.split(",")]
-            validate(values)
-
             return values
-        if isinstance(v, (list, str)):
-            validate(v)  # type: ignore
-
+        if isinstance(v, list):
             return v
         raise ValueError(v)
 

--- a/tests/ctl/core/config/test_security_settings.py
+++ b/tests/ctl/core/config/test_security_settings.py
@@ -22,7 +22,7 @@ class TestSecuritySettings:
         with pytest.raises(ValueError) as err:
             SecuritySettings(cors_origins="123")
 
-        assert "not a valid url" in str(err.value)
+        assert "Input should be a valid URL" in str(err.value)
 
     def test_validate_assemble_cors_origins_invalid_type(self):
         with pytest.raises(ValueError):
@@ -30,6 +30,21 @@ class TestSecuritySettings:
 
     def test_validate_assemble_cors_origins_string_of_urls(self):
         urls = ["http://localhost.com", "http://test.com"]
+        settings = SecuritySettings(cors_origins=", ".join(urls))
+
+        assert settings.cors_origins == urls
+
+    def test_validate_cors_origins_0_0_0_0_is_allowed(self):
+        urls = ["http://localhost.com", "http://0.0.0.0:8000"]
+        settings = SecuritySettings(cors_origins=", ".join(urls))
+
+        assert settings.cors_origins == urls
+
+    def test_validate_cors_origins_asterisk_wildcard_is_allowed(self):
+        """
+        Test that `*` is allowed as a special origin value.
+        """
+        urls = ["*"]
         settings = SecuritySettings(cors_origins=", ".join(urls))
 
         assert settings.cors_origins == urls

--- a/tests/lib/test_custom_types.py
+++ b/tests/lib/test_custom_types.py
@@ -207,11 +207,16 @@ class TestURLOriginString:
         "input_value, expected_validated_value",
         (
             ("https://example.com", "https://example.com"),
+            ("https://example.com:8000", "https://example.com:8000"),
             ("https://example.com/", "https://example.com"),
             ("https://example.com/path", None),
             ("https://example.com/path/", None),
             ("foobar", None),
-            ("*", "*"),
+            ("*", "*"),  # `*` is allowed as a special origin value
+            (
+                "http://0.0.0.0:8000",
+                "http://0.0.0.0:8000",
+            ),  # `0.0.0.0` had been rejected in the past
         ),
     )
     def test_valid_url_origin_strings(


### PR DESCRIPTION
Closes HA-481

### Description Of Changes

Improvements to CORS origin setting handling:
- only use a single validation code path for validating values set via 'traditional' config and set via API config (config proxy)
- allow `*` as a special-case origin URL
- do not rely on `validators` package for any URL validation
    - this has the side effect of allowing the `0.0.0.0` IP address as a valid origin, e.g. `http://0.0.0.0:8000`. this is a nonstandard CORS origin, but it's not something we think should be _disallowed_ for any particular reason

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
