### PR TITLE
GPP String (FidesJS & Fides API): When MspaCoveredTransaction is toggled off, Fides does not disable MspaOptOutOptionMode or MspaServiceProviderMode correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed pagination bugs on some tables [#5819](https://github.com/ethyca/fides/pull/5819)
 - Fixed load_samples to wrap variables in quotes to prevent YAML parsing errors [#5857](https://github.com/ethyca/fides/pull/5857)
 - Fixed incorrect value being set for `MonitorExecution.started` column [#5864](https://github.com/ethyca/fides/pull/5864)
+- Improved the behavior and state management of MSPA-related settings [#5861](https://github.com/ethyca/fides/pull/5861)
 
 ## [2.56.2](https://github.com/ethyca/fides/compare/2.56.1...2.56.2)
 

--- a/clients/admin-ui/cypress/e2e/consent-settings.cy.ts
+++ b/clients/admin-ui/cypress/e2e/consent-settings.cy.ts
@@ -116,6 +116,29 @@ describe("Consent settings", () => {
       cy.intercept("/api/v1/config?api_set=true", { body: {} });
       cy.visit(GLOBAL_CONSENT_CONFIG_ROUTE);
       cy.getByTestId("setting-Global Privacy Platform").within(() => {
+        // Test covered transactions checkbox behavior
+        cy.getByTestId("input-gpp.mspa_covered_transactions").click(); // Check
+        cy.getByTestId("input-gpp.mspa_service_provider_mode").click();
+        cy.getByTestId("input-gpp.mspa_covered_transactions").click({
+          force: true,
+        }); // Uncheck
+        cy.getByTestId("input-gpp.mspa_service_provider_mode").should(
+          "not.be.checked",
+        );
+        cy.getByTestId("input-gpp.mspa_opt_out_option_mode").should(
+          "not.be.checked",
+        );
+        cy.getByTestId("input-gpp.mspa_service_provider_mode").should(
+          "have.attr",
+          "disabled",
+        );
+        cy.getByTestId("input-gpp.mspa_opt_out_option_mode").should(
+          "have.attr",
+          "disabled",
+        );
+
+        // Re-enable covered transactions and test mode toggles
+        cy.getByTestId("input-gpp.mspa_covered_transactions").click();
         cy.getByTestId("input-gpp.mspa_service_provider_mode").click();
         cy.getByTestId("input-gpp.mspa_opt_out_option_mode").should(
           "have.attr",

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -446,6 +446,7 @@ interface CustomSwitchProps {
   tooltip?: string;
   variant?: "inline" | "condensed" | "stacked" | "switchFirst";
   isDisabled?: boolean;
+  onChange?: (checked: boolean) => void;
 }
 export const CustomSwitch = ({
   label,
@@ -454,8 +455,12 @@ export const CustomSwitch = ({
   onChange,
   isDisabled,
   ...props
-}: CustomSwitchProps & FieldHookConfig<boolean>) => {
-  const [field, meta] = useField({ ...props, type: "checkbox" });
+}: CustomSwitchProps & Omit<FieldHookConfig<boolean>, "onChange">) => {
+  const [field, meta] = useField({
+    name: props.name,
+    value: props.value,
+    type: "checkbox",
+  });
   const isInvalid = !!(meta.touched && meta.error);
   const innerSwitch = (
     <Field name={field.name}>
@@ -464,6 +469,7 @@ export const CustomSwitch = ({
           checked={field.checked}
           onChange={(v) => {
             setFieldValue(field.name, v);
+            onChange?.(v);
           }}
           disabled={isDisabled}
           className="mr-2"
@@ -542,11 +548,15 @@ export const CustomSwitch = ({
 export const CustomCheckbox = ({
   label,
   tooltip,
-  onChange,
   isDisabled,
   ...props
-}: Omit<CustomSwitchProps, "variant"> & FieldHookConfig<boolean>) => {
-  const [field, meta] = useField({ ...props, type: "checkbox" });
+}: Omit<CustomSwitchProps, "variant"> &
+  Omit<FieldHookConfig<boolean>, "onChange">) => {
+  const [field, meta] = useField({
+    name: props.name,
+    value: props.value,
+    type: "checkbox",
+  });
   const isInvalid = !!(meta.touched && meta.error);
 
   return (
@@ -555,7 +565,10 @@ export const CustomCheckbox = ({
         <Checkbox
           name={field.name}
           isChecked={field.checked}
-          onChange={field.onChange}
+          onChange={(e) => {
+            field.onChange(e);
+            props.onChange?.(e.target.checked);
+          }}
           onBlur={field.onBlur}
           data-testid={`input-${field.name}`}
           disabled={isDisabled}

--- a/clients/admin-ui/src/features/consent-settings/GppConfiguration.tsx
+++ b/clients/admin-ui/src/features/consent-settings/GppConfiguration.tsx
@@ -31,7 +31,9 @@ const GppConfiguration = () => {
   const { tcf: isTcfEnabled } = useFeatures();
   const gppSettings = useAppSelector(selectGppSettings);
   const isEnabled = !!gppSettings.enabled;
-  const { values } = useFormikContext<{ gpp: GPPApplicationConfigResponse }>();
+  const { values, setFieldValue } = useFormikContext<{
+    gpp: GPPApplicationConfigResponse;
+  }>();
   const showMspa = !!values.gpp.us_approach;
 
   return (
@@ -73,20 +75,32 @@ const GppConfiguration = () => {
                   name="gpp.mspa_covered_transactions"
                   label="All transactions covered by MSPA"
                   tooltip="When selected, the Fides CMP will communicate to downstream vendors that all preferences are covered under the MSPA."
+                  onChange={(checked) => {
+                    if (!checked) {
+                      setFieldValue("gpp.mspa_service_provider_mode", false);
+                      setFieldValue("gpp.mspa_opt_out_option_mode", false);
+                    }
+                  }}
                 />
                 <CustomSwitch
                   label="Enable MSPA service provider mode"
                   name="gpp.mspa_service_provider_mode"
                   variant="switchFirst"
                   tooltip="Enable service provider mode if you do not engage in any sales or sharing of personal information."
-                  isDisabled={Boolean(values.gpp.mspa_opt_out_option_mode)}
+                  isDisabled={
+                    !!values.gpp.mspa_opt_out_option_mode ||
+                    !values.gpp.mspa_covered_transactions
+                  }
                 />
                 <CustomSwitch
                   label="Enable MSPA opt-out option mode"
                   name="gpp.mspa_opt_out_option_mode"
                   variant="switchFirst"
                   tooltip="Enable opt-out option mode if you engage or may engage in the sales or sharing of personal information, or process any information for the purpose of targeted advertising."
-                  isDisabled={Boolean(values.gpp.mspa_service_provider_mode)}
+                  isDisabled={
+                    !!values.gpp.mspa_service_provider_mode ||
+                    !values.gpp.mspa_covered_transactions
+                  }
                 />
               </Section>
             ) : null}

--- a/clients/admin-ui/src/features/consent-settings/PurposeOverrides.tsx
+++ b/clients/admin-ui/src/features/consent-settings/PurposeOverrides.tsx
@@ -1,6 +1,5 @@
 import { Box, Flex, Text } from "fidesui";
 import { FieldArray, useFormikContext } from "formik";
-import { ChangeEvent } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import { CustomSwitch } from "~/features/common/form/inputs";
@@ -131,8 +130,8 @@ const PurposeOverrides = () => {
                 <Box>
                   <CustomSwitch
                     name={`purposeOverrides[${index}].is_included`}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                      if (!e.target.checked) {
+                    onChange={(checked) => {
+                      if (!checked) {
                         setFieldValue(
                           `purposeOverrides[${index}].is_consent`,
                           false,

--- a/clients/fides-js/__tests__/lib/gpp/us-notices.test.ts
+++ b/clients/fides-js/__tests__/lib/gpp/us-notices.test.ts
@@ -547,6 +547,33 @@ describe("setGppOptOutsFromCookieAndExperience", () => {
     expect(cmpApi.getGppString()).toEqual("DBABLA~BAAVVVVVVVVY.QA");
   });
 
+  it("sets MSPA fields to disabled when mspa_covered_transactions is false", () => {
+    const cmpApi = new CmpApi(1, 1);
+    const cookie = mockFidesCookie();
+    const experience = mockPrivacyExperience({
+      region: "us",
+      gpp_settings: {
+        enabled: true,
+        us_approach: GPPUSApproach.NATIONAL,
+        mspa_covered_transactions: false,
+        mspa_opt_out_option_mode: true,
+        mspa_service_provider_mode: true,
+        enable_tcfeu_string: true,
+      },
+    });
+    setGppOptOutsFromCookieAndExperience({
+      cmpApi,
+      cookie,
+      experience,
+    });
+    const section = cmpApi.getSection("usnat");
+    expect(section).toMatchObject({
+      MspaCoveredTransaction: 2,
+      MspaOptOutOptionMode: 0,
+      MspaServiceProviderMode: 0,
+    });
+  });
+
   it("can use US gpp fields when gpp is set to national", () => {
     const cmpApi = new CmpApi(1, 1);
     const cookie = mockFidesCookie({

--- a/clients/fides-js/src/lib/gpp/us-notices.ts
+++ b/clients/fides-js/src/lib/gpp/us-notices.ts
@@ -29,16 +29,31 @@ const setMspaSections = ({
       cmpApiField: UsNatField.MSPA_COVERED_TRANSACTION,
     },
     {
-      gppSettingField: gppSettings.mspa_opt_out_option_mode,
+      gppSettingField:
+        gppSettings.mspa_covered_transactions &&
+        gppSettings.mspa_opt_out_option_mode,
       cmpApiField: UsNatField.MSPA_OPT_OUT_OPTION_MODE,
     },
     {
-      gppSettingField: gppSettings.mspa_service_provider_mode,
+      gppSettingField:
+        gppSettings.mspa_covered_transactions &&
+        gppSettings.mspa_service_provider_mode,
       cmpApiField: UsNatField.MSPA_SERVICE_PROVIDER_MODE,
     },
   ];
+
   mspaFields.forEach(({ gppSettingField, cmpApiField }) => {
-    cmpApi.setFieldValue(sectionName, cmpApiField, gppSettingField ? 1 : 2);
+    const isCoveredTransactions =
+      cmpApiField === UsNatField.MSPA_COVERED_TRANSACTION;
+    let value = 2; // Default to No
+
+    if (!gppSettings.mspa_covered_transactions && !isCoveredTransactions) {
+      value = 0; // When covered transactions is false, other fields should be disabled
+    } else if (gppSettingField) {
+      value = 1; // Yes
+    }
+
+    cmpApi.setFieldValue(sectionName, cmpApiField, value);
   });
 };
 


### PR DESCRIPTION
Closes [LJ-416]

### Description Of Changes

While using GPP on a customer deployment, we observed that when MspaCoveredTransaction is toggled off, the values for MspaOptOutOptionMode and MspaServiceProviderMode are still set in the string.

### Code Changes

* Update FidesJS to set Opt Out Option and Service Provider modes to disabled "0" when Covered Transaction is false
* Update AdminUI to disable and set false the UI components for Opt Out Option and Service Provider modes when Covered Transaction checkbox is unchecked.

### Steps to Confirm

1. Get an experience ready for GPP
2. In Consent Settings try to check the "All transactions covered by MSPA" box and then try to change one of the toggles (you should still only be able to toggle one of the 2). Now uncheck the "All transactions covered by MSPA" and the other toggles should both be false and disabled.
3. When you go to the demo page and set a preference for the correct geolocation for the GPP experience, when you ping GPP `__gpp('ping', (data)=>{console.log(data)})` you should see that when `MspaCoveredTransaction` is 1 the other 2 have either 1 or 2, but when `MspaCoveredTransaction` is 2 (off) the other 2 both have 0 (disabled)

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-416]: https://ethyca.atlassian.net/browse/LJ-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ