### PR TITLE
ENG-889

### DIFF
--- a/src/fides/api/api/v1/endpoints/generic_overrides.py
+++ b/src/fides/api/api/v1/endpoints/generic_overrides.py
@@ -1,6 +1,8 @@
+from functools import partial
 from typing import Dict, List, Optional, Type, Union
 
 from fastapi import Depends, HTTPException, Query, Response, Security
+from fastapi.concurrency import run_in_threadpool
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from fastapi_pagination import Page, Params
@@ -224,9 +226,17 @@ async def list_dataset_paginated(
 
     pagination_params = Params(page=page or 1, size=size or 50)
     results = await async_paginate(db, filtered_query, pagination_params)
-    results.items = [  # type: ignore[attr-defined]
-        DatasetResponse.model_validate(result.__dict__) for result in results.items  # type: ignore[attr-defined]
-    ]
+
+    validated_items = []
+    for result in results.items:
+        # run pydantic validation in a threadpool to avoid blocking the main thread
+        validated_item = await run_in_threadpool(
+            partial(DatasetResponse.model_validate, result.__dict__)
+        )
+        validated_items.append(validated_item)
+
+    results.items = validated_items
+
     return results
 
 


### PR DESCRIPTION
Closes [ENG-889](https://ethyca.atlassian.net/browse/ENG-889?atlOrigin=eyJpIjoiMDAxNzQ0NzNlZjE0NDg0Y2E3N2M2NjlmZjQ3MmI4M2YiLCJwIjoiaiJ9)

### Description Of Changes

- Moves serialization of datasets, which is a synchronous and potentially long-running operation (i.e. with large datasets) to the default fastAPI threadpool to avoid blocking main thread on the `async` endpoint
- TODO: update FE to call the API with `minimal=true` to avoid this codepath altogether when not needed...

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-889]: https://ethyca.atlassian.net/browse/ENG-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ