### PR TITLE
LJ-579 Add logging for DSR session management and fix backend handler time calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Support setting publisher country code in Consent Settings [#5902](https://github.com/ethyca/fides/pull/5902)
 - Added option for disabling consent notice toggles [#5872](https://github.com/ethyca/fides/pull/5872)
 - Added UI to manually update Assets in the system asset view [#5914](https://github.com/ethyca/fides/pull/5914)
+- Added extra debug logging and fixed handler time calculation [#5927](https://github.com/ethyca/fides/pull/5927)
 
 ### Changed
 - Changed discovered asset "system" cell to use `user_assigned_system_key` property [#5908](https://github.com/ethyca/fides/pull/5908)

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -197,6 +197,9 @@ export default async function handler(
         propertyId,
         requestMinimalTCF: true,
       });
+      fidesDebugger(
+        `Fetched relevant experiences from server-side (${userLanguageString}).`,
+      );
       experienceIsValid(experience);
     }
   }

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -232,10 +232,13 @@ async def log_request(request: Request, call_next: Callable) -> Response:
         response = Response(status_code=500)
 
     handler_time = datetime.now() - start
+
+    # Take the total time in seconds and convert it to milliseconds, rounding to 3 decimal places
+    total_time = round(handler_time.total_seconds() * 1000, 3)
     logger.bind(
         method=request.method,
         status_code=response.status_code,
-        handler_time=f"{round(handler_time.microseconds * 0.001,3)}ms",
+        handler_time=f"{total_time}ms",
         path=request.url.path,
     ).info("Request received")
     return response

--- a/src/fides/api/tasks/__init__.py
+++ b/src/fides/api/tasks/__init__.py
@@ -79,7 +79,9 @@ class DatabaseTask(Task):  # pylint: disable=W0223
         # but a new session is instantiated each time the method is invoked
         # to prevent session overlap when requests are executing concurrently
         # when in task_always_eager mode (i.e. without proper workers)
-        return self._sessionmaker()
+        new_session = self._sessionmaker()
+        logger.debug(f"DatabaseTaskSession ID: {id(new_session)}. Self ID: {id(self)}")
+        return new_session
 
 
 def _create_celery(config: FidesConfig = CONFIG) -> Celery:

--- a/tests/api/test_logging.py
+++ b/tests/api/test_logging.py
@@ -1,7 +1,7 @@
 """Tests for the request logging middleware."""
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import Request, Response
@@ -13,9 +13,8 @@ from fides.api.main import log_request
 class TestLogRequest:
     """Tests for the request logging middleware timing functionality."""
 
-    @patch("fides.api.main.logger")
     @pytest.mark.asyncio
-    async def test_log_request_timing(self, mock_logger):
+    async def test_log_request_timing(self, loguru_caplog):
         """Test that the log_request middleware correctly calculates request handling time."""
         # Create a mock request
         mock_request = Request(
@@ -33,38 +32,29 @@ class TestLogRequest:
             await asyncio.sleep(0.1)  # 100ms delay
             return Response(status_code=200)
 
-        # Setup mock for chained calls
-        bound_logger = MagicMock()
-        mock_logger.bind.return_value = bound_logger
-
         response = await log_request(mock_request, mock_call_next)
 
         # Verify the response
         assert response.status_code == 200
 
-        # Verify the bind parameters
-        mock_logger.bind.assert_called_once()
-        bind_args = mock_logger.bind.call_args[1]
-
-        assert bind_args["method"] == "GET"
-        assert bind_args["status_code"] == 200
-        assert bind_args["path"] == "/test"
-        assert "handler_time" in bind_args
-        assert bind_args["handler_time"].endswith("ms")
+        # Verify the log message and its contents
+        assert "Request received" in loguru_caplog.text
+        log_record = loguru_caplog.records[0]
+        assert log_record.extra["method"] == "GET"
+        assert log_record.extra["status_code"] == 200
+        assert log_record.extra["path"] == "/test"
+        assert "handler_time" in log_record.extra
+        assert log_record.extra["handler_time"].endswith("ms")
 
         # Extract the handler_time value and convert it to float for comparison
-        handler_time_str = bind_args["handler_time"]
+        handler_time_str = log_record.extra["handler_time"]
         actual_ms = float(handler_time_str[:-2])  # Remove "ms" and convert to float
 
         # Timing should be at least 100ms since we added an artificial delay
         assert actual_ms >= 100
 
-        # Verify the info call on the bound logger
-        bound_logger.info.assert_called_once_with("Request received")
-
-    @patch("fides.api.main.logger")
     @pytest.mark.asyncio
-    async def test_log_request_timing_slow_request(self, mock_logger):
+    async def test_log_request_timing_slow_request(self, loguru_caplog):
         """
         Test that the log_request middleware correctly calculates request handling time
         for "slow" requests, i.e requests that take longer than 1 second to process.
@@ -85,38 +75,29 @@ class TestLogRequest:
             await asyncio.sleep(1.5)  # 1500ms delay
             return Response(status_code=200)
 
-        # Setup mock for chained calls
-        bound_logger = MagicMock()
-        mock_logger.bind.return_value = bound_logger
-
         response = await log_request(mock_request, mock_call_next)
 
         # Verify the response
         assert response.status_code == 200
 
-        # Verify the bind parameters
-        mock_logger.bind.assert_called_once()
-        bind_args = mock_logger.bind.call_args[1]
-
-        assert bind_args["method"] == "GET"
-        assert bind_args["status_code"] == 200
-        assert bind_args["path"] == "/test"
-        assert "handler_time" in bind_args
-        assert bind_args["handler_time"].endswith("ms")
+        # Verify the log message and its contents
+        assert "Request received" in loguru_caplog.text
+        log_record = loguru_caplog.records[0]
+        assert log_record.extra["method"] == "GET"
+        assert log_record.extra["status_code"] == 200
+        assert log_record.extra["path"] == "/test"
+        assert "handler_time" in log_record.extra
+        assert log_record.extra["handler_time"].endswith("ms")
 
         # Extract the handler_time value and convert it to float for comparison
-        handler_time_str = bind_args["handler_time"]
+        handler_time_str = log_record.extra["handler_time"]
         actual_ms = float(handler_time_str[:-2])  # Remove "ms" and convert to float
 
         # Timing should be at least 1000ms since we added an artificial delay
         assert actual_ms >= 1000
 
-        # Verify the info call on the bound logger
-        bound_logger.info.assert_called_once_with("Request received")
-
-    @patch("fides.api.main.logger")
     @pytest.mark.asyncio
-    async def test_log_request_error(self, mock_logger):
+    async def test_log_request_error(self, loguru_caplog):
         """Test that the log_request middleware correctly handles errors."""
         # Create a mock request
         mock_request = Request(
@@ -133,24 +114,16 @@ class TestLogRequest:
         async def mock_call_next(_):
             raise ValueError("Test error")
 
-        # Setup mock for chained calls
-        bound_logger = MagicMock()
-        mock_logger.bind.return_value = bound_logger
-
         response = await log_request(mock_request, mock_call_next)
 
         # Verify we get a 500 response for the error
         assert response.status_code == 500
 
-        # Verify the bind parameters
-        mock_logger.bind.assert_called_once()
-        bind_args = mock_logger.bind.call_args[1]
-
-        assert bind_args["method"] == "GET"
-        assert bind_args["status_code"] == 500
-        assert bind_args["path"] == "/test"
-        assert "handler_time" in bind_args
-        assert bind_args["handler_time"].endswith("ms")
-
-        # Verify the info call on the bound logger
-        bound_logger.info.assert_called_once_with("Request received")
+        # Verify the log message and its contents
+        assert "Request received" in loguru_caplog.text
+        log_record = loguru_caplog.records[0]
+        assert log_record.extra["method"] == "GET"
+        assert log_record.extra["status_code"] == 500
+        assert log_record.extra["path"] == "/test"
+        assert "handler_time" in log_record.extra
+        assert log_record.extra["handler_time"].endswith("ms")

--- a/tests/api/test_logging.py
+++ b/tests/api/test_logging.py
@@ -1,0 +1,156 @@
+"""Tests for the request logging middleware."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import Request, Response
+from starlette.datastructures import Headers
+
+from fides.api.main import log_request
+
+
+class TestLogRequest:
+    """Tests for the request logging middleware timing functionality."""
+
+    @patch("fides.api.main.logger")
+    @pytest.mark.asyncio
+    async def test_log_request_timing(self, mock_logger):
+        """Test that the log_request middleware correctly calculates request handling time."""
+        # Create a mock request
+        mock_request = Request(
+            scope={
+                "type": "http",
+                "method": "GET",
+                "path": "/test",
+                "headers": Headers({}),
+            },
+            receive=None,
+        )
+
+        # Create a mock response with artificial delay
+        async def mock_call_next(_):
+            await asyncio.sleep(0.1)  # 100ms delay
+            return Response(status_code=200)
+
+        # Setup mock for chained calls
+        bound_logger = MagicMock()
+        mock_logger.bind.return_value = bound_logger
+
+        response = await log_request(mock_request, mock_call_next)
+
+        # Verify the response
+        assert response.status_code == 200
+
+        # Verify the bind parameters
+        mock_logger.bind.assert_called_once()
+        bind_args = mock_logger.bind.call_args[1]
+
+        assert bind_args["method"] == "GET"
+        assert bind_args["status_code"] == 200
+        assert bind_args["path"] == "/test"
+        assert "handler_time" in bind_args
+        assert bind_args["handler_time"].endswith("ms")
+
+        # Extract the handler_time value and convert it to float for comparison
+        handler_time_str = bind_args["handler_time"]
+        actual_ms = float(handler_time_str[:-2])  # Remove "ms" and convert to float
+
+        # Timing should be at least 100ms since we added an artificial delay
+        assert actual_ms >= 100
+
+        # Verify the info call on the bound logger
+        bound_logger.info.assert_called_once_with("Request received")
+
+    @patch("fides.api.main.logger")
+    @pytest.mark.asyncio
+    async def test_log_request_timing_slow_request(self, mock_logger):
+        """
+        Test that the log_request middleware correctly calculates request handling time
+        for "slow" requests, i.e requests that take longer than 1 second to process.
+        """
+        # Create a mock request
+        mock_request = Request(
+            scope={
+                "type": "http",
+                "method": "GET",
+                "path": "/test",
+                "headers": Headers({}),
+            },
+            receive=None,
+        )
+
+        # Create a mock response with artificial delay
+        async def mock_call_next(_):
+            await asyncio.sleep(1.5)  # 1500ms delay
+            return Response(status_code=200)
+
+        # Setup mock for chained calls
+        bound_logger = MagicMock()
+        mock_logger.bind.return_value = bound_logger
+
+        response = await log_request(mock_request, mock_call_next)
+
+        # Verify the response
+        assert response.status_code == 200
+
+        # Verify the bind parameters
+        mock_logger.bind.assert_called_once()
+        bind_args = mock_logger.bind.call_args[1]
+
+        assert bind_args["method"] == "GET"
+        assert bind_args["status_code"] == 200
+        assert bind_args["path"] == "/test"
+        assert "handler_time" in bind_args
+        assert bind_args["handler_time"].endswith("ms")
+
+        # Extract the handler_time value and convert it to float for comparison
+        handler_time_str = bind_args["handler_time"]
+        actual_ms = float(handler_time_str[:-2])  # Remove "ms" and convert to float
+
+        # Timing should be at least 1000ms since we added an artificial delay
+        assert actual_ms >= 1000
+
+        # Verify the info call on the bound logger
+        bound_logger.info.assert_called_once_with("Request received")
+
+    @patch("fides.api.main.logger")
+    @pytest.mark.asyncio
+    async def test_log_request_error(self, mock_logger):
+        """Test that the log_request middleware correctly handles errors."""
+        # Create a mock request
+        mock_request = Request(
+            scope={
+                "type": "http",
+                "method": "GET",
+                "path": "/test",
+                "headers": Headers({}),
+            },
+            receive=None,
+        )
+
+        # Create a mock response that raises an exception
+        async def mock_call_next(_):
+            raise ValueError("Test error")
+
+        # Setup mock for chained calls
+        bound_logger = MagicMock()
+        mock_logger.bind.return_value = bound_logger
+
+        response = await log_request(mock_request, mock_call_next)
+
+        # Verify we get a 500 response for the error
+        assert response.status_code == 500
+
+        # Verify the bind parameters
+        mock_logger.bind.assert_called_once()
+        bind_args = mock_logger.bind.call_args[1]
+
+        assert bind_args["method"] == "GET"
+        assert bind_args["status_code"] == 500
+        assert bind_args["path"] == "/test"
+        assert "handler_time" in bind_args
+        assert bind_args["handler_time"].endswith("ms")
+
+        # Verify the info call on the bound logger
+        bound_logger.info.assert_called_once_with("Request received")


### PR DESCRIPTION
Closes [LJ-579](https://ethyca.atlassian.net/browse/LJ-579)

### Description Of Changes

- Adds logging for sessions in DatabaseTasks, hoping to provide more info for debugging customer issues
- Adds debug log in privacy-center, hoping to provide more info for performance testing on customer environments
- Fixes the way we were calculating handler time in `log_request`; we were using `timedelta.microseconds` instead of `total_seconds` so we were getting an inaccurate handler time for any request that took longer than 1s

### Steps to Confirm

1. Tests pass

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-579]: https://ethyca.atlassian.net/browse/LJ-579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ