### PR TITLE
Fix small UI bugs in Manual Task config screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Fixed
 - Fixed an issue with the preview while creating a new TCF Experience in the AdminUI [#6428](https://github.com/ethyca/fides/pull/6428)
+- Fixed link in Manage Secure Access modal [#6436](https://github.com/ethyca/fides/pull/6436)
 
 
 ## [2.67.1](https://github.com/ethyca/fides/compare/2.67.0...2.67.1)

--- a/clients/admin-ui/src/features/integrations/configure-tasks/CreateExternalUserModal.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-tasks/CreateExternalUserModal.tsx
@@ -6,9 +6,11 @@ import {
   AntTypography as Typography,
   useToast,
 } from "fidesui";
+import Link from "next/link";
 import { useState } from "react";
 
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
+import { USER_MANAGEMENT_ROUTE } from "~/features/common/nav/routes";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
 
 import { useCreateExternalUserMutation } from "./external-user.slice";
@@ -100,7 +102,7 @@ const CreateExternalUserModal = ({
         <Paragraph type="secondary">
           If you need to create an internal user that can log in to the Fides
           admin interface, please use the{" "}
-          <Typography.Link>Users page</Typography.Link> instead.
+          <Link href={USER_MANAGEMENT_ROUTE}>Users page</Link> instead.
         </Paragraph>
       </div>
 

--- a/clients/admin-ui/src/features/integrations/configure-tasks/TaskConfigTab.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-tasks/TaskConfigTab.tsx
@@ -221,7 +221,6 @@ const TaskConfigTab = ({ integration }: TaskConfigTabProps) => {
 
         <FidesTableV2
           tableInstance={tableInstance}
-          onRowClick={() => {}}
           emptyTableNotice={
             <Box textAlign="center" p={8}>
               <Paragraph type="secondary">


### PR DESCRIPTION
### Description Of Changes
Fixes task table showing you cursor: pointer when they're not clickable. Fixes User link in the Manage Access modal not working.

### Code Changes

* Removed onRowClick
* Added NextLink to the users page

### Steps to Confirm

You can use the preview link: https://fides-plus-nightly-git-eng-1121-ui-bugs-in-manual-a878e1-ethyca.vercel.app/login
with the nightlyBuild credentials for testing.
1.  Login to admin-ui and go to the integrations page
2. Click on a manual task integration and go to the Manual Tasks tab
3. Check if you hover over any row in the manual task table that you don't see a cursor: pointer
4. Open the Manage Secure Access modal
5. Click on the highlighted Users link and check it takes you to the Users Management page

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
