### PR TITLE
ENG-889

### DIFF
--- a/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/DatasetConfiguration.tsx
@@ -24,7 +24,7 @@ import { useAppSelector } from "~/app/hooks";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { DATASTORE_CONNECTION_ROUTE } from "~/features/common/nav/routes";
 import {
-  useGetAllDatasetsQuery,
+  useGetAllFilteredDatasetsQuery,
   useUpsertDatasetsMutation,
 } from "~/features/dataset";
 import { Dataset, DatasetConfigCtlDataset } from "~/types/api";
@@ -51,7 +51,9 @@ const DatasetConfiguration = () => {
     data: allDatasets,
     isLoading: isLoadingAllDatasets,
     error: loadAllDatasetsError,
-  } = useGetAllDatasetsQuery();
+  } = useGetAllFilteredDatasetsQuery({
+    minimal: true,
+  });
 
   const [selectedDatasetKey, setSelectedDatasetKey] = useState<
     string | undefined

--- a/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/add-connection/forms/YamlEditorForm.tsx
@@ -13,7 +13,7 @@ import React, { Fragment, useRef, useState } from "react";
 
 import { Editor, isYamlException } from "~/features/common/yaml/helpers";
 import YamlError from "~/features/common/yaml/YamlError";
-import { useGetAllDatasetsQuery } from "~/features/dataset";
+import { useGetAllFilteredDatasetsQuery } from "~/features/dataset";
 import { Dataset } from "~/types/api";
 
 type YamlEditorFormProps = {
@@ -40,7 +40,9 @@ const YamlEditorForm = ({
   const [isTouched, setIsTouched] = useState(false);
   const [isEmptyState, setIsEmptyState] = useState(!yamlData);
   const warningDisclosure = useDisclosure();
-  const { data: allDatasets } = useGetAllDatasetsQuery();
+  const { data: allDatasets } = useGetAllFilteredDatasetsQuery({
+    minimal: true,
+  });
   const [overWrittenKeys, setOverWrittenKeys] = useState<string[]>([]);
 
   const validate = (value: string) => {

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/YamlEditor.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/YamlEditor.tsx
@@ -5,7 +5,7 @@ import React, { Fragment, useRef, useState } from "react";
 
 import { Editor, isYamlException } from "~/features/common/yaml/helpers";
 import YamlError from "~/features/common/yaml/YamlError";
-import { useGetAllDatasetsQuery } from "~/features/dataset";
+import { useGetAllFilteredDatasetsQuery } from "~/features/dataset";
 import { Dataset } from "~/types/api";
 
 type YamlEditorFormProps = {
@@ -39,7 +39,9 @@ const YamlEditor = ({
   We need to get all the datasets, including saas datasets, so that we can verify that
   the fides_key is not already in use.
    */
-  const { data: allDatasets } = useGetAllDatasetsQuery();
+  const { data: allDatasets } = useGetAllFilteredDatasetsQuery({
+    minimal: true,
+  });
   const [overWrittenKeys, setOverWrittenKeys] = useState<string[]>([]);
 
   const validate = (value: string) => {

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/useDatasetConfigField.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/useDatasetConfigField.tsx
@@ -34,6 +34,7 @@ export const useDatasetConfigField = ({
 
   const { data: unlinkedDatasets } = useGetAllFilteredDatasetsQuery({
     onlyUnlinkedDatasets: true,
+    minimal: true,
   });
 
   const unlinkedDatasetOptions: Option[] = useMemo(


### PR DESCRIPTION
Closes [ENG-889](https://ethyca.atlassian.net/browse/ENG-889)

### Description Of Changes

- Moves serialization of datasets, which is a synchronous and potentially long-running operation (i.e. with large datasets) to the default fastAPI threadpool to avoid blocking main thread on the `async` endpoint
- update FE to call the API with `minimal=true` to avoid this codepath altogether when not needed...


### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
