### PR TITLE
Add unit test for rule target creation

### DIFF
--- a/tests/ops/api/v1/endpoints/test_policy_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_policy_endpoints.py
@@ -1286,6 +1286,29 @@ class TestRuleTargets:
         response_data = resp.json()["succeeded"]
         assert len(response_data) == 2
 
+    def test_create_rule_targets_with_invalid_rule_key(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        policy,
+    ):
+        """
+        Test that creating rule targets with an invalid rule key returns a 404
+        """
+        data = []
+        auth_header = generate_auth_header(scopes=[scopes.RULE_CREATE_OR_UPDATE])
+        resp = api_client.patch(
+            self.get_rule_url(policy.key, "invalid_rule_key"),
+            json=data,
+            headers=auth_header,
+        )
+
+        assert resp.status_code == 404
+        assert (
+            resp.json()["detail"]
+            == "No Rule found for key invalid_rule_key on Policy example_access_request_policy."
+        )
+
     def test_create_rule_targets_as_root(
         self,
         api_client: TestClient,


### PR DESCRIPTION
There is no ticket.

### Description Of Changes

Add a unit test to the rule target creation endpoint for the case where the rule key is invalid and the endpoint returns a 404 error.

The coverage percentage did not change much, but the lines that were missing coverage when returning 404 were covered.
![Screenshot 2025-04-01 at 12 01 15 PM](https://github.com/user-attachments/assets/e82f65f9-8eb9-4c2d-b8b0-dcb8966a17c1)
![Screenshot 2025-04-01 at 12 00 21 PM](https://github.com/user-attachments/assets/8d2930c4-fb9f-4a60-8de1-c2ac10bb6092)
![Screenshot 2025-04-01 at 12 02 45 PM](https://github.com/user-attachments/assets/7f6733a8-178f-4177-8693-08803b8fa092)
![Screenshot 2025-04-01 at 11 59 58 AM](https://github.com/user-attachments/assets/8754509a-220a-4849-9459-2d11ec2c6d18)



### Code Changes

- Create `test_create_rule_targets_with_invalid_rule_key`

### Steps to Confirm

1.  Run `nox -s dev -- shell`
2. Once in the terminal run `pytest tests/ops/api/v1/endpoints/ test_policy_endpoints.py::TestRuleTargets::test_create_rule_targets_with_invalid_rule_key`

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
