### PR TITLE
Reject All Options in TCF Experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added `reject_all_mechanism` to `PrivacyExperienceConfig` [#5952](https://github.com/ethyca/fides/pull/5952) https://github.com/ethyca/fides/labels/db-migration
 - Added DataHub dataset sync functionality UI with feedback and error handling [#5949](https://github.com/ethyca/fides/pull/5949)
 - Added `opt_in_only` to `Layer1ButtonOption` [#5958](https://github.com/ethyca/fides/pull/5958)
+- Added "Reject all" behavior and visibility options to TCF Experience config form [#5964](https://github.com/ethyca/fides/pull/5964)
 
 ### Changed
 - Bumped Next.js for all frontend apps to latest patch versions. [#5946](https://github.com/ethyca/fides/pull/5946)

--- a/clients/admin-ui/src/features/privacy-experience/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/Preview.tsx
@@ -151,9 +151,11 @@ const Preview = ({
     baseConfig.experience.experience_config.show_layer1_notices =
       !!values.privacy_notice_ids?.length && !!values.show_layer1_notices;
     baseConfig.experience.experience_config.layer1_button_options =
-      (values.component === ComponentType.BANNER_AND_MODAL &&
-        values.layer1_button_options) ||
-      Layer1ButtonOption.OPT_IN_OPT_OUT;
+      (values.component === ComponentType.BANNER_AND_MODAL ||
+        values.component === ComponentType.TCF_OVERLAY) &&
+      values.layer1_button_options
+        ? values.layer1_button_options
+        : Layer1ButtonOption.OPT_IN_OPT_OUT;
     baseConfig.options.preventDismissal = !values.dismissable;
     if (
       window.Fides &&

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -44,6 +44,7 @@ import {
   Layer1ButtonOption,
   LimitedPrivacyNoticeResponseSchema,
   Property,
+  RejectAllMechanism,
   SupportedLanguage,
 } from "~/types/api";
 
@@ -68,7 +69,29 @@ const componentTypeOptions: SelectProps["options"] = [
   },
 ];
 
-const buttonLayoutOptions: SelectProps["options"] = [
+const tcfRejectAllMechanismOptions: SelectProps["options"] = [
+  {
+    label: "Reject All",
+    value: RejectAllMechanism.REJECT_ALL,
+  },
+  {
+    label: "Reject Consent Only",
+    value: RejectAllMechanism.REJECT_CONSENT_ONLY,
+  },
+];
+
+const tcfBannerButtonOptions: SelectProps["options"] = [
+  {
+    label: "Banner and modal",
+    value: Layer1ButtonOption.OPT_IN_OPT_OUT,
+  },
+  {
+    label: "Modal only",
+    value: Layer1ButtonOption.OPT_IN_ONLY,
+  },
+];
+
+const bannerButtonOptions: SelectProps["options"] = [
   {
     label: "Opt In/Opt Out",
     value: Layer1ButtonOption.OPT_IN_OPT_OUT,
@@ -222,6 +245,49 @@ export const PrivacyExperienceForm = ({
         />
       )}
       <Collapse
+        in={values.component === ComponentType.TCF_OVERLAY}
+        animateOpacity
+      >
+        <ControlledSelect
+          name="reject_all_mechanism"
+          id="reject_all_mechanism"
+          options={tcfRejectAllMechanismOptions}
+          defaultValue={RejectAllMechanism.REJECT_ALL}
+          label="Reject all behavior"
+          layout="stacked"
+          disabled={values.component !== ComponentType.TCF_OVERLAY}
+          tooltip="Reject All: Blocks both consent and legitimate interest data processing across all purposes, features, and vendors. Reject Consent-Only: Blocks only consent-based processing, but allows legitimate interest processing to continue, requiring separate objection."
+        />
+      </Collapse>
+      <Collapse
+        in={
+          values.component === ComponentType.BANNER_AND_MODAL ||
+          values.component === ComponentType.TCF_OVERLAY
+        }
+        animateOpacity
+      >
+        <ControlledSelect
+          name="layer1_button_options"
+          id="layer1_button_options"
+          defaultValue={Layer1ButtonOption.OPT_IN_OPT_OUT}
+          options={
+            values.component === ComponentType.TCF_OVERLAY
+              ? tcfBannerButtonOptions
+              : bannerButtonOptions
+          }
+          label={
+            values.component === ComponentType.TCF_OVERLAY
+              ? "Reject all visibility"
+              : "Banner options"
+          }
+          layout="stacked"
+          disabled={
+            values.component !== ComponentType.BANNER_AND_MODAL &&
+            values.component !== ComponentType.TCF_OVERLAY
+          }
+        />
+      </Collapse>
+      <Collapse
         in={
           values.component !== ComponentType.PRIVACY_CENTER &&
           values.component !== ComponentType.HEADLESS
@@ -237,34 +303,6 @@ export const PrivacyExperienceForm = ({
           />
         </Box>
       </Collapse>
-      <Collapse
-        in={values.component === ComponentType.BANNER_AND_MODAL}
-        animateOpacity
-      >
-        <ControlledSelect
-          name="layer1_button_options"
-          id="layer1_button_options"
-          options={buttonLayoutOptions}
-          label="Banner options"
-          layout="stacked"
-          disabled={values.component !== ComponentType.BANNER_AND_MODAL}
-        />
-      </Collapse>
-      <ScrollableList
-        label="Associated properties"
-        addButtonLabel="Add property"
-        idField="id"
-        nameField="name"
-        allItems={allProperties.map((property: Property) => ({
-          id: property.id,
-          name: property.name,
-        }))}
-        values={values.properties ?? []}
-        setValues={(newValues) => setFieldValue("properties", newValues)}
-        draggable
-        maxHeight={100}
-        baseTestId="property"
-      />
       <Divider />
       <Heading fontSize="md" fontWeight="semibold">
         Privacy notices
@@ -277,7 +315,6 @@ export const PrivacyExperienceForm = ({
           setValues={(newValues) =>
             setFieldValue("privacy_notice_ids", newValues)
           }
-          // @ts-ignore
           canDeleteItem={(item: string): boolean => {
             return Boolean(item !== TCF_PLACEHOLDER_ID);
           }}
@@ -376,6 +413,26 @@ export const PrivacyExperienceForm = ({
           Edit experience text
         </Button>
       )}
+      <Divider />
+      <Heading fontSize="md" fontWeight="semibold">
+        Properties
+      </Heading>
+      <ScrollableList
+        label="Associated properties"
+        addButtonLabel="Add property"
+        idField="id"
+        nameField="name"
+        allItems={allProperties.map((property: Property) => ({
+          id: property.id,
+          name: property.name,
+        }))}
+        values={values.properties ?? []}
+        setValues={(newValues) => setFieldValue("properties", newValues)}
+        draggable
+        maxHeight={100}
+        baseTestId="property"
+      />
+      <Divider />
       <CustomSwitch
         name="auto_subdomain_cookie_deletion"
         id="auto_subdomain_cookie_deletion"

--- a/clients/fides-js/__tests__/__fixtures__/mock_experience.json
+++ b/clients/fides-js/__tests__/__fixtures__/mock_experience.json
@@ -16,6 +16,7 @@
     "dismissable": true,
     "show_layer1_notices": false,
     "layer1_button_options": "opt_in_opt_out",
+    "reject_all_mechanism": "reject_all",
     "allow_language_selection": true,
     "auto_detect_language": true,
     "auto_subdomain_cookie_deletion": true,

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -910,10 +910,11 @@ describe("i18n-utils", () => {
       component: string;
       experience_config: Omit<
         ExperienceConfig,
-        "component" | "layer1_button_options"
+        "component" | "layer1_button_options" | "reject_all_mechanism"
       > & {
         component: string;
         layer1_button_options: string;
+        reject_all_mechanism: string;
       };
       privacy_notices: Array<
         Omit<

--- a/clients/fides-js/docs/interfaces/FidesExperienceConfig.md
+++ b/clients/fides-js/docs/interfaces/FidesExperienceConfig.md
@@ -66,7 +66,7 @@ distinguish it from other experiences.
 
 This property corresponds with the "Banner options" in the Banner
 and Modal components. This helps determine which buttons are visible
-on the banner presented to the user. (e.g. `"acknowledge"` or `"opt_in_opt_out"`)
+on the banner presented to the user. (e.g. `"acknowledge"`, `"opt_in_opt_out"`, or `"opt_in_only" (TCF)`)
 
 ***
 
@@ -106,3 +106,12 @@ On Banner and Modal components, this option corresponds to the "Add privacy noti
 > **translations**: `Record`\<`string`, `any`\>[]
 
 List of all available translations for the current experience.
+
+***
+
+### reject\_all\_mechanism
+
+> **reject\_all\_mechanism**: `string`
+
+This corresponds with the "Reject all mechanism" configuration option for TCF overlay experiences.
+Determines whether opting out of all purposes blocks everything (both consent and legitimate interest processing) or only blocks consent-based processing while allowing legitimate interest to continue.

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -24,6 +24,7 @@ interface ConsentButtonProps {
   onRejectAll: () => void;
   options: FidesInitOptions;
   hideOptInOut?: boolean;
+  hideRejectAll?: boolean;
   isInModal?: boolean;
   isTCF?: boolean;
   isMinimalTCF?: boolean;
@@ -35,7 +36,8 @@ export const ConsentButtons = ({
   renderFirstButton,
   onAcceptAll,
   onRejectAll,
-  hideOptInOut = false,
+  hideOptInOut,
+  hideRejectAll,
   options,
   isInModal,
   isTCF,
@@ -86,13 +88,15 @@ export const ConsentButtons = ({
                 loading={isLoadingModal}
               />
             )}
-            <Button
-              buttonType={ButtonType.PRIMARY}
-              label={i18n.t("exp.reject_button_label")}
-              onClick={onRejectAll}
-              className="fides-reject-all-button"
-              loading={isGVLLoading}
-            />
+            {!hideRejectAll && (
+              <Button
+                buttonType={ButtonType.PRIMARY}
+                label={i18n.t("exp.reject_button_label")}
+                onClick={onRejectAll}
+                className="fides-reject-all-button"
+                loading={isGVLLoading}
+              />
+            )}
             <Button
               buttonType={ButtonType.PRIMARY}
               label={i18n.t("exp.accept_button_label")}

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -2,6 +2,7 @@ import { h, VNode } from "preact";
 
 import {
   FidesInitOptions,
+  Layer1ButtonOption,
   PrivacyExperience,
   PrivacyExperienceMinimal,
 } from "../../lib/consent-types";
@@ -40,6 +41,11 @@ export const TcfConsentButtons = ({
       onRejectAll={onRejectAll}
       renderFirstButton={renderFirstButton}
       isInModal={isInModal}
+      hideRejectAll={
+        !isInModal &&
+        experience.experience_config.layer1_button_options ===
+          Layer1ButtonOption.OPT_IN_ONLY
+      }
       options={options}
       isTCF
       isMinimalTCF={experience.minimal_tcf}

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -13,6 +13,7 @@ import {
   PrivacyExperience,
   PrivacyExperienceMinimal,
   PrivacyNoticeWithPreference,
+  RejectAllMechanism,
   ServingComponent,
 } from "../../lib/consent-types";
 import {
@@ -460,12 +461,29 @@ export const TcfOverlay = ({
             );
           })
           .map((n) => n.id) ?? EMPTY_ENABLED_IDS;
+      if (
+        experience?.experience_config?.reject_all_mechanism ===
+        RejectAllMechanism.REJECT_CONSENT_ONLY
+      ) {
+        // Do not reject legitimate interests if the reject all mechanism is set to "Reject Consent Only"
+        enabledIds.purposesLegint = draftIds.purposesLegint;
+        fidesDebugger(
+          "Reject all mechanism is set to 'Reject Consent Only'. Ignoring legitimate interests during opt out.",
+          enabledIds,
+          draftIds,
+        );
+      }
       handleUpdateAllPreferences(
         wasAutomated ? ConsentMethod.SCRIPT : ConsentMethod.REJECT,
         enabledIds,
       );
     },
-    [draftIds, handleUpdateAllPreferences, privacyNoticesWithBestTranslation],
+    [
+      draftIds,
+      experience?.experience_config?.reject_all_mechanism,
+      handleUpdateAllPreferences,
+      privacyNoticesWithBestTranslation,
+    ],
   );
 
   useEffect(() => {

--- a/clients/fides-js/src/docs/fides-experience-config.ts
+++ b/clients/fides-js/src/docs/fides-experience-config.ts
@@ -47,7 +47,7 @@ export interface FidesExperienceConfig {
   /**
    * This property corresponds with the "Banner options" in the Banner
    * and Modal components. This helps determine which buttons are visible
-   * on the banner presented to the user. (e.g. `"acknowledge"` or `"opt_in_opt_out"`)
+   * on the banner presented to the user. (e.g. `"acknowledge"`, `"opt_in_opt_out"`, or `"opt_in_only" (TCF)`)
    */
   layer1_button_options?: string;
 
@@ -75,6 +75,12 @@ export interface FidesExperienceConfig {
    * List of all available translations for the current experience.
    */
   translations: Array<Record<string, any>>;
+
+  /**
+   * This corresponds with the "Reject all mechanism" configuration option for TCF overlay experiences.
+   * Determines whether opting out of all purposes blocks everything (both consent and legitimate interest processing) or only blocks consent-based processing while allowing legitimate interest to continue.
+   */
+  reject_all_mechanism: string;
 
   /**
    * @internal

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -483,6 +483,7 @@ export interface ExperienceConfigMinimal
     | "auto_detect_language"
     | "dismissable"
     | "auto_subdomain_cookie_deletion"
+    | "layer1_button_options"
   > {
   translations: ExperienceConfigTranslationMinimal[];
 }
@@ -761,6 +762,7 @@ export enum Layer1ButtonOption {
   // defines the buttons to show in the layer 1 banner
   ACKNOWLEDGE = "acknowledge", // show acknowledge button
   OPT_IN_OPT_OUT = "opt_in_opt_out", // show opt in and opt out buttons
+  OPT_IN_ONLY = "opt_in_only", // TCF only, hide opt out button
 }
 
 export enum ConsentMethod {

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -484,6 +484,7 @@ export interface ExperienceConfigMinimal
     | "dismissable"
     | "auto_subdomain_cookie_deletion"
     | "layer1_button_options"
+    | "reject_all_mechanism"
   > {
   translations: ExperienceConfigTranslationMinimal[];
 }
@@ -763,6 +764,12 @@ export enum Layer1ButtonOption {
   ACKNOWLEDGE = "acknowledge", // show acknowledge button
   OPT_IN_OPT_OUT = "opt_in_opt_out", // show opt in and opt out buttons
   OPT_IN_ONLY = "opt_in_only", // TCF only, hide opt out button
+}
+
+export enum RejectAllMechanism {
+  // Applies to TCF only
+  REJECT_ALL = "reject_all", // reject all purposes and legitimate interests
+  REJECT_CONSENT_ONLY = "reject_consent_only", // do not reject legitimate interests
 }
 
 export enum ConsentMethod {

--- a/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
+++ b/clients/privacy-center/types/api/models/ExperienceConfigResponseNoNotices.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import { RejectAllMechanism } from "./RejectAllMechanism";
 import type { ComponentType } from "./ComponentType";
 import type { ExperienceTranslationResponse } from "./ExperienceTranslationResponse";
 import type { Layer1ButtonOption } from "./Layer1ButtonOption";
@@ -29,4 +30,5 @@ export type ExperienceConfigResponseNoNotices = {
   component: ComponentType;
   translations?: Array<ExperienceTranslationResponse>;
   properties?: Array<MinimalProperty>;
+  reject_all_mechanism?: RejectAllMechanism | null;
 };

--- a/clients/privacy-center/types/api/models/Layer1ButtonOption.ts
+++ b/clients/privacy-center/types/api/models/Layer1ButtonOption.ts
@@ -8,4 +8,5 @@
 export enum Layer1ButtonOption {
   ACKNOWLEDGE = "acknowledge",
   OPT_IN_OPT_OUT = "opt_in_opt_out",
+  OPT_IN_ONLY = "opt_in_only",
 }

--- a/clients/privacy-center/types/api/models/RejectAllMechanism.ts
+++ b/clients/privacy-center/types/api/models/RejectAllMechanism.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Reject all mechanism options - not formalized in the db.
+ * Used to configure the behavior of the reject all button in TCF experiences
+ */
+export enum RejectAllMechanism {
+  REJECT_ALL = "reject_all",
+  REJECT_CONSENT_ONLY = "reject_consent_only",
+}


### PR DESCRIPTION
Closes [LJ-502], [LJ-592]

### Description Of Changes
This PR implements two key TCF-related features:
1. Control over the "Reject All" mechanism behavior for TCF experiences
2. Control over the visibility of the "Reject All" button between Layer 1 (banner) and Layer 2 (modal)

### Code Changes
* Modified `PrivacyExperienceForm` to add:
  * New "Reject all behavior" dropdown for TCF experiences
  * Separate button layout options for TCF vs regular banner experiences
  * Tooltips explaining the reject mechanism behavior
* Updated `TcfConsentButtons` to conditionally hide reject button based on `layer1_button_options`
* Modified preview configuration to properly handle TCF button options (when TCF Preview gets implemented)
* Updated type definitions to support new configuration options

### Steps to Confirm
1. Create or edit a TCF experience in Admin UI
2. Verify the new "Reject all behavior" dropdown appears with options:
   * "Reject All" - rejects both consent and legitimate interest
   * "Reject Consent Only" - only rejects consent preferences
3. Verify the "Banner options" dropdown for TCF experiences shows:
   * "Banner and modal" - shows reject button in both layers
   * "Modal only" - hides reject button in Layer 1, shows in Layer 2
5. Confirm the reject button visibility matches the selected banner option
6. When Reject All Behavior is set to "Reject Consent Only":
  - Open the TCF modal, and change tabs to Legitimate Interest. Note that all are enabled by default.
  - Click "Opt out of all"
  - Re-open the modal without clearing cookies by clicking the manage preferences link on the demo page
  - Confirm that Legitimate Interests are all still enabled, only the Consent Purposes were rejected.


### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [x] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [x] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-502]: https://ethyca.atlassian.net/browse/LJ-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LJ-592]: https://ethyca.atlassian.net/browse/LJ-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ