### PR TITLE
LJ-700: Fix Special-purpose only vendors not correctly encoded in TC string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Developer Experience
 - Cleaning up test fixtures [#6008](https://github.com/ethyca/fides/pull/6008)
 
+### Fixed
+- Fix Special-purpose only vendors not correctly encoded in TC string [#6086](https://github.com/ethyca/fides/pull/6086)
+
 ## [2.60.0](https://github.com/ethyca/fides/compare/2.59.2...2.60.0)
 
 ### Added

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -160,12 +160,19 @@ export const generateFidesString = async ({
 
       // Set legitimate interest for special-purpose only vendors
       if (!experience.minimal_tcf && experience.gvl?.vendors) {
-        Object.entries(experience.gvl.vendors).forEach(([vendorId, vendor]) => {
-          // Check if vendor only has special purposes (no regular purposes)
-          if (vendor.specialPurposes?.length && (!vendor.purposes || vendor.purposes.length === 0)) {
-            tcModel.vendorLegitimateInterests.set(+vendorId);
-          }
-        });
+        (experience as PrivacyExperience).tcf_vendor_relationships?.forEach(
+          (relationship) => {
+            const { id } = decodeVendorId(relationship.id);
+            const vendor = experience.gvl?.vendors[id];
+            if (
+              vendor &&
+              vendor.specialPurposes?.length &&
+              (!vendor.purposes || vendor.purposes.length === 0)
+            ) {
+              tcModel.vendorLegitimateInterests.set(+id);
+            }
+          },
+        );
       }
 
       // Set purposes on tcModel
@@ -184,10 +191,6 @@ export const generateFidesString = async ({
         tcModel.specialFeatureOptins.set(+id);
       });
 
-      // note that we cannot set consent for special purposes nor features because the IAB policy states
-      // the user is not given choice by a CMP.
-      // See https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/
-      // and https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/63#issuecomment-581798996
       encodedString = TCString.encode(tcModel, {
         // We do not want to include vendors disclosed or publisher tc at the moment
         segments: [Segment.CORE],

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -158,6 +158,16 @@ export const generateFidesString = async ({
         }
       });
 
+      // Set legitimate interest for special-purpose only vendors
+      if (!experience.minimal_tcf && experience.gvl?.vendors) {
+        Object.entries(experience.gvl.vendors).forEach(([vendorId, vendor]) => {
+          // Check if vendor only has special purposes (no regular purposes)
+          if (vendor.specialPurposes?.length && (!vendor.purposes || vendor.purposes.length === 0)) {
+            tcModel.vendorLegitimateInterests.set(+vendorId);
+          }
+        });
+      }
+
       // Set purposes on tcModel
       tcStringPreferences.purposesConsent.forEach((purposeId) => {
         tcModel.purposeConsents.set(+purposeId);

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -159,7 +159,7 @@ export const generateFidesString = async ({
       });
 
       // Set legitimate interest for special-purpose only vendors
-      if (!experience.minimal_tcf && experience.gvl?.vendors) {
+      if (experience.gvl?.vendors) {
         (experience as PrivacyExperience).tcf_vendor_relationships?.forEach(
           (relationship) => {
             const { id } = decodeVendorId(relationship.id);

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -164,10 +164,16 @@ export const generateFidesString = async ({
           (relationship) => {
             const { id } = decodeVendorId(relationship.id);
             const vendor = experience.gvl?.vendors[id];
+            const isInVendorConsents = (
+              experience as PrivacyExperience
+            ).tcf_vendor_consents?.some(
+              (consent) => consent.id === relationship.id,
+            );
             if (
               vendor &&
               vendor.specialPurposes?.length &&
-              (!vendor.purposes || vendor.purposes.length === 0)
+              (!vendor.purposes || vendor.purposes.length === 0) &&
+              !isInVendorConsents
             ) {
               tcModel.vendorLegitimateInterests.set(+id);
             }


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/LJ-700

### Description Of Changes

Fix Special-purpose only vendors not correctly encoded in TC string

### Code Changes

* Update tcf encoding logic to consider special-purpose only vendors
* Adds specific test for this scenario

### Steps to Confirm

1.  Login to the Fides Admin UI 
2. Navigate to the Vendors configuration
3. Enable a special-purpose only vendor (e.g. SeenThis) in the vendor list
4. Save the configuration
5. Ensure you have a system with data use added in Admin-UI
6. Enable the TCF experience
7. Visit http://localhost:3001/fides-js-demo.html?geolocation=fr-idf&fides_locale=en 
8. Confirm that SeenThis vendor is listed under Purposes -> Legitimate Interest -> Special purposes section
<img width="704" alt="Screenshot 2025-04-24 at 2 41 09 PM" src="https://github.com/user-attachments/assets/8ffad9a8-ef15-446e-b7e5-7decf256d044" />

9. Make a consent choice (or just x out of the banner), the action doesn't matter
10. Inspect the generated TC string, either through the console (__tcfapi("getTCData", 2, console.log)), using the IAB chrome extension to inspect, or otherwise, to see that `SeenThis` is enabled (vendor 415)
<img width="226" alt="Screenshot 2025-04-24 at 2 43 30 PM" src="https://github.com/user-attachments/assets/974ecd51-f321-42f9-9790-1198b439f400" />

<img width="595" alt="Screenshot 2025-04-24 at 2 42 43 PM" src="https://github.com/user-attachments/assets/ca753b46-0138-47d9-b212-38e04e3c5795" />


### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
