### PR TITLE
System assets table updates

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -137,7 +137,7 @@ const actionCenterApi = baseApi.injectEndpoints({
         url: `/plus/discovery-monitor/${params.monitorId}/results`,
         body: params.urnList.map((urn) => ({
           urn,
-          system_key: params.systemKey,
+          user_assigned_system_key: params.systemKey,
         })),
       }),
       invalidatesTags: ["Discovery Monitor Results", "System Assets"],
@@ -151,7 +151,7 @@ const actionCenterApi = baseApi.injectEndpoints({
         url: `/plus/discovery-monitor/${params.monitorId}/results`,
         body: params.urnList.map((urn) => ({
           urn,
-          data_uses: params.dataUses,
+          user_assigned_data_uses: params.dataUses,
         })),
       }),
       invalidatesTags: ["Discovery Monitor Results"],

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
@@ -186,10 +186,13 @@ export const DiscoveredAssetsTable = ({
     }
     const assets = selectedAssets.map((asset) => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      const data_uses = uniq([...(asset.data_uses || []), ...newDataUses]);
+      const user_assigned_data_uses = uniq([
+        ...(asset.user_assigned_data_uses || asset.data_uses || []),
+        ...newDataUses,
+      ]);
       return {
         urn: asset.urn,
-        data_uses,
+        user_assigned_data_uses,
       };
     });
     const result = await updateAssetsMutation({
@@ -201,10 +204,13 @@ export const DiscoveredAssetsTable = ({
     } else {
       tableInstance.resetRowSelection();
       successAlert(
-        `Consent categories added to ${selectedUrns.length} assets from ${systemName}.`,
+        `Consent categories added to ${selectedUrns.length} assets${
+          systemName ? ` from ${systemName}` : ""
+        }.`,
         `Confirmed`,
       );
     }
+    setIsAddDataUseModalOpen(false);
   };
 
   const handleBulkIgnore = async () => {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetDataUseCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetDataUseCell.tsx
@@ -23,12 +23,14 @@ const DiscoveredAssetDataUseCell = ({
 
   const { getDataUseDisplayName } = useTaxonomies();
 
+  const currentDataUses =
+    asset.user_assigned_data_uses || asset.data_uses || [];
+
   const handleAddDataUse = async (newDataUse: string) => {
-    const existingUses = asset.data_uses || [];
     const result = await updateAssetsDataUseMutation({
       monitorId: asset.monitor_config_id!,
       urnList: [asset.urn],
-      dataUses: [...existingUses, newDataUse],
+      dataUses: [...currentDataUses, newDataUse],
     });
     if (isErrorResult(result)) {
       errorAlert(getErrorMessage(result.error));
@@ -42,11 +44,10 @@ const DiscoveredAssetDataUseCell = ({
   };
 
   const handleDeleteDataUse = async (useToDelete: string) => {
-    const existingUses = asset.data_uses || [];
     const result = await updateAssetsDataUseMutation({
       monitorId: asset.monitor_config_id!,
       urnList: [asset.urn],
-      dataUses: existingUses.filter((use) => use !== useToDelete),
+      dataUses: currentDataUses.filter((use) => use !== useToDelete),
     });
     if (isErrorResult(result)) {
       errorAlert(getErrorMessage(result.error));
@@ -58,7 +59,7 @@ const DiscoveredAssetDataUseCell = ({
     }
   };
 
-  const dataUses = asset.data_uses?.filter((use) => isConsentCategory(use));
+  const dataUses = currentDataUses.filter((use) => isConsentCategory(use));
 
   return (
     <TaxonomyCellContainer>

--- a/clients/admin-ui/src/features/system/tabs/system-assets/SystemAssetsDataUseCell.tsx
+++ b/clients/admin-ui/src/features/system/tabs/system-assets/SystemAssetsDataUseCell.tsx
@@ -1,15 +1,112 @@
-import useTaxonomies from "~/features/common/hooks/useTaxonomies";
-import { BadgeCellExpandable } from "~/features/common/table/v2/cells";
+import { AntTag as Tag, Box } from "fidesui";
+import { useState } from "react";
 
-const SystemAssetsDataUseCell = ({ values }: { values?: string[] }) => {
+import { getErrorMessage } from "~/features/common/helpers";
+import { useAlert } from "~/features/common/hooks/useAlert";
+import useTaxonomies from "~/features/common/hooks/useTaxonomies";
+import ConsentCategorySelect from "~/features/data-discovery-and-detection/action-center/ConsentCategorySelect";
+import TaxonomyCellContainer from "~/features/data-discovery-and-detection/tables/cells/TaxonomyCellContainer";
+import { useUpdateSystemAssetsMutation } from "~/features/system/system-assets.slice";
+import { Asset } from "~/types/api";
+import { isErrorResult } from "~/types/errors";
+
+const SystemAssetsDataUseCell = ({
+  asset,
+  systemId,
+}: {
+  asset: Asset;
+  systemId: string;
+}) => {
   const { getDataUseDisplayName } = useTaxonomies();
+  const [updateSystemAssets] = useUpdateSystemAssetsMutation();
+  const { errorAlert, successAlert } = useAlert();
+
+  const [isAdding, setIsAdding] = useState(false);
+
+  const handleAddDataUse = async (use: string) => {
+    const newDataUses = [...(asset.data_uses || []), use];
+    const result = await updateSystemAssets({
+      systemKey: systemId,
+      assets: [{ id: asset.id, data_uses: newDataUses }],
+    });
+    if (isErrorResult(result)) {
+      errorAlert(getErrorMessage(result.error));
+    } else {
+      successAlert(
+        `Consent category added to ${asset.asset_type} "${asset.name}".`,
+        `Confirmed`,
+      );
+    }
+  };
+
+  const handleDeleteDataUse = async (use: string) => {
+    const newDataUses = asset.data_uses?.filter((u) => u !== use);
+    const result = await updateSystemAssets({
+      systemKey: systemId,
+      assets: [{ id: asset.id, data_uses: newDataUses }],
+    });
+    if (isErrorResult(result)) {
+      errorAlert(getErrorMessage(result.error));
+    } else {
+      successAlert(
+        `Consent category removed from ${asset.asset_type} "${asset.name}".`,
+        `Confirmed`,
+      );
+    }
+  };
+
   const cellValues =
-    values?.map((use) => ({
+    asset.data_uses?.map((use) => ({
       label: getDataUseDisplayName(use),
       key: use,
     })) ?? [];
 
-  return <BadgeCellExpandable values={cellValues} />;
+  return (
+    <TaxonomyCellContainer>
+      {!isAdding && (
+        <>
+          {cellValues.map((use) => (
+            <Tag
+              key={use.key}
+              data-testid={`data-use-${use.key}`}
+              color="white"
+              closable
+              onClose={() => handleDeleteDataUse(use.key)}
+              closeButtonLabel="Remove data use"
+            >
+              {use.label}
+            </Tag>
+          ))}
+          <Tag
+            onClick={() => setIsAdding(true)}
+            data-testid="taxonomy-add-btn"
+            addable
+            aria-label="Add data use"
+          />
+        </>
+      )}
+      {isAdding && (
+        <Box
+          // eslint-disable-next-line tailwindcss/no-custom-classname
+          className="select-wrapper"
+          position="absolute"
+          zIndex={10}
+          top="0"
+          left="0"
+          width="100%"
+          height="max"
+          bgColor="#fff"
+        >
+          <ConsentCategorySelect
+            selectedTaxonomies={asset.data_uses || []}
+            onSelect={handleAddDataUse}
+            onBlur={() => setIsAdding(false)}
+            open
+          />
+        </Box>
+      )}
+    </TaxonomyCellContainer>
+  );
 };
 
 export default SystemAssetsDataUseCell;

--- a/clients/admin-ui/src/features/system/tabs/system-assets/SystemAssetsTable.tsx
+++ b/clients/admin-ui/src/features/system/tabs/system-assets/SystemAssetsTable.tsx
@@ -9,6 +9,7 @@ import {
   ConfirmationModal,
   Icons,
   Spacer,
+  Text,
   useDisclosure,
   useToast,
 } from "fidesui";
@@ -32,6 +33,8 @@ import AddEditAssetModal from "~/features/system/tabs/system-assets/AddEditAsset
 import useSystemAssetColumns from "~/features/system/tabs/system-assets/useSystemAssetColumns";
 import { Asset, SystemResponse } from "~/types/api";
 import { isErrorResult } from "~/types/errors";
+
+const COPY = `This page displays all assets associated with this system. Use the table below to review and manage these technologies for compliance and detailed insights.`;
 
 const SystemAssetsTable = ({ system }: { system: SystemResponse }) => {
   const {
@@ -97,6 +100,7 @@ const SystemAssetsTable = ({ system }: { system: SystemResponse }) => {
   };
 
   const columns = useSystemAssetColumns({
+    systemName: system.name ?? system.fides_key,
     systemKey: system.fides_key,
     onEditClick: handleEditAsset,
   });
@@ -147,6 +151,9 @@ const SystemAssetsTable = ({ system }: { system: SystemResponse }) => {
 
   return (
     <>
+      <Text fontSize="sm" mb={4}>
+        {COPY}
+      </Text>
       <TableActionBar>
         <SearchInput value={searchQuery} onChange={setSearchQuery} />
         <Spacer />

--- a/clients/admin-ui/src/features/system/tabs/system-assets/useSystemAssetColumns.tsx
+++ b/clients/admin-ui/src/features/system/tabs/system-assets/useSystemAssetColumns.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
-import { AntTag } from "fidesui";
+import { AntTag as Tag } from "fidesui";
 
 import { PRIVACY_NOTICE_REGION_RECORD } from "~/features/common/privacy-notice-regions";
 import { DefaultCell } from "~/features/common/table/v2";
@@ -62,7 +62,7 @@ const useSystemAssetColumns = ({
     }),
     columnHelper.display({
       id: "system",
-      cell: () => <AntTag color="white">{systemName}</AntTag>,
+      cell: () => <Tag color="white">{systemName}</Tag>,
       header: "System",
     }),
     columnHelper.accessor((row) => row.data_uses, {

--- a/clients/admin-ui/src/features/system/tabs/system-assets/useSystemAssetColumns.tsx
+++ b/clients/admin-ui/src/features/system/tabs/system-assets/useSystemAssetColumns.tsx
@@ -1,4 +1,5 @@
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { AntTag } from "fidesui";
 
 import { PRIVACY_NOTICE_REGION_RECORD } from "~/features/common/privacy-notice-regions";
 import { DefaultCell } from "~/features/common/table/v2";
@@ -14,9 +15,11 @@ import { Asset, PrivacyNoticeRegion } from "~/types/api";
 
 const useSystemAssetColumns = ({
   systemKey,
+  systemName,
   onEditClick,
 }: {
   systemKey: string;
+  systemName: string;
   onEditClick: (asset: Asset) => void;
 }) => {
   const columnHelper = createColumnHelper<Asset>();
@@ -57,10 +60,21 @@ const useSystemAssetColumns = ({
       cell: (props) => <DefaultCell value={props.getValue()} />,
       header: "Type",
     }),
+    columnHelper.display({
+      id: "system",
+      cell: () => <AntTag color="white">{systemName}</AntTag>,
+      header: "System",
+    }),
     columnHelper.accessor((row) => row.data_uses, {
       id: "data_uses",
-      cell: (props) => <SystemAssetsDataUseCell values={props.getValue()} />,
+      cell: (props) => (
+        <SystemAssetsDataUseCell
+          asset={props.row.original}
+          systemId={systemKey}
+        />
+      ),
       header: "Categories of consent",
+      size: 200,
     }),
     columnHelper.accessor((row) => row.locations, {
       id: "locations",
@@ -73,9 +87,7 @@ const useSystemAssetColumns = ({
         />
       ),
       header: "Locations",
-      meta: {
-        width: "auto",
-      },
+      size: 300,
     }),
     columnHelper.accessor((row) => row.domain, {
       id: "domain",


### PR DESCRIPTION
Closes HA-480

### Description Of Changes

Tweaks to system asset table.

* Can now update asset consent categories inline in the table
* Added explanatory copy to asset table
* Added "system" column to asset table (read-only for now)
* Fixes width of "location" column not to take up too much of the table on large screens

Also drive-by fixes for bulk actions on discovered assets, which were broken from the changes to `user_assigned_data_uses`.

### Steps to Confirm

1.  Populate some web monitor results
2. Add some assets to a system
3. View that system's "assets" tab in the system view
4. Should see "system" column
5. Should be able to edit (add, remove) assets' consent categories inline

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
