### PR TITLE
Skip fetching of request comments if it's running OSS

### DIFF
--- a/clients/admin-ui/src/features/privacy-requests/events-and-logs/hooks/usePrivacyRequestComments.ts
+++ b/clients/admin-ui/src/features/privacy-requests/events-and-logs/hooks/usePrivacyRequestComments.ts
@@ -1,6 +1,7 @@
 import { AntMessage as message } from "fidesui";
 import { useEffect } from "react";
 
+import { useFeatures } from "~/features/common/features";
 import { useGetCommentsQuery } from "~/features/privacy-requests/comments/privacy-request-comments.slice";
 import {
   ActivityTimelineItem,
@@ -12,15 +13,22 @@ import { CommentResponse } from "~/types/api/models/CommentResponse";
  * Hook for fetching and processing privacy request comments
  */
 export const usePrivacyRequestComments = (privacyRequestId: string) => {
+  const { plus: isPlusEnabled } = useFeatures();
+
   // Fetch comments data for this privacy request
   const {
     data: commentsData,
     isLoading,
     error,
-  } = useGetCommentsQuery({
-    privacy_request_id: privacyRequestId,
-    size: 100, // Use a reasonable limit
-  });
+  } = useGetCommentsQuery(
+    {
+      privacy_request_id: privacyRequestId,
+      size: 100, // Use a reasonable limit
+    },
+    {
+      skip: !isPlusEnabled,
+    },
+  );
 
   // Handle error state
   useEffect(() => {


### PR DESCRIPTION
### Description Of Changes

Skip fetching of request comments if it's running OSS, preventing an error toast from showing up.

### Code Changes

* Skip fetching of request comments if it's running OSS

### Steps to Confirm

1.  Go to the Privacy Request pages
2. Click on any Privacy Request
3. Check no error toast shows up

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
