### PR TITLE
Fix a typo in Vermont

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.59.0...main)
 
-
+### Fixed
+- Fixed typo in Vermont US state name [#6029](https://github.com/ethyca/fides/pull/6029)
 
 ## [2.59.0](https://github.com/ethyca/fides/compare/2.58.2...2.59.0)
 

--- a/clients/admin-ui/src/features/common/privacy-notice-regions.ts
+++ b/clients/admin-ui/src/features/common/privacy-notice-regions.ts
@@ -296,7 +296,7 @@ export const PRIVACY_NOTICE_REGION_RECORD: Record<PrivacyNoticeRegion, string> =
     [PrivacyNoticeRegion.US_UT]: "Utah",
     [PrivacyNoticeRegion.US_VA]: "Virginia",
     [PrivacyNoticeRegion.US_VI]: "United States Virgin Islands",
-    [PrivacyNoticeRegion.US_VT]: "Vermon",
+    [PrivacyNoticeRegion.US_VT]: "Vermont",
     [PrivacyNoticeRegion.US_WA]: "Washington",
     [PrivacyNoticeRegion.US_WV]: "West Virginia",
     [PrivacyNoticeRegion.US_WI]: "Wisconsin",


### PR DESCRIPTION
There is no associated ticket.

### Description Of Changes

There was a typo in "Vermont" that used to say "Vermon".

### Code Changes

- Text updated

### Steps to Confirm

1. In the left menu, go to Consent -> Experiences
2. Scroll down to Locations & Languages
3. Click "Add location"
4. Search for Vermont

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
