### PR TITLE
LJ-672 alpha - ignore

### DIFF
--- a/src/fides/api/api/v1/endpoints/storage_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/storage_endpoints.py
@@ -219,7 +219,7 @@ def put_config_secrets(
 
     msg = f"Secrets updated for StorageConfig with key: {config_key}."
     if verify:
-        status = secrets_are_valid(secrets_schema, storage_config.type)
+        status = secrets_are_valid(secrets_schema, storage_config)
         if status:
             logger.info(
                 "Storage secrets are valid for config with key '{}'", config_key
@@ -533,7 +533,7 @@ def put_default_config_secrets(
 
     msg = f"Secrets updated for default config of storage type: {storage_type.value}."
     if verify:
-        status = secrets_are_valid(secrets_schema, storage_config.type)
+        status = secrets_are_valid(secrets_schema, storage_config)
         if status:
             logger.info(
                 "Storage secrets are valid for default config of storage type '{}'",

--- a/src/fides/api/schemas/storage/storage.py
+++ b/src/fides/api/schemas/storage/storage.py
@@ -71,6 +71,8 @@ class StorageSecrets(Enum):
     # s3-specific
     AWS_ACCESS_KEY_ID = "aws_access_key_id"
     AWS_SECRET_ACCESS_KEY = "aws_secret_access_key"
+    REGION_NAME = "region_name"
+    AWS_ASSUME_ROLE = "assume_role_arn"
 
 
 class StorageSecretsLocal(BaseModel):
@@ -80,10 +82,10 @@ class StorageSecretsLocal(BaseModel):
 
 
 class StorageSecretsS3(BaseModel):
-    """The secrets required to connect to an S3 bucket."""
-
-    aws_access_key_id: str
-    aws_secret_access_key: str
+    aws_access_key_id: Optional[str] = None
+    aws_secret_access_key: Optional[str] = None
+    region_name: Optional[str] = None
+    assume_role_arn: Optional[str] = None
     model_config = ConfigDict(extra="forbid")
 
 

--- a/src/fides/api/service/storage/storage_authenticator_service.py
+++ b/src/fides/api/service/storage/storage_authenticator_service.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 from botocore.exceptions import ClientError
 
+from fides.api.models.storage import StorageConfig
 from fides.api.schemas.storage.storage import (
     SUPPORTED_STORAGE_SECRETS,
     AWSAuthMethod,
@@ -13,25 +14,19 @@ from fides.api.util.aws_util import get_aws_session
 
 def secrets_are_valid(
     secrets: SUPPORTED_STORAGE_SECRETS,
-    storage_type: Union[StorageType, str],
+    storage_config: StorageConfig,
 ) -> bool:
     """Authenticates upload destination with appropriate upload method"""
-    if not isinstance(storage_type, StorageType):
-        # try to coerce into an enum
-        try:
-            storage_type = StorageType[storage_type]
-        except KeyError:
-            raise ValueError(
-                "storage_type argument must be a valid StorageType enum member."
-            )
-    uploader: Any = _get_authenticator_from_config(storage_type)
-    return uploader(secrets)
+    uploader: Any = _get_authenticator_from_config(storage_config.type)  # type: ignore
+    return uploader(storage_config, secrets)
 
 
-def _s3_authenticator(secrets: Dict[StorageSecrets, Any]) -> bool:
+def _s3_authenticator(
+    config: StorageConfig, secrets: Dict[StorageSecrets, Any]
+) -> bool:
     """Authenticates secrets for s3, returns true if secrets are valid"""
     try:
-        get_aws_session(AWSAuthMethod.SECRET_KEYS.value, secrets.model_dump(mode="json"))  # type: ignore
+        get_aws_session(config.details["auth_method"] or AWSAuthMethod.SECRET_KEYS.value, secrets.model_dump(mode="json"))  # type: ignore
         return True
     except ClientError:
         return False

--- a/src/fides/api/tasks/storage.py
+++ b/src/fides/api/tasks/storage.py
@@ -130,7 +130,11 @@ def upload_to_s3(  # pylint: disable=R0913
         raise ValueError("Privacy request must be provided")
 
     try:
-        s3_client = get_s3_client(auth_method, storage_secrets)
+        s3_client = get_s3_client(
+            auth_method,
+            storage_secrets,
+            assume_role_arn=CONFIG.credentials["storage"].get("aws_s3_assume_role_arn"),
+        )
 
         # handles file chunking
         try:

--- a/tests/ops/api/v1/endpoints/test_storage_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_storage_endpoints.py
@@ -365,8 +365,6 @@ class TestPutStorageConfigSecretsS3:
         )
         assert response.status_code == 400
         assert response.json()["detail"] == [
-            "Field required ('aws_access_key_id',)",
-            "Field required ('aws_secret_access_key',)",
             "Extra inputs are not permitted ('bad_key',)",
         ]
 
@@ -459,8 +457,10 @@ class TestPutStorageConfigSecretsS3:
         get_aws_session_mock.assert_called_once_with(
             AWSAuthMethod.SECRET_KEYS.value,
             {
+                "assume_role_arn": None,
                 "aws_access_key_id": payload["aws_access_key_id"],
                 "aws_secret_access_key": payload["aws_secret_access_key"],
+                "region_name": None,
             },
         )
 
@@ -1110,8 +1110,6 @@ class TestPutDefaultStorageConfigSecretsS3:
         )
 
         assert response.json()["detail"] == [
-            "Field required ('aws_access_key_id',)",
-            "Field required ('aws_secret_access_key',)",
             "Extra inputs are not permitted ('bad_key',)",
         ]
         assert response.status_code == 400
@@ -1221,10 +1219,12 @@ class TestPutDefaultStorageConfigSecretsS3:
         response = api_client.put(url, headers=auth_header, json=payload)
         assert 200 == response.status_code
         get_aws_session_mock.assert_called_once_with(
-            AWSAuthMethod.SECRET_KEYS.value,
+            AWSAuthMethod.AUTOMATIC.value,
             {
                 "aws_access_key_id": payload["aws_access_key_id"],
                 "aws_secret_access_key": payload["aws_secret_access_key"],
+                "region_name": None,
+                "assume_role_arn": None,
             },
         )
 

--- a/tests/ops/util/test_storage_authenticator.py
+++ b/tests/ops/util/test_storage_authenticator.py
@@ -2,16 +2,14 @@ import boto3
 import pytest
 from botocore.exceptions import NoCredentialsError
 from moto import mock_aws
+from sqlalchemy.ext.mutable import MutableDict
 
 from fides.api.common_exceptions import StorageUploadError
 from fides.api.schemas.storage.storage import (
     AWSAuthMethod,
     StorageDetails,
     StorageSecrets,
-    StorageSecretsS3,
-    StorageType,
 )
-from fides.api.service.storage.storage_authenticator_service import secrets_are_valid
 from fides.api.util.aws_util import get_aws_session, get_s3_client
 
 
@@ -51,35 +49,6 @@ class TestGetS3Session:
                 AWSAuthMethod.AUTOMATIC.value,  # type: ignore
                 None,
             )
-
-    def test_secrets_are_valid_bad_storage_type(self):
-        with pytest.raises(ValueError):
-            secrets_are_valid(
-                StorageSecretsS3(
-                    aws_access_key_id="aws_access_key_id",
-                    aws_secret_access_key="aws_secret_access_key",
-                ),
-                "fake_storage_type",
-            )
-
-    def test_secrets_are_valid(self):
-        # just test we don't error out
-        assert not secrets_are_valid(
-            StorageSecretsS3(
-                aws_access_key_id="aws_access_key_id",
-                aws_secret_access_key="aws_secret_access_key",
-            ),
-            "s3",
-        )  # we expect this to fail because they're not real secret values
-
-        # just test we don't error out
-        assert not secrets_are_valid(
-            StorageSecretsS3(
-                aws_access_key_id="aws_access_key_id",
-                aws_secret_access_key="aws_secret_access_key",
-            ),
-            StorageType.s3,
-        )  # we expect this to fail because they're not real secret values
 
 
 @mock_aws


### PR DESCRIPTION
- **empty commit to start release 2.58.0**
- **LJ-599 Exclude field validations from fields that aren't being displayed (#5942)**
- **Disable bulk actions on action center 'Recent activity' tab (#5955)**
- **Fix help and account icons colors in menu (#5965)**
- **empty commit to start release 2.58.1**
- **Fix: Do not resurface dismissed banner (#5979)**
- **Update changelog for patch release (#5985)**
- **empty commit to start release 2.58.2**
- **LJ-652: Writes fides cookie during OT migration (#6009)**
- **Assume role arn and region config.**

Closes [<issue>]

### Description Of Changes

_Write some things here about the changes and any potential caveats_

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
