### PR TITLE
ENG-738 - Performance improvements for data detection - bulk insert ancestor links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Changed
 - Replaced some duplicated data formatting functionality with a single utility function. Additional maintainability updates on Manual Tasks. [#6390](https://github.com/ethyca/fides/pull/6390)
+- Refactored ancestor links creation to support bulk creation for multiple staged resources in a single operation [#6426](https://github.com/ethyca/fides/pull/6426)
 
 ### Developer Experience
 - Switching from Vault to 1password for SaaS test credentials [#6363](https://github.com/ethyca/fides/pull/6363)


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/ENG-738

### Description Of Changes

Refactored the `StagedResourceAncestor.create_staged_resource_ancestor_links` method to `create_all_staged_resource_ancestor_links` to improve performance when creating ancestor links for multiple staged resources.

The new method takes a dictionary mapping descendant URNs to sets of ancestor URNs, allowing bulk creation of all ancestor links using **batched database operations** instead of requiring multiple method calls. This approach uses configurable batch sizes to handle large datasets efficiently while avoiding PostgreSQL parameter limits.

### Code Changes

* Renamed `create_staged_resource_ancestor_links` to `create_all_staged_resource_ancestor_links`
* Changed method signature from (db, resource_urn: str, ancestor_urns: Set[str]) to (db, ancestor_links: Dict[str, Set[str]], batch_size: int = 10000)
* Updated method implementation to use batching for efficient bulk inserts
* Added batching logic to handle large datasets without hitting database parameter limits
* Updated unit tests to use the new method signature and test bulk operations

### Steps to Confirm

1. Run the unit tests for `TestStagedResourceAncestorModel` to ensure all functionality works correctly

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
