### PR TITLE
handle errors in redux queries

### DIFF
--- a/clients/admin-ui/src/app/store.ts
+++ b/clients/admin-ui/src/app/store.ts
@@ -144,7 +144,7 @@ export const rtkQueryErrorLogger: Middleware = () => (next) => (action) => {
       status: "error",
       title: payload?.status ?? "An error occured",
       description:
-        action.error.message ??
+        action?.error?.message ??
         payload?.error ??
         "An error occurred please check the console for more detail.",
     });

--- a/clients/admin-ui/src/app/store.ts
+++ b/clients/admin-ui/src/app/store.ts
@@ -2,9 +2,14 @@ import {
   AnyAction,
   combineReducers,
   configureStore,
+  isRejectedWithValue,
+  Middleware,
+  MiddlewareAPI,
+  MiddlewareApiConfig,
   StateFromReducersMapObject,
 } from "@reduxjs/toolkit";
 import { setupListeners } from "@reduxjs/toolkit/query/react";
+import { createStandaloneToast } from "fidesui";
 import {
   FLUSH,
   PAUSE,
@@ -23,6 +28,7 @@ import { baseApi } from "~/features/common/api.slice";
 import { featuresSlice } from "~/features/common/features";
 import { healthApi } from "~/features/common/health.slice";
 import { dirtyFormsSlice } from "~/features/common/hooks/dirty-forms.slice";
+import { DEFAULT_TOAST_PARAMS } from "~/features/common/toast";
 import { configWizardSlice } from "~/features/config-wizard/config-wizard.slice";
 import { connectionTypeSlice } from "~/features/connection-type";
 import { tcfConfigSlice } from "~/features/consent-settings/tcf/tcf-config.slice";
@@ -44,6 +50,10 @@ import { dictSuggestionsSlice } from "~/features/system/dictionary-form/dict-sug
 import { taxonomySlice } from "~/features/taxonomy";
 import { datasetTestSlice } from "~/features/test-datasets";
 import { userManagementSlice } from "~/features/user-management";
+
+const { toast } = createStandaloneToast({
+  defaultOptions: DEFAULT_TOAST_PARAMS,
+});
 
 /**
  * To prevent the "redux-perist failed to create sync storage. falling back to noop storage"
@@ -129,6 +139,19 @@ const persistConfig = {
 };
 
 export const persistedReducer = persistReducer(persistConfig, rootReducer);
+export const rtkQueryErrorLogger: Middleware = () => (next) => (action) => {
+  if (isRejectedWithValue(action)) {
+    const payload = action.payload as any;
+    toast({
+      status: "error",
+      title: payload?.status ?? "An error occured",
+      description: payload?.error,
+    });
+    // eslint-disable-next-line no-console
+    console.error(action.payload);
+  }
+  next(action);
+};
 
 export const makeStore = (
   preloadedState?: Parameters<typeof persistedReducer>[0],
@@ -140,7 +163,7 @@ export const makeStore = (
         serializableCheck: {
           ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
         },
-      }).concat(baseApi.middleware, healthApi.middleware),
+      }).concat(baseApi.middleware, healthApi.middleware, rtkQueryErrorLogger),
     devTools: true,
     preloadedState,
   });

--- a/clients/admin-ui/src/app/store.ts
+++ b/clients/admin-ui/src/app/store.ts
@@ -4,8 +4,6 @@ import {
   configureStore,
   isRejectedWithValue,
   Middleware,
-  MiddlewareAPI,
-  MiddlewareApiConfig,
   StateFromReducersMapObject,
 } from "@reduxjs/toolkit";
 import { setupListeners } from "@reduxjs/toolkit/query/react";

--- a/clients/admin-ui/src/app/store.ts
+++ b/clients/admin-ui/src/app/store.ts
@@ -139,7 +139,7 @@ const persistConfig = {
 export const persistedReducer = persistReducer(persistConfig, rootReducer);
 export const rtkQueryErrorLogger: Middleware = () => (next) => (action) => {
   if (isRejectedWithValue(action)) {
-    const payload = action.payload as any;
+    const payload = action?.payload as any;
     toast({
       status: "error",
       title: payload?.status ?? "An error occured",

--- a/clients/admin-ui/src/app/store.ts
+++ b/clients/admin-ui/src/app/store.ts
@@ -143,7 +143,10 @@ export const rtkQueryErrorLogger: Middleware = () => (next) => (action) => {
     toast({
       status: "error",
       title: payload?.status ?? "An error occured",
-      description: payload?.error,
+      description:
+        action.error.message ??
+        payload?.error ??
+        "An error occurred please check the console for more detail.",
     });
     // eslint-disable-next-line no-console
     console.error(action.payload);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6af85aa4-9943-43a8-ae2a-e1c5bcea624c)

### Description Of Changes

Adds a middleware that turns redux query failures into toasts. Should we consider pushing to an error page?

### Code Changes

- Redux error middleware.

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
