### PR TITLE
Fix manual tasks UI bugs

### DIFF
--- a/clients/admin-ui/src/features/common/table/v2/filters/GlobalFilterV2.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/filters/GlobalFilterV2.tsx
@@ -29,11 +29,12 @@ export const GlobalFilterV2 = ({
     setGlobalFilter(undefined);
   }, [setValue, setGlobalFilter]);
 
+  // Keep local state in sync with the externally-managed `globalFilter`.
   useEffect(() => {
-    if (!value) {
-      onClear();
+    if (!globalFilter) {
+      setValue(undefined);
     }
-  }, [value, onClear]);
+  }, [globalFilter]);
 
   return (
     <Box maxWidth="424px" width="100%">

--- a/clients/privacy-center/features/external-manual-tasks/ExternalStoreProvider.tsx
+++ b/clients/privacy-center/features/external-manual-tasks/ExternalStoreProvider.tsx
@@ -8,7 +8,7 @@
 
 "use client";
 
-import React, { ReactNode, useEffect } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 
@@ -37,7 +37,9 @@ const StoreDataLoader = ({
   children: ReactNode;
   settings: PrivacyCenterClientSettings;
   config?: Config | PrivacyCenterConfig;
-}): React.ReactElement => {
+}): React.ReactElement | null => {
+  const [hasInitializedStores, setHasInitializedStores] = useState(false);
+
   useEffect(() => {
     // Load settings into external store
     externalStore.dispatch(loadSettings(settings));
@@ -46,7 +48,14 @@ const StoreDataLoader = ({
     if (config) {
       externalStore.dispatch(loadConfig(config));
     }
+
+    // Mark stores as initialized so children can render
+    setHasInitializedStores(true);
   }, [settings, config]);
+
+  if (!hasInitializedStores) {
+    return null;
+  }
 
   return children as React.ReactElement;
 };

--- a/clients/privacy-center/features/external-manual-tasks/components/ExternalAuthLayout.tsx
+++ b/clients/privacy-center/features/external-manual-tasks/components/ExternalAuthLayout.tsx
@@ -13,6 +13,8 @@ import {
 import Image from "next/image";
 import React from "react";
 
+import { useConfig } from "~/features/common/config.slice";
+
 interface ExternalAuthLayoutProps {
   children: React.ReactNode;
   title?: string;
@@ -22,6 +24,8 @@ export const ExternalAuthLayout = ({
   children,
   title = "External Manual Tasks",
 }: ExternalAuthLayoutProps) => {
+  const config = useConfig();
+
   return (
     <Flex
       justify="center"
@@ -38,7 +42,7 @@ export const ExternalAuthLayout = ({
           {/* Fides Logo */}
           <Flex justify="center">
             <Image
-              src="/logo.svg"
+              src={config?.logo_path || "/logo.svg"}
               alt="Fides logo"
               width={205}
               height={46}


### PR DESCRIPTION
### Description Of Changes

Fix unresponsive navigation after going to the Manual Tasks tab. Fix wrong privacy center logo appearing.

### Code Changes

* Fix old bug in the GlobalFilterV2 component that caused a rendering loop
* Fix external task logo by fetching from the correct configs

### Steps to Confirm

1.  Go to Admin UI > Privacy Request page
2. Switch to the Manual Tasks tab
3. Click on any link on the nav menu and check that it navigates correctly

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
