### PR TITLE
ENG-886 Filter for connection config disabled to manual task

### DIFF
--- a/src/fides/api/task/manual/manual_task_utils.py
+++ b/src/fides/api/task/manual/manual_task_utils.py
@@ -72,11 +72,12 @@ def get_manual_task_addresses(db: Session) -> List[CollectionAddress]:
     that's part of the dataset graph, regardless of specific policy targets. This allows
     manual tasks to collect additional data that may be needed for the privacy request.
     """
-    # Get all connection configs that have manual tasks
+    # Get all connection configs that have manual tasks (excluding disabled ones)
     connection_configs_with_manual_tasks = (
         db.query(ConnectionConfig)
         .join(ManualTask, ConnectionConfig.id == ManualTask.parent_entity_id)
         .filter(ManualTask.parent_entity_type == "connection_config")
+        .filter(ConnectionConfig.disabled.is_(False))
         .all()
     )
 
@@ -170,11 +171,12 @@ def create_manual_task_instances_for_privacy_request(
     """Create ManualTaskInstance entries for all active manual tasks relevant to a privacy request."""
     instances = []
 
-    # Get all connection configs that have manual tasks
+    # Get all connection configs that have manual tasks (excluding disabled ones)
     connection_configs_with_manual_tasks = (
         db.query(ConnectionConfig)
         .join(ManualTask, ConnectionConfig.id == ManualTask.parent_entity_id)
         .filter(ManualTask.parent_entity_type == "connection_config")
+        .filter(ConnectionConfig.disabled.is_(False))
         .all()
     )
 

--- a/src/fides/api/util/connection_util.py
+++ b/src/fides/api/util/connection_util.py
@@ -278,27 +278,18 @@ def patch_connection_configs(
 
             # Automatically create a ManualTask if this is a connection config of type manual_task
             # and it doesn't already have one
-            if connection_config.connection_type == ConnectionType.manual_task:
-                # Check if manual task already exists
-                # querying directly to avoid relationship lazy loading issues
-                existing_manual_task = (
-                    db.query(ManualTask)
-                    .filter(
-                        ManualTask.parent_entity_id == connection_config.id,
-                        ManualTask.parent_entity_type == "connection_config",
-                    )
-                    .first()
+            if (
+                connection_config.connection_type == ConnectionType.manual_task
+                and not connection_config.manual_task
+            ):
+                ManualTask.create(
+                    db=db,
+                    data={
+                        "task_type": ManualTaskType.privacy_request,
+                        "parent_entity_id": connection_config.id,
+                        "parent_entity_type": ManualTaskParentEntityType.connection_config,
+                    },
                 )
-
-                if not existing_manual_task:
-                    ManualTask.create(
-                        db=db,
-                        data={
-                            "task_type": ManualTaskType.privacy_request,
-                            "parent_entity_id": connection_config.id,
-                            "parent_entity_type": ManualTaskParentEntityType.connection_config,
-                        },
-                    )
 
             created_or_updated.append(
                 ConnectionConfigurationResponse.model_validate(connection_config)


### PR DESCRIPTION
Closes [ENG-886](https://ethyca.atlassian.net/browse/ENG-886?atlOrigin=eyJpIjoiNzc4YWI0MjI3MDkwNGJiZTg0MTZjMWRiZWFhNDBjNzMiLCJwIjoiaiJ9)

### Description Of Changes

Added connection config filtering to ManualTask creation in DAG - this should ensure that only connection configs which are enabled show up in the request runner. This matches the overall dataset functionality [here](https://github.com/ethyca/fides/blob/a60607f201c3144d6150c6ef61a6c203f05ca2f8/src/fides/api/service/privacy_request/request_runner_service.py#L453)

### Code Changes

* Added filters for `ConnectionConfig.disabled.is_(False)` to various manual task dag functions. 

### Steps to Confirm

1.  Create a manual task connection config - enabled
2. Verify that the manual task appears in privacy requests.
3. Disable the connection config
4. Verify the manual task does not appear in new privacy requests.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-886]: https://ethyca.atlassian.net/browse/ENG-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ