### PR TITLE
fix dataset select

### DIFF
--- a/clients/admin-ui/src/features/dataset/dataset.slice.ts
+++ b/clients/admin-ui/src/features/dataset/dataset.slice.ts
@@ -198,6 +198,7 @@ export const selectAllFilteredDatasets: (state: RootState) => Dataset[] =
       (RootState) => RootState,
       datasetApi.endpoints.getAllFilteredDatasets.select({
         onlyUnlinkedDatasets: false,
+        minimal: true,
       }),
     ],
     (RootState, { data }) => data ?? emptyDatasets,


### PR DESCRIPTION
### Description Of Changes

Update dataset select in redux to match the updated query subscription that now has the minimal: true option

### Code Changes

* Update selectAllFilteredDatasets to use the minimal:true option

### Steps to Confirm

1.  Go to Systems page
2. Edit any system
3. Use the Dataset reference dropdown and check it is displaying options

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
