### PR TITLE
conditionally add TCF to the Experience type options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Cleaning up test fixtures [#6008](https://github.com/ethyca/fides/pull/6008)
 
 ### Fixed
+- TCF overlay option no longer an Experience option when TCF is not enabled [#6091](https://github.com/ethyca/fides/pull/6091)
 - Fixed GTM integration to properly handle duplicate notice keys [#6090](https://github.com/ethyca/fides/pull/6090)
 - Fix Special-purpose only vendors not correctly encoded in TC string [#6086](https://github.com/ethyca/fides/pull/6086)
 

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -11,7 +11,7 @@ import {
 } from "fidesui";
 import { useFormikContext } from "formik";
 import { useRouter } from "next/router";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import { CustomSwitch, CustomTextInput } from "~/features/common/form/inputs";

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -11,7 +11,7 @@ import {
 } from "fidesui";
 import { useFormikContext } from "formik";
 import { useRouter } from "next/router";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import { CustomSwitch, CustomTextInput } from "~/features/common/form/inputs";
@@ -23,6 +23,7 @@ import {
   selectLocationsRegulations,
   useGetLocationsRegulationsQuery,
 } from "~/features/locations/locations.slice";
+import { selectHealth as selectPlusHealth } from "~/features/plus/plus.slice";
 import { getSelectedRegionIds } from "~/features/privacy-experience/form/helpers";
 import { selectAllLanguages } from "~/features/privacy-experience/language.slice";
 import {
@@ -53,14 +54,11 @@ import { ControlledSelect } from "../common/form/ControlledSelect";
 import { useGetConfigurationSettingsQuery } from "../config-settings/config-settings.slice";
 import { TCFConfigSelect } from "./form/TCFConfigSelect";
 
-const componentTypeOptions: SelectProps["options"] = [
+// Base component type options without TCF overlay
+const baseComponentTypeOptions: SelectProps["options"] = [
   {
     label: "Banner and modal",
     value: ComponentType.BANNER_AND_MODAL,
-  },
-  {
-    label: "TCF overlay",
-    value: ComponentType.TCF_OVERLAY,
   },
   {
     label: "Modal",
@@ -75,6 +73,12 @@ const componentTypeOptions: SelectProps["options"] = [
     value: ComponentType.HEADLESS,
   },
 ];
+
+// The TCF overlay option to insert
+const tcfOverlayOption = {
+  label: "TCF overlay",
+  value: ComponentType.TCF_OVERLAY,
+};
 
 const tcfRejectAllMechanismOptions: SelectProps["options"] = [
   {
@@ -155,6 +159,7 @@ export const PrivacyExperienceForm = ({
   const router = useRouter();
   const isPublisherRestrictionsFlagEnabled =
     useFeatures()?.flags?.publisherRestrictions;
+  const plusHealth = useAppSelector(selectPlusHealth);
 
   const {
     values,
@@ -313,7 +318,17 @@ export const PrivacyExperienceForm = ({
       <ControlledSelect
         name="component"
         id="component"
-        options={componentTypeOptions}
+        options={useMemo(() => {
+          if (plusHealth?.tcf?.enabled) {
+            // Insert TCF overlay as the second item
+            return [
+              baseComponentTypeOptions[0],
+              tcfOverlayOption,
+              ...baseComponentTypeOptions.slice(1),
+            ];
+          }
+          return baseComponentTypeOptions;
+        }, [plusHealth])}
         label="Experience type"
         layout="stacked"
         disabled={!!initialValues.component}


### PR DESCRIPTION
Closes [LJ-723]

### Description Of Changes

Added conditional logic to display TCF overlay option in the Privacy Experience component type dropdown. The option now appears as the second item in the list only when TCF is enabled in the plusHealth configuration.

### Code Changes

* Created separate constants for base component options and the TCF overlay option
* Added a dependency on the plusHealth selector to access TCF enabled state
* Implemented a useMemo to conditionally insert the TCF overlay option when applicable
* Fixed array ordering to ensure TCF overlay appears as the second item

### Steps to Confirm
1. Verify TCF overlay option appears in the component dropdown when fidesplus `FIDES__CONSENT__TCF_ENABLED=true` env variable is set
2. Verify TCF overlay option is not visible when fidesplus `FIDES__CONSENT__TCF_ENABLED=false` env variable is set or when it's removed entirely
3. Confirm the TCF overlay option appears as the second item in the dropdown list

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-723]: https://ethyca.atlassian.net/browse/LJ-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ