### PR TITLE
Fix failing asset table test

### DIFF
--- a/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems-plus.cy.ts
@@ -491,7 +491,7 @@ describe("System management with Plus features", () => {
       cy.wait("@getSystemAssets");
       cy.getByTestId("row-0-col-name").should("contain", "ar_debug");
       cy.getByTestId("row-0-col-locations").should("contain", "United States");
-      cy.getByTestId("row-0-col-data_uses").should("contain", "analytics");
+      cy.getByTestId("row-0-col-data_uses").should("contain", "Analytics");
       cy.getByTestId("row-0-col-data_uses").should("not.contain", "employment");
     });
 


### PR DESCRIPTION
Closes unticketed

### Description Of Changes

Fixes a failing Cypress test on the system assets tab.

### Steps to Confirm

1.  CI passes

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
