### PR TITLE
Disable 'reclassify' option on fields in D&D UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Fixed
 - Updated relationships for Comments, Attachments and PrivacyRequests to remove overlap sqlalchemy error. [#5929](https://github.com/ethyca/fides/pull/5929)
+- Hide "Reclassify" option on fields in D&D tables [#5956](https://github.com/ethyca/fides/pull/5956)
 
 ### Removed
 - Removed datasetClassificationUpdates flag from admin UI. [#5950](https://github.com/ethyca/fides/pull/5950)

--- a/clients/admin-ui/cypress/e2e/discovery-detection.cy.ts
+++ b/clients/admin-ui/cypress/e2e/discovery-detection.cy.ts
@@ -444,6 +444,14 @@ describe("discovery and detection", () => {
           cy.getByTestId("taxonomy-add-btn").should("not.exist");
         });
       });
+
+      it("doesn't allow reclassifying fields", () => {
+        cy.getByTestId(
+          "row-my_bigquery_monitor.prj-bigquery-418515.test_dataset_1.consent-reports-20.address-col-actions",
+        ).within(() => {
+          cy.getByTestId("action-reclassify").should("not.exist");
+        });
+      });
     });
 
     describe("nested-field-level view", () => {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DiscoveryItemActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DiscoveryItemActionsCell.tsx
@@ -14,8 +14,9 @@ import {
 
 import { useAlert } from "~/features/common/hooks";
 import { DiscoveryMonitorItem } from "~/features/data-discovery-and-detection/types/DiscoveryMonitorItem";
+import { findResourceType } from "~/features/data-discovery-and-detection/utils/findResourceType";
 import getResourceName from "~/features/data-discovery-and-detection/utils/getResourceName";
-import { DiffStatus } from "~/types/api";
+import { DiffStatus, StagedResourceTypeValue } from "~/types/api";
 
 import ActionButton from "../../ActionButton";
 import {
@@ -66,9 +67,13 @@ const DiscoveryItemActionsCell = ({ resource }: DiscoveryItemActionsProps) => {
   const showMuteAction =
     itemHasClassificationChanges || childItemsHaveClassificationChanges;
 
+  const showReclassifyAction =
+    findResourceType(resource) !== StagedResourceTypeValue.FIELD;
+
   // if promote and mute are both shown, show "Reclassify" in an overflow menu
   // to avoid having too many buttons in the cell
-  const showReclassifyInOverflow = showPromoteAction && showMuteAction;
+  const showReclassifyInOverflow =
+    showPromoteAction && showMuteAction && showReclassifyAction;
 
   const handlePromote = async () => {
     await promoteResourceMutation({
@@ -123,7 +128,7 @@ const DiscoveryItemActionsCell = ({ resource }: DiscoveryItemActionsProps) => {
           loading={muteIsLoading}
         />
       )}
-      {!showReclassifyInOverflow && (
+      {showReclassifyAction && !showReclassifyInOverflow && (
         <ActionButton
           title="Reclassify"
           icon={<RepeatIcon />}
@@ -132,29 +137,31 @@ const DiscoveryItemActionsCell = ({ resource }: DiscoveryItemActionsProps) => {
           loading={confirmIsLoading}
         />
       )}
-      <Spacer />
       {showReclassifyInOverflow && (
-        <Menu>
-          <MenuButton
-            as={Button}
-            size="small"
-            // TS expects Chakra's type prop (HTML type) but we want to assign the Ant type
-            // @ts-ignore
-            type="text"
-            icon={<MoreIcon transform="rotate(90deg)" />}
-            className="w-6 gap-0"
-            data-testid="actions-overflow-btn"
-          />
-          <MenuList>
-            <MenuItem
-              onClick={handleReclassify}
-              icon={<RepeatIcon />}
-              data-testid="action-reclassify"
-            >
-              Reclassify
-            </MenuItem>
-          </MenuList>
-        </Menu>
+        <>
+          <Spacer />
+          <Menu>
+            <MenuButton
+              as={Button}
+              size="small"
+              // TS expects Chakra's type prop (HTML type) but we want to assign the Ant type
+              // @ts-ignore
+              type="text"
+              icon={<MoreIcon transform="rotate(90deg)" />}
+              className="w-6 gap-0"
+              data-testid="actions-overflow-btn"
+            />
+            <MenuList>
+              <MenuItem
+                onClick={handleReclassify}
+                icon={<RepeatIcon />}
+                data-testid="action-reclassify"
+              >
+                Reclassify
+              </MenuItem>
+            </MenuList>
+          </Menu>
+        </>
       )}
     </HStack>
   );


### PR DESCRIPTION
Closes HA-565

### Description Of Changes

Removes option to reclassify fields from data discovery result tables.

### Steps to Confirm

1. Populate D&D results
2. Send some results to classification and wait for it to complete
3. View a table-level field; should see option to reclassify in "Actions" cell
4. View a field-level field; should not see option to reclassify

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
