### PR TITLE
[ENG-951] update internal respondent

### DIFF
--- a/src/fides/api/models/fides_user.py
+++ b/src/fides/api/models/fides_user.py
@@ -136,7 +136,7 @@ class FidesUser(Base):
 
     @classmethod
     def create_respondent(cls, db: Session, data: dict[str, Any]) -> FidesUser:
-        """Create a respondent user. This user will not be able to login with a password and
+        """Create an external respondent user. This user will not be able to login with a password and
         requires an email address to be provided.
         """
         if not data.get("email_address"):
@@ -164,8 +164,10 @@ class FidesUser(Base):
         No validations are performed on the old/existing password within this function.
         """
         if self.permissions is not None:
-            if self.permissions.is_respondent():
-                raise ValueError("Password changes are not allowed for respondents")
+            if self.permissions.is_external_respondent():
+                raise ValueError(
+                    "Password changes are not allowed for external respondents"
+                )
 
         hashed_password, salt = FidesUser.hash_password(new_password)
         self.hashed_password = hashed_password  # type: ignore
@@ -176,9 +178,9 @@ class FidesUser(Base):
     def update_email_address(self, db: Session, new_email_address: str) -> None:
         """Updates the user's email address to the specified value."""
         if self.permissions is not None:
-            if self.permissions.is_respondent():
+            if self.permissions.is_external_respondent():
                 raise ValueError(
-                    "Email address changes are not allowed for respondents"
+                    "Email address changes are not allowed for external respondents"
                 )
 
         self.email_address = new_email_address  # type: ignore
@@ -201,8 +203,10 @@ class FidesUser(Base):
             )
 
         if self.permissions is not None:
-            if self.permissions.is_respondent():
-                raise SystemManagerException("Respondents cannot be system managers.")
+            if self.permissions.is_external_respondent():
+                raise SystemManagerException(
+                    "External respondents cannot be system managers."
+                )
 
         self.systems.append(system)
         self.save(db=db)

--- a/src/fides/api/models/fides_user_permissions.py
+++ b/src/fides/api/models/fides_user_permissions.py
@@ -5,11 +5,7 @@ from sqlalchemy.orm import Session, relationship
 
 from fides.api.db.base_class import Base
 from fides.api.models.fides_user import FidesUser
-from fides.api.oauth.roles import (
-    EXTERNAL_RESPONDENT,
-    RESPONDENT,
-    ROLES_TO_SCOPES_MAPPING,
-)
+from fides.api.oauth.roles import EXTERNAL_RESPONDENT, ROLES_TO_SCOPES_MAPPING
 
 
 class FidesUserPermissions(Base):
@@ -28,15 +24,15 @@ class FidesUserPermissions(Base):
 
         return sorted(list(set(all_scopes)))
 
-    def is_respondent(self) -> bool:
-        """Check if the user is a respondent."""
-        return any(role in self.roles for role in [RESPONDENT, EXTERNAL_RESPONDENT])
+    def is_external_respondent(self) -> bool:
+        """Check if the user is a external respondent."""
+        return any(role in self.roles for role in [EXTERNAL_RESPONDENT])
 
     def update_roles(self, db: Session, new_roles: List[str]) -> None:
         """Update the user's roles if allowed.
         Raises ValueError if role changes are not allowed."""
-        if self.is_respondent():
-            raise ValueError("Role changes are not allowed for respondents")
+        if self.is_external_respondent():
+            raise ValueError("Role changes are not allowed for external respondents")
 
         self.roles = new_roles
         self.save(db)

--- a/tests/ops/models/fides_user/test_fides_user_permissions.py
+++ b/tests/ops/models/fides_user/test_fides_user_permissions.py
@@ -57,20 +57,20 @@ class TestFidesUserPermissions:
     @pytest.mark.parametrize(
         "role, expected",
         [
-            (RESPONDENT, True),
+            (RESPONDENT, False),
             (EXTERNAL_RESPONDENT, True),
             (CONTRIBUTOR, False),
             (VIEWER, False),
         ],
     )
-    def test_is_respondent(
+    def test_is_external_respondent(
         self, db: Session, user: FidesUser, role: str, expected: bool
     ) -> None:
         permissions: FidesUserPermissions = FidesUserPermissions.create(
             db=db,
             data={"user_id": user.id, "roles": [role]},
         )
-        assert permissions.is_respondent() == expected
+        assert permissions.is_external_respondent() == expected
         user.delete(db)
 
     @pytest.mark.parametrize(
@@ -79,15 +79,11 @@ class TestFidesUserPermissions:
             ([CONTRIBUTOR], [RESPONDENT], None),
             ([CONTRIBUTOR], [VIEWER], None),
             ([CONTRIBUTOR], [CONTRIBUTOR], None),
-            (
-                [RESPONDENT],
-                [CONTRIBUTOR],
-                "Role changes are not allowed for respondents",
-            ),
+            ([RESPONDENT], [CONTRIBUTOR], None),
             (
                 [EXTERNAL_RESPONDENT],
                 [CONTRIBUTOR],
-                "Role changes are not allowed for respondents",
+                "Role changes are not allowed for external respondents",
             ),
         ],
     )


### PR DESCRIPTION
Closes [ENG-951](https://ethyca.atlassian.net/browse/ENG-951?atlOrigin=eyJpIjoiNzczOTRjODFlM2I1NDAwOWIyY2RiYWE4MDViZWJkMzgiLCJwIjoiaiJ9)

### Description Of Changes

This allows internal respondents much more freedom than they had originally. For more info see [slack thread](https://ethyca.slack.com/archives/C08SW6SBDKJ/p1752520607454119)

### Code Changes

* updated `is_respondent` function to be `is_external_respondent` and updated the tests for it.
* updated functionality to check for external respondent instead of all respondents.

### Steps to Confirm

1.  All tests pass
2. @lucanovera's front end things work

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
