### PR TITLE
Fix privacy request detail page layout issues with long titles

### DIFF
--- a/clients/admin-ui/src/features/privacy-requests/PrivacyRequest.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/PrivacyRequest.tsx
@@ -65,7 +65,7 @@ const PrivacyRequest = ({ data: initialData }: PrivacyRequestProps) => {
 
   return (
     <div className="flex gap-8">
-      <div className="flex-1">
+      <div className="w-2/3 grow 2xl:w-0">
         <Tabs
           items={items}
           activeKey={activeTabKey}

--- a/clients/admin-ui/src/features/privacy-requests/events-and-logs/ActivityTimelineEntry.module.scss
+++ b/clients/admin-ui/src/features/privacy-requests/events-and-logs/ActivityTimelineEntry.module.scss
@@ -50,24 +50,17 @@ $horizontal-padding: 20px;
 .header {
   width: 100%;
   display: flex;
-  flex-wrap: wrap;
   gap: 8px;
   align-items: center;
-  justify-content: space-between;
-}
+  justify-content: flex-start;
 
-.headerLeft {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
-  flex: 1;
-}
-
-.headerRight {
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
+  // For the header, we want to show all components
+  // in a single line, without wrapping or shrinking.
+  // (except for the title, which can shrink and will show ellipsis)
+  flex-wrap: nowrap;
+  & > * {
+    flex-shrink: 0;
+  }
 }
 
 .author {
@@ -75,6 +68,7 @@ $horizontal-padding: 20px;
 
 .title {
   font-weight: 600;
+  flex-shrink: 1;
 
   &--error {
     color: var(--fidesui-error);

--- a/clients/admin-ui/src/features/privacy-requests/events-and-logs/ActivityTimelineEntry.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/events-and-logs/ActivityTimelineEntry.tsx
@@ -40,49 +40,48 @@ const ActivityTimelineEntry = ({ item }: ActivityTimelineEntryProps) => {
   const content = (
     <>
       <div className={styles.header}>
-        <div className={styles.headerLeft}>
+        <span className={styles.author} data-testid="activity-timeline-author">
+          {author}:
+        </span>
+        {title && (
+          <Typography.Text
+            className={classNames(styles.title, {
+              [styles["title--error"]]: isError,
+              [styles["title--awaiting-input"]]: isAwaitingInput,
+            })}
+            ellipsis={{ tooltip: true }}
+            data-testid="activity-timeline-title"
+          >
+            {title}
+            {title}
+            {title}
+            {title}
+            {title}
+
+            {isError && " failed"}
+          </Typography.Text>
+        )}
+        <span
+          className={styles.timestamp}
+          data-testid="activity-timeline-timestamp"
+        >
+          {formattedDate}
+        </span>
+        <Tag
+          className={styles.type}
+          color={TimelineItemColorMap[type]}
+          data-testid="activity-timeline-type"
+        >
+          {type}
+        </Tag>
+        {showViewLog && (
           <span
-            className={styles.author}
-            data-testid="activity-timeline-author"
+            className={styles.viewLogs}
+            data-testid="activity-timeline-view-logs"
           >
-            {author}:
+            View Log
           </span>
-          {title && (
-            <Typography.Text
-              className={classNames(styles.title, {
-                [styles["title--error"]]: isError,
-                [styles["title--awaiting-input"]]: isAwaitingInput,
-              })}
-              ellipsis={{ tooltip: true }}
-              style={{ maxWidth: "33%" }}
-              data-testid="activity-timeline-title"
-            >
-              {title}
-              {isError && " failed"}
-            </Typography.Text>
-          )}
-          <span
-            className={styles.timestamp}
-            data-testid="activity-timeline-timestamp"
-          >
-            {formattedDate}
-          </span>
-          <Tag
-            className={styles.type}
-            color={TimelineItemColorMap[type]}
-            data-testid="activity-timeline-type"
-          >
-            {type}
-          </Tag>
-          {showViewLog && (
-            <span
-              className={styles.viewLogs}
-              data-testid="activity-timeline-view-logs"
-            >
-              View Log
-            </span>
-          )}
-        </div>
+        )}
       </div>
       {(description || hasAttachments) && (
         <div className="mt-2 flex justify-between pl-2.5 align-top">


### PR DESCRIPTION
### Description Of Changes
Fix issue where very long title cause an horizontal scroll in the privacy request detail page.

### Code Changes
* Removed headerLeft wrapper as it was not needed
* Adjusted styling for Privacy Request page
* Adjusted styling for activity entry, ensuring no wrap and that all children don't shrink
* Adjusted styling for activity entry title, removing arbitrary 33% max width in favor of displaying full width and shrink with ellipsis when needed

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
