### PR TITLE
Adds unordered list as an allowed HTML tag

### DIFF
--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -68,9 +68,7 @@ def validate_html_str(val: str) -> str:
         "u",
     }
 
-    ALLOWED_ATTRIBUTES = {
-        "a": {"href", "hreflang", "target"},
-    }
+    ALLOWED_ATTRIBUTES = {"a": {"href", "hreflang", "target"}, "ul": {"margin-left"}}
 
     if val:
         return clean(val, tags=ALLOWED_HTML_TAGS, attributes=ALLOWED_ATTRIBUTES)

--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -68,7 +68,7 @@ def validate_html_str(val: str) -> str:
         "u",
     }
 
-    ALLOWED_ATTRIBUTES = {"a": {"href", "hreflang", "target"}, "ul": {"margin-left"}}
+    ALLOWED_ATTRIBUTES = {"a": {"href", "hreflang", "target"}, "ul": {"style"}}
 
     if val:
         return clean(val, tags=ALLOWED_HTML_TAGS, attributes=ALLOWED_ATTRIBUTES)

--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -56,6 +56,7 @@ def validate_html_str(val: str) -> str:
         "i",
         "li",
         "ol",
+        "ul",
         "p",
         "pre",
         "q",


### PR DESCRIPTION
Closes ENG-960
### Description Of Changes
* Adds unordered list as an option in Experience text

### Code Changes

* Adds "ul" tag to the allowed_html_tags list and the "style" attribute so that we can margin-left adjust it

### Steps to Confirm

1. Deploy Fides with FIDES_PRIVACY_CENTER__ALLOW_HTML_DESCRIPTION=true
2. Add <ul> tag to the experience description and save
3. Re-open the editor -- the <ul> tag should not have been sanitized (it should still be there)

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
