### PR TITLE
fix: fidesui imports

### DIFF
--- a/clients/fidesui/src/FidesUIProvider.tsx
+++ b/clients/fidesui/src/FidesUIProvider.tsx
@@ -2,7 +2,7 @@ import {
   ChakraProvider as BaseChakraProvider,
   ChakraProviderProps,
 } from "@chakra-ui/react";
-import { ConfigProvider as BaseAntDesignProvider, ThemeConfig } from "antd/lib";
+import { ConfigProvider as BaseAntDesignProvider, ThemeConfig } from "antd/es";
 import { ReactNode } from "react";
 
 import { defaultAntTheme } from "./ant-theme";

--- a/clients/fidesui/src/components/floating-menu/FloatingMenu.tsx
+++ b/clients/fidesui/src/components/floating-menu/FloatingMenu.tsx
@@ -1,4 +1,4 @@
-import { Menu } from "antd/lib";
+import { Menu } from "antd/es";
 import { ComponentProps } from "react";
 
 import styles from "./FloatingMenu.module.scss";

--- a/clients/fidesui/src/components/select-inline/SelectInline.tsx
+++ b/clients/fidesui/src/components/select-inline/SelectInline.tsx
@@ -1,4 +1,4 @@
-import { Select } from "antd/lib";
+import { Select } from "antd/es";
 import React, { ComponentProps, useState } from "react";
 
 import { CustomTag as AntTag, CustomTypography } from "../../hoc";

--- a/clients/fidesui/src/hoc/CustomDateRangePicker.tsx
+++ b/clients/fidesui/src/hoc/CustomDateRangePicker.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight, Calendar } from "@carbon/icons-react";
 import { RangePickerProps } from "antd/es/date-picker";
-import { DatePicker } from "antd/lib";
+import { DatePicker } from "antd/es";
 import React from "react";
 
 const withCustomProps = (WrappedComponent: typeof DatePicker.RangePicker) => {

--- a/clients/fidesui/src/hoc/CustomSelect.tsx
+++ b/clients/fidesui/src/hoc/CustomSelect.tsx
@@ -1,6 +1,6 @@
 import { Checkmark, ChevronDown } from "@carbon/icons-react";
-import { Flex, Select, SelectProps, Typography } from "antd/lib";
-import { BaseOptionType, DefaultOptionType } from "antd/lib/select";
+import { Flex, Select, SelectProps, Typography } from "antd/es";
+import { BaseOptionType, DefaultOptionType } from "antd/es/select";
 import React from "react";
 
 const optionDescriptionRender = (
@@ -16,6 +16,7 @@ const optionDescriptionRender = (
       {!!description && (
         <Typography.Text
           type="secondary"
+
           className="text-wrap text-sm leading-tight"
         >
           {description}
@@ -27,7 +28,7 @@ const optionDescriptionRender = (
 
 const withCustomProps = (WrappedComponent: typeof Select) => {
   const WrappedSelect = <
-    ValueType = any,
+    ValueType,
     OptionType extends DefaultOptionType | BaseOptionType = DefaultOptionType,
   >({
     placeholder = "Select...",

--- a/clients/fidesui/src/hoc/CustomTable.tsx
+++ b/clients/fidesui/src/hoc/CustomTable.tsx
@@ -1,6 +1,6 @@
 import { SettingsAdjust } from "@carbon/icons-react";
 import { TableProps } from "antd/es/table";
-import { Table } from "antd/lib";
+import { Table } from "antd/es";
 import React from "react";
 
 import palette from "../palette/palette.module.scss";

--- a/clients/fidesui/src/hoc/CustomTag.tsx
+++ b/clients/fidesui/src/hoc/CustomTag.tsx
@@ -1,4 +1,4 @@
-import { Tag, TagProps } from "antd/lib";
+import { Tag, TagProps } from "antd/es";
 import { Icons } from "fidesui";
 import React, { useEffect, useRef } from "react";
 

--- a/clients/fidesui/src/hoc/CustomTooltip.tsx
+++ b/clients/fidesui/src/hoc/CustomTooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, TooltipProps } from "antd/lib";
+import { Tooltip, TooltipProps } from "antd/es";
 import React, { ReactElement } from "react";
 
 import styles from "./CustomTooltip.module.scss";

--- a/clients/fidesui/src/hoc/CustomTypography.tsx
+++ b/clients/fidesui/src/hoc/CustomTypography.tsx
@@ -1,5 +1,5 @@
-import type { TypographyProps } from "antd/lib";
-import { Typography } from "antd/lib";
+import type { TypographyProps } from "antd/es";
+import { Typography } from "antd/es";
 import classNames from "classnames";
 
 import styles from "./CustomTypography.module.scss";

--- a/clients/fidesui/src/index.ts
+++ b/clients/fidesui/src/index.ts
@@ -34,7 +34,7 @@ export type {
   RadioChangeEvent,
   UploadFile,
   UploadProps,
-} from "antd/lib";
+} from "antd/es";
 export {
   Alert as AntAlert,
   Avatar as AntAvatar,
@@ -67,17 +67,17 @@ export {
   Switch as AntSwitch,
   Tabs as AntTabs,
   Upload as AntUpload,
-} from "antd/lib";
+} from "antd/es";
 export type {
   BreadcrumbItemType as AntBreadcrumbItemType,
   BreadcrumbProps as AntBreadcrumbProps,
-} from "antd/lib/breadcrumb/Breadcrumb";
-export type { ListItemProps as AntListItemProps } from "antd/lib/list";
+} from "antd/es/breadcrumb/Breadcrumb";
+export type { ListItemProps as AntListItemProps } from "antd/es/list";
 export type {
   BaseOptionType as AntBaseOptionType,
   DefaultOptionType as AntDefaultOptionType,
-} from "antd/lib/select";
-export type { UploadChangeParam as AntUploadChangeParam } from "antd/lib/upload";
+} from "antd/es/select";
+export type { UploadChangeParam as AntUploadChangeParam } from "antd/es/upload";
 
 // Higher-order components
 export {


### PR DESCRIPTION
Closes [<issue>]

### Description Of Changes
Applications using the `fidesui` package were importing *all* of the assets from `antd` due to some imports incorrectly using `antd/lib` instead of `antd/es`.

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
