### PR TITLE
ENG-602

### DIFF
--- a/src/fides/api/models/attachment.py
+++ b/src/fides/api/models/attachment.py
@@ -51,6 +51,7 @@ class AttachmentReferenceType(str, EnumType):
     erasure_manual_webhook = "erasure_manual_webhook"
     privacy_request = "privacy_request"
     comment = "comment"
+    manual_task_submission = "manual_task_submission"
 
 
 class AttachmentReference(Base):

--- a/src/fides/service/manual_tasks/manual_task_config_service.py
+++ b/src/fides/service/manual_tasks/manual_task_config_service.py
@@ -1,171 +1,141 @@
 from typing import Any, Optional
 
 from loguru import logger
-from pydantic import ValidationError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Query, Session, selectinload
 
 from fides.api.models.manual_tasks.manual_task import ManualTask
 from fides.api.models.manual_tasks.manual_task_config import (
     ManualTaskConfig,
     ManualTaskConfigField,
 )
-from fides.api.models.manual_tasks.manual_task_log import ManualTaskLog
 from fides.api.schemas.manual_tasks.manual_task_config import (
     ManualTaskConfigResponse,
     ManualTaskConfigurationType,
-    ManualTaskFieldBase,
 )
-from fides.api.schemas.manual_tasks.manual_task_schemas import ManualTaskLogStatus
+from fides.service.manual_tasks.utils import validate_fields, with_task_logging
 
 
 class ManualTaskConfigService:
     def __init__(self, db: Session):
         self.db = db
 
-    # ------- Private Helper Methods -------
+    def _create_log_data(
+        self, task_id: str, config_id: Optional[str], details: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Create standard log data structure."""
+        return {"task_id": task_id, "config_id": config_id, "details": details}
 
-    def _get_fields(self, config: ManualTaskConfig) -> list[dict[str, Any]]:
-        """Get the fields for a config and returns them in the format expected by ManualTaskConfigResponse"""
-        fields = []
-        for field in config.field_definitions:
-            field_data = {
-                "field_key": field.field_key,
-                "field_type": field.field_type,
-                "field_metadata": field.field_metadata,
-            }
-            fields.append(field_data)
-        return fields
+    def _get_base_config_query(self) -> Query:
+        """Get base config query with field definitions loaded."""
+        return self.db.query(ManualTaskConfig).options(
+            selectinload(ManualTaskConfig.field_definitions)
+        )
 
-    def _get_response_data(self, config: ManualTaskConfig) -> dict[str, Any]:
-        """Get the data for a config and returns it in the format expected by ManualTaskConfigResponse"""
-        fields = self._get_fields(config)
-        return {
-            "id": config.id,
-            "task_id": config.task_id,
-            "config_type": config.config_type,
-            "version": config.version,
-            "is_current": config.is_current,
-            "fields": fields,
-            "created_at": config.created_at,
-            "updated_at": config.updated_at,
-        }
-
-    def _validate_fields(self, fields: list[dict[str, Any]]) -> None:
-        """Validate field data against the appropriate Pydantic model.
-        Raises a ValueError if the field data is invalid.
-        """
-        # Check for duplicate field keys
-        field_keys_set: set[str] = {str(field.get("field_key")) for field in fields}
-        if len(field_keys_set) != len(fields):
-            raise ValueError(
-                "Duplicate field keys found in field updates, field keys must be unique."
-            )
-        # Check that field_key is present for each field
-        for field in fields:
-            field_key = field.get("field_key")
-            if not field_key:
-                raise ValueError("Invalid field data: field_key is required")
-            # Skip validation for fields with empty metadata (used for removal)
-            if field.get("field_metadata") == {}:
-                continue
-
-            try:
-                field_type = field.get("field_type")
-                if not field_type:
-                    raise ValueError("Invalid field data: field_type is required")
-
-                field_model = ManualTaskFieldBase.get_field_model_for_type(field_type)
-                field_model.model_validate(field)
-            except ValidationError as e:
-                raise ValueError(f"Invalid field data: {str(e)}")
-            except ValueError as e:
-                raise ValueError(str(e))
-
-    def _re_create_existing_fields(
+    def _create_config_version(
         self,
-        previous_config: ManualTaskConfig,
-        new_config: ManualTaskConfig,
-        modified_field_keys: set[str],
-    ) -> None:
-        """Re-create fields from the previous config version that aren't being modified in the new version.
+        task: ManualTask,
+        config_type: str,
+        version: int,
+        is_current: bool = True,
+    ) -> ManualTaskConfig:
+        """Create a new config version."""
+        try:
+            ManualTaskConfigurationType(config_type)
+        except ValueError:
+            raise ValueError(f"Invalid config type: {config_type}")
 
-        When creating a new config version, we need to carry over any fields that aren't being
-        modified or removed. This method handles that by:
-        1. Looking at all fields in the previous config
-        2. For each field not in modified_field_keys (not being updated or removed):
-           - Creates a new field record with the same data but linked to the new config
-
-        This ensures that fields maintain continuity across versions unless explicitly changed.
-
-        Args:
-            previous_config: The previous version of the configuration
-            new_config: The new version being created
-            modified_field_keys: Set of field keys that are being updated or removed in the new version
-        """
-        # Prepare bulk insert data for unmodified fields
-        fields_to_create = [
-            {
-                "task_id": new_config.task_id,
-                "config_id": new_config.id,
-                "field_key": field.field_key,
-                "field_type": field.field_type,
-                "field_metadata": field.field_metadata,
-            }
-            for field in previous_config.field_definitions
-            if field.field_key not in modified_field_keys
-        ]
-
-        # Perform bulk insert if there are fields to create
-        if fields_to_create:
-            self.db.bulk_insert_mappings(ManualTaskConfigField, fields_to_create)
+        # Set all existing versions to non-current
+        if is_current:
+            self.db.query(ManualTaskConfig).filter(
+                ManualTaskConfig.task_id == task.id,
+                ManualTaskConfig.config_type == config_type,
+            ).update({"is_current": False})
             self.db.flush()
 
-    def _new_field_updates(
-        self, new_config: ManualTaskConfig, field_updates: list[dict[str, Any]]
-    ) -> None:
-        """Updates fields for a config.
-        Args:
-            new_config: The config to add fields to
-            field_updates: The fields to add or update
-        """
-        self._validate_fields(field_updates)
+        return ManualTaskConfig.create(
+            db=self.db,
+            data={
+                "task_id": task.id,
+                "config_type": config_type,
+                "version": version,
+                "is_current": is_current,
+            },
+        )
 
-        # Prepare bulk insert data
-        fields_to_create = [
-            {
-                "task_id": new_config.task_id,
-                "config_id": new_config.id,
-                "field_key": update["field_key"],
-                "field_type": update.get("field_type"),
-                "field_metadata": update.get("field_metadata", {}),
-            }
-            for update in field_updates
-        ]
+    def _handle_field_updates(
+        self,
+        config: ManualTaskConfig,
+        field_updates: Optional[list[dict[str, Any]]] = None,
+        fields_to_remove: Optional[list[str]] = None,
+        previous_config: Optional[ManualTaskConfig] = None,
+    ) -> set[str]:
+        """Handle field updates, removals, and recreation from previous version."""
+        modified_keys = set(fields_to_remove or [])
 
-        # Perform bulk insert
-        if fields_to_create:
-            self.db.bulk_insert_mappings(ManualTaskConfigField, fields_to_create)
-            self.db.flush()
+        if field_updates:
+            validate_fields(field_updates, is_submission=False)
+            fields_to_create = [
+                {
+                    "task_id": config.task_id,
+                    "config_id": config.id,
+                    "field_key": f["field_key"],
+                    "field_type": f.get("field_type"),
+                    "field_metadata": f.get("field_metadata", {}),
+                }
+                for f in field_updates
+            ]
+            if fields_to_create:
+                self.db.bulk_insert_mappings(ManualTaskConfigField, fields_to_create)
+                modified_keys.update(f["field_key"] for f in field_updates)
 
-    # ------- Public Configuration Methods -------
+        if previous_config:
+            # Recreate unmodified fields from previous version
+            unmodified = [
+                {
+                    "task_id": config.task_id,
+                    "config_id": config.id,
+                    "field_key": f.field_key,
+                    "field_type": f.field_type,
+                    "field_metadata": f.field_metadata,
+                }
+                for f in previous_config.field_definitions
+                if f.field_key not in modified_keys
+            ]
+            if unmodified:
+                self.db.bulk_insert_mappings(ManualTaskConfigField, unmodified)
+                previous_config.is_current = False
+
+        self.db.flush()
+        return modified_keys
 
     def to_response(self, config: ManualTaskConfig) -> ManualTaskConfigResponse:
-        """Convert a ManualTaskConfig model to a ManualTaskConfigResponse.
-
-        Args:
-            config: The config model to convert
-
-        Returns:
-            Optional[ManualTaskConfigResponse]: The response object, or None if config is None
-        """
-        return ManualTaskConfigResponse.model_validate(self._get_response_data(config))
+        """Convert config model to response object."""
+        return ManualTaskConfigResponse.model_validate(
+            {
+                "id": config.id,
+                "task_id": config.task_id,
+                "config_type": config.config_type,
+                "version": config.version,
+                "is_current": config.is_current,
+                "fields": [
+                    {
+                        "field_key": f.field_key,
+                        "field_type": f.field_type,
+                        "field_metadata": f.field_metadata,
+                    }
+                    for f in config.field_definitions
+                ],
+                "created_at": config.created_at,
+                "updated_at": config.updated_at,
+            }
+        )
 
     def get_current_config(
         self, task: ManualTask, config_type: str
-    ) -> Optional[ManualTaskConfig]:
-        """Get the current config for a task by config type."""
+    ) -> ManualTaskConfig:
+        """Get current config for task by type."""
         config = (
-            self.db.query(ManualTaskConfig)
+            self._get_base_config_query()
             .filter(
                 ManualTaskConfig.task_id == task.id,
                 ManualTaskConfig.config_type == config_type,
@@ -174,19 +144,18 @@ class ManualTaskConfigService:
             .first()
         )
 
-        if config:
-            self.db.refresh(config)
-            return config
-        raise ValueError(
-            f"No current config found for task {task.id} and type {config_type}"
-        )
+        if not config:
+            raise ValueError(
+                f"No current config found for task {task.id} and type {config_type}"
+            )
+        return config
 
     def list_config_type_versions(
         self, task: ManualTask, config_type: str
     ) -> list[ManualTaskConfig]:
         """List all versions of a config type for a task."""
         return (
-            self.db.query(ManualTaskConfig)
+            self._get_base_config_query()
             .filter(
                 ManualTaskConfig.task_id == task.id,
                 ManualTaskConfig.config_type == config_type,
@@ -204,68 +173,31 @@ class ManualTaskConfigService:
         field_key: str,
         version: int,
     ) -> Optional[ManualTaskConfig]:
-        """Get a task config by its id, field id, or config type.
-
-        This is a flexible lookup method that can find configs based on various filters.
-        It's normal for this method to return None if no config matches the given filters.
-
-        Args:
-            task: The task to get the config for
-            config_type: The type of config to get
-            field_id: The ID of a field in the config
-            config_id: The ID of the config
-            field_key: The key of a field in the config
-            version: The version number of the config
-
-        Returns:
-            The matching config if found, None otherwise
-        """
+        """Get config by various filters."""
         if not any([task, config_id, field_id, config_type]):
-            logger.debug("No filters provided to get_config. Returning None.")
+            logger.debug("No filters provided to get_config")
             return None
 
-        # Start with base query and add joins only if needed
-        query = self.db.query(ManualTaskConfig)
-
-        # Add join only once if either field_id or field_key is provided
+        query = self._get_base_config_query()
         if field_id or field_key:
-            query = query.join(ManualTaskConfigField)
+            query = query.join(ManualTaskConfig.field_definitions)
 
-        # Build filter conditions
-        filters = []
-        if task:
-            filters.append(ManualTaskConfig.task_id == task.id)
-        if config_id:
-            filters.append(ManualTaskConfig.id == config_id)
-        if field_id:
-            filters.append(ManualTaskConfigField.id == field_id)
-        if field_key:
-            filters.append(ManualTaskConfigField.field_key == field_key)
-        if version:
-            filters.append(ManualTaskConfig.version == version)
-        if config_type:
-            filters.append(ManualTaskConfig.config_type == config_type)
+        filters = [
+            f
+            for f in [
+                task and ManualTaskConfig.task_id == task.id,
+                config_id and ManualTaskConfig.id == config_id,
+                field_id and ManualTaskConfigField.id == field_id,
+                field_key and ManualTaskConfigField.field_key == field_key,
+                version and ManualTaskConfig.version == version,
+                config_type and ManualTaskConfig.config_type == config_type,
+            ]
+            if f
+        ]
 
-        # Apply all filters at once
-        if filters:
-            query = query.filter(*filters)
+        return query.filter(*filters).first()
 
-        result = query.first()
-        if not result:
-            logger.debug(
-                "No config found that matches filters: "
-                f"task {task.id if task else None}, "
-                f"config_id {config_id}, "
-                f"field_id {field_id}, "
-                f"field_key {field_key}, "
-                f"version {version}, "
-                f"config_type {config_type}"
-            )
-            return None
-
-        self.db.refresh(result)
-        return result
-
+    @with_task_logging("Creating new configuration version")
     def create_new_version(
         self,
         task: ManualTask,
@@ -273,147 +205,88 @@ class ManualTaskConfigService:
         field_updates: Optional[list[dict[str, Any]]] = None,
         fields_to_remove: Optional[list[str]] = None,
         previous_config: Optional[ManualTaskConfig] = None,
-    ) -> ManualTaskConfig:
-        """Create a new version of the configuration.
+    ) -> tuple[ManualTaskConfig, dict[str, Any]]:
+        """Create new version of configuration."""
+        new_config = self._create_config_version(
+            task, config_type, (previous_config.version + 1 if previous_config else 1)
+        )
 
-        Args:
-            task: The task to create a config for
-            config_type: The type of config to create
-            field_updates: Fields to add or update
-            fields_to_remove: Field keys to remove
-            previous_config: The previous config version, if any
-        """
-        new_version = previous_config.version + 1 if previous_config else 1
-        # Validate config_type
-        try:
-            ManualTaskConfigurationType(config_type)
-        except ValueError:
-            raise ValueError(f"Invalid config type: {config_type}")
+        self._handle_field_updates(
+            new_config, field_updates, fields_to_remove, previous_config
+        )
 
-        # Create new version
-        new_config = ManualTaskConfig.create(
-            db=self.db,
-            data={
-                "task_id": task.id,
+        return new_config, self._create_log_data(
+            task.id,
+            new_config.id,
+            {
                 "config_type": config_type,
-                "version": new_version,
-                "is_current": True,
-            },
-        )
-        modified_field_keys: set[str] = set()
-
-        # Handle field updates (additions and modifications)
-        if field_updates:
-            self._validate_fields(field_updates)
-            self._new_field_updates(new_config, field_updates)
-            modified_field_keys.update(
-                str(update.get("field_key")) for update in field_updates
-            )
-
-        # Handle field removals
-        if fields_to_remove:
-            modified_field_keys.update(fields_to_remove)
-
-        # Handle field updates (fields with no changes)
-        if previous_config is not None:
-            previous_config.is_current = False
-            self._re_create_existing_fields(
-                previous_config,
-                new_config,
-                modified_field_keys,
-            )
-
-        self.db.commit()
-
-        # Log the version creation
-        ManualTaskLog.create_log(
-            db=self.db,
-            task_id=task.id,
-            config_id=new_config.id,
-            status=ManualTaskLogStatus.created,
-            message=f"Created new version {new_config.version} of configuration",
-            details={
-                "previous_version": (
-                    previous_config.version if previous_config else None
-                ),
-                "field_updates": field_updates,
-                "fields_removed": fields_to_remove,
+                "version": new_config.version,
+                "added_field_keys": [f.get("field_key") for f in (field_updates or [])],
+                "removed_field_keys": fields_to_remove or [],
             },
         )
 
-        return new_config
-
+    @with_task_logging("Adding fields to configuration")
     def add_fields(
         self, task: ManualTask, config_type: str, fields: list[dict[str, Any]]
-    ) -> None:
-        """Add fields to a configuration.
+    ) -> tuple[ManualTaskConfig, dict[str, Any]]:
+        """Add fields to configuration."""
+        current = self.get_current_config(task, config_type)
+        self.create_new_version(task, config_type, fields, previous_config=current)
+        new_config = self.get_current_config(task, config_type)
 
-        Args:
-            task: The task to add fields to
-            config_type: The type of config to add fields to
-            fields: The fields to add
-        """
-        self._validate_fields(fields)
-        current_config = self.get_current_config(task, config_type)
-        if not current_config:
-            raise ValueError(
-                f"No current config found for task {task.id} and type {config_type}"
-            )
-
-        self.create_new_version(
-            task=task,
-            config_type=config_type,
-            field_updates=fields,
-            previous_config=current_config,
+        return new_config, self._create_log_data(
+            task.id,
+            current.id,
+            {
+                "config_type": config_type,
+                "previous_version": current.version,
+                "added_field_keys": [f.get("field_key") for f in fields],
+                "new_config_id": new_config.id,
+                "new_config_version": new_config.version,
+            },
         )
 
+    @with_task_logging("Removing fields from configuration")
     def remove_fields(
         self, task: ManualTask, config_type: str, field_keys: list[str]
-    ) -> None:
-        """Remove fields from a configuration.
-
-        Args:
-            task: The task to remove fields from
-            config_type: The type of config to remove fields from
-            field_keys: The keys of the fields to remove
-        """
-        current_config = self.get_current_config(task, config_type)
-        if not current_config:
-            raise ValueError(
-                f"No current config found for task {task.id} and type {config_type}"
-            )
-
-        # Get the actual ManualTaskConfig object with field definitions
-        config = self.db.query(ManualTaskConfig).filter_by(id=current_config.id).first()
-        if not config:
-            raise ValueError(f"Config with ID {current_config.id} not found")
-
-        # Create new version with removed fields
+    ) -> tuple[ManualTaskConfig, dict[str, Any]]:
+        """Remove fields from configuration."""
+        current = self.get_current_config(task, config_type)
         self.create_new_version(
-            task=task,
-            config_type=config_type,
-            fields_to_remove=field_keys,
-            previous_config=config,
+            task, config_type, fields_to_remove=field_keys, previous_config=current
+        )
+        new_config = self.get_current_config(task, config_type)
+
+        return new_config, self._create_log_data(
+            task.id,
+            current.id,
+            {
+                "config_type": config_type,
+                "version": current.version,
+                "deleted_field_keys": field_keys,
+                "new_config_id": new_config.id,
+                "new_config_version": new_config.version,
+            },
         )
 
-    def delete_config(self, task: ManualTask, config_id: str) -> None:
-        """Delete a config for a task.
-
-        Args:
-            task: The task to delete the config for
-            config_id: The ID of the config to delete
-
-        Raises:
-            ValueError: If there are active instances using this config
-        """
-        # TODO: when instances are implemented, we need to check for active instances
-
-        config = (
-            self.db.query(ManualTaskConfig)
-            .filter(ManualTaskConfig.id == config_id)
-            .first()
-        )
+    @with_task_logging("Deleting Manual Task configuration")
+    def delete_config(
+        self, task: ManualTask, config_id: str
+    ) -> tuple[ManualTaskConfig, dict[str, Any]]:
+        """Delete config for task."""
+        config = self.db.query(ManualTaskConfig).filter_by(id=config_id).first()
         if not config:
             raise ValueError(f"Config with ID {config_id} not found")
 
+        log_data = self._create_log_data(
+            task.id,
+            None,
+            {
+                "config_type": config.config_type,
+                "version": config.version,
+                "deleted_config_id": config_id,
+            },
+        )
         config.delete(self.db)
+        return config, log_data

--- a/src/fides/service/manual_tasks/manual_task_service.py
+++ b/src/fides/service/manual_tasks/manual_task_service.py
@@ -15,23 +15,14 @@ from fides.api.schemas.manual_tasks.manual_task_schemas import (
 from fides.service.manual_tasks.manual_task_config_service import (
     ManualTaskConfigService,
 )
-from fides.service.manual_tasks.manual_task_instance_service import (
-    ManualTaskInstanceService,
-)
 from fides.service.manual_tasks.utils import with_task_logging
 
-if TYPE_CHECKING:
-    from fides.api.models.manual_tasks.manual_task_instance import (
-        ManualTaskInstance,
-        ManualTaskSubmission,
-    )
 
 
 class ManualTaskService:
     def __init__(self, db: Session):
         self.db = db
         self.config_service = ManualTaskConfigService(db)
-        self.instance_service = ManualTaskInstanceService(db)
 
     def get_task(
         self,
@@ -289,41 +280,3 @@ class ManualTaskService:
         # Delete the configuration
         config_id = config.id
         self.config_service.delete_config(task, config_id)
-
-    def create_instance(
-        self, task_id: str, config_id: str, entity_id: str, entity_type: str
-    ) -> "ManualTaskInstance":
-        """Create a new instance for a task.
-
-        Args:
-            task_id: The task ID
-            config_id: The config ID
-            entity_id: The entity ID
-            entity_type: The entity type
-
-        Returns:
-            ManualTaskInstance: The new instance
-        """
-        self.get_task(task_id=task_id)
-        instance = self.instance_service.create_instance(
-            task_id, config_id, entity_id, entity_type
-        )
-        return cast("ManualTaskInstance", instance)
-
-    def create_submission(
-        self, instance_id: str, field_id: str, data: dict[str, Any]
-    ) -> "ManualTaskSubmission":
-        """Create a new submission for a task.
-
-        Args:
-            instance_id: The instance ID
-            field_id: The field ID
-            data: The data for the submission
-
-        Returns:
-            ManualTaskSubmission: The new submission
-        """
-        submission = self.instance_service.create_submission(
-            instance_id, field_id, data
-        )
-        return cast("ManualTaskSubmission", submission)

--- a/src/fides/service/manual_tasks/manual_task_service.py
+++ b/src/fides/service/manual_tasks/manual_task_service.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from loguru import logger
 from sqlalchemy import select
@@ -7,9 +7,7 @@ from sqlalchemy.orm import Session
 from fides.api.models.fides_user import FidesUser
 from fides.api.models.manual_tasks.manual_task import ManualTask, ManualTaskReference
 from fides.api.models.manual_tasks.manual_task_config import ManualTaskConfig
-from fides.api.models.manual_tasks.manual_task_log import ManualTaskLog
 from fides.api.schemas.manual_tasks.manual_task_schemas import (
-    ManualTaskLogStatus,
     ManualTaskParentEntityType,
     ManualTaskReferenceType,
     ManualTaskType,
@@ -17,12 +15,23 @@ from fides.api.schemas.manual_tasks.manual_task_schemas import (
 from fides.service.manual_tasks.manual_task_config_service import (
     ManualTaskConfigService,
 )
+from fides.service.manual_tasks.manual_task_instance_service import (
+    ManualTaskInstanceService,
+)
+from fides.service.manual_tasks.utils import with_task_logging
+
+if TYPE_CHECKING:
+    from fides.api.models.manual_tasks.manual_task_instance import (
+        ManualTaskInstance,
+        ManualTaskSubmission,
+    )
 
 
 class ManualTaskService:
     def __init__(self, db: Session):
         self.db = db
         self.config_service = ManualTaskConfigService(db)
+        self.instance_service = ManualTaskInstanceService(db)
 
     def get_task(
         self,
@@ -30,7 +39,7 @@ class ManualTaskService:
         parent_entity_id: Optional[str] = None,
         parent_entity_type: Optional[ManualTaskParentEntityType] = None,
         task_type: Optional[ManualTaskType] = None,
-    ) -> Optional[ManualTask]:
+    ) -> ManualTask:
         """Get the manual task using provided filters.
 
         This is a flexible lookup method that can find tasks based on various filters.
@@ -43,119 +52,190 @@ class ManualTaskService:
             task_type: The task type
 
         Returns:
-            Optional[ManualTask]: The matching task if found, None otherwise
+            ManualTask: The matching task
         """
         if not any([task_id, parent_entity_id, parent_entity_type, task_type]):
-            logger.debug("No filters provided to get_task. Returning None.")
-            return None
+            logger.debug("No filters provided to get_task")
+            raise ValueError("No filters provided to get_task")
 
-        # Build filter conditions
+        # Build filter conditions and a human-readable description
         filters = []
+        filter_desc = []
         if task_id:
             filters.append(ManualTask.id == task_id)
+            filter_desc.append(f"task_id={task_id}")
         if parent_entity_id:
             filters.append(ManualTask.parent_entity_id == parent_entity_id)
+            filter_desc.append(f"parent_entity_id={parent_entity_id}")
         if parent_entity_type:
             filters.append(ManualTask.parent_entity_type == parent_entity_type)
+            filter_desc.append(f"parent_entity_type={parent_entity_type}")
         if task_type:
             filters.append(ManualTask.task_type == task_type)
+            filter_desc.append(f"task_type={task_type}")
 
         # Apply all filters at once
         stmt = select(ManualTask)  # type: ignore[arg-type]
         if filters:
             stmt = stmt.where(*filters)
 
-        return self.db.execute(stmt).scalar_one_or_none()
+        task = self.db.execute(stmt).scalar_one_or_none()
+        if task is None:
+            logger.debug(f"No task found with filters: {filter_desc}")
+            raise ValueError(f"No task found with filters: {filter_desc}")
+        return task
 
-    # User Management
-    def assign_users_to_task(
-        self, db: Session, task: ManualTask, user_ids: list[str]
+    @with_task_logging("Verify user IDs")
+    def _non_existent_users(
+        self, non_existent_user_ids: list[str], *, task_id: str
     ) -> None:
-        """Assigns users to this task. We can assign one or more users to a task.
+        """Get users by their IDs.
 
         Args:
-            db: Database session
-            task: The task to assign users to
-            user_ids: List of user IDs to assign
+            non_existent_user_ids: List of non-existent user IDs
+            task_id: The task ID
+
+        Returns:
+            None
         """
-        user_ids = list(set(user_ids))  # Remove duplicates
-        if not user_ids:
-            raise ValueError("User ID is required for assignment")
+        if len(non_existent_user_ids) > 0:
+            raise ValueError(
+                f"User(s) {sorted(list(non_existent_user_ids))} do not exist"
+            )
 
-        # Get current assigned users
-        current_assigned_users = set(task.assigned_users)
+    def _create_log_data(self, task_id: str, details: dict[str, Any]) -> dict[str, Any]:
+        """Create standard log data structure.
 
-        # Get all existing users to assign
-        existing_users = set(
+        Args:
+            task_id: The task ID
+            details: The log details
+
+        Returns:
+            dict: The log data structure
+        """
+        return {
+            "task_id": task_id,
+            "details": details,
+        }
+
+    def _handle_user_errors(
+        self,
+        non_existent_users: list[str],
+        task_id: str,
+        details: dict[str, Any],
+        success_count: int,
+        error_key: str,
+    ) -> None:
+        """Handle errors for non-existent users.
+
+        Args:
+            non_existent_users: List of non-existent user IDs
+            task_id: The task ID
+            details: The log details to update
+            success_count: Number of successful operations
+            error_key: Key to use for error details
+
+        Raises:
+            ValueError: If no successful operations and users don't exist
+        """
+        try:
+            self._non_existent_users(non_existent_users, task_id=task_id)
+        except ValueError as e:
+            details[error_key] = sorted(non_existent_users)
+            if success_count == 0:
+                raise e
+
+    def _get_existing_users(self, user_ids: list[str]) -> set[str]:
+        """Get set of existing user IDs from the provided list.
+
+        Args:
+            user_ids: List of user IDs to check
+
+        Returns:
+            set: Set of existing user IDs
+        """
+        return set(
             user.id
-            for user in db.query(FidesUser).filter(FidesUser.id.in_(user_ids)).all()
+            for user in self.db.query(FidesUser)
+            .filter(FidesUser.id.in_(user_ids))
+            .all()
         )
-        users_to_assign = existing_users - current_assigned_users
 
-        # Prepare bulk insert data for valid assignments
-        assignments_to_create = [
-            {
-                "task_id": task.id,
-                "reference_id": user_id,
-                "reference_type": ManualTaskReferenceType.assigned_user,
-            }
-            for user_id in users_to_assign
-        ]
-
-        # Create assignments in bulk
-        if assignments_to_create:
-            db.bulk_insert_mappings(ManualTaskReference, assignments_to_create)
-            db.flush()
-            db.refresh(task)
-
-        # Log successful assignments and errors in bulk
-        log_entries = []
-        for user_id in user_ids:
-            if user_id not in existing_users:
-                # Log error for non-existent users
-                log_entries.append(
-                    {
-                        "task_id": task.id,
-                        "status": ManualTaskLogStatus.error,
-                        "message": f"Failed to add user {user_id} to task {task.id}: user does not exist",
-                        "details": {"user_id": user_id},
-                    }
-                )
-            elif user_id in users_to_assign:
-                # Only log successful assignments for newly assigned users
-                log_entries.append(
-                    {
-                        "task_id": task.id,
-                        "status": ManualTaskLogStatus.updated,
-                        "message": f"User {user_id} assigned to task",
-                        "details": {"assigned_user_id": user_id},
-                    }
-                )
-            # No log entry for already assigned users
-
-        # Create logs in bulk
-        if log_entries:
-            db.bulk_insert_mappings(ManualTaskLog, log_entries)
-            db.flush()
-            db.refresh(task)
-
-    def unassign_users_from_task(
-        self, db: Session, task: ManualTask, user_ids: list[str]
-    ) -> None:
-        """Remove the user assignment from this task.
+    def _handle_user_operation(
+        self,
+        task_id: str,
+        user_ids: list[str],
+        operation_type: str,
+        current_users: Optional[set[str]] = None,
+    ) -> tuple[set[str], dict[str, Any]]:
+        """Handle user assignment/unassignment operations.
 
         Args:
-            db: Database session
-            task: The task to unassign users from
-            user_ids: List of user IDs to unassign
-        """
-        user_ids = list(set(user_ids))  # Remove duplicates
-        if not user_ids:
-            raise ValueError("User ID is required for unassignment")
+            task_id: The task ID
+            user_ids: List of user IDs to process
+            operation_type: Type of operation ('assign' or 'unassign')
+            current_users: Optional set of current users
 
-        # Get references to unassign in a single query
-        references_to_unassign = (
-            db.query(ManualTaskReference)
+        Returns:
+            tuple: (processed_users, log_data)
+        """
+        if not (user_ids := list(set(user_ids))):
+            raise ValueError(f"User ID is required for {operation_type}ment")
+
+        existing_users = set(
+            u.id
+            for u in self.db.query(FidesUser).filter(FidesUser.id.in_(user_ids)).all()
+        )
+        processed_users = (
+            existing_users - (current_users or set())
+            if operation_type == "assign"
+            else existing_users
+        )
+        details = {f"{operation_type}ed_users": sorted(list(processed_users))}
+
+        if non_existing := list(set(user_ids) - existing_users):
+            try:
+                self._non_existent_users(non_existing, task_id=task_id)
+            except ValueError as e:
+                details[f"user_ids_not_{operation_type}ed"] = sorted(non_existing)
+                if not processed_users:
+                    raise e
+
+        return processed_users, {"task_id": task_id, "details": details}
+
+    @with_task_logging("Assign users to task")
+    def assign_users_to_task(
+        self, task_id: str, user_ids: list[str]
+    ) -> tuple[ManualTask, dict[str, Any]]:
+        task = self.get_task(task_id=task_id)
+        users_to_assign, log_data = self._handle_user_operation(
+            task_id, user_ids, "assign", set(task.assigned_users)
+        )
+
+        if users_to_assign:
+            self.db.bulk_insert_mappings(
+                ManualTaskReference,
+                [
+                    {
+                        "task_id": task.id,
+                        "reference_id": user_id,
+                        "reference_type": ManualTaskReferenceType.assigned_user,
+                    }
+                    for user_id in users_to_assign
+                ],
+            )
+            self.db.flush()
+            self.db.refresh(task)
+
+        return task, log_data
+
+    @with_task_logging("Unassign users from task")
+    def unassign_users_from_task(
+        self, task_id: str, user_ids: list[str]
+    ) -> tuple[ManualTask, dict[str, Any]]:
+        task = self.get_task(task_id=task_id)
+        refs_to_unassign = (
+            self.db.query(ManualTaskReference)
             .filter(
                 ManualTaskReference.task_id == task.id,
                 ManualTaskReference.reference_type
@@ -165,80 +245,85 @@ class ManualTaskService:
             .all()
         )
 
-        if references_to_unassign:
-            # Capture reference IDs before deletion
-            reference_ids = [ref.id for ref in references_to_unassign]
-            unassigned_user_ids = [ref.reference_id for ref in references_to_unassign]
-
-            # Delete references in bulk
-            db.query(ManualTaskReference).filter(
-                ManualTaskReference.id.in_(reference_ids)
+        if refs_to_unassign:
+            self.db.query(ManualTaskReference).filter(
+                ManualTaskReference.id.in_([ref.id for ref in refs_to_unassign])
             ).delete(synchronize_session=False)
-            db.flush()
-            db.refresh(task)
+            self.db.flush()
+            self.db.refresh(task)
 
-            # Prepare log entries for successful unassignments using captured user IDs
-            log_entries = [
-                {
-                    "task_id": task.id,
-                    "status": ManualTaskLogStatus.updated,
-                    "message": f"User {user_id} unassigned from task",
-                    "details": {"unassigned_user_id": user_id},
-                }
-                for user_id in unassigned_user_ids
-            ]
-
-            # Create logs in bulk
-            if log_entries:
-                db.bulk_insert_mappings(ManualTaskLog, log_entries)
-                db.flush()
-                db.refresh(task)
-
-        # Check if any users weren't unassigned
-        unassigned_user_ids_set = (
-            set(unassigned_user_ids) if references_to_unassign else set()
-        )
-        left_over_user_ids = [
-            user_id for user_id in user_ids if user_id not in unassigned_user_ids_set
-        ]
-        if left_over_user_ids:
-            logger.debug(
-                f"Users {left_over_user_ids} were not unassigned from task {task.id}: "
-                "users were not assigned to the task"
-            )
+        _, log_data = self._handle_user_operation(task_id, user_ids, "unassign")
+        return task, log_data
 
     def create_config(
-        self, task: ManualTask, config_type: str, fields: list[dict]
-    ) -> None:
+        self, config_type: str, fields: list[dict], task_id: str
+    ) -> ManualTaskConfig:
         """Create a new config for a task.
 
         Args:
-            db: Database session
-            task_id: The task ID
             config_type: The config type
             fields: The fields for the config
-        """
-        self.config_service.create_new_version(task, config_type, fields)
+            task_id: The task ID
 
-    def delete_config(self, task: ManualTask, config: ManualTaskConfig) -> None:
+        Returns:
+            ManualTaskConfig: The new config
+        """
+        task = self.get_task(task_id=task_id)
+        config = self.config_service.create_new_version(task, config_type, fields)
+        return cast(ManualTaskConfig, config)
+
+    def delete_config(self, config: ManualTaskConfig, task_id: str) -> None:
         """Delete this configuration.
         Args:
-            db: Database session
-            task: The task to delete the config from
             config: The config to delete
+            task_id: The task ID
         Raises:
             ValueError: If there are active instances using this configuration
-        """
-        # TODO: when instances are implemented, we need to check for active instances
+            ValueError: If the task does not exist
 
-        # Log the deletion
-        ManualTaskLog.create_log(
-            db=self.db,
-            task_id=task.id,
-            config_id=None,
-            status=ManualTaskLogStatus.complete,
-            message=f"Deleted manual task configuration for {config.config_type}",
-        )
+        Returns:
+            dict[str, Any]: The log details - intercepted by the `with_task_logging` decorator.
+        """
+        task = self.get_task(task_id=task_id)
 
         # Delete the configuration
-        self.config_service.delete_config(task, config.id)
+        config_id = config.id
+        self.config_service.delete_config(task, config_id)
+
+    def create_instance(
+        self, task_id: str, config_id: str, entity_id: str, entity_type: str
+    ) -> "ManualTaskInstance":
+        """Create a new instance for a task.
+
+        Args:
+            task_id: The task ID
+            config_id: The config ID
+            entity_id: The entity ID
+            entity_type: The entity type
+
+        Returns:
+            ManualTaskInstance: The new instance
+        """
+        self.get_task(task_id=task_id)
+        instance = self.instance_service.create_instance(
+            task_id, config_id, entity_id, entity_type
+        )
+        return cast("ManualTaskInstance", instance)
+
+    def create_submission(
+        self, instance_id: str, field_id: str, data: dict[str, Any]
+    ) -> "ManualTaskSubmission":
+        """Create a new submission for a task.
+
+        Args:
+            instance_id: The instance ID
+            field_id: The field ID
+            data: The data for the submission
+
+        Returns:
+            ManualTaskSubmission: The new submission
+        """
+        submission = self.instance_service.create_submission(
+            instance_id, field_id, data
+        )
+        return cast("ManualTaskSubmission", submission)

--- a/src/fides/service/manual_tasks/utils.py
+++ b/src/fides/service/manual_tasks/utils.py
@@ -1,0 +1,168 @@
+from functools import wraps
+from typing import Any, Callable, Optional, TypeVar, Union
+
+from loguru import logger
+from pydantic import ValidationError
+
+from fides.api.models.manual_tasks.manual_task_log import ManualTaskLog
+from fides.api.schemas.manual_tasks.manual_task_config import ManualTaskFieldBase
+from fides.api.schemas.manual_tasks.manual_task_schemas import ManualTaskLogStatus
+from fides.api.schemas.manual_tasks.manual_task_status import StatusType
+
+T = TypeVar("T")
+
+
+def validate_fields(fields: list[dict[str, Any]], is_submission: bool = False) -> None:
+    """Validate field data against the appropriate Pydantic model.
+
+    Args:
+        fields: List of field data to validate
+        is_submission: Whether the fields are for a submission (True) or configuration (False)
+
+    Raises:
+        ValueError: If the field data is invalid
+    """
+    # Check for duplicate field keys
+    if len({str(field.get("field_key")) for field in fields}) != len(fields):
+        raise ValueError("Duplicate field keys found in field updates, field keys must be unique.")
+
+    for field in fields:
+        if not field.get("field_key"):
+            raise ValueError("Invalid field data: field_key is required")
+        if not field.get("field_type"):
+            raise ValueError("Invalid field data: field_type is required")
+        if is_submission and "value" not in field:
+            raise ValueError("Invalid field data: value is required for submissions")
+        if not is_submission:
+            try:
+                field_model = ManualTaskFieldBase.get_field_model_for_type(field["field_type"])
+                field_model.model_validate(field)
+            except ValidationError as e:
+                raise ValueError(f"Invalid field data: {str(e)}")
+
+
+class TaskLogger:
+    """Class-based decorator for logging operation success/failure in service methods.
+    Args:
+        operation_name: The name of the operation to log
+        success_status: The status to log for successful operations
+
+    The decorated function can return either:
+    - A tuple of (return_value, log_details)
+    - Just the return value (in which case log details will be extracted from it)
+    """
+
+    def __init__(
+        self,
+        operation_name: str,
+        success_status: ManualTaskLogStatus = ManualTaskLogStatus.complete,
+    ) -> None:
+        self.operation_name = operation_name
+        self.success_status = success_status
+
+    def __call__(self, func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        def wrapped(service_self: Any, *args: Any, **kwargs: Any) -> T:
+            try:
+                result = func(service_self, *args, **kwargs)
+                return_value, log_data = (
+                    result if isinstance(result, tuple) and len(result) == 2
+                    else (result, {})
+                )
+                if hasattr(service_self, "db") and (task_id := self._get_task_id(return_value, kwargs)):
+                    self._log_success(service_self.db, task_id, return_value, log_data, kwargs)
+                return return_value
+            except Exception as e:
+                self._log_error(service_self, e, kwargs)
+                raise
+        return wrapped
+
+    def _get_task_id(self, result: Any, kwargs: dict) -> Optional[str]:
+        """Extract task_id from result or kwargs."""
+        return getattr(result, "task_id", None) or kwargs.get("task_id")
+
+    def _get_log_data(self, result: Any, kwargs: dict) -> dict:
+        """Create log data from result and kwargs."""
+        log_data = {}
+        for field in ["task_id", "config_id", "instance_id"]:
+            if value := getattr(result, field, None) or kwargs.get(field):
+                log_data[field] = value
+        log_data["details"] = kwargs.get("details", {})
+        return log_data
+
+    def _log_success(self, db: Any, task_id: str, result: Any, log_data: dict, kwargs: dict) -> None:
+        """Log successful operation."""
+        ManualTaskLog.create_log(
+            db=db,
+            **self._get_log_data(result, kwargs | log_data),
+            status=self.success_status,
+            message=self.operation_name,
+        )
+
+    def _log_error(self, service_self: Any, error: Exception, kwargs: dict) -> None:
+        """Log operation error."""
+        logger.error(f"Error in {self.operation_name}: {str(error)}")
+        if hasattr(service_self, "db") and (task_id := kwargs.get("task_id")):
+            ManualTaskLog.create_log(
+                db=service_self.db,
+                **self._get_log_data({}, kwargs),
+                status=ManualTaskLogStatus.error,
+                message=f"Error in {self.operation_name}: {str(error)}",
+            )
+
+    @staticmethod
+    def log_status_change(
+        db: Any,
+        task_id: str,
+        config_id: Optional[str] = None,
+        instance_id: Optional[str] = None,
+        previous_status: Optional[StatusType] = None,
+        new_status: Optional[StatusType] = None,
+        user_id: Optional[str] = None,
+    ) -> None:
+        """Log a status change event."""
+        ManualTaskLog.create_log(
+            db=db,
+            task_id=task_id,
+            config_id=config_id,
+            instance_id=instance_id,
+            status=ManualTaskLogStatus.in_progress,
+            message=f"Task instance status transitioning from {previous_status} to {new_status}",
+            details={
+                "previous_status": previous_status,
+                "new_status": new_status,
+                "user_id": user_id,
+            },
+        )
+
+    @staticmethod
+    def log_create(
+        db: Any,
+        task_id: str,
+        entity_type: str,
+        entity_id: str,
+        details: Optional[dict] = None,
+        user_id: Optional[str] = None,
+        status: ManualTaskLogStatus = ManualTaskLogStatus.created,
+    ) -> None:
+        """Log a creation event."""
+        id_fields = {
+            "task": {"task_id": task_id},
+            "config": {"task_id": task_id, "config_id": entity_id},
+            "instance": {"task_id": task_id, "instance_id": entity_id},
+            "submission": {"task_id": task_id, "instance_id": entity_id},
+        }
+        if entity_type not in id_fields:
+            raise ValueError(f"Invalid entity type: {entity_type}")
+
+        ManualTaskLog.create_log(
+            db=db,
+            **id_fields[entity_type],
+            status=status,
+            message=f"Created new {entity_type}",
+            details=details | {"user_id": user_id} if user_id else details or {},
+        )
+
+
+# Alias the class to maintain the original decorator name
+with_task_logging = TaskLogger

--- a/tests/service/manual_tasks/conftest.py
+++ b/tests/service/manual_tasks/conftest.py
@@ -1,25 +1,180 @@
-from fides.api.schemas.manual_tasks.manual_task_config import ManualTaskFieldType
+import pytest
+from sqlalchemy.orm import Session
+
+from fides.api.models.fides_user import FidesUser
+from fides.api.models.fides_user_permissions import FidesUserPermissions
+from fides.api.models.manual_tasks.manual_task import ManualTask, ManualTaskReference
+from fides.api.models.manual_tasks.manual_task_config import ManualTaskConfig
+from fides.api.oauth.roles import EXTERNAL_RESPONDENT, RESPONDENT
+from fides.api.schemas.manual_tasks.manual_task_schemas import (
+    ManualTaskParentEntityType,
+    ManualTaskReferenceType,
+    ManualTaskType,
+)
+from fides.service.manual_tasks.manual_task_config_service import (
+    ManualTaskConfigService,
+)
+from fides.service.manual_tasks.manual_task_service import ManualTaskService
 
 # Shared test data
 CONFIG_TYPE = "access_privacy_request"
+TEXT_FIELD_KEY = "test_field"
+CHECKBOX_FIELD_KEY = "test_checkbox_field"
+ATTACHMENT_FIELD_KEY = "test_attachment_field"
 FIELDS = [
+    # Text fields
     {
-        "field_key": "field1",
-        "field_type": ManualTaskFieldType.text,
+        "field_key": TEXT_FIELD_KEY,
+        "field_type": "text",
         "field_metadata": {
-            "label": "Field 1",
             "required": True,
-            "help_text": "This is field 1",
-            "placeholder": "Enter text here",
+            "label": "Test Field",
+            "help_text": "This is a test field",
+            "min_length": 1,
+            "max_length": 100,
+            "pattern": "^[a-zA-Z0-9]+$",
+            "placeholder": "Enter a value",
+            "default_value": "default_value",
         },
     },
+    # Checkbox fields
     {
-        "field_key": "field2",
-        "field_type": ManualTaskFieldType.text,
+        "field_key": CHECKBOX_FIELD_KEY,
+        "field_type": "checkbox",
         "field_metadata": {
-            "label": "Field 2",
-            "required": False,
-            "help_text": "This is field 2",
+            "required": True,
+            "label": "Test Checkbox Field",
+            "help_text": "This is a test checkbox field",
+        },
+    },
+    # Attachment fields
+    {
+        "field_key": ATTACHMENT_FIELD_KEY,
+        "field_type": "attachment",
+        "field_metadata": {
+            "required": True,
+            "label": "Test Attachment Field",
+            "help_text": "This is a test attachment field",
+            "file_types": ["text/plain", "application/pdf"],
+            "max_file_size": 1000000,
+            "max_file_count": 1,
         },
     },
 ]
+
+
+@pytest.fixture
+def manual_task(db: Session):
+    task = ManualTask.create(
+        db=db,
+        data={
+            "parent_entity_id": "test-parent-id",
+            "parent_entity_type": ManualTaskParentEntityType.connection_config,
+            "task_type": ManualTaskType.privacy_request,
+        },
+    )
+
+    ManualTaskReference.create(
+        db=db,
+        data={
+            "task_id": task.id,
+            "reference_id": task.parent_entity_id,
+            "reference_type": ManualTaskReferenceType.connection_config,
+        },
+    )
+
+    yield task
+    task.delete(db)
+
+
+@pytest.fixture
+def respondent_user(db: Session):
+    user = FidesUser.create(
+        db=db,
+        data={
+            "username": "test_respondent_user",
+            "email_address": "fides.respondent@ethyca.com",
+        },
+    )
+    FidesUserPermissions.create(db=db, data={"user_id": user.id, "roles": [RESPONDENT]})
+    yield user
+    user.delete(db)
+
+
+@pytest.fixture
+def external_user(db: Session):
+    user = FidesUser.create(
+        db=db,
+        data={
+            "username": "test_external_user",
+            "email_address": "user@not_ethyca.com",
+        },
+    )
+    FidesUserPermissions.create(
+        db=db, data={"user_id": user.id, "roles": [EXTERNAL_RESPONDENT]}
+    )
+    yield user
+    user.delete(db)
+
+
+@pytest.fixture
+def manual_task_config_service(db: Session):
+    return ManualTaskConfigService(db)
+
+
+@pytest.fixture
+def manual_task_config(
+    db: Session,
+    manual_task: ManualTask,
+    manual_task_config_service: ManualTaskConfigService,
+):
+    config = manual_task_config_service.create_new_version(
+        task=manual_task,
+        config_type=CONFIG_TYPE,
+        field_updates=FIELDS,
+    )
+    config = db.query(ManualTaskConfig).filter_by(id=config.id).first()
+    yield config
+    config.delete(db)
+
+
+@pytest.fixture
+def manual_task_service(db: Session):
+    return ManualTaskService(db)
+
+
+@pytest.fixture
+def manual_task_config_field_text(db: Session, manual_task_config: ManualTaskConfig):
+    field = next(
+        field
+        for field in manual_task_config.field_definitions
+        if field.field_key == TEXT_FIELD_KEY
+    )
+    yield field
+    field.delete(db)
+
+
+@pytest.fixture
+def manual_task_config_field_checkbox(
+    db: Session, manual_task_config: ManualTaskConfig
+):
+    field = next(
+        field
+        for field in manual_task_config.field_definitions
+        if field.field_key == CHECKBOX_FIELD_KEY
+    )
+    yield field
+    field.delete(db)
+
+
+@pytest.fixture
+def manual_task_config_field_attachment(
+    db: Session, manual_task_config: ManualTaskConfig
+):
+    field = next(
+        field
+        for field in manual_task_config.field_definitions
+        if field.field_key == ATTACHMENT_FIELD_KEY
+    )
+    yield field
+    field.delete(db)

--- a/tests/service/manual_tasks/test_manual_task_config_service.py
+++ b/tests/service/manual_tasks/test_manual_task_config_service.py
@@ -10,10 +10,18 @@ from fides.api.models.manual_tasks.manual_task_log import (
     ManualTaskLogStatus,
 )
 from fides.api.schemas.manual_tasks.manual_task_config import ManualTaskFieldType
+from fides.api.schemas.manual_tasks.manual_task_schemas import ManualTaskLogStatus
 from fides.service.manual_tasks.manual_task_config_service import (
     ManualTaskConfigService,
 )
-from tests.service.manual_tasks.conftest import CONFIG_TYPE, FIELDS
+
+from tests.service.manual_tasks.conftest import (
+    ATTACHMENT_FIELD_KEY,
+    CHECKBOX_FIELD_KEY,
+    CONFIG_TYPE,
+    FIELDS,
+    TEXT_FIELD_KEY,
+)
 
 
 @pytest.fixture
@@ -35,430 +43,239 @@ def manual_task_config_service(db: Session):
     return ManualTaskConfigService(db)
 
 
-class TestManualTaskConfigServiceBase:
-    """Base test class with common test data and utilities."""
-
-    config_type = CONFIG_TYPE
-    fields = FIELDS
-
-
-class TestManualTaskConfigCreation(TestManualTaskConfigServiceBase):
-    """Tests for creating new configurations."""
-
-    def test_create_new_version_no_previous_config(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test creating a new version when there is no previous config."""
-        # Execute
-        config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Verify
-        assert config is not None
-        assert config.config_type == self.config_type
-        assert config.version == 1
-        assert config.is_current is True
-        assert len(config.field_definitions) == len(self.fields)
-        field1 = next(
-            field for field in config.field_definitions if field.field_key == "field1"
-        )
-        field2 = next(
-            field for field in config.field_definitions if field.field_key == "field2"
-        )
-        assert (
-            field1.field_metadata["label"] == self.fields[0]["field_metadata"]["label"]
-        )
-        assert (
-            field2.field_metadata["label"] == self.fields[1]["field_metadata"]["label"]
-        )
-
-        # Verify log was created
-        log = (
-            db.query(ManualTaskLog)
-            .filter_by(task_id=manual_task.id)
-            .order_by(ManualTaskLog.created_at.desc())
-            .first()
-        )
-        assert log is not None
-        assert log.status == ManualTaskLogStatus.created
-        assert "Created new version 1 of configuration" in log.message
-        assert log.config_id == config.id
-
-    def test_create_new_version_with_previous_config(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test creating a new version when there is a previous config."""
-        # Setup - create initial config
-        initial_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Execute - create new version with modified fields
-        modified_fields = [
-            {
-                "field_key": "field1",
-                "field_type": ManualTaskFieldType.text,
-                "field_metadata": {
-                    "label": "Field 1 Updated",
-                    "required": True,
-                    "help_text": "This is field 1 updated",
-                },
-            }
-        ]
-        new_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=modified_fields,
-            previous_config=db.query(ManualTaskConfig)
-            .filter_by(id=initial_config.id)
-            .first(),
-        )
-
-        # Verify
-        assert new_config is not None
-        assert new_config.config_type == self.config_type
-        assert new_config.version == 2
-        assert new_config.is_current is True
-
-        # Verify previous config is no longer current
-        previous_config = (
-            db.query(ManualTaskConfig).filter_by(id=initial_config.id).first()
-        )
-        assert previous_config.is_current is False
-
-        # Verify fields
-        assert (
-            len(new_config.field_definitions) == 2
-        )  # one original field, one modified field
-        field1 = next(
-            field
-            for field in new_config.field_definitions
-            if field.field_key == "field1"
-        )
-        assert field1.field_metadata["label"] == "Field 1 Updated"
-        field2 = next(
-            field
-            for field in new_config.field_definitions
-            if field.field_key == "field2"
-        )
-        assert field2.field_metadata["label"] == "Field 2"
-
-
-class TestManualTaskConfigValidation(TestManualTaskConfigServiceBase):
-    """Tests for configuration validation."""
-
-    def test_invalid_config_type(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test creating a config with an invalid config type."""
-        with pytest.raises(ValueError, match="Invalid config type: invalid_type"):
-            manual_task_config_service.create_new_version(
-                task=manual_task,
-                config_type="invalid_type",
-                field_updates=self.fields,
-            )
-
-    def test_invalid_field_type(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test creating a config with an invalid field type."""
-        invalid_fields = [
-            {
-                "field_key": "field1",
-                "field_type": "invalid_type",
-                "field_metadata": {
-                    "label": "Field 1",
-                    "required": True,
-                },
-            }
-        ]
-        with pytest.raises(ValueError) as exc_info:
-            manual_task_config_service.create_new_version(
-                task=manual_task,
-                config_type=self.config_type,
-                field_updates=invalid_fields,
-            )
-        assert (
-            "Invalid field type: 'invalid_type' is not a valid ManualTaskFieldType"
-            in str(exc_info.value)
-        )
-
-    @pytest.mark.parametrize(
-        "field_type, field_metadata, expected_error",
-        [
-            pytest.param(
-                None,
-                {"label": "Field 1", "required": True},
-                "Invalid field data: field_type is required",
-                id="missing_field_type",
-            ),
-            pytest.param(
-                123,
-                {"label": "Field 1", "required": True},
-                "Invalid field type: expected string or ManualTaskFieldType, got int",
-                id="non_string_field_type",
-            ),
-            pytest.param(
-                "text",
-                {"invalid_key": "value"},
-                "Invalid field data",  # Pydantic validation error for missing required field
-                id="invalid_metadata_for_type",
-            ),
-        ],
+def test_create_new_version_no_previous_config(
+    db: Session,
+    manual_task: ManualTask,
+    manual_task_config_service: ManualTaskConfigService,
+):
+    """Test creating a new version when there is no previous config."""
+    config = manual_task_config_service.create_new_version(
+        task=manual_task,
+        config_type=CONFIG_TYPE,
+        field_updates=FIELDS,
     )
-    def test_field_type_validation_cases(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-        field_type: Any,
-        field_metadata: dict,
-        expected_error: str,
-    ):
-        """Test various field type validation scenarios."""
-        invalid_fields = [
-            {
-                "field_key": "field1",
-                "field_type": field_type,
-                "field_metadata": field_metadata,
-            }
-        ]
-        with pytest.raises(ValueError) as exc_info:
-            manual_task_config_service.create_new_version(
-                task=manual_task,
-                config_type=self.config_type,
-                field_updates=invalid_fields,
-            )
-        assert expected_error in str(exc_info.value)
 
-    def test_invalid_field_metadata(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test creating a config with invalid field metadata."""
-        invalid_fields = [
-            {
-                "field_key": "field1",
-                "field_type": ManualTaskFieldType.text,
-                "field_metadata": {
-                    "invalid_key": "invalid_value",  # Missing required 'label'
-                },
-            }
-        ]
-        with pytest.raises(ValueError, match="Invalid field data"):
-            manual_task_config_service.create_new_version(
-                task=manual_task,
-                config_type=self.config_type,
-                field_updates=invalid_fields,
-            )
+    assert config.config_type == CONFIG_TYPE
+    assert config.version == 1
+    assert config.is_current is True
+    assert len(config.field_definitions) == len(FIELDS)
 
-    def test_empty_field_key(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
+    # Verify field definitions match input
+    for field_def, field_input in zip(
+        sorted(config.field_definitions, key=lambda x: x.field_key),
+        sorted(FIELDS, key=lambda x: x["field_key"]),
     ):
-        """Test creating a config with empty field key."""
-        invalid_fields = [
-            {
-                "field_key": "",  # Empty field key
-                "field_type": ManualTaskFieldType.text,
-                "field_metadata": {
-                    "label": "Field 1",
-                    "required": True,
-                },
-            }
-        ]
-        with pytest.raises(ValueError, match="Invalid field data"):
-            manual_task_config_service.create_new_version(
-                task=manual_task,
-                config_type=self.config_type,
-                field_updates=invalid_fields,
-            )
+        assert field_def.field_key == field_input["field_key"]
+        assert field_def.field_type == field_input["field_type"]
+        assert (
+            field_def.field_metadata["label"] == field_input["field_metadata"]["label"]
+        )
 
-    def test_duplicate_field_keys(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test that multiple updates to the same field are rejected."""
-        duplicate_fields = [
-            {
-                "field_key": "field1",
-                "field_type": ManualTaskFieldType.text,
-                "field_metadata": {
-                    "label": "Field 1",
-                    "required": True,
-                },
+    # Verify log was created
+    log = (
+        db.query(ManualTaskLog)
+        .filter_by(task_id=manual_task.id)
+        .order_by(ManualTaskLog.created_at.desc())
+        .first()
+    )
+    assert log.status == ManualTaskLogStatus.complete
+    assert "Creating new configuration version" in log.message
+    assert log.config_id == config.id
+
+
+def test_create_new_version_with_previous_config(
+    db: Session,
+    manual_task: ManualTask,
+    manual_task_config: ManualTaskConfig,
+    manual_task_config_service: ManualTaskConfigService,
+):
+    """Test creating a new version when there is a previous config."""
+    modified_fields = [
+        {
+            "field_key": TEXT_FIELD_KEY,
+            "field_type": ManualTaskFieldType.text,
+            "field_metadata": {
+                "label": "Text Field Updated",
+                "required": True,
+                "help_text": "This is text field updated",
             },
+        }
+    ]
+    new_config = manual_task_config_service.create_new_version(
+        task=manual_task,
+        config_type=CONFIG_TYPE,
+        field_updates=modified_fields,
+        previous_config=manual_task_config,
+    )
+
+    assert new_config.config_type == CONFIG_TYPE
+    assert new_config.version == 2
+    assert new_config.is_current is True
+    assert not manual_task_config.is_current
+
+    # Verify updated field
+    text_field = next(
+        field
+        for field in new_config.field_definitions
+        if field.field_key == TEXT_FIELD_KEY
+    )
+    assert text_field.field_metadata["label"] == "Text Field Updated"
+
+    # Verify other fields remained unchanged
+    checkbox_field = next(
+        field
+        for field in new_config.field_definitions
+        if field.field_key == CHECKBOX_FIELD_KEY
+    )
+    assert checkbox_field.field_metadata["label"] == "Test Checkbox Field"
+
+
+@pytest.mark.parametrize(
+    "invalid_input,expected_error",
+    [
+        (
+            {"config_type": "invalid_type", "fields": FIELDS},
+            "Invalid config type: invalid_type",
+        ),
+        (
             {
-                "field_key": "field1",  # Duplicate field key
-                "field_type": ManualTaskFieldType.text,
-                "field_metadata": {
-                    "label": "Field 1 Duplicate",
-                    "required": False,
-                },
+                "config_type": CONFIG_TYPE,
+                "fields": [
+                    {
+                        "field_key": TEXT_FIELD_KEY,
+                        "field_type": "invalid_type",
+                        "field_metadata": {"label": "Text Field", "required": True},
+                    }
+                ],
             },
-        ]
-        with pytest.raises(
-            ValueError,
-            match="Duplicate field keys found in field updates, field keys must be unique.",
-        ):
-            manual_task_config_service.create_new_version(
-                task=manual_task,
-                config_type=self.config_type,
-                field_updates=duplicate_fields,
-            )
+            "Invalid field type: 'invalid_type' is not a valid ManualTaskFieldType",
+        ),
+        (
+            {
+                "config_type": CONFIG_TYPE,
+                "fields": [
+                    {
+                        "field_key": TEXT_FIELD_KEY,
+                        "field_type": None,
+                        "field_metadata": {"label": "Field 1", "required": True},
+                    }
+                ],
+            },
+            "Invalid field data: field_type is required",
+        ),
+        (
+            {
+                "config_type": CONFIG_TYPE,
+                "fields": [
+                    {
+                        "field_key": "",
+                        "field_type": ManualTaskFieldType.text,
+                        "field_metadata": {"label": "Field 1", "required": True},
+                    }
+                ],
+            },
+            "Invalid field data",
+        ),
+        (
+            {
+                "config_type": CONFIG_TYPE,
+                "fields": [
+                    {
+                        "field_key": TEXT_FIELD_KEY,
+                        "field_type": ManualTaskFieldType.text,
+                        "field_metadata": {"invalid_key": "value"},
+                    }
+                ],
+            },
+            "Invalid field data",
+        ),
+    ],
+)
+def test_config_validation(
+    manual_task: ManualTask,
+    manual_task_config_service: ManualTaskConfigService,
+    invalid_input: dict[str, Any],
+    expected_error: str,
+):
+    """Test various config validation scenarios."""
+    with pytest.raises(ValueError, match=expected_error):
+        manual_task_config_service.create_new_version(
+            task=manual_task,
+            config_type=invalid_input["config_type"],
+            field_updates=invalid_input["fields"],
+        )
 
 
-class TestManualTaskConfigRetrieval(TestManualTaskConfigServiceBase):
-    """Tests for retrieving configurations."""
-
-    def test_get_current_config(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
+def test_duplicate_field_keys(
+    manual_task: ManualTask,
+    manual_task_config_service: ManualTaskConfigService,
+):
+    """Test that multiple updates to the same field are rejected."""
+    duplicate_fields = [
+        {
+            "field_key": TEXT_FIELD_KEY,
+            "field_type": ManualTaskFieldType.text,
+            "field_metadata": {"label": "Field 1", "required": True},
+        },
+        {
+            "field_key": TEXT_FIELD_KEY,
+            "field_type": ManualTaskFieldType.text,
+            "field_metadata": {"label": "Field 1 Duplicate", "required": False},
+        },
+    ]
+    with pytest.raises(
+        ValueError,
+        match="Duplicate field keys found in field updates, field keys must be unique.",
     ):
-        """Test getting the current config."""
-        # Setup - create config
-        config = manual_task_config_service.create_new_version(
+        manual_task_config_service.create_new_version(
             task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
+            config_type=CONFIG_TYPE,
+            field_updates=duplicate_fields,
         )
 
-        # Execute
-        current_config = manual_task_config_service.get_current_config(
-            task=manual_task,
-            config_type=self.config_type,
-        )
 
-        # Verify
-        assert current_config is not None
-        assert current_config.id == config.id
-        assert current_config.version == 1
-        assert current_config.is_current is True
+def test_config_retrieval(
+    manual_task: ManualTask,
+    manual_task_config: ManualTaskConfig,
+    manual_task_config_service: ManualTaskConfigService,
+):
+    """Test various config retrieval methods."""
+    # Get by ID
+    config = manual_task_config_service.get_config(
+        task=manual_task,
+        config_type=CONFIG_TYPE,
+        field_id=None,
+        config_id=manual_task_config.id,
+        field_key=None,
+        version=None,
+    )
+    assert config.id == manual_task_config.id
 
-    def test_get_config_by_id(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test getting a config by its ID."""
-        # Setup - create config
-        config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
+    # Get by version
+    config = manual_task_config_service.get_config(
+        task=manual_task,
+        config_type=CONFIG_TYPE,
+        field_id=None,
+        config_id=None,
+        field_key=None,
+        version=1,
+    )
+    assert config.version == 1
 
-        # Execute
-        found_config = manual_task_config_service.get_config(
-            task=manual_task,
-            config_type=self.config_type,
-            field_id=None,
-            config_id=config.id,
-            field_key=None,
-            version=None,
-        )
+    # Get by field key
+    config = manual_task_config_service.get_config(
+        task=manual_task,
+        config_type=CONFIG_TYPE,
+        field_id=None,
+        config_id=None,
+        field_key=TEXT_FIELD_KEY,
+        version=None,
+    )
+    assert any(field.field_key == TEXT_FIELD_KEY for field in config.field_definitions)
 
-        # Verify
-        assert found_config is not None
-        assert found_config.id == config.id
-        assert found_config.version == 1
-        assert found_config.is_current is True
-
-    def test_get_config_by_version(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test getting a config by its version."""
-        # Setup - create config
-        config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Execute
-        found_config = manual_task_config_service.get_config(
-            task=manual_task,
-            config_type=self.config_type,
-            field_id=None,
-            config_id=None,
-            field_key=None,
-            version=1,
-        )
-
-        # Verify
-        assert found_config is not None
-        assert found_config.id == config.id
-        assert found_config.version == 1
-        assert found_config.is_current is True
-
-    def test_get_config_by_field_key(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test getting a config by field key."""
-        # Setup - create config
-        config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Execute
-        found_config = manual_task_config_service.get_config(
-            task=manual_task,
-            config_type=self.config_type,
-            field_id=None,
-            config_id=None,
-            field_key="field1",
-            version=None,
-        )
-
-        # Verify
-        assert found_config is not None
-        assert found_config.id == config.id
-        assert any(
-            field.field_key == "field1" for field in found_config.field_definitions
-        )
-
-    def test_get_config_no_filters(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test getting a config with no filters."""
-        config = manual_task_config_service.get_config(
+    # Get with no filters
+    assert (
+        manual_task_config_service.get_config(
             task=None,
             config_type=None,
             field_id=None,
@@ -466,420 +283,82 @@ class TestManualTaskConfigRetrieval(TestManualTaskConfigServiceBase):
             field_key=None,
             version=None,
         )
-        assert config is None
+        is None
+    )
 
 
-class TestManualTaskConfigVersioning(TestManualTaskConfigServiceBase):
-    """Tests for configuration versioning."""
+def test_field_management(
+    manual_task: ManualTask,
+    manual_task_config: ManualTaskConfig,
+    manual_task_config_service: ManualTaskConfigService,
+):
+    """Test field addition and removal."""
+    # Add new field
+    new_field = {
+        "field_key": "new_field",
+        "field_type": ManualTaskFieldType.text,
+        "field_metadata": {
+            "label": "New Field",
+            "required": False,
+            "help_text": "This is a new field",
+        },
+    }
+    manual_task_config_service.add_fields(manual_task, CONFIG_TYPE, [new_field])
+    current_config = manual_task_config_service.get_current_config(
+        manual_task, CONFIG_TYPE
+    )
+    assert len(current_config.field_definitions) == len(FIELDS) + 1
+    assert any(
+        field.field_key == "new_field" for field in current_config.field_definitions
+    )
 
-    def test_multiple_versions_sequence(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
+    # Remove field
+    manual_task_config_service.remove_fields(manual_task, CONFIG_TYPE, [TEXT_FIELD_KEY])
+    current_config = manual_task_config_service.get_current_config(
+        manual_task, CONFIG_TYPE
+    )
+    assert len(current_config.field_definitions) == len(FIELDS)
+    assert not any(
+        field.field_key == TEXT_FIELD_KEY for field in current_config.field_definitions
+    )
+
+
+def test_config_deletion(
+    db: Session,
+    manual_task: ManualTask,
+    manual_task_config: ManualTaskConfig,
+    manual_task_config_service: ManualTaskConfigService,
+):
+    """Test config deletion."""
+    config_id = manual_task_config.id
+    manual_task_config_service.delete_config(manual_task, config_id)
+    assert db.query(ManualTaskConfig).filter_by(id=config_id).first() is None
+
+    with pytest.raises(ValueError, match="Config with ID invalid-id not found"):
+        manual_task_config_service.delete_config(manual_task, "invalid-id")
+
+
+def test_config_response_conversion(
+    manual_task_config: ManualTaskConfig,
+    manual_task_config_service: ManualTaskConfigService,
+):
+    """Test converting config to response object."""
+    response = manual_task_config_service.to_response(manual_task_config)
+    assert response.id == manual_task_config.id
+    assert response.task_id == manual_task_config.task_id
+    assert response.config_type == manual_task_config.config_type
+    assert response.version == manual_task_config.version
+    assert response.is_current == manual_task_config.is_current
+    assert len(response.fields) == len(FIELDS)
+
+    for field, expected_field in zip(
+        sorted(response.fields, key=lambda x: x.field_key),
+        sorted(FIELDS, key=lambda x: x["field_key"]),
     ):
-        """Test creating multiple versions in sequence."""
-        # Create initial version
-        version1 = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Create second version
-        version2 = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-            previous_config=db.query(ManualTaskConfig)
-            .filter_by(id=version1.id)
-            .first(),
-        )
-
-        # Create third version
-        version3 = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-            previous_config=db.query(ManualTaskConfig)
-            .filter_by(id=version2.id)
-            .first(),
-        )
-
-        # Verify versions
-        versions = manual_task_config_service.list_config_type_versions(
-            task=manual_task,
-            config_type=self.config_type,
-        )
-        assert len(versions) == 3
-        assert versions[0].version == 3
-        assert versions[1].version == 2
-        assert versions[2].version == 1
-        assert versions[0].is_current is True
-        assert versions[1].is_current is False
-        assert versions[2].is_current is False
-
-
-class TestManualTaskConfigFieldUpdates(TestManualTaskConfigServiceBase):
-    """Tests for field updates and modifications."""
-
-    def test_update_field_type(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test updating a field's type."""
-        # Create initial config with text field
-        initial_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Update field type to checkbox
-        modified_fields = [
-            {
-                "field_key": "field1",
-                "field_type": ManualTaskFieldType.checkbox,
-                "field_metadata": {
-                    "label": "Field 1",
-                    "required": True,
-                },
-            }
-        ]
-        new_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=modified_fields,
-            previous_config=db.query(ManualTaskConfig)
-            .filter_by(id=initial_config.id)
-            .first(),
-        )
-
-        # Verify field type was updated
-        field1 = next(
-            field
-            for field in new_config.field_definitions
-            if field.field_key == "field1"
-        )
-        assert field1.field_type == ManualTaskFieldType.checkbox
-
-    def test_update_field_metadata_empty(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test removing a field using fields_to_remove parameter."""
-        # Create initial config
-        initial_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Remove field1 using explicit removal
-        new_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            fields_to_remove=["field1"],
-            previous_config=db.query(ManualTaskConfig)
-            .filter_by(id=initial_config.id)
-            .first(),
-        )
-
-        # Verify field was removed
-        assert len(new_config.field_definitions) == 1  # Only field2 remains
-        assert all(
-            field.field_key != "field1" for field in new_config.field_definitions
-        )
-        # Verify field2 is still present and unchanged
-        field2 = next(
-            field
-            for field in new_config.field_definitions
-            if field.field_key == "field2"
-        )
-        assert field2.field_metadata["label"] == "Field 2"
-
-    def test_update_nonexistent_field(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test updating a field that doesn't exist."""
-        # Create initial config
-        initial_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Try to update non-existent field
-        modified_fields = [
-            {
-                "field_key": "nonexistent_field",
-                "field_type": ManualTaskFieldType.text,
-                "field_metadata": {
-                    "label": "Nonexistent Field",
-                    "required": True,
-                },
-            }
-        ]
-        new_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=modified_fields,
-            previous_config=db.query(ManualTaskConfig)
-            .filter_by(id=initial_config.id)
-            .first(),
-        )
-
-        # Verify original fields remain unchanged
+        assert field.field_key == expected_field["field_key"]
+        assert field.field_type == expected_field["field_type"]
+        assert field.field_metadata.label == expected_field["field_metadata"]["label"]
         assert (
-            len(new_config.field_definitions) == len(self.fields) + 1
-        )  # one original fields, one new field
-        assert all(
-            field.field_key in ["field1", "field2", "nonexistent_field"]
-            for field in new_config.field_definitions
+            field.field_metadata.required
+            == expected_field["field_metadata"]["required"]
         )
-
-
-class TestManualTaskConfigFieldManagement(TestManualTaskConfigServiceBase):
-    """Tests for field management operations."""
-
-    def test_add_fields(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test adding fields to a configuration."""
-        # Setup - create initial config
-        initial_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Execute - add new field
-        new_field = {
-            "field_key": "field3",
-            "field_type": ManualTaskFieldType.text,
-            "field_metadata": {
-                "label": "Field 3",
-                "required": False,
-                "help_text": "This is field 3",
-            },
-        }
-        manual_task_config_service.add_fields(
-            manual_task, self.config_type, [new_field]
-        )
-
-        # Verify
-        current_config = manual_task_config_service.get_current_config(
-            manual_task, self.config_type
-        )
-        assert current_config is not None
-        assert len(current_config.field_definitions) == 3
-        field3 = next(
-            field
-            for field in current_config.field_definitions
-            if field.field_key == "field3"
-        )
-        assert field3.field_metadata["label"] == "Field 3"
-
-    def test_add_fields_no_current_config(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test adding fields when no current config exists."""
-        new_field = {
-            "field_key": "field1",
-            "field_type": ManualTaskFieldType.text,
-            "field_metadata": {
-                "label": "Field 1",
-                "required": True,
-            },
-        }
-        with pytest.raises(
-            ValueError,
-            match=f"No current config found for task {manual_task.id} and type {self.config_type}",
-        ):
-            manual_task_config_service.add_fields(
-                manual_task, self.config_type, [new_field]
-            )
-
-    def test_remove_fields(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test removing fields from a configuration."""
-        # Setup - create initial config
-        initial_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-        # Execute - remove field1
-        manual_task_config_service.remove_fields(
-            manual_task, self.config_type, ["field1"]
-        )
-
-        # Verify
-        current_config = manual_task_config_service.get_current_config(
-            manual_task, self.config_type
-        )
-        assert current_config is not None
-        assert len(current_config.field_definitions) == 1
-        assert all(
-            field.field_key != "field1" for field in current_config.field_definitions
-        )
-        field2 = next(
-            field
-            for field in current_config.field_definitions
-            if field.field_key == "field2"
-        )
-        assert field2.field_metadata["label"] == "Field 2"
-
-    def test_remove_fields_no_current_config(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test removing fields when no current config exists."""
-        with pytest.raises(
-            ValueError,
-            match=f"No current config found for task {manual_task.id} and type {self.config_type}",
-        ):
-            manual_task_config_service.remove_fields(
-                manual_task, self.config_type, ["field1"]
-            )
-
-    def test_remove_fields_explicit(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test removing fields using explicit field removal."""
-        # Setup - create initial config
-        initial_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Execute - remove field1 using explicit removal
-        new_config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            fields_to_remove=["field1"],
-            previous_config=initial_config,
-        )
-
-        # Verify
-        assert new_config is not None
-        assert new_config.config_type == self.config_type
-        assert new_config.version == 2
-        assert new_config.is_current is True
-        assert len(new_config.field_definitions) == 1  # Only field2 remains
-        assert all(
-            field.field_key != "field1" for field in new_config.field_definitions
-        )
-        field2 = next(
-            field
-            for field in new_config.field_definitions
-            if field.field_key == "field2"
-        )
-        assert field2.field_metadata["label"] == "Field 2"
-
-        # Verify log details include removed fields
-        log = (
-            db.query(ManualTaskLog)
-            .filter_by(task_id=manual_task.id)
-            .order_by(ManualTaskLog.created_at.desc())
-            .first()
-        )
-        assert log is not None
-        assert log.details.get("fields_removed") == ["field1"]
-
-
-class TestManualTaskConfigDeletion(TestManualTaskConfigServiceBase):
-    """Tests for configuration deletion."""
-
-    def test_delete_config(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test deleting a configuration."""
-        # Setup - create config
-        response = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Execute
-        manual_task_config_service.delete_config(manual_task, response.id)
-
-        # Verify
-        assert db.query(ManualTaskConfig).filter_by(id=response.id).first() is None
-
-    def test_delete_config_not_found(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test deleting a non-existent configuration."""
-        with pytest.raises(ValueError, match="Config with ID invalid-id not found"):
-            manual_task_config_service.delete_config(manual_task, "invalid-id")
-
-
-class TestManualTaskConfigResponseConversion(TestManualTaskConfigServiceBase):
-    """Tests for converting config models to response objects."""
-
-    def test_to_response(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_config_service: ManualTaskConfigService,
-    ):
-        """Test converting a config model to a response object."""
-        # Create a config
-        config = manual_task_config_service.create_new_version(
-            task=manual_task,
-            config_type=self.config_type,
-            field_updates=self.fields,
-        )
-
-        # Convert to response
-        response = manual_task_config_service.to_response(config)
-
-        # Verify response
-        assert response is not None
-        assert response.id == config.id
-        assert response.task_id == config.task_id
-        assert response.config_type == config.config_type
-        assert response.version == config.version
-        assert response.is_current == config.is_current
-        assert len(response.fields) == len(self.fields)
-        for field, expected_field in zip(response.fields, self.fields):
-            assert field.field_key == expected_field["field_key"]
-            assert field.field_type == expected_field["field_type"]
-            assert (
-                field.field_metadata.label == expected_field["field_metadata"]["label"]
-            )
-            assert (
-                field.field_metadata.required
-                == expected_field["field_metadata"]["required"]
-            )

--- a/tests/service/manual_tasks/test_manual_task_service.py
+++ b/tests/service/manual_tasks/test_manual_task_service.py
@@ -1,11 +1,13 @@
 import pytest
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from fides.api.models.fides_user import FidesUser
 from fides.api.models.fides_user_permissions import FidesUserPermissions
 from fides.api.models.manual_tasks.manual_task import ManualTask, ManualTaskReference
-from fides.api.models.manual_tasks.manual_task_config import ManualTaskConfig
+from fides.api.models.manual_tasks.manual_task_config import (
+    ManualTaskConfig,
+    ManualTaskConfigField,
+)
 from fides.api.models.manual_tasks.manual_task_log import (
     ManualTaskLog,
     ManualTaskLogStatus,
@@ -13,8 +15,6 @@ from fides.api.models.manual_tasks.manual_task_log import (
 from fides.api.oauth.roles import EXTERNAL_RESPONDENT, RESPONDENT
 from fides.api.schemas.manual_tasks.manual_task_config import (
     ManualTaskConfigurationType,
-    ManualTaskFieldType,
-    ManualTaskTextField,
 )
 from fides.api.schemas.manual_tasks.manual_task_schemas import (
     ManualTaskParentEntityType,
@@ -22,7 +22,12 @@ from fides.api.schemas.manual_tasks.manual_task_schemas import (
     ManualTaskType,
 )
 from fides.service.manual_tasks.manual_task_service import ManualTaskService
-from tests.service.manual_tasks.conftest import FIELDS
+from tests.service.manual_tasks.conftest import (
+    ATTACHMENT_FIELD_KEY,
+    CHECKBOX_FIELD_KEY,
+    FIELDS,
+    TEXT_FIELD_KEY,
+)
 
 
 @pytest.fixture
@@ -111,128 +116,160 @@ def verify_expected_logs(logs: list[ManualTaskLog], expected_messages: list[str]
 class TestGetTask:
     """Tests for the get_task method."""
 
-    def test_get_task_by_id(
+    @pytest.mark.parametrize(
+        "search_params,expected_error",
+        [
+            pytest.param(
+                {"task_id": "test-task-id"},
+                None,
+                id="task_id",
+            ),
+            pytest.param(
+                {
+                    "parent_entity_id": "test-parent-id",
+                    "parent_entity_type": ManualTaskParentEntityType.connection_config,
+                },
+                None,
+                id="parent_entity_id",
+            ),
+            pytest.param(
+                {"task_type": ManualTaskType.privacy_request},
+                None,
+                id="task_type",
+            ),
+            pytest.param(
+                {},
+                "No filters provided to get_task",
+                id="no_filters",
+            ),
+            pytest.param(
+                {"task_id": "invalid-id"},
+                r"No task found with filters: \['task_id=invalid-id'\]",
+                id="invalid_task_id",
+            ),
+            pytest.param(
+                {
+                    "parent_entity_id": "test-parent-id",
+                    "parent_entity_type": "invalid_type",
+                },
+                r"No task found with filters: \['parent_entity_id=test-parent-id', 'parent_entity_type=invalid_type'\]",
+                id="invalid_parent_entity_type",
+            ),
+            pytest.param(
+                {"task_type": "invalid_type"},
+                r"No task found with filters: \['task_type=invalid_type'\]",
+                id="invalid_task_type",
+            ),
+        ],
+    )
+    def test_get_task(
         self,
         db: Session,
         manual_task: ManualTask,
         manual_task_service: ManualTaskService,
+        search_params: dict,
+        expected_error: str,
     ):
-        assert manual_task_service.get_task(task_id=manual_task.id) == manual_task
+        """Test getting tasks with various search parameters."""
+        if "task_id" in search_params and search_params["task_id"] == "test-task-id":
+            search_params["task_id"] = manual_task.id
 
-    def test_get_task_by_parent_entity(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-    ):
-        assert (
-            manual_task_service.get_task(
-                parent_entity_id="test-parent-id",
-                parent_entity_type=ManualTaskParentEntityType.connection_config,
-            )
-            == manual_task
-        )
-
-    def test_get_task_by_type(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-    ):
-        assert (
-            manual_task_service.get_task(task_type=ManualTaskType.privacy_request)
-            == manual_task
-        )
-
-    def test_get_task_no_filters(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-    ):
-        assert manual_task_service.get_task() is None
-
-    def test_get_task_invalid_id(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-    ):
-        assert manual_task_service.get_task(task_id="invalid-id") is None
-
-    def test_get_task_invalid_parent_entity_type(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-    ):
-        assert (
-            manual_task_service.get_task(
-                parent_entity_id="test-parent-id",
-                parent_entity_type="invalid_type",
-            )
-            is None
-        )
-
-    def test_get_task_invalid_task_type(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-    ):
-        assert manual_task_service.get_task(task_type="invalid_type") is None
+        if expected_error:
+            with pytest.raises(ValueError, match=expected_error):
+                manual_task_service.get_task(**search_params)
+        else:
+            result = manual_task_service.get_task(**search_params)
+            assert result == manual_task
 
 
 class TestAssignUsersToTask:
     """Tests for the assign_users_to_task method."""
 
-    def test_assign_users_to_task_error_user_not_found(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-    ):
-        # Setup
-        user_ids = ["user1", "user2"]
-        manual_task_service.assign_users_to_task(db, manual_task, user_ids)
-
-        # Verify
-        assert len(manual_task.references) == 1  # The parent entity
-        assert all(ref.reference_id not in user_ids for ref in manual_task.references)
-
-        # Verify logs were created
-        # There should be at least 2 logs, one for each user
-        assert len(manual_task.logs) >= 2
-
-        # Get error logs
-        error_logs = [
-            log for log in manual_task.logs if log.status == ManualTaskLogStatus.error
-        ]
-        assert len(error_logs) == 2
-        for log in error_logs:
-            assert (
-                log.message
-                == f"Failed to add user {log.details['user_id']} to task {manual_task.id}: user does not exist"
-            )
-
-    def test_assign_users_to_task_success(
+    @pytest.mark.parametrize(
+        "user_ids,expected_assigned,expected_not_assigned,should_raise",
+        [
+            pytest.param(
+                ["user1", "user2", "respondent_user"],  # user_ids
+                ["respondent_user"],  # expected_assigned
+                ["user1", "user2"],  # expected_not_assigned
+                False,  # should_raise
+                id="user_ids",
+            ),
+            pytest.param(
+                ["respondent_user", "external_user"],  # user_ids
+                ["respondent_user", "external_user"],  # expected_assigned
+                [],  # expected_not_assigned
+                False,  # should_raise
+                id="respondent_user_external_user",
+            ),
+            pytest.param(
+                [],  # user_ids
+                [],  # expected_assigned
+                [],  # expected_not_assigned
+                True,  # should_raise
+                id="empty_user_ids",
+            ),
+            pytest.param(
+                ["respondent_user", "respondent_user"],  # user_ids
+                ["respondent_user"],  # expected_assigned
+                [],  # expected_not_assigned
+                False,  # should_raise
+                id="respondent_user_duplicate",
+            ),
+        ],
+    )
+    def test_assign_users_to_task(
         self,
         db: Session,
         manual_task: ManualTask,
         manual_task_service: ManualTaskService,
         respondent_user: FidesUser,
         external_user: FidesUser,
+        user_ids: list[str],
+        expected_assigned: list[str],
+        expected_not_assigned: list[str],
+        should_raise: bool,
     ):
+        """Test assigning users to tasks with various scenarios."""
+        # Replace placeholder user IDs with actual IDs
+        user_ids = [
+            (
+                respondent_user.id
+                if id == "respondent_user"
+                else external_user.id if id == "external_user" else id
+            )
+            for id in user_ids
+        ]
+        expected_assigned = [
+            (
+                respondent_user.id
+                if id == "respondent_user"
+                else external_user.id if id == "external_user" else id
+            )
+            for id in expected_assigned
+        ]
+
+        if should_raise:
+            with pytest.raises(ValueError, match="User ID is required for assignment"):
+                manual_task_service.assign_users_to_task(
+                    task_id=manual_task.id, user_ids=user_ids
+                )
+            return
+
         # Execute
         manual_task_service.assign_users_to_task(
-            db, manual_task, [respondent_user.id, external_user.id]
+            task_id=manual_task.id, user_ids=user_ids
         )
 
-        # Verify
-        assert len(manual_task.references) == 3  # The parent entity + the two users
+        # Verify references
+        expected_ref_count = 1 + len(
+            expected_assigned
+        )  # parent entity + assigned users
+        assert len(manual_task.references) == expected_ref_count
+
         verify_expected_reference_ids(
             manual_task,
-            [manual_task.parent_entity_id, respondent_user.id, external_user.id],
+            [manual_task.parent_entity_id] + expected_assigned,
         )
         verify_expected_reference_types(
             manual_task,
@@ -242,68 +279,53 @@ class TestAssignUsersToTask:
             ],
         )
 
-        # Verify logs were created
-        assert (
-            len(manual_task.logs) == 3
-        )  # Create task and update tasks for the two users
-
-    def test_assign_users_to_task_empty_list(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-    ):
-        with pytest.raises(ValueError, match="User ID is required for assignment"):
-            manual_task_service.assign_users_to_task(db, manual_task, [])
-
-    def test_assign_users_to_task_duplicate_users(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-        respondent_user: FidesUser,
-    ):
-        # Execute
-        manual_task_service.assign_users_to_task(
-            db, manual_task, [respondent_user.id, respondent_user.id]
+        # Verify logs
+        assign_log = next(
+            log for log in manual_task.logs if log.message == "Assign users to task"
         )
-
-        # Verify
-        assert (
-            len(manual_task.references) == 2
-        )  # The parent entity + one user (duplicate ignored)
-        assert all(
-            ref.reference_id == respondent_user.id
-            for ref in manual_task.references
-            if ref.reference_type == ManualTaskReferenceType.assigned_user
-        )
-
-        # Verify logs were created
-        assert len(manual_task.logs) == 2  # Create task and one update task
-
-    def test_assign_users_to_task_already_assigned(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-        respondent_user: FidesUser,
-    ):
-        # Setup - assign user first time
-        manual_task_service.assign_users_to_task(db, manual_task, [respondent_user.id])
-        initial_reference_count = len(manual_task.references)
-        initial_log_count = len(manual_task.logs)
-
-        # Execute - assign same user again
-        manual_task_service.assign_users_to_task(db, manual_task, [respondent_user.id])
-
-        # Verify - no new references or logs should be created
-        assert len(manual_task.references) == initial_reference_count
-        assert len(manual_task.logs) == initial_log_count
+        assert assign_log.details["assigned_users"] == sorted(expected_assigned)
+        if expected_not_assigned:
+            assert sorted(assign_log.details["user_ids_not_assigned"]) == sorted(
+                expected_not_assigned
+            )
 
 
 class TestUnassignUsersFromTask:
     """Tests for the unassign_users_from_task method."""
 
+    @pytest.mark.parametrize(
+        "initial_users,unassign_users,expected_remaining,expected_not_unassigned,should_raise",
+        [
+            (
+                ["respondent_user", "external_user"],  # initial_users
+                ["respondent_user", "external_user"],  # unassign_users
+                [],  # expected_remaining
+                [],  # expected_not_unassigned
+                False,  # should_raise
+            ),
+            (
+                ["respondent_user", "external_user"],  # initial_users
+                ["respondent_user", "user3"],  # unassign_users
+                ["external_user"],  # expected_remaining
+                ["user3"],  # expected_not_unassigned
+                False,  # should_raise
+            ),
+            (
+                [],  # initial_users
+                [],  # unassign_users
+                [],  # expected_remaining
+                [],  # expected_not_unassigned
+                True,  # should_raise
+            ),
+            (
+                ["respondent_user"],  # initial_users
+                ["respondent_user", "respondent_user"],  # unassign_users
+                [],  # expected_remaining
+                [],  # expected_not_unassigned
+                False,  # should_raise
+            ),
+        ],
+    )
     def test_unassign_users_from_task(
         self,
         db: Session,
@@ -311,17 +333,68 @@ class TestUnassignUsersFromTask:
         manual_task_service: ManualTaskService,
         respondent_user: FidesUser,
         external_user: FidesUser,
+        initial_users: list[str],
+        unassign_users: list[str],
+        expected_remaining: list[str],
+        expected_not_unassigned: list[str],
+        should_raise: bool,
     ):
-        # Setup
-        manual_task_service.assign_users_to_task(
-            db, manual_task, [respondent_user.id, external_user.id]
+        """Test unassigning users from tasks with various scenarios."""
+        # Replace placeholder user IDs with actual IDs
+        initial_users = [
+            (
+                respondent_user.id
+                if id == "respondent_user"
+                else external_user.id if id == "external_user" else id
+            )
+            for id in initial_users
+        ]
+        unassign_users = [
+            (
+                respondent_user.id
+                if id == "respondent_user"
+                else external_user.id if id == "external_user" else id
+            )
+            for id in unassign_users
+        ]
+        expected_remaining = [
+            (
+                respondent_user.id
+                if id == "respondent_user"
+                else external_user.id if id == "external_user" else id
+            )
+            for id in expected_remaining
+        ]
+
+        # Setup - assign initial users
+        if initial_users:
+            manual_task_service.assign_users_to_task(
+                task_id=manual_task.id, user_ids=initial_users
+            )
+
+        if should_raise:
+            with pytest.raises(
+                ValueError, match="User ID is required for unassignment"
+            ):
+                manual_task_service.unassign_users_from_task(
+                    task_id=manual_task.id, user_ids=unassign_users
+                )
+            return
+
+        # Execute
+        manual_task_service.unassign_users_from_task(
+            task_id=manual_task.id, user_ids=unassign_users
         )
 
-        # Verify
-        assert len(manual_task.references) == 3  # The parent entity + the two users
+        # Verify references
+        expected_ref_count = 1 + len(
+            expected_remaining
+        )  # parent entity + remaining users
+        assert len(manual_task.references) == expected_ref_count
+
         verify_expected_reference_ids(
             manual_task,
-            [manual_task.parent_entity_id, respondent_user.id, external_user.id],
+            [manual_task.parent_entity_id] + expected_remaining,
         )
         verify_expected_reference_types(
             manual_task,
@@ -331,132 +404,37 @@ class TestUnassignUsersFromTask:
             ],
         )
 
-        # Execute
-        manual_task_service.unassign_users_from_task(
-            db, manual_task, [respondent_user.id, external_user.id]
+        # Verify logs
+        unassign_log = next(
+            log for log in manual_task.logs if log.message == "Unassign users from task"
         )
-
-        # Verify
-        assert len(manual_task.references) == 1  # The parent entity
-        verify_expected_reference_ids(manual_task, [manual_task.parent_entity_id])
-        verify_expected_reference_types(
-            manual_task, [ManualTaskReferenceType.connection_config]
-        )
-
-        # Verify logs were created
-        assert (
-            len(manual_task.logs) == 5
-        )  # Create task and update tasks for the two users assign and unassign
-        update_logs = [
-            log for log in manual_task.logs if log.status == ManualTaskLogStatus.updated
-        ]
-        assert len(update_logs) == 4
-        verify_expected_logs(
-            update_logs,
-            [
-                f"User {respondent_user.id} unassigned from task",
-                f"User {external_user.id} unassigned from task",
-                f"User {respondent_user.id} assigned to task",
-                f"User {external_user.id} assigned to task",
-            ],
-        )
-
-    def test_unassign_users_from_task_partial(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-        respondent_user: FidesUser,
-        external_user: FidesUser,
-    ):
-        # Setup
-        assign_user_ids = [respondent_user.id, external_user.id]
-        unassign_user_ids = [respondent_user.id, "user3"]
-
-        manual_task_service.assign_users_to_task(db, manual_task, assign_user_ids)
-        # Execute
-        manual_task_service.unassign_users_from_task(db, manual_task, unassign_user_ids)
-
-        # Verify
-        assert len(manual_task.references) == 2  # The parent entity and external user
-        verify_expected_reference_ids(
-            manual_task, [manual_task.parent_entity_id, external_user.id]
-        )
-        verify_expected_reference_types(
-            manual_task,
-            [
-                ManualTaskReferenceType.connection_config,
-                ManualTaskReferenceType.assigned_user,
-            ],
-        )
-
-        # Verify logs were created
-        assert (
-            len(manual_task.logs) == 4
-        )  # Create task and update tasks for the two users (assigned) and one user unassigned
-
-        update_logs = [
-            log for log in manual_task.logs if log.status == ManualTaskLogStatus.updated
-        ]
-        verify_expected_logs(
-            update_logs,
-            [
-                f"User {respondent_user.id} unassigned from task",
-                f"User {respondent_user.id} assigned to task",
-                f"User {external_user.id} assigned to task",
-            ],
-        )
-
-    def test_unassign_users_from_task_empty_list(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-    ):
-        # Execute
-        with pytest.raises(ValueError, match="User ID is required for unassignment"):
-            manual_task_service.unassign_users_from_task(db, manual_task, [])
-
-    def test_unassign_users_from_task_duplicate_users(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-        respondent_user: FidesUser,
-    ):
-        # Setup
-        manual_task_service.assign_users_to_task(db, manual_task, [respondent_user.id])
-
-        # Execute
-        manual_task_service.unassign_users_from_task(
-            db, manual_task, [respondent_user.id, respondent_user.id]
-        )
-
-        # Verify
-        assert len(manual_task.references) == 1  # Only the parent entity
-        assert (
-            len(manual_task.logs) == 3
-        )  # Create task and two update tasks (assign and unassign)
+        successfully_unassigned = sorted(list(set(initial_users) & set(unassign_users)))
+        if successfully_unassigned:
+            assert unassign_log.details["unassigned_users"] == successfully_unassigned
+        if expected_not_unassigned:
+            assert sorted(unassign_log.details["user_ids_not_unassigned"]) == sorted(
+                expected_not_unassigned
+            )
 
 
 class TestManualTaskConfig:
     """Tests for the config-related methods."""
 
-    def test_create_config(
+    def test_config_lifecycle(
         self,
         db: Session,
         manual_task: ManualTask,
         manual_task_service: ManualTaskService,
     ):
-        """Test creating a new config for a task."""
-        # Execute
+        """Test the full lifecycle of a config - create and delete."""
+        # Create config
         manual_task_service.create_config(
-            task=manual_task,
+            task_id=manual_task.id,
             config_type=ManualTaskConfigurationType.access_privacy_request,
             fields=FIELDS,
         )
 
-        # Verify
+        # Verify config creation
         config = manual_task_service.config_service.get_current_config(
             task=manual_task,
             config_type=ManualTaskConfigurationType.access_privacy_request,
@@ -466,61 +444,54 @@ class TestManualTaskConfig:
         assert config.version == 1
         assert config.is_current is True
         assert len(config.field_definitions) == len(FIELDS)
-        field1 = next(
-            field for field in config.field_definitions if field.field_key == "field1"
-        )
-        field2 = next(
-            field for field in config.field_definitions if field.field_key == "field2"
-        )
-        assert field1.field_metadata["label"] == FIELDS[0]["field_metadata"]["label"]
-        assert field2.field_metadata["label"] == FIELDS[1]["field_metadata"]["label"]
 
-        # Verify log was created
-        log = (
+        # Verify field definitions
+        for field_key, expected_field in [
+            (TEXT_FIELD_KEY, FIELDS[0]),
+            (CHECKBOX_FIELD_KEY, FIELDS[1]),
+            (ATTACHMENT_FIELD_KEY, FIELDS[2]),
+        ]:
+            field = next(
+                field
+                for field in config.field_definitions
+                if field.field_key == field_key
+            )
+            assert (
+                field.field_metadata["label"]
+                == expected_field["field_metadata"]["label"]
+            )
+
+        # Verify creation logs
+        logs = (
             db.query(ManualTaskLog)
             .filter_by(task_id=manual_task.id)
             .order_by(ManualTaskLog.created_at.desc())
-            .first()
+            .all()
         )
-        assert log is not None
-        assert log.status == ManualTaskLogStatus.created
-        assert "Created new version 1 of configuration" in log.message
-        assert log.config_id == config.id
-
-    def test_delete_config(
-        self,
-        db: Session,
-        manual_task: ManualTask,
-        manual_task_service: ManualTaskService,
-    ):
-        """Test deleting a config for a task."""
-        # Setup - create config
-        manual_task_service.create_config(
-            task=manual_task,
-            config_type=ManualTaskConfigurationType.access_privacy_request,
-            fields=FIELDS,
+        assert any(
+            log.message == "Creating new configuration version"
+            and log.status == ManualTaskLogStatus.complete
+            and log.config_id == config.id
+            for log in logs
         )
-        config = manual_task_service.config_service.get_current_config(
-            task=manual_task,
-            config_type=ManualTaskConfigurationType.access_privacy_request,
-        )
-        assert config is not None
 
-        # Execute
-        manual_task_service.delete_config(manual_task, config)
+        # Delete config
+        manual_task_service.delete_config(config=config, task_id=manual_task.id)
+        db.commit()
+        db.refresh(manual_task)
 
-        # Verify
+        # Verify deletion
         assert db.query(ManualTaskConfig).filter_by(id=config.id).first() is None
 
-        # Verify log was created
-        log = (
+        # Query logs again after deletion
+        logs = (
             db.query(ManualTaskLog)
             .filter_by(task_id=manual_task.id)
             .order_by(ManualTaskLog.created_at.desc())
-            .first()
+            .all()
         )
-        assert log is not None
-        assert log.status == ManualTaskLogStatus.complete
-        assert (
-            f"Deleted manual task configuration for {config.config_type}" in log.message
+        assert any(
+            log.message == "Deleting Manual Task configuration"
+            and log.status == ManualTaskLogStatus.complete
+            for log in logs
         )

--- a/tests/service/manual_tasks/test_utils.py
+++ b/tests/service/manual_tasks/test_utils.py
@@ -1,0 +1,311 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fides.api.models.manual_tasks.manual_task_log import ManualTaskLog
+from fides.api.schemas.manual_tasks.manual_task_schemas import ManualTaskLogStatus
+from fides.api.schemas.manual_tasks.manual_task_status import StatusType
+from fides.service.manual_tasks.utils import TaskLogger, validate_fields
+
+
+def verify_expected_reference_types(manual_task, expected_reference_types):
+    """Verify that all references in the manual task have expected types."""
+    assert all(
+        ref.reference_type in expected_reference_types for ref in manual_task.references
+    )
+
+
+def verify_expected_reference_ids(manual_task, expected_reference_ids):
+    """Verify that all references in the manual task have expected IDs."""
+    assert all(
+        ref.reference_id in expected_reference_ids for ref in manual_task.references
+    )
+
+
+def verify_expected_logs(logs, expected_messages):
+    """Verify that all logs have expected messages."""
+    assert len(logs) == len(expected_messages)
+    assert all(log.message in expected_messages for log in logs)
+
+
+class TestValidateFields:
+    """Tests for the validate_fields function."""
+
+    @pytest.mark.parametrize(
+        "fields,is_submission,expected_error",
+        [
+            # Valid cases
+            pytest.param(
+                [
+                    {
+                        "field_key": "test_field",
+                        "field_type": "text",
+                        "field_metadata": {
+                            "label": "Test Field",
+                            "description": "A test field",
+                            "required": True,
+                        },
+                    }
+                ],
+                False,
+                None,
+                id="valid_fields",
+            ),
+            pytest.param(
+                [{"field_key": "test", "field_type": "text", "value": "test value"}],
+                True,
+                None,
+                id="valid_submission",
+            ),
+            # Error cases
+            pytest.param(
+                [
+                    {
+                        "field_key": "same_key",
+                        "field_type": "text",
+                        "field_metadata": {},
+                    },
+                    {
+                        "field_key": "same_key",
+                        "field_type": "text",
+                        "field_metadata": {},
+                    },
+                ],
+                False,
+                "Duplicate field keys found",
+                id="duplicate_field_keys",
+            ),
+            pytest.param(
+                [{"field_type": "text", "field_metadata": {}}],
+                False,
+                "field_key is required",
+                id="duplicate_field_keys",
+            ),
+            pytest.param(
+                [{"field_key": "test", "field_metadata": {}}],
+                False,
+                "field_type is required",
+                id="field_type_required",
+            ),
+            pytest.param(
+                [{"field_key": "test", "field_type": "text"}],
+                True,
+                "value is required for submissions",
+                id="value_required_for_submissions",
+            ),
+            pytest.param(
+                [
+                    {
+                        "field_key": "test",
+                        "field_type": "invalid_type",
+                        "field_metadata": {"label": "Test"},
+                    }
+                ],
+                False,
+                "Invalid field type",
+                id="invalid_field_type",
+            ),
+            pytest.param(
+                [
+                    {
+                        "field_key": "test",
+                        "field_type": "text",
+                        "field_metadata": {"invalid_key": "value"},
+                    }
+                ],
+                False,
+                "Invalid field data",
+                id="invalid_field_data",
+            ),
+        ],
+    )
+    def test_validate_fields(self, fields, is_submission, expected_error):
+        """Test field validation with various scenarios."""
+        if expected_error:
+            with pytest.raises(ValueError, match=expected_error):
+                validate_fields(fields, is_submission)
+        else:
+            validate_fields(fields, is_submission)  # Should not raise
+
+
+class TestTaskLogger:
+    """Tests for the TaskLogger decorator and utility methods."""
+
+    @pytest.fixture
+    def mock_db(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_service(self, mock_db):
+        service = MagicMock()
+        service.db = mock_db
+        return service
+
+    @pytest.mark.parametrize(
+        "return_value,expected_details,expected_status",
+        [
+            # Simple object return
+            (
+                type("TestResult", (), {"task_id": "123"}),
+                {},
+                ManualTaskLogStatus.complete,
+            ),
+            # Object with config_id
+            (
+                type("TestResult", (), {"task_id": "123", "config_id": "456"}),
+                {},
+                ManualTaskLogStatus.complete,
+            ),
+            # Tuple return with details
+            (
+                (
+                    type("TestResult", (), {"task_id": "123"}),
+                    {"details": {"test": "data"}},
+                ),
+                {"test": "data"},
+                ManualTaskLogStatus.complete,
+            ),
+            # Custom status
+            (
+                type("TestResult", (), {"task_id": "123"}),
+                {},
+                ManualTaskLogStatus.in_progress,
+            ),
+        ],
+    )
+    def test_successful_operations(
+        self, mock_service, return_value, expected_details, expected_status
+    ):
+        """Test successful operation logging with various return types."""
+
+        @TaskLogger("test operation", success_status=expected_status)
+        def test_method(self):
+            return return_value
+
+        with patch.object(ManualTaskLog, "create_log") as mock_create_log:
+            result = test_method(mock_service)
+
+            # Verify result
+            if isinstance(return_value, tuple):
+                assert result.task_id == return_value[0].task_id
+            else:
+                assert result.task_id == return_value.task_id
+
+            # Verify log
+            mock_create_log.assert_called_once()
+            call_args = mock_create_log.call_args[1]
+            assert call_args["task_id"] == "123"
+            assert call_args["status"] == expected_status
+            assert call_args["message"] == "test operation"
+            assert call_args["details"] == expected_details
+
+    @pytest.mark.parametrize(
+        "error_type,error_msg,task_id,expected_msg",
+        [
+            pytest.param(
+                ValueError,
+                "value error",
+                "123",
+                "Error in test operation: value error",
+            ),
+            pytest.param(
+                KeyError,
+                "key error",
+                "123",
+                "Error in test operation: 'key error'",
+            ),
+            pytest.param(
+                Exception,
+                "generic error",
+                None,
+                None,  # No message expected when task_id is None
+            ),
+        ],
+        ids=["value_error", "key_error", "no_task_id"],
+    )
+    def test_error_handling(
+        self, mock_service, error_type, error_msg, task_id, expected_msg
+    ):
+        """Test error logging with different error types."""
+
+        @TaskLogger("test operation")
+        def test_method(self, **kwargs):
+            raise error_type(error_msg)
+
+        with patch.object(ManualTaskLog, "create_log") as mock_create_log:
+            with pytest.raises(error_type):
+                test_method(mock_service, task_id=task_id)
+
+            if task_id:
+                mock_create_log.assert_called_once()
+                call_args = mock_create_log.call_args[1]
+                assert call_args["task_id"] == task_id
+                assert call_args["status"] == ManualTaskLogStatus.error
+                assert call_args["message"] == expected_msg
+            else:
+                mock_create_log.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "entity_type,entity_id,expected_id_fields",
+        [
+            ("task", "123", {"task_id": "123"}),
+            ("config", "456", {"task_id": "123", "config_id": "456"}),
+            ("instance", "789", {"task_id": "123", "instance_id": "789"}),
+            ("submission", "789", {"task_id": "123", "instance_id": "789"}),
+        ],
+        ids=["task", "config", "instance", "submission"],
+    )
+    def test_log_create(self, mock_db, entity_type, entity_id, expected_id_fields):
+        """Test creation logging for different entity types."""
+        with patch.object(ManualTaskLog, "create_log") as mock_create_log:
+            TaskLogger.log_create(
+                db=mock_db,
+                task_id="123",
+                entity_type=entity_type,
+                entity_id=entity_id,
+                details={"test": "data"},
+                user_id="user123",
+            )
+
+            mock_create_log.assert_called_once()
+            call_args = mock_create_log.call_args[1]
+            assert all(call_args[k] == v for k, v in expected_id_fields.items())
+            assert call_args["status"] == ManualTaskLogStatus.created
+            assert call_args["message"] == f"Created new {entity_type}"
+            assert call_args["details"] == {"test": "data", "user_id": "user123"}
+
+    def test_log_status_change(self, mock_db):
+        """Test status change logging."""
+        with patch.object(ManualTaskLog, "create_log") as mock_create_log:
+            TaskLogger.log_status_change(
+                db=mock_db,
+                task_id="123",
+                config_id="456",
+                instance_id="789",
+                previous_status=StatusType.pending,
+                new_status=StatusType.in_progress,
+                user_id="user123",
+            )
+
+            mock_create_log.assert_called_once()
+            call_args = mock_create_log.call_args[1]
+            assert call_args["task_id"] == "123"
+            assert call_args["config_id"] == "456"
+            assert call_args["instance_id"] == "789"
+            assert call_args["status"] == ManualTaskLogStatus.in_progress
+            assert "transitioning from pending to in_progress" in call_args["message"]
+            assert call_args["details"] == {
+                "previous_status": StatusType.pending,
+                "new_status": StatusType.in_progress,
+                "user_id": "user123",
+            }
+
+    def test_invalid_entity_type(self, mock_db):
+        """Test log_create with invalid entity type."""
+        with pytest.raises(ValueError, match="Invalid entity type"):
+            TaskLogger.log_create(
+                db=mock_db,
+                task_id="123",
+                entity_type="invalid",
+                entity_id="456",
+            )


### PR DESCRIPTION
Issue [ENG-602](https://ethyca.atlassian.net/browse/ENG-602)

### Description Of Changes
[Link](https://ethyca.atlassian.net/wiki/x/BoDq3w) to Product/Eng Design/Threat assesment pages

Needed to add some utility functions for better handling logging etc. This is pulled out into its own PR to cut down on the length of #6212 but ultimately is part of getting instances in. 

This is the full model - the area outlined in green is covered by this PR. 

![image](https://github.com/user-attachments/assets/5678d390-bc8a-4a0d-ab6a-ab78a05f9cb3)


#### The ManualTask model has the following elements. 

#6205 
**ManualTask**: This piece is the large concept which is used to connect a task to another operation. The model is open ended so we can reuse it in the future if we have another use case pop up. 

For this use case the task is an "integration" for a connection config. The `parent_entity` in the model will be the connection_config_id. This will help maintain the single integration for a connection config and give us a concrete link between the manual tasks for the associated privacy requests and the single connection config. 

**ManualTaskReference**: This is used to make associations with anything outside of the ManualTask hierarchy - the main use case that I know of at this time is users. When one or more users are assigned to a task there will be a reference created linking the `user_id`s to the `ManualTask.id` This allows us to have an indeterminate number of external entities associated with a task. This leaves the options open ended and allows for extensibility and re-use of the ManualTask classes.

#6208 
**ManualTaskConfig**: This is a single reference for a set of Fields. When a user sets up a ManualTask they will configure it with data needed to complete the task. This may be a check box or an attachment or a form with fields completed. A single Manual Task may have multiple configurations. (For this use case think: Access Privacy Requests vs Erasure Privacy Requests having potentially different required information.) The configurations are also versioned so when a user wants to change the required info existing instances of the task do not become null and the information can still be retrieved. (More on instances below)

**ManualTaskConfigField**: This is a single data input requirement for a config. A Config can have as many fields as the user wants. The fields can be attachments, checkboxes, or text. 

**You are here **

#6212 
**ManualTaskInstance**: A single instance of a ManualTask/Config being referenced. For this use case when a Privacy Request is created we will also create an instance of the Manual Task with the correct config (access vs erasure) This instance will be specific to the privacy request and all submissions will reference this specific instance. If a Config is updated it will create a new version and the instances will reference whatever version was active when they were created. This will keep us from losing data or the ability to retrieve data from specific submissions.  An instance of a task cannot be completed until all required fields have a submission.

**ManualTaskSubmission**: There is a single submission per ManualTaskConfigField per ManualTaskInstance. A submission would be the checkbox status (T/F), the text data or an attachment reference. Attachments are handled through the Attachment reference table so we don't need to do anything extra here to store their information.

Flow Chart for Manual DSR Tasks
![image](https://github.com/user-attachments/assets/5160d845-1083-4a34-8e25-1f7a22499dc1)


### Code Changes

* Added a util file with better logging handling
* Added tests
* Updated the other manual step services with the new configs
* Updated the other service's tests.

### Steps to Confirm

1.  This is currently not attached to any api endpoints. All tests should pass. 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-602]: https://ethyca.atlassian.net/browse/ENG-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ