### PR TITLE
Add icon for attachment that go in the access package

### DIFF
--- a/clients/admin-ui/src/features/privacy-requests/attachments/CustomUploadItem.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/attachments/CustomUploadItem.tsx
@@ -3,16 +3,20 @@ import {
   AntFlex as Flex,
   AntMessage as message,
   AntText as Text,
+  AntTooltip as Tooltip,
   Icons,
   UploadFile,
 } from "fidesui";
 import React, { useState } from "react";
+
+import { AttachmentType } from "~/types/api";
 
 import { useLazyGetAttachmentDetailsQuery } from "./privacy-request-attachments.slice";
 
 interface CustomAttachmentData {
   attachment_id: string;
   privacy_request_id: string;
+  attachment_type: AttachmentType;
 }
 
 interface CustomUploadItemProps {
@@ -54,12 +58,21 @@ const CustomUploadItem = ({ file }: CustomUploadItemProps) => {
     }
   };
 
+  const isAttachmentForAccessPackage =
+    file.customData?.attachment_type ===
+    AttachmentType.INCLUDE_WITH_ACCESS_PACKAGE;
+
   return (
     <Flex align="center" gap={8}>
       <Icons.Attachment className="shrink-0" />
       <Text ellipsis={{ tooltip: file.name }} className="grow">
         {file.name}
       </Text>
+      {isAttachmentForAccessPackage && (
+        <Tooltip title="This attachment will be included in the access package.">
+          <Icons.UserFilled className="shrink-0" />
+        </Tooltip>
+      )}
       <Button
         type="text"
         icon={<Icons.Download />}

--- a/clients/admin-ui/src/features/privacy-requests/attachments/RequestAttachments.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/attachments/RequestAttachments.tsx
@@ -68,6 +68,7 @@ const RequestAttachments = ({ subjectRequest }: RequestAttachmentsProps) => {
         customData: {
           attachment_id: attachment.id,
           privacy_request_id: subjectRequest.id,
+          attachment_type: attachment.attachment_type,
         },
       };
     }) || [];


### PR DESCRIPTION
### Description Of Changes

Add an icon to attachments that go in the access package to distinguish them from internal attachments.

### Code Changes

* Added icon with tooltip for access package attachments
* Updated tests

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
