### PR TITLE
Fix `extraDetails.preference` on `FidesUIChanged` events from FidesJS SDK to include the correct `notice_key` when using custom purposes in TCF experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed `/privacy-request/<id>/resubmit` endpoint so it doesn't queue the request twice [#5870](https://github.com/ethyca/fides/pull/5870)
 - Fixed the system assets table being the wrong width [#5879](https://github.com/ethyca/fides/pull/5879)
 - Fixed vendor override handling in FidesJS CMP [#5886](https://github.com/ethyca/fides/pull/5886)
+- Fix `extraDetails.preference` on `FidesUIChanged` events from FidesJS SDK to include the correct `notice_key` when using custom purposes in TCF experience [#5892](https://github.com/ethyca/fides/pull/5892)
 
 ## [2.56.2](https://github.com/ethyca/fides/compare/2.56.1...2.56.2)
 

--- a/clients/fides-js/src/components/tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/tcf/TcfPurposes.tsx
@@ -189,7 +189,9 @@ const TcfPurposes = ({
     let key;
     if (modelType === "customPurposesConsent") {
       type = "notice" as const;
-      key = `${item.id}`;
+      // For custom purposes (privacy notices), we can use the notice_key
+      // to be consistent with regular notices in FidesUIChanged events
+      key = (item as PrivacyNoticeWithBestTranslation).notice_key;
     } else if (modelType === "purposesConsent") {
       type = "tcf_purpose_consent" as const;
       key = `${type}_${item.id}`;


### PR DESCRIPTION
Closes [LJ-537]

### Description Of Changes

In #5859 when setting up the `FidesUIChanged` events with details about the preference being toggled, I missed that I could include the `notice_key` for custom purposes in a TCF experience and instead was returning the notice's database ID, oops!

### Code Changes

* Add test to toggle custom purposes in a TCF experience and inspect `FidesUIChanged` event
* Update `TcfToggles` to collect the notice's `notice_key` on the event instead

### Steps to Confirm

1.  Configure a TCF experience with a custom purpose and load in the Cookie House sample app
2. Subscribe to the `FidesUIChanged` event and inspect the `evt.details.extraDetails.preference` property to see the expected `key`:
```
window.addEventListener("FidesUIChanged", (evt) => {
  console.dir(evt.detail);
}); 
```

### Pre-Merge Checklist

* [X] Issue requirements met
* [X] All CI pipelines succeeded
* [X] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-537]: https://ethyca.atlassian.net/browse/LJ-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ