### PR TITLE
ENG-924 Add more logging for Redis cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,10 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Changed
 - Improvements to Generic Erasure Email Integrations so email batch jobs run with a Redis lock and execution time is configurable [#6316](https://github.com/ethyca/fides/pull/6316)
-<<<<<<< HEAD
 - Manual tasks table will now filter by the logged in user by default [#6317](https://github.com/ethyca/fides/pull/6317)
 - Privacy Center now only disables `custom-fides.css` polling when it receives a 404. It will continue to poll after receiving other HTTP Status Codes [#6319](https://github.com/ethyca/fides/pull/6319)
 - Privacy Center now retries when it receives an error HTTP Status code while retrieving `custom-fides.css` [#6319](https://github.com/ethyca/fides/pull/6319)
-=======
 - Removed flag `should_log` from `get_cache` method, behavior is now to always log, and improved exception handling [#6323](https://github.com/ethyca/fides/pull/6323)
->>>>>>> f1012789d (Add changelog)
 
 ### Developer Experience
 - Migrate tabs to Ant Design [#6260](https://github.com/ethyca/fides/pull/6260)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,13 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Changed
 - Improvements to Generic Erasure Email Integrations so email batch jobs run with a Redis lock and execution time is configurable [#6316](https://github.com/ethyca/fides/pull/6316)
+<<<<<<< HEAD
 - Manual tasks table will now filter by the logged in user by default [#6317](https://github.com/ethyca/fides/pull/6317)
 - Privacy Center now only disables `custom-fides.css` polling when it receives a 404. It will continue to poll after receiving other HTTP Status Codes [#6319](https://github.com/ethyca/fides/pull/6319)
 - Privacy Center now retries when it receives an error HTTP Status code while retrieving `custom-fides.css` [#6319](https://github.com/ethyca/fides/pull/6319)
+=======
+- Removed flag `should_log` from `get_cache` method, behavior is now to always log, and improved exception handling [#6323](https://github.com/ethyca/fides/pull/6323)
+>>>>>>> f1012789d (Add changelog)
 
 ### Developer Experience
 - Migrate tabs to Ant Design [#6260](https://github.com/ethyca/fides/pull/6260)

--- a/src/fides/api/app_setup.py
+++ b/src/fides/api/app_setup.py
@@ -232,7 +232,7 @@ def check_redis() -> None:
     """Check that Redis is healthy."""
     logger.info("Running Cache connection test...")
     try:
-        get_cache(should_log=True)
+        get_cache()
     except (RedisConnectionError, RedisError, ResponseError) as e:
         logger.error("Connection to cache failed: {}", str(e))
         return

--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -190,7 +190,7 @@ def _determine_redis_db_index(
     return CONFIG.redis.read_only_db_index if read_only else CONFIG.redis.db_index
 
 
-def get_cache(should_log: Optional[bool] = False) -> FidesopsRedis:
+def get_cache() -> FidesopsRedis:
     """Return a singleton connection to our Redis cache"""
 
     if not CONFIG.redis.enabled:
@@ -213,21 +213,20 @@ def get_cache(should_log: Optional[bool] = False) -> FidesopsRedis:
             ssl_ca_certs=CONFIG.redis.ssl_ca_certs,
             ssl_cert_reqs=CONFIG.redis.ssl_cert_reqs,
         )
-        if should_log:
-            logger.debug("New Redis connection created.")
 
-    if should_log:
-        logger.debug("Testing Redis connection...")
+        logger.debug("New Redis connection created.")
+
+    logger.debug("Testing Redis connection...")
     try:
         connected = _connection.ping()
-    except ConnectionErrorFromRedis:
+    except ConnectionErrorFromRedis as e:
         connected = False
+        logger.error("Redis connection failed with ConnectionErrorFromRedis: {}", e)
     else:
-        if should_log:
-            logger.debug("Redis connection succeeded.")
+        logger.debug("Redis connection succeeded.")
 
     if not connected:
-        logger.debug("Redis connection failed.")
+        logger.error("Redis connection failed.")
         raise common_exceptions.RedisConnectionError(
             "Unable to establish Redis connection. Fidesops is unable to accept PrivacyRequsts."
         )

--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -219,16 +219,18 @@ def get_cache() -> FidesopsRedis:
     logger.debug("Testing Redis connection...")
     try:
         connected = _connection.ping()
+        logger.debug("Redis connection succeeded.")
     except ConnectionErrorFromRedis as e:
         connected = False
         logger.error("Redis connection failed with ConnectionErrorFromRedis: {}", e)
-    else:
-        logger.debug("Redis connection succeeded.")
+    except Exception as e:
+        connected = False
+        logger.error("Redis connection failed with Exception: {}", e)
 
     if not connected:
         logger.error("Redis connection failed.")
         raise common_exceptions.RedisConnectionError(
-            "Unable to establish Redis connection. Fidesops is unable to accept PrivacyRequsts."
+            "Unable to establish Redis connection. Fides is unable to accept Privacy Requests."
         )
 
     return _connection

--- a/tests/api/util/test_cache.py
+++ b/tests/api/util/test_cache.py
@@ -272,7 +272,6 @@ class TestGetCache:
             mock_redis_instance = MagicMock()
             MockRedis.return_value = mock_redis_instance
 
-            # Mock ping to return True (successful connection)
             mock_redis_instance.ping.side_effect = Exception("Test exception")
 
             with pytest.raises(

--- a/tests/api/util/test_cache.py
+++ b/tests/api/util/test_cache.py
@@ -280,7 +280,7 @@ class TestGetCache:
             ):
                 get_cache()
 
-            assert (
-                "Redis connection failed with Exception: Test exception"
-                in loguru_caplog.text
-            )
+        assert (
+            "Redis connection failed with Exception: Test exception"
+            in loguru_caplog.text
+        )


### PR DESCRIPTION
Helps troubleshoot [ENG-924](https://ethyca.atlassian.net/browse/ENG-924)

### Description Of Changes

Removes the `should_log` flag from the `get_cache` method so we always log at debug level and makes sure to log any exception at error level.

### Steps to Confirm

1. Run Fides, you should see all the logs. 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-924]: https://ethyca.atlassian.net/browse/ENG-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ