### PR TITLE
ENG-1186 Fixing issue patching config with legacy values in the DB

### DIFF
--- a/src/fides/api/schemas/application_config.py
+++ b/src/fides/api/schemas/application_config.py
@@ -73,7 +73,8 @@ class ExecutionApplicationConfig(FidesSchema):
     memory_watchdog_enabled: Optional[bool] = None
     sql_dry_run: Optional[SqlDryRunMode] = None
 
-    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+    # Allow deprecated / unknown fields (e.g. “safe_mode”) to pass through
+    model_config = ConfigDict(use_enum_values=True, extra="ignore")
 
 
 class AdminUIConfig(FidesSchema):

--- a/tests/ops/api/v1/endpoints/test_config_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_config_endpoints.py
@@ -625,6 +625,45 @@ class TestPatchApplicationConfig:
         db.refresh(db_settings)
         assert db_settings.api_set["execution"]["memory_watchdog_enabled"] is True
 
+    def test_patch_application_config_with_legacy_and_new_field(
+        self,
+        api_client: TestClient,
+        generate_auth_header,
+        url,
+        db: Session,
+    ) -> None:
+        """Regression test:
+
+        1. Start with an existing ApplicationConfig in the DB that contains the *legacy* field `execution.safe_mode`.
+        2. Issue a PATCH that supplies a *new* supported field (`execution.sql_dry_run`).
+        3. Verify:
+           - The request succeeds (no ValidationError)
+           - The legacy field is silently dropped
+           - The new field is saved.
+        """
+
+        # Step 1 ‑ seed DB with legacy value
+        ApplicationConfig.update_api_set(
+            db,
+            {"execution": {"safe_mode": True}},
+            merge_updates=False,
+        )
+
+        # Sanity check that legacy value is present prior to patch
+        assert ApplicationConfig.get_api_set(db)["execution"]["safe_mode"] is True
+
+        # Step 2 ‑ PATCH with new supported value
+        patch_payload = {"execution": {"sql_dry_run": "access"}}
+        auth_header = generate_auth_header([scopes.CONFIG_UPDATE])
+        response = api_client.patch(url, headers=auth_header, json=patch_payload)
+
+        # Step 3a ‑ request succeeded
+        assert response.status_code == 200
+
+        # Step 3b ‑ new field persists and no validation errors occurred even with legacy field present
+        execution_config = ApplicationConfig.get_api_set(db).get("execution", {})
+        assert execution_config.get("sql_dry_run") == "access"
+
 
 @pytest.mark.usefixtures("original_cors_middleware_origins")
 class TestPutApplicationConfig:


### PR DESCRIPTION
Closes [ENG-1186]

### Description Of Changes

This was a a fix in the NYT prerelease image that addresses a specific issue with a config (safe_mode). Pulling it into main so that the NYT env is ok moving forward

### Code Changes

* Allows unknown extra fields in the Execution config to pass through without rejecting the change

### Steps to Confirm

1.  Tests included covers the change

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1186]: https://ethyca.atlassian.net/browse/ENG-1186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ