### PR TITLE
Add option to override Fides modal default view

### DIFF
--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -88,6 +88,17 @@ const getAllIds = (
   return modelList.map((m) => `${m.id}`);
 };
 
+// gets the index of the tab to show by default based on the fidesModalDefaultView option
+const parseModalDefaultView = (defaultView: string | undefined): number => {
+  const tab = defaultView?.split("/")[2];
+  if (!tab) {
+    return 0;
+  }
+  const tabKeys = ["purposes", "features", "vendors"];
+  const tabIndex = tabKeys.indexOf(tab);
+  return tabIndex === -1 ? 0 : tabIndex;
+};
+
 export const TcfOverlay = () => {
   const { fidesGlobal, setFidesGlobal } = useFidesGlobal();
   const {
@@ -553,7 +564,8 @@ export const TcfOverlay = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options.fidesConsentOverride]);
 
-  const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const initialTab = parseModalDefaultView(options.fidesModalDefaultView);
+  const [activeTabIndex, setActiveTabIndex] = useState(initialTab);
 
   const dispatchOpenBannerEvent = useCallback(() => {
     setServingComponent(ServingComponent.TCF_BANNER);

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -285,4 +285,17 @@ export interface FidesOptions {
    * Defaults to `"once"`.
    */
   fides_initialized_event_mode: "multiple" | "once" | "disable";
+
+  /**
+   * A URL-like route that determines which view is shown by default when the consent modal is opened.
+   * Currently only affects TCF.
+   *
+   * - "/tcf/purposes" (if not set, "purposes" is shown)
+   * - "/tcf/features"
+   * - "/tcf/vendors"
+   *
+   * Defaults to `undefined`.
+   *
+   */
+  fides_modal_default_view: string;
 }

--- a/clients/fides-js/src/lib/consent-constants.ts
+++ b/clients/fides-js/src/lib/consent-constants.ts
@@ -117,6 +117,12 @@ export const FIDES_OVERRIDE_OPTIONS_VALIDATOR_MAP: FidesOverrideValidatorMap[] =
       overrideKey: "fides_initialized_event_mode",
       validationRegex: /^(multiple|once|disable)$/,
     },
+    {
+      overrideName: "fidesModalDefaultView",
+      overrideType: "string",
+      overrideKey: "fides_modal_default_view",
+      validationRegex: /^\/tcf\/(purposes|features|vendors)$/,
+    },
   ];
 
 /**

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -164,6 +164,18 @@ export interface FidesInitOptions {
    * Defaults to "once".
    */
   fidesInitializedEventMode: "multiple" | "once" | "disable";
+
+  /**
+   * A URL-like route that determines which view is shown by default when the consent modal is opened.
+   * Currently only affects TCF.
+   *
+   * - "/tcf/purposes" (if not set, "purposes" is shown)
+   * - "/tcf/features"
+   * - "/tcf/vendors"
+   *
+   * Defaults to `undefined`.
+   */
+  fidesModalDefaultView?: string;
 }
 
 /**
@@ -808,6 +820,7 @@ export type FidesInitOptionsOverrides = Pick<
   | "fidesConsentNonApplicableFlagMode"
   | "fidesConsentFlagType"
   | "fidesInitializedEventMode"
+  | "fidesModalDefaultView"
 >;
 
 export type FidesExperienceTranslationOverrides = {

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -25354,6 +25354,21 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "privacy-center/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
+      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
Closes ENG-859

### Description Of Changes

Adds an option to Fides.js to override the tab that will be initially shown in the TCF modal.

### Steps to Confirm

1.  Set up a TCF experience
2. On the testing page, view the modal; should see "purposes" tab open by default
3. Test again, passing `fides_modal_default_view=%2Ftcf%2Fvendors` and `fides_modal_default_view=%2Ftcf%2Ffeatures` as URL query params
4. Should see the appropriate tab open by default when opening the modal

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
