### PR TITLE
Pinning azure-sql-edge to 1.0.7

### DIFF
--- a/docker/docker-compose.integration-mssql.yml
+++ b/docker/docker-compose.integration-mssql.yml
@@ -1,6 +1,6 @@
 services:
   mssql_example:
-    image: mcr.microsoft.com/azure-sql-edge:latest # Equivalent to SQL Server 2016
+    image: mcr.microsoft.com/azure-sql-edge:1.0.7 # Equivalent to SQL Server 2019
     ports:
       - 1433:1433
     environment:


### PR DESCRIPTION
Closes [LJ-518](https://ethyca.atlassian.net/browse/LJ-518)

### Description Of Changes

Pinning azure-sql-edge to 1.0.7 (equivalent to SQL Server 2019). This is the last version to support both AMD64 and ARM64. This means we can run this image on Github and on local M1 machines.

### Code Changes

* Updated `docker/docker-compose.integration-mssql.yml`

### Steps to Confirm

1.  The `Safe-Tests (3.10.16, ops-integration)` tests should pass

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
