### PR TITLE
Support Additional Consent string v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Changed
 - Attachment uploads now check for file extension types, retrieving and attachment also returns the file size. [#6124](https://github.com/ethyca/fides/pull/6124)
+- Updated the AC string version from v1 to v2 format, which now includes a disclosed vendors section [#6155](https://github.com/ethyca/fides/pull/6155)
 
 ### Developer Experience
 - Refactored Fides initialization code to reduce duplication and improve maintainability. [#6143](https://github.com/ethyca/fides/pull/6143)

--- a/clients/fides-js/__tests__/lib/consent-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/consent-utils.test.ts
@@ -16,6 +16,7 @@ import {
   encodeNoticeConsentString,
   getWindowObjFromPath,
   isPrivacyExperience,
+  isValidAcString,
   shouldResurfaceBanner,
 } from "~/lib/consent-utils";
 import { parseFidesDisabledNotices } from "~/lib/shared-consent-utils";
@@ -624,5 +625,23 @@ describe("applyOverridesToConsent", () => {
       essential: true,
       tracking: false,
     });
+  });
+});
+
+describe("isValidAcString", () => {
+  it("should return true for valid AC strings", () => {
+    expect(isValidAcString("1~1.2.3")).toBe(true);
+    expect(isValidAcString("2~1.2.3~dv.4.5")).toBe(true);
+    expect(isValidAcString("1~")).toBe(true);
+    expect(isValidAcString("2~")).toBe(false);
+    expect(isValidAcString("2~~dv.")).toBe(true);
+  });
+
+  it("should return false for invalid AC strings", () => {
+    expect(isValidAcString("1~1.2.3~dv.4.5")).toBe(false);
+    expect(isValidAcString("3~1.2.3")).toBe(false);
+    expect(isValidAcString("2~1.2.3~dv.4.5~dv.6.7")).toBe(false);
+    expect(isValidAcString("")).toBe(false);
+    expect(isValidAcString("1.2.3")).toBe(false);
   });
 });

--- a/clients/fides-js/__tests__/lib/gpp/string-to-consent-tcf.test.ts
+++ b/clients/fides-js/__tests__/lib/gpp/string-to-consent-tcf.test.ts
@@ -145,7 +145,7 @@ describe("fidesStringToConsent", () => {
     const cmpApi = new CmpApi(1, 1);
     fidesStringToConsent({
       fidesString:
-        "CQNvpkAQNvpkAGXABBENBfFgALAAAENAAAAAFyQAQFyAXJABAXIAAAAA,1~,DBABMA~CQNvpkAQNvpkAGXABBENBfFgALAAAENAAAAAFyQAQFyAXJABAXIAAAAA",
+        "CQNvpkAQNvpkAGXABBENBfFgALAAAENAAAAAFyQAQFyAXJABAXIAAAAA,2~~dv.,DBABMA~CQNvpkAQNvpkAGXABBENBfFgALAAAENAAAAAFyQAQFyAXJABAXIAAAAA",
       cmpApi,
     });
     expect(updateConsentPreferences).toHaveBeenCalledWith(
@@ -183,7 +183,7 @@ describe("fidesStringToConsent", () => {
     const cmpApi = new CmpApi(1, 1);
     fidesStringToConsent({
       fidesString:
-        "CQNvpkAQNvpkAGXABBENBfFgAAAAAAAAAAAAAAAAAAAA,1~,DBABMA~CQNvpkAQNvpkAGXABBENBfFgAAAAAAAAAAAAAAAAAAAA",
+        "CQNvpkAQNvpkAGXABBENBfFgAAAAAAAAAAAAAAAAAAAA,2~~dv.,DBABMA~CQNvpkAQNvpkAGXABBENBfFgAAAAAAAAAAAAAAAAAAAA",
       cmpApi,
     });
     expect(updateConsentPreferences).toHaveBeenCalledWith(
@@ -208,7 +208,7 @@ describe("fidesStringToConsent", () => {
     const cmpApi = new CmpApi(1, 1);
     fidesStringToConsent({
       fidesString:
-        "CQNvpkAQNvpkAGXABBENBfFgAJAAAAIAAAAAAAAAAAAA,1~,DBABMA~CQNvpkAQNvpkAGXABBENBfFgAJAAAAIAAAAAAAAAAAAA",
+        "CQNvpkAQNvpkAGXABBENBfFgAJAAAAIAAAAAAAAAAAAA,2~~dv.,DBABMA~CQNvpkAQNvpkAGXABBENBfFgAJAAAAIAAAAAAAAAAAAA",
       cmpApi,
     });
     expect(updateConsentPreferences).toHaveBeenCalledWith(

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -100,7 +100,7 @@ The string consists of four parts separated by commas in the format:
 
 ```ts
 console.log(Fides.fides_string);
-// "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+// "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,2~61.70~dv.33,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
 ```
 
 ***

--- a/clients/fides-js/docs/interfaces/FidesOptions.md
+++ b/clients/fides-js/docs/interfaces/FidesOptions.md
@@ -175,17 +175,25 @@ The string consists of four parts separated by commas in the format:
 
 #### Example
 
-// Complete string with all parts:
-// "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+Complete string with all parts:
+```
+"CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,2~61.70~dv.33,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+```
 
-// TC and AC strings only:
-// "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70"
+TC and AC strings only:
+```
+"CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,2~61.70~dv.33"
+```
 
-// GPP string only:
-// ",,DBABLA~BVAUAAAAAWA.QA"
+GPP string only:
+```
+",,DBABLA~BVAUAAAAAWA.QA"
+```
 
-// Notice Consent string only:
-// ",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+Notice Consent string only:
+```
+",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+```
 
 To properly encode the Notice Consent string, use the
 `window.Fides.encodeNoticeConsentString` function (see [Fides.encodeNoticeConsentString](Fides.md#encodenoticeconsentstring)) or write your own function that

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -53,7 +53,7 @@ const fidesScriptPlugins = ({ name, gzipWarnSizeKb, gzipErrorSizeKb }) => [
     IS_DEV
       ? {}
       : {
-          include: ["**/*.ts"],
+          include: ["**/*.ts", "**/*.tsx"],
           functions: ["fidesDebugger"],
         },
   ),

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -158,17 +158,25 @@ export interface FidesOptions {
    * - NC_STRING: Base64 encoded string of the user's Notice Consent preferences.
    *
    * @example
-   * // Complete string with all parts:
-   * // "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+   * Complete string with all parts:
+   * ```
+   * "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,2~61.70~dv.33,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+   * ```
    *
-   * // TC and AC strings only:
-   * // "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70"
+   * TC and AC strings only:
+   * ```
+   * "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,2~61.70~dv.33"
+   * ```
    *
-   * // GPP string only:
-   * // ",,DBABLA~BVAUAAAAAWA.QA"
+   * GPP string only:
+   * ```
+   * ",,DBABLA~BVAUAAAAAWA.QA"
+   * ```
    *
-   * // Notice Consent string only:
-   * // ",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+   * Notice Consent string only:
+   * ```
+   * ",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+   * ```
    *
    * To properly encode the Notice Consent string, use the
    * `window.Fides.encodeNoticeConsentString` function (see {@link Fides.encodeNoticeConsentString}) or write your own function that

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -90,7 +90,7 @@ export interface Fides {
    *
    * @example
    * console.log(Fides.fides_string);
-   * // "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,1~61.70,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
+   * // "CPzHq4APzHq4AAMABBENAUEAALAAAEOAAAAAAEAEACACAAAA,2~61.70~dv.33,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjowLCJhbmFseXRpY3MiOjF9"
    */
   fides_string?: string;
 

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -620,3 +620,14 @@ export const applyOverridesToConsent = (
 
   return consentValues;
 };
+
+export const isValidAcString = (acString: string) => {
+  const acVersion = acString.split("~")[0];
+  return Boolean(
+    acVersion &&
+      ["1", "2"].includes(acVersion) &&
+      acString?.match(
+        acVersion === "1" ? /\d~[0-9.]*$/ : /\d~[0-9.]*~dv.[0-9.]*$/,
+      ),
+  );
+};

--- a/clients/fides-js/src/lib/fides-string.ts
+++ b/clients/fides-js/src/lib/fides-string.ts
@@ -1,5 +1,6 @@
 import { CmpApi } from "@iabgpp/cmpapi";
 
+import { isValidAcString } from "./consent-utils";
 import { FIDES_SEPARATOR } from "./tcf/constants";
 import { VendorSources } from "./tcf/vendors";
 
@@ -75,13 +76,8 @@ export const decodeFidesString = (fidesString: string): DecodedFidesString => {
  * // returns [gacp.1, gacp.2, gacp.3]
  */
 export const consentIdsFromAcString = (acString: string) => {
-  const acVersion = acString.split("~")[0];
-  const isValidAcString =
-    !acVersion ||
-    (acVersion === "1" && !acString?.match(/\d~[0-9.]+$/)) ||
-    (acVersion === "2" && !acString?.match(/\d~[0-9.]+~dv.[0-9.]+$/)) ||
-    (acVersion !== "1" && acVersion !== "2");
-  if (!isValidAcString) {
+  const isValid = isValidAcString(acString);
+  if (!isValid) {
     fidesDebugger(
       acString && `Received invalid AC string "${acString}", returning no ids`,
     );

--- a/clients/fides-js/src/lib/fides-string.ts
+++ b/clients/fides-js/src/lib/fides-string.ts
@@ -19,21 +19,21 @@ export interface DecodedFidesString {
  *
  * The Fides string format is: `TC_STRING,AC_STRING,GPP_STRING,NC_STRING` where:
  * - TC_STRING: The TCF (Transparency & Consent Framework) string
- * - AC_STRING: The Additional Consent string, which is derived from TC_STRING
+ * - AC_STRING: The Additional Consent string
  * - GPP_STRING: The Global Privacy Platform string
  * - NC_STRING: A Base64 encoded stringified JSON object containing Notice Consent preferences
  *
  * Rules:
  * 1. If the string is empty or undefined, all parts are empty strings
  * 2. If only one part exists, it's treated as the TC string
- * 3. AC string can only exist if TC string exists (as it's derived from TC)
- * 4. GPP string is independent and can exist with or without TC/AC strings
- * 5. Notice Consent String is an optional part that can be used to pass notice consent preferences programatically
+ * 3. AC string can only exist if TC string exists. An AC string will not be processed if the TC string is not present.
+ * 4. GPP string is independent and can exist with or without other string parts
+ * 5. Notice Consent String is an optional part that can be used to pass notice consent preferences programatically. This can also exist independently.
  *
  * @example
  * // Complete string with all parts
- * decodeFidesString("CPzvOIA.IAAA,1~2.3.4,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9")
- * // Returns { tc: "CPzvOIA.IAAA", ac: "1~2.3.4", gpp: "DBABLA~BVAUAAAAAWA.QA", nc: "eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9" }
+ * decodeFidesString("CPzvOIA.IAAA,2~2.3.4~dv.1.5,DBABLA~BVAUAAAAAWA.QA,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9")
+ * // Returns { tc: "CPzvOIA.IAAA", ac: "2~2.3.4~dv.1.5", gpp: "DBABLA~BVAUAAAAAWA.QA", nc: "eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9" }
  *
  * // TC string only
  * decodeFidesString("CPzvOIA.IAAA")
@@ -42,6 +42,10 @@ export interface DecodedFidesString {
  * // GPP string only (with empty TC and AC)
  * decodeFidesString(",,DBABLA~BVAUAAAAAWA.QA")
  * // Returns { tc: "", ac: "", gpp: "DBABLA~BVAUAAAAAWA.QA", nc: "" }
+ *
+ * // Notice Consent String only
+ * decodeFidesString(",,,eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9")
+ * // Returns { tc: "", ac: "", gpp: "", nc: "eyJkYXRhX3NhbGVzX2FuZF9zaGFyaW5nIjoxLCJhbmFseXRpY3MiOjB9" }
  *
  * @param fidesString - The combined Fides string to decode
  * @returns An object containing the decoded TC, AC, GPP, and Notice Consent strings
@@ -60,12 +64,22 @@ export const decodeFidesString = (fidesString: string): DecodedFidesString => {
 /**
  * Given an AC string, return a list of its ids, encoded
  *
- * @example
+ * @example // V1 AC string
+ * consentIdsFromAcString("1~1.2.3")
  * // returns [gacp.1, gacp.2, gacp.3]
- * idsFromAcString("1~1.2.3")
+ *
+ * @example // V2 AC string
+ * consentIdsFromAcString("2~1.2.3~dv.4.5")
+ * // returns [gacp.1, gacp.2, gacp.3]
  */
-export const idsFromAcString = (acString: string) => {
-  if (!acString?.match(/\d~[0-9.]+$/)) {
+export const consentIdsFromAcString = (acString: string) => {
+  const acVersion = acString.split("~")[0];
+  if (
+    !acVersion ||
+    (acVersion === "1" && !acString?.match(/\d~[0-9.]+$/)) ||
+    (acVersion === "2" && !acString?.match(/\d~[0-9.]+~dv.[0-9.]+$/)) ||
+    (acVersion !== "1" && acVersion !== "2")
+  ) {
     fidesDebugger(
       acString && `Received invalid AC string "${acString}", returning no ids`,
     );

--- a/clients/fides-js/src/lib/fides-string.ts
+++ b/clients/fides-js/src/lib/fides-string.ts
@@ -62,7 +62,9 @@ export const decodeFidesString = (fidesString: string): DecodedFidesString => {
 };
 
 /**
- * Given an AC string, return a list of its ids, encoded
+ * Given an AC string, return a list of its ids, encoded.
+ * V2 AC strings include a list of disclosed vendors which we can ignore for the return value but
+ * we do use to validate the AC string format. The consent id list is formatted the same as V1.
  *
  * @example // V1 AC string
  * consentIdsFromAcString("1~1.2.3")
@@ -74,12 +76,12 @@ export const decodeFidesString = (fidesString: string): DecodedFidesString => {
  */
 export const consentIdsFromAcString = (acString: string) => {
   const acVersion = acString.split("~")[0];
-  if (
+  const isValidAcString =
     !acVersion ||
     (acVersion === "1" && !acString?.match(/\d~[0-9.]+$/)) ||
     (acVersion === "2" && !acString?.match(/\d~[0-9.]+~dv.[0-9.]+$/)) ||
-    (acVersion !== "1" && acVersion !== "2")
-  ) {
+    (acVersion !== "1" && acVersion !== "2");
+  if (!isValidAcString) {
     fidesDebugger(
       acString && `Received invalid AC string "${acString}", returning no ids`,
     );

--- a/clients/fides-js/src/lib/tcf/utils.ts
+++ b/clients/fides-js/src/lib/tcf/utils.ts
@@ -16,9 +16,9 @@ import {
   transformTcfPreferencesToCookieKeys,
 } from "../cookie";
 import {
+  consentIdsFromAcString,
   DecodedFidesString,
   decodeFidesString,
-  idsFromAcString,
 } from "../fides-string";
 import {
   transformConsentToFidesUserPreference,
@@ -96,7 +96,7 @@ export const buildTcfEntitiesFromCookieAndFidesString = (
     if (!tcString) {
       return tcfEntities;
     }
-    const acStringIds = idsFromAcString(acString);
+    const consentedAcStringIds = consentIdsFromAcString(acString);
 
     // Populate every field from tcModel
     const tcModel = TCString.decode(tcString);
@@ -107,13 +107,13 @@ export const buildTcfEntitiesFromCookieAndFidesString = (
       const tcIds = Array.from(tcModel[tcfModelKey])
         .filter(([, consented]) => consented)
         .map(([id]) => (isVendorKey ? `gvl.${id}` : id));
-      // @ts-ignore the array map should ensure we will get the right record type
+      // @ts-expect-error the array map should ensure we will get the correct record type
       tcfEntities[experienceKey] = experience[experienceKey]?.map((item) => {
         let consented = !!tcIds.find((id) => id === item.id);
         // Also check the AC string, which only applies to tcf_vendor_consents
         if (
           experienceKey === "tcf_vendor_consents" &&
-          acStringIds.find((id) => id === item.id)
+          consentedAcStringIds.find((id) => id === item.id)
         ) {
           consented = true;
         }

--- a/clients/privacy-center/cypress/e2e/consent-banner-gpp.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-gpp.cy.ts
@@ -344,7 +344,7 @@ describe("Fides-js GPP extension", () => {
     it("can handle a fides string being passed in", () => {
       cy.setCookie(
         "fides_string",
-        "CQNvpkAQNvpkAGXABBENBfFgALAAAENAAAAAFyQAQFyAXJABAXIAAAAA,1~,DBABMA~CQNvpkAQNvpkAGXABBENBfFgALAAAENAAAAAFyQAQFyAXJABAXIAAAAA",
+        "CQNvpkAQNvpkAGXABBENBfFgALAAAENAAAAAFyQAQFyAXJABAXIAAAAA,2~~dv.,DBABMA~CQNvpkAQNvpkAGXABBENBfFgALAAAENAAAAAFyQAQFyAXJABAXIAAAAA",
       );
       const cookie = mockCookie({
         tcf_version_hash: TCF_VERSION_HASH,

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -134,7 +134,7 @@ const assertTcOptIns = ({
   const tcString = fidesString?.split(FIDES_SEPARATOR)[0];
   expect(tcString).to.be.a("string");
   expect(tcString).to.not.equal("");
-  const model = TCString.decode(tcString!);
+  const model = TCString.decode(tcString);
   const values = Array.from(model[modelType].values()).sort();
   expect(values).to.eql(ids.sort());
 };
@@ -147,9 +147,10 @@ const assertAcOptIns = ({
   ids: number[];
 }) => {
   const { fides_string: fidesString } = cookie;
-  const acString = fidesString?.split("1~")[1];
+  const acString = fidesString?.split(",")[1];
   expect(acString).to.be.a("string");
-  const values = acString!
+  const acConsent = acString.split("~")[1];
+  const values = acConsent
     .split(".")
     .map((id) => +id)
     .sort();
@@ -551,7 +552,7 @@ describe("Fides-js TCF", () => {
                   consentMethod: "accept",
                 },
               });
-              expect(call.Fides.fides_string).to.contain(",1~");
+              expect(call.Fides.fides_string).to.contain(",2~~dv.");
             });
 
           // FidesUpdated call
@@ -572,7 +573,7 @@ describe("Fides-js TCF", () => {
                   consentMethod: "accept",
                 },
               });
-              expect(call.Fides.fides_string).to.contain(",1~");
+              expect(call.Fides.fides_string).to.contain(",2~~dv.");
             });
         });
 
@@ -1240,7 +1241,7 @@ describe("Fides-js TCF", () => {
                     consentMethod: "accept",
                   },
                 });
-                expect(call.Fides.fides_string).to.contain(",1~");
+                expect(call.Fides.fides_string).to.contain(",2~~dv.");
               });
 
             // FidesUpdated call
@@ -1261,7 +1262,7 @@ describe("Fides-js TCF", () => {
                     consentMethod: "accept",
                   },
                 });
-                expect(call.Fides.fides_string).to.contain(",1~");
+                expect(call.Fides.fides_string).to.contain(",2~~dv.");
               });
           });
 
@@ -1801,7 +1802,7 @@ describe("Fides-js TCF", () => {
                 expect(args[0]).to.equal(ConsentMethod.REJECT);
                 expect(args[1]).to.be.a("object");
                 // the TC str is dynamically updated upon save preferences with diff timestamp, so we do a fuzzy match
-                expect(args[2]).to.contain("AA,1~");
+                expect(args[2]).to.contain("AA,2~~dv.");
                 expect(args[3]).to.be.a("object");
                 // timeout means API call not made, which is expected
                 cy.on("fail", (error) => {
@@ -2586,7 +2587,7 @@ describe("Fides-js TCF", () => {
       setFidesCookie();
       // Purpose 7, Special Feature 1
       const fidesStringOverride =
-        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~";
+        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~~dv.";
       const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
       stubTCFExperience({ stubOptions: { fidesString: fidesStringOverride } });
       cy.window().then((win) => {
@@ -2677,7 +2678,7 @@ describe("Fides-js TCF", () => {
      */
     it("prefers preferences from fides_string option when both fides_string and experience is provided and cookie does not exist", () => {
       const fidesStringOverride =
-        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~";
+        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~~dv.";
       const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
       stubTCFExperience({ stubOptions: { fidesString: fidesStringOverride } });
       cy.window().then((win) => {
@@ -2769,7 +2770,7 @@ describe("Fides-js TCF", () => {
      */
     it("does nothing when fides_string option when both fides_string option and cookie exist but no experience exists (neither prefetch nor API)", () => {
       const fidesStringOverride =
-        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~";
+        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~~dv.";
       setFidesCookie();
       stubConfig(
         {
@@ -2800,7 +2801,7 @@ describe("Fides-js TCF", () => {
      */
     it("prefers preferences from fides_string option when both fides_string option and cookie exist and experience is fetched from API", () => {
       const fidesStringOverride =
-        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~";
+        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~~dv.";
       const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
       setFidesCookie();
       cy.fixture("consent/geolocation_tcf.json").then((geo) => {
@@ -2898,7 +2899,7 @@ describe("Fides-js TCF", () => {
      * EXPECTED RESULT: ignore invalid fides_string option and render experience as-is
      */
     it("can handle an invalid fides_string option and continue rendering the experience", () => {
-      const fidesStringOverride = "invalid-string,1~";
+      const fidesStringOverride = "invalid-string,2~~dv.";
       cy.fixture("consent/geolocation_tcf.json").then((geo) => {
         stubTCFExperience({
           stubOptions: { fidesString: fidesStringOverride },
@@ -2949,8 +2950,8 @@ describe("Fides-js TCF", () => {
     it("prefers preferences from fides_string option when fides_string override, custom pref API and cookie exist and experience is fetched from API", () => {
       // This fide str override opts in to all
       const fidesStringOverride =
-        "CP0gqMAP0gqMAGXABBENATEIABaAAEAAAAAAABEAAAAA,1~";
-      const fidesString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~";
+        "CP0gqMAP0gqMAGXABBENATEIABaAAEAAAAAAABEAAAAA,2~~dv.";
+      const fidesString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~~dv.";
       const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
       setFidesCookie();
       cy.fixture("consent/geolocation_tcf.json").then((geo) => {
@@ -3054,7 +3055,7 @@ describe("Fides-js TCF", () => {
      * EXPECTED RESULT: use preferences from preferences API, overrides cookie tcf_version_hash if returned in preferences API
      */
     it("prefers preferences from preferences API when custom pref API and cookie exist and experience is fetched from API", () => {
-      const fidesString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~";
+      const fidesString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~~dv.";
       const versionHash = "091834y";
       const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
       setFidesCookie();
@@ -3248,7 +3249,7 @@ describe("Fides-js TCF", () => {
     it("can use a fides_string to override a vendor consent", () => {
       // Opts in to all
       const fidesStringOverride =
-        "CP0gqMAP0gqMAGXABBENATEIABaAAEAAAAAAABEAAAAA,1~";
+        "CP0gqMAP0gqMAGXABBENATEIABaAAEAAAAAAABEAAAAA,2~~dv.";
       stubTCFExperience({ stubOptions: { fidesString: fidesStringOverride } });
       cy.window().then((win) => {
         win.__tcfapi("addEventListener", 2, cy.stub().as("TCFEvent"));
@@ -3286,7 +3287,7 @@ describe("Fides-js TCF", () => {
   describe("fides_string override options", () => {
     it("uses fides_string when set via cookie", () => {
       const fidesStringOverride =
-        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~";
+        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~~dv.";
       const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
       cy.getCookie("fides_string").should("not.exist");
       cy.setCookie("fides_string", fidesStringOverride);
@@ -3327,7 +3328,7 @@ describe("Fides-js TCF", () => {
 
     it("uses fides_string when set via query param", () => {
       const fidesStringOverride =
-        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~";
+        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~~dv.";
       const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
       cy.getCookie("fides_string").should("not.exist");
       stubTCFExperience({
@@ -3369,7 +3370,7 @@ describe("Fides-js TCF", () => {
 
     it("uses fides_string when set via window obj", () => {
       const fidesStringOverride =
-        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~";
+        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~~dv.";
       const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA"; // without disclosed vendors
       cy.getCookie("fides_string").should("not.exist");
       stubTCFExperience({
@@ -3411,7 +3412,7 @@ describe("Fides-js TCF", () => {
 
     it("uses fides_string when set via window obj at custom config path", () => {
       const fidesStringOverride =
-        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~";
+        "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~~dv.";
       const expectedTCString = "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA";
       cy.getCookie("fides_string").should("not.exist");
       stubTCFExperience({
@@ -3517,8 +3518,9 @@ describe("Fides-js TCF", () => {
 
   describe("ac string", () => {
     const AC_IDS = [42, 33, 49];
-    const acceptAllAcString = `1~${AC_IDS.sort().join(".")}`;
-    const rejectAllAcString = "1~";
+    const acceptAllAcString = `2~${AC_IDS.sort().join(".")}~dv.`;
+    const acceptSomeAcString = `2~33.42~dv.49`;
+    const rejectAllAcString = "2~~dv.33.42.49";
     beforeEach(() => {
       cy.fixture("consent/experience_tcf.json").then((payload) => {
         const experience = payload.items[0];
@@ -3554,7 +3556,7 @@ describe("Fides-js TCF", () => {
       });
     });
 
-    it("can opt in to AC vendors and generate string", () => {
+    it("can opt in to all AC vendors and generate string", () => {
       cy.get("#fides-tab-vendors").click();
       AC_IDS.forEach((id) => {
         // Turn all ACs on
@@ -3584,7 +3586,39 @@ describe("Fides-js TCF", () => {
       });
     });
 
-    it("can opt out of AC vendors and generate string", () => {
+    it("can opt in to some AC vendors and generate string", () => {
+      cy.get("#fides-tab-vendors").click();
+      AC_IDS.slice(0, 2).forEach((id) => {
+        cy.getByTestId(`toggle-AC ${id}`).click();
+      });
+      cy.get("button").contains("Save").click();
+      cy.wait("@patchPrivacyPreference").then((interception) => {
+        const { body } = interception.request;
+        const expected = [
+          { id: VENDOR_1.id, preference: "opt_out" },
+          ...AC_IDS.map((id) => ({
+            id: `gacp.${id}`,
+            preference: id === 49 ? "opt_out" : "opt_in",
+          })),
+        ];
+        expect(body.vendor_consent_preferences).to.eql(expected);
+        expect(body.method).to.eql(ConsentMethod.SAVE);
+
+        // Check the cookie
+        cy.waitUntilCookieExists(CONSENT_COOKIE_NAME).then(() => {
+          cy.getCookie(CONSENT_COOKIE_NAME).then((cookie) => {
+            const cookieKeyConsent: FidesCookie = JSON.parse(
+              decodeURIComponent(cookie!.value),
+            );
+            const { fides_string: tcString } = cookieKeyConsent;
+            const acString = tcString?.split(",")[1];
+            expect(acString).to.eql(acceptSomeAcString);
+          });
+        });
+      });
+    });
+
+    it("can opt out of all AC vendors and generate string", () => {
       cy.get("#fides-tab-vendors").click();
       cy.getByTestId("consent-modal").within(() => {
         cy.get("button").contains("Opt out of all").click();
@@ -3651,6 +3685,7 @@ describe("Fides-js TCF", () => {
           const parts = tcString.split(",");
           expect(parts.length).to.eql(1);
           expect(parts[0]).to.not.contain("1~");
+          expect(parts[0]).to.not.contain("2~");
           // But we can still access the AC string via `addtlConsent`
           expect(tcData.addtlConsent).to.eql(acceptAllAcString);
         });
@@ -3683,7 +3718,7 @@ describe("Fides-js TCF", () => {
       });
     });
 
-    it("can initialize from an AC string", () => {
+    it("can initialize from a v1 AC string", () => {
       const cookie = mockCookie({
         fides_string: "CPzbcgAPzbcgAGXABBENATEIAACAAAAAAAAAABEAAAAA",
       });
@@ -3692,6 +3727,33 @@ describe("Fides-js TCF", () => {
         stubOptions: {
           fidesString:
             "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,1~42.43.44",
+        },
+      });
+
+      cy.get("@FidesInitialized")
+        .should("have.been.calledTwice")
+        .its("lastCall.args.0.detail")
+        .then((updatedCookie: FidesCookie) => {
+          // TC string setting worked
+          assertTcOptIns({
+            cookie: updatedCookie,
+            modelType: "purposeConsents",
+            ids: [PURPOSE_7.id],
+          });
+          // AC string setting worked
+          assertAcOptIns({ cookie: updatedCookie, ids: [42, 43, 44] });
+        });
+    });
+
+    it("can initialize from a v2 AC string", () => {
+      const cookie = mockCookie({
+        fides_string: "CPzbcgAPzbcgAGXABBENATEIAACAAAAAAAAAABEAAAAA",
+      });
+      cy.setCookie(CONSENT_COOKIE_NAME, JSON.stringify(cookie));
+      stubTCFExperience({
+        stubOptions: {
+          fidesString:
+            "CPzevcAPzevcAGXABBENATEIAAIAAAAAAAAAAAAAAAAA,2~42.43.44~dv.33.49",
         },
       });
 


### PR DESCRIPTION
Closes [ENG-443]

### Description Of Changes

Updated the Additional Consent (AC) string format from version 1 to version 2, which now includes a disclosed vendors section with the "dv." prefix. This change ensures compatibility with [Google's updated AC string specification](https://support.google.com/admanager/answer/9681920?hl=en).

### Code Changes

* Updated AC string format from version 1 (`1~id1.id2.id3`) to version 2 (`2~id1.id2.id3~dv.id4.id5.id6`)
* Renamed `idsFromAcString` function to `consentIdsFromAcString` for better clarity
* Enhanced string validation in `consentIdsFromAcString` to handle both version 1 and version 2 AC strings
* Updated all test cases with the new AC string format
* Improved documentation with clearer code examples showing the new format

### Steps to Confirm
1. In Admin UI, add some systems that are not part of GVL (AC)
2. Configure and enable the TCF experience
3. Visit the TCF experience in the Privacy Center demo page
4. Open the TCF Modal and switch to the Vendors tab
5. Non-GVL vendors will appear in an "Other vendors" category, consent to some, but not others and save the consent.
7. Look at the fides_string portion of the created cookie
   - verify the first slot of the AC string is now a `2` (previously `1`)
   - verify the 2nd slot (after the first `~`) contains a dot separated list of the vendors IDs of the vendors you consented to
   - verify the 3rd slot (after the second `~`) contains the `dv.` prefix, followed by all of the vendor ID's that were presented in the UI, but were not consented.
8. Re-open the TCF modal and Opt-in to all. Verify all vendors are in the 2nd slot and no vendors are in the 3rd slot after the `dv.` prefix
9. Re-open the TCF modal and Opt-out of all. Verify that no vendors appear in the 2nd slot and all vendors are in the 3rd slot.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [x] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-443]: https://ethyca.atlassian.net/browse/ENG-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ