### PR TITLE
ENG-739: Add Request Filter for Awaiting Email Send + Improve Casing Consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Earlier initialization strategy for Shopify integration [#6202](https://github.com/ethyca/fides/pull/6202)
 
 ### Fixed
-- Added missing "Awaiting Email Send" status to privacy request statuses [#6218](https://github.com/ethyca/fides/pull/6218)
+- Added missing "Awaiting email send" status to privacy request statuses [#6218](https://github.com/ethyca/fides/pull/6218)
 
 ## [2.63.0](https://github.com/ethyca/fides/compare/2.62.0...2.63.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.64.0...main)
 
-### Addded
+### Added
 - AWS SES notification service now supports assumed roles through environment variable configuration through `FIDES__CREDENTIALS__NOTIFICATIONS__AWS_SES_ASSUME_ROLE_ARN` [#6206](https://github.com/ethyca/fides/pull/6206)
 - Added ManualTask and ManualTaskReference models, foundational for for ManualDSRs [#6205](https://github.com/ethyca/fides/pull/6205) https://github.com/ethyca/fides/labels/db-migration
 
@@ -29,6 +29,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 - TCF Banners will no longer resurface on reload after dismissal [#6200](https://github.com/ethyca/fides/pull/6200)
 - Earlier initialization strategy for Shopify integration [#6202](https://github.com/ethyca/fides/pull/6202)
+
+### Fixed
+- Added missing "Awaiting Email Send" status to privacy request statuses [#6218](https://github.com/ethyca/fides/pull/6218)
 
 ## [2.63.0](https://github.com/ethyca/fides/compare/2.62.0...2.63.0)
 

--- a/clients/admin-ui/src/features/integrations/integration-type-info/manualInfo.tsx
+++ b/clients/admin-ui/src/features/integrations/integration-type-info/manualInfo.tsx
@@ -20,7 +20,7 @@ const ManualOverview = () => (
     </InfoText>
     <InfoText>
       If you have manual integrations defined, privacy request execution will
-      exit early and remain in a state of <em>Requires input</em>. Once data has
+      exit early and remain in a state of <em>Requires Input</em>. Once data has
       been manually uploaded for all the manual integrations, then the privacy
       request can be resumed. Data uploaded for manual integrations is passed on
       directly to the data subject alongside the data package.

--- a/clients/admin-ui/src/features/integrations/integration-type-info/manualInfo.tsx
+++ b/clients/admin-ui/src/features/integrations/integration-type-info/manualInfo.tsx
@@ -20,7 +20,7 @@ const ManualOverview = () => (
     </InfoText>
     <InfoText>
       If you have manual integrations defined, privacy request execution will
-      exit early and remain in a state of <em>Requires Input</em>. Once data has
+      exit early and remain in a state of <em>Requires input</em>. Once data has
       been manually uploaded for all the manual integrations, then the privacy
       request can be resumed. Data uploaded for manual integrations is passed on
       directly to the data subject alongside the data package.

--- a/clients/admin-ui/src/features/privacy-requests/constants.ts
+++ b/clients/admin-ui/src/features/privacy-requests/constants.ts
@@ -2,7 +2,7 @@ import { ActionType, PrivacyRequestStatus } from "~/types/api";
 
 export const SubjectRequestStatusMap = new Map<PrivacyRequestStatus, string>([
   [PrivacyRequestStatus.APPROVED, "Approved"],
-  [PrivacyRequestStatus.AWAITING_EMAIL_SEND, "Awaiting email send"],
+  [PrivacyRequestStatus.AWAITING_EMAIL_SEND, "Awaiting Email Send"],
   [PrivacyRequestStatus.CANCELED, "Canceled"],
   [PrivacyRequestStatus.COMPLETE, "Completed"],
   [PrivacyRequestStatus.DENIED, "Denied"],
@@ -11,7 +11,7 @@ export const SubjectRequestStatusMap = new Map<PrivacyRequestStatus, string>([
   [PrivacyRequestStatus.PENDING, "New"],
   [PrivacyRequestStatus.PAUSED, "Paused"],
   [PrivacyRequestStatus.IDENTITY_UNVERIFIED, "Unverified"],
-  [PrivacyRequestStatus.REQUIRES_INPUT, "Requires input"],
+  [PrivacyRequestStatus.REQUIRES_INPUT, "Requires Input"],
 ]);
 
 export const SubjectRequestStatusOptions = [...SubjectRequestStatusMap].map(

--- a/clients/admin-ui/src/features/privacy-requests/constants.ts
+++ b/clients/admin-ui/src/features/privacy-requests/constants.ts
@@ -2,6 +2,7 @@ import { ActionType, PrivacyRequestStatus } from "~/types/api";
 
 export const SubjectRequestStatusMap = new Map<PrivacyRequestStatus, string>([
   [PrivacyRequestStatus.APPROVED, "Approved"],
+  [PrivacyRequestStatus.AWAITING_EMAIL_SEND, "Awaiting email send"],
   [PrivacyRequestStatus.CANCELED, "Canceled"],
   [PrivacyRequestStatus.COMPLETE, "Completed"],
   [PrivacyRequestStatus.DENIED, "Denied"],

--- a/clients/admin-ui/src/features/privacy-requests/constants.ts
+++ b/clients/admin-ui/src/features/privacy-requests/constants.ts
@@ -2,16 +2,16 @@ import { ActionType, PrivacyRequestStatus } from "~/types/api";
 
 export const SubjectRequestStatusMap = new Map<PrivacyRequestStatus, string>([
   [PrivacyRequestStatus.APPROVED, "Approved"],
-  [PrivacyRequestStatus.AWAITING_EMAIL_SEND, "Awaiting Email Send"],
+  [PrivacyRequestStatus.AWAITING_EMAIL_SEND, "Awaiting email send"],
   [PrivacyRequestStatus.CANCELED, "Canceled"],
   [PrivacyRequestStatus.COMPLETE, "Completed"],
   [PrivacyRequestStatus.DENIED, "Denied"],
   [PrivacyRequestStatus.ERROR, "Error"],
-  [PrivacyRequestStatus.IN_PROCESSING, "In Progress"],
+  [PrivacyRequestStatus.IN_PROCESSING, "In progress"],
   [PrivacyRequestStatus.PENDING, "New"],
   [PrivacyRequestStatus.PAUSED, "Paused"],
   [PrivacyRequestStatus.IDENTITY_UNVERIFIED, "Unverified"],
-  [PrivacyRequestStatus.REQUIRES_INPUT, "Requires Input"],
+  [PrivacyRequestStatus.REQUIRES_INPUT, "Requires input"],
 ]);
 
 export const SubjectRequestStatusOptions = [...SubjectRequestStatusMap].map(


### PR DESCRIPTION
Closes ENG-739

### Description Of Changes

It looks like we were missing the `Awaiting email send` status in the filter. This PR adds it.

### Code Changes

* Add "Awaiting Email Send" to the status filter dropdown on the request manager page.
* Improve consistency for casing in other status options

### Steps to Confirm

1. start server
2. browse to request manager
3. try to filter on all available statuses.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
