### PR TITLE
Refactor OT conent migration to use existing logic to auto apply preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Changed
 - Abstract OT consent migration logic, allow write to Fides preferences api [#6099](https://github.com/ethyca/fides/pull/6099)
+- Refactor OT consent migration [#6099](https://github.com/ethyca/fides/pull/6126)
 
 ### Developer Experience
 - Cleaning up test fixtures [#6008](https://github.com/ethyca/fides/pull/6008)

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -15,7 +15,6 @@ import {
   registerDefaultProviders,
 } from "./lib/consent-migration";
 import {
-  ConsentMethod,
   FidesConfig,
   FidesCookie,
   FidesExperienceTranslationOverrides,
@@ -37,7 +36,6 @@ import {
 import {
   consentCookieObjHasSomeConsentSet,
   getFidesConsentCookie,
-  saveFidesCookie,
   updateExperienceFromCookieConsentNotices,
 } from "./lib/cookie";
 import { initializeDebugger } from "./lib/debugger";
@@ -143,13 +141,11 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
 
   // Check for migrated consent from any registered providers
   let migratedConsent: NoticeConsent | undefined;
-  let migrationMethod: ConsentMethod | undefined;
 
   if (!getFidesConsentCookie()) {
     const { consent, method } = readConsentFromAnyProvider(optionsOverrides);
     if (consent && method) {
       migratedConsent = consent;
-      migrationMethod = method;
     }
   }
 
@@ -186,15 +182,6 @@ async function init(this: FidesGlobal, providedConfig?: FidesConfig) {
         `Could not decode ncString from ${fidesString}, it may be invalid. ${error}`,
       );
     }
-  }
-
-  if (migratedConsent && migrationMethod) {
-    // If we have migrated consent, we need to write the cookie to the browser
-    Object.assign(this.cookie.fides_meta, {
-      consentMethod: migrationMethod,
-    });
-    fidesDebugger("Saving migrated preferences to Fides cookie");
-    saveFidesCookie(this.cookie, config.options.base64Cookie);
   }
 
   const initialFides = getInitialFides({

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -173,12 +173,16 @@ const automaticallyApplyPreferences = async ({
         const preference = migratedConsent[notice.notice_key];
         if (preference !== undefined) {
           migratedConsentApplied = true;
+          const userPreference =
+            typeof preference === "boolean"
+              ? transformConsentToFidesUserPreference(
+                  preference,
+                  notice.consent_mechanism,
+                )
+              : preference;
           return new SaveConsentPreference(
             notice,
-            transformConsentToFidesUserPreference(
-              preference,
-              notice.consent_mechanism,
-            ),
+            userPreference,
             bestNoticeTranslation?.privacy_notice_history_id,
           );
         }

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -37,6 +37,7 @@ import {
 import { resolveConsentValue } from "./consent-value";
 import {
   getCookieByName,
+  getFidesConsentCookie,
   getOrMakeFidesCookie,
   isNewFidesCookie,
   makeConsentDefaultsLegacy,
@@ -130,7 +131,8 @@ const automaticallyApplyPreferences = async ({
   // Check for migrated consent from OneTrust
   const { consent: migratedConsent, method: migrationMethod } =
     readConsentFromAnyProvider(fidesOptions);
-  const hasMigratedConsent = !!migratedConsent && !!migrationMethod;
+  const hasMigratedConsent =
+    !!migratedConsent && !!migrationMethod && !getFidesConsentCookie();
 
   if (
     !context.globalPrivacyControl &&

--- a/clients/privacy-center/cypress/e2e/onetrust-migration.cy.ts
+++ b/clients/privacy-center/cypress/e2e/onetrust-migration.cy.ts
@@ -76,15 +76,16 @@ describe("OneTrust to Fides consent migration", () => {
           // Check that all expected preferences exist, regardless of order
           const expectedPreferences = [
             {
-              privacy_notice_history_id: "essential",
+              privacy_notice_history_id: "pri_notice-history-essential-en-000",
+              preference: "acknowledge",
+            },
+            {
+              privacy_notice_history_id: "pri_notice-history-analytics-en-000",
               preference: "opt_in",
             },
             {
-              privacy_notice_history_id: "analytics_opt_out",
-              preference: "opt_in",
-            },
-            {
-              privacy_notice_history_id: "advertising",
+              privacy_notice_history_id:
+                "pri_notice-history-advertising-en-000",
               preference: "opt_in",
             },
           ];
@@ -182,15 +183,15 @@ describe("OneTrust to Fides consent migration", () => {
         // Check that all expected preferences exist, regardless of order
         const expectedPreferences = [
           {
-            privacy_notice_history_id: "essential",
+            privacy_notice_history_id: "pri_notice-history-essential-en-000",
+            preference: "acknowledge",
+          },
+          {
+            privacy_notice_history_id: "pri_notice-history-analytics-en-000",
             preference: "opt_in",
           },
           {
-            privacy_notice_history_id: "analytics_opt_out",
-            preference: "opt_in",
-          },
-          {
-            privacy_notice_history_id: "advertising",
+            privacy_notice_history_id: "pri_notice-history-advertising-en-000",
             preference: "opt_out",
           },
         ];
@@ -283,15 +284,15 @@ describe("OneTrust to Fides consent migration", () => {
         // Check that all expected preferences exist, regardless of order
         const expectedPreferences = [
           {
-            privacy_notice_history_id: "essential",
+            privacy_notice_history_id: "pri_notice-history-essential-en-000",
             preference: "opt_out",
           },
           {
-            privacy_notice_history_id: "analytics_opt_out",
+            privacy_notice_history_id: "pri_notice-history-analytics-en-000",
             preference: "opt_out",
           },
           {
-            privacy_notice_history_id: "advertising",
+            privacy_notice_history_id: "pri_notice-history-advertising-en-000",
             preference: "opt_out",
           },
         ];


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/LJ-749

### Description Of Changes

Refactor OT consent migration to use existing logic to auto apply preferences

### Code Changes

Refactor OT consent migration to use existing logic to auto apply preferences

### Steps to Confirm

1. confirm tests pass
2. confirm no regressions in OT consent migration (https://ethyca.atlassian.net/browse/LJ-722)

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
