### PR TITLE
Apply overrides during initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Fixed
 - Fix Special-purpose vendors with restricted purposes not correctly encoded in TC string [#6145](https://github.com/ethyca/fides/pull/6145) https://github.com/ethyca/fides/labels/high-risk
+- Fixed an issue where consent mechanism string values and/or non-applicable notices not applied to Fides.consent during initialization [#6157](https://github.com/ethyca/fides/pull/6157)
 
 ## [2.61.1](https://github.com/ethyca/fides/compare/2.61.0...2.61.1)
 

--- a/clients/fides-js/src/lib/initialize.ts
+++ b/clients/fides-js/src/lib/initialize.ts
@@ -23,6 +23,7 @@ import {
   UserGeolocation,
 } from "./consent-types";
 import {
+  applyOverridesToConsent,
   constructFidesRegionString,
   experienceIsValid,
   getOverrideValidatorMapByType,
@@ -425,8 +426,14 @@ export const initialize = async ({
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { consent, fides_meta, identity, fides_string, tcf_consent } =
-    fides.cookie;
+  const { fides_meta, identity, fides_string, tcf_consent } = fides.cookie;
+  const consent = applyOverridesToConsent(
+    fides.cookie.consent,
+    fides.experience?.non_applicable_privacy_notices,
+    fides.experience?.privacy_notices,
+    options.fidesConsentFlagType ?? undefined,
+    options.fidesConsentNonApplicableFlagMode ?? undefined,
+  );
 
   // return an object with the updated Fides values
   return {

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -3279,6 +3279,27 @@ describe("Consent overlay", () => {
         });
       });
 
+      it("initializes with the correct consent values", () => {
+        cy.window().then((win) => {
+          win.Fides.init().then(() => {
+            expect(win.Fides.consent).to.have.property(
+              PRIVACY_NOTICE_KEY_1,
+              "opt_out",
+            );
+            expect(win.Fides.consent).to.have.property(
+              PRIVACY_NOTICE_KEY_2,
+              "acknowledge",
+            );
+            expect(win.Fides.consent).to.have.property(
+              PRIVACY_NOTICE_KEY_3,
+              "opt_in",
+            );
+            expect(win.Fides.consent).to.not.have.property("functional");
+            expect(win.Fides.consent).to.not.have.property("personalization");
+          });
+        });
+      });
+
       it("formats FidesInitialized events with consent mechanism strings and omits non-applicable notices", () => {
         cy.get("@FidesInitialized")
           .should("have.been.calledOnce")
@@ -3357,6 +3378,33 @@ describe("Consent overlay", () => {
               fidesConsentNonApplicableFlagMode:
                 ConsentNonApplicableFlagMode.INCLUDE,
             },
+          });
+        });
+      });
+
+      it("initializes with the correct consent values", () => {
+        cy.window().then((win) => {
+          win.Fides.init().then(() => {
+            expect(win.Fides.consent).to.have.property(
+              PRIVACY_NOTICE_KEY_1,
+              "opt_out",
+            );
+            expect(win.Fides.consent).to.have.property(
+              PRIVACY_NOTICE_KEY_2,
+              "acknowledge",
+            );
+            expect(win.Fides.consent).to.have.property(
+              PRIVACY_NOTICE_KEY_3,
+              "opt_in",
+            );
+            expect(win.Fides.consent).to.have.property(
+              "functional",
+              "not_applicable",
+            );
+            expect(win.Fides.consent).to.have.property(
+              "personalization",
+              "not_applicable",
+            );
           });
         });
       });

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -3279,6 +3279,15 @@ describe("Consent overlay", () => {
         });
       });
 
+      it("initializes the options correctly", () => {
+        cy.window().then((win) => {
+          expect(win.Fides.options).to.have.property(
+            "fidesConsentFlagType",
+            ConsentFlagType.CONSENT_MECHANISM,
+          );
+        });
+      });
+
       it("initializes with the correct consent values", () => {
         cy.window().then((win) => {
           win.Fides.init().then(() => {
@@ -3379,6 +3388,19 @@ describe("Consent overlay", () => {
                 ConsentNonApplicableFlagMode.INCLUDE,
             },
           });
+        });
+      });
+
+      it("initializes the options correctly", () => {
+        cy.window().then((win) => {
+          expect(win.Fides.options).to.have.property(
+            "fidesConsentFlagType",
+            ConsentFlagType.CONSENT_MECHANISM,
+          );
+          expect(win.Fides.options).to.have.property(
+            "fidesConsentNonApplicableFlagMode",
+            ConsentNonApplicableFlagMode.INCLUDE,
+          );
         });
       });
 


### PR DESCRIPTION
Closes [ENG-459]

### Description Of Changes

Fixes issue where `Fides.consent` wasn't respecting `fidesConsentFlagType` and `fidesConsentNonApplicableFlagMode` overrides until after a consent choice. This update ensures that value applies those overrides during initialization as well.

### Code Changes

* Pass the `Fides.cookie.consent` value through the `applyOverridesToConsent` method before using it to initialize the `Fides.consent` value.

### Steps to Confirm

1. Add `6sense` to system, which will give a handful of notices. Only enable 1 or 2 of the notices and add them to the US Modal Experience and enable it.
2. Visit the Privacy Center demo page with both overrides in their non-default state (eg. http://localhost:3001/fides-js-demo.html?geolocation=US-CA&fides_consent_non_applicable_flag_mode=include&fides_consent_flag_type=consent_mechanism)
3. DO NOT open the modal or make any consent choices.
4. In the console, type `Fides.consent` and press enter to get the initialized value of the `window.Fides.consent` object. (NOTE: this will be reflected on the demo page under Consent JSON section as well).
5. Validate that the overrides have been applied to the initial value. You should see something like  `{ marketing: "not_applicable", analytics: "not_applicable", ... }` depending which notices were left disabled in step 1.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-459]: https://ethyca.atlassian.net/browse/ENG-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ