### PR TITLE
Fix incorrect dataset reference format

### DIFF
--- a/clients/admin-ui/src/features/common/form/useFormFieldsFromSchema.ts
+++ b/clients/admin-ui/src/features/common/form/useFormFieldsFromSchema.ts
@@ -1,3 +1,5 @@
+import { cloneDeep } from "lodash";
+
 import {
   ConnectionTypeSecretSchemaProperty,
   ConnectionTypeSecretSchemaResponse,
@@ -47,16 +49,16 @@ export const useFormFieldsFromSchema = (
   };
 
   const preprocessValues = (values: Record<string, any>) => {
-    const updatedValues = { ...values };
+    const updatedValues = cloneDeep(values);
     if (secretsSchema) {
       Object.keys(secretsSchema.properties).forEach((key) => {
         if (
           secretsSchema.properties[key].allOf?.[0].$ref ===
           FIDES_DATASET_REFERENCE
         ) {
-          const referencePath = updatedValues[key]?.split(".");
+          const referencePath = updatedValues.secrets[key]?.split(".");
           if (referencePath) {
-            updatedValues[key] = {
+            updatedValues.secrets[key] = {
               dataset: referencePath.shift(),
               field: referencePath.join("."),
               direction: "from",


### PR DESCRIPTION
Closes ENG-747

### Description Of Changes

Fixes a regression where dataset reference fields in the integration forms were uploading in incorrect formats.

### Steps to Confirm

Ensure you have a Fides dataset associated with an integration.

1.  Add a Splash integration to a system
2. Enter a field under that dataset for the "Contact ID" field
3. Request should succeed

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required