### PR TITLE
Allow turbo to pass env variable

### DIFF
--- a/clients/fides-js/package.json
+++ b/clients/fides-js/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "dev": "rollup --watch -c --environment NODE_ENV:development",
-    "build": "rollup -c --environment NODE_ENV:production${IS_TEST:+,IS_TEST:true}",
+    "build": "rollup -c --environment NODE_ENV:production$(test \"$IS_TEST\" = \"true\" && echo \",IS_TEST:true\")",
     "build:test": "rollup -c --environment NODE_ENV:production,IS_TEST:true",
     "postbuild": "npm run docs:generate",
     "clean": "rm -rf dist .turbo node_modules",

--- a/clients/turbo.json
+++ b/clients/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.v1.json",
+  "globalEnv": ["IS_TEST"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Closes ENG-1035

### Description Of Changes

This change to the turbo configuration allows it to pass along the IS_TEST env variable.

Turbo is in [strict mode](https://turborepo.com/docs/crafting-your-repository/using-environment-variables#strict-mode) by default, which means that it will filter out all env variables that aren't specified.

We need this variable so we can pass IS_TEST and populate fides-js data-testids as needed.

Also, the npm build script was checking if IS_TEST was set at all, not actually evaluating its contents. So now we're doing that here. Previously it would have left the testids if this were explicitly set to false or anything else.

### Code Changes

* Updated turbo.json with the IS_TEST global variable.
* Update npm build script to check value of IS_TEST

### Steps to Confirm

Try running `npm run build` with IS_TEST set to `true`, with it set to `false`, and with it not set at all. (for this last one, you can run `unset IS_TEST`

1.  Navigate to fides/clients
2. set IS_TEST: `export IS_TEST=true`
3. Run `npm run build`
4. Count how many instances of data-testid we have in the compiled code: `grep -o '"data-testid"' fides-js/dist/*.js | wc -l` (Alternatively, start up the privacy center with an experience configured, and then check the banner for data-testids, such as on the Manage Preferences page)

The count for data-testId should be much lower when IS_TEST isn't set to true.

Results:

1. IS_TEST=false
```
grep -o '"data-testid"' fides-js/dist/*.js | wc -l
      12
```
2. IS_TEST=true
```
 grep -o '"data-testid"' fides-js/dist/*.js | wc -l
      38
```
3. IS_TEST is unset
```
  grep -o '"data-testid"' fides-js/dist/*.js | wc -l
      12
```


### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
