### PR TITLE
Support disabling Notice Toggles with override option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Add properties for user assigned systems/data_uses on staged resources [5841](https://github.com/ethyca/fides/pull/5841) https://github.com/ethyca/fides/labels/db-migration
 - Added tooltips to the buttons in the dataset test UI [#5899](https://github.com/ethyca/fides/pull/5899)
 - Added the ability to stop a test privacy request in the dataset test UI [#5901](https://github.com/ethyca/fides/pull/5901)
+- Added option for disabling consent notice toggles [#5872](https://github.com/ethyca/fides/pull/5872)
 
 ### Fixed
 - Fixed UX issues with website monitor form [#5884](https://github.com/ethyca/fides/pull/5884)

--- a/clients/fides-js/__tests__/lib/consent-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/consent-utils.test.ts
@@ -1,5 +1,8 @@
-import { getWindowObjFromPath, isPrivacyExperience } from "~/lib/consent-utils";
-
+import {
+  getWindowObjFromPath,
+  isPrivacyExperience,
+  parseFidesDisabledNotices,
+} from "../../src/lib/consent-utils";
 import mockExperienceJSON from "../__fixtures__/mock_experience.json";
 
 describe("isPrivacyExperience", () => {
@@ -78,4 +81,50 @@ describe("getWindowObjFromPath", () => {
       expect(getWindowObjFromPath(path as any)).toStrictEqual(expected);
     },
   );
+});
+
+describe("parseFidesDisabledNotices", () => {
+  it.each([
+    {
+      label: "undefined input",
+      value: undefined,
+      expected: [],
+    },
+    {
+      label: "empty string",
+      value: "",
+      expected: [],
+    },
+    {
+      label: "single notice",
+      value: "data_sales_and_sharing",
+      expected: ["data_sales_and_sharing"],
+    },
+    {
+      label: "multiple notices",
+      value: "data_sales_and_sharing,targeted_advertising,analytics_cookies",
+      expected: [
+        "data_sales_and_sharing",
+        "targeted_advertising",
+        "analytics_cookies",
+      ],
+    },
+    {
+      label: "notices with whitespace",
+      value:
+        " data_sales_and_sharing , targeted_advertising , analytics_cookies ",
+      expected: [
+        "data_sales_and_sharing",
+        "targeted_advertising",
+        "analytics_cookies",
+      ],
+    },
+    {
+      label: "notices with empty values",
+      value: "data_sales_and_sharing,,analytics_cookies,",
+      expected: ["data_sales_and_sharing", "analytics_cookies"],
+    },
+  ])("returns $expected when input is $label", ({ value, expected }) => {
+    expect(parseFidesDisabledNotices(value)).toStrictEqual(expected);
+  });
 });

--- a/clients/fides-js/docs/interfaces/FidesOptions.md
+++ b/clients/fides-js/docs/interfaces/FidesOptions.md
@@ -200,3 +200,15 @@ To decode this field, use:
 JSON.parse(decodeURIComponent(ot_fides_mapping))
 
 Field defaults to `undefined`.
+
+***
+
+### fides\_disabled\_notices
+
+> **fides\_disabled\_notices**: `string`
+
+A comma-separated list of notice_keys to disable their respective Toggle elements in the CMP Overlay.
+
+For example: "data_sales,data_sharing,analytics"
+
+Defaults to `undefined`.

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -16,7 +16,7 @@ const GZIP_SIZE_ERROR_KB = 45; // fail build if bundle size exceeds this
 const GZIP_SIZE_WARN_KB = 35; // log a warning if bundle size exceeds this
 
 // TCF
-const GZIP_SIZE_TCF_ERROR_KB = 87;
+const GZIP_SIZE_TCF_ERROR_KB = 90;
 const GZIP_SIZE_TCF_WARN_KB = 75;
 
 // Headless

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -104,17 +104,18 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
    * translation on every render.
    */
   const privacyNoticeItems: PrivacyNoticeItem[] = useMemo(
-    () =>
-      (experience.privacy_notices || []).map((notice) => {
-        // eslint-disable-next-line no-param-reassign
-        notice.disabled =
+    () => {
+      const privacyNotices = experience.privacy_notices ?? [];
+      return privacyNotices.map((notice) => {
+        const disabled =
           notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY ||
           (options.fidesDisabledNotices?.includes(notice.notice_key) ??
             false) ||
           notice.disabled;
         const bestTranslation = selectBestNoticeTranslation(i18n, notice);
-        return { notice, bestTranslation };
-      }),
+        return { notice: { ...notice, disabled }, bestTranslation };
+      });
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       experience.privacy_notices,

--- a/clients/fides-js/src/components/notices/NoticeToggles.tsx
+++ b/clients/fides-js/src/components/notices/NoticeToggles.tsx
@@ -16,7 +16,7 @@ export interface NoticeToggleProps {
   title: string;
   description?: string;
   checked: boolean;
-  disabled: boolean;
+  disabled?: boolean;
   gpcStatus: GpcStatus;
 }
 

--- a/clients/fides-js/src/components/tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/tcf/TcfPurposes.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "preact/hooks";
 
 import { UpdateEnabledIds } from "~/components/tcf/TcfTabs";
 
-import { ConsentMechanism, PrivacyExperience } from "../../lib/consent-types";
+import { PrivacyExperience } from "../../lib/consent-types";
 import {
   FidesEventDetailsPreference,
   FidesEventDetailsTrigger,
@@ -129,7 +129,7 @@ const TcfPurposes = ({
         purposes: uniquePurposes.filter((p) => p.isConsent),
         customPurposes: allCustomPurposesConsent.map((purpose) => ({
           ...purpose,
-          disabled: purpose.consent_mechanism === ConsentMechanism.NOTICE_ONLY,
+          disabled: purpose.disabled,
         })), // all custom purposes are "consent" purposes
         purposeModelType: "purposesConsent",
         enabledPurposeIds: enabledPurposeConsentIds,

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -178,4 +178,13 @@ export interface FidesOptions {
    *
    */
   ot_fides_mapping: string;
+
+  /**
+   * A comma-separated list of notice_keys to disable their respective Toggle elements in the CMP Overlay.
+   *
+   * For example: "data_sales,data_sharing,analytics"
+   *
+   * Defaults to `undefined`.
+   */
+  fides_disabled_notices: string;
 }

--- a/clients/fides-js/src/fides-headless.ts
+++ b/clients/fides-js/src/fides-headless.ts
@@ -45,7 +45,7 @@ import { customGetConsentPreferences } from "./services/external/preferences";
 declare global {
   interface Window {
     Fides: FidesGlobal;
-    fides_overrides: FidesOptions;
+    fides_overrides: Partial<FidesOptions>;
     fidesDebugger: (...args: unknown[]) => void;
   }
 }

--- a/clients/fides-js/src/fides-headless.ts
+++ b/clients/fides-js/src/fides-headless.ts
@@ -201,6 +201,7 @@ const _Fides: FidesGlobal = {
     fidesClearCookie: false,
     showFidesBrandLink: true,
     fidesConsentOverride: null,
+    fidesDisabledNotices: null,
   },
   fides_meta: {},
   identity: {},

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -57,7 +57,7 @@ import { customGetConsentPreferences } from "./services/external/preferences";
 declare global {
   interface Window {
     Fides: FidesGlobal;
-    fides_overrides: FidesOptions;
+    fides_overrides: Partial<FidesOptions>;
     __tcfapiLocator?: Window;
     __tcfapi?: (
       command: string,

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -256,6 +256,7 @@ const _Fides: FidesGlobal = {
     fidesClearCookie: false,
     showFidesBrandLink: false,
     fidesConsentOverride: null,
+    fidesDisabledNotices: null,
   },
   fides_meta: {},
   identity: {},

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -257,6 +257,7 @@ const _Fides: FidesGlobal = {
     showFidesBrandLink: true,
     fidesConsentOverride: null,
     otFidesMapping: null,
+    fidesDisabledNotices: null,
   },
   fides_meta: {},
   identity: {},

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -52,7 +52,7 @@ import { customGetConsentPreferences } from "./services/external/preferences";
 declare global {
   interface Window {
     Fides: FidesGlobal;
-    fides_overrides: FidesOptions;
+    fides_overrides: Partial<FidesOptions>;
     fidesDebugger: (...args: unknown[]) => void;
   }
 }

--- a/clients/fides-js/src/lib/consent-constants.ts
+++ b/clients/fides-js/src/lib/consent-constants.ts
@@ -1,9 +1,8 @@
 import {
-  FidesExperienceTranslationOverrides,
-  FidesInitOptionsOverrides,
-  FidesOptions,
-  OverrideExperienceTranslations,
+  FidesExperienceLanguageValidatorMap,
+  FidesOverrideValidatorMap,
 } from "./consent-types";
+import { parseFidesDisabledNotices } from "./consent-utils";
 import { LOCALE_REGEX } from "./i18n/i18n-constants";
 
 /**
@@ -25,121 +24,114 @@ export const VALID_ISO_3166_LOCATION_REGEX =
  * provided by customers just-in-time for the `Fides.init()` call and override
  * default FidesInitOptions, etc.
  */
-export const FIDES_OVERRIDE_OPTIONS_VALIDATOR_MAP: {
-  overrideName: keyof FidesInitOptionsOverrides;
-  overrideType: "string" | "boolean";
-  overrideKey: keyof FidesOptions;
-  validationRegex: RegExp;
-}[] = [
-  {
-    overrideName: "fidesEmbed",
-    overrideType: "boolean",
-    overrideKey: "fides_embed",
-    validationRegex: /^(true|false)$/,
-  },
-  {
-    overrideName: "fidesDisableSaveApi",
-    overrideType: "boolean",
-    overrideKey: "fides_disable_save_api",
-    validationRegex: /^(true|false)$/,
-  },
-  {
-    overrideName: "fidesDisableNoticesServedApi",
-    overrideType: "boolean",
-    overrideKey: "fides_disable_notices_served_api",
-    validationRegex: /^(true|false)$/,
-  },
-  {
-    overrideName: "fidesDisableBanner",
-    overrideType: "boolean",
-    overrideKey: "fides_disable_banner",
-    validationRegex: /^(true|false)$/,
-  },
-  {
-    overrideName: "fidesString",
-    overrideType: "string",
-    overrideKey: "fides_string",
-    validationRegex: /(.*)/,
-  },
-  {
-    overrideName: "fidesTcfGdprApplies",
-    overrideType: "boolean",
-    overrideKey: "fides_tcf_gdpr_applies",
-    validationRegex: /^(true|false)$/,
-  },
-  {
-    overrideName: "fidesLocale",
-    overrideType: "string",
-    overrideKey: "fides_locale",
-    validationRegex: LOCALE_REGEX,
-  },
-  {
-    overrideName: "fidesPrimaryColor",
-    overrideType: "string",
-    overrideKey: "fides_primary_color",
-    validationRegex: /(.*)/,
-  },
-  {
-    overrideName: "fidesClearCookie",
-    overrideType: "string",
-    overrideKey: "fides_clear_cookie",
-    validationRegex: /(.*)/,
-  },
-  {
-    overrideName: "fidesConsentOverride",
-    overrideType: "string",
-    overrideKey: "fides_consent_override",
-    validationRegex: /^(accept|reject)$/,
-  },
-  {
-    overrideName: "otFidesMapping",
-    overrideType: "string",
-    overrideKey: "ot_fides_mapping",
-    validationRegex: /(.*)/,
-  },
-  {
-    overrideName: "fidesDisabledNotices",
-    overrideType: "string",
-    overrideKey: "fides_disabled_notices",
-    validationRegex: /(.*)/,
-  },
-];
+export const FIDES_OVERRIDE_OPTIONS_VALIDATOR_MAP: FidesOverrideValidatorMap[] =
+  [
+    {
+      overrideName: "fidesEmbed",
+      overrideType: "boolean",
+      overrideKey: "fides_embed",
+      validationRegex: /^(true|false)$/,
+    },
+    {
+      overrideName: "fidesDisableSaveApi",
+      overrideType: "boolean",
+      overrideKey: "fides_disable_save_api",
+      validationRegex: /^(true|false)$/,
+    },
+    {
+      overrideName: "fidesDisableNoticesServedApi",
+      overrideType: "boolean",
+      overrideKey: "fides_disable_notices_served_api",
+      validationRegex: /^(true|false)$/,
+    },
+    {
+      overrideName: "fidesDisableBanner",
+      overrideType: "boolean",
+      overrideKey: "fides_disable_banner",
+      validationRegex: /^(true|false)$/,
+    },
+    {
+      overrideName: "fidesString",
+      overrideType: "string",
+      overrideKey: "fides_string",
+      validationRegex: /(.*)/,
+    },
+    {
+      overrideName: "fidesTcfGdprApplies",
+      overrideType: "boolean",
+      overrideKey: "fides_tcf_gdpr_applies",
+      validationRegex: /^(true|false)$/,
+    },
+    {
+      overrideName: "fidesLocale",
+      overrideType: "string",
+      overrideKey: "fides_locale",
+      validationRegex: LOCALE_REGEX,
+    },
+    {
+      overrideName: "fidesPrimaryColor",
+      overrideType: "string",
+      overrideKey: "fides_primary_color",
+      validationRegex: /(.*)/,
+    },
+    {
+      overrideName: "fidesClearCookie",
+      overrideType: "string",
+      overrideKey: "fides_clear_cookie",
+      validationRegex: /(.*)/,
+    },
+    {
+      overrideName: "fidesConsentOverride",
+      overrideType: "string",
+      overrideKey: "fides_consent_override",
+      validationRegex: /^(accept|reject)$/,
+    },
+    {
+      overrideName: "otFidesMapping",
+      overrideType: "string",
+      overrideKey: "ot_fides_mapping",
+      validationRegex: /(.*)/,
+    },
+    {
+      overrideName: "fidesDisabledNotices",
+      overrideType: "array",
+      overrideKey: "fides_disabled_notices",
+      validationRegex: /(.*)/,
+      transform: parseFidesDisabledNotices,
+    },
+  ];
 
 /**
  * Allows various user-provided experience lang overrides to be validated and mapped to the appropriate Fides variable.
  * overrideName is Fides internal, but overrideKey is the key the user uses to override the option.
  */
-export const FIDES_OVERRIDE_EXPERIENCE_LANGUAGE_VALIDATOR_MAP: {
-  overrideName: keyof FidesExperienceTranslationOverrides;
-  overrideType: "string";
-  overrideKey: keyof OverrideExperienceTranslations;
-  validationRegex: RegExp;
-}[] = [
-  {
-    overrideName: "title",
-    overrideType: "string",
-    overrideKey: "fides_title",
-    validationRegex: /(.*)/,
-  },
-  {
-    overrideName: "description",
-    overrideType: "string",
-    overrideKey: "fides_description",
-    validationRegex: /(.*)/,
-  },
-  {
-    overrideName: "privacy_policy_url",
-    overrideType: "string",
-    overrideKey: "fides_privacy_policy_url",
-    validationRegex: /(.*)/,
-  },
-  {
-    overrideName: "override_language",
-    overrideType: "string",
-    overrideKey: "fides_override_language",
-    validationRegex: LOCALE_REGEX,
-  },
-];
+export const FIDES_OVERRIDE_EXPERIENCE_LANGUAGE_VALIDATOR_MAP: FidesExperienceLanguageValidatorMap[] =
+  [
+    {
+      overrideName: "title",
+      overrideType: "string",
+      overrideKey: "fides_title",
+      validationRegex: /(.*)/,
+    },
+    {
+      overrideName: "description",
+      overrideType: "string",
+      overrideKey: "fides_description",
+      validationRegex: /(.*)/,
+    },
+    {
+      overrideName: "privacy_policy_url",
+      overrideType: "string",
+      overrideKey: "fides_privacy_policy_url",
+      validationRegex: /(.*)/,
+    },
+    {
+      overrideName: "override_language",
+      overrideType: "string",
+      overrideKey: "fides_override_language",
+      validationRegex: LOCALE_REGEX,
+    },
+  ];
 
 export const FIDES_OVERLAY_WRAPPER = "fides-overlay-wrapper";
 export const FIDES_I18N_ICON = "fides-i18n-icon";

--- a/clients/fides-js/src/lib/consent-constants.ts
+++ b/clients/fides-js/src/lib/consent-constants.ts
@@ -97,6 +97,12 @@ export const FIDES_OVERRIDE_OPTIONS_VALIDATOR_MAP: {
     overrideKey: "ot_fides_mapping",
     validationRegex: /(.*)/,
   },
+  {
+    overrideName: "fidesDisabledNotices",
+    overrideType: "string",
+    overrideKey: "fides_disabled_notices",
+    validationRegex: /(.*)/,
+  },
 ];
 
 /**

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -90,8 +90,8 @@ export interface FidesInitOptions {
   // Whether to include the GPP extension
   gppEnabled: boolean;
 
-  // Whether we should "embed" the fides.js overlay UI (ie. “Layer 2”) into a web page instead of as a pop-up
-  // overlay, and never render the banner (ie. “Layer 1”).
+  // Whether we should "embed" the fides.js overlay UI (ie. "Layer 2") into a web page instead of as a pop-up
+  // overlay, and never render the banner (ie. "Layer 1").
   fidesEmbed: boolean;
 
   // Whether we should disable saving consent preferences to the Fides API.
@@ -145,6 +145,9 @@ export interface FidesInitOptions {
 
   // If defined, maps OT cookie consent to Fides cookie consent
   otFidesMapping?: string | null;
+
+  // List of notice_keys to disable their respective Toggle elements in the CMP Overlay
+  fidesDisabledNotices: string[] | null;
 }
 
 /**
@@ -239,9 +242,9 @@ export interface FidesCookie {
 }
 
 export type GetPreferencesFnResp = {
-  // Overrides the value for Fides.consent for the user’s notice-based preferences (e.g. { data_sales: false })
+  // Overrides the value for Fides.consent for the user's notice-based preferences (e.g. { data_sales: false })
   consent?: NoticeConsent;
-  // Overrides the value for Fides.fides_string for the user’s TCF+AC preferences (e.g. 1a2a3a.AAABA,1~123.121)
+  // Overrides the value for Fides.fides_string for the user's TCF+AC preferences (e.g. 1a2a3a.AAABA,1~123.121)
   fides_string?: string;
   // An explicit version hash for provided fides_string when calculating whether consent should be re-triggered
   version_hash?: string;
@@ -719,6 +722,7 @@ export type FidesInitOptionsOverrides = Pick<
   | "fidesClearCookie"
   | "fidesConsentOverride"
   | "otFidesMapping"
+  | "fidesDisabledNotices"
 >;
 
 export type FidesExperienceTranslationOverrides = {

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -908,3 +908,27 @@ export type ConsentOption = {
 export type LegacyConsentConfig = {
   options: ConsentOption[];
 };
+
+interface FidesValidatorMap<T, K> {
+  overrideName: keyof T;
+  overrideType: "string" | "boolean" | "array";
+  overrideKey: K;
+  validationRegex: RegExp;
+  transform?: (value: string) => any;
+}
+
+export type FidesOverrideValidatorMap = FidesValidatorMap<
+  FidesInitOptionsOverrides,
+  keyof FidesOptions
+>;
+
+export type FidesExperienceLanguageValidatorMap = FidesValidatorMap<
+  FidesExperienceTranslationOverrides,
+  string
+>;
+
+export type FidesWindowOverrides = Partial<
+  FidesOptions & OverrideExperienceTranslations
+> & {
+  [key: string]: string | boolean | undefined;
+};

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -9,8 +9,10 @@ import {
   ConsentMechanism,
   EmptyExperience,
   FidesCookie,
+  FidesExperienceLanguageValidatorMap,
   FidesInitOptions,
-  FidesOptions,
+  FidesOverrideValidatorMap,
+  FidesWindowOverrides,
   GpcStatus,
   NoticeConsent,
   OverrideType,
@@ -143,8 +145,8 @@ export const validateOptions = (options: FidesInitOptions): boolean => {
 export const getOverrideValidatorMapByType = (
   overrideType: OverrideType,
 ):
-  | typeof FIDES_OVERRIDE_OPTIONS_VALIDATOR_MAP
-  | typeof FIDES_OVERRIDE_EXPERIENCE_LANGUAGE_VALIDATOR_MAP
+  | FidesOverrideValidatorMap[]
+  | FidesExperienceLanguageValidatorMap[]
   | null => {
   // eslint-disable-next-line default-case
   switch (overrideType) {
@@ -271,7 +273,7 @@ export const shouldResurfaceConsent = (
  */
 export const getWindowObjFromPath = (
   path: string[],
-): FidesOptions | undefined => {
+): FidesWindowOverrides | undefined => {
   // Implicitly start from the global "window" object
   if (path[0] === "window") {
     path.shift();
@@ -318,6 +320,23 @@ export const getGpcStatusFromNotice = ({
 
 export const defaultShowModal = () => {
   fidesDebugger("The current experience does not support displaying a modal.");
+};
+
+/**
+ * Parses a comma-separated string of notice keys into an array of strings.
+ * Handles undefined input, trims whitespace, and filters out empty strings.
+ */
+export const parseFidesDisabledNotices = (
+  value: string | undefined,
+): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((key) => key.trim())
+    .filter(Boolean);
 };
 
 export const createConsentPreferencesToSave = (

--- a/clients/fides-js/src/lib/tcf/types.ts
+++ b/clients/fides-js/src/lib/tcf/types.ts
@@ -220,6 +220,11 @@ export interface TcfOtherConsent {
 
 export type TcfModelType = keyof TcfOtherConsent;
 
+/**
+ * NOTE: EnabledIds is a bit of a misnomer, it's actually the accepted/opted-in ids.
+ * Keep that in mind when dealing with UI toggles that are
+ * disabled/enabled vs checked/unchecked.
+ */
 export interface EnabledIds {
   purposesConsent: string[];
   customPurposesConsent: string[];

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -67,6 +67,7 @@ export type PrivacyCenterClientSettings = Pick<
   | "FIDES_PRIMARY_COLOR"
   | "FIDES_CLEAR_COOKIE"
   | "FIDES_CONSENT_OVERRIDE"
+  | "FIDES_DISABLED_NOTICES"
 >;
 
 export type Styles = string;
@@ -355,6 +356,7 @@ export const loadPrivacyCenterEnvironment = async ({
     FIDES_PRIMARY_COLOR: settings.FIDES_PRIMARY_COLOR,
     FIDES_CLEAR_COOKIE: settings.FIDES_CLEAR_COOKIE,
     FIDES_CONSENT_OVERRIDE: settings.FIDES_CONSENT_OVERRIDE,
+    FIDES_DISABLED_NOTICES: settings.FIDES_DISABLED_NOTICES,
   };
 
   // For backwards-compatibility, override FIDES_API_URL with the value from the config file if present

--- a/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
+++ b/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
@@ -26,7 +26,7 @@ export interface PrivacyCenterSettings {
   OVERLAY_PARENT_ID: string | null; // (optional) ID of the parent DOM element where the overlay should be inserted
   MODAL_LINK_ID: string | null; // (optional) ID of the DOM element that should trigger the consent modal
   PRIVACY_CENTER_URL: string; // e.g. http://localhost:3001
-  FIDES_EMBED: boolean | false; // (optional) Whether we should "embed" the fides.js overlay UI (ie. “Layer 2”) into a web page
+  FIDES_EMBED: boolean | false; // (optional) Whether we should "embed" the fides.js overlay UI (ie. "Layer 2") into a web page
   FIDES_DISABLE_SAVE_API: boolean | false; // (optional) Whether we should disable saving consent preferences to the Fides API
   FIDES_DISABLE_NOTICES_SERVED_API: boolean | false; // (optional) Whether we should only disable saving notices served to the Fides API
   FIDES_DISABLE_BANNER: boolean | false; // (optional) Whether we should disable showing the banner
@@ -42,4 +42,5 @@ export interface PrivacyCenterSettings {
   FIDES_CLEAR_COOKIE: boolean; // (optional) deletes fides_consent cookie on reload
   SHOW_BRAND_LINK: boolean; // whether to render the Ethyca brand link
   FIDES_CONSENT_OVERRIDE: ConsentMethod.ACCEPT | ConsentMethod.REJECT | null; // (optional) sets a previously learned consent preference for the user
+  FIDES_DISABLED_NOTICES: string | null; // (optional) comma-separated list of notice_keys to disable in the CMP Overlay
 }

--- a/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
+++ b/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
@@ -100,6 +100,8 @@ const loadEnvironmentVariables = () => {
       (process.env.FIDES_PRIVACY_CENTER__FIDES_KNOWN_PREFERENCE as
         | ConsentMethod.ACCEPT
         | ConsentMethod.REJECT) || null,
+    FIDES_DISABLED_NOTICES:
+      process.env.FIDES_PRIVACY_CENTER__FIDES_DISABLED_NOTICES || null,
   };
   return settings;
 };

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf-custom-notices.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf-custom-notices.cy.ts
@@ -3024,4 +3024,32 @@ describe("Fides-js TCF", () => {
       });
     });
   });
+
+  describe("Disabled custom notices", () => {
+    it("should be disabled in the overlay", () => {
+      // Disable the analytics notice which is opted in by default
+      stubTCFExperience({
+        includeCustomPurposes: true,
+        stubOptions: {
+          fidesDisabledNotices: ["analytics_opt_out"],
+        },
+      });
+      cy.get("button").contains("Manage preferences").click();
+      cy.getByTestId("toggle-Analytics").find("input").should("be.disabled"); // disabled by override
+      cy.getByTestId("toggle-Analytics").find("input").should("be.checked"); // opted in by default
+      cy.getByTestId("toggle-Advertising English")
+        .find("input")
+        .should("not.be.disabled"); // unaffected by override
+      cy.getByTestId("toggle-Advertising English")
+        .find("input")
+        .should("not.be.checked"); // opted out by default
+
+      // Opt out of all has no effect
+      cy.getByTestId("fides-modal-content")
+        .contains("button", "Opt out of all")
+        .should("be.visible")
+        .click();
+      cy.getByTestId("toggle-Analytics").find("input").should("be.checked"); // still opted in
+    });
+  });
 });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -2895,6 +2895,40 @@ describe("Consent overlay", () => {
           "rgb(153, 144, 0)",
         );
       });
+      it("applies fides_disabled_notices override", () => {
+        // Disable the analytics notice which is opted in by default
+        let overrides = {
+          fides_disabled_notices: "analytics_opt_out",
+        };
+        cy.fixture("consent/experience_banner_modal.json").then(() => {
+          stubConfig(
+            {
+              options: {
+                customOptionsPath: TEST_OVERRIDE_WINDOW_PATH,
+              },
+            },
+            null,
+            null,
+            { ...overrides },
+          );
+        });
+        cy.get("button").contains("Manage preferences").click();
+        cy.getByTestId("toggle-Analytics").find("input").should("be.disabled"); // disabled by override
+        cy.getByTestId("toggle-Analytics").find("input").should("be.checked"); // opted in by default
+        cy.getByTestId("toggle-Advertising")
+          .find("input")
+          .should("not.be.disabled"); // unaffected by override
+        cy.getByTestId("toggle-Advertising")
+          .find("input")
+          .should("not.be.checked"); // opted out by default
+
+        // Opt out of all has no effect
+        cy.getByTestId("fides-modal-content")
+          .contains("button", "Opt out of all")
+          .should("be.visible")
+          .click();
+        cy.getByTestId("toggle-Analytics").find("input").should("be.checked"); // still opted in
+      });
     });
   });
 

--- a/clients/privacy-center/cypress/e2e/consent-notices.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-notices.cy.ts
@@ -314,7 +314,7 @@ describe("Privacy notice driven consent", () => {
   });
 
   describe("when user has consented before", () => {
-    it("renders from privacy notices when user has consented before", () => {
+    beforeEach(() => {
       const uuid = "4fbb6edf-34f6-4717-a6f1-541fd1e5d585";
       const createdAt = "2023-04-28T12:00:00.000Z";
       const updatedAt = "2023-04-29T12:00:00.000Z";
@@ -328,6 +328,8 @@ describe("Privacy notice driven consent", () => {
         },
       };
       cy.setCookie(CONSENT_COOKIE_NAME, JSON.stringify(cookie));
+    });
+    it("renders from privacy notices when user has consented before", () => {
       // Visit the consent page with notices enabled
       cy.visit("/consent");
       cy.getByTestId("consent");
@@ -353,6 +355,18 @@ describe("Privacy notice driven consent", () => {
           preferences.map((p: ConsentOptionCreate) => p.preference),
         ).to.eql(["opt_in", "opt_out", "acknowledge"]);
       });
+    });
+
+    it("applies FIDES_DISABLED_NOTICES override", () => {
+      const overrides = {
+        FIDES_DISABLED_NOTICES: "analytics_opt_out",
+        ...SETTINGS,
+      };
+      cy.visit("/consent");
+      cy.getByTestId("consent");
+      cy.overrideSettings(overrides);
+      cy.wait("@getExperience");
+      cy.getByTestId("toggle-Analytics").find("input").should("be.disabled"); // disabled by override
     });
   });
 

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -266,6 +266,7 @@ export default async function handler(
       fidesPrimaryColor: environment.settings.FIDES_PRIMARY_COLOR,
       fidesClearCookie: environment.settings.FIDES_CLEAR_COOKIE,
       fidesConsentOverride: environment.settings.FIDES_CONSENT_OVERRIDE,
+      fidesDisabledNotices: environment.settings.FIDES_DISABLED_NOTICES,
     },
     experience: experience || undefined,
     geolocation: geolocation || undefined,

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -8,6 +8,7 @@ import {
   experienceIsValid,
   fetchExperience,
   FidesConfig,
+  parseFidesDisabledNotices,
   PrivacyExperience,
   PrivacyExperienceMinimal,
   UserGeolocation,
@@ -266,7 +267,9 @@ export default async function handler(
       fidesPrimaryColor: environment.settings.FIDES_PRIMARY_COLOR,
       fidesClearCookie: environment.settings.FIDES_CLEAR_COOKIE,
       fidesConsentOverride: environment.settings.FIDES_CONSENT_OVERRIDE,
-      fidesDisabledNotices: environment.settings.FIDES_DISABLED_NOTICES,
+      fidesDisabledNotices: parseFidesDisabledNotices(
+        environment.settings.FIDES_DISABLED_NOTICES || undefined,
+      ),
     },
     experience: experience || undefined,
     geolocation: geolocation || undefined,


### PR DESCRIPTION
Closes [LJ-487]

### Description Of Changes

Adds support for disabling specific notice toggles in the CMP overlay via a new `fides_disabled_notices` configuration option. This allows clients to prevent users from toggling certain privacy notices while preserving their current consent state.

### Code Changes

* Added new `fides_disabled_notices` option to `FidesOptions` interface that accepts a comma-separated string of notice keys
* Implemented `parseFidesDisabledNotices` utility to parse the disabled notices string into an array
* Modified `NoticeOverlay` and `TcfOverlay` components to respect disabled notices:
  - Preserves consent state for disabled notices during accept/reject all actions
  - Disables toggle UI elements for specified notices
  - Updates consent handling logic to maintain disabled notice states
  - preserves existing disabling of Notice Only notices
* Updated type definitions to support new option and validator maps
* Added comprehensive tests for `parseFidesDisabledNotices` utility

### Steps to Confirm

1. Initialize an experience with notices in Admin UI
2. Visit demo page with appropriate geolocation and the override as a query param (eg. `/fides-js-demo.html?geolocation=us-ut&fides_disabled_notices=analytics,marketing`)
3. Verify disabled notices cannot be toggled in the CMP overlay
4. Confirm "Accept All" and "Reject All" preserve the state of disabled notices
5. Test with various combinations of disabled notices and consent mechanisms
6. Test with both TCF and non-TCF experiences that have custom notices applied.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [x] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [x] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-487]: https://ethyca.atlassian.net/browse/LJ-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ