### PR TITLE
fix: taxonomy search filter [ENG-823]

### DIFF
--- a/clients/admin-ui/src/features/common/dropdown/TaxonomySelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/TaxonomySelect.tsx
@@ -18,7 +18,7 @@ export const TaxonomyOption = ({ data }: { data: TaxonomySelectOption }) => {
   return (
     <Flex
       gap={12}
-      title={`${data.primaryName || ""}${data.primaryName ? ": " : ""}${data.name} - ${data.description}`}
+      title={`${data.primaryName}${data.primaryName && ": "}${data.name} - ${data.description}`}
     >
       <div>
         <strong>{data.primaryName || data.name}</strong>
@@ -44,9 +44,16 @@ export const TaxonomySelect = ({
     className: styles.option,
   }));
 
+  /*
+   * @description Matches options where the displayed value includes the input text 
+   */
+  const filterOption = (input: string, option?: TaxonomySelectOption) => [option?.primaryName, option?.name].join(": ").toLowerCase().includes(input.toLowerCase())
+  
   return (
     <Select<string, TaxonomySelectOption>
       options={selectOptions}
+      filterOption={filterOption}
+      optionFilterProp="label"
       autoFocus
       variant="borderless"
       optionRender={TaxonomyOption}


### PR DESCRIPTION
Closes [ENG-823]

### Description Of Changes

Matches options where the displayed value includes the input text.

### Code Changes

* _list your code changes here_

### Steps to Confirm

1. Go to Data Discovery Screen
2. Attempt to edit a data category
3. Confirm that search text properly filters out values

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
