### PR TITLE
Use gpp_settings.cmp_api_required to determine if GPP should be included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Updated privacy request handling to still succeed if not all identities are provided [#5836](https://github.com/ethyca/fides/pull/5836)
 - Refactored privacy request processing to never re-use sessions [#5862](https://github.com/ethyca/fides/pull/5862)
 - Updated hover state of menu items to be more visible [#5868](https://github.com/ethyca/fides/pull/5868)
+- Use `gpp_settings.cmp_api_required` to determine if GPP CMP API should be included in bundle [#5883](https://github.com/ethyca/fides/pull/5883)
 
 ### Developer Experience
 - Moved non-prod Admin UI dependencies to devDependencies [#5832](https://github.com/ethyca/fides/pull/5832)

--- a/clients/fides-js/src/lib/gpp/types.ts
+++ b/clients/fides-js/src/lib/gpp/types.ts
@@ -44,6 +44,10 @@ export type GPPSettings = {
    * Whether TC string should be included as a section in GPP
    */
   enable_tcfeu_string?: boolean;
+  /**
+   * Whether the GPP CMP API is required for the experience
+   */
+  cmp_api_required?: boolean;
 };
 
 export type GPPMechanismMapping = {

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -227,8 +227,9 @@ export default async function handler(
   if (forcedGppQuery === "true" && experience === undefined) {
     experience = {};
   }
+
   const gppEnabled =
-    (!!experience?.gpp_settings?.enabled || forcedGppQuery === "true") &&
+    (!!experience?.gpp_settings?.cmp_api_required || forcedGppQuery === "true") &&
     forcedGppQuery !== "debug";
 
   // Create the FidesConfig JSON that will be used to initialize fides.js unless in E2E mode (see below)

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -229,7 +229,8 @@ export default async function handler(
   }
 
   const gppEnabled =
-    (!!experience?.gpp_settings?.cmp_api_required || forcedGppQuery === "true") &&
+    (!!experience?.gpp_settings?.cmp_api_required ||
+      forcedGppQuery === "true") &&
     forcedGppQuery !== "debug";
 
   // Create the FidesConfig JSON that will be used to initialize fides.js unless in E2E mode (see below)


### PR DESCRIPTION
Closes [LJ-490](https://ethyca.atlassian.net/browse/LJ-490)

### Description Of Changes

Uses `gpp_settings.cmp_api_required` from the Privacy Center to decide whether or not the GPP JS API needs to be included in the fides JS bundle, rather than just looking at `gpp_settings.enabled`. 

### Steps to Confirm

* Enable TCF and GPP (national) in your fides .toml file and start fidesplus. The enable_tcfeu_string setting should be set to True.
* Enable three experiences:
    * TCF experience
    * US Modal experience , add a state to it that's not on the default Privacy Center experience (e.g us_wi)
    * Privacy Center experience , add a state to it that's not on the default US Modal experience and make sure no GPP notices are added in this experience
* Enable a GPP notice and add it to the US Modal experience 
* Run the privacy center 
* Go to the `fides-js-demo` site with the `geolocation` query param set to `eea`. In the console, check that `window.__gpp` is defined
*  Go to the `fides-js-demo` site with the `geolocation` query param set to the state you added to the US Modal experience. In the console, check that `window.__gpp` is defined
* Go to the `fides-js-demo` site with the `geolocation` query param set to the state you added to the Privacy Center experience. In the console, check that `window.__gpp` is **not** defined

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-490]: https://ethyca.atlassian.net/browse/LJ-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ