### PR TITLE
handle missing GVL from full experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Refactored Action Center tables to use new standardized table state management hooks [#6349](https://github.com/ethyca/fides/pull/6349)
 
 
+### Fixed
+- Handle missing GVL in TCF experience by displaying an error message instead of infinite spinners. [#6472](https://github.com/ethyca/fides/pull/6472)
+
 ## [2.68.0](https://github.com/ethyca/fides/compare/2.67.2...2.68.0)
 
 ### Added

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -36,10 +36,12 @@ export const TcfConsentButtons = ({
 
   if (!experience.minimal_tcf && isGVLLoading) {
     fidesDebugger("GVL data is not loaded for full TCF experience.");
-    return TcfLoadingErrorMessage({
-      generalLabel: "supporting GVL data",
-      excludeAcceptReject: true,
-    });
+    return (
+      <TcfLoadingErrorMessage
+        generalLabel="supporting GVL data"
+        excludeAcceptReject
+      />
+    );
   }
 
   return (

--- a/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
+++ b/clients/fides-js/src/components/tcf/TcfConsentButtons.tsx
@@ -7,6 +7,7 @@ import {
   PrivacyExperienceMinimal,
 } from "../../lib/consent-types";
 import { ConsentButtons } from "../ConsentButtons";
+import { TcfLoadingErrorMessage } from "./TcfLoadingErrorMessage";
 
 interface TcfConsentButtonProps {
   experience: PrivacyExperience | PrivacyExperienceMinimal;
@@ -32,6 +33,14 @@ export const TcfConsentButtons = ({
   }
 
   const isGVLLoading = Object.keys(experience.gvl || {}).length === 0;
+
+  if (!experience.minimal_tcf && isGVLLoading) {
+    fidesDebugger("GVL data is not loaded for full TCF experience.");
+    return TcfLoadingErrorMessage({
+      generalLabel: "supporting GVL data",
+      excludeAcceptReject: true,
+    });
+  }
 
   return (
     <ConsentButtons

--- a/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
+++ b/clients/fides-js/src/components/tcf/TcfLoadingErrorMessage.tsx
@@ -1,12 +1,16 @@
+import { Fragment } from "preact";
+
 import { useI18n } from "../../lib/i18n/i18n-context";
 import InfoBox from "../InfoBox";
 
 export const TcfLoadingErrorMessage = ({
   generalLabel,
   specificLabel,
+  excludeAcceptReject,
 }: {
   generalLabel: string;
-  specificLabel: string;
+  specificLabel?: string;
+  excludeAcceptReject?: boolean;
 }) => {
   // TODO: [ENG-1050] add translations for the error messages
   const { i18n } = useI18n();
@@ -17,12 +21,24 @@ export const TcfLoadingErrorMessage = ({
       }}
       data-testid="tcf-loading-error-message"
     >
-      There was an error loading the {generalLabel}. You may{" "}
-      <strong>{i18n.t("exp.accept_button_label").toLocaleLowerCase()}</strong>{" "}
-      or{" "}
-      <strong>{i18n.t("exp.reject_button_label").toLocaleLowerCase()}</strong>,
-      but in order to exercise your rights for {specificLabel}, please try again
-      later. If the problem persists, please contact the site owner.
+      There was an error loading the {generalLabel}.{" "}
+      {!excludeAcceptReject && !!specificLabel ? (
+        <Fragment>
+          You may{" "}
+          <strong>
+            {i18n.t("exp.accept_button_label").toLocaleLowerCase()}
+          </strong>{" "}
+          or{" "}
+          <strong>
+            {i18n.t("exp.reject_button_label").toLocaleLowerCase()}
+          </strong>{" "}
+          but in order to exercise your rights for {specificLabel}, please try
+          again later.{" "}
+        </Fragment>
+      ) : (
+        <Fragment>Please try again later. </Fragment>
+      )}
+      If the problem persists, please contact the site owner.
     </InfoBox>
   );
 };

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -4477,4 +4477,17 @@ describe("Fides-js TCF", () => {
       });
     });
   });
+
+  describe("when GVL data is missing", () => {
+    it("shows a loading error message when GVL is missing from full experience", () => {
+      stubTCFExperience({
+        experienceFullOverride: {
+          gvl: {} as never,
+        },
+      });
+      cy.waitUntilFidesInitialized().then(() => {
+        cy.getByTestId("tcf-loading-error-message").should("exist");
+      });
+    });
+  });
 });

--- a/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
+++ b/clients/privacy-center/cypress/e2e/consent-banner-tcf.cy.ts
@@ -243,6 +243,17 @@ describe("Fides-js TCF", () => {
         cy.get("div#fides-banner").should("not.exist");
       });
     });
+
+    it("shows a loading error message when GVL is missing from full experience", () => {
+      stubTCFExperience({
+        experienceFullOverride: {
+          gvl: {} as never,
+        },
+      });
+      cy.waitUntilFidesInitialized().then(() => {
+        cy.getByTestId("tcf-loading-error-message").should("exist");
+      });
+    });
   });
 
   describe("Payload optimization", () => {
@@ -4474,19 +4485,6 @@ describe("Fides-js TCF", () => {
             expect(firstCall.event).to.equal("FidesConsentLoaded");
             expect(secondCall.event).to.equal("FidesInitialized");
           });
-      });
-    });
-  });
-
-  describe("when GVL data is missing", () => {
-    it("shows a loading error message when GVL is missing from full experience", () => {
-      stubTCFExperience({
-        experienceFullOverride: {
-          gvl: {} as never,
-        },
-      });
-      cy.waitUntilFidesInitialized().then(() => {
-        cy.getByTestId("tcf-loading-error-message").should("exist");
       });
     });
   });


### PR DESCRIPTION
Closes [ENG-1080]

### Description Of Changes

Handle the case where GVL (Global Vendor List) data is missing for a full TCF experience by displaying a loading error message instead of infinitely spinning consent buttons. Updated the error message component to optionally exclude accept/reject actions and adjusted its usage accordingly. Added a Cypress test to verify the error message appears when GVL data is missing.

### Code Changes

* Updated `TcfConsentButtons.tsx` to check for missing GVL data and render `TcfLoadingErrorMessage` when appropriate.
* Enhanced `TcfLoadingErrorMessage.tsx` to support optional exclusion of accept/reject actions and improved conditional rendering.
* Added a Cypress test in `consent-banner-tcf.cy.ts` to confirm the error message is shown when GVL data is missing.

### Steps to Confirm
1. Configure a TCF experience in Admin UI
2. temporarily comment out the line `include_gvl: "true",` from `clients/fides-js/src/services/api.ts` to simulate a failure to load GVL.
3. Build fides-js and run privacy center locally.
4. Load the TCF experience with missing GVL data in the Privacy Center demo page (eg. http://localhost:3001/fides-js-demo.html?geolocation=eea)
5. Confirm that the loading error message appears instead of consent buttons once the full experience has loaded.
<img width="2562" height="748" alt="CleanShot 2025-08-18 at 14 30 21@2x" src="https://github.com/user-attachments/assets/613b9dd8-9e78-4ad2-a440-17a59bd59c3d" />



### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1080]: https://ethyca.atlassian.net/browse/ENG-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ