### PR TITLE
HA-686 - Fix cypress tests for integrations UI

### DIFF
--- a/.github/workflows/cypress_admin-ui.yml
+++ b/.github/workflows/cypress_admin-ui.yml
@@ -73,7 +73,7 @@ jobs:
   Admin-UI-Cypress:
     needs: prepare-matrix
     strategy:
-      fail-fast: false
+      fail-fast: false # We want every single job to run completely, we don't want one failing job on the matrix to stop the rest of them.
       matrix:
         spec_group: ${{ fromJson(needs.prepare-matrix.outputs.spec_groups) }}
     runs-on: ubuntu-latest

--- a/clients/admin-ui/cypress/e2e/integration-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/integration-management.cy.ts
@@ -90,7 +90,7 @@ describe("Integration management for data detection & discovery", () => {
     describe("adding an integration", () => {
       beforeEach(() => {
         cy.intercept("GET", "/api/v1/connection?*", {
-          // fixture: "connectors/bigquery_connection_list.json",
+          fixture: "connectors/bigquery_connection_list.json",
         }).as("getConnections");
         cy.intercept("GET", "/api/v1/connection_type?*", {
           fixture: "connectors/connection_types.json",


### PR DESCRIPTION
Closes [HA-686]

### Description Of Changes

Fix cypress tests for integrations ui

### Code Changes

* Updated cypress files to handle connection_type intercepts correctly.
* Added a tests splitter for Cypress-Admin-UI job

### Steps to Confirm

1.  Look at the Cypress-Admin-UI job

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[HA-686]: https://ethyca.atlassian.net/browse/HA-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ