### PR TITLE
Eng 908 safe mode bq delete

### DIFF
--- a/clients/admin-ui/src/types/api/models/ExecutionApplicationConfig.ts
+++ b/clients/admin-ui/src/types/api/models/ExecutionApplicationConfig.ts
@@ -6,4 +6,5 @@ export type ExecutionApplicationConfig = {
   subject_identity_verification_required?: boolean | null;
   disable_consent_identity_verification?: boolean | null;
   require_manual_request_approval?: boolean | null;
+  safe_mode?: boolean | null;
 };

--- a/clients/privacy-center/types/api/models/ExecutionApplicationConfig.ts
+++ b/clients/privacy-center/types/api/models/ExecutionApplicationConfig.ts
@@ -6,4 +6,5 @@ export type ExecutionApplicationConfig = {
   subject_identity_verification_required?: boolean | null;
   disable_consent_identity_verification?: boolean | null;
   require_manual_request_approval?: boolean | null;
+  safe_mode?: boolean | null;
 };

--- a/src/fides/api/schemas/application_config.py
+++ b/src/fides/api/schemas/application_config.py
@@ -62,6 +62,7 @@ class ExecutionApplicationConfig(FidesSchema):
     subject_identity_verification_required: Optional[bool] = None
     disable_consent_identity_verification: Optional[bool] = None
     require_manual_request_approval: Optional[bool] = None
+    safe_mode: Optional[bool] = None
     model_config = ConfigDict(extra="forbid")
 
 

--- a/src/fides/api/service/connectors/bigquery_connector.py
+++ b/src/fides/api/service/connectors/bigquery_connector.py
@@ -9,7 +9,6 @@ from sqlalchemy.sql.elements import TextClause
 
 from fides.api.common_exceptions import ConnectionException
 from fides.api.graph.execution import ExecutionNode
-from fides.api.models.application_config import ApplicationConfig
 from fides.api.models.connectionconfig import ConnectionTestStatus
 from fides.api.models.policy import Policy
 from fides.api.models.privacy_request import PrivacyRequest, RequestTask
@@ -132,6 +131,41 @@ class BigQueryConnector(SQLConnector):
             logger.exception(f"Error testing connection to remote BigQuery {str(e)}")
             raise ConnectionException(f"Connection error: {e}")
 
+    def _execute_statements_with_safe_mode(
+        self,
+        statements: List[Executable],
+        safe_mode_enabled: bool,
+        client: Engine,
+    ) -> int:
+        """
+        Execute SQL statements with safe mode support.
+
+        Args:
+            statements: List of SQL statements to execute
+            safe_mode_enabled: Whether safe mode is enabled
+            client: Database client engine
+
+        Returns:
+            Number of rows affected (0 in safe mode)
+        """
+        if not statements:
+            return 0
+
+        if safe_mode_enabled:
+            # In safe mode, log the statements instead of executing them
+            for stmt in statements:
+                logger.warning(f"SAFE MODE - Would execute SQL: {stmt}")
+            return 0
+
+        # Normal mode - execute the statements
+        row_count = 0
+        with client.connect() as connection:
+            for stmt in statements:
+                results = connection.execute(stmt)
+                logger.debug(f"Affected {results.rowcount} rows")
+                row_count += results.rowcount
+        return row_count
+
     def mask_data(
         self,
         node: ExecutionNode,
@@ -150,25 +184,16 @@ class BigQueryConnector(SQLConnector):
         # Check if safe_mode is enabled
         db: Session = Session.object_session(self.configuration)
         config_proxy = ConfigProxy(db)
-        safe_mode_enabled = getattr(config_proxy.execution, 'safe_mode', False)
+        safe_mode_enabled = getattr(config_proxy.execution, "safe_mode", False)
 
         # Check if we're using DELETE masking strategy
         if query_config.uses_delete_masking_strategy():
             # Use batched DELETE for better performance
             delete_stmts = query_config.generate_delete(client, input_data or {})
             logger.debug(f"Generated {len(delete_stmts)} DELETE statements")
-            if delete_stmts:
-                if safe_mode_enabled:
-                    # In safe mode, log the DELETE statements instead of executing them
-                    for delete_stmt in delete_stmts:
-                        logger.warning(f"SAFE MODE - Would execute DELETE: {delete_stmt}")
-                else:
-                    # Normal mode - execute the DELETE statements
-                    with client.connect() as connection:
-                        for delete_stmt in delete_stmts:
-                            delete_results = connection.execute(delete_stmt)
-                            logger.debug(f"Deleted {delete_results.rowcount} rows")
-                            update_or_delete_ct += delete_results.rowcount
+            update_or_delete_ct += self._execute_statements_with_safe_mode(
+                delete_stmts, safe_mode_enabled, client
+            )
         else:
             # For UPDATE operations, process each row individually since each row may have different masked values
             for row in rows:
@@ -178,18 +203,8 @@ class BigQueryConnector(SQLConnector):
                 logger.debug(
                     f"Generated {len(update_or_delete_stmts)} UPDATE statements"
                 )
-                if update_or_delete_stmts:
-                    if safe_mode_enabled:
-                        # In safe mode, log the UPDATE statements instead of executing them
-                        for update_or_delete_stmt in update_or_delete_stmts:
-                            logger.warning(f"SAFE MODE - Would execute UPDATE: {update_or_delete_stmt}")
-                    else:
-                        # Normal mode - execute the UPDATE statements
-                        with client.connect() as connection:
-                            for update_or_delete_stmt in update_or_delete_stmts:
-                                update_results = connection.execute(update_or_delete_stmt)
-                                logger.debug(f"Updated {update_results.rowcount} rows")
-                                update_or_delete_ct = (
-                                    update_or_delete_ct + update_results.rowcount
-                                )
+                update_or_delete_ct += self._execute_statements_with_safe_mode(
+                    update_or_delete_stmts, safe_mode_enabled, client
+                )
+
         return update_or_delete_ct

--- a/src/fides/api/service/connectors/sql_connector.py
+++ b/src/fides/api/service/connectors/sql_connector.py
@@ -24,7 +24,6 @@ from fides.api.common_exceptions import (
     SSHTunnelConfigNotFoundException,
 )
 from fides.api.graph.execution import ExecutionNode
-from fides.api.models.application_config import ApplicationConfig
 from fides.api.models.connectionconfig import ConnectionConfig, ConnectionTestStatus
 from fides.api.models.policy import Policy
 from fides.api.models.privacy_request import PrivacyRequest, RequestTask
@@ -190,7 +189,7 @@ class SQLConnector(BaseConnector[Engine]):
         # Check if safe_mode is enabled
         db: Session = Session.object_session(self.configuration)
         config_proxy = ConfigProxy(db)
-        safe_mode_enabled = getattr(config_proxy.execution, 'safe_mode', False)
+        safe_mode_enabled = getattr(config_proxy.execution, "safe_mode", False)
 
         for row in rows:
             update_stmt: Optional[TextClause] = query_config.generate_update_stmt(

--- a/src/fides/config/utils.py
+++ b/src/fides/config/utils.py
@@ -61,6 +61,7 @@ CONFIG_KEY_ALLOWLIST = {
         "task_retry_backoff",
         "require_manual_request_approval",
         "subject_identity_verification_required",
+        "safe_mode",
     ],
     "storage": [
         "active_default_storage_type",

--- a/tests/ops/service/connectors/test_bigquery_connector.py
+++ b/tests/ops/service/connectors/test_bigquery_connector.py
@@ -540,7 +540,8 @@ class TestBigQueryConnector:
         """Test that when safe_mode is enabled, DELETE statements are logged instead of executed"""
         # Set up safe_mode in the database
         from fides.api.models.application_config import ApplicationConfig
-        ApplicationConfig.update_config_set(db, {"execution": {"safe_mode": True}})
+
+        ApplicationConfig.update_api_set(db, {"execution": {"safe_mode": True}})
         db.commit()
 
         dataset_config = (
@@ -572,10 +573,10 @@ class TestBigQueryConnector:
         assert update_or_delete_ct == 0
 
         # Check that the DELETE statements were logged as warnings instead of executed
-        assert "SAFE MODE - Would execute DELETE:" in loguru_caplog.text
+        assert "SAFE MODE - Would execute SQL:" in loguru_caplog.text
 
         # Clean up: disable safe_mode
-        ApplicationConfig.update_config_set(db, {"execution": {"safe_mode": False}})
+        ApplicationConfig.update_api_set(db, {"execution": {"safe_mode": False}})
         db.commit()
 
     @pytest.mark.integration_external
@@ -589,12 +590,12 @@ class TestBigQueryConnector:
         mocker,
         loguru_caplog,
         db,
-        test_data_with_complex_objects,
     ):
         """Test that when safe_mode is disabled, DELETE statements are actually executed"""
         # Ensure safe_mode is disabled in the database
         from fides.api.models.application_config import ApplicationConfig
-        ApplicationConfig.update_config_set(db, {"execution": {"safe_mode": False}})
+
+        ApplicationConfig.update_api_set(db, {"execution": {"safe_mode": False}})
         db.commit()
 
         dataset_config = (
@@ -626,7 +627,7 @@ class TestBigQueryConnector:
         assert update_or_delete_ct >= 0
 
         # Check that we don't see safe mode logging
-        assert "SAFE MODE - Would execute DELETE:" not in loguru_caplog.text
+        assert "SAFE MODE - Would execute SQL:" not in loguru_caplog.text
 
 
 @pytest.mark.integration_external


### PR DESCRIPTION
Allows for ENG-908 to be verified via logs

### Description Of Changes

Adds a safe_mode configuration and uses it to log destructive SQL statements instead of executing them

### Code Changes

* safe_mode configuration
* safe_mode usage in bq and sql connectors
* autoamted tests for each

### Steps to Confirm

1. Update the configuration using this API call to enable safe mode:
``curl --request PATCH \
  --url 'http://localhost:3000/api/v1/config?api_set=true' \
  --header 'Authorization: Bearer YOUR_TOKEN' \
  --header 'Content-Type: application/json' \
  --data '
{
  "execution": {
    "safe_mode": false
  }
}'```

2. Verify the config was added
```curl --request GET \
  --url 'http://localhost:3000/api/v1/config?api_set=true' \
  --header 'Authorization: Bearer YOUR_TOKEN'```

3. Make sure you have a BigQuery integration with relevant rows to delete, then make an Erasure request. 
4. Verify that the "SAFE MODE - Would execute" log appears and would delete only the relevant rows 