### PR TITLE
fix fides debugger errors in privacy center

### DIFF
--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -41,7 +41,7 @@ const preactAliases = {
   ],
 };
 
-const fidesScriptPlugins = () => [
+const fidesScriptPlugins = (stripDebugger = false) => [
   alias(preactAliases),
   nodeResolve(),
   commonjs(),
@@ -51,7 +51,7 @@ const fidesScriptPlugins = () => [
   }),
   esbuild(),
   !IS_DEV && !IS_TEST && jsxRemoveAttributes(), // removes `data-testid`
-  !IS_DEV &&
+  (!IS_DEV || stripDebugger) &&
     strip({
       include: ["**/*.ts", "**/*.tsx"],
       functions: ["fidesDebugger"],
@@ -181,7 +181,7 @@ SCRIPTS.forEach(({ name, gzipErrorSizeKb, gzipWarnSizeKb, isExtension }) => {
   };
   const mjs = {
     input: `src/${name}.ts`,
-    plugins: fidesScriptPlugins(),
+    plugins: fidesScriptPlugins(true),
     output: [
       {
         // Compatible with ES module imports. Apps in this repo may be able to share the code.

--- a/clients/privacy-center/next.config.js
+++ b/clients/privacy-center/next.config.js
@@ -1,12 +1,3 @@
-const isDebugMode = process.env.FIDES_PRIVACY_CENTER__DEBUG === "true";
-const debugMarker = "=>";
-globalThis.fidesDebugger = isDebugMode
-  ? (...args) => console.log(`\x1b[33m${debugMarker}\x1b[0m`, ...args)
-  : () => {};
-globalThis.fidesError = isDebugMode
-  ? (...args) => console.log(`\x1b[31m${debugMarker}\x1b[0m`, ...args)
-  : () => {};
-
 const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
 });


### PR DESCRIPTION
Closes [ENG-1059]

### Description Of Changes

Always strips `fidesDebugger` from module exports

### Steps to Confirm

1. Run `turbo dev` from `/clients` directory with both `FIDES_PRIVACY_CENTER__IS_GEOLOCATION_ENABLED=true` and `FIDES_PRIVACY_CENTER__GEOLOCATION_API_URL=https://cdn-api.ethyca.com/location` environment variables in `clients/privacy-center/.env`
2. Load http://localhost:3001/ and ensure there are no errors.
