### PR TITLE
Change FidesJS bundle format from UMD to IIFE

### DIFF
--- a/.github/workflows/frontend_checks.yml
+++ b/.github/workflows/frontend_checks.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Format
         run: npm run format:ci
 
-      - name: Build FidesJS # needed for type checks
+      - name: Build FidesJS # needed for type checks and for the fides-bundle.test.ts unit tests
         working-directory: clients/fides-js
         run: npm run build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - AWS SES notification service now supports assumed roles through environment variable configuration through `FIDES__CREDENTIALS__NOTIFICATIONS__AWS_SES_ASSUME_ROLE_ARN` [#6206](https://github.com/ethyca/fides/pull/6206)
 
 ### Changed
-
 - TCF Banners will no longer resurface on reload after dismissal [#6200](https://github.com/ethyca/fides/pull/6200)
 - Earlier initialization strategy for Shopify integration [#6202](https://github.com/ethyca/fides/pull/6202)
+
+### Fixed
+- Changed FidesJS bundle format from UMD to IIFE to resolve RequireJS conflicts [#6209](https://github.com/ethyca/fides/pull/6209)
 
 ## [2.63.0](https://github.com/ethyca/fides/compare/2.62.0...2.63.0)
 

--- a/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
@@ -113,7 +113,7 @@ const Preview = ({
         setPreviewMode("standard");
       }
     } else if (window.FidesPreview) {
-      window.FidesPreview?.cleanup();
+      window.FidesPreview.cleanup();
     }
 
     return () => {

--- a/clients/fides-js/__tests__/fides-bundle.test.ts
+++ b/clients/fides-js/__tests__/fides-bundle.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Test to verify that the Fides bundle works in both IIFE and ESM formats.
+ * Assumes that the bundles have already been built using `npm run build`.
+ */
+import fs from "fs";
+import path from "path";
+
+/**
+ * Check if a file appears to be in IIFE format
+ */
+const isIIFEFormat = (content: string): boolean => {
+  return (
+    content.trim().startsWith("(function") ||
+    content.includes("window.Fides") ||
+    content.includes("var Fides")
+  );
+};
+
+/**
+ * Check if a file appears to be in ES Module format
+ */
+const isESMFormat = (content: string): boolean => {
+  return (
+    content.includes("export") ||
+    content.includes("import") ||
+    !content.includes("var Fides = ")
+  );
+};
+
+/**
+ * Check if a file does not contain AMD module checks
+ */
+const hasNoAMDChecks = (content: string): boolean => {
+  return !content.includes("define.amd");
+};
+
+/**
+ * Check if a file preserves existing globals (uses extend: true)
+ */
+const usesExtendOption = (content: string): boolean => {
+  // Look for patterns that indicate the extend option is being used
+  return (
+    content.includes("Object.assign") ||
+    content.includes("= window.Fides || {}") ||
+    content.includes("= globalThis.Fides || {}")
+  );
+};
+
+/**
+ * Helper function to validate bundle existence and format
+ */
+const validateBundle = (fileName: string, format: "iife" | "esm"): void => {
+  const distDir = path.join(process.cwd(), "dist");
+  const filePath = path.join(distDir, fileName);
+
+  expect(fs.existsSync(filePath)).toBe(true);
+
+  const content = fs.readFileSync(filePath, "utf8");
+
+  if (format === "iife") {
+    expect(isIIFEFormat(content)).toBe(true);
+    expect(hasNoAMDChecks(content)).toBe(true);
+    expect(usesExtendOption(content)).toBe(true);
+  } else if (format === "esm") {
+    expect(isESMFormat(content)).toBe(true);
+  }
+};
+
+const iifeBundles = ["fides.js", "fides-tcf.js", "fides-headless.js"];
+
+const esmBundles = [
+  "fides.mjs",
+  "fides-tcf.mjs",
+  "fides-headless.mjs",
+  "fides-ext-gpp.mjs",
+];
+
+/**
+ * Check that all required bundles exist before running tests
+ */
+const checkBundlesExist = (): void => {
+  const distDir = path.join(process.cwd(), "dist");
+  const allBundles = [...iifeBundles, ...esmBundles];
+  const missingBundles: string[] = [];
+
+  // Check if dist directory exists
+  if (!fs.existsSync(distDir)) {
+    throw new Error(
+      `❌ Build directory not found: ${distDir}\n` +
+        `Please run 'npm run build' to generate the bundles before running these tests.`,
+    );
+  }
+
+  // Check each bundle file
+  allBundles.forEach((fileName) => {
+    const filePath = path.join(distDir, fileName);
+    if (!fs.existsSync(filePath)) {
+      missingBundles.push(fileName);
+    }
+  });
+
+  if (missingBundles.length > 0) {
+    throw new Error(
+      `❌ Missing bundle files: ${missingBundles.join(", ")}\n` +
+        `Please run 'npm run build' to generate all bundles before running these tests.\n` +
+        `Expected bundles: ${allBundles.join(", ")}`,
+    );
+  }
+};
+
+describe("Fides Bundle Tests", () => {
+  beforeAll(() => {
+    try {
+      checkBundlesExist();
+    } catch (error) {
+      // Re-throw with additional context
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new Error(`Bundle validation failed: ${errorMessage}`);
+    }
+  });
+
+  describe("IIFE Browser Format", () => {
+    iifeBundles.forEach((fileName) => {
+      it(`should generate valid IIFE format for ${fileName}`, () => {
+        validateBundle(fileName, "iife");
+      });
+    });
+  });
+
+  describe("ES Module Format", () => {
+    esmBundles.forEach((fileName) => {
+      it(`should generate valid ESM format for ${fileName}`, () => {
+        validateBundle(fileName, "esm");
+      });
+    });
+  });
+});

--- a/clients/fides-js/__tests__/fides-bundle.test.ts
+++ b/clients/fides-js/__tests__/fides-bundle.test.ts
@@ -66,7 +66,12 @@ const validateBundle = (fileName: string, format: "iife" | "esm"): void => {
   }
 };
 
-const iifeBundles = ["fides.js", "fides-tcf.js", "fides-headless.js"];
+const iifeBundles = [
+  "fides.js",
+  "fides-tcf.js",
+  "fides-headless.js",
+  "fides-preview.js",
+];
 
 const esmBundles = [
   "fides.mjs",

--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -7,6 +7,24 @@
   "source": "./src/fides.ts",
   "module": "./dist/fides.mjs",
   "types": "./dist/fides.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/fides.mjs",
+      "require": "./dist/fides.js",
+      "types": "./dist/fides.d.ts"
+    },
+    "./tcf": {
+      "import": "./dist/fides-tcf.mjs",
+      "require": "./dist/fides-tcf.js",
+      "types": "./dist/fides-tcf.d.ts"
+    },
+    "./headless": {
+      "import": "./dist/fides-headless.mjs",
+      "require": "./dist/fides-headless.js",
+      "types": "./dist/fides-headless.d.ts"
+    },
+    "./dist/*": "./dist/*"
+  },
   "files": [
     "dist/**"
   ],

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -230,9 +230,12 @@ const previewScript = {
   output: [
     {
       file: "dist/fides-preview.js",
-      format: "umd",
+      format: "iife",
       name: "FidesPreview",
       sourcemap: false,
+      exports: "named",
+      extend: true,
+      manualChunks: false,
     },
   ],
 };

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -147,11 +147,12 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
     }),
     output: [
       {
-        // Intended for browser <script> tag - defines `Fides` global. Also supports UMD loaders.
+        // Intended for browser <script> tag - defines `Fides` global. Uses IIFE to avoid RequireJS conflicts.
         file: `dist/${name}.js`,
         name: isExtension ? undefined : "Fides",
-        format: isExtension ? undefined : "umd",
+        format: isExtension ? "es" : "iife",
         sourcemap: IS_DEV ? "inline" : false,
+        extend: true, // avoid overwriting existing window.Fides if it exists
       },
     ],
   };


### PR DESCRIPTION
Closes [ENG-724]

### Description Of Changes

Changed FidesJS bundle format from UMD to IIFE to resolve RequireJS conflicts and improve browser compatibility. Added comprehensive bundle testing to ensure all formats work correctly, and improved module exports configuration for better package resolution.

### Code Changes

* Changed rollup configuration to generate IIFE bundles instead of UMD format
* Added `extend: true` option to preserve existing global `Fides` objects
* Added comprehensive bundle format tests (`fides-bundle.test.ts`) to validate IIFE and ESM outputs
* Updated `package.json` with proper `exports` field for better module resolution
* Updated GitHub workflow comment to clarify build requirement for unit tests

### Steps to Confirm

1. Run `npm run build` in `clients/fides-js` to generate bundles
2. Run `npm run test:ci -- fides-bundle.test.ts` in `clients/fides-js` to verify all bundle formats are valid
3. Verify that existing integrations continue to work with the new IIFE format
   a. Admin UI Previews (switch between TCF and non-TCF) - checks that the fides-preview works as IIFE format config.
   b. Privacy Center demo page with valid experiences configured - checks that module imports work correctly with the new exports configuration as well as the IIFE format config.
4. Test that FidesJS loads correctly in browser environments without RequireJS conflicts
   a. Add `<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>` near the top of `clients/privacy-center/public/fides-js-demo.html` and make sure FidesJS still runs correctly without errors (`jsonview.js` will throw an error, but that's not our problem).

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-724]: https://ethyca.atlassian.net/browse/ENG-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ