### PR TITLE
LJ-685 - AWS SES setup requires both email and domain identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed two Georgia's in regions list and incorrect name for the state SD [#6036](https://github.com/ethyca/fides/pull/6036)
 - Fixed Privacy Center issue where unconfigured fields (eg. phone) were being passed as null form values [#6045](https://github.com/ethyca/fides/pull/6045)
 - Fixed performance issues in Data map report in Admin UI [#6046](https://github.com/ethyca/fides/pull/6046)
+- Fixed details requirements in AWS SES setup [#6047](https://github.com/ethyca/fides/pull/6047)
 
 ## [2.59.0](https://github.com/ethyca/fides/compare/2.58.2...2.59.0)
 

--- a/clients/admin-ui/src/types/api/models/MessagingServiceDetailsAWS_SES.ts
+++ b/clients/admin-ui/src/types/api/models/MessagingServiceDetailsAWS_SES.ts
@@ -6,7 +6,7 @@
  * The details required to represent an AWS SES email configuration.
  */
 export type MessagingServiceDetailsAWS_SES = {
-  email_from: string;
-  domain: string;
+  email_from?: string;
+  domain?: string;
   aws_region: string;
 };

--- a/src/fides/api/schemas/messaging/messaging.py
+++ b/src/fides/api/schemas/messaging/messaging.py
@@ -286,11 +286,20 @@ class MessagingServiceDetailsTwilioEmail(BaseModel):
 class MessagingServiceDetailsAWS_SES(BaseModel):
     """The details required to represent an AWS SES email configuration."""
 
-    email_from: str
-    domain: str
+    email_from: Optional[str] = None
+    domain: Optional[str] = None
     aws_region: str
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if not values.get("domain") and not values.get("email_from"):
+            raise ValueError(
+                "Either 'email_from' or 'domain' must be provided."
+            )
+        return values
 
 
 class MessagingServiceSecrets(Enum):

--- a/src/fides/api/schemas/messaging/messaging.py
+++ b/src/fides/api/schemas/messaging/messaging.py
@@ -296,9 +296,7 @@ class MessagingServiceDetailsAWS_SES(BaseModel):
     @classmethod
     def validate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         if not values.get("domain") and not values.get("email_from"):
-            raise ValueError(
-                "Either 'email_from' or 'domain' must be provided."
-            )
+            raise ValueError("Either 'email_from' or 'domain' must be provided.")
         return values
 
 

--- a/src/fides/service/messaging/aws_ses_service.py
+++ b/src/fides/service/messaging/aws_ses_service.py
@@ -97,28 +97,29 @@ class AWS_SES_Service:
 
     def validate_email_and_domain_status(self) -> None:
         """
-        Validate that the email and domain are verified in SES.
+        Validate that either the email or domain (or both) are verified in SES.
         """
         email = self.messaging_config_details.email_from
         domain = self.messaging_config_details.domain
         identities = list(filter(None, (email, domain)))
 
+        # Defensive code just in case, there should always be email_from or domain
+        if not identities:
+            raise AWS_SESException(
+                "No identity (email_from or domain) configured for SES validation."
+            )
+
         ses_client = self.get_ses_client()
         response = ses_client.get_identity_verification_attributes(
             Identities=identities
         )
-        email_status = (
-            response["VerificationAttributes"].get(email, {}).get("VerificationStatus")
-        )
-        domain_status = (
-            response["VerificationAttributes"].get(domain, {}).get("VerificationStatus")
-        )
-        if email and email_status != "Success":
-            logger.error(f"Email {email} is not verified in SES.")
-            raise AWS_SESException(f"Email {email} is not verified in SES.")
-        if domain and domain_status != "Success":
-            logger.error(f"Domain {domain} is not verified in SES.")
-            raise AWS_SESException(f"Domain {domain} is not verified in SES.")
+        attributes = response.get("VerificationAttributes", {})
+
+        for identity in identities:
+            status = attributes.get(identity, {}).get("VerificationStatus")
+            if status != "Success":
+                logger.error(f"{identity} is not verified in SES.")
+                raise AWS_SESException(f"{identity} is not verified in SES.")
 
     def send_email(
         self,
@@ -134,7 +135,7 @@ class AWS_SES_Service:
         ses_client = self.get_ses_client()
 
         from_address = self.messaging_config_details.email_from
-        if not from_address and self.messaging_config_details.domain:
+        if not from_address:
             from_address = f"noreply@{self.messaging_config_details.domain}"
 
         ses_client.send_email(

--- a/src/fides/service/messaging/aws_ses_service.py
+++ b/src/fides/service/messaging/aws_ses_service.py
@@ -136,6 +136,9 @@ class AWS_SES_Service:
 
         from_address = self.messaging_config_details.email_from
         if not from_address:
+            # If there is no email_from, there is a domain, and the domain was verified against SES.
+            # When you verify a domain identity, you can send email from any subdomain or email address of the
+            # verified domain without having to verify each one individually.
             from_address = f"noreply@{self.messaging_config_details.domain}"
 
         ses_client.send_email(

--- a/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
@@ -509,7 +509,6 @@ class TestPostMessagingConfig:
             "service_type": MessagingServiceType.aws_ses.value,
             "details": {
                 "aws_region": "us-east-1",
-
             },
         }
 
@@ -517,7 +516,13 @@ class TestPostMessagingConfig:
 
         response = api_client.post(url, headers=auth_header, json=aws_ses_payload)
         assert response.status_code == 422
-        assert response.json()["detail"] == [{'type': 'value_error', 'loc': ['body'], 'msg': "Value error, Either 'email_from' or 'domain' must be provided."}]
+        assert response.json()["detail"] == [
+            {
+                "type": "value_error",
+                "loc": ["body"],
+                "msg": "Value error, Either 'email_from' or 'domain' must be provided.",
+            }
+        ]
 
 
 class TestPatchMessagingConfig:

--- a/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_messaging_endpoints.py
@@ -434,6 +434,91 @@ class TestPostMessagingConfig:
         assert email_config.details == aws_ses_payload["details"]
         email_config.delete(db)
 
+    def test_post_aws_ses_email_config_domain_not_present(
+        self,
+        db,
+        url,
+        api_client,
+        generate_auth_header,
+    ):
+        aws_ses_payload = {
+            "key": "my_aws_ses_email_config",
+            "name": "aws_ses_email",
+            "service_type": MessagingServiceType.aws_ses.value,
+            "details": {
+                "aws_region": "us-east-1",
+                "email_from": "test@test.com",
+            },
+        }
+
+        auth_header = generate_auth_header([MESSAGING_CREATE_OR_UPDATE])
+
+        response = api_client.post(url, headers=auth_header, json=aws_ses_payload)
+        assert 200 == response.status_code
+        response_body = json.loads(response.text)
+        aws_ses_payload["details"]["domain"] = None
+        assert response_body == aws_ses_payload
+
+        email_config = db.query(MessagingConfig).filter_by(
+            key="my_aws_ses_email_config"
+        )[0]
+        assert email_config.details == aws_ses_payload["details"]
+        email_config.delete(db)
+
+    def test_post_aws_ses_email_config_email_from_not_present(
+        self,
+        db,
+        url,
+        api_client,
+        generate_auth_header,
+    ):
+        aws_ses_payload = {
+            "key": "my_aws_ses_email_config",
+            "name": "aws_ses_email",
+            "service_type": MessagingServiceType.aws_ses.value,
+            "details": {
+                "aws_region": "us-east-1",
+                "domain": "example.com",
+            },
+        }
+
+        auth_header = generate_auth_header([MESSAGING_CREATE_OR_UPDATE])
+
+        response = api_client.post(url, headers=auth_header, json=aws_ses_payload)
+        assert 200 == response.status_code
+        response_body = json.loads(response.text)
+        aws_ses_payload["details"]["email_from"] = None
+        assert response_body == aws_ses_payload
+
+        email_config = db.query(MessagingConfig).filter_by(
+            key="my_aws_ses_email_config"
+        )[0]
+        assert email_config.details == aws_ses_payload["details"]
+        email_config.delete(db)
+
+    def test_post_aws_ses_email_config_missing_details_data(
+        self,
+        db,
+        url,
+        api_client,
+        generate_auth_header,
+    ):
+        aws_ses_payload = {
+            "key": "my_aws_ses_email_config",
+            "name": "aws_ses_email",
+            "service_type": MessagingServiceType.aws_ses.value,
+            "details": {
+                "aws_region": "us-east-1",
+
+            },
+        }
+
+        auth_header = generate_auth_header([MESSAGING_CREATE_OR_UPDATE])
+
+        response = api_client.post(url, headers=auth_header, json=aws_ses_payload)
+        assert response.status_code == 422
+        assert response.json()["detail"] == [{'type': 'value_error', 'loc': ['body'], 'msg': "Value error, Either 'email_from' or 'domain' must be provided."}]
+
 
 class TestPatchMessagingConfig:
     @pytest.fixture(scope="function")

--- a/tests/service/messaging/test_aws_ses_service.py
+++ b/tests/service/messaging/test_aws_ses_service.py
@@ -136,7 +136,7 @@ class TestAWS_SES_Service:
         }
 
         with pytest.raises(
-            AWS_SESException, match="Email test@example.com is not verified in SES."
+            AWS_SESException, match="test@example.com is not verified in SES."
         ):
             aws_ses_service.validate_email_and_domain_status()
 
@@ -157,7 +157,7 @@ class TestAWS_SES_Service:
         }
 
         with pytest.raises(
-            AWS_SESException, match="Email test@example.com is not verified in SES."
+            AWS_SESException, match="test@example.com is not verified in SES."
         ):
             aws_ses_service.validate_email_and_domain_status()
 
@@ -179,7 +179,7 @@ class TestAWS_SES_Service:
         }
 
         with pytest.raises(
-            AWS_SESException, match="Domain example.com is not verified in SES."
+            AWS_SESException, match="example.com is not verified in SES."
         ):
             aws_ses_service.validate_email_and_domain_status()
 


### PR DESCRIPTION
Closes [LJ-685](https://ethyca.atlassian.net/browse/LJ-685)

### Description Of Changes

We used to take the `email_from` and `domain` as required in the AWS SES `messagingconfig`, but this depends on the configurations in AWS.

> In Amazon SES, you can create an identity at the domain level or you can create an email address identity. These identity types aren’t mutually exclusive. In most cases, creating a domain identity eliminates the need for creating and verifying individual email address identities, unless you want to apply custom configurations to a specific email address. Whether you create a domain and utilize email addresses based on the domain, or create individual email addresses, there are benefits to both approaches. (https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html)

Now when sending an email, only the data configured in `messagingconfig` is validated with SES.

### Code Changes

* Allows `email_from` or `domain` or both to exist in the `messagingconfig` detail.
* Validates against SES only the configured information.
* Unit tests added.

### Steps to Confirm

(Same as the [original PR](https://github.com/ethyca/fides/pull/5804))

1.  Edit your `fides.toml` to include the following changes under `[notifications]`:
```
notification_service_type = "aws_ses"
send_request_receipt_notification = true
```
2. Spin up Fides, Admin UI and Privacy Center
3. Set up an AWS Messaging Config through the API:
  - [POST /api/v1/messaging/config](http://localhost:8080/docs#/Messaging/post_config_api_v1_messaging_config_post)  Call the endpoint with the following payload:
  ```
{
  "service_type": "aws_ses",
  "details": {
    "domain": "mail.j1407b.com",
    "email_from": "eng@ethyca.com",
    "aws_region": "us-east-2"
  },
  "name": "AWS SES",
  "key": "aws_ses"
}
```
  - [PUT /api/v1/messaging/config/aws_ses/secret](http://localhost:8080/docs#/Messaging/put_config_secrets_api_v1_messaging_config__config_key__secret_put) with the API Keys from 1Pass; set `"auth_method": "secret_keys"` and get the values for `aws_access_key_id` and `aws_secret_access_key` from 1Pass (AWS sandboxProgrammaticUserSES).
4. Edit the default `privacy_request_receipt` template through the API: call [/api/v1/messaging/templates](http://localhost:8080/docs#/Messaging/update_basic_messaging_templates_api_v1_messaging_templates_put) with the following payload:
```
[
  {
    "type": "privacy_request_receipt",
    "content": {
      "body": "<img src=\"https://cdn.ethyca.com/fides-demo/emailheader.png\" alt=\"Ethyca\"><p>Hi there,</p><span>Your privacy request has been received. We're working on it</span><p>Thank you</p>",
      "subject": "Your privacy request has been received!!"
    }
  }
]
```
5. Submit a Privacy Request from the Privacy Center: use an email address that has been verified in the AWS SES console (if you want to use your own email , just log in to our AWS sandbox account, go to SES, click on "Identities" and add & verify your email) 
6. The email that you submitted in the privacy request should have received an email displaying the updated template with proper formatting.
7. Repeat the tests by changing the messagingconfig settings, removing the `email_from` or `domain`. If you remove the `email_from`, the received email should have the source "noreply@mail.j1407b.com."

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-685]: https://ethyca.atlassian.net/browse/LJ-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ