### PR TITLE
Migrate last remaining Chakra icon button to Ant

### DIFF
--- a/clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx
+++ b/clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx
@@ -289,14 +289,13 @@ export const CustomReportTemplates = ({
                       pb={3}
                       data-testid="custom-reports-empty-state"
                     >
-                      <IconButton
-                        variant="primary"
-                        backgroundColor="gray.500"
-                        isRound
-                        size="xs"
+                      <Button
+                        type="primary"
+                        size="small"
                         aria-label={`add ${CUSTOM_REPORT_TITLE}`}
                         icon={<AddIcon />}
                         onClick={modalOnOpen}
+                        className="rounded-full"
                         data-testid="add-report-button"
                       />
                       <Text fontSize="sm" textAlign="center" color="gray.500">


### PR DESCRIPTION
Closes HA-232

### Description Of Changes

Migrates an IconButton that was overlooked during the button migration to Ant.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
