### PR TITLE
Refactor validation types as enum

### DIFF
--- a/clients/fides-js/__tests__/lib/preferences.test.ts
+++ b/clients/fides-js/__tests__/lib/preferences.test.ts
@@ -5,6 +5,7 @@ import {
   FidesCookie,
   FidesGlobal,
   PrivacyExperience,
+  UpdateConsentValidation,
   UserConsentPreference,
 } from "../../src/lib/consent-types";
 import { decodeFidesString } from "../../src/lib/fides-string";
@@ -131,7 +132,7 @@ describe("preferences", () => {
           mockFides,
           {
             consent: { marketing: true },
-            validation: "throw",
+            validation: UpdateConsentValidation.THROW,
           },
           ConsentMethod.SCRIPT,
         ),
@@ -163,7 +164,7 @@ describe("preferences", () => {
           mockFides,
           {
             consent: { nonexistent: true },
-            validation: "throw",
+            validation: UpdateConsentValidation.THROW,
           },
           ConsentMethod.SCRIPT,
         ),
@@ -435,7 +436,7 @@ describe("preferences", () => {
           mockFides,
           {
             consent: { essential: UserConsentPreference.OPT_IN },
-            validation: "throw",
+            validation: UpdateConsentValidation.THROW,
           },
           ConsentMethod.SCRIPT,
         ),
@@ -446,7 +447,7 @@ describe("preferences", () => {
         mockFides,
         {
           consent: { essential: true },
-          validation: "throw",
+          validation: UpdateConsentValidation.THROW,
         },
         ConsentMethod.SCRIPT,
       );
@@ -483,7 +484,7 @@ describe("preferences", () => {
         mockFides,
         {
           consent: { essential: UserConsentPreference.OPT_IN },
-          validation: "warn",
+          validation: UpdateConsentValidation.WARN,
         },
         ConsentMethod.SCRIPT,
       );
@@ -499,7 +500,7 @@ describe("preferences", () => {
         mockFides,
         {
           consent: { essential: UserConsentPreference.OPT_IN },
-          validation: "ignore",
+          validation: UpdateConsentValidation.IGNORE,
         },
         ConsentMethod.SCRIPT,
       );
@@ -517,7 +518,7 @@ describe("preferences", () => {
           },
           ConsentMethod.SCRIPT,
         ),
-      ).rejects.toThrow("Validation must be 'throw', 'warn', or 'ignore'");
+      ).rejects.toThrow(/Validation must be one of/);
     });
 
     it("should handle NOTICE_ONLY consent mechanisms", async () => {
@@ -568,7 +569,7 @@ describe("preferences", () => {
             // This would be invalid with validation="throw", but we're using "ignore"
             essential: true,
           },
-          validation: "ignore",
+          validation: UpdateConsentValidation.IGNORE,
         },
         ConsentMethod.SCRIPT,
       );

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -204,7 +204,7 @@ export interface FidesGlobal
   updateConsent: (options: {
     consent?: NoticeConsent;
     fidesString?: string;
-    validation?: "throw" | "warn" | "ignore";
+    validation?: UpdateConsentValidation;
   }) => Promise<void>;
 }
 
@@ -724,6 +724,12 @@ export enum ConsentNonApplicableFlagMode {
 export enum ConsentFlagType {
   BOOLEAN = "boolean",
   CONSENT_MECHANISM = "consent_mechanism",
+}
+
+export enum UpdateConsentValidation {
+  THROW = "throw",
+  WARN = "warn",
+  IGNORE = "ignore",
 }
 
 // NOTE: This (and most enums!) could reasonably be replaced by string union

--- a/clients/fides-js/src/lib/init-utils.ts
+++ b/clients/fides-js/src/lib/init-utils.ts
@@ -8,6 +8,7 @@ import {
   FidesOptions,
   NoticeConsent,
   PrivacyExperience,
+  UpdateConsentValidation,
 } from "./consent-types";
 import {
   decodeNoticeConsentString,
@@ -153,7 +154,7 @@ export const getCoreFides = ({
       options: {
         consent?: NoticeConsent;
         fidesString?: string;
-        validation?: "throw" | "warn" | "ignore";
+        validation?: UpdateConsentValidation;
       },
     ): Promise<void> {
       return updateConsent(this, options);

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -12,6 +12,7 @@ import {
   PrivacyExperienceMinimal,
   PrivacyPreferencesRequest,
   SaveConsentPreference,
+  UpdateConsentValidation,
   UserConsentPreference,
 } from "./consent-types";
 import {
@@ -27,7 +28,6 @@ import { dispatchFidesEvent } from "./events";
 import { decodeFidesString } from "./fides-string";
 import { transformConsentToFidesUserPreference } from "./shared-consent-utils";
 import { TcfSavePreferences } from "./tcf/types";
-
 /**
  * Helper function to transform save prefs and call API
  */
@@ -250,7 +250,7 @@ export const updateConsent = async (
   options: {
     consent?: NoticeConsent;
     fidesString?: string;
-    validation?: "throw" | "warn" | "ignore";
+    validation?: UpdateConsentValidation;
   },
   consentMethod: ConsentMethod = ConsentMethod.SCRIPT,
 ): Promise<void> => {
@@ -264,19 +264,25 @@ export const updateConsent = async (
   if (!fides.cookie) {
     throw new Error("Cookie is not initialized");
   }
-  const { consent, fidesString, validation = "throw" } = options;
+  const {
+    consent,
+    fidesString,
+    validation = UpdateConsentValidation.THROW,
+  } = options;
 
-  if (!["throw", "warn", "ignore"].includes(validation)) {
+  if (!Object.values(UpdateConsentValidation).includes(validation)) {
     throw new Error(
-      "Validation must be 'throw', 'warn', or 'ignore' (default is 'throw')",
+      `Validation must be one of: ${Object.values(UpdateConsentValidation).join(
+        ", ",
+      )} (default is ${UpdateConsentValidation.THROW})`,
     );
   }
 
   const handleValidationError = (errorMessage: string) => {
-    if (validation === "throw") {
+    if (validation === UpdateConsentValidation.THROW) {
       throw new Error(errorMessage);
     }
-    if (validation === "warn") {
+    if (validation === UpdateConsentValidation.WARN) {
       // eslint-disable-next-line no-console
       console.warn(errorMessage);
     }


### PR DESCRIPTION
Closes [ENG-533]

### Description Of Changes

Simply converts the valid `validation` values to an enum and applies that everywhere.

### Code Changes

* Refactor to add `UpdateConsentValidation` enum
* Apply new enum
* Update tests

### Steps to Confirm

1. Passing tests

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-533]: https://ethyca.atlassian.net/browse/ENG-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ