### PR TITLE
TCF Experience option for selecting a restriction configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.59.0...main)
 
+### Added
+- Added support for selecting TCF Publisher Override configuration when configuring Privacy Experience [#6033](https://github.com/ethyca/fides/pull/6033)
+
 ### Changed
 - Changed how TCF Publisher Overrides gets configured in consent settings [#6013](https://github.com/ethyca/fides/pull/6013)
 - Frontend now do not generate `key` when creating a Website Monitor [#6041](https://github.com/ethyca/fides/pull/6041)

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -510,6 +510,9 @@ export const stubExperienceConfig = () => {
   cy.intercept("POST", "/api/v1/experience-config", {
     fixture: "privacy-experiences/experienceConfig.json",
   }).as("postExperience");
+  cy.intercept("GET", "/api/v1/plus/tcf/configurations*", {
+    fixture: "tcf/configurations.json",
+  }).as("getTcfConfigs");
   stubPlus(true);
 };
 

--- a/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/ConfigurePrivacyExperience.tsx
@@ -123,6 +123,11 @@ const ConfigurePrivacyExperience = ({
     values.privacy_notice_ids = values.privacy_notice_ids?.filter(
       (item) => item !== "tcf_purposes_placeholder",
     );
+    if (initialValues.tcf_configuration_id && !values.tcf_configuration_id) {
+      // If the TCF configuration gets cleared, set the TCF configuration ID to null to remove it on the DB side
+      // eslint-disable-next-line no-param-reassign
+      values.tcf_configuration_id = null;
+    }
     const valuesToSubmit = {
       ...values,
       disabled: passedInExperience?.disabled ?? true,

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -1,6 +1,7 @@
 import {
   AntButton as Button,
   AntSelectProps as SelectProps,
+  AntTooltip as Tooltip,
   ArrowForwardIcon,
   Box,
   Collapse,
@@ -19,6 +20,10 @@ import BackButton from "~/features/common/nav/BackButton";
 import { PRIVACY_EXPERIENCE_ROUTE } from "~/features/common/nav/routes";
 import { PRIVACY_NOTICE_REGION_RECORD } from "~/features/common/privacy-notice-regions";
 import ScrollableList from "~/features/common/ScrollableList";
+import {
+  selectTCFConfigFilters,
+  useGetTCFConfigurationsQuery,
+} from "~/features/consent-settings/tcf/tcf-config.slice";
 import {
   selectLocationsRegulations,
   useGetLocationsRegulationsQuery,
@@ -49,6 +54,7 @@ import {
 } from "~/types/api";
 
 import { ControlledSelect } from "../common/form/ControlledSelect";
+import { useGetConfigurationSettingsQuery } from "../config-settings/config-settings.slice";
 
 const componentTypeOptions: SelectProps["options"] = [
   {
@@ -151,6 +157,10 @@ export const PrivacyExperienceForm = ({
   const noticePageSize = useAppSelector(selectNoticePageSize);
   useGetAllPrivacyNoticesQuery({ page: noticePage, size: noticePageSize });
 
+  const { data: appConfig } = useGetConfigurationSettingsQuery({
+    api_set: true,
+  });
+
   const allPrivacyNoticesWithTcfPlaceholder: LimitedPrivacyNoticeResponseSchema[] =
     useMemo(() => {
       const noticesWithTcfPlaceholder = [...allPrivacyNotices];
@@ -203,6 +213,18 @@ export const PrivacyExperienceForm = ({
   useGetAllPropertiesQuery({ page: propertyPage, size: propertyPageSize });
   const allProperties = useAppSelector(selectAllProperties);
 
+  const tcfConfigFilters = useAppSelector(selectTCFConfigFilters);
+  const { data: tcfConfigs } = useGetTCFConfigurationsQuery(tcfConfigFilters);
+
+  const tcfConfigOptions = useMemo(
+    () =>
+      tcfConfigs?.items.map((config) => ({
+        label: config.name,
+        value: config.id,
+      })) ?? [],
+    [tcfConfigs],
+  );
+
   const buttonPanel = (
     <div className="flex justify-between border-t border-[#DEE5EE] p-4">
       <Button onClick={() => router.push(PRIVACY_EXPERIENCE_ROUTE)}>
@@ -248,16 +270,50 @@ export const PrivacyExperienceForm = ({
         in={values.component === ComponentType.TCF_OVERLAY}
         animateOpacity
       >
-        <ControlledSelect
-          name="reject_all_mechanism"
-          id="reject_all_mechanism"
-          options={tcfRejectAllMechanismOptions}
-          defaultValue={RejectAllMechanism.REJECT_ALL}
-          label="Reject all behavior"
-          layout="stacked"
-          disabled={values.component !== ComponentType.TCF_OVERLAY}
-          tooltip="Reject All: Blocks both consent and legitimate interest data processing across all purposes, features, and vendors. Reject Consent-Only: Blocks only consent-based processing, but allows legitimate interest processing to continue, requiring separate objection."
-        />
+        {values.component === ComponentType.TCF_OVERLAY && (
+          <Tooltip
+            title={
+              // eslint-disable-next-line no-nested-ternary
+              !appConfig?.consent?.override_vendor_purposes
+                ? "You must enable the Override vendor purposes setting in consent settings to select a TCF configuration."
+                : !tcfConfigOptions?.length
+                  ? "No TCF configurations found. Please create a TCF configuration in 'Consent settings' to select one."
+                  : undefined
+            }
+          >
+            <div>
+              <ControlledSelect
+                name="tcf_configuration_id"
+                id="tcf_configuration_id"
+                label="TCF Configuration"
+                options={tcfConfigOptions}
+                layout="stacked"
+                disabled={
+                  !tcfConfigOptions?.length ||
+                  !appConfig?.consent?.override_vendor_purposes
+                }
+                tooltip='Select a TCF configuration. Configurations are defined in "Consent settings" and apply to TCF privacy experiences.'
+                allowClear
+              />
+            </div>
+          </Tooltip>
+        )}
+      </Collapse>
+      <Collapse
+        in={values.component === ComponentType.TCF_OVERLAY}
+        animateOpacity
+      >
+        {values.component === ComponentType.TCF_OVERLAY && (
+          <ControlledSelect
+            name="reject_all_mechanism"
+            id="reject_all_mechanism"
+            options={tcfRejectAllMechanismOptions}
+            defaultValue={RejectAllMechanism.REJECT_ALL}
+            label="Reject all behavior"
+            layout="stacked"
+            tooltip="Reject All: Blocks both consent and legitimate interest data processing across all purposes, features, and vendors. Reject Consent-Only: Blocks only consent-based processing, but allows legitimate interest processing to continue, requiring separate objection."
+          />
+        )}
       </Collapse>
       <Collapse
         in={
@@ -266,26 +322,25 @@ export const PrivacyExperienceForm = ({
         }
         animateOpacity
       >
-        <ControlledSelect
-          name="layer1_button_options"
-          id="layer1_button_options"
-          defaultValue={Layer1ButtonOption.OPT_IN_OPT_OUT}
-          options={
-            values.component === ComponentType.TCF_OVERLAY
-              ? tcfBannerButtonOptions
-              : bannerButtonOptions
-          }
-          label={
-            values.component === ComponentType.TCF_OVERLAY
-              ? "Reject all visibility"
-              : "Banner options"
-          }
-          layout="stacked"
-          disabled={
-            values.component !== ComponentType.BANNER_AND_MODAL &&
-            values.component !== ComponentType.TCF_OVERLAY
-          }
-        />
+        {(values.component === ComponentType.BANNER_AND_MODAL ||
+          values.component === ComponentType.TCF_OVERLAY) && (
+          <ControlledSelect
+            name="layer1_button_options"
+            id="layer1_button_options"
+            defaultValue={Layer1ButtonOption.OPT_IN_OPT_OUT}
+            options={
+              values.component === ComponentType.TCF_OVERLAY
+                ? tcfBannerButtonOptions
+                : bannerButtonOptions
+            }
+            label={
+              values.component === ComponentType.TCF_OVERLAY
+                ? "Reject all visibility"
+                : "Banner options"
+            }
+            layout="stacked"
+          />
+        )}
       </Collapse>
       <Collapse
         in={
@@ -343,21 +398,25 @@ export const PrivacyExperienceForm = ({
           baseTestId="privacy-notice"
         />
       )}
-      {values.component === ComponentType.BANNER_AND_MODAL ? (
-        <>
-          <Collapse in={!!values.privacy_notice_ids?.length} animateOpacity>
-            <Box p="1px">
-              <CustomSwitch
-                name="show_layer1_notices"
-                id="show_layer1_notices"
-                label="Add privacy notices to banner"
-                variant="stacked"
-              />
-            </Box>
-          </Collapse>
-          <Divider />
-        </>
-      ) : null}
+      <Collapse
+        in={
+          values.component === ComponentType.BANNER_AND_MODAL &&
+          !!values.privacy_notice_ids?.length
+        }
+        animateOpacity
+      >
+        {values.component === ComponentType.BANNER_AND_MODAL && (
+          <Box p="1px">
+            <CustomSwitch
+              name="show_layer1_notices"
+              id="show_layer1_notices"
+              label="Add privacy notices to banner"
+              variant="stacked"
+            />
+          </Box>
+        )}
+      </Collapse>
+      <Divider />
       <Text as="h2" fontWeight="600">
         Locations & Languages
       </Text>

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -77,11 +77,11 @@ const componentTypeOptions: SelectProps["options"] = [
 
 const tcfRejectAllMechanismOptions: SelectProps["options"] = [
   {
-    label: "Reject All",
+    label: "Reject all",
     value: RejectAllMechanism.REJECT_ALL,
   },
   {
-    label: "Reject Consent Only",
+    label: "Reject consent only",
     value: RejectAllMechanism.REJECT_CONSENT_ONLY,
   },
 ];
@@ -99,7 +99,7 @@ const tcfBannerButtonOptions: SelectProps["options"] = [
 
 const bannerButtonOptions: SelectProps["options"] = [
   {
-    label: "Opt In/Opt Out",
+    label: "Opt in/Opt out",
     value: Layer1ButtonOption.OPT_IN_OPT_OUT,
   },
   {
@@ -311,7 +311,7 @@ export const PrivacyExperienceForm = ({
             defaultValue={RejectAllMechanism.REJECT_ALL}
             label="Reject all behavior"
             layout="stacked"
-            tooltip="Reject All: Blocks both consent and legitimate interest data processing across all purposes, features, and vendors. Reject Consent-Only: Blocks only consent-based processing, but allows legitimate interest processing to continue, requiring separate objection."
+            tooltip="Reject all: Blocks both consent and legitimate interest data processing across all purposes, features, and vendors. Reject consent-only: Blocks only consent-based processing, but allows legitimate interest processing to continue, requiring separate objection."
           />
         )}
       </Collapse>

--- a/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
+++ b/clients/admin-ui/src/types/api/models/ExperienceConfigCreate.ts
@@ -32,4 +32,5 @@ export type ExperienceConfigCreate = {
   privacy_notice_ids?: Array<string>;
   translations?: Array<ExperienceTranslationCreate>;
   properties?: Array<MinimalProperty>;
+  tcf_configuration_id?: string | null;
 };


### PR DESCRIPTION
Closes [LJ-623]

### Description Of Changes

This PR adds support for selecting TCF (Transparency & Consent Framework) Publisher Override configurations when configuring Privacy Experiences. It includes UI changes to allow users to select and manage TCF configurations within the privacy experience settings.

### Code Changes

* Added TCF configuration selection dropdown in Privacy Experience form
* Added handling for clearing TCF configuration (sets to null when cleared)
* Added new Cypress test for TCF configuration editing functionality

### Steps to Confirm

1. When running locally, make sure you have latest from `fidesplus` repo `main` branch and that TCF is enabled.
2. Navigate to the consent settings page in the Admin UI (`/settings/consent`)
3. Enable the Override vendor purposes option.
4. Create a new configuration
   - Click the "Create configuration +" button
   - Give your config a name and save it. (you should see the table appear below)
   - Add another
5. Navigate to a TCF privacy experience configuration
6. Verify the TCF Configuration dropdown is visible and populated with available configurations
7. Select a different TCF configuration and save - verify it updates successfully
8. Clear the TCF configuration and save - verify it clears successfully
9. Verify the dropdown is disabled if either:
   - Override vendor purposes setting is disabled in consent settings
   - No TCF configurations exist

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [x] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [x] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-623]: https://ethyca.atlassian.net/browse/LJ-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ