### PR TITLE
LJ-546 Add tcf_publisher_country_code to fides JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,7 @@ saas_config.toml
 
 # multilang migration backup files produced by db init
 multilang_migration_backup_*
+
+# Cursor
+
+.cursor/rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Support setting publisher country code in Consent Settings [#5902](https://github.com/ethyca/fides/pull/5902)
 - Added option for disabling consent notice toggles [#5872](https://github.com/ethyca/fides/pull/5872)
 - Added UI to manually update Assets in the system asset view [#5914](https://github.com/ethyca/fides/pull/5914)
+- Use the experience's `tcf_publisher_country_code` when building TC strings [#5921](https://github.com/ethyca/fides/pull/5921)
 
 ### Changed
 - Changed discovered asset "system" cell to use `user_assigned_system_key` property [#5908](https://github.com/ethyca/fides/pull/5908)

--- a/clients/fides-js/__tests__/lib/tcf/tcf.test.ts
+++ b/clients/fides-js/__tests__/lib/tcf/tcf.test.ts
@@ -1,0 +1,479 @@
+import { TCString } from "@iabtechlabtcf/core";
+
+import { PrivacyExperience, UserConsentPreference } from "~/lib/consent-types";
+import { generateFidesString } from "~/lib/tcf";
+import { FIDES_SEPARATOR } from "~/lib/tcf/constants";
+import {
+  GVLJson,
+  TCFFeatureRecord,
+  TCFPurposeConsentRecord,
+  TCFPurposeLegitimateInterestsRecord,
+  TCFVendorLegitimateInterestsRecord,
+} from "~/lib/tcf/types";
+
+describe("generateFidesString", () => {
+  // Test TCF data:
+  const mockGvl: GVLJson = {
+    vendors: {
+      740: {
+        id: 740,
+        name: "Test Vendor 740",
+        purposes: [1, 2, 3],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: "https://test.com/privacy",
+        usesCookies: true,
+        cookieMaxAgeSeconds: 86400,
+        cookieRefresh: false,
+        usesNonCookieAccess: false,
+      },
+      254: {
+        id: 254,
+        name: "Test Vendor 254",
+        purposes: [1, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: "https://test2.com/privacy",
+        usesCookies: true,
+        cookieMaxAgeSeconds: 86400,
+        cookieRefresh: false,
+        usesNonCookieAccess: false,
+      },
+    },
+    purposes: {
+      1: {
+        id: 1,
+        name: "Store and/or access information on a device",
+        description:
+          "Cookies, device identifiers, or other information can be stored or accessed on your device for the purposes presented to you.",
+      },
+      2: {
+        id: 2,
+        name: "Select basic ads",
+        description:
+          "Ads can be shown to you based on the content you're viewing, the app you're using, your approximate location, or your device type.",
+      },
+      3: {
+        id: 3,
+        name: "Create a personalised ads profile",
+        description:
+          "A profile can be built about you and your interests to show you personalised ads that are relevant to you.",
+      },
+      4: {
+        id: 4,
+        name: "Select personalised ads",
+        description:
+          "Personalised ads can be shown to you based on a profile about you.",
+      },
+      7: {
+        id: 7,
+        name: "Measure ad performance",
+        description:
+          "The performance and effectiveness of ads that you see or interact with can be measured.",
+      },
+      8: {
+        id: 8,
+        name: "Measure content performance",
+        description:
+          "The performance and effectiveness of content that you see or interact with can be measured.",
+      },
+      10: {
+        id: 10,
+        name: "Develop and improve products",
+        description:
+          "Your data can be used to improve existing systems and software, and to develop new products.",
+      },
+    },
+    specialPurposes: {
+      1: {
+        id: 1,
+        name: "Ensure security, prevent fraud, and debug",
+        description:
+          "Your data can be used to monitor for and prevent fraudulent activity, and ensure systems and processes work properly and securely.",
+      },
+      2: {
+        id: 2,
+        name: "Technically deliver ads or content",
+        description:
+          "Your device can receive and send information that allows you to see and interact with ads and content.",
+      },
+    },
+    features: {
+      1: {
+        id: 1,
+        name: "Match and combine offline data sources",
+        description:
+          "Data from offline data sources can be combined with your online activity in support of one or more purposes.",
+      },
+      2: {
+        id: 2,
+        name: "Link different devices",
+        description:
+          "Different devices can be determined as belonging to you or your household in support of one or more purposes.",
+      },
+      3: {
+        id: 3,
+        name: "Receive and use automatically-sent device characteristics for identification",
+        description:
+          "Your device might be distinguished from other devices based on information it automatically sends, such as IP address or browser type.",
+      },
+    },
+    specialFeatures: {
+      1: {
+        id: 1,
+        name: "Use precise geolocation data",
+        description:
+          "Your precise geolocation data can be used in support of one or more purposes.",
+      },
+    },
+    stacks: {
+      1: {
+        id: 1,
+        name: "Basic ads",
+        description: "Basic ads stack",
+        purposes: [1, 2, 3],
+        specialFeatures: [],
+      },
+      2: {
+        id: 2,
+        name: "Personalized ads",
+        description: "Personalized ads stack",
+        purposes: [1, 2, 3, 4],
+        specialFeatures: [],
+      },
+      3: {
+        id: 3,
+        name: "Ad measurement",
+        description: "Ad measurement stack",
+        purposes: [7],
+        specialFeatures: [],
+      },
+      4: {
+        id: 4,
+        name: "Content measurement",
+        description: "Content measurement stack",
+        purposes: [8],
+        specialFeatures: [],
+      },
+    },
+    dataCategories: {
+      1: {
+        id: 1,
+        name: "IP addresses",
+        description: "IP address and derived geographic location",
+      },
+      2: {
+        id: 2,
+        name: "Cookies and similar tech",
+        description: "Cookie identifiers and similar technologies",
+      },
+    },
+    vendorListVersion: 3,
+    tcfPolicyVersion: 2,
+    lastUpdated: "2023-01-01T00:00:00Z",
+    gvlSpecificationVersion: 3,
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const mockFeatures: TCFFeatureRecord[] = [
+    {
+      id: 1,
+      name: "Match and combine offline data sources",
+      description: "Feature 1 description",
+      default_preference: UserConsentPreference.ACKNOWLEDGE,
+      vendors: [
+        {
+          id: "gvl.740",
+          name: "Vendor 740",
+        },
+      ],
+      systems: [],
+    },
+    {
+      id: 2,
+      name: "Link different devices",
+      description: "Feature 2 description",
+      default_preference: UserConsentPreference.ACKNOWLEDGE,
+      vendors: [
+        {
+          id: "gvl.740",
+          name: "Vendor 740",
+        },
+      ],
+      systems: [],
+    },
+    {
+      id: 3,
+      name: "Receive and use automatically-sent device characteristics for identification",
+      description: "Feature 3 description",
+      default_preference: UserConsentPreference.ACKNOWLEDGE,
+      vendors: [
+        {
+          id: "gvl.740",
+          name: "Vendor 740",
+        },
+        {
+          id: "gvl.254",
+          name: "Vendor 254",
+        },
+      ],
+      systems: [],
+    },
+  ];
+  const mockTcfPurposeConsents: TCFPurposeConsentRecord[] = [
+    {
+      id: 1,
+      name: "Store and/or access information on a device",
+      description: "Purpose 1 description",
+      illustrations: [],
+      data_uses: [],
+      default_preference: UserConsentPreference.OPT_IN,
+      vendors: [
+        {
+          id: "gvl.740",
+          name: "Test Vendor 740",
+        },
+        {
+          id: "gvl.254",
+          name: "Test Vendor 254",
+        },
+      ],
+      systems: [],
+    },
+    {
+      id: 2,
+      name: "Select basic ads",
+      description: "Purpose 2 description",
+      illustrations: [],
+      data_uses: [],
+      default_preference: UserConsentPreference.OPT_IN,
+      vendors: [
+        {
+          id: "gvl.254",
+          name: "Test Vendor 254",
+        },
+      ],
+      systems: [],
+    },
+    {
+      id: 3,
+      name: "Create a personalised ads profile",
+      description: "Purpose 3 description",
+      illustrations: [],
+      data_uses: [],
+      default_preference: UserConsentPreference.OPT_IN,
+      vendors: [
+        {
+          id: "gvl.740",
+          name: "Test Vendor 740",
+        },
+        {
+          id: "gvl.254",
+          name: "Test Vendor 254",
+        },
+      ],
+      systems: [],
+    },
+    {
+      id: 4,
+      name: "Select personalised ads",
+      description: "Purpose 4 description",
+      illustrations: [],
+      data_uses: [],
+      default_preference: UserConsentPreference.OPT_IN,
+      vendors: [
+        {
+          id: "gvl.740",
+          name: "Test Vendor 740",
+        },
+        {
+          id: "gvl.254",
+          name: "Test Vendor 254",
+        },
+      ],
+      systems: [],
+    },
+    {
+      id: 7,
+      name: "Measure ad performance",
+      description: "Purpose 7 description",
+      illustrations: [],
+      data_uses: [],
+      default_preference: UserConsentPreference.OPT_IN,
+      vendors: [
+        {
+          id: "gvl.254",
+          name: "Test Vendor 254",
+        },
+      ],
+      systems: [],
+    },
+  ];
+
+  const mockTCfVendorsLegitimateInterest: TCFVendorLegitimateInterestsRecord[] =
+    [
+      {
+        id: "gvl.740",
+        name: "Test Vendor 740",
+        default_preference: UserConsentPreference.OPT_IN,
+        purpose_legitimate_interests: [
+          {
+            id: 2,
+            name: "Select basic ads",
+          },
+          {
+            id: 7,
+            name: "Measure ad performance",
+          },
+          {
+            id: 8,
+            name: "Measure content performance",
+          },
+          {
+            id: 10,
+            name: "Develop and improve products",
+          },
+        ],
+      },
+    ];
+
+  const mockTcfPurposeLegitimateInterests: TCFPurposeLegitimateInterestsRecord[] =
+    [
+      {
+        id: 2,
+        name: "Select basic ads",
+        description: "Purpose 2 legitimate interest description",
+        illustrations: [],
+        data_uses: ["marketing.advertising.serving"],
+        default_preference: UserConsentPreference.OPT_IN,
+        vendors: [
+          {
+            id: "gvl.740",
+            name: "Test Vendor 740",
+          },
+        ],
+        systems: [],
+      },
+      {
+        id: 7,
+        name: "Measure ad performance",
+        description: "Purpose 7 legitimate interest description",
+        illustrations: [],
+        data_uses: ["analytics.reporting.ad_performance"],
+        default_preference: UserConsentPreference.OPT_IN,
+        vendors: [
+          {
+            id: "gvl.740",
+            name: "Test Vendor 740",
+          },
+        ],
+        systems: [],
+      },
+      {
+        id: 8,
+        name: "Measure content performance",
+        description: "Purpose 8 legitimate interest description",
+        illustrations: [],
+        data_uses: ["analytics.reporting.content_performance"],
+        default_preference: UserConsentPreference.OPT_IN,
+        vendors: [
+          {
+            id: "gvl.740",
+            name: "Test Vendor 740",
+          },
+        ],
+        systems: [],
+      },
+      {
+        id: 10,
+        name: "Develop and improve products",
+        description: "Purpose 10 legitimate interest description",
+        illustrations: [],
+        data_uses: ["functional.service.improve"],
+        default_preference: UserConsentPreference.OPT_IN,
+        vendors: [
+          {
+            id: "gvl.740",
+            name: "Test Vendor 740",
+          },
+        ],
+        systems: [],
+      },
+    ];
+
+  const experience = {
+    gvl: mockGvl,
+    tcf_purpose_consents: mockTcfPurposeConsents,
+    tcf_purpose_legitimate_interests: mockTcfPurposeLegitimateInterests,
+    tcf_legitimate_interests_consent: [],
+    tcf_special_purposes: [],
+    tcf_features: mockFeatures,
+    tcf_vendor_legitimate_interests: mockTCfVendorsLegitimateInterest,
+    minimal_tcf: false,
+  } as unknown as PrivacyExperience;
+
+  it("generates a valid Fides String when no publisher country code is provided", async () => {
+    const fidesString = await generateFidesString({
+      experience,
+      tcStringPreferences: {
+        customPurposesConsent: [],
+        features: ["1", "2", "3"],
+        purposesConsent: ["1", "2", "3", "4", "7"],
+        purposesLegint: ["2", "7", "8", "10"],
+        specialFeatures: ["1"],
+        specialPurposes: ["1", "2"],
+        vendorsConsent: ["gvl.740", "gvl.254"],
+        vendorsLegint: ["gvl.740"],
+      },
+    });
+
+    expect(fidesString).not.toBeNull();
+    expect(fidesString).not.toBeUndefined();
+    expect(fidesString).not.toBe("");
+
+    const [tcfString] = fidesString.split(FIDES_SEPARATOR);
+
+    expect(tcfString).not.toBe("");
+
+    const decodedTCString = TCString.decode(tcfString);
+    expect(decodedTCString.publisherCountryCode).toBe("AA");
+  });
+
+  it("generates a valid Fides String when a publisher country code is provided", async () => {
+    const experienceWithPublisherCountryCode = {
+      ...experience,
+      tcf_publisher_country_code: "US",
+    } as unknown as PrivacyExperience;
+
+    const fidesString = await generateFidesString({
+      experience: experienceWithPublisherCountryCode,
+      tcStringPreferences: {
+        customPurposesConsent: [],
+        features: ["1", "2", "3"],
+        purposesConsent: ["1", "2", "3", "4", "7"],
+        purposesLegint: ["2", "7", "8", "10"],
+        specialFeatures: ["1"],
+        specialPurposes: ["1", "2"],
+        vendorsConsent: ["gvl.740", "gvl.254"],
+        vendorsLegint: ["gvl.740"],
+      },
+    });
+
+    expect(fidesString).not.toBeNull();
+    expect(fidesString).not.toBeUndefined();
+    expect(fidesString).not.toBe("");
+
+    const [tcfString] = fidesString.split(FIDES_SEPARATOR);
+
+    expect(tcfString).not.toBe("");
+
+    const decodedTCString = TCString.decode(tcfString);
+    expect(decodedTCString.publisherCountryCode).toBe("US");
+  });
+});

--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "jest --watchAll",
+    "test:no-watch": "jest",
     "test:ci": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -22,7 +22,6 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "jest --watchAll",
-    "test:no-watch": "jest",
     "test:ci": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -444,6 +444,7 @@ export type PrivacyExperience = {
   tcf_system_consents?: Array<TCFVendorConsentRecord>;
   tcf_system_legitimate_interests?: Array<TCFVendorLegitimateInterestsRecord>;
   tcf_system_relationships?: Array<TCFVendorRelationships>;
+  tcf_publisher_country_code?: string;
 
   /**
    * @deprecated For backwards compatibility purposes, whether the Experience should show a banner.
@@ -491,6 +492,7 @@ export interface PrivacyExperienceMinimal
     | "vendor_count"
     | "minimal_tcf"
     | "gvl"
+    | "tcf_publisher_country_code"
   > {
   experience_config: ExperienceConfigMinimal;
   vendor_count?: number;

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -91,6 +91,9 @@ export const generateFidesString = async ({
     tcModel.isServiceSpecific = true;
     tcModel.supportOOB = false;
 
+    if (experience.tcf_publisher_country_code) {
+      tcModel.publisherCountryCode = experience.tcf_publisher_country_code;
+    }
     // Narrow the GVL to say we've only showed these vendors provided by our experience
     const gvlUID = experience.minimal_tcf
       ? uniqueGvlVendorIdsFromMinimal(experience as PrivacyExperienceMinimal)


### PR DESCRIPTION
Closes [LJ-546](https://ethyca.atlassian.net/browse/LJ-546)

### Description Of Changes

This PR gets the `tcf_publisher_country_code` from the experience and uses it when building TC strings. 

### Code Changes

* Update the `PrivacyExperience` type to include the new optional field `tcf_publisher_country_code` 
* Updated `generateFidesString` to pass in the field to `TCModel` 
* Added tests

### Steps to Confirm

1. Enable TCF 
2. In the admin UI, go to Settings > Consent and select a Publisher Country code . Save
3. Enable a TCF experience
4. Go to http://localhost:3001/fides-js-demo.html?geolocation=eea and delete the cookie and refresh. 
5. Accept or reject notices 
6. Log `Fides.cookie` in the console and take the TC string (first part of the `fides_string`)
7. Decode it in https://iabgpp.com/
8. Check that the `publisherCountryCode` matches the one you set on the Admin UI 
9.  In the admin UI, go to Settings > Consent and remove the Publisher Country code
10. Go to http://localhost:3001/fides-js-demo.html?geolocation=eea and delete the cookie and refresh. 
11.  Accept or reject notices 
12. Log `Fides.cookie` in the console and take the TC string (first part of the `fides_string`)
13. Decode it in https://iabgpp.com/
14. Check that the `publisherCountryCode` is set to "AA"

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-546]: https://ethyca.atlassian.net/browse/LJ-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ