### PR TITLE
LJ-744 Fix special purpose vendor check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Suppressing SQLAlchemy logging related to caching queries [#6089](https://github.com/ethyca/fides/pull/6089)
 - FidesJS css variable `--fides-overlay-container-border-width` now applies to banner (only applied to modal before) [#6097](https://github.com/ethyca/fides/pull/6097) https://github.com/ethyca/fides/labels/high-risk
 - Fixed vendor restriction form validation and input handling [#6101](https://github.com/ethyca/fides/pull/6101)
+- Fixed special purpose vendor check in Fides JS logic [#6118](https://github.com/ethyca/fides/pull/6118)
 
 ## [2.60.0](https://github.com/ethyca/fides/compare/2.59.2...2.60.0)
 

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -176,6 +176,9 @@ export const generateFidesString = async ({
               vendor &&
               vendor.specialPurposes?.length &&
               (!vendor.purposes || vendor.purposes.length === 0) &&
+              (!vendor.flexiblePurposes ||
+                vendor.flexiblePurposes.length === 0) &&
+              (!vendor.legIntPurposes || vendor.legIntPurposes.length === 0) &&
               !isInVendorConsents
             ) {
               tcModel.vendorLegitimateInterests.set(+id);


### PR DESCRIPTION
Closes [LJ-744](https://ethyca.atlassian.net/browse/LJ-744)

### Description Of Changes

In the Publisher Restrictions work, we noticed that vendor 838 was getting included as a special purpose only vendor when it has other purposes as well; this is because we weren't checking the `legIntPurposes` section of the GVL vendor entry 

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-744]: https://ethyca.atlassian.net/browse/LJ-744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ