### PR TITLE
[ENG-984] Add dependencies as scalar field references inputs into access and erasure manual graph tasks

### DIFF
--- a/src/fides/api/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/service/privacy_request/request_runner_service.py
@@ -455,8 +455,13 @@ def run_privacy_request(
                     if not dataset_config.connection_config.disabled
                 ]
 
+                # Create a temporary graph from regular datasets to use for manual task dependency resolution
+                temp_dataset_graph = DatasetGraph(*dataset_graphs)
+
                 # Add manual task artificial graphs to dataset graphs
-                manual_task_graphs = create_manual_task_artificial_graphs(session)
+                manual_task_graphs = create_manual_task_artificial_graphs(
+                    session, temp_dataset_graph
+                )
                 dataset_graphs.extend(manual_task_graphs)
 
                 dataset_graph = DatasetGraph(*dataset_graphs)

--- a/tests/api/task/manual/test_manual_task_utils.py
+++ b/tests/api/task/manual/test_manual_task_utils.py
@@ -1,0 +1,222 @@
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from fides.api.graph.config import CollectionAddress
+from fides.api.models.connectionconfig import (
+    AccessLevel,
+    ConnectionConfig,
+    ConnectionType,
+)
+from fides.api.models.manual_task import ManualTask
+from fides.api.models.manual_task.conditional_dependency import (
+    ManualTaskConditionalDependency,
+    ManualTaskConditionalDependencyType,
+)
+from fides.api.task.manual.manual_task_address import ManualTaskAddress
+from fides.api.task.manual.manual_task_utils import create_manual_task_artificial_graphs
+
+
+class TestManualTaskUtilsConditionalDependencies:
+    """Test manual task utils functionality with conditional dependencies"""
+
+    @pytest.mark.usefixtures("connection_with_manual_access_task", "condition_gt_18")
+    def test_manual_task_dependencies_on_regular_tasks(
+        self, db: Session, connection_with_manual_access_task, mock_dataset_graph
+    ):
+        """Test that manual tasks establish dependencies on regular tasks when conditional dependencies reference their fields"""
+        connection_config, manual_task, _, _ = connection_with_manual_access_task
+
+        # Create artificial graphs with the mock dataset graph
+        graphs = create_manual_task_artificial_graphs(db, mock_dataset_graph)
+
+        # Should have one graph for the manual task
+        assert len(graphs) == 1
+
+        graph = graphs[0]
+
+        # Should have one collection per manual task
+        assert len(graph.collections) == 1
+
+        collection = graph.collections[0]
+
+        # Verify that the collection has dependencies on regular tasks
+        # The condition_gt_18 fixture references "user.profile.age" which should
+        # create a dependency on the "customer" collection from "postgres_example"
+        assert len(collection.after) > 0
+
+        # Check that the dependency includes the expected collection
+        expected_dependency = CollectionAddress("postgres_example", "customer")
+        assert expected_dependency in collection.after
+
+        # Verify the collection name uses the standard manual data collection name
+        expected_collection_name = "manual_data"
+        assert collection.name == expected_collection_name
+
+    @pytest.mark.usefixtures("connection_with_manual_access_task", "group_condition")
+    def test_manual_task_dependencies_from_group_conditions(
+        self, db: Session, connection_with_manual_access_task, mock_dataset_graph
+    ):
+        """Test that manual tasks establish dependencies from group conditional dependencies"""
+        connection_config, manual_task, _, _ = connection_with_manual_access_task
+
+        # Create artificial graphs with the mock dataset graph
+        graphs = create_manual_task_artificial_graphs(db, mock_dataset_graph)
+
+        # Should have one graph for the manual task
+        assert len(graphs) == 1
+
+        graph = graphs[0]
+
+        # Should have one collection per manual task
+        assert len(graph.collections) == 1
+
+        collection = graph.collections[0]
+
+        # Verify that the collection has dependencies on regular tasks
+        # The group_condition fixture references both "user.profile.age" and "billing.subscription.status"
+        # which should create dependencies on both "customer" and "payment_card" collections
+        assert len(collection.after) >= 2
+
+        # Check that the dependencies include the expected collections
+        expected_dependencies = {
+            CollectionAddress("postgres_example", "customer"),
+            CollectionAddress("postgres_example", "payment_card"),
+        }
+        assert expected_dependencies.issubset(collection.after)
+
+        # Verify the collection name uses the standard manual data collection name
+        expected_collection_name = "manual_data"
+        assert collection.name == expected_collection_name
+
+    @pytest.mark.usefixtures(
+        "connection_with_manual_access_task", "nested_group_condition"
+    )
+    def test_conditional_dependency_nested_group_fields_extraction(
+        self,
+        db: Session,
+        mock_dataset_graph,
+    ):
+        """Test that field addresses are extracted from nested group conditional dependencies"""
+
+        # Create artificial graphs with the mock dataset graph
+        graphs = create_manual_task_artificial_graphs(db, mock_dataset_graph)
+
+        # Should have one graph for the manual task
+        assert len(graphs) == 1
+
+        graph = graphs[0]
+        collection = graph.collections[0]
+
+        # Verify that field addresses from nested group children are included
+        field_names = [field.name for field in collection.fields]
+
+        # Should include conditional dependency fields from nested group children
+        assert "role" in field_names  # from "user.role"
+        assert "age" in field_names  # from "user.profile.age"
+        assert "status" in field_names  # from "billing.subscription.status"
+
+    @pytest.mark.usefixtures(
+        "connection_with_manual_access_task", "condition_gt_18", "condition_age_lt_65"
+    )
+    def test_no_duplicate_fields_from_conditional_dependencies(
+        self, db: Session, manual_task: ManualTask
+    ):
+        """Test that duplicate field addresses don't create duplicate fields"""
+
+        # Create artificial graphs
+        graphs = create_manual_task_artificial_graphs(db)
+
+        # Should have one graph for the manual task
+        assert len(graphs) == 1
+
+        graph = graphs[0]
+        collection = graph.collections[0]
+
+        # Verify that only one field is created for the duplicate field_address
+        field_names = [field.name for field in collection.fields]
+        age_fields = [name for name in field_names if name == "age"]
+
+        assert len(age_fields) == 1  # Should only have one "age" field
+
+    @pytest.mark.usefixtures("connection_with_manual_access_task")
+    def test_multiple_manual_tasks_get_separate_collections(
+        self, db: Session, connection_with_manual_access_task, mock_dataset_graph
+    ):
+        """Test that multiple manual tasks get separate collections with their own dependencies"""
+        connection_config, manual_task, _, _ = connection_with_manual_access_task
+
+        # Create a second connection config and manual task
+        second_connection_config = ConnectionConfig.create(
+            db=db,
+            data={
+                "name": "Second Manual Task Connection",
+                "key": f"manual_second_{uuid.uuid4()}",
+                "connection_type": ConnectionType.manual_task,
+                "access": AccessLevel.write,
+            },
+        )
+
+        # Create a second manual task with different conditional dependencies
+        second_manual_task = ManualTask.create(
+            db=db,
+            data={
+                "task_type": "privacy_request",
+                "parent_entity_id": second_connection_config.id,
+                "parent_entity_type": "connection_config",
+            },
+        )
+
+        # Add a conditional dependency to the second task
+        ManualTaskConditionalDependency.create(
+            db=db,
+            data={
+                "manual_task_id": second_manual_task.id,
+                "condition_type": ManualTaskConditionalDependencyType.leaf,
+                "field_address": "billing.subscription.status",
+                "operator": "eq",
+                "value": "active",
+                "sort_order": 1,
+            },
+        )
+
+        try:
+            # Create artificial graphs with the mock dataset graph
+            graphs = create_manual_task_artificial_graphs(db, mock_dataset_graph)
+
+            # Should have two graphs (one for each connection config)
+            assert len(graphs) == 2
+
+            # Find the graphs for each connection
+            first_graph = next(g for g in graphs if g.name == connection_config.key)
+            second_graph = next(
+                g for g in graphs if g.name == second_connection_config.key
+            )
+
+            # Each graph should have one collection
+            assert len(first_graph.collections) == 1
+            assert len(second_graph.collections) == 1
+
+            # Verify each collection has the correct name and dependencies
+            first_collection = first_graph.collections[0]
+            second_collection = second_graph.collections[0]
+
+            # Since we use 1:1 relationship, both collections use the same standard name
+            expected_collection_name = "manual_data"
+
+            assert first_collection.name == expected_collection_name
+            assert second_collection.name == expected_collection_name
+
+            # First task has no conditional dependencies, so no dependencies
+            assert len(first_collection.after) == 0
+
+            # Second task has conditional dependency on billing.subscription.status, so depends on payment_card
+            assert len(second_collection.after) == 1
+            expected_dependency = CollectionAddress("postgres_example", "payment_card")
+            assert expected_dependency in second_collection.after
+
+        finally:
+            # Clean up
+            second_manual_task.delete(db)
+            second_connection_config.delete(db)


### PR DESCRIPTION
Closes [ENG-984](https://ethyca.atlassian.net/browse/ENG-984?atlOrigin=eyJpIjoiZWJmNzFmOGQ0OTllNDc1NzkxYTgwMWM3OGM0YWY2YjEiLCJwIjoiaiJ9)


### Description Of Changes

This PR implements manual task input dependencies as scalar field references for access and erasure manual graph tasks. The result is that manual tasks are now able to receive data from upstream regular tasks based on conditional dependencies.

**Key Features Implemented**

- Conditional Dependency Field Resolution
Manual tasks can now reference fields from regular tasks through conditional dependencies
Field addresses like "user.profile.age" or "billing.subscription.status" are automatically resolved to their source collections
The system creates proper dependencies so manual tasks execute after the regular tasks that provide the required data

- Dynamic Collection Creation with Dependencies
Manual task collections are now created with after dependencies based on their conditional dependencies
Each manual task gets its own collection with fields that include both:
Regular manual task fields (from ManualTaskConfigFields)
Scalar fields derived from conditional dependency field addresses

- Graph Traversal Integration
Manual tasks are properly integrated into the graph traversal system
Dependencies are resolved at graph creation time using the actual dataset graph
ROOT edges are created to ensure manual tasks can execute, plus edges to dependency nodes

- Enhanced Test Coverage
  - Tests for: 
Conditional dependency field extraction
Group and nested group conditional dependencies
Multiple manual tasks with different dependencies
Traversal execution order validation
Integration tests with real graph execution

**Technical Implementation Details**

- Graph Traversal Changes:
Modified BaseTraversal to handle manual task dependencies properly
Added logic to create edges from ROOT to dependency nodes
Ensured manual tasks execute after their dependencies

- Request Runner Integration:
Updated run_privacy_request() to pass the dataset graph to manual task graph creation
This enables dependency resolution during privacy request execution

**Benefits**
Data Flow: Manual tasks can now receive and use data from upstream regular tasks
Conditional Logic: Manual tasks can be conditionally executed based on data from other tasks
Execution Order: Proper dependency management ensures correct execution order
Scalability: Multiple manual tasks can have different dependencies without conflicts
Backward Compatibility: Existing manual tasks without dependencies continue to work
This implementation enables sophisticated privacy request workflows where manual tasks can make decisions based on data retrieved by automated tasks, creating a more integrated and intelligent privacy request processing system.

* create_collection_for_connection_key() - Creates collections with dependencies
* _find_collections_for_conditional_dependencies() - Resolves field addresses to collections
* _get_collection_for_field_address() - Maps field addresses to collection addresses
* Enhanced create_manual_task_artificial_graphs() - Now accepts dataset graph for dependency resolution
* Added many tests

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
