### PR TITLE
ENG-682: Smarter and earlier initialization strategy for Shopify integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Changed
 
 - TCF Banners will no longer resurface on reload after dismissal [#6200](https://github.com/ethyca/fides/pull/6200)
+- Earlier initialization strategy for Shopify integration [#6202](https://github.com/ethyca/fides/pull/6202)
 
 ## [2.63.0](https://github.com/ethyca/fides/compare/2.62.0...2.63.0)
 

--- a/clients/fides-js/src/integrations/shopify.ts
+++ b/clients/fides-js/src/integrations/shopify.ts
@@ -107,33 +107,56 @@ const applyOptions = () => {
  * Call Fides.shopify to configure Shopify customer privacy.
  */
 export const shopify = () => {
-  setTimeout(() => {
-    if (!window.Shopify) {
-      throw Error(
-        "Fides.shopify was called but Shopify is not present in the page.",
+  let timeoutId: ReturnType<typeof setTimeout>;
+  let pollId: ReturnType<typeof setTimeout>;
+
+  const cleanup = () => {
+    clearTimeout(timeoutId);
+    clearTimeout(pollId);
+  };
+
+  // Poll for the Shopify API to be available
+  const poll = () => {
+    if (window.Shopify) {
+      cleanup();
+
+      // If the API is already present, simply call it.
+      if (window.Shopify.customerPrivacy) {
+        applyOptions();
+        return;
+      }
+
+      // Otherwise we need to load the feature before applying the options.
+      window.Shopify.loadFeatures(
+        [
+          {
+            name: "consent-tracking-api",
+            version: "0.1",
+          },
+        ],
+        (error) => {
+          if (error) {
+            throw Error("Fides could not load Shopify's consent-tracking-api");
+          }
+
+          applyOptions();
+        },
       );
-    }
-    // If the API is already present, simply call it.
-    if (window.Shopify.customerPrivacy) {
-      applyOptions();
       return;
     }
 
-    // Otherwise we need to load the feature before applying the options.
-    window.Shopify.loadFeatures(
-      [
-        {
-          name: "consent-tracking-api",
-          version: "0.1",
-        },
-      ],
-      (error) => {
-        if (error) {
-          throw Error("Fides could not load Shopify's consent-tracking-api");
-        }
+    // Continue polling every 200ms
+    pollId = setTimeout(poll, 200);
+  };
 
-        applyOptions();
-      },
+  // Set up 3-second timeout
+  timeoutId = setTimeout(() => {
+    cleanup();
+    throw Error(
+      "Fides.shopify was called but Shopify is not present in the page after 3 seconds.",
     );
   }, 3000);
+
+  // Start polling immediately
+  poll();
 };


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/ENG-682

### Description Of Changes

Currently we have an arbitrary 3000ms wait (3 secs) before loading Shopify. This change allows us to init Shopify early in init lifecycle, passing in defaults first, then updating as Fides completes initialization.

### Code Changes

* Update the Shopify integration to allow earlier initialization of Shopify.

### Steps to Confirm

1. In `fides-js-components-demo.html`, add the following code after Fides init (L:220):
```
window.Shopify = {
          customerPrivacy: {
            setTrackingConsent: function () {
              // This function is used to test the Shopify integration.
              // It will be called by the Shopify platform script.
              console.log("Shopify customer privacy function called");
            }
          }
        }
        Fides.shopify();
```
2. Nav to `http://localhost:3001/fides-js-components-demo.html`, and open up console
3. Reload page to see `Shopify customer privacy function called` immediately after `FidesReady` event.
<img width="1369" alt="Screenshot 2025-06-06 at 4 59 24 PM" src="https://github.com/user-attachments/assets/15a026de-3058-47ad-bf57-41c9b72c9921" />


### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
