### PR TITLE
ENG-72: Implements Fallback Locations in CMP (FE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Added
 - Exposes configuration settings for the async db engine connection [#6128](https://github.com/ethyca/fides/pull/6128)
 - Added support for uploading files as internal attachments to privacy requests [#6069](https://github.com/ethyca/fides/pull/6069)
+- Implements Fallback Locations in CMP [#6158](https://github.com/ethyca/fides/pull/6158)
 
 ### Changed
 - Attachment uploads now check for file extension types, retrieving and attachment also returns the file size. [#6124](https://github.com/ethyca/fides/pull/6124)

--- a/clients/admin-ui/src/features/common/privacy-notice-regions.ts
+++ b/clients/admin-ui/src/features/common/privacy-notice-regions.ts
@@ -320,6 +320,7 @@ export const PRIVACY_NOTICE_REGION_RECORD: Record<PrivacyNoticeRegion, string> =
     [PrivacyNoticeRegion.CARIBBEAN]: "Caribbean",
     [PrivacyNoticeRegion.EEA]: "European Economic Area (EEA)",
     [PrivacyNoticeRegion.NON_EEA]: "Non European Economic Area",
+    [PrivacyNoticeRegion.GLOBAL]: "Global",
   };
 
 export const PRIVACY_NOTICE_REGION_MAP = new Map(

--- a/clients/admin-ui/src/features/locations/LocationManagement.tsx
+++ b/clients/admin-ui/src/features/locations/LocationManagement.tsx
@@ -16,7 +16,7 @@ import { getErrorMessage } from "~/features/common/helpers";
 import ConfirmationModal from "~/features/common/modals/ConfirmationModal";
 import SearchInput from "~/features/common/SearchInput";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
-import { LocationRegulationResponse, Selection } from "~/types/api";
+import { LocationRegulationResponse, PrivacyNoticeRegion, Selection } from "~/types/api";
 import { isErrorResult } from "~/types/errors";
 
 import { REGULATIONS_ROUTE } from "../common/nav/routes";
@@ -29,7 +29,7 @@ const LocationManagement = ({ data }: { data: LocationRegulationResponse }) => {
   const toast = useToast();
   const confirmationDisclosure = useDisclosure();
   const [draftSelections, setDraftSelections] = useState<Array<Selection>>(
-    data.locations ?? [],
+    data.locations?.filter(l => l.id !== PrivacyNoticeRegion.GLOBAL) ?? [],
   );
   const [search, setSearch] = useState("");
   const [patchLocationsRegulationsMutationTrigger, { isLoading: isSaving }] =
@@ -38,7 +38,7 @@ const LocationManagement = ({ data }: { data: LocationRegulationResponse }) => {
   const locationGroupsByContinent = useMemo(
     () =>
       groupLocationsByContinent(
-        data.locations || [],
+        (data.locations || []).filter(l => l.id !== PrivacyNoticeRegion.GLOBAL),
         data.location_groups || [],
       ),
     [data],

--- a/clients/admin-ui/src/features/locations/LocationManagement.tsx
+++ b/clients/admin-ui/src/features/locations/LocationManagement.tsx
@@ -16,7 +16,11 @@ import { getErrorMessage } from "~/features/common/helpers";
 import ConfirmationModal from "~/features/common/modals/ConfirmationModal";
 import SearchInput from "~/features/common/SearchInput";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
-import { LocationRegulationResponse, PrivacyNoticeRegion, Selection } from "~/types/api";
+import {
+  LocationRegulationResponse,
+  PrivacyNoticeRegion,
+  Selection,
+} from "~/types/api";
 import { isErrorResult } from "~/types/errors";
 
 import { REGULATIONS_ROUTE } from "../common/nav/routes";
@@ -29,7 +33,7 @@ const LocationManagement = ({ data }: { data: LocationRegulationResponse }) => {
   const toast = useToast();
   const confirmationDisclosure = useDisclosure();
   const [draftSelections, setDraftSelections] = useState<Array<Selection>>(
-    data.locations?.filter(l => l.id !== PrivacyNoticeRegion.GLOBAL) ?? [],
+    data.locations?.filter((l) => l.id !== PrivacyNoticeRegion.GLOBAL) ?? [],
   );
   const [search, setSearch] = useState("");
   const [patchLocationsRegulationsMutationTrigger, { isLoading: isSaving }] =
@@ -38,7 +42,9 @@ const LocationManagement = ({ data }: { data: LocationRegulationResponse }) => {
   const locationGroupsByContinent = useMemo(
     () =>
       groupLocationsByContinent(
-        (data.locations || []).filter(l => l.id !== PrivacyNoticeRegion.GLOBAL),
+        (data.locations || []).filter(
+          (l) => l.id !== PrivacyNoticeRegion.GLOBAL,
+        ),
         data.location_groups || [],
       ),
     [data],

--- a/clients/admin-ui/src/types/api/models/PrivacyNoticeRegion.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyNoticeRegion.ts
@@ -316,4 +316,5 @@ export enum PrivacyNoticeRegion {
   CARIBBEAN = "caribbean",
   EEA = "eea",
   NON_EEA = "non_eea",
+  GLOBAL = "global",
 }

--- a/src/fides/api/models/location_regulation_selections.py
+++ b/src/fides/api/models/location_regulation_selections.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from enum import Enum
 from functools import lru_cache
 from os.path import dirname, join
-from typing import Any, Dict, Iterable, List, Set, Union
+from typing import Any, Dict, Iterable, List, Optional, Set, Union
 
 import yaml
 from pydantic import BaseModel

--- a/src/fides/api/models/location_regulation_selections.py
+++ b/src/fides/api/models/location_regulation_selections.py
@@ -295,7 +295,7 @@ class Continent(Enum):
     africa = "Africa"
     oceania = "Oceania"
     europe = "Europe"
-    global = "Global"
+    all = "All"
 
 
 class Selection(BaseModel):

--- a/src/fides/api/models/location_regulation_selections.py
+++ b/src/fides/api/models/location_regulation_selections.py
@@ -295,6 +295,7 @@ class Continent(Enum):
     africa = "Africa"
     oceania = "Oceania"
     europe = "Europe"
+    global = "Global"
 
 
 class Selection(BaseModel):

--- a/src/fides/api/models/location_regulation_selections.py
+++ b/src/fides/api/models/location_regulation_selections.py
@@ -295,7 +295,6 @@ class Continent(Enum):
     africa = "Africa"
     oceania = "Oceania"
     europe = "Europe"
-    all = "All"
 
 
 class Selection(BaseModel):
@@ -309,7 +308,7 @@ class LocationRegulationBase(Selection):
     """Base Location Regulation Schema"""
 
     name: str
-    continent: Continent
+    continent: Optional[Continent] = None
     default_selected: bool = False
 
 

--- a/src/fides/data/location/locations.yml
+++ b/src/fides/data/location/locations.yml
@@ -1538,7 +1538,7 @@ location_groups:
 - continent: Europe
   id: non_eea
   name: Non European Economic Area
-- continent: Global
+- continent: All
   id: global
   name: Global
 

--- a/src/fides/data/location/locations.yml
+++ b/src/fides/data/location/locations.yml
@@ -1545,13 +1545,6 @@ location_groups:
   name: Non European Economic Area
 
 
-##############
-### Global ###
-##############
-- id: global
-  name: Global
-
-
 
 ###################
 ### Regulations ###

--- a/src/fides/data/location/locations.yml
+++ b/src/fides/data/location/locations.yml
@@ -1538,7 +1538,9 @@ location_groups:
 - continent: Europe
   id: non_eea
   name: Non European Economic Area
-
+- continent: Global
+  id: global
+  name: Global
 
 
 

--- a/src/fides/data/location/locations.yml
+++ b/src/fides/data/location/locations.yml
@@ -1511,6 +1511,11 @@ locations:
   continent: North America
   regulation: [pipeda]
   default_selected: True
+- id: global
+  name: Global
+  belongs_to: []
+  regulation: []
+  default_selected: True
 
 
 
@@ -1538,8 +1543,12 @@ location_groups:
 - continent: Europe
   id: non_eea
   name: Non European Economic Area
-- continent: All
-  id: global
+
+
+##############
+### Global ###
+##############
+- id: global
   name: Global
 
 


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/ENG-72

Please test alongside https://github.com/ethyca/fidesplus/pull/2176

### Description Of Changes

- No longer need to set up all US states, can just use "United States" location. Same with "EEA". E.g. When visiting from "us-ca", an experience would show up that just has the "US" configured.
- Can designate a "global" fallback location on any experience, including TCF, etc. E.g. When visiting from a location outside of any existing location configured on your experiences, you will be shown the experience labeled with the "global" location.
- Can only configure one "global" fallback experience on a given property, same as other locations

### Code Changes

* Adds "global" fallback location
* Excludes it from showing in the "Locations" tab of Admin-UI
* Allows the global location to show up in experience locations configurations

### Steps to Confirm

* [ ] Please test alongside https://github.com/ethyca/fidesplus/pull/2176
* [ ] Following the `Description of Changes` section, test that each scenario is true
* [ ] See https://www.loom.com/share/b55d47643dac44c2889ec8cd84532621?sid=5529f31d-c6d9-4fb0-a294-4c2d43ba3281 for details


### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
