### PR TITLE
Reduce cypress threads to 2 for PC tests

### DIFF
--- a/clients/privacy-center/package.json
+++ b/clients/privacy-center/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf .turbo node_modules .next",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "cy:parallel": "cypress-parallel -s cy:run -t 5 -d cypress/e2e -n ../node_modules/cypress-multi-reporters",
+    "cy:parallel": "cypress-parallel -s cy:run -t 2 -d cypress/e2e -n ../node_modules/cypress-multi-reporters",
     "cy:start": "export NODE_ENV=test && export FIDES_PRIVACY_CENTER__IS_OVERLAY_ENABLED=true && npm run build && next start -p 3001",
     "analyze": "cross-env ANALYZE=true next build",
     "analyze:server": "cross-env BUNDLE_ANALYZE=server next build",


### PR DESCRIPTION
### Description Of Changes

I had added the cypress-parallels library to bring down the execution time on these tests. However, we're seeing some flakiness and it looks like me like the runners are getting resource constrained. This should ease up the stress on the runner by only running two threads, while at the same time, still giving us a gain on a single thread.
### Code Changes

* Changes the cy:parallel command to use 2 threads instead of 5.

### Steps to Confirm

1. The privacy center cypress tests should run successfully.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
