### PR TITLE
Support `FIDES_PRIVACY_CENTER__FIDES_JS_MAX_AGE_SECONDS` configuration option for `fides-privacy-center` to override default cache duration for /fides.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Added
 - Added `is_country` field on locations [#5885](https://github.com/ethyca/fides/pull/5885)
 - Added new `has_next` parameter for the `cursor` pagination strategy [#5888](https://github.com/ethyca/fides/pull/5888)
+- Support `FIDES_PRIVACY_CENTER__FIDES_JS_MAX_AGE_SECONDS` configuration option for `fides-privacy-center` to override default cache duration for /fides.js [#5909](https://github.com/ethyca/fides/pull/5909)
 
 ### Fixed
 - Fixed UX issues with website monitor form [#5884](https://github.com/ethyca/fides/pull/5884)

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -32,7 +32,7 @@ import {
 
 export type PrivacyCenterServerSettings = Pick<
   PrivacyCenterSettings,
-  "SERVER_SIDE_FIDES_API_URL"
+  "SERVER_SIDE_FIDES_API_URL" | "FIDES_JS_MAX_AGE_SECONDS"
 >;
 
 /**
@@ -275,6 +275,7 @@ export const loadServerSettings = (): PrivacyCenterServerSettings => {
   const serverSideSettings: PrivacyCenterServerSettings = {
     SERVER_SIDE_FIDES_API_URL:
       settings.SERVER_SIDE_FIDES_API_URL || settings.FIDES_API_URL,
+    FIDES_JS_MAX_AGE_SECONDS: settings.FIDES_JS_MAX_AGE_SECONDS,
   };
 
   return serverSideSettings;

--- a/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
+++ b/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
@@ -13,9 +13,9 @@ export interface PrivacyCenterSettings {
   SERVER_SIDE_FIDES_API_URL: string | null; // e.g. http://fides:8080/api/v1
   CONFIG_CSS_URL: string; // e.g. file:///app/config/config.css
   CONFIG_JSON_URL: string; // e.g. file:///app/config/config.json
-  SHOW_BRAND_LINK: boolean; // whether to render the Ethyca brand link
   CUSTOM_PROPERTIES: boolean; // (optional) (default: true) enables the use of a single privacy center instance to serve different properties on different paths with custom configs
   FIDES_PRIVACY_CENTER__ROOT_PROPERTY_PATH: string | null; // (optional) setting this will fetch a property when navigating the root ("/") path.
+  FIDES_JS_MAX_AGE_SECONDS: number; // (optional) how long to cache the /fides.js bundle for, in seconds. Defaults to 1 hour (DEFAULT_FIDES_JS_MAX_AGE_SECONDS)
 
   // Fides.js options
   DEBUG: boolean; // whether console logs are enabled for consent components
@@ -40,5 +40,6 @@ export interface PrivacyCenterSettings {
   BASE_64_COOKIE: boolean; // whether or not to encode cookie as base64 on top of the default JSON string
   FIDES_PRIMARY_COLOR: string | null; // (optional) sets fides primary color
   FIDES_CLEAR_COOKIE: boolean; // (optional) deletes fides_consent cookie on reload
+  SHOW_BRAND_LINK: boolean; // whether to render the Ethyca brand link
   FIDES_CONSENT_OVERRIDE: ConsentMethod.ACCEPT | ConsentMethod.REJECT | null; // (optional) sets a previously learned consent preference for the user
 }

--- a/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
+++ b/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
@@ -1,6 +1,13 @@
 import { PrivacyCenterSettings } from "~/app/server-utils/PrivacyCenterSettings";
 import { ConsentMethod } from "~/types/api";
 
+/**
+ * Default value for how long to cache the /fides.js bundle for, in seconds.
+ * This can be overriden via the FIDES_PRIVACY_CENTER__FIDES_JS_MAX_AGE_SECONDS
+ * environment variable.
+ */
+export const DEFAULT_FIDES_JS_MAX_AGE_SECONDS = 60 * 60;
+
 const loadEnvironmentVariables = () => {
   // Load environment variables
   const settings: PrivacyCenterSettings = {
@@ -20,6 +27,9 @@ const loadEnvironmentVariables = () => {
     CUSTOM_PROPERTIES: process.env.CUSTOM_PROPERTIES !== "false", // default: true
     FIDES_PRIVACY_CENTER__ROOT_PROPERTY_PATH:
       process.env.FIDES_PRIVACY_CENTER__ROOT_PROPERTY_PATH || null,
+    FIDES_JS_MAX_AGE_SECONDS:
+      Number(process.env.FIDES_PRIVACY_CENTER__FIDES_JS_MAX_AGE_SECONDS) ||
+      DEFAULT_FIDES_JS_MAX_AGE_SECONDS,
 
     // Overlay options
     DEBUG: process.env.FIDES_PRIVACY_CENTER__DEBUG

--- a/clients/privacy-center/cypress/e2e/fides-js.cy.ts
+++ b/clients/privacy-center/cypress/e2e/fides-js.cy.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_FIDES_JS_MAX_AGE_SECONDS } from "~/app/server-utils/loadEnvironmentVariables";
+
 describe("fides.js API route", () => {
   it("returns the fides.js package bundled with the global config", () => {
     cy.request("/fides.js").then((response) => {
@@ -125,13 +127,15 @@ describe("fides.js API route", () => {
       });
     });
 
-    it("stores publicly for at least one hour, at most one day", () => {
+    it("stores publicly for FIDES_PRIVACY_CENTER__FIDES_JS_MAX_AGE_SECONDS seconds", () => {
+      // NOTE: It's not possible to modify the environment variable in the test,
+      // so we just check the default value is respected here
       cy.get("@cacheHeaders").should("match", /public/);
       cy.get("@cacheHeaders")
         .invoke("match", /max-age=(?<expiry>\d+)/)
         .its("groups.expiry")
         .then(parseInt)
-        .should("be.within", 3600, 86400);
+        .should("equal", DEFAULT_FIDES_JS_MAX_AGE_SECONDS);
     });
 
     it("generates 'etag' that is consistent when re-requested", () => {

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -22,8 +22,6 @@ import {
 import { LOCATION_HEADERS, lookupGeolocation } from "~/common/geolocation";
 import { safeLookupPropertyId } from "~/common/property-id";
 
-// one hour, how long the client should cache fides.js for
-const FIDES_JS_MAX_AGE_SECONDS = 60 * 60;
 // one hour, how long until the custom-fides.css is refreshed
 const CUSTOM_FIDES_CSS_TTL_MS = 3600 * 1000;
 
@@ -339,7 +337,7 @@ export default async function handler(
 
   // Instruct any caches to store this response, since these bundles do not change often
   const cacheHeaders: CacheControl = {
-    "max-age": FIDES_JS_MAX_AGE_SECONDS,
+    "max-age": serverSettings.FIDES_JS_MAX_AGE_SECONDS,
     public: true,
   };
 


### PR DESCRIPTION
Closes [LJ-555]

### Description Of Changes

The Fides Privacy Center currently always sets the max-age cache control directive to 3600 seconds for /fides.js, which prevents us from configuring deployed environments with a smaller cache duration for the FidesJS bundle. This prevents us from doing rapid experiments in a production-like deployment where there is a CDN in front of the Privacy Center, such as demo environments, POC environments, or customer environments (pre-launch!).

We should allow this to be configurable via some environment variables so we can control this as part of the devops setup for an environment.

This adds a new `FIDES_PRIVACY_CENTER__FIDES_JS_MAX_AGE_SECONDS` setting that can be provided to the `fides-privacy-center` container, which will override the default value of 3600 seconds.

### Code Changes

* Add `FIDES_PRIVACY_CENTER__FIDES_JS_MAX_AGE_SECONDS` to supported environment variables for `fides-privacy-center`
* Modify `/fides-js` endpoint to respect the server setting for max age, instead of using a constant
* Update Cypress test to expect the max-age value to exactly match the default value in tests (note: this test will fail if the test harness is configured with a different ENV setting)

### Steps to Confirm

1.  Configure a `.env` file for your local privacy center with `FIDES_PRIVACY_CENTER__FIDES_JS_MAX_AGE_SECONDS=10` (or some other value)
2. Run the privacy center locally, and visit the `/fides.js` endpoint
3. Inspect the response headers to confirm that the max-age directive matches your environment variable setting

### Pre-Merge Checklist

* [X] Issue requirements met
* [ ] All CI pipelines succeeded
* [X] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [x] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls): https://github.com/ethyca/fidesdocs/pull/516
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-555]: https://ethyca.atlassian.net/browse/LJ-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ