### PR TITLE
LJ-702: Add url_recorded to consent report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.60.1...main)
 
+- Added Recorded URL to Consent Report [#6077](https://github.com/ethyca/fides/pull/6077)
 
 
 

--- a/clients/admin-ui/src/features/consent-reporting/hooks/useConsentReportingTableColumns.tsx
+++ b/clients/admin-ui/src/features/consent-reporting/hooks/useConsentReportingTableColumns.tsx
@@ -135,7 +135,9 @@ const useConsentReportingTableColumns = ({
       columnHelper.accessor((row) => row.url_recorded, {
         id: "url_recorded",
         cell: ({ getValue }) => <DefaultCell value={getValue()} />,
-        header: (props) => <DefaultCell value="Recorded URL" {...props} />,
+        header: (props) => (
+          <DefaultHeaderCell value="Recorded URL" {...props} />
+        ),
       }),
       columnHelper.accessor((row) => row.external_id, {
         id: "external_id",

--- a/clients/admin-ui/src/features/consent-reporting/hooks/useConsentReportingTableColumns.tsx
+++ b/clients/admin-ui/src/features/consent-reporting/hooks/useConsentReportingTableColumns.tsx
@@ -132,6 +132,11 @@ const useConsentReportingTableColumns = ({
         ),
         size: 120,
       }),
+      columnHelper.accessor((row) => row.url_recorded, {
+        id: "url_recorded",
+        cell: ({ getValue }) => <DefaultCell value={getValue()} />,
+        header: (props) => <DefaultCell value="Recorded URL" {...props} />,
+      }),
       columnHelper.accessor((row) => row.external_id, {
         id: "external_id",
         cell: ({ getValue }) => <DefaultCell value={getValue()} />,

--- a/clients/admin-ui/src/pages/consent/reporting/index.tsx
+++ b/clients/admin-ui/src/pages/consent/reporting/index.tsx
@@ -121,6 +121,7 @@ const ConsentReportingPage = () => {
                   icon={<Icons.Download />}
                   data-testid="download-btn"
                   onClick={() => setIsDownloadReportModalOpen(true)}
+                  aria-label="Download Consent Report"
                 />
                 <Dropdown
                   menu={{


### PR DESCRIPTION
- **Add recorded URL to consent report.**
- **Add aria label to textless button.**

Closes [LJ-702]

### Description Of Changes

This adds the recorded URL to the consent report.

![image](https://github.com/user-attachments/assets/763e61f9-316a-485a-b2d0-6bec0743aa08)

### Steps to Confirm

1. Make a consent choice.
2. Look at consent report.
3. Confirm column present.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-702]: https://ethyca.atlassian.net/browse/LJ-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ