### PR TITLE
Fix bug with GPP API not initializing with invalid Fides string override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed an issue with the preview while creating a new TCF Experience in the AdminUI [#6428](https://github.com/ethyca/fides/pull/6428)
 - Fixed link in Manage Secure Access modal [#6436](https://github.com/ethyca/fides/pull/6436)
 - Fixed some CI testing gaps [#6419](https://github.com/ethyca/fides/pull/6419)
+- Fixed a bug where providing an invalid `fides_string` as an override caused GPP to fail to initialize [#6452](https://github.com/ethyca/fides/pull/6452)
 
 
 ## [2.67.2](https://github.com/ethyca/fides/compare/2.67.1...2.67.2)

--- a/clients/fides-js/src/lib/gpp/string-to-consent.ts
+++ b/clients/fides-js/src/lib/gpp/string-to-consent.ts
@@ -199,14 +199,14 @@ export const fidesStringToConsent = ({
 }: FidesStringToConsentArgs) => {
   const { gpp: gppString }: DecodedFidesString = decodeFidesString(fidesString);
 
+  if (!fidesString || !gppString || !cmpApi) {
+    return;
+  }
+
   if (!isValidGppStringFormat(gppString)) {
     fidesDebugger(
       "GPP: Invalid GPP string format, skipping consent processing",
     );
-    return;
-  }
-
-  if (!fidesString || !gppString || !cmpApi) {
     return;
   }
 

--- a/clients/fides-js/src/lib/gpp/string-to-consent.ts
+++ b/clients/fides-js/src/lib/gpp/string-to-consent.ts
@@ -163,6 +163,21 @@ interface FidesStringToConsentArgs {
 }
 
 /**
+ * Basic validation of GPP string format without creating CMP API instances
+ * This prevents side effects when validating invalid strings
+ */
+const isValidGppStringFormat = (gppString: string): boolean => {
+  if (!gppString || typeof gppString !== "string") {
+    return false;
+  }
+
+  // GPP strings should contain valid characters and follow the expected format
+  // Basic pattern: starts with "DB" followed by alphanumeric characters, tildes, and dots
+  const gppPattern = /^DB[A-Za-z0-9~.]+$/;
+  return gppPattern.test(gppString);
+};
+
+/**
  * Converts a Fides string to consent preferences and updates the CMP API
  *
  * This function handles both TCF and non-TCF consent scenarios:
@@ -183,6 +198,14 @@ export const fidesStringToConsent = ({
   cmpApi,
 }: FidesStringToConsentArgs) => {
   const { gpp: gppString }: DecodedFidesString = decodeFidesString(fidesString);
+
+  if (!isValidGppStringFormat(gppString)) {
+    fidesDebugger(
+      "GPP: Invalid GPP string format, skipping consent processing",
+    );
+    return;
+  }
+
   if (!fidesString || !gppString || !cmpApi) {
     return;
   }


### PR DESCRIPTION
Closes ENG-812

### Description Of Changes

Fixes a bug where GPP would fail to initialize when some invalid values for `fides_string` were given as an override

### Steps to Confirm

1. In `fides-js-demo.html`, set a `window.fides_overrides` value with `fides_string: "\",,DBABLA~BAAaAAAAAABo.QA\""`
2. Set up an experience with a GPP notice
3. View the demo
4. In the console, run `__gpp("ping", console.log)`
5. Should see GPP object in the output
6. Repeat process with any invalid string you can think of; should always see GPP object in the output

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
