### PR TITLE
Fix console error when creating new TCF experience

### DIFF
--- a/clients/fides-js/src/fides-preview.ts
+++ b/clients/fides-js/src/fides-preview.ts
@@ -35,7 +35,7 @@ function cleanup(): void {
     currentScript.remove();
     currentScript = null;
     if (window.Fides) {
-      window.Fides.init = () => Promise.resolve();
+      window.Fides = undefined as unknown as FidesGlobal;
     }
   }
   currentMode = null;


### PR DESCRIPTION
Closes [ENG-1124]

### Description Of Changes

Clears out all of `window.Fides` when changing types, not just the init. Now that we have checks in place for loading scripts more than once, this causes problems.

### Steps to Confirm

1. Log in to Admin UI
2. Go to Experiences page
3. Click the “Create new experience” button
4. Change Experience type dropdown to “TCF Overlay”
5. You should see no console error and preview should load

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
