### PR TITLE
HA-524 - Fides should support Google Cloud Storage as a storage option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Added
 - Added support for selecting TCF Publisher Override configuration when configuring Privacy Experience [#6033](https://github.com/ethyca/fides/pull/6033)
+- Added Google Cloud Storage as a storage option [#6006](https://github.com/ethyca/fides/pull/6006)
 
 ### Changed
 - Changed how TCF Publisher Overrides gets configured in consent settings [#6013](https://github.com/ethyca/fides/pull/6013)

--- a/clients/admin-ui/src/features/privacy-requests/configuration/StorageConfiguration.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/StorageConfiguration.tsx
@@ -24,6 +24,7 @@ import {
   useGetStorageDetailsQuery,
 } from "~/features/privacy-requests/privacy-requests.slice";
 
+import GoogleCloudStorageConfiguration from "./GoogleCloudStorageConfiguration";
 import S3StorageConfiguration from "./S3StorageConfiguration";
 
 const StorageConfiguration = () => {
@@ -72,6 +73,13 @@ const StorageConfiguration = () => {
     }
   };
 
+  const storageComponents = {
+    s3: S3StorageConfiguration,
+    gcs: GoogleCloudStorageConfiguration,
+  };
+  const StorageConfigComponent =
+    storageComponents[storageValue as keyof typeof storageComponents];
+
   return (
     <Layout title="Configure Privacy Requests - Storage">
       <PageHeader
@@ -102,10 +110,14 @@ const StorageConfiguration = () => {
           your results. Fides currently supports{" "}
           <Text as="span" color="complimentary.500">
             Local
+          </Text>
+          {", "}
+          <Text as="span" color="complimentary.500">
+            S3
           </Text>{" "}
           and{" "}
           <Text as="span" color="complimentary.500">
-            S3
+            GCS
           </Text>{" "}
           storage methods.
         </Box>
@@ -126,11 +138,15 @@ const StorageConfiguration = () => {
             <Radio key="s3" value="s3" data-testid="option-s3">
               S3
             </Radio>
+            <Radio key="gcs" value="gcs" data-testid="option-gcs">
+              GCS
+            </Radio>
           </Flex>
         </Radio.Group>
-        {storageValue === "s3" && storageDetails ? (
-          <S3StorageConfiguration storageDetails={storageDetails} />
-        ) : null}
+
+        {StorageConfigComponent && storageDetails && (
+          <StorageConfigComponent storageDetails={storageDetails} />
+        )}
       </Box>
     </Layout>
   );

--- a/clients/admin-ui/src/features/privacy-requests/constants.ts
+++ b/clients/admin-ui/src/features/privacy-requests/constants.ts
@@ -43,4 +43,5 @@ export const messagingProviders = {
 export const storageTypes = {
   local: "local",
   s3: "s3",
+  gcs: "gcs",
 };

--- a/clients/admin-ui/src/features/privacy-requests/types.ts
+++ b/clients/admin-ui/src/features/privacy-requests/types.ts
@@ -159,12 +159,28 @@ export interface ConfigStorageDetailsRequest {
   format?: string;
 }
 
+export interface S3SecretsDetails {
+  aws_access_key_id: string;
+  aws_secret_access_key: string;
+}
+
+export interface GCSSecretsDetails {
+  type: string;
+  project_id: string;
+  private_key_id: string;
+  private_key: string;
+  client_email: string;
+  client_id: string;
+  auth_uri: string;
+  token_uri: string;
+  auth_provider_x509_cert_url: string;
+  client_x509_cert_url: string;
+  universe_domain: string;
+}
+
 export interface ConfigStorageSecretsDetailsRequest {
   type?: string;
-  details?: {
-    aws_access_key_id: string;
-    aws_secret_access_key: string;
-  };
+  details?: S3SecretsDetails | GCSSecretsDetails;
 }
 
 export interface ConfigMessagingRequest {

--- a/clients/admin-ui/src/types/api/models/GCSAuthMethod.ts
+++ b/clients/admin-ui/src/types/api/models/GCSAuthMethod.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export enum GCSAuthMethod {
+  ADC = "adc", // Application Default Credentials
+  SERVICE_ACCOUNT_KEYS = "service_account_keys",
+}

--- a/clients/admin-ui/src/types/api/models/StorageDestination.ts
+++ b/clients/admin-ui/src/types/api/models/StorageDestination.ts
@@ -5,6 +5,7 @@
 import type { ResponseFormat } from "./ResponseFormat";
 import type { StorageDetailsLocal } from "./StorageDetailsLocal";
 import type { StorageDetailsS3 } from "./StorageDetailsS3";
+import type { StorageDetailsGCS } from "./StorageDetailsGCS";
 import type { StorageType } from "./StorageType";
 
 /**
@@ -12,7 +13,7 @@ import type { StorageType } from "./StorageType";
  */
 export type StorageDestination = {
   type: StorageType;
-  details: StorageDetailsS3 | StorageDetailsLocal;
+  details: StorageDetailsS3 | StorageDetailsGCS | StorageDetailsLocal;
   format?: ResponseFormat | null;
   name: string;
   key?: string | null;

--- a/clients/admin-ui/src/types/api/models/StorageDestinationBase.ts
+++ b/clients/admin-ui/src/types/api/models/StorageDestinationBase.ts
@@ -5,6 +5,7 @@
 import type { ResponseFormat } from "./ResponseFormat";
 import type { StorageDetailsLocal } from "./StorageDetailsLocal";
 import type { StorageDetailsS3 } from "./StorageDetailsS3";
+import type { StorageDetailsGCS } from "./StorageDetailsGCS";
 import type { StorageType } from "./StorageType";
 
 /**
@@ -12,6 +13,6 @@ import type { StorageType } from "./StorageType";
  */
 export type StorageDestinationBase = {
   type: StorageType;
-  details: StorageDetailsS3 | StorageDetailsLocal;
+  details: StorageDetailsS3 | StorageDetailsGCS | StorageDetailsLocal;
   format?: ResponseFormat | null;
 };

--- a/clients/admin-ui/src/types/api/models/StorageDetailsGCS.ts
+++ b/clients/admin-ui/src/types/api/models/StorageDetailsGCS.ts
@@ -1,0 +1,15 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { GCSAuthMethod } from "./GCSAuthMethod";
+
+/**
+ * The details required to represent a Google Cloud Storage bucket.
+ */
+export type StorageDetailsGCS = {
+  naming?: string;
+  auth_method: GCSAuthMethod;
+  bucket: string;
+  max_retries?: number | null;
+};

--- a/clients/admin-ui/src/types/api/models/StorageTypeApiAccepted.ts
+++ b/clients/admin-ui/src/types/api/models/StorageTypeApiAccepted.ts
@@ -7,5 +7,6 @@
  */
 export enum StorageTypeApiAccepted {
   S3 = "s3",
+  GCS = "gcs",
   LOCAL = "local",
 }

--- a/clients/privacy-center/types/api/models/GCSAuthMethod.ts
+++ b/clients/privacy-center/types/api/models/GCSAuthMethod.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export enum GCSAuthMethod {
+  ADC = "adc", // Application Default Credentials
+  SERVICE_ACCOUNT_KEYS = "service_account_keys",
+}

--- a/clients/privacy-center/types/api/models/StorageDestination.ts
+++ b/clients/privacy-center/types/api/models/StorageDestination.ts
@@ -5,6 +5,7 @@
 import type { ResponseFormat } from "./ResponseFormat";
 import type { StorageDetailsLocal } from "./StorageDetailsLocal";
 import type { StorageDetailsS3 } from "./StorageDetailsS3";
+import type { StorageDetailsGCS } from "./StorageDetailsGCS";
 import type { StorageType } from "./StorageType";
 
 /**
@@ -12,7 +13,7 @@ import type { StorageType } from "./StorageType";
  */
 export type StorageDestination = {
   type: StorageType;
-  details: StorageDetailsS3 | StorageDetailsLocal;
+  details: StorageDetailsS3 | StorageDetailsGCS | StorageDetailsLocal;
   format?: ResponseFormat | null;
   name: string;
   key?: string | null;

--- a/clients/privacy-center/types/api/models/StorageDestinationBase.ts
+++ b/clients/privacy-center/types/api/models/StorageDestinationBase.ts
@@ -5,6 +5,7 @@
 import type { ResponseFormat } from "./ResponseFormat";
 import type { StorageDetailsLocal } from "./StorageDetailsLocal";
 import type { StorageDetailsS3 } from "./StorageDetailsS3";
+import type { StorageDetailsGCS } from "./StorageDetailsGCS";
 import type { StorageType } from "./StorageType";
 
 /**
@@ -12,6 +13,6 @@ import type { StorageType } from "./StorageType";
  */
 export type StorageDestinationBase = {
   type: StorageType;
-  details: StorageDetailsS3 | StorageDetailsLocal;
+  details: StorageDetailsS3 | StorageDetailsGCS | StorageDetailsLocal;
   format?: ResponseFormat | null;
 };

--- a/clients/privacy-center/types/api/models/StorageDetailsGCS.ts
+++ b/clients/privacy-center/types/api/models/StorageDetailsGCS.ts
@@ -1,0 +1,15 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { GCSAuthMethod } from "./GCSAuthMethod";
+
+/**
+ * The details required to represent a Google Cloud Storage bucket.
+ */
+export type StorageDetailsGCS = {
+  naming?: string;
+  auth_method: GCSAuthMethod;
+  bucket: string;
+  max_retries?: number | null;
+};

--- a/clients/privacy-center/types/api/models/StorageTypeApiAccepted.ts
+++ b/clients/privacy-center/types/api/models/StorageTypeApiAccepted.ts
@@ -7,5 +7,6 @@
  */
 export enum StorageTypeApiAccepted {
   S3 = "s3",
+  GCS = "gcs",
   LOCAL = "local",
 }

--- a/src/fides/api/api/v1/endpoints/storage_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/storage_endpoints.py
@@ -40,6 +40,7 @@ from fides.api.schemas.storage.storage import (
     FULLY_CONFIGURED_STORAGE_TYPES,
     AWSAuthMethod,
     BulkPutStorageConfigResponse,
+    GCSAuthMethod,
     StorageConfigStatus,
     StorageConfigStatusMessage,
     StorageDestination,
@@ -419,8 +420,7 @@ def get_storage_status(
 
 def _storage_config_requires_secrets(storage_config: StorageConfig) -> bool:
     return (
-        storage_config.details.get(StorageDetails.AUTH_METHOD.value, None)
-        == AWSAuthMethod.SECRET_KEYS.value
+        storage_config.details.get(StorageDetails.AUTH_METHOD.value, None) in [AWSAuthMethod.SECRET_KEYS.value, GCSAuthMethod.SERVICE_ACCOUNT_KEYS.value]
     )
 
 

--- a/src/fides/api/api/v1/endpoints/storage_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/storage_endpoints.py
@@ -419,9 +419,10 @@ def get_storage_status(
 
 
 def _storage_config_requires_secrets(storage_config: StorageConfig) -> bool:
-    return (
-        storage_config.details.get(StorageDetails.AUTH_METHOD.value, None) in [AWSAuthMethod.SECRET_KEYS.value, GCSAuthMethod.SERVICE_ACCOUNT_KEYS.value]
-    )
+    return storage_config.details.get(StorageDetails.AUTH_METHOD.value, None) in [
+        AWSAuthMethod.SECRET_KEYS.value,
+        GCSAuthMethod.SERVICE_ACCOUNT_KEYS.value,
+    ]
 
 
 @router.put(

--- a/src/fides/api/schemas/application_config.py
+++ b/src/fides/api/schemas/application_config.py
@@ -14,6 +14,7 @@ class StorageTypeApiAccepted(Enum):
     """Enum for storage destination types accepted in API updates"""
 
     s3 = "s3"
+    gcs = "gcs"
     local = "local"  # local should be used for testing only, not for processing real-world privacy requests
 
 

--- a/src/fides/api/schemas/storage/storage.py
+++ b/src/fides/api/schemas/storage/storage.py
@@ -61,10 +61,25 @@ class StorageDetailsS3(FileBasedStorageDetails):
     model_config = ConfigDict(use_enum_values=True)
 
 
+class GCSAuthMethod(str, Enum):
+    ADC = "adc"  # Application Default Credentials
+    SERVICE_ACCOUNT_KEYS = "service_account_keys"
+
+
+class StorageDetailsGCS(FileBasedStorageDetails):
+    """The details required to represent a Google Cloud Storage bucket."""
+
+    auth_method: GCSAuthMethod
+    bucket: str
+    max_retries: Optional[int] = 0
+    model_config = ConfigDict(use_enum_values=True)
+
+
 class StorageDetailsLocal(FileBasedStorageDetails):
     """The details required to configurate local storage configuration"""
 
 
+# FIXME: change its name to be aws specific and create a new one for gcs?
 class StorageSecrets(Enum):
     """Enum for storage secret keys"""
 
@@ -87,6 +102,23 @@ class StorageSecretsS3(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class StorageSecretsGCS(BaseModel):
+    """The secrets required to connect to a Google Cloud Storage bucket."""
+
+    type: str = "service_account"
+    project_id: str
+    private_key_id: str
+    private_key: str
+    client_email: str
+    client_id: str
+    auth_uri: str
+    token_uri: str
+    auth_provider_x509_cert_url: str
+    client_x509_cert_url: str
+    universe_domain: str
+    model_config = ConfigDict(extra="forbid")
+
+
 class StorageType(Enum):
     """Enum for storage destination types"""
 
@@ -99,6 +131,7 @@ class StorageType(Enum):
 
 FULLY_CONFIGURED_STORAGE_TYPES = (
     StorageType.s3,
+    StorageType.gcs,
 )  # storage types that are considered "fully configured"
 
 
@@ -108,6 +141,7 @@ class StorageDestinationBase(BaseModel):
     type: StorageType
     details: Union[
         StorageDetailsS3,
+        StorageDetailsGCS,
         StorageDetailsLocal,
     ] = Field(validate_default=True)
     format: Optional[ResponseFormat] = ResponseFormat.json.value  # type: ignore
@@ -145,6 +179,7 @@ class StorageDestinationBase(BaseModel):
         try:
             schema = {
                 StorageType.s3.value: StorageDetailsS3,
+                StorageType.gcs.value: StorageDetailsGCS,
                 StorageType.local.value: StorageDetailsLocal,
             }[storage_type]
         except KeyError:
@@ -209,7 +244,7 @@ class BulkPutStorageConfigResponse(BulkResponse):
     failed: List[BulkUpdateFailed] = []
 
 
-SUPPORTED_STORAGE_SECRETS = StorageSecretsS3
+SUPPORTED_STORAGE_SECRETS = Union[StorageSecretsS3, StorageSecretsGCS]
 
 
 class StorageConfigStatus(Enum):

--- a/src/fides/api/schemas/storage/storage.py
+++ b/src/fides/api/schemas/storage/storage.py
@@ -79,7 +79,6 @@ class StorageDetailsLocal(FileBasedStorageDetails):
     """The details required to configurate local storage configuration"""
 
 
-# FIXME: change its name to be aws specific and create a new one for gcs?
 class StorageSecrets(Enum):
     """Enum for storage secret keys"""
 

--- a/src/fides/api/schemas/storage/storage_secrets_docs_only.py
+++ b/src/fides/api/schemas/storage/storage_secrets_docs_only.py
@@ -1,9 +1,15 @@
+from typing import Union
+
 from fides.api.schemas.base_class import NoValidationSchema
-from fides.api.schemas.storage.storage import StorageSecretsS3
+from fides.api.schemas.storage.storage import StorageSecretsGCS, StorageSecretsS3
 
 
 class StorageSecretsS3Docs(StorageSecretsS3, NoValidationSchema):
     """The secrets required to connect to S3, for documentation"""
 
 
-possible_storage_secrets = StorageSecretsS3Docs
+class StorageSecretsGCSDocs(StorageSecretsGCS, NoValidationSchema):
+    """The secrets required to connect to Google Cloud Storage, for documentation"""
+
+
+possible_storage_secrets = Union[StorageSecretsS3Docs, StorageSecretsGCSDocs]

--- a/src/fides/api/service/storage/gcs.py
+++ b/src/fides/api/service/storage/gcs.py
@@ -28,6 +28,7 @@ def get_gcs_client(
             dict(storage_secrets)
         )
         storage_client = Client(credentials=credentials)
+
     else:
         logger.error("Google Cloud Storage auth method not supported: {}", auth_method)
         raise ValueError(

--- a/src/fides/api/service/storage/gcs.py
+++ b/src/fides/api/service/storage/gcs.py
@@ -25,10 +25,8 @@ def get_gcs_client(
             logger.warning(err_msg)
             raise StorageUploadError(err_msg)
 
-        # FIXME: should convert to json?
-        # creds_dict = json.loads(storage_secrets)
         credentials = service_account.Credentials.from_service_account_info(
-            storage_secrets
+            dict(storage_secrets)
         )
         storage_client = Client(credentials=credentials)
     else:

--- a/src/fides/api/service/storage/gcs.py
+++ b/src/fides/api/service/storage/gcs.py
@@ -1,0 +1,38 @@
+from typing import Dict, Optional
+
+from loguru import logger
+
+from google.cloud.storage import Client
+from google.oauth2 import service_account
+
+from fides.api.common_exceptions import StorageUploadError
+from fides.api.schemas.storage.storage import GCSAuthMethod
+
+
+def get_gcs_client(
+    auth_method: str,
+    storage_secrets: Optional[Dict],
+) -> Client:
+    """
+    Abstraction to retrieve a GCS client using secrets.
+    """
+    if auth_method == GCSAuthMethod.ADC.value:
+        storage_client = Client()
+
+    elif auth_method == GCSAuthMethod.SERVICE_ACCOUNT_KEYS.value:
+        if not storage_secrets:
+            err_msg = "Storage secrets not found for Google Cloud Storage."
+            logger.warning(err_msg)
+            raise StorageUploadError(err_msg)
+
+        # FIXME: should convert to json?
+        # creds_dict = json.loads(storage_secrets)
+        credentials = service_account.Credentials.from_service_account_info(
+            storage_secrets
+        )
+        storage_client = Client(credentials=credentials)
+    else:
+        logger.error("Google Cloud Storage auth method not supported: {}", auth_method)
+        raise ValueError(f"Google Cloud Storage auth method not supported: {auth_method}")
+
+    return storage_client

--- a/src/fides/api/service/storage/gcs.py
+++ b/src/fides/api/service/storage/gcs.py
@@ -1,9 +1,8 @@
 from typing import Dict, Optional
 
-from loguru import logger
-
-from google.cloud.storage import Client
+from google.cloud.storage import Client  # type: ignore
 from google.oauth2 import service_account
+from loguru import logger
 
 from fides.api.common_exceptions import StorageUploadError
 from fides.api.schemas.storage.storage import GCSAuthMethod
@@ -31,6 +30,8 @@ def get_gcs_client(
         storage_client = Client(credentials=credentials)
     else:
         logger.error("Google Cloud Storage auth method not supported: {}", auth_method)
-        raise ValueError(f"Google Cloud Storage auth method not supported: {auth_method}")
+        raise ValueError(
+            f"Google Cloud Storage auth method not supported: {auth_method}"
+        )
 
     return storage_client

--- a/src/fides/api/service/storage/storage_uploader_service.py
+++ b/src/fides/api/service/storage/storage_uploader_service.py
@@ -124,9 +124,9 @@ def _gcs_uploader(
         data,
         bucket_name,
         file_key,
+        config.format.value,
         privacy_request,
         auth_method,
-        config.format.value,
     )
 
 

--- a/src/fides/api/service/storage/storage_uploader_service.py
+++ b/src/fides/api/service/storage/storage_uploader_service.py
@@ -14,7 +14,7 @@ from fides.api.schemas.storage.storage import (
     StorageDetails,
     StorageType,
 )
-from fides.api.tasks.storage import upload_to_local, upload_to_s3
+from fides.api.tasks.storage import upload_to_gcs, upload_to_local, upload_to_s3
 
 
 def upload(
@@ -78,6 +78,7 @@ def _get_uploader_from_config_type(storage_type: StorageType) -> Any:
     return {
         StorageType.s3.value: _s3_uploader,
         StorageType.local.value: _local_uploader,
+        StorageType.gcs.value: _gcs_uploader,
     }[storage_type.value]
 
 
@@ -103,6 +104,29 @@ def _s3_uploader(
         privacy_request,
         document,
         auth_method,
+    )
+
+
+def _gcs_uploader(
+    _: Session,
+    config: StorageConfig,
+    data: Dict,
+    privacy_request: PrivacyRequest,
+) -> str:
+    """Constructs necessary info needed for Google Cloud Storage before calling upload"""
+    file_key: str = _construct_file_key(privacy_request.id, config)
+
+    bucket_name = config.details[StorageDetails.BUCKET.value]
+    auth_method = config.details[StorageDetails.AUTH_METHOD.value]
+
+    return upload_to_gcs(
+        config.secrets,
+        data,
+        bucket_name,
+        file_key,
+        privacy_request,
+        auth_method,
+        config.format.value,
     )
 
 

--- a/src/fides/api/service/storage/storage_uploader_service.py
+++ b/src/fides/api/service/storage/storage_uploader_service.py
@@ -124,7 +124,7 @@ def _gcs_uploader(
         data,
         bucket_name,
         file_key,
-        config.format.value,
+        config.format.value,  # type: ignore
         privacy_request,
         auth_method,
     )

--- a/src/fides/api/tasks/storage.py
+++ b/src/fides/api/tasks/storage.py
@@ -183,12 +183,13 @@ def upload_to_gcs(
         presigned_url = blob.generate_signed_url(
             version="v4",
             expiration=CONFIG.security.subject_request_download_link_ttl_seconds,
-            method="GET"
+            method="GET",
         )
         return presigned_url
     except Exception as e:
         logger.error(
-            "Encountered error while uploading and generating link for Google Cloud Storage object: {}", e
+            "Encountered error while uploading and generating link for Google Cloud Storage object: {}",
+            e,
         )
         raise e
 

--- a/src/fides/api/tasks/storage.py
+++ b/src/fides/api/tasks/storage.py
@@ -65,7 +65,7 @@ def encrypt_access_request_results(data: Union[str, bytes], request_id: str) -> 
 def write_to_in_memory_buffer(
     resp_format: str, data: Dict[str, Any], privacy_request: PrivacyRequest
 ) -> BytesIO:
-    """Write JSON/CSV data to in-memory file-like object to be passed to S3. Encrypt data if encryption key/nonce
+    """Write JSON/CSV data to in-memory file-like object to be passed to S3 or GCS. Encrypt data if encryption key/nonce
     has been cached for the given privacy request id
 
     :param resp_format: str, should be one of ResponseFormat
@@ -176,7 +176,14 @@ def upload_to_gcs(
 
         blob = bucket.blob(file_key)
         in_memory_file = write_to_in_memory_buffer(resp_format, data, privacy_request)
-        blob.upload_from_string(in_memory_file.getvalue())
+        content_type = {
+            ResponseFormat.json.value: "application/json",
+            ResponseFormat.csv.value: "application/zip",
+            ResponseFormat.html.value: "application/zip",
+        }
+        blob.upload_from_string(
+            in_memory_file.getvalue(), content_type=content_type[resp_format]
+        )
 
         logger.info("File {} uploaded to {}", file_key, blob.public_url)
 

--- a/src/fides/api/util/storage_util.py
+++ b/src/fides/api/util/storage_util.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from fides.api.schemas.storage.storage import (
     SUPPORTED_STORAGE_SECRETS,
+    StorageSecretsGCS,
     StorageSecretsS3,
     StorageType,
 )
@@ -31,6 +32,7 @@ def get_schema_for_secrets(
     try:
         schema = {
             StorageType.s3: StorageSecretsS3,
+            StorageType.gcs: StorageSecretsGCS,
         }[storage_type]
     except KeyError:
         raise ValueError(

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -89,6 +89,7 @@ from fides.api.schemas.redis_cache import (
 from fides.api.schemas.storage.storage import (
     AWSAuthMethod,
     FileNaming,
+    GCSAuthMethod,
     StorageDetails,
     StorageSecrets,
     StorageType,
@@ -367,6 +368,71 @@ def storage_config_default_s3_secret_keys(db: Session) -> Generator:
             "secrets": {
                 StorageSecrets.AWS_ACCESS_KEY_ID.value: "access_key_id",
                 StorageSecrets.AWS_SECRET_ACCESS_KEY.value: "secret_access_key",
+            },
+            "format": ResponseFormat.json,
+        },
+    )
+    yield sc
+
+
+@pytest.fixture(scope="function")
+def storage_config_default_gcs(db: Session) -> Generator:
+    """
+    Create and yield a default storage config, as defined by its
+    `is_default` flag being set to `True`. This is a Google Cloud Storage config.
+    """
+    sc = StorageConfig.create(
+        db=db,
+        data={
+            "name": default_storage_config_name(StorageType.gcs.value),
+            "type": StorageType.gcs,
+            "is_default": True,
+            "details": {
+                StorageDetails.NAMING.value: FileNaming.request_id.value,
+                StorageDetails.AUTH_METHOD.value: GCSAuthMethod.ADC.value,
+                StorageDetails.BUCKET.value: "test_bucket",
+            },
+            "format": ResponseFormat.json,
+        },
+    )
+    yield sc
+
+
+@pytest.fixture(scope="function")
+def storage_config_default_gcs_service_account_keys(db: Session) -> Generator:
+    """
+    Create and yield a default storage config, as defined by its
+    `is_default` flag being set to `True`. This is a Google Cloud Storage config.
+    """
+    sc = StorageConfig.create(
+        db=db,
+        data={
+            "name": default_storage_config_name(StorageType.gcs.value),
+            "type": StorageType.gcs,
+            "is_default": True,
+            "details": {
+                StorageDetails.NAMING.value: FileNaming.request_id.value,
+                StorageDetails.AUTH_METHOD.value: GCSAuthMethod.SERVICE_ACCOUNT_KEYS.value,
+                StorageDetails.BUCKET.value: "test_bucket",
+            },
+            "secrets": {
+                "type": "service_account",
+                "project_id": "test-project-123",
+                "private_key_id": "test-key-id-456",
+                "private_key": (
+                    "-----BEGIN PRIVATE KEY-----\n"
+                    "MIItest\n"
+                    "-----END PRIVATE KEY-----\n"
+                ),
+                "client_email": "test-service@test-project-123.iam.gserviceaccount.com",
+                "client_id": "123456789",
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                "auth_provider_x509_cert_url": (
+                    "https://www.googleapis.com/oauth2/v1/certs"
+                ),
+                "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-service%40test-project-123.iam.gserviceaccount.com",
+                "universe_domain": "googleapis.com",
             },
             "format": ResponseFormat.json,
         },

--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -154,12 +154,12 @@ class TestPatchApplicationConfig:
         )
         assert response.status_code == 422
 
-        # gcs is valid storage type but not allowed currently
+        # ethyca is valid storage type but not allowed currently
         # as an `active_default_storage_type``
         response = api_client.patch(
             url,
             headers=auth_header,
-            json={"storage": {"active_default_storage_type": StorageType.gcs.value}},
+            json={"storage": {"active_default_storage_type": StorageType.ethyca.value}},
         )
         assert response.status_code == 422
 
@@ -626,12 +626,12 @@ class TestPutApplicationConfig:
         )
         assert response.status_code == 422
 
-        # gcs is valid storage type but not allowed currently
+        # ethyca is valid storage type but not allowed currently
         # as an `active_default_storage_type``
         response = api_client.put(
             url,
             headers=auth_header,
-            json={"storage": {"active_default_storage_type": StorageType.gcs.value}},
+            json={"storage": {"active_default_storage_type": StorageType.ethyca.value}},
         )
         assert response.status_code == 422
 

--- a/tests/ops/api/v1/endpoints/test_storage_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_storage_endpoints.py
@@ -1650,3 +1650,55 @@ class TestGetStorageStatus:
         response = StorageConfigStatusMessage(**response.json())
         assert response.config_status == StorageConfigStatus.configured
         assert StorageType.s3.value in (response.detail)
+
+    @pytest.fixture(scope="function")
+    def active_default_storage_gcs(self, db, config_proxy: ConfigProxy):
+        """Set gcs as the `active_default_storage_type` property"""
+        original_value = config_proxy.storage.active_default_storage_type
+        ApplicationConfig.update_api_set(
+            db, {"storage": {"active_default_storage_type": StorageType.gcs.value}}
+        )
+        yield
+        ApplicationConfig.update_api_set(
+            db, {"storage": {"active_default_storage_type": original_value}}
+        )
+
+    @pytest.mark.usefixtures("active_default_storage_gcs", "storage_config_default_gcs")
+    def test_get_storage_status_gcs(
+        self,
+        url,
+        api_client: TestClient,
+        generate_auth_header,
+    ):
+        """
+        We should get back a successful response now that
+        we set gcs as the `active_default_storage_type` via app setting
+        and the config has been added via fixture
+        """
+        auth_header = generate_auth_header([STORAGE_READ])
+        response = api_client.get(url, headers=auth_header)
+        assert response.status_code == 200
+        response = StorageConfigStatusMessage(**response.json())
+        assert response.config_status == StorageConfigStatus.configured
+        assert StorageType.gcs.value in (response.detail)
+
+    @pytest.mark.usefixtures(
+        "active_default_storage_gcs", "storage_config_default_gcs_service_account_keys"
+    )
+    def test_get_storage_status_gcs_service_account_keys(
+        self,
+        url,
+        api_client: TestClient,
+        generate_auth_header,
+    ):
+        """
+        We should get back a successful response now that
+        we set gcs as the `active_default_storage_type` via app setting
+        and the config has been added via fixture
+        """
+        auth_header = generate_auth_header([STORAGE_READ])
+        response = api_client.get(url, headers=auth_header)
+        assert response.status_code == 200
+        response = StorageConfigStatusMessage(**response.json())
+        assert response.config_status == StorageConfigStatus.configured
+        assert StorageType.gcs.value in (response.detail)

--- a/tests/ops/service/storage/test_gcs.py
+++ b/tests/ops/service/storage/test_gcs.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fides.api.common_exceptions import StorageUploadError
+from fides.api.schemas.storage.storage import GCSAuthMethod
+from fides.api.service.storage.gcs import get_gcs_client
+
+
+class TestGetGCSClient:
+    def test_get_gcs_client_adc(self):
+        """Test getting GCS client using ADC authentication."""
+        with patch("fides.api.service.storage.gcs.Client") as mock_client:
+            mock_client.return_value = MagicMock()
+            client = get_gcs_client(GCSAuthMethod.ADC.value, None)
+            assert isinstance(client, MagicMock)
+            mock_client.assert_called_once()
+
+    def test_get_gcs_client_service_account(self):
+        """Test getting GCS client using service account authentication."""
+        test_secrets = {
+            "type": "service_account",
+            "project_id": "test-project-123",
+            "private_key_id": "test-key-id-456",
+            "private_key": (
+                "-----BEGIN PRIVATE KEY-----\n"
+                "MIItest\n"
+                "-----END PRIVATE KEY-----\n"
+            ),
+            "client_email": "test-service@test-project-123.iam.gserviceaccount.com",
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": (
+                "https://www.googleapis.com/oauth2/v1/certs"
+            ),
+            "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-service%40test-project-123.iam.gserviceaccount.com",
+        }
+
+        with patch(
+            "fides.api.service.storage.gcs.service_account.Credentials"
+        ) as mock_creds:
+            with patch("fides.api.service.storage.gcs.Client") as mock_client:
+                mock_credentials = MagicMock()
+                mock_creds.from_service_account_info.return_value = mock_credentials
+                mock_client.return_value = MagicMock()
+
+                client = get_gcs_client(
+                    GCSAuthMethod.SERVICE_ACCOUNT_KEYS.value, test_secrets
+                )
+
+                mock_creds.from_service_account_info.assert_called_once_with(
+                    test_secrets
+                )
+                mock_client.assert_called_once_with(credentials=mock_credentials)
+                assert isinstance(client, MagicMock)
+
+    def test_get_gcs_client_service_account_no_secrets(self):
+        """Test GCS client with service account auth and missing secrets."""
+        with pytest.raises(StorageUploadError) as exc_info:
+            get_gcs_client(GCSAuthMethod.SERVICE_ACCOUNT_KEYS.value, None)
+        assert "Storage secrets not found for Google Cloud Storage" in str(
+            exc_info.value
+        )
+
+    def test_get_gcs_client_invalid_auth_method(self):
+        """Test getting GCS client with invalid authentication method."""
+        invalid_auth = "invalid_auth"
+        with pytest.raises(ValueError) as exc_info:
+            get_gcs_client(invalid_auth, None)
+        expected_msg = "Google Cloud Storage auth method not supported: invalid_auth"
+        assert expected_msg in str(exc_info.value)

--- a/tests/ops/service/storage/test_gcs.py
+++ b/tests/ops/service/storage/test_gcs.py
@@ -35,6 +35,7 @@ class TestGetGCSClient:
                 "https://www.googleapis.com/oauth2/v1/certs"
             ),
             "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-service%40test-project-123.iam.gserviceaccount.com",
+            "universe_domain": "googleapis.com",
         }
 
         with patch(

--- a/tests/ops/service/storage/test_storage_uploader_service.py
+++ b/tests/ops/service/storage/test_storage_uploader_service.py
@@ -192,10 +192,12 @@ class TestS3Uploader:
         mock_upload_to_s3.assert_not_called()
 
 
+@mock.patch(
+    "fides.api.service.storage.storage_uploader_service.upload_to_gcs", autospec=True
+)
 class TestGCSUploader:
     """Test suite for Google Cloud Storage upload functionality."""
 
-    @mock.patch("fides.api.service.storage.storage_uploader_service.upload_to_gcs")
     def test_uploader_gcs_success_service_account_keys_auth(
         self,
         mock_upload_to_gcs: Mock,
@@ -228,7 +230,6 @@ class TestGCSUploader:
             "service_account_keys",
         )
 
-    @mock.patch("fides.api.service.storage.storage_uploader_service.upload_to_gcs")
     def test_uploader_gcs_success_adc_auth(
         self,
         mock_upload_to_gcs: Mock,
@@ -261,7 +262,6 @@ class TestGCSUploader:
             "adc",
         )
 
-    @mock.patch("fides.api.service.storage.storage_uploader_service.upload_to_gcs")
     def test_uploader_gcs_invalid_file_naming(
         self,
         mock_upload_to_gcs: Mock,
@@ -291,7 +291,6 @@ class TestGCSUploader:
 
         mock_upload_to_gcs.assert_not_called()
 
-    @mock.patch("fides.api.service.storage.storage_uploader_service.upload_to_gcs")
     def test_uploader_gcs_with_csv_format(
         self,
         mock_upload_to_gcs: Mock,
@@ -327,7 +326,6 @@ class TestGCSUploader:
             "adc",
         )
 
-    @mock.patch("fides.api.service.storage.storage_uploader_service.upload_to_gcs")
     def test_uploader_gcs_with_html_format(
         self,
         mock_upload_to_gcs: Mock,
@@ -363,7 +361,6 @@ class TestGCSUploader:
             "adc",
         )
 
-    @mock.patch("fides.api.service.storage.storage_uploader_service.upload_to_gcs")
     def test_uploader_gcs_missing_bucket(
         self,
         mock_upload_to_gcs: Mock,

--- a/tests/ops/tasks/test_storage.py
+++ b/tests/ops/tasks/test_storage.py
@@ -1,21 +1,22 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
+from google.cloud.storage import Blob, Bucket, Client
 
 from fides.api.schemas.storage.storage import ResponseFormat
 from fides.api.tasks.storage import upload_to_gcs
 from fides.config import CONFIG
 
 
+@patch("fides.api.tasks.storage.write_to_in_memory_buffer", autospec=True)
+@patch("fides.api.tasks.storage.get_gcs_client", autospec=True)
 class TestUploadToGCS:
-    @patch("fides.api.tasks.storage.write_to_in_memory_buffer")
-    @patch("fides.api.tasks.storage.get_gcs_client")
     def test_upload_to_gcs_success(
         self, mock_get_gcs_client, mock_write_to_in_memory_buffer
     ):
-        mock_storage_client = MagicMock()
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
+        mock_storage_client = create_autospec(Client)
+        mock_bucket = create_autospec(Bucket)
+        mock_blob = create_autospec(Blob)
         mock_in_memory_file = MagicMock()
 
         mock_get_gcs_client.return_value = mock_storage_client
@@ -54,15 +55,13 @@ class TestUploadToGCS:
         )
         assert result == "http://example.com/signed-url"
 
-    @patch("fides.api.tasks.storage.logger")
-    @patch("fides.api.tasks.storage.write_to_in_memory_buffer")
-    @patch("fides.api.tasks.storage.get_gcs_client")
+    @patch("fides.api.tasks.storage.logger", autospec=True)
     def test_upload_to_gcs_exception(
-        self, mock_get_gcs_client, mock_write_to_in_memory_buffer, mock_logger
+        self, mock_logger, mock_get_gcs_client, mock_write_to_in_memory_buffer
     ):
-        mock_storage_client = MagicMock()
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
+        mock_storage_client = create_autospec(Client)
+        mock_bucket = create_autospec(Bucket)
+        mock_blob = create_autospec(Blob)
         mock_in_memory_file = MagicMock()
 
         mock_get_gcs_client.return_value = mock_storage_client

--- a/tests/ops/tasks/test_storage.py
+++ b/tests/ops/tasks/test_storage.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fides.api.schemas.storage.storage import ResponseFormat
+from fides.api.tasks.storage import upload_to_gcs
+from fides.config import CONFIG
+
+
+class TestUploadToGCS:
+    @patch("fides.api.tasks.storage.write_to_in_memory_buffer")
+    @patch("fides.api.tasks.storage.get_gcs_client")
+    def test_upload_to_gcs_success(
+        self, mock_get_gcs_client, mock_write_to_in_memory_buffer
+    ):
+        mock_storage_client = MagicMock()
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_in_memory_file = MagicMock()
+
+        mock_get_gcs_client.return_value = mock_storage_client
+        mock_storage_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+        mock_write_to_in_memory_buffer.return_value = mock_in_memory_file
+        mock_blob.generate_signed_url.return_value = "http://example.com/signed-url"
+
+        privacy_request = MagicMock(id="test-request-id")
+
+        result = upload_to_gcs(
+            storage_secrets={"private_key_id": "test-private-key-id"},
+            data={"key": "value"},
+            bucket_name="test-bucket",
+            file_key="test-file",
+            resp_format=ResponseFormat.json.value,
+            privacy_request=privacy_request,
+            auth_method="test-auth-method",
+        )
+
+        mock_get_gcs_client.assert_called_once_with(
+            "test-auth-method", {"private_key_id": "test-private-key-id"}
+        )
+        mock_storage_client.bucket.assert_called_once_with("test-bucket")
+        mock_bucket.blob.assert_called_once_with("test-file")
+        mock_write_to_in_memory_buffer.assert_called_once_with(
+            ResponseFormat.json.value, {"key": "value"}, privacy_request
+        )
+        mock_blob.upload_from_string.assert_called_once_with(
+            mock_in_memory_file.getvalue(), content_type="application/json"
+        )
+        mock_blob.generate_signed_url.assert_called_once_with(
+            version="v4",
+            expiration=CONFIG.security.subject_request_download_link_ttl_seconds,
+            method="GET",
+        )
+        assert result == "http://example.com/signed-url"
+
+    @patch("fides.api.tasks.storage.logger")
+    @patch("fides.api.tasks.storage.write_to_in_memory_buffer")
+    @patch("fides.api.tasks.storage.get_gcs_client")
+    def test_upload_to_gcs_exception(
+        self, mock_get_gcs_client, mock_write_to_in_memory_buffer, mock_logger
+    ):
+        mock_storage_client = MagicMock()
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_in_memory_file = MagicMock()
+
+        mock_get_gcs_client.return_value = mock_storage_client
+        mock_storage_client.bucket.return_value = mock_bucket
+        mock_bucket.blob.return_value = mock_blob
+        mock_write_to_in_memory_buffer.return_value = mock_in_memory_file
+        error = Exception("Upload failed")
+        mock_blob.upload_from_string.side_effect = error
+
+        privacy_request = MagicMock(id="test-request-id")
+
+        with pytest.raises(Exception) as excinfo:
+            upload_to_gcs(
+                storage_secrets={"private_key_id": "test-private-key-id"},
+                data={"key": "value"},
+                bucket_name="test-bucket",
+                file_key="test-file",
+                resp_format=ResponseFormat.csv.value,
+                privacy_request=privacy_request,
+                auth_method="test-auth-method",
+            )
+
+        mock_get_gcs_client.assert_called_once_with(
+            "test-auth-method", {"private_key_id": "test-private-key-id"}
+        )
+        mock_storage_client.bucket.assert_called_once_with("test-bucket")
+        mock_bucket.blob.assert_called_once_with("test-file")
+        mock_write_to_in_memory_buffer.assert_called_once_with(
+            ResponseFormat.csv.value, {"key": "value"}, privacy_request
+        )
+        mock_blob.upload_from_string.assert_called_once_with(
+            mock_in_memory_file.getvalue(), content_type="application/zip"
+        )
+        mock_blob.generate_signed_url.assert_not_called()
+        mock_logger.error.assert_called_once_with(
+            "Encountered error while uploading and generating link for Google Cloud Storage object: {}",
+            error,
+        )
+        assert "Upload failed" in str(excinfo.value)

--- a/tests/ops/util/test_storage_authenticator.py
+++ b/tests/ops/util/test_storage_authenticator.py
@@ -1,6 +1,9 @@
+from unittest import mock
+
 import boto3
 import pytest
 from botocore.exceptions import NoCredentialsError
+from google.auth.exceptions import GoogleAuthError
 from moto import mock_aws
 
 from fides.api.common_exceptions import StorageUploadError
@@ -97,3 +100,108 @@ def test_get_s3_client_with_assume_role(storage_secrets):
     )
     assert s3_client is not None
     assert s3_client.list_buckets() is not None
+
+
+class TestGCSAuthenticator:
+    """Tests for GCS storage authenticator"""
+
+    @mock.patch("fides.api.service.storage.storage_authenticator_service.Request")
+    @mock.patch(
+        "fides.api.service.storage.storage_authenticator_service.service_account.Credentials"
+    )
+    def test_secrets_are_valid_for_gcs(self, mock_credentials, mock_request):
+        """Test GCS credentials validation with valid credentials"""
+        # Mock the credentials and request
+        mock_creds_instance = mock.MagicMock()
+        mock_credentials.from_service_account_info.return_value = mock_creds_instance
+
+        test_secrets = {
+            "type": "service_account",
+            "project_id": "test-project-123",
+            "private_key_id": "test-key-id-456",
+            "private_key": (
+                "-----BEGIN PRIVATE KEY-----\nMIItest\n-----END PRIVATE KEY-----\n"
+            ),
+            "client_email": "test-service@test-project-123.iam.gserviceaccount.com",
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": (
+                "https://www.googleapis.com/oauth2/v1/certs"
+            ),
+            "client_x509_cert_url": (
+                "https://www.googleapis.com/robot/v1/metadata/x509/"
+                "test-service%40test-project-123.iam.gserviceaccount.com"
+            ),
+        }
+
+        assert secrets_are_valid(test_secrets, StorageType.gcs)
+        mock_credentials.from_service_account_info.assert_called_once_with(
+            test_secrets,
+            scopes=["https://www.googleapis.com/auth/devstorage.read_only"],
+        )
+        mock_creds_instance.refresh.assert_called_once_with(mock_request())
+
+    @mock.patch("fides.api.service.storage.storage_authenticator_service.logger")
+    @mock.patch("fides.api.service.storage.storage_authenticator_service.Request")
+    @mock.patch(
+        "fides.api.service.storage.storage_authenticator_service.service_account.Credentials"
+    )
+    def test_secrets_are_invalid_for_gcs(
+        self, mock_credentials, mock_request, mock_logger
+    ):
+        """Test GCS credentials validation with invalid credentials"""
+        mock_creds_instance = mock.MagicMock()
+        mock_credentials.from_service_account_info.return_value = mock_creds_instance
+        error = GoogleAuthError("Invalid credentials")
+        mock_creds_instance.refresh.side_effect = error
+
+        test_secrets = {
+            "type": "service_account",
+            "project_id": "test-project-123",
+            "private_key_id": "invalid-key",
+            "private_key": "invalid-key-data",
+            "client_email": "test@test.com",
+        }
+
+        assert not secrets_are_valid(test_secrets, StorageType.gcs)
+        mock_credentials.from_service_account_info.assert_called_once_with(
+            test_secrets,
+            scopes=["https://www.googleapis.com/auth/devstorage.read_only"],
+        )
+        mock_creds_instance.refresh.assert_called_once_with(mock_request())
+        mock_logger.warning.assert_called_once_with(
+            "Google authentication error trying to authenticate GCS secrets: {}", error
+        )
+
+    @mock.patch("fides.api.service.storage.storage_authenticator_service.logger")
+    @mock.patch("fides.api.service.storage.storage_authenticator_service.Request")
+    @mock.patch(
+        "fides.api.service.storage.storage_authenticator_service.service_account.Credentials"
+    )
+    def test_secrets_validation_unexpected_error(
+        self, mock_credentials, mock_request, mock_logger
+    ):
+        """Test GCS credentials validation with unexpected error"""
+        mock_creds_instance = mock.MagicMock()
+        mock_credentials.from_service_account_info.return_value = mock_creds_instance
+        error = Exception("Unexpected error")
+        mock_creds_instance.refresh.side_effect = error
+
+        test_secrets = {
+            "type": "service_account",
+            "project_id": "test-project-123",
+            "private_key_id": "test-key",
+            "private_key": "test-key-data",
+            "client_email": "test@test.com",
+        }
+
+        assert not secrets_are_valid(test_secrets, StorageType.gcs)
+        mock_credentials.from_service_account_info.assert_called_once_with(
+            test_secrets,
+            scopes=["https://www.googleapis.com/auth/devstorage.read_only"],
+        )
+        mock_creds_instance.refresh.assert_called_once_with(mock_request())
+        mock_logger.warning.assert_called_once_with(
+            "Unexpected error authenticating GCS secrets: {}", error
+        )

--- a/tests/ops/util/test_storage_authenticator.py
+++ b/tests/ops/util/test_storage_authenticator.py
@@ -133,6 +133,7 @@ class TestGCSAuthenticator:
                 "https://www.googleapis.com/robot/v1/metadata/x509/"
                 "test-service%40test-project-123.iam.gserviceaccount.com"
             ),
+            "universe_domain": "googleapis.com",
         }
 
         assert secrets_are_valid(test_secrets, StorageType.gcs)

--- a/tests/ops/util/test_storage_util.py
+++ b/tests/ops/util/test_storage_util.py
@@ -1,6 +1,10 @@
 import pytest
 
-from fides.api.schemas.storage.storage import StorageSecretsS3, StorageType
+from fides.api.schemas.storage.storage import (
+    StorageSecretsGCS,
+    StorageSecretsS3,
+    StorageType,
+)
 from fides.api.util.storage_util import get_schema_for_secrets
 
 
@@ -35,7 +39,7 @@ class TestStorageUtil:
             )
         assert "Extra inputs are not permitted" in str(e)
 
-    def test_get_schema_for_secrets(self):
+    def test_get_schema_for_secrets_s3(self):
         secrets = get_schema_for_secrets(
             "s3",
             StorageSecretsS3(
@@ -55,3 +59,50 @@ class TestStorageUtil:
         )
         assert secrets.aws_access_key_id == "aws_access_key_id"
         assert secrets.aws_secret_access_key == "aws_secret_access_key"
+
+    def test_get_schema_for_secrets_gcs(self):
+        secrets = get_schema_for_secrets(
+            StorageType.gcs,
+            StorageSecretsGCS(
+                type="service_account",
+                project_id="test-project-123",
+                private_key_id="test-key-id-456",
+                private_key=(
+                    "-----BEGIN PRIVATE KEY-----\nMIItest\n-----END PRIVATE KEY-----\n"
+                ),
+                client_email="test-service@test-project-123.iam.gserviceaccount.com",
+                client_id="123456789",
+                auth_uri="https://accounts.google.com/o/oauth2/auth",
+                token_uri="https://oauth2.googleapis.com/token",
+                auth_provider_x509_cert_url=(
+                    "https://www.googleapis.com/oauth2/v1/certs"
+                ),
+                client_x509_cert_url=(
+                    "https://www.googleapis.com/robot/v1/metadata/x509/"
+                    "test-service%40test-project-123.iam.gserviceaccount.com"
+                ),
+                universe_domain="googleapis.com",
+            ),
+        )
+
+        assert secrets.type == "service_account"
+        assert secrets.project_id == "test-project-123"
+        assert secrets.private_key_id == "test-key-id-456"
+        assert secrets.private_key == (
+            "-----BEGIN PRIVATE KEY-----\nMIItest\n-----END PRIVATE KEY-----\n"
+        )
+        assert (
+            secrets.client_email
+            == "test-service@test-project-123.iam.gserviceaccount.com"
+        )
+        assert secrets.client_id == "123456789"
+        assert secrets.auth_uri == "https://accounts.google.com/o/oauth2/auth"
+        assert secrets.token_uri == "https://oauth2.googleapis.com/token"
+        assert secrets.auth_provider_x509_cert_url == (
+            "https://www.googleapis.com/oauth2/v1/certs"
+        )
+        assert secrets.client_x509_cert_url == (
+            "https://www.googleapis.com/robot/v1/metadata/x509/"
+            "test-service%40test-project-123.iam.gserviceaccount.com"
+        )
+        assert secrets.universe_domain == "googleapis.com"


### PR DESCRIPTION
Closes [HA-524](https://ethyca.atlassian.net/browse/HA-524)

### Description Of Changes

Google Cloud Storage (GCS) can now be chosen as storage for privacy requests.

### Code Changes

- Added GCS storage configuration UI component and related type definitions
- Extended storage schemas and endpoints to support GCS integration
- Created a new method to handle interactions with GCS: uploading files and generating signed URLs for secure access.
- Added authentication service for GCS.
- Updated storage upload service to handle GCS uploads
- Added test coverage for GCS functionality

### Steps to Confirm

1.  Create a default storage for GCS. Make a PUT request to `/api/v1/storage/default` with the following body:
```
{
  "type": "gcs",
  "details": {
    "naming": "request_id",
    "auth_method": "service_account_keys",
    "bucket": "prj-sandbox-55855-test-bucket",
    "max_retries": 0
  },
  "format": "json"
}
```
2. Make a PATCH request to `/api/v1/config` with the following body:
```
{
  "storage": {
    "active_default_storage_type": "gcs"
}
```
3. Add secrets for the new storage. Make a PUT request to `/api/v1/storage/default/{storage_type}/secret` with storage_type "gcp" and the body of the request is in 1password under the name "GCS prj-sandbox-55855-test-bucket".

**To test that the storage is working:**
1. Add a system
2. Add an Integration
3. Add dataset
4. Make sure the new storage is set as the default storage.
5. The environment variable `FIDES__SECURITY__SUBJECT_REQUEST_DOWNLOAD_UI_ENABLED` must be true to be able to download the files.
6. Create a new privacy request ("access your data")
7. Access the bucket in [https://console.cloud.google.com/storage/browser/prj-sandbox-55855-test-bucket](https://console.cloud.google.com/storage/browser/prj-sandbox-55855-test-bucket) and verify that the file is there with the correct content type
8. From the admin UI, access the privacy request and download the request results. It should open a new tab in the browser with the json.

**Another way to configure storage and its secrets:**
1. Go to `/privacy-requests/configure/storage`, select GCS and fill out the form. The secret details are in 1password under the name "GCS prj-sandbox-55855-test-bucket".

### Pre-Merge Checklist

* [ ] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [x] Followup issues created (include link) -> https://ethyca.atlassian.net/browse/HA-622
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [x] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[HA-524]: https://ethyca.atlassian.net/browse/HA-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ