### PR TITLE
Treat non-applicable keys as defaults which then get overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Cleaning up test fixtures [#6008](https://github.com/ethyca/fides/pull/6008)
 
 ### Fixed
+- Fixed GTM integration to properly handle duplicate notice keys [#6090](https://github.com/ethyca/fides/pull/6090)
 - Fix Special-purpose only vendors not correctly encoded in TC string [#6086](https://github.com/ethyca/fides/pull/6086)
 
 ## [2.60.0](https://github.com/ethyca/fides/compare/2.59.2...2.60.0)

--- a/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
@@ -6,6 +6,7 @@ import Script from "next/script";
 import React, { useEffect, useMemo, useState } from "react";
 
 import { PREVIEW_CONTAINER_ID } from "~/constants";
+import { useGetVendorReportQuery } from "~/features/plus/plus.slice";
 import { TranslationWithLanguageName } from "~/features/privacy-experience/form/helpers";
 import {
   buildBaseConfig,
@@ -21,7 +22,6 @@ import {
   PrivacyNoticeResponse,
 } from "~/types/api";
 
-import { useFeatures } from "../../common/features";
 import { COMPONENT_MAP } from "../constants";
 
 declare global {
@@ -83,7 +83,18 @@ const Preview = ({
     ComponentType.TCF_OVERLAY,
   ].includes(values.component);
 
-  const { systemsCount } = useFeatures();
+  /**
+   * Selects the number of vendors
+   * By using the paginated getVendorReport endpoint, we can get the total number of vendors
+   */
+  const { data: vendorReport } = useGetVendorReportQuery({
+    pageIndex: 1,
+    pageSize: 1,
+  });
+  const vendorCount = useMemo(
+    () => vendorReport?.total || 0,
+    [vendorReport?.total],
+  );
 
   useEffect(() => {
     if (
@@ -192,7 +203,7 @@ const Preview = ({
         ? values.layer1_button_options
         : Layer1ButtonOption.OPT_IN_OPT_OUT;
     updatedConfig.options.preventDismissal = !values.dismissable;
-    updatedConfig.experience.vendor_count = systemsCount;
+    updatedConfig.experience.vendor_count = vendorCount;
     updatedConfig.experience.experience_config.component = values.component;
     // reinitialize fides.js each time the form changes
     window.Fides.init(updatedConfig);
@@ -207,7 +218,7 @@ const Preview = ({
     baseConfig,
     allPrivacyNotices,
     isPreviewAvailable,
-    systemsCount,
+    vendorCount,
     fidesScriptLoaded,
     previewMode,
     values.privacy_notice_ids,


### PR DESCRIPTION
Closes [LJ-720]

### Description Of Changes

Fixed a bug in the GTM integration where duplicate notice keys between `privacy_notices` and `non_applicable_privacy_notices` arrays caused incorrect consent values to be reported. The issue occurred when custom notices were created with the same `notice_key` as existing notices.

### Code Changes

**GTM Integration Fix**: Completely reworked how consent values are initialized and applied in the GTM integration. Now it:
  1. First initializes an empty consent values object
  2. Sets defaults for non-applicable notices when needed
  3. Then overrides with actual consent values from configured notices
  4. This ensures proper prioritization even when duplicate keys exist

**Admin UI Preview Improvement**: Replaced the use of `systemsCount` with a proper `vendorCount` that is fetched from the vendor report API, providing more accurate vendor count data for previews.

### Steps to Confirm
1. Create a custom notice with the same `notice_key` as an existing notice (e.g., "data_sales_and_sharing")
2. Add only the custom notice to an experience
3. Verify the GTM integration correctly reports the consent value from the custom notice, not the default from the non-applicable notice
4. Confirm no duplicates appear in the `dataLayer` object

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-720]: https://ethyca.atlassian.net/browse/LJ-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ