### PR TITLE
Disable AMD in FidesJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,12 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added support for large (>1GB) database columns by writing the contents to external storage [#6199](https://github.com/ethyca/fides/pull/6199)
 
 ### Changed
-
 - TCF Banners will no longer resurface on reload after dismissal [#6200](https://github.com/ethyca/fides/pull/6200)
 - Earlier initialization strategy for Shopify integration [#6202](https://github.com/ethyca/fides/pull/6202)
 
 ### Fixed
 - Added missing "Awaiting email send" status to privacy request statuses [#6218](https://github.com/ethyca/fides/pull/6218)
+- Fixed FidesJS AMD module loading conflicts when RequireJS or other AMD loaders are present [#6210](https://github.com/ethyca/fides/pull/6210)
 
 ## [2.63.0](https://github.com/ethyca/fides/compare/2.62.0...2.63.0)
 

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -152,6 +152,9 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
         name: isExtension ? undefined : "Fides",
         format: isExtension ? undefined : "umd",
         sourcemap: IS_DEV ? "inline" : false,
+        amd: {
+          define: undefined, // prevent the bundle from registering itself as an AMD module, even if an AMD loader (like RequireJS) is present on the page. (FidesJS is not an AMD module.)
+        },
       },
     ],
   };

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -150,10 +150,10 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
         // Intended for browser <script> tag - defines `Fides` global. Also supports UMD loaders.
         file: `dist/${name}.js`,
         name: isExtension ? undefined : "Fides",
-        format: isExtension ? undefined : "umd",
+        format: isExtension ? "es" : "umd",
         sourcemap: IS_DEV ? "inline" : false,
         amd: {
-          define: undefined, // prevent the bundle from registering itself as an AMD module, even if an AMD loader (like RequireJS) is present on the page. (FidesJS is not an AMD module.)
+          define: undefined, // prevent the bundle from registering itself as an AMD module, even if an AMD loader (like RequireJS) is present on the page. This allows FidesJS to use Rollup's `umd` format to support both `iife` and `cjs` modules, but excludes AMD.
         },
       },
     ],


### PR DESCRIPTION
Closes [ENG-724]

### Description Of Changes

Fixed AMD module loading conflicts by preventing FidesJS from registering itself as an AMD module when RequireJS or other AMD loaders are present on the page.

### Code Changes

* Added `amd: { define: undefined }` configuration to Rollup UMD output to prevent AMD module registration

### Steps to Confirm

1. Run `npm run build` in `clients/fides-js` to generate bundles
2. Test that FidesJS loads correctly in browser environments without RequireJS conflicts by adding `<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>` near the top of `clients/privacy-center/public/fides-js-demo.html`. Load the demo page with a valid experience and make sure FidesJS still runs correctly without errors (`jsonview.js` will throw an error, but that's not our problem).

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-724]: https://ethyca.atlassian.net/browse/ENG-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ