### PR TITLE
Refactor GPP to be more DRY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.65.0...main)
 
 ### Developer Experience
-Refactored GPP utility functions to reduce code duplication and improve maintainability [#6318](https://github.com/ethyca/fides/pull/6318)
+- Refactored GPP utility functions to reduce code duplication and improve maintainability [#6318](https://github.com/ethyca/fides/pull/6318)
 
 ### Fixed
 - Fixed FidesJS GPP to use national section when a supported US state has no specific notices and approach is set to both. [#6307](https://github.com/ethyca/fides/pull/6307)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.65.0...main)
 
+### Developer Experience
+Refactored GPP utility functions to reduce code duplication and improve maintainability [#6318](https://github.com/ethyca/fides/pull/6318)
+
 ### Fixed
 - Fixed FidesJS GPP to use national section when a supported US state has no specific notices and approach is set to both. [#6307](https://github.com/ethyca/fides/pull/6307)
 - Fixed taxonomy search behavior to include label and value text

--- a/clients/fides-js/__tests__/lib/gpp/string-to-consent.test.ts
+++ b/clients/fides-js/__tests__/lib/gpp/string-to-consent.test.ts
@@ -12,11 +12,11 @@ import {
   PrivacyNoticeFramework,
   UserConsentPreference,
 } from "../../../src/lib/consent-types";
+import { GPPUSApproach } from "../../../src/lib/gpp/constants";
 import { makeStub } from "../../../src/lib/gpp/stub";
 import {
   GPPFieldMapping,
   GPPMechanismMapping,
-  GPPUSApproach,
 } from "../../../src/lib/gpp/types";
 import {
   updateConsent,

--- a/clients/fides-js/__tests__/lib/gpp/us-notices.test.ts
+++ b/clients/fides-js/__tests__/lib/gpp/us-notices.test.ts
@@ -9,11 +9,11 @@ import {
   PrivacyNoticeFramework,
   UserConsentPreference,
 } from "../../../src/lib/consent-types";
+import { GPPUSApproach } from "../../../src/lib/gpp/constants";
 import { makeStub } from "../../../src/lib/gpp/stub";
 import {
   GPPFieldMapping,
   GPPMechanismMapping,
-  GPPUSApproach,
 } from "../../../src/lib/gpp/types";
 import {
   setGppNoticesProvidedFromExperience,

--- a/clients/fides-js/src/fides-ext-gpp.ts
+++ b/clients/fides-js/src/fides-ext-gpp.ts
@@ -32,10 +32,11 @@ import { formatFidesStringWithGpp } from "./lib/fides-string";
 import {
   CMP_VERSION,
   FIDES_US_REGION_TO_GPP_SECTION,
+  GPPUSApproach,
 } from "./lib/gpp/constants";
 import { fidesStringToConsent } from "./lib/gpp/string-to-consent";
 import { makeStub } from "./lib/gpp/stub";
-import { GppFunction, GPPUSApproach } from "./lib/gpp/types";
+import { GppFunction } from "./lib/gpp/types";
 import {
   setGppNoticesProvidedFromExperience,
   setGppOptOutsFromCookieAndExperience,

--- a/clients/fides-js/src/lib/gpp/constants.ts
+++ b/clients/fides-js/src/lib/gpp/constants.ts
@@ -40,3 +40,9 @@ export const FIDES_US_REGION_TO_GPP_SECTION: Record<string, GPPSection> = {
   us_tn: { name: UsTn.NAME, id: UsTn.ID },
   us_tx: { name: UsTx.NAME, id: UsTx.ID },
 };
+
+export enum GPPUSApproach {
+  NATIONAL = "national",
+  STATE = "state",
+  ALL = "all",
+}

--- a/clients/fides-js/src/lib/gpp/gpp-utils.ts
+++ b/clients/fides-js/src/lib/gpp/gpp-utils.ts
@@ -1,3 +1,16 @@
+/**
+ * @fileoverview GPP utility functions for handling Global Privacy Platform operations.
+ *
+ * ⚠️  IMPORTANT: This file is synchronized between repositories!
+ *
+ * This file exists in both:
+ * - fides: clients/fides-js/src/lib/gpp/gpp-utils.ts
+ * - fidesplus: src/fidesplus/gpp_js_integration/gpp-utils.ts
+ *
+ * Any changes made to this file should be applied to both locations
+ * to maintain consistency between the open-source and enterprise versions.
+ */
+
 import { UsNatField } from "@iabgpp/cmpapi";
 
 import { FIDES_US_REGION_TO_GPP_SECTION, GPPUSApproach } from "./constants";

--- a/clients/fides-js/src/lib/gpp/gpp-utils.ts
+++ b/clients/fides-js/src/lib/gpp/gpp-utils.ts
@@ -1,0 +1,200 @@
+import { UsNatField } from "@iabgpp/cmpapi";
+
+import { FIDES_US_REGION_TO_GPP_SECTION, GPPUSApproach } from "./constants";
+import { GPPSection, GPPSettings, NoticeConsent, PrivacyNotice } from "./types";
+
+export const US_NATIONAL_REGION = "us";
+
+/**
+ * Checks if a given region is in the US based on the provided region string's prefix.
+ * Also returns true if the region is the US_NATIONAL_REGION.
+ */
+export const isUsRegion = (region: string) =>
+  region?.toLowerCase().startsWith("us");
+
+/**
+ * For US National, the privacy experience region is still the state where the user came from.
+ * However, the GPP field mapping will only contain "us", so make sure we use "us" (US_NATIONAL_REGION) when we are configured for the national case.
+ * Otherwise, we can use the experience region directly.
+ */
+export const deriveGppFieldRegion = ({
+  experienceRegion,
+  usApproach,
+}: {
+  experienceRegion: string;
+  usApproach: GPPUSApproach | undefined;
+}) => {
+  if (isUsRegion(experienceRegion) && usApproach === GPPUSApproach.NATIONAL) {
+    return US_NATIONAL_REGION;
+  }
+  return experienceRegion;
+};
+
+/**
+ * Generic interface for GPP API objects that can set field values
+ */
+export interface GPPApiLike {
+  setFieldValue(
+    sectionName: string,
+    field: string,
+    value: number | number[],
+  ): void;
+}
+
+/**
+ * Sets MSPA sections on a GPP API object (works with both GppModel and CmpApi)
+ */
+export const setMspaSections = ({
+  gppApi,
+  sectionName,
+  gppSettings,
+}: {
+  gppApi: GPPApiLike;
+  sectionName: string;
+  gppSettings: GPPSettings | undefined;
+}) => {
+  if (!gppSettings) {
+    return;
+  }
+
+  const mspaFields = [
+    {
+      gppSettingField: gppSettings.mspa_covered_transactions,
+      cmpApiField: UsNatField.MSPA_COVERED_TRANSACTION,
+    },
+    {
+      gppSettingField:
+        gppSettings.mspa_covered_transactions &&
+        gppSettings.mspa_opt_out_option_mode,
+      cmpApiField: UsNatField.MSPA_OPT_OUT_OPTION_MODE,
+    },
+    {
+      gppSettingField:
+        gppSettings.mspa_covered_transactions &&
+        gppSettings.mspa_service_provider_mode,
+      cmpApiField: UsNatField.MSPA_SERVICE_PROVIDER_MODE,
+    },
+  ];
+
+  mspaFields.forEach(({ gppSettingField, cmpApiField }) => {
+    const isCoveredTransactions =
+      cmpApiField === UsNatField.MSPA_COVERED_TRANSACTION;
+    let value = 2; // Default to No
+
+    if (!gppSettings.mspa_covered_transactions && !isCoveredTransactions) {
+      value = 0; // When covered transactions is false, other fields should be disabled
+    } else if (gppSettingField) {
+      value = 1; // Yes
+    }
+
+    gppApi.setFieldValue(sectionName, cmpApiField, value);
+  });
+};
+
+/**
+ * Common logic for determining GPP section and region from a privacy experience
+ */
+export const getGppSectionAndRegion = (
+  experienceRegion: string,
+  usApproach: GPPUSApproach | undefined,
+  notices: Array<{ gpp_field_mapping?: Array<{ region: string }> }> = [],
+): { gppRegion?: string; gppSection?: GPPSection } => {
+  let gppRegion = deriveGppFieldRegion({
+    experienceRegion,
+    usApproach,
+  });
+  let gppSection = FIDES_US_REGION_TO_GPP_SECTION[gppRegion];
+
+  if (!gppSection && usApproach === GPPUSApproach.ALL) {
+    // if we're using the "all" approach, and the user's state isn't supported yet, we should default to national.
+    gppRegion = US_NATIONAL_REGION;
+    gppSection = FIDES_US_REGION_TO_GPP_SECTION[gppRegion];
+  }
+
+  if (gppSection && usApproach === GPPUSApproach.ALL) {
+    // if we're using the "all" approach, and the current state is supported but no notices are provided for that state, we should default to national.
+    const hasNoticesForRegion = notices.some((notice) =>
+      notice.gpp_field_mapping?.find((fm) => fm.region === experienceRegion),
+    );
+    if (!hasNoticesForRegion) {
+      gppRegion = US_NATIONAL_REGION;
+      gppSection = FIDES_US_REGION_TO_GPP_SECTION[gppRegion];
+    }
+  }
+
+  if (
+    !gppSection ||
+    (gppRegion === US_NATIONAL_REGION && usApproach === GPPUSApproach.STATE)
+  ) {
+    // If we don't have a section, we can't set anything.
+    // If we're using the state approach we shouldn't return the national section, even if region is set to national.
+    return {};
+  }
+
+  return { gppRegion, gppSection };
+};
+
+export interface CmpApiUpdaterProps {
+  gppApi: GPPApiLike;
+  gppRegion: string;
+  gppSection: GPPSection;
+  privacyNotices: PrivacyNotice[];
+  noticeConsent?: NoticeConsent;
+}
+
+export const setOptOuts = ({
+  gppApi,
+  gppRegion,
+  gppSection,
+  privacyNotices,
+  noticeConsent,
+}: CmpApiUpdaterProps) => {
+  if (!noticeConsent) {
+    return;
+  }
+  privacyNotices.forEach((privacyNotice) => {
+    const { notice_key: noticeKey, gpp_field_mapping: fieldMapping } =
+      privacyNotice;
+    const consentValue = noticeConsent[noticeKey];
+    const gppMechanisms = fieldMapping?.find(
+      (fm) => fm.region === gppRegion,
+    )?.mechanism;
+    if (gppMechanisms) {
+      gppMechanisms.forEach((gppMechanism) => {
+        // In general, 0 = N/A, 1 = Opted out, 2 = Did not opt out
+        let value: string | string[] = gppMechanism.not_available; // if consentValue is undefined, we'll mark as N/A
+        if (consentValue === false) {
+          value = gppMechanism.opt_out;
+        } else if (consentValue) {
+          value = gppMechanism.not_opt_out;
+        }
+        let valueAsNum: number | number[] = +value;
+        if (value.length > 1) {
+          // If we have more than one bit, we should set it as an array, i.e. 111 should be [1,1,1]
+          valueAsNum = value.split("").map((v) => +v);
+        }
+        gppApi.setFieldValue(gppSection.name, gppMechanism.field, valueAsNum);
+      });
+    }
+  });
+};
+
+export const setNoticesProvided = ({
+  gppApi,
+  gppRegion,
+  gppSection,
+  privacyNotices,
+}: CmpApiUpdaterProps) => {
+  privacyNotices.forEach((notice) => {
+    const { gpp_field_mapping: fieldMapping } = notice;
+    const gppNotices = fieldMapping?.find(
+      (fm) => fm.region === gppRegion,
+    )?.notice;
+    if (gppNotices) {
+      gppNotices.forEach((gppNotice) => {
+        // 1 means notice was provided
+        gppApi.setFieldValue(gppSection.name, gppNotice, 1);
+      });
+    }
+  });
+};

--- a/clients/fides-js/src/lib/gpp/string-to-consent.ts
+++ b/clients/fides-js/src/lib/gpp/string-to-consent.ts
@@ -37,11 +37,7 @@ const getConsentFromGppCmpApi = ({
   const consent: NoticeConsent = {};
   const { privacy_notices: notices = [] } = experience;
 
-  const { gppRegion, gppSection } = getGppSectionAndRegion(
-    experience.region,
-    experience.gpp_settings?.us_approach,
-    experience.privacy_notices,
-  );
+  const { gppRegion, gppSection } = getGppSectionAndRegion(experience);
 
   if (!gppRegion || !gppSection) {
     fidesDebugger(

--- a/clients/fides-js/src/lib/gpp/string-to-consent.ts
+++ b/clients/fides-js/src/lib/gpp/string-to-consent.ts
@@ -18,7 +18,7 @@ import {
   createTcfSavePayloadFromMinExp,
   updateTCFCookie,
 } from "../tcf/utils";
-import { getGppSectionAndRegion } from "./us-notices";
+import { getGppSectionAndRegion } from "./gpp-utils";
 
 const FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS = [1, 3, 4, 5, 6];
 
@@ -37,7 +37,11 @@ const getConsentFromGppCmpApi = ({
   const consent: NoticeConsent = {};
   const { privacy_notices: notices = [] } = experience;
 
-  const { gppRegion, gppSection } = getGppSectionAndRegion(experience);
+  const { gppRegion, gppSection } = getGppSectionAndRegion(
+    experience.region,
+    experience.gpp_settings?.us_approach,
+    experience.privacy_notices,
+  );
 
   if (!gppRegion || !gppSection) {
     fidesDebugger(

--- a/clients/fides-js/src/lib/gpp/string-to-consent.ts
+++ b/clients/fides-js/src/lib/gpp/string-to-consent.ts
@@ -18,9 +18,7 @@ import {
   createTcfSavePayloadFromMinExp,
   updateTCFCookie,
 } from "../tcf/utils";
-import { FIDES_US_REGION_TO_GPP_SECTION } from "./constants";
-import { GPPUSApproach } from "./types";
-import { deriveGppFieldRegion, US_NATIONAL_REGION } from "./us-notices";
+import { getGppSectionAndRegion } from "./us-notices";
 
 const FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS = [1, 3, 4, 5, 6];
 
@@ -37,32 +35,13 @@ const getConsentFromGppCmpApi = ({
   experience: PrivacyExperience;
 }): NoticeConsent => {
   const consent: NoticeConsent = {};
-  const {
-    privacy_notices: notices = [],
-    region: experienceRegion,
-    gpp_settings: gppSettings,
-  } = experience;
-  const usApproach = gppSettings?.us_approach;
-  let gppRegion = deriveGppFieldRegion({
-    experienceRegion,
-    usApproach,
-  });
-  let gppSection = FIDES_US_REGION_TO_GPP_SECTION[gppRegion];
+  const { privacy_notices: notices = [] } = experience;
 
-  if (!gppSection && usApproach === GPPUSApproach.ALL) {
-    fidesDebugger(
-      'GPP: current state isn\'t supported, defaulting to USNat since "Both/All" approach is selected',
-    );
-    gppRegion = US_NATIONAL_REGION;
-    gppSection = FIDES_US_REGION_TO_GPP_SECTION[gppRegion];
-  }
+  const { gppRegion, gppSection } = getGppSectionAndRegion(experience);
 
-  if (
-    !gppSection ||
-    (gppRegion === US_NATIONAL_REGION && usApproach === GPPUSApproach.STATE)
-  ) {
+  if (!gppRegion || !gppSection) {
     fidesDebugger(
-      'GPP: current state isn\'t supported, returning empty consent since "US State" approach is selected',
+      "GPP: current state isn't supported, returning empty consent.",
     );
     return consent;
   }

--- a/clients/fides-js/src/lib/gpp/stub.ts
+++ b/clients/fides-js/src/lib/gpp/stub.ts
@@ -18,7 +18,7 @@ import { GppCallback, GppFunction } from "./types";
 interface GppEvent {
   id: number;
   callback: GppCallback;
-  parameter: any;
+  parameter: unknown;
 }
 
 interface MessageData {
@@ -34,7 +34,7 @@ const isMessageData = (data: unknown): data is MessageData =>
   typeof data === "object" && data != null && "__gppCall" in data;
 
 export const makeStub = () => {
-  const queue: any[] = [];
+  const queue: unknown[] = [];
   const events: GppEvent[] = [];
   let lastId: number | undefined;
 

--- a/clients/fides-js/src/lib/gpp/types.d.ts
+++ b/clients/fides-js/src/lib/gpp/types.d.ts
@@ -69,3 +69,10 @@ export interface GPPSection {
 
 export type NoticeConsent = Record<string, boolean | UserConsentPreference>;
 export type PrivacyNotice = PrivacyNoticeWithPreference;
+
+// Generic privacy experience type for GPP use
+export interface GPPPrivacyExperience {
+  region: string;
+  gpp_settings?: GPPSettings;
+  privacy_notices?: Array<PrivacyNotice>;
+}

--- a/clients/fides-js/src/lib/gpp/types.d.ts
+++ b/clients/fides-js/src/lib/gpp/types.d.ts
@@ -1,9 +1,14 @@
 import type { EventData, PingData } from "@iabgpp/cmpapi";
 
-export type GppCallback = (
-  event: PingData | EventData | boolean | null,
-  success: boolean,
-) => void;
+import {
+  PrivacyNoticeWithPreference,
+  UserConsentPreference,
+} from "../consent-types";
+import { GPPUSApproach } from "./constants";
+
+export interface GppCallback {
+  (event: PingData | EventData | boolean | null, success: boolean): void;
+}
 
 export type GppFunction = (
   command: string,
@@ -12,13 +17,7 @@ export type GppFunction = (
   version?: string,
 ) => void;
 
-export enum GPPUSApproach {
-  NATIONAL = "national",
-  STATE = "state",
-  ALL = "all",
-}
-
-export type GPPSettings = {
+export interface GPPSettings {
   enabled?: boolean;
   /**
    * National ('national') or state-by-state ('state') approach. Only required if regions includes US.
@@ -48,22 +47,25 @@ export type GPPSettings = {
    * Whether the GPP CMP API is required for the experience
    */
   cmp_api_required?: boolean;
-};
+}
 
-export type GPPMechanismMapping = {
+export interface GPPMechanismMapping {
   field: string;
   not_available: string;
   opt_out: string;
   not_opt_out: string;
-};
+}
 
-export type GPPFieldMapping = {
+export interface GPPFieldMapping {
   region: string;
   notice?: Array<string>;
   mechanism?: Array<GPPMechanismMapping>;
-};
+}
 
-export type GPPSection = {
+export interface GPPSection {
   name: string;
   id: number;
-};
+}
+
+export type NoticeConsent = Record<string, boolean | UserConsentPreference>;
+export type PrivacyNotice = PrivacyNoticeWithPreference;

--- a/clients/fides-js/src/lib/gpp/us-notices.ts
+++ b/clients/fides-js/src/lib/gpp/us-notices.ts
@@ -23,11 +23,7 @@ const updateGpp = (
   updater: (props: CmpApiUpdaterProps) => void,
   { cmpApi, experience, cookie }: UpdateGppProps,
 ) => {
-  const { gppRegion, gppSection } = getGppSectionAndRegion(
-    experience.region,
-    experience.gpp_settings?.us_approach,
-    experience.privacy_notices,
-  );
+  const { gppRegion, gppSection } = getGppSectionAndRegion(experience);
 
   if (!gppRegion || !gppSection) {
     // If we don't have a section, we can't set anything.

--- a/clients/fides-js/src/lib/gpp/us-notices.ts
+++ b/clients/fides-js/src/lib/gpp/us-notices.ts
@@ -1,214 +1,33 @@
 /**
  * Helper functions to set the GPP CMP API based on Fides values
- *
- * NOTE: Changes to this file should likely also be made in the
- * GPP encoder API implementation in `fidesplus`.
  */
 
-import { CmpApi, UsNatField } from "@iabgpp/cmpapi";
+import { CmpApi } from "@iabgpp/cmpapi";
 
 import { FidesCookie, PrivacyExperience } from "../consent-types";
-import { FIDES_US_REGION_TO_GPP_SECTION } from "./constants";
-import { GPPSection, GPPSettings, GPPUSApproach } from "./types";
+import {
+  CmpApiUpdaterProps,
+  getGppSectionAndRegion,
+  setMspaSections,
+  setNoticesProvided,
+  setOptOuts,
+} from "./gpp-utils";
+import { GPPSection } from "./types";
 
-export const US_NATIONAL_REGION = "us";
-
-const setMspaSections = ({
-  cmpApi,
-  sectionName,
-  gppSettings,
-}: {
+interface UpdateGppProps {
   cmpApi: CmpApi;
-  sectionName: string;
-  gppSettings: GPPSettings | undefined;
-}) => {
-  if (!gppSettings) {
-    return;
-  }
-
-  const mspaFields = [
-    {
-      gppSettingField: gppSettings.mspa_covered_transactions,
-      cmpApiField: UsNatField.MSPA_COVERED_TRANSACTION,
-    },
-    {
-      gppSettingField:
-        gppSettings.mspa_covered_transactions &&
-        gppSettings.mspa_opt_out_option_mode,
-      cmpApiField: UsNatField.MSPA_OPT_OUT_OPTION_MODE,
-    },
-    {
-      gppSettingField:
-        gppSettings.mspa_covered_transactions &&
-        gppSettings.mspa_service_provider_mode,
-      cmpApiField: UsNatField.MSPA_SERVICE_PROVIDER_MODE,
-    },
-  ];
-
-  mspaFields.forEach(({ gppSettingField, cmpApiField }) => {
-    const isCoveredTransactions =
-      cmpApiField === UsNatField.MSPA_COVERED_TRANSACTION;
-    let value = 2; // Default to No
-
-    if (!gppSettings.mspa_covered_transactions && !isCoveredTransactions) {
-      value = 0; // When covered transactions is false, other fields should be disabled
-    } else if (gppSettingField) {
-      value = 1; // Yes
-    }
-
-    cmpApi.setFieldValue(sectionName, cmpApiField, value);
-  });
-};
-
-/**
- * Checks if a given region is in the US based on the provided region string's prefix.
- * Also returns true if the region is the US_NATIONAL_REGION.
- */
-const isUsRegion = (region: string) => region?.toLowerCase().startsWith("us");
-
-/**
- * For US National, the privacy experience region is still the state where the user came from.
- * However, the GPP field mapping will only contain "us", so make sure we use "us" (US_NATIONAL_REGION) when we are configured for the national case.
- * Otherwise, we can use the experience region directly.
- */
-export const deriveGppFieldRegion = ({
-  experienceRegion,
-  usApproach,
-}: {
-  experienceRegion: string;
-  usApproach: GPPUSApproach | undefined;
-}) => {
-  if (isUsRegion(experienceRegion) && usApproach === GPPUSApproach.NATIONAL) {
-    return US_NATIONAL_REGION;
-  }
-  return experienceRegion;
-};
-
-type CmpApiUpdater = (props: {
-  cmpApi: CmpApi;
-  gppRegion: string;
-  gppSection: GPPSection;
   experience: PrivacyExperience;
   cookie?: FidesCookie;
-}) => void;
-
-export const getGppSectionAndRegion = (
-  experience: PrivacyExperience,
-): { gppRegion?: string; gppSection?: GPPSection } => {
-  const {
-    privacy_notices: notices = [],
-    region: experienceRegion,
-    gpp_settings: gppSettings,
-  } = experience;
-  const usApproach = gppSettings?.us_approach;
-  let gppRegion = deriveGppFieldRegion({
-    experienceRegion,
-    usApproach,
-  });
-  let gppSection = FIDES_US_REGION_TO_GPP_SECTION[gppRegion];
-
-  if (!gppSection && usApproach === GPPUSApproach.ALL) {
-    // if we're using the all approach, and the current state isn't supported, we should default to national
-    gppRegion = US_NATIONAL_REGION;
-    gppSection = FIDES_US_REGION_TO_GPP_SECTION[gppRegion];
-  }
-
-  if (gppSection && usApproach === GPPUSApproach.ALL) {
-    // if we're using the "all" approach, and the current state is supported but no notices are provided for that state, we should default to national.
-    const hasNoticesForRegion = notices.some((notice) =>
-      notice.gpp_field_mapping?.find((fm) => fm.region === experienceRegion),
-    );
-    if (!hasNoticesForRegion) {
-      gppRegion = US_NATIONAL_REGION;
-      gppSection = FIDES_US_REGION_TO_GPP_SECTION[gppRegion];
-    }
-  }
-
-  if (
-    !gppSection ||
-    (gppRegion === US_NATIONAL_REGION && usApproach === GPPUSApproach.STATE)
-  ) {
-    return {};
-  }
-  return { gppRegion, gppSection };
-};
-
-const setNoticesProvided: CmpApiUpdater = ({
-  cmpApi,
-  gppRegion,
-  gppSection,
-  experience,
-}) => {
-  const { privacy_notices: notices = [] } = experience;
-  notices.forEach((notice) => {
-    const { gpp_field_mapping: fieldMapping } = notice;
-    const gppNotices = fieldMapping?.find(
-      (fm) => fm.region === gppRegion,
-    )?.notice;
-    if (gppNotices) {
-      gppNotices.forEach((gppNotice) => {
-        // 1 means notice was provided
-        cmpApi.setFieldValue(gppSection.name, gppNotice, 1);
-      });
-    }
-  });
-};
-
-const setOptOuts: CmpApiUpdater = ({
-  cmpApi,
-  gppRegion,
-  gppSection,
-  experience,
-  cookie,
-}) => {
-  if (!cookie) {
-    return;
-  }
-  const { privacy_notices: notices = [] } = experience;
-  const { consent } = cookie;
-  const noticeKeys = Object.keys(consent);
-  noticeKeys.forEach((noticeKey) => {
-    const privacyNotice = notices?.find((n) => n.notice_key === noticeKey);
-    const consentValue = consent[noticeKey];
-    if (privacyNotice) {
-      const { gpp_field_mapping: fieldMapping } = privacyNotice;
-      const gppMechanisms = fieldMapping?.find(
-        (fm) => fm.region === gppRegion,
-      )?.mechanism;
-      if (gppMechanisms) {
-        gppMechanisms.forEach((gppMechanism) => {
-          // In general, 0 = N/A, 1 = Opted out, 2 = Did not opt out
-          let value: string | string[] = gppMechanism.not_available; // if consentValue is undefined, we'll mark as N/A
-          if (consentValue === false) {
-            value = gppMechanism.opt_out;
-          } else if (consentValue) {
-            value = gppMechanism.not_opt_out;
-          }
-          let valueAsNum: number | number[] = +value;
-          if (value.length > 1) {
-            // If we have more than one bit, we should set it as an array, i.e. 111 should be [1,1,1]
-            valueAsNum = value.split("").map((v) => +v);
-          }
-          cmpApi.setFieldValue(gppSection.name, gppMechanism.field, valueAsNum);
-        });
-      }
-    }
-  });
-};
-
+}
 const updateGpp = (
-  updater: CmpApiUpdater,
-  {
-    cmpApi,
-    experience,
-    cookie,
-  }: {
-    cmpApi: CmpApi;
-    experience: PrivacyExperience;
-    cookie?: FidesCookie;
-  },
+  updater: (props: CmpApiUpdaterProps) => void,
+  { cmpApi, experience, cookie }: UpdateGppProps,
 ) => {
-  const { gppRegion, gppSection } = getGppSectionAndRegion(experience);
+  const { gppRegion, gppSection } = getGppSectionAndRegion(
+    experience.region,
+    experience.gpp_settings?.us_approach,
+    experience.privacy_notices,
+  );
 
   if (!gppRegion || !gppSection) {
     // If we don't have a section, we can't set anything.
@@ -219,10 +38,20 @@ const updateGpp = (
   const sectionsChanged = new Set<GPPSection>();
   sectionsChanged.add(gppSection);
 
-  updater({ cmpApi, gppRegion, gppSection, experience, cookie });
+  updater({
+    gppApi: cmpApi,
+    gppRegion,
+    gppSection,
+    privacyNotices: experience.privacy_notices || [],
+    noticeConsent: cookie?.consent,
+  });
 
   const { gpp_settings: gppSettings } = experience;
-  setMspaSections({ cmpApi, sectionName: gppSection.name, gppSettings });
+  setMspaSections({
+    gppApi: cmpApi,
+    sectionName: gppSection.name,
+    gppSettings,
+  });
 
   return Array.from(sectionsChanged);
 };


### PR DESCRIPTION
Closes [ENG-891]

### Description Of Changes

Refactored GPP (Global Privacy Platform) code to eliminate duplication and improve maintainability. Extracted common GPP utility functions into a `gpp-utils.ts` file that can be duplicated between this and the `fidesplus` repo seamlessly.

### Code Changes

* Moved `GPPUSApproach` enum from `types.d.ts` to `constants.ts`
* Created new `gpp-utils.ts` file with shared utility functions: `setMspaSections`, `setOptOuts`, `setNoticesProvided`, and `getGppSectionAndRegion`
* Updated `string-to-consent.ts` to use centralized `getGppSectionAndRegion` function
* Updated all import statements across files and tests to use new locations
* Added JSDoc documentation indicating file synchronization between fides and fidesplus repositories

### Steps to Confirm

1. All tests pass
2. GPP strings get generated as expected.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-891]: https://ethyca.atlassian.net/browse/ENG-891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ