### PR TITLE
Consistent event trigger information in FidesJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added support for Salesforce custom object monitoring using Helios [#6096](https://github.com/ethyca/fides/pull/6096)
 - Added ManualTaskConfig and ManualTaskConfigField models, foundational for for ManualDSRs [#6208](https://github.com/ethyca/fides/pull/6208) https://github.com/ethyca/fides/labels/db-migration
 - Adds config for sale_of_data default in Fides Shopify integration [#6233](https://github.com/ethyca/fides/pull/6233)
+- Added detailed trigger tracking to all FidesJS events including element type, label, and interaction origin [#6229](https://github.com/ethyca/fides/pull/6229)
 - Added validation for URLs in website integration forms [#6230](https://github.com/ethyca/fides/pull/6230)
 
 ### Changed

--- a/clients/fides-js/docs/interfaces/FidesEvent.md
+++ b/clients/fides-js/docs/interfaces/FidesEvent.md
@@ -131,9 +131,8 @@ What consent method (if any) caused this event.
 
 > `optional` **trigger**: `object`
 
-What UI element (if any) triggered this event. Some scripts accept a
-trigger object as an optional parameter which can be used to customize
-the event details.
+What UI element (if any) triggered this event, as well as the origin of
+the event.
 
 #### extraDetails.trigger.origin?
 

--- a/clients/fides-js/docs/interfaces/FidesEvent.md
+++ b/clients/fides-js/docs/interfaces/FidesEvent.md
@@ -136,7 +136,7 @@ the event.
 
 #### extraDetails.trigger.origin?
 
-> `optional` **origin**: `string`
+> `optional` **origin**: `"fides"` \| `"external"`
 
 Where the event originated from. If the event was triggered using an
 SDK script, for example, this will be "external", meaning the event

--- a/clients/fides-js/docs/interfaces/FidesEvent.md
+++ b/clients/fides-js/docs/interfaces/FidesEvent.md
@@ -123,7 +123,7 @@ Whether the user should be shown the consent experience. Only available on Fides
 
 #### extraDetails.consentMethod?
 
-> `optional` **consentMethod**: `"accept"` \| `"reject"` \| `"save"` \| `"dismiss"` \| `"gpc"`
+> `optional` **consentMethod**: `"accept"` \| `"reject"` \| `"save"` \| `"dismiss"` \| `"acknowledge"` \| `"gpc"` \| `"script"` \| `"ot_migration"`
 
 What consent method (if any) caused this event.
 
@@ -131,14 +131,25 @@ What consent method (if any) caused this event.
 
 > `optional` **trigger**: `object`
 
-What UI element (if any) triggered this event.
+What UI element (if any) triggered this event. Some scripts accept a
+trigger object as an optional parameter which can be used to customize
+the event details.
 
-#### extraDetails.trigger.type
+#### extraDetails.trigger.origin?
 
-> **type**: `"toggle"`
+> `optional` **origin**: `string`
+
+Where the event originated from. If the event was triggered using an
+SDK script, for example, this will be "external", meaning the event
+was triggered by something other than a FidesJS UI element.
+
+#### extraDetails.trigger.type?
+
+> `optional` **type**: `"toggle"` \| `"button"` \| `"link"`
 
 The type of element that triggered the event. Additional types may be
-added over time (e.g. "button", "link"), so expect this type to grow.
+added over time, so expect this type to grow.
+Only present when origin is "fides".
 
 #### extraDetails.trigger.label?
 

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -135,6 +135,16 @@ const SCRIPTS = [
 const rollupOptions = [];
 
 /**
+ * Ignore circular dependency warnings from node_modules
+ * that we don't control.
+ */
+const onLog = (_, { code, message }) => {
+  if (code === "CIRCULAR_DEPENDENCY" && message.includes("node_modules")) {
+    return;
+  }
+};
+
+/**
  * For each of our entrypoint scripts, build .js, .mjs, and .d.ts outputs
  */
 SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
@@ -157,6 +167,7 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
         },
       },
     ],
+    onLog,
   };
   const mjs = {
     input: `src/${name}.ts`,
@@ -180,6 +191,7 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
         sourcemap: true,
       },
     ],
+    onLog,
   };
   const declaration = {
     input: `src/${name}.ts`,

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -14,8 +14,8 @@ import fs from "fs";
 
 const NAME = "fides";
 const IS_DEV = process.env.NODE_ENV === "development";
-const GZIP_SIZE_ERROR_KB = 45; // fail build if bundle size exceeds this
-const GZIP_SIZE_WARN_KB = 35; // log a warning if bundle size exceeds this
+const GZIP_SIZE_ERROR_KB = 50; // fail build if bundle size exceeds this
+const GZIP_SIZE_WARN_KB = 45; // log a warning if bundle size exceeds this
 
 // TCF
 const GZIP_SIZE_TCF_ERROR_KB = 91;

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -1,14 +1,13 @@
 import { ComponentChildren, FunctionComponent, h, VNode } from "preact";
 import { useEffect } from "preact/hooks";
 
-import { FidesEventTargetType } from "~/lib/events";
-
 import { getConsentContext } from "../lib/consent-context";
 import {
   GpcStatus,
   PrivacyExperience,
   PrivacyNoticeWithPreference,
 } from "../lib/consent-types";
+import { FidesEventTargetType } from "../lib/events";
 import { messageExists } from "../lib/i18n";
 import { useI18n } from "../lib/i18n/i18n-context";
 import { useEvent } from "../lib/providers/event-context";

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -1,6 +1,8 @@
 import { ComponentChildren, FunctionComponent, h, VNode } from "preact";
 import { useEffect } from "preact/hooks";
 
+import { FidesEventTargetType } from "~/lib/events";
+
 import { getConsentContext } from "../lib/consent-context";
 import {
   GpcStatus,
@@ -89,7 +91,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
             ariaLabel="Close banner"
             onClick={() => {
               setTrigger({
-                type: "button",
+                type: FidesEventTargetType.BUTTON,
                 label: "Close banner",
               });
               onClose();

--- a/clients/fides-js/src/components/ConsentBanner.tsx
+++ b/clients/fides-js/src/components/ConsentBanner.tsx
@@ -9,6 +9,7 @@ import {
 } from "../lib/consent-types";
 import { messageExists } from "../lib/i18n";
 import { useI18n } from "../lib/i18n/i18n-context";
+import { useEvent } from "../lib/providers/event-context";
 import CloseButton from "./CloseButton";
 import ExperienceDescription from "./ExperienceDescription";
 import { GpcBadge } from "./GpcBadge";
@@ -42,7 +43,7 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
 }) => {
   const { i18n } = useI18n();
   const showGpcBadge = getConsentContext().globalPrivacyControl;
-
+  const { setTrigger } = useEvent();
   useEffect(() => {
     if (bannerIsOpen) {
       onOpen();
@@ -86,7 +87,13 @@ const ConsentBanner: FunctionComponent<BannerProps> = ({
         <div id="fides-banner-inner">
           <CloseButton
             ariaLabel="Close banner"
-            onClick={onClose}
+            onClick={() => {
+              setTrigger({
+                type: "button",
+                label: "Close banner",
+              });
+              onClose();
+            }}
             hidden={window.Fides?.options?.preventDismissal || !dismissable}
           />
           <div id="fides-banner-inner-container">

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -8,6 +8,7 @@ import {
   PrivacyExperience,
   PrivacyNotice,
 } from "../lib/consent-types";
+import { FidesEventTargetType } from "../lib/events";
 import { useMediaQuery } from "../lib/hooks/useMediaQuery";
 import { DEFAULT_LOCALE, Locale, messageExists } from "../lib/i18n";
 import { useI18n } from "../lib/i18n/i18n-context";
@@ -87,7 +88,7 @@ export const ConsentButtons = ({
                 label={i18n.t("exp.privacy_preferences_link_label")}
                 onClick={() => {
                   setTrigger({
-                    type: "button",
+                    type: FidesEventTargetType.BUTTON,
                     label: i18n.t("exp.privacy_preferences_link_label"),
                   });
                   handleTCFManagePreferencesClick();
@@ -102,7 +103,7 @@ export const ConsentButtons = ({
                 label={i18n.t("exp.reject_button_label")}
                 onClick={() => {
                   setTrigger({
-                    type: "button",
+                    type: FidesEventTargetType.BUTTON,
                     label: i18n.t("exp.reject_button_label"),
                   });
                   onRejectAll();
@@ -116,7 +117,7 @@ export const ConsentButtons = ({
               label={i18n.t("exp.accept_button_label")}
               onClick={() => {
                 setTrigger({
-                  type: "button",
+                  type: FidesEventTargetType.BUTTON,
                   label: i18n.t("exp.accept_button_label"),
                 });
                 onAcceptAll();
@@ -149,7 +150,7 @@ export const ConsentButtons = ({
             label={i18n.t("exp.privacy_preferences_link_label")}
             onClick={() => {
               setTrigger({
-                type: "button",
+                type: FidesEventTargetType.BUTTON,
                 label: i18n.t("exp.privacy_preferences_link_label"),
               });
               onManagePreferencesClick();
@@ -217,7 +218,7 @@ export const NoticeConsentButtons = ({
           label={i18n.t("exp.acknowledge_button_label")}
           onClick={() => {
             setTrigger({
-              type: "button",
+              type: FidesEventTargetType.BUTTON,
               label: i18n.t("exp.acknowledge_button_label"),
             });
             handleAcknowledgeNotices();
@@ -233,7 +234,7 @@ export const NoticeConsentButtons = ({
           label={i18n.t("exp.save_button_label")}
           onClick={() => {
             setTrigger({
-              type: "button",
+              type: FidesEventTargetType.BUTTON,
               label: i18n.t("exp.save_button_label"),
             });
             handleSave();

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -11,12 +11,13 @@ import {
 import { useMediaQuery } from "../lib/hooks/useMediaQuery";
 import { DEFAULT_LOCALE, Locale, messageExists } from "../lib/i18n";
 import { useI18n } from "../lib/i18n/i18n-context";
+import { useEvent } from "../lib/providers/event-context";
 import BrandLink from "./BrandLink";
 import Button from "./Button";
 import LanguageSelector from "./LanguageSelector";
 import PrivacyPolicyLink from "./PrivacyPolicyLink";
 
-interface ConsentButtonProps {
+interface ConsentButtonsProps {
   availableLocales?: Locale[];
   onManagePreferencesClick?: () => void;
   renderFirstButton?: () => VNode | null;
@@ -43,15 +44,16 @@ export const ConsentButtons = ({
   isTCF,
   isMinimalTCF,
   isGVLLoading,
-}: ConsentButtonProps) => {
+}: ConsentButtonsProps) => {
   const [isLoadingModal, setIsLoadingModal] = useState<boolean>(false);
   const { i18n } = useI18n();
+  const { setTrigger } = useEvent();
   const isMobile = useMediaQuery("(max-width: 768px)");
   const includeLanguageSelector = i18n.availableLanguages?.length > 1;
   const includePrivacyPolicyLink =
     messageExists(i18n, "exp.privacy_policy_link_label") &&
     messageExists(i18n, "exp.privacy_policy_url");
-  const handleManagePreferencesClick = () => {
+  const handleTCFManagePreferencesClick = () => {
     const isReady = !isTCF || !isMinimalTCF;
     setIsLoadingModal(!isReady);
     if (onManagePreferencesClick && isReady) {
@@ -62,7 +64,7 @@ export const ConsentButtons = ({
 
   useEffect(() => {
     if (isLoadingModal && !isMinimalTCF) {
-      handleManagePreferencesClick();
+      handleTCFManagePreferencesClick();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoadingModal, isMinimalTCF]);
@@ -83,7 +85,13 @@ export const ConsentButtons = ({
               <Button
                 buttonType={ButtonType.SECONDARY}
                 label={i18n.t("exp.privacy_preferences_link_label")}
-                onClick={handleManagePreferencesClick}
+                onClick={() => {
+                  setTrigger({
+                    type: "button",
+                    label: i18n.t("exp.privacy_preferences_link_label"),
+                  });
+                  handleTCFManagePreferencesClick();
+                }}
                 className="fides-manage-preferences-button"
                 loading={isLoadingModal}
               />
@@ -92,7 +100,13 @@ export const ConsentButtons = ({
               <Button
                 buttonType={ButtonType.PRIMARY}
                 label={i18n.t("exp.reject_button_label")}
-                onClick={onRejectAll}
+                onClick={() => {
+                  setTrigger({
+                    type: "button",
+                    label: i18n.t("exp.reject_button_label"),
+                  });
+                  onRejectAll();
+                }}
                 className="fides-reject-all-button"
                 loading={isGVLLoading}
               />
@@ -100,7 +114,13 @@ export const ConsentButtons = ({
             <Button
               buttonType={ButtonType.PRIMARY}
               label={i18n.t("exp.accept_button_label")}
-              onClick={onAcceptAll}
+              onClick={() => {
+                setTrigger({
+                  type: "button",
+                  label: i18n.t("exp.accept_button_label"),
+                });
+                onAcceptAll();
+              }}
               className="fides-accept-all-button"
               loading={isGVLLoading}
             />
@@ -127,7 +147,13 @@ export const ConsentButtons = ({
           <Button
             buttonType={isMobile ? ButtonType.SECONDARY : ButtonType.TERTIARY}
             label={i18n.t("exp.privacy_preferences_link_label")}
-            onClick={onManagePreferencesClick}
+            onClick={() => {
+              setTrigger({
+                type: "button",
+                label: i18n.t("exp.privacy_preferences_link_label"),
+              });
+              onManagePreferencesClick();
+            }}
             className="fides-manage-preferences-button"
           />
         )}
@@ -166,6 +192,7 @@ export const NoticeConsentButtons = ({
   options,
 }: NoticeConsentButtonProps) => {
   const { i18n } = useI18n();
+  const { setTrigger } = useEvent();
   if (!experience.experience_config || !experience.privacy_notices) {
     return null;
   }
@@ -188,7 +215,13 @@ export const NoticeConsentButtons = ({
         <Button
           buttonType={ButtonType.PRIMARY}
           label={i18n.t("exp.acknowledge_button_label")}
-          onClick={handleAcknowledgeNotices}
+          onClick={() => {
+            setTrigger({
+              type: "button",
+              label: i18n.t("exp.acknowledge_button_label"),
+            });
+            handleAcknowledgeNotices();
+          }}
           className="fides-acknowledge-button"
         />
       );
@@ -198,7 +231,13 @@ export const NoticeConsentButtons = ({
         <Button
           buttonType={hideOptInOut ? ButtonType.PRIMARY : ButtonType.SECONDARY}
           label={i18n.t("exp.save_button_label")}
-          onClick={handleSave}
+          onClick={() => {
+            setTrigger({
+              type: "button",
+              label: i18n.t("exp.save_button_label"),
+            });
+            handleSave();
+          }}
           className="fides-save-button"
         />
       );

--- a/clients/fides-js/src/components/ConsentModal.tsx
+++ b/clients/fides-js/src/components/ConsentModal.tsx
@@ -2,6 +2,7 @@ import { ComponentChildren, h, VNode } from "preact";
 import { HTMLAttributes } from "preact/compat";
 
 import { Attributes } from "../lib/a11y-dialog";
+import { useEvent } from "../lib/providers/event-context";
 import CloseButton from "./CloseButton";
 import ConsentContent from "./ConsentContent";
 
@@ -19,7 +20,7 @@ const ConsentModal = ({
   renderModalFooter: () => VNode | null;
 }) => {
   const { container, overlay, dialog, title, closeButton } = attributes;
-
+  const { setTrigger } = useEvent();
   return (
     <div
       data-testid="consent-modal"
@@ -36,7 +37,13 @@ const ConsentModal = ({
           <div />
           <CloseButton
             ariaLabel="Close modal"
-            onClick={closeButton.onClick}
+            onClick={() => {
+              setTrigger({
+                type: "button",
+                label: "Close modal",
+              });
+              closeButton.onClick();
+            }}
             hidden={window.Fides.options.preventDismissal || !dismissable}
           />
         </div>

--- a/clients/fides-js/src/components/DataUseToggle.tsx
+++ b/clients/fides-js/src/components/DataUseToggle.tsx
@@ -1,6 +1,5 @@
 import { ComponentChildren, h, VNode } from "preact";
 
-import { FidesEventDetailsTrigger } from "../lib/events";
 import { useDisclosure } from "../lib/hooks";
 import Toggle from "./Toggle";
 
@@ -21,10 +20,7 @@ const DataUseToggle = ({
   noticeKey: string;
   title: string;
   checked: boolean;
-  onToggle: (
-    noticeKey: string,
-    triggerDetails: FidesEventDetailsTrigger,
-  ) => void;
+  onToggle: (noticeKey: string) => void;
   children?: ComponentChildren;
   badge?: string;
   gpcBadge?: VNode;

--- a/clients/fides-js/src/components/ExperienceDescription.tsx
+++ b/clients/fides-js/src/components/ExperienceDescription.tsx
@@ -1,8 +1,7 @@
 import { Fragment, h } from "preact";
 import { useContext, useEffect, useState } from "preact/hooks";
 
-import { FidesEventTargetType } from "~/lib/events";
-
+import { FidesEventTargetType } from "../lib/events";
 import { useEvent } from "../lib/providers/event-context";
 import { VendorButtonContext } from "../lib/tcf/vendor-button-context";
 import { stripHtml } from "../lib/ui-utils";

--- a/clients/fides-js/src/components/ExperienceDescription.tsx
+++ b/clients/fides-js/src/components/ExperienceDescription.tsx
@@ -58,7 +58,7 @@ const ExperienceDescription = ({
                 onClick={() => {
                   setTrigger({
                     type: "link",
-                    label: "__VENDOR_COUNT_LINK__",
+                    label: VENDOR_COUNT_LINK, // The assumption is that consistency is more important than the actual number of vendors here, so we use the replacement string. Change if this becomes problematic.
                   });
                   onVendorPageClick?.();
                 }}

--- a/clients/fides-js/src/components/ExperienceDescription.tsx
+++ b/clients/fides-js/src/components/ExperienceDescription.tsx
@@ -1,6 +1,8 @@
 import { Fragment, h } from "preact";
 import { useContext, useEffect, useState } from "preact/hooks";
 
+import { FidesEventTargetType } from "~/lib/events";
+
 import { useEvent } from "../lib/providers/event-context";
 import { VendorButtonContext } from "../lib/tcf/vendor-button-context";
 import { stripHtml } from "../lib/ui-utils";
@@ -58,7 +60,7 @@ const ExperienceDescription = ({
                 onClick={() => {
                   if (onVendorPageClick) {
                     setTrigger({
-                      type: "link",
+                      type: FidesEventTargetType.LINK,
                       label: VENDOR_COUNT_LINK, // The assumption is that consistency is more important than the actual number of vendors here, so we use the replacement string. Change if this becomes problematic.
                     });
                     onVendorPageClick();

--- a/clients/fides-js/src/components/ExperienceDescription.tsx
+++ b/clients/fides-js/src/components/ExperienceDescription.tsx
@@ -1,6 +1,7 @@
 import { Fragment, h } from "preact";
 import { useContext, useEffect, useState } from "preact/hooks";
 
+import { useEvent } from "../lib/providers/event-context";
 import { VendorButtonContext } from "../lib/tcf/vendor-button-context";
 import { stripHtml } from "../lib/ui-utils";
 
@@ -31,6 +32,7 @@ const ExperienceDescription = ({
 }) => {
   const [renderedDescription, setRenderedDescription] =
     useState<(string | h.JSX.Element)[]>();
+  const { setTrigger } = useEvent();
   let vendorCount = 0;
   const context = useContext(VendorButtonContext);
   if (context?.vendorCount) {
@@ -53,7 +55,13 @@ const ExperienceDescription = ({
               <button
                 type="button"
                 className="fides-link-button fides-vendor-count"
-                onClick={onVendorPageClick}
+                onClick={() => {
+                  setTrigger({
+                    type: "link",
+                    label: "__VENDOR_COUNT_LINK__",
+                  });
+                  onVendorPageClick?.();
+                }}
               >
                 {vendorCount}
               </button>{" "}

--- a/clients/fides-js/src/components/ExperienceDescription.tsx
+++ b/clients/fides-js/src/components/ExperienceDescription.tsx
@@ -56,11 +56,13 @@ const ExperienceDescription = ({
                 type="button"
                 className="fides-link-button fides-vendor-count"
                 onClick={() => {
-                  setTrigger({
-                    type: "link",
-                    label: VENDOR_COUNT_LINK, // The assumption is that consistency is more important than the actual number of vendors here, so we use the replacement string. Change if this becomes problematic.
-                  });
-                  onVendorPageClick?.();
+                  if (onVendorPageClick) {
+                    setTrigger({
+                      type: "link",
+                      label: VENDOR_COUNT_LINK, // The assumption is that consistency is more important than the actual number of vendors here, so we use the replacement string. Change if this becomes problematic.
+                    });
+                    onVendorPageClick();
+                  }
                 }}
               >
                 {vendorCount}

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -61,7 +61,7 @@ const Overlay: FunctionComponent<Props> = ({
   isUiBlocking,
 }) => {
   const { i18n } = useI18n();
-  const { dispatchFidesEventAndClearTrigger } = useEvent();
+  const { setServingComponent, dispatchFidesEventAndClearTrigger } = useEvent();
   const delayBannerMilliseconds = 100;
   const hasMounted = useHasMounted();
   const modalLinkId = options.modalLinkId || "fides-modal-link";
@@ -108,8 +108,9 @@ const Overlay: FunctionComponent<Props> = ({
         onDismiss();
       }
       dispatchFidesEventAndClearTrigger("FidesModalClosed", cookie, { saved });
+      setServingComponent(undefined);
     },
-    [dispatchFidesEventAndClearTrigger, cookie, onDismiss],
+    [dispatchFidesEventAndClearTrigger, cookie, onDismiss, setServingComponent],
   );
 
   const { instance, attributes } = useA11yDialog({

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -38,7 +38,7 @@ interface Props {
   experience: PrivacyExperience | PrivacyExperienceMinimal;
   cookie: FidesCookie;
   savedConsent: NoticeConsent;
-  onOpen: () => void;
+  onOpen: (origin?: string) => void;
   onDismiss: () => void;
   renderBanner: (props: RenderBannerProps) => VNode | null;
   renderModalContent?: () => VNode | null;
@@ -122,15 +122,18 @@ const Overlay: FunctionComponent<Props> = ({
     },
   });
 
-  const handleOpenModal = useCallback(() => {
-    if (options.fidesEmbed) {
-      setBannerIsOpen(false);
-    } else if (instance) {
-      setBannerIsOpen(false);
-      instance.show();
-      onOpen();
-    }
-  }, [instance, onOpen, options]);
+  const handleOpenModal = useCallback(
+    (origin = "fides") => {
+      if (options.fidesEmbed) {
+        setBannerIsOpen(false);
+      } else if (instance) {
+        setBannerIsOpen(false);
+        instance.show();
+        onOpen(origin);
+      }
+    },
+    [instance, onOpen, options],
+  );
 
   const handleCloseModalAfterSave = useCallback(() => {
     if (instance && !options.fidesEmbed) {
@@ -157,7 +160,9 @@ const Overlay: FunctionComponent<Props> = ({
 
   useEffect(() => {
     if (!!experience && !options.fidesEmbed) {
-      window.Fides.showModal = handleOpenModal;
+      window.Fides.showModal = () => {
+        handleOpenModal("external");
+      };
     }
     return () => {
       window.Fides.showModal = defaultShowModal;

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -14,9 +14,9 @@ import {
   PrivacyExperienceMinimal,
 } from "../lib/consent-types";
 import { defaultShowModal, shouldResurfaceBanner } from "../lib/consent-utils";
-import { dispatchFidesEvent } from "../lib/events";
 import { useElementById, useHasMounted } from "../lib/hooks";
 import { useI18n } from "../lib/i18n/i18n-context";
+import { useEvent } from "../lib/providers/event-context";
 import { blockPageScrolling, unblockPageScrolling } from "../lib/ui-utils";
 import ConsentContent from "./ConsentContent";
 import ConsentModal from "./ConsentModal";
@@ -61,6 +61,7 @@ const Overlay: FunctionComponent<Props> = ({
   isUiBlocking,
 }) => {
   const { i18n } = useI18n();
+  const { dispatchFidesEventAndClearTrigger } = useEvent();
   const delayBannerMilliseconds = 100;
   const hasMounted = useHasMounted();
   const modalLinkId = options.modalLinkId || "fides-modal-link";
@@ -103,12 +104,12 @@ const Overlay: FunctionComponent<Props> = ({
 
   const dispatchCloseEvent = useCallback(
     ({ saved = false }: { saved?: boolean }) => {
-      dispatchFidesEvent("FidesModalClosed", cookie, { saved });
       if (!saved) {
         onDismiss();
       }
+      dispatchFidesEventAndClearTrigger("FidesModalClosed", cookie, { saved });
     },
-    [cookie, onDismiss],
+    [dispatchFidesEventAndClearTrigger, cookie, onDismiss],
   );
 
   const { instance, attributes } = useA11yDialog({

--- a/clients/fides-js/src/components/Overlay.tsx
+++ b/clients/fides-js/src/components/Overlay.tsx
@@ -14,6 +14,7 @@ import {
   PrivacyExperienceMinimal,
 } from "../lib/consent-types";
 import { defaultShowModal, shouldResurfaceBanner } from "../lib/consent-utils";
+import { FidesEventOrigin } from "../lib/events";
 import { useElementById, useHasMounted } from "../lib/hooks";
 import { useI18n } from "../lib/i18n/i18n-context";
 import { useEvent } from "../lib/providers/event-context";
@@ -123,7 +124,7 @@ const Overlay: FunctionComponent<Props> = ({
   });
 
   const handleOpenModal = useCallback(
-    (origin = "fides") => {
+    (origin = FidesEventOrigin.FIDES) => {
       if (options.fidesEmbed) {
         setBannerIsOpen(false);
       } else if (instance) {
@@ -161,7 +162,7 @@ const Overlay: FunctionComponent<Props> = ({
   useEffect(() => {
     if (!!experience && !options.fidesEmbed) {
       window.Fides.showModal = () => {
-        handleOpenModal("external");
+        handleOpenModal(FidesEventOrigin.EXTERNAL);
       };
     }
     return () => {

--- a/clients/fides-js/src/components/Toggle.tsx
+++ b/clients/fides-js/src/components/Toggle.tsx
@@ -1,6 +1,6 @@
 import { h } from "preact";
 
-import { FidesEventDetailsTrigger } from "../lib/events";
+import { useEvent } from "../lib/providers/event-context";
 
 const Toggle = ({
   label,
@@ -16,14 +16,12 @@ const Toggle = ({
   name: string;
   id: string;
   checked: boolean;
-  onChange: (
-    noticeKey: string,
-    triggerDetails: FidesEventDetailsTrigger,
-  ) => void;
+  onChange: (noticeKey: string) => void;
   disabled?: boolean;
   onLabel?: string;
   offLabel?: string;
 }) => {
+  const { setTrigger } = useEvent();
   const labelText = checked ? onLabel : offLabel;
   return (
     <div className="fides-toggle" data-testid={`toggle-${label}`}>
@@ -33,11 +31,12 @@ const Toggle = ({
         aria-label={label}
         className="fides-toggle-input"
         onChange={() => {
-          onChange(id, {
+          setTrigger({
             type: "toggle",
             label,
             checked: !checked,
           });
+          onChange(id);
         }}
         checked={checked}
         role="switch"

--- a/clients/fides-js/src/components/Toggle.tsx
+++ b/clients/fides-js/src/components/Toggle.tsx
@@ -1,5 +1,6 @@
 import { h } from "preact";
 
+import { FidesEventTargetType } from "../lib/events";
 import { useEvent } from "../lib/providers/event-context";
 
 const Toggle = ({
@@ -32,7 +33,7 @@ const Toggle = ({
         className="fides-toggle-input"
         onChange={() => {
           setTrigger({
-            type: "toggle",
+            type: FidesEventTargetType.TOGGLE,
             label,
             checked: !checked,
           });

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -26,7 +26,10 @@ import {
   getFidesConsentCookie,
   updateCookieFromNoticePreferences,
 } from "../../lib/cookie";
-import { FidesEventDetailsPreference } from "../../lib/events";
+import {
+  FidesEventDetailsPreference,
+  FidesEventDetailsServingComponent,
+} from "../../lib/events";
 import { useNoticesServed } from "../../lib/hooks";
 import {
   selectBestExperienceConfigTranslation,
@@ -333,9 +336,8 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   const handleToggleChange = useCallback(
     (updatedKeys: Array<string>, preference: FidesEventDetailsPreference) => {
       const eventExtraDetails: FidesEvent["detail"]["extraDetails"] = {
-        servingComponent: servingComponentRef.current as NonNullable<
-          FidesEvent["detail"]["extraDetails"]
-        >["servingComponent"],
+        servingComponent:
+          servingComponentRef.current as FidesEventDetailsServingComponent,
         trigger: triggerRef.current,
         preference,
       };

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -314,20 +314,20 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
   ]);
 
   const handleToggleChange = useCallback(
-    (
-      updatedKeys: Array<string>,
-      triggerDetails: FidesEventDetailsTrigger,
-      preference: FidesEventDetailsPreference,
-    ) => {
+    (updatedKeys: Array<string>, preference: FidesEventDetailsPreference) => {
       const eventExtraDetails: FidesEvent["detail"]["extraDetails"] = {
         servingComponent: ServingComponent.MODAL,
-        trigger: triggerDetails,
+        trigger: triggerRef.current,
         preference,
       };
       setDraftEnabledNoticeKeys(updatedKeys);
-      dispatchFidesEvent("FidesUIChanged", cookie, eventExtraDetails);
+      dispatchFidesEventAndClearTrigger(
+        "FidesUIChanged",
+        cookie,
+        eventExtraDetails,
+      );
     },
-    [cookie, setDraftEnabledNoticeKeys],
+    [triggerRef, dispatchFidesEventAndClearTrigger, cookie],
   );
 
   const experienceConfig = experience.experience_config;

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -305,10 +305,17 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
     dispatchFidesEventAndClearTrigger("FidesUIShown", cookie);
   }, [cookie, dispatchFidesEventAndClearTrigger, setServingComponent]);
 
-  const dispatchOpenOverlayEvent = useCallback(() => {
-    setServingComponent(ServingComponent.MODAL);
-    dispatchFidesEventAndClearTrigger("FidesUIShown", cookie);
-  }, [cookie, dispatchFidesEventAndClearTrigger, setServingComponent]);
+  const dispatchOpenOverlayEvent = useCallback(
+    (origin?: string) => {
+      setServingComponent(ServingComponent.MODAL);
+      dispatchFidesEventAndClearTrigger("FidesUIShown", cookie, {
+        trigger: {
+          origin,
+        },
+      });
+    },
+    [cookie, dispatchFidesEventAndClearTrigger, setServingComponent],
+  );
 
   const handleDismiss = useCallback(() => {
     if (!consentCookieObjHasSomeConsentSet(parsedCookie?.consent)) {

--- a/clients/fides-js/src/components/notices/NoticeOverlay.tsx
+++ b/clients/fides-js/src/components/notices/NoticeOverlay.tsx
@@ -26,7 +26,11 @@ import {
   getFidesConsentCookie,
   updateCookieFromNoticePreferences,
 } from "../../lib/cookie";
-import { dispatchFidesEvent } from "../../lib/events";
+import {
+  dispatchFidesEvent,
+  FidesEventDetailsPreference,
+  FidesEventDetailsTrigger,
+} from "../../lib/events";
 import { useNoticesServed } from "../../lib/hooks";
 import {
   selectBestExperienceConfigTranslation,
@@ -309,6 +313,23 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
     parsedCookie?.consent,
   ]);
 
+  const handleToggleChange = useCallback(
+    (
+      updatedKeys: Array<string>,
+      triggerDetails: FidesEventDetailsTrigger,
+      preference: FidesEventDetailsPreference,
+    ) => {
+      const eventExtraDetails: FidesEvent["detail"]["extraDetails"] = {
+        servingComponent: ServingComponent.MODAL,
+        trigger: triggerDetails,
+        preference,
+      };
+      setDraftEnabledNoticeKeys(updatedKeys);
+      dispatchFidesEvent("FidesUIChanged", cookie, eventExtraDetails);
+    },
+    [cookie, setDraftEnabledNoticeKeys],
+  );
+
   const experienceConfig = experience.experience_config;
   if (!experienceConfig) {
     fidesDebugger("No experience config found");
@@ -382,16 +403,7 @@ const NoticeOverlay: FunctionComponent<OverlayProps> = ({
             <NoticeToggles
               noticeToggles={noticeToggles}
               enabledNoticeKeys={draftEnabledNoticeKeys}
-              onChange={(updatedKeys, triggerDetails, preference) => {
-                const eventExtraDetails: FidesEvent["detail"]["extraDetails"] =
-                  {
-                    servingComponent: "modal",
-                    trigger: triggerDetails,
-                    preference,
-                  };
-                setDraftEnabledNoticeKeys(updatedKeys);
-                dispatchFidesEvent("FidesUIChanged", cookie, eventExtraDetails);
-              }}
+              onChange={handleToggleChange}
             />
           </div>
         </div>

--- a/clients/fides-js/src/components/notices/NoticeToggles.tsx
+++ b/clients/fides-js/src/components/notices/NoticeToggles.tsx
@@ -1,10 +1,7 @@
 import { h } from "preact";
 
 import { GpcStatus } from "../../lib/consent-types";
-import {
-  FidesEventDetailsPreference,
-  FidesEventDetailsTrigger,
-} from "../../lib/events";
+import { FidesEventDetailsPreference } from "../../lib/events";
 import { DEFAULT_LOCALE, getCurrentLocale } from "../../lib/i18n";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import DataUseToggle from "../DataUseToggle";
@@ -29,15 +26,11 @@ export const NoticeToggles = ({
   enabledNoticeKeys: Array<string>;
   onChange: (
     keys: Array<string>,
-    triggerDetails: FidesEventDetailsTrigger,
     preferenceDetails: FidesEventDetailsPreference,
   ) => void;
 }) => {
   const { i18n } = useI18n();
-  const handleToggle = (
-    noticeKey: string,
-    triggerDetails: FidesEventDetailsTrigger,
-  ) => {
+  const handleToggle = (noticeKey: string) => {
     const preferenceDetails: FidesEventDetailsPreference = {
       key: noticeKey,
       type: "notice",
@@ -45,17 +38,12 @@ export const NoticeToggles = ({
 
     // Add the notice to list of enabled notices
     if (enabledNoticeKeys.indexOf(noticeKey) === -1) {
-      onChange(
-        [...enabledNoticeKeys, noticeKey],
-        triggerDetails,
-        preferenceDetails,
-      );
+      onChange([...enabledNoticeKeys, noticeKey], preferenceDetails);
     }
     // Remove the notice from the list of enabled notices
     else {
       onChange(
         enabledNoticeKeys.filter((n) => n !== noticeKey),
-        triggerDetails,
         preferenceDetails,
       );
     }

--- a/clients/fides-js/src/components/tcf/RecordsList.tsx
+++ b/clients/fides-js/src/components/tcf/RecordsList.tsx
@@ -1,7 +1,6 @@
 import { h, VNode } from "preact";
 
 import { PrivacyNoticeTranslation } from "../../lib/consent-types";
-import { FidesEventDetailsTrigger } from "../../lib/events";
 import { DEFAULT_LOCALE, getCurrentLocale } from "../../lib/i18n";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import DataUseToggle from "../DataUseToggle";
@@ -27,11 +26,7 @@ interface Props<T extends RecordListItem> {
   title: string;
   enabledIds: string[];
   renderToggleChild?: (item: T, isCustomPurpose?: boolean) => VNode;
-  onToggle: (
-    payload: string[],
-    item: T,
-    triggerDetails: FidesEventDetailsTrigger,
-  ) => void;
+  onToggle: (payload: string[], item: T) => void;
   renderBadgeLabel?: (item: T) => string | undefined;
   renderGpcBadge?: (item: T) => VNode | undefined;
   hideToggles?: boolean;
@@ -53,16 +48,15 @@ const RecordsList = <T extends RecordListItem>({
     return null;
   }
 
-  const handleToggle = (item: T, triggerDetails: FidesEventDetailsTrigger) => {
+  const handleToggle = (item: T) => {
     const purposeId = `${item.id}`;
     if (enabledIds.indexOf(purposeId) !== -1) {
       onToggle(
         enabledIds.filter((e) => e !== purposeId),
         item,
-        triggerDetails,
       );
     } else {
-      onToggle([...enabledIds, purposeId], item, triggerDetails);
+      onToggle([...enabledIds, purposeId], item);
     }
   };
 
@@ -91,8 +85,8 @@ const RecordsList = <T extends RecordListItem>({
           key={item.id}
           title={item.bestTranslation?.title || getNameForItem(item)}
           noticeKey={`${item.id}`}
-          onToggle={(_, triggerDetails) => {
-            handleToggle(item, triggerDetails);
+          onToggle={() => {
+            handleToggle(item);
           }}
           checked={enabledIds.indexOf(`${item.id}`) !== -1}
           badge={renderBadgeLabel ? renderBadgeLabel(item) : undefined}

--- a/clients/fides-js/src/components/tcf/TcfFeatures.tsx
+++ b/clients/fides-js/src/components/tcf/TcfFeatures.tsx
@@ -1,10 +1,7 @@
 import { h } from "preact";
 
 import { PrivacyExperience } from "../../lib/consent-types";
-import {
-  FidesEventDetailsPreference,
-  FidesEventDetailsTrigger,
-} from "../../lib/events";
+import { FidesEventDetailsPreference } from "../../lib/events";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import { TCFFeatureRecord, TCFSpecialFeatureRecord } from "../../lib/tcf/types";
 import EmbeddedVendorList from "./EmbeddedVendorList";
@@ -43,7 +40,6 @@ const TcfFeatures = ({
   enabledSpecialFeatureIds: string[];
   onChange: (
     payload: UpdateEnabledIds,
-    triggerDetails: FidesEventDetailsTrigger,
     preferenceDetails: FidesEventDetailsPreference,
   ) => void;
 }) => {
@@ -70,10 +66,9 @@ const TcfFeatures = ({
         title={i18n.t("static.tcf.special_features")}
         items={allSpecialFeatures ?? []}
         enabledIds={enabledSpecialFeatureIds}
-        onToggle={(newEnabledIds, item, triggerDetails) =>
+        onToggle={(newEnabledIds, item) =>
           onChange(
             { newEnabledIds, modelType: "specialFeatures" },
-            triggerDetails,
             {
               key: `tcf_special_feature_${item.id}`,
               type: "tcf_special_feature",

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -527,20 +527,16 @@ export const TcfOverlay = ({
   }, [handleUpdateAllPreferences, draftIds, parsedCookie?.consent]);
 
   const handleToggleChange = useCallback(
-    (
-      updatedIds: EnabledIds,
-      triggerDetails: FidesEventDetailsTrigger,
-      preference: FidesEventDetailsPreference,
-    ) => {
+    (updatedIds: EnabledIds, preference: FidesEventDetailsPreference) => {
       const eventExtraDetails: FidesEvent["detail"]["extraDetails"] = {
         servingComponent: ServingComponent.TCF_OVERLAY,
-        trigger: triggerDetails,
+        trigger: triggerRef.current,
         preference,
       };
       setDraftIds(updatedIds);
       dispatchFidesEvent("FidesUIChanged", cookie, eventExtraDetails);
     },
-    [cookie, setDraftIds],
+    [cookie, setDraftIds, triggerRef],
   );
 
   const handleTabChange = useCallback(

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -99,7 +99,8 @@ export const TcfOverlay = ({
     setCurrentLocale,
     setIsLoading: setIsI18nLoading,
   } = useI18n();
-  const { triggerRef, setTrigger } = useEvent();
+  const { triggerRef, setTrigger, dispatchFidesEventAndClearTrigger } =
+    useEvent();
   const parsedCookie: FidesCookie | undefined = getFidesConsentCookie();
   const minExperienceLocale =
     experienceMinimal?.experience_config?.translations?.[0]?.language;
@@ -521,10 +522,10 @@ export const TcfOverlay = ({
   }, [cookie]);
 
   const dispatchOpenOverlayEvent = useCallback(() => {
-    dispatchFidesEvent("FidesUIShown", cookie, {
+    dispatchFidesEventAndClearTrigger("FidesUIShown", cookie, {
       servingComponent: ServingComponent.TCF_OVERLAY,
     });
-  }, [cookie]);
+  }, [cookie, dispatchFidesEventAndClearTrigger]);
 
   const handleDismiss = useCallback(() => {
     if (!consentCookieObjHasSomeConsentSet(parsedCookie?.consent)) {

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -27,7 +27,6 @@ import {
 import {
   dispatchFidesEvent,
   FidesEventDetailsPreference,
-  FidesEventDetailsTrigger,
 } from "../../lib/events";
 import { useNoticesServed } from "../../lib/hooks";
 import {
@@ -42,6 +41,7 @@ import {
 } from "../../lib/i18n";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import { updateConsentPreferences } from "../../lib/preferences";
+import { useEvent } from "../../lib/providers/event-context";
 import { EMPTY_ENABLED_IDS } from "../../lib/tcf/constants";
 import { useGvl } from "../../lib/tcf/gvl-context";
 import {
@@ -99,6 +99,7 @@ export const TcfOverlay = ({
     setCurrentLocale,
     setIsLoading: setIsI18nLoading,
   } = useI18n();
+  const { triggerRef, setTrigger } = useEvent();
   const parsedCookie: FidesCookie | undefined = getFidesConsentCookie();
   const minExperienceLocale =
     experienceMinimal?.experience_config?.translations?.[0]?.language;
@@ -363,6 +364,7 @@ export const TcfOverlay = ({
         options,
         userLocationString: fidesRegionString,
         cookie,
+        eventTrigger: triggerRef.current,
         tcf,
         servedNoticeHistoryId,
         updateCookie: (oldCookie) =>
@@ -373,6 +375,8 @@ export const TcfOverlay = ({
             experienceFull || experienceMinimal,
             consentPreferencesToSave,
           ),
+      }).finally(() => {
+        setTrigger(undefined);
       });
       setDraftIds(enabledIds);
     },
@@ -385,6 +389,8 @@ export const TcfOverlay = ({
       privacyExperienceConfigHistoryId,
       privacyNoticesWithBestTranslation,
       servedNoticeHistoryId,
+      triggerRef,
+      setTrigger,
     ],
   );
 
@@ -652,7 +658,13 @@ export const TcfOverlay = ({
                     <Button
                       buttonType={ButtonType.SECONDARY}
                       label={i18n.t("exp.save_button_label")}
-                      onClick={() => onSave(ConsentMethod.SAVE, draftIds)}
+                      onClick={() => {
+                        setTrigger({
+                          type: "button",
+                          label: i18n.t("exp.save_button_label"),
+                        });
+                        onSave(ConsentMethod.SAVE, draftIds);
+                      }}
                       className="fides-save-button"
                     />
                   )}

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -24,7 +24,11 @@ import {
   consentCookieObjHasSomeConsentSet,
   getFidesConsentCookie,
 } from "../../lib/cookie";
-import { dispatchFidesEvent } from "../../lib/events";
+import {
+  dispatchFidesEvent,
+  FidesEventDetailsPreference,
+  FidesEventDetailsTrigger,
+} from "../../lib/events";
 import { useNoticesServed } from "../../lib/hooks";
 import {
   DEFAULT_LOCALE,
@@ -522,6 +526,30 @@ export const TcfOverlay = ({
     }
   }, [handleUpdateAllPreferences, draftIds, parsedCookie?.consent]);
 
+  const handleToggleChange = useCallback(
+    (
+      updatedIds: EnabledIds,
+      triggerDetails: FidesEventDetailsTrigger,
+      preference: FidesEventDetailsPreference,
+    ) => {
+      const eventExtraDetails: FidesEvent["detail"]["extraDetails"] = {
+        servingComponent: ServingComponent.TCF_OVERLAY,
+        trigger: triggerDetails,
+        preference,
+      };
+      setDraftIds(updatedIds);
+      dispatchFidesEvent("FidesUIChanged", cookie, eventExtraDetails);
+    },
+    [cookie, setDraftIds],
+  );
+
+  const handleTabChange = useCallback(
+    (tabIndex: number) => {
+      setActiveTabIndex(tabIndex);
+    },
+    [setActiveTabIndex],
+  );
+
   const experienceConfig =
     experienceFull?.experience_config || experienceMinimal.experience_config;
   if (!experienceConfig) {
@@ -596,22 +624,9 @@ export const TcfOverlay = ({
                 experience={experienceFull}
                 customNotices={privacyNoticesWithBestTranslation}
                 enabledIds={draftIds}
-                onChange={(updatedIds, triggerDetails, preference) => {
-                  const eventExtraDetails: FidesEvent["detail"]["extraDetails"] =
-                    {
-                      servingComponent: "modal",
-                      trigger: triggerDetails,
-                      preference,
-                    };
-                  setDraftIds(updatedIds);
-                  dispatchFidesEvent(
-                    "FidesUIChanged",
-                    cookie,
-                    eventExtraDetails,
-                  );
-                }}
+                onChange={handleToggleChange}
                 activeTabIndex={activeTabIndex}
-                onTabChange={setActiveTabIndex}
+                onTabChange={handleTabChange}
               />
             )
       }

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -27,6 +27,8 @@ import {
 import {
   dispatchFidesEvent,
   FidesEventDetailsPreference,
+  FidesEventDetailsServingComponent,
+  FidesEventTargetType,
 } from "../../lib/events";
 import { useNoticesServed } from "../../lib/hooks";
 import {
@@ -550,9 +552,8 @@ export const TcfOverlay = ({
   const handleToggleChange = useCallback(
     (updatedIds: EnabledIds, preference: FidesEventDetailsPreference) => {
       const eventExtraDetails: FidesEvent["detail"]["extraDetails"] = {
-        servingComponent: servingComponentRef.current as NonNullable<
-          FidesEvent["detail"]["extraDetails"]
-        >["servingComponent"],
+        servingComponent:
+          servingComponentRef.current as FidesEventDetailsServingComponent,
         trigger: triggerRef.current,
         preference,
       };
@@ -677,7 +678,7 @@ export const TcfOverlay = ({
                       label={i18n.t("exp.save_button_label")}
                       onClick={() => {
                         setTrigger({
-                          type: "button",
+                          type: FidesEventTargetType.BUTTON,
                           label: i18n.t("exp.save_button_label"),
                         });
                         onSave(ConsentMethod.SAVE, draftIds);

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -529,10 +529,17 @@ export const TcfOverlay = ({
     dispatchFidesEventAndClearTrigger("FidesUIShown", cookie);
   }, [cookie, dispatchFidesEventAndClearTrigger, setServingComponent]);
 
-  const dispatchOpenOverlayEvent = useCallback(() => {
-    setServingComponent(ServingComponent.TCF_OVERLAY);
-    dispatchFidesEventAndClearTrigger("FidesUIShown", cookie);
-  }, [cookie, dispatchFidesEventAndClearTrigger, setServingComponent]);
+  const dispatchOpenOverlayEvent = useCallback(
+    (origin?: string) => {
+      setServingComponent(ServingComponent.TCF_OVERLAY);
+      dispatchFidesEventAndClearTrigger("FidesUIShown", cookie, {
+        trigger: {
+          origin,
+        },
+      });
+    },
+    [cookie, dispatchFidesEventAndClearTrigger, setServingComponent],
+  );
 
   const handleDismiss = useCallback(() => {
     if (!consentCookieObjHasSomeConsentSet(parsedCookie?.consent)) {

--- a/clients/fides-js/src/components/tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/tcf/TcfPurposes.tsx
@@ -6,10 +6,7 @@ import { UpdateEnabledIds } from "~/components/tcf/TcfTabs";
 import { getConsentContext } from "../../lib/consent-context";
 import { PrivacyExperience } from "../../lib/consent-types";
 import { getGpcStatusFromNotice } from "../../lib/consent-utils";
-import {
-  FidesEventDetailsPreference,
-  FidesEventDetailsTrigger,
-} from "../../lib/events";
+import { FidesEventDetailsPreference } from "../../lib/events";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import { LEGAL_BASIS_OPTIONS } from "../../lib/tcf/constants";
 import { getUniquePurposeRecords, hasLegalBasis } from "../../lib/tcf/purposes";
@@ -95,7 +92,6 @@ const TcfPurposes = ({
   enabledSpecialPurposeIds: string[];
   onChange: (
     payload: UpdateEnabledIds,
-    triggerDetails: FidesEventDetailsTrigger,
     preferenceDetails: FidesEventDetailsPreference,
   ) => void;
 }) => {
@@ -190,7 +186,6 @@ const TcfPurposes = ({
       | PurposeRecord
       | PrivacyNoticeWithBestTranslation
       | TCFSpecialPurposeRecord,
-    triggerDetails: FidesEventDetailsTrigger,
   ) => {
     // Determine the preference being changed based on the model type:
     // - customPurposesConsent -> notice
@@ -225,7 +220,7 @@ const TcfPurposes = ({
       modelType,
     };
 
-    onChange(payload, triggerDetails, preferenceDetails);
+    onChange(payload, preferenceDetails);
   };
 
   return (
@@ -251,7 +246,7 @@ const TcfPurposes = ({
               ]
             : activeData.enabledPurposeIds
         }
-        onToggle={(newEnabledIds, item, triggerDetails) => {
+        onToggle={(newEnabledIds, item) => {
           const modelType =
             "bestTranslation" in item
               ? "customPurposesConsent"
@@ -270,7 +265,7 @@ const TcfPurposes = ({
             );
           }
 
-          handleToggle(modelType, filteredEnabledIds, item, triggerDetails);
+          handleToggle(modelType, filteredEnabledIds, item);
         }}
         renderToggleChild={(p, isCustomPurpose) => (
           <PurposeDetails
@@ -312,8 +307,8 @@ const TcfPurposes = ({
         title={i18n.t("static.tcf.special_purposes")}
         items={activeData.specialPurposes}
         enabledIds={activeData.enabledSpecialPurposeIds}
-        onToggle={(newEnabledIds, item, triggerDetails) =>
-          handleToggle("specialPurposes", newEnabledIds, item, triggerDetails)
+        onToggle={(newEnabledIds, item) =>
+          handleToggle("specialPurposes", newEnabledIds, item)
         }
         renderToggleChild={(p) => (
           <PurposeDetails type="specialPurposes" purpose={p} />

--- a/clients/fides-js/src/components/tcf/TcfTabs.tsx
+++ b/clients/fides-js/src/components/tcf/TcfTabs.tsx
@@ -2,10 +2,7 @@ import { h } from "preact";
 import { useCallback, useRef } from "preact/hooks";
 
 import { PrivacyExperience } from "../../lib/consent-types";
-import {
-  FidesEventDetailsPreference,
-  FidesEventDetailsTrigger,
-} from "../../lib/events";
+import { FidesEventDetailsPreference } from "../../lib/events";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import {
   EnabledIds,
@@ -37,7 +34,6 @@ const TcfTabs = ({
   enabledIds: EnabledIds;
   onChange: (
     payload: EnabledIds,
-    triggerDetails: FidesEventDetailsTrigger,
     preferenceDetails: FidesEventDetailsPreference,
   ) => void;
   activeTabIndex: number;
@@ -47,11 +43,10 @@ const TcfTabs = ({
   const handleUpdateDraftState = useCallback(
     (
       { newEnabledIds, modelType }: UpdateEnabledIds,
-      triggerDetails: FidesEventDetailsTrigger,
       preferenceDetails: FidesEventDetailsPreference,
     ) => {
       const updated = { ...enabledIds, [modelType]: newEnabledIds };
-      onChange(updated, triggerDetails, preferenceDetails);
+      onChange(updated, preferenceDetails);
     },
     [enabledIds, onChange],
   );

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -324,7 +324,6 @@ const TcfVendors = ({
   enabledVendorLegintIds: string[];
   onChange: (
     payload: UpdateEnabledIds,
-    triggerDetails: FidesEventDetailsTrigger,
     preferenceDetails: FidesEventDetailsPreference,
   ) => void;
 }) => {
@@ -365,7 +364,7 @@ const TcfVendors = ({
             ? enabledVendorConsentIds
             : enabledVendorLegintIds
         }
-        onChange={(newEnabledIds, vendor, triggerDetails) => {
+        onChange={(newEnabledIds, vendor) => {
           const modelType =
             activeLegalBasisOption.value === LegalBasisEnum.CONSENT.toString()
               ? "vendorsConsent"
@@ -398,7 +397,7 @@ const TcfVendors = ({
             vendor_name: vendor.name,
           };
 
-          onChange(payload, triggerDetails, preferenceDetails);
+          onChange(payload, preferenceDetails);
         }}
         // This key forces a rerender when legal basis changes, which allows paging to reset properly
         key={`vendor-data-${activeLegalBasisOption.value}`}

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -3,10 +3,7 @@ import { Fragment, h } from "preact";
 import { useMemo, useState } from "preact/hooks";
 
 import { PrivacyExperience } from "../../lib/consent-types";
-import {
-  FidesEventDetailsPreference,
-  FidesEventDetailsTrigger,
-} from "../../lib/events";
+import { FidesEventDetailsPreference } from "../../lib/events";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import { LEGAL_BASIS_OPTIONS } from "../../lib/tcf/constants";
 import {
@@ -254,11 +251,7 @@ const PagedVendorData = ({
   experience: PrivacyExperience;
   vendors: VendorRecord[];
   enabledIds: string[];
-  onChange: (
-    newIds: string[],
-    vendor: VendorRecord,
-    triggerDetails: FidesEventDetailsTrigger,
-  ) => void;
+  onChange: (newIds: string[], vendor: VendorRecord) => void;
 }) => {
   const { i18n } = useI18n();
   const { activeChunk, ...paging } = usePaging(vendors);

--- a/clients/fides-js/src/docs/fides-event.ts
+++ b/clients/fides-js/src/docs/fides-event.ts
@@ -162,7 +162,7 @@ export interface FidesEvent extends CustomEvent {
          * SDK script, for example, this will be "external", meaning the event
          * was triggered by something other than a FidesJS UI element.
          */
-        origin?: "fides" | "external" | string;
+        origin?: "fides" | "external";
 
         /**
          * The type of element that triggered the event. Additional types may be

--- a/clients/fides-js/src/docs/fides-event.ts
+++ b/clients/fides-js/src/docs/fides-event.ts
@@ -153,9 +153,8 @@ export interface FidesEvent extends CustomEvent {
         | "ot_migration";
 
       /**
-       * What UI element (if any) triggered this event. Some scripts accept a
-       * trigger object as an optional parameter which can be used to customize
-       * the event details.
+       * What UI element (if any) triggered this event, as well as the origin of
+       * the event.
        */
       trigger?: {
         /**

--- a/clients/fides-js/src/docs/fides-event.ts
+++ b/clients/fides-js/src/docs/fides-event.ts
@@ -142,17 +142,35 @@ export interface FidesEvent extends CustomEvent {
       /**
        * What consent method (if any) caused this event.
        */
-      consentMethod?: "accept" | "reject" | "save" | "dismiss" | "gpc";
+      consentMethod?:
+        | "accept"
+        | "reject"
+        | "save"
+        | "dismiss"
+        | "acknowledge"
+        | "gpc"
+        | "script"
+        | "ot_migration";
 
       /**
-       * What UI element (if any) triggered this event.
+       * What UI element (if any) triggered this event. Some scripts accept a
+       * trigger object as an optional parameter which can be used to customize
+       * the event details.
        */
       trigger?: {
         /**
-         * The type of element that triggered the event. Additional types may be
-         * added over time (e.g. "button", "link"), so expect this type to grow.
+         * Where the event originated from. If the event was triggered using an
+         * SDK script, for example, this will be "external", meaning the event
+         * was triggered by something other than a FidesJS UI element.
          */
-        type: "toggle";
+        origin?: "fides" | "external" | string;
+
+        /**
+         * The type of element that triggered the event. Additional types may be
+         * added over time, so expect this type to grow.
+         * Only present when origin is "fides".
+         */
+        type?: "toggle" | "button" | "link";
 
         /**
          * The UI label of the element that triggered the event.

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -831,6 +831,7 @@ export enum RejectAllMechanism {
   REJECT_CONSENT_ONLY = "reject_consent_only", // do not reject legitimate interests
 }
 
+// NOTE: updates to this enum should be reflected in the FidesEventDetailsTrigger type and vice versa
 export enum ConsentMethod {
   BUTTON = "button", // deprecated- keeping for backwards-compatibility
   REJECT = "reject",
@@ -839,7 +840,7 @@ export enum ConsentMethod {
   SAVE = "save",
   DISMISS = "dismiss",
   GPC = "gpc",
-  INDIVIDUAL_NOTICE = "individual_notice",
+  INDIVIDUAL_NOTICE = "individual_notice", // api only
   ACKNOWLEDGE = "acknowledge",
   OT_MIGRATION = "ot_migration",
 }

--- a/clients/fides-js/src/lib/events.ts
+++ b/clients/fides-js/src/lib/events.ts
@@ -84,6 +84,12 @@ export const dispatchFidesEvent = (
         .consentMethod as FidesEventExtraDetails["consentMethod"],
       ...extraDetails,
     };
+    if (!(extraDetails?.trigger as FidesEventDetailsTrigger)?.origin) {
+      constructedExtraDetails.trigger = {
+        ...(constructedExtraDetails.trigger as FidesEventDetailsTrigger),
+        ...({ origin: "fides" } as FidesEventDetailsTrigger),
+      } as FidesEventDetailsTrigger;
+    }
     const perfMark = performance?.mark?.(type);
     const timestamp = perfMark?.startTime;
     const normalizedCookie: FidesCookie | undefined = cookie;

--- a/clients/fides-js/src/lib/events.ts
+++ b/clients/fides-js/src/lib/events.ts
@@ -7,6 +7,17 @@ declare global {
   interface WindowEventMap extends Record<FidesEventType, FidesEvent> {}
 }
 
+export enum FidesEventOrigin {
+  FIDES = "fides",
+  EXTERNAL = "external",
+}
+
+export enum FidesEventTargetType {
+  TOGGLE = "toggle",
+  BUTTON = "button",
+  LINK = "link",
+}
+
 /**
  * Defines the type of "extra" details that can be optionally added to certain
  * events. This is intentionally vague. See the /docs/fides-event.ts
@@ -28,6 +39,13 @@ export type FidesEventDetail = FidesCookie & {
   extraDetails?: FidesEventExtraDetails;
   timestamp?: number;
 };
+
+/**
+ * Defines the properties available on event.detail.extraDetails.servingComponent
+ */
+export type FidesEventDetailsServingComponent = NonNullable<
+  DocsFidesEvent["detail"]["extraDetails"]
+>["servingComponent"];
 
 /**
  * Defines the properties available on event.detail.extraDetails.trigger
@@ -87,7 +105,7 @@ export const dispatchFidesEvent = (
     if (!(extraDetails?.trigger as FidesEventDetailsTrigger)?.origin) {
       constructedExtraDetails.trigger = {
         ...(constructedExtraDetails.trigger as FidesEventDetailsTrigger),
-        ...({ origin: "fides" } as FidesEventDetailsTrigger),
+        ...({ origin: FidesEventOrigin.FIDES } as FidesEventDetailsTrigger),
       } as FidesEventDetailsTrigger;
     }
     const perfMark = performance?.mark?.(type);

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -141,7 +141,7 @@ export const updateConsentPreferences = async ({
   // 2. Dispatch a "FidesUpdating" event with the new preferences
   dispatchFidesEvent("FidesUpdating", cookie, {
     ...eventExtraDetails,
-    ...trigger,
+    trigger,
   });
 
   // 3. Update the window.Fides object
@@ -206,7 +206,7 @@ export const updateConsentPreferences = async ({
   // 7. Dispatch a "FidesUpdated" event
   dispatchFidesEvent("FidesUpdated", cookie, {
     ...eventExtraDetails,
-    ...trigger,
+    trigger,
   });
 };
 

--- a/clients/fides-js/src/lib/providers/event-context.tsx
+++ b/clients/fides-js/src/lib/providers/event-context.tsx
@@ -1,0 +1,74 @@
+import { createContext, h } from "preact";
+import { MutableRefObject, ReactNode } from "preact/compat";
+import { useCallback, useContext, useMemo, useRef } from "preact/hooks";
+
+import { FidesCookie } from "../consent-types";
+import {
+  dispatchFidesEvent,
+  FidesEventDetailsTrigger,
+  FidesEventExtraDetails,
+  FidesEventType,
+} from "../events";
+
+interface UseEventProps {
+  triggerRef: MutableRefObject<FidesEventDetailsTrigger>;
+  setTrigger: (newValue: FidesEventDetailsTrigger) => void;
+  dispatchFidesEventAndClearTrigger: (
+    type: FidesEventType,
+    fidesCookie: FidesCookie | undefined,
+    extraDetails?: FidesEventExtraDetails,
+  ) => void;
+}
+
+const EventContext = createContext<UseEventProps | Record<any, never>>({});
+
+export const EventProvider = ({ children }: { children: ReactNode }) => {
+  const triggerRef = useRef<FidesEventDetailsTrigger>();
+
+  const updateContextValue = useCallback(
+    (newValue: FidesEventDetailsTrigger) => {
+      triggerRef.current = newValue;
+    },
+    [],
+  );
+
+  const dispatchFidesEventAndClearTrigger = useCallback(
+    (
+      type: FidesEventType,
+      fidesCookie: FidesCookie | undefined,
+      extraDetails?: FidesEventExtraDetails,
+    ) => {
+      dispatchFidesEvent(type, fidesCookie, {
+        ...extraDetails,
+        trigger: {
+          ...(extraDetails?.trigger as FidesEventDetailsTrigger),
+          ...triggerRef.current,
+        },
+      });
+      // Clear the trigger after dispatching
+      updateContextValue(undefined);
+    },
+    [updateContextValue],
+  );
+
+  const value: UseEventProps = useMemo(
+    () => ({
+      triggerRef,
+      setTrigger: updateContextValue,
+      dispatchFidesEventAndClearTrigger,
+    }),
+    [updateContextValue, dispatchFidesEventAndClearTrigger],
+  );
+
+  return (
+    <EventContext.Provider value={value}>{children}</EventContext.Provider>
+  );
+};
+
+export const useEvent = () => {
+  const context = useContext(EventContext);
+  if (!context || Object.keys(context).length === 0) {
+    throw new Error("useEvent must be used within a EventProvider");
+  }
+  return context as UseEventProps;
+};

--- a/clients/fides-js/src/lib/renderOverlay.tsx
+++ b/clients/fides-js/src/lib/renderOverlay.tsx
@@ -3,12 +3,15 @@ import { ContainerNode, h, render } from "preact";
 import NoticeOverlay from "../components/notices/NoticeOverlay";
 import { OverlayProps } from "../components/types";
 import { I18nProvider } from "./i18n/i18n-context";
+import { EventProvider } from "./providers/event-context";
 
 export const renderOverlay = (props: OverlayProps, parent: ContainerNode) => {
   const { i18n } = props;
   render(
     <I18nProvider i18nInstance={i18n}>
-      <NoticeOverlay {...props} />
+      <EventProvider>
+        <NoticeOverlay {...props} />
+      </EventProvider>
     </I18nProvider>,
     parent,
   );

--- a/clients/fides-js/src/lib/tcf/renderOverlay.tsx
+++ b/clients/fides-js/src/lib/tcf/renderOverlay.tsx
@@ -5,6 +5,7 @@ import { PrivacyExperienceMinimal } from "~/fides";
 import { TcfOverlay } from "../../components/tcf/TcfOverlay";
 import { OverlayProps } from "../../components/types";
 import { I18nProvider } from "../i18n/i18n-context";
+import { EventProvider } from "../providers/event-context";
 import { GVLProvider } from "./gvl-context";
 import { loadTcfMessagesFromFiles } from "./i18n/tcf-i18n-utils";
 import { VendorButtonProvider } from "./vendor-button-context";
@@ -24,10 +25,12 @@ export const renderOverlay = (props: OverlayProps, parent: ContainerNode) => {
     <I18nProvider i18nInstance={i18n}>
       <GVLProvider>
         <VendorButtonProvider>
-          <TcfOverlay
-            experienceMinimal={props.experience as PrivacyExperienceMinimal}
-            {...props}
-          />
+          <EventProvider>
+            <TcfOverlay
+              experienceMinimal={props.experience as PrivacyExperienceMinimal}
+              {...props}
+            />
+          </EventProvider>
         </VendorButtonProvider>
       </GVLProvider>
     </I18nProvider>,

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -506,6 +506,9 @@ describe("Fides-js TCF", () => {
                 extraDetails: {
                   consentMethod: undefined,
                   shouldShowExperience: true,
+                  trigger: {
+                    origin: "fides",
+                  },
                 },
                 fides_string: undefined,
               },
@@ -527,6 +530,9 @@ describe("Fides-js TCF", () => {
                 extraDetails: {
                   consentMethod: undefined,
                   shouldShowExperience: true,
+                  trigger: {
+                    origin: "fides",
+                  },
                 },
                 fides_string: undefined,
               });
@@ -548,13 +554,13 @@ describe("Fides-js TCF", () => {
               expect(updatingEvent.event).to.equal("FidesUpdating");
               expect(
                 updatingEvent.Fides.extraDetails.servingComponent,
-              ).to.equal(undefined);
+              ).to.equal("tcf_banner");
 
               // FidesUpdated event
               const updatedEvent = args[4][0];
               expect(updatedEvent.event).to.equal("FidesUpdated");
               expect(updatedEvent.Fides.extraDetails.servingComponent).to.equal(
-                undefined,
+                "tcf_banner",
               );
             });
 
@@ -574,6 +580,12 @@ describe("Fides-js TCF", () => {
                   : {},
                 extraDetails: {
                   consentMethod: "accept",
+                  servingComponent: "tcf_banner",
+                  trigger: {
+                    type: "button",
+                    label: "Opt in to all",
+                    origin: "fides",
+                  },
                 },
               });
               expect(call.Fides.fides_string).to.contain(",2~~dv.");
@@ -595,6 +607,12 @@ describe("Fides-js TCF", () => {
                   : {},
                 extraDetails: {
                   consentMethod: "accept",
+                  servingComponent: "tcf_banner",
+                  trigger: {
+                    type: "button",
+                    label: "Opt in to all",
+                    origin: "fides",
+                  },
                 },
               });
               expect(call.Fides.fides_string).to.contain(",2~~dv.");
@@ -1232,6 +1250,9 @@ describe("Fides-js TCF", () => {
                   extraDetails: {
                     consentMethod: undefined,
                     shouldShowExperience: true,
+                    trigger: {
+                      origin: "fides",
+                    },
                   },
                   fides_string: undefined,
                 },
@@ -1253,6 +1274,7 @@ describe("Fides-js TCF", () => {
                   extraDetails: {
                     consentMethod: undefined,
                     shouldShowExperience: true,
+                    trigger: { origin: "fides" },
                   },
                   fides_string: undefined,
                 });
@@ -1281,7 +1303,7 @@ describe("Fides-js TCF", () => {
                 expect(modalClosedEvent.event).to.equal("FidesModalClosed");
                 expect(
                   modalClosedEvent.Fides.extraDetails.servingComponent,
-                ).to.equal(undefined);
+                ).to.equal("tcf_overlay");
               });
 
             // FidesUpdating call
@@ -1300,6 +1322,12 @@ describe("Fides-js TCF", () => {
                     : {},
                   extraDetails: {
                     consentMethod: "accept",
+                    servingComponent: "tcf_overlay",
+                    trigger: {
+                      type: "button",
+                      label: "Opt in to all",
+                      origin: "fides",
+                    },
                   },
                 });
                 expect(call.Fides.fides_string).to.contain(",2~~dv.");
@@ -1321,6 +1349,12 @@ describe("Fides-js TCF", () => {
                     : {},
                   extraDetails: {
                     consentMethod: "accept",
+                    servingComponent: "tcf_overlay",
+                    trigger: {
+                      type: "button",
+                      label: "Opt in to all",
+                      origin: "fides",
+                    },
                   },
                 });
                 expect(call.Fides.fides_string).to.contain(",2~~dv.");

--- a/clients/privacy-center/cypress/e2e/consent-events.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-events.cy.ts
@@ -332,7 +332,7 @@ describe("Consent FidesEvents", () => {
           type: "FidesUIChanged",
           detail: {
             extraDetails: {
-              servingComponent: "modal",
+              servingComponent: "tcf_overlay",
               trigger: {
                 type: "toggle",
                 label: "Use profiles to select personalised advertising",
@@ -349,7 +349,7 @@ describe("Consent FidesEvents", () => {
           type: "FidesUIChanged",
           detail: {
             extraDetails: {
-              servingComponent: "modal",
+              servingComponent: "tcf_overlay",
               trigger: {
                 type: "toggle",
                 label: "Use profiles to select personalised advertising",
@@ -373,7 +373,7 @@ describe("Consent FidesEvents", () => {
         type: "FidesUIChanged",
         detail: {
           extraDetails: {
-            servingComponent: "modal",
+            servingComponent: "tcf_overlay",
             trigger: {
               type: "toggle",
               label: "Use profiles to select personalised content",
@@ -402,7 +402,7 @@ describe("Consent FidesEvents", () => {
         type: "FidesUIChanged",
         detail: {
           extraDetails: {
-            servingComponent: "modal",
+            servingComponent: "tcf_overlay",
             trigger: {
               type: "toggle",
               label: "Use limited data to select advertising",
@@ -438,7 +438,7 @@ describe("Consent FidesEvents", () => {
           type: "FidesUIChanged",
           detail: {
             extraDetails: {
-              servingComponent: "modal",
+              servingComponent: "tcf_overlay",
               trigger: {
                 type: "toggle",
                 label: "Captify",
@@ -459,7 +459,7 @@ describe("Consent FidesEvents", () => {
           type: "FidesUIChanged",
           detail: {
             extraDetails: {
-              servingComponent: "modal",
+              servingComponent: "tcf_overlay",
               trigger: {
                 type: "toggle",
                 label: "Captify",
@@ -485,7 +485,7 @@ describe("Consent FidesEvents", () => {
           type: "FidesUIChanged",
           detail: {
             extraDetails: {
-              servingComponent: "modal",
+              servingComponent: "tcf_overlay",
               trigger: {
                 type: "toggle",
                 label: "Meta",
@@ -506,7 +506,7 @@ describe("Consent FidesEvents", () => {
           type: "FidesUIChanged",
           detail: {
             extraDetails: {
-              servingComponent: "modal",
+              servingComponent: "tcf_overlay",
               trigger: {
                 type: "toggle",
                 label: "Meta",
@@ -683,7 +683,7 @@ describe("Consent FidesEvents", () => {
         type: "FidesUIChanged",
         detail: {
           extraDetails: {
-            servingComponent: "modal",
+            servingComponent: "tcf_overlay",
             trigger: {
               type: "toggle",
               label: "Advertising English",

--- a/clients/privacy-center/cypress/e2e/consent-events.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-events.cy.ts
@@ -89,7 +89,12 @@ describe("Consent FidesEvents", () => {
         { type: "FidesInitialized", detail: {} },
         {
           type: "FidesUIShown",
-          detail: { extraDetails: { servingComponent: "banner" } },
+          detail: {
+            extraDetails: {
+              servingComponent: "banner",
+              trigger: { origin: "fides" },
+            },
+          },
         },
       );
 
@@ -97,7 +102,16 @@ describe("Consent FidesEvents", () => {
       cy.get("#fides-banner .fides-manage-preferences-button").click();
       expectedEvents.push({
         type: "FidesUIShown",
-        detail: { extraDetails: { servingComponent: "modal" } },
+        detail: {
+          extraDetails: {
+            servingComponent: "modal",
+            trigger: {
+              type: "button",
+              label: "Manage preferences",
+              origin: "fides",
+            },
+          },
+        },
       });
 
       // Toggle Advertising notice on then off
@@ -113,6 +127,7 @@ describe("Consent FidesEvents", () => {
                 type: "toggle",
                 label: "Advertising",
                 checked: true,
+                origin: "fides",
               },
               preference: {
                 key: "advertising",
@@ -130,6 +145,7 @@ describe("Consent FidesEvents", () => {
                 type: "toggle",
                 label: "Advertising",
                 checked: false,
+                origin: "fides",
               },
               preference: {
                 key: "advertising",
@@ -151,6 +167,7 @@ describe("Consent FidesEvents", () => {
               type: "toggle",
               label: "Analytics",
               checked: false,
+              origin: "fides",
             },
             preference: {
               key: "analytics_opt_out",
@@ -169,12 +186,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "save",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Save",
-              // },
+              servingComponent: "modal",
+              trigger: {
+                label: "Save",
+                origin: "fides",
+                type: "button",
+              },
             },
           },
         },
@@ -183,12 +200,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "save",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Save",
-              // },
+              servingComponent: "modal",
+              trigger: {
+                label: "Save",
+                origin: "fides",
+                type: "button",
+              },
             },
           },
         },
@@ -210,12 +227,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "reject",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Opt out of all",
-              // },
+              servingComponent: "modal",
+              trigger: {
+                type: "button",
+                label: "Opt out of all",
+                origin: "fides",
+              },
             },
           },
         },
@@ -224,12 +241,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "reject",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Opt out of all",
-              // },
+              servingComponent: "modal",
+              trigger: {
+                type: "button",
+                label: "Opt out of all",
+                origin: "fides",
+              },
             },
           },
         },
@@ -251,12 +268,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "accept",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Opt in to all",
-              // },
+              servingComponent: "modal",
+              trigger: {
+                type: "button",
+                label: "Opt in to all",
+                origin: "fides",
+              },
             },
           },
         },
@@ -265,12 +282,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "accept",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Opt in to all",
-              // },
+              servingComponent: "modal",
+              trigger: {
+                type: "button",
+                label: "Opt in to all",
+                origin: "fides",
+              },
             },
           },
         },
@@ -337,6 +354,7 @@ describe("Consent FidesEvents", () => {
                 type: "toggle",
                 label: "Use profiles to select personalised advertising",
                 checked: true,
+                origin: "fides",
               },
               preference: {
                 key: "tcf_purpose_consent_4",
@@ -354,6 +372,7 @@ describe("Consent FidesEvents", () => {
                 type: "toggle",
                 label: "Use profiles to select personalised advertising",
                 checked: false,
+                origin: "fides",
               },
               preference: {
                 key: "tcf_purpose_consent_4",
@@ -378,6 +397,7 @@ describe("Consent FidesEvents", () => {
               type: "toggle",
               label: "Use profiles to select personalised content",
               checked: true,
+              origin: "fides",
             },
             preference: {
               key: "tcf_purpose_consent_6",
@@ -407,6 +427,7 @@ describe("Consent FidesEvents", () => {
               type: "toggle",
               label: "Use limited data to select advertising",
               checked: false,
+              origin: "fides",
             },
             preference: {
               key: "tcf_purpose_legitimate_interest_2",
@@ -443,6 +464,7 @@ describe("Consent FidesEvents", () => {
                 type: "toggle",
                 label: "Captify",
                 checked: true,
+                origin: "fides",
               },
               preference: {
                 key: "gvl.2",
@@ -464,6 +486,7 @@ describe("Consent FidesEvents", () => {
                 type: "toggle",
                 label: "Captify",
                 checked: false,
+                origin: "fides",
               },
               preference: {
                 key: "gvl.2",
@@ -490,6 +513,7 @@ describe("Consent FidesEvents", () => {
                 type: "toggle",
                 label: "Meta",
                 checked: true,
+                origin: "fides",
               },
               preference: {
                 key: "gacp.89",
@@ -511,6 +535,7 @@ describe("Consent FidesEvents", () => {
                 type: "toggle",
                 label: "Meta",
                 checked: false,
+                origin: "fides",
               },
               preference: {
                 key: "gacp.89",
@@ -534,12 +559,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "save",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Save",
-              // },
+              servingComponent: "tcf_overlay",
+              trigger: {
+                type: "button",
+                label: "Save",
+                origin: "fides",
+              },
             },
           },
         },
@@ -548,12 +573,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "save",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Save",
-              // },
+              servingComponent: "tcf_overlay",
+              trigger: {
+                type: "button",
+                label: "Save",
+                origin: "fides",
+              },
             },
           },
         },
@@ -575,12 +600,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "reject",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Opt out of all",
-              // },
+              servingComponent: "tcf_overlay",
+              trigger: {
+                type: "button",
+                label: "Opt out of all",
+                origin: "fides",
+              },
             },
           },
         },
@@ -589,12 +614,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "reject",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Opt out of all",
-              // },
+              servingComponent: "tcf_overlay",
+              trigger: {
+                type: "button",
+                label: "Opt out of all",
+                origin: "fides",
+              },
             },
           },
         },
@@ -616,12 +641,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "accept",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Opt in to all",
-              // },
+              servingComponent: "tcf_overlay",
+              trigger: {
+                type: "button",
+                label: "Opt in to all",
+                origin: "fides",
+              },
             },
           },
         },
@@ -630,12 +655,12 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               consentMethod: "accept",
-              // DEFER(LJ-478): Restore these checks after updating events to be more consistent
-              // servingComponent: "modal",
-              // trigger: {
-              //   type: "button",
-              //   label: "Opt in to all",
-              // },
+              servingComponent: "tcf_overlay",
+              trigger: {
+                type: "button",
+                label: "Opt in to all",
+                origin: "fides",
+              },
             },
           },
         },
@@ -688,6 +713,7 @@ describe("Consent FidesEvents", () => {
               type: "toggle",
               label: "Advertising English",
               checked: true,
+              origin: "fides",
             },
             preference: {
               key: "advertising", // Should use notice_key instead of ID

--- a/clients/privacy-center/cypress/e2e/consent-events.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-events.cy.ts
@@ -92,7 +92,7 @@ describe("Consent FidesEvents", () => {
           detail: {
             extraDetails: {
               servingComponent: "banner",
-              trigger: { origin: "fides" },
+              trigger: { origin: "fides" }, // automatically opened by fides-js
             },
           },
         },
@@ -215,7 +215,12 @@ describe("Consent FidesEvents", () => {
       cy.get("#fides-modal-link").click();
       expectedEvents.push({
         type: "FidesUIShown",
-        detail: { extraDetails: { servingComponent: "modal" } },
+        detail: {
+          extraDetails: {
+            servingComponent: "modal",
+            trigger: { origin: "external" },
+          },
+        },
       });
 
       // Click opt-out button to reject all notices
@@ -293,6 +298,49 @@ describe("Consent FidesEvents", () => {
                 label: "Opt in to all",
                 origin: "fides",
               },
+            },
+          },
+        },
+      );
+
+      // Open modal from Fides.showModal()
+      cy.window().then((win) => {
+        win.Fides.showModal();
+      });
+      expectedEvents.push({
+        type: "FidesUIShown",
+        detail: {
+          extraDetails: {
+            servingComponent: "modal",
+            trigger: { origin: "external" },
+          },
+        },
+      });
+
+      // Update preferences from Fides.updateConsent()
+      cy.window().then(async (win) => {
+        await win.Fides.updateConsent({
+          consent: {
+            analytics_opt_out: false,
+          },
+        });
+      });
+      expectedEvents.push(
+        {
+          type: "FidesUpdating",
+          detail: {
+            extraDetails: {
+              consentMethod: "script",
+              trigger: { origin: "external" },
+            },
+          },
+        },
+        {
+          type: "FidesUpdated",
+          detail: {
+            extraDetails: {
+              consentMethod: "script",
+              trigger: { origin: "external" },
             },
           },
         },

--- a/clients/privacy-center/cypress/e2e/consent-events.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-events.cy.ts
@@ -256,7 +256,12 @@ describe("Consent FidesEvents", () => {
       cy.get("#fides-modal-link").click();
       expectedEvents.push({
         type: "FidesUIShown",
-        detail: { extraDetails: { servingComponent: "modal" } },
+        detail: {
+          extraDetails: {
+            servingComponent: "modal",
+            trigger: { origin: "external" },
+          },
+        },
       });
 
       // Click opt-in button to accept all notices

--- a/clients/privacy-center/cypress/e2e/consent-third-party.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-third-party.cy.ts
@@ -74,6 +74,9 @@ describe("Consent third party extensions", () => {
                   extraDetails: {
                     consentMethod: undefined,
                     shouldShowExperience: true,
+                    trigger: {
+                      origin: "fides",
+                    },
                   },
                   fides_string: undefined,
                 },
@@ -93,6 +96,9 @@ describe("Consent third party extensions", () => {
                   extraDetails: {
                     consentMethod: undefined,
                     shouldShowExperience: true,
+                    trigger: {
+                      origin: "fides",
+                    },
                   },
                   fides_string: undefined,
                 });
@@ -112,6 +118,9 @@ describe("Consent third party extensions", () => {
                   extraDetails: {
                     servingComponent: "banner",
                     consentMethod: undefined,
+                    trigger: {
+                      origin: "fides",
+                    },
                   },
                   fides_string: undefined,
                 },
@@ -131,6 +140,12 @@ describe("Consent third party extensions", () => {
                   },
                   extraDetails: {
                     consentMethod: "accept",
+                    servingComponent: "banner",
+                    trigger: {
+                      origin: "fides",
+                      type: "button",
+                      label: "Opt in to all",
+                    },
                   },
                   fides_string: undefined,
                 },
@@ -149,6 +164,12 @@ describe("Consent third party extensions", () => {
                   },
                   extraDetails: {
                     consentMethod: "accept",
+                    servingComponent: "banner",
+                    trigger: {
+                      origin: "fides",
+                      type: "button",
+                      label: "Opt in to all",
+                    },
                   },
                   fides_string: undefined,
                 },
@@ -215,18 +236,13 @@ describe("Consent third party extensions", () => {
                 });
               cy.get("@dataLayerPush")
                 .its("firstCall.args.0.Fides.extraDetails")
-                .should(
-                  "deep.equal",
-                  isTCF
-                    ? {
-                        consentMethod: undefined,
-                        shouldShowExperience: true,
-                      }
-                    : {
-                        consentMethod: undefined,
-                        shouldShowExperience: true,
-                      },
-                );
+                .should("deep.equal", {
+                  consentMethod: undefined,
+                  shouldShowExperience: true,
+                  trigger: {
+                    origin: "fides",
+                  },
+                });
               // Second call should be from deprecated FidesInitialized
               cy.get("@dataLayerPush")
                 .its("secondCall.args.0.event")
@@ -243,6 +259,9 @@ describe("Consent third party extensions", () => {
                 .should("deep.equal", {
                   consentMethod: undefined,
                   shouldShowExperience: true,
+                  trigger: {
+                    origin: "fides",
+                  },
                 });
 
               // Third call is FidesUIShown when banner appears
@@ -261,6 +280,9 @@ describe("Consent third party extensions", () => {
                 .should("deep.equal", {
                   servingComponent: isTCF ? "tcf_banner" : "banner",
                   consentMethod: undefined,
+                  trigger: {
+                    origin: "fides",
+                  },
                 });
 
               // Fourth call is when the user accepts all
@@ -281,6 +303,12 @@ describe("Consent third party extensions", () => {
                 .then((args) => args[3][0].Fides.extraDetails)
                 .should("deep.equal", {
                   consentMethod: "accept",
+                  servingComponent: isTCF ? "tcf_banner" : "banner",
+                  trigger: {
+                    origin: "fides",
+                    type: "button",
+                    label: "Opt in to all",
+                  },
                 });
 
               // Last call is when the preferences finish updating
@@ -298,6 +326,12 @@ describe("Consent third party extensions", () => {
                 .its("lastCall.args.0.Fides.extraDetails")
                 .should("deep.equal", {
                   consentMethod: "accept",
+                  servingComponent: isTCF ? "tcf_banner" : "banner",
+                  trigger: {
+                    origin: "fides",
+                    type: "button",
+                    label: "Opt in to all",
+                  },
                 });
             });
           });
@@ -373,18 +407,13 @@ describe("Consent third party extensions", () => {
                 });
               cy.get("@dataLayerPush")
                 .its("firstCall.args.0.Fides.extraDetails")
-                .should(
-                  "deep.equal",
-                  isTCF
-                    ? {
-                        consentMethod: undefined,
-                        shouldShowExperience: true,
-                      }
-                    : {
-                        consentMethod: undefined,
-                        shouldShowExperience: true,
-                      },
-                );
+                .should("deep.equal", {
+                  consentMethod: undefined,
+                  shouldShowExperience: true,
+                  trigger: {
+                    origin: "fides",
+                  },
+                });
 
               // Second call should be from deprecated FidesInitialized
               cy.get("@dataLayerPush")
@@ -404,6 +433,9 @@ describe("Consent third party extensions", () => {
                 .should("deep.equal", {
                   consentMethod: undefined,
                   shouldShowExperience: true,
+                  trigger: {
+                    origin: "fides",
+                  },
                 });
 
               // Third call is FidesUIShown when banner appears
@@ -424,6 +456,9 @@ describe("Consent third party extensions", () => {
                 .should("deep.equal", {
                   servingComponent: isTCF ? "tcf_banner" : "banner",
                   consentMethod: undefined,
+                  trigger: {
+                    origin: "fides",
+                  },
                 });
 
               // Fourth call is when the user accepts all
@@ -446,6 +481,12 @@ describe("Consent third party extensions", () => {
                 .then((args) => args[3][0].Fides.extraDetails)
                 .should("deep.equal", {
                   consentMethod: "accept",
+                  servingComponent: isTCF ? "tcf_banner" : "banner",
+                  trigger: {
+                    origin: "fides",
+                    type: "button",
+                    label: "Opt in to all",
+                  },
                 });
 
               // Last call is when the preferences finish updating
@@ -465,6 +506,12 @@ describe("Consent third party extensions", () => {
                 .its("lastCall.args.0.Fides.extraDetails")
                 .should("deep.equal", {
                   consentMethod: "accept",
+                  servingComponent: isTCF ? "tcf_banner" : "banner",
+                  trigger: {
+                    origin: "fides",
+                    type: "button",
+                    label: "Opt in to all",
+                  },
                 });
             });
           });

--- a/clients/privacy-center/cypress/e2e/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent.cy.ts
@@ -407,6 +407,9 @@ describe("Consent settings", () => {
                 extraDetails: {
                   consentMethod: undefined,
                   shouldShowExperience: false,
+                  trigger: {
+                    origin: "fides",
+                  },
                 },
                 fides_string: undefined,
                 timestamp,


### PR DESCRIPTION
Closes [ENG-442]

### Description Of Changes

Implemented comprehensive event trigger tracking across all FidesJS UI components. Added a centralized event context system that captures detailed information about what UI element triggered each event, including the element type, label, and origin (internal vs external). This enables better analytics and debugging capabilities by providing granular details about user interactions with the consent interface.

### Code Changes

* Added `EventProvider` Preact context and `useEvent` Preact hook for centralized event trigger management
* Updated all button and toggle components to set trigger details before dispatching events
* Enhanced `FidesEvent` interface to include `origin`, expanded `type` options (`button`, `link`, `toggle`), and newer consent methods that had been previously left out (`acknowledge`, `script`, `ot_migration`)
* Modified `dispatchFidesEvent` to automatically include trigger context and serving component information
* Simplified component interfaces by removing trigger parameters from `onToggle` and similar handlers now that we can set these using the Preact context
* Renamed `ConsentButtonProps` to `ConsentButtonsProps` for consistency
* Renamed `handleManagePreferencesClick` to `handleTCFManagePreferencesClick` for clarity
* Updated `onOpen` callback to accept optional `origin` parameter to distinguish internal vs external modal triggers

### Steps to Confirm

1. Open a page with FidesJS consent components
2. Interact with various UI elements (accept/reject buttons, toggles, close buttons, preference links)
3. Listen for events in browser console (or run in Dev mode so they show up in the console)
4. Verify each event includes proper `extraDetails.trigger` information with `type`, `label`, and `origin` fields
5. Test external modal triggers via `window.Fides.showModal()` and verify `origin: "external"` is set
6. Test external consent triggers via `window.Fides.updateConsent()` and verify `origin: "external"` is set
7. Confirm toggle interactions include correct `checked` state in trigger details

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [x] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-442]: https://ethyca.atlassian.net/browse/ENG-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ