### PR TITLE
Fix build issue after pc merge

### DIFF
--- a/clients/admin-ui/src/pages/fides-js-docs.tsx
+++ b/clients/admin-ui/src/pages/fides-js-docs.tsx
@@ -4,7 +4,7 @@ import { NextPage } from "next";
 import SwaggerUI from "swagger-ui-react";
 
 // Only include API docs in development builds
-export const getServerSideProps = () => {
+export const getStaticProps = () => {
   if (process.env.NODE_ENV !== "development") {
     return {
       notFound: true,

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -24660,21 +24660,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "privacy-center/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.24.tgz",
-      "integrity": "sha512-9KuS+XUXM3T6v7leeWU0erpJ6NsFIwiTFD5nzNg8J5uo/DMIPvCp3L1Ao5HjbHX0gkWPB1VrKoo/Il4F0cGK2Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }


### PR DESCRIPTION
### Description Of Changes

Fix build issue after pc merge. The docs for fides-js were moved to admin-ui, but the export fails because the docs page uses getServerSideProps, so I changed it to getStaticProps. Docs are not included in production build anyways.

### Code Changes

* Replace getServerSideProps with getStaticProps
* Commit automatic package-lock update by nextjs

### Steps to Confirm

1.  Log in to admin ui
2. Go to Developer > Fides JS Docs
3. Check Swagger UI appears correctly
4. Go to the `clients/admin-ui` folder and run `npm export`
5. Check the previous command finishes without errors

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
