### PR TITLE
Apply new hooks to existing action center tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Developer Experience
 - Refactored table column header menu functionality to use column-level menu property instead of custom header cell components [#6481](https://github.com/ethyca/fides/pull/6481)
 - Added new npm task for Admin UI that enables optimized Cypress testing with API server connectivity during local development [#6483](https://github.com/ethyca/fides/pull/6483)
+- Added reusable table system with URL synchronization and Ant Design integration for standardized table behavior and deep linking support [#6447](https://github.com/ethyca/fides/pull/6447)
+- Refactored Action Center tables to use new standardized table state management hooks [#6349](https://github.com/ethyca/fides/pull/6349)
 
 
 ## [2.68.0](https://github.com/ethyca/fides/compare/2.67.2...2.68.0)
@@ -43,7 +45,6 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Improved logging of underlying errors when raising generic exceptions [#6420](https://github.com/ethyca/fides/pull/6420)
 - Manual Task Graph Tasks now receive data from any nodes referenced by their conditional dependencies. [#6402](https://github.com/ethyca/fides/pull/6402)
 - Added PrivacyCenterSettings to the config. [#6349](https://github.com/ethyca/fides/pull/6439)
-- Added reusable table system with URL synchronization and Ant Design integration for standardized table behavior and deep linking support [#6447](https://github.com/ethyca/fides/pull/6447)
 - Added DSR task conditional operators list types and data type/operator compatibility [#6429](https://github.com/ethyca/fides/pull/6429)
 - Added visual checkmark feedback and screen reader announcements for consent button interactions [#6451](https://github.com/ethyca/fides/pull/6451)
 - Added field to privacy center configuration to support location collection in privacy center actions [#6432](https://github.com/ethyca/fides/pull/6432)

--- a/clients/admin-ui/cypress/e2e/action-center/assets-results.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/assets-results.cy.ts
@@ -244,13 +244,7 @@ describe("Action center Asset Results", () => {
     });
 
     it("should bulk restore ignored assets", () => {
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(500); // wait for the original router to update
-      cy.getByTestId("asset-state-filter")
-        .contains("Ignored")
-        .click({ force: true });
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(500); // wait for the router to update
+      cy.clickAntTab("Ignored");
       cy.getByTestId("asset-state-filter").within(() => {
         cy.get(".ant-menu-item-selected").contains("Ignored").should("exist");
       });

--- a/clients/admin-ui/cypress/e2e/action-center/assets-results.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/assets-results.cy.ts
@@ -244,6 +244,8 @@ describe("Action center Asset Results", () => {
     });
 
     it("should bulk restore ignored assets", () => {
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500); // wait for the original router to update
       cy.clickAntTab("Ignored");
       cy.getByTestId("asset-state-filter").within(() => {
         cy.get(".ant-menu-item-selected").contains("Ignored").should("exist");

--- a/clients/admin-ui/cypress/e2e/action-center/systems-aggregate.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/systems-aggregate.cy.ts
@@ -189,7 +189,7 @@ describe("Action center system aggregate results", () => {
       cy.visit(`${ACTION_CENTER_ROUTE}/${webMonitorKey}#attention-required`);
       cy.location("hash").should("eq", "#attention-required");
 
-      cy.getAntTab("Recent activity").click();
+      cy.clickAntTab("Recent activity");
       cy.location("hash").should("eq", "#recent-activity");
 
       // "recent activity" tab should be read-only
@@ -203,7 +203,7 @@ describe("Action center system aggregate results", () => {
 
       cy.get(".ant-spin-spinning").should("not.exist");
 
-      cy.getAntTab("Ignored").click();
+      cy.clickAntTab("Ignored");
       cy.location("hash").should("eq", "#ignored");
 
       // "ignore" option should not show in bulk actions menu

--- a/clients/admin-ui/cypress/e2e/action-center/systems-aggregate.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/systems-aggregate.cy.ts
@@ -1,8 +1,6 @@
 import {
   stubPlus,
-  stubSystemVendors,
   stubTaxonomyEntities,
-  stubVendorList,
   stubWebsiteMonitor,
 } from "cypress/support/stubs";
 
@@ -219,6 +217,7 @@ describe("Action center system aggregate results", () => {
     it("maintains hash when clicking on a row", () => {
       // no hash (default tab)
       cy.visit(`${ACTION_CENTER_ROUTE}/${webMonitorKey}`);
+      cy.wait("@getSystemAggregateResults");
 
       cy.getAntTableRow("[undefined]").within(() => {
         cy.getByTestId("system-name-link").should(
@@ -228,7 +227,8 @@ describe("Action center system aggregate results", () => {
         );
       });
 
-      cy.get("[role='tab']").contains("Recent activity").click();
+      cy.clickAntTab("Recent activity");
+      cy.wait("@getSystemAggregateResults");
       cy.getAntTableRow("[undefined]").within(() => {
         cy.getByTestId("system-name-link").should(
           "have.attr",
@@ -237,7 +237,8 @@ describe("Action center system aggregate results", () => {
         );
       });
 
-      cy.get("[role='tab']").contains("Ignored").click();
+      cy.clickAntTab("Ignored");
+      cy.wait("@getSystemAggregateResults");
       cy.getAntTableRow("[undefined]").within(() => {
         cy.getByTestId("system-name-link").should(
           "have.attr",
@@ -246,7 +247,7 @@ describe("Action center system aggregate results", () => {
         );
       });
 
-      cy.get("[role='tab']").contains("Attention required").click();
+      cy.clickAntTab("Attention required");
       cy.getAntTableRow("[undefined]").within(() => {
         cy.getByTestId("system-name-link")
           .should(

--- a/clients/admin-ui/cypress/e2e/systems/plus/navigation.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems/plus/navigation.cy.ts
@@ -32,28 +32,23 @@ describe("System Navigation", () => {
     cy.location("hash").should("eq", "#information");
 
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500);
-    cy.getAntTab("Data uses").click({ force: true });
+    cy.clickAntTab("Data uses");
     cy.location("hash").should("eq", "#data-uses");
 
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500);
-    cy.getAntTab("Data flow").click({ force: true });
+    cy.clickAntTab("Data flow");
     cy.location("hash").should("eq", "#data-flow");
 
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500);
-    cy.getAntTab("Integrations").click({ force: true });
+    cy.clickAntTab("Integrations");
     cy.location("hash").should("eq", "#integrations");
 
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500);
-    cy.getAntTab("Assets").click({ force: true });
+    cy.clickAntTab("Assets");
     cy.location("hash").should("eq", "#assets");
 
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500);
-    cy.getAntTab("History").click({ force: true });
+    cy.clickAntTab("History");
     cy.location("hash").should("eq", "#history");
   });
 

--- a/clients/admin-ui/cypress/e2e/systems/plus/navigation.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems/plus/navigation.cy.ts
@@ -55,6 +55,7 @@ describe("System Navigation", () => {
   it("loads correct tab directly based on URL hash", () => {
     // Visit page with specific hash
     cy.visit(`${SYSTEM_ROUTE}/configure/demo_analytics_system#data-uses`);
+    cy.wait("@getMinimalUnlinkedDatasets");
 
     // Verify correct tab is active
     cy.getAntTab("Data uses").should("have.attr", "aria-selected", "true");

--- a/clients/admin-ui/cypress/support/ant-support.ts
+++ b/clients/admin-ui/cypress/support/ant-support.ts
@@ -42,6 +42,11 @@ declare global {
        * @example cy.getAntTab("Some tab").should("have.attr", "aria-disabled", "true");
        */
       getAntTab: (tab: string) => Chainable;
+      /**
+       * Click an option from an Ant Design Tabs component by label
+       * @param tab The label of the tab to click
+       */
+      clickAntTab: (tab: string) => Chainable;
 
       /**
        * Get a panel from an Ant Design Tabs component by label
@@ -174,8 +179,15 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add("getAntTab", (tab: string) =>
-  cy.get(`.ant-tabs-tab-btn`).filter(`:contains("${tab}")`),
+  cy
+    .get("[role='tab'], .ant-menu-horizontal  [role='menuitem']")
+    .filter(`:contains("${tab}")`),
 );
+Cypress.Commands.add("clickAntTab", (tab: string) => {
+  cy.getAntTab(tab).click({ force: true });
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(500); // Wait for the animation/router to complete
+});
 Cypress.Commands.add("getAntTabPanel", (tab: string) =>
   cy.get(`#rc-tabs-0-panel-${tab}`),
 );

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConsentBreakdownModal.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConsentBreakdownModal.tsx
@@ -79,7 +79,11 @@ export const ConsentBreakdownModal = ({
             showIcon
           />
         ) : (
-          <Table {...tableProps} columns={columns} />
+          <Table
+            {...tableProps}
+            columns={columns}
+            data-testid="consent-breakdown-modal-table"
+          />
         )}
       </Flex>
     </Modal>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/constants.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/constants.ts
@@ -16,3 +16,12 @@ export enum DiscoveredAssetsColumnKeys {
   CONSENT_AGGREGATED = "consent_aggregated",
   ACTIONS = "actions",
 }
+
+export enum DiscoveredSystemAggregateColumnKeys {
+  SYSTEM_NAME = "system_name",
+  TOTAL_UPDATES = "total_updates",
+  DATA_USE = "data_use",
+  LOCATIONS = "locations",
+  DOMAINS = "domains",
+  ACTIONS = "actions",
+}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/constants.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/constants.ts
@@ -25,3 +25,8 @@ export enum DiscoveredSystemAggregateColumnKeys {
   DOMAINS = "domains",
   ACTIONS = "actions",
 }
+
+export enum ConsentBreakdownColumnKeys {
+  LOCATION = "location",
+  PAGE = "page",
+}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useConsentBreakdownTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useConsentBreakdownTable.tsx
@@ -1,0 +1,112 @@
+import {
+  AntColumnsType as ColumnsType,
+  AntTypography as Typography,
+} from "fidesui";
+import { useMemo } from "react";
+
+import { PRIVACY_NOTICE_REGION_RECORD } from "~/features/common/privacy-notice-regions";
+import { DEFAULT_PAGE_SIZES } from "~/features/common/table/constants";
+import { useAntTable, useTableState } from "~/features/common/table/hooks";
+import {
+  ConsentBreakdown,
+  ConsentStatus,
+  PrivacyNoticeRegion,
+  StagedResourceAPIResponse,
+} from "~/types/api";
+
+import { useGetConsentBreakdownQuery } from "../action-center.slice";
+import { ConsentBreakdownColumnKeys } from "../constants";
+
+const { Link } = Typography;
+
+interface UseConsentBreakdownTableConfig {
+  stagedResource: StagedResourceAPIResponse;
+  status: ConsentStatus;
+}
+
+export const useConsentBreakdownTable = ({
+  stagedResource,
+  status,
+}: UseConsentBreakdownTableConfig) => {
+  const tableState = useTableState<ConsentBreakdownColumnKeys>({
+    pagination: {
+      defaultPageSize: 10,
+      pageSizeOptions: [10, ...DEFAULT_PAGE_SIZES],
+    },
+  });
+
+  const { pageIndex, pageSize } = tableState;
+
+  const { data, isFetching, isError } = useGetConsentBreakdownQuery({
+    stagedResourceUrn: stagedResource.urn,
+    status,
+    page: pageIndex,
+    size: pageSize,
+  });
+
+  const { items, total: totalRows } = useMemo(
+    () =>
+      data || {
+        items: [],
+        total: 0,
+        pages: 0,
+        filterOptions: { assigned_users: [], systems: [] },
+      },
+    [data],
+  );
+
+  const antTableConfig = useMemo(
+    () => ({
+      enableSelection: false,
+      getRowKey: (record: ConsentBreakdown) => record.location,
+      isLoading: isFetching,
+      dataSource: items,
+      totalRows: totalRows ?? 0,
+    }),
+    [isFetching, items, totalRows],
+  );
+
+  const antTable = useAntTable<ConsentBreakdown, ConsentBreakdownColumnKeys>(
+    tableState,
+    antTableConfig,
+  );
+
+  const columns: ColumnsType<ConsentBreakdown> = useMemo(
+    () => [
+      {
+        title: "Location",
+        dataIndex: ConsentBreakdownColumnKeys.LOCATION,
+        key: ConsentBreakdownColumnKeys.LOCATION,
+        render: (location: string) =>
+          PRIVACY_NOTICE_REGION_RECORD[location as PrivacyNoticeRegion] ??
+          location,
+      },
+      {
+        title: "Page",
+        dataIndex: ConsentBreakdownColumnKeys.PAGE,
+        key: ConsentBreakdownColumnKeys.PAGE,
+        render: (page: string) => (
+          <Link href={page} target="_blank" rel="noopener noreferrer">
+            {page}
+          </Link>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return {
+    // Table state and data
+    columns,
+    data,
+    isLoading: isFetching,
+    isError,
+    totalRows,
+
+    // Ant Design table integration
+    tableProps: antTable.tableProps,
+
+    // Utilities
+    hasData: items.length > 0,
+  };
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
@@ -13,6 +13,7 @@ import {
   SystemStagedResourcesAggregateRecord,
 } from "~/types/api";
 
+import { DiscoveredSystemAggregateColumnKeys } from "../constants";
 import { DiscoveryStatusIcon } from "../DiscoveryStatusIcon";
 import { DiscoveredSystemActionsCell } from "../tables/cells/DiscoveredSystemAggregateActionsCell";
 import { DiscoveredSystemStatusCell } from "../tables/cells/DiscoveredSystemAggregateStatusCell";
@@ -49,7 +50,7 @@ export const useDiscoveredSystemAggregateColumns = ({
             </Space>
           ),
           dataIndex: "name",
-          key: "system_name",
+          key: DiscoveredSystemAggregateColumnKeys.SYSTEM_NAME,
           fixed: "left",
           render: (_, record) => (
             <DiscoveredSystemStatusCell
@@ -61,11 +62,11 @@ export const useDiscoveredSystemAggregateColumns = ({
         {
           title: "Assets",
           dataIndex: "total_updates",
-          key: "total_updates",
+          key: DiscoveredSystemAggregateColumnKeys.TOTAL_UPDATES,
         },
         {
           title: "Categories of consent",
-          key: "data_use",
+          key: DiscoveredSystemAggregateColumnKeys.DATA_USE,
           render: (_, record) => (
             <DiscoveredSystemDataUseCell system={record} />
           ),
@@ -84,7 +85,7 @@ export const useDiscoveredSystemAggregateColumns = ({
             },
           },
           dataIndex: "locations",
-          key: "locations",
+          key: DiscoveredSystemAggregateColumnKeys.LOCATIONS,
           width: 250,
           render: (locations: string[]) => (
             <TagExpandableCell
@@ -118,7 +119,7 @@ export const useDiscoveredSystemAggregateColumns = ({
             },
           },
           dataIndex: "domains",
-          key: "domains",
+          key: DiscoveredSystemAggregateColumnKeys.DOMAINS,
           render: (domains: string[]) => (
             <ListExpandableCell
               values={domains}
@@ -134,7 +135,7 @@ export const useDiscoveredSystemAggregateColumns = ({
       if (!readonly) {
         baseColumns.push({
           title: "Actions",
-          key: "actions",
+          key: DiscoveredSystemAggregateColumnKeys.ACTIONS,
           render: (_, record) => (
             <DiscoveredSystemActionsCell
               system={record}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateColumns.tsx
@@ -24,7 +24,7 @@ interface UseDiscoveredSystemAggregateColumnsProps {
   monitorId: string;
   readonly: boolean;
   allowIgnore?: boolean;
-  onTabChange: (tab: ActionCenterTabHash) => void;
+  onTabChange: (tab: ActionCenterTabHash) => Promise<void>;
   consentStatus?: ConsentAlertInfo;
   rowClickUrl?: (record: SystemStagedResourcesAggregateRecord) => string;
 }

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateTable.tsx
@@ -201,7 +201,9 @@ export const useDiscoveredSystemAggregateTable = ({
         successToastParams(
           SuccessToastContent(
             `${totalUpdates} assets have been ignored and will not appear in future scans.`,
-            () => onTabChange(ActionCenterTabHash.IGNORED),
+            async () => {
+              await onTabChange(ActionCenterTabHash.IGNORED);
+            },
           ),
         ),
       );

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateTable.tsx
@@ -47,9 +47,6 @@ export const useDiscoveredSystemAggregateTable = ({
     useActionCenterTabs();
 
   const tableState = useTableState<DiscoveredSystemAggregateColumnKeys>({
-    pagination: {
-      defaultPageSize: 25,
-    },
     sorting: {
       validColumns: Object.values(DiscoveredSystemAggregateColumnKeys),
     },

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredSystemAggregateTable.tsx
@@ -1,0 +1,257 @@
+import { AntEmpty as Empty, useToast } from "fidesui";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
+import {
+  ACTION_CENTER_ROUTE,
+  SYSTEM_ROUTE,
+  UNCATEGORIZED_SEGMENT,
+} from "~/features/common/nav/routes";
+import { useAntTable, useTableState } from "~/features/common/table/hooks";
+import { errorToastParams, successToastParams } from "~/features/common/toast";
+import {
+  AlertLevel,
+  ConsentAlertInfo,
+  DiffStatus,
+  SystemStagedResourcesAggregateRecord,
+} from "~/types/api";
+
+import {
+  useAddMonitorResultSystemsMutation,
+  useGetDiscoveredSystemAggregateQuery,
+  useIgnoreMonitorResultSystemsMutation,
+} from "../action-center.slice";
+import { DiscoveredSystemAggregateColumnKeys } from "../constants";
+import { SuccessToastContent } from "../SuccessToastContent";
+import useActionCenterTabs, {
+  ActionCenterTabHash,
+} from "./useActionCenterTabs";
+import { useDiscoveredSystemAggregateColumns } from "./useDiscoveredSystemAggregateColumns";
+
+interface UseDiscoveredSystemAggregateTableConfig {
+  monitorId: string;
+}
+
+export const useDiscoveredSystemAggregateTable = ({
+  monitorId,
+}: UseDiscoveredSystemAggregateTableConfig) => {
+  const router = useRouter();
+  const toast = useToast();
+
+  const [firstPageConsentStatus, setFirstPageConsentStatus] = useState<
+    ConsentAlertInfo | undefined
+  >();
+
+  const { filterTabs, activeTab, onTabChange, activeParams, actionsDisabled } =
+    useActionCenterTabs();
+
+  const tableState = useTableState<DiscoveredSystemAggregateColumnKeys>({
+    pagination: {
+      defaultPageSize: 25,
+    },
+    sorting: {
+      validColumns: Object.values(DiscoveredSystemAggregateColumnKeys),
+    },
+  });
+
+  const { pageIndex, pageSize, searchQuery, updateSearch, resetState } =
+    tableState;
+
+  const { data, isLoading, isFetching } = useGetDiscoveredSystemAggregateQuery({
+    key: monitorId,
+    page: pageIndex,
+    size: pageSize,
+    search: searchQuery,
+    ...activeParams,
+  });
+
+  const [addMonitorResultSystemsMutation, { isLoading: isAddingResults }] =
+    useAddMonitorResultSystemsMutation();
+  const [ignoreMonitorResultSystemsMutation, { isLoading: isIgnoringResults }] =
+    useIgnoreMonitorResultSystemsMutation();
+
+  const anyBulkActionIsLoading = isAddingResults || isIgnoringResults;
+
+  // Helper function to generate consistent row keys
+  const getRecordKey = useCallback(
+    (record: SystemStagedResourcesAggregateRecord) =>
+      record.id ?? record.vendor_id ?? record.name ?? UNCATEGORIZED_SEGMENT,
+    [],
+  );
+
+  const rowClickUrl = useCallback(
+    (record: SystemStagedResourcesAggregateRecord) => {
+      const newUrl = `${ACTION_CENTER_ROUTE}/${monitorId}/${record.id ?? UNCATEGORIZED_SEGMENT}${activeTab ? `#${activeTab}` : ""}`;
+      return newUrl;
+    },
+    [monitorId, activeTab],
+  );
+
+  const antTableConfig = useMemo(
+    () => ({
+      enableSelection: true,
+      getRowKey: getRecordKey,
+      isLoading,
+      isFetching,
+      dataSource: data?.items || [],
+      totalRows: data?.total || 0,
+      customTableProps: {
+        locale: {
+          emptyText: (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="All caught up!"
+            />
+          ),
+        },
+      },
+    }),
+    [getRecordKey, isLoading, isFetching, data?.items, data?.total],
+  );
+
+  const antTable = useAntTable<
+    SystemStagedResourcesAggregateRecord,
+    DiscoveredSystemAggregateColumnKeys
+  >(tableState, antTableConfig);
+
+  const { selectedRows, resetSelections } = antTable;
+
+  const handleTabChange = useCallback(
+    async (tab: ActionCenterTabHash) => {
+      setFirstPageConsentStatus(undefined);
+      await onTabChange(tab);
+      resetState();
+      resetSelections();
+    },
+    [onTabChange, resetState, resetSelections],
+  );
+
+  const { columns } = useDiscoveredSystemAggregateColumns({
+    monitorId,
+    onTabChange: handleTabChange,
+    readonly: actionsDisabled,
+    allowIgnore: !activeParams.diff_status.includes(DiffStatus.MUTED),
+    consentStatus: firstPageConsentStatus,
+    rowClickUrl,
+  });
+
+  // Business logic effects
+  useEffect(() => {
+    if (data?.items && !firstPageConsentStatus) {
+      // this ensures that the column header remembers the consent status
+      // even when the user navigates to a different paginated page
+      const consentStatus = data.items.find(
+        (item) => item.consent_status?.status === AlertLevel.ALERT,
+      )?.consent_status;
+      setFirstPageConsentStatus(consentStatus ?? undefined);
+    }
+  }, [data, firstPageConsentStatus]);
+
+  const handleBulkAdd = useCallback(async () => {
+    const totalUpdates = selectedRows.reduce(
+      (acc, row) => acc + row.total_updates!,
+      0,
+    );
+
+    const result = await addMonitorResultSystemsMutation({
+      monitor_config_key: monitorId,
+      resolved_system_ids: selectedRows.map((row) => row.id!),
+    });
+
+    if (isErrorResult(result)) {
+      toast(errorToastParams(getErrorMessage(result.error)));
+    } else {
+      toast(
+        successToastParams(
+          SuccessToastContent(
+            `${totalUpdates} assets have been added to the system inventory.`,
+            () => router.push(SYSTEM_ROUTE),
+          ),
+        ),
+      );
+      resetSelections();
+    }
+  }, [
+    selectedRows,
+    addMonitorResultSystemsMutation,
+    monitorId,
+    toast,
+    router,
+    resetSelections,
+  ]);
+
+  const handleBulkIgnore = useCallback(async () => {
+    const totalUpdates = selectedRows.reduce(
+      (acc, row) => acc + row.total_updates!,
+      0,
+    );
+
+    const result = await ignoreMonitorResultSystemsMutation({
+      monitor_config_key: monitorId,
+      resolved_system_ids: selectedRows.map(
+        (row) => row.id ?? UNCATEGORIZED_SEGMENT,
+      ),
+    });
+
+    if (isErrorResult(result)) {
+      toast(errorToastParams(getErrorMessage(result.error)));
+    } else {
+      toast(
+        successToastParams(
+          SuccessToastContent(
+            `${totalUpdates} assets have been ignored and will not appear in future scans.`,
+            () => onTabChange(ActionCenterTabHash.IGNORED),
+          ),
+        ),
+      );
+      resetSelections();
+    }
+  }, [
+    selectedRows,
+    ignoreMonitorResultSystemsMutation,
+    monitorId,
+    toast,
+    onTabChange,
+    resetSelections,
+  ]);
+
+  const uncategorizedIsSelected = selectedRows.some((row) => row.id === null);
+
+  return {
+    // Table state and data
+    columns,
+    data,
+    isLoading,
+    isFetching,
+    searchQuery,
+    updateSearch,
+    resetState,
+
+    // Ant Design table integration
+    tableProps: antTable.tableProps,
+    selectionProps: antTable.selectionProps,
+
+    // Tab management
+    filterTabs,
+    activeTab,
+    handleTabChange,
+    activeParams,
+    actionsDisabled,
+
+    // Selection
+    selectedRows,
+    hasSelectedRows: antTable.hasSelectedRows,
+    resetSelections,
+    uncategorizedIsSelected,
+
+    // Business actions
+    handleBulkAdd,
+    handleBulkIgnore,
+
+    // Loading states
+    anyBulkActionIsLoading,
+    isAddingResults,
+    isIgnoringResults,
+  };
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
@@ -133,9 +133,9 @@ export const DiscoveredAssetsTable = ({
           label: tab.label,
         }))}
         selectedKeys={[activeTab]}
-        onClick={(menuInfo) =>
-          handleTabChange(menuInfo.key as ActionCenterTabHash)
-        }
+        onClick={async (menuInfo) => {
+          await handleTabChange(menuInfo.key as ActionCenterTabHash);
+        }}
         className="mb-4"
         data-testid="asset-state-filter"
       />

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredSystemAggregateTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredSystemAggregateTable.tsx
@@ -1,46 +1,20 @@
 import {
   AntButton as Button,
   AntDropdown as Dropdown,
-  AntEmpty as Empty,
   AntFlex as Flex,
+  AntMenu as Menu,
   AntSpace as Space,
   AntTable as Table,
-  AntTabs as Tabs,
   AntTooltip as Tooltip,
   Icons,
-  useToast,
 } from "fidesui";
-import { useRouter } from "next/router";
-import { useCallback, useEffect, useState } from "react";
 
-import { getErrorMessage } from "~/features/common/helpers";
-import {
-  ACTION_CENTER_ROUTE,
-  SYSTEM_ROUTE,
-  UNCATEGORIZED_SEGMENT,
-} from "~/features/common/nav/routes";
-import { DEFAULT_PAGE_SIZES } from "~/features/common/table/constants";
 import { SelectedText } from "~/features/common/table/SelectedText";
-import { errorToastParams, successToastParams } from "~/features/common/toast";
-import {
-  useAddMonitorResultSystemsMutation,
-  useGetDiscoveredSystemAggregateQuery,
-  useIgnoreMonitorResultSystemsMutation,
-} from "~/features/data-discovery-and-detection/action-center/action-center.slice";
-import useActionCenterTabs, {
-  ActionCenterTabHash,
-} from "~/features/data-discovery-and-detection/action-center/hooks/useActionCenterTabs";
-import { SuccessToastContent } from "~/features/data-discovery-and-detection/action-center/SuccessToastContent";
-import {
-  AlertLevel,
-  ConsentAlertInfo,
-  DiffStatus,
-  SystemStagedResourcesAggregateRecord,
-} from "~/types/api";
-import { isErrorResult } from "~/types/errors";
+import { DiffStatus } from "~/types/api";
 
 import { DebouncedSearchInput } from "../../../common/DebouncedSearchInput";
-import { useDiscoveredSystemAggregateColumns } from "../hooks/useDiscoveredSystemAggregateColumns";
+import { ActionCenterTabHash } from "../hooks/useActionCenterTabs";
+import { useDiscoveredSystemAggregateTable } from "../hooks/useDiscoveredSystemAggregateTable";
 
 interface DiscoveredSystemAggregateTableProps {
   monitorId: string;
@@ -49,221 +23,55 @@ interface DiscoveredSystemAggregateTableProps {
 export const DiscoveredSystemAggregateTable = ({
   monitorId,
 }: DiscoveredSystemAggregateTableProps) => {
-  const router = useRouter();
+  const {
+    // Table state and data
+    columns,
+    searchQuery,
+    updateSearch,
 
-  const [firstPageConsentStatus, setFirstPageConsentStatus] = useState<
-    ConsentAlertInfo | undefined
-  >();
+    // Ant Design table integration
+    tableProps,
+    selectionProps,
 
-  // Pagination state
-  const [pageIndex, setPageIndex] = useState(1);
-  const [pageSize, setPageSize] = useState(25);
+    // Tab management
+    filterTabs,
+    activeTab,
+    handleTabChange,
+    activeParams,
 
-  const [addMonitorResultSystemsMutation, { isLoading: isAddingResults }] =
-    useAddMonitorResultSystemsMutation();
-  const [ignoreMonitorResultSystemsMutation, { isLoading: isIgnoringResults }] =
-    useIgnoreMonitorResultSystemsMutation();
+    // Selection
+    selectedRows,
+    hasSelectedRows,
+    uncategorizedIsSelected,
 
-  const anyBulkActionIsLoading = isAddingResults || isIgnoringResults;
+    // Business actions
+    handleBulkAdd,
+    handleBulkIgnore,
 
-  const toast = useToast();
-
-  const [searchQuery, setSearchQuery] = useState("");
-
-  // Selection state
-  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
-  const [selectedRowsMap, setSelectedRowsMap] = useState<
-    Map<string, SystemStagedResourcesAggregateRecord>
-  >(new Map());
-
-  const resetSelections = () => {
-    setSelectedRowKeys([]);
-    setSelectedRowsMap(new Map());
-  };
-
-  // Helper function to generate consistent row keys
-  const getRecordKey = (record: SystemStagedResourcesAggregateRecord) =>
-    record.id ?? record.vendor_id ?? record.name ?? UNCATEGORIZED_SEGMENT;
-
-  const { filterTabs, activeTab, onTabChange, activeParams, actionsDisabled } =
-    useActionCenterTabs();
-
-  // Reset pagination when filters change
-  useEffect(() => {
-    setPageIndex(1);
-  }, [monitorId, searchQuery]);
-
-  // Reset selections when filters change
-  useEffect(() => {
-    resetSelections();
-  }, [monitorId, searchQuery, activeTab]);
-
-  const { data, isLoading, isFetching } = useGetDiscoveredSystemAggregateQuery({
-    key: monitorId,
-    page: pageIndex,
-    size: pageSize,
-    search: searchQuery,
-    ...activeParams,
-  });
-
-  useEffect(() => {
-    if (data?.items && !firstPageConsentStatus) {
-      // this ensures that the column header remembers the consent status
-      // even when the user navigates to a different paginated page
-      const consentStatus = data.items.find(
-        (item) => item.consent_status?.status === AlertLevel.ALERT,
-      )?.consent_status;
-      setFirstPageConsentStatus(consentStatus ?? undefined);
-    }
-  }, [data, firstPageConsentStatus]);
-
-  // Update selectedRowKeys to only show current page selections when data changes
-  useEffect(() => {
-    if (data?.items) {
-      const currentPageSelectedKeys = data.items
-        .filter((item) => {
-          const key = getRecordKey(item);
-          return selectedRowsMap.has(String(key));
-        })
-        .map((item) => getRecordKey(item));
-      setSelectedRowKeys(currentPageSelectedKeys);
-    }
-  }, [data, selectedRowsMap]);
-
-  // Get selected rows from the map
-  const selectedRows = Array.from(selectedRowsMap.values());
-
-  const handleTabChange = (tab: ActionCenterTabHash) => {
-    setFirstPageConsentStatus(undefined);
-    onTabChange(tab);
-    resetSelections();
-  };
-
-  const rowClickUrl = useCallback(
-    (record: SystemStagedResourcesAggregateRecord) => {
-      const newUrl = `${ACTION_CENTER_ROUTE}/${monitorId}/${record.id ?? UNCATEGORIZED_SEGMENT}${activeTab ? `#${activeTab}` : ""}`;
-      return newUrl;
-    },
-    [monitorId, activeTab],
-  );
-
-  const { columns } = useDiscoveredSystemAggregateColumns({
-    monitorId,
-    onTabChange: handleTabChange,
-    readonly: actionsDisabled,
-    allowIgnore: !activeParams.diff_status.includes(DiffStatus.MUTED),
-    consentStatus: firstPageConsentStatus,
-    rowClickUrl,
-  });
-
-  const handleBulkAdd = async () => {
-    const totalUpdates = selectedRows.reduce(
-      (acc, row) => acc + row.total_updates!,
-      0,
-    );
-
-    const result = await addMonitorResultSystemsMutation({
-      monitor_config_key: monitorId,
-      resolved_system_ids: selectedRows.map((row) => row.id!),
-    });
-
-    if (isErrorResult(result)) {
-      toast(errorToastParams(getErrorMessage(result.error)));
-    } else {
-      toast(
-        successToastParams(
-          SuccessToastContent(
-            `${totalUpdates} assets have been added to the system inventory.`,
-            () => router.push(SYSTEM_ROUTE),
-          ),
-        ),
-      );
-      resetSelections();
-    }
-  };
-
-  const handleBulkIgnore = async () => {
-    const totalUpdates = selectedRows.reduce(
-      (acc, row) => acc + row.total_updates!,
-      0,
-    );
-
-    const result = await ignoreMonitorResultSystemsMutation({
-      monitor_config_key: monitorId,
-      resolved_system_ids: selectedRows.map(
-        (row) => row.id ?? UNCATEGORIZED_SEGMENT,
-      ),
-    });
-
-    if (isErrorResult(result)) {
-      toast(errorToastParams(getErrorMessage(result.error)));
-    } else {
-      toast(
-        successToastParams(
-          SuccessToastContent(
-            `${totalUpdates} assets have been ignored and will not appear in future scans.`,
-            () => onTabChange(ActionCenterTabHash.IGNORED),
-          ),
-        ),
-      );
-      resetSelections();
-    }
-  };
-
-  const uncategorizedIsSelected = selectedRows.some((row) => row.id === null);
-
-  const rowSelection = {
-    selectedRowKeys,
-    onChange: (
-      newSelectedRowKeys: React.Key[],
-      newSelectedRows: SystemStagedResourcesAggregateRecord[],
-    ) => {
-      setSelectedRowKeys(newSelectedRowKeys);
-
-      // Update the map with current page selections
-      const newMap = new Map(selectedRowsMap);
-
-      // Remove deselected items from current page
-      if (data?.items) {
-        data.items.forEach((item) => {
-          const key = getRecordKey(item);
-          if (!newSelectedRowKeys.includes(key)) {
-            newMap.delete(String(key));
-          }
-        });
-      }
-
-      // Add newly selected items
-      newSelectedRows.forEach((row) => {
-        const key = getRecordKey(row);
-        newMap.set(String(key), row);
-      });
-
-      setSelectedRowsMap(newMap);
-    },
-  };
-
-  const handleTableChange = (pagination: any) => {
-    setPageIndex(pagination.current);
-    setPageSize(pagination.pageSize);
-  };
+    // Loading states
+    anyBulkActionIsLoading,
+  } = useDiscoveredSystemAggregateTable({ monitorId });
 
   return (
     <>
-      <Tabs
+      <Menu
+        aria-label="Asset state filter"
+        mode="horizontal"
         items={filterTabs.map((tab) => ({
           key: tab.hash,
           label: tab.label,
         }))}
-        activeKey={activeTab}
-        onChange={(tab) => handleTabChange(tab as ActionCenterTabHash)}
+        selectedKeys={[activeTab]}
+        onClick={(menuInfo) =>
+          handleTabChange(menuInfo.key as ActionCenterTabHash)
+        }
+        className="mb-4"
+        data-testid="asset-state-filter"
       />
       <Flex justify="space-between" align="center" className="mb-4">
-        <DebouncedSearchInput value={searchQuery} onChange={setSearchQuery} />
+        <DebouncedSearchInput value={searchQuery} onChange={updateSearch} />
         <Space size="large">
-          {!!selectedRowKeys.length && (
-            <SelectedText count={selectedRows.length} />
-          )}
+          {hasSelectedRows && <SelectedText count={selectedRows.length} />}
           <Dropdown
             menu={{
               items: [
@@ -300,7 +108,7 @@ export const DiscoveredSystemAggregateTable = ({
               icon={<Icons.ChevronDown />}
               iconPosition="end"
               loading={anyBulkActionIsLoading}
-              disabled={!selectedRowKeys.length}
+              disabled={!hasSelectedRows}
               data-testid="bulk-actions-menu"
             >
               Actions
@@ -308,30 +116,7 @@ export const DiscoveredSystemAggregateTable = ({
           </Dropdown>
         </Space>
       </Flex>
-      <Table
-        dataSource={data?.items || []}
-        columns={columns}
-        loading={isLoading || isFetching}
-        rowKey={(record) =>
-          record.id ?? record.vendor_id ?? record.name ?? UNCATEGORIZED_SEGMENT
-        }
-        rowSelection={rowSelection}
-        pagination={{
-          current: pageIndex,
-          pageSize,
-          pageSizeOptions: DEFAULT_PAGE_SIZES,
-          total: data?.total || 0,
-        }}
-        onChange={handleTableChange}
-        locale={{
-          emptyText: (
-            <Empty
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description="All caught up!"
-            />
-          ),
-        }}
-      />
+      <Table {...tableProps} columns={columns} rowSelection={selectionProps} />
     </>
   );
 };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredSystemAggregateTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredSystemAggregateTable.tsx
@@ -62,9 +62,9 @@ export const DiscoveredSystemAggregateTable = ({
           label: tab.label,
         }))}
         selectedKeys={[activeTab]}
-        onClick={(menuInfo) =>
-          handleTabChange(menuInfo.key as ActionCenterTabHash)
-        }
+        onClick={async (menuInfo) => {
+          await handleTabChange(menuInfo.key as ActionCenterTabHash);
+        }}
         className="mb-4"
         data-testid="asset-state-filter"
       />

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetActionsCell.tsx
@@ -22,7 +22,7 @@ import { SuccessToastContent } from "../../SuccessToastContent";
 
 interface DiscoveredAssetActionsCellProps {
   asset: StagedResourceAPIResponse;
-  onTabChange: (tab: ActionCenterTabHash) => void;
+  onTabChange: (tab: ActionCenterTabHash) => Promise<void>;
 }
 
 export const DiscoveredAssetActionsCell = ({
@@ -85,7 +85,9 @@ export const DiscoveredAssetActionsCell = ({
         successToastParams(
           SuccessToastContent(
             `${type} "${name}" has been ignored and will not appear in future scans.`,
-            () => onTabChange(ActionCenterTabHash.IGNORED),
+            async () => {
+              await onTabChange(ActionCenterTabHash.IGNORED);
+            },
           ),
         ),
       );

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemAggregateActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredSystemAggregateActionsCell.tsx
@@ -25,7 +25,7 @@ interface DiscoveredSystemActionsCellProps {
   monitorId: string;
   system: SystemStagedResourcesAggregateRecord;
   allowIgnore?: boolean;
-  onTabChange: (tab: ActionCenterTabHash) => void;
+  onTabChange: (tab: ActionCenterTabHash) => Promise<void>;
 }
 
 export const DiscoveredSystemActionsCell = ({
@@ -87,7 +87,9 @@ export const DiscoveredSystemActionsCell = ({
             systemName
               ? `${totalUpdates} assets from ${systemName} have been ignored and will not appear in future scans.`
               : `${totalUpdates} uncategorized assets have been ignored and will not appear in future scans.`,
-            () => onTabChange(ActionCenterTabHash.IGNORED),
+            async () => {
+              await onTabChange(ActionCenterTabHash.IGNORED);
+            },
           ),
         ),
       );


### PR DESCRIPTION
Closes [ENG-1210]

### Description Of Changes

- Using the new `useTableState` and `useAntTable` hooks, refactored the remaining action center tables.
- Added new Cypress command for consistent tab interaction handling and updated existing tests to use the standardized approach.

### Code Changes

* Created `useConsentBreakdownTable` custom hook to manage table state, data fetching, and column configuration
* Added `ConsentBreakdownColumnKeys` and `DiscoveredSystemAggregateColumnKeys` enums for better type safety as per new established pattern
* Refactored `ConsentBreakdownModal` to use the new hook, reducing component complexity
* Added `clickAntTab` Cypress command that handles tab clicking with proper timing
* Updated Cypress tests to use the new `clickAntTab` command instead of manual selectors
* Enhanced `getAntTab` selector to support both tabs and horizontal menu items
* Removed unused imports and cleaned up component dependencies

### Steps to Confirm

1. Navigate to [Action Center](https://fides-plus-nightly-git-gill-eng-1210apply-new-hoo-c86f95-ethyca.vercel.app/data-discovery/action-center/Ethyca_Website_monitor/[undefined]#attention-required) and verify consent breakdown modal table by clicking the (i) next to one of the "without consent" statuses.
2. Test tab navigation in [Action Center system aggregate view](https://fides-plus-nightly-git-gill-eng-1210apply-new-hoo-c86f95-ethyca.vercel.app/data-discovery/action-center/Ethyca_Website_monitor) and ensure its table appears correctly.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1210]: https://ethyca.atlassian.net/browse/ENG-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ