### PR TITLE
support specifying particular diff statuses for reclassification

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/discovery-detection.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/discovery-detection.slice.ts
@@ -138,6 +138,7 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
         unmute_children?: boolean;
         start_classification?: boolean;
         classify_monitored_resources?: boolean;
+        diff_statuses_to_classify?: DiffStatus[];
       }
     >({
       query: (params) => ({
@@ -146,6 +147,7 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
           {
             unmute_children: params.unmute_children,
             classify_monitored_resources: params.classify_monitored_resources,
+            diff_statuses_to_classify: params.diff_statuses_to_classify,
           },
           { arrayFormat: "none" },
         )}`,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DiscoveryItemActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/tables/cells/DiscoveryItemActionsCell.tsx
@@ -109,7 +109,13 @@ const DiscoveryItemActionsCell = ({ resource }: DiscoveryItemActionsProps) => {
       staged_resource_urn: resource.urn,
       monitor_config_id: resource.monitor_config_id!,
       start_classification: true,
-      classify_monitored_resources: true,
+      // these are the diff statuses of resources that should be sent to 're-classification'
+      diff_statuses_to_classify: [
+        DiffStatus.CLASSIFICATION_ADDITION,
+        DiffStatus.CLASSIFICATION_UPDATE,
+        DiffStatus.CLASSIFYING,
+        DiffStatus.CLASSIFICATION_QUEUED,
+      ],
     });
     if (isErrorResult(result)) {
       errorAlert(


### PR DESCRIPTION
Partially closes https://ethyca.atlassian.net/browse/ENG-664

### Description Of Changes

Updates to the 're-classification' button to integrate with a new endpoint parameter that allows for classifying resources with specific `diff_status` values.

This effectively prevents 'already-monitored' resources (classified + promoted) from being re-classified unnecessarily.

### Steps to Confirm

1. tested with some sample D&D data and confirmed in my dev tools that the correct API response was being sent by the FE 👍 
![image](https://github.com/user-attachments/assets/a9be9a09-32b0-4291-9e63-9808b0472405)


### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
