### PR TITLE
HA-635: Postgres Connector SSL Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added PostgreSQL connection config form to the "integrations" page to support use with discovery monitors [#6018](https://github.com/ethyca/fides/pull/6018)
 - Update the Datahub Permissions section to include required permissions from Datahub [#6052](https://github.com/ethyca/fides/pull/6052)
 - Added the ability to create new TCF Experiences within Admin UI [#6055](https://github.com/ethyca/fides/pull/6055)
+- PostgresSQL connection config now supports SSL Mode [#6068](https://github.com/ethyca/fides/pull/6068
+)
 
 ### Added
 - Added assumed role arn capabilities to aws Storage [#6027](https://github.com/ethyca/fides/pull/6027)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added PostgreSQL connection config form to the "integrations" page to support use with discovery monitors [#6018](https://github.com/ethyca/fides/pull/6018)
 - Update the Datahub Permissions section to include required permissions from Datahub [#6052](https://github.com/ethyca/fides/pull/6052)
 - Added the ability to create new TCF Experiences within Admin UI [#6055](https://github.com/ethyca/fides/pull/6055)
-- PostgresSQL connection config now supports SSL Mode [#6068](https://github.com/ethyca/fides/pull/6068
-)
+- PostgreSQL connection config now supports SSL Mode [#6068](https://github.com/ethyca/fides/pull/6068)
 
 ### Added
 - Added assumed role arn capabilities to aws Storage [#6027](https://github.com/ethyca/fides/pull/6027)

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_postgres.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_postgres.py
@@ -46,6 +46,10 @@ class PostgreSQLSchema(ConnectionConfigSecretsSchema):
         title="Schema",
         description="The default schema to be used for the database connection (defaults to public).",
     )
+    ssl_mode: Optional[str] = Field(
+        default=None,
+        title="SSL Mode",
+    )
 
     _required_components: ClassVar[List[str]] = [
         "host",

--- a/src/fides/api/service/connectors/postgres_connector.py
+++ b/src/fides/api/service/connectors/postgres_connector.py
@@ -37,7 +37,8 @@ class PostgreSQLConnector(SQLConnector):
         netloc = config.host
         port = f":{config.port}" if config.port else ""
         dbname = f"/{config.dbname}" if config.dbname else ""
-        return f"postgresql://{user_password}{netloc}{port}{dbname}"
+        query = f"?sslmode=${config.ssl_mode}" if config.ssl_mode else ""
+        return f"postgresql://{user_password}{netloc}{port}{dbname}{query}"
 
     def build_ssh_uri(self, local_address: tuple) -> str:
         """Build URI of format postgresql://[user[:password]@][ssh_host][:ssh_port][/dbname]"""
@@ -53,7 +54,8 @@ class PostgreSQLConnector(SQLConnector):
         netloc = local_host
         port = f":{local_port}" if local_port else ""
         dbname = f"/{config.dbname}" if config.dbname else ""
-        return f"postgresql://{user_password}{netloc}{port}{dbname}"
+        query = f"?sslmode=${config.ssl_mode}" if config.ssl_mode else ""
+        return f"postgresql://{user_password}{netloc}{port}{dbname}{query}"
 
     # Overrides SQLConnector.create_client
     def create_client(self) -> Engine:

--- a/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_config_endpoints.py
@@ -1509,6 +1509,7 @@ class TestPutConnectionConfigSecrets:
             "password": None,
             "db_schema": None,
             "ssh_required": False,
+            "ssl_mode": None,
         }
         assert connection_config.last_test_timestamp is None
         assert connection_config.last_test_succeeded is None
@@ -2337,6 +2338,7 @@ class TestPatchConnectionConfigSecrets:
             "password": previous_secrets["password"],
             "db_schema": None,  # Was not set in the payload nor in the fixture
             "ssh_required": False,  # Was not set in the payload nor in the fixture
+            "ssl_mode": None,  # Was not set in the payload nor in the fixture
         }
         assert connection_config.last_test_timestamp is None
         assert connection_config.last_test_succeeded is None

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -1131,6 +1131,10 @@ class TestGetConnectionSecretSchema:
                     "default": False,
                     "type": "boolean",
                 },
+                "ssl_mode": {
+                    "title": "SSL Mode",
+                    "type": "string",
+                },
             },
             "required": ["host"],
         }

--- a/tests/ops/integration_tests/test_connection_configuration_integration.py
+++ b/tests/ops/integration_tests/test_connection_configuration_integration.py
@@ -93,6 +93,7 @@ class TestPostgresConnectionPutSecretsAPI:
             "username": "postgres",
             "password": "postgres",
             "db_schema": None,
+            "ssl_mode": None,
         }
 
         auth_header = generate_auth_header(scopes=[CONNECTION_CREATE_OR_UPDATE])

--- a/tests/ops/integration_tests/test_connection_configuration_integration.py
+++ b/tests/ops/integration_tests/test_connection_configuration_integration.py
@@ -93,7 +93,6 @@ class TestPostgresConnectionPutSecretsAPI:
             "username": "postgres",
             "password": "postgres",
             "db_schema": None,
-            "ssl_mode": None,
         }
 
         auth_header = generate_auth_header(scopes=[CONNECTION_CREATE_OR_UPDATE])
@@ -120,6 +119,7 @@ class TestPostgresConnectionPutSecretsAPI:
             "password": "postgres",
             "db_schema": None,
             "ssh_required": False,
+            "ssl_mode": None,
         }
         assert connection_config.last_test_timestamp is not None
         assert connection_config.last_test_succeeded is True

--- a/tests/ops/integration_tests/test_connection_configuration_integration.py
+++ b/tests/ops/integration_tests/test_connection_configuration_integration.py
@@ -73,6 +73,7 @@ class TestPostgresConnectionPutSecretsAPI:
             "password": None,
             "db_schema": None,
             "ssh_required": False,
+            "ssl_mode": None,
         }
         assert connection_config.last_test_timestamp is not None
         assert connection_config.last_test_succeeded is False


### PR DESCRIPTION
- **Add ssl mode as an option to postgres connector.**

Closes [HA-635]

### Description Of Changes

Adds SSL Mode to PG Connector

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  Configure a monitor or connector and use SSL Mode.
2.  Configure a monitor or connector and do not use SSL Mode.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
* Followup issues:
  * [ ] Followup issues created (include link)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[HA-635]: https://ethyca.atlassian.net/browse/HA-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ