### PR TITLE
Cypress tests for Purpose overrides in Consent Settings

### DIFF
--- a/clients/admin-ui/cypress/e2e/consent-settings.cy.ts
+++ b/clients/admin-ui/cypress/e2e/consent-settings.cy.ts
@@ -301,9 +301,28 @@ describe("Consent settings", () => {
       });
 
       it("allows changing the TCF configuration", () => {
+        cy.getAllLocalStorage().then((ls) => {
+          expect(ls["http://localhost:3000"]?.selectedTCFConfigId).to.not.exist;
+        });
         cy.getByTestId("tcf-config-dropdown-trigger").click();
         cy.getByTestId("tcf-config-item-tcf_config_2").click();
         cy.getByTestId("apply-config-button").click();
+        cy.getByTestId("tcf-config-dropdown-trigger").should(
+          "have.text",
+          "Strict TCF Config",
+        );
+        cy.getAllLocalStorage().then((ls) => {
+          expect(ls["http://localhost:3000"]?.selectedTCFConfigId).to.eq(
+            `"tcf_config_2"`,
+          );
+        });
+        // check that the selected config gets remembered with new page load
+        cy.visit(GLOBAL_CONSENT_CONFIG_ROUTE);
+        cy.getAllLocalStorage().then((ls) => {
+          expect(ls["http://localhost:3000"]?.selectedTCFConfigId).to.eq(
+            `"tcf_config_2"`,
+          );
+        });
         cy.getByTestId("tcf-config-dropdown-trigger").should(
           "have.text",
           "Strict TCF Config",

--- a/clients/admin-ui/cypress/e2e/consent-settings.cy.ts
+++ b/clients/admin-ui/cypress/e2e/consent-settings.cy.ts
@@ -1,7 +1,10 @@
-import { stubLocations, stubPlus } from "cypress/support/stubs";
+import { stubLocations, stubPlus, stubTCFConfig } from "cypress/support/stubs";
 
 import { GLOBAL_CONSENT_CONFIG_ROUTE } from "~/features/common/nav/routes";
-
+import {
+  FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS,
+  RESTRICTION_TYPE_LABELS,
+} from "~/features/consent-settings/tcf/constants";
 describe("Consent settings", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/v1/plus/tcf/purpose_overrides", { body: [] });
@@ -190,7 +193,7 @@ describe("Consent settings", () => {
     });
 
     describe("TCF disabled", () => {
-      it("does not show GPP Europe if TCF is not enabled", () => {
+      beforeEach(() => {
         stubPlus(true, {
           core_fides_version: "1.9.6",
           fidesplus_server: "healthy",
@@ -215,8 +218,197 @@ describe("Consent settings", () => {
         cy.intercept("/api/v1/config?api_set=false", { body: DEFAULT_CONFIG });
         cy.intercept("/api/v1/config?api_set=true", { body: {} });
         cy.visit(GLOBAL_CONSENT_CONFIG_ROUTE);
+      });
+
+      it("does not show GPP Europe if TCF is not enabled", () => {
         cy.getByTestId("section-GPP U.S.").should("exist");
         cy.getByTestId("section-GPP Europe").should("not.exist");
+      });
+
+      it("does not show Publisher Restrictions if TCF is not enabled", () => {
+        cy.getByTestId(
+          "setting-Transparency & Consent Framework settings",
+        ).should("exist");
+        cy.contains("TCF status Disabled").should("exist");
+        cy.getByTestId("setting-Publisher restrictions").should("not.exist");
+      });
+    });
+  });
+
+  describe("Publisher restrictions", () => {
+    describe("New configs", () => {
+      beforeEach(() => {
+        cy.intercept("/api/v1/config?api_set=false", { body: {} });
+        cy.intercept("/api/v1/config?api_set=true", { body: {} });
+        cy.intercept("PATCH", "/api/v1/config", { body: {} }).as("patchConfig");
+        cy.intercept("GET", "/api/v1/plus/tcf/configurations", {
+          body: { items: [] },
+        }).as("getTCFConfigs");
+        cy.intercept("POST", "/api/v1/plus/tcf/configurations", {
+          body: { id: "new-config-id" },
+        }).as("createConfig");
+        cy.visit(GLOBAL_CONSENT_CONFIG_ROUTE);
+      });
+      it("displays TCF override toggle and handles state change", () => {
+        cy.contains("TCF status Enabled").should("exist");
+        cy.getByTestId("tcf-override-toggle").should("exist");
+        cy.getByTestId("tcf-override-toggle").click();
+        cy.getByTestId("tcf-override-toggle").should(
+          "have.attr",
+          "aria-checked",
+          "true",
+        );
+      });
+
+      it("allows creating a new TCF configuration", () => {
+        cy.getByTestId("tcf-override-toggle").click();
+        cy.getByTestId("create-config-button").click();
+        cy.getByTestId("input-name").type("New Config");
+        cy.getByTestId("save-config-button").click();
+        cy.wait("@createConfig");
+        cy.contains("Successfully created TCF configuration").should(
+          "be.visible",
+        );
+      });
+    });
+
+    describe("TCF override enabled and config created", () => {
+      beforeEach(() => {
+        stubTCFConfig();
+        cy.visit(GLOBAL_CONSENT_CONFIG_ROUTE);
+      });
+
+      it("shows configuration dropdown when overrides are enabled", () => {
+        cy.getByTestId("tcf-config-dropdown-trigger")
+          .should("exist")
+          .should("have.text", "Default TCF Config");
+        cy.getByTestId("tcf-config-dropdown-trigger").click();
+        cy.contains("TCF configurations").should("be.visible");
+        cy.getByTestId("tcf-config-item-tcf_config_1").should("exist");
+        cy.getByTestId("tcf-config-item-tcf_config_2").should("exist");
+        cy.getByTestId("delete-config-button")
+          .should("exist")
+          .should("have.length", 2);
+        cy.getByTestId("create-config-button").should("exist");
+        cy.getByTestId("apply-config-button").should("exist");
+      });
+
+      it("allows creating a new TCF configuration when configs exist", () => {
+        cy.getByTestId("tcf-config-dropdown-trigger").click();
+        cy.getByTestId("create-config-button").click();
+        cy.getByTestId("input-name").should("exist");
+        cy.getByTestId("save-config-button").should("exist");
+      });
+
+      it("allows changing the TCF configuration", () => {
+        cy.getByTestId("tcf-config-dropdown-trigger").click();
+        cy.getByTestId("tcf-config-item-tcf_config_2").click();
+        cy.getByTestId("apply-config-button").click();
+        cy.getByTestId("tcf-config-dropdown-trigger").should(
+          "have.text",
+          "Strict TCF Config",
+        );
+      });
+
+      it("displays publisher restrictions table with correct data", () => {
+        cy.wait("@getTcfPurposes");
+        cy.getByTestId("publisher-restrictions-table").should("exist");
+        cy.fixture("tcf/purposes.json").then(
+          (data: {
+            purposes: Record<number, any>;
+            special_purposes: Record<number, any>;
+          }) => {
+            // shows all purposes
+            Object.values(data.purposes).forEach((purpose) => {
+              cy.contains(purpose.name).should("be.visible");
+              cy.getByTestId(`restriction-type-cell-${purpose.id}`).should(
+                "have.text",
+                "none",
+              );
+              cy.getByTestId(`flexibility-tag-${purpose.id}`).should(
+                "have.text",
+                FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(purpose.id)
+                  ? "No"
+                  : "Yes",
+              );
+              cy.getByTestId(`edit-restriction-btn-${purpose.id}`).should(
+                FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(purpose.id)
+                  ? "not.exist"
+                  : "exist",
+              );
+            });
+          },
+        );
+      });
+
+      it("allows adding a new publisher restriction", () => {
+        cy.intercept(
+          "GET",
+          "/api/v1/plus/tcf/configurations/*/publisher_restrictions?purpose_id=*",
+          {
+            body: { items: [] },
+          },
+        ).as("getTcfRestrictions");
+        cy.getByTestId("edit-restriction-btn-2").click({ force: true });
+        cy.getByTestId("add-restriction-button").click();
+        cy.getByTestId("controlled-select-restriction_type").antSelect(
+          "Require consent",
+        );
+        cy.getByTestId("controlled-select-vendor_restriction").antSelect(
+          "Restrict specific vendors",
+        );
+        cy.getByTestId("controlled-select-vendor_ids").should("be.visible");
+        cy.getByTestId("controlled-select-vendor_restriction").antSelect(
+          "Restrict all vendors",
+        );
+        cy.getByTestId("controlled-select-vendor_ids").should("not.be.visible");
+        cy.getByTestId("save-restriction-button").click();
+        cy.wait("@createRestriction");
+        cy.contains("Restriction created successfully").should("be.visible");
+      });
+
+      it("allows deleting an existing restriction", () => {
+        cy.getByTestId("edit-restriction-btn-2").click({ force: true });
+        cy.getByTestId("delete-restriction-button").first().click();
+        cy.getByTestId("continue-btn").click();
+        cy.wait("@deleteRestriction");
+        cy.contains("Publisher restriction deleted successfully").should(
+          "be.visible",
+        );
+      });
+
+      it("validates vendor ID input format", () => {
+        cy.intercept(
+          "GET",
+          "/api/v1/plus/tcf/configurations/*/publisher_restrictions?purpose_id=*",
+          {
+            body: { items: [] },
+          },
+        ).as("getTcfRestrictions");
+        cy.getByTestId("edit-restriction-btn-2").click({ force: true });
+        cy.getByTestId("add-restriction-button").click();
+        cy.getByTestId("controlled-select-restriction_type").antSelect(
+          "Require consent",
+        );
+        cy.getByTestId("controlled-select-vendor_restriction").antSelect(
+          "Restrict specific vendors",
+        );
+        // a more comprehensive test of the validation exists in the unit tests, this is just a check of the UI for the error message
+        cy.get("input[id='vendor_ids']").type("invalid format{enter}");
+        cy.get("input[id='vendor_ids']").blur();
+        cy.getByTestId("error-vendor_ids").should("be.visible");
+      });
+
+      it("displays purpose restrictions table correctly", () => {
+        cy.getByTestId("edit-restriction-btn-2").click({ force: true });
+        cy.getByTestId("fidesTable").should("exist");
+        // mock purpose includes all restriction types, so we can check that all are present and that the Add Restriction button is disabled
+        Object.values(RESTRICTION_TYPE_LABELS).forEach((label) => {
+          cy.contains(label).should("exist");
+        });
+        cy.getByTestId("add-restriction-button")
+          .should("exist")
+          .should("be.disabled");
       });
     });
   });

--- a/clients/admin-ui/cypress/fixtures/tcf/configurations.json
+++ b/clients/admin-ui/cypress/fixtures/tcf/configurations.json
@@ -1,0 +1,18 @@
+{
+  "items": [
+    {
+      "id": "tcf_config_1",
+      "name": "Default TCF Config",
+      "description": "Standard TCF setup"
+    },
+    {
+      "id": "tcf_config_2",
+      "name": "Strict TCF Config",
+      "description": "More restrictive TCF setup"
+    }
+  ],
+  "total": 2,
+  "page": 1,
+  "size": 50,
+  "pages": 1
+}

--- a/clients/admin-ui/cypress/fixtures/tcf/publisher-restrictions.json
+++ b/clients/admin-ui/cypress/fixtures/tcf/publisher-restrictions.json
@@ -1,0 +1,47 @@
+{
+  "items": [
+    {
+      "purpose_id": 2,
+      "restriction_type": "require_consent",
+      "vendor_restriction": "allow_specific_vendors",
+      "range_entries": [
+        {
+          "start_vendor_id": 49,
+          "end_vendor_id": 51
+        }
+      ],
+      "id": "tcf_75f0c466-ce9e-4140-bcfc-93cb8acbdfc2",
+      "tcf_configuration_id": "tcf_642bf84f-78d4-495d-ad75-666325578722"
+    },
+    {
+      "purpose_id": 2,
+      "restriction_type": "require_legitimate_interest",
+      "vendor_restriction": "restrict_specific_vendors",
+      "range_entries": [
+        {
+          "start_vendor_id": 50,
+          "end_vendor_id": null
+        }
+      ],
+      "id": "tcf_3a478fc0-36b8-42a6-8503-6ce32863c58e",
+      "tcf_configuration_id": "tcf_642bf84f-78d4-495d-ad75-666325578722"
+    },
+    {
+      "purpose_id": 2,
+      "restriction_type": "purpose_restriction",
+      "vendor_restriction": "restrict_specific_vendors",
+      "range_entries": [
+        {
+          "start_vendor_id": 51,
+          "end_vendor_id": null
+        }
+      ],
+      "id": "tcf_0feb7324-0b2b-4e25-bd9e-faac7b3ccb05",
+      "tcf_configuration_id": "tcf_642bf84f-78d4-495d-ad75-666325578722"
+    }
+  ],
+  "total": 3,
+  "page": 1,
+  "size": 50,
+  "pages": 1
+}

--- a/clients/admin-ui/cypress/fixtures/tcf/purposes.json
+++ b/clients/admin-ui/cypress/fixtures/tcf/purposes.json
@@ -1,0 +1,149 @@
+{
+  "purposes": {
+    "1": {
+      "id": 1,
+      "name": "Store and/or access information on a device",
+      "description": "Cookies, device or similar online identifiers (e.g. login-based identifiers, randomly assigned identifiers, network based identifiers) together with other information (e.g. browser type and information, language, screen size, supported technologies etc.) can be stored or read on your device to recognise it each time it connects to an app or to a website, for one or several of the purposes presented here. ",
+      "illustrations": [
+        "Most purposes explained in this notice rely on the storage or accessing of information from your device when you use an app or visit a website. For example, a vendor or publisher might need to store a cookie on your device during your first visit on a website, to be able to recognise your device during your next visits (by accessing this cookie each time)."
+      ],
+      "data_uses": ["functional.storage"]
+    },
+    "2": {
+      "id": 2,
+      "name": "Use limited data to select advertising",
+      "description": "Advertising presented to you on this service can be based on limited data, such as the website or app you are using, your non-precise location, your device type or which content you are (or have been) interacting with (for example, to limit the number of times an ad is presented to you).",
+      "illustrations": [
+        "A car manufacturer wants to promote its electric vehicles to environmentally conscious users living in the city after office hours. The advertising is presented on a page with related content (such as an article on climate change actions) after 6:30 p.m. to users whose non-precise location suggests that they are in an urban zone.",
+        "A large producer of watercolour paints wants to carry out an online advertising campaign for its latest watercolour range, diversifying its audience to reach as many amateur and professional artists as possible and avoiding showing the ad next to mismatched content (for instance, articles about how to paint your house). The number of times that the ad has been presented to you is detected and limited, to avoid presenting it too often."
+      ],
+      "data_uses": [
+        "marketing.advertising.first_party.contextual",
+        "marketing.advertising.frequency_capping",
+        "marketing.advertising.negative_targeting"
+      ]
+    },
+    "3": {
+      "id": 3,
+      "name": "Create profiles for personalised advertising",
+      "description": "Information about your activity on this service (such as forms you submit, content you look at) can be stored and combined with other information about you (for example, information from your previous activity on this service and other websites or apps) or similar users. This is then used to build or improve a profile about you (that might include possible interests and personal aspects). Your profile can be used (also later) to present advertising that appears more relevant based on your possible interests by this and other entities.",
+      "illustrations": [
+        "If you read several articles about the best bike accessories to buy, this information could be used to create a profile about your interest in bike accessories. Such a profile may be used or improved later on, on the same or a different website or app to present you with advertising for a particular bike accessory brand. If you also look at a configurator for a vehicle on a luxury car manufacturer website, this information could be combined with your interest in bikes to refine your profile and make an assumption that you are interested in luxury cycling gear.",
+        "An apparel company wishes to promote its new line of high-end baby clothes. It gets in touch with an agency that has a network of clients with high income customers (such as high-end supermarkets) and asks the agency to create profiles of young parents or couples who can be assumed to be wealthy and to have a new child, so that these can later be used to present advertising within partner apps based on those profiles."
+      ],
+      "data_uses": ["marketing.advertising.profiling"]
+    },
+    "4": {
+      "id": 4,
+      "name": "Use profiles to select personalised advertising",
+      "description": "Advertising presented to you on this service can be based on your advertising profiles, which can reflect your activity on this service or other websites or apps (like the forms you submit, content you look at), possible interests and personal aspects.",
+      "illustrations": [
+        "An online retailer wants to advertise a limited sale on running shoes. It wants to target advertising to users who previously looked at running shoes on its mobile app. Tracking technologies might be used to recognise that you have previously used the mobile app to consult running shoes, in order to present you with the corresponding advertisement on the app.",
+        "A profile created for personalised advertising in relation to a person having searched for bike accessories on a website can be used to present the relevant advertisement for bike accessories on a mobile app of another organisation."
+      ],
+      "data_uses": [
+        "marketing.advertising.first_party.targeted",
+        "marketing.advertising.third_party.targeted"
+      ]
+    },
+    "5": {
+      "id": 5,
+      "name": "Create profiles to personalise content",
+      "description": "Information about your activity on this service (for instance, forms you submit, non-advertising content you look at) can be stored and combined with other information about you (such as your previous activity on this service or other websites or apps) or similar users. This is then used to build or improve a profile about you (which might for example include possible interests and personal aspects). Your profile can be used (also later) to present content that appears more relevant based on your possible interests, such as by adapting the order in which content is shown to you, so that it is even easier for you to find content that matches your interests.",
+      "illustrations": [
+        "You read several articles on how to build a treehouse on a social media platform. This information might be added to a profile to mark your interest in content related to outdoors as well as do-it-yourself guides (with the objective of allowing the personalisation of content, so that for example you are presented with more blog posts and articles on treehouses and wood cabins in the future).",
+        "You have viewed three videos on space exploration across different TV apps. An unrelated news platform with which you have had no contact builds a profile based on that viewing behaviour, marking space exploration as a topic of possible interest for other videos."
+      ],
+      "data_uses": ["personalize.content.profiling"]
+    },
+    "6": {
+      "id": 6,
+      "name": "Use profiles to select personalised content",
+      "description": "Content presented to you on this service can be based on your content personalisation profiles, which can reflect your activity on this or other services (for instance, the forms you submit, content you look at), possible interests and personal aspects, such as by adapting the order in which content is shown to you, so that it is even easier for you to find (non-advertising) content that matches your interests.",
+      "illustrations": [
+        "You read articles on vegetarian food on a social media platform and then use the cooking app of an unrelated company. The profile built about you on the social media platform will be used to present you vegetarian recipes on the welcome screen of the cooking app.",
+        "You have viewed three videos about rowing across different websites. An unrelated video sharing platform will recommend five other videos on rowing that may be of interest to you when you use your TV app, based on a profile built about you when you visited those different websites to watch online videos."
+      ],
+      "data_uses": ["personalize.content.profiled"]
+    },
+    "7": {
+      "id": 7,
+      "name": "Measure advertising performance",
+      "description": "Information regarding which advertising is presented to you and how you interact with it can be used to determine how well an advert has worked for you or other users and whether the goals of the advertising were reached. For instance, whether you saw an ad, whether you clicked on it, whether it led you to buy a product or visit a website, etc. This is very helpful to understand the relevance of advertising campaigns.",
+      "illustrations": [
+        "You have clicked on an advertisement about a “black Friday” discount by an online shop on the website of a publisher and purchased a product. Your click will be linked to this purchase. Your interaction and that of other users will be measured to know how many clicks on the ad led to a purchase.",
+        "You are one of very few to have clicked on an advertisement about an “international appreciation day” discount by an online gift shop within the app of a publisher. The publisher wants to have reports to understand how often a specific ad placement within the app, and notably the “international appreciation day” ad, has been viewed or clicked by you and other users, in order to help the publisher and its partners (such as agencies) optimise ad placements."
+      ],
+      "data_uses": ["analytics.reporting.ad_performance"]
+    },
+    "8": {
+      "id": 8,
+      "name": "Measure content performance",
+      "description": "Information regarding which content is presented to you and how you interact with it can be used to determine whether the (non-advertising) content e.g. reached its intended audience and matched your interests. For instance, whether you read an article, watch a video, listen to a podcast or look at a product description, how long you spent on this service and the web pages you visit etc. This is very helpful to understand the relevance of (non-advertising) content that is shown to you.",
+      "illustrations": [
+        "You have read a blog post about hiking on a mobile app of a publisher and followed a link to a recommended and related post. Your interactions will be recorded as showing that the initial hiking post was useful to you and that it was successful in interesting you in the related post. This will be measured to know whether to produce more posts on hiking in the future and where to place them on the home screen of the mobile app.",
+        "You were presented a video on fashion trends, but you and several other users stopped watching after 30 seconds. This information is then used to evaluate the right length of future videos on fashion trends."
+      ],
+      "data_uses": ["analytics.reporting.content_performance"]
+    },
+    "9": {
+      "id": 9,
+      "name": "Understand audiences through statistics or combinations of data from different sources",
+      "description": "Reports can be generated based on the combination of data sets (like user profiles, statistics, market research, analytics data) regarding your interactions and those of other users with advertising or (non-advertising) content to identify common characteristics (for instance, to determine which target audiences are more receptive to an ad campaign or to certain contents).",
+      "illustrations": [
+        "The owner of an online bookstore wants commercial reporting showing the proportion of visitors who consulted and left its site without buying, or consulted and bought the last celebrity autobiography of the month, as well as the average age and the male/female distribution of each category. Data relating to your navigation on its site and to your personal characteristics is then used and combined with other such data to produce these statistics.",
+        "An advertiser wants to better understand the type of audience interacting with its adverts. It calls upon a research institute to compare the characteristics of users who interacted with the ad with typical attributes of users of similar platforms, across different devices. This comparison reveals to the advertiser that its ad audience is mainly accessing the adverts through mobile devices and is likely in the 45-60 age range."
+      ],
+      "data_uses": ["analytics.reporting.campaign_insights"]
+    },
+    "10": {
+      "id": 10,
+      "name": "Develop and improve services",
+      "description": "Information about your activity on this service, such as your interaction with ads or content, can be very helpful to improve products and services and to build new products and services based on user interactions, the type of audience, etc. This specific purpose does not include the development or improvement of user profiles and identifiers.",
+      "illustrations": [
+        "A technology platform working with a social media provider notices a growth in mobile app users, and sees based on their profiles that many of them are connecting through mobile connections. It uses a new technology to deliver ads that are formatted for mobile devices and that are low-bandwidth, to improve their performance.",
+        "An advertiser is looking for a way to display ads on a new type of consumer device. It collects information regarding the way users interact with this new kind of device to determine whether it can build a new mechanism for displaying advertising on this type of device."
+      ],
+      "data_uses": ["functional.service.improve"]
+    },
+    "11": {
+      "id": 11,
+      "name": "Use limited data to select content",
+      "description": "Content presented to you on this service can be based on limited data, such as the website or app you are using, your non-precise location, your device type, or which content you are (or have been) interacting with (for example, to limit the number of times a video or an article is presented to you).",
+      "illustrations": [
+        "A travel magazine has published an article on its website about the new online courses proposed by a language school, to improve travelling experiences abroad. The school’s blog posts are inserted directly at the bottom of the page, and selected on the basis of your non-precise location (for instance, blog posts explaining the course curriculum for different languages than the language of the country you are situated in).",
+        "A sports news mobile app has started a new section of articles covering the most recent football games. Each article includes videos hosted by a separate streaming platform showcasing the highlights of each match. If you fast-forward a video, this information may be used to select a shorter video to play next."
+      ],
+      "data_uses": ["personalize.content.limited"]
+    }
+  },
+  "special_purposes": {
+    "1": {
+      "id": 1,
+      "name": "Ensure security, prevent and detect fraud, and fix errors",
+      "description": "Your data can be used to monitor for and prevent unusual and possibly fraudulent activity (for example, regarding advertising, ad clicks by bots), and ensure systems and processes work properly and securely. It can also be used to correct any problems you, the publisher or the advertiser may encounter in the delivery of content and ads and in your interaction with them.",
+      "illustrations": [
+        "An advertising intermediary delivers ads from various advertisers to its network of partnering websites. It notices a large increase in clicks on ads relating to one advertiser, and uses data regarding the source of the clicks to determine that 80% of the clicks come from bots rather than humans."
+      ],
+      "data_uses": ["essential.fraud_detection", "essential.service.security"]
+    },
+    "2": {
+      "id": 2,
+      "name": "Deliver and present advertising and content",
+      "description": "Certain information (like an IP address or device capabilities) is used to ensure the technical compatibility of the content or advertising, and to facilitate the transmission of the content or ad to your device.",
+      "illustrations": [
+        "Clicking on a link in an article might normally send you to another page or part of the article. To achieve this, 1°) your browser sends a request to a server linked to the website, 2°) the server answers back (“here is the article you asked for”), using technical information automatically included in the request sent by your device, to properly display the information / images that are part of the article you asked for. Technically, such exchange of information is necessary to deliver the content that appears on your screen."
+      ],
+      "data_uses": ["marketing.advertising.serving"]
+    },
+    "3": {
+      "id": 3,
+      "name": "Save and communicate privacy choices",
+      "description": "The choices you make regarding the purposes and entities listed in this notice are saved and made available to those entities in the form of digital signals (such as a string of characters). This is necessary in order to enable both this service and those entities to respect such choices.",
+      "illustrations": [
+        "When you visit a website and are offered a choice between consenting to the use of profiles for personalised advertising or not consenting, the choice you make is saved and made available to advertising providers, so that advertising presented to you respects that choice."
+      ],
+      "data_uses": ["functional.storage.privacy_preferences"]
+    }
+  }
+}

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -598,3 +598,48 @@ export const stubDataCatalog = () => {
     pages: 1,
   }).as("getAvailableDatabases");
 };
+
+export const stubTCFConfig = () => {
+  cy.intercept("/api/v1/config?api_set=false", {
+    body: { consent: { override_vendor_purposes: true } },
+  });
+  cy.intercept("/api/v1/config?api_set=true", {
+    body: { consent: { override_vendor_purposes: true } },
+  });
+  cy.intercept("PATCH", "/api/v1/config", { body: {} }).as("patchConfig");
+  cy.intercept("GET", "/api/v1/plus/tcf/configurations*", {
+    fixture: "tcf/configurations.json",
+  }).as("getTcfConfigs");
+  cy.intercept("GET", "/api/v1/purposes", {
+    fixture: "tcf/purposes.json",
+  }).as("getTcfPurposes");
+  cy.intercept(
+    "GET",
+    "/api/v1/plus/tcf/configurations/*/publisher_restrictions?purpose_id=*",
+    {
+      fixture: "tcf/publisher-restrictions.json",
+    },
+  ).as("getTcfRestrictions");
+  cy.intercept(
+    "DELETE",
+    "/api/v1/plus/tcf/configurations/*/publisher_restrictions/*",
+    {
+      body: {},
+    },
+  ).as("deleteRestriction");
+  cy.fixture("tcf/configurations.json").then((data) => {
+    cy.intercept("GET", "/api/v1/plus/tcf/configurations/*", {
+      body: data.items[0],
+    }).as("getTCFConfig");
+  });
+  cy.intercept("POST", "/api/v1/plus/tcf/configurations", {
+    body: { id: "new-config-id" },
+  }).as("createConfig");
+  cy.intercept(
+    "POST",
+    "/api/v1/plus/tcf/configurations/*/publisher_restrictions",
+    {
+      body: {},
+    },
+  ).as("createRestriction");
+};

--- a/clients/admin-ui/src/features/consent-settings/PublisherSettings.tsx
+++ b/clients/admin-ui/src/features/consent-settings/PublisherSettings.tsx
@@ -25,7 +25,7 @@ const PublisherSettings = () => {
   ].sort((a, b) => (a.name < b.name ? -1 : 1));
 
   return isTcfEnabled ? (
-    <SettingsBox title="Publisher Settings">
+    <SettingsBox title="Publisher settings">
       <Typography.Paragraph className="mb-3">
         Specify the country in which your organization operates for TCF
         compliance. This setting will determine the &apos;Publisher Country Code

--- a/clients/admin-ui/src/features/consent-settings/tcf/CreateTCFConfigModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/CreateTCFConfigModal.tsx
@@ -76,6 +76,7 @@ export const CreateTCFConfigModal = ({
                   type="primary"
                   htmlType="submit"
                   disabled={!isValid || !dirty}
+                  data-testid="save-config-button"
                 >
                   Save
                 </Button>

--- a/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionActionCell.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionActionCell.tsx
@@ -56,10 +56,18 @@ export const PublisherRestrictionActionCell = ({
   return (
     <>
       <Space>
-        <Button size="small" onClick={() => setIsEditModalOpen(true)}>
+        <Button
+          size="small"
+          onClick={() => setIsEditModalOpen(true)}
+          data-testid="edit-restriction-button"
+        >
           Edit
         </Button>
-        <Button size="small" onClick={() => setIsDeleteModalOpen(true)}>
+        <Button
+          size="small"
+          onClick={() => setIsDeleteModalOpen(true)}
+          data-testid="delete-restriction-button"
+        >
           Delete
         </Button>
       </Space>

--- a/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
@@ -101,7 +101,10 @@ export const PublisherRestrictionsConfig = ({
                   </DocsLink>{" "}
                   in our docs.
                 </Text>
-                <Button onClick={() => setIsCreateModalOpen(true)}>
+                <Button
+                  onClick={() => setIsCreateModalOpen(true)}
+                  data-testid="create-config-button"
+                >
                   Create configuration +
                 </Button>
               </>

--- a/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
@@ -46,13 +46,26 @@ export const PublisherRestrictionsConfig = ({
 
   // Automatically select first configuration when available
   useEffect(() => {
-    if (tcfConfigurations?.items?.length && !selectedTCFConfigId) {
+    if (
+      !isTcfConfigurationsLoading &&
+      tcfConfigurations?.items?.length &&
+      !selectedTCFConfigId
+    ) {
       setSelectedTCFConfigId(tcfConfigurations.items[0].id);
     }
-    if (selectedTCFConfigId && !tcfConfigurations?.items?.length) {
+    if (
+      !isTcfConfigurationsLoading &&
+      selectedTCFConfigId &&
+      !tcfConfigurations?.items?.length
+    ) {
       setSelectedTCFConfigId(null);
     }
-  }, [tcfConfigurations?.items, selectedTCFConfigId, setSelectedTCFConfigId]);
+  }, [
+    isTcfConfigurationsLoading,
+    tcfConfigurations?.items,
+    selectedTCFConfigId,
+    setSelectedTCFConfigId,
+  ]);
 
   return (
     <SettingsBox title="Publisher restrictions" fontSize="sm">

--- a/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsTable.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsTable.tsx
@@ -65,11 +65,13 @@ const FauxColumnHeader = ({
     style={{
       borderLeft: borderLeft ? "solid 1px" : "none",
       borderColor: "var(--ant-color-border)",
+      fontWeight: 500,
+      whiteSpace: "nowrap",
       width,
       ...style,
     }}
   >
-    <Text fontWeight="medium">{children}</Text>
+    {children}
   </Flex>
 );
 
@@ -124,6 +126,7 @@ export const PublisherRestrictionsTable = ({
       }}
       aria-label="Publisher restrictions table"
       role="table"
+      data-testid="publisher-restrictions-table"
     >
       <FauxRow
         isHeader
@@ -132,12 +135,12 @@ export const PublisherRestrictionsTable = ({
         }}
       >
         <FauxColumnHeader width="600px">TCF purpose</FauxColumnHeader>
-        <FauxColumnHeader flex={1} borderLeft>
-          Restrictions{" "}
+        <FauxColumnHeader flex={1} gap={3} borderLeft>
+          Restrictions
           <QuestionTooltip label="Restrictions control how vendors are permitted to process data for specific purposes. Fides supports three restriction types: Purpose Restriction to completely disallow data processing for a purpose, Require Consent to allow processing only with explicit user consent, and Require Legitimate Interest to allow processing based on legitimate business interest unless the user objects." />
         </FauxColumnHeader>
-        <FauxColumnHeader width="100px" borderLeft>
-          Flexible{" "}
+        <FauxColumnHeader width="100px" gap={3} borderLeft>
+          Flexible
           <QuestionTooltip label='Indicates whether the legal basis for this purpose can be overridden by publisher restrictions. If marked "No," the purpose has a fixed legal basis defined by the TCF and cannot be changed.' />
         </FauxColumnHeader>
         <FauxColumnHeader width="100px" borderLeft>
@@ -152,7 +155,11 @@ export const PublisherRestrictionsTable = ({
           <FauxTableCell width="600px">
             Purpose {purpose.id}: {purpose.name}
           </FauxTableCell>
-          <FauxTableCell flex={1} borderLeft>
+          <FauxTableCell
+            flex={1}
+            borderLeft
+            data-testid={`restriction-type-cell-${purpose.id}`}
+          >
             {isLoading ? (
               <Skeleton height="16px" width="100%" />
             ) : (
@@ -175,9 +182,16 @@ export const PublisherRestrictionsTable = ({
           </FauxTableCell>
           <FauxTableCell width="100px" borderLeft>
             {FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(purpose.id) ? (
-              <Tag color="error">No</Tag>
+              <Tag color="error" data-testid={`flexibility-tag-${purpose.id}`}>
+                No
+              </Tag>
             ) : (
-              <Tag color="success">Yes</Tag>
+              <Tag
+                color="success"
+                data-testid={`flexibility-tag-${purpose.id}`}
+              >
+                Yes
+              </Tag>
             )}
           </FauxTableCell>
           <FauxTableCell width="100px" borderLeft>
@@ -189,7 +203,12 @@ export const PublisherRestrictionsTable = ({
                 passHref
                 legacyBehavior
               >
-                <Button size="small">Edit</Button>
+                <Button
+                  size="small"
+                  data-testid={`edit-restriction-btn-${purpose.id}`}
+                >
+                  Edit
+                </Button>
               </NextLink>
             )}
           </FauxTableCell>

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -291,8 +291,17 @@ export const PurposeRestrictionFormModal = ({
                 />
               </Collapse>
               <Flex justify="flex-end" className="gap-3 pt-4">
-                <Button onClick={onClose}>Cancel</Button>
-                <Button type="primary" htmlType="submit">
+                <Button
+                  onClick={onClose}
+                  data-testid="cancel-restriction-button"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="primary"
+                  htmlType="submit"
+                  data-testid="save-restriction-button"
+                >
                   Save
                 </Button>
               </Flex>

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -218,7 +218,7 @@ export const PurposeRestrictionFormModal = ({
         onSubmit={handleSubmit}
         validationSchema={validationSchema}
       >
-        {({ values, validateField }) => (
+        {({ values, validateField, setTouched }) => (
           <Form>
             <Flex vertical className="gap-6">
               <Text className="text-sm">
@@ -270,6 +270,9 @@ export const PurposeRestrictionFormModal = ({
                   onBlur={() => {
                     // Add small delay to allow Ant Select to create tag before validation
                     setTimeout(() => {
+                      setTouched({
+                        vendor_ids: true,
+                      });
                       validateField("vendor_ids");
                     }, 100);
                   }}

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionsTable.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionsTable.tsx
@@ -14,7 +14,11 @@ import {
   TableActionBar,
   TableSkeletonLoader,
 } from "~/features/common/table/v2";
-import { RangeEntry, TCFVendorRestriction } from "~/types/api";
+import {
+  RangeEntry,
+  TCFRestrictionType,
+  TCFVendorRestriction,
+} from "~/types/api";
 
 import { PurposeRestrictionFormModal } from "./PurposeRestrictionFormModal";
 import { useGetPublisherRestrictionsQuery } from "./tcf-config.slice";
@@ -82,6 +86,10 @@ export const PurposeRestrictionsTable = () => {
       item.vendor_restriction === TCFVendorRestriction.RESTRICT_ALL_VENDORS,
   );
 
+  const hasAllRestrictTypes = Object.values(TCFRestrictionType).every((type) =>
+    transformedData.some((item) => item.restriction_type === type),
+  );
+
   const table = useReactTable<PurposeRestriction>({
     getCoreRowModel: getCoreRowModel(),
     columns,
@@ -104,15 +112,19 @@ export const PurposeRestrictionsTable = () => {
         <Spacer />
         <Tooltip
           title={
+            // eslint-disable-next-line no-nested-ternary
             hasRestrictAllVendors
               ? 'Each vendor must have a unique restriction type. When "Restrict all vendors" is active for any restriction type, no other restrictions can be added.'
-              : undefined
+              : hasAllRestrictTypes
+                ? "Each purpose must have a unique restriction type. When all restriction types are active, no other restrictions can be added. Use the 'Edit' button to change the vendor restrictions on each type."
+                : undefined
           }
         >
           <Button
             type="primary"
             onClick={handleOpenModal}
-            disabled={hasRestrictAllVendors}
+            disabled={hasRestrictAllVendors || hasAllRestrictTypes}
+            data-testid="add-restriction-button"
           >
             Add restriction +
           </Button>

--- a/clients/admin-ui/src/features/consent-settings/tcf/TCFConfigurationDropdown.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/TCFConfigurationDropdown.tsx
@@ -88,6 +88,7 @@ const ConfigurationList = ({
       <Flex
         key={config.id}
         className={userCanDeleteConfigs ? "justify-between" : "justify-start"}
+        data-testid={`tcf-config-item-${config.id}`}
       >
         <Radio
           value={config.id}

--- a/clients/admin-ui/src/features/consent-settings/tcf/TCFOverrideToggle.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/TCFOverrideToggle.tsx
@@ -112,6 +112,7 @@ export const TCFOverrideToggle = ({
             checked={isChecked}
             defaultChecked={defaultChecked}
             onClick={handleBeforeChange}
+            data-testid="tcf-override-toggle"
           />
           <Text>Override vendor purposes</Text>
           <QuestionTooltip label="Toggle on if you want to globally change any flexible legal bases or remove TCF purposes from your CMP" />


### PR DESCRIPTION
Closes [LJ-668]

### Description Of Changes

Changes primarily focus on expanding test coverage for Purpose overrides in Consent Settings

### Code Changes

* Added new test cases for TCF configuration management including:
  - Creating, selecting, and managing TCF configurations
  - Handling publisher restrictions table display and interactions
  - Validating vendor ID input formats
  - Testing restriction type management (require consent, legitimate interest)
* Added new test fixtures for TCF configurations and publisher restrictions
* Improved test organization by consolidating TCF-related tests
* Refactored publisher settings tests to be more focused and reduce code duplication
* Fixed validation for vendor ID input format in the UI
* Removed redundant GPP configuration tests that were moved to TCF-specific sections

### Steps to Confirm

Passing Admin UI Cypress tests is all that's needed here

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* `CHANGELOG.md` update not necessary
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-668]: https://ethyca.atlassian.net/browse/LJ-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ