### PR TITLE
Action center asset row persistence updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Changed discovered asset "system" cell to use `user_assigned_system_key` property [#5908](https://github.com/ethyca/fides/pull/5908)
 - Changed Dataset endpoint, it now has `minimal` parameter, and can be filtered by `fides_meta.namespace.connection_type` [#5915](https://github.com/ethyca/fides/pull/5915)
 - Datahub integration now allows datasets to be selected [#5926](https://github.com/ethyca/fides/pull/5926)
-- Add tab-based filtering and row persistence to web monitor assets table [#5933](https://github.com/ethyca/fides/pull/5933)
 
 ### Fixed
 - Fixed UX issues with website monitor form [#5884](https://github.com/ethyca/fides/pull/5884)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,10 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added size thresholds to S3 upload and retrieval methods for more efficient document processing. [#5922](https://github.com/ethyca/fides/pull/5922)
 - Added support for Notice Consent String integration in Fides String [#5895](https://github.com/ethyca/fides/pull/5895)
 - Added support for new options for Fides.gtm method [#5917](https://github.com/ethyca/fides/pull/5917)
-
-### Changed
 - Changed discovered asset "system" cell to use `user_assigned_system_key` property [#5908](https://github.com/ethyca/fides/pull/5908)
 - Changed Dataset endpoint, it now has `minimal` parameter, and can be filtered by `fides_meta.namespace.connection_type` [#5915](https://github.com/ethyca/fides/pull/5915)
 - Datahub integration now allows datasets to be selected [#5926](https://github.com/ethyca/fides/pull/5926)
+- Add tab-based filtering and row persistence to web monitor assets table [#5933](https://github.com/ethyca/fides/pull/5933)
 
 ### Fixed
 - Fixed UX issues with website monitor form [#5884](https://github.com/ethyca/fides/pull/5884)

--- a/clients/admin-ui/cypress/e2e/action-center.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center.cy.ts
@@ -393,7 +393,7 @@ describe("Action center", () => {
         cy.getByTestId("system-badge").click();
       });
       cy.wait("@getSystemsPaginated");
-      cy.getByTestId("add-new-system").click();
+      cy.getByTestId("add-new-system").click({ force: true });
       cy.getByTestId("add-modal-content").should("exist");
       cy.getByTestId("vendor-name-select").antSelect("Aniview LTD");
       cy.getByTestId("save-btn").click();
@@ -512,6 +512,36 @@ describe("Action center", () => {
         "contain",
         "Consent categories added to 3 assets from Google Tag Manager.",
       );
+    });
+
+    describe("tab navigation", () => {
+      it("updates URL hash when switching tabs", () => {
+        cy.visit(
+          `${ACTION_CENTER_ROUTE}/${webMonitorKey}/${systemId}#attention-required`,
+        );
+        cy.location("hash").should("eq", "#attention-required");
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+        cy.getByTestId("tab-Recent activity").click({ force: true });
+        cy.location("hash").should("eq", "#recent-activity");
+        // "recent activity" tab should be read-only
+        cy.getByTestId("row-0-col-system").within(() => {
+          cy.getByTestId("system-badge")
+            .should("exist")
+            .should("not.have.attr", "onClick");
+          cy.getByTestId("add-system-btn").should("not.exist");
+        });
+        cy.getByTestId("row-0-col-data_use").within(() => {
+          cy.getByTestId("taxonomy-add-btn").should("not.exist");
+        });
+        cy.getByTestId("col-actions").should("not.exist");
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+        cy.getByTestId("tab-Ignored").click({ force: true });
+        cy.location("hash").should("eq", "#ignored");
+      });
     });
   });
 });

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -1,6 +1,7 @@
 import { baseApi } from "~/features/common/api.slice";
 import { getQueryParamsFromArray } from "~/features/common/utils";
 import {
+  DiffStatus,
   Page_StagedResourceAPIResponse_,
   StagedResourceAPIResponse,
 } from "~/types/api";
@@ -14,6 +15,13 @@ import {
 interface MonitorResultSystemQueryParams {
   monitor_config_key: string;
   resolved_system_ids: string[];
+}
+
+interface DiscoveredAssetsQueryParams {
+  key: string;
+  system?: string;
+  search?: string;
+  diff_status?: DiffStatus[];
 }
 
 const actionCenterApi = baseApi.injectEndpoints({
@@ -51,16 +59,16 @@ const actionCenterApi = baseApi.injectEndpoints({
     }),
     getDiscoveredAssets: build.query<
       Page_StagedResourceAPIResponse_,
-      { key: string; system: string; search: string } & PaginationQueryParams
+      DiscoveredAssetsQueryParams & PaginationQueryParams
     >({
-      query: ({ key, system, page = 1, size = 20, search }) => ({
+      query: ({ key, system, page = 1, size = 20, search, diff_status }) => ({
         url: `/plus/discovery-monitor/${key}/results`,
         params: {
           resolved_system_id: system,
           page,
           size,
           search,
-          diff_status: "addition",
+          diff_status,
           sort_by: "urn",
         },
       }),
@@ -151,7 +159,7 @@ const actionCenterApi = baseApi.injectEndpoints({
         url: `/plus/discovery-monitor/${params.monitorId}/results`,
         body: params.urnList.map((urn) => ({
           urn,
-          data_uses: params.dataUses,
+          user_assigned_data_uses: params.dataUses,
         })),
       }),
       invalidatesTags: ["Discovery Monitor Results"],

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsColumns.tsx
@@ -15,7 +15,11 @@ import { PrivacyNoticeRegion, StagedResourceAPIResponse } from "~/types/api";
 
 import { SystemCell } from "../tables/cells/SystemCell";
 
-export const useDiscoveredAssetsColumns = () => {
+export const useDiscoveredAssetsColumns = ({
+  readonly,
+}: {
+  readonly: boolean;
+}) => {
   const columnHelper = createColumnHelper<StagedResourceAPIResponse>();
 
   const columns: ColumnDef<StagedResourceAPIResponse, any>[] = [
@@ -56,6 +60,7 @@ export const useDiscoveredAssetsColumns = () => {
           <SystemCell
             aggregateSystem={props.row.original}
             monitorConfigId={props.row.original.monitor_config_id}
+            readonly={readonly}
           />
         ),
       header: "System",
@@ -67,7 +72,10 @@ export const useDiscoveredAssetsColumns = () => {
     columnHelper.display({
       id: "data_use",
       cell: (props) => (
-        <DiscoveredAssetDataUseCell asset={props.row.original} />
+        <DiscoveredAssetDataUseCell
+          asset={props.row.original}
+          readonly={readonly}
+        />
       ),
       header: "Categories of consent",
       size: 400,
@@ -122,16 +130,21 @@ export const useDiscoveredAssetsColumns = () => {
         disableRowClick: true,
       },
     }),
-    columnHelper.display({
-      id: "actions",
-      cell: (props) => (
-        <DiscoveredAssetActionsCell asset={props.row.original} />
-      ),
-      header: "Actions",
-      meta: {
-        disableRowClick: true,
-      },
-    }),
   ];
+
+  if (!readonly) {
+    columns.push(
+      columnHelper.display({
+        id: "actions",
+        cell: (props) => (
+          <DiscoveredAssetActionsCell asset={props.row.original} />
+        ),
+        header: "Actions",
+        meta: {
+          disableRowClick: true,
+        },
+      }),
+    );
+  }
   return { columns };
 };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
@@ -124,7 +124,8 @@ export const DiscoveredAssetsTable = ({
 
   useEffect(() => {
     if (data) {
-      const firstSystemName = data.items[0]?.system || systemId || "";
+      const firstSystemName =
+        data.items[0]?.system || systemName || systemId || "";
       setTotalPages(data.pages || 1);
       setSystemName(firstSystemName);
       onSystemName?.(firstSystemName);

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/SystemCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/SystemCell.tsx
@@ -12,11 +12,13 @@ import { StagedResourceAPIResponse } from "~/types/api";
 interface SystemCellProps {
   aggregateSystem: StagedResourceAPIResponse;
   monitorConfigId: string;
+  readonly?: boolean;
 }
 
 export const SystemCell = ({
   aggregateSystem,
   monitorConfigId,
+  readonly,
 }: SystemCellProps) => {
   const {
     resource_type: assetType,
@@ -65,6 +67,16 @@ export const SystemCell = ({
   };
 
   const currentSystemKey = userAssignedSystemKey || systemKey;
+
+  if (readonly) {
+    return (
+      <div style={getTableTHandTDStyles()}>
+        <Tag data-testid="system-badge" color="white">
+          {systemName}
+        </Tag>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/useDiscoveredAssetsTabs.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/useDiscoveredAssetsTabs.tsx
@@ -1,0 +1,102 @@
+import { useRouter } from "next/router";
+import { useCallback, useState } from "react";
+
+import { DiffStatus } from "~/types/api";
+
+const DISCOVERED_ASSETS_TABLE_TABS = {
+  ATTENTION_REQUIRED: {
+    index: 0,
+    hash: "#attention-required",
+  },
+  RECENT_ACTIVITY: {
+    index: 1,
+    hash: "#recent-activity",
+  },
+  IGNORED: {
+    index: 2,
+    hash: "#ignored",
+  },
+};
+
+const getTabFromHash = (hash: string) => {
+  const normalizedHash = hash.startsWith("#") ? hash : `#${hash}`;
+  return Object.values(DISCOVERED_ASSETS_TABLE_TABS).find(
+    (tab) => tab.hash === normalizedHash,
+  );
+};
+
+const getTabFromIndex = (index: number) => {
+  return Object.values(DISCOVERED_ASSETS_TABLE_TABS).find(
+    (tab) => tab.index === index,
+  );
+};
+
+export const useDiscoveredAssetsTabs = ({ systemId }: { systemId: string }) => {
+  const router = useRouter();
+  const getInitialTabIndex = () => {
+    const hash: string = router.asPath.split("#")[1];
+    return hash
+      ? getTabFromHash(hash)?.index
+      : DISCOVERED_ASSETS_TABLE_TABS.ATTENTION_REQUIRED.index;
+  };
+
+  const [filterTabIndex, setFilterTabIndex] = useState(getInitialTabIndex());
+
+  const onTabChange = useCallback(
+    async (index: number) => {
+      // Update local state first
+      setFilterTabIndex(index);
+
+      // Update URL if router is ready
+      if (router.isReady) {
+        const tab = getTabFromIndex(index);
+        if (tab) {
+          const newQuery = { ...router.query };
+
+          await router.replace(
+            {
+              pathname: router.pathname,
+              query: newQuery,
+              hash: tab.hash,
+            },
+            undefined,
+            { shallow: true },
+          );
+        }
+      }
+    },
+    [router],
+  );
+
+  const filterTabs = [
+    {
+      label: "Attention required",
+      params: {
+        diff_status: [DiffStatus.ADDITION],
+        system: systemId,
+      },
+    },
+    {
+      label: "Recent activity",
+      params: {
+        diff_status: [DiffStatus.MONITORED],
+      },
+    },
+    {
+      label: "Ignored",
+      params: {
+        diff_status: [DiffStatus.MUTED],
+        system: systemId,
+      },
+    },
+  ];
+
+  return {
+    filterTabs,
+    filterTabIndex,
+    onTabChange,
+    activeParams: filterTabs[filterTabIndex!].params,
+  };
+};
+
+export default useDiscoveredAssetsTabs;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/useDiscoveredAssetsTabs.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/useDiscoveredAssetsTabs.tsx
@@ -31,7 +31,7 @@ const getTabFromIndex = (index: number) => {
   );
 };
 
-export const useDiscoveredAssetsTabs = ({ systemId }: { systemId: string }) => {
+const useDiscoveredAssetsTabs = ({ systemId }: { systemId: string }) => {
   const router = useRouter();
   const getInitialTabIndex = () => {
     const hash: string = router.asPath.split("#")[1];


### PR DESCRIPTION
Closes HA-471

### Description Of Changes

Updates discovered asset table so assets don't disappear from the table while being edited; also adds a tab view that filters on resource diff status and system.

![Screenshot 2025-03-25 at 11 22 32](https://github.com/user-attachments/assets/2cdb360d-f4ea-41c8-ae93-31e6dc4af946)

* "Attention required" is the replacement for the previous default view that shows `addition` resources.
* "Recent activity" shows all resources from the current _monitor_ (not just system) that have been promoted to system assets; resources in this view can't be edited and there is no "Actions" column in the table
* "Ignored" shows all ignored resources; resources here can be edited

### Code Changes

* Add tabs and tab hash and filter handling to the DiscoveredAssetsTable
* Add a read-only variant of the system and data use cells

### Steps to Confirm

1. Populate some web monitor results
2. Assign a system and consent categories to some assets and add them
3. Ignore some assets
4. The assets you added should show up under "recent activity" _and_ in the applicable system's assets tab
5. They should be editable in the system assets table, but not in "recent activity"
6. The assets you ignored should show up under "ignored"; should be able to edit and add them as normal
7. Navigate to a different system's results under the same monitor
8. The assets you added should show up under "recent activity" here also

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
