### PR TITLE
Fixing Cypress job

### DIFF
--- a/.github/workflows/cypress_admin-ui.yml
+++ b/.github/workflows/cypress_admin-ui.yml
@@ -63,7 +63,7 @@ jobs:
           for file, count in files:
               # Find the group with the smallest total test count
               min_group_idx = group_counts.index(min(group_counts))
-              groups[min_group_idx].append(file)
+              groups[min_group_idx].append(f"cypress/e2e/{file}")
               group_counts[min_group_idx] += count
 
           # Format for GitHub Actions
@@ -104,7 +104,7 @@ jobs:
           start: npm run cy:start
           wait-on: "http://localhost:3000"
           wait-on-timeout: 180
-          spec: cypress/e2e/{${{ matrix.spec_group }}}
+          spec: ${{ matrix.spec_group }}
 
       - uses: actions/upload-artifact@v4
         if: failure()


### PR DESCRIPTION
### Description Of Changes

The [latest version](https://github.com/cypress-io/github-action/compare/v6.10.0...v6.10.1) of the `cypress-io` Github action updated the `brace-expansion`. This meant that strings like this
```
 cypress/e2e/{a.cy.ts,b.cy.ts}
 ```
 are now treated as literal strings instead of expanding them to
 ```
cypress/e2e/a.cy.ts
cypress/e2e/b.cy.ts
 ```

### Code Changes

* This PR updates the way we define the Cypress tests paths so we don't rely on brace expansions

### Steps to Confirm

1.  The tests should pass

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
