### PR TITLE
Adding certifi to fix SSL CA Error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ anyio==3.7.1
 APScheduler==3.9.1.post1
 asyncpg==0.27.0
 boto3==1.26.1
+certifi==2024.8.30
 celery[pytest]==5.2.7
 click_default_group==1.2.2
 cloud-sql-python-connector==1.9.2

--- a/src/fides/api/service/connectors/saas/authenticated_client.py
+++ b/src/fides/api/service/connectors/saas/authenticated_client.py
@@ -50,6 +50,7 @@ class AuthenticatedClient:
         rate_limit_config: Optional[RateLimitConfig] = None,
     ):
         self.session = Session()
+        self.session.verify = certifi.where()
         self.uri = uri
         self.configuration = configuration
         self.client_config = client_config
@@ -225,8 +226,7 @@ class AuthenticatedClient:
         if isinstance(prepared_request.body, str):
             prepared_request.body = prepared_request.body.encode("utf-8")
 
-        response = self.session.send(prepared_request, verify=certifi.where())
-
+        response = self.session.send(prepared_request)
         ignore_error = self._should_ignore_error(
             status_code=response.status_code, errors_to_ignore=ignore_errors
         )

--- a/src/fides/api/service/connectors/saas/authenticated_client.py
+++ b/src/fides/api/service/connectors/saas/authenticated_client.py
@@ -7,7 +7,7 @@ from functools import wraps
 from time import sleep
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 from urllib.parse import urlparse
-
+import certifi
 from loguru import logger
 from requests import PreparedRequest, Request, Response, Session
 
@@ -224,7 +224,7 @@ class AuthenticatedClient:
         if isinstance(prepared_request.body, str):
             prepared_request.body = prepared_request.body.encode("utf-8")
 
-        response = self.session.send(prepared_request)
+        response = self.session.send(prepared_request, verify=certifi.where())
 
         ignore_error = self._should_ignore_error(
             status_code=response.status_code, errors_to_ignore=ignore_errors

--- a/src/fides/api/service/connectors/saas/authenticated_client.py
+++ b/src/fides/api/service/connectors/saas/authenticated_client.py
@@ -7,6 +7,7 @@ from functools import wraps
 from time import sleep
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 from urllib.parse import urlparse
+
 import certifi
 from loguru import logger
 from requests import PreparedRequest, Request, Response, Session

--- a/tests/ops/service/connectors/saas/test_authenticated_client.py
+++ b/tests/ops/service/connectors/saas/test_authenticated_client.py
@@ -4,6 +4,7 @@ import unittest.mock as mock
 from email.utils import formatdate
 from typing import Any, Dict, Generator
 
+import certifi
 import pytest
 from loguru import logger
 from requests import ConnectionError, Response, Session
@@ -189,6 +190,10 @@ class TestAuthenticatedClient:
         test_authenticated_client.uri = test_http_server
         test_authenticated_client.send(request_params)
 
+    def test_clients_append_certifi_path(
+        self, test_authenticated_client, test_http_server
+    ):
+        assert test_authenticated_client.session.verify == certifi.where()
 
 @pytest.mark.unit_saas
 class TestRetryAfterHeaderParsing:

--- a/tests/ops/service/connectors/saas/test_authenticated_client.py
+++ b/tests/ops/service/connectors/saas/test_authenticated_client.py
@@ -195,6 +195,7 @@ class TestAuthenticatedClient:
     ):
         assert test_authenticated_client.session.verify == certifi.where()
 
+
 @pytest.mark.unit_saas
 class TestRetryAfterHeaderParsing:
     def test_retry_after_parses_seconds_response(self):


### PR DESCRIPTION
Closes[ LJ-728](https://ethyca.atlassian.net/browse/LJ-728?atlOrigin=eyJpIjoiMDkyMGFkOWVmMjEzNDcyOThkNzhkZjhkNTdkZjg2YTgiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

### Description Of Changes

We were having trouble hitting Shopify subdomains recently, with the integration returning an SSL Error of an invalid CA. 
We confirmed that from the server, we were able to access those endpoints, so it was a problem with Fides not getting the Certificates correctly. 

This should point which certificates to use directly. 

### Code Changes

* Using [Certifi](https://pypi.org/project/certifi/) to get the proper CA 

### Steps to Confirm

1.  DSRs where we had problems with SSL should pass 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
