### PR TITLE
Simplify Special Purpose vendor logic

### DIFF
--- a/clients/fides-js/src/lib/tcf.ts
+++ b/clients/fides-js/src/lib/tcf.ts
@@ -172,21 +172,14 @@ export const generateFidesString = async ({
 
       // Set legitimate interest for special-purpose only vendors and vendors that
       // have declared only purposes based on consent (no LI) + at least one SP
-      if (experience.gvl?.vendors) {
-        (experience as PrivacyExperience).tcf_vendor_relationships?.forEach(
-          (relationship) => {
-            const { id } = decodeVendorId(relationship.id);
-            const vendor = experience.gvl?.vendors[id];
-            if (
-              vendor &&
-              vendor.specialPurposes?.length &&
-              (!vendor.legIntPurposes || vendor.legIntPurposes.length === 0)
-            ) {
-              tcModel.vendorLegitimateInterests.set(+id);
-            }
-          },
-        );
-      }
+      Object.values(experience.gvl?.vendors ?? {}).forEach((vendor) => {
+        if (
+          !!vendor.specialPurposes?.length &&
+          !vendor.legIntPurposes?.length
+        ) {
+          tcModel.vendorLegitimateInterests.set(vendor.id);
+        }
+      });
 
       // Set purposes on tcModel
       tcStringPreferences.purposesConsent.forEach((purposeId) => {


### PR DESCRIPTION
Closes [ENG-76]

### Description Of Changes

Simplified special-purpose vendor logic to avoid potential edge case bug. The previous implementation relied on `tcf_vendor_relationships` (only available in Full TCF response) to look up vendors, which could fail for users on slow connections who make consent choices before the full experience loads. Now directly iterates over GVL vendors to set legitimate interests for special-purpose only vendors.

This change is possible because of recent updates made in https://github.com/ethyca/fidesplus/pull/2190 which only returns GVL vendors that are relevant to the current experience.

### Code Changes

* Replaced `tcf_vendor_relationships` lookup with direct iteration over `experience.gvl.vendors`
* Simplified vendor filtering logic to use `Object.values()` instead of relationship-based lookup

### Steps to Confirm
1. Set up a vendor in Admin UI that has no Legitimate Interest but does have Special Purpose (eg. SeenThis)
3. Test TCF consent experience on a simulated slow connection (`/fides-js-demo.html?geolocation=eea`)
4. Verify that special-purpose vendors still have legitimate interests set correctly
5. Confirm the change works with both minimal (quickly opt-out on a slow connection) and full TCF responses (opt-out after response is returned)
6. Check that vendor legitimate interests are properly applied in the TC string generation

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-76]: https://ethyca.atlassian.net/browse/ENG-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ