### PR TITLE
ENG-1057: fix email template to remove reference to PDF format

### DIFF
--- a/src/fides/api/service/privacy_request/dsr_package/templates/welcome.html
+++ b/src/fides/api/service/privacy_request/dsr_package/templates/welcome.html
@@ -49,7 +49,7 @@
             <p>
                This web link contains all data requested as part of your Data Subject Request (DSR). Your
                information has been compiled from the following areas. Click on each section to open a file and view
-               your data in PDF format.
+               your data.
             </p>
          </div>
          <div class="dataset-list">

--- a/src/fides/api/service/privacy_request/dsr_package/templates/welcome.html
+++ b/src/fides/api/service/privacy_request/dsr_package/templates/welcome.html
@@ -48,7 +48,7 @@
          <div class="dsr-information-text">
             <p>
                This web link contains all data requested as part of your Data Subject Request (DSR). Your
-               information has been compiled from the following areas. Click on each section to open a file and view
+               information has been compiled from the following areas. Click on each section to open and view
                your data.
             </p>
          </div>


### PR DESCRIPTION
Closes [ENG-1057]

### Description Of Changes

Minor update to remove a reference to PDF in the DSR email template.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1057]: https://ethyca.atlassian.net/browse/ENG-1057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ