### PR TITLE
fix border width to respect variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed GTM integration to properly handle duplicate notice keys [#6090](https://github.com/ethyca/fides/pull/6090)
 - Fix Special-purpose only vendors not correctly encoded in TC string [#6086](https://github.com/ethyca/fides/pull/6086)
 - Suppressing SQLAlchemy logging related to caching queries [#6089](https://github.com/ethyca/fides/pull/6089)
+- FidesJS css variable `--fides-overlay-container-border-width` now applies to banner (only applied to modal before) [#6097](https://github.com/ethyca/fides/pull/6097) https://github.com/ethyca/fides/labels/high-risk
 
 ## [2.60.0](https://github.com/ethyca/fides/compare/2.59.2...2.60.0)
 

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -1111,7 +1111,8 @@ button.fides-banner-button.fides-menu-item:not([aria-pressed="true"]):hover {
   div#fides-banner {
     width: 75%;
     border-radius: var(--fides-overlay-component-border-radius);
-    border: 1px solid var(--fides-overlay-primary-color);
+    border: var(--fides-overlay-container-border-width) solid
+      var(--fides-overlay-primary-color);
   }
 
   div#fides-banner-container.fides-banner-bottom {


### PR DESCRIPTION
Closes [LJ-725]

### Description Of Changes

When the `--fides-overlay-container-border-width` css variable is set, it doesn't apply to the banner as expected, only the modal.

It does however get applied to the mobile version of the banner, which is where the bug stems from. When the responsive version of the banner was updated, this width was hard coded instead of using the variable.

Fixing this should be low risk in the ecosystem of custom css because if anyone is trying to use that variable to adjust the width, they are likely not being successful and using something _hard coded_ and that will STILL APPLY when this variable gets added to the responsive styling, but it has been marked as https://github.com/ethyca/fides/labels/high-risk in the change log just in case.

### Code Changes

* replaced hard coded value with variable

### Steps to Confirm

1. Enable the default Canada Banner + Modal experience in Admin UI
2. Visit the privacy center demo page `/fides-js-demo.html?geolocation=ca-qu`
3. Border should be normal 1px
4. Paste the following CSS into the `<head>` of `fides-js-demo.html`
```
<style>
  :root {
    --fides-overlay-container-border-width: 10px;
  }
</style>
```
5. Reload the demo page `/fides-js-demo.html?geolocation=ca-qu`
6. Both the banner and the modal should respect the new variable value

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [x] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-725]: https://ethyca.atlassian.net/browse/LJ-725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ