### PR TITLE
preserve selections across pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Developer Experience
 - Migrated Action Center tables to Ant Design [#6349](https://github.com/ethyca/fides/pull/6349)
 
+### Fixed
+- Fixed an issue where row selections in Action Center tables did not persist across pages [#6357](https://github.com/ethyca/fides/pull/6357)
+
 ## [2.66.0](https://github.com/ethyca/fides/compare/2.65.2...2.66.0)
 
 ### Added


### PR DESCRIPTION
Closes [ENG-867]

### Description Of Changes

Updates the Action Center tables to persist row selections across pagination. This allows users to select items on multiple pages and perform bulk actions on the entire selection. The total count of selected items is now accurately displayed and updated as the user navigates through pages. Selections are reset when filters or tabs are changed to avoid unintended actions.

### Code Changes

*   **`DiscoveredAssetsTable.tsx` & `DiscoveredSystemAggregateTable.tsx`**
    *   Replaced `selectedRows` state array with a `selectedRowsMap` to store selections across all pages.
    *   Updated the `rowSelection.onChange` logic to manage the `selectedRowsMap`, preserving selections when paginating.
    *   Added a `useEffect` to sync the visible checkbox state (`selectedRowKeys`) with the persisted selections for the current page.
    *   Updated the displayed count of selected items to reflect the total number of selections from all pages.

### Steps to Confirm

1.  Visit the Vercel Nightly Build (link below)
2. Go to the About page
3. Enable "Web Monitor" and "Asset consent status labels" feature flags
4. Visit the Action Center in left nav
5. Click to "Review" the existing we monitor results for ethyca.com
3. Click a System name in the left-most column
4. Select a few rows on the first page.
5. Navigate to the next page.
6. Confirm the selected count still reflects the items chosen from the first page.
7. Select a few more rows on the current page.
8. Verify that the selected count now includes items from all pages.
9. Go back to the first page and ensure the original selections are still checked.
10. Perform a bulk action (e.g., "Assign a system") and confirm it applies to all selected items across all pages.
11. Verify that selections are cleared after the action is successful.
12. Change a switch to another tab and confirm that selections are cleared.


### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-867]: https://ethyca.atlassian.net/browse/ENG-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ