### PR TITLE
ENG-783: Handle older browsers that do not support .size on URLSearchParams

### DIFF
--- a/clients/fides-js/src/lib/size-of.ts
+++ b/clients/fides-js/src/lib/size-of.ts
@@ -1,0 +1,3 @@
+export default function sizeOf(searchParams: URLSearchParams) {
+  return Array.from(searchParams).length;
+}

--- a/clients/fides-js/src/services/api.ts
+++ b/clients/fides-js/src/services/api.ts
@@ -12,6 +12,7 @@ import {
   RecordsServedResponse,
 } from "../lib/consent-types";
 import { Locale } from "../lib/i18n";
+import sizeOf from "../lib/size-of";
 import { GVLTranslations } from "../lib/tcf/types";
 
 export enum FidesEndpointPaths {
@@ -166,7 +167,7 @@ export const fetchGvlTranslations = async (
   try {
     response = await fetch(
       `${fidesApiUrl}${FidesEndpointPaths.GVL_TRANSLATIONS}${
-        params.size > 0 ? "?" : ""
+        sizeOf(params) > 0 ? "?" : ""
       }${params.toString()}`,
       fetchOptions,
     );


### PR DESCRIPTION
Closes [ENG-783]

### Description Of Changes

Older browsers do not support .size on URLSearchParams

This is a recent enough API that some close to 1% of users see this with global enough traffic. 


### Steps to Confirm

1. Try using Fides in an older browser ¯\\_(ツ)_/¯ 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-783]: https://ethyca.atlassian.net/browse/ENG-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ