### PR TITLE
Update Add Vendor tooltip to match navigation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - FidesJS css variable `--fides-overlay-container-border-width` now applies to banner (only applied to modal before) [#6097](https://github.com/ethyca/fides/pull/6097) https://github.com/ethyca/fides/labels/high-risk
 - Fixed vendor restriction form validation and input handling [#6101](https://github.com/ethyca/fides/pull/6101)
 - Fixed special purpose vendor check in Fides JS logic [#6118](https://github.com/ethyca/fides/pull/6118)
+- Update Add Vendor tooltip to match navigation option [#6111](https://github.com/ethyca/fides/pull/6111)
 
 ## [2.60.0](https://github.com/ethyca/fides/compare/2.59.2...2.60.0)
 

--- a/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
+++ b/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
@@ -71,7 +71,7 @@ export const VendorSourceCell = ({ value }: { value: string }) => {
 };
 
 const ADDED_VENDOR_TOOLTIP_LABEL =
-  "This vendor has already been added. You can view the properties of this vendor by going to View Systems.";
+  "This vendor has already been added. You can view the properties of this vendor by going to the System Inventory.";
 
 type MultipleSystemTable = DictSystems;
 


### PR DESCRIPTION
Closes [LJ-742]

### Description Of Changes

This updates a tooltip to refer to a nav menu item by name so it's more clear where the user should go to see the vendor information.

### Code Changes

* Just a tweak to the the tooltip text in one spot

### Steps to Confirm

1.  Go to Vendors / Add Vendor
2. Add any vendor
3. Go back to Vendors / Add Vendor
4. Hover over the added vendor to see the new tooltip.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-742]: https://ethyca.atlassian.net/browse/LJ-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ