### PR TITLE
Configure role assumption in create client.

### DIFF
--- a/src/fides/api/tasks/storage.py
+++ b/src/fides/api/tasks/storage.py
@@ -122,9 +122,6 @@ def upload_to_s3(  # pylint: disable=R0913
         s3_client = get_s3_client(
             auth_method,
             storage_secrets,
-            assume_role_arn=CONFIG.credentials.get(  # pylint: disable=no-member
-                "storage", {}
-            ).get("aws_s3_assume_role_arn"),
         )
     except (ClientError, ParamValidationError) as e:
         logger.error(f"Error getting s3 client: {str(e)}")

--- a/src/fides/api/util/aws_util.py
+++ b/src/fides/api/util/aws_util.py
@@ -8,6 +8,8 @@ from loguru import logger
 from fides.api.common_exceptions import StorageUploadError
 from fides.api.schemas.storage.storage import AWSAuthMethod, StorageSecrets
 
+from fides.config import CONFIG
+
 
 def get_aws_session(
     auth_method: str,
@@ -95,10 +97,16 @@ def get_s3_client(
     If an `assume_role_arn` is provided, the secrets will be used to
     assume that role and return a Session instantiated with that role.
     """
+
+    configured_assume_role_arn = CONFIG.credentials.get(
+        "storage", {}
+    ).get(  # pylint: disable=no-member
+        "aws_s3_assume_role_arn"
+    )
     session = get_aws_session(
         auth_method=auth_method,
         storage_secrets=storage_secrets,
-        assume_role_arn=assume_role_arn,
+        assume_role_arn=assume_role_arn or configured_assume_role_arn,
     )
 
     # Configure S3 client to use signature version 4 for KMS compatibility


### PR DESCRIPTION
Closes [ENG-1141]

### Description Of Changes

Configure S3 role assumption in client creation code so that all uses support role assumption.

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
