### PR TITLE
ENG-924 Remove all logger calls in get_cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,11 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - https://github.com/ethyca/fides/labels/high-risk: to indicate that a change is a "high-risk" change that could potentially lead to unanticipated regressions or degradations
 - https://github.com/ethyca/fides/labels/db-migration: to indicate that a given change includes a DB migration
 
-## [Unreleased](https://github.com/ethyca/fides/compare/2.65.0...main)
+## [Unreleased](https://github.com/ethyca/fides/compare/2.65.2...main)
 
 ### Added
 - Replaced Asset's `with_consent` field with the enum `consent_status` field and added indexes to the `StagedResource` table [#6287](https://github.com/ethyca/fides/pull/6287)
 
-### Changed
-- Improvements to Generic Erasure Email Integrations so email batch jobs run with a Redis lock and execution time is configurable [#6316](https://github.com/ethyca/fides/pull/6316)
-- Manual tasks table will now filter by the logged in user by default [#6317](https://github.com/ethyca/fides/pull/6317)
-- Privacy Center now only disables `custom-fides.css` polling when it receives a 404. It will continue to poll after receiving other HTTP Status Codes [#6319](https://github.com/ethyca/fides/pull/6319)
-- Privacy Center now retries when it receives an error HTTP Status code while retrieving `custom-fides.css` [#6319](https://github.com/ethyca/fides/pull/6319)
 
 ### Developer Experience
 - Migrate tabs to Ant Design [#6260](https://github.com/ethyca/fides/pull/6260)
@@ -38,6 +33,19 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed FidesJS GPP to use national section when a supported US state has no specific notices and approach is set to both. [#6307](https://github.com/ethyca/fides/pull/6307)
 - Fixed taxonomy search behavior to include label and value text
 - Fixed FidesJS to use consistent served_notice_history_id across all consent flows for improved analytics correlation [#6312](https://github.com/ethyca/fides/pull/6312)
+
+## [2.65.2](https://github.com/ethyca/fides/compare/2.65.1...2.65.2)
+
+### Fixed
+- Fixed hanging test privacy requests by removing all logger calls from `get_cache` [#6328](https://github.com/ethyca/fides/pull/6328)
+
+## [2.65.1](https://github.com/ethyca/fides/compare/2.65.0...2.65.1)
+
+### Changed
+- Improvements to Generic Erasure Email Integrations so email batch jobs run with a Redis lock and execution time is configurable [#6316](https://github.com/ethyca/fides/pull/6316)
+- Privacy Center now only disables `custom-fides.css` polling when it receives a 404. It will continue to poll after receiving other HTTP Status Codes [#6319](https://github.com/ethyca/fides/pull/6319)
+- Privacy Center now retries when it receives an error HTTP Status code while retrieving `custom-fides.css` [#6319](https://github.com/ethyca/fides/pull/6319)
+- Manual tasks table will now filter by the logged in user by default [#6317](https://github.com/ethyca/fides/pull/6317)
 
 ## [2.65.0](https://github.com/ethyca/fides/compare/2.64.2...2.65.0)
 

--- a/src/fides/api/app_setup.py
+++ b/src/fides/api/app_setup.py
@@ -232,7 +232,7 @@ def check_redis() -> None:
     """Check that Redis is healthy."""
     logger.info("Running Cache connection test...")
     try:
-        get_cache(should_log=True)
+        get_cache()
     except (RedisConnectionError, RedisError, ResponseError) as e:
         logger.error("Connection to cache failed: {}", str(e))
         return

--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -233,14 +233,10 @@ def get_read_only_cache() -> FidesopsRedis:
     """
     # If read-only is not enabled, return the regular cache
     if not CONFIG.redis.read_only_enabled:
-        logger.debug(
-            "Read-only Redis is not enabled. Returning writeable cache connection instead."
-        )
         return get_cache()
 
     global _read_only_connection  # pylint: disable=W0603
     if _read_only_connection is None:
-        logger.debug("Creating new read-only Redis connection...")
         _read_only_connection = FidesopsRedis(  # type: ignore[call-overload]
             charset=CONFIG.redis.charset,
             decode_responses=CONFIG.redis.decode_responses,
@@ -257,15 +253,10 @@ def get_read_only_cache() -> FidesopsRedis:
     try:
         # Test the connection by attempting to ping the Redis server
         connected = _read_only_connection.ping()
-        logger.debug("Read-only Redis connection established successfully.")
-    except Exception as e:
-        logger.error(f"Failed to connect to read-only Redis: {e}")
+    except Exception:
         connected = False
 
     if not connected:
-        logger.error(
-            "Unable to establish read-only Redis connection. Returning writeable cache connection instead."
-        )
         # If we can't connect to the read-only cache, fall back to the regular cache
         return get_cache()
 

--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -190,7 +190,7 @@ def _determine_redis_db_index(
     return CONFIG.redis.read_only_db_index if read_only else CONFIG.redis.db_index
 
 
-def get_cache(should_log: Optional[bool] = False) -> FidesopsRedis:
+def get_cache() -> FidesopsRedis:
     """Return a singleton connection to our Redis cache"""
 
     if not CONFIG.redis.enabled:
@@ -200,7 +200,6 @@ def get_cache(should_log: Optional[bool] = False) -> FidesopsRedis:
 
     global _connection  # pylint: disable=W0603
     if _connection is None:
-        logger.debug("Creating new Redis connection...")
         _connection = FidesopsRedis(  # type: ignore[call-overload]
             charset=CONFIG.redis.charset,
             decode_responses=CONFIG.redis.decode_responses,
@@ -213,21 +212,13 @@ def get_cache(should_log: Optional[bool] = False) -> FidesopsRedis:
             ssl_ca_certs=CONFIG.redis.ssl_ca_certs,
             ssl_cert_reqs=CONFIG.redis.ssl_cert_reqs,
         )
-        if should_log:
-            logger.debug("New Redis connection created.")
 
-    if should_log:
-        logger.debug("Testing Redis connection...")
     try:
         connected = _connection.ping()
     except ConnectionErrorFromRedis:
         connected = False
-    else:
-        if should_log:
-            logger.debug("Redis connection succeeded.")
 
     if not connected:
-        logger.debug("Redis connection failed.")
         raise common_exceptions.RedisConnectionError(
             "Unable to establish Redis connection. Fidesops is unable to accept PrivacyRequsts."
         )


### PR DESCRIPTION
Closes [ENG-924](https://ethyca.atlassian.net/browse/ENG-924)

### Description Of Changes

After a lot of troubleshooting, we found that the `logger` calls inside the `get_cache` method are causing Celery workers to hang indefinitely, particularly when running test privacy requests. The problem seems to be an interaction between the `loguru` module and our singleton pattern for Redis connections. There's more relevant context in the Jira ticket.

This PR removes all calls to `logger` inside our `get_cache` method as a quick fix while we work on a more long-term solution. Ticket for longer-term solution: https://ethyca.atlassian.net/browse/ENG-933

### Steps to Confirm

We tested in RC already

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-924]: https://ethyca.atlassian.net/browse/ENG-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ