### PR TITLE
TCF Publisher Restriction support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added the ability to create new TCF Experiences within Admin UI [#6055](https://github.com/ethyca/fides/pull/6055)
 - PostgreSQL connection config now supports SSL Mode [#6068](https://github.com/ethyca/fides/pull/6068)
 - Added ability to "restore" ignored assets in action center [#6080](https://github.com/ethyca/fides/pull/6080)
+- Added support for TCF publisher restrictions in FidesJS [#6102](https://github.com/ethyca/fides/pull/6102)
 
 ### Changed
 - Changed how TCF Publisher Overrides gets configured in consent settings (behind beta feature flag) [#6013](https://github.com/ethyca/fides/pull/6013)

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -160,7 +160,7 @@ export const TcfOverlay = ({
    * The full experience is fetched after the component mounts, so we store it
    * in state to trigger a re-render when it arrives.
    */
-  const [experience, setExperience] = useState<PrivacyExperience>();
+  const [experienceFull, setExperienceFull] = useState<PrivacyExperience>();
 
   useEffect(() => {
     if (!!userlocale && bestLocale !== minExperienceLocale) {
@@ -203,7 +203,7 @@ export const TcfOverlay = ({
           };
           window.Fides.experience.minimal_tcf = false;
 
-          setExperience(fullExperience);
+          setExperienceFull(fullExperience);
         }
       }
     });
@@ -215,11 +215,11 @@ export const TcfOverlay = ({
   const [draftIds, setDraftIds] = useState<EnabledIds>(EMPTY_ENABLED_IDS);
 
   useEffect(() => {
-    if (experience) {
-      loadMessagesFromExperience(i18n, experience, translationOverrides);
+    if (experienceFull) {
+      loadMessagesFromExperience(i18n, experienceFull, translationOverrides);
       if (!userlocale || bestLocale === defaultLocale) {
         // English (default) GVL translations are part of the full experience, so we load them here.
-        loadGVLMessagesFromExperience(i18n, experience);
+        loadGVLMessagesFromExperience(i18n, experienceFull);
       } else {
         setCurrentLocale(bestLocale);
         if (!isGVLLangLoading) {
@@ -228,10 +228,10 @@ export const TcfOverlay = ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [experience]);
+  }, [experienceFull]);
 
   useEffect(() => {
-    if (!experience) {
+    if (!experienceFull) {
       const defaultIds = EMPTY_ENABLED_IDS;
       if (experienceMinimal?.privacy_notices) {
         defaultIds.customPurposesConsent = getEnabledIdsNotice(
@@ -251,7 +251,7 @@ export const TcfOverlay = ({
         tcf_vendor_legitimate_interests: legintVendors = [],
         tcf_system_consents: consentSystems = [],
         tcf_system_legitimate_interests: legintSystems = [],
-      } = experience as PrivacyExperience;
+      } = experienceFull as PrivacyExperience;
 
       // Vendors and systems are the same to the FE, so we combine them here
       setDraftIds({
@@ -266,7 +266,7 @@ export const TcfOverlay = ({
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [experience, experienceMinimal]);
+  }, [experienceFull, experienceMinimal]);
 
   useEffect(() => {
     if (experienceMinimal.vendor_count && setVendorCount) {
@@ -278,7 +278,7 @@ export const TcfOverlay = ({
   // reporting APIs, based on the selected locale
   const privacyExperienceConfigHistoryId: string | undefined = useMemo(() => {
     const experienceConfig =
-      experience?.experience_config || experienceMinimal.experience_config;
+      experienceFull?.experience_config || experienceMinimal.experience_config;
     if (experienceConfig) {
       const bestTranslation = selectBestExperienceConfigTranslation(
         i18n,
@@ -287,7 +287,7 @@ export const TcfOverlay = ({
       return bestTranslation?.privacy_experience_config_history_id;
     }
     return undefined;
-  }, [experienceMinimal, experience, i18n]);
+  }, [experienceMinimal, experienceFull, i18n]);
 
   const customPurposes: (string | undefined)[] = useMemo(() => {
     const notices = privacyNoticesWithBestTranslation.map(
@@ -308,7 +308,7 @@ export const TcfOverlay = ({
   }, [experienceMinimal, gvlTranslations]);
 
   const tcfNoticesServed = constructTCFNoticesServedProps(
-    experience || experienceMinimal,
+    experienceFull || experienceMinimal,
   );
 
   const { servedNoticeHistoryId } = useNoticesServed({
@@ -326,24 +326,24 @@ export const TcfOverlay = ({
     options,
     userGeography: fidesRegionString,
     acknowledgeMode: false,
-    privacyExperience: experience || experienceMinimal,
+    privacyExperience: experienceFull || experienceMinimal,
     tcfNoticesServed,
   });
 
   const handleUpdateAllPreferences = useCallback(
     (consentMethod: ConsentMethod, enabledIds: EnabledIds) => {
-      if (!experience && !experienceMinimal) {
+      if (!experienceFull && !experienceMinimal) {
         return;
       }
       let tcf: TcfSavePreferences;
-      if (!experience && experienceMinimal?.minimal_tcf) {
+      if (!experienceFull && experienceMinimal?.minimal_tcf) {
         tcf = createTcfSavePayloadFromMinExp({
           experience: experienceMinimal,
           enabledIds,
         });
       } else {
         tcf = createTcfSavePayload({
-          experience: experience as PrivacyExperience,
+          experience: experienceFull as PrivacyExperience,
           enabledIds,
         });
       }
@@ -354,7 +354,7 @@ export const TcfOverlay = ({
       updateConsentPreferences({
         consentPreferencesToSave,
         privacyExperienceConfigHistoryId,
-        experience: experience || experienceMinimal,
+        experience: experienceFull || experienceMinimal,
         consentMethod,
         options,
         userLocationString: fidesRegionString,
@@ -366,7 +366,7 @@ export const TcfOverlay = ({
             oldCookie,
             tcf,
             enabledIds,
-            experience || experienceMinimal,
+            experienceFull || experienceMinimal,
             consentPreferencesToSave,
           ),
       });
@@ -374,7 +374,7 @@ export const TcfOverlay = ({
     },
     [
       cookie,
-      experience,
+      experienceFull,
       experienceMinimal,
       fidesRegionString,
       options,
@@ -387,12 +387,12 @@ export const TcfOverlay = ({
   const handleAcceptAll = useCallback(
     (wasAutomated?: boolean) => {
       let allIds: EnabledIds;
-      let exp = experience || experienceMinimal;
+      let exp = experienceFull || experienceMinimal;
       const enabledActiveNotices = privacyNoticesWithBestTranslation.filter(
         (n) => !n.disabled || draftIds.customPurposesConsent.includes(n.id),
       );
       if (!exp.minimal_tcf) {
-        exp = experience as PrivacyExperience;
+        exp = experienceFull as PrivacyExperience;
         allIds = {
           purposesConsent: getAllIds(exp.tcf_purpose_consents),
           customPurposesConsent: getAllIds(enabledActiveNotices),
@@ -441,7 +441,7 @@ export const TcfOverlay = ({
     },
     [
       draftIds.customPurposesConsent,
-      experience,
+      experienceFull,
       experienceMinimal,
       handleUpdateAllPreferences,
       privacyNoticesWithBestTranslation,
@@ -462,7 +462,7 @@ export const TcfOverlay = ({
           })
           .map((n) => n.id) ?? EMPTY_ENABLED_IDS;
       if (
-        experience?.experience_config?.reject_all_mechanism ===
+        experienceFull?.experience_config?.reject_all_mechanism ===
         RejectAllMechanism.REJECT_CONSENT_ONLY
       ) {
         // Do not reject legitimate interests if the reject all mechanism is set to "Reject Consent Only"
@@ -480,7 +480,7 @@ export const TcfOverlay = ({
     },
     [
       draftIds,
-      experience?.experience_config?.reject_all_mechanism,
+      experienceFull?.experience_config?.reject_all_mechanism,
       handleUpdateAllPreferences,
       privacyNoticesWithBestTranslation,
     ],
@@ -522,7 +522,7 @@ export const TcfOverlay = ({
   }, [handleUpdateAllPreferences, draftIds, parsedCookie?.consent]);
 
   const experienceConfig =
-    experience?.experience_config || experienceMinimal.experience_config;
+    experienceFull?.experience_config || experienceMinimal.experience_config;
   if (!experienceConfig) {
     fidesDebugger("No experience config found");
     return null;
@@ -533,7 +533,7 @@ export const TcfOverlay = ({
   return (
     <Overlay
       options={options}
-      experience={experience || experienceMinimal}
+      experience={experienceFull || experienceMinimal}
       cookie={cookie}
       savedConsent={savedConsent}
       onVendorPageClick={() => {
@@ -565,7 +565,7 @@ export const TcfOverlay = ({
             onVendorPageClick={goToVendorTab}
             renderButtonGroup={() => (
               <TcfConsentButtons
-                experience={experience || experienceMinimal}
+                experience={experienceFull || experienceMinimal}
                 onManagePreferencesClick={onManagePreferencesClick}
                 onAcceptAll={() => {
                   handleAcceptAll();
@@ -588,11 +588,11 @@ export const TcfOverlay = ({
         );
       }}
       renderModalContent={
-        !experience
+        !experienceFull
           ? undefined
           : () => (
               <TcfTabs
-                experience={experience}
+                experience={experienceFull}
                 customNotices={privacyNoticesWithBestTranslation}
                 enabledIds={draftIds}
                 onChange={(updatedIds, triggerDetails, preference) => {
@@ -616,7 +616,7 @@ export const TcfOverlay = ({
             )
       }
       renderModalFooter={
-        !experience
+        !experienceFull
           ? undefined
           : ({ onClose }) => {
               const onSave = (
@@ -628,7 +628,7 @@ export const TcfOverlay = ({
               };
               return (
                 <TcfConsentButtons
-                  experience={experience}
+                  experience={experienceFull}
                   onAcceptAll={() => {
                     handleAcceptAll();
                     onClose();

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -15,6 +15,7 @@ import type {
   TCFFeatureRecord,
   TCFFeatureSave,
   TcfOtherConsent,
+  TcfPublisherRestriction,
   TCFPurposeConsentRecord,
   TCFPurposeLegitimateInterestsRecord,
   TCFPurposeSave,
@@ -449,6 +450,7 @@ export type PrivacyExperience = {
   tcf_system_legitimate_interests?: Array<TCFVendorLegitimateInterestsRecord>;
   tcf_system_relationships?: Array<TCFVendorRelationships>;
   tcf_publisher_country_code?: string;
+  tcf_publisher_restrictions?: Array<TcfPublisherRestriction>;
 
   /**
    * @deprecated For backwards compatibility purposes, whether the Experience should show a banner.
@@ -501,6 +503,7 @@ export interface PrivacyExperienceMinimal
     | "gvl"
     | "tcf_publisher_country_code"
     | "non_applicable_privacy_notices"
+    | "tcf_publisher_restrictions"
   > {
   experience_config: ExperienceConfigMinimal;
   vendor_count?: number;

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -198,14 +198,21 @@ export const generateFidesString = async ({
         tcModel.specialFeatureOptins.set(+id);
       });
 
-      // Process tcf_publisher_restrictions if available
+      // Process publisher restrictions if available
       if (
         experience.tcf_publisher_restrictions &&
         experience.tcf_publisher_restrictions.length > 0
       ) {
         experience.tcf_publisher_restrictions.forEach(
           (restriction: TcfPublisherRestriction) => {
-            // For each vendor in the restriction's vendors array
+            // NOTE: While this documentation https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/TCF-Implementation-Guidelines.md#pubrestrenc
+            // mentions "it might be more efficient to encode a small number of range restriction
+            // segments using a specific encoding scheme," this is referring to the CMP's interface (Admin UI)
+            // providing a mechanism for handling ranges, but the TCModel.publisherRestrictions object does
+            // not support ranges. We must add each vendor id as a separate publisher restriction because
+            // that's what the TCModel we're using for our encoding supports.
+            // See https://github.com/InteractiveAdvertisingBureau/iabtcf-es/tree/master/modules/core#setting-publisher-restrictions
+            // for more information about the loop below.
             restriction.vendors.forEach((vendorId: number) => {
               const purposeRestriction = new PurposeRestriction();
               purposeRestriction.purposeId = restriction.purpose_id;

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -107,19 +107,21 @@ export const generateFidesString = async ({
           const { id } = decodeVendorId(vendorId);
           tcModel.vendorConsents.set(+id);
 
-          // Legacy: look up each vendor in the GVL vendors list to see if they have a purpose list.
-          // If they do not it means they have been set in Admin UI as Vendor Overrides to
-          // require consent. In that case we need to set a publisher restriction for the
-          // vendor's flexible purposes.
-          const vendor = experience.gvl?.vendors[id];
-          if (vendor && !vendor?.purposes?.length) {
-            vendor.flexiblePurposes.forEach((purpose) => {
-              const purposeRestriction = new PurposeRestriction();
-              purposeRestriction.purposeId = purpose;
-              purposeRestriction.restrictionType =
-                RestrictionType.REQUIRE_CONSENT;
-              tcModel.publisherRestrictions.add(+id, purposeRestriction);
-            });
+          if (!experience.tcf_publisher_restrictions?.length) {
+            // Legacy: look up each vendor in the GVL vendors list to see if they have a purpose list.
+            // If they do not it means they have been set in Admin UI as Vendor Overrides to
+            // require consent. In that case we need to set a publisher restriction for the
+            // vendor's flexible purposes.
+            const vendor = experience.gvl?.vendors[id];
+            if (vendor && !vendor?.purposes?.length) {
+              vendor.flexiblePurposes.forEach((purpose) => {
+                const purposeRestriction = new PurposeRestriction();
+                purposeRestriction.purposeId = purpose;
+                purposeRestriction.restrictionType =
+                  RestrictionType.REQUIRE_CONSENT;
+                tcModel.publisherRestrictions.add(+id, purposeRestriction);
+              });
+            }
           }
         }
       });

--- a/clients/fides-js/src/lib/tcf/types.ts
+++ b/clients/fides-js/src/lib/tcf/types.ts
@@ -295,3 +295,9 @@ interface GvlDataCategory {
 }
 export type GvlDataCategories = Record<number, GvlDataCategory>;
 export type GvlDataDeclarations = number[];
+
+export type TcfPublisherRestriction = {
+  purpose_id: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11; // 11 purpose consents
+  restriction_type: 0 | 1 | 2 | 3; // 0 = purpose restriction, 1 = consent only, 2 = legitimate interest only, 3 = not used
+  vendors: number[];
+};


### PR DESCRIPTION
Closes [LJ-624]

### Description Of Changes

Adds support for TCF publisher restrictions when creating the TCF String

### Code Changes

* Added `tcf_publisher_restrictions` to PrivacyExperience and PrivacyExperienceMinimal types
* Added TcfPublisherRestriction type definition
* Updated generateFidesString to handle publisher restrictions when generating TC string
* Added logic to process publisher restrictions in TC string generation
* Renamed `experience` state variable to `experienceFull` throughout TcfOverlay.tsx for clarity (I was getting confused reading through that file)

### Steps to Confirm
Testing currently requires using branch `LJ-625-add-tcf-publisher-restrictions-subquery` to run your fidesplus backend.

1. Test that publisher restrictions are properly encoded in the TC string by:
   - Setting up a publisher restriction configuration in the admin UI (see below)
   - Enabling the TCF experience with the configuration you created selected in the TCF Configuration dropdown
   - Opening the TCF overlay on the Privacy Center demo page (eg. `/fides-js-demo.html?geolocation=eea`)
   - Accepting all preferences
   - Verifying the generated TC string contains the correct publisher restrictions by copying the TCF string from the cookie and pasting it in https://iabgpp.com and scrolling down to the very bottom of the page. As long as the IDs you entered are valid vendor IDs included in the experience, the list should reflect the restrictions you configured
2. Confirm that existing functionality (consent management, vendor preferences, etc.) continues to work as expected

### Steps to setting up a publisher restriction configuration
1. Ensure the Publisher Restrictions feature flag is enabled in Admin UI
1. Ensure you have some vendors enabled. It's best if you know what their GVL vendor ID is.
1. Navigate to the consent settings page (`/settings/consent`)
1. Enable the Override vendor purposes toggle
1. Click the "Create configuration +" button. Give your config a name and save it.
1. Click an "Edit" button, which takes you to the Consent Configuration page
1. Click "Add restriction +"
1. Choose any of the options and follow the instructions. Any vendor ID you choose that's not a vendor added to the system will be ignored, so it's best if you use those ID's as you go.
9. Add another restriction if you want.
10. Use the breadcrumb to go back to the consent settings page.
11. Do similar for other purposes

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [x] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-624]: https://ethyca.atlassian.net/browse/LJ-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ