### PR TITLE
Fix vendor lists in context + Type fixes

### DIFF
--- a/clients/fides-js/src/lib/tcf/types.ts
+++ b/clients/fides-js/src/lib/tcf/types.ts
@@ -249,7 +249,9 @@ export type VendorRecord = TCFVendorConsentRecord &
     isGvl: boolean;
   };
 
-export interface PurposeRecord extends TCFPurposeConsentRecord {
+export interface PurposeRecord
+  extends TCFPurposeConsentRecord,
+    TCFPurposeLegitimateInterestsRecord {
   isConsent: boolean;
   isLegint: boolean;
 }


### PR DESCRIPTION
Closes [ENG-396]

### Description Of Changes

Refactored the TCF purposes component to properly map vendors to purpose records. This fixes an issue where vendors weren't being properly displayed when switching between consent and legitimate interest legal bases in the TCF UI.

### Code Changes

* Updated `PurposeRecord` interface to extend both `TCFPurposeConsentRecord` and `TCFPurposeLegitimateInterestsRecord`
* Replaced the specific `TCFPurposeRecord` type alias with more specific purpose record types in the `PurposeDetails` component
* Enhanced the `useMemo` hook in `TcfPurposes` to properly map vendors from the appropriate source to each purpose record

### Steps to Confirm
1. Navigate to a TCF privacy center demo (eg `/fides-js-demo.html?geolocation=eea`) and open the TCF modal
2. Switch between "Consent" and "Legitimate interest" tabs in the Purposes list.
3. Verify that vendors are correctly displayed for each purpose in both tabs. Previously, the Legitimate interest vendors were showing up as Consent vendors. See [ENG-396] for screenshots to get a sense of what to look for.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
