### PR TITLE
ensure we show all frames in our profiler output

### DIFF
--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -136,7 +136,7 @@ if CONFIG.dev_mode:
             await call_next(request)
             profiler.stop()
             logger.debug("Request Profiled!")
-            return HTMLResponse(profiler.output_text(timeline=True))
+            return HTMLResponse(profiler.output_text(timeline=True, show_all=True))
 
         return await call_next(request)
 


### PR DESCRIPTION
### Description Of Changes

We're not showing all frames in our endpoint profiler output, which in practice seems to make that output pretty useless. This switch has the output show all frames - which can definitely be a bit verbose. But what's the point of profiling if it's not comprehensive? :)

Note: this was used to help find and confirm a [potentially important performance improvement](https://github.com/ethyca/fidesplus/pull/2167) to our `GET /privacy experience` endpoint

### Code Changes

* set `show_all=True` in our profiler output

### Steps to Confirm

1.  send a `profile-request: true` header in any API calls against a fides webserver
2. locally with this change, i get an output that starts like this:
```

  _     ._   __/__   _ _  _  _ _/_   Recorded: 10:38:10  Samples:  67
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.921     CPU time: 0.703
/   _/                      v4.5.1

Program: /usr/local/bin/uvicorn --host 0.0.0.0 --port 8080 --reload --reload-dir src --reload-dir data --reload-dir /fidesplus/ethyca-fides/src --reload-include=*.yml fidesplus.main:fidesplus_app

0.920 run  asyncio/runners.py:8
|- 0.067 coro  starlette/middleware/base.py:146
|  |- 0.009 GZipMiddleware.__call__  starlette/middleware/gzip.py:17
|  |  `- 0.009 dict.__call__  starlette/middleware/base.py:101
|  |     `- 0.009 SlowAPIMiddleware.dispatch  slowapi/middleware.py:117
|  |        |- 0.007 _find_route_handler  slowapi/middleware.py:18
|  |        |  |- 0.002 APIRoute.matches  fastapi/routing.py:538
|  |        |  |  `- 0.002 APIRoute.matches  starlette/routing.py:255
|  |        |  |     `- 0.002 get_route_path  starlette/_utils.py:96
|  |        |  |        |- 0.001 [self]  starlette/_utils.py
|  |        |  |        `- 0.001 sub  re.py:202
|  |        |  |- 0.002 [self]  slowapi/middleware.py
|  |        |  `- 0.003 APIRoute.matches  fastapi/routing.py:538
...
```
and includes useful information that shows our own function calls:
```
`- 0.828 wrapper  fidesplus/api/endpoint_cache.py:119
   |                                   |- 0.826 privacy_experience_list  fidesplus/api/routes/privacy_experiences.py:393
   |                                   |  |- 0.023 PrivacyExperience.component  fides/api/models/privacy_experience.py:603
   |                                   |  |  `- 0.023 InstrumentedAttribute.__get__  sqlalchemy/orm/attributes.py:466
   |                                   |  |     `- 0.023 ScalarObjectAttributeImpl.get  sqlalchemy/orm/attributes.py:908
   |                                   |  |        `- 0.023 ScalarObjectAttributeImpl._fire_loader_callables  sqlalchemy/orm/attributes.py:951
```

3. on plus-rc, which doesn't have this change, the same profile output is basically useless:
```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 10:42:00  Samples:  84
 /_//_/// /_\ / //_// / //_'/ //     Duration: 3.286     CPU time: 1.587
/   _/                      v4.5.1

Program: /usr/local/bin/fidesplus

3.286 run  asyncio/runners.py:8
|- 0.258 privacy_experience_list  fidesplus/api/routes/privacy_experiences.py:393
|     [21 frames hidden]  fidesplus, starlette, anyio, fides, s...
|- 0.154 privacy_experience_list  fidesplus/api/routes/privacy_experiences.py:393
|     [5 frames hidden]  fidesplus, starlette, anyio
`- 2.848 privacy_experience_list  fidesplus/api/routes/privacy_experiences.py:393
      [10 frames hidden]  fidesplus, starlette, anyio, fastapi
         2.750 run_sync_in_worker_thread  anyio/_backends/_asyncio.py:834
         `- 2.750 [await]  anyio/_backends/_asyncio.py
```

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
