### PR TITLE
Update to iabtcf v1.5.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Changed
 - Attachment uploads now check for file extension types, retrieving and attachment also returns the file size. [#6124](https://github.com/ethyca/fides/pull/6124)
+- Locked down the version for @iabtechlabtcf packages for better control [#LJ-415](https://github.com/ethyca/fides/pull/LJ-415)
+
+### Fixed
+- Fix Special-purpose vendors with restricted purposes not correctly encoded in TC string [#LJ-415](https://github.com/ethyca/fides/pull/LJ-415)
 
 
 ## [2.61.0](https://github.com/ethyca/fides/compare/2.60.1...2.61.0)

--- a/clients/fides-js/__tests__/lib/tcf/tcf.test.ts
+++ b/clients/fides-js/__tests__/lib/tcf/tcf.test.ts
@@ -477,7 +477,7 @@ describe("generateFidesString", () => {
     expect(decodedTCString.publisherCountryCode).toBe("US");
   });
 
-  it("saves special purpose vendor to legitimate interest appropriately", async () => {
+  it("saves special purpose vendor to Vendor Legitimate Interest ", async () => {
     // This test only check for opt out, but is applicable regardless of consent choice
     const experienceWithSpecialPurposeVendors = {
       ...experience,
@@ -505,6 +505,12 @@ describe("generateFidesString", () => {
           features: [],
           special_features: [],
           url: "https://test.com/privacy",
+        },
+        {
+          id: "gvl.740",
+          name: "Special Purpose and Legitimate Interest Vendor",
+          special_purposes: [1],
+          features: [],
         },
       ],
       gvl: {
@@ -570,7 +576,7 @@ describe("generateFidesString", () => {
         specialFeatures: [],
         specialPurposes: [], // Preferences are not saved here
         vendorsConsent: [], // User opted out of all vendors
-        vendorsLegint: [], // No explicit legitimate interest consent
+        vendorsLegint: ["gvl.740"],
       },
     });
 
@@ -583,6 +589,7 @@ describe("generateFidesString", () => {
 
     // Verify the special purpose only vendors are appropriately added to the legitimate interest section
     expect(decodedTCString.vendorConsents.size).toBe(0);
+    expect(decodedTCString.vendorLegitimateInterests.has(740)).toBe(true);
     expect(decodedTCString.vendorLegitimateInterests.has(777)).toBe(false);
     expect(decodedTCString.vendorLegitimateInterests.has(888)).toBe(true);
     expect(decodedTCString.vendorLegitimateInterests.has(999)).toBe(true);

--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@iabgpp/cmpapi": "file:./src/lib/gpp/modules/cmpapi",
-    "@iabtechlabtcf/cmpapi": "^1.5.8",
-    "@iabtechlabtcf/core": "^1.5.7",
+    "@iabtechlabtcf/cmpapi": "1.5.15",
+    "@iabtechlabtcf/core": "1.5.15",
     "@rollup/plugin-replace": "^6.0.2",
     "a11y-dialog": "^7.5.2",
     "base-64": "^1.0.0",

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -167,16 +167,10 @@ export const generateFidesString = async ({
           (relationship) => {
             const { id } = decodeVendorId(relationship.id);
             const vendor = experience.gvl?.vendors[id];
-            // ensure specialPurposes includes purposes that are not forbidden
-            const nonForbiddenSpecialPurposes =
-              vendor?.specialPurposes?.filter(
-                (p) => !FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(p),
-              ) || [];
             if (
               vendor &&
-              (vendor.purposes.length === 0 || vendor.purposes.length > 0) &&
               vendor.legIntPurposes.length === 0 &&
-              nonForbiddenSpecialPurposes.length > 0
+              vendor.specialPurposes.length > 0
             ) {
               tcModel.vendorLegitimateInterests.set(+id);
             }

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -161,25 +161,22 @@ export const generateFidesString = async ({
         }
       });
 
-      // Set legitimate interest for special-purpose only vendors
+      // Set legitimate interest for special-purpose vendors
       if (experience.gvl?.vendors) {
         (experience as PrivacyExperience).tcf_vendor_relationships?.forEach(
           (relationship) => {
             const { id } = decodeVendorId(relationship.id);
             const vendor = experience.gvl?.vendors[id];
-            const isInVendorConsents = (
-              experience as PrivacyExperience
-            ).tcf_vendor_consents?.some(
-              (consent) => consent.id === relationship.id,
-            );
+            // ensure specialPurposes includes purposes that are not forbidden
+            const nonForbiddenSpecialPurposes =
+              vendor?.specialPurposes?.filter(
+                (p) => !FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(p),
+              ) || [];
             if (
               vendor &&
-              vendor.specialPurposes?.length &&
-              (!vendor.purposes || vendor.purposes.length === 0) &&
-              (!vendor.flexiblePurposes ||
-                vendor.flexiblePurposes.length === 0) &&
-              (!vendor.legIntPurposes || vendor.legIntPurposes.length === 0) &&
-              !isInVendorConsents
+              (vendor.purposes.length === 0 || vendor.purposes.length > 0) &&
+              vendor.legIntPurposes.length === 0 &&
+              nonForbiddenSpecialPurposes.length > 0
             ) {
               tcModel.vendorLegitimateInterests.set(+id);
             }

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -151,8 +151,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@iabgpp/cmpapi": "file:./src/lib/gpp/modules/cmpapi",
-        "@iabtechlabtcf/cmpapi": "^1.5.8",
-        "@iabtechlabtcf/core": "^1.5.7",
+        "@iabtechlabtcf/cmpapi": "1.5.15",
+        "@iabtechlabtcf/core": "1.5.15",
         "@rollup/plugin-replace": "^6.0.2",
         "a11y-dialog": "^7.5.2",
         "base-64": "^1.0.0",
@@ -2223,6 +2223,7 @@
       "version": "1.5.15",
       "resolved": "https://registry.npmjs.org/@iabtechlabtcf/cmpapi/-/cmpapi-1.5.15.tgz",
       "integrity": "sha512-ls5hhGqUuLaBhJqzUvSMTQE8BnqBgdFB8APPC9ofD3tGI+T6GG53zDtHvK/eBYCQh6i0fJCIQ3ERVWkEflR0XA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@iabtechlabtcf/core": ">=1.0.0"
       }
@@ -25195,21 +25196,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "privacy-center/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
-      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/clients/privacy-center/cypress/e2e/consent-banner-gpp.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-gpp.cy.ts
@@ -202,7 +202,7 @@ describe("Fides-js GPP extension", () => {
             // date-based and changes each day. The first 6 characters are the
             // "Created" date, the next 6 are the "Last Updated" date.
             expect(args[3][0].pingData.gppString).to.match(
-              /DBABMA~[a-zA-Z0-9_]{6}[a-zA-Z0-9_]{6}AGXABBENArEoABaAAEAAAAAAABEAAAAA/,
+              /DBABMA~[a-zA-Z0-9_]{6}[a-zA-Z0-9_]{6}AGXABBENArEoABaAAEAAAAAAABEAAiAA/,
             );
             // the `PurposeConsents` should match the gpp string
             expect(

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -439,7 +439,7 @@ describe("Fides-js TCF", () => {
             assertTcOptIns({
               cookie: cookieKeyConsent,
               modelType: "vendorLegitimateInterests",
-              ids: [],
+              ids: [fidesVendorIdToId(VENDOR_1.id)],
             });
             expect(
               cookieKeyConsent.tcf_consent.system_consent_preferences,
@@ -665,7 +665,7 @@ describe("Fides-js TCF", () => {
               assertTcOptIns({
                 cookie: cookieKeyConsent,
                 modelType: "vendorLegitimateInterests",
-                ids: [],
+                ids: [fidesVendorIdToId(VENDOR_1.id)],
               });
               expect(
                 cookieKeyConsent.tcf_consent.system_consent_preferences,
@@ -1138,7 +1138,7 @@ describe("Fides-js TCF", () => {
               assertTcOptIns({
                 cookie: cookieKeyConsent,
                 modelType: "vendorLegitimateInterests",
-                ids: [],
+                ids: [fidesVendorIdToId(VENDOR_1.id)],
               });
               expect(
                 cookieKeyConsent.tcf_consent.system_consent_preferences,
@@ -1354,7 +1354,7 @@ describe("Fides-js TCF", () => {
                 assertTcOptIns({
                   cookie: cookieKeyConsent,
                   modelType: "vendorLegitimateInterests",
-                  ids: [],
+                  ids: [fidesVendorIdToId(VENDOR_1.id)],
                 });
                 expect(
                   cookieKeyConsent.tcf_consent.system_consent_preferences,
@@ -1538,7 +1538,7 @@ describe("Fides-js TCF", () => {
               assertTcOptIns({
                 cookie: cookieKeyConsent,
                 modelType: "vendorLegitimateInterests",
-                ids: [],
+                ids: [fidesVendorIdToId(VENDOR_1.id)],
               });
               expect(
                 cookieKeyConsent.tcf_consent
@@ -1576,7 +1576,7 @@ describe("Fides-js TCF", () => {
               assertTcOptIns({
                 cookie: cookieKeyConsent,
                 modelType: "vendorLegitimateInterests",
-                ids: [],
+                ids: [fidesVendorIdToId(VENDOR_1.id)],
               });
               expect(
                 cookieKeyConsent.tcf_consent
@@ -1743,7 +1743,7 @@ describe("Fides-js TCF", () => {
               assertTcOptIns({
                 cookie: cookieKeyConsent,
                 modelType: "vendorLegitimateInterests",
-                ids: [],
+                ids: [fidesVendorIdToId(VENDOR_1.id)],
               });
               expect(
                 cookieKeyConsent.tcf_consent
@@ -1872,7 +1872,7 @@ describe("Fides-js TCF", () => {
             assertTcOptIns({
               cookie: cookieKeyConsent,
               modelType: "vendorLegitimateInterests",
-              ids: [],
+              ids: [fidesVendorIdToId(VENDOR_1.id)],
             });
             expect(
               cookieKeyConsent.tcf_consent.system_consent_preferences,
@@ -2154,7 +2154,7 @@ describe("Fides-js TCF", () => {
           assertTcOptIns({
             cookie: cookieKeyConsent,
             modelType: "vendorLegitimateInterests",
-            ids: [],
+            ids: [fidesVendorIdToId(VENDOR_1.id)],
           });
           expect(
             cookieKeyConsent.tcf_consent
@@ -2240,7 +2240,6 @@ describe("Fides-js TCF", () => {
         cy.getByTestId("consent-modal").within(() => {
           cy.get("button").contains("Opt in to all").click();
         });
-        // On slow connections, we should explicitly wait for FidesUpdated
         cy.get("@FidesUpdated")
           .should("have.been.calledOnce")
           .its("lastCall.args.0.detail.extraDetails.consentMethod")
@@ -2272,7 +2271,10 @@ describe("Fides-js TCF", () => {
               1: false,
               [vendorIdOnly]: true,
             });
-            expect(tcData.vendor.legitimateInterests).to.eql({});
+            expect(tcData.vendor.legitimateInterests).to.eql({
+              1: false,
+              [vendorIdOnly]: true,
+            });
           });
       });
 
@@ -2339,7 +2341,10 @@ describe("Fides-js TCF", () => {
               1: false,
               [vendorIdOnly]: true,
             });
-            expect(tcData.vendor.legitimateInterests).to.eql({});
+            expect(tcData.vendor.legitimateInterests).to.eql({
+              1: false,
+              [vendorIdOnly]: true,
+            });
           });
       });
     });


### PR DESCRIPTION
Closes [LJ-415]

### Description Of Changes

Our `package-lock.json` file was already updated to the `1.5.15` version, but this change updates the `package.json` to be more precise and specific about versions so we don't accidentally upgrade when we're not ready in the future.

Version `1.5.15` also includes a fix that we need to tweak our own CMP code to support. That fix is also included in this PR

### Code Changes

* Add static version to iabtechlabtcf packages
* Remove checks for vendors with purpose consent when considering adding Special Purpose vendors to Legitimate Interest list.

### Steps to Confirm

1. In Admin UI remove all vendors, and add in the following vendors:
   - "SeenThis" `gvl.415` (purpose consent: no, LI: no, special purposes: yes)
   - "Adhese" `gvl.553` (purpose consent: yes, LI: no, special purposes: yes)
   - "M6 Publicite" `gvl.1407` (purpose consent: yes, LI: no, special purposes: no)
1. Enable the TCF experience
1. In the PC demo page for TCF, Opt in to all
1. Grab the TCF String from the cookie and plug it in to https://iabgpp.com/
1. Verify that the Vendor Consents list includes both `553` and `1407`
1. Verify that the Vendor Legitimate Interests list includes both `415` and `553`
1. Note that because "Adhese" `553` has both purpose consent and special interests it correctly appears in both lists.
1. Delete the cookie and reload the demo page and Opt out of all
1. Grab the TCF String from the cookie and plug it in to https://iabgpp.com/
1. Verify that the Vendor Consents list is empty
1. Verify that the Vendor Legitimate Interests list still includes both `415` and `553`


### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-415]: https://ethyca.atlassian.net/browse/LJ-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ