### PR TITLE
Andres/ha 642

### DIFF
--- a/clients/admin-ui/src/features/integrations/useIntegrationFilterTabs.tsx
+++ b/clients/admin-ui/src/features/integrations/useIntegrationFilterTabs.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useFlags } from "~/features/common/features/features.slice";
 import { IntegrationTypeInfo } from "~/features/integrations/add-integration/allIntegrationTypes";
 
 export enum IntegrationFilterTabs {
@@ -12,7 +13,11 @@ export enum IntegrationFilterTabs {
 }
 
 const useIntegrationFilterTabs = (integrationTypes?: IntegrationTypeInfo[]) => {
-  const tabs = Object.values(IntegrationFilterTabs);
+  const { flags } = useFlags();
+  const tabs = Object.values(IntegrationFilterTabs).filter(
+    (tab) =>
+      tab !== IntegrationFilterTabs.IDENTITY_PROVIDER || flags.oktaMonitor,
+  );
 
   const [tabIndex, setTabIndex] = useState(0);
   const currentTab = tabs[tabIndex];


### PR DESCRIPTION
Closes [HA-642]

### Description Of Changes

Adding use of oktaMonitor flag for hidding Identity Provider tab on Integrations UI

### Code Changes

* Updated clients/admin-ui/src/features/integrations/useIntegrationFilterTabs.tsx 

### Steps to Confirm

1.  Use the feature flag to show/hide the IDP tab on integrations UI

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[HA-642]: https://ethyca.atlassian.net/browse/HA-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ