### PR TITLE
Improved API call loading/failure handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Fixed
 - Fixed an issue where row selections in Action Center tables did not persist across pages [#6357](https://github.com/ethyca/fides/pull/6357)
 - Fixed bug where an error toast appeared in a privacy request page when running Fides OSS [#6364](https://github.com/ethyca/fides/pull/6364)
+- Enhanced TCF API loading and failure handling [#6387](https://github.com/ethyca/fides/pull/6387)
 - Escaping column names with spaces for BigQuery [#6380](https://github.com/ethyca/fides/pull/6380)
 - Fixed horizontal scroll appearing in the privacy request detail page when datasets with very long names are used [#6389](https://github.com/ethyca/fides/pull/6389)
 - Fixed performance issues with large dataset traversals [#6353](https://github.com/ethyca/fides/pull/6353)

--- a/clients/fides-js/__tests__/lib/hooks/use-retryable-fetch.test.ts
+++ b/clients/fides-js/__tests__/lib/hooks/use-retryable-fetch.test.ts
@@ -1,0 +1,303 @@
+import {
+  FetchState,
+  useRetryableFetch,
+} from "../../../src/lib/hooks/useRetryableFetch";
+
+// Mock preact/hooks
+const mockUseState = jest.fn();
+const mockUseEffect = jest.fn();
+
+jest.mock("preact/hooks", () => ({
+  useState: (...args: any[]) => mockUseState(...args),
+  useEffect: (...args: any[]) => mockUseEffect(...args),
+}));
+
+describe("useRetryableFetch", () => {
+  let stateValues: Record<string, any> = {};
+  let setterCallbacks: Record<string, (newValue: any) => void> = {};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    stateValues = {};
+    setterCallbacks = {};
+
+    // Mock useState to track state changes
+    mockUseState.mockImplementation((initialValue: any) => {
+      const key = Math.random().toString();
+      stateValues[key] = initialValue;
+      const setter = (newValue: any) => {
+        stateValues[key] =
+          typeof newValue === "function"
+            ? newValue(stateValues[key])
+            : newValue;
+      };
+      setterCallbacks[key] = setter;
+      return [stateValues[key], setter];
+    });
+
+    // Mock useEffect to capture and call effects
+    mockUseEffect.mockImplementation((effect: () => void | (() => void)) => {
+      // Call effect immediately for testing
+      const cleanup = effect();
+      return cleanup;
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns initial state correctly", () => {
+    const fetcher = jest.fn();
+
+    const result = useRetryableFetch({ fetcher, enabled: false });
+
+    expect(result.data).toBeUndefined();
+    expect(result.fetchState).toBe(FetchState.Idle);
+    expect(result.isLoading).toBe(false);
+    expect(result.isError).toBe(false);
+    expect(typeof result.retry).toBe("function");
+  });
+
+  it("calls fetcher when enabled", () => {
+    const fetcher = jest.fn().mockResolvedValue({ foo: "bar" });
+
+    useRetryableFetch({ fetcher, enabled: true });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call fetcher when disabled", () => {
+    const fetcher = jest.fn();
+
+    useRetryableFetch({ fetcher, enabled: false });
+
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("sets loading state when enabled", () => {
+    const fetcher = jest.fn().mockResolvedValue({ data: "test" });
+
+    // Mock useState calls to track state changes
+    const fetchStateValue = FetchState.Idle;
+    const setFetchState: (value: FetchState) => void = jest.fn();
+
+    mockUseState
+      .mockReturnValueOnce([undefined, jest.fn()]) // data state
+      .mockReturnValueOnce([fetchStateValue, setFetchState]); // fetchState
+
+    useRetryableFetch({ fetcher, enabled: true });
+
+    // Verify that setFetchState was called with Loading
+    expect(mockUseEffect).toHaveBeenCalled();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses default config values", () => {
+    const fetcher = jest.fn().mockResolvedValue({ data: "test" });
+
+    const result = useRetryableFetch({ fetcher });
+
+    // Should be enabled by default
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result.isLoading).toBe(false); // Initial state before effect runs
+  });
+
+  it("provides retry function", () => {
+    const fetcher = jest.fn().mockResolvedValue({ data: "test" });
+
+    const result = useRetryableFetch({ fetcher, enabled: false });
+
+    expect(typeof result.retry).toBe("function");
+
+    // Test retry function
+    result.retry();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles fetch errors and sets error state", async () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error("Network error"));
+
+    // Set up mock to track state changes
+    let fetchStateValue = FetchState.Idle;
+    const setFetchState = jest.fn((newValue) => {
+      fetchStateValue =
+        typeof newValue === "function" ? newValue(fetchStateValue) : newValue;
+    });
+
+    mockUseState
+      .mockReturnValueOnce([undefined, jest.fn()]) // data state
+      .mockReturnValueOnce([fetchStateValue, setFetchState]); // fetchState
+
+    const result = useRetryableFetch({ fetcher, enabled: true });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBe(false); // Initial state
+  });
+
+  it("accepts retry configuration", () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error("Network error"));
+    const config = {
+      maxAttempts: 3,
+      backoffFactor: 100,
+      shouldRetry: jest.fn().mockReturnValue(true),
+    };
+
+    useRetryableFetch({ fetcher, config, enabled: true });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts custom shouldRetry function", () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error("Network error"));
+    const shouldRetry = jest.fn().mockReturnValue(false); // Always deny retries
+
+    const config = {
+      maxAttempts: 5,
+      backoffFactor: 100,
+      shouldRetry,
+    };
+
+    useRetryableFetch({ fetcher, config, enabled: true });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates response and retries on validation failure", () => {
+    const fetcher = jest.fn().mockResolvedValue({ invalid: true });
+    const validator = jest.fn().mockReturnValue(false); // Always fails validation
+
+    const config = {
+      maxAttempts: 3,
+      backoffFactor: 100,
+      shouldRetry: jest.fn().mockReturnValue(true),
+    };
+
+    useRetryableFetch({
+      fetcher,
+      validator,
+      config,
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSuccess callback when fetch succeeds", () => {
+    const mockData = { success: true };
+    const fetcher = jest.fn().mockResolvedValue(mockData);
+    const onSuccess = jest.fn();
+    const validator = jest.fn().mockReturnValue(true);
+
+    // Mock successful state transition
+    let dataValue: any;
+    let fetchStateValue = FetchState.Idle;
+
+    const setData = jest.fn((newValue) => {
+      dataValue =
+        typeof newValue === "function" ? newValue(dataValue) : newValue;
+    });
+    const setFetchState = jest.fn((newValue) => {
+      fetchStateValue =
+        typeof newValue === "function" ? newValue(fetchStateValue) : newValue;
+    });
+
+    mockUseState
+      .mockReturnValueOnce([dataValue, setData])
+      .mockReturnValueOnce([fetchStateValue, setFetchState]);
+
+    useRetryableFetch({
+      fetcher,
+      validator,
+      onSuccess,
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles error state configuration", () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error("Persistent error"));
+    const config = {
+      maxAttempts: 2,
+      backoffFactor: 50,
+      shouldRetry: jest.fn().mockReturnValue(true),
+    };
+
+    let fetchStateValue = FetchState.Idle;
+    const setFetchState = jest.fn((newValue) => {
+      fetchStateValue =
+        typeof newValue === "function" ? newValue(fetchStateValue) : newValue;
+    });
+
+    mockUseState
+      .mockReturnValueOnce([undefined, jest.fn()]) // data state
+      .mockReturnValueOnce([fetchStateValue, setFetchState]); // fetchState
+
+    useRetryableFetch({ fetcher, config, enabled: true });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets state when retry is called manually", () => {
+    const fetcher = jest.fn().mockResolvedValue({ data: "test" });
+
+    let dataValue: any = "previous data";
+    let fetchStateValue = FetchState.Success;
+
+    const setData = jest.fn((newValue) => {
+      dataValue =
+        typeof newValue === "function" ? newValue(dataValue) : newValue;
+    });
+    const setFetchState = jest.fn((newValue) => {
+      fetchStateValue =
+        typeof newValue === "function" ? newValue(fetchStateValue) : newValue;
+    });
+
+    mockUseState
+      .mockReturnValueOnce([dataValue, setData])
+      .mockReturnValueOnce([fetchStateValue, setFetchState]);
+
+    const result = useRetryableFetch({ fetcher, enabled: false });
+
+    // Manually call retry
+    result.retry();
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses default validator when none provided", () => {
+    const fetcher = jest.fn().mockResolvedValue({ data: "test" });
+
+    useRetryableFetch({ fetcher, enabled: true });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles validation failure that exceeds max attempts", () => {
+    const fetcher = jest.fn().mockResolvedValue({ invalid: true });
+    const validator = jest.fn().mockReturnValue(false); // Always fails validation
+    const config = {
+      maxAttempts: 2,
+      backoffFactor: 50,
+      shouldRetry: jest.fn().mockReturnValue(true),
+    };
+
+    let fetchStateValue = FetchState.Idle;
+    const setFetchState = jest.fn((newValue) => {
+      fetchStateValue =
+        typeof newValue === "function" ? newValue(fetchStateValue) : newValue;
+    });
+
+    mockUseState
+      .mockReturnValueOnce([undefined, jest.fn()]) // data state
+      .mockReturnValueOnce([fetchStateValue, setFetchState]); // fetchState
+
+    useRetryableFetch({
+      fetcher,
+      validator,
+      config,
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -21,7 +21,7 @@ const GZIP_SIZE_ERROR_KB = 50; // fail build if bundle size exceeds this
 const GZIP_SIZE_WARN_KB = 45; // log a warning if bundle size exceeds this
 
 // TCF
-const GZIP_SIZE_TCF_ERROR_KB = 93;
+const GZIP_SIZE_TCF_ERROR_KB = 95;
 const GZIP_SIZE_TCF_WARN_KB = 75;
 
 // Headless

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -20,7 +20,7 @@ import PrivacyPolicyLink from "./PrivacyPolicyLink";
 interface ConsentButtonsProps {
   availableLocales?: Locale[];
   onManagePreferencesClick?: () => void;
-  renderFirstButton?: () => VNode | null;
+  renderFirstButton?: () => VNode | null | false;
   onAcceptAll: () => void;
   onRejectAll: () => void;
   options: FidesInitOptions;

--- a/clients/fides-js/src/components/ConsentButtons.tsx
+++ b/clients/fides-js/src/components/ConsentButtons.tsx
@@ -1,5 +1,4 @@
 import { Fragment, VNode } from "preact";
-import { useEffect, useState } from "preact/hooks";
 
 import {
   ButtonType,
@@ -29,7 +28,6 @@ interface ConsentButtonsProps {
   hideRejectAll?: boolean;
   isInModal?: boolean;
   isTCF?: boolean;
-  isMinimalTCF?: boolean;
   isGVLLoading?: boolean;
 }
 export const ConsentButtons = ({
@@ -43,10 +41,8 @@ export const ConsentButtons = ({
   options,
   isInModal,
   isTCF,
-  isMinimalTCF,
   isGVLLoading,
 }: ConsentButtonsProps) => {
-  const [isLoadingModal, setIsLoadingModal] = useState<boolean>(false);
   const { i18n } = useI18n();
   const { setTrigger } = useEvent();
   const isMobile = useMediaQuery("(max-width: 768px)");
@@ -54,21 +50,7 @@ export const ConsentButtons = ({
   const includePrivacyPolicyLink =
     messageExists(i18n, "exp.privacy_policy_link_label") &&
     messageExists(i18n, "exp.privacy_policy_url");
-  const handleTCFManagePreferencesClick = () => {
-    const isReady = !isTCF || !isMinimalTCF;
-    setIsLoadingModal(!isReady);
-    if (onManagePreferencesClick && isReady) {
-      onManagePreferencesClick();
-    }
-  };
   const includeBrandLink = isInModal && options.showFidesBrandLink;
-
-  useEffect(() => {
-    if (isLoadingModal && !isMinimalTCF) {
-      handleTCFManagePreferencesClick();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoadingModal, isMinimalTCF]);
 
   return (
     <div id="fides-button-group">
@@ -91,11 +73,10 @@ export const ConsentButtons = ({
                     type: FidesEventTargetType.BUTTON,
                     label: i18n.t("exp.privacy_preferences_link_label"),
                   });
-                  handleTCFManagePreferencesClick();
+                  onManagePreferencesClick();
                 }}
                 className="fides-manage-preferences-button"
                 id="fides-manage-preferences-button"
-                loading={isLoadingModal}
               />
             )}
             {!hideRejectAll && (

--- a/clients/fides-js/src/components/InfoBox.tsx
+++ b/clients/fides-js/src/components/InfoBox.tsx
@@ -2,12 +2,21 @@ import { ComponentChild, ComponentChildren } from "preact";
 
 const InfoBox = ({
   title,
+  isError,
   children,
 }: {
   title?: ComponentChild;
+  isError?: boolean;
   children: ComponentChildren;
 }) => (
-  <div className="fides-info-box">
+  <div
+    className="fides-info-box"
+    style={{
+      backgroundColor: isError
+        ? "var(--fides-overlay-background-error-color)"
+        : undefined,
+    }}
+  >
     {title ? <p className="fides-gpc-header">{title}</p> : null}
     {children}
   </div>

--- a/clients/fides-js/src/components/InfoBox.tsx
+++ b/clients/fides-js/src/components/InfoBox.tsx
@@ -1,23 +1,15 @@
-import { ComponentChild, ComponentChildren } from "preact";
+import { ComponentChild, ComponentChildren, ComponentProps } from "preact";
 
 const InfoBox = ({
   title,
-  isError,
   children,
+  ...props
 }: {
   title?: ComponentChild;
-  isError?: boolean;
   children: ComponentChildren;
-}) => (
-  <div
-    className="fides-info-box"
-    style={{
-      backgroundColor: isError
-        ? "var(--fides-overlay-background-error-color)"
-        : undefined,
-    }}
-  >
-    {title ? <p className="fides-gpc-header">{title}</p> : null}
+} & ComponentProps<"div">) => (
+  <div className="fides-info-box" {...props}>
+    {!!title && <p className="fides-gpc-header">{title}</p>}
     {children}
   </div>
 );

--- a/clients/fides-js/src/components/MenuItem.tsx
+++ b/clients/fides-js/src/components/MenuItem.tsx
@@ -14,7 +14,7 @@ const MenuItem: FunctionComponent<MenuItemProps> = ({
   <button
     type="button"
     role="menuitemradio"
-    aria-checked={isActive || undefined}
+    aria-checked={isActive}
     {...props}
     className={`fides-banner-button fides-menu-item ${className || ""}`}
   >

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -14,9 +14,9 @@
   --fides-overlay-gpc-overridden-background-color: #e53e3e;
   --fides-overlay-gpc-overridden-text-color: white;
   --fides-overlay-brand-link-logo-color: #2b2e35;
-
   --fides-overlay-background-dark-color: #e2e8f0;
-  --fides-overlay-width: 680px;
+  --fides-overlay-skeleton-gradient-from-color: rgba(0, 0, 0, 0.06);
+  --fides-overlay-skeleton-gradient-to-color: rgba(0, 0, 0, 0.15);
   /* Buttons */
   --fides-overlay-primary-button-background-color: var(
     --fides-overlay-primary-color
@@ -30,6 +30,7 @@
   --fides-overlay-secondary-button-background-hover-color: var(
     --fides-overlay-hover-color
   );
+  --fides-overlay-neutral-background-color: #edf2f7;
   --fides-overlay-secondary-button-text-color: #2d3748;
   --fides-overlay-secondary-button-border-color: var(
     --fides-overlay-primary-color
@@ -38,6 +39,7 @@
   --fides-overlay-title-font-color: var(--fides-overlay-font-color);
   --fides-overlay-body-font-color: var(--fides-overlay-font-color);
   --fides-overlay-link-font-color: var(--fides-overlay-font-color-dark);
+  --fides-overlay-line-height: 1.4em;
   /* Switches */
   --fides-overlay-primary-active-color: var(--fides-overlay-primary-color);
   --fides-overlay-inactive-color: #e2e8f0;
@@ -55,6 +57,7 @@
   --fides-overlay-language-button-border-radius: 4px;
 
   /* Everything else */
+  --fides-overlay-width: 680px;
   --fides-overlay-font-family: Inter, sans-serif;
   --fides-base-font-size: 16px;
   --8px: calc(var(--fides-base-font-size) * 0.5);
@@ -115,7 +118,7 @@ div#fides-overlay-wrapper * {
   font-family: var(--fides-overlay-font-family);
   font-size: var(--fides-overlay-font-size-body);
   white-space: pre-line;
-  line-height: 1.4em;
+  line-height: var(--fides-overlay-line-height);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -213,6 +216,7 @@ div#fides-banner-heading {
   display: flex;
   margin-right: 13px;
   align-items: center;
+  justify-content: space-between; /* for GPC notice */
 }
 
 .fides-banner-title {
@@ -302,6 +306,10 @@ button.fides-banner-button.fides-banner-button-secondary[disabled] {
   background: var(--fides-overlay-secondary-button-background-hover-color);
 }
 
+button.fides-banner-button[disabled] {
+  color: var(--fides-overlay-inactive-font-color);
+}
+
 button.fides-banner-button.fides-banner-button-tertiary {
   background: none;
   border: none;
@@ -322,8 +330,8 @@ button.fides-banner-button.fides-acknowledge-button {
   border: 2px solid transparent;
   border-top: 2px solid;
   border-right: 2px solid;
-  border-top-color: var(--fides-overlay-primary-color);
-  border-right-color: var(--fides-overlay-primary-color);
+  border-top-color: var(--fides-overlay-skeleton-gradient-from-color);
+  border-right-color: var(--fides-overlay-skeleton-gradient-from-color);
   border-radius: 50%;
   width: 1em;
   height: 1em;
@@ -337,8 +345,8 @@ button.fides-banner-button.fides-acknowledge-button {
 }
 
 .fides-banner-button-secondary .fides-spinner {
-  border-top-color: var(--fides-overlay-secondary-button-border-color);
-  border-right-color: var(--fides-overlay-secondary-button-border-color);
+  border-top-color: var(--fides-overlay-inactive-font-color);
+  border-right-color: var(--fides-overlay-inactive-font-color);
 }
 
 /** Modal */
@@ -959,7 +967,7 @@ div#fides-overlay-wrapper .fides-toggle .fides-toggle-display {
 
 /* Info box */
 .fides-info-box {
-  background-color: var(--fides-overlay-hover-color);
+  background-color: var(--fides-overlay-neutral-background-color);
   border-radius: var(--fides-overlay-component-border-radius);
   padding: 16px;
   margin: 10px 0;
@@ -1206,5 +1214,48 @@ button.fides-banner-button.fides-menu-item:not([aria-checked="true"]):hover {
     position: absolute;
     left: var(--fides-overlay-padding);
     bottom: var(--fides-overlay-padding);
+  }
+}
+
+.fides-data-toggle-skeleton__container {
+  min-height: 40px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.fides-skeleton__component {
+  background: linear-gradient(
+    90deg,
+    var(--fides-overlay-skeleton-gradient-from-color) 25%,
+    var(--fides-overlay-skeleton-gradient-to-color) 37%,
+    var(--fides-overlay-skeleton-gradient-from-color) 63%
+  );
+  background-size: 400% 100%;
+  animation-name: fides-skeleton-loading;
+  animation-duration: 1.4s;
+  animation-timing-function: ease;
+  animation-iteration-count: infinite;
+}
+
+.fides-skeleton__text {
+  width: 60%;
+  height: var(--fides-overlay-line-height);
+  border-radius: var(--fides-overlay-component-border-radius);
+}
+
+.fides-skeleton__switch {
+  width: 50px;
+  height: 24px;
+  border-radius: 100vw;
+}
+
+@keyframes fides-skeleton-loading {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
   }
 }

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -1224,6 +1224,13 @@ button.fides-banner-button.fides-menu-item:not([aria-checked="true"]):hover {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding-inline: 12px;
+  border-bottom: 1px solid var(--fides-overlay-row-divider-color);
+}
+
+.fides-notice-toggle .fides-skeleton__container:hover {
+  cursor: default;
+  background-color: unset;
 }
 
 .fides-skeleton__component {

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -15,6 +15,7 @@
   --fides-overlay-gpc-overridden-text-color: white;
   --fides-overlay-brand-link-logo-color: #2b2e35;
   --fides-overlay-background-dark-color: #e2e8f0;
+  --fides-overlay-background-error-color: #f7c2c2;
   --fides-overlay-skeleton-gradient-from-color: rgba(0, 0, 0, 0.06);
   --fides-overlay-skeleton-gradient-to-color: rgba(0, 0, 0, 0.15);
   /* Buttons */

--- a/clients/fides-js/src/components/fides.css
+++ b/clients/fides-js/src/components/fides.css
@@ -18,6 +18,7 @@
   --fides-overlay-background-error-color: #f7c2c2;
   --fides-overlay-skeleton-gradient-from-color: rgba(0, 0, 0, 0.06);
   --fides-overlay-skeleton-gradient-to-color: rgba(0, 0, 0, 0.15);
+  --fides-overlay-inactive-font-color: #a0aec0;
   /* Buttons */
   --fides-overlay-primary-button-background-color: var(
     --fides-overlay-primary-color
@@ -36,6 +37,7 @@
   --fides-overlay-secondary-button-border-color: var(
     --fides-overlay-primary-color
   );
+  --fides-overlay-secondary-button-border-color-disabled: #a0aec0;
   /* Text */
   --fides-overlay-title-font-color: var(--fides-overlay-font-color);
   --fides-overlay-body-font-color: var(--fides-overlay-font-color);
@@ -44,7 +46,6 @@
   /* Switches */
   --fides-overlay-primary-active-color: var(--fides-overlay-primary-color);
   --fides-overlay-inactive-color: #e2e8f0;
-  --fides-overlay-inactive-font-color: #a0aec0;
   --fides-overlay-disabled-color: #e1e7ee;
   /* Dividers */
   --fides-overlay-row-divider-color: #e2e8f0;
@@ -309,6 +310,10 @@ button.fides-banner-button.fides-banner-button-secondary[disabled] {
 
 button.fides-banner-button[disabled] {
   color: var(--fides-overlay-inactive-font-color);
+}
+
+button.fides-banner-button.fides-banner-button-secondary[disabled] {
+  border-color: var(--fides-overlay-secondary-button-border-color-disabled);
 }
 
 button.fides-banner-button.fides-banner-button-tertiary {

--- a/clients/fides-js/src/components/tcf/RecordsListSkeletons.tsx
+++ b/clients/fides-js/src/components/tcf/RecordsListSkeletons.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  rows?: number;
+}
+
+export const RecordsListSkeletons = ({ rows = 3 }: Props) => {
+  return (
+    <div className="fides-notice-toggle" data-testid="records-list-skeletons">
+      {Array.from({ length: rows }).map((_, index) => (
+        <div
+          className="fides-notice-toggle-title"
+          // eslint-disable-next-line react/no-array-index-key
+          key={`fides-skeleton-bar-${index}`}
+        >
+          <div className="fides-data-toggle-skeleton__container">
+            <div className="fides-skeleton__component fides-skeleton__text" />
+            <div className="fides-skeleton__component fides-skeleton__switch" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/clients/fides-js/src/components/tcf/RecordsListSkeletons.tsx
+++ b/clients/fides-js/src/components/tcf/RecordsListSkeletons.tsx
@@ -7,14 +7,12 @@ export const RecordsListSkeletons = ({ rows = 3 }: Props) => {
     <div className="fides-notice-toggle" data-testid="records-list-skeletons">
       {Array.from({ length: rows }).map((_, index) => (
         <div
-          className="fides-notice-toggle-title"
+          className="fides-data-toggle-skeleton__container"
           // eslint-disable-next-line react/no-array-index-key
           key={`fides-skeleton-bar-${index}`}
         >
-          <div className="fides-data-toggle-skeleton__container">
-            <div className="fides-skeleton__component fides-skeleton__text" />
-            <div className="fides-skeleton__component fides-skeleton__switch" />
-          </div>
+          <div className="fides-skeleton__component fides-skeleton__text" />
+          <div className="fides-skeleton__component fides-skeleton__switch" />
         </div>
       ))}
     </div>

--- a/clients/fides-js/src/components/tcf/TCFBannerSupplemental.tsx
+++ b/clients/fides-js/src/components/tcf/TCFBannerSupplemental.tsx
@@ -31,7 +31,9 @@ export const TCFBannerSupplemental = ({
             </h2>
           </div>
         )}
-      <div className="fides-banner__content">
+      {/* adding tabindex because the content is scrollable so a11y requires it to be focusable */}
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+      <div className="fides-banner__content" tabIndex={0}>
         <ul className="fides-banner__purpose-list">
           {customPurposes?.map((purpose) => (
             <li key={purpose} className="fides-banner__purpose-item">

--- a/clients/fides-js/src/components/tcf/TCFBannerSupplemental.tsx
+++ b/clients/fides-js/src/components/tcf/TCFBannerSupplemental.tsx
@@ -31,7 +31,8 @@ export const TCFBannerSupplemental = ({
             </h2>
           </div>
         )}
-      {/* adding tabindex because the content is scrollable so a11y requires it to be focusable */}
+      {/* adding tabindex because the content is scrollable so a11y requires it to be focusable
+          see https://accessibilityinsights.io/info-examples/web/scrollable-region-focusable/ */}
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
       <div className="fides-banner__content" tabIndex={0}>
         <ul className="fides-banner__purpose-list">

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -48,7 +48,6 @@ export const TcfConsentButtons = ({
       }
       options={options}
       isTCF
-      isMinimalTCF={experience.minimal_tcf}
       isGVLLoading={isGVLLoading}
     />
   );

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -14,7 +14,7 @@ interface TcfConsentButtonProps {
   onManagePreferencesClick?: () => void;
   onRejectAll: () => void;
   onAcceptAll: () => void;
-  renderFirstButton?: () => VNode;
+  renderFirstButton?: () => VNode | false;
   isInModal?: boolean;
 }
 

--- a/clients/fides-js/src/components/tcf/TcfFeatures.tsx
+++ b/clients/fides-js/src/components/tcf/TcfFeatures.tsx
@@ -1,7 +1,11 @@
 import { PrivacyExperience } from "../../lib/consent-types";
 import { FidesEventDetailsPreference } from "../../lib/events";
 import { useI18n } from "../../lib/i18n/i18n-context";
-import { TCFFeatureRecord, TCFSpecialFeatureRecord } from "../../lib/tcf/types";
+import {
+  EnabledIds,
+  TCFFeatureRecord,
+  TCFSpecialFeatureRecord,
+} from "../../lib/tcf/types";
 import EmbeddedVendorList from "./EmbeddedVendorList";
 import RecordsList, { RecordListType } from "./RecordsList";
 import { UpdateEnabledIds } from "./TcfTabs";
@@ -28,20 +32,22 @@ const FeatureChildren = ({
 const TcfFeatures = ({
   allFeatures,
   allSpecialFeatures,
-  enabledFeatureIds,
-  enabledSpecialFeatureIds,
+  enabledIds,
   onChange,
 }: {
   allFeatures: PrivacyExperience["tcf_features"];
   allSpecialFeatures: PrivacyExperience["tcf_special_features"];
-  enabledFeatureIds: string[];
-  enabledSpecialFeatureIds: string[];
+  enabledIds: EnabledIds;
   onChange: (
     payload: UpdateEnabledIds,
     preferenceDetails: FidesEventDetailsPreference,
   ) => void;
 }) => {
   const { i18n } = useI18n();
+  const {
+    features: enabledFeatureIds,
+    specialFeatures: enabledSpecialFeatureIds,
+  } = enabledIds;
   return (
     <div>
       <RecordsList<TCFFeatureRecord>

--- a/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
+++ b/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
@@ -1,0 +1,22 @@
+import { useI18n } from "../../lib/i18n/i18n-context";
+import InfoBox from "../InfoBox";
+
+export const TcfLoadingErrorMessage = ({
+  generalLabel,
+  specificLabel,
+}: {
+  generalLabel: string;
+  specificLabel: string;
+}) => {
+  const { i18n } = useI18n();
+  return (
+    <InfoBox>
+      There was an error loading the {generalLabel}. You may{" "}
+      <strong>{i18n.t("exp.accept_button_label").toLocaleLowerCase()}</strong>{" "}
+      or{" "}
+      <strong>{i18n.t("exp.reject_button_label").toLocaleLowerCase()}</strong>,
+      but in order to exercise your rights for {specificLabel}, please try again
+      later. If the problem persists, please contact the site owner.
+    </InfoBox>
+  );
+};

--- a/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
+++ b/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
@@ -10,7 +10,7 @@ export const TcfLoadingErrorMessage = ({
 }) => {
   const { i18n } = useI18n();
   return (
-    <InfoBox>
+    <InfoBox isError>
       There was an error loading the {generalLabel}. You may{" "}
       <strong>{i18n.t("exp.accept_button_label").toLocaleLowerCase()}</strong>{" "}
       or{" "}

--- a/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
+++ b/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
@@ -10,7 +10,12 @@ export const TcfLoadingErrorMessage = ({
 }) => {
   const { i18n } = useI18n();
   return (
-    <InfoBox isError>
+    <InfoBox
+      style={{
+        backgroundColor: "var(--fides-overlay-background-error-color)",
+      }}
+      data-testid="tcf-loading-error-message"
+    >
       There was an error loading the {generalLabel}. You may{" "}
       <strong>{i18n.t("exp.accept_button_label").toLocaleLowerCase()}</strong>{" "}
       or{" "}

--- a/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
+++ b/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
@@ -8,6 +8,7 @@ export const TcfLoadingErrorMessage = ({
   generalLabel: string;
   specificLabel: string;
 }) => {
+  // TODO: add translations for the error messages
   const { i18n } = useI18n();
   return (
     <InfoBox

--- a/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
+++ b/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
@@ -8,7 +8,7 @@ export const TcfLoadingErrorMessage = ({
   generalLabel: string;
   specificLabel: string;
 }) => {
-  // TODO: add translations for the error messages
+  // TODO: [ENG-1050] add translations for the error messages
   const { i18n } = useI18n();
   return (
     <InfoBox

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -680,63 +680,54 @@ export const TcfOverlay = () => {
           </ConsentBanner>
         );
       }}
-      renderModalContent={
-        !experienceFull
-          ? undefined
-          : () => (
-              <TcfTabs
-                experience={experienceFull}
-                customNotices={privacyNoticesWithBestTranslation}
-                enabledIds={draftIds}
-                onChange={handleToggleChange}
-                activeTabIndex={activeTabIndex}
-                onTabChange={handleTabChange}
+      renderModalContent={() => (
+        <TcfTabs
+          experience={experienceFull || experienceMinimal}
+          customNotices={privacyNoticesWithBestTranslation}
+          enabledIds={draftIds}
+          onChange={handleToggleChange}
+          activeTabIndex={activeTabIndex}
+          onTabChange={handleTabChange}
+        />
+      )}
+      renderModalFooter={({ onClose }) => {
+        const onSave = (consentMethod: ConsentMethod, keys: EnabledIds) => {
+          handleUpdateAllPreferences(consentMethod, keys);
+          onClose();
+        };
+        return (
+          <TcfConsentButtons
+            experience={experienceFull || experienceMinimal}
+            onAcceptAll={() => {
+              handleAcceptAll();
+              onClose();
+            }}
+            onRejectAll={() => {
+              handleRejectAll();
+              onClose();
+            }}
+            renderFirstButton={() => (
+              <Button
+                buttonType={ButtonType.SECONDARY}
+                label={experienceFull ? i18n.t("exp.save_button_label") : ""}
+                onClick={() => {
+                  setTrigger({
+                    type: FidesEventTargetType.BUTTON,
+                    label: i18n.t("exp.save_button_label"),
+                  });
+                  onSave(ConsentMethod.SAVE, draftIds);
+                }}
+                className="fides-save-button"
+                id="fides-save-button"
+                disabled={!experienceFull}
+                loading={!experienceFull}
               />
-            )
-      }
-      renderModalFooter={
-        !experienceFull
-          ? undefined
-          : ({ onClose }) => {
-              const onSave = (
-                consentMethod: ConsentMethod,
-                keys: EnabledIds,
-              ) => {
-                handleUpdateAllPreferences(consentMethod, keys);
-                onClose();
-              };
-              return (
-                <TcfConsentButtons
-                  experience={experienceFull}
-                  onAcceptAll={() => {
-                    handleAcceptAll();
-                    onClose();
-                  }}
-                  onRejectAll={() => {
-                    handleRejectAll();
-                    onClose();
-                  }}
-                  renderFirstButton={() => (
-                    <Button
-                      buttonType={ButtonType.SECONDARY}
-                      label={i18n.t("exp.save_button_label")}
-                      onClick={() => {
-                        setTrigger({
-                          type: FidesEventTargetType.BUTTON,
-                          label: i18n.t("exp.save_button_label"),
-                        });
-                        onSave(ConsentMethod.SAVE, draftIds);
-                      }}
-                      className="fides-save-button"
-                      id="fides-save-button"
-                    />
-                  )}
-                  isInModal
-                  options={options}
-                />
-              );
-            }
-      }
+            )}
+            isInModal
+            options={options}
+          />
+        );
+      }}
     />
   );
 };

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -79,6 +79,9 @@ import { TCFBannerSupplemental } from "./TCFBannerSupplemental";
 import { TcfConsentButtons } from "./TcfConsentButtons";
 import TcfTabs from "./TcfTabs";
 
+const TCF_FULL_MAX_RETRIES = 5;
+const TCF_FULL_BACKOFF_FACTOR = 1000;
+
 const getAllIds = (
   modelList: TcfModels | Array<PrivacyNoticeWithPreference>,
 ) => {
@@ -225,8 +228,6 @@ export const TcfOverlay = () => {
     fidesDebugger("Fetching full TCF experience...");
 
     const retryFetch = async (attempt = 1): Promise<void> => {
-      const TCF_FULL_MAX_RETRIES = 5;
-      const TCF_FULL_BACKOFF_FACTOR = 1000;
       try {
         const result = await fetchExperience({
           userLocationString: fidesRegionString,

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -723,33 +723,31 @@ export const TcfOverlay = () => {
               handleRejectAll();
               onClose();
             }}
-            renderFirstButton={() =>
-              fullExperienceState !== FetchState.Error && (
-                <Button
-                  buttonType={ButtonType.SECONDARY}
-                  label={
-                    experienceFull ? i18n.t("exp.save_button_label") : "Save"
-                  }
-                  onClick={() => {
-                    setTrigger({
-                      type: FidesEventTargetType.BUTTON,
-                      label: i18n.t("exp.save_button_label"),
-                    });
-                    onSave(ConsentMethod.SAVE, draftIds);
-                  }}
-                  className="fides-save-button"
-                  id="fides-save-button"
-                  disabled={
-                    !experienceFull &&
-                    fullExperienceState === FetchState.Loading
-                  }
-                  loading={
-                    !experienceFull &&
-                    fullExperienceState === FetchState.Loading
-                  }
-                />
-              )
-            }
+            renderFirstButton={() => (
+              <Button
+                buttonType={ButtonType.SECONDARY}
+                label={
+                  experienceFull ? i18n.t("exp.save_button_label") : "Save"
+                }
+                onClick={() => {
+                  setTrigger({
+                    type: FidesEventTargetType.BUTTON,
+                    label: i18n.t("exp.save_button_label"),
+                  });
+                  onSave(ConsentMethod.SAVE, draftIds);
+                }}
+                className="fides-save-button"
+                id="fides-save-button"
+                disabled={
+                  (!experienceFull &&
+                    fullExperienceState === FetchState.Loading) ||
+                  fullExperienceState === FetchState.Error
+                }
+                loading={
+                  !experienceFull && fullExperienceState === FetchState.Loading
+                }
+              />
+            )}
             isInModal
             options={options}
           />

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -79,8 +79,8 @@ import { TCFBannerSupplemental } from "./TCFBannerSupplemental";
 import { TcfConsentButtons } from "./TcfConsentButtons";
 import TcfTabs from "./TcfTabs";
 
-const TCF_FULL_MAX_RETRIES = 5;
-const TCF_FULL_BACKOFF_FACTOR = 1000;
+const TCF_FULL_MAX_ATTEMPTS = 4; // initial attempt + 3 retries
+const TCF_FULL_BACKOFF_FACTOR = 1000; // exponential backoff
 
 const getAllIds = (
   modelList: TcfModels | Array<PrivacyNoticeWithPreference>,
@@ -255,20 +255,20 @@ export const TcfOverlay = () => {
             setExperienceFull(fullExperience);
             setIsFullExperienceLoading(false);
           }
-        } else if (attempt < TCF_FULL_MAX_RETRIES) {
+        } else if (attempt < TCF_FULL_MAX_ATTEMPTS) {
           setTimeout(
             () => retryFetch(attempt + 1),
-            attempt * TCF_FULL_BACKOFF_FACTOR,
+            TCF_FULL_BACKOFF_FACTOR * 2 ** (attempt - 1),
           );
         } else {
           setIsFullExperienceError(true);
           setIsFullExperienceLoading(false);
         }
       } catch (error) {
-        if (attempt < TCF_FULL_MAX_RETRIES) {
+        if (attempt < TCF_FULL_MAX_ATTEMPTS) {
           setTimeout(
             () => retryFetch(attempt + 1),
-            attempt * TCF_FULL_BACKOFF_FACTOR,
+            TCF_FULL_BACKOFF_FACTOR * 2 ** (attempt - 1),
           );
         } else {
           setIsFullExperienceError(true);

--- a/clients/fides-js/src/components/tcf/TcfPurposes.tsx
+++ b/clients/fides-js/src/components/tcf/TcfPurposes.tsx
@@ -74,26 +74,26 @@ const TcfPurposes = ({
   allPurposesConsent = [],
   allCustomPurposesConsent = [],
   allPurposesLegint = [],
-  allSpecialPurposes,
-  enabledPurposeConsentIds,
-  enabledCustomPurposeConsentIds,
-  enabledPurposeLegintIds,
-  enabledSpecialPurposeIds,
+  allSpecialPurposes = [],
+  enabledIds,
   onChange,
 }: {
-  allPurposesConsent: TCFPurposeConsentRecord[] | undefined;
-  allCustomPurposesConsent: Array<PrivacyNoticeWithBestTranslation> | undefined;
-  enabledPurposeConsentIds: string[];
-  allSpecialPurposes: PrivacyExperience["tcf_special_purposes"];
-  allPurposesLegint: TCFPurposeLegitimateInterestsRecord[] | undefined;
-  enabledPurposeLegintIds: string[];
-  enabledCustomPurposeConsentIds: string[];
-  enabledSpecialPurposeIds: string[];
+  allPurposesConsent?: TCFPurposeConsentRecord[];
+  allCustomPurposesConsent?: Array<PrivacyNoticeWithBestTranslation>;
+  allSpecialPurposes?: PrivacyExperience["tcf_special_purposes"];
+  allPurposesLegint?: TCFPurposeLegitimateInterestsRecord[];
+  enabledIds: EnabledIds;
   onChange: (
     payload: UpdateEnabledIds,
     preferenceDetails: FidesEventDetailsPreference,
   ) => void;
 }) => {
+  const {
+    purposesConsent: enabledPurposeConsentIds,
+    customPurposesConsent: enabledCustomPurposeConsentIds,
+    purposesLegint: enabledPurposeLegintIds,
+    specialPurposes: enabledSpecialPurposeIds,
+  } = enabledIds;
   const { i18n } = useI18n();
   const { uniquePurposes } = useMemo(
     () =>
@@ -120,7 +120,6 @@ const TcfPurposes = ({
     specialPurposes: TCFSpecialPurposeRecord[];
     enabledSpecialPurposeIds: string[];
   } = useMemo(() => {
-    const specialPurposes = allSpecialPurposes ?? [];
     const consentPurposes: PurposeRecord[] = uniquePurposes
       .filter((p) => p.isConsent)
       .map((p) => ({
@@ -143,7 +142,7 @@ const TcfPurposes = ({
         purposeModelType: "purposesConsent",
         enabledPurposeIds: enabledPurposeConsentIds,
         enabledCustomPurposeIds: enabledCustomPurposeConsentIds,
-        specialPurposes: specialPurposes.filter((sp) =>
+        specialPurposes: allSpecialPurposes.filter((sp) =>
           hasLegalBasis(sp, LegalBasisEnum.CONSENT),
         ),
         enabledSpecialPurposeIds,
@@ -153,7 +152,7 @@ const TcfPurposes = ({
       purposes: legintPurposes,
       purposeModelType: "purposesLegint",
       enabledPurposeIds: enabledPurposeLegintIds,
-      specialPurposes: specialPurposes.filter((sp) =>
+      specialPurposes: allSpecialPurposes.filter((sp) =>
         hasLegalBasis(sp, LegalBasisEnum.LEGITIMATE_INTERESTS),
       ),
       enabledSpecialPurposeIds,

--- a/clients/fides-js/src/components/tcf/TcfTabs.tsx
+++ b/clients/fides-js/src/components/tcf/TcfTabs.tsx
@@ -5,6 +5,7 @@ import {
   PrivacyExperienceMinimal,
 } from "../../lib/consent-types";
 import { FidesEventDetailsPreference } from "../../lib/events";
+import { FetchState } from "../../lib/hooks";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import { PAGE_SIZE } from "../../lib/paging";
 import {
@@ -33,8 +34,7 @@ const TcfTabs = ({
   onChange,
   activeTabIndex,
   onTabChange,
-  isFullExperienceLoading,
-  isFullExperienceError,
+  fullExperienceState,
 }: {
   experience: PrivacyExperience | PrivacyExperienceMinimal;
   customNotices: PrivacyNoticeWithBestTranslation[] | undefined;
@@ -45,8 +45,7 @@ const TcfTabs = ({
   ) => void;
   activeTabIndex: number;
   onTabChange: (tabIndex: number) => void;
-  isFullExperienceLoading: boolean;
-  isFullExperienceError: boolean;
+  fullExperienceState: FetchState;
 }) => {
   const { i18n } = useI18n();
   const handleUpdateDraftState = useCallback(
@@ -66,16 +65,16 @@ const TcfTabs = ({
       type: "purposes",
       content: (
         <div>
-          {!isFullExperienceError && (
+          {fullExperienceState !== FetchState.Error && (
             <InfoBox>{i18n.t("static.tcf.purposes.description")}</InfoBox>
           )}
-          {isFullExperienceError && (
+          {fullExperienceState === FetchState.Error && (
             <TcfLoadingErrorMessage
               generalLabel="purposes and special features for which your data can be processed"
               specificLabel="specific purposes"
             />
           )}
-          {isFullExperienceLoading && (
+          {fullExperienceState === FetchState.Loading && (
             <RecordsListSkeletons
               rows={
                 ((experience as PrivacyExperienceMinimal)
@@ -84,7 +83,7 @@ const TcfTabs = ({
               }
             />
           )}
-          {!isFullExperienceLoading && !isFullExperienceError && (
+          {fullExperienceState === FetchState.Success && (
             <TcfPurposes
               allPurposesConsent={
                 (experience as PrivacyExperience).tcf_purpose_consents
@@ -109,16 +108,16 @@ const TcfTabs = ({
       type: "features",
       content: (
         <div>
-          {!isFullExperienceError && (
+          {fullExperienceState !== FetchState.Error && (
             <InfoBox>{i18n.t("static.tcf.features.description")}</InfoBox>
           )}
-          {isFullExperienceError && (
+          {fullExperienceState === FetchState.Error && (
             <TcfLoadingErrorMessage
               generalLabel="features for which your data can be processed"
               specificLabel="special features"
             />
           )}
-          {isFullExperienceLoading && (
+          {fullExperienceState === FetchState.Loading && (
             <RecordsListSkeletons
               rows={
                 ((experience as PrivacyExperienceMinimal).tcf_feature_ids
@@ -128,7 +127,7 @@ const TcfTabs = ({
               }
             />
           )}
-          {!isFullExperienceLoading && !isFullExperienceError && (
+          {fullExperienceState === FetchState.Success && (
             <TcfFeatures
               allFeatures={(experience as PrivacyExperience).tcf_features}
               allSpecialFeatures={
@@ -146,16 +145,16 @@ const TcfTabs = ({
       type: "vendors",
       content: (
         <div>
-          {!isFullExperienceError && (
+          {fullExperienceState !== FetchState.Error && (
             <InfoBox>{i18n.t("static.tcf.vendors.description")}</InfoBox>
           )}
-          {isFullExperienceError && (
+          {fullExperienceState === FetchState.Error && (
             <TcfLoadingErrorMessage
               generalLabel="vendors who can process your data and the purposes or features of processing they declare"
               specificLabel="each vendor based on the legal basis they assert"
             />
           )}
-          {isFullExperienceLoading && (
+          {fullExperienceState === FetchState.Loading && (
             <RecordsListSkeletons
               rows={Math.min(
                 (experience as PrivacyExperienceMinimal).tcf_vendor_consent_ids
@@ -164,7 +163,7 @@ const TcfTabs = ({
               )}
             />
           )}
-          {!isFullExperienceLoading && !isFullExperienceError && (
+          {fullExperienceState === FetchState.Success && (
             <TcfVendors
               experience={experience as PrivacyExperience}
               enabledIds={enabledIds}

--- a/clients/fides-js/src/components/tcf/TcfTabs.tsx
+++ b/clients/fides-js/src/components/tcf/TcfTabs.tsx
@@ -14,6 +14,7 @@ import {
 import InfoBox from "../InfoBox";
 import { RecordsListSkeletons } from "./RecordsListSkeletons";
 import TcfFeatures from "./TcfFeatures";
+import { TcfLoadingErrorMessage } from "./TcfLoadingErrorMessage";
 import TcfPurposes from "./TcfPurposes";
 import TcfVendors from "./TcfVendors";
 
@@ -32,6 +33,8 @@ const TcfTabs = ({
   onChange,
   activeTabIndex,
   onTabChange,
+  isFullExperienceLoading,
+  isFullExperienceError,
 }: {
   experience: PrivacyExperience | PrivacyExperienceMinimal;
   customNotices: PrivacyNoticeWithBestTranslation[] | undefined;
@@ -42,6 +45,8 @@ const TcfTabs = ({
   ) => void;
   activeTabIndex: number;
   onTabChange: (tabIndex: number) => void;
+  isFullExperienceLoading: boolean;
+  isFullExperienceError: boolean;
 }) => {
   const { i18n } = useI18n();
   const handleUpdateDraftState = useCallback(
@@ -61,8 +66,16 @@ const TcfTabs = ({
       type: "purposes",
       content: (
         <div>
-          <InfoBox>{i18n.t("static.tcf.purposes.description")}</InfoBox>
-          {experience.minimal_tcf ? (
+          {!isFullExperienceError && (
+            <InfoBox>{i18n.t("static.tcf.purposes.description")}</InfoBox>
+          )}
+          {isFullExperienceError && (
+            <TcfLoadingErrorMessage
+              generalLabel="purposes and special features for which your data is being processed"
+              specificLabel="specific purposes"
+            />
+          )}
+          {isFullExperienceLoading && (
             <RecordsListSkeletons
               rows={
                 ((experience as PrivacyExperienceMinimal)
@@ -70,7 +83,8 @@ const TcfTabs = ({
                 (customNotices?.length ?? 0)
               }
             />
-          ) : (
+          )}
+          {!isFullExperienceLoading && !isFullExperienceError && (
             <TcfPurposes
               allPurposesConsent={
                 (experience as PrivacyExperience).tcf_purpose_consents
@@ -95,8 +109,16 @@ const TcfTabs = ({
       type: "features",
       content: (
         <div>
-          <InfoBox>{i18n.t("static.tcf.features.description")}</InfoBox>
-          {experience.minimal_tcf ? (
+          {!isFullExperienceError && (
+            <InfoBox>{i18n.t("static.tcf.features.description")}</InfoBox>
+          )}
+          {isFullExperienceError && (
+            <TcfLoadingErrorMessage
+              generalLabel="features for which your data is being processed"
+              specificLabel="special features"
+            />
+          )}
+          {isFullExperienceLoading && (
             <RecordsListSkeletons
               rows={
                 ((experience as PrivacyExperienceMinimal).tcf_feature_ids
@@ -105,7 +127,8 @@ const TcfTabs = ({
                   .tcf_special_feature_ids?.length ?? 0)
               }
             />
-          ) : (
+          )}
+          {!isFullExperienceLoading && !isFullExperienceError && (
             <TcfFeatures
               allFeatures={(experience as PrivacyExperience).tcf_features}
               allSpecialFeatures={
@@ -123,8 +146,16 @@ const TcfTabs = ({
       type: "vendors",
       content: (
         <div>
-          <InfoBox>{i18n.t("static.tcf.vendors.description")}</InfoBox>
-          {experience.minimal_tcf ? (
+          {!isFullExperienceError && (
+            <InfoBox>{i18n.t("static.tcf.vendors.description")}</InfoBox>
+          )}
+          {isFullExperienceError && (
+            <TcfLoadingErrorMessage
+              generalLabel="vendors processing your data and the purposes or features of processing they declare"
+              specificLabel="each vendor based on the legal basis they assert"
+            />
+          )}
+          {isFullExperienceLoading && (
             <RecordsListSkeletons
               rows={Math.min(
                 (experience as PrivacyExperienceMinimal).tcf_vendor_consent_ids
@@ -132,7 +163,8 @@ const TcfTabs = ({
                 PAGE_SIZE,
               )}
             />
-          ) : (
+          )}
+          {!isFullExperienceLoading && !isFullExperienceError && (
             <TcfVendors
               experience={experience as PrivacyExperience}
               enabledIds={enabledIds}

--- a/clients/fides-js/src/components/tcf/TcfTabs.tsx
+++ b/clients/fides-js/src/components/tcf/TcfTabs.tsx
@@ -71,7 +71,7 @@ const TcfTabs = ({
           )}
           {isFullExperienceError && (
             <TcfLoadingErrorMessage
-              generalLabel="purposes and special features for which your data is being processed"
+              generalLabel="purposes and special features for which your data can be processed"
               specificLabel="specific purposes"
             />
           )}
@@ -114,7 +114,7 @@ const TcfTabs = ({
           )}
           {isFullExperienceError && (
             <TcfLoadingErrorMessage
-              generalLabel="features for which your data is being processed"
+              generalLabel="features for which your data can be processed"
               specificLabel="special features"
             />
           )}
@@ -151,7 +151,7 @@ const TcfTabs = ({
           )}
           {isFullExperienceError && (
             <TcfLoadingErrorMessage
-              generalLabel="vendors processing your data and the purposes or features of processing they declare"
+              generalLabel="vendors who can process your data and the purposes or features of processing they declare"
               specificLabel="each vendor based on the legal basis they assert"
             />
           )}

--- a/clients/fides-js/src/components/tcf/TcfTabs.tsx
+++ b/clients/fides-js/src/components/tcf/TcfTabs.tsx
@@ -1,13 +1,18 @@
 import { useCallback, useRef } from "preact/hooks";
 
-import { PrivacyExperience } from "../../lib/consent-types";
+import {
+  PrivacyExperience,
+  PrivacyExperienceMinimal,
+} from "../../lib/consent-types";
 import { FidesEventDetailsPreference } from "../../lib/events";
 import { useI18n } from "../../lib/i18n/i18n-context";
+import { PAGE_SIZE } from "../../lib/paging";
 import {
   EnabledIds,
   PrivacyNoticeWithBestTranslation,
 } from "../../lib/tcf/types";
 import InfoBox from "../InfoBox";
+import { RecordsListSkeletons } from "./RecordsListSkeletons";
 import TcfFeatures from "./TcfFeatures";
 import TcfPurposes from "./TcfPurposes";
 import TcfVendors from "./TcfVendors";
@@ -28,7 +33,7 @@ const TcfTabs = ({
   activeTabIndex,
   onTabChange,
 }: {
-  experience: PrivacyExperience;
+  experience: PrivacyExperience | PrivacyExperienceMinimal;
   customNotices: PrivacyNoticeWithBestTranslation[] | undefined;
   enabledIds: EnabledIds;
   onChange: (
@@ -57,17 +62,31 @@ const TcfTabs = ({
       content: (
         <div>
           <InfoBox>{i18n.t("static.tcf.purposes.description")}</InfoBox>
-          <TcfPurposes
-            allPurposesConsent={experience.tcf_purpose_consents}
-            allCustomPurposesConsent={customNotices}
-            allPurposesLegint={experience.tcf_purpose_legitimate_interests}
-            allSpecialPurposes={experience.tcf_special_purposes}
-            enabledPurposeConsentIds={enabledIds.purposesConsent}
-            enabledCustomPurposeConsentIds={enabledIds.customPurposesConsent}
-            enabledPurposeLegintIds={enabledIds.purposesLegint}
-            enabledSpecialPurposeIds={enabledIds.specialPurposes}
-            onChange={handleUpdateDraftState}
-          />
+          {experience.minimal_tcf ? (
+            <RecordsListSkeletons
+              rows={
+                ((experience as PrivacyExperienceMinimal)
+                  .tcf_purpose_consent_ids?.length ?? 0) +
+                (customNotices?.length ?? 0)
+              }
+            />
+          ) : (
+            <TcfPurposes
+              allPurposesConsent={
+                (experience as PrivacyExperience).tcf_purpose_consents
+              }
+              allCustomPurposesConsent={customNotices}
+              allPurposesLegint={
+                (experience as PrivacyExperience)
+                  .tcf_purpose_legitimate_interests
+              }
+              allSpecialPurposes={
+                (experience as PrivacyExperience).tcf_special_purposes
+              }
+              enabledIds={enabledIds}
+              onChange={handleUpdateDraftState}
+            />
+          )}
         </div>
       ),
     },
@@ -77,13 +96,25 @@ const TcfTabs = ({
       content: (
         <div>
           <InfoBox>{i18n.t("static.tcf.features.description")}</InfoBox>
-          <TcfFeatures
-            allFeatures={experience.tcf_features}
-            allSpecialFeatures={experience.tcf_special_features}
-            enabledFeatureIds={enabledIds.features}
-            enabledSpecialFeatureIds={enabledIds.specialFeatures}
-            onChange={handleUpdateDraftState}
-          />
+          {experience.minimal_tcf ? (
+            <RecordsListSkeletons
+              rows={
+                ((experience as PrivacyExperienceMinimal).tcf_feature_ids
+                  ?.length ?? 0) +
+                ((experience as PrivacyExperienceMinimal)
+                  .tcf_special_feature_ids?.length ?? 0)
+              }
+            />
+          ) : (
+            <TcfFeatures
+              allFeatures={(experience as PrivacyExperience).tcf_features}
+              allSpecialFeatures={
+                (experience as PrivacyExperience).tcf_special_features
+              }
+              enabledIds={enabledIds}
+              onChange={handleUpdateDraftState}
+            />
+          )}
         </div>
       ),
     },
@@ -93,12 +124,21 @@ const TcfTabs = ({
       content: (
         <div>
           <InfoBox>{i18n.t("static.tcf.vendors.description")}</InfoBox>
-          <TcfVendors
-            experience={experience}
-            enabledVendorConsentIds={enabledIds.vendorsConsent}
-            enabledVendorLegintIds={enabledIds.vendorsLegint}
-            onChange={handleUpdateDraftState}
-          />
+          {experience.minimal_tcf ? (
+            <RecordsListSkeletons
+              rows={Math.min(
+                (experience as PrivacyExperienceMinimal).tcf_vendor_consent_ids
+                  ?.length ?? 0,
+                PAGE_SIZE,
+              )}
+            />
+          ) : (
+            <TcfVendors
+              experience={experience as PrivacyExperience}
+              enabledIds={enabledIds}
+              onChange={handleUpdateDraftState}
+            />
+          )}
         </div>
       ),
     },

--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -8,6 +8,7 @@ import { useI18n } from "../../lib/i18n/i18n-context";
 import { LEGAL_BASIS_OPTIONS } from "../../lib/tcf/constants";
 import {
   EmbeddedPurpose,
+  EnabledIds,
   GvlDataCategories,
   GvlDataDeclarations,
   LegalBasisEnum,
@@ -336,18 +337,20 @@ const PagedVendorData = ({
 
 const TcfVendors = ({
   experience,
-  enabledVendorConsentIds,
-  enabledVendorLegintIds,
+  enabledIds,
   onChange,
 }: {
   experience: PrivacyExperience;
-  enabledVendorConsentIds: string[];
-  enabledVendorLegintIds: string[];
+  enabledIds: EnabledIds;
   onChange: (
     payload: UpdateEnabledIds,
     preferenceDetails: FidesEventDetailsPreference,
   ) => void;
 }) => {
+  const {
+    vendorsConsent: enabledVendorConsentIds,
+    vendorsLegint: enabledVendorLegintIds,
+  } = enabledIds;
   // Combine the various vendor objects into one object for convenience
   const vendors = useMemo(
     () => transformExperienceToVendorRecords(experience),

--- a/clients/fides-js/src/lib/hooks/index.ts
+++ b/clients/fides-js/src/lib/hooks/index.ts
@@ -3,8 +3,8 @@ export { default as useElementById } from "./useElementById";
 export { default as useHasMounted } from "./useHasMounted";
 export { default as useNoticesServed } from "./useNoticesServed";
 export {
+  FetchState,
   type RetryConfig,
   useRetryableFetch,
-  FetchState,
 } from "./useRetryableFetch";
 export { default as useUUID4 } from "./useUUID4";

--- a/clients/fides-js/src/lib/hooks/index.ts
+++ b/clients/fides-js/src/lib/hooks/index.ts
@@ -2,5 +2,9 @@ export { default as useDisclosure } from "./useDisclosure";
 export { default as useElementById } from "./useElementById";
 export { default as useHasMounted } from "./useHasMounted";
 export { default as useNoticesServed } from "./useNoticesServed";
-export { type RetryConfig, useRetryableFetch } from "./useRetryableFetch";
+export {
+  type RetryConfig,
+  useRetryableFetch,
+  FetchState,
+} from "./useRetryableFetch";
 export { default as useUUID4 } from "./useUUID4";

--- a/clients/fides-js/src/lib/hooks/index.ts
+++ b/clients/fides-js/src/lib/hooks/index.ts
@@ -2,5 +2,5 @@ export { default as useDisclosure } from "./useDisclosure";
 export { default as useElementById } from "./useElementById";
 export { default as useHasMounted } from "./useHasMounted";
 export { default as useNoticesServed } from "./useNoticesServed";
+export { type RetryConfig, useRetryableFetch } from "./useRetryableFetch";
 export { default as useUUID4 } from "./useUUID4";
-export { useRetryableFetch, type RetryConfig } from "./useRetryableFetch";

--- a/clients/fides-js/src/lib/hooks/index.ts
+++ b/clients/fides-js/src/lib/hooks/index.ts
@@ -3,3 +3,4 @@ export { default as useElementById } from "./useElementById";
 export { default as useHasMounted } from "./useHasMounted";
 export { default as useNoticesServed } from "./useNoticesServed";
 export { default as useUUID4 } from "./useUUID4";
+export { useRetryableFetch, type RetryConfig } from "./useRetryableFetch";

--- a/clients/fides-js/src/lib/hooks/useRetryableFetch.ts
+++ b/clients/fides-js/src/lib/hooks/useRetryableFetch.ts
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "preact/hooks";
+
+export interface RetryConfig {
+  maxAttempts?: number;
+  backoffFactor?: number;
+  shouldRetry?: (attempt: number, result: any, error?: Error) => boolean;
+}
+
+interface UseRetryableFetchOptions<T> {
+  fetcher: () => Promise<T>;
+  validator?: (result: T) => boolean;
+  onSuccess?: (result: T) => void;
+  config?: RetryConfig;
+  enabled?: boolean;
+}
+
+interface UseRetryableFetchResult<T> {
+  data: T | undefined;
+  loading: boolean;
+  error: boolean;
+  retry: () => void;
+}
+
+const DEFAULT_CONFIG: Required<RetryConfig> = {
+  maxAttempts: 4,
+  backoffFactor: 1000,
+  shouldRetry: () => true,
+};
+
+export const useRetryableFetch = <T>({
+  fetcher,
+  validator = () => true,
+  onSuccess,
+  config = {},
+  enabled = true,
+}: UseRetryableFetchOptions<T>): UseRetryableFetchResult<T> => {
+  const [data, setData] = useState<T | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const finalConfig = { ...DEFAULT_CONFIG, ...config };
+
+  const executeWithRetry = async (attempt = 1): Promise<void> => {
+    try {
+      const result = await fetcher();
+
+      if (validator(result)) {
+        setData(result);
+        setLoading(false);
+        setError(false);
+        onSuccess?.(result);
+      } else if (
+        attempt < finalConfig.maxAttempts &&
+        finalConfig.shouldRetry(attempt, result)
+      ) {
+        setTimeout(
+          () => executeWithRetry(attempt + 1),
+          finalConfig.backoffFactor * 2 ** (attempt - 1),
+        );
+      } else {
+        setError(true);
+        setLoading(false);
+      }
+    } catch (err) {
+      if (
+        attempt < finalConfig.maxAttempts &&
+        finalConfig.shouldRetry(attempt, null, err as Error)
+      ) {
+        setTimeout(
+          () => executeWithRetry(attempt + 1),
+          finalConfig.backoffFactor * 2 ** (attempt - 1),
+        );
+      } else {
+        setError(true);
+        setLoading(false);
+      }
+    }
+  };
+
+  const retry = () => {
+    setLoading(true);
+    setError(false);
+    setData(undefined);
+    executeWithRetry();
+  };
+
+  useEffect(() => {
+    if (enabled) {
+      setLoading(true);
+      setError(false);
+      executeWithRetry();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+
+  return {
+    data,
+    loading,
+    error,
+    retry,
+  };
+};

--- a/clients/fides-js/src/lib/hooks/useRetryableFetch.ts
+++ b/clients/fides-js/src/lib/hooks/useRetryableFetch.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "preact/hooks";
 
+import {
+  TCF_FULL_BACKOFF_FACTOR,
+  TCF_FULL_MAX_ATTEMPTS,
+} from "../tcf/constants";
+
 export interface RetryConfig {
   maxAttempts?: number;
   backoffFactor?: number;
@@ -22,8 +27,8 @@ interface UseRetryableFetchResult<T> {
 }
 
 const DEFAULT_CONFIG: Required<RetryConfig> = {
-  maxAttempts: 4,
-  backoffFactor: 1000,
+  maxAttempts: TCF_FULL_MAX_ATTEMPTS,
+  backoffFactor: TCF_FULL_BACKOFF_FACTOR,
   shouldRetry: () => true,
 };
 

--- a/clients/fides-js/src/lib/preferences.ts
+++ b/clients/fides-js/src/lib/preferences.ts
@@ -20,6 +20,7 @@ import {
 import {
   applyOverridesToConsent,
   constructFidesRegionString,
+  createConsentProxy,
   decodeNoticeConsentString,
 } from "./consent-utils";
 import {
@@ -165,7 +166,14 @@ export const updateConsentPreferences = async ({
     window.Fides?.experience?.non_applicable_privacy_notices,
     window.Fides?.experience?.privacy_notices,
   );
-  window.Fides.consent = normalizedConsent;
+  const hasPrivacyNotices =
+    !!window.Fides?.experience?.non_applicable_privacy_notices ||
+    !!window.Fides?.experience?.privacy_notices;
+  window.Fides.consent = createConsentProxy(
+    normalizedConsent,
+    options,
+    hasPrivacyNotices,
+  );
   window.Fides.fides_string = cookie.fides_string;
   window.Fides.tcf_consent = cookie.tcf_consent;
 

--- a/clients/fides-js/src/lib/tcf/constants.ts
+++ b/clients/fides-js/src/lib/tcf/constants.ts
@@ -104,3 +104,6 @@ export const EMPTY_ENABLED_IDS: EnabledIds = {
   vendorsConsent: [],
   vendorsLegint: [],
 };
+
+export const TCF_FULL_MAX_ATTEMPTS = 4; // initial attempt + 3 retries
+export const TCF_FULL_BACKOFF_FACTOR = 1000; // exponential backoff

--- a/clients/fides-js/src/services/api.ts
+++ b/clients/fides-js/src/services/api.ts
@@ -270,13 +270,18 @@ export const patchNoticesServed = async ({
     ...PATCH_FETCH_OPTIONS,
     body: JSON.stringify(request),
   };
-  const response = await fetch(
-    `${options.fidesApiUrl}${FidesEndpointPaths.NOTICES_SERVED}`,
-    fetchOptions,
-  );
-  if (!response.ok) {
-    fidesDebugger("Error patching notices served. Response:", response);
+  try {
+    const response = await fetch(
+      `${options.fidesApiUrl}${FidesEndpointPaths.NOTICES_SERVED}`,
+      fetchOptions,
+    );
+    if (!response.ok) {
+      fidesDebugger("Error patching notices served. Response:", response);
+      return null;
+    }
+    return await response.json();
+  } catch (error) {
+    fidesDebugger("Error patching notices served. Error:", error);
     return null;
   }
-  return response.json();
 };

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -1178,7 +1178,7 @@ describe("Fides-js TCF", () => {
           "vendors who can process your data",
         );
 
-        cy.get("#fides-save-button").should("not.exist");
+        cy.get("#fides-save-button").should("be.disabled");
         cy.get("button").contains("Opt in to all").should("be.visible");
         cy.get("button").contains("Opt out of all").should("be.visible");
       });

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -12,7 +12,10 @@ import {
   RejectAllMechanism,
 } from "fides-js";
 
-import { FIDES_SEPARATOR } from "../../../fides-js/src/lib/tcf/constants";
+import {
+  FIDES_SEPARATOR,
+  TCF_FULL_MAX_ATTEMPTS,
+} from "../../../fides-js/src/lib/tcf/constants";
 import {
   API_URL,
   TCF_VERSION_HASH,
@@ -1140,41 +1143,39 @@ describe("Fides-js TCF", () => {
         cy.get("#fides-save-button .fides-spinner").should("be.visible");
 
         // Wait for multiple retries to occur and then check for error state
-        cy.wait("@getPrivacyExperienceError");
-        cy.wait("@getPrivacyExperienceError");
-        cy.wait("@getPrivacyExperienceError");
-        cy.wait("@getPrivacyExperienceError");
-        cy.wait("@getPrivacyExperienceError");
+        Array.from({ length: TCF_FULL_MAX_ATTEMPTS }).forEach(() => {
+          cy.wait("@getPrivacyExperienceError");
+        });
 
         // Check that error messages are displayed in each tab
         cy.get("#fides-tab-purposes").click();
-        cy.getByTestId("tcf-loading-error-message").should(
-          "contain",
-          "There was an error loading",
-        );
+        cy.getByTestId("tcf-loading-error-message")
+          .eq(0)
+          .should("be.visible")
+          .should("contain", "There was an error loading");
         cy.getByTestId("tcf-loading-error-message").should(
           "contain",
           "purposes and special features",
         );
 
         cy.get("#fides-tab-features").click();
-        cy.getByTestId("tcf-loading-error-message").should(
-          "contain",
-          "There was an error loading",
-        );
+        cy.getByTestId("tcf-loading-error-message")
+          .eq(1)
+          .should("be.visible")
+          .should("contain", "There was an error loading");
         cy.getByTestId("tcf-loading-error-message").should(
           "contain",
           "features for which your data",
         );
 
         cy.get("#fides-tab-vendors").click();
+        cy.getByTestId("tcf-loading-error-message")
+          .eq(2)
+          .should("be.visible")
+          .should("contain", "There was an error loading");
         cy.getByTestId("tcf-loading-error-message").should(
           "contain",
-          "There was an error loading",
-        );
-        cy.getByTestId("tcf-loading-error-message").should(
-          "contain",
-          "vendors processing your data",
+          "vendors who can process your data",
         );
 
         cy.get("#fides-save-button").should("not.exist");

--- a/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner.cy.ts
@@ -962,7 +962,7 @@ describe("Consent overlay", () => {
           cy.get(
             "#fides-modal .fides-modal-notices .fides-toggle-input:first",
           ).click();
-          cy.get("#fides-modal .fides-save-button").click();
+          cy.get("#fides-modal #fides-save-button").click();
           cy.wait("@patchPrivacyPreference").then((interception) => {
             const { method, preferences } = interception.request.body;
             expect(method).to.eq("save");
@@ -979,12 +979,12 @@ describe("Consent overlay", () => {
           cy.get(
             "#fides-modal .fides-modal-notices .fides-toggle-input:first",
           ).should("be.checked");
-          cy.get("#fides-modal .fides-save-button").click();
+          cy.get("#fides-modal #fides-save-button").click();
           cy.get("#fides-modal-link").click();
           cy.get(
             "#fides-modal .fides-modal-notices .fides-toggle-input:first",
           ).should("be.checked");
-          cy.get("#fides-modal .fides-save-button").click();
+          cy.get("#fides-modal #fides-save-button").click();
           // We still should not fire any FidesUpdated events
           cy.get("@FidesUpdated").should("have.been.calledTwice");
         });

--- a/clients/privacy-center/cypress/e2e/consent-events.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-events.cy.ts
@@ -175,7 +175,7 @@ describe("Consent FidesEvents", () => {
       });
 
       // Save current preference selections
-      cy.get("#fides-modal .fides-save-button").click();
+      cy.get("#fides-modal #fides-save-button").click();
       expectedEvents.push(
         { type: "FidesModalClosed", detail: {} },
         {
@@ -824,7 +824,7 @@ describe("Consent FidesEvents", () => {
       });
 
       // Save preferences - this should trigger FidesUpdating and FidesUpdated events
-      cy.get("#fides-modal .fides-save-button").click();
+      cy.get("#fides-modal #fides-save-button").click();
       expectedEvents.push(
         { type: "FidesModalClosed", detail: {} },
         {

--- a/clients/privacy-center/pages/api/fides-js.ts
+++ b/clients/privacy-center/pages/api/fides-js.ts
@@ -12,7 +12,7 @@ import {
   PrivacyExperience,
   PrivacyExperienceMinimal,
   UserGeolocation,
-} from "fides-js"; // NOTE: these import from the mjs file so a prod FidesJS build is needed to test changes
+} from "fides-js"; // NOTE: these import from the mjs file
 import { promises as fsPromises } from "fs";
 import type { NextApiRequest, NextApiResponse } from "next";
 import pRetry from "p-retry";
@@ -229,8 +229,9 @@ export default async function handler(
       try {
         /*
          * Since we don't know what the experience will be when the initial call is made,
-         * we supply the minimal request to the api endpoint with the understanding that if
-         * TCF is being returned, we want the minimal version. It will be ignored otherwise.
+         * we supply the minimal request (requestMinimalTCF) to the api endpoint with the
+         * understanding that if TCF is being returned, we want the minimal version. It will
+         * be ignored otherwise.
          */
         experience = await pRetry(
           () =>

--- a/clients/privacy-center/public/fides-js-demo.html
+++ b/clients/privacy-center/public/fides-js-demo.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>fides-js script demo page</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
Closes [ENG-940]

### Description Of Changes

1. Improved compliance by automatically defaulting any property accessed on `Fides.consent` as `false` in case an experience fails to load or is empty. (ie. `Fides.consent.whatever` will return `false`)

2. Improved TCF (Transparency and Consent Framework) error handling and user experience by implementing retry mechanisms for API calls and better loading states. When the full TCF experience fails to load due to network issues or API failures, users now see appropriate loading indicators and error messages, while still being able to accept/reject consent. The system now uses a retry-able fetch hook with exponential back-off for more reliable API communication.

### Code Changes

* Added `useRetryableFetch` hook to `TcfOverlay` with retry logic for fetching full TCF experience
* Created `TcfLoadingErrorMessage` component to display user-friendly error messages when TCF data fails to load
* Added `RecordsListSkeletons` component for skeleton loading states during data fetching
* Removed manual loading state management from `ConsentButtons` that was causing UX issues
* Updated CSS variables and styles to support skeleton loading animations and error states without affecting existing customer styles.
* Enhanced `InfoBox` component to accept additional props for error styling
* Fixed accessibility issues by adding `tabIndex` to scrollable content and improving `aria-checked` values
* Increased TCF bundle size limit from 92KB to 95KB to accommodate new features (increased by 0.4k, now totaling 92.46k)
* Simplified consent button logic by removing `isMinimalTCF` prop dependencies
* Updated type definitions to allow `false` return values from render functions for when we remove the save button on failure.

### Steps to Confirm
1. Navigate to the demo page in the Vercel deploy with TCF consent banner (`/fides-js-demo.html?geolocation=eea`)
2. Block network requests to simulate API failures and verify error messages appear
3. Test that users can still accept/reject consent even when full experience fails to load
4. Verify skeleton loading states appear during data fetching
5. Confirm retry mechanism works by restoring network and observing successful data load

<img width="1526" height="802" alt="CleanShot 2025-07-25 at 14 10 45@2x" src="https://github.com/user-attachments/assets/6f338e60-eb92-49e0-b8fb-b9feef149653" />

<img width="1444" height="820" alt="CleanShot 2025-07-25 at 14 10 29@2x" src="https://github.com/user-attachments/assets/6e6b5a33-77da-480d-bf65-0cc503ef07e0" />

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-940]: https://ethyca.atlassian.net/browse/ENG-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ