### PR TITLE
LJ-499 Enable Consent Reporting by default / Update lookup table columns

### DIFF
--- a/clients/admin-ui/src/features/common/nav/nav-config.tsx
+++ b/clients/admin-ui/src/features/common/nav/nav-config.tsx
@@ -166,7 +166,6 @@ export const NAV_CONFIG: NavConfigGroup[] = [
       {
         title: "Consent reporting",
         path: routes.CONSENT_REPORTING_ROUTE,
-        requiresFlag: "consentReporting",
         requiresPlus: true,
         scopes: [ScopeRegistryEnum.PRIVACY_NOTICE_READ],
       },

--- a/clients/admin-ui/src/features/consent-reporting/hooks/useConsentLookupTableColumns.tsx
+++ b/clients/admin-ui/src/features/consent-reporting/hooks/useConsentLookupTableColumns.tsx
@@ -18,10 +18,12 @@ const columnHelper = createColumnHelper<PreferenceWithNoticeInformation>();
 const useConsentLookupTableColumns = () => {
   const columns = useMemo(
     () => [
-      columnHelper.accessor((row) => row.notice_id, {
-        id: "notice_id",
+      columnHelper.accessor((row) => row.notice_name, {
+        id: "notice_name",
         cell: ({ getValue }) => <DefaultCell value={getValue()} />,
-        header: (props) => <DefaultHeaderCell value="Notice Id" {...props} />,
+        header: (props) => (
+          <DefaultHeaderCell value="Privacy notice" {...props} />
+        ),
         enableSorting: false,
       }),
       columnHelper.accessor((row) => row.notice_key, {

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -24,12 +24,6 @@
     "test": true,
     "production": false
   },
-  "consentReporting": {
-    "description": "Page to download consent reports by date",
-    "development": true,
-    "test": true,
-    "production": false
-  },
   "dataDiscoveryAndDetection": {
     "description": "Data discovery and detection",
     "development": true,

--- a/clients/admin-ui/src/types/api/models/PreferenceWithNoticeInformation.ts
+++ b/clients/admin-ui/src/types/api/models/PreferenceWithNoticeInformation.ts
@@ -11,6 +11,7 @@ export type PreferenceWithNoticeInformation = {
   privacy_notice_history_id: string;
   preference: UserConsentPreference;
   notice_key: string;
+  notice_name: string;
   notice_id: string;
   version: number;
 };


### PR DESCRIPTION
### Description Of Changes

Update lookup table column from showing the notice id to showing the notice name. Remove flag for consent reporting screen, have it on by default.

### Code Changes

* Update PreferenceWithNoticeInformation model
* Update column table to use new notice_name property
* Remove feature flag for consentReporting
* Remove feature flag limitation for showing Consent Reporting in navigation menu

### Steps to Confirm

1. Login to admin-ui
2. Check Consent Reporting screen is in menu
3. Go to Settings > About Fides
4. Check there's no Consent Reporting flag in the screen
5. Go to Consent > Consent Reporting page
6. Copy the User Device ID for any non-TCF row
7. Click the three dots in the top right of the table and then click on Consent preference lookup
8. In the modal, search using the copied User Device ID
9. Check that in the results table the first column now says "Privacy notice" and the values shown for that column are notice names and not ids.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
