### PR TITLE
Lj 462 Reduce Logging for Disabled Cache on SQLAlchemy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Fixed
 - Fix Special-purpose only vendors not correctly encoded in TC string [#6086](https://github.com/ethyca/fides/pull/6086)
+- Suppressing SQLAlchemy logging related to caching queries [#6089](https://github.com/ethyca/fides/pull/6089)
 
 ## [2.60.0](https://github.com/ethyca/fides/compare/2.59.2...2.60.0)
 

--- a/src/fides/api/service/connectors/redshift_connector.py
+++ b/src/fides/api/service/connectors/redshift_connector.py
@@ -1,7 +1,5 @@
 from typing import Dict, Union
 from urllib.parse import quote_plus
-import logging
-
 
 from loguru import logger
 from sqlalchemy import text
@@ -78,13 +76,11 @@ class RedshiftConnector(SQLConnector):
     def set_schema(self, connection: Connection) -> None:
         """Sets the search_path for the duration of the session"""
         config = self.secrets_schema(**self.configuration.secrets or {})
-
         if config.db_schema:
             logger.info("Setting Redshift search_path before retrieving data")
-            with suppress_logging():
-                stmt = text("SET search_path to :search_path")
-                stmt = stmt.bindparams(search_path=config.db_schema)
-                connection.execute(stmt)
+            stmt = text("SET search_path to :search_path")
+            stmt = stmt.bindparams(search_path=config.db_schema)
+            connection.execute(stmt)
 
     # Overrides SQLConnector.query_config
     def query_config(self, node: ExecutionNode) -> RedshiftQueryConfig:

--- a/src/fides/api/service/connectors/redshift_connector.py
+++ b/src/fides/api/service/connectors/redshift_connector.py
@@ -1,5 +1,7 @@
 from typing import Dict, Union
 from urllib.parse import quote_plus
+import logging
+
 
 from loguru import logger
 from sqlalchemy import text
@@ -76,11 +78,13 @@ class RedshiftConnector(SQLConnector):
     def set_schema(self, connection: Connection) -> None:
         """Sets the search_path for the duration of the session"""
         config = self.secrets_schema(**self.configuration.secrets or {})
+
         if config.db_schema:
             logger.info("Setting Redshift search_path before retrieving data")
-            stmt = text("SET search_path to :search_path")
-            stmt = stmt.bindparams(search_path=config.db_schema)
-            connection.execute(stmt)
+            with suppress_logging():
+                stmt = text("SET search_path to :search_path")
+                stmt = stmt.bindparams(search_path=config.db_schema)
+                connection.execute(stmt)
 
     # Overrides SQLConnector.query_config
     def query_config(self, node: ExecutionNode) -> RedshiftQueryConfig:

--- a/src/fides/api/util/logger.py
+++ b/src/fides/api/util/logger.py
@@ -15,6 +15,7 @@ from loguru import logger
 from loguru._handler import Message
 
 from fides.api.schemas.privacy_request import LogEntry, PrivacyRequestSource
+from fides.api.util.sqlalchemy_filter import SQLAlchemyGeneratedFilter
 from fides.config import CONFIG, FidesConfig
 
 if TYPE_CHECKING:
@@ -159,6 +160,11 @@ def setup(config: FidesConfig) -> None:
     for name in logging.root.manager.loggerDict.keys():
         logging.getLogger(name).handlers = []
         logging.getLogger(name).propagate = True
+
+    # Apply filter to remove generated timing logs
+    sqlalchemy_generated_filter = SQLAlchemyGeneratedFilter()
+    sqlalchemy_engine_logger = logging.getLogger("sqlalchemy.engine.Engine")
+    sqlalchemy_engine_logger.addFilter(sqlalchemy_generated_filter)
 
     handlers = []
 

--- a/src/fides/api/util/sqlalchemy_filter.py
+++ b/src/fides/api/util/sqlalchemy_filter.py
@@ -9,7 +9,7 @@ class SQLAlchemyGeneratedFilter(logging.Filter):
     which typically come from sqlalchemy.engine.Engine when executing cached queries.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # List of substrings to filter out
         self.patterns = [
@@ -18,7 +18,7 @@ class SQLAlchemyGeneratedFilter(logging.Filter):
             "does not support caching",
         ]
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         # Only filter records from sqlalchemy.engine.Engine
         if record.name == "sqlalchemy.engine.Engine":
             message = record.getMessage()

--- a/src/fides/api/util/sqlalchemy_filter.py
+++ b/src/fides/api/util/sqlalchemy_filter.py
@@ -5,20 +5,17 @@ class SQLAlchemyGeneratedFilter(logging.Filter):
     """
     Logging filter that removes SQLAlchemy engine logs containing timing information.
 
-    This filter specifically targets logs containing timing information patterns
-    which typically come from sqlalchemy.engine.Engine when displaying query execution times.
+    This filter specifically targets logs containing error messages from sqlalchemy.engine.Engine
+    which typically come from sqlalchemy.engine.Engine when executing cached queries.
     """
 
     def __init__(self):
         super().__init__()
         # List of substrings to filter out
         self.patterns = [
-            "no key",
             "cached since",
-            "generated in",
             "caching disabled",
             "does not support caching",
-            "unknown",
         ]
 
     def filter(self, record):

--- a/src/fides/api/util/sqlalchemy_filter.py
+++ b/src/fides/api/util/sqlalchemy_filter.py
@@ -1,0 +1,33 @@
+import logging
+
+
+class SQLAlchemyGeneratedFilter(logging.Filter):
+    """
+    Logging filter that removes SQLAlchemy engine logs containing timing information.
+
+    This filter specifically targets logs containing timing information patterns
+    which typically come from sqlalchemy.engine.Engine when displaying query execution times.
+    """
+
+    def __init__(self):
+        super().__init__()
+        # List of substrings to filter out
+        self.patterns = [
+            "no key",
+            "cached since",
+            "generated in",
+            "caching disabled",
+            "does not support caching",
+            "unknown",
+        ]
+
+    def filter(self, record):
+        # Only filter records from sqlalchemy.engine.Engine
+        if record.name == "sqlalchemy.engine.Engine":
+            message = record.getMessage()
+            # Check if any of the patterns exist in the message
+            for pattern in self.patterns:
+                if pattern in message:
+                    return False  # Filter out the log entry
+
+        return True  # Keep all other log entries

--- a/tests/ops/util/test_logger.py
+++ b/tests/ops/util/test_logger.py
@@ -1,10 +1,10 @@
+import logging
 import os
 from datetime import datetime
 
 import pytest
 from loguru import logger
 from loguru._handler import Message
-import logging
 
 from fides.api.schemas.privacy_request import PrivacyRequestSource
 from fides.api.util.cache import get_cache
@@ -16,8 +16,8 @@ from fides.api.util.logger import (
     _log_warning,
     suppress_logging,
 )
-from fides.config import CONFIG
 from fides.api.util.sqlalchemy_filter import SQLAlchemyGeneratedFilter
+from fides.config import CONFIG
 
 
 @pytest.mark.unit
@@ -183,9 +183,15 @@ class TestSQLAlchemyLogger:
         sqlalchemy_logger.addFilter(filter)
 
         # Log messages that should be filtered out
-        sqlalchemy_logger.info("This message was cached since yesterday and should be filtered")
-        sqlalchemy_logger.info("This message indicates caching disabled and should be filtered")
-        sqlalchemy_logger.info("[dialect redshift+psycopg2 does not support caching 0.00016s] {'email': ('atestingemail@email.com',)")
+        sqlalchemy_logger.info(
+            "This message was cached since yesterday and should be filtered"
+        )
+        sqlalchemy_logger.info(
+            "This message indicates caching disabled and should be filtered"
+        )
+        sqlalchemy_logger.info(
+            "[dialect redshift+psycopg2 does not support caching 0.00016s] {'email': ('atestingemail@email.com',)"
+        )
 
         # Log a message that should not be filtered out
         sqlalchemy_logger.info("This message should appear in logs")
@@ -194,9 +200,24 @@ class TestSQLAlchemyLogger:
         log_messages = loguru_caplog.text
         assert "This message should appear in logs" in log_messages
         assert "This message contains no key and should be filtered" not in log_messages
-        assert "This message was cached since yesterday and should be filtered" not in log_messages
-        assert "This message was generated in 0.001s and should be filtered" not in log_messages
-        assert "This message indicates caching disabled and should be filtered" not in log_messages
-        assert "This message does not support caching and should be filtered" not in log_messages
+        assert (
+            "This message was cached since yesterday and should be filtered"
+            not in log_messages
+        )
+        assert (
+            "This message was generated in 0.001s and should be filtered"
+            not in log_messages
+        )
+        assert (
+            "This message indicates caching disabled and should be filtered"
+            not in log_messages
+        )
+        assert (
+            "This message does not support caching and should be filtered"
+            not in log_messages
+        )
         assert "This message is unknown and should be filtered" not in log_messages
-        assert "[dialect redshift+psycopg2 does not support caching 0.00016s] {'email': ('atestingemail@email.com',)" not in log_messages
+        assert (
+            "[dialect redshift+psycopg2 does not support caching 0.00016s] {'email': ('atestingemail@email.com',)"
+            not in log_messages
+        )


### PR DESCRIPTION
Closes LJ#462

### Description Of Changes

We were having trouble with unwanted SQLAlchemy log message related to caching issues with third-party dialects like Redshift.

### Code Changes

* Implemented a SQLAlchemyGeneratedFilter in sqlalchemy_filter.py to filter out specific unwanted log messages from the SQLAlchemy engine. (Thanks @galvana )
* Added a new test suite TestSQLAlchemyLogger in test_logger.py to ensure that the SQLAlchemyGeneratedFilter correctly filters out unwanted log messages.

### Steps to Confirm

1. Run the test suite in test_logger.py to ensure that the SQLAlchemyGeneratedFilter is correctly filtering out the specified log messages.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
