### PR TITLE
Allow OT migration to auto write to fides preferences api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added Recorded URL to Consent Report [#6077](https://github.com/ethyca/fides/pull/6077)
 - Added ConnectionType.okta, OktaSchema, OktaConnector as support for the Okta Monitor [#6078](https://github.com/ethyca/fides/pull/6078)
 
+### Changed
+- Abstract OT consent migration logic, allow write to Fides preferences api [#6099](https://github.com/ethyca/fides/pull/6099)
+
 ### Developer Experience
 - Cleaning up test fixtures [#6008](https://github.com/ethyca/fides/pull/6008)
 

--- a/clients/fides-js/src/lib/consent-migration/index.ts
+++ b/clients/fides-js/src/lib/consent-migration/index.ts
@@ -1,0 +1,85 @@
+import {
+  ConsentMethod,
+  FidesInitOptionsOverrides,
+  NoticeConsent,
+} from "../consent-types";
+import { OneTrustProvider } from "./onetrust";
+import {
+  ConsentMigrationProvider,
+  ConsentMigrationProviderName,
+} from "./types";
+
+/**
+ * Registry of consent migration providers
+ */
+const providers: Map<ConsentMigrationProviderName, ConsentMigrationProvider> =
+  new Map();
+
+/**
+ * Register a new consent migration provider
+ * @param name Unique identifier for the provider
+ * @param provider Implementation of ConsentMigrationProvider
+ */
+export function registerProvider(
+  name: ConsentMigrationProviderName,
+  provider: ConsentMigrationProvider,
+) {
+  providers.set(name, provider);
+}
+
+/**
+ * Register default providers
+ */
+export function registerDefaultProviders(
+  optionsOverrides: Partial<FidesInitOptionsOverrides>,
+) {
+  // Register OneTrust provider if configured
+  if (optionsOverrides.otFidesMapping) {
+    registerProvider(
+      ConsentMigrationProviderName.ONETRUST,
+      new OneTrustProvider(),
+    );
+  }
+}
+
+/**
+ * Try to read consent from all registered providers
+ * @param optionsOverrides Configuration options containing provider mappings
+ * @returns Object containing the mapped consent and migration method from the first successful provider
+ */
+export function readConsentFromAnyProvider(
+  optionsOverrides: Partial<FidesInitOptionsOverrides>,
+): { consent: NoticeConsent | undefined; method: ConsentMethod | undefined } {
+  // Try each registered provider
+  let foundConsent: NoticeConsent | undefined;
+  let foundProviderName: ConsentMigrationProviderName | undefined;
+
+  // Find the first provider that can provide consent
+  Array.from(providers).some(([name, provider]) => {
+    const cookieValue = provider.getConsentCookie();
+    if (!cookieValue) {
+      fidesDebugger(`No consent cookie found for provider: ${name}`);
+      return false;
+    }
+
+    // Let the provider determine if it can handle these options
+    const consent = provider.convertToFidesConsent(
+      cookieValue,
+      optionsOverrides,
+    );
+    if (consent) {
+      foundConsent = consent;
+      foundProviderName = name;
+      return true;
+    }
+    return false;
+  });
+
+  if (!foundProviderName) {
+    return { consent: undefined, method: undefined };
+  }
+
+  // Get the provider using the Map's get method
+  const provider = providers.get(foundProviderName);
+  return { consent: foundConsent, method: provider!.migrationMethod };
+}

--- a/clients/fides-js/src/lib/consent-migration/onetrust.ts
+++ b/clients/fides-js/src/lib/consent-migration/onetrust.ts
@@ -1,0 +1,92 @@
+import {
+  ConsentMethod,
+  FidesInitOptionsOverrides,
+  NoticeConsent,
+  OtToFidesConsentMapping,
+} from "../consent-types";
+import { getCookieByName } from "../cookie";
+import { ConsentMigrationProvider } from "./types";
+
+/**
+ * OneTrust implementation of consent migration
+ */
+export class OneTrustProvider implements ConsentMigrationProvider {
+  readonly cookieName = "OptanonConsent";
+
+  readonly migrationMethod = ConsentMethod.OT_MIGRATION;
+
+  getConsentCookie(): string | undefined {
+    return getCookieByName(this.cookieName);
+  }
+
+  convertToFidesConsent(
+    cookieValue: string,
+    options: Partial<FidesInitOptionsOverrides>,
+  ): NoticeConsent | undefined {
+    // Only proceed if we have a mapping
+    if (!options.otFidesMapping) {
+      return undefined;
+    }
+
+    try {
+      const decodedString = decodeURIComponent(options.otFidesMapping);
+      const strippedString = decodedString.replace(/^'|'$/g, "");
+      const mappingParsed: OtToFidesConsentMapping = JSON.parse(strippedString);
+      const fidesConsent = this.parseCookieValue(cookieValue, mappingParsed);
+
+      if (fidesConsent) {
+        fidesDebugger(
+          `Fides consent built based on OneTrust consent: ${JSON.stringify(fidesConsent)}`,
+        );
+      }
+      return fidesConsent;
+    } catch (e) {
+      fidesDebugger(
+        `Failed to map OneTrust consent to Fides consent due to: ${e}`,
+      );
+      return undefined;
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private parseCookieValue(
+    cookieValue: string,
+    mapping: OtToFidesConsentMapping,
+  ): NoticeConsent | undefined {
+    // Initialize an empty Fides consent object
+    const fidesConsent: NoticeConsent = {};
+
+    // Extract the groups parameter
+    const groupsMatch = cookieValue.match(/groups=([^&]*)/);
+
+    if (!groupsMatch || !groupsMatch[1]) {
+      return fidesConsent; // Return empty object if groups not found
+    }
+
+    // Parse the groups string into an object
+    const groupsStr = groupsMatch[1];
+    const groupPairs = groupsStr.split(",");
+
+    // Process only the categories found in the cookie
+    groupPairs.forEach((pair) => {
+      const [category, consentValue] = pair.split(":");
+
+      // Skip if category is not in our mapping
+      if (!mapping[category]) {
+        return;
+      }
+
+      // Add the corresponding Fides keys to the result with appropriate consent value
+      mapping[category].forEach((fidesKey: string) => {
+        const isConsented = consentValue === "1";
+
+        // Set fides key based on current consent
+        if (fidesConsent[fidesKey] === undefined) {
+          fidesConsent[fidesKey] = isConsented;
+        }
+      });
+    });
+
+    return fidesConsent;
+  }
+}

--- a/clients/fides-js/src/lib/consent-migration/types.ts
+++ b/clients/fides-js/src/lib/consent-migration/types.ts
@@ -1,0 +1,42 @@
+import {
+  ConsentMethod,
+  FidesInitOptionsOverrides,
+  NoticeConsent,
+} from "../consent-types";
+
+/**
+ * Enum of supported consent migration providers
+ */
+export enum ConsentMigrationProviderName {
+  ONETRUST = "onetrust",
+}
+
+/**
+ * Interface for consent migration providers
+ */
+export interface ConsentMigrationProvider {
+  /**
+   * The name of the cookie used by this provider
+   */
+  readonly cookieName: string;
+
+  /**
+   * The consent method used by this provider
+   */
+  readonly migrationMethod: ConsentMethod;
+
+  /**
+   * Get the consent cookie value for this provider
+   */
+  getConsentCookie(): string | undefined;
+
+  /**
+   * Convert the provider's consent format to Fides consent format
+   * @param cookieValue The raw cookie value
+   * @param options The Fides options containing provider-specific mappings
+   */
+  convertToFidesConsent(
+    cookieValue: string,
+    options: Partial<FidesInitOptionsOverrides>,
+  ): NoticeConsent | undefined;
+}

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -782,6 +782,7 @@ export enum ConsentMethod {
   GPC = "gpc",
   INDIVIDUAL_NOTICE = "individual_notice",
   ACKNOWLEDGE = "acknowledge",
+  OT_MIGRATION = "ot_migration",
 }
 
 export type PrivacyPreferencesRequest = {

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -8,7 +8,6 @@ import {
   FidesCookie,
   LegacyConsentConfig,
   NoticeConsent,
-  OtToFidesConsentMapping,
   PrivacyExperience,
   PrivacyNoticeWithPreference,
   SaveConsentPreference,
@@ -25,7 +24,6 @@ import type { TcfOtherConsent, TcfSavePreferences } from "./tcf/types";
  * Save the cookie under the name "fides_consent" for 365 days
  */
 export const CONSENT_COOKIE_NAME = "fides_consent";
-export const OT_CONSENT_COOKIE_NAME = "OptanonConsent";
 export const CONSENT_COOKIE_MAX_AGE_DAYS = 365;
 
 /**
@@ -98,64 +96,6 @@ export const makeFidesCookie = (consent?: NoticeConsent): FidesCookie => {
  */
 export const getCookieByName = (cookieName: string): string | undefined =>
   cookies.get(cookieName);
-
-/**
- * Retrieve and decode OneTrust consent cookie
- */
-export const getOTConsentCookie = (): string | undefined => {
-  const cookieString = getCookieByName(OT_CONSENT_COOKIE_NAME);
-  if (!cookieString) {
-    return undefined;
-  }
-  return cookieString;
-};
-
-/**
- * Translates OneTrust cookie consent to Fides consent format
- * @param {string} otCookieValue - Value of the OptanonConsent cookie
- * @param {Object} otToFidesMapping - Object mapping OT categories to arrays of Fides keys
- * @returns {NoticeConsent} - Fides consent object
- */
-export const otCookieToFidesConsent = (
-  otCookieValue: string,
-  otToFidesMapping: OtToFidesConsentMapping,
-): NoticeConsent => {
-  // Initialize an empty Fides consent object
-  const fidesConsent: NoticeConsent = {};
-
-  // Extract the groups parameter
-  const groupsMatch = otCookieValue.match(/groups=([^&]*)/);
-
-  if (!groupsMatch || !groupsMatch[1]) {
-    return fidesConsent; // Return empty object if groups not found
-  }
-
-  // Parse the groups string into an object
-  const groupsStr = groupsMatch[1];
-  const groupPairs = groupsStr.split(",");
-
-  // Process only the categories found in the cookie
-  groupPairs.forEach((pair) => {
-    const [category, consentValue] = pair.split(":");
-
-    // Skip if category is not in our mapping
-    if (!otToFidesMapping[category]) {
-      return;
-    }
-
-    // Add the corresponding Fides keys to the result with appropriate consent value
-    otToFidesMapping[category].forEach((fidesKey: string) => {
-      const isConsented = consentValue === "1";
-
-      // Set fides key based on current consent
-      if (fidesConsent[fidesKey] === undefined) {
-        fidesConsent[fidesKey] = isConsented;
-      }
-    });
-  });
-
-  return fidesConsent;
-};
 
 /**
  * Retrieve and decode fides consent cookie

--- a/clients/privacy-center/cypress/e2e/onetrust-migration.cy.ts
+++ b/clients/privacy-center/cypress/e2e/onetrust-migration.cy.ts
@@ -68,22 +68,33 @@ describe("OneTrust to Fides consent migration", () => {
 
         // Verify that the preferences were saved to the API with the correct method
         cy.wait("@patchPrivacyPreference").then((interception) => {
-          expect(interception.request.body).to.deep.include({
-            method: ConsentMethod.OT_MIGRATION,
-            preferences: [
-              {
-                privacy_notice_history_id: "essential",
-                preference: "opt_in",
-              },
-              {
-                privacy_notice_history_id: "analytics_opt_out",
-                preference: "opt_in",
-              },
-              {
-                privacy_notice_history_id: "advertising",
-                preference: "opt_in",
-              },
-            ],
+          // Check method separately since order doesn't matter for that
+          expect(interception.request.body.method).to.equal(
+            ConsentMethod.OT_MIGRATION,
+          );
+
+          // Check that all expected preferences exist, regardless of order
+          const expectedPreferences = [
+            {
+              privacy_notice_history_id: "essential",
+              preference: "opt_in",
+            },
+            {
+              privacy_notice_history_id: "analytics_opt_out",
+              preference: "opt_in",
+            },
+            {
+              privacy_notice_history_id: "advertising",
+              preference: "opt_in",
+            },
+          ];
+
+          const actualPreferences = interception.request.body.preferences;
+          expect(actualPreferences).to.have.length(expectedPreferences.length);
+
+          // For each expected preference, ensure it exists in the actual preferences
+          expectedPreferences.forEach((expected) => {
+            expect(actualPreferences).to.deep.include(expected);
           });
         });
 
@@ -163,22 +174,33 @@ describe("OneTrust to Fides consent migration", () => {
 
       // Verify that the preferences were saved to the API with the correct method
       cy.wait("@patchPrivacyPreference").then((interception) => {
-        expect(interception.request.body).to.deep.include({
-          method: ConsentMethod.OT_MIGRATION,
-          preferences: [
-            {
-              privacy_notice_history_id: "essential",
-              preference: "opt_in",
-            },
-            {
-              privacy_notice_history_id: "analytics_opt_out",
-              preference: "opt_in",
-            },
-            {
-              privacy_notice_history_id: "advertising",
-              preference: "opt_out",
-            },
-          ],
+        // Check method separately since order doesn't matter for that
+        expect(interception.request.body.method).to.equal(
+          ConsentMethod.OT_MIGRATION,
+        );
+
+        // Check that all expected preferences exist, regardless of order
+        const expectedPreferences = [
+          {
+            privacy_notice_history_id: "essential",
+            preference: "opt_in",
+          },
+          {
+            privacy_notice_history_id: "analytics_opt_out",
+            preference: "opt_in",
+          },
+          {
+            privacy_notice_history_id: "advertising",
+            preference: "opt_out",
+          },
+        ];
+
+        const actualPreferences = interception.request.body.preferences;
+        expect(actualPreferences).to.have.length(expectedPreferences.length);
+
+        // For each expected preference, ensure it exists in the actual preferences
+        expectedPreferences.forEach((expected) => {
+          expect(actualPreferences).to.deep.include(expected);
         });
       });
 
@@ -253,22 +275,33 @@ describe("OneTrust to Fides consent migration", () => {
 
       // Verify that the preferences were saved to the API with the correct method
       cy.wait("@patchPrivacyPreference").then((interception) => {
-        expect(interception.request.body).to.deep.include({
-          method: ConsentMethod.OT_MIGRATION,
-          preferences: [
-            {
-              privacy_notice_history_id: "essential",
-              preference: "opt_out",
-            },
-            {
-              privacy_notice_history_id: "analytics_opt_out",
-              preference: "opt_out",
-            },
-            {
-              privacy_notice_history_id: "advertising",
-              preference: "opt_out",
-            },
-          ],
+        // Check method separately since order doesn't matter for that
+        expect(interception.request.body.method).to.equal(
+          ConsentMethod.OT_MIGRATION,
+        );
+
+        // Check that all expected preferences exist, regardless of order
+        const expectedPreferences = [
+          {
+            privacy_notice_history_id: "essential",
+            preference: "opt_out",
+          },
+          {
+            privacy_notice_history_id: "analytics_opt_out",
+            preference: "opt_out",
+          },
+          {
+            privacy_notice_history_id: "advertising",
+            preference: "opt_out",
+          },
+        ];
+
+        const actualPreferences = interception.request.body.preferences;
+        expect(actualPreferences).to.have.length(expectedPreferences.length);
+
+        // For each expected preference, ensure it exists in the actual preferences
+        expectedPreferences.forEach((expected) => {
+          expect(actualPreferences).to.deep.include(expected);
         });
       });
 


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/LJ-722

### Description Of Changes

Allow OT migration to auto write to fides preferences api

### Code Changes

* Adds code to automatically write to consent prefs api when we have OT consent
* Adds test assertions

### Steps to Confirm

1. In fides-js-demo, uncomment out the `window.fides_overrides` declaration. Add a new field, `ot_fides_mapping` that will hold your OT -> fides mappings. 
Example core data: 
```
{
    C0001: ["essential"],
    C0002: ["analytics"],
    C0004: ["advertising", "marketing"],
  }
```
To prep this, you'll need to JSON.stringify, then URL-encode it.
Here's my resulting fides_overrides obj:
```
window.fides_overrides = {
          fides_embed: true,
          ot_fides_mapping: "%7B%22C0001%22%3A%5B%22essential%22%5D%2C%22C0002%22%3A%5B%22analytics%22%5D%2C%22C0004%22%3A%5B%22advertising%22%2C%22marketing%22%5D%7D"
        };
```
3. Manually add the OT cookie to your browser. Below where you set the overrides, you'll need to set:
```
document.cookie =
             "OptanonConsent=isGpcEnabled=0&datestamp=Fri+Mar+07+2025+19%3A51%3A06+GMT%2B0100+(Central+European+Standard+Time)&version=202409.1.0&browserGpcFlag=0&isIABGlobal=false&hosts=&consentId=f9c105b8-48e3-401a-87e9-363ad1f77531&interactionCount=1&isAnonUser=1&landingPath=NotLandingPage&groups=C0003%3A1%2CC0002%3A1%2CC0004%3A1%2CC0005%3A0%2CC0001%3A1%2CC0009%3A0%2CV2STACK42%3A0&AwaitingReconsent=false";
```
Look at the `groups` param. Take that value and url-decode it. These groups map to either 0 (opted out) or 1 (opted in). 
4. Based on our onetrust consent cookie and our mappings, we should see the essential / analytics / advertising / marketing notices opted-in by default, if they exist
5. We should see the `fides_consent` cookie written to the browser and consent vals should reflect the `window.Fides.consent` values. Note that the consent method in the cookie is "ot_migration"
6. We should see new entries in Consent Reporting in Admin UI for the "ot_migration" consent

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
