### PR TITLE
Remove cypress-parallel from Cypress CI run

### DIFF
--- a/.github/workflows/cypress_privacy-center.yml
+++ b/.github/workflows/cypress_privacy-center.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Cypress Privacy Center E2E Tests
         uses: cypress-io/github-action@v6
         with:
-          command: npm run cy:parallel
           working-directory: clients/privacy-center
           install: false
           start: npm run cy:start


### PR DESCRIPTION
### Description Of Changes

The Privacy Center Cypress Tests were being a little flakey with cypress-parallel, so this goes back to using the regular cypress command. I left in the library and the command in the package.json as some may find it useful to run locally. It does quite well for that use case.

### Code Changes

Removed the custom command from the github workflow

### Steps to Confirm

Running the Privacy Center Cypress workflow should show the normal cypress run command being used, not cy:parallel.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
