### PR TITLE
Read-only database connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Adds integration tests for Enterprise Bigquery DSR nested fields [#5969](https://github.com/ethyca/fides/pull/5969)
 - Added `tcf_configuration_id` to `PrivacyExperienceConfig` and fixes `TCFPublisherRestriction` validations [#6012](https://github.com/ethyca/fides/pull/6012) https://github.com/ethyca/fides/labels/db-migration
 - Added a `--separate-files` flag to the `fides pull dataset` CLI command to pull each dataset into its own file [#6007](https://github.com/ethyca/fides/pull/6007)
+- Added a `readonly_server` database setting to support specifying a read-only database [#6023](https://github.com/ethyca/fides/pull/6023)
 
 ### Changed
 - Bumped Next.js for all frontend apps to latest patch versions. [#5946](https://github.com/ethyca/fides/pull/5946)

--- a/src/fides/api/api/deps.py
+++ b/src/fides/api/api/deps.py
@@ -12,7 +12,7 @@ from fides.config import get_config as get_app_config
 from fides.config.config_proxy import ConfigProxy
 
 _engine = None
-_read_engine = None
+_readonly_engine = None
 
 
 def get_config() -> FidesConfig:
@@ -76,9 +76,9 @@ def get_readonly_api_session() -> Session:
     if not CONFIG.database.sqlalchemy_readonly_database_uri:
         return get_api_session()
 
-    global _read_engine  # pylint: disable=W0603
-    if not _read_engine:
-        _read_engine = get_db_engine(
+    global _readonly_engine  # pylint: disable=W0603
+    if not _readonly_engine:
+        _readonly_engine = get_db_engine(
             database_uri=CONFIG.database.sqlalchemy_readonly_database_uri,
             pool_size=CONFIG.database.api_engine_pool_size,
             max_overflow=CONFIG.database.api_engine_max_overflow,
@@ -86,7 +86,7 @@ def get_readonly_api_session() -> Session:
             keepalives_interval=CONFIG.database.api_engine_keepalives_interval,
             keepalives_count=CONFIG.database.api_engine_keepalives_count,
         )
-    SessionLocal = get_db_session(CONFIG, engine=_read_engine)
+    SessionLocal = get_db_session(CONFIG, engine=_readonly_engine)
     db = SessionLocal()
     return db
 

--- a/src/fides/api/api/deps.py
+++ b/src/fides/api/api/deps.py
@@ -12,6 +12,7 @@ from fides.config import get_config as get_app_config
 from fides.config.config_proxy import ConfigProxy
 
 _engine = None
+_read_engine = None
 
 
 def get_config() -> FidesConfig:
@@ -23,6 +24,15 @@ def get_db() -> Generator:
     """Return our database session"""
     try:
         db = get_api_session()
+        yield db
+    finally:
+        db.close()
+
+
+def get_readonly_db() -> Generator:
+    """Return our readonly database session"""
+    try:
+        db = get_readonly_api_session()
         yield db
     finally:
         db.close()
@@ -57,6 +67,26 @@ def get_api_session() -> Session:
             keepalives_count=CONFIG.database.api_engine_keepalives_count,
         )
     SessionLocal = get_db_session(CONFIG, engine=_engine)
+    db = SessionLocal()
+    return db
+
+
+def get_readonly_api_session() -> Session:
+    """Gets the shared read-only database session to use for API functionality"""
+    if not CONFIG.database.sqlalchemy_readonly_database_uri:
+        return get_api_session()
+
+    global _read_engine  # pylint: disable=W0603
+    if not _read_engine:
+        _read_engine = get_db_engine(
+            database_uri=CONFIG.database.sqlalchemy_readonly_database_uri,
+            pool_size=CONFIG.database.api_engine_pool_size,
+            max_overflow=CONFIG.database.api_engine_max_overflow,
+            keepalives_idle=CONFIG.database.api_engine_keepalives_idle,
+            keepalives_interval=CONFIG.database.api_engine_keepalives_interval,
+            keepalives_count=CONFIG.database.api_engine_keepalives_count,
+        )
+    SessionLocal = get_db_session(CONFIG, engine=_read_engine)
     db = SessionLocal()
     return db
 

--- a/src/fides/config/database_settings.py
+++ b/src/fides/config/database_settings.py
@@ -65,6 +65,17 @@ class DatabaseSettings(FidesSettings):
         default="default-db",
         description="The hostname of the application database server.",
     )
+    readonly_server: Optional[str] = Field(
+        default=None,
+        description="The hostname of the application read database server.",
+    )
+
+    # TODO (LJ-663): add optional readonly_user
+    # TODO (LJ-663): add optional readonly_password
+    # TODO (LJ-663): add optional readonly_port
+    # TODO (LJ-663): add optional readonly_params
+    # TODO (LJ-663): add optional readonly_db
+
     task_engine_pool_size: int = Field(
         default=50,
         description="Number of concurrent database connections Fides will use for executing privacy request tasks, either locally or on each worker. Note that the pool begins with no connections, but as they are requested the connections are maintained and reused up to this limit.",
@@ -103,6 +114,11 @@ class DatabaseSettings(FidesSettings):
     sqlalchemy_database_uri: str = Field(
         default="",
         description="Programmatically created connection string for the application database.",
+        exclude=True,
+    )
+    sqlalchemy_readonly_database_uri: Optional[str] = Field(
+        default=None,
+        description="Programmatically created connection string for the read-only application database.",
         exclude=True,
     )
     sqlalchemy_test_database_uri: str = Field(
@@ -206,6 +222,36 @@ class DatabaseSettings(FidesSettings):
                 username=info.data.get("user"),
                 password=info.data.get("password"),
                 host=info.data.get("server"),
+                port=port,
+                path=f"{info.data.get('db') or ''}",
+                query=(
+                    urlencode(
+                        cast(Dict, info.data.get("params")), quote_via=quote, safe="/"
+                    )
+                    if info.data.get("params")
+                    else None
+                ),
+            )
+        )
+
+    @field_validator("sqlalchemy_readonly_database_uri", mode="before")
+    @classmethod
+    def assemble_readonly_db_connection(
+        cls, v: Optional[str], info: ValidationInfo
+    ) -> Optional[str]:
+        """Join DB connection credentials into a synchronous connection string."""
+        if isinstance(v, str) and v:
+            return v
+        if not info.data.get("readonly_server"):
+            return None
+        port: int = port_integer_converter(info)
+        return str(
+            # TODO: support optional readonly params for user, password, etc.
+            PostgresDsn.build(  # pylint: disable=no-member
+                scheme="postgresql",
+                username=info.data.get("user"),
+                password=info.data.get("password"),
+                host=info.data.get("readonly_server"),
                 port=port,
                 path=f"{info.data.get('db') or ''}",
                 query=(


### PR DESCRIPTION
### Description Of Changes

Updates `DatabaseSettings` to be able to specify a read-only database server. This is phase one, a more complete implementation will be added in https://ethyca.atlassian.net/browse/LJ-663

### Code Changes

* Added `readonly_server` and `sqlalchemy_readonly_database_uri` to `DatabaseSettings`
* Added `get_readonly_api_session`, it falls back to a normal database session if `readonly_server` is not provided

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
