### PR TITLE
Handle IS_TEST param for fides-js builds to include test ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Optimized BigQuery deletions by issuing only a single delete statement per partition [#6340](https://github.com/ethyca/fides/pull/6340)
 - Increased the limit for dataset configurations from 50 to 1000 on the integration config page [#6367](https://github.com/ethyca/fides/pull/6367)
 - Updates the API so respondents will only be able to see their own user info [#6368](https://github.com/ethyca/fides/pull/6368)
+- Pass `IS_TEST` build parameter to Dockfile for dev builds to preserve dev `data-testid` attributes [#6382] (https://github.com/ethyca/fides/pull/6382)
 
 ### Developer Experience
 - Migrated Action Center tables to Ant Design [#6349](https://github.com/ethyca/fides/pull/6349)

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,10 @@ COPY clients/ .
 ####################
 FROM frontend AS built_frontend
 
+# IS_TEST enables test IDs in fides-js
+ARG IS_TEST=false
+ENV IS_TEST=$IS_TEST
+
 # Imports the Fides package version from the backend
 COPY --from=backend /fides/version.json ./version.json
 

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -50,12 +50,15 @@ def generate_buildx_command(
     image_tags: List[str],
     docker_build_target: str,
     dockerfile_path: str = ".",
+    build_args: Dict[str, str] = None,
 ) -> Tuple[str, ...]:
     """
     Generate the command for building and publishing an image.
 
     See tests for example usage in `test_docker_nox.py`
     """
+    build_args = build_args or {}
+
     buildx_command: Tuple[str, ...] = (
         "docker",
         "buildx",
@@ -65,8 +68,13 @@ def generate_buildx_command(
         f"--target={docker_build_target}",
         "--platform",
         DOCKER_PLATFORMS,
-        dockerfile_path,
     )
+
+    # Add build arguments
+    for arg_name, arg_value in build_args.items():
+        buildx_command += (f"--build-arg", f"{arg_name}={arg_value}")
+
+    buildx_command += (dockerfile_path,)
 
     for tag in image_tags:
         buildx_command += ("--tag", f"{tag}{IMAGE_SUFFIX}")
@@ -238,11 +246,17 @@ def push(session: nox.Session, tag: str, app: str) -> None:
     }
 
     app_info_map = {
-        "fides": {"image": IMAGE, "target": "prod", "path": "."},
+        "fides": {
+            "image": IMAGE,
+            "target": "prod",
+            "path": ".",
+            "build_args": {"IS_TEST": "true"} if tag == "dev" else {},
+        },
         "privacy_center": {
             "image": PRIVACY_CENTER_IMAGE,
             "target": "prod_pc",
             "path": ".",
+            "build_args": {"IS_TEST": "true"} if tag == "dev" else {},
         },
         "sample_app": {
             "image": SAMPLE_APP_IMAGE,
@@ -269,6 +283,7 @@ def push(session: nox.Session, tag: str, app: str) -> None:
         image_tags=full_tags,
         docker_build_target=app_info["target"],
         dockerfile_path=app_info["path"],
+        build_args=app_info.get("build_args", {}),
     )
 
     session.run(*buildx_command, external=True)

--- a/noxfiles/docker_nox.py
+++ b/noxfiles/docker_nox.py
@@ -72,7 +72,7 @@ def generate_buildx_command(
 
     # Add build arguments
     for arg_name, arg_value in build_args.items():
-        buildx_command += (f"--build-arg", f"{arg_name}={arg_value}")
+        buildx_command += ("--build-arg", f"{arg_name}={arg_value}")
 
     buildx_command += (dockerfile_path,)
 


### PR DESCRIPTION
Closes [ENG-1035](https://ethyca.atlassian.net/browse/ENG-1035)

### Description Of Changes

Adds back missing data-testid attributes in FidesJS components for development Docker builds. The issue occurred because FidesJS builds were stripping test IDs even in dev environments, making some e2e Privacy Center tests break.

The solution adds an IS_TEST build argument that preserves test IDs only for dev builds while maintaining the current behavior (stripped test IDs) for all production builds.

### Code Changes

* Dockerfile: Added ARG IS_TEST=false and ENV IS_TEST=$IS_TEST to the frontend build stage to accept and propagate the test flag
* docker_nox.py: Modified app_info_map to conditionally pass --build-arg IS_TEST=true for fides and the privacy center when tag == "dev"

### Steps to Confirm

1. To test the Dockerfile change, you can locally build the image and pass it the IS_TEST argument. So something like: `docker build --build-arg IS_TEST=true --target=prod_pc -t test-privacy-center-with-testids .`
2. As far as the nox file change, you can test most of it by adding the following before the last line

```
session.log(f"Generated buildx command: {' '.join(buildx_command)}")
return
```

That will show you the build command being run. For extra thoroughness, you could take the command, remove the ''--push" flag, and then build it locally as well.

I'll also pull down the dev image when it gets published after this is merged so I can double check.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1035]: https://ethyca.atlassian.net/browse/ENG-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ