### PR TITLE
FIDES-2059: Resurface TCF Banner on Reject or Dismiss

### DIFF
--- a/clients/fides-js/__tests__/lib/consent-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/consent-utils.test.ts
@@ -345,7 +345,7 @@ describe("shouldResurfaceBanner", () => {
       },
       savedConsent: mockSavedConsent,
       options: {},
-      expected: false,
+      expected: true,
     },
     {
       label: "returns false for modal component",

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -274,9 +274,18 @@ export const shouldResurfaceBanner = (
     if (!!options && isConsentOverride(options)) {
       return false;
     }
+
+    if (
+      cookie.fides_meta.consentMethod === ConsentMethod.DISMISS ||
+      cookie.fides_meta.consentMethod === ConsentMethod.REJECT
+    ) {
+      return true;
+    }
+
     if (experience.meta?.version_hash) {
       return experience.meta.version_hash !== cookie.tcf_version_hash;
     }
+
     return true;
   }
   // Never surface banner for modal-only or headless experiences


### PR DESCRIPTION
Closes [FIDES-2059]

### Description Of Changes

This PR resurfaces the banner after reject or dismiss for TCF experiences. This is for POC purposes only and should be productionized at a later date pending need.

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[FIDES-2059]: https://ethyca.atlassian.net/browse/FIDES-2059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ