### PR TITLE
feat: include repo-wide cursor rule to prevent info disclosure

### DIFF
--- a/.cursor/rules/sensitive-info-protection.mdc
+++ b/.cursor/rules/sensitive-info-protection.mdc
@@ -3,12 +3,6 @@ description:
 globs:
 alwaysApply: true
 ---
----
-description: Protection against customer and internal sensitive information disclosure in public OSS repository
-globs: ["**/*"]
-alwaysApply: true
----
-
 # 🔒 CRITICAL: Public Repository Security - Zero Tolerance for Sensitive Information
 
 This is a **PUBLIC OSS repository**. Any customer or internal sensitive information committed here is immediately visible to the entire world and permanently recorded in git history.


### PR DESCRIPTION
Unticketed change

### Description Of Changes

Add cursor rule to prevent sensitive information disclosure to this public repository (`ethyca/fides`). This rule provides protection against accidentally committing customer data, internal system details, and other sensitive information, particularly important given Background Agents' access to full Slack thread context.

### Code Changes

* Added `.cursor/rules/sensitive-info-protection.mdc`
* Configured as "Always" rule type to apply to all files (`alwaysApply: true`)

### Steps to Confirm

1. Verify the rule appears in Cursor Settings > Rules as an active rule

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
