### PR TITLE
Fix: Ignore `null` fields from `identity_inputs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Fixed
 - Fixed typo in Vermont US state name [#6029](https://github.com/ethyca/fides/pull/6029)
 - Fixed two Georgia's in regions list and incorrect name for the state SD [#6036](https://github.com/ethyca/fides/pull/6036)
+- Fixed Privacy Center issue where unconfigured fields (eg. phone) were being passed as null form values [#6045](https://github.com/ethyca/fides/pull/6045)
 
 ## [2.59.0](https://github.com/ethyca/fides/compare/2.58.2...2.59.0)
 

--- a/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
@@ -107,7 +107,7 @@ const usePrivacyRequestForm = ({
         Object.entries(action.identity_inputs ?? {})
           // we have to support name as an identity_input for legacy purposes
           // but we ignore it since it's not unique enough to be treated as an identity
-          .filter(([key]) => key !== "name")
+          .filter(([key, field]) => key !== "name" && !!field)
           .map(([key, field]) => {
             const value = fallbackNull(values[key]);
             if (typeof field === "string") {


### PR DESCRIPTION
Closes [LJ-686]

### Description Of Changes

When a identity_inputs value is set to null, do not set a label/value for it on the response

for example:
```
{
  ...
  identity_inputs: {
    "name": null,
    "email": "required",
    "phone": null
  }
  ...
}
```
should ignore "name" and "phone" when setting default values in the form response, since they have no form elements.

### Code Changes

* filter if the field is not defined

### Steps to Confirm

1. In local privacy center, set config.json to have an `identity_inputs` property like the one in the example above
2. Run privacy center and attempt to "Access your data" by filling in your email address
3. You should be able to submit the form successfully and without errors.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-686]: https://ethyca.atlassian.net/browse/LJ-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ