### PR TITLE
release 2.60.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed details requirements in AWS SES setup [#6047](https://github.com/ethyca/fides/pull/6047)
 - Addressed some performance issues with Experience configuration previews [#6055](https://github.com/ethyca/fides/pull/6055)
 - Fixed icon sizing in request manager table [#6079](https://github.com/ethyca/fides/pull/6079)
+- Fixed GCP SQL connection to support ip_type [#6065](https://github.com/ethyca/fides/pull/6065)
 
 ## [2.59.2](https://github.com/ethyca/fides/compare/2.59.1...2.59.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 
 
+### Fixed
+- Fix Special-purpose only vendors not correctly encoded in TC string [#6086](https://github.com/ethyca/fides/pull/6086)
+
 ## [2.60.0](https://github.com/ethyca/fides/compare/2.59.2...2.60.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Added
 - Migrate `Cookies` resources to `Asset` resources of type `Cookie` [#5776](https://github.com/ethyca/fides/pull/5776) https://github.com/ethyca/fides/labels/db-migration https://github.com/ethyca/fides/labels/high-risk
-- Added support for selecting TCF Publisher Override configuration when configuring Privacy Experience [#6033](https://github.com/ethyca/fides/pull/6033)
+- Added support for selecting TCF Publisher Override configuration when configuring Privacy Experience (behind beta feature flag) [#6033](https://github.com/ethyca/fides/pull/6033)
 - Added Google Cloud Storage as a storage option [#6006](https://github.com/ethyca/fides/pull/6006)
 - Update the Datahub Permissions section to include required permissions from Datahub [#6052](https://github.com/ethyca/fides/pull/6052)
 - Added assumed role arn capabilities to aws Storage [#6027](https://github.com/ethyca/fides/pull/6027)
@@ -41,7 +41,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added ability to "restore" ignored assets in action center [#6080](https://github.com/ethyca/fides/pull/6080)
 
 ### Changed
-- Changed how TCF Publisher Overrides gets configured in consent settings [#6013](https://github.com/ethyca/fides/pull/6013)
+- Changed how TCF Publisher Overrides gets configured in consent settings (behind beta feature flag) [#6013](https://github.com/ethyca/fides/pull/6013)
 - Frontend now do not generate `key` when creating a Website Monitor [#6041](https://github.com/ethyca/fides/pull/6041)
 - Integrations manage modals now are cappable of showing a small description [#6037](https://github.com/ethyca/fides/pull/6037)
 - UI now allows assigning of non-consent-category data uses to system assets [#6049](https://github.com/ethyca/fides/pull/6049)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Addressed some performance issues with Experience configuration previews [#6055](https://github.com/ethyca/fides/pull/6055)
 - Fixed icon sizing in request manager table [#6079](https://github.com/ethyca/fides/pull/6079)
 - Fixed GCP SQL connection to support ip_type [#6065](https://github.com/ethyca/fides/pull/6065)
+- TCF overlay option no longer an Experience option when TCF is not enabled [#6091](https://github.com/ethyca/fides/pull/6091)
 
 ## [2.59.2](https://github.com/ethyca/fides/compare/2.59.1...2.59.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 
 ### Fixed
+- Fixed GTM integration to properly handle duplicate notice keys [#6090](https://github.com/ethyca/fides/pull/6090)
 - Fix Special-purpose only vendors not correctly encoded in TC string [#6086](https://github.com/ethyca/fides/pull/6086)
 
 ## [2.60.0](https://github.com/ethyca/fides/compare/2.59.2...2.60.0)

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/TestConnectionMessage.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/TestConnectionMessage.tsx
@@ -3,21 +3,24 @@ import React from "react";
 
 type TestConnectionMessageProps = {
   status: "success" | "error";
+  failure_reason?: string;
 };
 
-const TestConnectionMessage = ({ status }: TestConnectionMessageProps) => (
-  <>
-    {status === "success" && (
-      <Text data-testid="toast-success-msg">
-        Connection test was successful
-      </Text>
-    )}
-    {status === "error" && (
-      <Text data-testid="toast-error-msg">
-        Test failed: please check your connection info
-      </Text>
-    )}
-  </>
-);
+const TestConnectionMessage = ({
+  status,
+  failure_reason,
+}: TestConnectionMessageProps) => {
+  if (status === "error") {
+    let description = "Connection test failed.";
+    if (failure_reason) {
+      description += ` ${failure_reason}`;
+    }
+    return <Text data-testid="toast-error-msg">{description}</Text>;
+  }
+
+  return (
+    <Text data-testid="toast-success-msg">Connection test was successful</Text>
+  );
+};
 
 export default TestConnectionMessage;

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -381,7 +381,12 @@ export const ConnectorParameters = ({
     const toastParams = {
       ...DEFAULT_TOAST_PARAMS,
       status,
-      description: <TestConnectionMessage status={status} />,
+      description: (
+        <TestConnectionMessage
+          status={status}
+          failure_reason={value.data?.failure_reason}
+        />
+      ),
     };
     toast(toastParams);
   };

--- a/clients/admin-ui/src/features/datastore-connections/useTestConnection.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/useTestConnection.tsx
@@ -32,7 +32,11 @@ const useTestConnection = (
     } else if (result.data?.test_status === "succeeded") {
       toast({ status: "success", description: "Connected successfully" });
     } else if (result.data?.test_status === "failed") {
-      toast({ status: "warning", description: "Connection test failed" });
+      let description = "Connection test failed.";
+      if (result.data?.failure_reason) {
+        description += ` ${result.data?.failure_reason}`;
+      }
+      toast({ status: "warning", description });
     }
   };
 

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -48,6 +48,7 @@ import {
   SupportedLanguage,
 } from "~/types/api";
 
+import { useFeatures } from "../common/features";
 import { ControlledSelect } from "../common/form/ControlledSelect";
 import { useGetConfigurationSettingsQuery } from "../config-settings/config-settings.slice";
 import { TCFConfigSelect } from "./form/TCFConfigSelect";
@@ -152,6 +153,8 @@ export const PrivacyExperienceForm = ({
   onCreateTranslation: (lang: SupportedLanguage) => ExperienceTranslation;
 }) => {
   const router = useRouter();
+  const isPublisherRestrictionsFlagEnabled =
+    useFeatures()?.flags?.publisherRestrictions;
 
   const {
     values,
@@ -318,14 +321,18 @@ export const PrivacyExperienceForm = ({
         isRequired
       />
       <Collapse
-        in={values.component === ComponentType.TCF_OVERLAY}
+        in={
+          values.component === ComponentType.TCF_OVERLAY &&
+          isPublisherRestrictionsFlagEnabled
+        }
         animateOpacity
       >
-        {values.component === ComponentType.TCF_OVERLAY && (
-          <TCFConfigSelect
-            overridesEnabled={appConfig?.consent?.override_vendor_purposes}
-          />
-        )}
+        {values.component === ComponentType.TCF_OVERLAY &&
+          isPublisherRestrictionsFlagEnabled && (
+            <TCFConfigSelect
+              overridesEnabled={appConfig?.consent?.override_vendor_purposes}
+            />
+          )}
       </Collapse>
       <Collapse
         in={values.component === ComponentType.TCF_OVERLAY}

--- a/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
@@ -6,6 +6,7 @@ import Script from "next/script";
 import React, { useEffect, useMemo, useState } from "react";
 
 import { PREVIEW_CONTAINER_ID } from "~/constants";
+import { useGetVendorReportQuery } from "~/features/plus/plus.slice";
 import { TranslationWithLanguageName } from "~/features/privacy-experience/form/helpers";
 import {
   buildBaseConfig,
@@ -21,7 +22,6 @@ import {
   PrivacyNoticeResponse,
 } from "~/types/api";
 
-import { useFeatures } from "../../common/features";
 import { COMPONENT_MAP } from "../constants";
 
 declare global {
@@ -83,7 +83,18 @@ const Preview = ({
     ComponentType.TCF_OVERLAY,
   ].includes(values.component);
 
-  const { systemsCount } = useFeatures();
+  /**
+   * Selects the number of vendors
+   * By using the paginated getVendorReport endpoint, we can get the total number of vendors
+   */
+  const { data: vendorReport } = useGetVendorReportQuery({
+    pageIndex: 1,
+    pageSize: 1,
+  });
+  const vendorCount = useMemo(
+    () => vendorReport?.total || 0,
+    [vendorReport?.total],
+  );
 
   useEffect(() => {
     if (
@@ -192,7 +203,7 @@ const Preview = ({
         ? values.layer1_button_options
         : Layer1ButtonOption.OPT_IN_OPT_OUT;
     updatedConfig.options.preventDismissal = !values.dismissable;
-    updatedConfig.experience.vendor_count = systemsCount;
+    updatedConfig.experience.vendor_count = vendorCount;
     updatedConfig.experience.experience_config.component = values.component;
     // reinitialize fides.js each time the form changes
     window.Fides.init(updatedConfig);
@@ -207,7 +218,7 @@ const Preview = ({
     baseConfig,
     allPrivacyNotices,
     isPreviewAvailable,
-    systemsCount,
+    vendorCount,
     fidesScriptLoaded,
     previewMode,
     values.privacy_notice_ids,

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -41,5 +41,11 @@
     "development": true,
     "test": true,
     "production": false
+  },
+  "publisherRestrictions": {
+    "description": "TCF publisher restrictions",
+    "development": true,
+    "test": true,
+    "production": false
   }
 }

--- a/clients/admin-ui/src/types/api/index.ts
+++ b/clients/admin-ui/src/types/api/index.ts
@@ -208,6 +208,7 @@ export type { GenerateRequestPayload } from "./models/GenerateRequestPayload";
 export type { GenerateResponse } from "./models/GenerateResponse";
 export { GenerateTypes } from "./models/GenerateTypes";
 export type { GetRegistrationStatusResponse } from "./models/GetRegistrationStatusResponse";
+export type { GoogleCloudSQLIPType } from "./models/GoogleCloudSQLIPType";
 export type { GoogleCloudSQLMySQLDocsSchema } from "./models/GoogleCloudSQLMySQLDocsSchema";
 export type { GoogleCloudSQLPostgresDocsSchema } from "./models/GoogleCloudSQLPostgresDocsSchema";
 export type { GPPApplicationConfig } from "./models/GPPApplicationConfig";

--- a/clients/admin-ui/src/types/api/models/GoogleCloudSQLIPType.ts
+++ b/clients/admin-ui/src/types/api/models/GoogleCloudSQLIPType.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * IP type of a Google Cloud SQL instance.
+ */
+export enum GoogleCloudSQLIPType {
+  PUBLIC = "public",
+  PRIVATE = "private",
+  PRIVATE_SERVICE_CONNECT = "psc",
+}

--- a/clients/admin-ui/src/types/api/models/GoogleCloudSQLMySQLDocsSchema.ts
+++ b/clients/admin-ui/src/types/api/models/GoogleCloudSQLMySQLDocsSchema.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds } from "./fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds";
+import type { GoogleCloudSQLIPType } from "./GoogleCloudSQLIPType";
 
 /**
  * Google Cloud SQL MySQL Secrets Schema for API Docs
@@ -21,4 +22,8 @@ export type GoogleCloudSQLMySQLDocsSchema = {
    * The contents of the key file that contains authentication credentials for a service account in GCP.
    */
   keyfile_creds: fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds;
+  /**
+   * Specify the IP Address type required for the database (defaults to public).
+   */
+  ip_type?: GoogleCloudSQLIPType | null;
 };

--- a/clients/admin-ui/src/types/api/models/GoogleCloudSQLPostgresDocsSchema.ts
+++ b/clients/admin-ui/src/types/api/models/GoogleCloudSQLPostgresDocsSchema.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds } from "./fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds";
+import type { GoogleCloudSQLIPType } from "./GoogleCloudSQLIPType";
 
 /**
  * Google Cloud SQL Postgres Secrets Schema for API Docs
@@ -25,4 +26,8 @@ export type GoogleCloudSQLPostgresDocsSchema = {
    * The contents of the key file that contains authentication credentials for a service account in GCP.
    */
   keyfile_creds: fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds;
+  /**
+   * Specify the IP Address type required for the database (defaults to public).
+   */
+  ip_type?: GoogleCloudSQLIPType | null;
 };

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -303,6 +303,16 @@ regular/embedded mode with `fides_embed`, overriding the user's language with
 FidesJS with the initial configuration, but taking into account any new overrides
 such as the `fides_overrides` global or the query params.
 
+#### Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `config`? | `any` |
+
+#### Returns
+
+`Promise`\<`void`\>
+
 #### Example
 
 Disable FidesJS initialization and trigger manually instead:
@@ -336,16 +346,6 @@ Configure overrides after loading Fides.js tag.
   </script>
 </head>
 ```
-
-#### Parameters
-
-| Parameter | Type |
-| ------ | ------ |
-| `config`? | `any` |
-
-#### Returns
-
-`Promise`\<`void`\>
 
 ***
 

--- a/clients/fides-js/src/fides-preview.ts
+++ b/clients/fides-js/src/fides-preview.ts
@@ -34,8 +34,6 @@ function cleanup(): void {
     // Remove the script from DOM to ensure complete cleanup
     currentScript.remove();
     currentScript = null;
-    // @ts-ignore - We know this is safe as we're cleaning up the global
-    window.Fides = null;
   }
   currentMode = null;
 }

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -32,6 +32,33 @@ export interface GtmOptions {
   flag_type?: GtmFlagType;
 }
 
+/**
+ * Composes consent values based on the consent mechanism and flag type
+ */
+const composeConsent = (
+  consent: Record<string, boolean>,
+  privacyNotices: any[] | undefined,
+  flagType: GtmFlagType,
+): Record<string, boolean | string> => {
+  const consentValues: Record<string, boolean | string> = {};
+
+  Object.entries(consent).forEach(([key, value]) => {
+    if (privacyNotices && flagType === GtmFlagType.CONSENT_MECHANISM) {
+      const relevantNotice = privacyNotices.find(
+        (notice) => notice.notice_key === key,
+      );
+      consentValues[key] = transformConsentToFidesUserPreference(
+        value,
+        relevantNotice?.consent_mechanism,
+      );
+    } else {
+      consentValues[key] = value;
+    }
+  });
+
+  return consentValues;
+};
+
 // Helper function to push the Fides variable to the GTM data layer from a FidesEvent
 const pushFidesVariableToGTM = (
   fidesEvent: {
@@ -51,23 +78,12 @@ const pushFidesVariableToGTM = (
       nonApplicableFlagMode = GtmNonApplicableFlagMode.OMIT,
     flag_type: flagType = GtmFlagType.BOOLEAN,
   } = options ?? {};
-  const consentValues: FidesVariable["consent"] = JSON.parse(
-    JSON.stringify(consent),
-  );
+  const consentValues: FidesVariable["consent"] = {};
   const privacyNotices = window.Fides?.experience?.privacy_notices;
   const nonApplicablePrivacyNotices =
     window.Fides?.experience?.non_applicable_privacy_notices;
 
-  if (privacyNotices && flagType === GtmFlagType.CONSENT_MECHANISM) {
-    Object.entries(consent).forEach(([key, value]) => {
-      consentValues[key] = transformConsentToFidesUserPreference(
-        value,
-        privacyNotices.find((notice) => notice.notice_key === key)
-          ?.consent_mechanism,
-      );
-    });
-  }
-
+  // First set defaults for non-applicable privacy notices if needed
   if (
     nonApplicableFlagMode === GtmNonApplicableFlagMode.INCLUDE &&
     nonApplicablePrivacyNotices
@@ -76,6 +92,14 @@ const pushFidesVariableToGTM = (
       consentValues[key] =
         flagType === GtmFlagType.CONSENT_MECHANISM ? "not_applicable" : true;
     });
+  }
+
+  // Then override with actual consent values
+  if (consent) {
+    Object.assign(
+      consentValues,
+      composeConsent(consent, privacyNotices, flagType),
+    );
   }
 
   // Construct the Fides variable that will be pushed to GTM

--- a/clients/privacy-center/types/api/index.ts
+++ b/clients/privacy-center/types/api/index.ts
@@ -182,6 +182,7 @@ export type { GenerateRequestPayload } from "./models/GenerateRequestPayload";
 export type { GenerateResponse } from "./models/GenerateResponse";
 export { GenerateTypes } from "./models/GenerateTypes";
 export type { GetRegistrationStatusResponse } from "./models/GetRegistrationStatusResponse";
+export type { GoogleCloudSQLIPType } from "./models/GoogleCloudSQLIPType";
 export type { GoogleCloudSQLMySQLDocsSchema } from "./models/GoogleCloudSQLMySQLDocsSchema";
 export type { GoogleCloudSQLPostgresDocsSchema } from "./models/GoogleCloudSQLPostgresDocsSchema";
 export type { GPPApplicationConfig } from "./models/GPPApplicationConfig";

--- a/clients/privacy-center/types/api/models/GoogleCloudSQLIPType.ts
+++ b/clients/privacy-center/types/api/models/GoogleCloudSQLIPType.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * IP type of a Google Cloud SQL instance.
+ */
+export enum GoogleCloudSQLIPType {
+  PUBLIC = "public",
+  PRIVATE = "private",
+  PRIVATE_SERVICE_CONNECT = "psc",
+}

--- a/clients/privacy-center/types/api/models/GoogleCloudSQLMySQLDocsSchema.ts
+++ b/clients/privacy-center/types/api/models/GoogleCloudSQLMySQLDocsSchema.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds } from "./fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds";
+import type { GoogleCloudSQLIPType } from "./GoogleCloudSQLIPType";
 
 /**
  * Google Cloud SQL MySQL Secrets Schema for API Docs
@@ -21,4 +22,8 @@ export type GoogleCloudSQLMySQLDocsSchema = {
    * The contents of the key file that contains authentication credentials for a service account in GCP.
    */
   keyfile_creds: fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_mysql__KeyfileCreds;
+  /**
+   * Specify the IP Address type required for the database (defaults to public).
+   */
+  ip_type?: GoogleCloudSQLIPType | null;
 };

--- a/clients/privacy-center/types/api/models/GoogleCloudSQLPostgresDocsSchema.ts
+++ b/clients/privacy-center/types/api/models/GoogleCloudSQLPostgresDocsSchema.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds } from "./fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds";
+import type { GoogleCloudSQLIPType } from "./GoogleCloudSQLIPType";
 
 /**
  * Google Cloud SQL Postgres Secrets Schema for API Docs
@@ -25,4 +26,8 @@ export type GoogleCloudSQLPostgresDocsSchema = {
    * The contents of the key file that contains authentication credentials for a service account in GCP.
    */
   keyfile_creds: fides__api__schemas__connection_configuration__connection_secrets_google_cloud_sql_postgres__KeyfileCreds;
+  /**
+   * Specify the IP Address type required for the database (defaults to public).
+   */
+  ip_type?: GoogleCloudSQLIPType | null;
 };

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_google_cloud_sql_mysql.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_google_cloud_sql_mysql.py
@@ -8,6 +8,9 @@ from fides.api.schemas.base_class import NoValidationSchema
 from fides.api.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
 
 
 class KeyfileCreds(BaseModel):
@@ -51,6 +54,11 @@ class GoogleCloudSQLMySQLSchema(ConnectionConfigSecretsSchema):
         json_schema_extra={"sensitive": True},
         description="The contents of the key file that contains authentication credentials for a service account in GCP.",
     )
+    ip_type: Optional[GoogleCloudSQLIPType] = Field(
+        default=None,
+        title="IP type",
+        description="Specify the IP Address type required for your database (defaults to public). See the Google Cloud documentation for more information about connection options: https://cloud.google.com/sql/docs/postgres/connect-overview",
+    )
 
     _required_components: ClassVar[List[str]] = [
         "db_iam_user",
@@ -65,6 +73,15 @@ class GoogleCloudSQLMySQLSchema(ConnectionConfigSecretsSchema):
         if isinstance(v, str):
             v = json.loads(v)
         return KeyfileCreds.model_validate(v)
+
+    @field_validator("ip_type", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v: Optional[str]) -> Optional[GoogleCloudSQLIPType]:
+        if v == "":
+            return None
+        if v is not None:
+            return GoogleCloudSQLIPType(v)
+        return v
 
 
 class GoogleCloudSQLMySQLDocsSchema(GoogleCloudSQLMySQLSchema, NoValidationSchema):

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_google_cloud_sql_postgres.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_google_cloud_sql_postgres.py
@@ -8,6 +8,9 @@ from fides.api.schemas.base_class import NoValidationSchema
 from fides.api.schemas.connection_configuration.connection_secrets import (
     ConnectionConfigSecretsSchema,
 )
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
 
 
 class KeyfileCreds(BaseModel):
@@ -57,6 +60,11 @@ class GoogleCloudSQLPostgresSchema(ConnectionConfigSecretsSchema):
         json_schema_extra={"sensitive": True},
         description="The contents of the key file that contains authentication credentials for a service account in GCP.",
     )
+    ip_type: Optional[GoogleCloudSQLIPType] = Field(
+        default=None,
+        title="IP type",
+        description="Specify the IP Address type required for your database (defaults to public). See the Google Cloud documentation for more information about connection options: https://cloud.google.com/sql/docs/postgres/connect-overview",
+    )
 
     _required_components: ClassVar[List[str]] = [
         "db_iam_user",
@@ -70,6 +78,15 @@ class GoogleCloudSQLPostgresSchema(ConnectionConfigSecretsSchema):
         if isinstance(v, str):
             v = json.loads(v)
         return KeyfileCreds.model_validate(v)
+
+    @field_validator("ip_type", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v: Optional[str]) -> Optional[GoogleCloudSQLIPType]:
+        if v == "":
+            return None
+        if v is not None:
+            return GoogleCloudSQLIPType(v)
+        return v
 
 
 class GoogleCloudSQLPostgresDocsSchema(

--- a/src/fides/api/schemas/connection_configuration/enums/google_cloud_sql_ip_type.py
+++ b/src/fides/api/schemas/connection_configuration/enums/google_cloud_sql_ip_type.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class GoogleCloudSQLIPType(str, Enum):
+    """Enum for Google Cloud SQL IP types"""
+
+    public = "public"
+    private = "private"
+    private_service_connect = "psc"

--- a/src/fides/api/service/connectors/google_cloud_mysql_connector.py
+++ b/src/fides/api/service/connectors/google_cloud_mysql_connector.py
@@ -8,6 +8,9 @@ from sqlalchemy.engine import Engine, LegacyCursorResult, create_engine  # type:
 from fides.api.schemas.connection_configuration.connection_secrets_google_cloud_sql_mysql import (
     GoogleCloudSQLMySQLSchema,
 )
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
 from fides.api.service.connectors.sql_connector import SQLConnector
 from fides.api.util.collection_util import Row
 from fides.config import get_config
@@ -37,6 +40,7 @@ class GoogleCloudSQLMySQLConnector(SQLConnector):
             conn: pymysql.connections.Connection = connector.connect(
                 config.instance_connection_name,
                 "pymysql",
+                ip_type=config.ip_type or GoogleCloudSQLIPType.public,
                 user=config.db_iam_user,
                 db=config.dbname,
                 enable_iam_auth=True,

--- a/src/fides/api/service/connectors/google_cloud_postgres_connector.py
+++ b/src/fides/api/service/connectors/google_cloud_postgres_connector.py
@@ -16,6 +16,9 @@ from fides.api.graph.execution import ExecutionNode
 from fides.api.schemas.connection_configuration.connection_secrets_google_cloud_sql_postgres import (
     GoogleCloudSQLPostgresSchema,
 )
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
 from fides.api.service.connectors.query_configs.google_cloud_postgres_query_config import (
     GoogleCloudSQLPostgresQueryConfig,
 )
@@ -53,6 +56,7 @@ class GoogleCloudSQLPostgresConnector(SQLConnector):
             conn: pg8000.dbapi.Connection = connector.connect(
                 config.instance_connection_name,
                 "pg8000",
+                ip_type=config.ip_type or GoogleCloudSQLIPType.public,
                 user=config.db_iam_user,
                 db=config.dbname or self.default_db_name,
                 enable_iam_auth=True,

--- a/src/fides/api/service/connectors/sql_connector.py
+++ b/src/fides/api/service/connectors/sql_connector.py
@@ -119,8 +119,8 @@ class SQLConnector(BaseConnector[Engine]):
             )
         except ClientResponseError as e:
             raise ConnectionException(f"Connection error: {e.message}")
-        except Exception:
-            raise ConnectionException("Connection error.")
+        except Exception as exc:
+            raise ConnectionException(f"Connection error: {exc}")
 
         return ConnectionTestStatus.succeeded
 

--- a/src/fides/api/tasks/storage.py
+++ b/src/fides/api/tasks/storage.py
@@ -134,7 +134,9 @@ def upload_to_s3(  # pylint: disable=R0913
         s3_client = get_s3_client(
             auth_method,
             storage_secrets,
-            assume_role_arn=CONFIG.credentials["storage"].get("aws_s3_assume_role_arn"),
+            assume_role_arn=CONFIG.credentials.get(  # pylint: disable=no-member
+                "storage", {}
+            ).get("aws_s3_assume_role_arn"),
         )
 
         # handles file chunking

--- a/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_connection_template_endpoints.py
@@ -1150,6 +1150,12 @@ class TestGetConnectionSecretSchema:
 
         assert resp.json() == {
             "definitions": {
+                "GoogleCloudSQLIPType": {
+                    "description": "Enum for Google " "Cloud SQL IP types",
+                    "enum": ["public", "private", "psc"],
+                    "title": "GoogleCloudSQLIPType",
+                    "type": "string",
+                },
                 "KeyfileCreds": {
                     "description": "Schema that holds Google "
                     "Cloud SQL for Postgres "
@@ -1190,7 +1196,7 @@ class TestGetConnectionSecretSchema:
                     "required": ["project_id", "universe_domain"],
                     "title": "KeyfileCreds",
                     "type": "object",
-                }
+                },
             },
             "description": "Schema to validate the secrets needed to connect to Google "
             "Cloud SQL for Postgres",
@@ -1223,6 +1229,11 @@ class TestGetConnectionSecretSchema:
                     "account in GCP.",
                     "sensitive": True,
                     "title": "Keyfile creds",
+                },
+                "ip_type": {
+                    "allOf": [{"$ref": "#/definitions/GoogleCloudSQLIPType"}],
+                    "description": "Specify the IP Address type required for your database (defaults to public). See the Google Cloud documentation for more information about connection options: https://cloud.google.com/sql/docs/postgres/connect-overview",
+                    "title": "IP type",
                 },
             },
             "required": ["db_iam_user", "instance_connection_name", "keyfile_creds"],

--- a/tests/ops/schemas/connection_configuration/test_connection_secrets_google_cloud_sql_mysql.py
+++ b/tests/ops/schemas/connection_configuration/test_connection_secrets_google_cloud_sql_mysql.py
@@ -1,0 +1,30 @@
+import pytest
+
+from fides.api.schemas.connection_configuration.connection_secrets_google_cloud_sql_mysql import (
+    GoogleCloudSQLMySQLSchema,
+)
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
+
+
+class TestGoogleCloudSQLMySQLSchema:
+    """Tests for GoogleCloudSQLMySQLSchema validation and field validators"""
+
+    def test_empty_string_to_none_validator(self):
+        """Test the empty_string_to_none validator for ip_type field"""
+        # Test with empty string
+        result = GoogleCloudSQLMySQLSchema.empty_string_to_none("")
+        assert result is None
+
+        # Test with None value
+        result = GoogleCloudSQLMySQLSchema.empty_string_to_none(None)
+        assert result is None
+
+        # Test with valid IP type
+        result = GoogleCloudSQLMySQLSchema.empty_string_to_none("public")
+        assert result == GoogleCloudSQLIPType.public
+
+        # Test with invalid IP type
+        with pytest.raises(ValueError):
+            GoogleCloudSQLMySQLSchema.empty_string_to_none("INVALID_TYPE")

--- a/tests/ops/schemas/connection_configuration/test_connection_secrets_google_cloud_sql_postgres.py
+++ b/tests/ops/schemas/connection_configuration/test_connection_secrets_google_cloud_sql_postgres.py
@@ -1,0 +1,30 @@
+import pytest
+
+from fides.api.schemas.connection_configuration.connection_secrets_google_cloud_sql_postgres import (
+    GoogleCloudSQLPostgresSchema,
+)
+from fides.api.schemas.connection_configuration.enums.google_cloud_sql_ip_type import (
+    GoogleCloudSQLIPType,
+)
+
+
+class TestGoogleCloudSQLPostgresSchema:
+    """Tests for GoogleCloudSQLPostgresSchema validation and field validators"""
+
+    def test_empty_string_to_none_validator(self):
+        """Test the empty_string_to_none validator for ip_type field"""
+        # Test with empty string
+        result = GoogleCloudSQLPostgresSchema.empty_string_to_none("")
+        assert result is None
+
+        # Test with None value
+        result = GoogleCloudSQLPostgresSchema.empty_string_to_none(None)
+        assert result is None
+
+        # Test with valid IP type
+        result = GoogleCloudSQLPostgresSchema.empty_string_to_none("public")
+        assert result == GoogleCloudSQLIPType.public
+
+        # Test with invalid IP type
+        with pytest.raises(ValueError):
+            GoogleCloudSQLPostgresSchema.empty_string_to_none("INVALID_TYPE")

--- a/tests/ops/service/connectors/test_google_cloud_mysql_connector.py
+++ b/tests/ops/service/connectors/test_google_cloud_mysql_connector.py
@@ -1,0 +1,150 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.cloud.sql.connector import Connector
+from google.oauth2.service_account import Credentials
+from sqlalchemy.engine import Engine
+
+from fides.api.schemas.connection_configuration.enums import (
+    google_cloud_sql_ip_type as ip_type,
+)
+from fides.api.service.connectors.google_cloud_mysql_connector import (
+    GoogleCloudSQLMySQLConnector,
+)
+
+
+@pytest.fixture
+def mock_config():
+    return {
+        "db_iam_user": "test-user",
+        "instance_connection_name": "project:region:instance",
+        "dbname": "test-db",
+        "keyfile_creds": {
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "key123",
+            "private_key": (
+                "-----BEGIN PRIVATE KEY-----\n"
+                "MIIE...sample...key\n"
+                "-----END PRIVATE KEY-----\n"
+            ),
+            "client_email": "test@test-project.iam.gserviceaccount.com",
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": (
+                "https://www.googleapis.com/oauth2/v1/certs"
+            ),
+            "client_x509_cert_url": (
+                "https://www.googleapis.com/robot/v1/metadata/x509/"
+                "test.iam.gserviceaccount.com"
+            ),
+            "universe_domain": "googleapis.com",
+        },
+        "ip_type": ip_type.GoogleCloudSQLIPType.private,
+    }
+
+
+@pytest.fixture
+def connector(mock_config):
+    connector = GoogleCloudSQLMySQLConnector(
+        configuration=MagicMock(secrets=mock_config)
+    )
+    return connector
+
+
+@patch(
+    "fides.api.service.connectors.google_cloud_mysql_connector"
+    ".service_account.Credentials",
+    autospec=True,
+)
+@patch(
+    "fides.api.service.connectors.google_cloud_mysql_connector" ".Connector",
+    autospec=True,
+)
+@patch(
+    "fides.api.service.connectors.google_cloud_mysql_connector" ".create_engine",
+    autospec=True,
+)
+class TestGoogleCloudSQLMySQLConnectorCreateClient:
+    """Tests for GoogleCloudSQLMySQLConnector.create_client method."""
+
+    def test_success(
+        self,
+        mock_create_engine,
+        mock_connector_class,
+        mock_credentials_class,
+        connector,
+        mock_config,
+    ):
+        """Test successful creation of a database client."""
+        mock_credentials = MagicMock(spec=Credentials)
+        mock_credentials_class.from_service_account_info.return_value = mock_credentials
+        mock_connector_instance = MagicMock(spec=Connector)
+        mock_connector_class.return_value = mock_connector_instance
+        mock_db_connection = MagicMock()
+        mock_connector_instance.connect.return_value = mock_db_connection
+        mock_engine = MagicMock(spec=Engine)
+        mock_create_engine.return_value = mock_engine
+
+        result = connector.create_client()
+
+        mock_credentials_class.from_service_account_info.assert_called_once_with(
+            dict(mock_config["keyfile_creds"])
+        )
+        mock_connector_class.assert_called_once_with(credentials=mock_credentials)
+
+        # Get the creator function that was passed to create_engine
+        creator_fn = mock_create_engine.call_args[1]["creator"]
+        # Call the creator function to verify it calls connect with right params
+        creator_fn()
+        mock_connector_instance.connect.assert_called_once_with(
+            mock_config["instance_connection_name"],
+            "pymysql",
+            ip_type=mock_config["ip_type"],
+            user=mock_config["db_iam_user"],
+            db=mock_config["dbname"],
+            enable_iam_auth=True,
+        )
+
+        mock_create_engine.assert_called_once()
+        assert mock_create_engine.call_args[0][0] == "mysql+pymysql://"
+        assert result == mock_engine
+
+    def test_with_default_ip_type(
+        self,
+        mock_create_engine,
+        mock_connector_class,
+        mock_credentials_class,
+        connector,
+        mock_config,
+    ):
+        """Test client creation with default IP type."""
+        # Remove ip_type from config
+        connector.configuration.secrets["ip_type"] = None
+
+        mock_credentials_class.from_service_account_info.return_value = MagicMock(
+            spec=Credentials
+        )
+        mock_connector_instance = MagicMock(spec=Connector)
+        mock_connector_class.return_value = mock_connector_instance
+        mock_db_connection = MagicMock()
+        mock_connector_instance.connect.return_value = mock_db_connection
+        mock_engine = MagicMock(spec=Engine)
+        mock_create_engine.return_value = mock_engine
+
+        result = connector.create_client()
+
+        # Get and call the creator function
+        creator_fn = mock_create_engine.call_args[1]["creator"]
+        creator_fn()
+        # Verify connect was called with default IP type
+        mock_connector_instance.connect.assert_called_once_with(
+            mock_config["instance_connection_name"],
+            "pymysql",
+            ip_type=ip_type.GoogleCloudSQLIPType.public,  # Default IP type
+            user=mock_config["db_iam_user"],
+            db=mock_config["dbname"],
+            enable_iam_auth=True,
+        )
+        assert result == mock_engine

--- a/tests/ops/service/connectors/test_google_cloud_postgres_connector.py
+++ b/tests/ops/service/connectors/test_google_cloud_postgres_connector.py
@@ -1,0 +1,189 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.cloud.sql.connector import Connector
+from google.oauth2.service_account import Credentials
+from sqlalchemy.engine import Engine
+
+from fides.api.schemas.connection_configuration.enums import (
+    google_cloud_sql_ip_type as ip_type,
+)
+from fides.api.service.connectors.google_cloud_postgres_connector import (
+    GoogleCloudSQLPostgresConnector,
+)
+
+
+@pytest.fixture
+def mock_config():
+    return {
+        "db_iam_user": "test-user",
+        "instance_connection_name": "project:region:instance",
+        "dbname": "test-db",
+        "db_schema": "public",
+        "keyfile_creds": {
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "key123",
+            "private_key": (
+                "-----BEGIN PRIVATE KEY-----\n"
+                "MIIE...sample...key\n"
+                "-----END PRIVATE KEY-----\n"
+            ),
+            "client_email": "test@test-project.iam.gserviceaccount.com",
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": (
+                "https://www.googleapis.com/oauth2/v1/certs"
+            ),
+            "client_x509_cert_url": (
+                "https://www.googleapis.com/robot/v1/metadata/x509/"
+                "test.iam.gserviceaccount.com"
+            ),
+            "universe_domain": "googleapis.com",
+        },
+        "ip_type": ip_type.GoogleCloudSQLIPType.private,
+    }
+
+
+@pytest.fixture
+def connector(mock_config):
+    connector = GoogleCloudSQLPostgresConnector(
+        configuration=MagicMock(secrets=mock_config)
+    )
+    return connector
+
+
+@patch(
+    "fides.api.service.connectors.google_cloud_postgres_connector"
+    ".service_account.Credentials",
+    autospec=True,
+)
+@patch(
+    "fides.api.service.connectors.google_cloud_postgres_connector" ".Connector",
+    autospec=True,
+)
+@patch(
+    "fides.api.service.connectors.google_cloud_postgres_connector" ".create_engine",
+    autospec=True,
+)
+class TestGoogleCloudSQLPostgresConnectorCreateClient:
+    """Tests for GoogleCloudSQLPostgresConnector.create_client method."""
+
+    def test_success(
+        self,
+        mock_create_engine,
+        mock_connector_class,
+        mock_credentials_class,
+        connector,
+        mock_config,
+    ):
+        """Test successful creation of a database client."""
+        mock_credentials = MagicMock(spec=Credentials)
+        mock_credentials_class.from_service_account_info.return_value = mock_credentials
+        mock_connector_instance = MagicMock(spec=Connector)
+        mock_connector_class.return_value = mock_connector_instance
+        mock_db_connection = MagicMock()
+        mock_connector_instance.connect.return_value = mock_db_connection
+        mock_engine = MagicMock(spec=Engine)
+        mock_create_engine.return_value = mock_engine
+
+        result = connector.create_client()
+
+        mock_credentials_class.from_service_account_info.assert_called_once_with(
+            dict(mock_config["keyfile_creds"])
+        )
+        mock_connector_class.assert_called_once_with(credentials=mock_credentials)
+
+        # Get the creator function that was passed to create_engine
+        creator_fn = mock_create_engine.call_args[1]["creator"]
+        # Call the creator function to verify it calls connect with right params
+        creator_fn()
+        mock_connector_instance.connect.assert_called_once_with(
+            mock_config["instance_connection_name"],
+            "pg8000",
+            ip_type=mock_config["ip_type"],
+            user=mock_config["db_iam_user"],
+            db=mock_config["dbname"],
+            enable_iam_auth=True,
+        )
+
+        mock_create_engine.assert_called_once()
+        assert mock_create_engine.call_args[0][0] == "postgresql+pg8000://"
+        assert result == mock_engine
+
+    def test_with_default_db(
+        self,
+        mock_create_engine,
+        mock_connector_class,
+        mock_credentials_class,
+        connector,
+        mock_config,
+    ):
+        """Test client creation with default database name."""
+        # Modify config to remove dbname
+        connector.configuration.secrets["dbname"] = None
+
+        mock_credentials_class.from_service_account_info.return_value = MagicMock(
+            spec=Credentials
+        )
+        mock_connector_instance = MagicMock(spec=Connector)
+        mock_connector_class.return_value = mock_connector_instance
+        mock_db_connection = MagicMock()
+        mock_connector_instance.connect.return_value = mock_db_connection
+        mock_engine = MagicMock(spec=Engine)
+        mock_create_engine.return_value = mock_engine
+
+        result = connector.create_client()
+
+        # Get and call the creator function
+        creator_fn = mock_create_engine.call_args[1]["creator"]
+        creator_fn()
+        # Verify connect was called with default database
+        mock_connector_instance.connect.assert_called_once_with(
+            mock_config["instance_connection_name"],
+            "pg8000",
+            ip_type=mock_config["ip_type"],
+            user=mock_config["db_iam_user"],
+            db="postgres",
+            enable_iam_auth=True,
+        )
+        assert result == mock_engine
+
+    def test_with_default_ip_type(
+        self,
+        mock_create_engine,
+        mock_connector_class,
+        mock_credentials_class,
+        connector,
+        mock_config,
+    ):
+        """Test client creation with default IP type."""
+        # Remove ip_type from config
+        connector.configuration.secrets["ip_type"] = None
+
+        mock_credentials_class.from_service_account_info.return_value = MagicMock(
+            spec=Credentials
+        )
+        mock_connector_instance = MagicMock(spec=Connector)
+        mock_connector_class.return_value = mock_connector_instance
+        mock_db_connection = MagicMock()
+        mock_connector_instance.connect.return_value = mock_db_connection
+        mock_engine = MagicMock(spec=Engine)
+        mock_create_engine.return_value = mock_engine
+
+        result = connector.create_client()
+
+        # Get and call the creator function
+        creator_fn = mock_create_engine.call_args[1]["creator"]
+        creator_fn()
+        # Verify connect was called with default IP type
+        mock_connector_instance.connect.assert_called_once_with(
+            mock_config["instance_connection_name"],
+            "pg8000",
+            ip_type=ip_type.GoogleCloudSQLIPType.public,  # Default IP type
+            user=mock_config["db_iam_user"],
+            db=mock_config["dbname"],
+            enable_iam_auth=True,
+        )
+        assert result == mock_engine


### PR DESCRIPTION
- **empty commit to start release 2.60.0**
- **LJ-700: Fix Special-purpose only vendors not correctly encoded in TC string (#6086)**
- **Safely navigate environment variables. (#6087)**
- **fix experience errors when window.Fides isn't present (#6084)**
- **Add feature flag for TCF Publisher Restriction configs (#6088)**
- **HA-631 - Add support for ip_type for GCP SQL connection (#6065)**
- **conditionally add TCF to the Experience type options (#6091)**
- **Treat non-applicable keys as defaults which then get overridden (#6090)**

Closes [<issue>]

### Description Of Changes

_Write some things here about the changes and any potential caveats_

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
