### PR TITLE
ENG-1128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Replaced some duplicated data formatting functionality with a single utility function. Additional maintainability updates on Manual Tasks. [#6390](https://github.com/ethyca/fides/pull/6390)
 - Refactored ancestor links creation to support bulk creation for multiple staged resources in a single operation [#6426](https://github.com/ethyca/fides/pull/6426)
 - Optimized StagedResource ancestors() and descendants() methods [#6444](https://github.com/ethyca/fides/pull/6444)
+- Data migration to update `.` in `MonitorConfig.key`s to `_` and update all references to these values [#6441](https://github.com/ethyca/fides/pull/6441) https://github.com/ethyca/fides/labels/db-migration
 
 ### Developer Experience
 - Switching from Vault to 1password for SaaS test credentials [#6363](https://github.com/ethyca/fides/pull/6363)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Replaced some duplicated data formatting functionality with a single utility function. Additional maintainability updates on Manual Tasks. [#6390](https://github.com/ethyca/fides/pull/6390)
 - Refactored ancestor links creation to support bulk creation for multiple staged resources in a single operation [#6426](https://github.com/ethyca/fides/pull/6426)
 - Optimized StagedResource ancestors() and descendants() methods [#6444](https://github.com/ethyca/fides/pull/6444)
-- Data migration to update `.` in `MonitorConfig.key`s to `_` and update all references to these values [#6441](https://github.com/ethyca/fides/pull/6441) https://github.com/ethyca/fides/labels/db-migration
+- Data migration to update `.` in `MonitorConfig.key`s to `_` and update all references to these values [#6441](https://github.com/ethyca/fides/pull/6441) https://github.com/ethyca/fides/labels/db-migration https://github.com/ethyca/fides/labels/high-risk
 
 ### Developer Experience
 - Switching from Vault to 1password for SaaS test credentials [#6363](https://github.com/ethyca/fides/pull/6363)

--- a/src/fides/api/alembic/migrations/versions/2f3c1a2d6b10_disallow_dot_in_monitor_key_and_update_refs.py
+++ b/src/fides/api/alembic/migrations/versions/2f3c1a2d6b10_disallow_dot_in_monitor_key_and_update_refs.py
@@ -1,4 +1,15 @@
-"""disallow_dot_in_monitor_key_and_update_refs
+"""
+Disallow dots in monitor keys and update references to monitor keys.
+
+This is a data migration.
+
+This migration does the following:
+- Fetches a mapping of old monitor keys containing '.' to new, safe keys (replace '.' with '_').
+- Persists the mapping into the dbcache table.
+- Drops the FK constraints on the stagedresourceancestor table.
+- Updates the monitorconfig.key, monitorexecution.monitor_config_key, stagedresource.monitor_config_id, stagedresource.urn, stagedresource.parent, stagedresource.children, stagedresource.meta, stagedresourceancestor.ancestor_urn, and stagedresourceancestor.descendant_urn to reference new keys.
+- Recreates the FK constraints on the stagedresourceancestor table.
+- Adds a CHECK constraint to forbid dots in monitorconfig.key going forward.
 
 Revision ID: 2f3c1a2d6b10
 Revises: a7065df4dcf1

--- a/src/fides/api/alembic/migrations/versions/2f3c1a2d6b10_disallow_dot_in_monitor_key_and_update_refs.py
+++ b/src/fides/api/alembic/migrations/versions/2f3c1a2d6b10_disallow_dot_in_monitor_key_and_update_refs.py
@@ -111,7 +111,7 @@ def _update_stagedresource_monitor_config_id(
     logger.info("Finished updating stagedresource monitor_config_id.")
 
 
-def _replace_prefix_sql(prefix_col: str, table: str, column: str) -> str:
+def _replace_prefix_sql(table: str, column: str) -> str:
     """
     Returns SQL snippet to replace leading '<old>.' prefix in a text column with '<new>.' while preserving the rest of the string.
     Assumes parameters :old and :new are bound.
@@ -131,13 +131,9 @@ def _update_stagedresource_urns_and_parent(
     for old, new in mapping.items():
         params = {"old": old, "new": new, "old_prefix": f"{old}.%"}
         # urn
-        conn.execute(
-            sa.text(_replace_prefix_sql("urn", "stagedresource", "urn")), params
-        )
+        conn.execute(sa.text(_replace_prefix_sql("stagedresource", "urn")), params)
         # parent
-        conn.execute(
-            sa.text(_replace_prefix_sql("parent", "stagedresource", "parent")), params
-        )
+        conn.execute(sa.text(_replace_prefix_sql("stagedresource", "parent")), params)
     logger.info("Finished updating stagedresource urns and parent.")
 
 
@@ -207,7 +203,7 @@ def _update_stagedresource_meta_json(conn: Connection, mapping: Dict[str, str]) 
                         CASE WHEN (meta->>'top_level_field_urn') LIKE :old_prefix
                              THEN :new || SUBSTRING((meta->>'top_level_field_urn') FROM CHAR_LENGTH(:old) + 1)
                              ELSE (meta->>'top_level_field_urn') END
-                    ), '{}'::jsonb),
+                    ), 'null'::jsonb),
                     true
                 )
                 WHERE meta ? 'top_level_field_urn'
@@ -225,20 +221,12 @@ def _update_stagedresourceancestor(conn: Connection, mapping: Dict[str, str]) ->
         params = {"old": old, "new": new, "old_prefix": f"{old}.%"}
         # ancestor_urn
         conn.execute(
-            sa.text(
-                _replace_prefix_sql(
-                    "ancestor_urn", "stagedresourceancestor", "ancestor_urn"
-                )
-            ),
+            sa.text(_replace_prefix_sql("stagedresourceancestor", "ancestor_urn")),
             params,
         )
         # descendant_urn
         conn.execute(
-            sa.text(
-                _replace_prefix_sql(
-                    "descendant_urn", "stagedresourceancestor", "descendant_urn"
-                )
-            ),
+            sa.text(_replace_prefix_sql("stagedresourceancestor", "descendant_urn")),
             params,
         )
     logger.info("Finished updating stagedresourceancestor.")

--- a/src/fides/api/alembic/migrations/versions/2f3c1a2d6b10_disallow_dot_in_monitor_key_and_update_refs.py
+++ b/src/fides/api/alembic/migrations/versions/2f3c1a2d6b10_disallow_dot_in_monitor_key_and_update_refs.py
@@ -1,0 +1,221 @@
+"""disallow_dot_in_monitor_key_and_update_refs
+
+Revision ID: 2f3c1a2d6b10
+Revises: a7065df4dcf1
+Create Date: 2025-08-11 00:00:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection
+
+# revision identifiers, used by Alembic.
+revision = "2f3c1a2d6b10"
+down_revision = "a7065df4dcf1"
+branch_labels = None
+depends_on = None
+
+
+def _fetch_monitor_key_mapping(conn: Connection) -> Dict[str, str]:
+    """
+    Build a mapping of old monitor keys containing '.' to new, safe keys (replace '.' with '_').
+    Ensures uniqueness by appending a short numeric suffix when needed.
+    """
+    rows = conn.execute(sa.text("""
+        SELECT key FROM monitorconfig
+    """)).fetchall()
+    existing_keys = {r[0] for r in rows}
+
+    mapping: Dict[str, str] = {}
+    taken: set[str] = set(existing_keys)
+
+    for old_key in sorted(existing_keys):
+        if "." not in old_key:
+            continue
+        base = old_key.replace(".", "_")
+        new_key = base
+        # ensure uniqueness
+        if new_key in taken:
+            i = 1
+            while f"{base}_{i}" in taken:
+                i += 1
+            new_key = f"{base}_{i}"
+        mapping[old_key] = new_key
+        taken.add(new_key)
+    return mapping
+
+
+def _update_monitorconfig_keys(conn: Connection, mapping: Dict[str, str]) -> None:
+    for old, new in mapping.items():
+        conn.execute(
+            sa.text(
+                """
+                UPDATE monitorconfig
+                SET key = :new
+                WHERE key = :old
+                """
+            ),
+            {"old": old, "new": new},
+        )
+
+
+def _update_monitorexecution(conn: Connection, mapping: Dict[str, str]) -> None:
+    for old, new in mapping.items():
+        conn.execute(
+            sa.text(
+                """
+                UPDATE monitorexecution
+                SET monitor_config_key = :new
+                WHERE monitor_config_key = :old
+                """
+            ),
+            {"old": old, "new": new},
+        )
+
+
+def _update_stagedresource_monitor_config_id(conn: Connection, mapping: Dict[str, str]) -> None:
+    for old, new in mapping.items():
+        conn.execute(
+            sa.text(
+                """
+                UPDATE stagedresource
+                SET monitor_config_id = :new
+                WHERE monitor_config_id = :old
+                """
+            ),
+            {"old": old, "new": new},
+        )
+
+
+def _replace_prefix_sql(prefix_col: str, table: str, column: str) -> str:
+    """
+    Returns SQL snippet to replace leading '<old>.' prefix in a text column with '<new>.' while preserving the rest of the string.
+    Assumes parameters :old and :new are bound.
+    """
+    # substring from old prefix length + 1 (since we want to keep the starting '.')
+    return f"""
+        UPDATE {table}
+        SET {column} = :new || SUBSTRING({column} FROM CHAR_LENGTH(:old) + 1)
+        WHERE {column} LIKE :old_prefix
+    """
+
+
+def _update_stagedresource_urns_and_parent(conn: Connection, mapping: Dict[str, str]) -> None:
+    for old, new in mapping.items():
+        params = {"old": old, "new": new, "old_prefix": f"{old}.%"}
+        # urn
+        conn.execute(sa.text(_replace_prefix_sql("urn", "stagedresource", "urn")), params)
+        # parent
+        conn.execute(sa.text(_replace_prefix_sql("parent", "stagedresource", "parent")), params)
+
+
+def _update_stagedresource_children_array(conn: Connection, mapping: Dict[str, str]) -> None:
+    for old, new in mapping.items():
+        conn.execute(
+            sa.text(
+                """
+                UPDATE stagedresource
+                SET children = (
+                    SELECT COALESCE(array_agg(
+                        CASE WHEN val LIKE :old_prefix
+                             THEN :new || SUBSTRING(val FROM CHAR_LENGTH(:old) + 1)
+                             ELSE val END
+                    ), '{}')
+                    FROM unnest(children) AS val
+                )
+                WHERE children IS NOT NULL
+                AND EXISTS (SELECT 1 FROM unnest(children) AS v WHERE v LIKE :old_prefix)
+                """
+            ),
+            {"old": old, "new": new, "old_prefix": f"{old}.%"},
+        )
+
+
+def _update_stagedresource_meta_json(conn: Connection, mapping: Dict[str, str]) -> None:
+    for old, new in mapping.items():
+        params = {"old": old, "new": new, "old_prefix": f"{old}.%"}
+        # Update direct_child_urns array in meta
+        conn.execute(
+            sa.text(
+                """
+                UPDATE stagedresource
+                SET meta = jsonb_set(
+                    meta,
+                    '{direct_child_urns}',
+                    (
+                      SELECT COALESCE(jsonb_agg(
+                        CASE WHEN elem LIKE :old_prefix
+                             THEN to_jsonb(:new || SUBSTRING(elem FROM CHAR_LENGTH(:old) + 1))
+                             ELSE to_jsonb(elem) END
+                      ), '[]'::jsonb)
+                      FROM jsonb_array_elements_text(COALESCE(meta->'direct_child_urns','[]'::jsonb)) AS elem
+                    ),
+                    true
+                )
+                WHERE meta ? 'direct_child_urns'
+                """
+            ),
+            params,
+        )
+        # Update top_level_field_urn string in meta
+        conn.execute(
+            sa.text(
+                """
+                UPDATE stagedresource
+                SET meta = jsonb_set(
+                    meta,
+                    '{top_level_field_urn}',
+                    to_jsonb(
+                        CASE WHEN (meta->>'top_level_field_urn') LIKE :old_prefix
+                             THEN :new || SUBSTRING((meta->>'top_level_field_urn') FROM CHAR_LENGTH(:old) + 1)
+                             ELSE (meta->>'top_level_field_urn') END
+                    ),
+                    true
+                )
+                WHERE meta ? 'top_level_field_urn'
+                """
+            ),
+            params,
+        )
+
+
+def _update_stagedresourceancestor(conn: Connection, mapping: Dict[str, str]) -> None:
+    for old, new in mapping.items():
+        params = {"old": old, "new": new, "old_prefix": f"{old}.%"}
+        # ancestor_urn
+        conn.execute(sa.text(_replace_prefix_sql("ancestor_urn", "stagedresourceancestor", "ancestor_urn")), params)
+        # descendant_urn
+        conn.execute(sa.text(_replace_prefix_sql("descendant_urn", "stagedresourceancestor", "descendant_urn")), params)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    mapping = _fetch_monitor_key_mapping(conn)
+    if mapping:
+        _update_monitorconfig_keys(conn, mapping)
+        _update_monitorexecution(conn, mapping)
+        _update_stagedresource_monitor_config_id(conn, mapping)
+        _update_stagedresource_urns_and_parent(conn, mapping)
+        _update_stagedresource_children_array(conn, mapping)
+        _update_stagedresource_meta_json(conn, mapping)
+        _update_stagedresourceancestor(conn, mapping)
+
+    # Add CHECK constraint to forbid dots in monitorconfig.key going forward
+    op.create_check_constraint(
+        "ck_monitorconfig_key_no_dots",
+        "monitorconfig",
+        "key NOT LIKE '%.%'",
+    )
+
+
+def downgrade() -> None:
+    # Remove the CHECK constraint
+    op.drop_constraint("ck_monitorconfig_key_no_dots", "monitorconfig", type_="check")
+    # Data downgrades are not supported because the original keys are not retained.
+    # This is intentional to keep references consistent.
+    pass

--- a/src/fides/api/alembic/migrations/versions/2f3c1a2d6b10_disallow_dot_in_monitor_key_and_update_refs.py
+++ b/src/fides/api/alembic/migrations/versions/2f3c1a2d6b10_disallow_dot_in_monitor_key_and_update_refs.py
@@ -252,6 +252,9 @@ def upgrade() -> None:
         logger.info("Beginning monitorconfig key 'dot' migration...")
 
         # Persist mapping into dbcache for API retrieval/debugging
+        # NOTE: this mapping is persisted only as a temporary measure (i.e. for a few releases)
+        # just in case we want to revert this data migration for any reason.
+        # TODO: remove the cache entry in a future migration!
         logger.info("Persisting monitor key mapping to dbcache...")
         mapping_json = json.dumps(mapping)
         conn.execute(
@@ -332,6 +335,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     # Remove the CHECK constraint
     op.drop_constraint("ck_monitorconfig_key_no_dots", "monitorconfig", type_="check")
-    # Data downgrades are not supported because the original keys are not retained.
-    # This is intentional to keep references consistent.
+    # Data downgrade left blank intentionally - if needed, we have the old key mapping in
+    # the dbcache entry and a data migration reversal can be written on an adhoc basis.
     pass

--- a/src/fides/api/db/base_class.py
+++ b/src/fides/api/db/base_class.py
@@ -109,6 +109,19 @@ class FidesBase:
         """
         return f"{self.__tablename__}.id"
 
+    @classmethod
+    def sanitize_key(cls: Type[T], proposed_key: str) -> str:
+        """
+        Sanitize the key by removing invalid characters.
+
+        Invalid characters are based on the allowed characters defined in this module.
+        Note that this differs slightly from the allowed characters in `sanitize_fides_key`
+        from `core/utils.py`; specifically, `.` are disallowed (converted to `_`) here, while
+        they are allowed in `sanitize_fides_key`. This is because `.` must be allowed in
+        `fides_key`s (), but they are not allowed in `key`s.
+        """
+        return ALLOWED_CHARS.sub("_", proposed_key)
+
     id = Column(String(255), primary_key=True, index=True, default=generate_uuid)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(
@@ -323,6 +336,7 @@ class OrmWrappedFidesBase(FidesBase):
                 )
 
         return OrmWrappedFidesBase.persist_obj(db, self)
+
 
     @classmethod
     def persist_obj(cls: Type[T], db: Session, resource: T) -> T:

--- a/src/fides/api/db/base_class.py
+++ b/src/fides/api/db/base_class.py
@@ -115,7 +115,7 @@ class FidesBase:
         return f"{self.__tablename__}.id"
 
     @classmethod
-    def sanitize_key(cls: Type[T], proposed_key: str) -> str:
+    def sanitize_key(cls, proposed_key: str) -> str:
         """
         Sanitize the key by removing invalid characters.
 

--- a/src/fides/api/db/base_class.py
+++ b/src/fides/api/db/base_class.py
@@ -123,7 +123,7 @@ class FidesBase:
         Note that this differs slightly from the allowed characters in `sanitize_fides_key`
         from `core/utils.py`; specifically, `.` are disallowed (converted to `_`) here, while
         they are allowed in `sanitize_fides_key`. This is because `.` must be allowed in
-        `fides_key`s (), but they are not allowed in `key`s.
+        `fides_key`s, but they are not allowed in `key`s.
         """
         return DISALLOWED_CHARS.sub("_", proposed_key)
 

--- a/src/fides/api/models/db_cache.py
+++ b/src/fides/api/models/db_cache.py
@@ -14,6 +14,14 @@ class DBCacheNamespace(Enum):
 
     LIST_PRIVACY_EXPERIENCE = "list-privacy-experience"
 
+    # NOTE: monitor config key mapping entry is populated by migration
+    # 2f3c1a2d6b10_disallow_dot_in_monitor_key_and_update_refs as a temporary means of
+    # storing the mapping of 'old' monitor config keys with dots in them
+    # to their new keys without dots.
+    # This is a safety measure, in case we need to revert that data migration for whatever reason.
+    # TODO: remove this cache entry in a future migration.
+    MONITOR_CONFIG_KEY_MAPPING = "monitor-config-key-mapping"
+
 
 class DBCache(Base):
     """

--- a/src/fides/api/models/detection_discovery/core.py
+++ b/src/fides/api/models/detection_discovery/core.py
@@ -9,6 +9,7 @@ from loguru import logger
 from sqlalchemy import (
     ARRAY,
     Boolean,
+    CheckConstraint,
     Column,
     DateTime,
     ForeignKey,
@@ -171,6 +172,10 @@ class MonitorConfig(Base):
     )
 
     shared_config = relationship(SharedMonitorConfig)
+
+    CheckConstraint(  # type: ignore
+        "key NOT LIKE '%.%'", name="ck_monitorconfig_key_no_dots"
+    )
 
     @property
     def classify_params(self) -> dict:

--- a/src/fides/api/models/detection_discovery/core.py
+++ b/src/fides/api/models/detection_discovery/core.py
@@ -23,9 +23,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.future import select
-from sqlalchemy.orm import RelationshipProperty, Session, relationship
+from sqlalchemy.orm import RelationshipProperty, Session, relationship, validates
 from sqlalchemy.orm.query import Query
-from sqlalchemy.orm import validates
 
 from fides.api.db.base_class import Base, FidesBase
 from fides.api.models.connectionconfig import ConnectionConfig

--- a/src/fides/api/models/detection_discovery/core.py
+++ b/src/fides/api/models/detection_discovery/core.py
@@ -173,8 +173,10 @@ class MonitorConfig(Base):
 
     shared_config = relationship(SharedMonitorConfig)
 
-    CheckConstraint(  # type: ignore
-        "key NOT LIKE '%.%'", name="ck_monitorconfig_key_no_dots"
+    __table_args__ = (
+        CheckConstraint(  # type: ignore
+            "key NOT LIKE '%.%'", name="ck_monitorconfig_key_no_dots"
+        ),
     )
 
     @property

--- a/src/fides/api/models/detection_discovery/core.py
+++ b/src/fides/api/models/detection_discovery/core.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.future import select
 from sqlalchemy.orm import RelationshipProperty, Session, relationship
 from sqlalchemy.orm.query import Query
+from sqlalchemy.orm import validates
 
 from fides.api.db.base_class import Base, FidesBase
 from fides.api.models.connectionconfig import ConnectionConfig
@@ -331,6 +332,12 @@ class MonitorConfig(Base):
                 cron_trigger_dict["day"] = execution_start_date.day
                 cron_trigger_dict["month"] = execution_start_date.month
             data["monitor_execution_trigger"] = cron_trigger_dict
+
+    @validates("key")
+    def validate_key_no_dots(self, _key: str, value: str) -> str:
+        if value and "." in value:
+            raise ValueError('MonitorConfig.key cannot contain "." characters')
+        return value
 
 
 class StagedResourceAncestor(Base):


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/ENG-1128

Done alongside https://github.com/ethyca/fidesplus/pull/2417

### Description Of Changes

Adds a new `FidesBase.sanitize_key` classmethod to sanitize a `key` value based on the `ALLOWED_CHARS` specified in the `base_class` module, which is the criteria used when `save`ing a `OrmWrappedFidesBase`. Specifically, this disallows `.` from the `key` value.

Additionally, this PR includes a significant data migration to migrate any `MonitorConfig.key`s  that currently had a `.` in them - the `.` are replaced with `_`, and new conflicts are accounted for by appending an integer as needed. This migration is needed because, before this change, there was a gap in our validation logic that allowed `MonitorConfig`s to be created with these `key`s, which would cause downstream problems. Since we are now _disallowing_  `MonitorConfig.key`s with `.` in them (see https://github.com/ethyca/fidesplus/pull/2417), we need to update any existing `MonitorConfig.key`s with `.` in them, and the many pointers in our DB to these `key` values -- specifically, `StagedResource.urn`s include a `MonitorConfig.key` as their first component, so we need to update these `urn`s and all their references.

We also now include DB-level validation on the `MonitorConfig.key` column, in addition to the API-level validation added in the fidesplus PR referenced above.

NOTE: there is no downgrade migration specified for the data migration here. If we need to revert the data migration for any reason, that will be a manual effort. We've stored the old -> new monitor config key "mapping" in the `DBCache` DB table as an artifact, in case we do need to walk back our steps manually in any case.

### Code Changes

* [x] Add `FidesBase.sanitize_key` classmethod that sanitizes an input value based on the `ALLOWED_CHARS` that determines valid `FidesBase.key`s
* [x] Database validation for `MonitorConfig.key`s to prevent them from containing `.` in their values 
* [x] (Data) migration to update existing `MonitorConfig.key`s that have `.` in them and their many referrences 

### Steps to Confirm

See fidesplus PR for manual testing steps

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [x] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [x] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [x] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
