### PR TITLE
ENG-1022 skip fetching manual tasks when not running in plus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Fixed
 - Fixed an issue where row selections in Action Center tables did not persist across pages [#6357](https://github.com/ethyca/fides/pull/6357)
+- Fixed bug where an error toast appeared in a privacy request page when running Fides OSS [#6364](https://github.com/ethyca/fides/pull/6364)
+
 
 ## [2.66.0](https://github.com/ethyca/fides/compare/2.65.2...2.66.0)
 

--- a/clients/admin-ui/src/features/privacy-requests/events-and-logs/hooks/usePrivacyRequestManualTasks.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/events-and-logs/hooks/usePrivacyRequestManualTasks.tsx
@@ -1,6 +1,7 @@
 import { AntMessage as message } from "fidesui";
 import { useEffect, useMemo } from "react";
 
+import { useFeatures } from "~/features/common/features";
 import { formatUser } from "~/features/common/utils";
 import { useGetTasksQuery } from "~/features/manual-tasks/manual-tasks.slice";
 import {
@@ -10,17 +11,22 @@ import {
 import { ManualFieldListItem, ManualFieldStatus } from "~/types/api";
 
 export const usePrivacyRequestManualTasks = (privacyRequestId: string) => {
+  const { plus: isPlusEnabled } = useFeatures();
+
   const {
     data: tasksData,
     isLoading,
     error,
-  } = useGetTasksQuery({
-    page: 1,
-    size: 100,
-    privacyRequestId,
-    status: undefined, // Get all statuses, we'll filter for completed/skipped
-    includeFullSubmissionDetails: true,
-  });
+  } = useGetTasksQuery(
+    {
+      page: 1,
+      size: 100,
+      privacyRequestId,
+      status: undefined, // Get all statuses, we'll filter for completed/skipped
+      includeFullSubmissionDetails: true,
+    },
+    { skip: !isPlusEnabled },
+  );
 
   useEffect(() => {
     if (error) {


### PR DESCRIPTION
### Description Of Changes

Fix bug in OSS where visiting any privacy request results in an error toast for the manual task fetching.

### Code Changes

* Skip manual task fetching if not running fides plus

### Steps to Confirm
Run fides oss
1.  Visit any privacy request detail page
2. Check no error toast message appears

(regression) 
1. Visit https://fides-plus-nightly-git-eng-1022-fix-error-toast-s-a0702b-ethyca.vercel.app/privacy-requests/pri_3fbd42eb-d188-4660-bd64-f8748892cb0b(use Fides nightly build credentials)
2. Check at the bottom of the Activity there is an entry for "Task completed"

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
