### PR TITLE
Disable bulk actions on action center 'Recent activity' tab

### DIFF
--- a/clients/admin-ui/cypress/e2e/action-center.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center.cy.ts
@@ -525,6 +525,7 @@ describe("Action center", () => {
         cy.wait(500);
         cy.getByTestId("tab-Recent activity").click({ force: true });
         cy.location("hash").should("eq", "#recent-activity");
+
         // "recent activity" tab should be read-only
         cy.getByTestId("bulk-actions-menu").should("be.disabled");
         cy.getByTestId("row-0-col-system").within(() => {
@@ -543,6 +544,12 @@ describe("Action center", () => {
         cy.wait(500);
         cy.getByTestId("tab-Ignored").click({ force: true });
         cy.location("hash").should("eq", "#ignored");
+        // "ignore" option should not show in bulk actions menu
+        cy.getByTestId("row-0-col-select").find("label").click();
+        cy.getByTestId("row-2-col-select").find("label").click();
+        cy.getByTestId("row-3-col-select").find("label").click();
+        cy.getByTestId("bulk_actions_menu").click();
+        cy.getByTestId("bulk-ignore").should("not.exist");
       });
     });
   });

--- a/clients/admin-ui/cypress/e2e/action-center.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center.cy.ts
@@ -514,7 +514,7 @@ describe("Action center", () => {
       );
     });
 
-    describe("tab navigation", () => {
+    describe.only("tab navigation", () => {
       it("updates URL hash when switching tabs", () => {
         cy.visit(
           `${ACTION_CENTER_ROUTE}/${webMonitorKey}/${systemId}#attention-required`,
@@ -548,7 +548,7 @@ describe("Action center", () => {
         cy.getByTestId("row-0-col-select").find("label").click();
         cy.getByTestId("row-2-col-select").find("label").click();
         cy.getByTestId("row-3-col-select").find("label").click();
-        cy.getByTestId("bulk_actions_menu").click();
+        cy.getByTestId("bulk-actions-menu").click();
         cy.getByTestId("bulk-ignore").should("not.exist");
       });
     });

--- a/clients/admin-ui/cypress/e2e/action-center.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center.cy.ts
@@ -526,6 +526,7 @@ describe("Action center", () => {
         cy.getByTestId("tab-Recent activity").click({ force: true });
         cy.location("hash").should("eq", "#recent-activity");
         // "recent activity" tab should be read-only
+        cy.getByTestId("bulk-actions-menu").should("be.disabled");
         cy.getByTestId("row-0-col-system").within(() => {
           cy.getByTestId("system-badge")
             .should("exist")
@@ -535,6 +536,7 @@ describe("Action center", () => {
         cy.getByTestId("row-0-col-data_use").within(() => {
           cy.getByTestId("taxonomy-add-btn").should("not.exist");
         });
+        cy.getByTestId("row-0-col-select").should("not.exist");
         cy.getByTestId("col-actions").should("not.exist");
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/clients/admin-ui/cypress/e2e/action-center.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center.cy.ts
@@ -514,7 +514,7 @@ describe("Action center", () => {
       );
     });
 
-    describe.only("tab navigation", () => {
+    describe("tab navigation", () => {
       it("updates URL hash when switching tabs", () => {
         cy.visit(
           `${ACTION_CENTER_ROUTE}/${webMonitorKey}/${systemId}#attention-required`,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsColumns.tsx
@@ -22,26 +22,7 @@ export const useDiscoveredAssetsColumns = ({
 }) => {
   const columnHelper = createColumnHelper<StagedResourceAPIResponse>();
 
-  const columns: ColumnDef<StagedResourceAPIResponse, any>[] = [
-    columnHelper.display({
-      id: "select",
-      cell: ({ row }) => (
-        <IndeterminateCheckboxCell
-          isChecked={row.getIsSelected()}
-          onChange={row.getToggleSelectedHandler()}
-          dataTestId={`select-${row.original.name || row.id}`}
-        />
-      ),
-      header: ({ table }) => (
-        <IndeterminateCheckboxCell
-          isChecked={table.getIsAllPageRowsSelected()}
-          isIndeterminate={table.getIsSomeRowsSelected()}
-          onChange={table.getToggleAllRowsSelectedHandler()}
-          dataTestId="select-all-rows"
-        />
-      ),
-      maxSize: 40,
-    }),
+  const readonlyColumns: ColumnDef<StagedResourceAPIResponse, any>[] = [
     columnHelper.accessor((row) => row.name, {
       id: "name",
       cell: (props) => <DefaultCell value={props.getValue()} />,
@@ -132,19 +113,42 @@ export const useDiscoveredAssetsColumns = ({
     }),
   ];
 
-  if (!readonly) {
-    columns.push(
-      columnHelper.display({
-        id: "actions",
-        cell: (props) => (
-          <DiscoveredAssetActionsCell asset={props.row.original} />
-        ),
-        header: "Actions",
-        meta: {
-          disableRowClick: true,
-        },
-      }),
-    );
+  if (readonly) {
+    return { columns: readonlyColumns };
   }
-  return { columns };
+
+  const editableColumns = [
+    columnHelper.display({
+      id: "select",
+      cell: ({ row }) => (
+        <IndeterminateCheckboxCell
+          isChecked={row.getIsSelected()}
+          onChange={row.getToggleSelectedHandler()}
+          dataTestId={`select-${row.original.name || row.id}`}
+        />
+      ),
+      header: ({ table }) => (
+        <IndeterminateCheckboxCell
+          isChecked={table.getIsAllPageRowsSelected()}
+          isIndeterminate={table.getIsSomeRowsSelected()}
+          onChange={table.getToggleAllRowsSelectedHandler()}
+          dataTestId="select-all-rows"
+        />
+      ),
+      maxSize: 40,
+    }),
+    ...readonlyColumns,
+    columnHelper.display({
+      id: "actions",
+      cell: (props) => (
+        <DiscoveredAssetActionsCell asset={props.row.original} />
+      ),
+      header: "Actions",
+      meta: {
+        disableRowClick: true,
+      },
+    }),
+  ];
+
+  return { columns: editableColumns };
 };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
@@ -132,8 +132,12 @@ export const DiscoveredAssetsTable = ({
     }
   }, [data, systemId, onSystemName, setTotalPages, systemName]);
 
+  const disableEditing = activeParams.diff_status.includes(
+    DiffStatus.MONITORED,
+  );
+
   const { columns } = useDiscoveredAssetsColumns({
-    readonly: activeParams.diff_status.includes(DiffStatus.MONITORED),
+    readonly: disableEditing,
   });
 
   const tableInstance = useReactTable({
@@ -293,7 +297,11 @@ export const DiscoveredAssetsTable = ({
                 iconPosition="end"
                 loading={anyBulkActionIsLoading}
                 data-testid="bulk-actions-menu"
-                disabled={!selectedUrns.length || anyBulkActionIsLoading}
+                disabled={
+                  !selectedUrns.length ||
+                  anyBulkActionIsLoading ||
+                  disableEditing
+                }
                 // @ts-ignore - `type` prop is for Ant button, not Chakra MenuButton
                 type="primary"
               >

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
@@ -331,14 +331,18 @@ export const DiscoveredAssetsTable = ({
                 >
                   Assign system
                 </MenuItem>
-                <MenuDivider />
-                <MenuItem
-                  fontSize="small"
-                  onClick={handleBulkIgnore}
-                  data-testid="bulk-ignore"
-                >
-                  Ignore
-                </MenuItem>
+                {!activeParams.diff_status.includes(DiffStatus.MUTED) && (
+                  <>
+                    <MenuDivider />
+                    <MenuItem
+                      fontSize="small"
+                      onClick={handleBulkIgnore}
+                      data-testid="bulk-ignore"
+                    >
+                      Ignore
+                    </MenuItem>
+                  </>
+                )}
               </MenuList>
             </Menu>
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetActionsCell.tsx
@@ -6,6 +6,7 @@ import {
 
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { useAlert } from "~/features/common/hooks";
+import { DiffStatus } from "~/types/api";
 import { StagedResourceAPIResponse } from "~/types/api/models/StagedResourceAPIResponse";
 
 import {
@@ -29,7 +30,8 @@ export const DiscoveredAssetActionsCell = ({
 
   const anyActionIsLoading = isAddingResults || isIgnoringResults;
 
-  const { urn, name, resource_type: type } = asset;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { urn, name, resource_type: type, diff_status } = asset;
 
   const handleAdd = async () => {
     const result = await addMonitorResultAssetsMutation({
@@ -79,15 +81,17 @@ export const DiscoveredAssetActionsCell = ({
           Add
         </Button>
       </Tooltip>
-      <Button
-        data-testid="ignore-btn"
-        size="small"
-        onClick={handleIgnore}
-        disabled={anyActionIsLoading}
-        loading={isIgnoringResults}
-      >
-        Ignore
-      </Button>
+      {diff_status !== DiffStatus.MUTED && (
+        <Button
+          data-testid="ignore-btn"
+          size="small"
+          onClick={handleIgnore}
+          disabled={anyActionIsLoading}
+          loading={isIgnoringResults}
+        >
+          Ignore
+        </Button>
+      )}
     </Space>
   );
 };


### PR DESCRIPTION
Closes HA-566

### Description Of Changes

Disables bulk resource actions on the "Recent activity" tab in the action center UI and removes checkbox column.

### Steps to Confirm

1. Populate some web monitor resources
2. Promote some resources
3. View "Recent activity" tab
4. Should see the resources you promoted in the table
5. Should not be able to edit inline
6. "Actions" menu should be disabled

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
