### PR TITLE
Experience Preview Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added SSL Mode field for MySQL connections [#6048](https://github.com/ethyca/fides/pull/6048)
 - Added PostgreSQL connection config form to the "integrations" page to support use with discovery monitors [#6018](https://github.com/ethyca/fides/pull/6018)
 - Update the Datahub Permissions section to include required permissions from Datahub [#6052](https://github.com/ethyca/fides/pull/6052)
+- Added the ability to create new TCF Experiences within Admin UI [#6055](https://github.com/ethyca/fides/pull/6055)
 
 ### Added
 - Added assumed role arn capabilities to aws Storage [#6027](https://github.com/ethyca/fides/pull/6027)
@@ -40,6 +41,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - UI now allows assigning of non-consent-category data uses to system assets [#6049](https://github.com/ethyca/fides/pull/6049)
 - Updated bulk ignore assets toast message [#6043](https://github.com/ethyca/fides/pull/6043)
 - Updated consent automation models to support echo detection in Fidesplus [#6054](https://github.com/ethyca/fides/pull/6054)
+- Updated UI behavior for editing languages in the Experience config for consistency and clarity [#6055](https://github.com/ethyca/fides/pull/6055)
 
 ### Developer Experience
 - Reduced animations on Cypress tests in Privacy Center for quicker results [#5976](https://github.com/ethyca/fides/pull/5976)
@@ -53,6 +55,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed performance issues in Data map report in Admin UI [#6046](https://github.com/ethyca/fides/pull/6046)
 - Fixed details requirements in AWS SES setup [#6047](https://github.com/ethyca/fides/pull/6047)
 - Fixed startup issues with Celery workers [#6058](https://github.com/ethyca/fides/pull/6058)
+- Addressed some performance issues with Experience configuration previews [#6055](https://github.com/ethyca/fides/pull/6055)
 
 ## [2.59.1](https://github.com/ethyca/fides/compare/2.59.0...2.59.1)
 

--- a/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-experiences.cy.ts
@@ -463,14 +463,16 @@ describe("Privacy experiences", () => {
       });
 
       it("shows the preview for the translation currently being edited", () => {
-        cy.getByTestId("language-row-fr").click();
+        cy.getByTestId("language-row-fr").realHover();
+        cy.getByTestId("edit-language-row-fr").click({ force: true });
         cy.get(`#${PREVIEW_CONTAINER_ID}`).contains(
           "Gestion du consentement et des préférences",
         );
       });
 
       it("allows discarding unsaved changes after showing a modal", () => {
-        cy.getByTestId("language-row-en").click();
+        cy.getByTestId("language-row-en").realHover();
+        cy.getByTestId("edit-language-row-en").click({ force: true });
         cy.getByTestId("input-translations.0.title")
           .clear()
           .type("Some other title");
@@ -482,7 +484,8 @@ describe("Privacy experiences", () => {
       });
 
       it("allows changing the default language after showing a modal", () => {
-        cy.getByTestId("language-row-fr").click();
+        cy.getByTestId("language-row-fr").realHover();
+        cy.getByTestId("edit-language-row-fr").click({ force: true });
         cy.getByTestId("input-translations.1.is_default").click();
         cy.getByTestId("save-btn").click();
         cy.getByTestId("warning-modal-confirm-btn").click();
@@ -495,6 +498,7 @@ describe("Privacy experiences", () => {
       it("can add new translations with all required fields", () => {
         const components = [
           { type: ComponentType.PRIVACY_CENTER, displayName: "Privacy center" },
+          { type: ComponentType.HEADLESS, displayName: "Headless" },
           { type: ComponentType.MODAL, displayName: "Modal" },
           {
             type: ComponentType.BANNER_AND_MODAL,

--- a/clients/admin-ui/src/features/common/ScrollableList.tsx
+++ b/clients/admin-ui/src/features/common/ScrollableList.tsx
@@ -3,9 +3,9 @@ import {
   AntSelect as Select,
   Box,
   ChakraProps,
-  DeleteIcon,
   DragHandleIcon,
   Flex,
+  Icons,
   List,
   SmallAddIcon,
   Text,
@@ -21,6 +21,7 @@ const ScrollableListItem = <T extends unknown>({
   label,
   draggable,
   onDeleteItem,
+  onEditItem,
   tooltip,
   onRowClick,
   maxH = 10,
@@ -30,6 +31,7 @@ const ScrollableListItem = <T extends unknown>({
   label: string;
   draggable?: boolean;
   onDeleteItem?: (item: T) => void;
+  onEditItem?: (item: T) => void;
   tooltip?: string;
   onRowClick?: (item: T) => void;
   maxH?: number;
@@ -91,7 +93,16 @@ const ScrollableListItem = <T extends unknown>({
           <Button
             aria-label="Delete"
             onClick={() => onDeleteItem(item)}
-            icon={<DeleteIcon boxSize={3} />}
+            icon={<Icons.TrashCan />}
+            size="small"
+            className="invisible absolute right-2 bg-white group-hover:visible"
+          />
+        )}
+        {onEditItem && (
+          <Button
+            aria-label="Edit"
+            onClick={() => onEditItem(item)}
+            icon={<Icons.Edit />}
             size="small"
             className="invisible absolute right-2 bg-white group-hover:visible"
           />
@@ -162,6 +173,7 @@ const ScrollableList = <T extends unknown>({
   canDeleteItem,
   getTooltip,
   onRowClick,
+  onEditItem,
   selectOnAdd,
   getItemLabel,
   createNewValue,
@@ -180,6 +192,7 @@ const ScrollableList = <T extends unknown>({
   canDeleteItem?: (item: T) => boolean;
   getTooltip?: (item: T) => string | undefined;
   onRowClick?: (item: T) => void;
+  onEditItem?: (item: T) => void;
   selectOnAdd?: boolean;
   getItemLabel?: (item: T) => string;
   createNewValue?: (opt: Option) => T;
@@ -262,6 +275,7 @@ const ScrollableList = <T extends unknown>({
                   ? handleDeleteItem
                   : undefined
               }
+              onEditItem={onEditItem}
               onRowClick={onRowClick}
               draggable
               maxH={maxHeight}

--- a/clients/admin-ui/src/features/common/ScrollableList.tsx
+++ b/clients/admin-ui/src/features/common/ScrollableList.tsx
@@ -96,6 +96,7 @@ const ScrollableListItem = <T extends unknown>({
             icon={<Icons.TrashCan />}
             size="small"
             className="invisible absolute right-2 bg-white group-hover:visible"
+            data-testid={`delete-${rowTestId}`}
           />
         )}
         {onEditItem && (
@@ -105,6 +106,7 @@ const ScrollableListItem = <T extends unknown>({
             icon={<Icons.Edit />}
             size="small"
             className="invisible absolute right-2 bg-white group-hover:visible"
+            data-testid={`edit-${rowTestId}`}
           />
         )}
       </Flex>
@@ -245,6 +247,9 @@ const ScrollableList = <T extends unknown>({
     setValues([newValue, ...values.slice()]);
     if (selectOnAdd && onRowClick) {
       onRowClick(newValue);
+    }
+    if (selectOnAdd && onEditItem) {
+      onEditItem(newValue);
     }
   };
 

--- a/clients/admin-ui/src/features/common/ScrollableList.tsx
+++ b/clients/admin-ui/src/features/common/ScrollableList.tsx
@@ -1,6 +1,7 @@
 import {
   AntButton as Button,
   AntSelect as Select,
+  AntSpace as Space,
   Box,
   ChakraProps,
   DragHandleIcon,
@@ -89,26 +90,26 @@ const ScrollableListItem = <T extends unknown>({
           </Text>
           <InfoTooltip label={tooltip} />
         </Flex>
-        {onDeleteItem && (
-          <Button
-            aria-label="Delete"
-            onClick={() => onDeleteItem(item)}
-            icon={<Icons.TrashCan />}
-            size="small"
-            className="invisible absolute right-2 bg-white group-hover:visible"
-            data-testid={`delete-${rowTestId}`}
-          />
-        )}
-        {onEditItem && (
-          <Button
-            aria-label="Edit"
-            onClick={() => onEditItem(item)}
-            icon={<Icons.Edit />}
-            size="small"
-            className="invisible absolute right-2 bg-white group-hover:visible"
-            data-testid={`edit-${rowTestId}`}
-          />
-        )}
+        <Space className="invisible absolute right-2 bg-white group-hover:visible">
+          {onEditItem && (
+            <Button
+              aria-label="Edit"
+              onClick={() => onEditItem(item)}
+              icon={<Icons.Edit />}
+              size="small"
+              data-testid={`edit-${rowTestId}`}
+            />
+          )}
+          {onDeleteItem && (
+            <Button
+              aria-label="Delete"
+              onClick={() => onDeleteItem(item)}
+              icon={<Icons.TrashCan />}
+              size="small"
+              data-testid={`delete-${rowTestId}`}
+            />
+          )}
+        </Space>
       </Flex>
     </Reorder.Item>
   );

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -1,7 +1,6 @@
 import {
   AntButton as Button,
   AntSelectProps as SelectProps,
-  AntTooltip as Tooltip,
   ArrowForwardIcon,
   Box,
   Collapse,
@@ -20,10 +19,6 @@ import BackButton from "~/features/common/nav/BackButton";
 import { PRIVACY_EXPERIENCE_ROUTE } from "~/features/common/nav/routes";
 import { PRIVACY_NOTICE_REGION_RECORD } from "~/features/common/privacy-notice-regions";
 import ScrollableList from "~/features/common/ScrollableList";
-import {
-  selectTCFConfigFilters,
-  useGetTCFConfigurationsQuery,
-} from "~/features/consent-settings/tcf/tcf-config.slice";
 import {
   selectLocationsRegulations,
   useGetLocationsRegulationsQuery,
@@ -55,11 +50,16 @@ import {
 
 import { ControlledSelect } from "../common/form/ControlledSelect";
 import { useGetConfigurationSettingsQuery } from "../config-settings/config-settings.slice";
+import { TCFConfigSelect } from "./form/TCFConfigSelect";
 
 const componentTypeOptions: SelectProps["options"] = [
   {
     label: "Banner and modal",
     value: ComponentType.BANNER_AND_MODAL,
+  },
+  {
+    label: "TCF overlay",
+    value: ComponentType.TCF_OVERLAY,
   },
   {
     label: "Modal",
@@ -127,7 +127,9 @@ export const PrivacyExperienceConfigColumnLayout = ({
   </Flex>
 );
 
-function privacyNoticeIdsWithTcfId(values: ExperienceConfigCreate): string[] {
+const privacyNoticeIdsWithTcfId = (
+  values: ExperienceConfigCreate,
+): string[] => {
   if (!values.privacy_notice_ids) {
     return [TCF_PLACEHOLDER_ID];
   }
@@ -136,7 +138,7 @@ function privacyNoticeIdsWithTcfId(values: ExperienceConfigCreate): string[] {
     noticeIdsWithTcfId.push(TCF_PLACEHOLDER_ID);
   }
   return noticeIdsWithTcfId;
-}
+};
 
 export const PrivacyExperienceForm = ({
   allPrivacyNotices,
@@ -151,8 +153,15 @@ export const PrivacyExperienceForm = ({
 }) => {
   const router = useRouter();
 
-  const { values, setFieldValue, dirty, isValid, isSubmitting, initialValues } =
-    useFormikContext<ExperienceConfigCreate>();
+  const {
+    values,
+    setFieldValue,
+    dirty,
+    isValid,
+    isSubmitting,
+    initialValues,
+    setValues,
+  } = useFormikContext<ExperienceConfigCreate>();
   const noticePage = useAppSelector(selectNoticePage);
   const noticePageSize = useAppSelector(selectNoticePageSize);
   useGetAllPrivacyNoticesQuery({ page: noticePage, size: noticePageSize });
@@ -213,18 +222,6 @@ export const PrivacyExperienceForm = ({
   useGetAllPropertiesQuery({ page: propertyPage, size: propertyPageSize });
   const allProperties = useAppSelector(selectAllProperties);
 
-  const tcfConfigFilters = useAppSelector(selectTCFConfigFilters);
-  const { data: tcfConfigs } = useGetTCFConfigurationsQuery(tcfConfigFilters);
-
-  const tcfConfigOptions = useMemo(
-    () =>
-      tcfConfigs?.items.map((config) => ({
-        label: config.name,
-        value: config.id,
-      })) ?? [],
-    [tcfConfigs],
-  );
-
   const buttonPanel = (
     <div className="flex justify-between border-t border-[#DEE5EE] p-4">
       <Button onClick={() => router.push(PRIVACY_EXPERIENCE_ROUTE)}>
@@ -242,6 +239,61 @@ export const PrivacyExperienceForm = ({
     </div>
   );
 
+  const handleComponentChange = (value: ComponentType) => {
+    if (!values.component) {
+      return;
+    }
+    const newComponent = value as ComponentType;
+
+    // Reset common fields that might need to be unset
+    const updates: Partial<ExperienceConfigCreate> = {
+      tcf_configuration_id: undefined,
+      layer1_button_options: undefined,
+      show_layer1_notices: false,
+    };
+
+    // Handle TCF specific fields
+    if (newComponent !== ComponentType.TCF_OVERLAY) {
+      updates.reject_all_mechanism = undefined;
+      // Remove TCF placeholder from privacy notices if present
+      if (values.privacy_notice_ids?.includes(TCF_PLACEHOLDER_ID)) {
+        updates.privacy_notice_ids = values.privacy_notice_ids.filter(
+          (id) => id !== TCF_PLACEHOLDER_ID,
+        );
+      }
+    } else {
+      updates.privacy_notice_ids = [TCF_PLACEHOLDER_ID];
+    }
+
+    // Set component specific defaults
+    switch (newComponent) {
+      case ComponentType.PRIVACY_CENTER:
+      case ComponentType.HEADLESS:
+        updates.dismissable = undefined;
+        updates.layer1_button_options = undefined;
+        updates.show_layer1_notices = undefined;
+        break;
+      case ComponentType.BANNER_AND_MODAL:
+        updates.layer1_button_options = Layer1ButtonOption.OPT_IN_OPT_OUT;
+        break;
+      case ComponentType.TCF_OVERLAY:
+        updates.layer1_button_options = Layer1ButtonOption.OPT_IN_OPT_OUT;
+        updates.reject_all_mechanism = RejectAllMechanism.REJECT_ALL;
+        break;
+      case ComponentType.MODAL:
+        updates.layer1_button_options = undefined;
+        updates.show_layer1_notices = undefined;
+        break;
+      default:
+        break;
+    }
+
+    setValues({
+      ...values,
+      ...updates,
+    });
+    setFieldValue("component", value);
+  };
   return (
     <PrivacyExperienceConfigColumnLayout buttonPanel={buttonPanel}>
       <BackButton backPath={PRIVACY_EXPERIENCE_ROUTE} mt={4} />
@@ -255,48 +307,24 @@ export const PrivacyExperienceForm = ({
         isRequired
         variant="stacked"
       />
-      {values.component !== ComponentType.TCF_OVERLAY && (
-        <ControlledSelect
-          name="component"
-          id="component"
-          options={componentTypeOptions}
-          label="Experience type"
-          layout="stacked"
-          disabled={!!initialValues.component}
-          isRequired
-        />
-      )}
+      <ControlledSelect
+        name="component"
+        id="component"
+        options={componentTypeOptions}
+        label="Experience type"
+        layout="stacked"
+        disabled={!!initialValues.component}
+        onChange={handleComponentChange}
+        isRequired
+      />
       <Collapse
         in={values.component === ComponentType.TCF_OVERLAY}
         animateOpacity
       >
         {values.component === ComponentType.TCF_OVERLAY && (
-          <Tooltip
-            title={
-              // eslint-disable-next-line no-nested-ternary
-              !appConfig?.consent?.override_vendor_purposes
-                ? "You must enable the Override vendor purposes setting in consent settings to select a TCF configuration."
-                : !tcfConfigOptions?.length
-                  ? "No TCF configurations found. Please create a TCF configuration in 'Consent settings' to select one."
-                  : undefined
-            }
-          >
-            <div>
-              <ControlledSelect
-                name="tcf_configuration_id"
-                id="tcf_configuration_id"
-                label="TCF Configuration"
-                options={tcfConfigOptions}
-                layout="stacked"
-                disabled={
-                  !tcfConfigOptions?.length ||
-                  !appConfig?.consent?.override_vendor_purposes
-                }
-                tooltip='Select a TCF configuration. Configurations are defined in "Consent settings" and apply to TCF privacy experiences.'
-                allowClear
-              />
-            </div>
-          </Tooltip>
+          <TCFConfigSelect
+            overridesEnabled={appConfig?.consent?.override_vendor_purposes}
+          />
         )}
       </Collapse>
       <Collapse

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -450,7 +450,7 @@ export const PrivacyExperienceForm = ({
             createNewValue={(opt) =>
               onCreateTranslation(opt.value as SupportedLanguage)
             }
-            onRowClick={onSelectTranslation}
+            onEditItem={onSelectTranslation}
             selectOnAdd
             draggable
             baseTestId="language"

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperiencesTable.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperiencesTable.tsx
@@ -18,6 +18,7 @@ import {
   useServerSidePagination,
 } from "common/table/v2";
 import { AntButton as Button, Flex, HStack, Text, VStack } from "fidesui";
+import { useRouter } from "next/router";
 import { useEffect, useMemo } from "react";
 
 import { PRIVACY_EXPERIENCE_ROUTE } from "~/features/common/nav/routes";
@@ -46,6 +47,7 @@ const emptyExperienceResponse = {
 };
 
 const EmptyTableExperience = () => {
+  const router = useRouter();
   return (
     <VStack
       mt={6}
@@ -67,13 +69,7 @@ const EmptyTableExperience = () => {
         </Text>
       </VStack>
       <Button
-        onClick={() => {
-          // NOTE: do not use router.push here!
-          // The experience Preview relies on loading the FidesJS script dynamically
-          // and caching it can cause problems especially when switching between
-          // TCF and non-TCF experiences.
-          window.location.href = `${PRIVACY_EXPERIENCE_ROUTE}/new`;
-        }}
+        onClick={() => router.push(`${PRIVACY_EXPERIENCE_ROUTE}/new`)}
         size="small"
         type="primary"
         data-testid="add-privacy-experience-btn"
@@ -86,6 +82,7 @@ const EmptyTableExperience = () => {
 const columnHelper = createColumnHelper<ExperienceConfigListViewResponse>();
 
 export const PrivacyExperiencesTable = () => {
+  const router = useRouter();
   const { isLoading: isLoadingHealthCheck } = useGetHealthQuery();
 
   // Permissions
@@ -210,11 +207,7 @@ export const PrivacyExperiencesTable = () => {
 
   const onRowClick = ({ id }: ExperienceConfigListViewResponse) => {
     if (userCanUpdate) {
-      // NOTE: do not use router.push here!
-      // The experience Preview relies on loading the FidesJS script dynamically
-      // and caching it can cause problems especially when switching between
-      // TCF and non-TCF experiences.
-      window.location.href = `${PRIVACY_EXPERIENCE_ROUTE}/${id}`;
+      router.push(`${PRIVACY_EXPERIENCE_ROUTE}/${id}`);
     }
   };
 
@@ -235,13 +228,7 @@ export const PrivacyExperiencesTable = () => {
               </Restrict>
             </HStack>
             <Button
-              onClick={() => {
-                // NOTE: do not use router.push here!
-                // The experience Preview relies on loading the FidesJS script dynamically
-                // and caching it can cause problems especially when switching between
-                // TCF and non-TCF experiences.
-                window.location.href = `${PRIVACY_EXPERIENCE_ROUTE}/new`;
-              }}
+              onClick={() => router.push(`${PRIVACY_EXPERIENCE_ROUTE}/new`)}
               type="primary"
               data-testid="add-privacy-experience-btn"
             >

--- a/clients/admin-ui/src/features/privacy-experience/form/TCFConfigSelect.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/form/TCFConfigSelect.tsx
@@ -1,0 +1,52 @@
+import { AntTooltip as Tooltip } from "fidesui";
+import { useMemo } from "react";
+
+import { useAppSelector } from "~/app/hooks";
+import { ControlledSelect } from "~/features/common/form/ControlledSelect";
+import {
+  selectTCFConfigFilters,
+  useGetTCFConfigurationsQuery,
+} from "~/features/consent-settings/tcf/tcf-config.slice";
+
+export const TCFConfigSelect = ({
+  overridesEnabled,
+}: {
+  overridesEnabled: boolean;
+}) => {
+  const tcfConfigFilters = useAppSelector(selectTCFConfigFilters);
+  const { data: tcfConfigs } = useGetTCFConfigurationsQuery(tcfConfigFilters);
+
+  const tcfConfigOptions = useMemo(
+    () =>
+      tcfConfigs?.items.map((config) => ({
+        label: config.name,
+        value: config.id,
+      })) ?? [],
+    [tcfConfigs],
+  );
+  return (
+    <Tooltip
+      title={
+        // eslint-disable-next-line no-nested-ternary
+        !overridesEnabled
+          ? "You must enable the Override vendor purposes setting in consent settings to select a TCF configuration."
+          : !tcfConfigOptions?.length
+            ? "No TCF configurations found. Please create a TCF configuration in 'Consent settings' to select one."
+            : undefined
+      }
+    >
+      <div>
+        <ControlledSelect
+          name="tcf_configuration_id"
+          id="tcf_configuration_id"
+          label="TCF Configuration"
+          options={tcfConfigOptions}
+          layout="stacked"
+          disabled={!tcfConfigOptions?.length || !overridesEnabled}
+          tooltip='Select a TCF configuration. Configurations are defined in "Consent settings" and apply to TCF privacy experiences.'
+          allowClear
+        />
+      </div>
+    </Tooltip>
+  );
+};

--- a/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
@@ -1,6 +1,7 @@
 import { FidesGlobal } from "fides-js/src/lib/consent-types";
 import { AntFlex as Flex, Text } from "fidesui";
 import { useFormikContext } from "formik";
+import { useRouter } from "next/router";
 import Script from "next/script";
 import React, { useEffect, useMemo, useState } from "react";
 
@@ -8,6 +9,7 @@ import { PREVIEW_CONTAINER_ID } from "~/constants";
 import { TranslationWithLanguageName } from "~/features/privacy-experience/form/helpers";
 import {
   buildBaseConfig,
+  generateMockNotices,
   translationOrDefault,
 } from "~/features/privacy-experience/preview/helpers";
 import theme from "~/theme";
@@ -67,10 +69,13 @@ const Preview = ({
   translation?: TranslationWithLanguageName;
   isMobilePreview: boolean;
 }) => {
+  const router = useRouter();
+  const isNewExperience = router.pathname.includes("/new");
   const { values } = useFormikContext<ExperienceConfigCreate>();
   const [noticesOnConfig, setNoticesOnConfig] = useState<
     PrivacyNoticeResponse[]
   >([]);
+  const [fidesScriptLoaded, setFidesScriptLoaded] = useState(false);
   const isPreviewAvailable = [
     ComponentType.BANNER_AND_MODAL,
     ComponentType.MODAL,
@@ -80,50 +85,55 @@ const Preview = ({
   const { systemsCount } = useFeatures();
 
   useEffect(() => {
-    if (values.privacy_notice_ids) {
-      const notices = values.privacy_notice_ids
-        .map((id) => allPrivacyNotices.find((notice) => notice?.id === id))
-        .map((notice) => {
-          if (
-            values.component === ComponentType.TCF_OVERLAY &&
-            notice !== undefined
-          ) {
-            return {
-              ...notice,
-              translations: [
-                {
-                  language: "en",
-                  text: notice?.name,
-                },
-              ],
-            };
-          }
-          return notice;
-        })
-        .filter(
-          (notice): notice is PrivacyNoticeResponse => notice !== undefined,
+    if (initialValues && values.component && allPrivacyNotices) {
+      if (values.privacy_notice_ids) {
+        const notices = generateMockNotices(
+          values.privacy_notice_ids,
+          values.component,
+          allPrivacyNotices,
         );
-      setNoticesOnConfig(notices);
-    } else {
-      setNoticesOnConfig([]);
+        setNoticesOnConfig(notices);
+      } else {
+        setNoticesOnConfig([]);
+      }
     }
-  }, [values.privacy_notice_ids, allPrivacyNotices, values.component]);
+  }, [
+    values.privacy_notice_ids,
+    allPrivacyNotices,
+    values.component,
+    initialValues,
+  ]);
 
-  // Create the base FidesConfig JSON that will be used to initialize fides.js
-  const baseConfig = useMemo(
-    () => buildBaseConfig(initialValues, noticesOnConfig),
-    [initialValues, noticesOnConfig],
-  );
-
-  const fidesJsScript =
-    values.component === ComponentType.TCF_OVERLAY
+  const memoizedFidesJsScript = useMemo(() => {
+    return values.component === ComponentType.TCF_OVERLAY
       ? "/lib/fides-tcf.js"
       : "/lib/fides.js";
+  }, [values.component]);
+
+  const baseConfig = useMemo(() => {
+    return values.component
+      ? buildBaseConfig(
+          { ...initialValues, component: values.component },
+          noticesOnConfig,
+        )
+      : null;
+  }, [initialValues, noticesOnConfig, values.component]);
 
   useEffect(() => {
+    if (
+      !isPreviewAvailable ||
+      !fidesScriptLoaded ||
+      !window.Fides ||
+      (!values.privacy_notice_ids?.length &&
+        values.component !== ComponentType.TCF_OVERLAY)
+    ) {
+      return;
+    }
+    const updatedConfig = baseConfig;
     // if current component is a modal, we want to force fides.js to show a modal, not a banner component
     if (values.component === ComponentType.MODAL) {
-      baseConfig.experience.experience_config.component = ComponentType.MODAL;
+      updatedConfig.experience.experience_config.component =
+        ComponentType.MODAL;
     }
     // if we're editing a translation, we want to preview the banner/modal with that language,
     // otherwise we show first translation if exists, else keep default
@@ -132,47 +142,53 @@ const Preview = ({
     );
     if (values.translations?.length) {
       if (currentTranslation) {
-        baseConfig.experience.available_locales = [
-          ...(baseConfig.experience.available_locales || []),
+        updatedConfig.experience.available_locales = [
+          ...(updatedConfig.experience.available_locales || []),
           currentTranslation.language,
         ];
-        baseConfig.experience.experience_config.translations[0] =
+        updatedConfig.experience.experience_config.translations[0] =
           translationOrDefault(currentTranslation);
-        baseConfig.options.fidesLocale = currentTranslation.language;
+        updatedConfig.options.fidesLocale = currentTranslation.language;
       } else if (values.translations) {
-        baseConfig.experience.experience_config.translations[0] =
+        updatedConfig.experience.experience_config.translations[0] =
           translationOrDefault(values.translations[0]);
-        baseConfig.options.fidesLocale = values.translations[0].language;
+        updatedConfig.options.fidesLocale = values.translations[0].language;
       }
     }
-    baseConfig.experience.experience_config.show_layer1_notices =
-      !!noticesOnConfig?.length && !!values.show_layer1_notices;
-    baseConfig.experience.experience_config.layer1_button_options =
+    updatedConfig.experience.experience_config.show_layer1_notices =
+      !!values.privacy_notice_ids?.length && !!values.show_layer1_notices;
+    updatedConfig.experience.experience_config.layer1_button_options =
       (values.component === ComponentType.BANNER_AND_MODAL ||
         values.component === ComponentType.TCF_OVERLAY) &&
       values.layer1_button_options
         ? values.layer1_button_options
         : Layer1ButtonOption.OPT_IN_OPT_OUT;
-    baseConfig.options.preventDismissal = !values.dismissable;
-    baseConfig.experience.vendor_count = systemsCount;
-    baseConfig.experience.experience_config.component = values.component;
-    if (
-      window.Fides &&
-      (noticesOnConfig?.length ||
-        values.component === ComponentType.TCF_OVERLAY) &&
-      isPreviewAvailable
-    ) {
-      // reinitialize fides.js each time the form changes
-      window.Fides.init(baseConfig as any);
-    }
+    updatedConfig.options.preventDismissal = !values.dismissable;
+    updatedConfig.experience.vendor_count = systemsCount;
+    updatedConfig.experience.experience_config.component = values.component;
+    // reinitialize fides.js each time the form changes
+    window.Fides.init(updatedConfig);
+
+    /**
+     * NOTE: as tempting as it may be to just include the full values object in the dependency array,
+     * it's not a good idea because it will cause the preview to re-render constantly as the form is updated.
+     * Not all form fields require a preview re-render, the fields chosen here are very intentional.
+     */
   }, [
-    values,
-    noticesOnConfig,
     translation,
     baseConfig,
     allPrivacyNotices,
     isPreviewAvailable,
     systemsCount,
+    fidesScriptLoaded,
+    values.privacy_notice_ids,
+    values.component,
+    values.translations,
+    values.show_layer1_notices,
+    values.layer1_button_options,
+    values.dismissable,
+    initialValues,
+    noticesOnConfig,
   ]);
 
   const modal = document.getElementById("fides-modal");
@@ -200,7 +216,7 @@ const Preview = ({
   }
 
   if (
-    !noticesOnConfig?.length &&
+    !values.privacy_notice_ids?.length &&
     values.component !== ComponentType.TCF_OVERLAY
   ) {
     return (
@@ -350,10 +366,13 @@ const Preview = ({
       )}
       <Script
         id="fides-js-script"
-        src={fidesJsScript}
+        src={memoizedFidesJsScript}
         onReady={() => {
           if (!window.Fides.experience) {
-            window.Fides?.init(baseConfig as any);
+            if (isNewExperience) {
+              window.Fides?.init(baseConfig);
+            }
+            setFidesScriptLoaded(true);
           }
         }}
       />

--- a/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-experience/preview/helpers.ts
@@ -6,6 +6,7 @@ import {
   ExperienceConfigCreate,
   ExperienceTranslation,
   Layer1ButtonOption,
+  LimitedPrivacyNoticeResponseSchema,
   PrivacyNoticeResponse,
   SupportedLanguage,
 } from "~/types/api";
@@ -150,4 +151,31 @@ export const translationOrDefault = (
     is_default: translation.is_default,
     ...newTextFields,
   };
+};
+
+export const generateMockNotices = (
+  privacyNoticeIds: string[],
+  component: ComponentType,
+  allPrivacyNotices: (LimitedPrivacyNoticeResponseSchema | undefined)[],
+) => {
+  if (!privacyNoticeIds) {
+    return [];
+  }
+  return privacyNoticeIds
+    .map((id) => allPrivacyNotices.find((notice) => notice?.id === id))
+    .map((notice) => {
+      if (component === ComponentType.TCF_OVERLAY && notice !== undefined) {
+        return {
+          ...notice,
+          translations: [
+            {
+              language: "en",
+              text: notice?.name,
+            },
+          ],
+        };
+      }
+      return notice;
+    })
+    .filter((notice): notice is PrivacyNoticeResponse => notice !== undefined);
 };

--- a/clients/admin-ui/src/pages/api/fides-preview.js.ts
+++ b/clients/admin-ui/src/pages/api/fides-preview.js.ts
@@ -1,0 +1,67 @@
+import fs from "fs";
+import type { NextApiRequest, NextApiResponse } from "next";
+import path from "path";
+
+export default async function handler(_: NextApiRequest, res: NextApiResponse) {
+  try {
+    const standardPath = path.join(process.cwd(), "public", "lib", "fides.js");
+    const tcfPath = path.join(process.cwd(), "public", "lib", "fides-tcf.js");
+
+    const standardContent = fs.readFileSync(standardPath, "utf-8");
+    const tcfContent = fs.readFileSync(tcfPath, "utf-8");
+
+    // Create a wrapper that manages execution lifecycle
+    const wrapperScript = `
+      (function() {
+        // Store the script contents but don't execute them
+        const scripts = {
+          standard: ${JSON.stringify(standardContent)},
+          tcf: ${JSON.stringify(tcfContent)}
+        };
+
+        // Track current state
+        let currentMode = null;
+        let currentScript = null;
+
+        // Cleanup function to remove previous execution
+        function cleanup() {
+          if (currentScript) {
+            // Remove the script from DOM to ensure complete cleanup
+            currentScript.remove();
+            currentScript = null;
+            window.Fides = null;
+          }
+          currentMode = null;
+        }
+
+        // Global control method
+        window.FidesPreview = function(mode = 'standard') {
+          if (currentMode === mode) {
+            return; // Already in this mode
+          }
+
+          // Clean up previous execution
+          cleanup();
+
+          // Create and execute new script
+          currentScript = document.createElement('script');
+          currentScript.textContent = scripts[mode];
+          currentMode = mode;
+
+          // Execute the new script
+          document.head.appendChild(currentScript);
+        };
+
+        // Expose cleanup function directly
+        window.FidesPreview.cleanup = cleanup;
+      })();
+    `;
+
+    res.setHeader("Content-Type", "application/javascript");
+    res.status(200).send(wrapperScript);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("Error serving Fides preview script:", error);
+    res.status(500).json({ error: "Failed to serve Fides preview script" });
+  }
+}

--- a/clients/admin-ui/src/pages/consent/privacy-experience/[id].tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-experience/[id].tsx
@@ -1,4 +1,4 @@
-import { Center, Spinner, Text } from "fidesui";
+import { Center, Flex, Spinner, Text } from "fidesui";
 import { useRouter } from "next/router";
 
 import Layout from "~/features/common/Layout";
@@ -25,9 +25,11 @@ const PrivacyExperienceDetailPage = () => {
   if (isLoading || isTranslationsLoading) {
     return (
       <Layout title="Privacy experience">
-        <Center>
-          <Spinner />
-        </Center>
+        <Flex className="size-full items-center justify-center overflow-scroll">
+          <Center>
+            <Spinner />
+          </Center>
+        </Flex>
       </Layout>
     );
   }

--- a/clients/admin-ui/src/theme/global.scss
+++ b/clients/admin-ui/src/theme/global.scss
@@ -36,6 +36,10 @@ h6 {
   --ant-button-default-hover-bg: var(--fidesui-neutral-200);
   --ant-button-default-bg: var(--fidesui-neutral-50);
 }
+.ant-btn-icon {
+  // fixes misalignment of Carbon icons in buttons
+  line-height: 1;
+}
 
 // Input labels should have a font weight of 600
 .ant-form-item-label {

--- a/clients/admin-ui/src/types/window.d.ts
+++ b/clients/admin-ui/src/types/window.d.ts
@@ -3,5 +3,9 @@ export {};
 declare global {
   interface Window {
     Cypress?: boolean;
+    FidesPreview: {
+      (mode: string): void;
+      cleanup: () => void;
+    };
   }
 }


### PR DESCRIPTION
Closes [LJ-681] & [LJ-637]

### Description Of Changes

This PR introduces several UI/UX improvements to the Privacy Experience configuration interface, particularly around TCF (Transparency & Consent Framework) configuration and component editing. Key changes include improved component type handling, better UI interactions, and code organization improvements.

### Code Changes

1. Performance
   * Extracted TCF configuration selection into a new separate component (`TCFConfigSelect`) so that it doesn't call the configs endpoint unless it's needed
   * Updated useEffect that renders the preview so it only watches for relevant form values (doesn't re-render when changing experience name, for example)
2. Usability/UX improvements
   * Added edit functionality to `ScrollableList` component with new edit icon and handler and Changed translation row click to use `onEditItem` instead of `onRowClick`
   * Replaced Chakra `DeleteIcon` with Carbon `Icons.TrashCan` component
3. FidesJS script issues resolved
   * New `fides-preview.js` endpoint which will hot-swap fides.js and fides-tcf as need. Also clears itself when leaving the Preview page.
   * This allowed us to revert direct window.location changes to use Next.js router again
4. Create new TCF Experiences
   * Added TCF overlay as a new Experience Type option
   * Updated Experience Type change handling with proper field resets when switching between types

### Steps to Confirm

1. Navigate to Privacy Experiences table in Admin UI (`/consent/privacy-experience`)
2. View the TCF Experience and then click the Back arrow button to return to the table
3. Now view the Banner + Modal Experience and ensure the correct banner and modal are in the preview (not TCF)
4. Verify that navigation between pages works smoothly without page reload
5. Go back again and view the TCF Experience again and ensure the correct banner and modal are in the preview (not banner+modal)
6. Verify that Language options now show an edit icon button on hover
7. Check that translations can be edited by clicking the edit icon button
8. Return to the Privacy Experiences table
9. Create a new Experience by clicking the [Create new experience] button
10. Test switching between different component types (especially to/from TCF overlay) and verify fields reset correctly

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-681]: https://ethyca.atlassian.net/browse/LJ-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LJ-637]: https://ethyca.atlassian.net/browse/LJ-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ