### PR TITLE
Add notice consent to Fides string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added UI to manually update Assets in the system asset view [#5914](https://github.com/ethyca/fides/pull/5914)
 - Use the experience's `tcf_publisher_country_code` when building TC strings [#5921](https://github.com/ethyca/fides/pull/5921)
 - Added size thresholds to S3 upload and retrieval methods for more efficient document processing. [#5922](https://github.com/ethyca/fides/pull/5922)
+- Added support for Notice Consent String integration in Fides String [#5895](https://github.com/ethyca/fides/pull/5895)
 
 ### Changed
 - Changed discovered asset "system" cell to use `user_assigned_system_key` property [#5908](https://github.com/ethyca/fides/pull/5908)

--- a/clients/fides-js/__tests__/lib/fides-string.test.ts
+++ b/clients/fides-js/__tests__/lib/fides-string.test.ts
@@ -179,7 +179,7 @@ describe("fidesString", () => {
 
       it("appends GPP string to TC string when AC string is empty", () => {
         const cmpApi = new CmpApi(1, 1);
-        window.Fides.fides_string = "CPzvOIA.IAAA,";
+        window.Fides.fides_string = "CPzvOIA.IAAA";
         jest
           .spyOn(cmpApi, "getGppString")
           .mockReturnValue("DBABLA~BVAUAAAAAWA.QA");
@@ -196,6 +196,48 @@ describe("fidesString", () => {
 
         const result = formatFidesStringWithGpp(cmpApi);
         expect(result).toBe(",,DBABLA~BVAUAAAAAWA.QA");
+      });
+
+      it("injects GPP string to existing TC, AC, and NC strings", () => {
+        const cmpApi = new CmpApi(1, 1);
+        window.Fides.fides_string =
+          "CPzvOIA.IAAA,1~2.3.4,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9";
+        jest
+          .spyOn(cmpApi, "getGppString")
+          .mockReturnValue("DBABLA~BVAUAAAAAWA.QA");
+
+        const result = formatFidesStringWithGpp(cmpApi);
+        expect(result).toBe(
+          "CPzvOIA.IAAA,1~2.3.4,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9",
+        );
+      });
+
+      it("injects GPP string to TC string when AC string is empty and NC string exists", () => {
+        const cmpApi = new CmpApi(1, 1);
+        window.Fides.fides_string =
+          "CPzvOIA.IAAA,,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9";
+        jest
+          .spyOn(cmpApi, "getGppString")
+          .mockReturnValue("DBABLA~BVAUAAAAAWA.QA");
+
+        const result = formatFidesStringWithGpp(cmpApi);
+        expect(result).toBe(
+          "CPzvOIA.IAAA,,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9",
+        );
+      });
+
+      it("injects GPP string when only NC string exists", () => {
+        const cmpApi = new CmpApi(1, 1);
+        window.Fides.fides_string =
+          ",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9";
+        jest
+          .spyOn(cmpApi, "getGppString")
+          .mockReturnValue("DBABLA~BVAUAAAAAWA.QA");
+
+        const result = formatFidesStringWithGpp(cmpApi);
+        expect(result).toBe(
+          ",,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9",
+        );
       });
     });
   });

--- a/clients/fides-js/__tests__/lib/fides-string.test.ts
+++ b/clients/fides-js/__tests__/lib/fides-string.test.ts
@@ -27,7 +27,7 @@ describe("fidesString", () => {
       // Empty string
       {
         fidesString: "",
-        expected: { tc: "", ac: "", gpp: "" },
+        expected: { tc: "", ac: "", gpp: "", nc: "" },
       },
       // TC string only
       {
@@ -36,6 +36,7 @@ describe("fidesString", () => {
           tc: "CPzvOIAPzvOIAGXABBENAUEAAACAAAAAAAAAAAAAAAAA.IAAA",
           ac: "",
           gpp: "",
+          nc: "",
         },
       },
       // Without vendors disclosed
@@ -45,12 +46,13 @@ describe("fidesString", () => {
           tc: "CPzvOIAPzvOIAGXABBENAUEAAACAAAAAAAAAAAAAAAAA",
           ac: "",
           gpp: "",
+          nc: "",
         },
       },
       // Invalid case of only AC string- need core TC string
       {
         fidesString: ",1~2.3.4",
-        expected: { tc: "", ac: "", gpp: "" },
+        expected: { tc: "", ac: "", gpp: "", nc: "" },
       },
       // Both TC and AC string
       {
@@ -60,12 +62,13 @@ describe("fidesString", () => {
           tc: "CPzvOIAPzvOIAGXABBENAUEAAACAAAAAAAAAAAAAAAAA.IAAA",
           ac: "1~2.3.4",
           gpp: "",
+          nc: "",
         },
       },
       // GPP string only
       {
         fidesString: ",,DBABLA~BVAUAAAAAWA.QA",
-        expected: { tc: "", ac: "", gpp: "DBABLA~BVAUAAAAAWA.QA" },
+        expected: { tc: "", ac: "", gpp: "DBABLA~BVAUAAAAAWA.QA", nc: "" },
       },
       // TC + GPP string
       {
@@ -75,6 +78,7 @@ describe("fidesString", () => {
           tc: "CPzvOIAPzvOIAGXABBENAUEAAACAAAAAAAAAAAAAAAAA.IAAA",
           ac: "",
           gpp: "DBABLA~BVAUAAAAAWA.QA",
+          nc: "",
         },
       },
       // Complete string (TC + AC + GPP)
@@ -85,6 +89,7 @@ describe("fidesString", () => {
           tc: "CPzvOIAPzvOIAGXABBENAUEAAACAAAAAAAAAAAAAAAAA.IAAA",
           ac: "1~2.3.4",
           gpp: "DBABLA~BVAUAAAAAWA.QA",
+          nc: "",
         },
       },
       // No trailing comma when no GPP
@@ -95,16 +100,7 @@ describe("fidesString", () => {
           tc: "CPzvOIAPzvOIAGXABBENAUEAAACAAAAAAAAAAAAAAAAA.IAAA",
           ac: "1~2.3.4",
           gpp: "",
-        },
-      },
-      // With extra unexpected stuff
-      {
-        fidesString:
-          "CPzvOIAPzvOIAGXABBENAUEAAACAAAAAAAAAAAAAAAAA.IAAA,1~2.3.4,DBABLA~BVAUAAAAAWA.QA,extrastuff",
-        expected: {
-          tc: "CPzvOIAPzvOIAGXABBENAUEAAACAAAAAAAAAAAAAAAAA.IAAA",
-          ac: "1~2.3.4",
-          gpp: "DBABLA~BVAUAAAAAWA.QA",
+          nc: "",
         },
       },
     ])(

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -378,3 +378,28 @@ console.log(encoded); // "eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOj
 #### Returns
 
 `string`
+
+***
+
+### decodeNoticeConsentString()
+
+> **decodeNoticeConsentString**: (`base64String`) => `object`
+
+Decode a Notice Consent string into a user's consent preferences. See [FidesOptions.fides_string](FidesOptions.md#fides_string) for more details.
+
+#### Example
+
+```ts
+const decoded = Fides.decodeNoticeConsentString("eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9");
+console.log(decoded); // {data_sales_and_sharing: false, analytics: true}
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `base64String` | `string` | The Notice Consent string to decode. |
+
+#### Returns
+
+`object`

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -75,34 +75,25 @@ A `Fides.consent` value showing the user has opted-in to analytics, but not mark
 
 > `optional` **fides\_string**: `string`
 
-User's current consent string(s) combined into a single value. The string
-consists of three parts separated by commas in the format:
-`TC_STRING,AC_STRING,GPP_STRING` where:
+User's current consent string(s) combined into a single value. This is used by
+FidesJS to store IAB consent strings from various frameworks such as TCF, GPP,
+and Google's "Additional Consent" string. Additionally, we support passing a
+Notice Consent string, which is a base64 encoded string of the user's Notice
+Consent preferences. See [FidesOptions.fides_string](FidesOptions.md#fides_string) for more details.
+
+The string consists of four parts separated by commas in the format:
+`TC_STRING,AC_STRING,GPP_STRING,NC_STRING` where:
 
 - TC_STRING: IAB TCF (Transparency & Consent Framework) string
-- AC_STRING: Google's Additional Consent string, derived from TC_STRING
+- AC_STRING: Google's Additional Consent string
 - GPP_STRING: IAB GPP (Global Privacy Platform) string
-
-Note: The AC_STRING can only exist if TC_STRING exists, as it's derived from it.
-When GPP is enabled, the GPP_STRING portion is automatically initialized during
-FidesJS initialization, either preserving any existing GPP string or using a
-default value. The GPP_STRING is independent and can exist with or without the
-other strings.
+- NC_STRING: Base64 encoded string of the user's Notice Consent preferences.
 
 #### Example
 
 ```ts
-// Complete string with all parts:
 console.log(Fides.fides_string);
-// "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70,DBABLA~BVAUAAAAAWA.QA"
-
-// TC and AC strings only (no GPP):
-console.log(Fides.fides_string);
-// "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70"
-
-// GPP string only:
-console.log(Fides.fides_string);
-// ",,DBABLA~BVAUAAAAAWA.QA"
+// "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
 ```
 
 ***
@@ -362,3 +353,28 @@ preferences) or in the case when the previous consent is no longer valid.
 #### Returns
 
 `boolean`
+
+***
+
+### encodeNoticeConsentString()
+
+> **encodeNoticeConsentString**: (`consent`) => `string`
+
+Encode the user's consent preferences into a Notice Consent string. See [FidesOptions.fides_string](FidesOptions.md#fides_string) for more details.
+
+#### Example
+
+```ts
+const encoded = Fides.encodeNoticeConsentString({data_sales_and_sharing:0,analytics:1});
+console.log(encoded); // "eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `consent` | `Record`\<`string`, `boolean` \| `0` \| `1`\> | The user's consent preferences to encode. (Numeric values are supported for smaller string results and will be decoded to boolean values) |
+
+#### Returns
+
+`string`

--- a/clients/fides-js/docs/interfaces/FidesOptions.md
+++ b/clients/fides-js/docs/interfaces/FidesOptions.md
@@ -142,7 +142,39 @@ Defaults to `undefined`.
 Override the current user's `fides_string` consent preferences (see [Fides.fides_string](Fides.md#fides_string)). Can be used to synchronize consent preferences for a
 registered user from a custom backend, where the `fides_string` could be
 provided by the server across multiple devices, etc.
-selecting the best translations for the FidesJS UI.
+
+The string consists of four parts separated by commas in the format:
+`TC_STRING,AC_STRING,GPP_STRING,NC_STRING` where:
+
+- TC_STRING: IAB TCF (Transparency & Consent Framework) string
+- AC_STRING: Google's Additional Consent string
+- GPP_STRING: IAB GPP (Global Privacy Platform) string
+- NC_STRING: Base64 encoded string of the user's Notice Consent preferences.
+
+#### Example
+
+// Complete string with all parts:
+// "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+
+// TC and AC strings only:
+// "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70"
+
+// GPP string only:
+// ",,DBABLA~BVAUAAAAAWA.QA"
+
+// Notice Consent string only:
+// ",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+
+To properly encode the Notice Consent string, use the
+`window.Fides.encodeNoticeConsentString` function (see [Fides.encodeNoticeConsentString](Fides.md#encodenoticeconsentstring)) or write your own function that
+looks something like:
+```ts
+function encodeNoticeConsentString(consent: Record<string, boolean | 0 | 1>) {
+  return btoa(JSON.stringify(consent));
+}
+```
+
+Note: The Notice Consent string will take precedence over [GPC](/docs/regulations/gpc) as well as any prior user consent.
 
 Defaults to `undefined`.
 

--- a/clients/fides-js/docs/interfaces/FidesOptions.md
+++ b/clients/fides-js/docs/interfaces/FidesOptions.md
@@ -174,6 +174,9 @@ function encodeNoticeConsentString(consent: Record<string, boolean | 0 | 1>) {
 }
 ```
 
+For debugging purposes, you can decode the Notice Consent string using the
+`window.Fides.decodeNoticeConsentString` function (see [Fides.decodeNoticeConsentString](Fides.md#decodenoticeconsentstring)).
+
 Note: The Notice Consent string will take precedence over [GPC](/docs/regulations/gpc) and override any prior user consent.
 
 Defaults to `undefined`.

--- a/clients/fides-js/docs/interfaces/FidesOptions.md
+++ b/clients/fides-js/docs/interfaces/FidesOptions.md
@@ -174,7 +174,7 @@ function encodeNoticeConsentString(consent: Record<string, boolean | 0 | 1>) {
 }
 ```
 
-Note: The Notice Consent string will take precedence over [GPC](/docs/regulations/gpc) as well as any prior user consent.
+Note: The Notice Consent string will take precedence over [GPC](/docs/regulations/gpc) and override any prior user consent.
 
 Defaults to `undefined`.
 

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -11,17 +11,15 @@ import {
 } from "preact/hooks";
 
 import { useA11yDialog } from "../lib/a11y-dialog";
-import { isConsentOverride } from "../lib/common-utils";
 import { FIDES_OVERLAY_WRAPPER } from "../lib/consent-constants";
 import {
-  ComponentType,
   FidesCookie,
   FidesInitOptions,
   NoticeConsent,
   PrivacyExperience,
   PrivacyExperienceMinimal,
 } from "../lib/consent-types";
-import { defaultShowModal, shouldResurfaceConsent } from "../lib/consent-utils";
+import { defaultShowModal, shouldResurfaceBanner } from "../lib/consent-utils";
 import { dispatchFidesEvent } from "../lib/events";
 import { useElementById, useHasMounted } from "../lib/hooks";
 import { useI18n } from "../lib/i18n/i18n-context";
@@ -71,21 +69,15 @@ const Overlay: FunctionComponent<Props> = ({
   const { i18n } = useI18n();
   const delayBannerMilliseconds = 100;
   const hasMounted = useHasMounted();
-  const isAutomatedConsent = isConsentOverride(options);
   const modalLinkId = options.modalLinkId || "fides-modal-link";
   const modalLinkIsDisabled =
     !experience || !!options.fidesEmbed || options.modalLinkId === "";
   const modalLink = useElementById(modalLinkId, modalLinkIsDisabled);
   const modalLinkRef = useRef<HTMLElement | null>(null);
 
-  const showBanner = useMemo(
-    () =>
-      !isAutomatedConsent &&
-      !options.fidesDisableBanner &&
-      experience.experience_config?.component !== ComponentType.MODAL &&
-      shouldResurfaceConsent(experience, cookie, savedConsent),
-    [cookie, savedConsent, experience, options, isAutomatedConsent],
-  );
+  const showBanner = useMemo(() => {
+    return shouldResurfaceBanner(experience, cookie, savedConsent, options);
+  }, [cookie, savedConsent, experience, options]);
 
   const [bannerIsOpen, setBannerIsOpen] = useState(
     options.fidesEmbed ? showBanner : false,

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -58,7 +58,6 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
       return experience.privacy_notices.map((notice) => {
         const val = resolveConsentValue(
           notice,
-          getConsentContext(),
           consent || savedConsent || parsedCookie?.consent,
         );
         return val ? (notice.notice_key as PrivacyNotice["notice_key"]) : "";

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../lib/consent-utils";
 import { resolveConsentValue } from "../../lib/consent-value";
 import {
+  consentCookieObjHasSomeConsentSet,
   getFidesConsentCookie,
   updateCookieFromNoticePreferences,
 } from "../../lib/cookie";
@@ -44,13 +45,13 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   experience,
   fidesRegionString,
   cookie,
-  savedConsent,
   propertyId,
 }) => {
   const { i18n, currentLocale, setCurrentLocale } = useI18n();
+  const parsedCookie: FidesCookie | undefined = getFidesConsentCookie();
+  const savedConsent = window.Fides.saved_consent;
 
   // TODO (PROD-1792): restore useMemo here but ensure that saved changes are respected
-  const parsedCookie: FidesCookie | undefined = getFidesConsentCookie();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const initialEnabledNoticeKeys = (consent?: NoticeConsent) => {
     if (experience.privacy_notices) {
@@ -281,8 +282,13 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   }, [cookie, options.debug]);
 
   const handleDismiss = useCallback(() => {
-    handleUpdatePreferences(ConsentMethod.DISMISS, initialEnabledNoticeKeys());
-  }, [handleUpdatePreferences, initialEnabledNoticeKeys]);
+    if (!consentCookieObjHasSomeConsentSet(cookie.consent)) {
+      handleUpdatePreferences(
+        ConsentMethod.DISMISS,
+        initialEnabledNoticeKeys(),
+      );
+    }
+  }, [handleUpdatePreferences, initialEnabledNoticeKeys, cookie.consent]);
 
   const experienceConfig = experience.experience_config;
   if (!experienceConfig) {

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -282,13 +282,17 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   }, [cookie, options.debug]);
 
   const handleDismiss = useCallback(() => {
-    if (!consentCookieObjHasSomeConsentSet(cookie.consent)) {
+    if (!consentCookieObjHasSomeConsentSet(parsedCookie?.consent)) {
       handleUpdatePreferences(
         ConsentMethod.DISMISS,
         initialEnabledNoticeKeys(),
       );
     }
-  }, [handleUpdatePreferences, initialEnabledNoticeKeys, cookie.consent]);
+  }, [
+    handleUpdatePreferences,
+    initialEnabledNoticeKeys,
+    parsedCookie?.consent,
+  ]);
 
   const experienceConfig = experience.experience_config;
   if (!experienceConfig) {

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -18,6 +18,7 @@ import {
   experienceIsValid,
   isPrivacyExperience,
 } from "../../lib/consent-utils";
+import { consentCookieObjHasSomeConsentSet } from "../../lib/cookie";
 import { dispatchFidesEvent } from "../../lib/events";
 import { useNoticesServed } from "../../lib/hooks";
 import {
@@ -492,8 +493,10 @@ export const TcfOverlay = ({
   }, [cookie, options.debug]);
 
   const handleDismiss = useCallback(() => {
-    handleUpdateAllPreferences(ConsentMethod.DISMISS, draftIds);
-  }, [handleUpdateAllPreferences, draftIds]);
+    if (!consentCookieObjHasSomeConsentSet(cookie.consent)) {
+      handleUpdateAllPreferences(ConsentMethod.DISMISS, draftIds);
+    }
+  }, [handleUpdateAllPreferences, draftIds, cookie.consent]);
 
   const experienceConfig =
     experience?.experience_config || experienceMinimal.experience_config;

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -9,6 +9,7 @@ import {
   ButtonType,
   ConsentMechanism,
   ConsentMethod,
+  FidesCookie,
   PrivacyExperience,
   PrivacyExperienceMinimal,
   PrivacyNoticeWithPreference,
@@ -18,7 +19,10 @@ import {
   experienceIsValid,
   isPrivacyExperience,
 } from "../../lib/consent-utils";
-import { consentCookieObjHasSomeConsentSet } from "../../lib/cookie";
+import {
+  consentCookieObjHasSomeConsentSet,
+  getFidesConsentCookie,
+} from "../../lib/cookie";
 import { dispatchFidesEvent } from "../../lib/events";
 import { useNoticesServed } from "../../lib/hooks";
 import {
@@ -90,6 +94,7 @@ export const TcfOverlay = ({
     setCurrentLocale,
     setIsLoading: setIsI18nLoading,
   } = useI18n();
+  const parsedCookie: FidesCookie | undefined = getFidesConsentCookie();
   const minExperienceLocale =
     experienceMinimal?.experience_config?.translations?.[0]?.language;
   const defaultLocale = i18n.getDefaultLocale();
@@ -493,10 +498,10 @@ export const TcfOverlay = ({
   }, [cookie, options.debug]);
 
   const handleDismiss = useCallback(() => {
-    if (!consentCookieObjHasSomeConsentSet(cookie.consent)) {
+    if (!consentCookieObjHasSomeConsentSet(parsedCookie?.consent)) {
       handleUpdateAllPreferences(ConsentMethod.DISMISS, draftIds);
     }
-  }, [handleUpdateAllPreferences, draftIds, cookie.consent]);
+  }, [handleUpdateAllPreferences, draftIds, parsedCookie?.consent]);
 
   const experienceConfig =
     experience?.experience_config || experienceMinimal.experience_config;

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -126,7 +126,38 @@ export interface FidesOptions {
    * Fides.fides_string}). Can be used to synchronize consent preferences for a
    * registered user from a custom backend, where the `fides_string` could be
    * provided by the server across multiple devices, etc.
-   * selecting the best translations for the FidesJS UI.
+   *
+   * The string consists of four parts separated by commas in the format:
+   * `TC_STRING,AC_STRING,GPP_STRING,NC_STRING` where:
+   *
+   * - TC_STRING: IAB TCF (Transparency & Consent Framework) string
+   * - AC_STRING: Google's Additional Consent string
+   * - GPP_STRING: IAB GPP (Global Privacy Platform) string
+   * - NC_STRING: Base64 encoded string of the user's Notice Consent preferences.
+   *
+   * @example
+   * // Complete string with all parts:
+   * // "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+   *
+   * // TC and AC strings only:
+   * // "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70"
+   *
+   * // GPP string only:
+   * // ",,DBABLA~BVAUAAAAAWA.QA"
+   *
+   * // Notice Consent string only:
+   * // ",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+   *
+   * To properly encode the Notice Consent string, use the
+   * `window.Fides.encodeNoticeConsentString` function (see {@link Fides.encodeNoticeConsentString}) or write your own function that
+   * looks something like:
+   * ```ts
+   * function encodeNoticeConsentString(consent: Record<string, boolean | 0 | 1>) {
+   *   return btoa(JSON.stringify(consent));
+   * }
+   * ```
+   *
+   * Note: The Notice Consent string will take precedence over [GPC](/docs/regulations/gpc) as well as any prior user consent.
    *
    * Defaults to `undefined`.
    */

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -157,6 +157,9 @@ export interface FidesOptions {
    * }
    * ```
    *
+   * For debugging purposes, you can decode the Notice Consent string using the
+   * `window.Fides.decodeNoticeConsentString` function (see {@link Fides.decodeNoticeConsentString}).
+   *
    * Note: The Notice Consent string will take precedence over [GPC](/docs/regulations/gpc) and override any prior user consent.
    *
    * Defaults to `undefined`.

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -157,7 +157,7 @@ export interface FidesOptions {
    * }
    * ```
    *
-   * Note: The Notice Consent string will take precedence over [GPC](/docs/regulations/gpc) as well as any prior user consent.
+   * Note: The Notice Consent string will take precedence over [GPC](/docs/regulations/gpc) and override any prior user consent.
    *
    * Defaults to `undefined`.
    */

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -286,6 +286,21 @@ export interface Fides {
   ) => string;
 
   /**
+   * Decode a Notice Consent string into a user's consent preferences. See {@link FidesOptions.fides_string} for more details.
+   *
+   * @example
+   * ```ts
+   * const decoded = Fides.decodeNoticeConsentString("eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9");
+   * console.log(decoded); // {data_sales_and_sharing: false, analytics: true}
+   * ```
+   *
+   * @param base64String The Notice Consent string to decode.
+   */
+  decodeNoticeConsentString: (base64String: string) => {
+    [noticeKey: string]: boolean;
+  };
+
+  /**
    * NOTE: The properties below are all marked @internal, despite being exported
    * on the global Fides object. This is because they are mostly implementation
    * details and internals that we probably *should* be hiding, to avoid

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -66,32 +66,23 @@ export interface Fides {
   consent: Record<string, boolean>;
 
   /**
-   * User's current consent string(s) combined into a single value. The string
-   * consists of three parts separated by commas in the format:
-   * `TC_STRING,AC_STRING,GPP_STRING` where:
+   * User's current consent string(s) combined into a single value. This is used by
+   * FidesJS to store IAB consent strings from various frameworks such as TCF, GPP,
+   * and Google's "Additional Consent" string. Additionally, we support passing a
+   * Notice Consent string, which is a base64 encoded string of the user's Notice
+   * Consent preferences. See {@link FidesOptions.fides_string} for more details.
+   *
+   * The string consists of four parts separated by commas in the format:
+   * `TC_STRING,AC_STRING,GPP_STRING,NC_STRING` where:
    *
    * - TC_STRING: IAB TCF (Transparency & Consent Framework) string
-   * - AC_STRING: Google's Additional Consent string, derived from TC_STRING
+   * - AC_STRING: Google's Additional Consent string
    * - GPP_STRING: IAB GPP (Global Privacy Platform) string
-   *
-   * Note: The AC_STRING can only exist if TC_STRING exists, as it's derived from it.
-   * When GPP is enabled, the GPP_STRING portion is automatically initialized during
-   * FidesJS initialization, either preserving any existing GPP string or using a
-   * default value. The GPP_STRING is independent and can exist with or without the
-   * other strings.
+   * - NC_STRING: Base64 encoded string of the user's Notice Consent preferences.
    *
    * @example
-   * // Complete string with all parts:
    * console.log(Fides.fides_string);
-   * // "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70,DBABLA~BVAUAAAAAWA.QA"
-   *
-   * // TC and AC strings only (no GPP):
-   * console.log(Fides.fides_string);
-   * // "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70"
-   *
-   * // GPP string only:
-   * console.log(Fides.fides_string);
-   * // ",,DBABLA~BVAUAAAAAWA.QA"
+   * // "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
    */
   fides_string?: string;
 
@@ -278,6 +269,21 @@ export interface Fides {
    * preferences) or in the case when the previous consent is no longer valid.
    */
   shouldShowExperience: () => boolean;
+
+  /**
+   * Encode the user's consent preferences into a Notice Consent string. See {@link FidesOptions.fides_string} for more details.
+   *
+   * @example
+   * ```ts
+   * const encoded = Fides.encodeNoticeConsentString({data_sales_and_sharing:0,analytics:1});
+   * console.log(encoded); // "eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+   * ```
+   *
+   * @param consent The user's consent preferences to encode. (Numeric values are supported for smaller string results and will be decoded to boolean values)
+   */
+  encodeNoticeConsentString: (
+    consent: Record<string, boolean | 0 | 1>,
+  ) => string;
 
   /**
    * NOTE: The properties below are all marked @internal, despite being exported

--- a/clients/fides-js/src/fides-ext-gpp.ts
+++ b/clients/fides-js/src/fides-ext-gpp.ts
@@ -25,7 +25,7 @@ import {
 import {
   allNoticesAreDefaultOptIn,
   isPrivacyExperience,
-  shouldResurfaceConsent,
+  shouldResurfaceBanner,
 } from "./lib/consent-utils";
 import { saveFidesCookie } from "./lib/cookie";
 import { formatFidesStringWithGpp } from "./lib/fides-string";
@@ -176,7 +176,12 @@ const initializeGppCmpApi = () => {
     //    - User has no existing preferences (either in cookie, fides_string, or mapped to notices)
     if (
       !fidesString &&
-      (!shouldResurfaceConsent(experience, event.detail, savedConsent) ||
+      (!shouldResurfaceBanner(
+        experience,
+        event.detail,
+        savedConsent,
+        options,
+      ) ||
         (!options.tcfEnabled &&
           allNoticesAreDefaultOptIn(experience.privacy_notices) &&
           !userHasExistingPrefs(

--- a/clients/fides-js/src/fides-headless.ts
+++ b/clients/fides-js/src/fides-headless.ts
@@ -12,6 +12,7 @@ import { shopify } from "./integrations/shopify";
 import { raise } from "./lib/common-utils";
 import {
   FidesConfig,
+  FidesCookie,
   FidesExperienceTranslationOverrides,
   FidesGlobal,
   FidesInitOptionsOverrides,
@@ -33,6 +34,7 @@ import {
 } from "./lib/cookie";
 import { initializeDebugger } from "./lib/debugger";
 import { dispatchFidesEvent, onFidesEvent } from "./lib/events";
+import { DecodedFidesString, decodeFidesString } from "./lib/fides-string";
 import { DEFAULT_LOCALE, DEFAULT_MODAL_LINK_LABEL } from "./lib/i18n";
 import {
   getInitialCookie,
@@ -117,7 +119,10 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
   // DEFER: not implemented - ability to override Fides consent with OneTrust overrides
   const consentPrefsOverrides: GetPreferencesFnResp | null =
     await customGetConsentPreferences(config);
-  // DEFER: not implemented - ability to override notice-based consent with the consentPrefsOverrides.consent obj
+  // if we don't already have a fidesString override, use fidesString from consent prefs if they exist
+  if (!optionsOverrides.fidesString && consentPrefsOverrides?.fides_string) {
+    optionsOverrides.fidesString = consentPrefsOverrides.fides_string;
+  }
   const overrides: Partial<FidesOverrides> = {
     optionsOverrides,
     consentPrefsOverrides,
@@ -129,7 +134,6 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
   };
   this.cookie = {
     ...getInitialCookie(config),
-    ...overrides.consentPrefsOverrides?.consent,
   };
 
   // Keep a copy of saved consent from the cookie, since we update the "cookie"
@@ -137,6 +141,25 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
   this.saved_consent = {
     ...this.cookie.consent,
   };
+
+  // Update the fidesString if we have an override and the NC portion is valid
+  const { fidesString } = config.options;
+  if (fidesString) {
+    try {
+      // Make sure Notice Consent string is valid before we assign it
+      const { nc: ncString }: DecodedFidesString =
+        decodeFidesString(fidesString);
+      this.decodeNoticeConsentString(ncString);
+      const updatedCookie: Partial<FidesCookie> = {
+        fides_string: fidesString,
+      };
+      this.cookie = { ...this.cookie, ...updatedCookie };
+    } catch (error) {
+      fidesDebugger(
+        `Could not decode ncString from ${fidesString}, it may be invalid. ${error}`,
+      );
+    }
+  }
 
   const initialFides = getInitialFides({
     ...config,

--- a/clients/fides-js/src/fides-headless.ts
+++ b/clients/fides-js/src/fides-headless.ts
@@ -9,7 +9,7 @@ import { blueconic } from "./integrations/blueconic";
 import { gtm } from "./integrations/gtm";
 import { meta } from "./integrations/meta";
 import { shopify } from "./integrations/shopify";
-import { isConsentOverride, raise } from "./lib/common-utils";
+import { raise } from "./lib/common-utils";
 import {
   FidesConfig,
   FidesExperienceTranslationOverrides,
@@ -24,8 +24,7 @@ import {
 import {
   defaultShowModal,
   encodeNoticeConsentString,
-  isPrivacyExperience,
-  shouldResurfaceConsent,
+  shouldResurfaceBanner,
 } from "./lib/consent-utils";
 import {
   consentCookieObjHasSomeConsentSet,
@@ -221,21 +220,11 @@ const _Fides: FidesGlobal = {
   initialized: false,
   onFidesEvent,
   shouldShowExperience() {
-    if (!isPrivacyExperience(this.experience)) {
-      // Nothing to show if there's no experience
-      return false;
-    }
-    if (isConsentOverride(this.options)) {
-      // If consent preference override exists, we should not show the experience
-      return false;
-    }
-    if (!this.cookie) {
-      throw new Error("Should have a cookie");
-    }
-    return shouldResurfaceConsent(
+    return shouldResurfaceBanner(
       this.experience,
       this.cookie,
       this.saved_consent,
+      this.options,
     );
   },
   meta,

--- a/clients/fides-js/src/fides-headless.ts
+++ b/clients/fides-js/src/fides-headless.ts
@@ -23,6 +23,7 @@ import {
 } from "./lib/consent-types";
 import {
   defaultShowModal,
+  encodeNoticeConsentString,
   isPrivacyExperience,
   shouldResurfaceConsent,
 } from "./lib/consent-utils";
@@ -241,6 +242,7 @@ const _Fides: FidesGlobal = {
   shopify,
   showModal: defaultShowModal,
   getModalLinkLabel: () => DEFAULT_MODAL_LINK_LABEL,
+  encodeNoticeConsentString,
 };
 
 updateWindowFides(_Fides);

--- a/clients/fides-js/src/fides-headless.ts
+++ b/clients/fides-js/src/fides-headless.ts
@@ -22,6 +22,7 @@ import {
   PrivacyExperience,
 } from "./lib/consent-types";
 import {
+  decodeNoticeConsentString,
   defaultShowModal,
   encodeNoticeConsentString,
   shouldResurfaceBanner,
@@ -232,6 +233,7 @@ const _Fides: FidesGlobal = {
   showModal: defaultShowModal,
   getModalLinkLabel: () => DEFAULT_MODAL_LINK_LABEL,
   encodeNoticeConsentString,
+  decodeNoticeConsentString,
 };
 
 updateWindowFides(_Fides);

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -13,6 +13,7 @@ import { TCString } from "@iabtechlabtcf/core";
 
 import {
   defaultShowModal,
+  encodeNoticeConsentString,
   FidesCookie,
   isPrivacyExperience,
   shouldResurfaceConsent,
@@ -300,6 +301,7 @@ const _Fides: FidesGlobal = {
   shopify,
   showModal: defaultShowModal,
   getModalLinkLabel: () => DEFAULT_MODAL_LINK_LABEL,
+  encodeNoticeConsentString,
 };
 
 if (typeof window !== "undefined") {

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -15,14 +15,13 @@ import {
   defaultShowModal,
   encodeNoticeConsentString,
   FidesCookie,
-  isPrivacyExperience,
-  shouldResurfaceConsent,
+  shouldResurfaceBanner,
 } from "./fides";
 import { blueconic } from "./integrations/blueconic";
 import { gtm } from "./integrations/gtm";
 import { meta } from "./integrations/meta";
 import { shopify } from "./integrations/shopify";
-import { isConsentOverride, raise } from "./lib/common-utils";
+import { raise } from "./lib/common-utils";
 import {
   FidesConfig,
   FidesExperienceTranslationOverrides,
@@ -280,21 +279,11 @@ const _Fides: FidesGlobal = {
   initialized: false,
   onFidesEvent,
   shouldShowExperience() {
-    if (!isPrivacyExperience(this.experience)) {
-      // Nothing to show if there's no experience
-      return false;
-    }
-    if (isConsentOverride(this.options)) {
-      // If consent preference was automatic, we should not show the experience
-      return false;
-    }
-    if (!this.cookie) {
-      throw new Error("Should have a cookie");
-    }
-    return shouldResurfaceConsent(
+    return shouldResurfaceBanner(
       this.experience,
       this.cookie,
       this.saved_consent,
+      this.options,
     );
   },
   meta,

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -12,6 +12,7 @@ import type { TCData } from "@iabtechlabtcf/cmpapi";
 import { TCString } from "@iabtechlabtcf/core";
 
 import {
+  decodeNoticeConsentString,
   defaultShowModal,
   encodeNoticeConsentString,
   FidesCookie,
@@ -291,6 +292,7 @@ const _Fides: FidesGlobal = {
   showModal: defaultShowModal,
   getModalLinkLabel: () => DEFAULT_MODAL_LINK_LABEL,
   encodeNoticeConsentString,
+  decodeNoticeConsentString,
 };
 
 if (typeof window !== "undefined") {

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -160,7 +160,6 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
   };
   this.cookie = {
     ...getInitialCookie(config),
-    ...overrides.consentPrefsOverrides?.consent,
   };
 
   // Keep a copy of saved consent from the cookie, since we update the "cookie"

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -9,7 +9,7 @@ import { blueconic } from "./integrations/blueconic";
 import { gtm } from "./integrations/gtm";
 import { meta } from "./integrations/meta";
 import { shopify } from "./integrations/shopify";
-import { isConsentOverride, raise } from "./lib/common-utils";
+import { raise } from "./lib/common-utils";
 import {
   FidesConfig,
   FidesExperienceTranslationOverrides,
@@ -26,8 +26,7 @@ import {
 import {
   defaultShowModal,
   encodeNoticeConsentString,
-  isPrivacyExperience,
-  shouldResurfaceConsent,
+  shouldResurfaceBanner,
 } from "./lib/consent-utils";
 import {
   consentCookieObjHasSomeConsentSet,
@@ -277,18 +276,7 @@ const _Fides: FidesGlobal = {
   initialized: false,
   onFidesEvent,
   shouldShowExperience() {
-    if (!isPrivacyExperience(this.experience)) {
-      // Nothing to show if there's no experience
-      return false;
-    }
-    if (isConsentOverride(this.options)) {
-      // If consent preference override exists, we should not show the experience
-      return false;
-    }
-    if (!this.cookie) {
-      throw new Error("Should have a cookie");
-    }
-    return shouldResurfaceConsent(
+    return shouldResurfaceBanner(
       this.experience,
       this.cookie,
       this.saved_consent,

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -25,6 +25,7 @@ import {
 } from "./lib/consent-types";
 import {
   defaultShowModal,
+  encodeNoticeConsentString,
   isPrivacyExperience,
   shouldResurfaceConsent,
 } from "./lib/consent-utils";
@@ -297,6 +298,7 @@ const _Fides: FidesGlobal = {
   shopify,
   showModal: defaultShowModal,
   getModalLinkLabel: () => DEFAULT_MODAL_LINK_LABEL,
+  encodeNoticeConsentString,
 };
 
 updateWindowFides(_Fides);

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -24,6 +24,7 @@ import {
   PrivacyExperience,
 } from "./lib/consent-types";
 import {
+  decodeNoticeConsentString,
   defaultShowModal,
   encodeNoticeConsentString,
   shouldResurfaceBanner,
@@ -287,6 +288,7 @@ const _Fides: FidesGlobal = {
   showModal: defaultShowModal,
   getModalLinkLabel: () => DEFAULT_MODAL_LINK_LABEL,
   encodeNoticeConsentString,
+  decodeNoticeConsentString,
 };
 
 updateWindowFides(_Fides);

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -161,6 +161,7 @@ export interface FidesGlobal extends Fides {
   cookie?: FidesCookie;
   config?: FidesConfig;
   consent: NoticeConsent;
+  encodeNoticeConsentString?: (noticeConsent: NoticeConsent) => string;
   experience:
     | PrivacyExperience
     | PrivacyExperienceMinimal

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -248,9 +248,7 @@ export interface FidesCookie {
 }
 
 export type GetPreferencesFnResp = {
-  // Overrides the value for Fides.consent for the user's notice-based preferences (e.g. { data_sales: false })
-  consent?: NoticeConsent;
-  // Overrides the value for Fides.fides_string for the user's TCF+AC preferences (e.g. 1a2a3a.AAABA,1~123.121)
+  // Overrides the value for Fides.fides_string for the user's consent preferences
   fides_string?: string;
   // An explicit version hash for provided fides_string when calculating whether consent should be re-triggered
   version_hash?: string;

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -161,7 +161,9 @@ export interface FidesGlobal extends Fides {
   cookie?: FidesCookie;
   config?: FidesConfig;
   consent: NoticeConsent;
-  encodeNoticeConsentString?: (noticeConsent: NoticeConsent) => string;
+  encodeNoticeConsentString: (
+    noticeConsent: Record<string, boolean | 0 | 1>,
+  ) => string;
   experience:
     | PrivacyExperience
     | PrivacyExperienceMinimal

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -164,6 +164,9 @@ export interface FidesGlobal extends Fides {
   encodeNoticeConsentString: (
     noticeConsent: Record<string, boolean | 0 | 1>,
   ) => string;
+  decodeNoticeConsentString: (base64String: string) => {
+    [noticeKey: string]: boolean;
+  };
   experience:
     | PrivacyExperience
     | PrivacyExperienceMinimal

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -256,7 +256,10 @@ export const shouldResurfaceBanner = (
     experience.experience_config?.component === ComponentType.TCF_OVERLAY &&
     !!cookie
   ) {
-    if (experience.meta?.version_hash) {
+    if (
+      experience.meta?.version_hash &&
+      cookie.fides_meta.consentMethod !== ConsentMethod.DISMISS
+    ) {
       return experience.meta.version_hash !== cookie.tcf_version_hash;
     }
     return true;

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -354,3 +354,53 @@ export const createConsentPreferencesToSave = (
       item.bestTranslation?.privacy_notice_history_id,
     );
   });
+
+/**
+ * Encodes consent data into a base64 string for the Notice Consent slot
+ * @param consentData Object mapping notice keys to boolean consent values
+ * @returns Base64 encoded string representation of the consent data
+ */
+export const encodeNoticeConsentString = (consentData: {
+  [noticeKey: string]: boolean | 0 | 1;
+}): string => {
+  try {
+    const jsonString = JSON.stringify(consentData);
+    return btoa(jsonString.replace(/\s/g, ""));
+  } catch (error) {
+    throw new Error("Failed to encode Notice Consent string:", {
+      cause: error,
+    });
+  }
+};
+
+/**
+ * Decodes a base64 Notice Consent string back into consent data
+ * @param base64String The base64 encoded Notice Consent string
+ * @returns Decoded consent data object or null if decoding fails
+ */
+export const decodeNoticeConsentString = (
+  base64String: string,
+): {
+  [noticeKey: string]: boolean;
+} => {
+  if (!base64String) {
+    return {};
+  }
+
+  try {
+    const jsonString = atob(base64String);
+    const parsedData = JSON.parse(jsonString);
+
+    // Convert any numeric values (1 or 0) to boolean
+    return Object.fromEntries(
+      Object.entries(parsedData).map(([key, value]) => [
+        key,
+        value === 0 || value === 1 ? !!value : Boolean(value),
+      ]),
+    );
+  } catch (error) {
+    throw new Error("Failed to decode Notice Consent string:", {
+      cause: error,
+    });
+  }
+};

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -212,10 +212,26 @@ export const experienceIsValid = (
  */
 export const getTcfDefaultPreference = (tcfObject: TcfModelsRecord) =>
   tcfObject.default_preference ?? UserConsentPreference.OPT_OUT;
-
 /**
- * Returns true if there are notices in the experience that require a user preference
- * or if an experience's version hash does not match up.
+ * Determines whether the consent banner should be shown to the user based on various conditions.
+ *
+ * The banner will NOT be shown if:
+ * - Banner is explicitly disabled via fidesDisableBanner option
+ * - No valid privacy experience exists
+ * - Experience is modal-only or headless component type
+ * - No privacy notices exist in the experience
+ * - Consent was previously set via override
+ *
+ * The banner WILL be shown if:
+ * - No prior consent exists
+ * - For TCF experiences, when version_hash doesn't match saved hash
+ * - Prior consent was only recorded via "dismiss" or "gpc" methods
+ *
+ * @param experience - The privacy experience configuration
+ * @param cookie - The current Fides cookie state
+ * @param savedConsent - Previously saved notice consent preferences
+ * @param options - Optional FidesJS initialization options
+ * @returns boolean indicating whether banner should be shown
  */
 export const shouldResurfaceBanner = (
   experience:

--- a/clients/fides-js/src/lib/consent-value.ts
+++ b/clients/fides-js/src/lib/consent-value.ts
@@ -31,14 +31,12 @@ export const resolveLegacyConsentValue = (
 
 export const resolveConsentValue = (
   notice: PrivacyNoticeWithPreference,
-  context: ConsentContext,
   consent: NoticeConsent | undefined,
 ): boolean => {
   if (notice.consent_mechanism === ConsentMechanism.NOTICE_ONLY) {
     return true;
   }
   // Note about GPC - consent has already applied to the cookie at this point, so we can trust preference there
-  // DEFER (PROD-1780): delete context arg for safety
   if (consent && noticeHasConsentInCookie(notice, consent)) {
     return !!consent[notice.notice_key];
   }

--- a/clients/fides-js/src/lib/fides-string.ts
+++ b/clients/fides-js/src/lib/fides-string.ts
@@ -11,7 +11,7 @@ export interface DecodedFidesString {
   tc: string;
   ac: string;
   gpp: string;
-  nc: string; // Base64 encoded Notice Consent String
+  nc: string;
 }
 
 /**

--- a/clients/fides-js/src/lib/fides-string.ts
+++ b/clients/fides-js/src/lib/fides-string.ts
@@ -11,17 +11,17 @@ export interface DecodedFidesString {
   tc: string;
   ac: string;
   gpp: string;
-  noticeConsent: string; // Base64 encoded Notice Consent String
+  nc: string; // Base64 encoded Notice Consent String
 }
 
 /**
  * Decodes a Fides string into its component parts.
  *
- * The Fides string format is: `TC_STRING,AC_STRING,GPP_STRING,NOTICE_CONSENT_STRING` where:
+ * The Fides string format is: `TC_STRING,AC_STRING,GPP_STRING,NC_STRING` where:
  * - TC_STRING: The TCF (Transparency & Consent Framework) string
  * - AC_STRING: The Additional Consent string, which is derived from TC_STRING
  * - GPP_STRING: The Global Privacy Platform string
- * - NOTICE_CONSENT_STRING: A Base64 encoded stringified JSON object containing notice consent preferences
+ * - NC_STRING: A Base64 encoded stringified JSON object containing Notice Consent preferences
  *
  * Rules:
  * 1. If the string is empty or undefined, all parts are empty strings
@@ -33,30 +33,28 @@ export interface DecodedFidesString {
  * @example
  * // Complete string with all parts
  * decodeFidesString("CPzvOIA.IAAA,1~2.3.4,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9")
- * // Returns { tc: "CPzvOIA.IAAA", ac: "1~2.3.4", gpp: "DBABLA~BVAUAAAAAWA.QA", noticeConsent: "eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9" }
+ * // Returns { tc: "CPzvOIA.IAAA", ac: "1~2.3.4", gpp: "DBABLA~BVAUAAAAAWA.QA", nc: "eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9" }
  *
  * // TC string only
  * decodeFidesString("CPzvOIA.IAAA")
- * // Returns { tc: "CPzvOIA.IAAA", ac: "", gpp: "", noticeConsent: "" }
+ * // Returns { tc: "CPzvOIA.IAAA", ac: "", gpp: "", nc: "" }
  *
  * // GPP string only (with empty TC and AC)
  * decodeFidesString(",,DBABLA~BVAUAAAAAWA.QA")
- * // Returns { tc: "", ac: "", gpp: "DBABLA~BVAUAAAAAWA.QA", noticeConsent: "" }
+ * // Returns { tc: "", ac: "", gpp: "DBABLA~BVAUAAAAAWA.QA", nc: "" }
  *
  * @param fidesString - The combined Fides string to decode
  * @returns An object containing the decoded TC, AC, GPP, and Notice Consent strings
  */
 export const decodeFidesString = (fidesString: string): DecodedFidesString => {
   if (!fidesString) {
-    return { tc: "", ac: "", gpp: "", noticeConsent: "" };
+    return { tc: "", ac: "", gpp: "", nc: "" };
   }
 
-  const [tc = "", ac = "", gpp = "", noticeConsent = ""] =
+  const [tc = "", ac = "", gpp = "", nc = ""] =
     fidesString.split(FIDES_SEPARATOR);
   // If there's no TC, remove AC
-  return tc
-    ? { tc, ac, gpp, noticeConsent }
-    : { tc: "", ac: "", gpp, noticeConsent };
+  return tc ? { tc, ac, gpp, nc } : { tc: "", ac: "", gpp, nc };
 };
 
 /**

--- a/clients/fides-js/src/lib/gpp/string-to-consent.ts
+++ b/clients/fides-js/src/lib/gpp/string-to-consent.ts
@@ -209,7 +209,8 @@ export const fidesStringToConsent = ({
   fidesString,
   cmpApi,
 }: FidesStringToConsentArgs) => {
-  if (!fidesString || !cmpApi) {
+  const { gpp: gppString }: DecodedFidesString = decodeFidesString(fidesString);
+  if (!fidesString || !gppString || !cmpApi) {
     return;
   }
 
@@ -228,7 +229,6 @@ export const fidesStringToConsent = ({
   const isTCF =
     experience.experience_config.component === ComponentType.TCF_OVERLAY;
 
-  const { gpp: gppString }: DecodedFidesString = decodeFidesString(fidesString);
   const fidesRegionString = constructFidesRegionString(geolocation);
   const matchTranslation = experience.experience_config.translations.find((t) =>
     areLocalesEqual(t.language, locale),

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -23,6 +23,7 @@ import {
 } from "./consent-types";
 import {
   constructFidesRegionString,
+  encodeNoticeConsentString,
   experienceIsValid,
   getOverrideValidatorMapByType,
   getWindowObjFromPath,
@@ -454,8 +455,11 @@ export const initialize = async ({
         options,
         overrides?.experienceTranslationOverrides,
       );
-      // eslint-disable-next-line no-param-reassign
+
+      /* eslint-disable no-param-reassign */
       fides.locale = i18n.locale || DEFAULT_LOCALE;
+      fides.encodeNoticeConsentString = encodeNoticeConsentString;
+      /* eslint-enable no-param-reassign */
 
       // Provide the modal link label function to the client based on the current locale unless specified via props.
       getModalLinkLabel = (props) =>

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -152,6 +152,21 @@ const automaticallyApplyPreferences = async ({
       const noticeConsent = decodeNoticeConsentString(noticeConsentString);
 
       if (notice.consent_mechanism !== ConsentMechanism.NOTICE_ONLY) {
+        // Notice Consent string takes precedence over GPC and overrides any prior consent
+        if (noticeConsent) {
+          const preference = noticeConsent[notice.notice_key];
+          if (preference !== undefined) {
+            noticeConsentApplied = true;
+            return new SaveConsentPreference(
+              notice,
+              transformConsentToFidesUserPreference(
+                preference,
+                notice.consent_mechanism,
+              ),
+              bestNoticeTranslation?.privacy_notice_history_id,
+            );
+          }
+        }
         // only apply GPC for notices that do not have prior consent
         if (
           context.globalPrivacyControl &&
@@ -168,21 +183,6 @@ const automaticallyApplyPreferences = async ({
             ),
             bestNoticeTranslation?.privacy_notice_history_id,
           );
-        }
-        // Notice Consent string overrides GPC and any prior consent
-        if (noticeConsent) {
-          const preference = noticeConsent[notice.notice_key];
-          if (preference !== undefined) {
-            noticeConsentApplied = true;
-            return new SaveConsentPreference(
-              notice,
-              transformConsentToFidesUserPreference(
-                preference,
-                notice.consent_mechanism,
-              ),
-              bestNoticeTranslation?.privacy_notice_history_id,
-            );
-          }
         }
       }
       return new SaveConsentPreference(

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -158,7 +158,7 @@ const automaticallyApplyGPCPreferences = async ({
       return new SaveConsentPreference(
         notice,
         transformConsentToFidesUserPreference(
-          resolveConsentValue(notice, context, savedConsent),
+          resolveConsentValue(notice, savedConsent),
           notice.consent_mechanism,
         ),
         bestNoticeTranslation?.privacy_notice_history_id,

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -198,13 +198,13 @@ const automaticallyApplyPreferences = async ({
 
   if (gpcApplied || noticeConsentApplied) {
     let consentMethod: ConsentMethod = ConsentMethod.SCRIPT;
-    if (gpcApplied) {
-      fidesDebugger("Updating consent preferences with GPC");
-      consentMethod = ConsentMethod.GPC;
-    }
     if (noticeConsentApplied) {
       fidesDebugger("Updating consent preferences with Notice Consent string");
       consentMethod = ConsentMethod.SCRIPT;
+    }
+    if (gpcApplied) {
+      fidesDebugger("Updating consent preferences with GPC");
+      consentMethod = ConsentMethod.GPC;
     }
     await updateConsentPreferences({
       servedNoticeHistoryId: uuidv4(),

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -24,7 +24,6 @@ import {
 import {
   constructFidesRegionString,
   decodeNoticeConsentString,
-  encodeNoticeConsentString,
   experienceIsValid,
   getOverrideValidatorMapByType,
   getWindowObjFromPath,
@@ -496,10 +495,8 @@ export const initialize = async ({
         overrides?.experienceTranslationOverrides,
       );
 
-      /* eslint-disable no-param-reassign */
+      // eslint-disable-next-line no-param-reassign
       fides.locale = i18n.locale || DEFAULT_LOCALE;
-      fides.encodeNoticeConsentString = encodeNoticeConsentString;
-      /* eslint-enable no-param-reassign */
 
       // Provide the modal link label function to the client based on the current locale unless specified via props.
       getModalLinkLabel = (props) =>

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -114,7 +114,7 @@ const automaticallyApplyPreferences = async ({
   }
 
   const context = getConsentContext();
-  const { noticeConsent: noticeConsentString } = decodeFidesString(
+  const { nc: noticeConsentString } = decodeFidesString(
     fidesOptions.fidesString || "",
   );
   if (context.globalPrivacyControl) {

--- a/clients/fides-js/src/lib/tcf/utils.ts
+++ b/clients/fides-js/src/lib/tcf/utils.ts
@@ -1,7 +1,6 @@
 import { TCString } from "@iabtechlabtcf/core";
 
 import { extractIds } from "../common-utils";
-import { getConsentContext } from "../consent-context";
 import {
   ConsentMechanism,
   FidesCookie,
@@ -274,11 +273,10 @@ export const getEnabledIdsNotice = (
     return [];
   }
   const parsedCookie: FidesCookie | undefined = getFidesConsentCookie();
-  const context = getConsentContext();
 
   return noticeList
     .map((notice) => {
-      const value = resolveConsentValue(notice, context, parsedCookie?.consent);
+      const value = resolveConsentValue(notice, parsedCookie?.consent);
       return { ...notice, consentValue: value };
     })
     .filter((notice) => notice.consentValue)

--- a/clients/privacy-center/cypress/e2e/banner-overlay-dismissal.cy.ts
+++ b/clients/privacy-center/cypress/e2e/banner-overlay-dismissal.cy.ts
@@ -140,6 +140,20 @@ describe("Banner and modal dismissal", () => {
               cy.get("#fides-banner").should("be.visible");
               cy.get("@FidesUpdated").should("not.have.been.called");
             });
+
+            it("should resurface the banner if dismissed without consent", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("#fides-banner .fides-close-button").click();
+              cy.reload();
+              cy.get("#fides-banner").should("be.visible");
+            });
+
+            it("should not resurface the banner if consented without dismissing", () => {
+              cy.get("#fides-banner").should("be.visible");
+              cy.get("#fides-banner .fides-reject-all-button").click();
+              cy.reload();
+              cy.get("#fides-banner").should("not.be.visible");
+            });
           });
 
           describe("when using the modal", () => {

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -1155,6 +1155,7 @@ describe("Consent overlay", () => {
 
         it("shows indicators that GPC has been applied", () => {
           // In the banner
+          cy.get("div#fides-banner").should("be.visible");
           cy.get("div#fides-banner").within(() => {
             cy.get("span").contains("Global Privacy Control");
           });


### PR DESCRIPTION
Closes [LJ-305]

### Description Of Changes

Introduces Notice Consent String functionality to the FidesJS client, allowing programmatic control of notice consent preferences through a base64-encoded string. The changes include:

- New encoding/decoding utilities for Notice Consent strings
- Integration with the existing Fides string format in a new fourth slot
- Automated application of Notice Consent preferences during initialization

### Code Changes

* Added `encodeNoticeConsentString` and `decodeNoticeConsentString` utility functions and exposed `encodeNoticeConsentString` to the Fides window object.
* Updated `DecodedFidesString` interface to include `noticeConsent` field
* Modified `initialize` to handle Notice Consent string application
* Removed unused `context` parameter from `resolveConsentValue`
* Added comprehensive tests for Notice Consent string encoding/decoding

### Steps to Confirm

1. In Admin UI set up a Banner, a Banner/Modal, and a TCF experience with various consent notices.
2. Load the demo page and use the provided `window.Fides.encodeNoticeConsentString()` to get a Notice Consent String. Use the keys for the consent notices configured in step 1. Get the encoded string for various combinations of true/false values for those.
4. Revisit the demo page with the `fides_string=...` query string, and use each encoded Notice Consent string noted above as the value in the fourth slot of the comma separated Fides String (eg. `fides_string=,,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowfQ==`)
5. Ensure that
  * ...the banner never shows when the fides_string is passed in for the banner/modal experience (Note: TCF banner should still show because TCF consent still needs to be asked for (only custom purposes have been set)
  * ...the preferences are automatically set as expected. Open the modal using the modal link  to ensure the same preferences were saved (toggle switches match)
  * ...the cookie `consent` value is correct and the `consentMethod` should be "script"
  * ...the payload of the `api/v1/privacy-preferences` endpoint is correct.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] Documentation added for new Notice Consent string functionality


[LJ-305]: https://ethyca.atlassian.net/browse/LJ-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ