### PR TITLE
ENG-1096 Add execution log when DSR enters awaiting_email_send status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added PrivacyCenterSettings to the config. [#6349](https://github.com/ethyca/fides/pull/6439)
 - Added DSR task conditional operators list types and data type/operator compatibility [#6429](https://github.com/ethyca/fides/pull/6429)
 - Added visual checkmark feedback and screen reader announcements for consent button interactions [#6451](https://github.com/ethyca/fides/pull/6451)
+- Added execution log when DSR enters awaiting_email_send status [#6462](https://github.com/ethyca/fides/pull/6462)
 
 ### Changed
 - Improved data extraction for object fields to return complete data structures instead of empty containers in data package when no nested fields where specified [#6424](https://github.com/ethyca/fides/pull/6424)

--- a/src/fides/api/models/privacy_request/privacy_request.py
+++ b/src/fides/api/models/privacy_request/privacy_request.py
@@ -1009,6 +1009,21 @@ class PrivacyRequest(
         """Put the privacy request in a state of awaiting_email_send"""
         if self.awaiting_email_send_at is None:
             self.awaiting_email_send_at = datetime.utcnow()
+            # Add execution log to inform user that processing is paused for email send
+            ExecutionLog.create(
+                db=db,
+                data={
+                    "privacy_request_id": self.id,
+                    "connection_key": None,
+                    "dataset_name": "Pending batch email send",
+                    "collection_name": None,
+                    "status": ExecutionLogStatus.pending,
+                    "message": "Privacy request paused pending batch email send job",
+                    "action_type": (
+                        self.policy.get_action_type() if self.policy else None
+                    ),
+                },
+            )
         self.status = PrivacyRequestStatus.awaiting_email_send
         self.save(db=db)
 

--- a/tests/ops/service/privacy_request/test_request_runner_service.py
+++ b/tests/ops/service/privacy_request/test_request_runner_service.py
@@ -1764,13 +1764,9 @@ class TestConsentEmailStep:
             == PrivacyRequestStatus.awaiting_email_send
         )
         assert privacy_request_with_consent_policy.awaiting_email_send_at is not None
-        last_log = (
-            privacy_request_with_consent_policy.execution_logs.order_by(
-                ExecutionLog.created_at
-            )
-            .desc()
-            .first()
-        )
+        last_log = privacy_request_with_consent_policy.execution_logs.order_by(
+            ExecutionLog.created_at.desc()
+        ).first()
         assert last_log.status == ExecutionLogStatus.pending
         assert last_log.message == "Privacy request paused pending batch email send job"
         assert last_log.dataset_name == "Pending batch email send"

--- a/tests/ops/service/privacy_request/test_request_runner_service.py
+++ b/tests/ops/service/privacy_request/test_request_runner_service.py
@@ -1764,6 +1764,16 @@ class TestConsentEmailStep:
             == PrivacyRequestStatus.awaiting_email_send
         )
         assert privacy_request_with_consent_policy.awaiting_email_send_at is not None
+        last_log = (
+            privacy_request_with_consent_policy.execution_logs.order_by(
+                ExecutionLog.created_at
+            )
+            .desc()
+            .first()
+        )
+        assert last_log.status == ExecutionLogStatus.pending
+        assert last_log.message == "Privacy request paused pending batch email send job"
+        assert last_log.dataset_name == "Pending batch email send"
 
     def test_needs_batch_email_send_no_consent_preferences(
         self, db, privacy_request_with_consent_policy


### PR DESCRIPTION
Closes [ENG-1096](https://ethyca.atlassian.net/browse/ENG-1096)

### Description Of Changes

When a DSR enters the `awaiting_email_send` status there's no execution log added which can sometimes make it confusing for users to understand why the request is waiting. This PR adds an `ExecutionLog` instance before setting the DSR in `awaiting_email_send` status.

### Steps to Confirm

1.  Set up an email integration (e.g Generic Erasure Email)
2. Run a DSR
3. You should see this log on the DSR detail page: "Privacy request paused pending batch email send job" 
<img width="713" height="514" alt="Screenshot of admin UI screen that shows the new log" src="https://github.com/user-attachments/assets/c9c9b4a0-f433-4b3f-8746-23bad4bb0b82" />

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1096]: https://ethyca.atlassian.net/browse/ENG-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ