### PR TITLE
hide manual integrations from integrations screen unless flag is on

### DIFF
--- a/clients/admin-ui/src/pages/integrations/index.tsx
+++ b/clients/admin-ui/src/pages/integrations/index.tsx
@@ -11,6 +11,7 @@ import type { NextPage } from "next";
 import React, { useMemo, useState } from "react";
 
 import { FidesTab } from "~/features/common/DataTabs";
+import { useFlags } from "~/features/common/features/features.slice";
 import FidesSpinner from "~/features/common/FidesSpinner";
 import Layout from "~/features/common/Layout";
 import PageHeader from "~/features/common/PageHeader";
@@ -30,8 +31,18 @@ const IntegrationListView: NextPage = () => {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
 
+  // DEFER (ENG-675): Remove this once the alpha feature is released
+  const { flags } = useFlags();
+  const supportedIntegrations = useMemo(() => {
+    return SUPPORTED_INTEGRATIONS.filter((integration) => {
+      return (
+        integration !== "manual_webhook" || flags.alphaNewManualIntegration
+      );
+    });
+  }, [flags.alphaNewManualIntegration]);
+
   const { data, isLoading } = useGetAllDatastoreConnectionsQuery({
-    connection_type: SUPPORTED_INTEGRATIONS,
+    connection_type: supportedIntegrations,
     size: pageSize,
     page,
   });


### PR DESCRIPTION
### Description Of Changes
New manual integration UI should be hidden behind a feature flag. Existing manual connections were appearing even if the flag was on. This change filters out the manual connection type if the flag is off.

### Code Changes

* Filter out supported integrations array based on flag status

### Steps to Confirm

1.  Go to /settings/about/alpha and make sure the alpha feature flag is off
2. Go to any system detail page, go to the Integration tab, choose Manual Process and save
3. Go to the /integrations page and make sure no manual integration appears there

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
