### PR TITLE
Allow non-flexible Purposes to add Purpose Restriction

### DIFF
--- a/clients/admin-ui/cypress/e2e/consent-settings.cy.ts
+++ b/clients/admin-ui/cypress/e2e/consent-settings.cy.ts
@@ -351,9 +351,7 @@ describe("Consent settings", () => {
                   : "Yes",
               );
               cy.getByTestId(`edit-restriction-btn-${purpose.id}`).should(
-                FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(purpose.id)
-                  ? "not.exist"
-                  : "exist",
+                "exist",
               );
             });
           },

--- a/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsTable.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsTable.tsx
@@ -195,22 +195,18 @@ export const PublisherRestrictionsTable = ({
             )}
           </FauxTableCell>
           <FauxTableCell width="100px" borderLeft>
-            {FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(purpose.id) ? (
-              <div />
-            ) : (
-              <NextLink
-                href={`/settings/consent/${config?.id}/${purpose.id}`}
-                passHref
-                legacyBehavior
+            <NextLink
+              href={`/settings/consent/${config?.id}/${purpose.id}`}
+              passHref
+              legacyBehavior
+            >
+              <Button
+                size="small"
+                data-testid={`edit-restriction-btn-${purpose.id}`}
               >
-                <Button
-                  size="small"
-                  data-testid={`edit-restriction-btn-${purpose.id}`}
-                >
-                  Edit
-                </Button>
-              </NextLink>
-            )}
+                Edit
+              </Button>
+            </NextLink>
           </FauxTableCell>
         </FauxRow>
       ))}

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -1,11 +1,13 @@
 import {
   AntButton as Button,
   AntFlex as Flex,
+  AntTooltip as Tooltip,
   Collapse,
   Text,
   useToast,
 } from "fidesui";
 import { Form, Formik } from "formik";
+import { useEffect, useState } from "react";
 import * as Yup from "yup";
 
 import { ControlledSelect } from "~/features/common/form/ControlledSelect";
@@ -19,6 +21,7 @@ import {
 } from "~/types/api";
 
 import {
+  FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS,
   RESTRICTION_TYPE_LABELS,
   VENDOR_RESTRICTION_LABELS,
 } from "./constants";
@@ -65,6 +68,17 @@ export const PurposeRestrictionFormModal = ({
   const toast = useToast();
   const [createRestriction] = useCreatePublisherRestrictionMutation();
   const [updateRestriction] = useUpdatePublisherRestrictionMutation();
+  const [isPurposeFlexible, setIsPurposeFlexible] = useState(true);
+  useEffect(() => {
+    if (
+      purposeId &&
+      FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(+purposeId)
+    ) {
+      setIsPurposeFlexible(false);
+      // eslint-disable-next-line no-param-reassign
+      initialValues.restriction_type = TCFRestrictionType.PURPOSE_RESTRICTION;
+    }
+  }, [initialValues, purposeId]);
 
   // Get the list of restriction types that are already in use for this purpose
   const usedRestrictionTypes = existingRestrictions
@@ -227,14 +241,24 @@ export const PurposeRestrictionFormModal = ({
                 listed vendors are restricted or allowed, and specify which
                 vendor IDs the restriction applies to.
               </Text>
-              <ControlledSelect
-                name="restriction_type"
-                label="Restriction type"
-                options={restrictionTypeOptions}
-                layout="stacked"
-                tooltip="Choose how vendors are permitted to process data for this purpose. This setting overrides the vendor's declared legal basis in the Global Vendor List."
-                isRequired
-              />
+              <Tooltip
+                title={
+                  !isPurposeFlexible
+                    ? "Non-flexible purposes only support Purpose restrictions and cannot be restricted by consent or legitimate interest settings."
+                    : undefined
+                }
+              >
+                <ControlledSelect
+                  name="restriction_type"
+                  label="Restriction type"
+                  options={restrictionTypeOptions}
+                  layout="stacked"
+                  tooltip="Choose how vendors are permitted to process data for this purpose. This setting overrides the vendor's declared legal basis in the Global Vendor List."
+                  isRequired
+                  disabled={!isPurposeFlexible}
+                  className="w-full" // tooltip wrapper makes this necessary
+                />
+              </Tooltip>
               <ControlledSelect
                 name="vendor_restriction"
                 label="Vendor restriction"

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -7,7 +7,6 @@ import {
   useToast,
 } from "fidesui";
 import { Form, Formik } from "formik";
-import { useEffect, useState } from "react";
 import * as Yup from "yup";
 
 import { ControlledSelect } from "~/features/common/form/ControlledSelect";
@@ -68,17 +67,9 @@ export const PurposeRestrictionFormModal = ({
   const toast = useToast();
   const [createRestriction] = useCreatePublisherRestrictionMutation();
   const [updateRestriction] = useUpdatePublisherRestrictionMutation();
-  const [isPurposeFlexible, setIsPurposeFlexible] = useState(true);
-  useEffect(() => {
-    if (
-      purposeId &&
-      FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(+purposeId)
-    ) {
-      setIsPurposeFlexible(false);
-      // eslint-disable-next-line no-param-reassign
-      initialValues.restriction_type = TCFRestrictionType.PURPOSE_RESTRICTION;
-    }
-  }, [initialValues, purposeId]);
+  const isPurposeFlexible = !(
+    purposeId && FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(+purposeId)
+  );
 
   // Get the list of restriction types that are already in use for this purpose
   const usedRestrictionTypes = existingRestrictions
@@ -228,7 +219,12 @@ export const PurposeRestrictionFormModal = ({
   return (
     <FormModal isOpen={isOpen} onClose={onClose} title="Edit restriction">
       <Formik
-        initialValues={initialValues}
+        initialValues={{
+          ...initialValues,
+          restriction_type: isPurposeFlexible
+            ? initialValues.restriction_type
+            : TCFRestrictionType.PURPOSE_RESTRICTION,
+        }}
         onSubmit={handleSubmit}
         validationSchema={validationSchema}
       >

--- a/clients/admin-ui/src/pages/settings/consent/[configuration_id]/[purpose_id].tsx
+++ b/clients/admin-ui/src/pages/settings/consent/[configuration_id]/[purpose_id].tsx
@@ -1,23 +1,14 @@
-import {
-  AntFlex as Flex,
-  AntSpace as Space,
-  Skeleton,
-  Text,
-  useToast,
-} from "fidesui";
+import { AntFlex as Flex, AntSpace as Space, Skeleton, Text } from "fidesui";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
 import DocsLink from "~/features/common/DocsLink";
 import FixedLayout from "~/features/common/FixedLayout";
 import PageHeader from "~/features/common/PageHeader";
 import { useGetPurposesQuery } from "~/features/common/purpose.slice";
 import SettingsBox from "~/features/consent-settings/SettingsBox";
-import {
-  FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS,
-  PUBLISHER_RESTRICTIONS_DOCS_URL,
-} from "~/features/consent-settings/tcf/constants";
+import { PUBLISHER_RESTRICTIONS_DOCS_URL } from "~/features/consent-settings/tcf/constants";
 import { PurposeRestrictionsTable } from "~/features/consent-settings/tcf/PurposeRestrictionsTable";
 import { useGetTCFConfigurationQuery } from "~/features/consent-settings/tcf/tcf-config.slice";
 
@@ -27,7 +18,6 @@ const ConsentConfigurationPage: NextPage = () => {
     router.query.configuration_id as string,
   );
   const purposeId = decodeURIComponent(router.query.purpose_id as string);
-  const toast = useToast();
 
   const { data: purposes, isLoading: isPurposesLoading } =
     useGetPurposesQuery();
@@ -36,22 +26,6 @@ const ConsentConfigurationPage: NextPage = () => {
   const purpose = useMemo(() => {
     return purposes?.purposes[purposeId];
   }, [purposes, purposeId]);
-
-  useEffect(() => {
-    if (
-      purposeId &&
-      FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(
-        parseInt(purposeId, 10),
-      )
-    ) {
-      toast({
-        status: "error",
-        title: `Purpose ${purposeId} is not flexible`,
-        description: "Please select a different purpose.",
-      });
-      router.replace("/settings/consent");
-    }
-  }, [purposeId, toast, router]);
 
   return (
     <FixedLayout title="Consent Configuration">


### PR DESCRIPTION
Closes [LJ-694]

### Description Of Changes

Removes restrictions on editing purpose restrictions for non-flexible purposes in TCF consent settings. Instead of blocking editing entirely, the UI now allows users to create restrictions for these purposes but limits them to only use Purpose Restriction type.

### Code Changes

* Removed code that hid the "Edit" button for non-flexible purposes in `PublisherRestrictionsTable`
* Added state and logic in `PurposeRestrictionFormModal` to disable the Restriction Type dropdown for non-flexible purposes
* Added a tooltip explanation for why the Restriction Type is disabled
* Removed the error toast and redirect in the purpose config page (`[purpose_id].tsx`) that prevented accessing non-flexible purposes

### Steps to Confirm
1. Navigate to a TCF consent configuration (`/settings/consent`)
2. Attempt to edit restrictions for a non-flexible purpose (those with "No" in the Flexible column)
3. Verify that the Edit button is visible and the form opens
4. Confirm the Restriction type is set to Purpose restriction and cannot be changed
NOTE: Backend validation with throw an error for now, @JadeCara is working to address this

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your 
change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Bug fix for current release work, no entry required
* Followup issues:
  * [ ] Followup issues created (include link)
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-694]: https://ethyca.atlassian.net/browse/LJ-694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ