### PR TITLE
Fix external UI bugs

### DIFF
--- a/clients/admin-ui/src/features/manual-tasks/manual-tasks.slice.ts
+++ b/clients/admin-ui/src/features/manual-tasks/manual-tasks.slice.ts
@@ -29,13 +29,13 @@ export const manualTasksApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getTasks: build.query<ManualFieldSearchResponse, TaskQueryParams | void>({
       query: (params) => {
-        const queryParams = params || { page: 1, size: 10 };
+        const queryParams = params || { page: 1, size: 25 };
         const searchParams = new URLSearchParams();
 
         // Convert page to be 1-indexed for API
         const page = queryParams.page || 1;
         searchParams.append("page", String(page));
-        searchParams.append("size", String(queryParams.size || 10));
+        searchParams.append("size", String(queryParams.size || 25));
 
         if (queryParams.status) {
           searchParams.append("status", queryParams.status);
@@ -81,6 +81,9 @@ export const manualTasksApi = baseApi.injectEndpoints({
         } = payload;
 
         const formData = new FormData();
+
+        // Append field_key (consistent with complete task implementation)
+        formData.append("field_key", manualFieldId);
 
         // Append field_value if provided
         if (fieldValue !== undefined && fieldValue !== null) {

--- a/clients/admin-ui/src/features/manual-tasks/manual-tasks.slice.ts
+++ b/clients/admin-ui/src/features/manual-tasks/manual-tasks.slice.ts
@@ -82,9 +82,6 @@ export const manualTasksApi = baseApi.injectEndpoints({
 
         const formData = new FormData();
 
-        // Append field_key (consistent with complete task implementation)
-        formData.append("field_key", manualFieldId);
-
         // Append field_value if provided
         if (fieldValue !== undefined && fieldValue !== null) {
           formData.append("field_value", fieldValue);
@@ -136,7 +133,6 @@ export const manualTasksApi = baseApi.injectEndpoints({
         } = payload;
 
         const formData = new FormData();
-        formData.append("field_key", manualFieldId);
 
         // Append all other fields from body
         Object.entries(body).forEach(([key, value]) => {

--- a/clients/privacy-center/app/external-tasks/ExternalTasksClient.tsx
+++ b/clients/privacy-center/app/external-tasks/ExternalTasksClient.tsx
@@ -166,6 +166,12 @@ const ExternalTasksClientInner = ({
     (verifyOtpError ? "Failed to verify code. Please try again." : null);
 
   const renderAuthContent = () => {
+    // If user is authenticated, show authenticated content regardless of token
+    if (authStep === "authenticated") {
+      return <ExternalTaskLayout />;
+    }
+
+    // For non-authenticated users, require token
     if (!token) {
       return <NoAccessTokenMessage />;
     }
@@ -193,9 +199,6 @@ const ExternalTasksClientInner = ({
             error={combinedError}
           />
         );
-
-      case "authenticated":
-        return <ExternalTaskLayout />;
 
       default:
         return null;

--- a/clients/privacy-center/features/external-manual-tasks/components/ExternalCompleteTaskModal.tsx
+++ b/clients/privacy-center/features/external-manual-tasks/components/ExternalCompleteTaskModal.tsx
@@ -69,7 +69,6 @@ export const ExternalCompleteTaskModal = ({
       await completeTask({
         privacy_request_id: task.privacy_request.id,
         manual_field_id: task.manual_field_id,
-        field_key: task.manual_field_id,
         field_value: getFieldValue(),
         comment_text: comment || undefined,
         attachment: fileList.length > 0 ? fileList[0].originFileObj : undefined,

--- a/clients/privacy-center/features/external-manual-tasks/components/ExternalCompleteTaskModal.tsx
+++ b/clients/privacy-center/features/external-manual-tasks/components/ExternalCompleteTaskModal.tsx
@@ -69,6 +69,7 @@ export const ExternalCompleteTaskModal = ({
       await completeTask({
         privacy_request_id: task.privacy_request.id,
         manual_field_id: task.manual_field_id,
+        field_key: task.manual_field_id,
         field_value: getFieldValue(),
         comment_text: comment || undefined,
         attachment: fileList.length > 0 ? fileList[0].originFileObj : undefined,

--- a/clients/privacy-center/features/external-manual-tasks/components/ExternalManualTasks.tsx
+++ b/clients/privacy-center/features/external-manual-tasks/components/ExternalManualTasks.tsx
@@ -35,8 +35,8 @@ const statusMap: Record<ManualFieldStatus, { color: string; label: string }> = {
   [ManualFieldStatus.SKIPPED]: { color: "marble", label: "Skipped" },
 };
 
-// Page sizes for external users (simplified)
-const PAGE_SIZES = ["10", "25", "50"];
+// Page sizes for external users (match admin UI)
+const PAGE_SIZES = ["25", "50", "100"];
 
 // Extract column definitions for external users
 const getExternalColumns = (
@@ -74,6 +74,7 @@ const getExternalColumns = (
       { text: "Completed", value: ManualFieldStatus.COMPLETED },
       { text: "Skipped", value: ManualFieldStatus.SKIPPED },
     ],
+    filterMultiple: false,
   },
   {
     title: "System",
@@ -81,6 +82,7 @@ const getExternalColumns = (
     key: "system_name",
     width: 200,
     filters: systemFilters,
+    filterMultiple: false,
   },
   {
     title: "Type",
@@ -96,6 +98,7 @@ const getExternalColumns = (
       { text: "Access", value: ManualFieldRequestType.ACCESS },
       { text: "Erasure", value: ManualFieldRequestType.ERASURE },
     ],
+    filterMultiple: false,
   },
   {
     title: "Days left",
@@ -151,9 +154,9 @@ export const ExternalManualTasks = () => {
   const [pageIndex, setPageIndex] = useState(1);
   const [pageSize, setPageSize] = useState(25);
   const [filters, setFilters] = useState<{
-    status?: string[];
-    systemName?: string[];
-    requestType?: string[];
+    status?: string;
+    systemName?: string;
+    requestType?: string;
   }>({});
 
   // Use external tasks query
@@ -161,9 +164,9 @@ export const ExternalManualTasks = () => {
     page: pageIndex,
     size: pageSize,
     // Pass filter parameters to API
-    status: filters.status?.[0] as ManualFieldStatus,
-    systemName: filters.systemName?.[0],
-    requestType: filters.requestType?.[0] as ManualFieldRequestType,
+    status: filters.status as ManualFieldStatus,
+    systemName: filters.systemName,
+    requestType: filters.requestType as ManualFieldRequestType,
   });
 
   const {
@@ -197,13 +200,13 @@ export const ExternalManualTasks = () => {
     const newFilters: typeof filters = {};
 
     if (tableFilters.status) {
-      newFilters.status = tableFilters.status;
+      [newFilters.status] = tableFilters.status as string[];
     }
     if (tableFilters.system_name) {
-      newFilters.systemName = tableFilters.system_name;
+      [newFilters.systemName] = tableFilters.system_name as string[];
     }
     if (tableFilters.request_type) {
-      newFilters.requestType = tableFilters.request_type;
+      [newFilters.requestType] = tableFilters.request_type as string[];
     }
 
     setFilters(newFilters);

--- a/clients/privacy-center/features/external-manual-tasks/components/ExternalSkipTaskModal.tsx
+++ b/clients/privacy-center/features/external-manual-tasks/components/ExternalSkipTaskModal.tsx
@@ -52,7 +52,6 @@ export const ExternalSkipTaskModal = ({
       await skipTask({
         privacy_request_id: task.privacy_request.id,
         manual_field_id: task.manual_field_id,
-        field_key: task.manual_field_id,
         skip_reason: comment,
       }).unwrap();
 

--- a/clients/privacy-center/features/external-manual-tasks/external-manual-tasks.slice.ts
+++ b/clients/privacy-center/features/external-manual-tasks/external-manual-tasks.slice.ts
@@ -144,7 +144,6 @@ export const externalManualTasksApi = externalBaseApi.injectEndpoints({
       {
         privacy_request_id: string;
         manual_field_id: string;
-        field_key: string;
         field_value?: string;
         comment_text?: string;
         attachment?: File;
@@ -154,16 +153,12 @@ export const externalManualTasksApi = externalBaseApi.injectEndpoints({
         const {
           privacy_request_id: privacyRequestId,
           manual_field_id: manualFieldId,
-          field_key: fieldKey,
           field_value: fieldValue,
           comment_text: commentText,
           attachment,
         } = payload;
 
         const formData = new FormData();
-
-        // Append field_key (consistent with admin UI and skip task implementation)
-        formData.append("field_key", fieldKey);
 
         // Append field_value if provided
         if (fieldValue !== undefined && fieldValue !== null) {
@@ -199,7 +194,6 @@ export const externalManualTasksApi = externalBaseApi.injectEndpoints({
       {
         privacy_request_id: string;
         manual_field_id: string;
-        field_key: string;
         skip_reason: string;
       }
     >({
@@ -207,12 +201,10 @@ export const externalManualTasksApi = externalBaseApi.injectEndpoints({
         const {
           privacy_request_id: privacyRequestId,
           manual_field_id: manualFieldId,
-          field_key: fieldKey,
           skip_reason: skipReason,
         } = payload;
 
         const formData = new FormData();
-        formData.append("field_key", fieldKey);
         formData.append("skip_reason", skipReason);
         formData.append("comment_text", skipReason);
         formData.append("comment_type", CommentType.NOTE);

--- a/clients/privacy-center/features/external-manual-tasks/external-manual-tasks.slice.ts
+++ b/clients/privacy-center/features/external-manual-tasks/external-manual-tasks.slice.ts
@@ -144,6 +144,7 @@ export const externalManualTasksApi = externalBaseApi.injectEndpoints({
       {
         privacy_request_id: string;
         manual_field_id: string;
+        field_key: string;
         field_value?: string;
         comment_text?: string;
         attachment?: File;
@@ -153,12 +154,16 @@ export const externalManualTasksApi = externalBaseApi.injectEndpoints({
         const {
           privacy_request_id: privacyRequestId,
           manual_field_id: manualFieldId,
+          field_key: fieldKey,
           field_value: fieldValue,
           comment_text: commentText,
           attachment,
         } = payload;
 
         const formData = new FormData();
+
+        // Append field_key (consistent with admin UI and skip task implementation)
+        formData.append("field_key", fieldKey);
 
         // Append field_value if provided
         if (fieldValue !== undefined && fieldValue !== null) {


### PR DESCRIPTION
### Description Of Changes

Make external task ui allow only a single value for every column filtering (api only supports that). Remove unnecessary param to complete action for consistency with admin-ui. Fix skip task.

### Code Changes

* use filterMultiple false option in the column filtering
* update filtering code
* remove unnecessary field key param
* update pagination sizes to match admin-ui
* fix auth layout

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
