### PR TITLE
Revert tables to use Ant filter icon

### DIFF
--- a/clients/fidesui/src/ant-theme/global.scss
+++ b/clients/fidesui/src/ant-theme/global.scss
@@ -118,15 +118,6 @@ h6 {
 }
 
 /*
-  For the filter icon in the table, we want to highlight the background when it's active
-  This is to make it more visible that the filter is active, given we changed
-  Ant's solid icon with a Carbon icon which has lines.
-*/
-.ant-table-filter-trigger.active {
-  background-color: var(--fidesui-neutral-100);
-}
-
-/*
   This is to match the font size of the table cells when other Ant components are used in a cell component (eg. Text, Link, List, etc.).
 */
 .ant-table-cell * {

--- a/clients/fidesui/src/ant-theme/global.scss
+++ b/clients/fidesui/src/ant-theme/global.scss
@@ -117,6 +117,10 @@ h6 {
   font-weight: 500;
 }
 
+.ant-table-wrapper .ant-table {
+  --ant-table-header-icon-color: var(--fidesui-neutral-300);
+}
+
 /*
   This is to match the font size of the table cells when other Ant components are used in a cell component (eg. Text, Link, List, etc.).
 */

--- a/clients/fidesui/src/hoc/CustomTable.tsx
+++ b/clients/fidesui/src/hoc/CustomTable.tsx
@@ -1,20 +1,8 @@
-import { SettingsAdjust } from "@carbon/icons-react";
 import { TableProps } from "antd/es/table";
 import { Table } from "antd/lib";
 import React from "react";
 
-import palette from "../palette/palette.module.scss";
 import { PAGE_SIZES } from "./CustomPagination";
-
-// Filter icon component for consistent styling
-const FilterIcon = (filtered: boolean) => (
-  <SettingsAdjust
-    style={{
-      color: filtered ? palette.FIDESUI_MINOS : palette.FIDESUI_NEUTRAL_500,
-      width: "14px",
-    }}
-  />
-);
 
 /**
  * Higher-order component that adds consistent styling and enhanced functionality to Ant Design's Table component.
@@ -30,32 +18,11 @@ const FilterIcon = (filtered: boolean) => (
 export const CustomTable = <RecordType = any,>({
   size = "small",
   bordered = true,
-  columns,
   pagination,
   dataSource,
   scroll = { scrollToFirstRowOnChange: true, x: "max-content" },
   ...props
 }: TableProps<RecordType>) => {
-  // Enhance columns with custom filter icon if they have filters
-  const enhancedColumns = React.useMemo(() => {
-    if (!columns) {
-      return columns;
-    }
-
-    return columns.map((column) => {
-      // If column has filters but no custom filterIcon, add our Carbon filter icon
-      if (column.filters && !column.filterIcon) {
-        return {
-          ellipsis: true,
-          filterIcon: FilterIcon,
-          fontSize: "sm",
-          ...column,
-        };
-      }
-      return column;
-    });
-  }, [columns]);
-
   const paginationDefaults = React.useMemo(() => {
     if (pagination === false || !pagination) {
       return pagination;
@@ -75,7 +42,6 @@ export const CustomTable = <RecordType = any,>({
     <Table
       size={size}
       bordered={bordered}
-      columns={enhancedColumns}
       pagination={paginationDefaults}
       dataSource={dataSource}
       scroll={scroll}

--- a/clients/fidesui/src/hoc/CustomTable.tsx
+++ b/clients/fidesui/src/hoc/CustomTable.tsx
@@ -10,7 +10,6 @@ import { PAGE_SIZES } from "./CustomPagination";
  * Default customizations:
  * - Uses "small" size for more compact rows
  * - Enables bordered styling for better visual separation
- * - Uses Carbon SettingsAdjust icon for table column filters
  * - Automatically hides pagination when there's only one page
  * - Uses CustomPagination defaults (showSizeChanger=true, consistent PAGE_SIZES)
  *


### PR DESCRIPTION
Closes [ENG-1101]

### Description Of Changes

Lets use the ANT filter and sort icons, selected state should use minos, default should be neutral-300. These icons are useful and have statefulness which is nice.

### Code Changes

* Remove custom icon from CustomTable
* Set default color to neutral 300

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1101]: https://ethyca.atlassian.net/browse/ENG-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ