### PR TITLE
Adding missing table detection for erasures

### DIFF
--- a/qa/scenarios/bigquery_table_not_found.py
+++ b/qa/scenarios/bigquery_table_not_found.py
@@ -232,6 +232,24 @@ class BigQueryTableNotFound(QATestScenario):
                 elif key == 'field' and old_table and new_table and isinstance(value, str) and value.startswith(f"{old_table}."):
                     # Update field references like "customer.id" to "customer_missing.id"
                     result[key] = value.replace(f"{old_table}.", f"{new_table}.")
+                elif key == "erase_after" and isinstance(value, list):
+                    # Update erase_after references like ["bigquery_example_test_dataset.employee"]
+                    updated_erase_after = []
+                    for item in value:
+                        if isinstance(item, str) and item.startswith(f"{old_dataset}."):
+                            updated_item = item.replace(
+                                f"{old_dataset}.", f"{new_dataset}."
+                            )
+                            # Also update table references if needed
+                            if old_table and new_table:
+                                updated_item = updated_item.replace(
+                                    f"{new_dataset}.{old_table}",
+                                    f"{new_dataset}.{new_table}",
+                                )
+                            updated_erase_after.append(updated_item)
+                        else:
+                            updated_erase_after.append(item)
+                    result[key] = updated_erase_after
                 else:
                     result[key] = self._deep_copy_and_update_references(value, old_dataset, new_dataset, old_table, new_table)
             return result

--- a/tests/ops/service/privacy_request/test_bigquery_privacy_requests.py
+++ b/tests/ops/service/privacy_request/test_bigquery_privacy_requests.py
@@ -3,6 +3,7 @@ import pytest
 from fides.api.models.privacy_request import ExecutionLog
 from fides.api.models.privacy_request.privacy_request import PrivacyRequest
 from fides.api.models.worker_task import ExecutionLogStatus
+from fides.api.schemas.policy import ActionType
 from tests.ops.service.privacy_request.test_request_runner_service import (
     PRIVACY_REQUEST_TASK_TIMEOUT_EXTERNAL,
     get_privacy_request_results,
@@ -271,3 +272,133 @@ def test_bigquery_missing_tables_handling(
     assert log.message and any(
         keyword in log.message.lower() for keyword in ["not found", "missing", scenario]
     ), f"Expected message about missing table, got: {log.message}"
+
+
+@pytest.mark.integration_external
+@pytest.mark.integration_bigquery
+@pytest.mark.parametrize("dsr_version", ["use_dsr_2_0", "use_dsr_3_0"])
+def test_bigquery_missing_tables_handling_erasure_leaf_collection(
+    db,
+    erasure_policy,
+    dsr_version,
+    request,
+    bigquery_missing_table_resources,
+    run_privacy_request_task,
+):
+    """
+    Test BigQuery missing table handling during erasure operations for leaf collections:
+    - Missing leaf collections complete successfully during access (skipped gracefully)
+    - Erasure then runs normally and completes successfully
+    """
+    request.getfixturevalue(dsr_version)
+
+    # Get dataset config for customer_profile (leaf collection)
+    dataset_config = request.getfixturevalue("bigquery_missing_customer_profile_config")
+    missing_collection_key = f"{dataset_config.fides_key}:customer_profile_missing"
+
+    # Create privacy request with erasure policy
+    data = {
+        "requested_at": "2021-08-30T16:09:37.359Z",
+        "policy_key": erasure_policy.key,
+        "identity": {"email": bigquery_missing_table_resources["email"]},
+    }
+
+    # Execute request - should complete successfully
+    pr = get_privacy_request_results(
+        db,
+        erasure_policy,
+        run_privacy_request_task,
+        data,
+        task_timeout=PRIVACY_REQUEST_TASK_TIMEOUT_EXTERNAL,
+    )
+
+    # Verify execution logs for erasure operations only
+    execution_logs = (
+        db.query(ExecutionLog)
+        .filter_by(privacy_request_id=pr.id, action_type=ActionType.erasure)
+        .all()
+    )
+
+    # Find logs for the missing collection
+    missing_collection_logs = [
+        log
+        for log in execution_logs
+        if f"{log.dataset_name}:{log.collection_name}" == missing_collection_key
+    ]
+
+    # Verify erasure completed successfully for the leaf collection
+    assert (
+        missing_collection_logs
+    ), f"No erasure logs found for {missing_collection_key}"
+
+    complete_logs = [
+        log
+        for log in missing_collection_logs
+        if log.status == ExecutionLogStatus.complete
+    ]
+    assert (
+        complete_logs
+    ), f"Expected erasure to complete successfully for leaf collection"
+
+
+@pytest.mark.integration_external
+@pytest.mark.integration_bigquery
+@pytest.mark.parametrize("dsr_version", ["use_dsr_2_0", "use_dsr_3_0"])
+def test_bigquery_missing_tables_handling_erasure_dependency_collection(
+    db,
+    erasure_policy,
+    dsr_version,
+    request,
+    bigquery_missing_table_resources,
+    run_privacy_request_task,
+):
+    """
+    Test BigQuery missing table handling during erasure operations for collections with dependencies:
+    - Missing collections with dependencies fail during access (hard error)
+    - Erasure phase never runs for these collections
+    """
+    request.getfixturevalue(dsr_version)
+
+    # Get dataset config for customer (collection with dependencies)
+    dataset_config = request.getfixturevalue("bigquery_missing_customer_config")
+    missing_collection_key = f"{dataset_config.fides_key}:customer_missing"
+
+    # Create privacy request with erasure policy
+    data = {
+        "requested_at": "2021-08-30T16:09:37.359Z",
+        "policy_key": erasure_policy.key,
+        "identity": {"email": bigquery_missing_table_resources["email"]},
+    }
+
+    # Execute request - should fail due to missing dependency collection
+    try:
+        pr = get_privacy_request_results(
+            db,
+            erasure_policy,
+            run_privacy_request_task,
+            data,
+            task_timeout=PRIVACY_REQUEST_TASK_TIMEOUT_EXTERNAL,
+        )
+    except Exception:
+        # For dependency errors, get the most recent privacy request
+        pr = db.query(PrivacyRequest).order_by(PrivacyRequest.created_at.desc()).first()
+
+    # Verify execution logs for erasure operations only
+    execution_logs = (
+        db.query(ExecutionLog)
+        .filter_by(privacy_request_id=pr.id, action_type=ActionType.erasure)
+        .all()
+    )
+
+    # Find logs for the missing collection
+    missing_collection_logs = [
+        log
+        for log in execution_logs
+        if f"{log.dataset_name}:{log.collection_name}" == missing_collection_key
+    ]
+
+    # Verify that erasure never ran for the collection with dependencies
+    # Since access failed, erasure phase should not have been attempted
+    assert (
+        not missing_collection_logs
+    ), f"Erasure should not have run for collection with failed dependencies, but found logs: {missing_collection_logs}"


### PR DESCRIPTION
### Description Of Changes

Continuation of https://github.com/ethyca/fides/pull/6397. 
### Code Changes

* Adding similar missing table checks for `SQLConnector.mask_data`

### Steps to Confirm

1.  Start Fides and the Admin UI
2. Run the `python qa bigquery_table_not_found setup` QA scenario
3. Submit an erasure request for `customer-1@example.com`
4. The request should finish, the `customer_profile` collection should be skipped for the access steps and complete (with 0 results) for the erasure steps
5. Run the `python qa bigquery_table_not_found setup --table customer` QA scenario (note the `customer` param)
6. Submit an erasure request for `customer-1@example.com`
7. Verify the access errors and that the erasure doesn't run

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
