### PR TITLE
Lj 609 sanitization allow link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Added
 - Added `reject_all_mechanism` to `PrivacyExperienceConfig` [#5952](https://github.com/ethyca/fides/pull/5952) https://github.com/ethyca/fides/labels/db-migration
 - Added DataHub dataset sync functionality UI with feedback and error handling [#5949](https://github.com/ethyca/fides/pull/5949)
+- Added support for links in `<a>` tags on the custom HTML description [#5960](https://github.com/ethyca/fides/pull/5960)
 
 ### Changed
 - Bumped Next.js for all frontend apps to latest patch versions. [#5946](https://github.com/ethyca/fides/pull/5946)

--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -68,7 +68,7 @@ def validate_html_str(val: str) -> str:
     }
 
     ALLOWED_ATTRIBUTES = {
-        "a": ["href", "target"],
+        "a": {"href", "target"},
     }
 
     if val:

--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -66,8 +66,13 @@ def validate_html_str(val: str) -> str:
         "strong",
         "u",
     }
+
+    ALLOWED_ATTRIBUTES = {
+        "a": ["href", "target"],
+    }
+
     if val:
-        return clean(val, tags=ALLOWED_HTML_TAGS)
+        return clean(val, tags=ALLOWED_HTML_TAGS, attributes=ALLOWED_ATTRIBUTES)
     return val
 
 

--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -68,7 +68,7 @@ def validate_html_str(val: str) -> str:
     }
 
     ALLOWED_ATTRIBUTES = {
-        "a": {"href", "target"},
+        "a": {"href", "hreflang", "target"},
     }
 
     if val:

--- a/tests/api/v1/endpoints/test_html_sanitization.py
+++ b/tests/api/v1/endpoints/test_html_sanitization.py
@@ -45,7 +45,6 @@ def test_html_sanitization_blocks_script_tags_injections():
 
     assert sanitized == expected
 
-
 def test_html_sanitization_blocks_javascript_url_injections():
     """Test that the validate_html_str function blocks javascript url injections"""
 
@@ -65,5 +64,27 @@ def test_html_sanitization_blocks_form_injections():
     sanitized = validate_html_str(test_html)
 
     expected = 'See our <a href="https://www.somerandomwebsite.com/cookies/" target="_blank" rel="noopener noreferrer">privacy policy</a>'
+
+    assert sanitized == expected
+
+def test_html_sanitization_blocks_img_onalert_injections():
+    """Test that the validate_html_str function blocks img onalert injections"""
+
+    test_html = 'See our <img src=x:alert(alt) onerror=eval(src) alt=xss>Cookie policy'
+
+    sanitized = validate_html_str(test_html)
+
+    expected = 'See our Cookie policy'
+
+    assert sanitized == expected
+
+def test_html_sanitization_blocks_div_with_onclick_injection():
+    """Test that the validate_html_str function blocks div with onclick injection"""
+
+    test_html = 'See our <div onclick="alert(\'XSS\')">privacy policy</div>'
+
+    sanitized = validate_html_str(test_html)
+
+    expected = 'See our <div>privacy policy</div>'
 
     assert sanitized == expected

--- a/tests/api/v1/endpoints/test_html_sanitization.py
+++ b/tests/api/v1/endpoints/test_html_sanitization.py
@@ -1,0 +1,21 @@
+
+#!/usr/bin/env python3
+"""
+Final test to understand NH3's handling of link attributes.
+Testing with different attribute combinations to find what's allowed.
+"""
+
+from src.fides.api.custom_types import validate_html_str
+
+
+
+def test_html_sanitization():
+    """Test that the validate_html_str function sanitizes the HTML string correctly, keeping the target attribute"""
+
+    test_html = 'See our <a href="https://www.somerandomwebsite.com/cookies/" target="_blank">privacy policy</a>'
+
+    sanitized = validate_html_str(test_html)
+
+    expected = 'See our <a href="https://www.somerandomwebsite.com/cookies/" target="_blank" rel="noopener noreferrer">privacy policy</a>'
+
+    assert sanitized == expected

--- a/tests/api/v1/endpoints/test_html_sanitization.py
+++ b/tests/api/v1/endpoints/test_html_sanitization.py
@@ -12,6 +12,7 @@ def test_html_sanitization_with_target_attribute():
 
     assert sanitized == expected
 
+
 def test_html_sanitization_with_hreflang_attribute():
     """Test that the validate_html_str function sanitizes the HTML string correctly, keeping the hreflang attribute"""
 
@@ -22,6 +23,7 @@ def test_html_sanitization_with_hreflang_attribute():
     expected = 'See our <a href="https://www.somerandomwebsite.com/cookies/" hreflang="en" rel="noopener noreferrer">privacy policy</a>'
 
     assert sanitized == expected
+
 
 def test_html_sanitization_blocks_event_handler_injections():
     """Test that the validate_html_str function blocks script injection"""
@@ -34,6 +36,7 @@ def test_html_sanitization_blocks_event_handler_injections():
 
     assert sanitized == expected
 
+
 def test_html_sanitization_blocks_script_tags_injections():
     """Test that the validate_html_str function blocks script tag injections"""
 
@@ -45,16 +48,18 @@ def test_html_sanitization_blocks_script_tags_injections():
 
     assert sanitized == expected
 
+
 def test_html_sanitization_blocks_javascript_url_injections():
     """Test that the validate_html_str function blocks javascript url injections"""
 
-    test_html = 'See our <a href="javascript:alert(\'XSS\')">privacy policy</a>'
+    test_html = "See our <a href=\"javascript:alert('XSS')\">privacy policy</a>"
 
     sanitized = validate_html_str(test_html)
 
     expected = 'See our <a rel="noopener noreferrer">privacy policy</a>'
 
     assert sanitized == expected
+
 
 def test_html_sanitization_blocks_form_injections():
     """Test that the validate_html_str function blocks form injections"""
@@ -67,24 +72,26 @@ def test_html_sanitization_blocks_form_injections():
 
     assert sanitized == expected
 
+
 def test_html_sanitization_blocks_img_onalert_injections():
     """Test that the validate_html_str function blocks img onalert injections"""
 
-    test_html = 'See our <img src=x:alert(alt) onerror=eval(src) alt=xss>Cookie policy'
+    test_html = "See our <img src=x:alert(alt) onerror=eval(src) alt=xss>Cookie policy"
 
     sanitized = validate_html_str(test_html)
 
-    expected = 'See our Cookie policy'
+    expected = "See our Cookie policy"
 
     assert sanitized == expected
+
 
 def test_html_sanitization_blocks_div_with_onclick_injection():
     """Test that the validate_html_str function blocks div with onclick injection"""
 
-    test_html = 'See our <div onclick="alert(\'XSS\')">privacy policy</div>'
+    test_html = "See our <div onclick=\"alert('XSS')\">privacy policy</div>"
 
     sanitized = validate_html_str(test_html)
 
-    expected = 'See our <div>privacy policy</div>'
+    expected = "See our <div>privacy policy</div>"
 
     assert sanitized == expected

--- a/tests/api/v1/endpoints/test_html_sanitization.py
+++ b/tests/api/v1/endpoints/test_html_sanitization.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 """
 Final test to understand NH3's handling of link attributes.
@@ -6,7 +5,6 @@ Testing with different attribute combinations to find what's allowed.
 """
 
 from src.fides.api.custom_types import validate_html_str
-
 
 
 def test_html_sanitization():

--- a/tests/api/v1/endpoints/test_html_sanitization.py
+++ b/tests/api/v1/endpoints/test_html_sanitization.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python3
-"""
-Final test to understand NH3's handling of link attributes.
-Testing with different attribute combinations to find what's allowed.
-"""
-
 from src.fides.api.custom_types import validate_html_str
 
 

--- a/tests/api/v1/endpoints/test_html_sanitization.py
+++ b/tests/api/v1/endpoints/test_html_sanitization.py
@@ -1,10 +1,66 @@
 from src.fides.api.custom_types import validate_html_str
 
 
-def test_html_sanitization():
+def test_html_sanitization_with_target_attribute():
     """Test that the validate_html_str function sanitizes the HTML string correctly, keeping the target attribute"""
 
     test_html = 'See our <a href="https://www.somerandomwebsite.com/cookies/" target="_blank">privacy policy</a>'
+
+    sanitized = validate_html_str(test_html)
+
+    expected = 'See our <a href="https://www.somerandomwebsite.com/cookies/" target="_blank" rel="noopener noreferrer">privacy policy</a>'
+
+    assert sanitized == expected
+
+def test_html_sanitization_with_hreflang_attribute():
+    """Test that the validate_html_str function sanitizes the HTML string correctly, keeping the hreflang attribute"""
+
+    test_html = 'See our <a href="https://www.somerandomwebsite.com/cookies/" hreflang="en" >privacy policy</a>'
+
+    sanitized = validate_html_str(test_html)
+
+    expected = 'See our <a href="https://www.somerandomwebsite.com/cookies/" hreflang="en" rel="noopener noreferrer">privacy policy</a>'
+
+    assert sanitized == expected
+
+def test_html_sanitization_blocks_event_handler_injections():
+    """Test that the validate_html_str function blocks script injection"""
+
+    test_html = 'See our <a href="https://www.somerandomwebsite.com/cookies/" onclick="alert(\'XSS\')">privacy policy</a>'
+
+    sanitized = validate_html_str(test_html)
+
+    expected = 'See our <a href="https://www.somerandomwebsite.com/cookies/" rel="noopener noreferrer">privacy policy</a>'
+
+    assert sanitized == expected
+
+def test_html_sanitization_blocks_script_tags_injections():
+    """Test that the validate_html_str function blocks script tag injections"""
+
+    test_html = 'See our <a href="https://www.somerandomwebsite.com/cookies/" target="_blank"><script>alert("xss")</script>privacy policy</a> here.'
+
+    sanitized = validate_html_str(test_html)
+
+    expected = 'See our <a href="https://www.somerandomwebsite.com/cookies/" target="_blank" rel="noopener noreferrer">privacy policy</a> here.'
+
+    assert sanitized == expected
+
+
+def test_html_sanitization_blocks_javascript_url_injections():
+    """Test that the validate_html_str function blocks javascript url injections"""
+
+    test_html = 'See our <a href="javascript:alert(\'XSS\')">privacy policy</a>'
+
+    sanitized = validate_html_str(test_html)
+
+    expected = 'See our <a rel="noopener noreferrer">privacy policy</a>'
+
+    assert sanitized == expected
+
+def test_html_sanitization_blocks_form_injections():
+    """Test that the validate_html_str function blocks form injections"""
+
+    test_html = 'See our <a href="https://www.somerandomwebsite.com/cookies/" target="_blank">privacy policy</a><form action="https://www.amaliciouswebsite.com/hacking/" method="post"><input type="hidden" name="hackingstuff" value="somerandomvalue">'
 
     sanitized = validate_html_str(test_html)
 


### PR DESCRIPTION
Closes [LJ 607 ](https://ethyca.atlassian.net/browse/LJ-607)/ [LJ 609](https://ethyca.atlassian.net/browse/LJ-609) (Duplicated)

### Description Of Changes

During HTML rendering of custom templates, we've found that we are removing the target link and href pages, due to nh3 sanitization. We have to allow these attributes in for links

### Code Changes

Updating the custom_types.py  validation to include allowed atributes on the <a> level

### Steps to Confirm

* Set up the  FIDES_PRIVACY_CENTER__ALLOW_HTML_DESCRIPTION=true env variable 
* Create a custom html modal with an <a> tag and link and href attrbiutes 
* see that they are rendered appropiately

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
