### PR TITLE
updates Fides interface docs

### DIFF
--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -362,3 +362,56 @@ preferences) or in the case when the previous consent is no longer valid.
 #### Returns
 
 `boolean`
+
+***
+
+### geolocation?
+
+> `optional` **geolocation**: `any`
+
+The detected geolocation that Fides uses to determine the user's experience.
+This field is read-only.
+
+#### Example
+
+```ts
+{
+  "country": "ca",
+  "location": "ca-on",
+  "region": "on"
+}
+```
+
+***
+
+### locale
+
+> **locale**: `string`
+
+The detected i18n locale that Fides uses to determine the language shown to the user.
+
+#### Example
+
+```ts
+"en"
+```
+
+This field is read-only.
+
+***
+
+### identity
+
+> **identity**: `Record`\<`string`, `string`\>
+
+The user's identity values, which only include a copy of the fides user device id that we store in the fides_consent cookie e.g.
+
+#### Example
+
+```ts
+{
+  "fides_user_device_id": "1234-"
+}
+```
+
+This field is read-only.

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -280,6 +280,47 @@ export interface Fides {
   shouldShowExperience: () => boolean;
 
   /**
+   * The detected geolocation that Fides uses to determine the user's experience.
+   * This field is read-only.
+   *
+   * @example
+   * ```ts
+   * {
+   *   "country": "ca",
+   *   "location": "ca-on",
+   *   "region": "on"
+   * }
+   * ```
+   */
+  geolocation?: any;
+
+  /**
+   * The detected i18n locale that Fides uses to determine the language shown to the user.
+   *
+   * @example
+   * ```ts
+   * "en"
+   * ```
+   *
+   * This field is read-only.
+   */
+  locale: string;
+
+  /**
+   * The user's identity values, which only include a copy of the fides user device id that we store in the fides_consent cookie e.g.
+   *
+   * @example
+   * ```ts
+   * {
+   *   "fides_user_device_id": "1234-"
+   * }
+   * ```
+   *
+   * This field is read-only.
+   */
+  identity: Record<string, string>;
+
+  /**
    * NOTE: The properties below are all marked @internal, despite being exported
    * on the global Fides object. This is because they are mostly implementation
    * details and internals that we probably *should* be hiding, to avoid
@@ -307,23 +348,6 @@ export interface Fides {
    * @internal
    */
   fides_meta: Record<any, any>;
-
-  /**
-   * @internal
-   */
-  geolocation?: any;
-
-  /**
-   * @internal
-   */
-  locale: string;
-
-  /**
-   * DEFER (PROD-1815): This probably *should* be part of the documented SDK.
-   *
-   * @internal
-   */
-  identity: Record<string, string>;
 
   /**
    * @internal


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/LJ-431

### Description Of Changes

Exposes and documents `geolocation`, `locale`, `identity` in our `Fides` interface docs.

### Code Changes

* Regenerates typedocs for Fides interface after some updates to remove "internal" flag.

### Steps to Confirm

1.  All tests pass
2. See that https://ethyca.com/docs/dev-docs/js/reference/interfaces/Fides docs are up to date

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
