### PR TITLE
split out provided identity and added tests

### DIFF
--- a/src/fides/api/models/privacy_request/__init__.py
+++ b/src/fides/api/models/privacy_request/__init__.py
@@ -10,14 +10,13 @@ from .privacy_request import (
     PrivacyRequest,
     PrivacyRequestError,
     PrivacyRequestNotifications,
-    ProvidedIdentity,
-    ProvidedIdentityType,
     RequestTask,
     TraversalDetails,
     generate_request_callback_pre_approval_jwe,
     generate_request_callback_resume_jwe,
     generate_request_task_callback_jwe,
 )
+from .provided_identity import ProvidedIdentity, ProvidedIdentityType
 
 __all__ = [
     "Consent",

--- a/src/fides/api/models/privacy_request/consent.py
+++ b/src/fides/api/models/privacy_request/consent.py
@@ -13,10 +13,8 @@ from sqlalchemy.orm import Session, relationship
 
 from fides.api.db.base_class import Base  # type: ignore[attr-defined]
 from fides.api.db.util import EnumColumn
-from fides.api.models.privacy_request.privacy_request import (
-    CustomPrivacyRequestField,
-    ProvidedIdentity,
-)
+from fides.api.models.privacy_request.privacy_request import CustomPrivacyRequestField
+from fides.api.models.privacy_request.provided_identity import ProvidedIdentity
 from fides.api.schemas.privacy_request import PrivacyRequestSource
 from fides.api.schemas.redis_cache import (
     CustomPrivacyRequestField as CustomPrivacyRequestFieldSchema,

--- a/tests/api/models/privacy_request/test_provided_identity.py
+++ b/tests/api/models/privacy_request/test_provided_identity.py
@@ -1,0 +1,163 @@
+import pytest
+
+from fides.api.models.privacy_request.provided_identity import (
+    ProvidedIdentity,
+    ProvidedIdentityType,
+)
+from fides.api.schemas.redis_cache import Identity
+
+
+@pytest.fixture
+def provided_identity_data():
+    provided_identity_value = "test_email@ethyca.com"
+    return {
+        "field_name": "email",
+        "hashed_value": ProvidedIdentity.hash_value(provided_identity_value),
+        "encrypted_value": {"value": provided_identity_value},
+    }
+
+
+def test_create_provided_identity(db, provided_identity_data, privacy_request):
+    # Test with privacy_request_id as None and as a valid privacy_request_id
+    for privacy_request_id in [None, privacy_request.id]:
+        provided_identity_data["privacy_request_id"] = privacy_request_id
+        provided_identity = ProvidedIdentity.create(db, data=provided_identity_data)
+
+        # Query the ProvidedIdentity
+        retrieved_identity = (
+            db.query(ProvidedIdentity)
+            .filter_by(hashed_value=provided_identity_data["hashed_value"])
+            .first()
+        )
+        assert retrieved_identity is not None
+        assert retrieved_identity.field_name == "email"
+        assert retrieved_identity.privacy_request_id == privacy_request_id
+
+        provided_identity.delete(db)
+
+
+@pytest.mark.parametrize(
+    "hash_function",
+    [
+        ProvidedIdentity.bcrypt_hash_value,
+        ProvidedIdentity.hash_value,
+    ],
+    ids=["bcrypt_hash_value", "hash_value"],
+)
+def test_hash_value_basic(hash_function):
+    value = "test_value"
+    hashed_value = hash_function(value)
+
+    assert hashed_value is not None
+    assert isinstance(hashed_value, str)
+    assert hashed_value != value  # Ensure the hash is different from the input
+
+
+@pytest.mark.parametrize(
+    "hash_function",
+    [
+        ProvidedIdentity.bcrypt_hash_value,
+        ProvidedIdentity.hash_value,
+    ],
+    ids=["bcrypt_hash_value", "hash_value"],
+)
+def test_hash_value_deterministic(hash_function):
+    value = "test_value"
+    hashed_value_1 = hash_function(value)
+    hashed_value_2 = hash_function(value)
+
+    # If the function is deterministic, the hashes should match
+    assert hashed_value_1 == hashed_value_2
+
+
+@pytest.mark.parametrize(
+    "hash_function",
+    [
+        ProvidedIdentity.bcrypt_hash_value,
+        ProvidedIdentity.hash_value,
+    ],
+    ids=["bcrypt_hash_value", "hash_value"],
+)
+def test_hash_value_different_inputs(hash_function):
+    value_1 = "test_value_1"
+    value_2 = "test_value_2"
+
+    hashed_value_1 = hash_function(value_1)
+    hashed_value_2 = hash_function(value_2)
+
+    # Ensure different inputs produce different hashes
+    assert hashed_value_1 != hashed_value_2
+
+
+@pytest.mark.parametrize(
+    "hash_function",
+    [
+        ProvidedIdentity.bcrypt_hash_value,
+        ProvidedIdentity.hash_value,
+    ],
+    ids=["bcrypt_hash_value", "hash_value"],
+)
+def test_hash_value_empty_string(hash_function):
+    value = ""
+    hashed_value = hash_function(value)
+
+    assert hashed_value is not None
+    assert isinstance(hashed_value, str)
+
+
+@pytest.mark.parametrize(
+    "hash_function",
+    [
+        ProvidedIdentity.bcrypt_hash_value,
+        ProvidedIdentity.hash_value,
+    ],
+    ids=["bcrypt_hash_value", "hash_value"],
+)
+def test_hash_value_large_input(hash_function):
+    value = "a" * 10000  # Very large input
+    hashed_value = hash_function(value)
+
+    assert hashed_value is not None
+    assert isinstance(hashed_value, str)
+
+
+def test_migrate_hashed_fields(db, provided_identity_data):
+    provided_identity = ProvidedIdentity.create(db, data=provided_identity_data)
+    provided_identity.migrate_hashed_fields()
+    assert provided_identity.is_hash_migrated
+    provided_identity.delete(db)
+
+
+def test_as_identity_schema_basic(db, provided_identity_data):
+    provided_identity = ProvidedIdentity.create(db, data=provided_identity_data)
+
+    # Call the as_identity_schema method
+    identity_schema = provided_identity.as_identity_schema()
+
+    assert isinstance(identity_schema, Identity)
+    assert identity_schema.phone_number is None
+    assert identity_schema.email == "test_email@ethyca.com"
+    assert identity_schema.ga_client_id is None
+    assert identity_schema.ljt_readerID is None
+    assert identity_schema.fides_user_device_id is None
+    assert identity_schema.external_id is None
+
+    provided_identity.delete(db)
+
+
+def test_as_identity_schema_missing_encrypted_value(db, provided_identity_data):
+    provided_identity_data.pop("encrypted_value")
+    provided_identity = ProvidedIdentity.create(db, data=provided_identity_data)
+
+    # Call the as_identity_schema method
+    identity_schema = provided_identity.as_identity_schema()
+
+    assert isinstance(identity_schema, Identity)
+    assert identity_schema.phone_number is None
+    assert identity_schema.email is None
+    assert identity_schema.ga_client_id is None
+    assert identity_schema.ljt_readerID is None
+    assert identity_schema.fides_user_device_id is None
+    assert identity_schema.external_id is None
+
+    provided_identity.delete(db)


### PR DESCRIPTION
### Description Of Changes

Doing some clean up and adding some unit tests for elements in src/fides/api/modes/privacy_requests.py. This file has gotten really large so moving this into a directory and breaking out well defined elements into their own files. This will also make adding unit tests less cumbersome.

This PR splits out Provided Identity specific elements into their own file. I have also added several unit tests for each class/function.

Previous PR:
* consent.py: `Consent`, `ConsentRequest`
* execution_logs.py - `ExecutionLogs`, `EXECUTION_CHECKPOINTS`, `COMPLETED_EXECUTION_LOG_STATUSES`, `EXITED_EXECUTION_LOG_STATUSES`, `can_run_checkpoint`

**Current PR:**
* provided_identity.py: `ProvidedIdentityType`, `ProvidedIdentity`

Future PRs in the pipeline will further break out:
* request_task.py: `TraversalDetails`, `RequestTask`
* webhook.py: `CallbackType`, `SecondPartyRequestFormat`, `generate_request_callback_resume_jwe`, `generate_request_callback_pre_approval_jwe`, `generate_request_task_callback_jwe`

### Code Changes

* Added `src/fides/api/modes/provided_identity.py` and moved `ProvidedIdentityType`, `ProvidedIdentity` to that file
* Added import statements to the `__init__.py` so that existing imports will continue to work.
* Added unit tests for `ProvidedIdentity` class.

### Steps to Confirm

1.  There should be no change in functionality. All tests should pass

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
