### PR TITLE
LJ-745 Better enum checking

### DIFF
--- a/src/fides/api/service/storage/util.py
+++ b/src/fides/api/service/storage/util.py
@@ -42,6 +42,6 @@ def get_allowed_file_type_or_raise(file_key: str) -> str:
         logger.warning(f"File key {file_key} does not have a file extension")
         raise ValueError(error_msg)
     file_type = file_key.split(".")[-1]
-    if file_type not in [ft.name for ft in AllowedFileType]:
+    if file_type not in [ft for ft in AllowedFileType.__members__.keys()]:
         raise ValueError(error_msg)
     return AllowedFileType[file_type].value

--- a/src/fides/api/service/storage/util.py
+++ b/src/fides/api/service/storage/util.py
@@ -42,6 +42,8 @@ def get_allowed_file_type_or_raise(file_key: str) -> str:
         logger.warning(f"File key {file_key} does not have a file extension")
         raise ValueError(error_msg)
     file_type = file_key.split(".")[-1]
-    if file_type not in [extension for extension, _ in AllowedFileType.__members__.items()]:
+    if file_type not in [
+        extension for extension, _ in AllowedFileType.__members__.items()
+    ]:
         raise ValueError(error_msg)
     return AllowedFileType[file_type].value

--- a/src/fides/api/service/storage/util.py
+++ b/src/fides/api/service/storage/util.py
@@ -42,8 +42,7 @@ def get_allowed_file_type_or_raise(file_key: str) -> str:
         logger.warning(f"File key {file_key} does not have a file extension")
         raise ValueError(error_msg)
     file_type = file_key.split(".")[-1]
-    if file_type not in [
-        extension for extension, _ in AllowedFileType.__members__.items()
-    ]:
+    try:
+        return AllowedFileType[file_type].value
+    except KeyError:
         raise ValueError(error_msg)
-    return AllowedFileType[file_type].value

--- a/src/fides/api/service/storage/util.py
+++ b/src/fides/api/service/storage/util.py
@@ -42,6 +42,6 @@ def get_allowed_file_type_or_raise(file_key: str) -> str:
         logger.warning(f"File key {file_key} does not have a file extension")
         raise ValueError(error_msg)
     file_type = file_key.split(".")[-1]
-    if file_type not in [ft for ft in AllowedFileType.__members__.keys()]:
+    if file_type not in [extension for extension, _ in AllowedFileType.__members__.items()]:
         raise ValueError(error_msg)
     return AllowedFileType[file_type].value

--- a/tests/ops/service/storage/test_util.py
+++ b/tests/ops/service/storage/test_util.py
@@ -20,6 +20,13 @@ from fides.api.service.storage.util import (
             AllowedFileType.txt.value,
             id="not_a_file_type_dot_txt",
         ),
+        param("test.jpg", AllowedFileType.jpg.value, id="jpg"),
+        param("test.jpeg", AllowedFileType.jpeg.value, id="jpeg"),
+        param("test.png", AllowedFileType.png.value, id="png"),
+        param("test.xls", AllowedFileType.xls.value, id="xls"),
+        param("test.xlsx", AllowedFileType.xlsx.value, id="xlsx"),
+        param("test.csv", AllowedFileType.csv.value, id="csv"),
+        param("test.zip", AllowedFileType.zip.value, id="zip"),
         param(
             "test.not_a_file_type.txt.pdf",
             AllowedFileType.pdf.value,


### PR DESCRIPTION
Issue [745](https://ethyca.atlassian.net/browse/LJ-745)

### Description Of Changes

Found an edge case - both `jpg` and `jpeg` have the same value which caused some unexpected behavior. Updated the checking code to use `members` rather than `name`

### Code Changes

* Updated the function
* Added more tests!

### Steps to Confirm

1. All tests should pass - the endpoint work will be in fidesplus.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
