### PR TITLE
Add a new method to Fides object for updating user consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added support for uploading files as internal attachments to privacy requests [#6069](https://github.com/ethyca/fides/pull/6069)
 - Implements Fallback Locations in CMP [#6158](https://github.com/ethyca/fides/pull/6158)
 - Added dedicated Celery queues for discovery monitor operations (detection, classification, and promotion) [#6144](https://github.com/ethyca/fides/pull/6144)
+- Added a new method to Fides object for updating user consent [#6151](https://github.com/ethyca/fides/pull/6151)
 
 ### Changed
 - Attachment uploads now check for file extension types, retrieving and attachment also returns the file size. [#6124](https://github.com/ethyca/fides/pull/6124)

--- a/clients/fides-js/__tests__/lib/preferences.test.ts
+++ b/clients/fides-js/__tests__/lib/preferences.test.ts
@@ -1,0 +1,342 @@
+/* eslint-disable global-require */
+import {
+  FidesCookie,
+  FidesGlobal,
+  NoticeValues,
+  PrivacyExperience,
+  UserConsentPreference,
+} from "../../src/lib/consent-types";
+import { decodeFidesString } from "../../src/lib/fides-string";
+import {
+  updateConsent,
+  updateConsentPreferences,
+} from "../../src/lib/preferences";
+import mockExperienceJSON from "../__fixtures__/mock_experience.json";
+
+// Mock dependencies
+jest.mock("../../src/lib/fides-string");
+jest.mock("../../src/lib/consent-utils");
+
+// Setup mocks
+const mockDecodeFidesString = decodeFidesString as jest.MockedFunction<
+  typeof decodeFidesString
+>;
+
+describe("preferences", () => {
+  const mockExperience: Partial<PrivacyExperience> = mockExperienceJSON as any;
+  const updatePreferencesSpy = jest
+    .spyOn(require("../../src/lib/preferences"), "updateConsentPreferences")
+    .mockResolvedValue(undefined) as jest.MockedFunction<
+    typeof updateConsentPreferences
+  >;
+  beforeAll(() => {
+    window.fidesDebugger = jest.fn();
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("updateConsent", () => {
+    // Create a mock Fides object that we can reuse in tests
+    const createMockFides = (overrides = {}): FidesGlobal => {
+      const mockCookie: FidesCookie = {
+        consent: {},
+        identity: {},
+        fides_meta: {},
+        tcf_consent: {},
+      };
+
+      return {
+        consent: {},
+        experience: mockExperience,
+        geolocation: { country: "US" },
+        locale: "en",
+        options: {
+          debug: true,
+          fidesApiUrl: "https://example.com/api",
+          fidesDisableSaveApi: false,
+        },
+        fides_meta: {},
+        identity: {},
+        tcf_consent: {},
+        saved_consent: {},
+        config: { propertyId: "prop1" },
+        initialized: true,
+        cookie: mockCookie,
+        encodeNoticeConsentString: jest.fn().mockReturnValue("encoded-string"),
+        decodeNoticeConsentString: jest
+          .fn()
+          .mockReturnValue({ analytics: true }),
+        ...overrides,
+      } as unknown as FidesGlobal;
+    };
+
+    // Test: Successfully updating consent with a consent object
+    it("should update consent with a consent object", async () => {
+      // ARRANGE
+      const mockFides = createMockFides();
+      mockFides.experience!.privacy_notices = [
+        {
+          id: "notice1",
+          notice_key: "analytics",
+          translations: [
+            {
+              language: "en",
+              privacy_notice_history_id: "history-analytics",
+            },
+          ],
+          cookies: [],
+          created_at: "",
+          updated_at: "",
+        },
+        {
+          id: "notice2",
+          notice_key: "marketing",
+          translations: [
+            {
+              language: "en",
+              privacy_notice_history_id: "history-marketing",
+            },
+          ],
+          cookies: [],
+          created_at: "",
+          updated_at: "",
+        },
+      ];
+      const consentValues: NoticeValues = {
+        analytics: true,
+        marketing: false,
+      };
+
+      // ACT
+      await updateConsent(mockFides, { consent: consentValues });
+
+      // ASSERT
+      expect(updatePreferencesSpy).toHaveBeenCalledTimes(1);
+
+      // Verify cookie consent was updated
+      const updateCookieFn = updatePreferencesSpy.mock.calls[0][0].updateCookie;
+      const updatedCookie = await updateCookieFn({} as FidesCookie);
+      expect(updatedCookie.consent).toEqual(consentValues);
+
+      // Verify consentPreferencesToSave contains correct preferences
+      const savedPreferences =
+        updatePreferencesSpy.mock.calls[0][0].consentPreferencesToSave;
+      expect(savedPreferences).toHaveLength(2);
+      expect(savedPreferences![0].consentPreference).toBe(
+        UserConsentPreference.OPT_IN,
+      );
+      expect(savedPreferences![1].consentPreference).toBe(
+        UserConsentPreference.OPT_OUT,
+      );
+    });
+
+    // Test: Successfully updating consent with a fidesString
+    it("should update consent with a fidesString", async () => {
+      // ARRANGE
+      const mockFides = createMockFides();
+      const fidesString = "tc.encoded-nc-string.gpp";
+
+      mockDecodeFidesString.mockReturnValue({
+        tc: "tc",
+        ac: "",
+        gpp: "gpp",
+        nc: "encoded-nc-string",
+      });
+
+      // ACT
+      await updateConsent(mockFides, { fidesString });
+
+      // ASSERT
+      expect(mockDecodeFidesString).toHaveBeenCalledWith(fidesString);
+      expect(mockFides.decodeNoticeConsentString).toHaveBeenCalledWith(
+        "encoded-nc-string",
+      );
+      expect(updatePreferencesSpy).toHaveBeenCalledTimes(1);
+
+      // Verify cookie fides_string was updated
+      const updateCookieFn = updatePreferencesSpy.mock.calls[0][0].updateCookie;
+      const updatedCookie = await updateCookieFn({} as FidesCookie);
+      expect(updatedCookie.fides_string).toBe(fidesString);
+    });
+
+    // Test: fidesString should take priority over consent object
+    it("should prioritize fidesString over consent object", async () => {
+      // ARRANGE
+      const mockFides = createMockFides();
+      const consentValues: NoticeValues = {
+        analytics: false,
+        marketing: true,
+      };
+      const fidesString = "tc.encoded-nc-string.gpp";
+
+      mockDecodeFidesString.mockReturnValue({
+        tc: "tc",
+        ac: "",
+        gpp: "gpp",
+        nc: "encoded-nc-string",
+      });
+
+      const decodedConsent = {
+        analytics: true,
+        marketing: false,
+      };
+
+      mockFides.decodeNoticeConsentString = jest
+        .fn()
+        .mockReturnValue(decodedConsent);
+
+      // ACT
+      await updateConsent(mockFides, { consent: consentValues, fidesString });
+
+      // ASSERT
+      expect(updatePreferencesSpy).toHaveBeenCalledTimes(1);
+
+      // Verify the decoded string values are used, not the consent object
+      const updateCookieFn = updatePreferencesSpy.mock.calls[0][0].updateCookie;
+      const updatedCookie = await updateCookieFn({} as FidesCookie);
+      expect(updatedCookie.consent).toEqual(decodedConsent);
+    });
+
+    // Test: Error if neither consent nor fidesString are provided
+    it("should reject if neither consent nor fidesString are provided", async () => {
+      // ARRANGE
+      const mockFides = createMockFides();
+
+      // ACT & ASSERT
+      await expect(updateConsent(mockFides, {})).rejects.toThrow(
+        "Either consent or fidesString must be provided",
+      );
+    });
+
+    // Test: Error if fidesString is invalid
+    it("should reject if fidesString is invalid", async () => {
+      // ARRANGE
+      const mockFides = createMockFides();
+      const fidesString = "invalid-string";
+
+      mockDecodeFidesString.mockImplementation(() => {
+        throw new Error("Invalid format");
+      });
+
+      // ACT & ASSERT
+      await expect(updateConsent(mockFides, { fidesString })).rejects.toThrow(
+        "Invalid fidesString provided: Invalid format",
+      );
+    });
+
+    // Test: Error if cookie is not initialized
+    it("should reject if cookie is not initialized", async () => {
+      // ARRANGE
+      const mockFides = createMockFides({ cookie: undefined });
+      const consentValues: NoticeValues = {
+        analytics: true,
+      };
+
+      // ACT & ASSERT
+      await expect(
+        updateConsent(mockFides, { consent: consentValues }),
+      ).rejects.toThrow("Cookie is not initialized");
+    });
+
+    // Test: Error if experience is not available
+    it("should reject if experience is not available", async () => {
+      // ARRANGE
+      const mockFides = createMockFides({ experience: undefined });
+      const consentValues: NoticeValues = {
+        analytics: true,
+      };
+
+      // ACT & ASSERT
+      await expect(
+        updateConsent(mockFides, { consent: consentValues }),
+      ).rejects.toThrow("Cannot update consent without an experience");
+    });
+
+    // Test: Warning when notice key doesn't exist in experience
+    it("should log a warning when notice key does not exist in experience", async () => {
+      // ARRANGE
+      const mockFides = createMockFides();
+      const consentValues: NoticeValues = {
+        analytics: true,
+        nonexistent: false,
+      };
+
+      // ACT
+      await updateConsent(mockFides, { consent: consentValues });
+
+      // ASSERT
+      expect(window.fidesDebugger).toHaveBeenCalledWith(
+        'Warning: Notice key "nonexistent" does not exist in the current experience',
+      );
+
+      // Only analytics should be saved, not nonexistent
+      const savedPreferences =
+        updatePreferencesSpy.mock.calls[0][0].consentPreferencesToSave;
+      expect(savedPreferences).toHaveLength(1);
+      expect(savedPreferences![0].notice.notice_key).toBe("analytics");
+    });
+
+    // Test: Creates fidesString with proper format when none exists
+    it("should create proper fidesString format when none exists", async () => {
+      // ARRANGE
+      const mockFides = createMockFides();
+      const consentValues: NoticeValues = {
+        analytics: true,
+      };
+
+      // ACT
+      await updateConsent(mockFides, { consent: consentValues });
+
+      // ASSERT
+      const updateCookieFn = updatePreferencesSpy.mock.calls[0][0].updateCookie;
+      const updatedCookie = await updateCookieFn({} as FidesCookie);
+
+      // Should have format .nc. (empty tc and gpp sections)
+      expect(updatedCookie.fides_string).toBe(".encoded-string.");
+    });
+
+    // Test: Preserves existing fidesString parts when updating consent
+    it("should preserve existing fidesString parts when updating with consent", async () => {
+      // ARRANGE
+      const existingFidesString = "existing-tc.existing-nc.existing-gpp";
+      const mockFides = createMockFides({
+        cookie: {
+          consent: {},
+          identity: {},
+          fides_meta: {},
+          tcf_consent: {},
+          fides_string: existingFidesString,
+        },
+      });
+
+      const consentValues: NoticeValues = {
+        analytics: true,
+      };
+
+      mockDecodeFidesString.mockReturnValue({
+        tc: "existing-tc",
+        ac: "",
+        gpp: "existing-gpp",
+        nc: "existing-nc",
+      });
+
+      // ACT
+      await updateConsent(mockFides, { consent: consentValues });
+
+      // ASSERT
+      expect(mockFides.encodeNoticeConsentString).toHaveBeenCalledWith(
+        consentValues,
+      );
+
+      const updateCookieFn = updatePreferencesSpy.mock.calls[0][0].updateCookie;
+      const updatedCookie = await updateCookieFn({} as FidesCookie);
+
+      // Should maintain tc and gpp sections, but update nc section
+      expect(updatedCookie.fides_string).toBe(
+        "existing-tc.encoded-string.existing-gpp",
+      );
+    });
+  });
+});

--- a/clients/fides-js/__tests__/lib/preferences.test.ts
+++ b/clients/fides-js/__tests__/lib/preferences.test.ts
@@ -209,9 +209,7 @@ describe("preferences", () => {
       const mockFides = createMockFides();
 
       // ACT & ASSERT
-      await expect(updateConsent(mockFides, {})).rejects.toThrow(
-        "Either consent or fidesString must be provided",
-      );
+      await expect(updateConsent(mockFides, {})).rejects.toThrow();
     });
 
     // Test: Error if fidesString is invalid
@@ -225,9 +223,7 @@ describe("preferences", () => {
       });
 
       // ACT & ASSERT
-      await expect(updateConsent(mockFides, { fidesString })).rejects.toThrow(
-        "Invalid fidesString provided: Invalid format",
-      );
+      await expect(updateConsent(mockFides, { fidesString })).rejects.toThrow();
     });
 
     // Test: Error if cookie is not initialized
@@ -255,31 +251,7 @@ describe("preferences", () => {
       // ACT & ASSERT
       await expect(
         updateConsent(mockFides, { consent: consentValues }),
-      ).rejects.toThrow("Cannot update consent without an experience");
-    });
-
-    // Test: Warning when notice key doesn't exist in experience
-    it("should log a warning when notice key does not exist in experience", async () => {
-      // ARRANGE
-      const mockFides = createMockFides();
-      const consentValues: NoticeValues = {
-        analytics: true,
-        nonexistent: false,
-      };
-
-      // ACT
-      await updateConsent(mockFides, { consent: consentValues });
-
-      // ASSERT
-      expect(window.fidesDebugger).toHaveBeenCalledWith(
-        'Warning: Notice key "nonexistent" does not exist in the current experience',
-      );
-
-      // Only analytics should be saved, not nonexistent
-      const savedPreferences =
-        updatePreferencesSpy.mock.calls[0][0].consentPreferencesToSave;
-      expect(savedPreferences).toHaveLength(1);
-      expect(savedPreferences![0].notice.notice_key).toBe("analytics");
+      ).rejects.toThrow();
     });
   });
 });

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -529,8 +529,8 @@ This field is read-only.
 
 > **updateConsent**: (`options`) => `Promise`\<`void`\>
 
-Updates user consent preferences with either a consent object or fidesString.
-If both are provided, fidesString takes priority.
+Updates user consent preferences with either a `consent` object or `fidesString`.
+If both are provided, `fidesString` takes priority.
 
 #### Parameters
 

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -522,3 +522,43 @@ The user's identity values, which only include a copy of the fides user device i
 ```
 
 This field is read-only.
+
+***
+
+### updateConsent()
+
+> **updateConsent**: (`options`) => `Promise`\<`void`\>
+
+Updates user consent preferences with either a consent object or fidesString.
+If both are provided, fidesString takes priority.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `options` | `object` | Options for updating consent |
+| `options.consent`? | `Record`\<`string`, `boolean`\> | Object mapping notice keys to consent values |
+| `options.fidesString`? | `string` | A Fides string containing encoded consent preferences |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Examples
+
+Update consent using notice keys and boolean values:
+```ts
+Fides.updateConsent({
+  consent: {
+    data_sales_and_sharing: false,
+    analytics: true
+  }
+});
+```
+
+Update consent using a fidesString:
+```ts
+Fides.updateConsent({
+  fidesString: ",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+});
+```

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -408,8 +408,8 @@ export interface Fides {
   identity: Record<string, string>;
 
   /**
-   * Updates user consent preferences with either a consent object or fidesString.
-   * If both are provided, fidesString takes priority.
+   * Updates user consent preferences with either a `consent` object or `fidesString`.
+   * If both are provided, `fidesString` takes priority.
    *
    * @example
    * Update consent using notice keys and boolean values:

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -408,6 +408,38 @@ export interface Fides {
   identity: Record<string, string>;
 
   /**
+   * Updates user consent preferences with either a consent object or fidesString.
+   * If both are provided, fidesString takes priority.
+   *
+   * @example
+   * Update consent using notice keys and boolean values:
+   * ```ts
+   * Fides.updateConsent({
+   *   consent: {
+   *     data_sales_and_sharing: false,
+   *     analytics: true
+   *   }
+   * });
+   * ```
+   *
+   * @example
+   * Update consent using a fidesString:
+   * ```ts
+   * Fides.updateConsent({
+   *   fidesString: ",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+   * });
+   * ```
+   *
+   * @param options - Options for updating consent
+   * @param options.consent - Object mapping notice keys to consent values
+   * @param options.fidesString - A Fides string containing encoded consent preferences
+   */
+  updateConsent: (options: {
+    consent?: Record<string, boolean>;
+    fidesString?: string;
+  }) => Promise<void>;
+
+  /**
    * NOTE: The properties below are all marked @internal, despite being exported
    * on the global Fides object. This is because they are mostly implementation
    * details and internals that we probably *should* be hiding, to avoid

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -34,8 +34,13 @@ export interface Fides {
   /**
    * User's current consent preferences, formatted as a key/value object with:
    * - key: the applicable Fides `notice_key` (e.g. `data_sales_and_sharing`, `analytics`)
-   * - value: `true` or `false`, depending on whether or not the current user
-   * has consented to the notice
+   * - value:
+   *   - `true` or `false` boolean values (where true means opt-in/consent granted, false means opt-out/consent declined)
+   *   - or one of these string values:
+   *     - `"opt_in"` - user has explicitly opted in to this notice
+   *     - `"opt_out"` - user has explicitly opted out of this notice
+   *     - `"acknowledge"` - user has acknowledged this notice (for notice-only consent mechanisms)
+   *     - `"not_applicable"` - notice is not applicable to the user's region/context
    *
    * Note that FidesJS will automatically set default consent preferences based
    * on the type of notice - so, for example a typical "opt-in" analytics notice
@@ -64,12 +69,21 @@ export interface Fides {
    * ```
    *
    * @example
-   * A `Fides.consent` value showing the user has opted-in to analytics, but not marketing using a consent mechanism string:
+   * A `Fides.consent` value showing the user has opted-in to analytics, but not marketing using consent mechanism strings:
    * ```ts
    * {
    *   "analytics": "opt_in",
    *   "marketing": "opt_out"
    * }
+   * ```
+   *
+   * @example
+   * A `Fides.consent` value showing a notice-only consent mechanism with acknowledgment:
+   * ```ts
+   * {
+   *   "terms_of_service": "acknowledge"
+   * }
+   * ```
    */
   consent: Record<string, boolean | string>;
 
@@ -423,6 +437,18 @@ export interface Fides {
    * ```
    *
    * @example
+   * Update consent using string values instead of booleans:
+   * ```ts
+   * Fides.updateConsent({
+   *   consent: {
+   *     data_sales_and_sharing: "opt_out",
+   *     analytics: "opt_in",
+   *     terms_of_service: "acknowledge"
+   *   }
+   * });
+   * ```
+   *
+   * @example
    * Update consent using a fidesString:
    * ```ts
    * Fides.updateConsent({
@@ -430,13 +456,39 @@ export interface Fides {
    * });
    * ```
    *
+   * @example
+   * Control validation behavior:
+   * ```ts
+   * // With validation="warn" - logs warnings but doesn't throw errors
+   * Fides.updateConsent({
+   *   consent: { notice_key: invalidValue },
+   *   validation: "warn"
+   * });
+   *
+   * // With validation="ignore" - silently accepts invalid values
+   * Fides.updateConsent({
+   *   consent: { notice_key: invalidValue },
+   *   validation: "ignore"
+   * });
+   * ```
+   *
    * @param options - Options for updating consent
-   * @param options.consent - Object mapping notice keys to consent values
+   * @param options.consent - Object mapping notice keys to consent values:
+   *   - Boolean values: `true` (opt-in/consent granted) or `false` (opt-out/consent declined)
+   *   - String values:
+   *     - `"opt_in"` - user has explicitly opted in to this notice
+   *     - `"opt_out"` - user has explicitly opted out of this notice
+   *     - `"acknowledge"` - ONLY valid for notices with "notice_only" consent mechanism
    * @param options.fidesString - A Fides string containing encoded consent preferences
+   * @param options.validation - Controls validation behavior: "throw" (default), "warn", or "ignore"
+   *   - "throw": Throws an error if any consent value is invalid (default)
+   *   - "warn": Logs a warning if any consent value is invalid, but continues processing
+   *   - "ignore": Silently accepts invalid values without validation
    */
   updateConsent: (options: {
-    consent?: Record<string, boolean>;
+    consent?: Record<string, boolean | string>;
     fidesString?: string;
+    validation?: "throw" | "warn" | "ignore";
   }) => Promise<void>;
 
   /**

--- a/clients/fides-js/src/fides-headless.ts
+++ b/clients/fides-js/src/fides-headless.ts
@@ -16,7 +16,6 @@ import {
   NoticeValues,
   OverrideType,
 } from "./lib/consent-types";
-import { shouldResurfaceBanner } from "./lib/consent-utils";
 import { updateExperienceFromCookieConsentNotices } from "./lib/cookie";
 import { initializeDebugger } from "./lib/debugger";
 import { dispatchFidesEvent } from "./lib/events";
@@ -153,20 +152,6 @@ const initialFides = getCoreFides({});
 const _Fides: FidesGlobal = {
   ...initialFides,
   init,
-  reinitialize() {
-    if (!this.config || !this.initialized) {
-      raise("Fides must be initialized before reinitializing");
-    }
-    return this.init();
-  },
-  shouldShowExperience() {
-    return shouldResurfaceBanner(
-      this.experience,
-      this.cookie,
-      this.saved_consent,
-      this.options,
-    );
-  },
 };
 
 updateWindowFides(_Fides);

--- a/clients/fides-js/src/fides-tcf.ts
+++ b/clients/fides-js/src/fides-tcf.ts
@@ -11,7 +11,7 @@
 import type { TCData } from "@iabtechlabtcf/cmpapi";
 import { TCString } from "@iabtechlabtcf/core";
 
-import { FidesCookie, shouldResurfaceBanner } from "./fides";
+import { FidesCookie } from "./fides";
 import {
   FidesConfig,
   FidesExperienceTranslationOverrides,
@@ -215,20 +215,6 @@ const initialFides = getCoreFides({ tcfEnabled: true });
 const _Fides: FidesGlobal = {
   ...initialFides,
   init,
-  reinitialize() {
-    if (!this.config || !this.initialized) {
-      raise("Fides must be initialized before reinitializing");
-    }
-    return this.init();
-  },
-  shouldShowExperience() {
-    return shouldResurfaceBanner(
-      this.experience,
-      this.cookie,
-      this.saved_consent ?? {},
-      this.options,
-    );
-  },
 };
 
 if (typeof window !== "undefined") {

--- a/clients/fides-js/src/fides.ts
+++ b/clients/fides-js/src/fides.ts
@@ -21,7 +21,6 @@ import {
   NoticeValues,
   OverrideType,
 } from "./lib/consent-types";
-import { shouldResurfaceBanner } from "./lib/consent-utils";
 import {
   getFidesConsentCookie,
   updateExperienceFromCookieConsentNotices,
@@ -184,20 +183,6 @@ const initialFides = getCoreFides({});
 const _Fides: FidesGlobal = {
   ...initialFides,
   init,
-  reinitialize() {
-    if (!this.config || !this.initialized) {
-      raise("Fides must be initialized before reinitializing");
-    }
-    return this.init();
-  },
-  shouldShowExperience() {
-    return shouldResurfaceBanner(
-      this.experience,
-      this.cookie,
-      this.saved_consent ?? {},
-      this.options,
-    );
-  },
 };
 
 updateWindowFides(_Fides);

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -200,6 +200,10 @@ export interface FidesGlobal extends Omit<Fides, "gtm" | "consent"> {
   shopify: typeof shopify;
   shouldShowExperience: () => boolean;
   showModal: () => void;
+  updateConsent: (options: {
+    consent?: NoticeValues;
+    fidesString?: string;
+  }) => Promise<void>;
 }
 
 /**
@@ -218,6 +222,7 @@ export interface OtToFidesConsentMapping {
  * Store the user's consent preferences as well as implicit consent preferences if applicable
  * as notice_key -> boolean pairs or notice_key -> consent_mechanism pairs, depending on
  * the value of `Fides.options.fidesConsentFlagType` and `Fides.options.fidesConsentNonApplicableFlagMode`.
+ * NOTE: This should only be used for externally facing consent preferences, not for internal use (browser cookie, window events, Fides.consent, etc). Use NoticeValues to store and track consent internally.
  * eg.
  * {
  *   "data_sales": false,

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -164,7 +164,8 @@ export interface FidesInitOptions {
  * ensure that the documented interface isn't overly specific in areas we may
  * need to change.
  */
-export interface FidesGlobal extends Omit<Fides, "gtm" | "consent"> {
+export interface FidesGlobal
+  extends Omit<Fides, "gtm" | "consent" | "updateConsent"> {
   cookie?: FidesCookie;
   config?: FidesConfig;
   consent: NoticeConsent;
@@ -201,8 +202,9 @@ export interface FidesGlobal extends Omit<Fides, "gtm" | "consent"> {
   shouldShowExperience: () => boolean;
   showModal: () => void;
   updateConsent: (options: {
-    consent?: NoticeValues;
+    consent?: NoticeConsent;
     fidesString?: string;
+    validation?: "throw" | "warn" | "ignore";
   }) => Promise<void>;
 }
 

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -222,7 +222,9 @@ export interface OtToFidesConsentMapping {
  * Store the user's consent preferences as well as implicit consent preferences if applicable
  * as notice_key -> boolean pairs or notice_key -> consent_mechanism pairs, depending on
  * the value of `Fides.options.fidesConsentFlagType` and `Fides.options.fidesConsentNonApplicableFlagMode`.
- * NOTE: This should only be used for externally facing consent preferences, not for internal use (browser cookie, window events, Fides.consent, etc). Use NoticeValues to store and track consent internally.
+ * NOTE: When sending consent preferences externally (browser cookie, window events, Fides.consent, etc.),
+ * use this `NoticeConsent` Type. For accepting preferences (updateConsent, etc.) and for internal tracking
+ * and processing, use the `NoticeValues` Type.
  * eg.
  * {
  *   "data_sales": false,

--- a/clients/fides-js/src/lib/init-utils.ts
+++ b/clients/fides-js/src/lib/init-utils.ts
@@ -6,7 +6,7 @@ import {
   FidesCookie,
   FidesGlobal,
   FidesOptions,
-  NoticeValues,
+  NoticeConsent,
   PrivacyExperience,
 } from "./consent-types";
 import {
@@ -150,7 +150,11 @@ export const getCoreFides = ({
     },
     updateConsent(
       this: FidesGlobal,
-      options: { consent?: NoticeValues; fidesString?: string },
+      options: {
+        consent?: NoticeConsent;
+        fidesString?: string;
+        validation?: "throw" | "warn" | "ignore";
+      },
     ): Promise<void> {
       return updateConsent(this, options);
     },

--- a/clients/fides-js/src/lib/init-utils.ts
+++ b/clients/fides-js/src/lib/init-utils.ts
@@ -12,6 +12,7 @@ import {
   decodeNoticeConsentString,
   defaultShowModal,
   encodeNoticeConsentString,
+  shouldResurfaceBanner,
 } from "./consent-utils";
 import {
   consentCookieObjHasSomeConsentSet,
@@ -65,7 +66,7 @@ export const getCoreFides = ({
   tcfEnabled = false,
 }: {
   tcfEnabled?: boolean;
-}): Omit<FidesGlobal, "init" | "reinitialize" | "shouldShowExperience"> => {
+}): Omit<FidesGlobal, "init"> => {
   return {
     consent: {},
     experience: undefined,
@@ -119,5 +120,19 @@ export const getCoreFides = ({
     getModalLinkLabel: () => DEFAULT_MODAL_LINK_LABEL,
     encodeNoticeConsentString,
     decodeNoticeConsentString,
+    reinitialize(this: FidesGlobal): Promise<void> {
+      if (!this.config || !this.initialized) {
+        raise("Fides must be initialized before reinitializing");
+      }
+      return this.init();
+    },
+    shouldShowExperience(this: FidesGlobal): boolean {
+      return shouldResurfaceBanner(
+        this.experience,
+        this.cookie,
+        this.saved_consent,
+        this.options,
+      );
+    },
   };
 };

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -243,7 +243,7 @@ export const updateConsent = async (
 
   if (!fides.experience) {
     return Promise.reject(
-      new Error("Cannot update consent without an experience"),
+      new Error("Experience must be initialized before updating consent"),
     );
   }
 

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -12,7 +12,10 @@ import {
   SaveConsentPreference,
   UserConsentPreference,
 } from "./consent-types";
-import { applyOverridesToConsent } from "./consent-utils";
+import {
+  applyOverridesToConsent,
+  constructFidesRegionString,
+} from "./consent-utils";
 import { removeCookiesFromBrowser, saveFidesCookie } from "./cookie";
 import { dispatchFidesEvent } from "./events";
 import { decodeFidesString } from "./fides-string";
@@ -290,6 +293,9 @@ export const updateConsent = async (
         .privacy_experience_config_history_id;
   }
 
+  const fidesRegionString =
+    constructFidesRegionString(fides.geolocation) || undefined;
+
   // Call updateConsentPreferences with necessary parameters
   return updateConsentPreferences({
     consentPreferencesToSave,
@@ -299,7 +305,7 @@ export const updateConsent = async (
       | PrivacyExperienceMinimal,
     consentMethod: ConsentMethod.SAVE,
     options: fides.options,
-    userLocationString: fides.geolocation?.country, // Using country as the location string
+    userLocationString: fidesRegionString,
     cookie: fides.cookie,
     servedNoticeHistoryId: undefined, // Not passing a served notice ID
     updateCookie: async () => updatedCookie,

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -189,6 +189,14 @@ export const updateConsent = async (
       new Error("Either consent or fidesString must be provided"),
     );
   }
+  if (!fides.experience) {
+    return Promise.reject(
+      new Error("Experience must be initialized before updating consent"),
+    );
+  }
+  if (!fides.cookie) {
+    return Promise.reject(new Error("Cookie is not initialized"));
+  }
 
   const { consent, fidesString } = options;
 
@@ -211,10 +219,6 @@ export const updateConsent = async (
   }
 
   // Clone current cookie for updating
-  if (!fides.cookie) {
-    return Promise.reject(new Error("Cookie is not initialized"));
-  }
-
   const updatedCookie: FidesCookie = {
     consent: { ...(fides.cookie.consent || {}) },
     identity: { ...(fides.cookie.identity || {}) },
@@ -243,12 +247,6 @@ export const updateConsent = async (
     } else {
       updatedCookie.fides_string = `.${newNcString}.`;
     }
-  }
-
-  if (!fides.experience) {
-    return Promise.reject(
-      new Error("Experience must be initialized before updating consent"),
-    );
   }
 
   // Prepare consentPreferencesToSave by mapping from finalConsent

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -181,6 +181,7 @@ export const updateConsentPreferences = async ({
 export const updateConsent = async (
   fides: FidesGlobal,
   options: { consent?: NoticeValues; fidesString?: string },
+  consentMethod: ConsentMethod = ConsentMethod.SCRIPT,
 ): Promise<void> => {
   // If neither consent nor fidesString is provided, raise an error
   if (!options?.consent && !options?.fidesString) {
@@ -303,7 +304,7 @@ export const updateConsent = async (
     experience: fides.experience as
       | PrivacyExperience
       | PrivacyExperienceMinimal,
-    consentMethod: ConsentMethod.SAVE,
+    consentMethod,
     options: fides.options,
     userLocationString: fidesRegionString,
     cookie: fides.cookie,

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -179,14 +179,14 @@ export const updateConsent = async (
   fides: FidesGlobal,
   options: { consent?: NoticeValues; fidesString?: string },
 ): Promise<void> => {
-  const { consent, fidesString } = options;
-
   // If neither consent nor fidesString is provided, raise an error
-  if (!consent && !fidesString) {
+  if (!options?.consent && !options?.fidesString) {
     return Promise.reject(
       new Error("Either consent or fidesString must be provided"),
     );
   }
+
+  const { consent, fidesString } = options;
 
   let finalConsent = consent || {};
 

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -3638,7 +3638,7 @@ describe("Consent overlay", () => {
     });
   });
 
-  describe.only("when updating consent using window.Fides.updateConsent", () => {
+  describe("when updating consent using window.Fides.updateConsent", () => {
     beforeEach(() => {
       cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
       cy.fixture("consent/fidesjs_options_banner_modal.json").then((config) => {

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -3637,4 +3637,118 @@ describe("Consent overlay", () => {
       });
     });
   });
+
+  describe("when updating consent using window.Fides.updateConsent", () => {
+    beforeEach(() => {
+      cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
+      cy.fixture("consent/fidesjs_options_banner_modal.json").then((config) => {
+        stubConfig({
+          experience: {
+            experience_config: {
+              ...config.experience.experience_config,
+              ...{ component: ComponentType.HEADLESS },
+            },
+          },
+        });
+      });
+    });
+
+    it("should update the consent cookie using consent object", () => {
+      cy.window().then((win) => {
+        // Initial consent
+        cy.window()
+          .its("Fides")
+          .its("consent")
+          .should("eql", {
+            [PRIVACY_NOTICE_KEY_1]: false,
+            [PRIVACY_NOTICE_KEY_2]: true,
+            [PRIVACY_NOTICE_KEY_3]: true,
+          });
+
+        // Update consent
+        win.Fides.updateConsent({
+          consent: {
+            [PRIVACY_NOTICE_KEY_1]: true,
+            [PRIVACY_NOTICE_KEY_2]: false,
+            [PRIVACY_NOTICE_KEY_3]: false,
+          },
+        });
+
+        // Verify consent was updated
+        cy.window()
+          .its("Fides")
+          .its("consent")
+          .should("eql", {
+            [PRIVACY_NOTICE_KEY_1]: true,
+            [PRIVACY_NOTICE_KEY_2]: false,
+            [PRIVACY_NOTICE_KEY_3]: false,
+          });
+      });
+    });
+
+    it("should update the consent cookie using fidesString", () => {
+      cy.window().then((win) => {
+        // Initial consent
+        cy.window()
+          .its("Fides")
+          .its("consent")
+          .should("eql", {
+            [PRIVACY_NOTICE_KEY_1]: false,
+            [PRIVACY_NOTICE_KEY_2]: true,
+            [PRIVACY_NOTICE_KEY_3]: true,
+          });
+
+        // Update consent
+        win.Fides.updateConsent({
+          fidesString:
+            ",,,eyJhZHZlcnRpc2luZyI6dHJ1ZSwiZXNzZW50aWFsIjpmYWxzZSwiYW5hbHl0aWNzX29wdF9vdXQiOmZhbHNlfQ==",
+        });
+
+        // Verify consent was updated
+        cy.window()
+          .its("Fides")
+          .its("consent")
+          .should("eql", {
+            [PRIVACY_NOTICE_KEY_1]: true,
+            [PRIVACY_NOTICE_KEY_2]: false,
+            [PRIVACY_NOTICE_KEY_3]: false,
+          });
+      });
+    });
+
+    it("should update the consent cookie using fidesString when both are provided", () => {
+      cy.window().then((win) => {
+        // Initial consent
+        cy.window()
+          .its("Fides")
+          .its("consent")
+          .should("eql", {
+            [PRIVACY_NOTICE_KEY_1]: false,
+            [PRIVACY_NOTICE_KEY_2]: true,
+            [PRIVACY_NOTICE_KEY_3]: true,
+          });
+
+        // Update consent
+        win.Fides.updateConsent({
+          consent: {
+            [PRIVACY_NOTICE_KEY_1]: false,
+            [PRIVACY_NOTICE_KEY_2]: true,
+            [PRIVACY_NOTICE_KEY_3]: false,
+          },
+          fidesString:
+            ",,,eyJhZHZlcnRpc2luZyI6dHJ1ZSwiZXNzZW50aWFsIjpmYWxzZSwiYW5hbHl0aWNzX29wdF9vdXQiOmZhbHNlfQ==",
+        });
+
+        // Verify consent was updated from the fidesString and not the consent object
+        cy.window()
+          .its("Fides")
+          .its("consent")
+          .should("eql", {
+            [PRIVACY_NOTICE_KEY_1]: true,
+            [PRIVACY_NOTICE_KEY_2]: false,
+            [PRIVACY_NOTICE_KEY_3]: false,
+          });
+      });
+    });
+  });
 });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -3638,7 +3638,7 @@ describe("Consent overlay", () => {
     });
   });
 
-  describe("when updating consent using window.Fides.updateConsent", () => {
+  describe.only("when updating consent using window.Fides.updateConsent", () => {
     beforeEach(() => {
       cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
       cy.fixture("consent/fidesjs_options_banner_modal.json").then((config) => {
@@ -3669,8 +3669,8 @@ describe("Consent overlay", () => {
         win.Fides.updateConsent({
           consent: {
             [PRIVACY_NOTICE_KEY_1]: true,
-            [PRIVACY_NOTICE_KEY_2]: false,
-            [PRIVACY_NOTICE_KEY_3]: false,
+            [PRIVACY_NOTICE_KEY_2]: UserConsentPreference.ACKNOWLEDGE,
+            [PRIVACY_NOTICE_KEY_3]: UserConsentPreference.OPT_OUT,
           },
         });
 
@@ -3680,7 +3680,7 @@ describe("Consent overlay", () => {
           .its("consent")
           .should("eql", {
             [PRIVACY_NOTICE_KEY_1]: true,
-            [PRIVACY_NOTICE_KEY_2]: false,
+            [PRIVACY_NOTICE_KEY_2]: true,
             [PRIVACY_NOTICE_KEY_3]: false,
           });
       });
@@ -3710,7 +3710,7 @@ describe("Consent overlay", () => {
           .its("consent")
           .should("eql", {
             [PRIVACY_NOTICE_KEY_1]: true,
-            [PRIVACY_NOTICE_KEY_2]: false,
+            [PRIVACY_NOTICE_KEY_2]: true,
             [PRIVACY_NOTICE_KEY_3]: false,
           });
       });
@@ -3732,7 +3732,7 @@ describe("Consent overlay", () => {
         win.Fides.updateConsent({
           consent: {
             [PRIVACY_NOTICE_KEY_1]: false,
-            [PRIVACY_NOTICE_KEY_2]: true,
+            [PRIVACY_NOTICE_KEY_2]: UserConsentPreference.ACKNOWLEDGE,
             [PRIVACY_NOTICE_KEY_3]: false,
           },
           fidesString:
@@ -3745,7 +3745,7 @@ describe("Consent overlay", () => {
           .its("consent")
           .should("eql", {
             [PRIVACY_NOTICE_KEY_1]: true,
-            [PRIVACY_NOTICE_KEY_2]: false,
+            [PRIVACY_NOTICE_KEY_2]: true,
             [PRIVACY_NOTICE_KEY_3]: false,
           });
       });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -3701,7 +3701,7 @@ describe("Consent overlay", () => {
         // Update consent
         win.Fides.updateConsent({
           fidesString:
-            ",,,eyJhZHZlcnRpc2luZyI6dHJ1ZSwiZXNzZW50aWFsIjpmYWxzZSwiYW5hbHl0aWNzX29wdF9vdXQiOmZhbHNlfQ==",
+            ",,,eyJhZHZlcnRpc2luZyI6dHJ1ZSwiZXNzZW50aWFsIjp0cnVlLCJhbmFseXRpY3Nfb3B0X291dCI6ZmFsc2V9",
         });
 
         // Verify consent was updated
@@ -3736,7 +3736,7 @@ describe("Consent overlay", () => {
             [PRIVACY_NOTICE_KEY_3]: false,
           },
           fidesString:
-            ",,,eyJhZHZlcnRpc2luZyI6dHJ1ZSwiZXNzZW50aWFsIjpmYWxzZSwiYW5hbHl0aWNzX29wdF9vdXQiOmZhbHNlfQ==",
+            ",,,eyJhZHZlcnRpc2luZyI6dHJ1ZSwiZXNzZW50aWFsIjp0cnVlLCJhbmFseXRpY3Nfb3B0X291dCI6ZmFsc2V9",
         });
 
         // Verify consent was updated from the fidesString and not the consent object


### PR DESCRIPTION
Closes [LJ-684]

### Description Of Changes

Added a new `updateConsent` method to the Fides interface, allowing developers to programmatically update user consent preferences using either a consent object or fidesString.

### Code Changes

* Added comprehensive tests for the `updateConsent` function in preferences module
* Updated Fides interface documentation to include the new `updateConsent` method
* Implemented error handling for various edge cases in the consent update process

### Steps to Confirm
1. Add `6Sense` vendor in Admin UI
2. Enable Analytics, Data sales and sharing, and Essential notices
3. Create a Headless experience and add those 3 notices to it
4. Add location Utah to the Headless experience
5. Visit the privacy center demo page for Utah (`/fides-js-demo.html?geolocation=us-ut`)
6. Verify updating consent works with a plain consent object by pasting the following in to the browser devtools console. You should see the values updated in the main window, in Fides.consent, and the cookie.
```
Fides.encodeNoticeConsentString({ data_sales_and_sharing: false, analytics: true }))
```
7. Delete the cookie and reload the demo (do this between each step below)
8. Verify updating consent works with a `fidesString`
```
Fides.updateConsent({ fidesString: ",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjpmYWxzZSwiYW5hbHl0aWNzIjp0cnVlfQ==" })
```
9. Confirm error handling for invalid inputs works correctly by pasting the following in to the borwser devtools console:
```
Fides.updateConsent({invalid: true});
```
10. Test that `fidesString` takes priority when both options are provided:
```javascript
Fides.updateConsent({
  consent: {
    data_sales_and_sharing: false,
    analytics: true,
  },
  fidesString: ",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjpmYWxzZSwiYW5hbHl0aWNzIjp0cnVlfQ=="
});
```
11. Verify consent mechanism types are handled correctly by running:
```
Fides.updateConsent({ consent: { data_sales_and_sharing: "opt_out", analytics: "opt_in" } });
```
12. Verify with mixed value types:
```
Fides.updateConsent({ consent: { analytics: true, data_sales_and_sharing: "opt_out" } });
```
13. Test validation mode behavior:
   ```
   // Try to use an invalid value with validation='reject'
     Fides.updateConsent({ 
       consent: { essential: true }, // should be "acknowledge" 
       validation: "reject" 
     });
   
   // Try with validation='warn' - should warn but not throw
   Fides.updateConsent({ 
     consent: { essential: true }, 
     validation: "warn" 
   });
   // Check console for warning
   
   // Try with validation='ignore' - should not warn or throw
   Fides.updateConsent({ 
     consent: { essential: true }, 
     validation: "ignore" 
   });
   ```

14. Test NOTICE_ONLY consent mechanism:
```javascript
Fides.updateConsent({ consent: { essential: "acknowledge" } });
```

15. Test error handling scenarios:
```
Fides.updateConsent({});
```
```
Fides.updateConsent({ fidesString: "invalid-string" });
```
```
Fides.updateConsent({ 
  consent: { analytics: true }, 
  validation: "invalid" 
});
```

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [x] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [x] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[LJ-684]: https://ethyca.atlassian.net/browse/LJ-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ