### PR TITLE
ENG-1002 improved safe_mode (now sql_dry_run)

### DIFF
--- a/clients/admin-ui/src/types/api/models/ExecutionApplicationConfig.ts
+++ b/clients/admin-ui/src/types/api/models/ExecutionApplicationConfig.ts
@@ -2,9 +2,18 @@
 /* tslint:disable */
 /* eslint-disable */
 
+/**
+ * SQL dry run mode for controlling execution of SQL statements in privacy requests
+ */
+export enum SqlDryRunMode {
+  NONE = "none",
+  ACCESS = "access",
+  ERASURE = "erasure",
+}
+
 export type ExecutionApplicationConfig = {
   subject_identity_verification_required?: boolean | null;
   disable_consent_identity_verification?: boolean | null;
   require_manual_request_approval?: boolean | null;
-  sql_dry_run?: boolean | null;
+  sql_dry_run?: SqlDryRunMode | null;
 };

--- a/clients/admin-ui/src/types/api/models/ExecutionApplicationConfig.ts
+++ b/clients/admin-ui/src/types/api/models/ExecutionApplicationConfig.ts
@@ -6,5 +6,5 @@ export type ExecutionApplicationConfig = {
   subject_identity_verification_required?: boolean | null;
   disable_consent_identity_verification?: boolean | null;
   require_manual_request_approval?: boolean | null;
-  safe_mode?: boolean | null;
+  sql_dry_run?: boolean | null;
 };

--- a/clients/privacy-center/types/api/models/ExecutionApplicationConfig.ts
+++ b/clients/privacy-center/types/api/models/ExecutionApplicationConfig.ts
@@ -2,9 +2,18 @@
 /* tslint:disable */
 /* eslint-disable */
 
+/**
+ * SQL dry run mode for controlling execution of SQL statements in privacy requests
+ */
+export enum SqlDryRunMode {
+  NONE = "none",
+  ACCESS = "access",
+  ERASURE = "erasure",
+}
+
 export type ExecutionApplicationConfig = {
   subject_identity_verification_required?: boolean | null;
   disable_consent_identity_verification?: boolean | null;
   require_manual_request_approval?: boolean | null;
-  sql_dry_run?: boolean | null;
+  sql_dry_run?: SqlDryRunMode | null;
 };

--- a/clients/privacy-center/types/api/models/ExecutionApplicationConfig.ts
+++ b/clients/privacy-center/types/api/models/ExecutionApplicationConfig.ts
@@ -6,5 +6,5 @@ export type ExecutionApplicationConfig = {
   subject_identity_verification_required?: boolean | null;
   disable_consent_identity_verification?: boolean | null;
   require_manual_request_approval?: boolean | null;
-  safe_mode?: boolean | null;
+  sql_dry_run?: boolean | null;
 };

--- a/src/fides/api/schemas/application_config.py
+++ b/src/fides/api/schemas/application_config.py
@@ -62,7 +62,8 @@ class ExecutionApplicationConfig(FidesSchema):
     subject_identity_verification_required: Optional[bool] = None
     disable_consent_identity_verification: Optional[bool] = None
     require_manual_request_approval: Optional[bool] = None
-    safe_mode: Optional[bool] = None
+    sql_dry_run: Optional[bool] = None
+
     model_config = ConfigDict(extra="forbid")
 
 

--- a/src/fides/api/schemas/application_config.py
+++ b/src/fides/api/schemas/application_config.py
@@ -11,6 +11,14 @@ from fides.api.schemas.messaging.messaging import MessagingServiceType
 from fides.config.admin_ui_settings import ErrorNotificationMode
 
 
+class SqlDryRunMode(str, Enum):
+    """SQL dry run mode for controlling execution of SQL statements in privacy requests"""
+
+    none = "none"
+    access = "access"
+    erasure = "erasure"
+
+
 class StorageTypeApiAccepted(Enum):
     """Enum for storage destination types accepted in API updates"""
 
@@ -62,9 +70,9 @@ class ExecutionApplicationConfig(FidesSchema):
     subject_identity_verification_required: Optional[bool] = None
     disable_consent_identity_verification: Optional[bool] = None
     require_manual_request_approval: Optional[bool] = None
-    sql_dry_run: Optional[bool] = None
+    sql_dry_run: Optional[SqlDryRunMode] = None
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
 
 
 class AdminUIConfig(FidesSchema):

--- a/src/fides/api/service/connectors/bigquery_connector.py
+++ b/src/fides/api/service/connectors/bigquery_connector.py
@@ -130,33 +130,31 @@ class BigQueryConnector(SQLConnector):
             logger.exception(f"Error testing connection to remote BigQuery {str(e)}")
             raise ConnectionException(f"Connection error: {e}")
 
-    def _execute_statements_with_safe_mode(
+    def _execute_statements_with_sql_dry_run(
         self,
         statements: List[Executable],
-        safe_mode_enabled: bool,
+        sql_dry_run_enabled: bool,
         client: Engine,
     ) -> int:
         """
-        Execute SQL statements with safe mode support.
+        Execute SQL statements with sql_dry_run support.
 
         Args:
             statements: List of SQL statements to execute
-            safe_mode_enabled: Whether safe mode is enabled
-            client: Database client engine
+            sql_dry_run_enabled: Whether sql_dry_run mode is enabled
+            client: Database engine
 
         Returns:
-            Number of rows affected (0 in safe mode)
+            int: Number of affected rows (0 in sql_dry_run mode)
         """
         if not statements:
             return 0
 
-        if safe_mode_enabled:
-            # In safe mode, log the statements instead of executing them
+        if sql_dry_run_enabled:
             for stmt in statements:
-                logger.warning(f"SAFE MODE - Would execute SQL: {stmt}")
+                logger.warning(f"SQL DRY RUN - Would execute SQL: {stmt}")
             return 0
 
-        # Normal mode - execute the statements
         row_count = 0
         with client.connect() as connection:
             for stmt in statements:
@@ -180,19 +178,15 @@ class BigQueryConnector(SQLConnector):
         update_or_delete_ct = 0
         client = self.client()
 
-        # Check if safe_mode is enabled
-        safe_mode_enabled = self.get_safe_mode_enabled()
+        sql_dry_run_enabled = self.get_sql_dry_run_enabled()
 
-        # Check if we're using DELETE masking strategy
         if query_config.uses_delete_masking_strategy():
-            # Use batched DELETE for better performance
             delete_stmts = query_config.generate_delete(client, input_data or {})
             logger.debug(f"Generated {len(delete_stmts)} DELETE statements")
-            update_or_delete_ct += self._execute_statements_with_safe_mode(
-                delete_stmts, safe_mode_enabled, client
+            update_or_delete_ct += self._execute_statements_with_sql_dry_run(
+                delete_stmts, sql_dry_run_enabled, client
             )
         else:
-            # For UPDATE operations, process each row individually since each row may have different masked values
             for row in rows:
                 update_or_delete_stmts: List[Executable] = query_config.generate_update(
                     row, policy, privacy_request, client
@@ -200,8 +194,7 @@ class BigQueryConnector(SQLConnector):
                 logger.debug(
                     f"Generated {len(update_or_delete_stmts)} UPDATE statements"
                 )
-                update_or_delete_ct += self._execute_statements_with_safe_mode(
-                    update_or_delete_stmts, safe_mode_enabled, client
+                update_or_delete_ct += self._execute_statements_with_sql_dry_run(
+                    update_or_delete_stmts, sql_dry_run_enabled, client
                 )
-
         return update_or_delete_ct

--- a/src/fides/api/service/connectors/sql_connector.py
+++ b/src/fides/api/service/connectors/sql_connector.py
@@ -60,7 +60,7 @@ class SQLConnector(BaseConnector[Engine]):
             )
         self.ssh_server: sshtunnel._ForwardServer = None
 
-    def should_dry_run(self, mode_to_check) -> bool:
+    def should_dry_run(self, mode_to_check: SqlDryRunMode) -> bool:
         """
         Check if SQL dry run is enabled for the specified mode.
 

--- a/src/fides/config/utils.py
+++ b/src/fides/config/utils.py
@@ -61,7 +61,7 @@ CONFIG_KEY_ALLOWLIST = {
         "task_retry_backoff",
         "require_manual_request_approval",
         "subject_identity_verification_required",
-        "safe_mode",
+        "sql_dry_run",
     ],
     "storage": [
         "active_default_storage_type",

--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -62,7 +62,7 @@ class TestPatchApplicationConfig:
             "execution": {
                 "subject_identity_verification_required": True,
                 "require_manual_request_approval": True,
-                "safe_mode": False,
+                "sql_dry_run": False,
             },
             "security": {
                 "cors_origins": [
@@ -320,18 +320,18 @@ class TestPatchApplicationConfig:
         )
         assert db_settings.api_set["security"] == security_payload
 
-    def test_patch_application_config_safe_mode(
+    def test_patch_application_config_sql_dry_run(
         self,
         api_client: TestClient,
         generate_auth_header,
         url,
         db: Session,
     ):
-        """Test that safe_mode can be updated individually"""
+        """Test that sql_dry_run can be updated individually"""
         auth_header = generate_auth_header([scopes.CONFIG_UPDATE])
 
-        # Test setting safe_mode to True
-        updated_payload = {"execution": {"safe_mode": True}}
+        # Test setting sql_dry_run to True
+        updated_payload = {"execution": {"sql_dry_run": True}}
         response = api_client.patch(
             url,
             headers=auth_header,
@@ -339,14 +339,14 @@ class TestPatchApplicationConfig:
         )
         assert response.status_code == 200
         response_settings = response.json()
-        assert response_settings["execution"]["safe_mode"] is True
+        assert response_settings["execution"]["sql_dry_run"] is True
 
         # Verify it was saved to the database
         db_settings = db.query(ApplicationConfig).first()
-        assert db_settings.api_set["execution"]["safe_mode"] is True
+        assert db_settings.api_set["execution"]["sql_dry_run"] is True
 
-        # Test setting safe_mode to False
-        updated_payload = {"execution": {"safe_mode": False}}
+        # Test setting sql_dry_run to False
+        updated_payload = {"execution": {"sql_dry_run": False}}
         response = api_client.patch(
             url,
             headers=auth_header,
@@ -354,11 +354,11 @@ class TestPatchApplicationConfig:
         )
         assert response.status_code == 200
         response_settings = response.json()
-        assert response_settings["execution"]["safe_mode"] is False
+        assert response_settings["execution"]["sql_dry_run"] is False
 
         # Verify it was updated in the database
         db.refresh(db_settings)
-        assert db_settings.api_set["execution"]["safe_mode"] is False
+        assert db_settings.api_set["execution"]["sql_dry_run"] is False
 
     def test_patch_application_config_notifications_properties(
         self,

--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -327,11 +327,13 @@ class TestPatchApplicationConfig:
         url,
         db: Session,
     ):
-        """Test that sql_dry_run can be updated individually"""
+        """Test that sql_dry_run can be updated with enum values"""
+        from fides.api.schemas.application_config import SqlDryRunMode
+
         auth_header = generate_auth_header([scopes.CONFIG_UPDATE])
 
-        # Test setting sql_dry_run to True
-        updated_payload = {"execution": {"sql_dry_run": True}}
+        # Test setting sql_dry_run to access
+        updated_payload = {"execution": {"sql_dry_run": SqlDryRunMode.access.value}}
         response = api_client.patch(
             url,
             headers=auth_header,
@@ -339,14 +341,14 @@ class TestPatchApplicationConfig:
         )
         assert response.status_code == 200
         response_settings = response.json()
-        assert response_settings["execution"]["sql_dry_run"] is True
+        assert response_settings["execution"]["sql_dry_run"] == "access"
 
         # Verify it was saved to the database
         db_settings = db.query(ApplicationConfig).first()
-        assert db_settings.api_set["execution"]["sql_dry_run"] is True
+        assert db_settings.api_set["execution"]["sql_dry_run"] == "access"
 
-        # Test setting sql_dry_run to False
-        updated_payload = {"execution": {"sql_dry_run": False}}
+        # Test setting sql_dry_run to erasure
+        updated_payload = {"execution": {"sql_dry_run": SqlDryRunMode.erasure.value}}
         response = api_client.patch(
             url,
             headers=auth_header,
@@ -354,11 +356,26 @@ class TestPatchApplicationConfig:
         )
         assert response.status_code == 200
         response_settings = response.json()
-        assert response_settings["execution"]["sql_dry_run"] is False
+        assert response_settings["execution"]["sql_dry_run"] == "erasure"
 
         # Verify it was updated in the database
         db.refresh(db_settings)
-        assert db_settings.api_set["execution"]["sql_dry_run"] is False
+        assert db_settings.api_set["execution"]["sql_dry_run"] == "erasure"
+
+        # Test setting sql_dry_run to none
+        updated_payload = {"execution": {"sql_dry_run": SqlDryRunMode.none.value}}
+        response = api_client.patch(
+            url,
+            headers=auth_header,
+            json=updated_payload,
+        )
+        assert response.status_code == 200
+        response_settings = response.json()
+        assert response_settings["execution"]["sql_dry_run"] == "none"
+
+        # Verify it was updated in the database
+        db.refresh(db_settings)
+        assert db_settings.api_set["execution"]["sql_dry_run"] == "none"
 
     def test_patch_application_config_notifications_properties(
         self,

--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -62,7 +62,7 @@ class TestPatchApplicationConfig:
             "execution": {
                 "subject_identity_verification_required": True,
                 "require_manual_request_approval": True,
-                "sql_dry_run": False,
+                "sql_dry_run": "none",
             },
             "security": {
                 "cors_origins": [

--- a/tests/ops/service/connectors/test_bigquery_connector.py
+++ b/tests/ops/service/connectors/test_bigquery_connector.py
@@ -1,11 +1,13 @@
 import logging
 from typing import Generator
+from unittest.mock import MagicMock, patch
 
 import pytest
 import sqlalchemy
 from fideslang.models import Dataset, MaskingStrategies, MaskingStrategyOverride
 from loguru import logger
 from sqlalchemy import text
+from sqlalchemy.engine import Engine
 
 from fides.api.graph.config import CollectionAddress
 from fides.api.graph.graph import DatasetGraph
@@ -18,8 +20,6 @@ from fides.api.schemas.namespace_meta.bigquery_namespace_meta import (
 )
 from fides.api.service.connectors.bigquery_connector import BigQueryConnector
 from tests.fixtures.bigquery_fixtures import seed_bigquery_integration_db
-from unittest.mock import MagicMock, patch
-from sqlalchemy.engine import Engine
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/ops/service/connectors/test_bigquery_connector.py
+++ b/tests/ops/service/connectors/test_bigquery_connector.py
@@ -28,105 +28,6 @@ def update_bigquery_data(bigquery_test_engine):
     seed_bigquery_integration_db(bigquery_test_engine)
 
 
-class TestBigQueryConnectorUnit:
-    """Unit tests for BigQuery connector that don't require external credentials"""
-
-    def test_execute_statements_with_sql_dry_run_enabled(self, loguru_caplog):
-        """Test _execute_statements_with_sql_dry_run when dry run is enabled"""
-        # Create a mock connector
-        mock_connection_config = MagicMock()
-        mock_connection_config.secrets = {"keyfile_creds": "fake_creds"}
-
-        connector = BigQueryConnector(mock_connection_config)
-
-        # Mock statements
-        mock_statements = [
-            text("DELETE FROM table1 WHERE id = 1"),
-            text("DELETE FROM table2 WHERE id = 2"),
-        ]
-
-        # Mock client
-        mock_client = MagicMock(spec=Engine)
-
-        # Call the function with sql_dry_run enabled
-        result = connector._execute_statements_with_sql_dry_run(
-            statements=mock_statements,
-            sql_dry_run_enabled=True,
-            client=mock_client,
-        )
-
-        # Assertions
-        assert result == 0  # Should return 0 affected rows in dry run mode
-        assert "SQL DRY RUN - Would execute SQL:" in loguru_caplog.text
-        assert "DELETE FROM table1 WHERE id = 1" in loguru_caplog.text
-        assert "DELETE FROM table2 WHERE id = 2" in loguru_caplog.text
-
-        # Should not attempt to connect to database
-        mock_client.connect.assert_not_called()
-
-    def test_execute_statements_with_sql_dry_run_disabled(self):
-        """Test _execute_statements_with_sql_dry_run when dry run is disabled"""
-        # Create a mock connector
-        mock_connection_config = MagicMock()
-        mock_connection_config.secrets = {"keyfile_creds": "fake_creds"}
-
-        connector = BigQueryConnector(mock_connection_config)
-
-        # Mock statements
-        mock_statements = [
-            text("DELETE FROM table1 WHERE id = 1"),
-            text("DELETE FROM table2 WHERE id = 2"),
-        ]
-
-        # Mock client and connection
-        mock_client = MagicMock(spec=Engine)
-        mock_connection = MagicMock()
-        mock_client.connect.return_value.__enter__.return_value = mock_connection
-
-        # Mock execute results
-        mock_result1 = MagicMock()
-        mock_result1.rowcount = 3
-        mock_result2 = MagicMock()
-        mock_result2.rowcount = 5
-        mock_connection.execute.side_effect = [mock_result1, mock_result2]
-
-        # Call the function with sql_dry_run disabled
-        result = connector._execute_statements_with_sql_dry_run(
-            statements=mock_statements,
-            sql_dry_run_enabled=False,
-            client=mock_client,
-        )
-
-        # Assertions
-        assert result == 8  # Should return sum of affected rows (3 + 5)
-        mock_client.connect.assert_called_once()
-        assert mock_connection.execute.call_count == 2
-        mock_connection.execute.assert_any_call(mock_statements[0])
-        mock_connection.execute.assert_any_call(mock_statements[1])
-
-    def test_execute_statements_with_sql_dry_run_empty_statements(self):
-        """Test _execute_statements_with_sql_dry_run with empty statements list"""
-        # Create a mock connector
-        mock_connection_config = MagicMock()
-        mock_connection_config.secrets = {"keyfile_creds": "fake_creds"}
-
-        connector = BigQueryConnector(mock_connection_config)
-
-        # Mock client
-        mock_client = MagicMock(spec=Engine)
-
-        # Call the function with empty statements
-        result = connector._execute_statements_with_sql_dry_run(
-            statements=[],
-            sql_dry_run_enabled=False,
-            client=mock_client,
-        )
-
-        # Assertions
-        assert result == 0  # Should return 0 for empty statements
-        mock_client.connect.assert_not_called()
-
-
 @pytest.mark.integration_external
 @pytest.mark.integration_bigquery
 class TestBigQueryConnector:
@@ -626,8 +527,6 @@ class TestBigQueryConnector:
         assert len(results) == 1
         assert results[0]["email"] == "customer-1@example.com"
 
-    @pytest.mark.integration_external
-    @pytest.mark.integration_bigquery
     def test_mask_data_sql_dry_run_enabled(
         self,
         bigquery_example_test_dataset_config_with_namespace_and_partitioning_meta: DatasetConfig,
@@ -677,8 +576,6 @@ class TestBigQueryConnector:
         )
         db.commit()
 
-    @pytest.mark.integration_external
-    @pytest.mark.integration_bigquery
     def test_mask_data_sql_dry_run_disabled(
         self,
         bigquery_example_test_dataset_config_with_namespace_and_partitioning_meta: DatasetConfig,
@@ -723,8 +620,6 @@ class TestBigQueryConnector:
         assert update_or_delete_ct >= 0
         assert "SQL DRY RUN - Would execute SQL:" not in loguru_caplog.text
 
-    @pytest.mark.integration_external
-    @pytest.mark.integration_bigquery
     def test_sql_dry_run_enabled_comprehensive(
         self,
         bigquery_example_test_dataset_config_with_namespace_and_partitioning_meta: DatasetConfig,
@@ -793,8 +688,6 @@ class TestBigQueryConnector:
         )
         db.commit()
 
-    @pytest.mark.integration_external
-    @pytest.mark.integration_bigquery
     def test_sql_dry_run_disabled_comprehensive(
         self,
         bigquery_example_test_dataset_config_with_namespace_and_partitioning_meta: DatasetConfig,
@@ -858,6 +751,101 @@ class TestBigQueryConnector:
 
         # Check that we don't see sql_dry_run logging
         assert "SQL DRY RUN - Would execute SQL:" not in loguru_caplog.text
+
+    def test_execute_statements_with_sql_dry_run_enabled(self, loguru_caplog):
+        """Test _execute_statements_with_sql_dry_run when dry run is enabled"""
+        # Create a mock connector
+        mock_connection_config = MagicMock()
+        mock_connection_config.secrets = {"keyfile_creds": "fake_creds"}
+
+        connector = BigQueryConnector(mock_connection_config)
+
+        # Mock statements
+        mock_statements = [
+            text("DELETE FROM table1 WHERE id = 1"),
+            text("DELETE FROM table2 WHERE id = 2"),
+        ]
+
+        # Mock client
+        mock_client = MagicMock(spec=Engine)
+
+        # Call the function with sql_dry_run enabled
+        result = connector._execute_statements_with_sql_dry_run(
+            statements=mock_statements,
+            sql_dry_run_enabled=True,
+            client=mock_client,
+        )
+
+        # Assertions
+        assert result == 0  # Should return 0 affected rows in dry run mode
+        assert "SQL DRY RUN - Would execute SQL:" in loguru_caplog.text
+        assert "DELETE FROM table1 WHERE id = 1" in loguru_caplog.text
+        assert "DELETE FROM table2 WHERE id = 2" in loguru_caplog.text
+
+        # Should not attempt to connect to database
+        mock_client.connect.assert_not_called()
+
+    def test_execute_statements_with_sql_dry_run_disabled(self):
+        """Test _execute_statements_with_sql_dry_run when dry run is disabled"""
+        # Create a mock connector
+        mock_connection_config = MagicMock()
+        mock_connection_config.secrets = {"keyfile_creds": "fake_creds"}
+
+        connector = BigQueryConnector(mock_connection_config)
+
+        # Mock statements
+        mock_statements = [
+            text("DELETE FROM table1 WHERE id = 1"),
+            text("DELETE FROM table2 WHERE id = 2"),
+        ]
+
+        # Mock client and connection
+        mock_client = MagicMock(spec=Engine)
+        mock_connection = MagicMock()
+        mock_client.connect.return_value.__enter__.return_value = mock_connection
+
+        # Mock execute results
+        mock_result1 = MagicMock()
+        mock_result1.rowcount = 3
+        mock_result2 = MagicMock()
+        mock_result2.rowcount = 5
+        mock_connection.execute.side_effect = [mock_result1, mock_result2]
+
+        # Call the function with sql_dry_run disabled
+        result = connector._execute_statements_with_sql_dry_run(
+            statements=mock_statements,
+            sql_dry_run_enabled=False,
+            client=mock_client,
+        )
+
+        # Assertions
+        assert result == 8  # Should return sum of affected rows (3 + 5)
+        mock_client.connect.assert_called_once()
+        assert mock_connection.execute.call_count == 2
+        mock_connection.execute.assert_any_call(mock_statements[0])
+        mock_connection.execute.assert_any_call(mock_statements[1])
+
+    def test_execute_statements_with_sql_dry_run_empty_statements(self):
+        """Test _execute_statements_with_sql_dry_run with empty statements list"""
+        # Create a mock connector
+        mock_connection_config = MagicMock()
+        mock_connection_config.secrets = {"keyfile_creds": "fake_creds"}
+
+        connector = BigQueryConnector(mock_connection_config)
+
+        # Mock client
+        mock_client = MagicMock(spec=Engine)
+
+        # Call the function with empty statements
+        result = connector._execute_statements_with_sql_dry_run(
+            statements=[],
+            sql_dry_run_enabled=False,
+            client=mock_client,
+        )
+
+        # Assertions
+        assert result == 0  # Should return 0 for empty statements
+        mock_client.connect.assert_not_called()
 
 
 @pytest.mark.integration_external

--- a/tests/ops/service/connectors/test_sql_connector.py
+++ b/tests/ops/service/connectors/test_sql_connector.py
@@ -1,0 +1,287 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+from sqlalchemy import text
+
+from fides.api.graph.execution import ExecutionNode
+from fides.api.models.privacy_request import PrivacyRequest, RequestTask
+from fides.api.service.connectors.sql_connector import SQLConnector
+
+
+class MockSecretsSchema(BaseModel):
+    """Minimal secrets schema for testing"""
+
+    pass
+
+
+class MockSQLConnector(SQLConnector):
+    """Mock SQL connector for testing base functionality"""
+
+    secrets_schema = MockSecretsSchema
+
+    def build_uri(self):
+        return "sqlite:///:memory:"
+
+
+class TestSQLConnectorDryRun:
+    """Test sql_dry_run functionality for the base SQLConnector class"""
+
+    @pytest.fixture
+    def mock_connection_config(self):
+        """Create a mock connection config"""
+        mock_config = MagicMock()
+        mock_config.secrets = {}
+        return mock_config
+
+    @pytest.fixture
+    def mock_connector(self, mock_connection_config):
+        """Create a mock SQL connector"""
+        connector = MockSQLConnector(mock_connection_config)
+        return connector
+
+    @pytest.fixture
+    def mock_execution_node(self):
+        """Create a mock execution node"""
+        node = MagicMock(spec=ExecutionNode)
+        node.address = MagicMock()
+        node.address.collection = "test_table"
+
+        # Mock the collection attribute and its methods
+        node.collection = MagicMock()
+        node.collection.custom_request_fields.return_value = ["field1", "field2"]
+
+        return node
+
+    @pytest.fixture
+    def mock_privacy_request(self):
+        """Create a mock privacy request"""
+        return MagicMock(spec=PrivacyRequest)
+
+    @pytest.fixture
+    def mock_request_task(self):
+        """Create a mock request task"""
+        return MagicMock(spec=RequestTask)
+
+    def test_retrieve_data_sql_dry_run_enabled(
+        self,
+        mock_connector,
+        mock_execution_node,
+        mock_privacy_request,
+        mock_request_task,
+        loguru_caplog,
+        db,
+    ):
+        """Test that retrieve_data logs SQL instead of executing when sql_dry_run is enabled"""
+        from fides.api.models.application_config import ApplicationConfig
+
+        ApplicationConfig.update_api_set(db, {"execution": {"sql_dry_run": True}})
+        db.commit()
+
+        mock_query_config = MagicMock()
+        mock_query_config.generate_query.return_value = text(
+            "SELECT * FROM test_table WHERE id = :id"
+        )
+
+        with (
+            patch.object(
+                mock_connector, "query_config", return_value=mock_query_config
+            ),
+            patch.object(mock_connector, "client") as mock_client,
+        ):
+
+            results = mock_connector.retrieve_data(
+                node=mock_execution_node,
+                policy=MagicMock(),
+                privacy_request=mock_privacy_request,
+                request_task=mock_request_task,
+                input_data={"id": [1, 2, 3]},
+            )
+
+            assert results == []
+            assert "SQL DRY RUN - Would execute SQL:" in loguru_caplog.text
+            mock_client.return_value.connect.assert_not_called()
+
+        ApplicationConfig.update_api_set(db, {"execution": {"sql_dry_run": False}})
+        db.commit()
+
+    def test_retrieve_data_sql_dry_run_disabled(
+        self,
+        mock_connector,
+        mock_execution_node,
+        mock_privacy_request,
+        mock_request_task,
+        loguru_caplog,
+        db,
+    ):
+        """Test that retrieve_data executes SQL normally when sql_dry_run is disabled"""
+        from fides.api.models.application_config import ApplicationConfig
+
+        ApplicationConfig.update_api_set(db, {"execution": {"sql_dry_run": False}})
+        db.commit()
+
+        mock_query_config = MagicMock()
+        mock_query_config.generate_query.return_value = text(
+            "SELECT * FROM test_table WHERE id = :id"
+        )
+        mock_query_config.partitioning = None
+
+        mock_connection = MagicMock()
+        mock_results = MagicMock()
+        mock_connection.execute.return_value = mock_results
+
+        with (
+            patch.object(
+                mock_connector, "query_config", return_value=mock_query_config
+            ),
+            patch.object(mock_connector, "client") as mock_client,
+            patch.object(
+                mock_connector, "cursor_result_to_rows", return_value=[{"id": 1}]
+            ),
+            patch.object(mock_connector, "set_schema"),
+        ):
+
+            mock_client.return_value.connect.return_value.__enter__.return_value = (
+                mock_connection
+            )
+
+            results = mock_connector.retrieve_data(
+                node=mock_execution_node,
+                policy=MagicMock(),
+                privacy_request=mock_privacy_request,
+                request_task=mock_request_task,
+                input_data={"id": [1, 2, 3]},
+            )
+
+            assert results == [{"id": 1}]
+            assert "SQL DRY RUN - Would execute SQL:" not in loguru_caplog.text
+            mock_connection.execute.assert_called_once()
+
+    def test_execute_standalone_retrieval_query_sql_dry_run_enabled(
+        self,
+        mock_connector,
+        mock_execution_node,
+        loguru_caplog,
+        db,
+    ):
+        """Test that execute_standalone_retrieval_query logs SQL instead of executing when sql_dry_run is enabled"""
+        from fides.api.models.application_config import ApplicationConfig
+
+        ApplicationConfig.update_api_set(db, {"execution": {"sql_dry_run": True}})
+        db.commit()
+
+        mock_query_config = MagicMock()
+        mock_query_config.generate_raw_query.return_value = text(
+            "SELECT field1, field2 FROM test_table WHERE id = :id"
+        )
+
+        with (
+            patch.object(
+                mock_connector, "query_config", return_value=mock_query_config
+            ),
+            patch.object(mock_connector, "client") as mock_client,
+        ):
+
+            results = mock_connector.execute_standalone_retrieval_query(
+                node=mock_execution_node,
+                fields=["field1", "field2"],
+                filters={"id": [1, 2, 3]},
+            )
+
+            assert results == []
+            assert "SQL DRY RUN - Would execute SQL:" in loguru_caplog.text
+            mock_client.return_value.connect.assert_not_called()
+
+        ApplicationConfig.update_api_set(db, {"execution": {"sql_dry_run": False}})
+        db.commit()
+
+    def test_mask_data_sql_dry_run_enabled(
+        self,
+        mock_connector,
+        mock_execution_node,
+        mock_privacy_request,
+        mock_request_task,
+        loguru_caplog,
+        db,
+    ):
+        """Test that mask_data logs SQL instead of executing when sql_dry_run is enabled"""
+        from fides.api.models.application_config import ApplicationConfig
+
+        ApplicationConfig.update_api_set(db, {"execution": {"sql_dry_run": True}})
+        db.commit()
+
+        mock_query_config = MagicMock()
+        mock_query_config.generate_update_stmt.return_value = text(
+            "UPDATE test_table SET name = NULL WHERE id = :id"
+        )
+
+        with (
+            patch.object(
+                mock_connector, "query_config", return_value=mock_query_config
+            ),
+            patch.object(mock_connector, "client") as mock_client,
+        ):
+
+            affected_rows = mock_connector.mask_data(
+                node=mock_execution_node,
+                policy=MagicMock(),
+                privacy_request=mock_privacy_request,
+                request_task=mock_request_task,
+                rows=[{"id": 1, "name": "test"}],
+            )
+
+            assert affected_rows == 0
+            assert "SQL DRY RUN - Would execute SQL:" in loguru_caplog.text
+            mock_client.return_value.connect.assert_not_called()
+
+        ApplicationConfig.update_api_set(db, {"execution": {"sql_dry_run": False}})
+        db.commit()
+
+    def test_mask_data_sql_dry_run_disabled(
+        self,
+        mock_connector,
+        mock_execution_node,
+        mock_privacy_request,
+        mock_request_task,
+        loguru_caplog,
+        db,
+    ):
+        """Test that mask_data executes SQL normally when sql_dry_run is disabled"""
+        from fides.api.models.application_config import ApplicationConfig
+
+        ApplicationConfig.update_api_set(db, {"execution": {"sql_dry_run": False}})
+        db.commit()
+
+        mock_query_config = MagicMock()
+        mock_query_config.generate_update_stmt.return_value = text(
+            "UPDATE test_table SET name = NULL WHERE id = :id"
+        )
+
+        mock_connection = MagicMock()
+        mock_results = MagicMock()
+        mock_results.rowcount = 1
+        mock_connection.execute.return_value = mock_results
+
+        with (
+            patch.object(
+                mock_connector, "query_config", return_value=mock_query_config
+            ),
+            patch.object(mock_connector, "client") as mock_client,
+            patch.object(mock_connector, "set_schema"),
+        ):
+
+            mock_client.return_value.connect.return_value.__enter__.return_value = (
+                mock_connection
+            )
+
+            affected_rows = mock_connector.mask_data(
+                node=mock_execution_node,
+                policy=MagicMock(),
+                privacy_request=mock_privacy_request,
+                request_task=mock_request_task,
+                rows=[{"id": 1, "name": "test"}],
+            )
+
+            assert affected_rows == 1
+            assert "SQL DRY RUN - Would execute SQL:" not in loguru_caplog.text
+            mock_connection.execute.assert_called_once()


### PR DESCRIPTION
Closes [ENG-1002](https://ethyca.atlassian.net/browse/ENG-1002)

### Description Of Changes

More complete solution for the "safe mode" feature which has been more accurately renamed to sql_dry_run

### Code Changes

* Rename to sql_dry_run
* Updated code to apply to SELECT statements - as part of this change sql_dry_run is en enum with possible values "access", "erasure", and "none". None, default, and null all operate with no change. Access and erasure must be set separately to allow erasure tasks to make their required select statements.
* New tests written for base class and BQ connector
* NOTE: No changes were required in other SQL connectors as they did not override the SQL statement generation of the base class

### Steps to Confirm

I think we can rely on automated tests for this one given the established patterns and manual testing on the existing feature

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1002]: https://ethyca.atlassian.net/browse/ENG-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ