### PR TITLE
Handle edge case in staged resource ancestor data migration

### DIFF
--- a/src/fides/api/migrations/post_upgrade_index_creation.py
+++ b/src/fides/api/migrations/post_upgrade_index_creation.py
@@ -182,7 +182,7 @@ def create_object(db: Session, object_statement: str, object_name: str) -> None:
 def check_and_create_objects(
     db: Session, table_object_map: Dict[str, List[Dict[str, str]]], lock: Lock
 ) -> Dict[str, str]:
-    """Returns a dictionary of any indices or constraints that are in the process of being created."""
+    """Returns a dictionary of any indices or constraints that were created."""
     object_info: Dict[str, str] = {}
     for _, objects in table_object_map.items():
         for object_data in objects:
@@ -203,7 +203,7 @@ def check_and_create_objects(
                             continue
 
                 create_object(db, object_statement, object_name)
-                object_info[object_name] = "in progress"
+                object_info[object_name] = "created"
             else:
                 logger.debug(
                     f"Object {object_name} already exists, skipping index/constraint creation"
@@ -248,7 +248,7 @@ def post_upgrade_index_creation_task() -> None:
                     f"Post upgrade index creation output: {json.dumps(object_info)}"
                 )
             else:
-                logger.debug("All indices and constraints created")
+                logger.debug("All indices and constraints already created")
 
 
 def initiate_post_upgrade_index_creation() -> None:


### PR DESCRIPTION
### Description Of Changes

Handles an edge case in the staged resource ancestor creation where we have `children` pointers in our staged resources that refer to URNs of nonexistent `stagedresource`s. This is an unexpected state, but it's one we've seen in practice, so we should guard against it.

Without this update, we'd create `stagedresourceancestor` links that point to the nonexistent `stagedresource` records, and then we get a constraint error when trying to create the FK constraint on `stagedresourceancestor.descendant_urn`.

### Code Changes

- [x] in our data migration: keep track of all existent `stagedresource` records, and only create `stagedresourceancestor` links to existent records
- [x] tweak some logging in our index creation script to be more accurate 

### Steps to Confirm

1. confirmed this handled our edge case locally with a sample dataset that showed the problem initially

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [x] Ensure that your downrev is up to date with the latest revision on `main`
  * [x] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
