### PR TITLE
Refactor search inputs and update asset search placeholders

### DIFF
--- a/clients/admin-ui/src/features/common/DebouncedSearchInput.tsx
+++ b/clients/admin-ui/src/features/common/DebouncedSearchInput.tsx
@@ -1,14 +1,14 @@
 import { debounce } from "lodash";
 import { useCallback, useState } from "react";
 
-import SearchBar from "~/features/common/SearchBar";
+import SearchInput, { SearchInputProps } from "~/features/common/SearchInput";
 
-interface SearchInputProps {
-  value: string;
-  onChange: (newValue: string) => void;
-}
-
-export const SearchInput = ({ value, onChange }: SearchInputProps) => {
+export const DebouncedSearchInput = ({
+  value,
+  onChange,
+  placeholder,
+  ...props
+}: SearchInputProps) => {
   const INPUT_CHANGE_DELAY = 500;
   const [currentInput, setCurrentInput] = useState(value);
 
@@ -30,10 +30,12 @@ export const SearchInput = ({ value, onChange }: SearchInputProps) => {
   };
 
   return (
-    <SearchBar
-      search={currentInput}
+    <SearchInput
+      value={currentInput}
       onChange={handleOnChange}
       onClear={onClear}
+      placeholder={placeholder}
+      {...props}
     />
   );
 };

--- a/clients/admin-ui/src/features/common/SearchInput.tsx
+++ b/clients/admin-ui/src/features/common/SearchInput.tsx
@@ -13,7 +13,6 @@ export interface SearchInputProps extends Omit<InputProps, "onChange"> {
 }
 
 const SearchInput = ({
-  value,
   onChange,
   withIcon,
   onClear,
@@ -27,7 +26,6 @@ const SearchInput = ({
     <Space.Compact className="w-96" data-testid="search-bar">
       <Input
         autoComplete="off"
-        value={value}
         onChange={handleSearchChange}
         placeholder={placeholder || "Search..."}
         prefix={withIcon ? <SearchLineIcon boxSize={4} /> : undefined}

--- a/clients/admin-ui/src/features/common/SearchInput.tsx
+++ b/clients/admin-ui/src/features/common/SearchInput.tsx
@@ -6,9 +6,7 @@ import {
   SearchLineIcon,
 } from "fidesui";
 
-export interface SearchInputProps
-  extends Omit<InputProps, "onChange" | "value"> {
-  value?: string;
+export interface SearchInputProps extends Omit<InputProps, "onChange"> {
   onChange: (value: string) => void;
   withIcon?: boolean;
   onClear?: () => void;

--- a/clients/admin-ui/src/features/common/SearchInput.tsx
+++ b/clients/admin-ui/src/features/common/SearchInput.tsx
@@ -6,20 +6,22 @@ import {
   SearchLineIcon,
 } from "fidesui";
 
-interface Props extends Omit<InputProps, "onChange"> {
-  search?: string;
+export interface SearchInputProps
+  extends Omit<InputProps, "onChange" | "value"> {
+  value?: string;
   onChange: (value: string) => void;
   withIcon?: boolean;
   onClear?: () => void;
 }
-const SearchBar = ({
-  search,
+
+const SearchInput = ({
+  value,
   onChange,
   withIcon,
   onClear,
   placeholder,
   ...props
-}: Props) => {
+}: SearchInputProps) => {
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     onChange(event.target.value);
 
@@ -27,7 +29,7 @@ const SearchBar = ({
     <Space.Compact className="w-96" data-testid="search-bar">
       <Input
         autoComplete="off"
-        value={search}
+        value={value}
         onChange={handleSearchChange}
         placeholder={placeholder || "Search..."}
         prefix={withIcon ? <SearchLineIcon boxSize={4} /> : undefined}
@@ -38,4 +40,4 @@ const SearchBar = ({
   );
 };
 
-export default SearchBar;
+export default SearchInput;

--- a/clients/admin-ui/src/features/common/system-data-flow/DataFlowSystemsModal.tsx
+++ b/clients/admin-ui/src/features/common/system-data-flow/DataFlowSystemsModal.tsx
@@ -1,4 +1,3 @@
-import SearchBar from "common/SearchBar";
 import {
   AntButton as Button,
   AntSwitch as Switch,
@@ -20,6 +19,7 @@ import {
 import { useFormikContext } from "formik";
 import { useMemo, useState } from "react";
 
+import SearchInput from "~/features/common/SearchInput";
 import { DataFlow, System } from "~/types/api";
 
 import DataFlowSystemsTable from "./DataFlowSystemsTable";
@@ -131,8 +131,8 @@ const DataFlowSystemsModal = ({
                   </FormControl>
                 </Box>
               </Flex>
-              <SearchBar
-                search={searchFilter}
+              <SearchInput
+                value={searchFilter}
                 onChange={setSearchFilter}
                 placeholder="Search for systems"
                 data-testid="system-search"

--- a/clients/admin-ui/src/features/common/table/v2/filters/GlobalFilterV2.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/filters/GlobalFilterV2.tsx
@@ -1,7 +1,8 @@
-import SearchBar from "common/SearchBar";
 import { debounce } from "common/utils";
 import { Box } from "fidesui";
 import { useCallback, useEffect, useMemo, useState } from "react";
+
+import SearchInput from "~/features/common/SearchInput";
 
 type GlobalFilterProps = {
   globalFilter: any;
@@ -36,7 +37,7 @@ export const GlobalFilterV2 = ({
 
   return (
     <Box maxWidth="424px" width="100%">
-      <SearchBar
+      <SearchInput
         onChange={(changeValue) => {
           setValue(changeValue);
           onChange(changeValue);

--- a/clients/admin-ui/src/features/common/table/v2/filters/GlobalFilterV2.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/filters/GlobalFilterV2.tsx
@@ -43,7 +43,7 @@ export const GlobalFilterV2 = ({
           onChange(changeValue);
         }}
         onClear={onClear}
-        search={value || ""}
+        value={value || ""}
         placeholder={placeholder}
         data-testid={testid}
       />

--- a/clients/admin-ui/src/features/data-catalog/staged-resources/CatalogResourcesTable.tsx
+++ b/clients/admin-ui/src/features/data-catalog/staged-resources/CatalogResourcesTable.tsx
@@ -8,6 +8,7 @@ import {
 import { Box, Flex } from "fidesui";
 import { useEffect, useMemo, useState } from "react";
 
+import { DebouncedSearchInput } from "~/features/common/DebouncedSearchInput";
 import {
   FidesTableV2,
   PaginationBar,
@@ -19,7 +20,6 @@ import EmptyCatalogTableNotice from "~/features/data-catalog/datasets/EmptyCatal
 import CatalogResourceDetailDrawer from "~/features/data-catalog/staged-resources/CatalogResourceDetailDrawer";
 import useCatalogResourceColumns from "~/features/data-catalog/useCatalogResourceColumns";
 import { useGetMonitorResultsQuery } from "~/features/data-discovery-and-detection/discovery-detection.slice";
-import { SearchInput } from "~/features/data-discovery-and-detection/SearchInput";
 import { findResourceType } from "~/features/data-discovery-and-detection/utils/findResourceType";
 import resourceHasChildren from "~/features/data-discovery-and-detection/utils/resourceHasChildren";
 import { DiffStatus, StagedResourceAPIResponse } from "~/types/api";
@@ -123,7 +123,10 @@ const CatalogResourcesTable = ({
       <TableActionBar>
         <Flex gap={6} align="center">
           <Box flexShrink={0}>
-            <SearchInput value={searchQuery} onChange={setSearchQuery} />
+            <DebouncedSearchInput
+              value={searchQuery}
+              onChange={setSearchQuery}
+            />
           </Box>
         </Flex>
       </TableActionBar>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
@@ -48,7 +48,7 @@ import AddDataUsesModal from "~/features/data-discovery-and-detection/action-cen
 import useActionCenterTabs from "~/features/data-discovery-and-detection/action-center/tables/useActionCenterTabs";
 import { DiffStatus } from "~/types/api";
 
-import { SearchInput } from "../../SearchInput";
+import { DebouncedSearchInput } from "../../../common/DebouncedSearchInput";
 import { AssignSystemModal } from "../AssignSystemModal";
 import { useDiscoveredAssetsColumns } from "../hooks/useDiscoveredAssetsColumns";
 
@@ -288,7 +288,11 @@ export const DiscoveredAssetsTable = ({
         onChange={handleTabChange}
       />
       <TableActionBar>
-        <SearchInput value={searchQuery} onChange={setSearchQuery} />
+        <DebouncedSearchInput
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder="Search by asset name..."
+        />
         <Flex alignItems="center">
           {!!selectedUrns.length && (
             <Text

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredSystemAggregateTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredSystemAggregateTable.tsx
@@ -42,7 +42,7 @@ import useActionCenterTabs from "~/features/data-discovery-and-detection/action-
 import { DiffStatus } from "~/types/api";
 import { isErrorResult } from "~/types/errors";
 
-import { SearchInput } from "../../SearchInput";
+import { DebouncedSearchInput } from "../../../common/DebouncedSearchInput";
 import { useDiscoveredSystemAggregateColumns } from "../hooks/useDiscoveredSystemAggregateColumns";
 import { MonitorSystemAggregate } from "../types";
 
@@ -210,7 +210,10 @@ export const DiscoveredSystemAggregateTable = ({
         >
           <Flex gap={6} align="center">
             <Box flexShrink={0}>
-              <SearchInput value={searchQuery} onChange={setSearchQuery} />
+              <DebouncedSearchInput
+                value={searchQuery}
+                onChange={setSearchQuery}
+              />
             </Box>
           </Flex>
           <Flex align="center">

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/ActivityTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/ActivityTable.tsx
@@ -32,7 +32,7 @@ import {
   StagedResourceAPIResponse,
 } from "~/types/api";
 
-import { SearchInput } from "../SearchInput";
+import { DebouncedSearchInput } from "../../common/DebouncedSearchInput";
 import { ResourceActivityTypeEnum } from "../types/ResourceActivityTypeEnum";
 import findProjectFromUrn from "../utils/findProjectFromUrn";
 import findActivityType from "../utils/getResourceActivityLabel";
@@ -187,7 +187,10 @@ const ActivityTable = ({
       <TableActionBar>
         <Flex gap={6} align="center">
           <Box flexShrink={0}>
-            <SearchInput value={searchQuery} onChange={setSearchQuery} />
+            <DebouncedSearchInput
+              value={searchQuery}
+              onChange={setSearchQuery}
+            />
           </Box>
           <IconLegendTooltip />
         </Flex>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DetectionResultTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DetectionResultTable.tsx
@@ -29,7 +29,7 @@ import getResourceRowName from "~/features/data-discovery-and-detection/utils/ge
 import isNestedField from "~/features/data-discovery-and-detection/utils/isNestedField";
 import { StagedResource, StagedResourceTypeValue } from "~/types/api";
 
-import { SearchInput } from "../SearchInput";
+import { DebouncedSearchInput } from "../../common/DebouncedSearchInput";
 
 const EMPTY_RESPONSE = {
   items: [],
@@ -182,7 +182,10 @@ const DetectionResultTable = ({ resourceUrn }: MonitorResultTableProps) => {
         >
           <Flex gap={6} align="center">
             <Box flexShrink={0}>
-              <SearchInput value={searchQuery} onChange={setSearchQuery} />
+              <DebouncedSearchInput
+                value={searchQuery}
+                onChange={setSearchQuery}
+              />
             </Box>
             <IconLegendTooltip />
           </Flex>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryResultTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/DiscoveryResultTable.tsx
@@ -38,7 +38,7 @@ import {
   StagedResourceTypeValue,
 } from "~/types/api";
 
-import { SearchInput } from "../SearchInput";
+import { DebouncedSearchInput } from "../../common/DebouncedSearchInput";
 
 const EMPTY_RESPONSE = {
   items: [],
@@ -186,7 +186,10 @@ const DiscoveryResultTable = ({ resourceUrn }: MonitorResultTableProps) => {
       <TableActionBar>
         <Flex gap={6} align="center">
           <Box flexShrink={0}>
-            <SearchInput value={searchQuery} onChange={setSearchQuery} />
+            <DebouncedSearchInput
+              value={searchQuery}
+              onChange={setSearchQuery}
+            />
           </Box>
           <IconLegendTooltip />
         </Flex>

--- a/clients/admin-ui/src/features/locations/LocationManagement.tsx
+++ b/clients/admin-ui/src/features/locations/LocationManagement.tsx
@@ -14,7 +14,7 @@ import { useMemo, useState } from "react";
 
 import { getErrorMessage } from "~/features/common/helpers";
 import ConfirmationModal from "~/features/common/modals/ConfirmationModal";
-import SearchBar from "~/features/common/SearchBar";
+import SearchInput from "~/features/common/SearchInput";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
 import { LocationRegulationResponse, Selection } from "~/types/api";
 import { isErrorResult } from "~/types/errors";
@@ -93,10 +93,10 @@ const LocationManagement = ({ data }: { data: LocationRegulationResponse }) => {
   return (
     <VStack alignItems="start" spacing={4}>
       <Box maxWidth="510px" width="100%">
-        <SearchBar
+        <SearchInput
           onChange={setSearch}
           placeholder="Search"
-          search={search}
+          value={search}
           onClear={() => setSearch("")}
         />
       </Box>

--- a/clients/admin-ui/src/features/locations/RegulationManagement.tsx
+++ b/clients/admin-ui/src/features/locations/RegulationManagement.tsx
@@ -15,7 +15,7 @@ import { useMemo, useState } from "react";
 import { getErrorMessage } from "~/features/common/helpers";
 import ConfirmationModal from "~/features/common/modals/ConfirmationModal";
 import { LOCATIONS_ROUTE } from "~/features/common/nav/routes";
-import SearchBar from "~/features/common/SearchBar";
+import SearchInput from "~/features/common/SearchInput";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
 import ToastLink from "~/features/common/ToastLink";
 import {
@@ -98,10 +98,10 @@ const RegulationManagement = ({
   return (
     <VStack alignItems="start" spacing={4}>
       <Box maxWidth="510px" width="100%">
-        <SearchBar
+        <SearchInput
           onChange={setSearch}
           placeholder="Search"
-          search={search}
+          value={search}
           onClear={() => setSearch("")}
         />
       </Box>

--- a/clients/admin-ui/src/features/system/tabs/system-assets/SystemAssetsTable.tsx
+++ b/clients/admin-ui/src/features/system/tabs/system-assets/SystemAssetsTable.tsx
@@ -15,6 +15,7 @@ import {
 } from "fidesui";
 import { useEffect, useState } from "react";
 
+import { DebouncedSearchInput } from "~/features/common/DebouncedSearchInput";
 import { getErrorMessage } from "~/features/common/helpers";
 import {
   FidesTableV2,
@@ -24,7 +25,6 @@ import {
   useServerSidePagination,
 } from "~/features/common/table/v2";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
-import { SearchInput } from "~/features/data-discovery-and-detection/SearchInput";
 import {
   useDeleteSystemAssetsMutation,
   useGetSystemAssetsQuery,
@@ -155,7 +155,11 @@ const SystemAssetsTable = ({ system }: { system: SystemResponse }) => {
         {COPY}
       </Text>
       <TableActionBar>
-        <SearchInput value={searchQuery} onChange={setSearchQuery} />
+        <DebouncedSearchInput
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder="Search by asset name..."
+        />
         <Spacer />
         <Button
           icon={<Icons.Add />}

--- a/clients/admin-ui/src/features/user-management/AssignSystemsModal.tsx
+++ b/clients/admin-ui/src/features/user-management/AssignSystemsModal.tsx
@@ -18,7 +18,7 @@ import {
 } from "fidesui";
 import { useMemo, useState } from "react";
 
-import SearchBar from "~/features/common/SearchBar";
+import SearchInput from "~/features/common/SearchInput";
 import { useGetAllSystemsQuery } from "~/features/system";
 import { System } from "~/types/api";
 
@@ -116,8 +116,8 @@ const AssignSystemsModal = ({
                   </FormControl>
                 </Box>
               </Flex>
-              <SearchBar
-                search={searchFilter}
+              <SearchInput
+                value={searchFilter}
                 onChange={setSearchFilter}
                 placeholder="Search for systems"
                 data-testid="system-search"

--- a/clients/admin-ui/src/features/user-management/UserManagementTableActions.tsx
+++ b/clients/admin-ui/src/features/user-management/UserManagementTableActions.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { USER_MANAGEMENT_ROUTE } from "~/features/common/nav/routes";
 import Restrict from "~/features/common/Restrict";
-import SearchBar from "~/features/common/SearchBar";
+import SearchInput from "~/features/common/SearchInput";
 import { ScopeRegistryEnum } from "~/types/api";
 
 import { selectUserFilters, setUsernameSearch } from "./user-management.slice";
@@ -29,8 +29,8 @@ const UserManagementTableActions = () => {
 
   return (
     <Stack direction="row" spacing={4} mb={6}>
-      <SearchBar
-        search={username}
+      <SearchInput
+        value={username}
         onChange={handleSearchChange}
         placeholder="Search by Username"
       />

--- a/clients/admin-ui/src/pages/data-discovery/action-center/index.tsx
+++ b/clients/admin-ui/src/pages/data-discovery/action-center/index.tsx
@@ -8,6 +8,7 @@ import {
 import NextLink from "next/link";
 import { useCallback, useEffect, useState } from "react";
 
+import { DebouncedSearchInput } from "~/features/common/DebouncedSearchInput";
 import Layout from "~/features/common/Layout";
 import { ACTION_CENTER_ROUTE } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
@@ -21,7 +22,6 @@ import { DisabledMonitorsPage } from "~/features/data-discovery-and-detection/ac
 import { EmptyMonitorsResult } from "~/features/data-discovery-and-detection/action-center/EmptyMonitorsResult";
 import { MonitorResult } from "~/features/data-discovery-and-detection/action-center/MonitorResult";
 import { MonitorAggregatedResults } from "~/features/data-discovery-and-detection/action-center/types";
-import { SearchInput } from "~/features/data-discovery-and-detection/SearchInput";
 
 const ActionCenterPage = () => {
   const toast = useToast();
@@ -135,7 +135,7 @@ const ActionCenterPage = () => {
       />
 
       <Flex className="justify-between py-6">
-        <SearchInput value={searchQuery} onChange={setSearchQuery} />
+        <DebouncedSearchInput value={searchQuery} onChange={setSearchQuery} />
       </Flex>
 
       <List


### PR DESCRIPTION
Closes HA-547

### Description Of Changes

![Screenshot 2025-04-17 at 15 33 55](https://github.com/user-attachments/assets/10c29d7a-a93d-42a8-88fb-6584b1b8a4e5)

Updates placeholder in asset table search bars (both in action center results and system "assets" tab) to "Search by asset name..."; also some while-I'm-in-there refactors.

### Code Changes

* Renames `SearchInput` to `DebouncedSearchInput` to make purpose clearer and moves out of D&D-specific directory
* Renames `SearchBar` to `SearchInput` for consistency
* Refactors `SearchInput` and `DebouncedSearchInput` to share a prop type that more naturally extends Ant's `InputProps`

### Steps to Confirm

1. Verify placeholders have been updated
2. General regression

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
