### PR TITLE
fix incorrect calls to tcf api update method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Fixed
 - Fixed UX issues with website monitor form [#5884](https://github.com/ethyca/fides/pull/5884)
 - Removed excessive authorization debug logs [#5920](https://github.com/ethyca/fides/pull/5920)
+- Fixed fix incorrect calls to TCF api update method [#5916](https://github.com/ethyca/fides/pull/5916)
 
 ## [2.57.0](https://github.com/ethyca/fides/compare/2.56.2...2.57.0)
 

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 /**
  * FidesJS: JavaScript SDK for Fides (https://github.com/ethyca/fides)
  *
@@ -134,6 +135,7 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
   makeStub({
     gdprAppliesDefault: optionsOverrides?.fidesTcfGdprApplies,
   });
+
   const experienceTranslationOverrides: Partial<FidesExperienceTranslationOverrides> =
     getOverridesByType<Partial<FidesExperienceTranslationOverrides>>(
       OverrideType.EXPERIENCE_TRANSLATION,
@@ -200,6 +202,7 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
     updateWindowFides(this);
     dispatchFidesEvent("FidesInitialized", this.cookie, config.options.debug, {
       shouldShowExperience: this.shouldShowExperience(),
+      firstInit: true,
     });
   }
   this.experience = initialFides?.experience ?? config.experience;
@@ -218,6 +221,7 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
   // Dispatch the "FidesInitialized" event to update listeners with the initial state.
   dispatchFidesEvent("FidesInitialized", this.cookie, config.options.debug, {
     shouldShowExperience: this.shouldShowExperience(),
+    firstInit: false,
   });
 }
 

--- a/clients/fides-js/src/lib/tcf/stub.ts
+++ b/clients/fides-js/src/lib/tcf/stub.ts
@@ -142,7 +142,17 @@ export const makeStub = ({
   if (!cmpFrame) {
     // we have recur'd up the windows and have found no __tcfapiLocator frame
     addFrame(TCF_FRAME_NAME);
-    currentWindow.__tcfapi = tcfAPIHandler;
+    const tcfApi = tcfAPIHandler;
+    if (typeof tcfApi !== "function") {
+      throw new Error("TCF API failed to initialize");
+    }
+    currentWindow.__tcfapi = tcfApi;
     currentWindow.addEventListener("message", postMessageEventHandler, false);
+
+    if (currentWindow.Fides.options.debug) {
+      currentWindow?.__tcfapi?.("addEventListener", 2, (data) =>
+        fidesDebugger("TCF API Updated", data, data.eventStatus),
+      );
+    }
   }
 };

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -174,6 +174,13 @@ describe("Fides-js TCF", () => {
     it("should render the banner if there is no saved version hash", () => {
       cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
       stubTCFExperience({});
+      cy.window().then((win) => {
+        win.__tcfapi("addEventListener", 2, ({ eventStatus }) => {
+          if (eventStatus) {
+            expect(eventStatus).to.eql("tcloaded");
+          }
+        });
+      });
       cy.waitUntilFidesInitialized().then(() => {
         cy.get("@FidesUIShown").should("have.been.calledOnce");
         cy.get("div#fides-banner").should("be.visible");
@@ -186,6 +193,13 @@ describe("Fides-js TCF", () => {
       });
       cy.setCookie(CONSENT_COOKIE_NAME, JSON.stringify(cookie));
       stubTCFExperience({});
+      cy.window().then((win) => {
+        win.__tcfapi("addEventListener", 2, ({ eventStatus }) => {
+          if (eventStatus) {
+            expect(eventStatus).to.eql("cmpuishown");
+          }
+        });
+      });
       cy.waitUntilFidesInitialized().then(() => {
         cy.get("@FidesUIShown").should("have.been.calledOnce");
         cy.get("div#fides-banner").should("be.visible");
@@ -198,6 +212,13 @@ describe("Fides-js TCF", () => {
       });
       cy.setCookie(CONSENT_COOKIE_NAME, JSON.stringify(cookie));
       stubTCFExperience({});
+      cy.window().then((win) => {
+        win.__tcfapi("addEventListener", 2, ({ eventStatus }) => {
+          if (eventStatus) {
+            expect(eventStatus).to.eql("tcloaded");
+          }
+        });
+      });
       cy.waitUntilFidesInitialized().then(() => {
         // The banner has a delay, so in order to assert its non-existence, we have
         // to give it a chance to come up first. Otherwise, the following gets will
@@ -468,6 +489,7 @@ describe("Fides-js TCF", () => {
                 extraDetails: {
                   consentMethod: undefined,
                   shouldShowExperience: true,
+                  firstInit: false,
                 },
                 fides_string: undefined,
               },
@@ -1114,6 +1136,7 @@ describe("Fides-js TCF", () => {
                   extraDetails: {
                     consentMethod: undefined,
                     shouldShowExperience: true,
+                    firstInit: false,
                   },
                   fides_string: undefined,
                 },


### PR DESCRIPTION
Closes [LJ-506]

### Description Of Changes

The Fides TCF CMP is setting a tcloaded status incorrectly, when a user has no previously saved TC Data. According to the [CMP documentation](https://ethyca.atlassian.net/jira/software/projects/HA/boards/187/backlog?selectedIssue=HA-149), the tcloaded event should not fire when a string is either not present OR when it is determined to be outdated and the UI will be shown to users

### Code Changes

ONLY fire TCF `update` method when applicable:

1. Never on modal close, no change is made at that point so no `update` is needed
2. Only `update` during fides.js initialization if:
    - TC string was _already set_ on a prior visit.
    - We are _not_ going to show the banner (i.e. the TCF hash has not changed).
    - It is the _first_ init (This should only ever happen once per visit).

### Steps to Confirm

Use new `fidesDebugger` logs to help verify!

1. Create a TCF experience
2. Load that experience in the Demo page with debug enabled and running in dev mode (eg. turbo run dev)
3. On first load without a cookie or consent, ensure that you see in the logs for "TCF API Updated" with the last line of `cmpuishown` and NOT `tcloaded`. There should only be one log for "TCF API Updated" at this point.
4. Make a consent choice (eg. Opt in to all), ensure that you see a new entry in the logs for "TCF API Updated" with the last line of `useractioncomplete`.
5. Open the modal by clicking the "manage preferences" link, ensure that you see the `cmpuishown` event in the logs again.
6. Close the modal or make a change, ensure that you see the `useractioncomplete` event again.
7. Reload the demo page without deleting the cookie
8. Ensure that you only see _one_ entry in the logs for "TCF API Updated" the last line of `tcloaded` because the 3 bullet points above apply to this current state.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-506]: https://ethyca.atlassian.net/browse/LJ-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ