### PR TITLE
Improve Formik performance on datamap report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed typo in Vermont US state name [#6029](https://github.com/ethyca/fides/pull/6029)
 - Fixed two Georgia's in regions list and incorrect name for the state SD [#6036](https://github.com/ethyca/fides/pull/6036)
 - Fixed Privacy Center issue where unconfigured fields (eg. phone) were being passed as null form values [#6045](https://github.com/ethyca/fides/pull/6045)
+- Fixed performance issues in Data map report in Admin UI [#6046](https://github.com/ethyca/fides/pull/6046)
 
 ## [2.59.0](https://github.com/ethyca/fides/compare/2.58.2...2.59.0)
 

--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -132,7 +132,7 @@ describe("Data map report table", () => {
     });
   });
 
-  describe.skip("Column customization", () => {
+  describe("Column customization", () => {
     it("should show/hide columns", () => {
       // hide
       cy.getByTestId("more-menu").click();

--- a/clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx
+++ b/clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx
@@ -24,7 +24,7 @@ import {
   useToast,
   VStack,
 } from "fidesui";
-import { Form, Formik } from "formik";
+import { Form, Formik, FormikState, useFormikContext } from "formik";
 import { useEffect, useMemo, useState } from "react";
 
 import { AddIcon } from "~/features/common/custom-fields/icons/AddIcon";
@@ -55,7 +55,12 @@ interface CustomReportTemplatesProps {
   savedReportId: string; // from local storage
   tableStateToSave: CustomReportTableState | undefined;
   currentColumnMap?: Record<string, string>;
-  onCustomReportSaved: (customReport: CustomReportResponse | null) => void;
+  onCustomReportSaved: (
+    customReport: CustomReportResponse | null,
+    resetForm: (
+      nextState?: Partial<FormikState<Record<string, string>>> | undefined,
+    ) => void,
+  ) => void;
   onSavedReportDeleted: () => void;
 }
 
@@ -104,6 +109,7 @@ export const CustomReportTemplates = ({
   const [reportToDelete, setReportToDelete] =
     useState<CustomReportResponseMinimal>();
   const [showSpinner, setShowSpinner] = useState<boolean>(false);
+  const { resetForm } = useFormikContext();
 
   const buttonLabel = useMemo(() => {
     const reportName = customReportsList?.items.find(
@@ -157,7 +163,7 @@ export const CustomReportTemplates = ({
     if (fetchedReport) {
       setShowSpinner(false);
       if (fetchedReport.id !== savedReportId) {
-        onCustomReportSaved(fetchedReport);
+        onCustomReportSaved(fetchedReport, resetForm);
       }
       popoverOnClose();
     } else if (selectedReportId) {
@@ -165,7 +171,7 @@ export const CustomReportTemplates = ({
       setShowSpinner(true);
     } else {
       // form was reset, apply the reset
-      onCustomReportSaved(null);
+      onCustomReportSaved(null, resetForm);
       popoverOnClose();
     }
   };
@@ -384,7 +390,9 @@ export const CustomReportTemplates = ({
         unavailableNames={customReportsList?.items.map((customReport) => {
           return customReport.name;
         })}
-        onCreateCustomReport={onCustomReportSaved}
+        onCreateCustomReport={(customReport) =>
+          onCustomReportSaved(customReport, resetForm)
+        }
       />
       <ConfirmationModal
         isOpen={deleteIsOpen}

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -20,7 +20,7 @@ import {
   useToast,
   WarningIcon,
 } from "fidesui";
-import { useField, useFormikContext } from "formik";
+import { FastField, useFormikContext } from "formik";
 import { isBoolean } from "lodash";
 import { ReactElement, ReactNode, useEffect, useMemo, useState } from "react";
 
@@ -398,11 +398,11 @@ export const EditableHeaderCell = <T,>({
   isEditing: boolean;
 }) => {
   const headerId = props.column.columnDef.id || "";
-  const [field] = useField(headerId);
   const { submitForm } = useFormikContext();
   return isEditing ? (
-    <Input
-      {...field}
+    <FastField
+      name={headerId}
+      as={Input}
       maxLength={80}
       placeholder={defaultValue}
       aria-label="Edit column name"

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -69,6 +69,7 @@ import {
   getDatamapReportColumns,
   getDefaultColumn,
 } from "./DatamapReportTableColumns";
+import { RenameColumnsButtons } from "./RenameColumnsButtons";
 import { getColumnOrder, getGrouping, getPrefixColumns } from "./utils";
 
 const emptyMinimalDatamapReportResponse: Page_DatamapReport_ = {
@@ -496,152 +497,121 @@ export const DatamapReportTable = () => {
         initialValues={columnNameMapOverrides}
         onSubmit={handleColumnRenaming}
       >
-        {({ submitForm, resetForm }) => (
-          <>
-            <TableActionBar>
-              <GlobalFilterV2
-                globalFilter={globalFilter}
-                setGlobalFilter={updateGlobalFilter}
-                placeholder="System name, Fides key, or ID"
-              />
-              <Flex alignItems="center" gap={2}>
-                {userCanSeeReports && (
-                  <CustomReportTemplates
-                    reportType={ReportType.DATAMAP}
-                    savedReportId={savedCustomReportId}
-                    tableStateToSave={{
-                      groupBy,
-                      filters: selectedFilters,
-                      columnOrder,
-                      columnVisibility,
-                    }}
-                    currentColumnMap={columnNameMapOverrides}
-                    onCustomReportSaved={(customReport) =>
-                      handleSavedReport(customReport, resetForm)
-                    }
-                    onSavedReportDeleted={() => {
-                      setSavedCustomReportId("");
-                    }}
-                  />
-                )}
-                <Menu>
-                  <MenuButton
-                    as={Button}
-                    icon={<ChevronDownIcon />}
-                    iconPosition="end"
-                    loading={groupChangeStarted}
-                    data-testid="group-by-menu"
-                  >
-                    Group by {getMenuDisplayValue()}
-                  </MenuButton>
-                  <MenuList zIndex={11} data-testid="group-by-menu-list">
-                    <MenuItemOption
-                      onClick={() => {
-                        onGroupChange(DATAMAP_GROUPING.SYSTEM_DATA_USE);
-                      }}
-                      isChecked={DATAMAP_GROUPING.SYSTEM_DATA_USE === groupBy}
-                      value={DATAMAP_GROUPING.SYSTEM_DATA_USE}
-                      data-testid="group-by-system-data-use"
-                    >
-                      System
-                    </MenuItemOption>
-                    <MenuItemOption
-                      onClick={() => {
-                        onGroupChange(DATAMAP_GROUPING.DATA_USE_SYSTEM);
-                      }}
-                      isChecked={DATAMAP_GROUPING.DATA_USE_SYSTEM === groupBy}
-                      value={DATAMAP_GROUPING.DATA_USE_SYSTEM}
-                      data-testid="group-by-data-use-system"
-                    >
-                      Data use
-                    </MenuItemOption>
-                  </MenuList>
-                </Menu>
-                <Button
-                  data-testid="filter-multiple-systems-btn"
-                  onClick={onFilterModalOpen}
-                >
-                  Filter
-                </Button>
-                <Button
-                  aria-label="Export report"
-                  data-testid="export-btn"
-                  onClick={onExportReportOpen}
-                  icon={<DownloadLightIcon ml="1.5px" />}
+        <>
+          <TableActionBar>
+            <GlobalFilterV2
+              globalFilter={globalFilter}
+              setGlobalFilter={updateGlobalFilter}
+              placeholder="System name, Fides key, or ID"
+            />
+            <Flex alignItems="center" gap={2}>
+              {userCanSeeReports && (
+                <CustomReportTemplates
+                  reportType={ReportType.DATAMAP}
+                  savedReportId={savedCustomReportId}
+                  tableStateToSave={{
+                    groupBy,
+                    filters: selectedFilters,
+                    columnOrder,
+                    columnVisibility,
+                  }}
+                  currentColumnMap={columnNameMapOverrides}
+                  onCustomReportSaved={(customReport, resetForm) =>
+                    handleSavedReport(customReport, resetForm)
+                  }
+                  onSavedReportDeleted={() => {
+                    setSavedCustomReportId("");
+                  }}
                 />
-                <Menu placement="bottom-end">
-                  <MenuButton
-                    as={Button}
-                    icon={<MoreIcon className="rotate-90" />}
-                    data-testid="more-menu"
-                    aria-label="More options"
-                    className="w-6 gap-0"
-                  />
-                  <MenuList data-testid="more-menu-list">
-                    <MenuItem
-                      onClick={onColumnSettingsOpen}
-                      data-testid="edit-columns-btn"
-                    >
-                      Edit columns
-                    </MenuItem>
-                    <MenuItem
-                      onClick={() => setIsRenamingColumns(true)}
-                      data-testid="rename-columns-btn"
-                    >
-                      Rename columns
-                    </MenuItem>
-                  </MenuList>
-                </Menu>
-                {isRenamingColumns && (
-                  <div className="flex gap-2">
-                    <Button
-                      size="small"
-                      data-testid="rename-columns-reset-btn"
-                      onClick={() => {
-                        setColumnNameMapOverrides({});
-                        setSavedCustomReportId("");
-                        resetForm({ values: {} });
-                        setIsRenamingColumns(false);
-                      }}
-                    >
-                      Reset all
-                    </Button>
-                    <Button
-                      size="small"
-                      data-testid="rename-columns-cancel-btn"
-                      onClick={() => {
-                        resetForm({ values: columnNameMapOverrides });
-                        setIsRenamingColumns(false);
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      size="small"
-                      type="primary"
-                      htmlType="submit"
-                      data-testid="rename-columns-apply-btn"
-                      onClick={submitForm}
-                    >
-                      Apply
-                    </Button>
-                  </div>
-                )}
-              </Flex>
-            </TableActionBar>
-            <Form>
-              <FidesTableV2<DatamapReport>
-                tableInstance={tableInstance}
-                columnExpandStorageKey={
-                  DATAMAP_LOCAL_STORAGE_KEYS.COLUMN_EXPANSION_STATE
-                }
-                columnWrapStorageKey={
-                  DATAMAP_LOCAL_STORAGE_KEYS.WRAPPING_COLUMNS
-                }
+              )}
+              <Menu>
+                <MenuButton
+                  as={Button}
+                  icon={<ChevronDownIcon />}
+                  iconPosition="end"
+                  loading={groupChangeStarted}
+                  data-testid="group-by-menu"
+                >
+                  Group by {getMenuDisplayValue()}
+                </MenuButton>
+                <MenuList zIndex={11} data-testid="group-by-menu-list">
+                  <MenuItemOption
+                    onClick={() => {
+                      onGroupChange(DATAMAP_GROUPING.SYSTEM_DATA_USE);
+                    }}
+                    isChecked={DATAMAP_GROUPING.SYSTEM_DATA_USE === groupBy}
+                    value={DATAMAP_GROUPING.SYSTEM_DATA_USE}
+                    data-testid="group-by-system-data-use"
+                  >
+                    System
+                  </MenuItemOption>
+                  <MenuItemOption
+                    onClick={() => {
+                      onGroupChange(DATAMAP_GROUPING.DATA_USE_SYSTEM);
+                    }}
+                    isChecked={DATAMAP_GROUPING.DATA_USE_SYSTEM === groupBy}
+                    value={DATAMAP_GROUPING.DATA_USE_SYSTEM}
+                    data-testid="group-by-data-use-system"
+                  >
+                    Data use
+                  </MenuItemOption>
+                </MenuList>
+              </Menu>
+              <Button
+                data-testid="filter-multiple-systems-btn"
+                onClick={onFilterModalOpen}
+              >
+                Filter
+              </Button>
+              <Button
+                aria-label="Export report"
+                data-testid="export-btn"
+                onClick={onExportReportOpen}
+                icon={<DownloadLightIcon ml="1.5px" />}
               />
-            </Form>
-          </>
-        )}
+              <Menu placement="bottom-end">
+                <MenuButton
+                  as={Button}
+                  icon={<MoreIcon className="rotate-90" />}
+                  data-testid="more-menu"
+                  aria-label="More options"
+                  className="w-6 gap-0"
+                />
+                <MenuList data-testid="more-menu-list">
+                  <MenuItem
+                    onClick={onColumnSettingsOpen}
+                    data-testid="edit-columns-btn"
+                  >
+                    Edit columns
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => setIsRenamingColumns(true)}
+                    data-testid="rename-columns-btn"
+                  >
+                    Rename columns
+                  </MenuItem>
+                </MenuList>
+              </Menu>
+              {isRenamingColumns && (
+                <RenameColumnsButtons
+                  columnNameMapOverrides={columnNameMapOverrides}
+                  setColumnNameMapOverrides={setColumnNameMapOverrides}
+                  setSavedCustomReportId={setSavedCustomReportId}
+                  setIsRenamingColumns={setIsRenamingColumns}
+                />
+              )}
+            </Flex>
+          </TableActionBar>
+          <Form>
+            <FidesTableV2<DatamapReport>
+              tableInstance={tableInstance}
+              columnExpandStorageKey={
+                DATAMAP_LOCAL_STORAGE_KEYS.COLUMN_EXPANSION_STATE
+              }
+              columnWrapStorageKey={DATAMAP_LOCAL_STORAGE_KEYS.WRAPPING_COLUMNS}
+            />
+          </Form>
+        </>
       </Formik>
 
       <PaginationBar

--- a/clients/admin-ui/src/features/datamap/reporting/RenameColumnsButtons.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/RenameColumnsButtons.tsx
@@ -1,0 +1,52 @@
+import { AntButton as Button } from "fidesui";
+import { useFormikContext } from "formik";
+
+interface RenameColumnsButtonsProps {
+  columnNameMapOverrides: Record<string, string>;
+  setColumnNameMapOverrides: (overrides: Record<string, string>) => void;
+  setSavedCustomReportId: (id: string) => void;
+  setIsRenamingColumns: (isRenaming: boolean) => void;
+}
+export const RenameColumnsButtons = ({
+  columnNameMapOverrides,
+  setColumnNameMapOverrides,
+  setSavedCustomReportId,
+  setIsRenamingColumns,
+}: RenameColumnsButtonsProps) => {
+  const { submitForm, resetForm } = useFormikContext();
+  return (
+    <div className="flex gap-2">
+      <Button
+        size="small"
+        data-testid="rename-columns-reset-btn"
+        onClick={() => {
+          setColumnNameMapOverrides({});
+          setSavedCustomReportId("");
+          resetForm({ values: {} });
+          setIsRenamingColumns(false);
+        }}
+      >
+        Reset all
+      </Button>
+      <Button
+        size="small"
+        data-testid="rename-columns-cancel-btn"
+        onClick={() => {
+          resetForm({ values: columnNameMapOverrides });
+          setIsRenamingColumns(false);
+        }}
+      >
+        Cancel
+      </Button>
+      <Button
+        size="small"
+        type="primary"
+        htmlType="submit"
+        data-testid="rename-columns-apply-btn"
+        onClick={submitForm}
+      >
+        Apply
+      </Button>
+    </div>
+  );
+};


### PR DESCRIPTION
Closes: [LJ-687]

### Description Of Changes

Cypress tests were becoming flaky on the data map report due to the fact that Formik was re-rendering the entire table with every form change, causing a react performance issue. Tests were timing out and failing eventually because of it.

This performance issue was also causing some visible slowness in the UI for the end user.

To address both the Cypress and user issues, I've gone ahead and refactored the Formik implementation to rely more heavily on `useFormikContext` rather than wrapping the entire Formik child in a function that passes those same values in.

The result is much faster and the tests are no longer flaky
![CleanShot 2025-04-14 at 16 53 00@2x](https://github.com/user-attachments/assets/0b3a9dbf-9fd5-4307-8192-03c83add4fad)


### Code Changes

* Updated form handling in `DatamapReportTable` to use Formik context more effectively by removing the child wrapper function
* Added `resetForm` parameter to `onCustomReportSaved` callback to allow using `useFormikContext` instead of passing it around from the child function
* Extracted column renaming buttons into a new `RenameColumnsButtons` component to allow using `useFormikContext`
* Replaced `useField` with `FastField` in `EditableHeaderCell` for better performance
* Enabled previously skipped column customization tests by removing `.skip` from the test description

### Steps to Confirm
1. Navigate to the Data Map Report table
3. Verify column renaming functionality works:
   - Reset all button clears customizations
   - Cancel button reverts changes
   - Apply button saves changes
4. Confirm the column customization tests are now passing

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-687]: https://ethyca.atlassian.net/browse/LJ-687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ