### PR TITLE
Table migration mini POC using Cursor

### DIFF
--- a/clients/admin-ui/src/features/common/nav/nav-config.tsx
+++ b/clients/admin-ui/src/features/common/nav/nav-config.tsx
@@ -311,6 +311,11 @@ if (process.env.NEXT_PUBLIC_APP_ENV === "development") {
         path: routes.FORMS_POC_ROUTE,
         scopes: [],
       },
+      {
+        title: "Table Migration POC",
+        path: routes.TABLE_MIGRATION_POC_ROUTE,
+        scopes: [],
+      },
     ],
   });
 }

--- a/clients/admin-ui/src/features/common/nav/routes.ts
+++ b/clients/admin-ui/src/features/common/nav/routes.ts
@@ -73,4 +73,5 @@ export const OPENID_AUTHENTICATION_ROUTE = "/settings/openid-authentication";
 
 export const ANT_POC_ROUTE = "/poc/ant-components";
 export const FORMS_POC_ROUTE = "/poc/forms";
+export const TABLE_MIGRATION_POC_ROUTE = "/poc/table-migration";
 export const FIDES_JS_DOCS = "/fides-js-docs";

--- a/clients/admin-ui/src/pages/poc/table-migration.tsx
+++ b/clients/admin-ui/src/pages/poc/table-migration.tsx
@@ -1,27 +1,195 @@
+import type { ColumnsType } from "antd/es/table";
+import { useFeatures } from "common/features";
 import {
+  AntButton as Button,
+  AntFlex as Flex,
+  AntInput as Input,
   AntLayout as Layout,
   AntRow as Row,
+  AntSpace as Space,
+  AntTable as Table,
+  AntTag as Tag,
   AntTypography as Typography,
 } from "fidesui";
+import { useRouter } from "next/router";
+import { useState } from "react";
+
+import { ADD_MULTIPLE_VENDORS_ROUTE } from "~/features/common/nav/routes";
+import AddVendor from "~/features/configure-consent/AddVendor";
+import {
+  ConsentManagementModal,
+  useConsentManagementModal,
+} from "~/features/configure-consent/ConsentManagementModal";
+import { useGetVendorReportQuery } from "~/features/plus/plus.slice";
+import { SystemSummary } from "~/types/api";
 
 const { Content } = Layout;
 const { Title, Paragraph } = Typography;
 
 export const TableMigrationPOC = () => {
+  const { tcf: isTcfEnabled, dictionaryService } = useFeatures();
+  const router = useRouter();
+  const [searchText, setSearchText] = useState<string>("");
+  const [pageSize, setPageSize] = useState<number>(25);
+  const [pageIndex, setPageIndex] = useState<number>(1);
+  const [systemFidesKey, setSystemFidesKey] = useState<string>();
+
+  const {
+    isOpen: isRowModalOpen,
+    onOpen: onRowModalOpen,
+    onClose: onRowModalClose,
+  } = useConsentManagementModal();
+
+  const { data: vendorReport, isLoading } = useGetVendorReportQuery({
+    pageIndex,
+    pageSize,
+    search: searchText,
+    dataUses: "",
+    legalBasis: "",
+    purposes: "",
+    specialPurposes: "",
+    consentCategories: "",
+  });
+
+  const totalRows = vendorReport?.total || 0;
+  const items = vendorReport?.items || [];
+
+  const onSearch = (value: string) => {
+    setSearchText(value);
+    setPageIndex(1);
+  };
+
+  const onTableChange = (pagination: any) => {
+    setPageIndex(pagination.current);
+    setPageSize(pagination.pageSize);
+  };
+
+  const onRowClick = (record: SystemSummary) => {
+    setSystemFidesKey(record.fides_key);
+    onRowModalOpen();
+  };
+
+  const goToAddMultiple = () => {
+    router.push(ADD_MULTIPLE_VENDORS_ROUTE);
+  };
+
+  // Table columns configuration
+  const columns: ColumnsType<SystemSummary> = [
+    {
+      title: "Vendor",
+      dataIndex: "name",
+      key: "name",
+    },
+    ...(isTcfEnabled
+      ? [
+          {
+            title: "TCF purpose",
+            dataIndex: "data_uses",
+            key: "tcf_purpose",
+            render: (count: number) => (
+              <Tag>
+                {count} {count === 1 ? "purpose" : "purposes"}
+              </Tag>
+            ),
+          },
+          {
+            title: "Data use",
+            dataIndex: "data_uses",
+            key: "data_uses",
+            render: (count: number) => (
+              <Tag>
+                {count} {count === 1 ? "data use" : "data uses"}
+              </Tag>
+            ),
+          },
+          {
+            title: "Legal basis",
+            dataIndex: "legal_bases",
+            key: "legal_bases",
+            render: (count: number) => (
+              <Tag>
+                {count} {count === 1 ? "basis" : "bases"}
+              </Tag>
+            ),
+          },
+        ]
+      : [
+          {
+            title: "Categories",
+            dataIndex: "consent_categories",
+            key: "consent_categories",
+            render: (count: number) => (
+              <Tag>
+                {count} {count === 1 ? "category" : "categories"}
+              </Tag>
+            ),
+          },
+          {
+            title: "Cookies",
+            dataIndex: "cookies",
+            key: "cookies",
+            render: (count: number) => (
+              <Tag>
+                {count} {count === 1 ? "cookie" : "cookies"}
+              </Tag>
+            ),
+          },
+        ]),
+  ];
+
   return (
     <Content className="overflow-auto px-10 py-6">
       <Row>
         <Title>Table Migration POC</Title>
       </Row>
-      <Paragraph>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-        mollit anim id est laborum.
+      <Paragraph className="mb-6">
+        This is a demonstration of migrating the ConsentManagementTable from
+        TanStack Table to Ant Design Table.
       </Paragraph>
+
+      {isRowModalOpen && systemFidesKey ? (
+        <ConsentManagementModal
+          isOpen={isRowModalOpen}
+          fidesKey={systemFidesKey}
+          onClose={onRowModalClose}
+        />
+      ) : null}
+
+      <Flex justify="space-between" align="center" className="mb-4">
+        <Input.Search
+          placeholder="Search"
+          onSearch={onSearch}
+          style={{ width: 300 }}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+        />
+        <Space size={8}>
+          <AddVendor
+            buttonLabel="Add vendors"
+            onButtonClick={dictionaryService ? goToAddMultiple : undefined}
+          />
+          <Button>Filter</Button>
+        </Space>
+      </Flex>
+
+      <Table
+        dataSource={items}
+        columns={columns}
+        loading={isLoading}
+        rowKey="id"
+        pagination={{
+          current: pageIndex,
+          pageSize,
+          total: totalRows,
+          showSizeChanger: true,
+          pageSizeOptions: [25, 50, 100],
+        }}
+        onChange={onTableChange}
+        onRow={(record) => ({
+          onClick: () => onRowClick(record),
+          style: { cursor: "pointer" },
+        })}
+      />
     </Content>
   );
 };

--- a/clients/admin-ui/src/pages/poc/table-migration.tsx
+++ b/clients/admin-ui/src/pages/poc/table-migration.tsx
@@ -320,6 +320,7 @@ export const TableMigrationPOC = () => {
           onClick: () => onRowClick(record),
           style: { cursor: "pointer" },
         })}
+        size="small"
       />
     </Content>
   );

--- a/clients/admin-ui/src/pages/poc/table-migration.tsx
+++ b/clients/admin-ui/src/pages/poc/table-migration.tsx
@@ -12,7 +12,7 @@ import {
   AntTypography as Typography,
 } from "fidesui";
 import { useRouter } from "next/router";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import { ADD_MULTIPLE_VENDORS_ROUTE } from "~/features/common/nav/routes";
@@ -52,6 +52,7 @@ const LEGAL_BASIS_OPTIONS = [
 export const TableMigrationPOC = () => {
   const { tcf: isTcfEnabled, dictionaryService } = useFeatures();
   const router = useRouter();
+  const [searchInput, setSearchInput] = useState<string>("");
   const [searchText, setSearchText] = useState<string>("");
   const [pageSize, setPageSize] = useState<number>(25);
   const [pageIndex, setPageIndex] = useState<number>(1);
@@ -148,9 +149,27 @@ export const TableMigrationPOC = () => {
   const totalRows = vendorReport?.total || 0;
   const items = vendorReport?.items || [];
 
+  // Debounced search handler
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchText(searchInput);
+      if (pageIndex !== 1) {
+        setPageIndex(1);
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchInput, pageIndex]);
+
+  const onSearchInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setSearchInput(e.target.value);
+    },
+    [],
+  );
+
   const onSearch = (value: string) => {
-    setSearchText(value);
-    setPageIndex(1);
+    setSearchInput(value);
   };
 
   const handleTableChange = (
@@ -272,8 +291,8 @@ export const TableMigrationPOC = () => {
           placeholder="Search"
           onSearch={onSearch}
           style={{ width: 300 }}
-          value={searchText}
-          onChange={(e) => setSearchText(e.target.value)}
+          value={searchInput}
+          onChange={onSearchInputChange}
         />
         <Space size={8}>
           <AddVendor

--- a/clients/admin-ui/src/pages/poc/table-migration.tsx
+++ b/clients/admin-ui/src/pages/poc/table-migration.tsx
@@ -1,0 +1,29 @@
+import {
+  AntLayout as Layout,
+  AntRow as Row,
+  AntTypography as Typography,
+} from "fidesui";
+
+const { Content } = Layout;
+const { Title, Paragraph } = Typography;
+
+export const TableMigrationPOC = () => {
+  return (
+    <Content className="overflow-auto px-10 py-6">
+      <Row>
+        <Title>Table Migration POC</Title>
+      </Row>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum.
+      </Paragraph>
+    </Content>
+  );
+};
+
+export default TableMigrationPOC;

--- a/clients/admin-ui/src/pages/poc/table-migration.tsx
+++ b/clients/admin-ui/src/pages/poc/table-migration.tsx
@@ -159,7 +159,8 @@ export const TableMigrationPOC = () => {
     }, 300);
 
     return () => clearTimeout(timer);
-  }, [searchInput, pageIndex]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchInput]);
 
   const onSearchInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/clients/fidesui/src/index.ts
+++ b/clients/fidesui/src/index.ts
@@ -54,6 +54,7 @@ export {
   Skeleton as AntSkeleton,
   Space as AntSpace,
   Switch as AntSwitch,
+  Table as AntTable,
   Tabs as AntTabs,
   Tooltip as AntTooltip,
   Upload as AntUpload,


### PR DESCRIPTION
Closes [ENG-437]

### Description Of Changes

Cursor prompts:

1. `@ConsentManagementTable.tsx` uses custom table components built with TanStack and Chakra. We want to recreate this exact table functionality, but ONLY using AntTable from Fides UI. You can ignore the filter for now. Add this new Ant Table version to the `@table-migration.tsx` page. Try to avoid using non-Ant components
2. Instead of a filter button that will open a custom modal, can we implement the same filter functionality using Ant Table's built in Column Filtering?
3. the filter looks good, but the api query doesn't seem to be configured right. The end result of selecting and applying the filters should look something like `...plus/system/consent-management/report?page=1&size=25&purposes=2&purposes=3` but it currently looks something like `...plus/system/consent-management/report?page=1&size=25&2,3,2,3`
4. let's debounce the search input at 300ms

### Code Changes

* 100% AI generated code


[ENG-437]: https://ethyca.atlassian.net/browse/ENG-437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ