### PR TITLE
Fix default tab not loading with Manual Task integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Developer Experience
 - Switching from Vault to 1password for SaaS test credentials [#6363](https://github.com/ethyca/fides/pull/6363)
 
+### Fixed
+- Fix default tab not being set in the integration detail page for Manual Tasks integrations [#6417](https://github.com/ethyca/fides/pull/6417)
+
+
 ## [2.67.0](https://github.com/ethyca/fides/compare/2.66.2...2.67.0)
 
 ### Added

--- a/clients/admin-ui/src/features/integrations/add-integration/allIntegrationTypes.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/allIntegrationTypes.tsx
@@ -32,7 +32,7 @@ export type IntegrationTypeInfo = {
   description?: ReactNode;
   instructions?: ReactNode;
   tags: string[];
-  enabledFeatures: IntegrationFeatureEnum[];
+  enabledFeatures?: IntegrationFeatureEnum[];
 };
 
 // Define SaaS integrations
@@ -78,7 +78,7 @@ const EMPTY_TYPE = {
   },
   category: ConnectionCategory.DATA_WAREHOUSE,
   tags: [],
-  enabledFeatures: [] as IntegrationFeatureEnum[],
+  enabledFeatures: undefined,
 };
 
 const getIntegrationTypeInfo = (

--- a/clients/admin-ui/src/features/integrations/hooks/useFeatureBasedTabs.tsx
+++ b/clients/admin-ui/src/features/integrations/hooks/useFeatureBasedTabs.tsx
@@ -1,0 +1,191 @@
+import {
+  AntButton as Button,
+  AntTabsProps as TabsProps,
+  Box,
+  Flex,
+  Spacer,
+  useDisclosure,
+} from "fidesui";
+import { useMemo } from "react";
+
+import MonitorConfigTab from "~/features/integrations/configure-monitor/MonitorConfigTab";
+import DatahubDataSyncTab from "~/features/integrations/configure-scan/DatahubDataSyncTab";
+import TaskConfigTab from "~/features/integrations/configure-tasks/TaskConfigTab";
+import ConfigureIntegrationModal from "~/features/integrations/ConfigureIntegrationModal";
+import ConnectionStatusNotice, {
+  ConnectionStatusData,
+} from "~/features/integrations/ConnectionStatusNotice";
+import { IntegrationFeatureEnum } from "~/features/integrations/IntegrationFeatureEnum";
+import { ConnectionSystemTypeMap } from "~/types/api";
+
+interface UseFeatureBasedTabsProps {
+  connection: any;
+  enabledFeatures?: IntegrationFeatureEnum[];
+  integrationOption?: ConnectionSystemTypeMap;
+  testData: ConnectionStatusData;
+  needsAuthorization: boolean;
+  handleAuthorize: () => void;
+  testConnection: () => void;
+  testIsLoading: boolean;
+  description?: React.ReactNode;
+  overview?: React.ReactNode;
+  instructions?: React.ReactNode;
+  supportsConnectionTest: boolean;
+}
+
+export const useFeatureBasedTabs = ({
+  connection,
+  enabledFeatures,
+  integrationOption,
+  testData,
+  needsAuthorization,
+  handleAuthorize,
+  testConnection,
+  testIsLoading,
+  description,
+  overview,
+  instructions,
+  supportsConnectionTest,
+}: UseFeatureBasedTabsProps) => {
+  const { onOpen, isOpen, onClose } = useDisclosure();
+
+  const tabs = useMemo(() => {
+    // Don't show tabs until enabledFeatures is loaded
+    if (!enabledFeatures) {
+      return [];
+    }
+    const tabItems: TabsProps["items"] = [];
+
+    // Show Details tab for integrations without connection, Connection tab for others
+    if (enabledFeatures?.includes(IntegrationFeatureEnum.WITHOUT_CONNECTION)) {
+      tabItems.push({
+        label: "Details",
+        key: "details",
+        children: (
+          <Box>
+            <Flex>
+              <Button onClick={onOpen} data-testid="manage-btn">
+                Edit integration
+              </Button>
+            </Flex>
+
+            <ConfigureIntegrationModal
+              isOpen={isOpen}
+              onClose={onClose}
+              connection={connection!}
+              description={description}
+            />
+            {overview}
+            {instructions}
+          </Box>
+        ),
+      });
+    } else {
+      tabItems.push({
+        label: "Connection",
+        key: "connection",
+        children: (
+          <Box>
+            {supportsConnectionTest && (
+              <Flex
+                borderRadius="md"
+                outline="1px solid"
+                outlineColor="gray.100"
+                align="center"
+                p={3}
+              >
+                <Flex flexDirection="column">
+                  <ConnectionStatusNotice
+                    testData={testData}
+                    connectionOption={integrationOption}
+                  />
+                </Flex>
+                <Spacer />
+                <div className="flex gap-4">
+                  {needsAuthorization && (
+                    <Button
+                      onClick={handleAuthorize}
+                      data-testid="authorize-integration-btn"
+                    >
+                      Authorize integration
+                    </Button>
+                  )}
+                  {!needsAuthorization && (
+                    <Button
+                      onClick={testConnection}
+                      loading={testIsLoading}
+                      data-testid="test-connection-btn"
+                    >
+                      Test connection
+                    </Button>
+                  )}
+                  <Button onClick={onOpen} data-testid="manage-btn">
+                    Manage
+                  </Button>
+                </div>
+              </Flex>
+            )}
+            <ConfigureIntegrationModal
+              isOpen={isOpen}
+              onClose={onClose}
+              connection={connection!}
+              description={description}
+            />
+            {overview}
+            {instructions}
+          </Box>
+        ),
+      });
+    }
+
+    // Add conditional tabs based on enabled features
+    if (enabledFeatures?.includes(IntegrationFeatureEnum.DATA_SYNC)) {
+      tabItems.push({
+        label: "Data sync",
+        key: "data-sync",
+        children: <DatahubDataSyncTab integration={connection!} />,
+      });
+    }
+
+    if (enabledFeatures?.includes(IntegrationFeatureEnum.DATA_DISCOVERY)) {
+      tabItems.push({
+        label: "Data discovery",
+        key: "data-discovery",
+        children: (
+          <MonitorConfigTab
+            integration={connection!}
+            integrationOption={integrationOption}
+          />
+        ),
+      });
+    }
+
+    if (enabledFeatures?.includes(IntegrationFeatureEnum.TASKS)) {
+      tabItems.push({
+        label: "Manual tasks",
+        key: "manual-tasks",
+        children: <TaskConfigTab integration={connection!} />,
+      });
+    }
+
+    return tabItems;
+  }, [
+    connection,
+    enabledFeatures,
+    integrationOption,
+    testData,
+    needsAuthorization,
+    handleAuthorize,
+    testConnection,
+    testIsLoading,
+    onOpen,
+    isOpen,
+    onClose,
+    description,
+    overview,
+    instructions,
+    supportsConnectionTest,
+  ]);
+
+  return tabs;
+};

--- a/clients/admin-ui/src/pages/integrations/[id].tsx
+++ b/clients/admin-ui/src/pages/integrations/[id].tsx
@@ -81,8 +81,6 @@ const IntegrationDetailView: NextPage = () => {
     supportsConnectionTest,
   });
 
-  console.log("tabs", tabs);
-
   const { activeTab, onTabChange } = useURLHashedTabs({
     tabKeys: tabs.map((tab) => tab.key),
   });

--- a/clients/admin-ui/src/pages/integrations/[id].tsx
+++ b/clients/admin-ui/src/pages/integrations/[id].tsx
@@ -1,14 +1,4 @@
-import {
-  AntButton as Button,
-  AntFlex,
-  AntTabs as Tabs,
-  AntTabsProps as TabsProps,
-  Box,
-  Flex,
-  Spacer,
-  Spinner,
-  useDisclosure,
-} from "fidesui";
+import { AntFlex, AntTabs as Tabs, Spinner } from "fidesui";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 
@@ -21,14 +11,9 @@ import useTestConnection from "~/features/datastore-connections/useTestConnectio
 import getIntegrationTypeInfo, {
   SUPPORTED_INTEGRATIONS,
 } from "~/features/integrations/add-integration/allIntegrationTypes";
-import MonitorConfigTab from "~/features/integrations/configure-monitor/MonitorConfigTab";
-import DatahubDataSyncTab from "~/features/integrations/configure-scan/DatahubDataSyncTab";
-import TaskConfigTab from "~/features/integrations/configure-tasks/TaskConfigTab";
-import ConfigureIntegrationModal from "~/features/integrations/ConfigureIntegrationModal";
-import ConnectionStatusNotice from "~/features/integrations/ConnectionStatusNotice";
+import { useFeatureBasedTabs } from "~/features/integrations/hooks/useFeatureBasedTabs";
 import { useIntegrationAuthorization } from "~/features/integrations/hooks/useIntegrationAuthorization";
 import IntegrationBox from "~/features/integrations/IntegrationBox";
-import { IntegrationFeatureEnum } from "~/features/integrations/IntegrationFeatureEnum";
 import { IntegrationSetupSteps } from "~/features/integrations/setup-steps/IntegrationSetupSteps";
 import { SaasConnectionTypes } from "~/features/integrations/types/SaasConnectionTypes";
 import useIntegrationOption from "~/features/integrations/useIntegrationOption";
@@ -65,8 +50,6 @@ const IntegrationDetailView: NextPage = () => {
     testData,
   });
 
-  const { onOpen, isOpen, onClose } = useDisclosure();
-
   const { overview, instructions, description, enabledFeatures } =
     getIntegrationTypeInfo(
       connection?.connection_type,
@@ -83,118 +66,22 @@ const IntegrationDetailView: NextPage = () => {
   const supportsConnectionTest =
     connection?.connection_type !== ConnectionType.MANUAL_TASK;
 
-  const tabs: TabsProps["items"] = [];
+  const tabs = useFeatureBasedTabs({
+    connection,
+    enabledFeatures,
+    integrationOption,
+    testData,
+    needsAuthorization,
+    handleAuthorize,
+    testConnection,
+    testIsLoading,
+    description,
+    overview,
+    instructions,
+    supportsConnectionTest,
+  });
 
-  // Show Details tab for integrations without connection, Connection tab for others
-  if (enabledFeatures?.includes(IntegrationFeatureEnum.WITHOUT_CONNECTION)) {
-    tabs.push({
-      label: "Details",
-      key: "details",
-      children: (
-        <Box>
-          <Flex>
-            <Button onClick={onOpen} data-testid="manage-btn">
-              Edit integration
-            </Button>
-          </Flex>
-
-          <ConfigureIntegrationModal
-            isOpen={isOpen}
-            onClose={onClose}
-            connection={connection!}
-            description={description}
-          />
-          {overview}
-          {instructions}
-        </Box>
-      ),
-    });
-  } else {
-    tabs.push({
-      label: "Connection",
-      key: "connection",
-      children: (
-        <Box>
-          {supportsConnectionTest && (
-            <Flex
-              borderRadius="md"
-              outline="1px solid"
-              outlineColor="gray.100"
-              align="center"
-              p={3}
-            >
-              <Flex flexDirection="column">
-                <ConnectionStatusNotice
-                  testData={testData}
-                  connectionOption={integrationOption}
-                />
-              </Flex>
-              <Spacer />
-              <div className="flex gap-4">
-                {needsAuthorization && (
-                  <Button
-                    onClick={handleAuthorize}
-                    data-testid="authorize-integration-btn"
-                  >
-                    Authorize integration
-                  </Button>
-                )}
-                {!needsAuthorization && (
-                  <Button
-                    onClick={testConnection}
-                    loading={testIsLoading}
-                    data-testid="test-connection-btn"
-                  >
-                    Test connection
-                  </Button>
-                )}
-                <Button onClick={onOpen} data-testid="manage-btn">
-                  Manage
-                </Button>
-              </div>
-            </Flex>
-          )}
-          <ConfigureIntegrationModal
-            isOpen={isOpen}
-            onClose={onClose}
-            connection={connection!}
-            description={description}
-          />
-          {overview}
-          {instructions}
-        </Box>
-      ),
-    });
-  }
-
-  // Add conditional tabs based on enabled features
-  if (enabledFeatures?.includes(IntegrationFeatureEnum.DATA_SYNC)) {
-    tabs.push({
-      label: "Data sync",
-      key: "data-sync",
-      children: <DatahubDataSyncTab integration={connection!} />,
-    });
-  }
-
-  if (enabledFeatures?.includes(IntegrationFeatureEnum.DATA_DISCOVERY)) {
-    tabs.push({
-      label: "Data discovery",
-      key: "data-discovery",
-      children: (
-        <MonitorConfigTab
-          integration={connection!}
-          integrationOption={integrationOption}
-        />
-      ),
-    });
-  }
-  if (enabledFeatures?.includes(IntegrationFeatureEnum.TASKS)) {
-    tabs.push({
-      label: "Manual tasks",
-      key: "manual-tasks",
-      children: <TaskConfigTab integration={connection!} />,
-    });
-  }
+  console.log("tabs", tabs);
 
   const { activeTab, onTabChange } = useURLHashedTabs({
     tabKeys: tabs.map((tab) => tab.key),


### PR DESCRIPTION
### Description Of Changes

Fixes an issue where if you open the integration detail page for a Manual Task integration, the first tab isn't active and the tab content area is empty.

The issue was caused because during loading the EMPTY_TYPE response was being used and the "Connection" tab is shown. After loading the real integration, the "Details" tab is returned instead, but the "Connection" tab was used already to initialized the state. The solution was to set enabledFeatures to undefined, and don't return the tabs until the real integration enabledFeatures is loaded. 

### Code Changes

* Changed EMPTY_TYPE.enabledFeatures to undefined
* Don't return tabs array until enabledFeatures is fully loaded
* Move tab calculation code to a new useFeatureBasedTabs hook

### Steps to Confirm

1.  Login to admin-ui using the preview link
2. Go to integrations and click on a manual task integration
3. Check the Details tab is active by default and it shows content

(regression)
4. Find any other type of integration and click on it
5. Check the Connection tab is active by default and it shows content

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
