### PR TITLE
Include exports field to improve 3rd party usage

### DIFF
--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -10,6 +10,23 @@
   "files": [
     "dist/**"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/fides.mjs",
+      "require": "./dist/fides.js",
+      "types": "./dist/fides.d.ts"
+    },
+    "./headless": {
+      "import": "./dist/fides-headless.mjs",
+      "require": "./dist/fides-headless.js",
+      "types": "./dist/fides-headless.d.ts"
+    },
+    "./tcf": {
+      "import": "./dist/fides-tcf.mjs",
+      "require": "./dist/fides-tcf.js",
+      "types": "./dist/fides-tcf.d.ts"
+    }
+  },
   "scripts": {
     "dev": "NODE_ENV=development rollup --watch -c",
     "build": "NODE_ENV=production rollup -c",

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -6,13 +6,13 @@ import {
   FidesCookie,
   FidesEndpointPaths,
   Layer1ButtonOption,
+  NoticeConsent,
   PrivacyExperience,
   PrivacyExperienceMinimal,
   RejectAllMechanism,
 } from "fides-js";
-import { NoticeConsent } from "fides-js/src/lib/consent-types";
-import { FIDES_SEPARATOR } from "fides-js/src/lib/tcf/constants";
 
+import { FIDES_SEPARATOR } from "../../../fides-js/src/lib/tcf/constants";
 import {
   API_URL,
   TCF_VERSION_HASH,

--- a/clients/privacy-center/cypress/e2e/consent-events.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-events.cy.ts
@@ -1,8 +1,5 @@
-import {
-  ConsentFlagType,
-  ConsentNonApplicableFlagMode,
-} from "fides-js/src/lib/consent-types";
-import type { FidesEventDetail, FidesEventType } from "fides-js/src/lib/events";
+import type { FidesEventDetail, FidesEventType } from "fides-js";
+import { ConsentFlagType, ConsentNonApplicableFlagMode } from "fides-js";
 
 import { stubConfig, stubTCFExperience } from "../support/stubs";
 

--- a/clients/privacy-center/cypress/e2e/consent-third-party.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-third-party.cy.ts
@@ -1,10 +1,9 @@
-import { CONSENT_COOKIE_NAME } from "fides-js";
-import { stubConfig, stubTCFExperience } from "support/stubs";
-
 import {
+  CONSENT_COOKIE_NAME,
   ConsentFlagType,
   ConsentNonApplicableFlagMode,
-} from "../../../fides-js/src/lib/consent-types";
+} from "fides-js";
+import { stubConfig, stubTCFExperience } from "support/stubs";
 
 const PRIVACY_NOTICE_KEY_1 = "advertising";
 const PRIVACY_NOTICE_KEY_2 = "essential";


### PR DESCRIPTION
### Description Of Changes

Added modern `exports` field to package.json to improve package resolution and enable direct imports of different Fides variants. This allows customers to import specific builds (headless, TCF) directly using clean import paths while maintaining backward compatibility with existing usage patterns.

Solves the following issues:

- Only main `fides.mjs` was referenced in package.json "module" field
- Missing modern "exports" field for better package resolution
- Other variants (TCF, headless) weren't exposed through package exports

Example:

```
// Main Fides SDK
import { init } from 'fides-js';

// Headless version (no UI)
import { init } from 'fides-js/headless';

// TCF-enabled version
import { init } from 'fides-js/tcf';
```