### PR TITLE
Update IAB TCF with Special Purpose exception fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,14 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Changed
 - Attachment uploads now check for file extension types, retrieving and attachment also returns the file size. [#6124](https://github.com/ethyca/fides/pull/6124)
 - Updated the AC string version from v1 to v2 format, which now includes a disclosed vendors section [#6155](https://github.com/ethyca/fides/pull/6155)
+- Locked down the version for @iabtechlabtcf packages for better control [#6145](https://github.com/ethyca/fides/pull/6145)
 
 ### Developer Experience
 - Refactored Fides initialization code to reduce duplication and improve maintainability. [#6143](https://github.com/ethyca/fides/pull/6143)
 - Improved endpoint profiler to output all frames. [#6153](https://github.com/ethyca/fides/pull/6153)
+
+### Fixed
+- Fix Special-purpose vendors with restricted purposes not correctly encoded in TC string [#6145](https://github.com/ethyca/fides/pull/6145) https://github.com/ethyca/fides/labels/high-risk
 
 ## [2.61.1](https://github.com/ethyca/fides/compare/2.61.0...2.61.1)
 

--- a/clients/fides-js/__tests__/lib/tcf/tcf.test.ts
+++ b/clients/fides-js/__tests__/lib/tcf/tcf.test.ts
@@ -12,6 +12,9 @@ import {
 } from "~/lib/tcf/types";
 
 describe("generateFidesString", () => {
+  beforeAll(() => {
+    window.fidesDebugger = () => {};
+  });
   // Test TCF data:
   const mockGvl: GVLJson = {
     vendors: {
@@ -483,21 +486,77 @@ describe("generateFidesString", () => {
       ...experience,
       tcf_vendor_relationships: [
         {
+          id: "gvl.111",
+        },
+        {
+          id: "gvl.222",
+        },
+        {
+          id: "gvl.333",
+        },
+        {
+          id: "gvl.444",
+        },
+        {
+          id: "gvl.888",
+        },
+        {
           id: "gvl.999",
-          name: "Special Purpose Only Vendor",
-          purposes: [],
-          legitimate_interest_purposes: [],
-          special_purposes: [1, 2],
-          features: [],
-          special_features: [],
-          flexible_purposes: [],
-          url: "https://test.com/privacy",
         },
       ],
       gvl: {
         ...mockGvl,
         vendors: {
-          ...mockGvl.vendors,
+          111: {
+            id: 111,
+            name: "Vendor with only purposes",
+            purposes: [1, 2, 3],
+            legIntPurposes: [],
+            flexiblePurposes: [],
+            specialPurposes: [],
+            features: [],
+            specialFeatures: [],
+          },
+          222: {
+            id: 222,
+            name: "Vendor with only legitimate interests",
+            purposes: [],
+            legIntPurposes: [7, 8],
+            flexiblePurposes: [],
+            specialPurposes: [],
+            features: [],
+            specialFeatures: [],
+          },
+          333: {
+            id: 333,
+            name: "Vendor with purposes and legitimate interests",
+            purposes: [1, 2, 3],
+            legIntPurposes: [7, 8],
+            flexiblePurposes: [],
+            specialPurposes: [],
+            features: [],
+            specialFeatures: [],
+          },
+          444: {
+            id: 444,
+            name: "Vendor with purposes, legitimate interests and special purposes",
+            purposes: [1, 2],
+            legIntPurposes: [7, 8],
+            flexiblePurposes: [],
+            specialPurposes: [1, 2],
+            features: [],
+            specialFeatures: [],
+          },
+          888: {
+            id: 888,
+            name: "Vendor with purposes, no legitimate interest, special purpose",
+            purposes: [1, 2, 3],
+            legIntPurposes: [],
+            flexiblePurposes: [],
+            specialPurposes: [1],
+            features: [],
+            specialFeatures: [],
+          },
           999: {
             id: 999,
             name: "Special Purpose Only Vendor",
@@ -507,11 +566,6 @@ describe("generateFidesString", () => {
             specialPurposes: [1, 2], // Only special purposes
             features: [],
             specialFeatures: [],
-            policyUrl: "https://test.com/privacy",
-            usesCookies: true,
-            cookieMaxAgeSeconds: 86400,
-            cookieRefresh: false,
-            usesNonCookieAccess: false,
           },
         },
       },
@@ -539,6 +593,18 @@ describe("generateFidesString", () => {
     const decodedTCString = TCString.decode(tcfString);
 
     // Verify the special purpose vendor is in legitimate interest section regardless of user choice
+    expect(decodedTCString.vendorLegitimateInterests.has(888)).toBe(true);
     expect(decodedTCString.vendorLegitimateInterests.has(999)).toBe(true);
+
+    // Verify the rest of the vendors are not in either section because the user opted out and
+    // they have no special purposes
+    expect(decodedTCString.vendorConsents.has(111)).toBe(false);
+    expect(decodedTCString.vendorConsents.has(222)).toBe(false);
+    expect(decodedTCString.vendorConsents.has(333)).toBe(false);
+    expect(decodedTCString.vendorConsents.has(444)).toBe(false);
+    expect(decodedTCString.vendorLegitimateInterests.has(111)).toBe(false);
+    expect(decodedTCString.vendorLegitimateInterests.has(222)).toBe(false);
+    expect(decodedTCString.vendorLegitimateInterests.has(333)).toBe(false);
+    expect(decodedTCString.vendorLegitimateInterests.has(444)).toBe(false);
   });
 });

--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@iabgpp/cmpapi": "file:./src/lib/gpp/modules/cmpapi",
-    "@iabtechlabtcf/cmpapi": "^1.5.8",
-    "@iabtechlabtcf/core": "^1.5.7",
+    "@iabtechlabtcf/cmpapi": "1.5.15",
+    "@iabtechlabtcf/core": "1.5.15",
     "@rollup/plugin-replace": "^6.0.2",
     "a11y-dialog": "^7.5.2",
     "base-64": "^1.0.0",

--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -170,25 +170,17 @@ export const generateFidesString = async ({
         }
       });
 
-      // Set legitimate interest for special-purpose only vendors
+      // Set legitimate interest for special-purpose only vendors and vendors that
+      // have declared only purposes based on consent (no LI) + at least one SP
       if (experience.gvl?.vendors) {
         (experience as PrivacyExperience).tcf_vendor_relationships?.forEach(
           (relationship) => {
             const { id } = decodeVendorId(relationship.id);
             const vendor = experience.gvl?.vendors[id];
-            const isInVendorConsents = (
-              experience as PrivacyExperience
-            ).tcf_vendor_consents?.some(
-              (consent) => consent.id === relationship.id,
-            );
             if (
               vendor &&
               vendor.specialPurposes?.length &&
-              (!vendor.purposes || vendor.purposes.length === 0) &&
-              (!vendor.flexiblePurposes ||
-                vendor.flexiblePurposes.length === 0) &&
-              (!vendor.legIntPurposes || vendor.legIntPurposes.length === 0) &&
-              !isInVendorConsents
+              (!vendor.legIntPurposes || vendor.legIntPurposes.length === 0)
             ) {
               tcModel.vendorLegitimateInterests.set(+id);
             }
@@ -241,6 +233,11 @@ export const generateFidesString = async ({
         // We do not want to include vendors disclosed or publisher tc at the moment
         segments: [Segment.CORE],
       });
+
+      fidesDebugger(
+        "TC String encoded",
+        `https://iabgpp.com/#${encodedString}`,
+      );
 
       // Attach the AC string, which only applies to tcf_vendor_consents (no LI exists in AC)
       const disclosedVendorIds = experience.minimal_tcf

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -151,8 +151,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@iabgpp/cmpapi": "file:./src/lib/gpp/modules/cmpapi",
-        "@iabtechlabtcf/cmpapi": "^1.5.8",
-        "@iabtechlabtcf/core": "^1.5.7",
+        "@iabtechlabtcf/cmpapi": "1.5.15",
+        "@iabtechlabtcf/core": "1.5.15",
         "@rollup/plugin-replace": "^6.0.2",
         "a11y-dialog": "^7.5.2",
         "base-64": "^1.0.0",
@@ -2223,6 +2223,7 @@
       "version": "1.5.15",
       "resolved": "https://registry.npmjs.org/@iabtechlabtcf/cmpapi/-/cmpapi-1.5.15.tgz",
       "integrity": "sha512-ls5hhGqUuLaBhJqzUvSMTQE8BnqBgdFB8APPC9ofD3tGI+T6GG53zDtHvK/eBYCQh6i0fJCIQ3ERVWkEflR0XA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@iabtechlabtcf/core": ">=1.0.0"
       }

--- a/clients/privacy-center/cypress/e2e/consent-banner-gpp.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-gpp.cy.ts
@@ -202,7 +202,7 @@ describe("Fides-js GPP extension", () => {
             // date-based and changes each day. The first 6 characters are the
             // "Created" date, the next 6 are the "Last Updated" date.
             expect(args[3][0].pingData.gppString).to.match(
-              /DBABMA~[a-zA-Z0-9_]{6}[a-zA-Z0-9_]{6}AGXABBENArEoABaAAEAAAAAAABEAAAAA/,
+              /DBABMA~[a-zA-Z0-9_]{6}[a-zA-Z0-9_]{6}AGXABBENArEoABaAAEAAAAAAABEAAiAA/,
             );
             // the `PurposeConsents` should match the gpp string
             expect(

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -440,7 +440,7 @@ describe("Fides-js TCF", () => {
             assertTcOptIns({
               cookie: cookieKeyConsent,
               modelType: "vendorLegitimateInterests",
-              ids: [],
+              ids: [fidesVendorIdToId(VENDOR_1.id)],
             });
             expect(
               cookieKeyConsent.tcf_consent.system_consent_preferences,
@@ -666,7 +666,7 @@ describe("Fides-js TCF", () => {
               assertTcOptIns({
                 cookie: cookieKeyConsent,
                 modelType: "vendorLegitimateInterests",
-                ids: [],
+                ids: [fidesVendorIdToId(VENDOR_1.id)],
               });
               expect(
                 cookieKeyConsent.tcf_consent.system_consent_preferences,
@@ -1139,7 +1139,7 @@ describe("Fides-js TCF", () => {
               assertTcOptIns({
                 cookie: cookieKeyConsent,
                 modelType: "vendorLegitimateInterests",
-                ids: [],
+                ids: [fidesVendorIdToId(VENDOR_1.id)],
               });
               expect(
                 cookieKeyConsent.tcf_consent.system_consent_preferences,
@@ -1355,7 +1355,7 @@ describe("Fides-js TCF", () => {
                 assertTcOptIns({
                   cookie: cookieKeyConsent,
                   modelType: "vendorLegitimateInterests",
-                  ids: [],
+                  ids: [fidesVendorIdToId(VENDOR_1.id)],
                 });
                 expect(
                   cookieKeyConsent.tcf_consent.system_consent_preferences,
@@ -1539,7 +1539,7 @@ describe("Fides-js TCF", () => {
               assertTcOptIns({
                 cookie: cookieKeyConsent,
                 modelType: "vendorLegitimateInterests",
-                ids: [],
+                ids: [fidesVendorIdToId(VENDOR_1.id)],
               });
               expect(
                 cookieKeyConsent.tcf_consent
@@ -1577,7 +1577,7 @@ describe("Fides-js TCF", () => {
               assertTcOptIns({
                 cookie: cookieKeyConsent,
                 modelType: "vendorLegitimateInterests",
-                ids: [],
+                ids: [fidesVendorIdToId(VENDOR_1.id)],
               });
               expect(
                 cookieKeyConsent.tcf_consent
@@ -1744,7 +1744,7 @@ describe("Fides-js TCF", () => {
               assertTcOptIns({
                 cookie: cookieKeyConsent,
                 modelType: "vendorLegitimateInterests",
-                ids: [],
+                ids: [fidesVendorIdToId(VENDOR_1.id)],
               });
               expect(
                 cookieKeyConsent.tcf_consent
@@ -1873,7 +1873,7 @@ describe("Fides-js TCF", () => {
             assertTcOptIns({
               cookie: cookieKeyConsent,
               modelType: "vendorLegitimateInterests",
-              ids: [],
+              ids: [fidesVendorIdToId(VENDOR_1.id)],
             });
             expect(
               cookieKeyConsent.tcf_consent.system_consent_preferences,
@@ -2155,7 +2155,7 @@ describe("Fides-js TCF", () => {
           assertTcOptIns({
             cookie: cookieKeyConsent,
             modelType: "vendorLegitimateInterests",
-            ids: [],
+            ids: [fidesVendorIdToId(VENDOR_1.id)],
           });
           expect(
             cookieKeyConsent.tcf_consent
@@ -2241,7 +2241,6 @@ describe("Fides-js TCF", () => {
         cy.getByTestId("consent-modal").within(() => {
           cy.get("button").contains("Opt in to all").click();
         });
-        // On slow connections, we should explicitly wait for FidesUpdated
         cy.get("@FidesUpdated")
           .should("have.been.calledOnce")
           .its("lastCall.args.0.detail.extraDetails.consentMethod")
@@ -2273,7 +2272,10 @@ describe("Fides-js TCF", () => {
               1: false,
               [vendorIdOnly]: true,
             });
-            expect(tcData.vendor.legitimateInterests).to.eql({});
+            expect(tcData.vendor.legitimateInterests).to.eql({
+              1: false,
+              [vendorIdOnly]: true,
+            });
           });
       });
 
@@ -2340,7 +2342,10 @@ describe("Fides-js TCF", () => {
               1: false,
               [vendorIdOnly]: true,
             });
-            expect(tcData.vendor.legitimateInterests).to.eql({});
+            expect(tcData.vendor.legitimateInterests).to.eql({
+              1: false,
+              [vendorIdOnly]: true,
+            });
           });
       });
     });


### PR DESCRIPTION
Closes [LJ-415]

### Description Of Changes

_Write some things here about the changes and any potential caveats_

### Code Changes

* _list your code changes here_

### Steps to Confirm

1. Add the following Vendors in Admin UI. This table illustrates each vendor's legal basis in the GVL

| ID   | Name       | PC | LI | SP |
| ---- | ---------- | -- | -- | -- |
| 232  | Rockerbox  | x  | x  |    |
| 415  | SeenThis   |    |    | x  |
| 509  | One Tech   |    | x  |    |
| 553  | **Adhese** | x  |    | x  |
| 740  | 6Sense     | x  | x  | x  |
| 1261 | Encore DM  | x  | x  |    |
| 1407 | M6 Pub.    | x  |    |    |

<sub>PC = Purpose Consent | LI = Legitimate Interest | SP = Special Purpose | FP = Flexible Purpose</sub>

NOTE: **Adhese** is the only vendor that should be affected by this fix, since they only have PC and SP. The rest have been added to help validate that fact!

2. Enable the default TCF experience
3. Visit the Privacy Center demo page for TCF (eg. `/fides-js-demo.html?geolocation=eea`)
4. Opt out of all
5. Grab the TCF String from the cookie and plug it in to https://iabgpp.com/ in a separate tab
8. Verify that opting out leaves the Vendor Consent section blank
9. Verify that opting out results in only 415 (Special Purpose only) and 553 (only purposes based on consent (no LI) + at least one SP)

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [x] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[LJ-415]: https://ethyca.atlassian.net/browse/LJ-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ