### PR TITLE
LJ-622 Refactor TCFPublisherRestrictions to use async methods

### DIFF
--- a/tests/api/models/test_tcf_publisher_restrictions.py
+++ b/tests/api/models/test_tcf_publisher_restrictions.py
@@ -13,25 +13,16 @@ from fides.api.models.tcf_publisher_restrictions import (
 )
 
 
-class TestCreateTCFPublisherRestriction:
-    @pytest.fixture
-    def tcf_config(self, db: Session) -> Generator[TCFConfiguration, None, None]:
-        """Create a TCF configuration for testing."""
-        config = TCFConfiguration.create(
-            db=db,
-            data={
-                "name": "test-config",
-                "id": "test-config",
-            },
-        )
-        yield config
-        # Cleanup
-        config.delete(db)
+class TestCreateTCFPublisherRestrictionAsync:
+    """
+    Same tests as in TestCreateTCFPublisherRestriction, but using the create_async method.
+    """
 
-    def test_create_valid_restriction(
-        self, db: Session, tcf_config: TCFConfiguration
-    ) -> None:
-        """Test creating a valid publisher restriction."""
+    @pytest.fixture
+    async def existing_restriction(
+        self, async_session: AsyncSession, tcf_config: TCFConfiguration
+    ) -> AsyncGenerator[TCFPublisherRestriction, None]:
+        """Create an existing restriction for testing updates."""
         data = {
             "tcf_configuration_id": tcf_config.id,
             "purpose_id": 2,
@@ -42,184 +33,13 @@ class TestCreateTCFPublisherRestriction:
                 {"start_vendor_id": 7, "end_vendor_id": 10},
             ],
         }
-        restriction = TCFPublisherRestriction.create(db=db, data=data)
-        assert restriction.purpose_id == 2
-        assert len(restriction.range_entries) == 2
-        assert restriction.range_entries[0]["start_vendor_id"] == 1
-        assert restriction.range_entries[0]["end_vendor_id"] == 5
-        assert restriction.range_entries[1]["start_vendor_id"] == 7
-        assert restriction.range_entries[1]["end_vendor_id"] == 10
-
-        # Test that the restriction is created in the database
-        restriction = (
-            db.query(TCFPublisherRestriction)
-            .filter(TCFPublisherRestriction.id == restriction.id)
-            .first()
+        restriction = await TCFPublisherRestriction.create_async(
+            async_db=async_session, data=data
         )
-        assert restriction is not None
-        assert restriction.restriction_type == TCFRestrictionType.require_consent
-        assert (
-            restriction.vendor_restriction
-            == TCFVendorRestriction.allow_specific_vendors
-        )
-        assert len(restriction.range_entries) == 2
+        yield restriction
 
-    def test_invalid_range_entry(
-        self, db: Session, tcf_config: TCFConfiguration
-    ) -> None:
-        """Test that creating a restriction with invalid range entry fails."""
-        data = {
-            "tcf_configuration_id": tcf_config.id,
-            "purpose_id": 2,
-            "restriction_type": TCFRestrictionType.purpose_restriction,
-            "vendor_restriction": TCFVendorRestriction.allow_specific_vendors,
-            "range_entries": [
-                {"start_vendor_id": 5, "end_vendor_id": 1},  # end < start
-            ],
-        }
-        with pytest.raises(
-            ValueError, match="end_vendor_id must be greater than start_vendor_id"
-        ):
-            TCFPublisherRestriction.create(db=db, data=data)
-
-    @pytest.mark.parametrize(
-        "range_entries",
-        [
-            pytest.param(
-                [
-                    {"start_vendor_id": 1, "end_vendor_id": 5},
-                    {"start_vendor_id": 18, "end_vendor_id": 25},
-                    {"start_vendor_id": 3, "end_vendor_id": 7},
-                ],
-                id="overlapping_middle",
-            ),
-            pytest.param(
-                [
-                    {"start_vendor_id": 1, "end_vendor_id": 5},
-                    {"start_vendor_id": 5, "end_vendor_id": 10},
-                ],
-                id="touching_endpoints",
-            ),
-            pytest.param(
-                [
-                    {"start_vendor_id": 1, "end_vendor_id": 10},
-                    {"start_vendor_id": 5, "end_vendor_id": 7},
-                ],
-                id="nested_range",
-            ),
-            pytest.param(
-                [
-                    {"start_vendor_id": 1, "end_vendor_id": 5},
-                    {"start_vendor_id": 2, "end_vendor_id": 3},
-                    {"start_vendor_id": 4, "end_vendor_id": 6},
-                ],
-                id="multiple_overlaps",
-            ),
-        ],
-    )
-    def test_overlapping_ranges(
-        self,
-        db: Session,
-        tcf_config: TCFConfiguration,
-        range_entries: list,
-    ) -> None:
-        """Test that creating a restriction with overlapping ranges fails.
-
-        Args:
-            range_entries: List of vendor ranges to test
-        """
-        data = {
-            "tcf_configuration_id": tcf_config.id,
-            "purpose_id": 2,
-            "restriction_type": TCFRestrictionType.purpose_restriction,
-            "vendor_restriction": TCFVendorRestriction.allow_specific_vendors,
-            "range_entries": range_entries,
-        }
-        with pytest.raises(ValueError, match="Overlapping ranges found"):
-            TCFPublisherRestriction.create(db=db, data=data)
-
-    def test_restrict_all_vendors_with_entries(
-        self, db: Session, tcf_config: TCFConfiguration
-    ) -> None:
-        """Test that restrict_all_vendors cannot have range entries."""
-        data = {
-            "tcf_configuration_id": tcf_config.id,
-            "purpose_id": 2,
-            "restriction_type": TCFRestrictionType.purpose_restriction,
-            "vendor_restriction": TCFVendorRestriction.restrict_all_vendors,
-            "range_entries": [
-                {"start_vendor_id": 1, "end_vendor_id": 5},
-            ],
-        }
-        with pytest.raises(
-            ValueError, match="restrict_all_vendors cannot have any range entries"
-        ):
-            TCFPublisherRestriction.create(db=db, data=data)
-
-    def test_single_vendor_range(
-        self, db: Session, tcf_config: TCFConfiguration
-    ) -> None:
-        """Test creating a restriction with a single vendor (no end_vendor_id)."""
-        data = {
-            "tcf_configuration_id": tcf_config.id,
-            "purpose_id": 2,
-            "restriction_type": TCFRestrictionType.purpose_restriction,
-            "vendor_restriction": TCFVendorRestriction.allow_specific_vendors,
-            "range_entries": [
-                {"start_vendor_id": 1},  # Single vendor
-            ],
-        }
-        restriction = TCFPublisherRestriction.create(db=db, data=data)
-        assert len(restriction.range_entries) == 1
-        assert restriction.range_entries[0]["start_vendor_id"] == 1
-        assert restriction.range_entries[0]["end_vendor_id"] is None
-
-        # Test that the restriction is created in the database
-        restriction = (
-            db.query(TCFPublisherRestriction)
-            .filter(TCFPublisherRestriction.id == restriction.id)
-            .first()
-        )
-        assert restriction is not None
-        assert restriction.restriction_type == TCFRestrictionType.purpose_restriction
-        assert (
-            restriction.vendor_restriction
-            == TCFVendorRestriction.allow_specific_vendors
-        )
-        assert len(restriction.range_entries) == 1
-
-    def test_restrict_all_no_range_entries(
-        self, db: Session, tcf_config: TCFConfiguration
-    ) -> None:
-        """Test that restrict_all_vendors without range entries is valid."""
-        data = {
-            "tcf_configuration_id": tcf_config.id,
-            "purpose_id": 2,
-            "restriction_type": TCFRestrictionType.purpose_restriction,
-            "vendor_restriction": TCFVendorRestriction.restrict_all_vendors,
-            "range_entries": [],
-        }
-        restriction = TCFPublisherRestriction.create(db=db, data=data)
-        assert restriction.range_entries == []
-
-        # Test that the restriction is created in the database
-        restriction = (
-            db.query(TCFPublisherRestriction)
-            .filter(TCFPublisherRestriction.id == restriction.id)
-            .first()
-        )
-        assert restriction is not None
-        assert restriction.range_entries == []
-        assert restriction.restriction_type == TCFRestrictionType.purpose_restriction
-        assert (
-            restriction.vendor_restriction == TCFVendorRestriction.restrict_all_vendors
-        )
-
-
-class TestCreateTCFPublisherRestrictionAsync:
-    """
-    Same tests as in TestCreateTCFPublisherRestriction, but using the create_async method.
-    """
+        await async_session.delete(restriction)
+        await async_session.commit()
 
     @pytest.fixture
     async def tcf_config(
@@ -346,6 +166,25 @@ class TestCreateTCFPublisherRestrictionAsync:
             "restriction_type": TCFRestrictionType.require_legitimate_interest,
             "vendor_restriction": TCFVendorRestriction.restrict_specific_vendors,
             "range_entries": range_entries,
+        }
+        with pytest.raises(ValueError, match="Overlapping ranges found"):
+            await TCFPublisherRestriction.create_async(
+                async_db=async_session, data=data
+            )
+
+    async def test_overlapping_ranges_with_existing_restriction(
+        self,
+        async_session: AsyncSession,
+        tcf_config: TCFConfiguration,
+        existing_restriction: TCFPublisherRestriction,
+    ) -> None:
+        """Test that creating a restriction with ranges overlapping a different restriction fails."""
+        data = {
+            "tcf_configuration_id": tcf_config.id,
+            "purpose_id": existing_restriction.purpose_id,
+            "restriction_type": TCFRestrictionType.require_legitimate_interest,
+            "vendor_restriction": TCFVendorRestriction.restrict_specific_vendors,
+            "range_entries": [{"start_vendor_id": 3, "end_vendor_id": 6}],
         }
         with pytest.raises(ValueError, match="Overlapping ranges found"):
             await TCFPublisherRestriction.create_async(
@@ -545,3 +384,218 @@ class TestTCFPublisherRestrictionInstantiation:
         assert restriction.range_entries[0]["end_vendor_id"] == 5
         assert restriction.range_entries[1]["start_vendor_id"] == 7
         assert restriction.range_entries[1]["end_vendor_id"] == 10
+
+
+class TestUpdateTCFPublisherRestrictionAsync:
+    """Test cases for the update_async method of TCFPublisherRestriction."""
+
+    @pytest.fixture
+    async def tcf_config(
+        self, async_session: AsyncSession
+    ) -> AsyncGenerator[TCFConfiguration, None]:
+        """Create a TCF configuration for testing."""
+        async with async_session.begin():
+            insert_stmt = insert(TCFConfiguration).values(
+                {"name": "test-config", "id": "test-config"}
+            )
+            result = await async_session.execute(insert_stmt)
+            record_id = result.inserted_primary_key.id
+
+            config = await async_session.execute(
+                select(TCFConfiguration).where(TCFConfiguration.id == record_id)
+            )
+            config = config.scalars().first()
+
+        yield config
+
+        await async_session.delete(config)
+        await async_session.commit()
+
+    @pytest.fixture
+    async def existing_restriction(
+        self, async_session: AsyncSession, tcf_config: TCFConfiguration
+    ) -> AsyncGenerator[TCFPublisherRestriction, None]:
+        """Create an existing restriction for testing updates."""
+        data = {
+            "tcf_configuration_id": tcf_config.id,
+            "purpose_id": 8,
+            "restriction_type": TCFRestrictionType.require_consent,
+            "vendor_restriction": TCFVendorRestriction.allow_specific_vendors,
+            "range_entries": [
+                {"start_vendor_id": 1, "end_vendor_id": 5},
+                {"start_vendor_id": 7, "end_vendor_id": 10},
+            ],
+        }
+        restriction = await TCFPublisherRestriction.create_async(
+            async_db=async_session, data=data
+        )
+        yield restriction
+
+        await async_session.delete(restriction)
+        await async_session.commit()
+
+    async def test_update_valid_restriction(
+        self,
+        async_session: AsyncSession,
+        existing_restriction: TCFPublisherRestriction,
+    ) -> None:
+        """Test updating a restriction with valid data."""
+        update_data = {
+            "restriction_type": TCFRestrictionType.require_legitimate_interest,
+            "vendor_restriction": TCFVendorRestriction.restrict_specific_vendors,
+            "range_entries": [
+                {"start_vendor_id": 15, "end_vendor_id": 20},
+                {"start_vendor_id": 25, "end_vendor_id": 30},
+            ],
+        }
+        updated = await existing_restriction.update_async(
+            async_db=async_session, data=update_data
+        )
+
+        # Verify the update was successful
+        assert (
+            updated.restriction_type == TCFRestrictionType.require_legitimate_interest
+        )
+        assert (
+            updated.vendor_restriction == TCFVendorRestriction.restrict_specific_vendors
+        )
+        assert len(updated.range_entries) == 2
+        assert updated.range_entries[0]["start_vendor_id"] == 15
+        assert updated.range_entries[0]["end_vendor_id"] == 20
+        assert updated.range_entries[1]["start_vendor_id"] == 25
+        assert updated.range_entries[1]["end_vendor_id"] == 30
+
+        # Verify the update persisted in the database
+        db_restriction = await async_session.execute(
+            select(TCFPublisherRestriction).where(
+                TCFPublisherRestriction.id == existing_restriction.id
+            )
+        )
+        db_restriction = db_restriction.scalars().first()
+        assert db_restriction is not None
+        assert (
+            db_restriction.restriction_type
+            == TCFRestrictionType.require_legitimate_interest
+        )
+        assert (
+            db_restriction.vendor_restriction
+            == TCFVendorRestriction.restrict_specific_vendors
+        )
+        assert len(db_restriction.range_entries) == 2
+
+    async def test_update_invalid_range_entry(
+        self,
+        async_session: AsyncSession,
+        existing_restriction: TCFPublisherRestriction,
+    ) -> None:
+        """Test that updating with invalid range entry fails."""
+        update_data = {
+            "range_entries": [
+                {"start_vendor_id": 5, "end_vendor_id": 1},  # end < start
+            ],
+        }
+        with pytest.raises(
+            ValueError, match="end_vendor_id must be greater than start_vendor_id"
+        ):
+            await existing_restriction.update_async(
+                async_db=async_session, data=update_data
+            )
+
+    async def test_update_overlapping_ranges(
+        self,
+        async_session: AsyncSession,
+        existing_restriction: TCFPublisherRestriction,
+    ) -> None:
+        """Test that updating with overlapping ranges fails."""
+        update_data = {
+            "vendor_restriction": existing_restriction.vendor_restriction,
+            "range_entries": [
+                {"start_vendor_id": 1, "end_vendor_id": 10},
+                {
+                    "start_vendor_id": 5,
+                    "end_vendor_id": 15,
+                },  # Overlaps with first range
+            ],
+        }
+        with pytest.raises(ValueError, match="Overlapping ranges found"):
+            await existing_restriction.update_async(
+                async_db=async_session, data=update_data
+            )
+
+    async def test_update_restrict_all_vendors_with_entries(
+        self,
+        async_session: AsyncSession,
+        existing_restriction: TCFPublisherRestriction,
+    ) -> None:
+        """Test that updating to restrict_all_vendors with range entries fails."""
+        update_data = {
+            "vendor_restriction": TCFVendorRestriction.restrict_all_vendors,
+            "range_entries": [
+                {"start_vendor_id": 1, "end_vendor_id": 5},
+            ],
+        }
+        with pytest.raises(
+            ValueError, match="restrict_all_vendors cannot have any range entries"
+        ):
+            await existing_restriction.update_async(
+                async_db=async_session, data=update_data
+            )
+
+    async def test_update_single_vendor_range(
+        self,
+        async_session: AsyncSession,
+        existing_restriction: TCFPublisherRestriction,
+    ) -> None:
+        """Test updating to a single vendor range (no end_vendor_id)."""
+        update_data = {
+            "vendor_restriction": existing_restriction.vendor_restriction,
+            "range_entries": [
+                {"start_vendor_id": 1},  # Single vendor
+            ],
+        }
+        updated = await existing_restriction.update_async(
+            async_db=async_session, data=update_data
+        )
+        assert len(updated.range_entries) == 1
+        assert updated.range_entries[0]["start_vendor_id"] == 1
+        assert updated.range_entries[0]["end_vendor_id"] is None
+
+    async def test_update_overlapping_with_existing_purpose(
+        self,
+        async_session: AsyncSession,
+        tcf_config: TCFConfiguration,
+        existing_restriction: TCFPublisherRestriction,
+    ) -> None:
+        """Test that updating ranges that would overlap with another restriction for the same purpose fails."""
+        # Create another restriction for the same purpose
+        other_data = {
+            "tcf_configuration_id": tcf_config.id,
+            "purpose_id": existing_restriction.purpose_id,  # Same purpose
+            "restriction_type": TCFRestrictionType.require_consent,
+            "vendor_restriction": TCFVendorRestriction.allow_specific_vendors,
+            "range_entries": [
+                {"start_vendor_id": 20, "end_vendor_id": 25},
+            ],
+        }
+        other_restriction = await TCFPublisherRestriction.create_async(
+            async_db=async_session, data=other_data
+        )
+
+        # Try to update the first restriction with ranges that would overlap with the second
+        update_data = {
+            "vendor_restriction": existing_restriction.vendor_restriction,
+            "range_entries": [
+                {
+                    "start_vendor_id": 15,
+                    "end_vendor_id": 22,
+                },  # Overlaps with other restriction
+            ],
+        }
+        with pytest.raises(ValueError, match="Overlapping ranges found"):
+            await existing_restriction.update_async(
+                async_db=async_session, data=update_data
+            )
+
+        # Cleanup
+        await async_session.delete(other_restriction)
+        await async_session.commit()

--- a/tests/api/models/test_tcf_publisher_restrictions.py
+++ b/tests/api/models/test_tcf_publisher_restrictions.py
@@ -97,6 +97,25 @@ class TestCreateTCFPublisherRestrictionAsync:
         assert restriction is not None
         assert len(restriction.range_entries) == 2
 
+    def test_create_sync_throws_error(
+        self, db: Session, tcf_config: TCFConfiguration
+    ) -> None:
+        """
+        Test that the sync create method throws an error telling users to use the async method.
+        """
+        data = {
+            "tcf_configuration_id": tcf_config.id,
+            "purpose_id": 8,
+            "restriction_type": TCFRestrictionType.require_consent,
+            "vendor_restriction": TCFVendorRestriction.allow_specific_vendors,
+            "range_entries": [
+                {"start_vendor_id": 1, "end_vendor_id": 5},
+                {"start_vendor_id": 7, "end_vendor_id": 10},
+            ],
+        }
+        with pytest.raises(NotImplementedError, match="Use create_async instead"):
+            TCFPublisherRestriction.create(db=db, data=data)
+
     async def test_invalid_range_entry(
         self, async_session: AsyncSession, tcf_config: TCFConfiguration
     ) -> None:


### PR DESCRIPTION
### Description Of Changes

Adds the `update_async` method in the `TCFPublisherRestriction` model, and also adds validation. The validation is as follows: a single TCF configuration may have multiple restrictions for the same purpose, as long as there are no overlapping vendor ranges for those restrictions (for the same purpose) 

Additionally, I replaced the implementation of `create` so it throws a `NotImplemented` error -- I think it's confusing to have two ways to create the instances and we want to move towards async sessions in the future anyways. The fidesplus logic for this feature uses exclusively async sessions so it won't be a problem, and this avoids having to duplicate all the validation logic for both sync and async sessions. 

No changelog entry since this model is brand new and will be new in this release .

### Steps to Confirm

1.  Tests pass 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
