### PR TITLE
Updated a couple dev requirements to resolve docker build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,6 @@ RUN apt-get update && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python Dependencies
-
-COPY dev-requirements.txt .
-RUN pip install --user -U pip --no-cache-dir -r dev-requirements.txt
-
 # Activate a Python venv
 RUN python3 -m venv /opt/fides
 ENV PATH="/opt/fides/bin:${PATH}"
@@ -164,6 +159,8 @@ FROM backend AS prod
 COPY --from=built_frontend /fides/clients/admin-ui/out/ /fides/src/fides/ui-build/static/admin
 USER root
 # Install without a symlink
+RUN pip install --no-cache-dir setuptools wheel
+RUN pip install --no-cache-dir --upgrade packaging
 RUN python setup.py sdist
 
 # USER root commented out for debugging

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 black==24.3.0
-debugpy==1.8.5
+debugpy==1.8.12
 Faker==14.1.0
 GitPython==3.1.41
 isort==5.12.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ pytest-mock==3.14.0
 pytest-rerunfailures==14.0
 pytest==7.2.2
 requests-mock==1.10.0
-setuptools>=64.0.2
+setuptools>=77.0.1
 sqlalchemy-stubs==0.4
 types-paramiko==3.0.0.10
 types-PyYAML==6.0.11

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 black==24.3.0
-debugpy==1.6.3
+debugpy==1.8.5
 Faker==14.1.0
 GitPython==3.1.41
 isort==5.12.0
@@ -10,7 +10,7 @@ pre-commit==2.20.0
 pylint==3.2.5
 pytest-asyncio==0.19.0
 pytest-cov==4.0.0
-pytest-env==0.6.2
+pytest-env==0.8.1
 pytest-mock==3.14.0
 pytest-rerunfailures==14.0
 pytest==7.2.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 black==24.3.0
-debugpy==1.8.5
+debugpy==1.6.3
 Faker==14.1.0
 GitPython==3.1.41
 isort==5.12.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 black==24.3.0
-debugpy==1.8.12
+debugpy==1.8.5
 Faker==14.1.0
 GitPython==3.1.41
 isort==5.12.0
@@ -10,12 +10,12 @@ pre-commit==2.20.0
 pylint==3.2.5
 pytest-asyncio==0.19.0
 pytest-cov==4.0.0
-pytest-env==0.8.1
+pytest-env==0.7.0
 pytest-mock==3.14.0
 pytest-rerunfailures==14.0
 pytest==7.2.2
 requests-mock==1.10.0
-setuptools>=77.0.1
+setuptools>=64.0.2
 sqlalchemy-stubs==0.4
 types-paramiko==3.0.0.10
 types-PyYAML==6.0.11


### PR DESCRIPTION
### Description Of Changes

Updated Dockerfile and pytest-env version.
This was probably caused by the underlying image we use getting an update in the last 24 hours. 
https://hub.docker.com/layers/library/python/3.10.16-slim-bookworm/images/sha256-83f353e03a40bbebc8d2fe1fcd2d7357d8613e92512c556b02483a670eeb7211

### Code Changes

* updated pytest-env version.
* updated Dockerfile

### Steps to Confirm

1.  None - docker builds

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
