### PR TITLE
Admin UI Publisher Restriction UX Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fix Special-purpose only vendors not correctly encoded in TC string [#6086](https://github.com/ethyca/fides/pull/6086)
 - Suppressing SQLAlchemy logging related to caching queries [#6089](https://github.com/ethyca/fides/pull/6089)
 - FidesJS css variable `--fides-overlay-container-border-width` now applies to banner (only applied to modal before) [#6097](https://github.com/ethyca/fides/pull/6097) https://github.com/ethyca/fides/labels/high-risk
+- Fixed vendor restriction form validation and input handling [#6101](https://github.com/ethyca/fides/pull/6101)
 
 ## [2.60.0](https://github.com/ethyca/fides/compare/2.59.2...2.60.0)
 

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -30,6 +30,7 @@ import { errorToastParams } from "~/features/common/toast";
 import { formatDate, sentenceCase } from "~/features/common/utils";
 import { RTKResult } from "~/types/errors";
 
+import { InfoTooltip } from "../../InfoTooltip";
 import { FidesCellProps, FidesCellState } from "./FidesCell";
 
 export const DefaultCell = <T,>({
@@ -473,3 +474,22 @@ export const EnableCell = ({
     </>
   );
 };
+
+type TextWithInfoIconHeaderProps<T> = {
+  value: ReactNode;
+  helperText: string;
+} & HeaderContext<T, unknown> &
+  TextProps;
+
+export const TextWithInfoIconHeader = <T,>({
+  value,
+  helperText,
+  ...props
+}: TextWithInfoIconHeaderProps<T>) => (
+  <Flex alignItems="center" gap={1} {...props}>
+    <Text fontSize="xs" lineHeight={9} fontWeight="medium">
+      {value}
+    </Text>
+    <InfoTooltip label={helperText} />
+  </Flex>
+);

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -287,6 +287,7 @@ export const PurposeRestrictionFormModal = ({
                     values.vendor_restriction ===
                     TCFVendorRestriction.RESTRICT_ALL_VENDORS
                   }
+                  tokenSeparators={[",", " "]}
                   onBlur={() => {
                     // Add small delay to allow Ant Select to create tag before validation
                     setTimeout(() => {
@@ -295,19 +296,6 @@ export const PurposeRestrictionFormModal = ({
                       });
                       validateField("vendor_ids");
                     }, 100);
-                  }}
-                  onInputKeyDown={(e) => {
-                    // disable space and comma keys to help avoid confusion on the expected behavior
-                    // eg. prevent attempting to type "123, 1-100" and enter or "123 1-100" and enter
-                    if (
-                      e.key === " " ||
-                      e.code === "Space" ||
-                      e.key === "," ||
-                      e.code === "Comma"
-                    ) {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }
                   }}
                   helperText="Enter IDs (e.g. 123) or ranges (e.g. 1-10) and press enter"
                   isRequired

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -119,9 +119,9 @@ export const PurposeRestrictionFormModal = ({
       value: TCFVendorRestriction.RESTRICT_ALL_VENDORS,
       label:
         VENDOR_RESTRICTION_LABELS[TCFVendorRestriction.RESTRICT_ALL_VENDORS],
-      disabled: existingRestrictions.length > 0,
+      disabled: usedRestrictionTypes.length > 0,
       title:
-        existingRestrictions.length > 0
+        usedRestrictionTypes.length > 0
           ? "Cannot restrict all vendors when other restrictions exist"
           : undefined,
     },

--- a/clients/admin-ui/src/features/consent-settings/tcf/usePurposeRestrictionTableColumns.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/usePurposeRestrictionTableColumns.tsx
@@ -1,8 +1,8 @@
 import { createColumnHelper } from "@tanstack/react-table";
 import { useMemo } from "react";
 
-import { InfoTooltip } from "~/features/common/InfoTooltip";
 import { DefaultCell, DefaultHeaderCell } from "~/features/common/table/v2";
+import { TextWithInfoIconHeader } from "~/features/common/table/v2/cells";
 import { TCFRestrictionType, TCFVendorRestriction } from "~/types/api";
 
 import {
@@ -43,13 +43,9 @@ export const usePurposeRestrictionTableColumns = () => {
           <DefaultCell value={getValue().join(", ") || "All vendors"} />
         ),
         header: (props) => (
-          <DefaultHeaderCell
-            value={
-              <>
-                Vendors{" "}
-                <InfoTooltip label="Specify which vendors the restriction applies to. You can apply restrictions to all vendors, specific vendors by their IDs, or allow only certain vendors while restricting the rest." />
-              </>
-            }
+          <TextWithInfoIconHeader
+            value="Vendors"
+            helperText="Specify which vendors the restriction applies to. You can apply restrictions to all vendors, specific vendors by their IDs, or allow only certain vendors while restricting the rest."
             {...props}
           />
         ),


### PR DESCRIPTION
### Description Of Changes

Improves vendor restriction handling in TCF consent settings and fixes UI components. Updates the vendor restriction form to better handle input validation and adds a reusable text header component with info tooltips.

### Code Changes

* Added new `TextWithInfoIconHeader` component for consistent header styling with tooltips
* Updated vendor restriction form to:
  - Fix validation logic for "Restrict All Vendors" option
  - Add token separators for vendor ID input (to handle commas and spaces correctly)
  - Remove unnecessary key event handling

### Steps to Confirm
1. Make sure Publisher restrictions feature flag is enabled in `/settings/about`
2. Go to Consent settings `/settings/consent` and make sure "Override vendor purposes" is enabled
3. Create a new Configuration
4. Edit a purpose and add a restriction
5. Select a Restriction type and either vendor restriction that is NOT Restrict all vendors
6. Paste the following in to the Vendor IDs field: `100,200,300` and press the return key
7. The field should convert that to individual tags
8. Now try typing in "100 200 300" with spaces and press the return key.
9. Pasting and typing should work for both commas and spaces. Play around with that.
10. Confirm info tooltip appears correctly in Vendors table header

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [x] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
