### PR TITLE
fix experience errors when window.Fides isn't present

### DIFF
--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -303,6 +303,16 @@ regular/embedded mode with `fides_embed`, overriding the user's language with
 FidesJS with the initial configuration, but taking into account any new overrides
 such as the `fides_overrides` global or the query params.
 
+#### Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `config`? | `any` |
+
+#### Returns
+
+`Promise`\<`void`\>
+
 #### Example
 
 Disable FidesJS initialization and trigger manually instead:
@@ -336,16 +346,6 @@ Configure overrides after loading Fides.js tag.
   </script>
 </head>
 ```
-
-#### Parameters
-
-| Parameter | Type |
-| ------ | ------ |
-| `config`? | `any` |
-
-#### Returns
-
-`Promise`\<`void`\>
 
 ***
 

--- a/clients/fides-js/src/fides-preview.ts
+++ b/clients/fides-js/src/fides-preview.ts
@@ -34,8 +34,6 @@ function cleanup(): void {
     // Remove the script from DOM to ensure complete cleanup
     currentScript.remove();
     currentScript = null;
-    // @ts-ignore - We know this is safe as we're cleaning up the global
-    window.Fides = null;
   }
   currentMode = null;
 }


### PR DESCRIPTION
Closes [LJ-711]

### Description Of Changes
Part of the clean up function was setting `window.Fides` to null. This creates a race condition where sometimes the rest of the cleanup hasn't taken place yet, or the new iteration hasn't been created yet and the assumption of the code at that time is that window.Fides exists. At any rate, setting that to null was a bit overkill for the cleanup anyway, let's just remove it for now.

### Code Changes

* remove setting window.Fides to null in the fides-preview script

### Steps to Confirm

1. Save a TCF experience a few times in Admin UI

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-711]: https://ethyca.atlassian.net/browse/LJ-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ