### PR TITLE
Add keyboard accessible CustomTooltip HOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Developer Experience
 - Updated SQLAlchemy models to match the contents of the Alembic migrations [#6262](https://github.com/ethyca/fides/pull/6262)
 
+### Fixed
+- Fixed an accessibility issue where tooltips could not be triggered by keyboard focus. [#6276](https://github.com/ethyca/fides/pull/6276)
+
 ## [2.64.1](https://github.com/ethyca/fides/compare/2.64.0...2.64.1)
 
 ### Fixed

--- a/clients/admin-ui/src/pages/poc/ant-components.tsx
+++ b/clients/admin-ui/src/pages/poc/ant-components.tsx
@@ -209,9 +209,12 @@ const AntPOC: NextPage = () => {
             <Card title="Tooltip" variant="borderless" className="h-full">
               <Space direction="vertical">
                 <Tooltip title="I'm a tooltip">
-                  <span>Hover this text</span>
+                  Hover or focus this text
                 </Tooltip>
-                <InfoTooltip label="Tooltip will show on mouse enter." />
+                <InfoTooltip label="Tooltip will show on mouse enter or focus." />
+                <Tooltip title="Focus styles don't change for naturally focusable elements like buttons">
+                  <Button>Button with tooltip</Button>
+                </Tooltip>
               </Space>
             </Card>
           </Col>

--- a/clients/admin-ui/src/theme/ant.ts
+++ b/clients/admin-ui/src/theme/ant.ts
@@ -90,5 +90,10 @@ export const antTheme: AntThemeConfig = {
       fontSizeSM: 12,
       titleMarginBottom: 0,
     },
+    Tag: {
+      colorText: palette.FIDESUI_NEUTRAL_900,
+      colorIcon: palette.FIDESUI_NEUTRAL_700,
+      colorIconHover: palette.FIDESUI_NEUTRAL_900,
+    },
   },
 };

--- a/clients/fidesui/src/hoc/CustomTag.module.scss
+++ b/clients/fidesui/src/hoc/CustomTag.module.scss
@@ -9,10 +9,13 @@
   line-height: calc(var(--ant-line-height-sm) * var(--ant-font-size-sm) - 2px);
   min-height: calc(var(--ant-line-height-sm) * var(--ant-font-size-sm));
   :global(svg:not([data-icon])) {
+    // `data-icon` comes from Ant icons, we don't want to override those,
+    // only the Carbon icons.
+    // If you need to override the size, use the `style` prop.
     width: 10px;
     height: 10px;
-    margin-inline-start: 0; // we're using gap instead
   }
+  --ant-padding-xxs: 0; //we're using gap instead
 }
 
 .buttonTag {

--- a/clients/fidesui/src/hoc/CustomTag.tsx
+++ b/clients/fidesui/src/hoc/CustomTag.tsx
@@ -73,20 +73,21 @@ const withCustomProps = (WrappedComponent: typeof Tag) => {
           ? "calc((var(--ant-padding-xs) * 0.5))"
           : undefined,
       },
-      className: `${styles.tag} ${className || ""}`.trim(),
+      className: `${styles.tag} ${className ?? ""}`.trim(),
       bordered: retainDefaultBorder,
-      closeIcon: props.closable ? (
-        // Ant's own close icon doesn't currently use a button element,
-        // so we need to use our own for accessibility.
-        <button
-          type="button"
-          className={styles.closeButton}
-          aria-label={closeButtonLabel}
-        >
-          <Icons.CloseLarge size={10} />
-        </button>
-      ) : undefined,
       ...props,
+      closeIcon:
+        (props.closable ?? props.onClose) ? (
+          // Ant's own close icon doesn't currently use a button element,
+          // so we need to use our own for accessibility.
+          <button
+            type="button"
+            className={styles.closeButton}
+            aria-label={closeButtonLabel}
+          >
+            {props.closeIcon ?? <Icons.CloseLarge size={10} />}
+          </button>
+        ) : undefined,
       children: (
         <>
           {hasSparkle && <SparkleIcon />}

--- a/clients/fidesui/src/hoc/CustomTooltip.module.scss
+++ b/clients/fidesui/src/hoc/CustomTooltip.module.scss
@@ -1,0 +1,14 @@
+@use "sass:map";
+@use "../palette/palette.module.scss" as palette;
+
+.tooltipChild {
+  --custom-tooltip-outline-width: 1px;
+  &:focus-visible {
+    outline: var(--custom-tooltip-outline-width) dashed
+      map.get(palette.$colors, "minos");
+    outline-offset: 1px;
+    transition:
+      outline-offset 0s,
+      outline 0s;
+  }
+}

--- a/clients/fidesui/src/hoc/CustomTooltip.tsx
+++ b/clients/fidesui/src/hoc/CustomTooltip.tsx
@@ -1,0 +1,101 @@
+import { Tooltip, TooltipProps } from "antd/lib";
+import React, { ReactElement } from "react";
+
+import styles from "./CustomTooltip.module.scss";
+
+interface CustomTooltipProps extends Omit<TooltipProps, "children"> {
+  children: ReactElement | string;
+  tabIndex?: number;
+}
+
+/**
+ * Higher-order component that adds keyboard accessibility support to Ant Design's Tooltip component.
+ * Automatically adds tabindex, onFocus, and onBlur handlers to the child element to make tooltips
+ * accessible via keyboard navigation. This only works when there's exactly one child element.
+ */
+const withCustomProps = (WrappedComponent: typeof Tooltip) => {
+  const WrappedTooltip = ({ children, ...props }: CustomTooltipProps) => {
+    let childElement: ReactElement;
+    if (typeof children === "string") {
+      // If children is a string, wrap it in a span to make it focusable
+      childElement = <span>{children}</span>;
+    } else if (!React.isValidElement(children)) {
+      return <WrappedComponent {...props}>{children}</WrappedComponent>;
+    } else {
+      childElement = children;
+    }
+
+    const existingProps = childElement.props as CustomTooltipProps;
+    const elementType = childElement.type as string;
+
+    // Check if element is naturally focusable (button, anchor, input, etc.)
+    const isNaturallyFocusable = [
+      "button",
+      "a",
+      "input",
+      "textarea",
+      "select",
+    ].includes(elementType);
+
+    // Create enhanced props for keyboard accessibility
+    const enhancedProps = {
+      ...existingProps,
+      // Only add tabIndex if element isn't naturally focusable and doesn't already have one
+      tabIndex:
+        existingProps.tabIndex ?? (isNaturallyFocusable ? undefined : 0),
+      className:
+        `${existingProps.className ?? ""} ${!isNaturallyFocusable ? styles.tooltipChild : ""}`.trim(),
+    };
+
+    // Clone the child element with enhanced props
+    const enhancedChild = React.cloneElement(childElement, enhancedProps);
+
+    return (
+      <WrappedComponent {...props} trigger={["focus", "hover"]}>
+        {enhancedChild}
+      </WrappedComponent>
+    );
+  };
+
+  return WrappedTooltip;
+};
+
+/**
+ * CustomTooltip extends Ant Design's Tooltip component with keyboard accessibility support.
+ * It automatically adds tabindex to the child element, and sets the trigger to "focus" and "hover".
+ * allowing keyboard users to trigger tooltips by focusing on the element.
+ *
+ * Features:
+ * - Automatically adds tabIndex={0} to non-focusable elements (skips buttons, anchors, inputs, etc.)
+ * - Shows tooltip on focus and hover
+ * - Only works with single child elements (React limitation for cloneElement)
+ *
+ * @example
+ * ```tsx
+ * // Basic usage with button (no tabIndex added - naturally focusable)
+ * <Tooltip title="Helpful information">
+ *   <button>Hover or focus me</button>
+ * </Tooltip>
+ *
+ * // With non-focusable element (tabIndex={0} added automatically)
+ * <Tooltip title="Status information">
+ *   <span>Basic text</span>
+ * </Tooltip>
+ *
+ * // With string (<span tabIndex={0} /> added automatically)
+ * <Tooltip title="Status information">
+ *   "Basic text"
+ * </Tooltip>
+ *
+ * // With anchor tag (no tabIndex added - naturally focusable)
+ * <Tooltip title="Link information">
+ *   <a href="#example">Link text</a>
+ * </Tooltip>
+ *
+ * // Override behavior with explicit tabIndex
+ * <Tooltip title="Custom tab order">
+ *   <div tabIndex={1}>Custom focus order</div>
+ * </Tooltip>
+ * ```
+ */
+export const CustomTooltip = withCustomProps(Tooltip);

--- a/clients/fidesui/src/hoc/index.tsx
+++ b/clients/fidesui/src/hoc/index.tsx
@@ -2,4 +2,5 @@ export * from "./CustomDateRangePicker";
 export * from "./CustomSelect";
 export * from "./CustomTable";
 export * from "./CustomTag";
+export * from "./CustomTooltip";
 export * from "./CustomTypography";

--- a/clients/fidesui/src/index.ts
+++ b/clients/fidesui/src/index.ts
@@ -67,7 +67,6 @@ export {
   Steps as AntSteps,
   Switch as AntSwitch,
   Tabs as AntTabs,
-  Tooltip as AntTooltip,
   Upload as AntUpload,
 } from "antd/lib";
 export type {
@@ -87,6 +86,7 @@ export {
   CustomSelect as AntSelect,
   CustomTable as AntTable,
   CustomTag as AntTag,
+  CustomTooltip as AntTooltip,
   CustomTypography as AntTypography,
 } from "./hoc";
 


### PR DESCRIPTION
Closes [ENG-849]

### Description Of Changes

Introduces a new Higher-Order Component (HOC) `CustomTooltip` that wraps the Ant Design `Tooltip` to provide enhanced keyboard accessibility. This HOC automatically adds a `tabIndex` to non-focusable elements, allowing them to receive focus and trigger the tooltip. It also applies a custom focus-visible style for better visibility.

### Code Changes

*   **`fidesui`**
    *   Added a new `CustomTooltip` HOC that automatically provides keyboard accessibility (focus trigger, `tabIndex`) to Ant Design's Tooltip.
    *   Exported `CustomTooltip` as the default `AntTooltip` from the `fidesui` library.
*   **`admin-ui`**
    *   Updated the POC page to demonstrate the new tooltip behaviors.
    *   Added theme overrides for the `Tag` component.

### Steps to Confirm

1.  Navigate to the Ant components POC page at `/poc/ant-components`.
2.  Hover over the various tooltipped elements to confirm the tooltips appear as expected.
3.  Use the `Tab` key to navigate the page.
4.  Confirm that the text "Hover or focus this text" receives focus, shows a dashed outline, and displays its tooltip.
5.  Confirm that the "Button with tooltip" also receives focus and displays its tooltip, but without the custom dashed outline.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-849]: https://ethyca.atlassian.net/browse/ENG-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ