### PR TITLE
LJ-683: Adds new embedded-consent route to PC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.59.0...main)
 
+### Added
+- Adds embedded-consent route to Privacy Center [#6040](https://github.com/ethyca/fides/pull/6040)
+
 ### Changed
 - Changed how TCF Publisher Overrides gets configured in consent settings [#6013](https://github.com/ethyca/fides/pull/6013)
 

--- a/clients/privacy-center/public/embedded-consent.html
+++ b/clients/privacy-center/public/embedded-consent.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html>
+<head>
+    <title>Fides-js Embedded Consent</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!--
+      Pass along any params to the fides.js script. For example, visiting
+      http://localhost:3001/embedded-consent?geolocation=fr-id
+      will pass a geolocation query param to fides.js
+    -->
+    <script>
+        (function () {
+            window.fides_overrides = {
+                fides_embed: true,
+                // fides_disable_banner: true
+            }
+            const params = new URLSearchParams(window.location.search);
+            const gpp = params.get("gpp");
+            const src = `/fides.js${!!params.size ? `?${params.toString()}` : ""}`;
+            document.write('<script src="' + src + '"><\/script>');
+            if (gpp === "debug") {
+                document.write('<script src="/fides-ext-gpp.js"><\/script>');
+            }
+        })();
+    </script>
+
+    <style>
+        body {
+            font-family: var(--fides-overlay-font-family);
+            color: var(--fides-overlay-font-color-dark);
+            font-size: var(--fides-overlay-font-size-body);
+            background-color: var(--fides-overlay-background-color);
+        }
+
+        /* Allow the embedded consent modal to fill the width of the screen */
+        #fides-embed-container {
+            --fides-overlay-width: 'auto'
+        }
+        #fides-embed-no-results {
+            display: none;
+            text-align: center;
+            font-family: var(--fides-overlay-font-family);
+            color: var(--fides-overlay-font-color-dark);
+            font-size: var(--fides-overlay-font-size-body);
+        }
+        #fides-embed-no-results .close {
+            cursor: pointer;
+            font-size: 1.5em;
+            position: absolute;
+            right: 0;
+            top: 0;
+            padding: 10px;
+        }
+    </style>
+</head>
+
+<body>
+<main>
+    <div id="fides-embed-container" ></div>
+    <H3 id="fides-embed-no-results">
+        <span class="close">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none">
+              <path
+                  fill="#2D3748"
+                  d="m8 7.057 3.3-3.3.943.943-3.3 3.3 3.3 3.3-.943.943-3.3-3.3-3.3 3.3-.943-.943 3.3-3.3-3.3-3.3.943-.943 3.3 3.3Z"
+              />
+            </svg>
+        </span>
+        <div>Consent is not available in your region.</div>
+    </H3>
+</main>
+<script>
+    const onInitialized = () => {
+        window.document
+            .getElementById("fides-embed-no-results")
+            .setAttribute("style", "display: block");
+    }
+
+    // Handle both synchronous & asynchronous initialization
+    if (Fides.initialized) {
+        onInitialized();
+    } else {
+        window.addEventListener("FidesInitialized", onInitialized);
+    }
+
+    window.addEventListener("FidesUIShown", () => {
+        window.document
+            .getElementById("fides-embed-no-results")
+            .setAttribute("style", "display: none");
+    });
+</script>
+</body>
+</html>

--- a/clients/privacy-center/public/embedded-consent.html
+++ b/clients/privacy-center/public/embedded-consent.html
@@ -17,9 +17,13 @@
         const params = new URLSearchParams(window.location.search);
         const gpp = params.get("gpp");
         const src = `/fides.js${!!params.size ? `?${params.toString()}` : ""}`;
-        document.write('<script src="' + src + '"><\/script>');
+        const script = document.createElement("script");
+        script.src = src;
+        document.head.appendChild(script);
         if (gpp === "debug") {
-          document.write('<script src="/fides-ext-gpp.js"><\/script>');
+          const gppScript = document.createElement("script");
+          gppScript.src = "/fides-ext-gpp.js";
+          document.head.appendChild(gppScript);
         }
       })();
     </script>

--- a/clients/privacy-center/public/embedded-consent.html
+++ b/clients/privacy-center/public/embedded-consent.html
@@ -86,7 +86,7 @@
       };
 
       // Handle both synchronous & asynchronous initialization
-      if (Fides.initialized) {
+      if (window.Fides?.initialized) {
         onInitialized();
       } else {
         window.addEventListener("FidesInitialized", onInitialized);

--- a/clients/privacy-center/public/embedded-consent.html
+++ b/clients/privacy-center/public/embedded-consent.html
@@ -46,7 +46,7 @@
         color: var(--fides-overlay-font-color-dark);
         font-size: var(--fides-overlay-font-size-body);
       }
-      .no-results--is-hidden{
+      .no-results--is-hidden {
         display: none;
       }
       .no-results__close {
@@ -62,8 +62,8 @@
 
   <body>
     <main>
-      <div id="fides-embed-container" class="container></div>
-      <h3 id="fides-embed-no-results" class="no-results">
+      <div id="fides-embed-container" class="container"></div>
+      <h3 id="fides-embed-no-results" class="no-results no-results--is-hidden">
         <span class="no-results__close">
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -82,6 +82,21 @@
     </main>
     <script>
       const onInitialized = () => {
+        let fidesUIShown = false;
+        window.addEventListener("FidesUIShown", () => {
+          fidesUIShown = true;
+          window.document
+            .getElementById("fides-embed-no-results")
+            .classList.add("no-results--is-hidden");
+        });
+        setTimeout(function () {
+          if (!fidesUIShown) {
+            window.document
+              .getElementById("fides-embed-no-results")
+              .classList.remove("no-results--is-hidden");
+          }
+        }, 200);
+      };
 
       // Handle both synchronous & asynchronous initialization
       if (window.Fides?.initialized) {
@@ -89,12 +104,6 @@
       } else {
         window.addEventListener("FidesInitialized", onInitialized);
       }
-
-      window.addEventListener("FidesUIShown", () => {
-        window.document
-          .getElementById("fides-embed-no-results")
-          .classList.add("no-results--is-hidden");
-      });
     </script>
   </body>
 </html>

--- a/clients/privacy-center/public/embedded-consent.html
+++ b/clients/privacy-center/public/embedded-consent.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
-<head>
+  <head>
     <title>Fides-js Embedded Consent</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!--
@@ -9,85 +9,90 @@
       will pass a geolocation query param to fides.js
     -->
     <script>
-        (function () {
-            window.fides_overrides = {
-                fides_embed: true,
-                // fides_disable_banner: true
-            }
-            const params = new URLSearchParams(window.location.search);
-            const gpp = params.get("gpp");
-            const src = `/fides.js${!!params.size ? `?${params.toString()}` : ""}`;
-            document.write('<script src="' + src + '"><\/script>');
-            if (gpp === "debug") {
-                document.write('<script src="/fides-ext-gpp.js"><\/script>');
-            }
-        })();
+      (function () {
+        window.fides_overrides = {
+          fides_embed: true,
+          // fides_disable_banner: true
+        };
+        const params = new URLSearchParams(window.location.search);
+        const gpp = params.get("gpp");
+        const src = `/fides.js${!!params.size ? `?${params.toString()}` : ""}`;
+        document.write('<script src="' + src + '"><\/script>');
+        if (gpp === "debug") {
+          document.write('<script src="/fides-ext-gpp.js"><\/script>');
+        }
+      })();
     </script>
 
     <style>
-        body {
-            font-family: var(--fides-overlay-font-family);
-            color: var(--fides-overlay-font-color-dark);
-            font-size: var(--fides-overlay-font-size-body);
-            background-color: var(--fides-overlay-background-color);
-        }
+      body {
+        font-family: var(--fides-overlay-font-family);
+        color: var(--fides-overlay-font-color-dark);
+        font-size: var(--fides-overlay-font-size-body);
+        background-color: var(--fides-overlay-background-color);
+      }
 
-        /* Allow the embedded consent modal to fill the width of the screen */
-        #fides-embed-container {
-            --fides-overlay-width: 'auto'
-        }
-        #fides-embed-no-results {
-            display: none;
-            text-align: center;
-            font-family: var(--fides-overlay-font-family);
-            color: var(--fides-overlay-font-color-dark);
-            font-size: var(--fides-overlay-font-size-body);
-        }
-        #fides-embed-no-results .close {
-            cursor: pointer;
-            font-size: 1.5em;
-            position: absolute;
-            right: 0;
-            top: 0;
-            padding: 10px;
-        }
+      /* Allow the embedded consent modal to fill the width of the screen */
+      #fides-embed-container {
+        --fides-overlay-width: "auto";
+      }
+      #fides-embed-no-results {
+        display: none;
+        text-align: center;
+        font-family: var(--fides-overlay-font-family);
+        color: var(--fides-overlay-font-color-dark);
+        font-size: var(--fides-overlay-font-size-body);
+      }
+      #fides-embed-no-results .close {
+        cursor: pointer;
+        font-size: 1.5em;
+        position: absolute;
+        right: 0;
+        top: 0;
+        padding: 10px;
+      }
     </style>
-</head>
+  </head>
 
-<body>
-<main>
-    <div id="fides-embed-container" ></div>
-    <H3 id="fides-embed-no-results">
+  <body>
+    <main>
+      <div id="fides-embed-container"></div>
+      <h3 id="fides-embed-no-results">
         <span class="close">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none">
-              <path
-                  fill="#2D3748"
-                  d="m8 7.057 3.3-3.3.943.943-3.3 3.3 3.3 3.3-.943.943-3.3-3.3-3.3 3.3-.943-.943 3.3-3.3-3.3-3.3.943-.943 3.3 3.3Z"
-              />
-            </svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="none"
+          >
+            <path
+              fill="#2D3748"
+              d="m8 7.057 3.3-3.3.943.943-3.3 3.3 3.3 3.3-.943.943-3.3-3.3-3.3 3.3-.943-.943 3.3-3.3-3.3-3.3.943-.943 3.3 3.3Z"
+            />
+          </svg>
         </span>
         <div>Consent is not available in your region.</div>
-    </H3>
-</main>
-<script>
-    const onInitialized = () => {
+      </h3>
+    </main>
+    <script>
+      const onInitialized = () => {
         window.document
-            .getElementById("fides-embed-no-results")
-            .setAttribute("style", "display: block");
-    }
+          .getElementById("fides-embed-no-results")
+          .setAttribute("style", "display: block");
+      };
 
-    // Handle both synchronous & asynchronous initialization
-    if (Fides.initialized) {
+      // Handle both synchronous & asynchronous initialization
+      if (Fides.initialized) {
         onInitialized();
-    } else {
+      } else {
         window.addEventListener("FidesInitialized", onInitialized);
-    }
+      }
 
-    window.addEventListener("FidesUIShown", () => {
+      window.addEventListener("FidesUIShown", () => {
         window.document
-            .getElementById("fides-embed-no-results")
-            .setAttribute("style", "display: none");
-    });
-</script>
-</body>
+          .getElementById("fides-embed-no-results")
+          .setAttribute("style", "display: none");
+      });
+    </script>
+  </body>
 </html>

--- a/clients/privacy-center/public/embedded-consent.html
+++ b/clients/privacy-center/public/embedded-consent.html
@@ -37,17 +37,19 @@
       }
 
       /* Allow the embedded consent modal to fill the width of the screen */
-      #fides-embed-container {
+      .container {
         --fides-overlay-width: "auto";
       }
-      #fides-embed-no-results {
-        display: none;
+      .no-results {
         text-align: center;
         font-family: var(--fides-overlay-font-family);
         color: var(--fides-overlay-font-color-dark);
         font-size: var(--fides-overlay-font-size-body);
       }
-      #fides-embed-no-results .close {
+      .no-results--is-hidden{
+        display: none;
+      }
+      .no-results__close {
         cursor: pointer;
         font-size: 1.5em;
         position: absolute;
@@ -60,9 +62,9 @@
 
   <body>
     <main>
-      <div id="fides-embed-container"></div>
-      <h3 id="fides-embed-no-results">
-        <span class="close">
+      <div id="fides-embed-container" class="container></div>
+      <h3 id="fides-embed-no-results" class="no-results">
+        <span class="no-results__close">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="16"
@@ -80,10 +82,6 @@
     </main>
     <script>
       const onInitialized = () => {
-        window.document
-          .getElementById("fides-embed-no-results")
-          .setAttribute("style", "display: block");
-      };
 
       // Handle both synchronous & asynchronous initialization
       if (window.Fides?.initialized) {
@@ -95,7 +93,7 @@
       window.addEventListener("FidesUIShown", () => {
         window.document
           .getElementById("fides-embed-no-results")
-          .setAttribute("style", "display: none");
+          .classList.add("no-results--is-hidden");
       });
     </script>
   </body>


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/LJ-683

### Description Of Changes

Adds new embedded-consent route in PC to be used by TCF mobile SDK. 

Features:

1. Forwards any query params to the fides.js script, including geolocation and property_id
2. Loads the 1st layer TCF banner, allows clicking to the 2nd layer modal
3. Displays a message and "x" in the edge case where there is no Fides UI. Clicking "X" does not do anything as this is a placeholder button for the mobile SDK to bind to.

### Code Changes

* Adds new /embedded-consent route to privacy center

### Steps to Confirm

1. Set up TCF experience for eea location
2. Disable US experiences
3. Navigate to http://localhost:3001/embedded-consent.html?geolocation=eea, confirm embedded TCF banner displays
5. Navigate to http://localhost:3001/embedded-consent.html?geolocation=us-ca, confirm err message appears with "x" button.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
