### PR TITLE
[ENG-1133] Added privacy center settings to config

### DIFF
--- a/src/fides/config/__init__.py
+++ b/src/fides/config/__init__.py
@@ -29,6 +29,7 @@ from .fides_settings import FidesSettings
 from .helpers import handle_deprecated_env_variables, handle_deprecated_fields
 from .logging_settings import LoggingSettings
 from .notification_settings import NotificationSettings
+from .privacy_center_settings import PrivacyCenterSettings
 from .redis_settings import RedisSettings
 from .security_settings import SecuritySettings
 from .user_settings import UserSettings
@@ -82,6 +83,7 @@ class FidesConfig(FidesSettings):
     logging: LoggingSettings
     notifications: NotificationSettings
     redis: RedisSettings
+    privacy_center: PrivacyCenterSettings
     security: SecuritySettings
     user: UserSettings
 
@@ -111,6 +113,7 @@ class FidesConfig(FidesSettings):
             self.security,
             self.execution,
             self.admin_ui,
+            self.privacy_center,
         ]:
             for key, value in settings.model_dump(mode="json").items():  # type: ignore
                 log.debug(
@@ -161,6 +164,7 @@ def build_config(config_dict: Dict[str, Any]) -> FidesConfig:
         "execution": ExecutionSettings,
         "logging": LoggingSettings,
         "notifications": NotificationSettings,
+        "privacy_center": PrivacyCenterSettings,
         "redis": RedisSettings,
         "security": SecuritySettings,
         "user": UserSettings,

--- a/src/fides/config/config_proxy.py
+++ b/src/fides/config/config_proxy.py
@@ -90,6 +90,12 @@ class AdminUISettingsProxy(ConfigProxyBase):
     url: SerializeAsAny[Optional[AnyHttpUrlStringRemovesSlash]] = None
 
 
+class PrivacyCenterSettingsProxy(ConfigProxyBase):
+    prefix = "privacy_center"
+
+    url: SerializeAsAny[Optional[AnyHttpUrlStringRemovesSlash]] = None
+
+
 class NotificationSettingsProxy(ConfigProxyBase):
     prefix = "notifications"
 
@@ -177,6 +183,7 @@ class ConfigProxy:
         self.storage = StorageSettingsProxy(db)
         self.security = SecuritySettingsProxy(db)
         self.consent = ConsentSettingsProxy(db)
+        self.privacy_center = PrivacyCenterSettingsProxy(db)
 
     def load_current_cors_domains_into_middleware(self, app: FastAPI) -> None:
         """

--- a/src/fides/config/privacy_center_settings.py
+++ b/src/fides/config/privacy_center_settings.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+from pydantic import Field, SerializeAsAny
+from pydantic_settings import SettingsConfigDict
+
+from fides.api.custom_types import AnyHttpUrlStringRemovesSlash
+
+from .fides_settings import FidesSettings
+
+
+class PrivacyCenterSettings(FidesSettings):
+    """Configuration settings for the Privacy Center."""
+
+    url: SerializeAsAny[Optional[AnyHttpUrlStringRemovesSlash]] = Field(
+        default=None, description="The base URL for the Privacy Center."
+    )
+    model_config = SettingsConfigDict(env_prefix="FIDES__PRIVACY_CENTER__")

--- a/tests/ctl/core/config/test_privacy_center_settings.py
+++ b/tests/ctl/core/config/test_privacy_center_settings.py
@@ -1,0 +1,98 @@
+# pylint: disable=missing-docstring, redefined-outer-name
+import os
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from fides.config import get_config
+from fides.config.privacy_center_settings import PrivacyCenterSettings
+
+REQUIRED_ENV_VARS = {
+    "FIDES__SECURITY__APP_ENCRYPTION_KEY": "OLMkv91j8DHiDAULnK5Lxx3kSCov30b3",
+    "FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID": "fidesadmin",
+    "FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET": "fidesadminsecret",
+    "FIDES__SECURITY__DRP_JWT_SECRET": "secret",
+}
+
+
+@pytest.mark.unit
+class TestPrivacyCenterSettings:
+    """Test class for PrivacyCenterSettings configuration."""
+
+    def test_privacy_center_settings_defaults(self):
+        """Test that PrivacyCenterSettings has correct default values."""
+        settings = PrivacyCenterSettings()
+        assert settings.url is None
+
+    @patch.dict(
+        os.environ,
+        {
+            "FIDES__PRIVACY_CENTER__URL": "https://privacy.example.com/",
+        },
+        clear=True,
+    )
+    def test_privacy_center_settings_from_env(self):
+        """Test PrivacyCenterSettings configuration from environment variables."""
+        settings = PrivacyCenterSettings()
+        assert (
+            str(settings.url) == "https://privacy.example.com"
+        )  # Trailing slash removed
+
+    @patch.dict(
+        os.environ,
+        {
+            "FIDES__PRIVACY_CENTER__URL": "https://privacy.example.com",
+        },
+        clear=True,
+    )
+    def test_privacy_center_settings_url_without_trailing_slash(self):
+        """Test that URL without trailing slash is preserved."""
+        settings = PrivacyCenterSettings()
+        assert str(settings.url) == "https://privacy.example.com"
+
+    def test_privacy_center_settings_invalid_url(self):
+        """Test that invalid URL raises validation error."""
+        with pytest.raises(ValidationError):
+            PrivacyCenterSettings(url="not-a-valid-url")
+
+    @patch.dict(
+        os.environ,
+        {
+            "FIDES__PRIVACY_CENTER__URL": "invalid-url",
+        },
+        clear=True,
+    )
+    def test_privacy_center_settings_invalid_url_from_env(self):
+        """Test that invalid URL from environment raises validation error."""
+        with pytest.raises(ValidationError):
+            PrivacyCenterSettings()
+
+
+@patch.dict(
+    os.environ,
+    {
+        "FIDES__PRIVACY_CENTER__URL": "https://privacy.example.com/",
+        **REQUIRED_ENV_VARS,
+    },
+    clear=True,
+)
+@pytest.mark.unit
+def test_privacy_center_config_integration():
+    """Test that PrivacyCenterSettings integrates correctly with main config system."""
+    config = get_config()
+    assert str(config.privacy_center.url) == "https://privacy.example.com"
+
+
+@patch.dict(
+    os.environ,
+    {
+        **REQUIRED_ENV_VARS,
+    },
+    clear=True,
+)
+@pytest.mark.unit
+def test_privacy_center_config_defaults_in_main_config():
+    """Test that privacy center defaults are correctly set in main config."""
+    config = get_config()
+    assert config.privacy_center.url is None


### PR DESCRIPTION
Closes [ENG-1133](https://ethyca.atlassian.net/browse/ENG-1133?atlOrigin=eyJpIjoiMzk4NzBjNmEzMGU2NGM5MzhiYTBkOWVlNmEzYzZkZjIiLCJwIjoiaiJ9)

### Description Of Changes

This PR introduces a new environment variable `FIDES__PRIVACY_CENTER__URL` to configure the Privacy Center URL in Fides backend configuration. This change allowes us to send communications with the correct url to external respondents.

* New Configuration Class: Added PrivacyCenterSettings with URL field that accepts optional HTTP URLs
* URL Validation: Uses AnyHttpUrlStringRemovesSlash type to ensure proper URL format and automatically remove trailing slashes
* Environment Variable: Supports FIDES__PRIVACY_CENTER__URL environment variable following Fides naming conventions
* Integration: Integrated into the main FidesConfig system alongside other configuration sections

Files Added/Modified:
src/fides/config/privacy_center_settings.py - New configuration class
src/fides/config/__init__.py - Integration with main config system
src/fides/config/config_proxy.py - Added proxy support for Privacy Center settings
tests/ctl/core/config/test_privacy_center_settings.py - Comprehensive test suite

Configuration Usage:
```bash
# Set via environment variable
export FIDES__PRIVACY_CENTER__URL="https://privacy.example.com"

# Or in fides.toml
[privacy_center]
url = "https://privacy.example.com"
```
Code Usage:

```bash
from fides.config import get_config

config = get_config()
privacy_center_url = config.privacy_center.url 
```

### Code Changes

* added new privacy_center_settings.py
* added the PrivacyCenterSettings to config proxy 
* added tests  

### Steps to Confirm

1.  

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
