### PR TITLE
LJ-471 Fix privacy request /resubmit endpoint so it won't queue the request twice 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Updated privacy request handling to still succeed if not all identities are provided [#5836](https://github.com/ethyca/fides/pull/5836)
 - Refactored privacy request processing to never re-use sessions [#5862](https://github.com/ethyca/fides/pull/5862)
 
-
 ### Developer Experience
 - Moved non-prod Admin UI dependencies to devDependencies [#5832](https://github.com/ethyca/fides/pull/5832)
 - Prevent Admin UI and Privacy Center from starting when running `nox -s dev` with datastore params [#5843](https://github.com/ethyca/fides/pull/5843)
@@ -47,6 +46,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Improved the behavior and state management of MSPA-related settings [#5861](https://github.com/ethyca/fides/pull/5861)
 - Fixed CORS origins handling to be more consistent across config (toml/env var) and API settings; allow `0.0.0.0` as an origin [#5853](https://github.com/ethyca/fides/pull/5853)
 - Fixed an issue with the update payloads for select SaaS integrations [#5860](https://github.com/ethyca/fides/pull/5860)
+- Fixed `/privacy-request/<id>/resubmit` endpoint so it doesn't queue the request twice [#5870](https://github.com/ethyca/fides/pull/5870)
 
 ## [2.56.2](https://github.com/ethyca/fides/compare/2.56.1...2.56.2)
 

--- a/tests/service/test_privacy_request_service.py
+++ b/tests/service/test_privacy_request_service.py
@@ -11,6 +11,7 @@ from fides.api.models.connectionconfig import ConnectionConfig
 from fides.api.models.fides_user import FidesUser
 from fides.api.models.fides_user_permissions import FidesUserPermissions
 from fides.api.models.policy import Policy
+from fides.api.models.pre_approval_webhook import PreApprovalWebhook
 from fides.api.models.privacy_request import (
     ExecutionLog,
     ExecutionLogStatus,
@@ -28,7 +29,14 @@ from fides.service.privacy_request.privacy_request_service import PrivacyRequest
 from tests.conftest import wait_for_tasks_to_complete
 
 
+@pytest.mark.integration
+@pytest.mark.integration_postgres
 class TestPrivacyRequestService:
+    """
+    Since these tests actually run the privacy request using the posgres database, we need to
+    mark them all as integration tests.
+    """
+
     @pytest.fixture
     def mock_messaging_service(self) -> MessagingService:
         return create_autospec(MessagingService)
@@ -78,6 +86,7 @@ class TestPrivacyRequestService:
         "postgres_integration_db",
         "automatically_approved",
         "postgres_example_test_dataset_config",
+        "allow_custom_privacy_request_field_collection_enabled",
     )
     def test_resubmit_complete_privacy_request(
         self,
@@ -102,7 +111,9 @@ class TestPrivacyRequestService:
             "first_name": {"label": "First name", "value": "John"}
         }
         policy_key = policy.key
-        encryption_key = "thisisnotarealkey"
+        encryption_key = (
+            "fake-key-1234567"  # this is not a real key, but it has to be 16 bytes
+        )
         property_id = property_a.id
         source = PrivacyRequestSource.request_manager
         submitted_by = reviewing_user.id
@@ -166,6 +177,8 @@ class TestPrivacyRequestService:
         )
         assert error_logs.count() == 0
 
+    @pytest.mark.integration
+    @pytest.mark.integration_postgres
     @pytest.mark.usefixtures("automatically_approved")
     def test_cannot_resubmit_complete_privacy_request(
         self,
@@ -186,6 +199,8 @@ class TestPrivacyRequestService:
             privacy_request_service.resubmit_privacy_request(privacy_request.id)
         assert "Cannot resubmit a complete privacy request" in str(exc)
 
+    @pytest.mark.integration
+    @pytest.mark.integration_postgres
     @pytest.mark.usefixtures("require_manual_request_approval")
     def test_cannot_resubmit_pending_privacy_request(
         self,
@@ -227,6 +242,7 @@ class TestPrivacyRequestService:
         connection_config: ConnectionConfig,
         property_a: Property,
         reviewing_user: FidesUser,
+        pre_approval_webhooks: list[PreApprovalWebhook],
     ):
         """
         Test that resubmit does not automatically approve the request if require_manual_request_approval
@@ -236,6 +252,7 @@ class TestPrivacyRequestService:
         # to force the privacy request to error
         secrets = connection_config.secrets
         host = secrets.pop("host")
+
         db.commit()
 
         external_id = "ext-123"
@@ -245,7 +262,9 @@ class TestPrivacyRequestService:
             "first_name": {"label": "First name", "value": "John"}
         }
         policy_key = policy.key
-        encryption_key = "thisisnotarealkey"
+        encryption_key = (
+            "fake-key-1234567"  # this is not a real key, but it has to be 16 bytes
+        )
         property_id = property_a.id
         source = PrivacyRequestSource.request_manager
         submitted_by = reviewing_user.id
@@ -264,7 +283,14 @@ class TestPrivacyRequestService:
             authenticated=True,
             submitted_by=submitted_by,
         )
+        # Manually approve it
+        privacy_request_service.approve_privacy_requests(
+            request_ids=[privacy_request.id], suppress_notification=True
+        )
         privacy_request_id = privacy_request.id
+
+        wait_for_tasks_to_complete(db, privacy_request, ActionType.access)
+        db.refresh(privacy_request)
 
         error_logs = privacy_request.execution_logs.filter(
             ExecutionLog.status == ExecutionLogStatus.error
@@ -279,12 +305,119 @@ class TestPrivacyRequestService:
         privacy_request = privacy_request_service.resubmit_privacy_request(
             privacy_request.id
         )
+        db.refresh(privacy_request)
+
+        # Check that privacy request is still pending
+        assert privacy_request.id == privacy_request_id
+        assert privacy_request.status == PrivacyRequestStatus.pending
+
+        # verify that the error logs from the original attempt
+        # were deleted as part of the re-submission
+        error_logs = privacy_request.execution_logs.filter(
+            ExecutionLog.status == ExecutionLogStatus.error
+        )
+        assert error_logs.count() == 0
+
+    @pytest.mark.integration
+    @pytest.mark.integration_postgres
+    @pytest.mark.usefixtures(
+        "use_dsr_3_0",
+        "postgres_integration_db",
+        "require_manual_request_approval",
+        "postgres_example_test_dataset_config",
+    )
+    def test_resubmit_automatically_approves_request_if_no_webhooks(
+        self,
+        db: Session,
+        privacy_request_service: PrivacyRequestService,
+        mock_messaging_service: MessagingService,
+        policy: Policy,
+        connection_config: ConnectionConfig,
+        property_a: Property,
+        reviewing_user: FidesUser,
+    ):
+        """
+        Test that resubmit does not automatically approve the request if require_manual_request_approval
+        is True and there's PreApproval webhooks created
+        """
+        # remove the host from the Postgres example connection
+        # to force the privacy request to error
+        secrets = connection_config.secrets
+        host = secrets.pop("host")
+
+        db.commit()
+
+        external_id = "ext-123"
+        requested_at = datetime.now(timezone.utc)
+        identity = Identity(email="jane@example.com")
+        custom_privacy_request_fields = {
+            "first_name": {"label": "First name", "value": "John"}
+        }
+        policy_key = policy.key
+        encryption_key = (
+            "fake-key-1234567"  # this is not a real key, but it has to be 16 bytes
+        )
+        property_id = property_a.id
+        source = PrivacyRequestSource.request_manager
+        submitted_by = reviewing_user.id
+
+        privacy_request = privacy_request_service.create_privacy_request(
+            PrivacyRequestCreate(
+                external_id=external_id,
+                requested_at=requested_at,
+                identity=identity,
+                custom_privacy_request_fields=custom_privacy_request_fields,
+                policy_key=policy_key,
+                encryption_key=encryption_key,
+                property_id=property_id,
+                source=source,
+            ),
+            authenticated=True,
+            submitted_by=submitted_by,
+        )
+        # Manually approve it
+        privacy_request_service.approve_privacy_requests(
+            request_ids=[privacy_request.id],
+            suppress_notification=True,
+        )
+        privacy_request_id = privacy_request.id
+
         wait_for_tasks_to_complete(db, privacy_request, ActionType.access)
         db.refresh(privacy_request)
 
-        # Check id and status
+        error_logs = privacy_request.execution_logs.filter(
+            ExecutionLog.status == ExecutionLogStatus.error
+        )
+        assert error_logs.count() > 0
+
+        # re-add the host to fix the Postgres connection
+        connection_config.secrets["host"] = host
+        db.commit()
+
+        # resubmit the request and wait for it to complete
+        privacy_request = privacy_request_service.resubmit_privacy_request(
+            privacy_request.id
+        )
+        db.refresh(privacy_request)
+
+        # Check that privacy request is complete and fields were copied properly
         assert privacy_request.id == privacy_request_id
-        assert privacy_request.status == PrivacyRequestStatus.pending
+        assert privacy_request.status == PrivacyRequestStatus.complete
+        assert privacy_request.external_id == external_id
+        assert privacy_request.requested_at == requested_at
+        assert privacy_request.get_persisted_identity() == identity
+        assert (
+            privacy_request.get_persisted_custom_privacy_request_fields()
+            == custom_privacy_request_fields
+        )
+        assert privacy_request.policy.key == policy_key
+        assert privacy_request.get_cached_encryption_key() == encryption_key
+        assert privacy_request.property_id == property_id
+        assert privacy_request.source == source
+        assert privacy_request.submitted_by == submitted_by
+
+        # verify the approval email was not sent out
+        mock_messaging_service.send_request_approved.assert_not_called()
 
         # verify that the error logs from the original attempt
         # were deleted as part of the re-submission


### PR DESCRIPTION
Closes [LJ-471](https://ethyca.atlassian.net/browse/LJ-471)

### Description Of Changes

When `require_manual_request_approval` is set to True and there's at least one pre approval webhook, resubmitting a privacy request was causing it to get queued twice. This was because both the pre approval webhook and the resubmit code were queuing the request. 

This changes the resubmit code so that:
- if `require_manual_request_approval` is set to `True` and there are pre approval webhooks, we only trigger the webhooks and don't auto-approve the request
- if `require_manual_request_approval` is set to `True` and there are no pre approval webhooks, then the request was originally approved by a person, so re-submitting will auto-approve the request 
- If `require_manual_request_approval` is set to `False`, we auto approve the request 

### Code Changes

* Update `resubmit_privacy_request` method 
* Add tests

### Steps to Confirm

1.  Update your fides `.toml` with the following settings :
```
# under [execution]
require_manual_request_approval = true
use_dsr_3_0 = true

# under [celery]
task_always_eager = false
```
2. Set up a mock pre approval webhook 
3. Set up an integration (e.g postgres) and use incorrect credentials so that requests will fail 
4. Create a privacy request ; it should error
5. Fix the integration credentials so they work 
6. Re-submit the privacy request 
7. Look at the logs: you should see the following log only once "Queueing privacy request from step None"

Alternatively, just look at `tests/service/test_privacy_request_service.py` and check that they pass 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-471]: https://ethyca.atlassian.net/browse/LJ-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ