### PR TITLE
Actually fix Publish Fides action

### DIFF
--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -35,8 +35,11 @@ jobs:
           cd clients
           npm run prod-export-admin-ui
 
-      - name: Install Twine, wheel, and setuptools
-        run: pip install twine setuptools wheel
+      - name: Install setuptools
+        run: pip install setuptools -U
+
+      - name: Install Twine and wheel
+        run: pip install twine wheel
 
       # The git reset is required here because the build modifies
       # egg-info and the wheel becomes a dirty version


### PR DESCRIPTION

### Description Of Changes

Actually fix the Publish Fides action by installing a newer setuptools version. 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
