### PR TITLE
Remove global fides when cleaning up preview

### DIFF
--- a/clients/fides-js/src/fides-preview.ts
+++ b/clients/fides-js/src/fides-preview.ts
@@ -34,6 +34,7 @@ function cleanup(): void {
     // Remove the script from DOM to ensure complete cleanup
     currentScript.remove();
     currentScript = null;
+    window.Fides = undefined as unknown as FidesGlobal;
   }
   currentMode = null;
 }


### PR DESCRIPTION
Closes [ENG-457]

### Description Of Changes

sets `window.Fides = undefined` after cleaning up the preview script (which fires when leaving the preview page) to prevent banner from accidentally initializing in the non-preview state.