### PR TITLE
Adding read-only UI view for policies

### DIFF
--- a/clients/admin-ui/src/features/common/nav/nav-config.tsx
+++ b/clients/admin-ui/src/features/common/nav/nav-config.tsx
@@ -123,15 +123,16 @@ export const NAV_CONFIG: NavConfigGroup[] = [
       {
         title: "Request manager",
         path: routes.PRIVACY_REQUESTS_ROUTE,
+        exact: true,
         scopes: [
           ScopeRegistryEnum.PRIVACY_REQUEST_READ,
           ScopeRegistryEnum.PRIVACY_REQUEST_CREATE,
         ],
       },
       {
-        title: "Connection manager",
-        path: routes.DATASTORE_CONNECTION_ROUTE,
-        scopes: [ScopeRegistryEnum.CONNECTION_CREATE_OR_UPDATE],
+        title: "Request policies",
+        path: routes.PRIVACY_POLICY_ROUTE,
+        scopes: [ScopeRegistryEnum.PRIVACY_REQUEST_READ],
       },
       {
         title: "Configuration",

--- a/clients/admin-ui/src/features/common/nav/routes.ts
+++ b/clients/admin-ui/src/features/common/nav/routes.ts
@@ -39,6 +39,7 @@ export const DATA_CATALOG_ROUTE = "/data-catalog";
 export const DATASTORE_CONNECTION_ROUTE = "/datastore-connection";
 export const PRIVACY_REQUESTS_ROUTE = "/privacy-requests";
 export const PRIVACY_REQUESTS_CONFIGURATION_ROUTE = `${PRIVACY_REQUESTS_ROUTE}/configure`;
+export const PRIVACY_POLICY_ROUTE = "/policies";
 
 // Consent group
 export const PRIVACY_EXPERIENCE_ROUTE = "/consent/privacy-experience";

--- a/clients/admin-ui/src/features/policy/policy.slice.ts
+++ b/clients/admin-ui/src/features/policy/policy.slice.ts
@@ -1,5 +1,9 @@
 import { baseApi } from "~/features/common/api.slice";
-import { Page_PolicyResponse_ } from "~/types/api";
+import {
+  Page_PolicyResponse_,
+  Page_RuleResponseWithTargets_,
+  RuleResponseWithTargets,
+} from "~/types/api";
 
 // Policy API
 const policyApi = baseApi.injectEndpoints({
@@ -8,7 +12,33 @@ const policyApi = baseApi.injectEndpoints({
       query: () => ({ url: `/dsr/policy` }),
       providesTags: () => ["Policies"],
     }),
+
+    // Fetch rule details for a specific policy and rule
+    getRuleWithTargets: build.query<
+      RuleResponseWithTargets,
+      { policyKey: string; ruleKey: string }
+    >({
+      query: ({ policyKey, ruleKey }) => ({
+        url: `/dsr/policy/${policyKey}/rule/${ruleKey}`,
+      }),
+      providesTags: () => ["Policies"],
+    }),
+
+    // Fetch all rules for a policy with their targets
+    getPolicyRules: build.query<
+      Page_RuleResponseWithTargets_,
+      { policyKey: string }
+    >({
+      query: ({ policyKey }) => ({
+        url: `/dsr/policy/${policyKey}/rule`,
+      }),
+      providesTags: () => ["Policies"],
+    }),
   }),
 });
 
-export const { useGetPoliciesQuery } = policyApi;
+export const {
+  useGetPoliciesQuery,
+  useGetRuleWithTargetsQuery,
+  useGetPolicyRulesQuery,
+} = policyApi;

--- a/clients/admin-ui/src/pages/policies.tsx
+++ b/clients/admin-ui/src/pages/policies.tsx
@@ -1,0 +1,318 @@
+/* eslint-disable react/no-unstable-nested-components */
+import {
+  ColumnDef,
+  createColumnHelper,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { AntButton as Button, Box, Center, Link, Text } from "fidesui";
+import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useCallback, useMemo, useState } from "react";
+
+import FixedLayout from "~/features/common/FixedLayout";
+import { GearLightIcon } from "~/features/common/Icon";
+import PageHeader from "~/features/common/PageHeader";
+import {
+  DefaultCell,
+  DefaultHeaderCell,
+  FidesTableV2,
+  GlobalFilterV2,
+  TableActionBar,
+  TableSkeletonLoader,
+} from "~/features/common/table/v2";
+import { BadgeCell } from "~/features/common/table/v2/cells";
+import { useGetPoliciesQuery } from "~/features/policy/policy.slice";
+import { PolicyResponse } from "~/types/api";
+
+const columnHelper = createColumnHelper<PolicyResponse>();
+
+// Function to format action types to be more readable
+const formatActionType = (actionType: string | null): string => {
+  if (!actionType) {
+    return "Consent";
+  }
+
+  // Map action types to more readable values with proper capitalization
+  switch (actionType.toLowerCase()) {
+    case "access":
+      return "Access";
+    case "erasure":
+    case "deletion":
+      return "Erasure";
+    case "consent":
+      return "Consent";
+    case "sale:opt_out":
+      return "Sale Opt-Out";
+    case "sale:opt_in":
+      return "Sale Opt-In";
+    case "access:categories":
+      return "Access Categories";
+    case "access:specific":
+      return "Access Specific";
+    default:
+      // Convert snake_case to Title Case
+      return actionType
+        .split("_")
+        .map(
+          (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+        )
+        .join(" ");
+  }
+};
+
+const EmptyTableNotice = () => (
+  <Center py={10}>
+    <Text>No policies found</Text>
+  </Center>
+);
+
+// Define badge cell for policy keys
+const KeyBadgeCell = ({ getValue }: { getValue: () => string | null }) => {
+  const value = getValue();
+  if (!value) {
+    return <DefaultCell value="-" />;
+  }
+  return <BadgeCell value={value} color="marble" />;
+};
+
+// Action type badge cell that shows the action type in a colored badge
+const ActionTypeBadgeCell = ({
+  getValue,
+}: {
+  getValue: () => string | null;
+}) => {
+  const value = getValue();
+  if (!value) {
+    return <BadgeCell value="Consent" color="caution" />;
+  }
+
+  // Format the display text
+  const displayText = formatActionType(value);
+
+  // Choose color based on action type
+  let color;
+  switch (value.toLowerCase()) {
+    case "access":
+      color = "success";
+      break;
+    case "deletion":
+    case "erasure":
+      color = "error";
+      break;
+    case "consent":
+      color = "success";
+      break;
+    case "sale:opt_out":
+    case "sale:opt_in":
+      color = "alert";
+      break;
+    default:
+      color = "minos";
+  }
+
+  return <BadgeCell value={displayText} color={color} />;
+};
+
+// Execution timeframe badge cell
+const TimeframeBadgeCell = ({
+  getValue,
+}: {
+  getValue: () => number | null;
+}) => {
+  const value = getValue();
+  if (!value) {
+    return <DefaultCell value="-" />;
+  }
+
+  return <DefaultCell value={`${value} days`} />;
+};
+
+// Action cell for policies
+const PolicyActionsCell = ({
+  policy,
+  onViewRules,
+}: {
+  policy: PolicyResponse;
+  onViewRules: (policy: PolicyResponse) => void;
+}) => {
+  return (
+    <Button
+      aria-label="View rules"
+      icon={<GearLightIcon />}
+      onClick={(e) => {
+        e.stopPropagation();
+        onViewRules(policy);
+      }}
+      data-testid={`view-rules-${policy.key || policy.name}`}
+      size="small"
+    >
+      View rules
+    </Button>
+  );
+};
+
+const PoliciesPage: NextPage = () => {
+  const router = useRouter();
+  const { data, isLoading } = useGetPoliciesQuery();
+  const [globalFilter, setGlobalFilter] = useState<string>();
+
+  const updateGlobalFilter = useCallback(
+    (searchTerm: string) => {
+      setGlobalFilter(searchTerm);
+    },
+    [setGlobalFilter],
+  );
+
+  const policies = useMemo(() => data?.items || [], [data]);
+
+  // Filter out policies with null drp_action
+  const validPolicies = useMemo(() => {
+    return policies.filter((policy) => policy.drp_action !== null);
+  }, [policies]);
+
+  const filteredPolicies = useMemo(() => {
+    if (!globalFilter) {
+      return validPolicies;
+    }
+
+    const lowerCaseFilter = globalFilter.toLowerCase();
+    return validPolicies.filter(
+      (policy) =>
+        policy.name.toLowerCase().includes(lowerCaseFilter) ||
+        (policy.key && policy.key.toLowerCase().includes(lowerCaseFilter)) ||
+        (policy.drp_action &&
+          policy.drp_action.toLowerCase().includes(lowerCaseFilter)),
+    );
+  }, [validPolicies, globalFilter]);
+
+  const handleRowClick = useCallback(
+    (policy: PolicyResponse) => {
+      // Navigate to policy detail page
+      router.push({
+        pathname: "/policies/[policyKey]",
+        query: { policyKey: policy.key || encodeURIComponent(policy.name) },
+      });
+    },
+    [router],
+  );
+
+  // eslint-disable-next-line react/jsx-no-useless-fragment, react-hooks/exhaustive-deps
+  const columns = useMemo(
+    () =>
+      [
+        columnHelper.accessor((row) => row.name, {
+          id: "name",
+          // eslint-disable-next-line react/jsx-no-useless-fragment
+          cell: (props) => <DefaultCell value={props.getValue()} />,
+          // eslint-disable-next-line react/jsx-no-useless-fragment
+          header: (props) => (
+            <DefaultHeaderCell value="Policy Name" {...props} />
+          ),
+          size: 180,
+        }),
+        columnHelper.accessor((row) => row.key, {
+          id: "key",
+          // eslint-disable-next-line react/jsx-no-useless-fragment
+          cell: (props) => <KeyBadgeCell getValue={() => props.getValue()} />,
+          // eslint-disable-next-line react/jsx-no-useless-fragment
+          header: (props) => (
+            <DefaultHeaderCell value="Policy Key" {...props} />
+          ),
+          size: 150,
+        }),
+        columnHelper.accessor((row) => row.drp_action, {
+          id: "drp_action",
+          // eslint-disable-next-line react/jsx-no-useless-fragment
+          cell: (props) => (
+            <ActionTypeBadgeCell getValue={() => props.getValue()} />
+          ),
+          // eslint-disable-next-line react/jsx-no-useless-fragment
+          header: (props) => (
+            <DefaultHeaderCell value="Action Type" {...props} />
+          ),
+          size: 150,
+        }),
+        columnHelper.accessor((row) => row.execution_timeframe, {
+          id: "execution_timeframe",
+          // eslint-disable-next-line react/jsx-no-useless-fragment
+          cell: (props) => (
+            <TimeframeBadgeCell getValue={() => props.getValue()} />
+          ),
+          // eslint-disable-next-line react/jsx-no-useless-fragment
+          header: (props) => (
+            <DefaultHeaderCell value="Execution Timeframe" {...props} />
+          ),
+          size: 180,
+        }),
+        columnHelper.display({
+          id: "actions",
+          header: (props) => <DefaultHeaderCell value="Actions" {...props} />,
+          cell: ({ row }) => (
+            <PolicyActionsCell
+              policy={row.original}
+              onViewRules={handleRowClick}
+            />
+          ),
+          meta: {
+            disableRowClick: true,
+          },
+          size: 120,
+        }),
+      ] as ColumnDef<PolicyResponse, any>[],
+    [handleRowClick],
+  );
+
+  const tableInstance = useReactTable<PolicyResponse>({
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    columns,
+    data: filteredPolicies,
+    columnResizeMode: "onChange",
+  });
+
+  return (
+    <FixedLayout title="Request policies">
+      <PageHeader heading="Request policies" data-testid="privacy-policies" />
+
+      <Box mb={4}>
+        <Text fontSize="sm" color="gray.600">
+          Request policies and rules must be created via the Fides API. See{" "}
+          <Link
+            href="https://ethyca.com/docs/dev-docs/configuration/policies/request-policies"
+            color="blue.500"
+            textDecoration="underline"
+            isExternal
+          >
+            documentation
+          </Link>{" "}
+          for details.
+        </Text>
+      </Box>
+
+      {isLoading ? (
+        <TableSkeletonLoader rowHeight={36} numRows={15} />
+      ) : (
+        <Box data-testid="policy-table">
+          <TableActionBar>
+            <GlobalFilterV2
+              globalFilter={globalFilter}
+              setGlobalFilter={updateGlobalFilter}
+              placeholder="Search"
+              testid="policy-search"
+            />
+          </TableActionBar>
+          <FidesTableV2
+            tableInstance={tableInstance}
+            emptyTableNotice={<EmptyTableNotice />}
+          />
+        </Box>
+      )}
+    </FixedLayout>
+  );
+};
+
+export default PoliciesPage;

--- a/clients/admin-ui/src/pages/policies/[policyKey].tsx
+++ b/clients/admin-ui/src/pages/policies/[policyKey].tsx
@@ -1,0 +1,355 @@
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { AntButton as Button, Box, Center, Spinner, Text } from "fidesui";
+import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useMemo } from "react";
+
+import FixedLayout from "~/features/common/FixedLayout";
+import { PRIVACY_POLICY_ROUTE } from "~/features/common/nav/routes";
+import PageHeader from "~/features/common/PageHeader";
+import {
+  DefaultCell,
+  DefaultHeaderCell,
+  FidesTableV2,
+} from "~/features/common/table/v2";
+import {
+  BadgeCell,
+  BadgeCellExpandable,
+} from "~/features/common/table/v2/cells";
+import {
+  useGetPoliciesQuery,
+  useGetPolicyRulesQuery,
+} from "~/features/policy/policy.slice";
+import { DrpAction, RuleResponseWithTargets } from "~/types/api";
+
+const columnHelper = createColumnHelper<RuleResponseWithTargets>();
+
+// Handle empty state when no rules are found
+const EmptyTableNotice = ({
+  hasRulesButAllFiltered = false,
+}: {
+  hasRulesButAllFiltered?: boolean;
+}) => (
+  <Center py={10}>
+    <Text>
+      {hasRulesButAllFiltered
+        ? "All rules for this policy have been filtered out."
+        : "No rules found for this policy."}
+    </Text>
+  </Center>
+);
+
+// Basic cell components
+const NameCell = ({ getValue }: { getValue: () => string | null }) => (
+  <DefaultCell value={getValue() || "-"} />
+);
+
+const NameHeader = (props: any) => (
+  <DefaultHeaderCell value="Rule Name" {...props} />
+);
+
+// Function to format action types to be more readable
+const formatActionType = (actionType: string | null): string => {
+  if (!actionType) return "-";
+
+  // Map common action types with proper capitalization
+  const actionTypeMap: Record<string, string> = {
+    access: "Access",
+    erasure: "Erasure",
+    deletion: "Erasure",
+    consent: "Consent",
+  };
+
+  const key = actionType.toLowerCase();
+  return (
+    actionTypeMap[key] ||
+    actionType
+      .split("_")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join(" ")
+  );
+};
+
+// Action type cell component
+const ActionTypeCell = ({ getValue }: { getValue: () => string | null }) => (
+  <DefaultCell value={formatActionType(getValue())} />
+);
+
+const ActionTypeHeader = (props: any) => (
+  <DefaultHeaderCell value="Action Type" {...props} />
+);
+
+// Masking strategy cell components
+const MaskingStrategyCell = ({ getValue }: { getValue: () => any }) => {
+  const data = getValue();
+  const value = data.strategy;
+
+  if (!value || value === "not_applicable") {
+    return (
+      <DefaultCell
+        value={value ? "Not applicable" : "None specified"}
+        color="gray.500"
+      />
+    );
+  }
+
+  // Map masking strategies to colors and display names
+  const strategyMap: Record<string, { color: string; displayName: string }> = {
+    null_rewrite: { color: "error", displayName: "Null Rewrite" },
+    string_rewrite: { color: "success", displayName: "String Rewrite" },
+    hash: { color: "minos", displayName: "Hash" },
+    hmac: { color: "caution", displayName: "HMAC" },
+    random_string_rewrite: { color: "alert", displayName: "Random String" },
+    aes_encrypt: { color: "info", displayName: "AES Encrypt" },
+  };
+
+  const strategy = strategyMap[value] || { color: "minos", displayName: value };
+  return <BadgeCell value={strategy.displayName} color={strategy.color} />;
+};
+
+// Masking strategy renderer
+const MaskingStrategyCellRenderer = ({
+  getValue,
+  row,
+}: {
+  getValue: () => any;
+  row: any;
+}) => {
+  const value = getValue();
+  const getCellValue = () => ({
+    strategy: value,
+    rowData: row.original,
+  });
+  return <MaskingStrategyCell getValue={getCellValue} />;
+};
+
+const MaskingStrategyHeaderCell = (props: any) => (
+  <DefaultHeaderCell value="Masking Strategy" {...props} />
+);
+
+// Targets cell component
+const TargetsCell = ({ getValue }: { getValue: () => any[] }) => {
+  const targets = getValue();
+
+  if (!targets?.length) return <DefaultCell value="-" />;
+
+  return (
+    <Box
+      maxWidth="100%"
+      overflowX="visible"
+      overflowY="visible"
+      whiteSpace="normal"
+      py={1}
+    >
+      <BadgeCellExpandable values={targets} />
+    </Box>
+  );
+};
+
+const TargetsHeader = (props: any) => (
+  <DefaultHeaderCell value="Targets" {...props} />
+);
+
+// Helper to extract masking strategy
+const extractMaskingStrategy = (rule: any): string | null => {
+  if (!rule.masking_strategy) return null;
+
+  return typeof rule.masking_strategy === "string"
+    ? rule.masking_strategy
+    : rule.masking_strategy.strategy || null;
+};
+
+const PolicyDetailPage: NextPage = () => {
+  const router = useRouter();
+  const policyKey = router.query.policyKey as string;
+
+  // Fetch policy data
+  const { data: policiesData, isLoading: isPoliciesLoading } =
+    useGetPoliciesQuery();
+  const { data: rulesData, isLoading: isRulesLoading } = useGetPolicyRulesQuery(
+    { policyKey },
+    { skip: !policyKey },
+  );
+
+  // Find the current policy
+  const policy = useMemo(() => {
+    if (!policiesData?.items || !policyKey) return null;
+
+    return policiesData.items.find(
+      (p) => p.key === policyKey || p.name === decodeURIComponent(policyKey),
+    );
+  }, [policiesData, policyKey]);
+
+  // Filter and format rules
+  const rules = useMemo(() => {
+    // No policy or rules data
+    if (!policy) return [];
+
+    // Get rules from API response or policy object
+    const sourceRules = rulesData?.items?.length
+      ? rulesData.items
+      : policy.rules || [];
+
+    // Filter out consent rules and null drp_action rules
+    return sourceRules
+      .filter(
+        (rule) =>
+          rule.action_type?.toLowerCase() !== "consent" &&
+          (rule as any).drp_action !== null,
+      )
+      .map((rule) => {
+        // If using policy.rules, we need to add targets
+        if (!rulesData?.items?.length && policy.rules?.includes(rule)) {
+          return {
+            ...rule,
+            targets:
+              rulesData?.items?.find((r) => r.key === rule.key)?.targets || [],
+          };
+        }
+        return rule;
+      });
+  }, [rulesData, policy]);
+
+  // Define table columns
+  const columns = useMemo(() => {
+    const baseColumns = [
+      columnHelper.accessor((row) => row.name, {
+        id: "name",
+        cell: NameCell,
+        header: NameHeader,
+        size: 150,
+      }),
+      columnHelper.accessor((row) => row.action_type, {
+        id: "action_type",
+        cell: ActionTypeCell,
+        header: ActionTypeHeader,
+        size: 120,
+      }),
+    ];
+
+    // Add masking strategy column for deletion policies
+    if (policy?.drp_action === DrpAction.DELETION) {
+      baseColumns.push(
+        columnHelper.accessor((row) => extractMaskingStrategy(row), {
+          id: "masking_strategy",
+          cell: MaskingStrategyCellRenderer,
+          header: MaskingStrategyHeaderCell,
+          size: 130,
+        }),
+      );
+    }
+
+    // Add targets column
+    baseColumns.push(
+      columnHelper.accessor(
+        (row) =>
+          (row.targets || []).map((t) => ({
+            label: t.data_category,
+            key: t.data_category,
+          })),
+        {
+          id: "targets",
+          cell: TargetsCell,
+          header: TargetsHeader,
+          size: 450,
+        },
+      ),
+    );
+
+    return baseColumns;
+  }, [policy?.drp_action]);
+
+  // Table instance
+  const tableInstance = useReactTable<RuleResponseWithTargets>({
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    columns,
+    data: rules,
+    columnResizeMode: "onChange",
+    defaultColumn: {
+      minSize: 80,
+      maxSize: 1000,
+    },
+  });
+
+  // Loading state
+  if (isPoliciesLoading || isRulesLoading) {
+    return (
+      <FixedLayout title="Loading Policy...">
+        <Center height="80vh">
+          <Spinner size="xl" />
+        </Center>
+      </FixedLayout>
+    );
+  }
+
+  // Policy not found
+  if (!policy) {
+    return (
+      <FixedLayout title="Policy Not Found">
+        <Center height="50vh" flexDirection="column" gap={4}>
+          <Text fontSize="xl">Policy not found</Text>
+          <Button onClick={() => router.push(PRIVACY_POLICY_ROUTE)}>
+            Back to Policies
+          </Button>
+        </Center>
+      </FixedLayout>
+    );
+  }
+
+  return (
+    <FixedLayout title={`Policy - ${policy.name}`}>
+      <PageHeader
+        heading="Request policy rules"
+        breadcrumbItems={[
+          { title: "All request policies", href: PRIVACY_POLICY_ROUTE },
+          { title: policy.name },
+        ]}
+        data-testid="policy-details"
+      />
+
+      <Box className="mb-4">
+        <Text fontSize="sm" color="gray.600" className="mb-2">
+          {policy.drp_action === DrpAction.DELETION ? (
+            <>
+              Rules define how data is processed for this policy. For deletion
+              policies, masking strategies specify how data should be
+              transformed or removed. Different strategies apply different
+              transformations to the data.
+            </>
+          ) : (
+            <>
+              Rules define how data is processed for this policy. Each rule
+              specifies which data categories are affected and how they should
+              be handled.
+            </>
+          )}
+        </Text>
+      </Box>
+
+      {rules.length === 0 ? (
+        <EmptyTableNotice
+          hasRulesButAllFiltered={policy?.rules?.some(
+            (rule) => rule.action_type?.toLowerCase() === "consent",
+          )}
+        />
+      ) : (
+        <Box data-testid="policy-rules-table" className="overflow-visible">
+          <FidesTableV2
+            tableInstance={tableInstance}
+            emptyTableNotice={<EmptyTableNotice />}
+          />
+        </Box>
+      )}
+    </FixedLayout>
+  );
+};
+
+export default PolicyDetailPage;

--- a/clients/admin-ui/src/utils/policy.ts
+++ b/clients/admin-ui/src/utils/policy.ts
@@ -1,0 +1,39 @@
+/**
+ * Format a timeframe into a readable string
+ * @param timeframe Object with days, hours, minutes or just a number of days
+ * @returns Formatted timeframe string
+ */
+export const formatTimeframe = (
+  timeframe:
+    | number
+    | { days?: number; hours?: number; minutes?: number }
+    | null
+    | undefined,
+): string => {
+  // Handle null/undefined cases
+  if (!timeframe) {
+    return "";
+  }
+
+  // Parse the input format
+  const days = typeof timeframe === "number" ? timeframe : timeframe.days || 0;
+  const hours = typeof timeframe === "number" ? 0 : timeframe.hours || 0;
+  const minutes = typeof timeframe === "number" ? 0 : timeframe.minutes || 0;
+
+  // If no time values, return empty string
+  if (!days && !hours && !minutes) {
+    return "";
+  }
+
+  // Format each time unit with proper pluralization
+  const parts = [
+    days > 0 && `${days} day${days !== 1 ? "s" : ""}`,
+    hours > 0 && `${hours} hour${hours !== 1 ? "s" : ""}`,
+    minutes > 0 && `${minutes} minute${minutes !== 1 ? "s" : ""}`,
+  ].filter(Boolean); // Remove falsy values
+
+  return parts.join(", ");
+};
+
+// For backward compatibility
+export const calculateTimeframe = formatTimeframe;


### PR DESCRIPTION
### Description Of Changes

Adding read-only UI view for policies. Includes a link to the docs for policy creation

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
