### PR TITLE
Fix: Do not resurface dismissed banner

### DIFF
--- a/clients/fides-js/__tests__/lib/consent-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/consent-utils.test.ts
@@ -372,7 +372,7 @@ describe("shouldResurfaceBanner", () => {
       expected: true,
     },
     {
-      label: "returns true when consent method is DISMISS",
+      label: "returns false when consent method is DISMISS",
       experience: mockExperience,
       cookie: {
         ...mockCookie,
@@ -380,7 +380,7 @@ describe("shouldResurfaceBanner", () => {
       },
       savedConsent: mockSavedConsent,
       options: {},
-      expected: true,
+      expected: false,
     },
     {
       label: "returns true when notice consent is missing",

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -80,7 +80,9 @@ const Overlay: FunctionComponent<Props> = ({
   }, [disableBanner]);
 
   const [bannerIsOpen, setBannerIsOpen] = useState(
-    options.fidesEmbed ? !disableBanner : false,
+    options.fidesEmbed
+      ? shouldResurfaceBanner(experience, cookie, savedConsent, options)
+      : false,
   );
 
   useEffect(() => {

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -72,6 +72,9 @@ const Overlay: FunctionComponent<Props> = ({
 
   useEffect(() => {
     if (disableBanner === null) {
+      // We check for disableBanner being `null` so that this only ever gets set
+      // during initialization and not with every change to the cookie/consent.
+      // This is also why exaustive-deps is being ignored below.
       setDisableBanner(
         !shouldResurfaceBanner(experience, cookie, savedConsent, options),
       );
@@ -79,6 +82,7 @@ const Overlay: FunctionComponent<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [disableBanner]);
 
+  // When fidesEmbed is enabled, this should be set immediately (don't wait for css animation support)
   const [bannerIsOpen, setBannerIsOpen] = useState(
     options.fidesEmbed
       ? shouldResurfaceBanner(experience, cookie, savedConsent, options)

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -303,6 +303,7 @@ const _Fides: FidesGlobal = {
       this.experience,
       this.cookie,
       this.saved_consent,
+      this.options,
     );
   },
   meta,

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -284,13 +284,8 @@ export const shouldResurfaceBanner = (
     return false;
   }
 
-  // resurface in the special case where the saved consent
-  // is only recorded with a consentMethod of "dismiss" or "gpc"
-  if (
-    cookie &&
-    (cookie.fides_meta.consentMethod === ConsentMethod.GPC ||
-      cookie.fides_meta.consentMethod === ConsentMethod.DISMISS)
-  ) {
+  // resurface in the special case where the saved consent is "gpc"
+  if (cookie?.fides_meta.consentMethod === ConsentMethod.GPC) {
     return true;
   }
 

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -241,7 +241,7 @@ export const shouldResurfaceBanner = (
     | undefined,
   cookie: FidesCookie | undefined,
   savedConsent: NoticeConsent,
-  options?: FidesInitOptions,
+  options: FidesInitOptions,
 ): boolean => {
   // Never resurface banner if it is disabled
   if (options?.fidesDisableBanner) {

--- a/clients/privacy-center/cypress/e2e/banner-overlay-dismissal.cy.ts
+++ b/clients/privacy-center/cypress/e2e/banner-overlay-dismissal.cy.ts
@@ -141,11 +141,11 @@ describe("Banner and modal dismissal", () => {
               cy.get("@FidesUpdated").should("not.have.been.called");
             });
 
-            it("should resurface the banner if dismissed without consent", () => {
+            it("should not resurface the banner if dismissed without consent", () => {
               cy.get("#fides-banner").should("be.visible");
               cy.get("#fides-banner .fides-close-button").click();
               cy.reload();
-              cy.get("#fides-banner").should("be.visible");
+              cy.get("#fides-banner").should("not.be.visible");
             });
 
             it("should not resurface the banner if consented without dismissing", () => {


### PR DESCRIPTION
Closes [LJ-62]

### Description Of Changes

Reverts update to banner behavior [made in recent PR](https://github.com/ethyca/fides/pull/5895/files#diff-f16513cf5775803ac3c57f5e37c86e581999176bea890715fad7b35451b60cbeL247)

### Code Changes

* removes check for Dismiss consent type before resurfacing the banner

### Steps to Confirm

1. Load any banner + modal experience in demo page
2. Dismiss the banner
3. Reload the page
4. Confirm banner does not re-appear

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-62]: https://ethyca.atlassian.net/browse/LJ-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ