### PR TITLE
HA-631 - Add support for ip_type for GCP SQL connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed details requirements in AWS SES setup [#6047](https://github.com/ethyca/fides/pull/6047)
 - Addressed some performance issues with Experience configuration previews [#6055](https://github.com/ethyca/fides/pull/6055)
 - Fixed icon sizing in request manager table [#6079](https://github.com/ethyca/fides/pull/6079)
+- Fixed GCP SQL connection to support ip_type [#6065](https://github.com/ethyca/fides/pull/6065)
 
 ## [2.59.2](https://github.com/ethyca/fides/compare/2.59.1...2.59.2)
 
@@ -81,7 +82,6 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Fixed
 - Fixed Privacy Center issue where unconfigured fields (eg. phone) were being passed as null form values [#6045](https://github.com/ethyca/fides/pull/6045)
 - Fixed startup issues with Celery workers [#6058](https://github.com/ethyca/fides/pull/6058)
-- Fixed GCP SQL connection to support ip_type [#6065](https://github.com/ethyca/fides/pull/6065)
 
 
 ## [2.59.1](https://github.com/ethyca/fides/compare/2.59.0...2.59.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Fixed
 - Fixed Privacy Center issue where unconfigured fields (eg. phone) were being passed as null form values [#6045](https://github.com/ethyca/fides/pull/6045)
 - Fixed startup issues with Celery workers [#6058](https://github.com/ethyca/fides/pull/6058)
+- Fixed GCP SQL connection to support ip_type [#6065](https://github.com/ethyca/fides/pull/6065)
 
 
 ## [2.59.1](https://github.com/ethyca/fides/compare/2.59.0...2.59.1)

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/TestConnectionMessage.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/TestConnectionMessage.tsx
@@ -3,21 +3,24 @@ import React from "react";
 
 type TestConnectionMessageProps = {
   status: "success" | "error";
+  failure_reason?: string;
 };
 
-const TestConnectionMessage = ({ status }: TestConnectionMessageProps) => (
-  <>
-    {status === "success" && (
-      <Text data-testid="toast-success-msg">
-        Connection test was successful
-      </Text>
-    )}
-    {status === "error" && (
-      <Text data-testid="toast-error-msg">
-        Test failed: please check your connection info
-      </Text>
-    )}
-  </>
-);
+const TestConnectionMessage = ({
+  status,
+  failure_reason,
+}: TestConnectionMessageProps) => {
+  if (status === "error") {
+    let description = "Connection test failed.";
+    if (failure_reason) {
+      description += ` ${failure_reason}`;
+    }
+    return <Text data-testid="toast-error-msg">{description}</Text>;
+  }
+
+  return (
+    <Text data-testid="toast-success-msg">Connection test was successful</Text>
+  );
+};
 
 export default TestConnectionMessage;

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -381,7 +381,12 @@ export const ConnectorParameters = ({
     const toastParams = {
       ...DEFAULT_TOAST_PARAMS,
       status,
-      description: <TestConnectionMessage status={status} />,
+      description: (
+        <TestConnectionMessage
+          status={status}
+          failure_reason={value.data?.failure_reason}
+        />
+      ),
     };
     toast(toastParams);
   };

--- a/clients/admin-ui/src/features/datastore-connections/useTestConnection.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/useTestConnection.tsx
@@ -32,7 +32,11 @@ const useTestConnection = (
     } else if (result.data?.test_status === "succeeded") {
       toast({ status: "success", description: "Connected successfully" });
     } else if (result.data?.test_status === "failed") {
-      toast({ status: "warning", description: "Connection test failed" });
+      let description = "Connection test failed.";
+      if (result.data?.failure_reason) {
+        description += ` ${result.data?.failure_reason}`;
+      }
+      toast({ status: "warning", description });
     }
   };
 

--- a/clients/admin-ui/src/types/api/index.ts
+++ b/clients/admin-ui/src/types/api/index.ts
@@ -208,6 +208,7 @@ export type { GenerateRequestPayload } from "./models/GenerateRequestPayload";
 export type { GenerateResponse } from "./models/GenerateResponse";
 export { GenerateTypes } from "./models/GenerateTypes";
 export type { GetRegistrationStatusResponse } from "./models/GetRegistrationStatusResponse";
+export type { GoogleCloudSQLIPType } from "./models/GoogleCloudSQLIPType";
 export type { GoogleCloudSQLMySQLDocsSchema } from "./models/GoogleCloudSQLMySQLDocsSchema";
 export type { GoogleCloudSQLPostgresDocsSchema } from "./models/GoogleCloudSQLPostgresDocsSchema";
 export type { GPPApplicationConfig } from "./models/GPPApplicationConfig";

--- a/clients/admin-ui/src/types/api/models/GoogleCloudSQLIPType.ts
+++ b/clients/admin-ui/src/types/api/models/GoogleCloudSQLIPType.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * IP type of a Google Cloud SQL instance.
+ */
+export enum GoogleCloudSQLIPType {
+  PUBLIC = "public",
+  PRIVATE = "private",
+  PRIVATE_SERVICE_CONNECT = "psc",
+}

--- a/clients/admin-ui/src/types/api/models/GoogleCloudSQLMySQLDocsSchema.ts
+++ b/clients/admin-ui/src/types/api/models/GoogleCloudSQLMySQLDocsSchema.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds } from "./fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds";
+import type { GoogleCloudSQLIPType } from "./GoogleCloudSQLIPType";
 
 /**
  * Google Cloud SQL MySQL Secrets Schema for API Docs
@@ -21,4 +22,8 @@ export type GoogleCloudSQLMySQLDocsSchema = {
    * The contents of the key file that contains authentication credentials for a service account in GCP.
    */
   keyfile_creds: fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds;
+  /**
+   * Specify the IP Address type required for the database (defaults to public).
+   */
+  ip_type?: GoogleCloudSQLIPType | null;
 };

--- a/clients/admin-ui/src/types/api/models/GoogleCloudSQLPostgresDocsSchema.ts
+++ b/clients/admin-ui/src/types/api/models/GoogleCloudSQLPostgresDocsSchema.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds } from "./fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds";
+import type { GoogleCloudSQLIPType } from "./GoogleCloudSQLIPType";
 
 /**
  * Google Cloud SQL Postgres Secrets Schema for API Docs
@@ -25,4 +26,8 @@ export type GoogleCloudSQLPostgresDocsSchema = {
    * The contents of the key file that contains authentication credentials for a service account in GCP.
    */
   keyfile_creds: fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds;
+  /**
+   * Specify the IP Address type required for the database (defaults to public).
+   */
+  ip_type?: GoogleCloudSQLIPType | null;
 };

--- a/clients/privacy-center/types/api/index.ts
+++ b/clients/privacy-center/types/api/index.ts
@@ -182,6 +182,7 @@ export type { GenerateRequestPayload } from "./models/GenerateRequestPayload";
 export type { GenerateResponse } from "./models/GenerateResponse";
 export { GenerateTypes } from "./models/GenerateTypes";
 export type { GetRegistrationStatusResponse } from "./models/GetRegistrationStatusResponse";
+export type { GoogleCloudSQLIPType } from "./models/GoogleCloudSQLIPType";
 export type { GoogleCloudSQLMySQLDocsSchema } from "./models/GoogleCloudSQLMySQLDocsSchema";
 export type { GoogleCloudSQLPostgresDocsSchema } from "./models/GoogleCloudSQLPostgresDocsSchema";
 export type { GPPApplicationConfig } from "./models/GPPApplicationConfig";

--- a/clients/privacy-center/types/api/models/GoogleCloudSQLIPType.ts
+++ b/clients/privacy-center/types/api/models/GoogleCloudSQLIPType.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * IP type of a Google Cloud SQL instance.
+ */
+export enum GoogleCloudSQLIPType {
+  PUBLIC = "public",
+  PRIVATE = "private",
+  PRIVATE_SERVICE_CONNECT = "psc",
+}

--- a/clients/privacy-center/types/api/models/GoogleCloudSQLMySQLDocsSchema.ts
+++ b/clients/privacy-center/types/api/models/GoogleCloudSQLMySQLDocsSchema.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds } from "./fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds";
+import type { GoogleCloudSQLIPType } from "./GoogleCloudSQLIPType";
 
 /**
  * Google Cloud SQL MySQL Secrets Schema for API Docs
@@ -21,4 +22,8 @@ export type GoogleCloudSQLMySQLDocsSchema = {
    * The contents of the key file that contains authentication credentials for a service account in GCP.
    */
   keyfile_creds: fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds;
+  /**
+   * Specify the IP Address type required for the database (defaults to public).
+   */
+  ip_type?: GoogleCloudSQLIPType | null;
 };

--- a/clients/privacy-center/types/api/models/GoogleCloudSQLPostgresDocsSchema.ts
+++ b/clients/privacy-center/types/api/models/GoogleCloudSQLPostgresDocsSchema.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds } from "./fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds";
+import type { GoogleCloudSQLIPType } from "./GoogleCloudSQLIPType";
 
 /**
  * Google Cloud SQL Postgres Secrets Schema for API Docs
@@ -25,4 +26,8 @@ export type GoogleCloudSQLPostgresDocsSchema = {
    * The contents of the key file that contains authentication credentials for a service account in GCP.
    */
   keyfile_creds: fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds;
+  /**
+   * Specify the IP Address type required for the database (defaults to public).
+   */
+  ip_type?: GoogleCloudSQLIPType | null;
 };

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_google_cloud_sql_mysql.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_google_cloud_sql_mysql.py
@@ -8,6 +8,9 @@ from fides.api.schemas.base_class import NoValidationSchema
 from fides.api.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
 
 
 class KeyfileCreds(BaseModel):
@@ -51,6 +54,11 @@ class GoogleCloudSQLMySQLSchema(ConnectionConfigSecretsSchema):
         json_schema_extra={"sensitive": True},
         description="The contents of the key file that contains authentication credentials for a service account in GCP.",
     )
+    ip_type: Optional[GoogleCloudSQLIPType] = Field(
+        default=None,
+        title="IP type",
+        description="Specify the IP Address type required for your database (defaults to public). See the Google Cloud documentation for more information about connection options: https://cloud.google.com/sql/docs/postgres/connect-overview",
+    )
 
     _required_components: ClassVar[List[str]] = [
         "db_iam_user",
@@ -65,6 +73,15 @@ class GoogleCloudSQLMySQLSchema(ConnectionConfigSecretsSchema):
         if isinstance(v, str):
             v = json.loads(v)
         return KeyfileCreds.model_validate(v)
+
+    @field_validator("ip_type", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v: Optional[str]) -> Optional[GoogleCloudSQLIPType]:
+        if v == "":
+            return None
+        if v is not None:
+            return GoogleCloudSQLIPType(v)
+        return v
 
 
 class GoogleCloudSQLMySQLDocsSchema(GoogleCloudSQLMySQLSchema, NoValidationSchema):

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_google_cloud_sql_postgres.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_google_cloud_sql_postgres.py
@@ -8,6 +8,9 @@ from fides.api.schemas.base_class import NoValidationSchema
 from fides.api.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
 
 
 class KeyfileCreds(BaseModel):
@@ -57,6 +60,11 @@ class GoogleCloudSQLPostgresSchema(ConnectionConfigSecretsSchema):
         json_schema_extra={"sensitive": True},
         description="The contents of the key file that contains authentication credentials for a service account in GCP.",
     )
+    ip_type: Optional[GoogleCloudSQLIPType] = Field(
+        default=None,
+        title="IP type",
+        description="Specify the IP Address type required for your database (defaults to public). See the Google Cloud documentation for more information about connection options: https://cloud.google.com/sql/docs/postgres/connect-overview",
+    )
 
     _required_components: ClassVar[List[str]] = [
         "db_iam_user",
@@ -70,6 +78,15 @@ class GoogleCloudSQLPostgresSchema(ConnectionConfigSecretsSchema):
         if isinstance(v, str):
             v = json.loads(v)
         return KeyfileCreds.model_validate(v)
+
+    @field_validator("ip_type", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v: Optional[str]) -> Optional[GoogleCloudSQLIPType]:
+        if v == "":
+            return None
+        if v is not None:
+            return GoogleCloudSQLIPType(v)
+        return v
 
 
 class GoogleCloudSQLPostgresDocsSchema(

--- a/src/fides/api/schemas/connection_configuration/enums/google_cloud_sql_ip_type.py
+++ b/src/fides/api/schemas/connection_configuration/enums/google_cloud_sql_ip_type.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class GoogleCloudSQLIPType(str, Enum):
+    """Enum for Google Cloud SQL IP types"""
+
+    public = "public"
+    private = "private"
+    private_service_connect = "psc"

--- a/src/fides/api/service/connectors/google_cloud_mysql_connector.py
+++ b/src/fides/api/service/connectors/google_cloud_mysql_connector.py
@@ -8,6 +8,9 @@ from sqlalchemy.engine import Engine, LegacyCursorResult, create_engine  # type:
 from fides.api.schemas.connection_configuration.connection_secrets_google_cloud_sql_mysql import (
     GoogleCloudSQLMySQLSchema,
 )
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
 from fides.api.service.connectors.sql_connector import SQLConnector
 from fides.api.util.collection_util import Row
 from fides.config import get_config
@@ -37,6 +40,7 @@ class GoogleCloudSQLMySQLConnector(SQLConnector):
             conn: pymysql.connections.Connection = connector.connect(
                 config.instance_connection_name,
                 "pymysql",
+                ip_type=config.ip_type or GoogleCloudSQLIPType.public,
                 user=config.db_iam_user,
                 db=config.dbname,
                 enable_iam_auth=True,

--- a/src/fides/api/service/connectors/google_cloud_postgres_connector.py
+++ b/src/fides/api/service/connectors/google_cloud_postgres_connector.py
@@ -16,6 +16,9 @@ from fides.api.graph.execution import ExecutionNode
 from fides.api.schemas.connection_configuration.connection_secrets_google_cloud_sql_postgres import (
     GoogleCloudSQLPostgresSchema,
 )
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
 from fides.api.service.connectors.query_configs.google_cloud_postgres_query_config import (
     GoogleCloudSQLPostgresQueryConfig,
 )
@@ -53,6 +56,7 @@ class GoogleCloudSQLPostgresConnector(SQLConnector):
             conn: pg8000.dbapi.Connection = connector.connect(
                 config.instance_connection_name,
                 "pg8000",
+                ip_type=config.ip_type or GoogleCloudSQLIPType.public,
                 user=config.db_iam_user,
                 db=config.dbname or self.default_db_name,
                 enable_iam_auth=True,

--- a/src/fides/api/service/connectors/sql_connector.py
+++ b/src/fides/api/service/connectors/sql_connector.py
@@ -119,8 +119,8 @@ class SQLConnector(BaseConnector[Engine]):
             )
         except ClientResponseError as e:
             raise ConnectionException(f"Connection error: {e.message}")
-        except Exception:
-            raise ConnectionException("Connection error.")
+        except Exception as exc:
+            raise ConnectionException(f"Connection error: {exc}")
 
         return ConnectionTestStatus.succeeded
 

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -1150,6 +1150,12 @@ class TestGetConnectionSecretSchema:
 
         assert resp.json() == {
             "definitions": {
+                "GoogleCloudSQLIPType": {
+                    "description": "Enum for Google " "Cloud SQL IP types",
+                    "enum": ["public", "private", "psc"],
+                    "title": "GoogleCloudSQLIPType",
+                    "type": "string",
+                },
                 "KeyfileCreds": {
                     "description": "Schema that holds Google "
                     "Cloud SQL for Postgres "
@@ -1190,7 +1196,7 @@ class TestGetConnectionSecretSchema:
                     "required": ["project_id", "universe_domain"],
                     "title": "KeyfileCreds",
                     "type": "object",
-                }
+                },
             },
             "description": "Schema to validate the secrets needed to connect to Google "
             "Cloud SQL for Postgres",
@@ -1223,6 +1229,11 @@ class TestGetConnectionSecretSchema:
                     "account in GCP.",
                     "sensitive": True,
                     "title": "Keyfile creds",
+                },
+                "ip_type": {
+                    "allOf": [{"$ref": "#/definitions/GoogleCloudSQLIPType"}],
+                    "description": "Specify the IP Address type required for your database (defaults to public). See the Google Cloud documentation for more information about connection options: https://cloud.google.com/sql/docs/postgres/connect-overview",
+                    "title": "IP type",
                 },
             },
             "required": ["db_iam_user", "instance_connection_name", "keyfile_creds"],

--- a/tests/ops/schemas/connection_configuration/test_connection_secrets_google_cloud_sql_mysql.py
+++ b/tests/ops/schemas/connection_configuration/test_connection_secrets_google_cloud_sql_mysql.py
@@ -1,0 +1,30 @@
+import pytest
+
+from fides.api.schemas.connection_configuration.connection_secrets_google_cloud_sql_mysql import (
+    GoogleCloudSQLMySQLSchema,
+)
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
+
+
+class TestGoogleCloudSQLMySQLSchema:
+    """Tests for GoogleCloudSQLMySQLSchema validation and field validators"""
+
+    def test_empty_string_to_none_validator(self):
+        """Test the empty_string_to_none validator for ip_type field"""
+        # Test with empty string
+        result = GoogleCloudSQLMySQLSchema.empty_string_to_none("")
+        assert result is None
+
+        # Test with None value
+        result = GoogleCloudSQLMySQLSchema.empty_string_to_none(None)
+        assert result is None
+
+        # Test with valid IP type
+        result = GoogleCloudSQLMySQLSchema.empty_string_to_none("public")
+        assert result == GoogleCloudSQLIPType.public
+
+        # Test with invalid IP type
+        with pytest.raises(ValueError):
+            GoogleCloudSQLMySQLSchema.empty_string_to_none("INVALID_TYPE")

--- a/tests/ops/schemas/connection_configuration/test_connection_secrets_google_cloud_sql_postgres.py
+++ b/tests/ops/schemas/connection_configuration/test_connection_secrets_google_cloud_sql_postgres.py
@@ -1,0 +1,30 @@
+import pytest
+
+from fides.api.schemas.connection_configuration.connection_secrets_google_cloud_sql_postgres import (
+    GoogleCloudSQLPostgresSchema,
+)
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
+
+
+class TestGoogleCloudSQLPostgresSchema:
+    """Tests for GoogleCloudSQLPostgresSchema validation and field validators"""
+
+    def test_empty_string_to_none_validator(self):
+        """Test the empty_string_to_none validator for ip_type field"""
+        # Test with empty string
+        result = GoogleCloudSQLPostgresSchema.empty_string_to_none("")
+        assert result is None
+
+        # Test with None value
+        result = GoogleCloudSQLPostgresSchema.empty_string_to_none(None)
+        assert result is None
+
+        # Test with valid IP type
+        result = GoogleCloudSQLPostgresSchema.empty_string_to_none("public")
+        assert result == GoogleCloudSQLIPType.public
+
+        # Test with invalid IP type
+        with pytest.raises(ValueError):
+            GoogleCloudSQLPostgresSchema.empty_string_to_none("INVALID_TYPE")

--- a/tests/ops/service/connectors/test_google_cloud_mysql_connector.py
+++ b/tests/ops/service/connectors/test_google_cloud_mysql_connector.py
@@ -1,0 +1,150 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.cloud.sql.connector import Connector
+from google.oauth2.service_account import Credentials
+from sqlalchemy.engine import Engine
+
+from fides.api.schemas.connection_configuration.enums import (
+    google_cloud_sql_ip_type as ip_type,
+)
+from fides.api.service.connectors.google_cloud_mysql_connector import (
+    GoogleCloudSQLMySQLConnector,
+)
+
+
+@pytest.fixture
+def mock_config():
+    return {
+        "db_iam_user": "test-user",
+        "instance_connection_name": "project:region:instance",
+        "dbname": "test-db",
+        "keyfile_creds": {
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "key123",
+            "private_key": (
+                "-----BEGIN PRIVATE KEY-----\n"
+                "MIIE...sample...key\n"
+                "-----END PRIVATE KEY-----\n"
+            ),
+            "client_email": "test@test-project.iam.gserviceaccount.com",
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": (
+                "https://www.googleapis.com/oauth2/v1/certs"
+            ),
+            "client_x509_cert_url": (
+                "https://www.googleapis.com/robot/v1/metadata/x509/"
+                "test.iam.gserviceaccount.com"
+            ),
+            "universe_domain": "googleapis.com",
+        },
+        "ip_type": ip_type.GoogleCloudSQLIPType.private,
+    }
+
+
+@pytest.fixture
+def connector(mock_config):
+    connector = GoogleCloudSQLMySQLConnector(
+        configuration=MagicMock(secrets=mock_config)
+    )
+    return connector
+
+
+@patch(
+    "fides.api.service.connectors.google_cloud_mysql_connector"
+    ".service_account.Credentials",
+    autospec=True,
+)
+@patch(
+    "fides.api.service.connectors.google_cloud_mysql_connector" ".Connector",
+    autospec=True,
+)
+@patch(
+    "fides.api.service.connectors.google_cloud_mysql_connector" ".create_engine",
+    autospec=True,
+)
+class TestGoogleCloudSQLMySQLConnectorCreateClient:
+    """Tests for GoogleCloudSQLMySQLConnector.create_client method."""
+
+    def test_success(
+        self,
+        mock_create_engine,
+        mock_connector_class,
+        mock_credentials_class,
+        connector,
+        mock_config,
+    ):
+        """Test successful creation of a database client."""
+        mock_credentials = MagicMock(spec=Credentials)
+        mock_credentials_class.from_service_account_info.return_value = mock_credentials
+        mock_connector_instance = MagicMock(spec=Connector)
+        mock_connector_class.return_value = mock_connector_instance
+        mock_db_connection = MagicMock()
+        mock_connector_instance.connect.return_value = mock_db_connection
+        mock_engine = MagicMock(spec=Engine)
+        mock_create_engine.return_value = mock_engine
+
+        result = connector.create_client()
+
+        mock_credentials_class.from_service_account_info.assert_called_once_with(
+            dict(mock_config["keyfile_creds"])
+        )
+        mock_connector_class.assert_called_once_with(credentials=mock_credentials)
+
+        # Get the creator function that was passed to create_engine
+        creator_fn = mock_create_engine.call_args[1]["creator"]
+        # Call the creator function to verify it calls connect with right params
+        creator_fn()
+        mock_connector_instance.connect.assert_called_once_with(
+            mock_config["instance_connection_name"],
+            "pymysql",
+            ip_type=mock_config["ip_type"],
+            user=mock_config["db_iam_user"],
+            db=mock_config["dbname"],
+            enable_iam_auth=True,
+        )
+
+        mock_create_engine.assert_called_once()
+        assert mock_create_engine.call_args[0][0] == "mysql+pymysql://"
+        assert result == mock_engine
+
+    def test_with_default_ip_type(
+        self,
+        mock_create_engine,
+        mock_connector_class,
+        mock_credentials_class,
+        connector,
+        mock_config,
+    ):
+        """Test client creation with default IP type."""
+        # Remove ip_type from config
+        connector.configuration.secrets["ip_type"] = None
+
+        mock_credentials_class.from_service_account_info.return_value = MagicMock(
+            spec=Credentials
+        )
+        mock_connector_instance = MagicMock(spec=Connector)
+        mock_connector_class.return_value = mock_connector_instance
+        mock_db_connection = MagicMock()
+        mock_connector_instance.connect.return_value = mock_db_connection
+        mock_engine = MagicMock(spec=Engine)
+        mock_create_engine.return_value = mock_engine
+
+        result = connector.create_client()
+
+        # Get and call the creator function
+        creator_fn = mock_create_engine.call_args[1]["creator"]
+        creator_fn()
+        # Verify connect was called with default IP type
+        mock_connector_instance.connect.assert_called_once_with(
+            mock_config["instance_connection_name"],
+            "pymysql",
+            ip_type=ip_type.GoogleCloudSQLIPType.public,  # Default IP type
+            user=mock_config["db_iam_user"],
+            db=mock_config["dbname"],
+            enable_iam_auth=True,
+        )
+        assert result == mock_engine

--- a/tests/ops/service/connectors/test_google_cloud_postgres_connector.py
+++ b/tests/ops/service/connectors/test_google_cloud_postgres_connector.py
@@ -1,0 +1,189 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.cloud.sql.connector import Connector
+from google.oauth2.service_account import Credentials
+from sqlalchemy.engine import Engine
+
+from fides.api.schemas.connection_configuration.enums import (
+    google_cloud_sql_ip_type as ip_type,
+)
+from fides.api.service.connectors.google_cloud_postgres_connector import (
+    GoogleCloudSQLPostgresConnector,
+)
+
+
+@pytest.fixture
+def mock_config():
+    return {
+        "db_iam_user": "test-user",
+        "instance_connection_name": "project:region:instance",
+        "dbname": "test-db",
+        "db_schema": "public",
+        "keyfile_creds": {
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "key123",
+            "private_key": (
+                "-----BEGIN PRIVATE KEY-----\n"
+                "MIIE...sample...key\n"
+                "-----END PRIVATE KEY-----\n"
+            ),
+            "client_email": "test@test-project.iam.gserviceaccount.com",
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": (
+                "https://www.googleapis.com/oauth2/v1/certs"
+            ),
+            "client_x509_cert_url": (
+                "https://www.googleapis.com/robot/v1/metadata/x509/"
+                "test.iam.gserviceaccount.com"
+            ),
+            "universe_domain": "googleapis.com",
+        },
+        "ip_type": ip_type.GoogleCloudSQLIPType.private,
+    }
+
+
+@pytest.fixture
+def connector(mock_config):
+    connector = GoogleCloudSQLPostgresConnector(
+        configuration=MagicMock(secrets=mock_config)
+    )
+    return connector
+
+
+@patch(
+    "fides.api.service.connectors.google_cloud_postgres_connector"
+    ".service_account.Credentials",
+    autospec=True,
+)
+@patch(
+    "fides.api.service.connectors.google_cloud_postgres_connector" ".Connector",
+    autospec=True,
+)
+@patch(
+    "fides.api.service.connectors.google_cloud_postgres_connector" ".create_engine",
+    autospec=True,
+)
+class TestGoogleCloudSQLPostgresConnectorCreateClient:
+    """Tests for GoogleCloudSQLPostgresConnector.create_client method."""
+
+    def test_success(
+        self,
+        mock_create_engine,
+        mock_connector_class,
+        mock_credentials_class,
+        connector,
+        mock_config,
+    ):
+        """Test successful creation of a database client."""
+        mock_credentials = MagicMock(spec=Credentials)
+        mock_credentials_class.from_service_account_info.return_value = mock_credentials
+        mock_connector_instance = MagicMock(spec=Connector)
+        mock_connector_class.return_value = mock_connector_instance
+        mock_db_connection = MagicMock()
+        mock_connector_instance.connect.return_value = mock_db_connection
+        mock_engine = MagicMock(spec=Engine)
+        mock_create_engine.return_value = mock_engine
+
+        result = connector.create_client()
+
+        mock_credentials_class.from_service_account_info.assert_called_once_with(
+            dict(mock_config["keyfile_creds"])
+        )
+        mock_connector_class.assert_called_once_with(credentials=mock_credentials)
+
+        # Get the creator function that was passed to create_engine
+        creator_fn = mock_create_engine.call_args[1]["creator"]
+        # Call the creator function to verify it calls connect with right params
+        creator_fn()
+        mock_connector_instance.connect.assert_called_once_with(
+            mock_config["instance_connection_name"],
+            "pg8000",
+            ip_type=mock_config["ip_type"],
+            user=mock_config["db_iam_user"],
+            db=mock_config["dbname"],
+            enable_iam_auth=True,
+        )
+
+        mock_create_engine.assert_called_once()
+        assert mock_create_engine.call_args[0][0] == "postgresql+pg8000://"
+        assert result == mock_engine
+
+    def test_with_default_db(
+        self,
+        mock_create_engine,
+        mock_connector_class,
+        mock_credentials_class,
+        connector,
+        mock_config,
+    ):
+        """Test client creation with default database name."""
+        # Modify config to remove dbname
+        connector.configuration.secrets["dbname"] = None
+
+        mock_credentials_class.from_service_account_info.return_value = MagicMock(
+            spec=Credentials
+        )
+        mock_connector_instance = MagicMock(spec=Connector)
+        mock_connector_class.return_value = mock_connector_instance
+        mock_db_connection = MagicMock()
+        mock_connector_instance.connect.return_value = mock_db_connection
+        mock_engine = MagicMock(spec=Engine)
+        mock_create_engine.return_value = mock_engine
+
+        result = connector.create_client()
+
+        # Get and call the creator function
+        creator_fn = mock_create_engine.call_args[1]["creator"]
+        creator_fn()
+        # Verify connect was called with default database
+        mock_connector_instance.connect.assert_called_once_with(
+            mock_config["instance_connection_name"],
+            "pg8000",
+            ip_type=mock_config["ip_type"],
+            user=mock_config["db_iam_user"],
+            db="postgres",
+            enable_iam_auth=True,
+        )
+        assert result == mock_engine
+
+    def test_with_default_ip_type(
+        self,
+        mock_create_engine,
+        mock_connector_class,
+        mock_credentials_class,
+        connector,
+        mock_config,
+    ):
+        """Test client creation with default IP type."""
+        # Remove ip_type from config
+        connector.configuration.secrets["ip_type"] = None
+
+        mock_credentials_class.from_service_account_info.return_value = MagicMock(
+            spec=Credentials
+        )
+        mock_connector_instance = MagicMock(spec=Connector)
+        mock_connector_class.return_value = mock_connector_instance
+        mock_db_connection = MagicMock()
+        mock_connector_instance.connect.return_value = mock_db_connection
+        mock_engine = MagicMock(spec=Engine)
+        mock_create_engine.return_value = mock_engine
+
+        result = connector.create_client()
+
+        # Get and call the creator function
+        creator_fn = mock_create_engine.call_args[1]["creator"]
+        creator_fn()
+        # Verify connect was called with default IP type
+        mock_connector_instance.connect.assert_called_once_with(
+            mock_config["instance_connection_name"],
+            "pg8000",
+            ip_type=ip_type.GoogleCloudSQLIPType.public,  # Default IP type
+            user=mock_config["db_iam_user"],
+            db=mock_config["dbname"],
+            enable_iam_auth=True,
+        )
+        assert result == mock_engine


### PR DESCRIPTION
Closes [HA-631](https://ethyca.atlassian.net/browse/HA-631)

### Description Of Changes

- Add the ability to specify the “IP Type” as an optional connection argument using Google Cloud SQL (mysql and postgres). This applies to connection tests in:
   - Integrations -> Connection

- In case of connection error, display error information in admin-ui.

### Code Changes

- Added GCP SQL IP Type Support
  - New ip_type field with options: "public", "private", "psc"
  - Applied to both MySQL and PostgreSQL connectors
  - Default value is "public" if not specified
- UI Error Handling Improvements
  - Enhanced error messages in connection test responses
  - Added failure reason display in the UI

### Steps to Confirm

1. Have an integration with Google Cloud SQL MySQL (credentials in 1password)
2. Set the IP type to "public" and see that the connection test works.
3. Set the IP type to empty and see that the connection test works.
4. Set the IP type to "private" and see that the connection test fails and the admin-ui displays an error message with the error coming from Google.
5. Set the IP type to "psc" and see that the connection test fails and the admin-UI displays an error message with the error coming from Google.
7. Repeat tests with Postgres instead of MySQL.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[HA-631]: https://ethyca.atlassian.net/browse/HA-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ