### PR TITLE
Fides 1926

### DIFF
--- a/src/fides/api/service/connectors/query_configs/mysql_query_config.py
+++ b/src/fides/api/service/connectors/query_configs/mysql_query_config.py
@@ -1,4 +1,7 @@
-from typing import List
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy import text
+from sqlalchemy.sql.elements import TextClause
 
 from fides.api.service.connectors.query_configs.query_config import SQLQueryConfig
 
@@ -7,6 +10,13 @@ class MySQLQueryConfig(SQLQueryConfig):
     """
     Generates SQL valid for MySQL
     """
+
+    def generate_raw_query(
+        self, field_list: List[str], filters: Dict[str, List[Any]]
+    ) -> Optional[TextClause]:
+        formatted_field_list = [f"`{field}`" for field in field_list]
+        raw_query = super().generate_raw_query(formatted_field_list, filters)
+        return raw_query  # type: ignore
 
     def get_formatted_query_string(
         self,

--- a/tests/ops/service/connectors/test_mysql_query_config.py
+++ b/tests/ops/service/connectors/test_mysql_query_config.py
@@ -1,0 +1,34 @@
+import pytest
+from sqlalchemy import text
+
+
+@pytest.mark.integration_external
+@pytest.mark.integration_mysql
+class TestMySQLQueryConfig:
+    """
+    Verify that the generate_query method of MySQLQueryConfig correctly adjusts
+    the columns to process keywords.
+    """
+
+    def test_generate_raw_query_with_backticks(self, connection_config_mysql):
+        """Test that column names are properly wrapped in backticks in the generated query."""
+
+        # Test with regular column names
+        field_list = ["id", "email", "name"]
+        filters = {"email": ["test@example.com"]}
+
+        query = connection_config_mysql.generate_raw_query(field_list, filters)
+        assert isinstance(query, text)
+        assert "`id`" in str(query)
+        assert "`email`" in str(query)
+        assert "`name`" in str(query)
+
+        # Test with reserved keyword as column name
+        field_list = ["select", "from", "where"]
+        filters = {"select": ["test"]}
+
+        query = connection_config_mysql.generate_raw_query(field_list, filters)
+        assert isinstance(query, text)
+        assert "`select`" in str(query)
+        assert "`from`" in str(query)
+        assert "`where`" in str(query)


### PR DESCRIPTION
Closes FIDES-1926

### Description Of Changes
Allows MySQL integration to complete Helios D&D steps for a DB using keywords in columns.

### Code Changes

* MySQLConfig updates generate_raw_query to add backticks to fields

### Steps to Confirm

1.  A MySQL DB using reserved keywords as column names can successfully complete Helios D&D

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
