### PR TITLE
privacy creates manual task instances

### DIFF
--- a/tests/service/test_privacy_request_service.py
+++ b/tests/service/test_privacy_request_service.py
@@ -1,21 +1,38 @@
 from datetime import datetime, timezone
-from unittest.mock import create_autospec
+from typing import Generator
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import ObjectDeletedError
 
 from fides.api.common_exceptions import FidesopsException
+from fides.api.models.audit_log import AuditLog, AuditLogAction
 from fides.api.models.client import ClientDetail
 from fides.api.models.connectionconfig import ConnectionConfig
 from fides.api.models.fides_user import FidesUser
 from fides.api.models.fides_user_permissions import FidesUserPermissions
+from fides.api.models.manual_tasks.manual_task import ManualTask
+from fides.api.models.manual_tasks.manual_task_config import ManualTaskConfig
+from fides.api.models.manual_tasks.manual_task_instance import ManualTaskInstance
 from fides.api.models.policy import Policy
 from fides.api.models.pre_approval_webhook import PreApprovalWebhook
 from fides.api.models.privacy_request import ExecutionLog
 from fides.api.models.property import Property
 from fides.api.models.worker_task import ExecutionLogStatus
 from fides.api.oauth.roles import APPROVER
+from fides.api.schemas.manual_tasks.manual_task_config import (
+    ManualTaskConfigurationType,
+    ManualTaskFieldType,
+)
+from fides.api.schemas.manual_tasks.manual_task_schemas import (
+    ManualTaskParentEntityType,
+)
+from fides.api.schemas.manual_tasks.manual_task_status import StatusType
+from fides.api.schemas.messaging.messaging import (
+    MessagingActionType,
+    MessagingServiceType,
+)
 from fides.api.schemas.policy import ActionType
 from fides.api.schemas.privacy_request import (
     PrivacyRequestCreate,
@@ -24,9 +41,24 @@ from fides.api.schemas.privacy_request import (
 )
 from fides.api.schemas.redis_cache import Identity
 from fides.config.config_proxy import ConfigProxy
+from fides.service.manual_tasks.manual_task_service import ManualTaskService
 from fides.service.messaging.messaging_service import MessagingService
 from fides.service.privacy_request.privacy_request_service import PrivacyRequestService
 from tests.conftest import wait_for_tasks_to_complete
+
+
+@pytest.fixture
+def mock_messaging_service() -> MessagingService:
+    mock_service = create_autospec(MessagingService)
+    mock_service.dispatch_message = MagicMock()
+    return mock_service
+
+
+@pytest.fixture
+def privacy_request_service(
+    db: Session, mock_messaging_service
+) -> PrivacyRequestService:
+    return PrivacyRequestService(db, ConfigProxy(db), mock_messaging_service)
 
 
 @pytest.mark.integration
@@ -36,16 +68,6 @@ class TestPrivacyRequestService:
     Since these tests actually run the privacy request using the posgres database, we need to
     mark them all as integration tests.
     """
-
-    @pytest.fixture
-    def mock_messaging_service(self) -> MessagingService:
-        return create_autospec(MessagingService)
-
-    @pytest.fixture
-    def privacy_request_service(
-        self, db: Session, mock_messaging_service
-    ) -> PrivacyRequestService:
-        return PrivacyRequestService(db, ConfigProxy(db), mock_messaging_service)
 
     @pytest.fixture
     def reviewing_user(self, db):
@@ -425,3 +447,107 @@ class TestPrivacyRequestService:
             ExecutionLog.status == ExecutionLogStatus.error
         )
         assert error_logs.count() == 0
+
+
+@pytest.mark.integration
+@pytest.mark.integration_postgres
+class TestPrivacyRequestServiceManualTasks:
+    @pytest.fixture
+    def manual_task_service(self, db: Session) -> ManualTaskService:
+        return ManualTaskService(db)
+
+    @pytest.fixture
+    def manual_task(
+        self, db: Session, connection_config: ConnectionConfig
+    ) -> Generator[ManualTask, None, None]:
+        manual_task = ManualTask.create(
+            db=db,
+            data={
+                "task_type": "privacy_request",
+                "parent_entity_id": connection_config.id,
+                "parent_entity_type": ManualTaskParentEntityType.connection_config,
+            },
+        )
+        yield manual_task
+        manual_task.delete(db)
+
+    @pytest.fixture
+    def manual_task_config(
+        self,
+        db: Session,
+        manual_task: ManualTask,
+        manual_task_service: ManualTaskService,
+    ) -> Generator[ManualTaskConfig, None, None]:
+        fields = [
+            {
+                "field_key": "field1",
+                "field_type": ManualTaskFieldType.text,
+                "field_metadata": {
+                    "label": "Field 1",
+                    "required": True,
+                    "help_text": "This is field 1",
+                    "placeholder": "Enter text here",
+                },
+            },
+        ]
+        config = manual_task_service.create_config(
+            ManualTaskConfigurationType.access_privacy_request, fields, manual_task.id
+        )
+        yield config
+        config.delete(db)
+
+    @pytest.mark.integration
+    @pytest.mark.integration_postgres
+    def test_create_privacy_request_creates_manual_task_instance(
+        self,
+        db: Session,
+        privacy_request_service: PrivacyRequestService,
+        policy: Policy,
+        connection_config: ConnectionConfig,
+        manual_task: ManualTask,
+        manual_task_config: ManualTaskConfig,
+    ) -> None:
+        """Test that creating a privacy request creates a manual task instance if a manual task exists."""
+
+        # Create privacy request
+        privacy_request = privacy_request_service.create_privacy_request(
+            PrivacyRequestCreate(
+                policy_key=policy.key,
+                identity=Identity(email="test@example.com"),
+                connection_config_id=connection_config.id,
+            ),
+            authenticated=True,
+        )
+
+        # Verify manual task instance was created
+        manual_task_instance = ManualTaskInstance.filter(
+            db=db,
+            conditions=(
+                (ManualTaskInstance.task_id == manual_task.id)
+                & (ManualTaskInstance.config_id == manual_task_config.id)
+                & (ManualTaskInstance.entity_id == privacy_request.id)
+                & (ManualTaskInstance.entity_type == "privacy_request")
+            ),
+        ).first()
+
+        assert manual_task_instance is not None
+        assert manual_task_instance.status == StatusType.pending
+
+        # Cleanup
+        manual_task_instance.delete(db)
+        privacy_request.delete(db)
+
+    def test_create_manual_task_instances_no_tasks(
+        self,
+        db: Session,
+        privacy_request_service: PrivacyRequestService,
+        policy: Policy,
+    ) -> None:
+        """Test creating manual task instances when no manual tasks exist."""
+        privacy_request = privacy_request_service.create_privacy_request(
+            PrivacyRequestCreate(
+                policy_key=policy.key,
+                identity=Identity(email="test@example.com"),
+            ),
+            authenticated=True,
+        )


### PR DESCRIPTION
Issue [ENG-762](https://ethyca.atlassian.net/browse/ENG-762)

### Description Of Changes

When a privacy request is created - if it has any ManualTaskConfigs with manual tasks and configs set up, it will create an instance for completion. 

### Code Changes

* Added functionality to `privacy_request_service` That will create a `manual_task_instance` for that privacy request if there is a manual task connection, with task and config set up. 

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-762]: https://ethyca.atlassian.net/browse/ENG-762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ