### PR TITLE
Fix hover/selecter colors in main menu

### DIFF
--- a/clients/admin-ui/src/theme/global.scss
+++ b/clients/admin-ui/src/theme/global.scss
@@ -53,9 +53,11 @@ h6 {
       }
     }
 
-    &:hover,
-    &:focus-within {
+    &:focus-within:not(.ant-menu-item-selected) {
       background-color: var(--fidesui-neutral-800);
+    }
+    &:hover {
+      --ant-menu-dark-item-hover-bg: var(--fidesui-neutral-800);
     }
   }
 


### PR DESCRIPTION
### Description Of Changes

Fix problem with hover/selected colors.

### Code Changes

* Split css rule for focus/hover
* Make hover rule override ant variable
* Modify focus-within rule (for accessibility) to exclude selected elements

### Steps to Confirm

1. Login to admin-ui
2. Hover over the menu items and check the background is gray
3. Click on a submenu item and check the selector color background is sandstone
4. Reload the page
5. Use keyboard tab/arrows to navigate up and down the menu items
6. Check the focused menu item background color is gray

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
