### PR TITLE
Adding missing non-KMS S3 test case

### DIFF
--- a/tests/ops/service/storage/test_s3.py
+++ b/tests/ops/service/storage/test_s3.py
@@ -868,3 +868,76 @@ def test_s3_signature_version_4(
         response.status_code == 200
     ), "URL with signature v4 must work for KMS objects"
     assert response.content == test_content
+
+
+@pytest.mark.integration_external
+def test_s3_signature_version_4_non_kms(
+    aws_credentials, regular_s3_bucket, test_object_key
+):
+    """
+    Test that signature version 4 works correctly with non-KMS S3 buckets.
+
+    Validates that:
+    1. Presigned URLs work with signature version 4 on regular buckets
+    2. Our s3_client maintains backward compatibility with non-KMS buckets
+    """
+    test_content = b"Test content for non-KMS signature version validation"
+
+    # Upload test object without KMS encryption
+    standard_client = boto3.client(
+        "s3",
+        aws_access_key_id=aws_credentials["aws_access_key_id"],
+        aws_secret_access_key=aws_credentials["aws_secret_access_key"],
+        region_name=aws_credentials["region"],
+    )
+
+    standard_client.put_object(
+        Bucket=regular_s3_bucket,
+        Key=test_object_key,
+        Body=test_content,
+    )
+
+    # Test using our S3 client with signature version 4
+    storage_secrets = {
+        StorageSecrets.AWS_ACCESS_KEY_ID.value: aws_credentials["aws_access_key_id"],
+        StorageSecrets.AWS_SECRET_ACCESS_KEY.value: aws_credentials[
+            "aws_secret_access_key"
+        ],
+        "region_name": aws_credentials["region"],
+    }
+
+    s3_client = get_s3_client(
+        auth_method=AWSAuthMethod.SECRET_KEYS.value, storage_secrets=storage_secrets
+    )
+
+    # Verify client uses signature version 4
+    assert s3_client.meta.config.signature_version == "s3v4"
+
+    # Generate presigned URL with v4 for non-KMS bucket (should work)
+    presigned_url = s3_client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": regular_s3_bucket, "Key": test_object_key},
+        ExpiresIn=3600,
+    )
+
+    # Verify URL works for non-KMS bucket
+    response = requests.get(presigned_url, timeout=10)
+    assert (
+        response.status_code == 200
+    ), "URL with signature v4 must work for non-KMS objects"
+    assert response.content == test_content
+
+    # Test that signature v4 maintains compatibility by also testing
+    # with standard client (which defaults to different signature version)
+    standard_presigned_url = standard_client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": regular_s3_bucket, "Key": test_object_key},
+        ExpiresIn=3600,
+    )
+
+    # Verify both URLs work for non-KMS bucket
+    response_standard = requests.get(standard_presigned_url, timeout=10)
+    assert (
+        response_standard.status_code == 200
+    ), "Standard client URL should work for non-KMS objects"
+    assert response_standard.content == test_content


### PR DESCRIPTION
### Description Of Changes

Adding a missing test case to make sure non-KMS S3 buckets work with the new signature v4

### Steps to Confirm

1.  Tests should pass

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
