### PR TITLE
ENG-738 - Update the ancestors and descendants functions to create a single SQL query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Improved data extraction for object fields to return complete data structures instead of empty containers in data package when no nested fields where specified [#6424](https://github.com/ethyca/fides/pull/6424)
 - Replaced some duplicated data formatting functionality with a single utility function. Additional maintainability updates on Manual Tasks. [#6390](https://github.com/ethyca/fides/pull/6390)
 - Refactored ancestor links creation to support bulk creation for multiple staged resources in a single operation [#6426](https://github.com/ethyca/fides/pull/6426)
+- Optimized StagedResource ancestors() and descendants() methods [#6444](https://github.com/ethyca/fides/pull/6444)
 
 ### Developer Experience
 - Switching from Vault to 1password for SaaS test credentials [#6363](https://github.com/ethyca/fides/pull/6363)

--- a/tests/ops/models/detection_discovery/test_core.py
+++ b/tests/ops/models/detection_discovery/test_core.py
@@ -1054,13 +1054,13 @@ class TestStagedResourceAncestorModel:
 
         # Verify relationships
         sr2 = StagedResource.get_urn(db, staged_resource_2.urn)
-        assert len(sr2.ancestors()) == 1
-        assert sr2.ancestors()[0].urn == staged_resource_1.urn
+        assert len(sr2.ancestors(db)) == 1
+        assert sr2.ancestors(db)[0].urn == staged_resource_1.urn
 
         sr3 = StagedResource.get_urn(db, staged_resource_3.urn)
-        assert len(sr3.ancestors()) == 2
+        assert len(sr3.ancestors(db)) == 2
         ancestor_resources_from_descendant = {
-            ancestor.urn for ancestor in sr3.ancestors()
+            ancestor.urn for ancestor in sr3.ancestors(db)
         }
         assert ancestor_resources_from_descendant == {
             staged_resource_1.urn,
@@ -1068,8 +1068,8 @@ class TestStagedResourceAncestorModel:
         }
 
         sr1 = StagedResource.get_urn(db, staged_resource_1.urn)
-        assert len(sr1.descendants()) == 2  # Both resource_2 and resource_3
-        descendant_urns_from_ancestor = {desc.urn for desc in sr1.descendants()}
+        assert len(sr1.descendants(db)) == 2  # Both resource_2 and resource_3
+        descendant_urns_from_ancestor = {desc.urn for desc in sr1.descendants(db)}
         assert descendant_urns_from_ancestor == {
             staged_resource_2.urn,
             staged_resource_3.urn,
@@ -1264,12 +1264,12 @@ class TestStagedResourceAncestorModel:
             .first()
             is not None
         )
-        assert {desc.urn for desc in staged_resource_1.descendants()} == {
+        assert {desc.urn for desc in staged_resource_1.descendants(db)} == {
             descendant_to_delete_urn,
             other_descendant_urn,
         }
-        assert {anc.urn for anc in staged_resource_2.ancestors()} == {ancestor_urn}
-        assert {anc.urn for anc in staged_resource_3.ancestors()} == {ancestor_urn}
+        assert {anc.urn for anc in staged_resource_2.ancestors(db)} == {ancestor_urn}
+        assert {anc.urn for anc in staged_resource_3.ancestors(db)} == {ancestor_urn}
 
         # Delete one descendant resource
         db.delete(staged_resource_2)
@@ -1297,10 +1297,10 @@ class TestStagedResourceAncestorModel:
         db.refresh(staged_resource_3)
 
         # Verify relationships are updated
-        assert {desc.urn for desc in staged_resource_1.descendants()} == {
+        assert {desc.urn for desc in staged_resource_1.descendants(db)} == {
             other_descendant_urn
         }
-        assert {anc.urn for anc in staged_resource_3.ancestors()} == {ancestor_urn}
+        assert {anc.urn for anc in staged_resource_3.ancestors(db)} == {ancestor_urn}
 
     def test_cascade_delete_when_ancestor_is_deleted(
         self,
@@ -1343,14 +1343,14 @@ class TestStagedResourceAncestorModel:
             .first()
             is not None
         )
-        assert {anc.urn for anc in staged_resource_3.ancestors()} == {
+        assert {anc.urn for anc in staged_resource_3.ancestors(db)} == {
             ancestor_to_delete_urn,
             other_ancestor_urn,
         }
-        assert {desc.urn for desc in staged_resource_1.descendants()} == {
+        assert {desc.urn for desc in staged_resource_1.descendants(db)} == {
             descendant_urn
         }
-        assert {desc.urn for desc in staged_resource_2.descendants()} == {
+        assert {desc.urn for desc in staged_resource_2.descendants(db)} == {
             descendant_urn
         }
 
@@ -1380,9 +1380,9 @@ class TestStagedResourceAncestorModel:
         db.refresh(staged_resource_3)
 
         # Verify relationships are updated
-        assert {anc.urn for anc in staged_resource_3.ancestors()} == {
+        assert {anc.urn for anc in staged_resource_3.ancestors(db)} == {
             other_ancestor_urn
         }
-        assert {desc.urn for desc in staged_resource_2.descendants()} == {
+        assert {desc.urn for desc in staged_resource_2.descendants(db)} == {
             descendant_urn
         }


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/ENG-738

### Description Of Changes

This PR optimizes the ancestors() and descendants() methods in the StagedResource model. 

The original implementation relied on SQLAlchemy relationships (self.ancestor_links and self.descendant_links) which could trigger multiple database queries when accessing related objects. The new implementation uses single, explicit SQL queries with joins to fetch all ancestors or descendants in one database roundtrip.

### Code Changes

* Modified StagedResource.ancestors() method to accept a `db: Session` parameter and use explicit SQLAlchemy query with join instead of relationship traversal
* Modified StagedResource.descendants() method to accept a `db: Session` parameter and use explicit SQLAlchemy query with join instead of relationship traversal
* Updated all test calls to pass the database session parameter to the modified methods

### Steps to Confirm

1.  Run the existing tests to ensure all relationship queries still work correctly

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
