### PR TITLE
Update request table action icons to carbon and fix sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed performance issues in Data map report in Admin UI [#6046](https://github.com/ethyca/fides/pull/6046)
 - Fixed details requirements in AWS SES setup [#6047](https://github.com/ethyca/fides/pull/6047)
 - Addressed some performance issues with Experience configuration previews [#6055](https://github.com/ethyca/fides/pull/6055)
+- Fixed icon sizing in request manager table [#6079](https://github.com/ethyca/fides/pull/6079)
 
 ## [2.59.2](https://github.com/ethyca/fides/compare/2.59.1...2.59.2)
 

--- a/clients/admin-ui/src/features/privacy-requests/RequestTableActions.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestTableActions.tsx
@@ -1,9 +1,7 @@
 import {
   AntButton as Button,
-  CheckIcon,
-  CloseIcon,
-  DeleteIcon,
   HStack,
+  Icons,
   Portal,
   StackProps,
   Text,
@@ -47,7 +45,7 @@ export const RequestTableActions = ({
       <Button
         title="Approve"
         aria-label="Approve"
-        icon={<CheckIcon w={2} h={2} />}
+        icon={<Icons.Checkmark />}
         onClick={approvalModal.onOpen}
         loading={isLoading}
         disabled={isLoading}
@@ -66,7 +64,7 @@ export const RequestTableActions = ({
       <Button
         title="Deny"
         aria-label="Deny"
-        icon={<CloseIcon w={2} h={2} />}
+        icon={<Icons.Close />}
         onClick={denyModal.onOpen}
         loading={isLoading}
         disabled={isLoading}
@@ -82,7 +80,7 @@ export const RequestTableActions = ({
         <Button
           title="Delete"
           aria-label="Delete"
-          icon={<DeleteIcon w={2} h={2} />}
+          icon={<Icons.TrashCan size={14} />}
           onClick={deleteModal.onOpen}
           loading={isLoading}
           disabled={isLoading}


### PR DESCRIPTION
### Description Of Changes

Update request table action icons to carbon and fix sizing

### Code Changes

* Update action icons to Carbon icons
* Update size of trash icon to 14 (visually it looks heavier than the others with default size)

### Steps to Confirm

1.  Login to admin-ui
2. Go to Privacy Request > Request managers
3. Looks at the actions column icons
4. Check we're using carbon icons, that the sizing make sense for the size of the button and that they're centered

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
