### PR TITLE
Fix params getting encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed link in Manage Secure Access modal [#6436](https://github.com/ethyca/fides/pull/6436)
 - Fixed some CI testing gaps [#6419](https://github.com/ethyca/fides/pull/6419)
 - Fixed a bug where providing an invalid `fides_string` as an override caused GPP to fail to initialize [#6452](https://github.com/ethyca/fides/pull/6452)
+- Fixed encoding of privacy request filters and CSV export parameters. [#6449](https://github.com/ethyca/fides/pull/6449)
 
 
 ## [2.67.2](https://github.com/ethyca/fides/compare/2.67.1...2.67.2)

--- a/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -42,36 +42,72 @@ export function mapFiltersToSearchParams({
   verbose,
   sort_direction,
   sort_field,
-}: Partial<PrivacyRequestParams>): any {
-  let fromISO;
+}: Partial<PrivacyRequestParams>): URLSearchParams {
+  let fromISO: Date | undefined;
   if (from) {
     fromISO = new Date(from);
     fromISO.setUTCHours(0, 0, 0);
   }
 
-  let toISO;
+  let toISO: Date | undefined;
   if (to) {
     toISO = new Date(to);
     toISO.setUTCHours(23, 59, 59);
   }
 
-  return {
-    include_identities: "true",
-    include_custom_privacy_request_fields: "true",
-    ...(action_type && action_type.length > 0
-      ? { action_type: action_type.join("&action_type=") }
-      : {}),
-    ...(status && status.length > 0 ? { status: status.join("&status=") } : {}),
-    ...(id ? { request_id: id } : {}),
-    ...(fuzzy_search_str ? { fuzzy_search_str } : {}),
-    ...(fromISO ? { created_gt: fromISO.toISOString() } : {}),
-    ...(toISO ? { created_lt: toISO.toISOString() } : {}),
-    ...(page ? { page: `${page}` } : {}),
-    ...(typeof size !== "undefined" ? { size: `${size}` } : {}),
-    ...(verbose ? { verbose } : {}),
-    ...(sort_direction ? { sort_direction } : {}),
-    ...(sort_field ? { sort_field } : {}),
-  };
+  const params = new URLSearchParams();
+
+  params.set("include_identities", "true");
+  params.set("include_custom_privacy_request_fields", "true");
+
+  if (Array.isArray(action_type) && action_type.length > 0) {
+    action_type.forEach((value) => {
+      params.append("action_type", String(value));
+    });
+  }
+
+  if (Array.isArray(status) && status.length > 0) {
+    status.forEach((value) => {
+      params.append("status", String(value));
+    });
+  }
+
+  if (id) {
+    params.set("request_id", id);
+  }
+
+  if (fuzzy_search_str) {
+    params.set("fuzzy_search_str", fuzzy_search_str);
+  }
+
+  if (fromISO && !Number.isNaN(fromISO.getTime())) {
+    params.set("created_gt", fromISO.toISOString());
+  }
+  if (toISO && !Number.isNaN(toISO.getTime())) {
+    params.set("created_lt", toISO.toISOString());
+  }
+
+  if (page) {
+    params.set("page", `${page}`);
+  }
+
+  if (typeof size !== "undefined") {
+    params.set("size", `${size}`);
+  }
+
+  if (typeof verbose !== "undefined") {
+    params.set("verbose", String(verbose));
+  }
+
+  if (sort_direction) {
+    params.set("sort_direction", sort_direction);
+  }
+
+  if (sort_field) {
+    params.set("sort_field", sort_field);
+  }
+
+  return params;
 }
 
 export const requestCSVDownload = async ({
@@ -86,25 +122,22 @@ export const requestCSVDownload = async ({
     return null;
   }
 
-  return fetch(
-    `${BASE_URL}/privacy-request?${new URLSearchParams({
-      ...mapFiltersToSearchParams({
-        id,
-        from,
-        to,
-        status,
-        action_type,
-      }),
-      download_csv: "true",
-    })}`,
-    {
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        Authorization: `Bearer ${token}`,
-        "X-Fides-Source": "fidesops-admin-ui",
-      },
+  const params = mapFiltersToSearchParams({
+    id,
+    from,
+    to,
+    status,
+    action_type,
+  });
+  params.set("download_csv", "true");
+
+  return fetch(`${BASE_URL}/privacy-request?${params.toString()}`, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      Authorization: `Bearer ${token}`,
+      "X-Fides-Source": "fidesops-admin-ui",
     },
-  )
+  })
     .then(async (response) => {
       if (!response.ok) {
         if (response.status === 400) {
@@ -317,9 +350,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
       Partial<PrivacyRequestParams>
     >({
       query: (filters) => ({
-        url: `privacy-request?${decodeURIComponent(
-          new URLSearchParams(mapFiltersToSearchParams(filters)).toString(),
-        )}`,
+        url: `privacy-request?${mapFiltersToSearchParams(filters).toString()}`,
       }),
       providesTags: () => ["Request"],
       async onQueryStarted(_key, { dispatch, queryFulfilled }) {


### PR DESCRIPTION
Closes [ENG-1151]

### Description Of Changes

Refactored privacy request query parameter construction to use URLSearchParams, ensuring correct encoding and proper handling of repeated parameters. Guarded date filters against invalid values and streamlined CSV download parameter building.

### Code Changes

* Updated `mapFiltersToSearchParams` to return `URLSearchParams` and build params via `params.set/append`, including repeated `action_type` and `status` values
* Added date guards to avoid sending invalid `created_gt/created_lt` values
* Standardized boolean and number param serialization with explicit `String(...)`
* Updated `requestCSVDownload` to reuse the shared param builder and append `download_csv=true`
* Simplified `privacyRequestApi` query URL to use `.toString()` without `decodeURIComponent`

### Steps to Confirm
1. Filter privacy requests with multiple `status` and `action_type` (Request type) values and verify the network request uses repeated `status`/`action_type` params and correct URL encoding
2. Apply a date range and verify `created_gt`/`created_lt` appear, are valid ISO strings, and represent start/end of the selected days (UTC 00:00:00 and 23:59:59)
3. Trigger CSV export and verify `download_csv=true` and the same filters are applied to the CSV request
4. Confirm the privacy requests list loads and paginates correctly with filters applied, with no console or network errors

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1151]: https://ethyca.atlassian.net/browse/ENG-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ