### PR TITLE
ENG-1122 Show brand image and badge for test website monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Changed
 - Manual Tasks now check conditional dependencies and either skip or wait for input based on the evaluation.[#6440](https://github.com/ethyca/fides/pull/6440)
 - Changed Fides.js banner title attributes for better SEO + a11y support [#6470](https://github.com/ethyca/fides/pull/6470)
+- Test Website Monitors now show the brand image and a "test monitor" tag [#6476](https://github.com/ethyca/fides/pull/6476)
 
 ## [2.68.0](https://github.com/ethyca/fides/compare/2.67.2...2.68.0)
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorResult.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorResult.tsx
@@ -7,6 +7,7 @@ import {
   AntListItemProps as ListItemProps,
   AntRow as Row,
   AntSkeleton as Skeleton,
+  AntTag as Tag,
   AntTypography as Typography,
   Icons,
 } from "fidesui";
@@ -19,6 +20,7 @@ import {
   getDomain,
   getWebsiteIconUrl,
 } from "~/features/common/utils";
+import { ConnectionType } from "~/types/api";
 
 import { DiscoveryStatusIcon } from "./DiscoveryStatusIcon";
 import { MonitorAggregatedResults } from "./types";
@@ -43,6 +45,7 @@ export const MonitorResult = ({
     last_monitored: lastMonitored,
     secrets,
     key,
+    connection_type: connectionType,
   } = monitorSummary;
 
   const property = useMemo(() => {
@@ -96,6 +99,11 @@ export const MonitorResult = ({
                     {`${totalUpdates} assets detected${property ? ` on ${property}` : ""}`}
                   </NextLink>
                   <DiscoveryStatusIcon consentStatus={consentStatus} />
+                  {connectionType === ConnectionType.TEST_WEBSITE && (
+                    <Tag color="nectar" style={{ fontWeight: "normal" }}>
+                      test monitor
+                    </Tag>
+                  )}
                 </Flex>
               }
               description={`${assetCountString} detected.`}

--- a/src/fides/api/util/connection_type.py
+++ b/src/fides/api/util/connection_type.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Set
+from typing import Any, Dict, Optional, Set
 
 from fides.api.common_exceptions import NoSuchConnectionTypeSecretSchemaError
 from fides.api.models.connectionconfig import ConnectionType
@@ -141,7 +141,9 @@ def get_connection_type_secret_schema(*, connection_type: str) -> dict[str, Any]
     Note that this does not return actual secrets, instead we return the *types* of
     secret fields needed to authenticate.
     """
-    connection_system_types: list[ConnectionSystemTypeMap] = get_connection_types()
+    connection_system_types: list[ConnectionSystemTypeMap] = get_connection_types(
+        include_test_connections=True
+    )
     if not any(item.identifier == connection_type for item in connection_system_types):
         raise NoSuchConnectionTypeSecretSchemaError(
             f"No connection type found with name '{connection_type}'."
@@ -189,15 +191,15 @@ def get_connection_type_secret_schema(*, connection_type: str) -> dict[str, Any]
     return schema
 
 
-def get_connection_types(
-    search: str | None = None,
-    system_type: SystemType | None = None,
-    action_types: Set[ActionType] = SUPPORTED_ACTION_TYPES,
-) -> list[ConnectionSystemTypeMap]:
-    def is_match(elem: str) -> bool:
-        """If a search query param was included, is it a substring of an available connector type?"""
-        return search.lower() in elem.lower() if search else True
+def _is_match(elem: str, search: Optional[str] = None) -> bool:
+    """If a search query param was included, is it a substring of an available connector type?"""
+    return search.lower() in elem.lower() if search else True
 
+
+def get_saas_connection_types(
+    action_types: Set[ActionType] = SUPPORTED_ACTION_TYPES,
+    search: Optional[str] = None,
+) -> list[ConnectionSystemTypeMap]:
     def saas_request_type_filter(connection_type: str) -> bool:
         """
         If any of the request type filters are set to true,
@@ -216,6 +218,45 @@ def get_connection_types(
             action_type in template.supported_actions for action_type in action_types
         )
 
+    saas_connection_types: list[ConnectionSystemTypeMap] = []
+    saas_types: list[str] = sorted(
+        [
+            saas_type
+            for saas_type in ConnectorRegistry.connector_types()
+            if _is_match(saas_type, search) and saas_request_type_filter(saas_type)
+        ]
+    )
+
+    for item in saas_types:
+        connector_template = ConnectorRegistry.get_connector_template(item)
+        if connector_template is not None:
+            saas_connection_types.append(
+                ConnectionSystemTypeMap(
+                    identifier=item,
+                    type=SystemType.saas,
+                    human_readable=connector_template.human_readable,
+                    encoded_icon=connector_template.icon,
+                    authorization_required=connector_template.authorization_required,
+                    user_guide=connector_template.user_guide,
+                    supported_actions=connector_template.supported_actions,
+                )
+            )
+
+    return saas_connection_types
+
+
+# FIXME: this function needs a refactor
+def get_connection_types(
+    search: str | None = None,
+    system_type: SystemType | None = None,
+    action_types: Set[ActionType] = SUPPORTED_ACTION_TYPES,
+    include_test_connections: bool = False,
+) -> list[ConnectionSystemTypeMap]:
+    """
+    Returns a list of ConnectionSystemTypeMap objects that match the given search and system type.
+
+    If include_test_connections is True, test connections like test_website will be included in the response.
+    """
     connection_system_types: list[ConnectionSystemTypeMap] = []
     if (system_type == SystemType.database or system_type is None) and (
         ActionType.access in action_types or ActionType.erasure in action_types
@@ -238,7 +279,7 @@ def get_connection_types(
                     ConnectionType.sovrn,
                     ConnectionType.test_website,
                 ]
-                and is_match(conn_type.value)
+                and _is_match(conn_type.value, search)
             ],
             key=lambda x: x.value,
         )
@@ -254,28 +295,10 @@ def get_connection_types(
             ]
         )
     if system_type == SystemType.saas or system_type is None:
-        saas_types: list[str] = sorted(
-            [
-                saas_type
-                for saas_type in ConnectorRegistry.connector_types()
-                if is_match(saas_type) and saas_request_type_filter(saas_type)
-            ]
+        saas_connection_types = get_saas_connection_types(
+            action_types=action_types, search=search
         )
-
-        for item in saas_types:
-            connector_template = ConnectorRegistry.get_connector_template(item)
-            if connector_template is not None:
-                connection_system_types.append(
-                    ConnectionSystemTypeMap(
-                        identifier=item,
-                        type=SystemType.saas,
-                        human_readable=connector_template.human_readable,
-                        encoded_icon=connector_template.icon,
-                        authorization_required=connector_template.authorization_required,
-                        user_guide=connector_template.user_guide,
-                        supported_actions=connector_template.supported_actions,
-                    )
-                )
+        connection_system_types.extend(saas_connection_types)
 
     if (system_type == SystemType.manual or system_type is None) and (
         ActionType.access in action_types or ActionType.erasure in action_types
@@ -285,7 +308,7 @@ def get_connection_types(
                 manual_type.value
                 for manual_type in ConnectionType
                 if manual_type == ConnectionType.manual_webhook
-                and is_match(manual_type.value)
+                and _is_match(manual_type.value, search)
             ]
         )
         connection_system_types.extend(
@@ -307,7 +330,7 @@ def get_connection_types(
                 for email_type in ConnectionType
                 if email_type
                 in ERASURE_EMAIL_CONNECTOR_TYPES + CONSENT_EMAIL_CONNECTOR_TYPES
-                and is_match(email_type.value)
+                and _is_match(email_type.value, search)
                 and (  # include consent or erasure connectors if requested, respectively
                     (
                         ActionType.consent in action_types
@@ -337,6 +360,18 @@ def get_connection_types(
                 )
                 for email_type in email_types
             ]
+        )
+
+    if include_test_connections and (
+        system_type == SystemType.website or system_type is None
+    ):
+        connection_system_types.append(
+            ConnectionSystemTypeMap(
+                identifier=ConnectionType.test_website,
+                type=SystemType.website,
+                human_readable=ConnectionType.test_website.human_readable,
+                supported_actions=[],
+            )
         )
 
     return connection_system_types

--- a/src/fides/api/util/connection_type.py
+++ b/src/fides/api/util/connection_type.py
@@ -367,7 +367,7 @@ def get_connection_types(
     ):
         connection_system_types.append(
             ConnectionSystemTypeMap(
-                identifier=ConnectionType.test_website,
+                identifier=ConnectionType.test_website.value,
                 type=SystemType.website,
                 human_readable=ConnectionType.test_website.human_readable,
                 supported_actions=[],

--- a/tests/ops/util/test_connection_type.py
+++ b/tests/ops/util/test_connection_type.py
@@ -260,3 +260,14 @@ def test_get_connection_type_secret_schemas_aws():
     s3_secret_schema = get_connection_type_secret_schema(connection_type="s3")
     s3_required = s3_secret_schema["required"]
     assert "auth_method" in s3_required
+
+
+def test_get_connection_type_secret_schemas_test_website():
+    test_website_schema = get_connection_type_secret_schema(
+        connection_type="test_website"
+    )
+    website_schema = get_connection_type_secret_schema(connection_type="website")
+
+    assert test_website_schema == website_schema
+    assert test_website_schema["required"] == ["url"]
+    assert test_website_schema["properties"]["url"]["format"] == "uri"


### PR DESCRIPTION
Closes [ENG-1122](https://ethyca.atlassian.net/browse/ENG-1122)

### Description Of Changes

This PR consists of two changes: 
- A backend change that allows getting the secrets schema for the `test_website` connection type so that we can return the configured `url` (which the UI uses to pull brand logo) 
- A frontend change that adds the `test monitor` tag to test website monitors in the action center

### Steps to Confirm

1. Run a test website monitor for `https://ethyca.com`
2. Look in the action center, both the url and brand image should be present, as well as a tag that reads `test monitor`

<img width="1487" height="719" alt="Screenshot of action center with multiple test monitors and a single real web monitor" src="https://github.com/user-attachments/assets/d49c0f9b-7781-4f4e-ba48-bc39409e93a0" />


### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1122]: https://ethyca.atlassian.net/browse/ENG-1122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ