### PR TITLE
Eng 899 research and correct task instance creation 3

### DIFF
--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -25354,21 +25354,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "privacy-center/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
-      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -25354,6 +25354,21 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "privacy-center/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
+      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/fides/api/task/manual/manual_task_graph_task.py
+++ b/src/fides/api/task/manual/manual_task_graph_task.py
@@ -90,7 +90,6 @@ class ManualTaskGraphTask(GraphTask):
             ManualTaskConfigurationType.access_privacy_request,
         )
 
-
         if submitted_data is not None:
             result: List[Row] = [submitted_data] if submitted_data else []
             self.request_task.access_data = result
@@ -134,7 +133,7 @@ class ManualTaskGraphTask(GraphTask):
                     ManualTaskInstance.entity_type
                     == ManualTaskEntityType.privacy_request,
                     # Only check for instances of the same config type
-                    ManualTaskConfig.config_type == allowed_config_type
+                    ManualTaskConfig.config_type == allowed_config_type,
                 )
                 .first()
             )
@@ -298,7 +297,8 @@ class ManualTaskGraphTask(GraphTask):
             for manual_task in manual_tasks
             for config in manual_task.configs
             if config.is_current
-            and config.config_type == ManualTaskConfigurationType.erasure_privacy_request
+            and config.config_type
+            == ManualTaskConfigurationType.erasure_privacy_request
         ]
 
         if not has_erasure_configs:

--- a/src/fides/api/task/manual/manual_task_graph_task.py
+++ b/src/fides/api/task/manual/manual_task_graph_task.py
@@ -139,7 +139,6 @@ class ManualTaskGraphTask(GraphTask):
                 .first()
             )
             if existing_task_instance:
-                logger.info(f"An instance already exists for this privacy request and config type {allowed_config_type} – no need to create another one tied to a newer config version. {existing_task_instance}")
                 # An instance already exists for this privacy request and config type – no need
                 # to create another one tied to a newer config version.
                 continue
@@ -147,10 +146,9 @@ class ManualTaskGraphTask(GraphTask):
             # Check each active config for instances (now we know none exist yet for this config type)
             for config in manual_task.configs:
                 if not config.is_current or config.config_type != allowed_config_type:
-                    logger.info(f"Skipping config {config.id}, {config.config_type} because it is not current or not relevant for this request type")
                     # Skip configs that are not current or not relevant for this request type
                     continue
-                logger.info(f"Creating a new instance for config {config.id}, {config.config_type}")
+
                 ManualTaskInstance.create(
                     db=db,
                     data={

--- a/src/fides/api/task/manual/manual_task_graph_task.py
+++ b/src/fides/api/task/manual/manual_task_graph_task.py
@@ -7,6 +7,7 @@ from fides.api.common_exceptions import AwaitingAsyncTaskCallback
 from fides.api.models.attachment import AttachmentType
 from fides.api.models.manual_task import (
     ManualTask,
+    ManualTaskConfig,
     ManualTaskConfigurationType,
     ManualTaskEntityType,
     ManualTaskFieldType,
@@ -66,6 +67,13 @@ class ManualTaskGraphTask(GraphTask):
             self.log_end(ActionType.access)
             return []
 
+        if not self.resources.request.policy.get_rules_for_action(
+            action_type=ActionType.access
+        ):
+            # TODO: This will be changed with Manual Task Dependencies Implementation.
+            self.log_end(ActionType.access)
+            return []
+
         # Check/create manual task instances for ACCESS configs only
         self._ensure_manual_task_instances(
             db,
@@ -82,12 +90,6 @@ class ManualTaskGraphTask(GraphTask):
             ManualTaskConfigurationType.access_privacy_request,
         )
 
-        if not self.resources.request.policy.get_rules_for_action(
-            action_type=ActionType.access
-        ):
-            # TODO: This will be changed with Manual Task Dependencies Implementation.
-            self.log_end(ActionType.access)
-            return []
 
         if submitted_data is not None:
             result: List[Row] = [submitted_data] if submitted_data else []
@@ -118,33 +120,37 @@ class ManualTaskGraphTask(GraphTask):
 
         for manual_task in manual_tasks:
             # ------------------------------------------------------------------
-            # Short-circuit: if instances already exist for this task & entity
-            # (no matter what config version they were created for) we should reuse
-            # them instead of creating a brand-new one that would result in
-            # duplicates when configurations are versioned after the privacy
-            # request has started.
+            # Check if instances already exist for this task & entity with the SAME config type
+            # This prevents duplicates when configurations are versioned after the privacy
+            # request has started, while allowing different config types (access vs erasure)
+            # to have separate instances.
             # ------------------------------------------------------------------
             existing_task_instance = (
                 db.query(ManualTaskInstance)
+                .join(ManualTaskInstance.config)  # Join to access config information
                 .filter(
                     ManualTaskInstance.task_id == manual_task.id,
                     ManualTaskInstance.entity_id == privacy_request.id,
                     ManualTaskInstance.entity_type
                     == ManualTaskEntityType.privacy_request,
+                    # Only check for instances of the same config type
+                    ManualTaskConfig.config_type == allowed_config_type
                 )
                 .first()
             )
             if existing_task_instance:
-                # An instance already exists for this privacy request – no need
+                logger.info(f"An instance already exists for this privacy request and config type {allowed_config_type} – no need to create another one tied to a newer config version. {existing_task_instance}")
+                # An instance already exists for this privacy request and config type – no need
                 # to create another one tied to a newer config version.
                 continue
 
-            # Check each active config for instances (now we know none exist yet)
+            # Check each active config for instances (now we know none exist yet for this config type)
             for config in manual_task.configs:
                 if not config.is_current or config.config_type != allowed_config_type:
+                    logger.info(f"Skipping config {config.id}, {config.config_type} because it is not current or not relevant for this request type")
                     # Skip configs that are not current or not relevant for this request type
                     continue
-
+                logger.info(f"Creating a new instance for config {config.id}, {config.config_type}")
                 ManualTaskInstance.create(
                     db=db,
                     data={
@@ -285,6 +291,20 @@ class ManualTaskGraphTask(GraphTask):
         manual_tasks = get_manual_tasks_for_connection_config(db, connection_key)
         if not manual_tasks:
             # No manual tasks defined – nothing to erase
+            self.log_end(ActionType.erasure)
+            return 0
+
+        # Check if any manual tasks have ERASURE configs
+        has_erasure_configs = [
+            config
+            for manual_task in manual_tasks
+            for config in manual_task.configs
+            if config.is_current
+            and config.config_type == ManualTaskConfigurationType.erasure_privacy_request
+        ]
+
+        if not has_erasure_configs:
+            # No erasure configs - complete immediately
             self.log_end(ActionType.erasure)
             return 0
 

--- a/src/fides/api/task/manual/manual_task_utils.py
+++ b/src/fides/api/task/manual/manual_task_utils.py
@@ -217,7 +217,7 @@ def create_manual_task_instances_for_privacy_request(
                             ManualTaskConfigurationType.access_privacy_request,
                             ManualTaskConfigurationType.erasure_privacy_request,
                         ]
-                    ).filter(ManualTaskConfig.is_current.is_(True))
+                    )
                 )
             elif has_access_rules:
                 # Only access rules - only include access configurations

--- a/tests/api/task/test_manual_task_integration.py
+++ b/tests/api/task/test_manual_task_integration.py
@@ -660,13 +660,15 @@ class TestManualTaskGraphTaskInstanceCreation:
             },
         )
 
-    def test_access_request_creates_access_instances_only(self, db, test_privacy_request, test_manual_task_with_both_configs):
+    def test_access_request_creates_access_instances_only(
+        self, db, test_privacy_request, test_manual_task_with_both_configs
+    ):
         """Test that access_request creates only access instances"""
         manual_task, access_config, erasure_config = test_manual_task_with_both_configs
 
         # Create graph task
-        from fides.api.task.manual.manual_task_graph_task import ManualTaskGraphTask
         from fides.api.task.graph_task import GraphTask
+        from fides.api.task.manual.manual_task_graph_task import ManualTaskGraphTask
         from fides.api.task.task_resources import TaskResources
 
         # Mock execution node
@@ -690,9 +692,11 @@ class TestManualTaskGraphTaskInstanceCreation:
         )
 
         # Count instances before
-        initial_instances = db.query(ManualTaskInstance).filter(
-            ManualTaskInstance.entity_id == test_privacy_request.id
-        ).count()
+        initial_instances = (
+            db.query(ManualTaskInstance)
+            .filter(ManualTaskInstance.entity_id == test_privacy_request.id)
+            .count()
+        )
         assert initial_instances == 0
 
         # Call access_request
@@ -703,20 +707,34 @@ class TestManualTaskGraphTaskInstanceCreation:
             pass
 
         # Count instances after - should only have access instances
-        access_instances = db.query(ManualTaskInstance).join(ManualTaskConfig).filter(
-            ManualTaskInstance.entity_id == test_privacy_request.id,
-            ManualTaskConfig.config_type == ManualTaskConfigurationType.access_privacy_request
-        ).count()
+        access_instances = (
+            db.query(ManualTaskInstance)
+            .join(ManualTaskConfig)
+            .filter(
+                ManualTaskInstance.entity_id == test_privacy_request.id,
+                ManualTaskConfig.config_type
+                == ManualTaskConfigurationType.access_privacy_request,
+            )
+            .count()
+        )
 
-        erasure_instances = db.query(ManualTaskInstance).join(ManualTaskConfig).filter(
-            ManualTaskInstance.entity_id == test_privacy_request.id,
-            ManualTaskConfig.config_type == ManualTaskConfigurationType.erasure_privacy_request
-        ).count()
+        erasure_instances = (
+            db.query(ManualTaskInstance)
+            .join(ManualTaskConfig)
+            .filter(
+                ManualTaskInstance.entity_id == test_privacy_request.id,
+                ManualTaskConfig.config_type
+                == ManualTaskConfigurationType.erasure_privacy_request,
+            )
+            .count()
+        )
 
         assert access_instances == 1
         assert erasure_instances == 0
 
-    def test_erasure_request_creates_erasure_instances_only(self, db, test_privacy_request, test_manual_task_with_both_configs):
+    def test_erasure_request_creates_erasure_instances_only(
+        self, db, test_privacy_request, test_manual_task_with_both_configs
+    ):
         """Test that erasure_request creates only erasure instances"""
         manual_task, access_config, erasure_config = test_manual_task_with_both_configs
 
@@ -745,9 +763,11 @@ class TestManualTaskGraphTaskInstanceCreation:
         )
 
         # Count instances before
-        initial_instances = db.query(ManualTaskInstance).filter(
-            ManualTaskInstance.entity_id == test_privacy_request.id
-        ).count()
+        initial_instances = (
+            db.query(ManualTaskInstance)
+            .filter(ManualTaskInstance.entity_id == test_privacy_request.id)
+            .count()
+        )
         assert initial_instances == 0
 
         # Call erasure_request
@@ -758,20 +778,34 @@ class TestManualTaskGraphTaskInstanceCreation:
             pass
 
         # Count instances after - should only have erasure instances
-        access_instances = db.query(ManualTaskInstance).join(ManualTaskConfig).filter(
-            ManualTaskInstance.entity_id == test_privacy_request.id,
-            ManualTaskConfig.config_type == ManualTaskConfigurationType.access_privacy_request
-        ).count()
+        access_instances = (
+            db.query(ManualTaskInstance)
+            .join(ManualTaskConfig)
+            .filter(
+                ManualTaskInstance.entity_id == test_privacy_request.id,
+                ManualTaskConfig.config_type
+                == ManualTaskConfigurationType.access_privacy_request,
+            )
+            .count()
+        )
 
-        erasure_instances = db.query(ManualTaskInstance).join(ManualTaskConfig).filter(
-            ManualTaskInstance.entity_id == test_privacy_request.id,
-            ManualTaskConfig.config_type == ManualTaskConfigurationType.erasure_privacy_request
-        ).count()
+        erasure_instances = (
+            db.query(ManualTaskInstance)
+            .join(ManualTaskConfig)
+            .filter(
+                ManualTaskInstance.entity_id == test_privacy_request.id,
+                ManualTaskConfig.config_type
+                == ManualTaskConfigurationType.erasure_privacy_request,
+            )
+            .count()
+        )
 
         assert access_instances == 0
         assert erasure_instances == 1
 
-    def test_access_request_skips_deleted_configs(self, db, test_privacy_request, test_manual_task_with_both_configs):
+    def test_access_request_skips_deleted_configs(
+        self, db, test_privacy_request, test_manual_task_with_both_configs
+    ):
         """Test that access_request skips configs that are not current"""
         manual_task, access_config, erasure_config = test_manual_task_with_both_configs
 
@@ -808,12 +842,16 @@ class TestManualTaskGraphTaskInstanceCreation:
         assert result == []
 
         # No instances should be created
-        instances = db.query(ManualTaskInstance).filter(
-            ManualTaskInstance.entity_id == test_privacy_request.id
-        ).count()
+        instances = (
+            db.query(ManualTaskInstance)
+            .filter(ManualTaskInstance.entity_id == test_privacy_request.id)
+            .count()
+        )
         assert instances == 0
 
-    def test_erasure_request_skips_deleted_configs(self, db, test_privacy_request, test_manual_task_with_both_configs):
+    def test_erasure_request_skips_deleted_configs(
+        self, db, test_privacy_request, test_manual_task_with_both_configs
+    ):
         """Test that erasure_request skips configs that are not current"""
         manual_task, access_config, erasure_config = test_manual_task_with_both_configs
 
@@ -850,12 +888,16 @@ class TestManualTaskGraphTaskInstanceCreation:
         assert result == 0
 
         # No instances should be created
-        instances = db.query(ManualTaskInstance).filter(
-            ManualTaskInstance.entity_id == test_privacy_request.id
-        ).count()
+        instances = (
+            db.query(ManualTaskInstance)
+            .filter(ManualTaskInstance.entity_id == test_privacy_request.id)
+            .count()
+        )
         assert instances == 0
 
-    def test_access_and_erasure_instances_coexist(self, db, test_privacy_request, test_manual_task_with_both_configs):
+    def test_access_and_erasure_instances_coexist(
+        self, db, test_privacy_request, test_manual_task_with_both_configs
+    ):
         """Test that access and erasure instances can coexist for the same privacy request"""
         manual_task, access_config, erasure_config = test_manual_task_with_both_configs
 
@@ -896,15 +938,27 @@ class TestManualTaskGraphTaskInstanceCreation:
             pass
 
         # Should have both access and erasure instances
-        access_instances = db.query(ManualTaskInstance).join(ManualTaskConfig).filter(
-            ManualTaskInstance.entity_id == test_privacy_request.id,
-            ManualTaskConfig.config_type == ManualTaskConfigurationType.access_privacy_request
-        ).count()
+        access_instances = (
+            db.query(ManualTaskInstance)
+            .join(ManualTaskConfig)
+            .filter(
+                ManualTaskInstance.entity_id == test_privacy_request.id,
+                ManualTaskConfig.config_type
+                == ManualTaskConfigurationType.access_privacy_request,
+            )
+            .count()
+        )
 
-        erasure_instances = db.query(ManualTaskInstance).join(ManualTaskConfig).filter(
-            ManualTaskInstance.entity_id == test_privacy_request.id,
-            ManualTaskConfig.config_type == ManualTaskConfigurationType.erasure_privacy_request
-        ).count()
+        erasure_instances = (
+            db.query(ManualTaskInstance)
+            .join(ManualTaskConfig)
+            .filter(
+                ManualTaskInstance.entity_id == test_privacy_request.id,
+                ManualTaskConfig.config_type
+                == ManualTaskConfigurationType.erasure_privacy_request,
+            )
+            .count()
+        )
 
         assert access_instances == 1
         assert erasure_instances == 1

--- a/tests/task/manual/test_manual_task_instance_filter.py
+++ b/tests/task/manual/test_manual_task_instance_filter.py
@@ -390,7 +390,7 @@ class TestManualTaskInstanceFiltering:
         privacy_request = request.getfixturevalue(policy_fixture)
 
         # Create artificial graphs using the utility function
-        graphs = create_manual_task_artificial_graphs(db, privacy_request.policy)
+        graphs = create_manual_task_artificial_graphs(db)
 
         # Should include exactly one graph
         assert len(graphs) == 1


### PR DESCRIPTION
Closes [ENG-899]

### Description Of Changes

The bug where access instances were being created on erasure tasks showed back up after the last change. 
I have made another update to fix that issue and added tests.

### Code Changes

* One of the last changes caused extra instances to start popping up again, especially when a config had been deleted. 

### Steps to Confirm

1.  Spin up FidesPlus banch `ENG-899-research-and-correct-task-instance-creation` pointed at this fides branch.
2. Create a couple manual task integrations with access and erasure tasks
3. Delete an erasure task
4. Create an erasure privacy request
5. Verify it does not create extra instances or stop the task from processing. 

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-899]: https://ethyca.atlassian.net/browse/ENG-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ