### PR TITLE
Add support for consent mechanism string values and non-applicable notices in FidesJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Added
 - Added Recorded URL to Consent Report [#6077](https://github.com/ethyca/fides/pull/6077)
+- Added support for consent mechanism string values and non-applicable notices in FidesJS [#6115](https://github.com/ethyca/fides/pull/6115)
 - Added ConnectionType.okta, OktaSchema, OktaConnector as support for the Okta Monitor [#6078](https://github.com/ethyca/fides/pull/6078)
 - Added "View" detail links to success toasts in action center [#6113](https://github.com/ethyca/fides/pull/6113)
 - Setting to allow Admin UI errors to be surfaced to a toast. [#6121](https://github.com/ethyca/fides/pull/6121)

--- a/clients/fides-js/.eslintrc.cjs
+++ b/clients/fides-js/.eslintrc.cjs
@@ -5,6 +5,27 @@ module.exports = {
     tsconfigRootDir: __dirname,
   },
   parser: "@typescript-eslint/parser",
+  overrides: [
+    {
+      // Prevent ~/ imports in .ts files
+      files: ["**/*.ts"],
+      excludedFiles: ["**/__tests__/**"],
+      rules: {
+        "no-restricted-imports": [
+          "error",
+          {
+            patterns: [
+              {
+                group: ["~/*"],
+                message:
+                  "The ~/ path alias should not be used in .ts files. Use relative paths instead.",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
   rules: {
     "import/no-cycle": "off",
     "import/extensions": "off",

--- a/clients/fides-js/__tests__/integrations/gtm.test.ts
+++ b/clients/fides-js/__tests__/integrations/gtm.test.ts
@@ -1,9 +1,9 @@
 import { FidesEventType } from "../../src/docs";
+import { gtm } from "../../src/integrations/gtm";
 import {
   ConsentFlagType,
   ConsentNonApplicableFlagMode,
-  gtm,
-} from "../../src/integrations/gtm";
+} from "../../src/lib/consent-types";
 
 const fidesEvents: Record<FidesEventType, boolean> = {
   FidesInitializing: false,

--- a/clients/fides-js/__tests__/integrations/gtm.test.ts
+++ b/clients/fides-js/__tests__/integrations/gtm.test.ts
@@ -1,8 +1,8 @@
 import { FidesEventType } from "../../src/docs";
 import {
+  ConsentFlagType,
+  ConsentNonApplicableFlagMode,
   gtm,
-  GtmFlagType,
-  GtmNonApplicableFlagMode,
 } from "../../src/integrations/gtm";
 
 const fidesEvents: Record<FidesEventType, boolean> = {
@@ -77,7 +77,7 @@ describe("gtm", () => {
       } as any,
     } as any;
 
-    gtm({ flag_type: GtmFlagType.CONSENT_MECHANISM });
+    gtm({ flag_type: ConsentFlagType.CONSENT_MECHANISM });
     window.dispatchEvent(
       new CustomEvent("FidesUpdated", {
         detail: {
@@ -118,7 +118,7 @@ describe("gtm", () => {
       } as any,
     } as any;
 
-    gtm({ non_applicable_flag_mode: GtmNonApplicableFlagMode.INCLUDE });
+    gtm({ non_applicable_flag_mode: ConsentNonApplicableFlagMode.INCLUDE });
     window.dispatchEvent(
       new CustomEvent("FidesUpdated", {
         detail: {
@@ -138,7 +138,7 @@ describe("gtm", () => {
   });
 
   test("that fides includes not applicable privacy notices and transforms them to strings", () => {
-    gtm({ non_applicable_flag_mode: GtmNonApplicableFlagMode.INCLUDE });
+    gtm({ non_applicable_flag_mode: ConsentNonApplicableFlagMode.INCLUDE });
     window.Fides = {
       experience: {
         privacy_notices: [
@@ -160,8 +160,8 @@ describe("gtm", () => {
     } as any;
 
     gtm({
-      non_applicable_flag_mode: GtmNonApplicableFlagMode.INCLUDE,
-      flag_type: GtmFlagType.CONSENT_MECHANISM,
+      non_applicable_flag_mode: ConsentNonApplicableFlagMode.INCLUDE,
+      flag_type: ConsentFlagType.CONSENT_MECHANISM,
     });
     window.dispatchEvent(
       new CustomEvent("FidesUpdated", {

--- a/clients/fides-js/__tests__/lib/consent-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/consent-utils.test.ts
@@ -1,21 +1,33 @@
 import {
   ComponentType,
+  ConsentFlagType,
   ConsentMechanism,
   ConsentMethod,
+  ConsentNonApplicableFlagMode,
   FidesCookie,
+  FidesGlobal,
   NoticeConsent,
   PrivacyExperience,
+  UserConsentPreference,
 } from "~/lib/consent-types";
 import {
+  applyOverridesToConsent,
   decodeNoticeConsentString,
   encodeNoticeConsentString,
   getWindowObjFromPath,
   isPrivacyExperience,
-  parseFidesDisabledNotices,
   shouldResurfaceBanner,
 } from "~/lib/consent-utils";
+import { parseFidesDisabledNotices } from "~/lib/shared-consent-utils";
 
 import mockExperienceJSON from "../__fixtures__/mock_experience.json";
+
+// Add Fides to Window interface for testing
+declare global {
+  interface Window {
+    Fides: FidesGlobal;
+  }
+}
 
 describe("isPrivacyExperience", () => {
   it.each([
@@ -407,5 +419,210 @@ describe("shouldResurfaceBanner", () => {
         options as any,
       ),
     ).toBe(expected);
+  });
+});
+
+describe("applyOverridesToConsent", () => {
+  // Store original window.Fides
+  let originalFides: any;
+
+  beforeEach(() => {
+    // Store original and set up mock
+    originalFides = window.Fides;
+    window.Fides = {
+      options: {
+        fidesConsentFlagType: null,
+        fidesConsentNonApplicableFlagMode: null,
+      },
+    } as any;
+  });
+
+  afterEach(() => {
+    // Restore original
+    window.Fides = originalFides;
+  });
+
+  it("should return the original consent values when no overrides are applied", () => {
+    const consent = { analytics: true, marketing: false };
+    const result = applyOverridesToConsent(consent, [], []);
+    expect(result).toEqual(consent);
+  });
+
+  it("should handle non-applicable notices with OMIT mode (default)", () => {
+    const consent = { analytics: true, marketing: false };
+    const nonApplicableNotices = ["essential", "personalization"];
+    const result = applyOverridesToConsent(consent, nonApplicableNotices, []);
+
+    // Non-applicable notices should be omitted by default
+    expect(result).toEqual(consent);
+    expect(result.essential).toBeUndefined();
+    expect(result.personalization).toBeUndefined();
+  });
+
+  it("should handle non-applicable notices with INCLUDE mode", () => {
+    const consent = { analytics: true, marketing: false };
+    const nonApplicableNotices = ["essential", "personalization"];
+    const result = applyOverridesToConsent(
+      consent,
+      nonApplicableNotices,
+      [],
+      undefined,
+      ConsentNonApplicableFlagMode.INCLUDE,
+    );
+
+    // Non-applicable notices should be included with true values
+    expect(result).toEqual({
+      analytics: true,
+      marketing: false,
+      essential: true,
+      personalization: true,
+    });
+  });
+
+  it("should use the window.Fides options for non-applicable flag mode if not explicitly provided", () => {
+    window.Fides = {
+      options: {
+        fidesConsentNonApplicableFlagMode: ConsentNonApplicableFlagMode.INCLUDE,
+      },
+    } as any;
+
+    const consent = { analytics: true, marketing: false };
+    const nonApplicableNotices = ["essential", "personalization"];
+    const result = applyOverridesToConsent(consent, nonApplicableNotices, []);
+
+    // Non-applicable notices should be included because of window.Fides options
+    expect(result).toEqual({
+      analytics: true,
+      marketing: false,
+      essential: true,
+      personalization: true,
+    });
+  });
+
+  it("should convert boolean consent values to consent mechanism strings when flagType is CONSENT_MECHANISM", () => {
+    const consent = { analytics: true, marketing: false };
+    const privacyNotices = [
+      {
+        notice_key: "analytics",
+        consent_mechanism: ConsentMechanism.OPT_IN,
+      },
+      {
+        notice_key: "marketing",
+        consent_mechanism: ConsentMechanism.OPT_OUT,
+      },
+    ] as any;
+
+    const result = applyOverridesToConsent(
+      consent,
+      [],
+      privacyNotices,
+      ConsentFlagType.CONSENT_MECHANISM,
+    );
+
+    // Boolean values should be converted to consent mechanism strings
+    expect(result).toEqual({
+      analytics: UserConsentPreference.OPT_IN,
+      marketing: UserConsentPreference.OPT_OUT,
+    });
+  });
+
+  it("should use consent_mechanism strings for non-applicable notices when both flagType and mode are set", () => {
+    const consent = { analytics: true, marketing: false };
+    const nonApplicableNotices = ["essential", "personalization"];
+    const privacyNotices = [
+      {
+        notice_key: "analytics",
+        consent_mechanism: ConsentMechanism.OPT_IN,
+      },
+      {
+        notice_key: "marketing",
+        consent_mechanism: ConsentMechanism.OPT_OUT,
+      },
+    ] as any;
+
+    const result = applyOverridesToConsent(
+      consent,
+      nonApplicableNotices,
+      privacyNotices,
+      ConsentFlagType.CONSENT_MECHANISM,
+      ConsentNonApplicableFlagMode.INCLUDE,
+    );
+
+    // Non-applicable notices should be included as NOT_APPLICABLE
+    expect(result).toEqual({
+      analytics: UserConsentPreference.OPT_IN,
+      marketing: UserConsentPreference.OPT_OUT,
+      essential: UserConsentPreference.NOT_APPLICABLE,
+      personalization: UserConsentPreference.NOT_APPLICABLE,
+    });
+  });
+
+  it("should use the window.Fides options for flag type if not explicitly provided", () => {
+    window.Fides = {
+      options: {
+        fidesConsentFlagType: ConsentFlagType.CONSENT_MECHANISM,
+      },
+    } as any;
+
+    const consent = { analytics: true, marketing: false };
+    const privacyNotices = [
+      {
+        notice_key: "analytics",
+        consent_mechanism: ConsentMechanism.OPT_IN,
+      },
+      {
+        notice_key: "marketing",
+        consent_mechanism: ConsentMechanism.OPT_OUT,
+      },
+    ] as any;
+
+    const result = applyOverridesToConsent(consent, [], privacyNotices);
+
+    // Boolean values should be converted to consent mechanism strings because of window.Fides options
+    expect(result).toEqual({
+      analytics: UserConsentPreference.OPT_IN,
+      marketing: UserConsentPreference.OPT_OUT,
+    });
+  });
+
+  it("should handle string consent values already formatted as consent mechanism strings", () => {
+    const consent = {
+      analytics: UserConsentPreference.OPT_IN,
+      marketing: UserConsentPreference.OPT_OUT,
+    };
+
+    const result = applyOverridesToConsent(
+      consent,
+      [],
+      [],
+      ConsentFlagType.CONSENT_MECHANISM,
+    );
+
+    // String values should remain unchanged
+    expect(result).toEqual(consent);
+  });
+
+  it("should convert consent mechanism strings to boolean values when flagType is BOOLEAN", () => {
+    const consent = {
+      analytics: UserConsentPreference.OPT_IN,
+      marketing: UserConsentPreference.OPT_OUT,
+      essential: UserConsentPreference.ACKNOWLEDGE,
+      tracking: UserConsentPreference.NOT_APPLICABLE,
+    };
+
+    const result = applyOverridesToConsent(
+      consent,
+      [],
+      [],
+      ConsentFlagType.BOOLEAN,
+    );
+
+    // String values should be converted to booleans
+    expect(result).toEqual({
+      analytics: true,
+      marketing: false,
+      essential: true,
+      tracking: false,
+    });
   });
 });

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -36,7 +36,7 @@ existence of Fides *or* subscribe to the global `FidesInitialized` event (see
 
 ### consent
 
-> **consent**: `Record`\<`string`, `boolean`\>
+> **consent**: `Record`\<`string`, `string` \| `boolean`\>
 
 User's current consent preferences, formatted as a key/value object with:
 - key: the applicable Fides `notice_key` (e.g. `data_sales_and_sharing`, `analytics`)
@@ -68,6 +68,13 @@ A `Fides.consent` value showing the user has opted-in to analytics, but not mark
   "marketing": false
 }
 ```
+
+A `Fides.consent` value showing the user has opted-in to analytics, but not marketing using a consent mechanism string:
+```ts
+{
+  "analytics": "opt_in",
+  "marketing": "opt_out"
+}
 
 ***
 

--- a/clients/fides-js/docs/interfaces/FidesOptions.md
+++ b/clients/fides-js/docs/interfaces/FidesOptions.md
@@ -238,9 +238,9 @@ Defaults to `undefined`.
 
 > **ot\_fides\_mapping**: `string`
 
-Given a OneTrust → Fides notice mapping exists and the OneTrust cookie exists, Fides will “migrate” those consents to Fides privacy notices, and write to the Fides cookie.
+Given a OneTrust → Fides notice mapping exists and the OneTrust cookie exists, Fides will "migrate" those consents to Fides privacy notices, and write to the Fides cookie.
 
-This way, Fides customers that are migrating away from OneTrust don’t need to show their users new consent dialogues when switching to Fides.
+This way, Fides customers that are migrating away from OneTrust don't need to show their users new consent dialogues when switching to Fides.
 that those preferences are respected.
 
 Example original otFidesMapping data:
@@ -257,6 +257,35 @@ To decode this field, use:
 JSON.parse(decodeURIComponent(ot_fides_mapping))
 
 Field defaults to `undefined`.
+
+***
+
+### fides\_consent\_non\_applicable\_flag\_mode
+
+> **fides\_consent\_non\_applicable\_flag\_mode**: `"omit"` \| `"include"`
+
+Define how non-applicable privacy notices are handled.
+
+When set to "include", consent preferences will include notices in the system that are not applicable
+to the current experience, and will set the notice as implicitly consented.
+
+When set to "omit" (default), non-applicable notices will be omitted.
+
+Defaults to "omit".
+
+***
+
+### fides\_consent\_flag\_type
+
+> **fides\_consent\_flag\_type**: `"boolean"` \| `"consent_mechanism"`
+
+Define the type of flag to use for consent values.
+
+When set to "boolean", consent preferences will be set as boolean values.
+When set to "consent_mechanism", consent preferences will be set as string values based on the
+consent mechanism (e.g. "opt-in", "opt-out", "non-applicable").
+
+Defaults to "boolean".
 
 ***
 

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -188,7 +188,11 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
     ],
   };
 
-  rollupOptions.push(...[js, mjs, declaration]);
+  if (IS_DEV) {
+    rollupOptions.push(...[js, declaration]);
+  } else {
+    rollupOptions.push(...[js, mjs, declaration]);
+  }
 });
 
 // Add preview script build configuration

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -34,6 +34,7 @@ import {
 } from "../../lib/i18n";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import { updateConsentPreferences } from "../../lib/preferences";
+import { transformUserPreferenceToBoolean } from "../../lib/shared-consent-utils";
 import ConsentBanner from "../ConsentBanner";
 import { NoticeConsentButtons } from "../ConsentButtons";
 import Overlay from "../Overlay";
@@ -141,7 +142,14 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
 
   window.addEventListener("FidesUpdating", (event) => {
     // If GPC is being applied after initialization, we need to update the initial overlay to reflect the new state. This is especially important for Firefox browsers (Gecko) because GPC gets applied rather late due to how it handles queuing the `setTimeout` on the last step of our `initialize` function.
-    setDraftEnabledNoticeKeys(initialEnabledNoticeKeys(event.detail.consent));
+    const { consent } = event.detail;
+    Object.keys(consent).forEach((key) => {
+      const value = consent[key];
+      if (typeof value === "string") {
+        consent[key] = transformUserPreferenceToBoolean(value);
+      }
+    });
+    setDraftEnabledNoticeKeys(initialEnabledNoticeKeys(consent));
   });
 
   const isAllNoticeOnly = privacyNoticeItems.every(

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -55,7 +55,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const initialEnabledNoticeKeys = (consent?: NoticeConsent) => {
     if (experience.privacy_notices) {
-      // ensure we have most up-to-date cookie vals
+      // ensure we have most up-to-date cookie vals. If we don't have any consent, use the savedConsent which will be the default values that haven't been passed through the privacy_notices yet so it's perfect to use here.
       return experience.privacy_notices.map((notice) => {
         const val = resolveConsentValue(
           notice,

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -34,7 +34,7 @@ import {
 } from "../../lib/i18n";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import { updateConsentPreferences } from "../../lib/preferences";
-import { transformUserPreferenceToBoolean } from "../../lib/shared-consent-utils";
+import { processExternalConsentValue } from "../../lib/shared-consent-utils";
 import ConsentBanner from "../ConsentBanner";
 import { NoticeConsentButtons } from "../ConsentButtons";
 import Overlay from "../Overlay";
@@ -143,11 +143,8 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   window.addEventListener("FidesUpdating", (event) => {
     // If GPC is being applied after initialization, we need to update the initial overlay to reflect the new state. This is especially important for Firefox browsers (Gecko) because GPC gets applied rather late due to how it handles queuing the `setTimeout` on the last step of our `initialize` function.
     const { consent } = event.detail;
-    Object.keys(consent).forEach((key) => {
-      const value = consent[key];
-      if (typeof value === "string") {
-        consent[key] = transformUserPreferenceToBoolean(value);
-      }
+    Object.entries(consent).forEach(([key, value]) => {
+      consent[key] = processExternalConsentValue(value);
     });
     setDraftEnabledNoticeKeys(initialEnabledNoticeKeys(consent));
   });

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -212,9 +212,9 @@ export interface FidesOptions {
   fides_consent_override: "accept" | "reject";
 
   /**
-   * Given a OneTrust → Fides notice mapping exists and the OneTrust cookie exists, Fides will “migrate” those consents to Fides privacy notices, and write to the Fides cookie.
+   * Given a OneTrust → Fides notice mapping exists and the OneTrust cookie exists, Fides will "migrate" those consents to Fides privacy notices, and write to the Fides cookie.
    *
-   * This way, Fides customers that are migrating away from OneTrust don’t need to show their users new consent dialogues when switching to Fides.
+   * This way, Fides customers that are migrating away from OneTrust don't need to show their users new consent dialogues when switching to Fides.
    * that those preferences are respected.
    *
    * Example original otFidesMapping data:
@@ -234,6 +234,29 @@ export interface FidesOptions {
    *
    */
   ot_fides_mapping: string;
+
+  /**
+   * Define how non-applicable privacy notices are handled.
+   *
+   * When set to "include", consent preferences will include notices in the system that are not applicable
+   * to the current experience, and will set the notice as implicitly consented.
+   *
+   * When set to "omit" (default), non-applicable notices will be omitted.
+   *
+   * Defaults to "omit".
+   */
+  fides_consent_non_applicable_flag_mode: "omit" | "include";
+
+  /**
+   * Define the type of flag to use for consent values.
+   *
+   * When set to "boolean", consent preferences will be set as boolean values.
+   * When set to "consent_mechanism", consent preferences will be set as string values based on the
+   * consent mechanism (e.g. "opt-in", "opt-out", "non-applicable").
+   *
+   * Defaults to "boolean".
+   */
+  fides_consent_flag_type: "boolean" | "consent_mechanism";
 
   /**
    * A comma-separated list of notice_keys to disable their respective Toggle elements in the CMP Overlay.

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -62,8 +62,16 @@ export interface Fides {
    *   "marketing": false
    * }
    * ```
+   *
+   * @example
+   * A `Fides.consent` value showing the user has opted-in to analytics, but not marketing using a consent mechanism string:
+   * ```ts
+   * {
+   *   "analytics": "opt_in",
+   *   "marketing": "opt_out"
+   * }
    */
-  consent: Record<string, boolean>;
+  consent: Record<string, boolean | string>;
 
   /**
    * User's current consent string(s) combined into a single value. This is used by
@@ -443,6 +451,7 @@ export interface Fides {
   saved_consent: Record<string, boolean>;
 
   /**
+   * @deprecated
    * @internal
    */
   tcf_consent: any;

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -412,6 +412,8 @@ export interface Fides {
   config?: any;
 
   /**
+   * Helps keep track of the real time values to be saved to the cookie. Gets updated during initialization, when the user toggles consent preferences, etc. and ultimately is used to update the browser cookie, the Fides.consent object, and the Fides.saved_consent object which represent more persistent values.
+   *
    * @internal
    */
   cookie?: any;
@@ -434,6 +436,8 @@ export interface Fides {
   options: any;
 
   /**
+   * Represents the initial cookie consent values whether default or saved in the browser cookie. Compare to cookie.consent which represents the unsaved consent values we're going to end up saving to the browser cookie. In some cases we need to access the initial values saved in the cookie, rather than the current unsaved values.
+   *
    * @internal
    */
   saved_consent: Record<string, boolean>;

--- a/clients/fides-js/src/fides-headless.ts
+++ b/clients/fides-js/src/fides-headless.ts
@@ -19,6 +19,7 @@ import {
   FidesOptions,
   FidesOverrides,
   GetPreferencesFnResp,
+  NoticeValues,
   OverrideType,
   PrivacyExperience,
 } from "./lib/consent-types";
@@ -139,7 +140,7 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
   // Keep a copy of saved consent from the cookie, since we update the "cookie"
   // value during initialization based on overrides, experience, etc.
   this.saved_consent = {
-    ...this.cookie.consent,
+    ...(this.cookie.consent as NoticeValues),
   };
 
   // Update the fidesString if we have an override and the NC portion is valid

--- a/clients/fides-js/src/fides-headless.ts
+++ b/clients/fides-js/src/fides-headless.ts
@@ -226,6 +226,8 @@ const _Fides: FidesGlobal = {
     showFidesBrandLink: true,
     fidesConsentOverride: null,
     fidesDisabledNotices: null,
+    fidesConsentNonApplicableFlagMode: null,
+    fidesConsentFlagType: null,
   },
   fides_meta: {},
   identity: {},

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -31,6 +31,7 @@ import {
   FidesOptions,
   FidesOverrides,
   GetPreferencesFnResp,
+  NoticeValues,
   OverrideType,
   PrivacyExperience,
 } from "./lib/consent-types";
@@ -165,7 +166,7 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
   // Keep a copy of saved consent from the cookie, since we update the "cookie"
   // value during initialization based on overrides, experience, etc.
   this.saved_consent = {
-    ...this.cookie.consent,
+    ...(this.cookie.consent as NoticeValues),
   };
 
   // Update the fidesString if we have an override and the TC portion is valid

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -261,6 +261,8 @@ const _Fides: FidesGlobal = {
     showFidesBrandLink: false,
     fidesConsentOverride: null,
     fidesDisabledNotices: null,
+    fidesConsentNonApplicableFlagMode: null,
+    fidesConsentFlagType: null,
   },
   fides_meta: {},
   identity: {},

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -315,6 +315,8 @@ const _Fides: FidesGlobal = {
     fidesConsentOverride: null,
     otFidesMapping: null,
     fidesDisabledNotices: null,
+    fidesConsentNonApplicableFlagMode: null,
+    fidesConsentFlagType: null,
   },
   fides_meta: {},
   identity: {},

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -29,7 +29,6 @@ import {
   OverrideType,
   PrivacyExperience,
   SaveConsentPreference,
-  UserConsentPreference,
 } from "./lib/consent-types";
 import {
   decodeNoticeConsentString,
@@ -58,10 +57,7 @@ import {
 import { initOverlay } from "./lib/initOverlay";
 import { updateConsentPreferences } from "./lib/preferences";
 import { renderOverlay } from "./lib/renderOverlay";
-import {
-  transformConsentToFidesUserPreference,
-  transformUserPreferenceToBoolean,
-} from "./lib/shared-consent-utils";
+import { transformConsentToFidesUserPreference } from "./lib/shared-consent-utils";
 import { customGetConsentPreferences } from "./services/external/preferences";
 
 declare global {
@@ -254,17 +250,11 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
         if (!notice) {
           return null;
         }
-        if (typeof value === "string") {
-          // eslint-disable-next-line no-param-reassign
-          value = transformUserPreferenceToBoolean(
-            value as UserConsentPreference,
-          );
-        }
-        return new SaveConsentPreference(
-          notice,
-          transformConsentToFidesUserPreference(value),
-          key,
-        );
+        const userPreference =
+          typeof value === "boolean"
+            ? transformConsentToFidesUserPreference(value)
+            : value;
+        return new SaveConsentPreference(notice, userPreference, key);
       })
       .filter((pref): pref is SaveConsentPreference => pref !== null);
 

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -167,7 +167,7 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
     ...config,
     options: { ...config.options, ...overrides.optionsOverrides },
   };
-  this.cookie = getInitialCookie(config);
+  this.cookie = getInitialCookie(config); // also adds legacy consent values to the cookie
   this.cookie.consent = {
     ...this.cookie.consent,
     ...migratedConsent,

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -28,6 +28,7 @@ import {
   OverrideType,
   PrivacyExperience,
   SaveConsentPreference,
+  UserConsentPreference,
 } from "./lib/consent-types";
 import {
   decodeNoticeConsentString,
@@ -56,7 +57,10 @@ import {
 import { initOverlay } from "./lib/initOverlay";
 import { updateConsentPreferences } from "./lib/preferences";
 import { renderOverlay } from "./lib/renderOverlay";
-import { transformConsentToFidesUserPreference } from "./lib/shared-consent-utils";
+import {
+  transformConsentToFidesUserPreference,
+  transformUserPreferenceToBoolean,
+} from "./lib/shared-consent-utils";
 import { customGetConsentPreferences } from "./services/external/preferences";
 
 declare global {
@@ -248,6 +252,12 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
         const notice = noticeMap.get(key);
         if (!notice) {
           return null;
+        }
+        if (typeof value === "string") {
+          // eslint-disable-next-line no-param-reassign
+          value = transformUserPreferenceToBoolean(
+            value as UserConsentPreference,
+          );
         }
         return new SaveConsentPreference(
           notice,

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -25,6 +25,7 @@ import {
   FidesOverrides,
   GetPreferencesFnResp,
   NoticeConsent,
+  NoticeValues,
   OverrideType,
   PrivacyExperience,
   SaveConsentPreference,
@@ -175,7 +176,7 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
   // Keep a copy of saved consent from the cookie, since we update the "cookie"
   // value during initialization based on overrides, experience, etc.
   this.saved_consent = {
-    ...this.cookie.consent,
+    ...(this.cookie.consent as NoticeValues),
   };
 
   // Update the fidesString if we have an override and the NC portion is valid

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -5,8 +5,8 @@ import {
   FidesGlobal,
   NoticeConsent,
 } from "../lib/consent-types";
+import { applyOverridesToConsent } from "../lib/consent-utils";
 import { FidesEventDetail } from "../lib/events";
-import { applyOverridesToConsent } from "../lib/shared-consent-utils";
 
 declare global {
   interface Window {

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -17,19 +17,19 @@ type FidesVariable = Omit<FidesEvent["detail"], "consent"> & {
   consent: Record<string, boolean | string>;
 };
 
-export enum GtmNonApplicableFlagMode {
+export enum ConsentNonApplicableFlagMode {
   OMIT = "omit",
   INCLUDE = "include",
 }
 
-export enum GtmFlagType {
+export enum ConsentFlagType {
   BOOLEAN = "boolean",
   CONSENT_MECHANISM = "consent_mechanism",
 }
 
 export interface GtmOptions {
-  non_applicable_flag_mode?: GtmNonApplicableFlagMode;
-  flag_type?: GtmFlagType;
+  non_applicable_flag_mode?: ConsentNonApplicableFlagMode;
+  flag_type?: ConsentFlagType;
 }
 
 /**
@@ -38,12 +38,12 @@ export interface GtmOptions {
 const composeConsent = (
   consent: Record<string, boolean>,
   privacyNotices: any[] | undefined,
-  flagType: GtmFlagType,
+  flagType: ConsentFlagType,
 ): Record<string, boolean | string> => {
   const consentValues: Record<string, boolean | string> = {};
 
   Object.entries(consent).forEach(([key, value]) => {
-    if (privacyNotices && flagType === GtmFlagType.CONSENT_MECHANISM) {
+    if (privacyNotices && flagType === ConsentFlagType.CONSENT_MECHANISM) {
       const relevantNotice = privacyNotices.find(
         (notice) => notice.notice_key === key,
       );
@@ -75,8 +75,8 @@ const pushFidesVariableToGTM = (
   const { consent, extraDetails, fides_string, timestamp } = detail;
   const {
     non_applicable_flag_mode:
-      nonApplicableFlagMode = GtmNonApplicableFlagMode.OMIT,
-    flag_type: flagType = GtmFlagType.BOOLEAN,
+      nonApplicableFlagMode = ConsentNonApplicableFlagMode.OMIT,
+    flag_type: flagType = ConsentFlagType.BOOLEAN,
   } = options ?? {};
   const consentValues: FidesVariable["consent"] = {};
   const privacyNotices = window.Fides?.experience?.privacy_notices;
@@ -85,12 +85,14 @@ const pushFidesVariableToGTM = (
 
   // First set defaults for non-applicable privacy notices if needed
   if (
-    nonApplicableFlagMode === GtmNonApplicableFlagMode.INCLUDE &&
+    nonApplicableFlagMode === ConsentNonApplicableFlagMode.INCLUDE &&
     nonApplicablePrivacyNotices
   ) {
     nonApplicablePrivacyNotices.forEach((key) => {
       consentValues[key] =
-        flagType === GtmFlagType.CONSENT_MECHANISM ? "not_applicable" : true;
+        flagType === ConsentFlagType.CONSENT_MECHANISM
+          ? "not_applicable"
+          : true;
     });
   }
 

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -1,11 +1,7 @@
 import { FidesEvent, FidesEventType } from "../docs";
-import {
-  FidesGlobal,
-  NoticeConsent,
-  UserConsentPreference,
-} from "../lib/consent-types";
+import { FidesGlobal, UserConsentPreference } from "../lib/consent-types";
 import { FidesEventDetail } from "../lib/events";
-import { transformConsentToFidesUserPreference } from "../lib/shared-consent-utils";
+import { composeConsent } from "../lib/shared-consent-utils";
 
 declare global {
   interface Window {
@@ -35,39 +31,6 @@ export interface GtmOptions {
   non_applicable_flag_mode?: ConsentNonApplicableFlagMode;
   flag_type?: ConsentFlagType;
 }
-
-/**
- * Composes consent values based on the consent mechanism and flag type
- */
-const composeConsent = (
-  consent: NoticeConsent,
-  privacyNotices: any[] | undefined,
-  flagType: ConsentFlagType,
-): NoticeConsent => {
-  const consentValues: NoticeConsent = {};
-
-  Object.entries(consent).forEach(([key, value]) => {
-    if (privacyNotices && flagType === ConsentFlagType.CONSENT_MECHANISM) {
-      // If value is already a UserConsentPreference string, use it directly
-      if (typeof value === "string") {
-        consentValues[key] = value;
-      } else {
-        const relevantNotice = privacyNotices.find(
-          (notice) => notice.notice_key === key,
-        );
-        // Otherwise transform boolean to UserConsentPreference
-        consentValues[key] = transformConsentToFidesUserPreference(
-          value,
-          relevantNotice?.consent_mechanism,
-        );
-      }
-    } else {
-      consentValues[key] = value;
-    }
-  });
-
-  return consentValues;
-};
 
 // Helper function to push the Fides variable to the GTM data layer from a FidesEvent
 const pushFidesVariableToGTM = (

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -73,11 +73,18 @@ const pushFidesVariableToGTM = (
   const { detail, type } = fidesEvent;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const { consent, extraDetails, fides_string, timestamp } = detail;
+
+  // Get options from either the provided options or the Fides config, with
+  // provided options taking precedence
+  const overrideOptions = window.Fides?.options;
   const {
     non_applicable_flag_mode:
-      nonApplicableFlagMode = ConsentNonApplicableFlagMode.OMIT,
-    flag_type: flagType = ConsentFlagType.BOOLEAN,
+      nonApplicableFlagMode = overrideOptions?.fidesConsentNonApplicableFlagMode ??
+        ConsentNonApplicableFlagMode.OMIT,
+    flag_type: flagType = overrideOptions?.fidesConsentFlagType ??
+      ConsentFlagType.BOOLEAN,
   } = options ?? {};
+
   const consentValues: FidesVariable["consent"] = {};
   const privacyNotices = window.Fides?.experience?.privacy_notices;
   const nonApplicablePrivacyNotices =

--- a/clients/fides-js/src/integrations/gtm.ts
+++ b/clients/fides-js/src/integrations/gtm.ts
@@ -1,5 +1,9 @@
 import { FidesEvent, FidesEventType } from "../docs";
-import { FidesGlobal } from "../lib/consent-types";
+import {
+  FidesGlobal,
+  NoticeConsent,
+  UserConsentPreference,
+} from "../lib/consent-types";
 import { FidesEventDetail } from "../lib/events";
 import { transformConsentToFidesUserPreference } from "../lib/shared-consent-utils";
 
@@ -36,21 +40,27 @@ export interface GtmOptions {
  * Composes consent values based on the consent mechanism and flag type
  */
 const composeConsent = (
-  consent: Record<string, boolean>,
+  consent: NoticeConsent,
   privacyNotices: any[] | undefined,
   flagType: ConsentFlagType,
-): Record<string, boolean | string> => {
-  const consentValues: Record<string, boolean | string> = {};
+): NoticeConsent => {
+  const consentValues: NoticeConsent = {};
 
   Object.entries(consent).forEach(([key, value]) => {
     if (privacyNotices && flagType === ConsentFlagType.CONSENT_MECHANISM) {
-      const relevantNotice = privacyNotices.find(
-        (notice) => notice.notice_key === key,
-      );
-      consentValues[key] = transformConsentToFidesUserPreference(
-        value,
-        relevantNotice?.consent_mechanism,
-      );
+      // If value is already a UserConsentPreference string, use it directly
+      if (typeof value === "string") {
+        consentValues[key] = value;
+      } else {
+        const relevantNotice = privacyNotices.find(
+          (notice) => notice.notice_key === key,
+        );
+        // Otherwise transform boolean to UserConsentPreference
+        consentValues[key] = transformConsentToFidesUserPreference(
+          value,
+          relevantNotice?.consent_mechanism,
+        );
+      }
     } else {
       consentValues[key] = value;
     }
@@ -98,7 +108,7 @@ const pushFidesVariableToGTM = (
     nonApplicablePrivacyNotices.forEach((key) => {
       consentValues[key] =
         flagType === ConsentFlagType.CONSENT_MECHANISM
-          ? "not_applicable"
+          ? UserConsentPreference.NOT_APPLICABLE
           : true;
     });
   }

--- a/clients/fides-js/src/integrations/shopify.ts
+++ b/clients/fides-js/src/integrations/shopify.ts
@@ -1,5 +1,5 @@
 import { MARKETING_CONSENT_KEYS } from "../lib/consent-constants";
-import { NoticeConsent, UserConsentPreference } from "../lib/consent-types";
+import { NoticeConsent } from "../lib/consent-types";
 import { transformUserPreferenceToBoolean } from "../lib/shared-consent-utils";
 
 declare global {
@@ -53,19 +53,15 @@ function createShopifyConsent(fidesConsent: NoticeConsent): ShopifyConsent {
       key,
       values.some((value) => {
         const consentValue = fidesConsent[value];
-        return typeof consentValue === "boolean"
-          ? consentValue
-          : transformUserPreferenceToBoolean(
-              consentValue as UserConsentPreference,
-            );
+        return typeof consentValue === "string"
+          ? transformUserPreferenceToBoolean(consentValue)
+          : consentValue;
       }) ||
         (values.some((value) => {
           const consentValue = fidesConsent[value];
-          return typeof consentValue === "boolean"
-            ? !consentValue
-            : !transformUserPreferenceToBoolean(
-                consentValue as UserConsentPreference,
-              );
+          return typeof consentValue === "string"
+            ? !transformUserPreferenceToBoolean(consentValue)
+            : !consentValue;
         })
           ? false
           : undefined),
@@ -103,8 +99,9 @@ const applyOptions = () => {
   );
 
   // If Fides was already initialized, push consent to Shopify immediately
-  if (window.Fides?.initialized) {
-    pushConsentToShopify(window.Fides.consent);
+  if (window.Fides?.initialized && window.Fides.cookie) {
+    // cookie will always be present in the Fides object after initialization. Event details above also use the cookie.consent so let's stay consistent.
+    pushConsentToShopify(window.Fides.cookie.consent);
   }
 };
 

--- a/clients/fides-js/src/lib/consent-constants.ts
+++ b/clients/fides-js/src/lib/consent-constants.ts
@@ -99,6 +99,18 @@ export const FIDES_OVERRIDE_OPTIONS_VALIDATOR_MAP: FidesOverrideValidatorMap[] =
       validationRegex: /(.*)/,
       transform: parseFidesDisabledNotices,
     },
+    {
+      overrideName: "fidesConsentNonApplicableFlagMode",
+      overrideType: "string",
+      overrideKey: "fides_consent_non_applicable_flag_mode",
+      validationRegex: /^(omit|include)$/,
+    },
+    {
+      overrideName: "fidesConsentFlagType",
+      overrideType: "string",
+      overrideKey: "fides_consent_flag_type",
+      validationRegex: /^(boolean|consent_mechanism)$/,
+    },
   ];
 
 /**

--- a/clients/fides-js/src/lib/consent-constants.ts
+++ b/clients/fides-js/src/lib/consent-constants.ts
@@ -2,8 +2,8 @@ import {
   FidesExperienceLanguageValidatorMap,
   FidesOverrideValidatorMap,
 } from "./consent-types";
-import { parseFidesDisabledNotices } from "./consent-utils";
 import { LOCALE_REGEX } from "./i18n/i18n-constants";
+import { parseFidesDisabledNotices } from "./shared-consent-utils";
 
 /**
  * Regex to validate a [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code:

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -5,7 +5,11 @@ import type {
   FidesOptions,
 } from "../docs";
 import { blueconic } from "../integrations/blueconic";
-import type { gtm } from "../integrations/gtm";
+import type {
+  ConsentFlagType,
+  ConsentNonApplicableFlagMode,
+  gtm,
+} from "../integrations/gtm";
 import type { meta } from "../integrations/meta";
 import type { shopify } from "../integrations/shopify";
 import type { FidesEventDetail } from "./events";
@@ -149,6 +153,12 @@ export interface FidesInitOptions {
 
   // List of notice_keys to disable their respective Toggle elements in the CMP Overlay
   fidesDisabledNotices: string[] | null;
+
+  // Determines how non-applicable privacy notices are handled (omit or include)
+  fidesConsentNonApplicableFlagMode: ConsentNonApplicableFlagMode | null;
+
+  // The type of value to use for consent (boolean or consent_mechanism)
+  fidesConsentFlagType: ConsentFlagType | null;
 }
 
 /**
@@ -736,6 +746,8 @@ export type FidesInitOptionsOverrides = Pick<
   | "fidesConsentOverride"
   | "otFidesMapping"
   | "fidesDisabledNotices"
+  | "fidesConsentNonApplicableFlagMode"
+  | "fidesConsentFlagType"
 >;
 
 export type FidesExperienceTranslationOverrides = {

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -5,11 +5,7 @@ import type {
   FidesOptions,
 } from "../docs";
 import { blueconic } from "../integrations/blueconic";
-import type {
-  ConsentFlagType,
-  ConsentNonApplicableFlagMode,
-  gtm,
-} from "../integrations/gtm";
+import type { gtm } from "../integrations/gtm";
 import type { meta } from "../integrations/meta";
 import type { shopify } from "../integrations/shopify";
 import type { FidesEventDetail } from "./events";
@@ -708,6 +704,16 @@ export enum UserConsentPreference {
   ACKNOWLEDGE = "acknowledge",
   NOT_APPLICABLE = "not_applicable",
   TCF = "tcf",
+}
+
+export enum ConsentNonApplicableFlagMode {
+  OMIT = "omit",
+  INCLUDE = "include",
+}
+
+export enum ConsentFlagType {
+  BOOLEAN = "boolean",
+  CONSENT_MECHANISM = "consent_mechanism",
 }
 
 // NOTE: This (and most enums!) could reasonably be replaced by string union

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -168,7 +168,7 @@ export interface FidesInitOptions {
  * ensure that the documented interface isn't overly specific in areas we may
  * need to change.
  */
-export interface FidesGlobal extends Omit<Fides, "gtm"> {
+export interface FidesGlobal extends Omit<Fides, "gtm" | "consent"> {
   cookie?: FidesCookie;
   config?: FidesConfig;
   consent: NoticeConsent;
@@ -190,7 +190,7 @@ export interface FidesGlobal extends Omit<Fides, "gtm"> {
   identity: FidesJSIdentity;
   initialized: boolean;
   options: FidesInitOptions;
-  saved_consent: NoticeConsent;
+  saved_consent: NoticeValues;
   tcf_consent: TcfOtherConsent;
   blueconic: typeof blueconic;
   gtm: typeof gtm;
@@ -219,14 +219,35 @@ export interface OtToFidesConsentMapping {
 }
 
 /**
- * Store the user's consent preferences as notice_key -> boolean pairs, e.g.
+ * Store the user's consent preferences as well as implicit consent preferences if applicable
+ * as notice_key -> boolean pairs or notice_key -> consent_mechanism pairs, depending on
+ * the value of `Fides.options.fidesConsentFlagType` and `Fides.options.fidesConsentNonApplicableFlagMode`.
+ * eg.
+ * {
+ *   "data_sales": false,
+ *   "analytics": true,
+ *   ...
+ * }
+ * or
+ * {
+ *   "data_sales": "opt_out",
+ *   "analytics": "not_applicable",
+ *   ...
+ * }
+ */
+export type NoticeConsent = Record<string, boolean | UserConsentPreference>;
+
+/**
+ * Store the user's explicit consent preferences as notice_key -> boolean pairs,
+ * regardless of the value of `Fides.options.fidesConsentFlagType` and
+ * `Fides.options.fidesConsentNonApplicableFlagMode`.
  * {
  *   "data_sales": false,
  *   "analytics": true,
  *   ...
  * }
  */
-export type NoticeConsent = Record<string, boolean>;
+export type NoticeValues = Record<string, boolean>;
 
 /**
  * Store the user's identity values, e.g.
@@ -685,6 +706,7 @@ export enum UserConsentPreference {
   OPT_IN = "opt_in",
   OPT_OUT = "opt_out",
   ACKNOWLEDGE = "acknowledge",
+  NOT_APPLICABLE = "not_applicable",
   TCF = "tcf",
 }
 

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -31,8 +31,8 @@ import {
 } from "./consent-types";
 import {
   noticeHasConsentInCookie,
+  processExternalConsentValue,
   transformConsentToFidesUserPreference,
-  transformUserPreferenceToBoolean,
 } from "./shared-consent-utils";
 import { TcfModelsRecord } from "./tcf/types";
 
@@ -520,18 +520,12 @@ const normalizeConsentValues = ({
 
   // For boolean case, we need to transform any consent mechanism strings to booleans
   if (flagType !== ConsentFlagType.CONSENT_MECHANISM) {
-    Object.keys(consent).forEach((key) => {
-      const value = consent[key];
-      if (typeof value === "string") {
-        // Transform consent mechanism strings to booleans
-        normalizedConsentValues[key] = transformUserPreferenceToBoolean(
-          value as UserConsentPreference,
-        );
-      } else {
-        normalizedConsentValues[key] = value;
-      }
-    });
-    return normalizedConsentValues;
+    return Object.fromEntries(
+      Object.entries(consent).map(([key, value]) => [
+        key,
+        processExternalConsentValue(value),
+      ]),
+    );
   }
 
   // For consent mechanism case, we need the consent mechanisms to transform booleans

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -7,8 +7,10 @@ import {
 import { ConsentContext } from "./consent-context";
 import {
   ComponentType,
+  ConsentFlagType,
   ConsentMechanism,
   ConsentMethod,
+  ConsentNonApplicableFlagMode,
   EmptyExperience,
   FidesCookie,
   FidesExperienceLanguageValidatorMap,
@@ -30,6 +32,7 @@ import {
 import {
   noticeHasConsentInCookie,
   transformConsentToFidesUserPreference,
+  transformUserPreferenceToBoolean,
 } from "./shared-consent-utils";
 import { TcfModelsRecord } from "./tcf/types";
 
@@ -368,23 +371,6 @@ export const defaultShowModal = () => {
   fidesDebugger("The current experience does not support displaying a modal.");
 };
 
-/**
- * Parses a comma-separated string of notice keys into an array of strings.
- * Handles undefined input, trims whitespace, and filters out empty strings.
- */
-export const parseFidesDisabledNotices = (
-  value: string | undefined,
-): string[] => {
-  if (!value) {
-    return [];
-  }
-
-  return value
-    .split(",")
-    .map((key) => key.trim())
-    .filter(Boolean);
-};
-
 export const createConsentPreferencesToSave = (
   privacyNoticeList: PrivacyNoticeItem[],
   enabledPrivacyNoticeKeys: string[],
@@ -449,4 +435,188 @@ export const decodeNoticeConsentString = (
       cause: error,
     });
   }
+};
+
+interface HandleNonApplicableNoticesOptions {
+  consent: NoticeConsent;
+  nonApplicableNotices: string[];
+  flagType: ConsentFlagType;
+  mode?: ConsentNonApplicableFlagMode;
+}
+
+/**
+ * Handles non-applicable notices in the consent object based on the flag type and mode
+ * @param consent - The consent values to modify
+ * @param nonApplicableNotices - List of notice keys that are not applicable
+ * @param flagType - The target format for normalization
+ * @param mode - Whether to include or omit non-applicable notices
+ */
+const handleNonApplicableNotices = ({
+  consent,
+  nonApplicableNotices,
+  flagType,
+  mode = ConsentNonApplicableFlagMode.OMIT,
+}: HandleNonApplicableNoticesOptions): NoticeConsent => {
+  if (!nonApplicableNotices?.length) {
+    return consent;
+  }
+
+  const result = { ...consent };
+
+  if (mode === ConsentNonApplicableFlagMode.INCLUDE) {
+    // Add non-applicable notices with appropriate values
+    nonApplicableNotices.forEach((key) => {
+      result[key] =
+        flagType === ConsentFlagType.CONSENT_MECHANISM
+          ? UserConsentPreference.NOT_APPLICABLE
+          : true;
+    });
+  } else {
+    // Remove non-applicable notices
+    nonApplicableNotices.forEach((key) => {
+      delete result[key];
+    });
+  }
+
+  return result;
+};
+
+type NoticeConsentMechanismMap = {
+  [key: string]: ConsentMechanism;
+};
+
+interface BaseNormalizeConsentValuesOptions {
+  consent: NoticeConsent;
+}
+
+interface BooleanConsentOptions extends BaseNormalizeConsentValuesOptions {
+  flagType?: ConsentFlagType.BOOLEAN;
+  consentMechanisms?: NoticeConsentMechanismMap;
+}
+
+interface ConsentMechanismOptions extends BaseNormalizeConsentValuesOptions {
+  flagType: ConsentFlagType.CONSENT_MECHANISM;
+  consentMechanisms: NoticeConsentMechanismMap;
+}
+
+type NormalizeConsentValuesOptions =
+  | BooleanConsentOptions
+  | ConsentMechanismOptions;
+
+/**
+ * Normalizes consent values between boolean and consent mechanism formats.
+ * For boolean format: converts consent mechanism strings to booleans
+ * For consent mechanism format: converts booleans to consent mechanism strings
+ * @param consent - The consent values to normalize
+ * @param flagType - The target format for normalization
+ * @param consentMechanisms - Required when converting booleans to consent mechanisms
+ */
+const normalizeConsentValues = ({
+  consent,
+  flagType = ConsentFlagType.BOOLEAN,
+  consentMechanisms,
+}: NormalizeConsentValuesOptions): NoticeConsent => {
+  const normalizedConsentValues: NoticeConsent = {};
+
+  // For boolean case, we need to transform any consent mechanism strings to booleans
+  if (flagType !== ConsentFlagType.CONSENT_MECHANISM) {
+    Object.keys(consent).forEach((key) => {
+      const value = consent[key];
+      if (typeof value === "string") {
+        // Transform consent mechanism strings to booleans
+        normalizedConsentValues[key] = transformUserPreferenceToBoolean(
+          value as UserConsentPreference,
+        );
+      } else {
+        normalizedConsentValues[key] = value;
+      }
+    });
+    return normalizedConsentValues;
+  }
+
+  // For consent mechanism case, we need the consent mechanisms to transform booleans
+  const hasBooleanValues = Object.values(consent).some(
+    (value) => typeof value === "boolean",
+  );
+  if (hasBooleanValues && !consentMechanisms) {
+    throw new Error(
+      "Cannot transform boolean consent values to consent mechanisms without consent mechanisms map",
+    );
+  }
+
+  // If no boolean values, return as is
+  if (!hasBooleanValues) {
+    return { ...consent };
+  }
+
+  Object.keys(consent).forEach((key) => {
+    const value = consent[key];
+    if (typeof value === "string") {
+      normalizedConsentValues[key] = value;
+    } else {
+      const consentMechanism = (consentMechanisms as NoticeConsentMechanismMap)[
+        key
+      ];
+      normalizedConsentValues[key] = transformConsentToFidesUserPreference(
+        value,
+        consentMechanism,
+      );
+    }
+  });
+
+  return normalizedConsentValues;
+};
+
+export const applyOverridesToConsent = (
+  fidesConsent: NoticeConsent,
+  nonApplicablePrivacyNotices: string[] | undefined,
+  privacyNotices: PrivacyNoticeWithPreference[] | undefined = [],
+  flagTypeOverride?: ConsentFlagType,
+  nonApplicableFlagModeOverride?: ConsentNonApplicableFlagMode,
+): NoticeConsent => {
+  const consent = { ...fidesConsent };
+  // Get options from either the provided options or the Fides config, with
+  // provided options taking precedence
+  const overrideOptions = window.Fides?.options;
+  const nonApplicableFlagMode =
+    nonApplicableFlagModeOverride ??
+    overrideOptions?.fidesConsentNonApplicableFlagMode ??
+    ConsentNonApplicableFlagMode.OMIT;
+  const flagType =
+    flagTypeOverride ??
+    overrideOptions?.fidesConsentFlagType ??
+    ConsentFlagType.BOOLEAN;
+
+  const consentValues: NoticeConsent = {};
+
+  // Handle non-applicable privacy notices based on mode
+  Object.assign(
+    consentValues,
+    handleNonApplicableNotices({
+      consent: {},
+      nonApplicableNotices: nonApplicablePrivacyNotices ?? [],
+      flagType,
+      mode: nonApplicableFlagMode,
+    }),
+  );
+
+  // Then override with actual consent values
+  const consentMechanisms = privacyNotices.reduce(
+    (acc, notice) => ({
+      ...acc,
+      [notice.notice_key]: notice.consent_mechanism,
+    }),
+    {},
+  );
+
+  Object.assign(
+    consentValues,
+    normalizeConsentValues({
+      consent,
+      consentMechanisms,
+      flagType,
+    }),
+  );
+
+  return consentValues;
 };

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -385,7 +385,7 @@ export const updateCookieFromNoticePreferences = async (
  * default values). This is used during initialization to override saved cookie
  * values with newer values from the experience.
  */
-export const getConsentStateFromExperience = (
+const getConsentStateFromExperience = (
   experience: PrivacyExperience,
 ): NoticeConsent => {
   const consent: NoticeConsent = {};

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -15,6 +15,7 @@ import {
 } from "./consent-types";
 import { resolveLegacyConsentValue } from "./consent-value";
 import {
+  processExternalConsentValue,
   transformConsentToFidesUserPreference,
   transformUserPreferenceToBoolean,
 } from "./shared-consent-utils";
@@ -149,11 +150,8 @@ export const getOrMakeFidesCookie = (
   // If the cookie is saved using consent mechanism because of the fidesConsentFlagType override, we need to convert it to boolean for internal use
   if (parsedCookie?.consent) {
     const { consent } = parsedCookie;
-    Object.keys(consent).forEach((key) => {
-      const value = consent[key];
-      if (typeof value === "string") {
-        consent[key] = transformUserPreferenceToBoolean(value);
-      }
+    Object.entries(consent).forEach(([key, value]) => {
+      consent[key] = processExternalConsentValue(value);
     });
   }
 

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -11,6 +11,7 @@ import {
   PrivacyExperience,
   PrivacyNoticeWithPreference,
   SaveConsentPreference,
+  UserConsentPreference,
 } from "./consent-types";
 import { resolveLegacyConsentValue } from "./consent-value";
 import {
@@ -50,7 +51,7 @@ export const consentCookieObjHasSomeConsentSet = (
     return false;
   }
   return Object.values(consent).some(
-    (val: boolean | undefined) => val !== undefined,
+    (val: boolean | UserConsentPreference | undefined) => val !== undefined,
   );
 };
 

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -145,6 +145,18 @@ export const getOrMakeFidesCookie = (
 
   // Check for an existing cookie for this device
   let parsedCookie: FidesCookie | undefined = getFidesConsentCookie();
+
+  // If the cookie is saved using consent mechanism because of the fidesConsentFlagType override, we need to convert it to boolean for internal use
+  if (parsedCookie?.consent) {
+    const { consent } = parsedCookie;
+    Object.keys(consent).forEach((key) => {
+      const value = consent[key];
+      if (typeof value === "string") {
+        consent[key] = transformUserPreferenceToBoolean(value);
+      }
+    });
+  }
+
   if (!parsedCookie) {
     fidesDebugger(
       `No existing Fides consent cookie found, returning defaults.`,

--- a/clients/fides-js/src/lib/events.ts
+++ b/clients/fides-js/src/lib/events.ts
@@ -1,6 +1,6 @@
 import type { FidesEvent as DocsFidesEvent, FidesEventType } from "../docs";
 import { FidesCookie } from "./consent-types";
-import { applyOverridesToConsent } from "./shared-consent-utils";
+import { applyOverridesToConsent } from "./consent-utils";
 
 // Bonus points: update the WindowEventMap interface with our custom event types
 declare global {

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -20,6 +20,7 @@ import {
   FidesOverrides,
   FidesWindowOverrides,
   NoticeConsent,
+  NoticeValues,
   OverrideType,
   PrivacyExperience,
   SaveConsentPreference,
@@ -311,7 +312,7 @@ export const getInitialFides = ({
   updateExperienceFromCookieConsent,
 }: {
   cookie: FidesCookie;
-  savedConsent: NoticeConsent;
+  savedConsent: NoticeValues;
 } & FidesConfig & {
     updateExperienceFromCookieConsent: (props: {
       experience: PrivacyExperience;

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -11,9 +11,9 @@ import {
   SaveConsentPreference,
   UserConsentPreference,
 } from "./consent-types";
+import { applyOverridesToConsent } from "./consent-utils";
 import { removeCookiesFromBrowser, saveFidesCookie } from "./cookie";
 import { dispatchFidesEvent } from "./events";
-import { applyOverridesToConsent } from "./shared-consent-utils";
 import { TcfSavePreferences } from "./tcf/types";
 
 /**

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -4,6 +4,7 @@ import {
   ConsentOptionCreate,
   FidesCookie,
   FidesInitOptions,
+  NoticeValues,
   PrivacyExperience,
   PrivacyExperienceMinimal,
   PrivacyPreferencesRequest,
@@ -112,7 +113,7 @@ export const updateConsentPreferences = async ({
   // 4. Save preferences to the cookie in the browser
   fidesDebugger("Saving preferences to cookie");
   saveFidesCookie(cookie, options.base64Cookie);
-  window.Fides.saved_consent = cookie.consent;
+  window.Fides.saved_consent = cookie.consent as NoticeValues;
 
   // 5. Save preferences to API (if not disabled)
   if (!options.fidesDisableSaveApi) {

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -13,6 +13,7 @@ import {
 } from "./consent-types";
 import { removeCookiesFromBrowser, saveFidesCookie } from "./cookie";
 import { dispatchFidesEvent } from "./events";
+import { applyOverridesToConsent } from "./shared-consent-utils";
 import { TcfSavePreferences } from "./tcf/types";
 
 /**
@@ -106,13 +107,21 @@ export const updateConsentPreferences = async ({
 
   // 3. Update the window.Fides object
   fidesDebugger("Updating window.Fides");
-  window.Fides.consent = cookie.consent;
+  const normalizedConsent = applyOverridesToConsent(
+    cookie.consent,
+    window.Fides?.experience?.non_applicable_privacy_notices,
+    window.Fides?.experience?.privacy_notices,
+  );
+  window.Fides.consent = normalizedConsent;
   window.Fides.fides_string = cookie.fides_string;
   window.Fides.tcf_consent = cookie.tcf_consent;
 
   // 4. Save preferences to the cookie in the browser
   fidesDebugger("Saving preferences to cookie");
-  saveFidesCookie(cookie, options.base64Cookie);
+  saveFidesCookie(
+    { ...cookie, consent: normalizedConsent },
+    options.base64Cookie,
+  );
   window.Fides.saved_consent = cookie.consent as NoticeValues;
 
   // 5. Save preferences to API (if not disabled)

--- a/clients/fides-js/src/lib/shared-consent-utils.ts
+++ b/clients/fides-js/src/lib/shared-consent-utils.ts
@@ -50,6 +50,27 @@ export const transformConsentToFidesUserPreference = (
 };
 
 /**
+ * Used to process consent values from externally accessible sources (Cookie, Events, Fides.consent)
+ * If the experience is set to use consent mechanism as the consent value, we need to transform the
+ * value to a boolean for internal use.
+ *
+ * Type-checks a consent value and transforms it if it's a string.
+ * If the value is a string, it converts it to a boolean using transformUserPreferenceToBoolean.
+ * Otherwise, returns the original value.
+ *
+ * @param value - The ambiguous consent value to process.
+ * @returns The processed consent value as a boolean for internal use.
+ */
+export const processExternalConsentValue = (
+  value: boolean | UserConsentPreference,
+): boolean => {
+  if (typeof value === "string") {
+    return transformUserPreferenceToBoolean(value);
+  }
+  return value;
+};
+
+/**
  * Parses a comma-separated string of notice keys into an array of strings.
  * Handles undefined input, trims whitespace, and filters out empty strings.
  */

--- a/clients/fides-js/src/lib/shared-consent-utils.ts
+++ b/clients/fides-js/src/lib/shared-consent-utils.ts
@@ -1,8 +1,5 @@
-import {} from "../integrations/gtm";
 import {
-  ConsentFlagType,
   ConsentMechanism,
-  ConsentNonApplicableFlagMode,
   NoticeConsent,
   PrivacyNoticeWithPreference,
   UserConsentPreference,
@@ -52,186 +49,19 @@ export const transformConsentToFidesUserPreference = (
   return UserConsentPreference.OPT_OUT;
 };
 
-interface HandleNonApplicableNoticesOptions {
-  consent: NoticeConsent;
-  nonApplicableNotices: string[];
-  flagType: ConsentFlagType;
-  mode?: ConsentNonApplicableFlagMode;
-}
-
 /**
- * Handles non-applicable notices in the consent object based on the flag type and mode
- * @param consent - The consent values to modify
- * @param nonApplicableNotices - List of notice keys that are not applicable
- * @param flagType - The target format for normalization
- * @param mode - Whether to include or omit non-applicable notices
+ * Parses a comma-separated string of notice keys into an array of strings.
+ * Handles undefined input, trims whitespace, and filters out empty strings.
  */
-export const handleNonApplicableNotices = ({
-  consent,
-  nonApplicableNotices,
-  flagType,
-  mode = ConsentNonApplicableFlagMode.OMIT,
-}: HandleNonApplicableNoticesOptions): NoticeConsent => {
-  if (!nonApplicableNotices?.length) {
-    return consent;
+export const parseFidesDisabledNotices = (
+  value: string | undefined,
+): string[] => {
+  if (!value) {
+    return [];
   }
 
-  const result = { ...consent };
-
-  if (mode === ConsentNonApplicableFlagMode.INCLUDE) {
-    // Add non-applicable notices with appropriate values
-    nonApplicableNotices.forEach((key) => {
-      result[key] =
-        flagType === ConsentFlagType.CONSENT_MECHANISM
-          ? UserConsentPreference.NOT_APPLICABLE
-          : true;
-    });
-  } else {
-    // Remove non-applicable notices
-    nonApplicableNotices.forEach((key) => {
-      delete result[key];
-    });
-  }
-
-  return result;
-};
-
-type NoticeConsentMechanismMap = {
-  [key: string]: ConsentMechanism;
-};
-
-interface BaseNormalizeConsentValuesOptions {
-  consent: NoticeConsent;
-}
-
-interface BooleanConsentOptions extends BaseNormalizeConsentValuesOptions {
-  flagType?: ConsentFlagType.BOOLEAN;
-  consentMechanisms?: NoticeConsentMechanismMap;
-}
-
-interface ConsentMechanismOptions extends BaseNormalizeConsentValuesOptions {
-  flagType: ConsentFlagType.CONSENT_MECHANISM;
-  consentMechanisms: NoticeConsentMechanismMap;
-}
-
-type NormalizeConsentValuesOptions =
-  | BooleanConsentOptions
-  | ConsentMechanismOptions;
-
-/**
- * Normalizes consent values between boolean and consent mechanism formats.
- * For boolean format: converts consent mechanism strings to booleans
- * For consent mechanism format: converts booleans to consent mechanism strings
- * @param consent - The consent values to normalize
- * @param flagType - The target format for normalization
- * @param consentMechanisms - Required when converting booleans to consent mechanisms
- */
-export const normalizeConsentValues = ({
-  consent,
-  flagType = ConsentFlagType.BOOLEAN,
-  consentMechanisms,
-}: NormalizeConsentValuesOptions): NoticeConsent => {
-  const normalizedConsentValues: NoticeConsent = {};
-
-  // For boolean case, we need to transform any consent mechanism strings to booleans
-  if (flagType !== ConsentFlagType.CONSENT_MECHANISM) {
-    Object.keys(consent).forEach((key) => {
-      const value = consent[key];
-      if (typeof value === "string") {
-        // Transform consent mechanism strings to booleans
-        normalizedConsentValues[key] = transformUserPreferenceToBoolean(
-          value as UserConsentPreference,
-        );
-      } else {
-        normalizedConsentValues[key] = value;
-      }
-    });
-    return normalizedConsentValues;
-  }
-
-  // For consent mechanism case, we need the consent mechanisms to transform booleans
-  const hasBooleanValues = Object.values(consent).some(
-    (value) => typeof value === "boolean",
-  );
-  if (hasBooleanValues && !consentMechanisms) {
-    throw new Error(
-      "Cannot transform boolean consent values to consent mechanisms without consent mechanisms map",
-    );
-  }
-
-  // If no boolean values, return as is
-  if (!hasBooleanValues) {
-    return { ...consent };
-  }
-
-  Object.keys(consent).forEach((key) => {
-    const value = consent[key];
-    if (typeof value === "string") {
-      normalizedConsentValues[key] = value;
-    } else {
-      const consentMechanism = (consentMechanisms as NoticeConsentMechanismMap)[
-        key
-      ];
-      normalizedConsentValues[key] = transformConsentToFidesUserPreference(
-        value,
-        consentMechanism,
-      );
-    }
-  });
-
-  return normalizedConsentValues;
-};
-
-export const applyOverridesToConsent = (
-  fidesConsent: NoticeConsent,
-  nonApplicablePrivacyNotices: string[] | undefined,
-  privacyNotices: PrivacyNoticeWithPreference[] | undefined = [],
-  flagTypeOverride?: ConsentFlagType,
-  nonApplicableFlagModeOverride?: ConsentNonApplicableFlagMode,
-): NoticeConsent => {
-  const consent = { ...fidesConsent };
-  // Get options from either the provided options or the Fides config, with
-  // provided options taking precedence
-  const overrideOptions = window.Fides?.options;
-  const nonApplicableFlagMode =
-    nonApplicableFlagModeOverride ??
-    overrideOptions?.fidesConsentNonApplicableFlagMode ??
-    ConsentNonApplicableFlagMode.OMIT;
-  const flagType =
-    flagTypeOverride ??
-    overrideOptions?.fidesConsentFlagType ??
-    ConsentFlagType.BOOLEAN;
-
-  const consentValues: NoticeConsent = {};
-
-  // Handle non-applicable privacy notices based on mode
-  Object.assign(
-    consentValues,
-    handleNonApplicableNotices({
-      consent: {},
-      nonApplicableNotices: nonApplicablePrivacyNotices ?? [],
-      flagType,
-      mode: nonApplicableFlagMode,
-    }),
-  );
-
-  // Then override with actual consent values
-  const consentMechanisms = privacyNotices.reduce(
-    (acc, notice) => ({
-      ...acc,
-      [notice.notice_key]: notice.consent_mechanism,
-    }),
-    {},
-  );
-
-  Object.assign(
-    consentValues,
-    normalizeConsentValues({
-      consent,
-      consentMechanisms,
-      flagType,
-    }),
-  );
-
-  return consentValues;
+  return value
+    .split(",")
+    .map((key) => key.trim())
+    .filter(Boolean);
 };

--- a/clients/fides-js/src/lib/shared-consent-utils.ts
+++ b/clients/fides-js/src/lib/shared-consent-utils.ts
@@ -1,3 +1,5 @@
+import { ConsentFlagType } from "~/integrations/gtm";
+
 import {
   ConsentMechanism,
   NoticeConsent,
@@ -47,4 +49,37 @@ export const transformConsentToFidesUserPreference = (
     return UserConsentPreference.OPT_IN;
   }
   return UserConsentPreference.OPT_OUT;
+};
+
+/**
+ * Composes consent values based on the consent mechanism and flag type
+ */
+export const composeConsent = (
+  consent: NoticeConsent,
+  privacyNotices: any[] | undefined,
+  flagType: ConsentFlagType,
+): NoticeConsent => {
+  const consentValues: NoticeConsent = {};
+
+  Object.entries(consent).forEach(([key, value]) => {
+    if (privacyNotices && flagType === ConsentFlagType.CONSENT_MECHANISM) {
+      // If value is already a UserConsentPreference string, use it directly
+      if (typeof value === "string") {
+        consentValues[key] = value;
+      } else {
+        const relevantNotice = privacyNotices.find(
+          (notice) => notice.notice_key === key,
+        );
+        // Otherwise transform boolean to UserConsentPreference
+        consentValues[key] = transformConsentToFidesUserPreference(
+          value,
+          relevantNotice?.consent_mechanism,
+        );
+      }
+    } else {
+      consentValues[key] = value;
+    }
+  });
+
+  return consentValues;
 };

--- a/clients/fides-js/src/lib/shared-consent-utils.ts
+++ b/clients/fides-js/src/lib/shared-consent-utils.ts
@@ -51,35 +51,88 @@ export const transformConsentToFidesUserPreference = (
   return UserConsentPreference.OPT_OUT;
 };
 
-/**
- * Composes consent values based on the consent mechanism and flag type
- */
-export const composeConsent = (
-  consent: NoticeConsent,
-  privacyNotices: any[] | undefined,
-  flagType: ConsentFlagType,
-): NoticeConsent => {
-  const consentValues: NoticeConsent = {};
+type NoticeConsentMechanismMap = {
+  [key: string]: ConsentMechanism;
+};
 
-  Object.entries(consent).forEach(([key, value]) => {
-    if (privacyNotices && flagType === ConsentFlagType.CONSENT_MECHANISM) {
-      // If value is already a UserConsentPreference string, use it directly
+interface BaseNormalizeConsentValuesOptions {
+  consent: NoticeConsent;
+}
+
+interface BooleanConsentOptions extends BaseNormalizeConsentValuesOptions {
+  flagType?: ConsentFlagType.BOOLEAN;
+  consentMechanisms?: NoticeConsentMechanismMap;
+}
+
+interface ConsentMechanismOptions extends BaseNormalizeConsentValuesOptions {
+  flagType: ConsentFlagType.CONSENT_MECHANISM;
+  consentMechanisms: NoticeConsentMechanismMap;
+}
+
+type NormalizeConsentValuesOptions =
+  | BooleanConsentOptions
+  | ConsentMechanismOptions;
+
+/**
+ * Normalizes consent values between boolean and consent mechanism formats.
+ * For boolean format: converts consent mechanism strings to booleans
+ * For consent mechanism format: converts booleans to consent mechanism strings
+ * @param consent - The consent values to normalize
+ * @param flagType - The target format for normalization
+ * @param consentMechanisms - Required when converting booleans to consent mechanisms
+ */
+export const normalizeConsentValues = ({
+  consent,
+  flagType = ConsentFlagType.BOOLEAN,
+  consentMechanisms,
+}: NormalizeConsentValuesOptions): NoticeConsent => {
+  const normalizedConsentValues: NoticeConsent = {};
+
+  // For boolean case, we need to transform any consent mechanism strings to booleans
+  if (flagType !== ConsentFlagType.CONSENT_MECHANISM) {
+    Object.keys(consent).forEach((key) => {
+      const value = consent[key];
       if (typeof value === "string") {
-        consentValues[key] = value;
+        // Transform consent mechanism strings to booleans
+        normalizedConsentValues[key] = transformUserPreferenceToBoolean(
+          value as UserConsentPreference,
+        );
       } else {
-        const relevantNotice = privacyNotices.find(
-          (notice) => notice.notice_key === key,
-        );
-        // Otherwise transform boolean to UserConsentPreference
-        consentValues[key] = transformConsentToFidesUserPreference(
-          value,
-          relevantNotice?.consent_mechanism,
-        );
+        normalizedConsentValues[key] = value;
       }
+    });
+    return normalizedConsentValues;
+  }
+
+  // For consent mechanism case, we need the consent mechanisms to transform booleans
+  const hasBooleanValues = Object.values(consent).some(
+    (value) => typeof value === "boolean",
+  );
+  if (hasBooleanValues && !consentMechanisms) {
+    throw new Error(
+      "Cannot transform boolean consent values to consent mechanisms without consent mechanisms map",
+    );
+  }
+
+  // If no boolean values, return as is
+  if (!hasBooleanValues) {
+    return { ...consent };
+  }
+
+  Object.keys(consent).forEach((key) => {
+    const value = consent[key];
+    if (typeof value === "string") {
+      normalizedConsentValues[key] = value;
     } else {
-      consentValues[key] = value;
+      const consentMechanism = (consentMechanisms as NoticeConsentMechanismMap)[
+        key
+      ];
+      normalizedConsentValues[key] = transformConsentToFidesUserPreference(
+        value,
+        consentMechanism,
+      );
     }
   });
 
-  return consentValues;
+  return normalizedConsentValues;
 };

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -67,6 +67,8 @@ export type PrivacyCenterClientSettings = Pick<
   | "FIDES_CLEAR_COOKIE"
   | "FIDES_CONSENT_OVERRIDE"
   | "FIDES_DISABLED_NOTICES"
+  | "FIDES_CONSENT_NON_APPLICABLE_FLAG_MODE"
+  | "FIDES_CONSENT_FLAG_TYPE"
 >;
 
 export type Styles = string;
@@ -326,6 +328,9 @@ export const getClientSettings = (): PrivacyCenterClientSettings => {
     FIDES_CLEAR_COOKIE: settings.FIDES_CLEAR_COOKIE,
     FIDES_CONSENT_OVERRIDE: settings.FIDES_CONSENT_OVERRIDE,
     FIDES_DISABLED_NOTICES: settings.FIDES_DISABLED_NOTICES,
+    FIDES_CONSENT_NON_APPLICABLE_FLAG_MODE:
+      settings.FIDES_CONSENT_NON_APPLICABLE_FLAG_MODE,
+    FIDES_CONSENT_FLAG_TYPE: settings.FIDES_CONSENT_FLAG_TYPE,
   };
 
   return clientSettings;

--- a/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
+++ b/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
@@ -1,4 +1,8 @@
-import { ConsentMethod } from "~/types/api";
+import type { ConsentMethod } from "~/types/api";
+import type {
+  ConsentFlagType,
+  ConsentNonApplicableFlagMode,
+} from "~/types/config";
 
 /**
  * Settings that can be controlled using ENV vars on the server.
@@ -43,4 +47,6 @@ export interface PrivacyCenterSettings {
   SHOW_BRAND_LINK: boolean; // whether to render the Ethyca brand link
   FIDES_CONSENT_OVERRIDE: ConsentMethod.ACCEPT | ConsentMethod.REJECT | null; // (optional) sets a previously learned consent preference for the user
   FIDES_DISABLED_NOTICES: string | null; // (optional) comma-separated list of notice_keys to disable in the CMP Overlay
+  FIDES_CONSENT_NON_APPLICABLE_FLAG_MODE: ConsentNonApplicableFlagMode | null; // (optional) determines how non-applicable privacy notices are handled (omit|include)
+  FIDES_CONSENT_FLAG_TYPE: ConsentFlagType | null; // (optional) determines the type of value to use for consent (boolean|consent_mechanism)
 }

--- a/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
+++ b/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
@@ -1,5 +1,9 @@
 import { PrivacyCenterSettings } from "~/app/server-utils/PrivacyCenterSettings";
-import { ConsentMethod } from "~/types/api";
+import type { ConsentMethod } from "~/types/api";
+import type {
+  ConsentFlagType,
+  ConsentNonApplicableFlagMode,
+} from "~/types/config";
 
 /**
  * Default value for how long to cache the /fides.js bundle for, in seconds.
@@ -102,6 +106,14 @@ const loadEnvironmentVariables = () => {
         | ConsentMethod.REJECT) || null,
     FIDES_DISABLED_NOTICES:
       process.env.FIDES_PRIVACY_CENTER__FIDES_DISABLED_NOTICES || null,
+    FIDES_CONSENT_NON_APPLICABLE_FLAG_MODE:
+      (process.env
+        .FIDES_PRIVACY_CENTER__FIDES_CONSENT_NON_APPLICABLE_FLAG_MODE as ConsentNonApplicableFlagMode) ||
+      null,
+    FIDES_CONSENT_FLAG_TYPE:
+      (process.env
+        .FIDES_PRIVACY_CENTER__FIDES_CONSENT_FLAG_TYPE as ConsentFlagType) ||
+      null,
   };
   return settings;
 };

--- a/clients/privacy-center/components/consent/notice-driven/NoticeDrivenConsent.tsx
+++ b/clients/privacy-center/components/consent/notice-driven/NoticeDrivenConsent.tsx
@@ -448,13 +448,12 @@ export const resolveConsentValue = (
   );
   if (preferenceExistsInCookie) {
     return transformConsentToFidesUserPreference(
-      // @ts-ignore
-      cookie.consent[notice.notice_key],
+      cookie.consent[notice.notice_key] as boolean,
       notice.consent_mechanism,
-    );
+    ) as UserConsentPreference;
   }
 
-  return notice.default_preference!;
+  return notice.default_preference as UserConsentPreference;
 };
 
 export default NoticeDrivenConsent;

--- a/clients/privacy-center/cypress/e2e/consent-events.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-events.cy.ts
@@ -1,3 +1,7 @@
+import {
+  ConsentFlagType,
+  ConsentNonApplicableFlagMode,
+} from "fides-js/src/lib/consent-types";
 import type { FidesEventDetail, FidesEventType } from "fides-js/src/lib/events";
 
 import { stubConfig, stubTCFExperience } from "../support/stubs";
@@ -691,6 +695,106 @@ describe("Consent FidesEvents", () => {
       });
 
       expectFidesEventSequence(expectedEvents);
+    });
+  });
+
+  describe("when using consent mechanism flags and non-applicable notices", () => {
+    beforeEach(() => {
+      // Load the banner_and_modal experience
+      const fixture = "experience_banner_modal.json";
+      cy.fixture(`consent/${fixture}`).then((data) => {
+        let experience = data.items[0];
+
+        // Add non-applicable privacy notices
+        experience.non_applicable_privacy_notices = [
+          "essential",
+          "personalization",
+        ];
+
+        stubConfig({
+          experience,
+          options: {
+            fidesConsentFlagType: ConsentFlagType.CONSENT_MECHANISM,
+            fidesConsentNonApplicableFlagMode:
+              ConsentNonApplicableFlagMode.INCLUDE,
+          },
+        });
+      });
+    });
+
+    it("should correctly format consent values in events based on flag type and mode", () => {
+      // Create our array of expected events
+      const expectedEvents: FidesEventExpectation[] = [];
+
+      // Initialize and show banner
+      expectedEvents.push(
+        { type: "FidesInitializing", detail: {} },
+        { type: "FidesInitialized", detail: {} },
+        {
+          type: "FidesUIShown",
+          detail: { extraDetails: { servingComponent: "banner" } },
+        },
+      );
+
+      // Open modal from banner button
+      cy.get("#fides-banner .fides-manage-preferences-button").click();
+      expectedEvents.push({
+        type: "FidesUIShown",
+        detail: { extraDetails: { servingComponent: "modal" } },
+      });
+
+      // Save preferences - this should trigger FidesUpdating and FidesUpdated events
+      cy.get("#fides-modal .fides-save-button").click();
+      expectedEvents.push(
+        { type: "FidesModalClosed", detail: {} },
+        {
+          type: "FidesUpdating",
+          detail: {
+            extraDetails: {
+              consentMethod: "save",
+            },
+          },
+        },
+        {
+          type: "FidesUpdated",
+          detail: {
+            extraDetails: {
+              consentMethod: "save",
+            },
+          },
+        },
+      );
+
+      // Verify the sequence of events
+      cy.log(
+        "Verify FidesUpdated event has correctly formatted consent values",
+      );
+      cy.get("@AllFidesEvents").then((stub: any) => {
+        // Get the FidesUpdated event
+        const updatedEvent = stub
+          .getCalls()
+          .find((call) => call.args[0].type === "FidesUpdated");
+        expect(updatedEvent).to.exist;
+
+        const { detail } = updatedEvent.args[0];
+
+        // Check consent formatting - values should be strings like "opt_in" not booleans
+        expect(detail.consent).to.be.an("object");
+        Object.values(detail.consent).forEach((value) => {
+          expect(value).to.be.a("string");
+        });
+
+        // Verify consent contains values for applicable notices with string mechanisms
+        expect(detail.consent).to.have.any.keys([
+          "advertising",
+          "analytics_opt_out",
+        ]);
+
+        // Verify non-applicable notices are included with "not_applicable" value
+        expect(detail.consent).to.include.keys("essential", "personalization");
+        expect(detail.consent.essential).to.equal("acknowledge");
+        expect(detail.consent.personalization).to.equal("not_applicable");
+      });
     });
   });
 });

--- a/clients/privacy-center/cypress/e2e/consent-third-party.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-third-party.cy.ts
@@ -2,9 +2,9 @@ import { CONSENT_COOKIE_NAME } from "fides-js";
 import { stubConfig, stubTCFExperience } from "support/stubs";
 
 import {
-  GtmFlagType,
-  GtmNonApplicableFlagMode,
-} from "~/../fides-js/src/integrations/gtm";
+  ConsentFlagType,
+  ConsentNonApplicableFlagMode,
+} from "../../../fides-js/src/lib/consent-types";
 
 const PRIVACY_NOTICE_KEY_1 = "advertising";
 const PRIVACY_NOTICE_KEY_2 = "essential";
@@ -147,7 +147,7 @@ describe("Consent third party extensions", () => {
               includeCustomPurposes: true,
               demoPageWindowParams: {
                 gtmOptions: {
-                  flag_type: GtmFlagType.CONSENT_MECHANISM,
+                  flag_type: ConsentFlagType.CONSENT_MECHANISM,
                 },
               },
             });
@@ -163,7 +163,7 @@ describe("Consent third party extensions", () => {
               undefined,
               {
                 gtmOptions: {
-                  flag_type: GtmFlagType.CONSENT_MECHANISM,
+                  flag_type: ConsentFlagType.CONSENT_MECHANISM,
                 },
               },
             );
@@ -278,7 +278,8 @@ describe("Consent third party extensions", () => {
               },
               demoPageWindowParams: {
                 gtmOptions: {
-                  non_applicable_flag_mode: GtmNonApplicableFlagMode.INCLUDE,
+                  non_applicable_flag_mode:
+                    ConsentNonApplicableFlagMode.INCLUDE,
                 },
               },
             });
@@ -300,7 +301,8 @@ describe("Consent third party extensions", () => {
               undefined,
               {
                 gtmOptions: {
-                  non_applicable_flag_mode: GtmNonApplicableFlagMode.INCLUDE,
+                  non_applicable_flag_mode:
+                    ConsentNonApplicableFlagMode.INCLUDE,
                 },
               },
             );

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -267,9 +267,12 @@ export default async function handler(
       fidesPrimaryColor: environment.settings.FIDES_PRIMARY_COLOR,
       fidesClearCookie: environment.settings.FIDES_CLEAR_COOKIE,
       fidesConsentOverride: environment.settings.FIDES_CONSENT_OVERRIDE,
-      fidesDisabledNotices: parseFidesDisabledNotices(
-        environment.settings.FIDES_DISABLED_NOTICES || undefined,
-      ),
+      fidesDisabledNotices: environment.settings.FIDES_DISABLED_NOTICES
+        ? parseFidesDisabledNotices(environment.settings.FIDES_DISABLED_NOTICES)
+        : null,
+      fidesConsentNonApplicableFlagMode:
+        environment.settings.FIDES_CONSENT_NON_APPLICABLE_FLAG_MODE,
+      fidesConsentFlagType: environment.settings.FIDES_CONSENT_FLAG_TYPE,
     },
     experience: experience || undefined,
     geolocation: geolocation || undefined,

--- a/clients/privacy-center/types/config.ts
+++ b/clients/privacy-center/types/config.ts
@@ -95,3 +95,13 @@ export type PrivacyRequestOption = {
   identity_inputs?: IdentityInputs;
   custom_privacy_request_fields?: CustomPrivacyRequestFields;
 };
+
+export enum ConsentNonApplicableFlagMode {
+  OMIT = "omit",
+  INCLUDE = "include",
+}
+
+export enum ConsentFlagType {
+  BOOLEAN = "boolean",
+  CONSENT_MECHANISM = "consent_mechanism",
+}


### PR DESCRIPTION
Closes [LJ-628]

### Description Of Changes

Added support for configurable consent flag types and non-applicable notice handling. This introduces two new configuration options: `fidesConsentFlagType` (for choosing between boolean or consent mechanism string formats) and `fidesConsentNonApplicableFlagMode` (for controlling whether non-applicable notices are included or omitted). These changes take what was originally applied only to GTM, and made it available to all externally facing consent objects (`Fides.consent`, events, browser cookie).

### Code Changes

* Added configuration options in FidesOptions for flag type and non-applicable notice mode
* Updated Fides interface to support both boolean and string consent values
* Created utility functions to handle different consent flag types and non-applicable notices
* Refactored GTM integration to use shared consent types
* Modified `NoticeOverlay` component to handle string consent values
* Added transformer functions to convert between different consent representation formats
* Bonus: Added ESLint rule to prevent ~/ imports (excludes test files)
* Bonus: Updated Rollup config to handle development mode more efficiently

### Steps to Confirm
1. Initialize Fides SDK with `fidesConsentFlagType: "consent_mechanism"` option and verify values use string format (`/fides-js-demo.html?geolocation=us-ca&fides_consent_flag_type=consent_mechanism`)
2. Initialize with `fidesConsentNonApplicableFlagMode: "include"` and confirm non-applicable notices are included (`/fides-js-demo.html?geolocation=us-ut&fides_consent_non_applicable_flag_mode=include`)
3. Test using both (`/fides-js-demo.html?geolocation=us-ut&fides_consent_non_applicable_flag_mode=include&fides_consent_flag_type=consent_mechanism`)
4. Verify GTM integration works with both consent flag types
5. Verify GPC works with both consent flag types

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-628]: https://ethyca.atlassian.net/browse/LJ-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ