### PR TITLE
fix: web monitor locations select [ENG-1223]

### DIFF
--- a/clients/admin-ui/src/features/common/dropdown/DataCategorySelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/DataCategorySelect.tsx
@@ -21,7 +21,7 @@ const DataCategorySelect = ({
     : getActiveDataCategories();
 
   const options: TaxonomySelectOption[] = dataCategories
-    .filter((category) => !selectedTaxonomies.includes(category.fides_key))
+    .filter((category) => !selectedTaxonomies?.includes(category.fides_key))
     .map((category) => {
       const { name, primaryName } = getDataCategoryDisplayNameProps(
         category.fides_key,

--- a/clients/admin-ui/src/features/common/dropdown/DataUseSelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/DataUseSelect.tsx
@@ -17,7 +17,7 @@ const DataUseSelect = ({
   const dataUses = showDisabled ? getDataUses() : getActiveDataUses();
 
   const options: TaxonomySelectOption[] = dataUses
-    .filter((dataUse) => !selectedTaxonomies.includes(dataUse.fides_key))
+    .filter((dataUse) => !selectedTaxonomies?.includes(dataUse.fides_key))
     .map((dataUse) => {
       const { name, primaryName } = getDataUseDisplayNameProps(
         dataUse.fides_key,

--- a/clients/admin-ui/src/features/common/dropdown/FilterSelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/FilterSelect.tsx
@@ -1,18 +1,19 @@
 import { AntSelect as Select, AntSelectProps as SelectProps } from "fidesui";
 
-export const FilterSelect = <ValueType,>({
-  ...props
-}: SelectProps<ValueType>) => {
-  const isMulti = props.mode === "multiple";
-  return (
-    <Select<ValueType>
-      defaultActiveFirstOption={false}
-      maxTagCount="responsive"
-      allowClear
-      dropdownStyle={isMulti ? undefined : { width: "auto", minWidth: "200px" }}
-      className="w-auto"
-      data-testid="filter-select"
-      {...props}
-    />
-  );
-};
+export const FilterSelect = ({ ...props }: SelectProps) => (
+  <Select
+    defaultActiveFirstOption={false}
+    maxTagCount="responsive"
+    allowClear
+    styles={
+      props.mode
+        ? undefined
+        : {
+            popup: { root: { width: "auto", minWidth: "200px" } },
+          }
+    }
+    className="w-auto"
+    data-testid="filter-select"
+    {...props}
+  />
+);

--- a/clients/admin-ui/src/features/common/dropdown/TaxonomySelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/TaxonomySelect.tsx
@@ -1,7 +1,8 @@
 import {
   AntFlex as Flex,
   AntSelect as Select,
-  AntSelectProps as SelectProps,
+  ICustomMultiSelectProps,
+  ICustomSelectProps,
 } from "fidesui";
 
 import styles from "./TaxonomySelect.module.scss";
@@ -35,16 +36,20 @@ export const TaxonomyOption = ({
   );
 };
 
-export interface TaxonomySelectProps
-  extends Omit<SelectProps<string, TaxonomySelectOption>, "options"> {
-  selectedTaxonomies: string[];
-  showDisabled?: boolean;
-}
+interface ITaxonomySelectProps
+  extends ICustomSelectProps<string, TaxonomySelectOption> {}
+interface ITaxonomyMultiSelectProps
+  extends ICustomMultiSelectProps<string, TaxonomySelectOption> {}
 
-export const TaxonomySelect = ({
-  options,
-  ...props
-}: SelectProps<string, TaxonomySelectOption>) => {
+export type TaxonomySelectProps = (
+  | ITaxonomySelectProps
+  | ITaxonomyMultiSelectProps
+) & {
+  showDisabled?: boolean;
+  selectedTaxonomies?: string[];
+};
+
+export const TaxonomySelect = ({ options, ...props }: TaxonomySelectProps) => {
   const selectOptions = options?.map((opt) => ({
     ...opt,
     className: styles.option,
@@ -69,7 +74,7 @@ export const TaxonomySelect = ({
       autoFocus
       variant="borderless"
       optionRender={TaxonomyOption}
-      dropdownStyle={{ minWidth: "500px" }}
+      styles={{ popup: { root: { minWidth: "500px" } } }}
       className="w-full p-0"
       data-testid="taxonomy-select"
       {...props}

--- a/clients/admin-ui/src/features/common/form/FormikDateTimeInput.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikDateTimeInput.tsx
@@ -41,6 +41,10 @@ export const FormikDateTimeInput = ({
         id={id ?? name}
         name={name}
         data-testid={`input-${name}`}
+        style={{
+          width: "100%",
+          ...props.style,
+        }}
         {...props}
       />
     </Form.Item>

--- a/clients/admin-ui/src/features/common/form/FormikDateTimeInput.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikDateTimeInput.tsx
@@ -33,8 +33,8 @@ export const FormikDateTimeInput = ({
       htmlFor={id ?? name}
     >
       <DatePicker
-        name={name}
         id={id ?? name}
+        name={name}
         data-testid={`input-${name}`}
         {...props}
       />

--- a/clients/admin-ui/src/features/common/form/FormikDateTimeInput.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikDateTimeInput.tsx
@@ -5,8 +5,12 @@ import {
   AntFormItemProps as FormItemProps,
 } from "fidesui";
 
+/*
+ * @description: Transitory component that migrates away from chakra while retaining formik
+ */
 export const FormikDateTimeInput = ({
   error,
+  touched,
   required,
   tooltip,
   label,
@@ -24,8 +28,9 @@ export const FormikDateTimeInput = ({
   }) => {
   return (
     <Form.Item
-      validateStatus={error ? "error" : undefined}
-      help={error}
+      validateStatus={touched && !!error ? "error" : undefined}
+      help={touched && error}
+      hasFeedback={touched && !!error}
       required={required}
       tooltip={tooltip}
       label={label}

--- a/clients/admin-ui/src/features/common/form/FormikDateTimeInput.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikDateTimeInput.tsx
@@ -1,20 +1,11 @@
 import {
+  AntDatePicker as DatePicker,
+  AntDatePickerProps as DatePickerProps,
   AntForm as Form,
   AntFormItemProps as FormItemProps,
-  LocationSelect,
-  LocationSelectProps,
 } from "fidesui";
 
-export type FormikLocationSelectProps = LocationSelectProps &
-  Pick<
-    FormItemProps,
-    "required" | "name" | "label" | "tooltip" | "help" | "extra"
-  > & {
-    touched?: boolean;
-    error?: string;
-  };
-
-export const FormikLocationSelect = ({
+export const FormikDateTimeInput = ({
   error,
   required,
   tooltip,
@@ -23,7 +14,14 @@ export const FormikLocationSelect = ({
   name,
   id,
   ...props
-}: FormikLocationSelectProps) => {
+}: DatePickerProps &
+  Pick<
+    FormItemProps,
+    "required" | "name" | "label" | "tooltip" | "help" | "extra"
+  > & {
+    touched?: boolean;
+    error?: string;
+  }) => {
   return (
     <Form.Item
       validateStatus={error ? "error" : undefined}
@@ -34,9 +32,10 @@ export const FormikLocationSelect = ({
       extra={extra}
       htmlFor={id ?? name}
     >
-      <LocationSelect
+      <DatePicker
+        name={name}
         id={id ?? name}
-        data-testid={`controlled-select-${name}`}
+        data-testid={`input-${name}`}
         {...props}
       />
     </Form.Item>

--- a/clients/admin-ui/src/features/common/form/FormikLocationSelect.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikLocationSelect.tsx
@@ -16,6 +16,7 @@ export type FormikLocationSelectProps = LocationSelectProps &
 
 export const FormikLocationSelect = ({
   error,
+  touched,
   required,
   tooltip,
   label,
@@ -26,8 +27,9 @@ export const FormikLocationSelect = ({
 }: FormikLocationSelectProps) => {
   return (
     <Form.Item
-      validateStatus={error ? "error" : undefined}
-      help={error}
+      validateStatus={touched && !!error ? "error" : undefined}
+      help={touched && error}
+      hasFeedback={touched && !!error}
       required={required}
       tooltip={tooltip}
       label={label}

--- a/clients/admin-ui/src/features/common/form/FormikLocationSelect.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikLocationSelect.tsx
@@ -1,0 +1,44 @@
+import {
+  AntForm as Form,
+  AntFormItemProps as FormItemProps,
+  LocationSelect,
+  LocationSelectProps,
+} from "fidesui";
+
+export type FormikLocationSelectProps = LocationSelectProps &
+  Pick<
+    FormItemProps,
+    "required" | "name" | "label" | "tooltip" | "help" | "extra"
+  > & {
+    touched?: boolean;
+    error?: string;
+  };
+
+export const FormikLocationSelect = ({
+  error,
+  required,
+  tooltip,
+  label,
+  extra,
+  name,
+  id,
+  ...props
+}: FormikLocationSelectProps) => {
+  return (
+    <Form.Item
+      status={error ? "error" : undefined}
+      help={error}
+      required={required}
+      tooltip={tooltip}
+      label={label}
+      extra={extra}
+      htmlFor={id ?? name}
+    >
+      <LocationSelect
+        id={id ?? name}
+        data-testid={`controlled-select-${name}`}
+        {...props}
+      />
+    </Form.Item>
+  );
+};

--- a/clients/admin-ui/src/features/common/form/FormikSelect.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikSelect.tsx
@@ -13,11 +13,13 @@ export type FormikSelectProps = ComponentProps<typeof Select> &
     error?: string;
     touched?: boolean;
   };
+
 /*
  * @description: Transitory component that migrates away from chakra while retaining formik
  */
 export const FormikSelect = ({
   error,
+  touched,
   required,
   tooltip,
   label,
@@ -58,8 +60,9 @@ export const FormikSelect = ({
 
   return (
     <Form.Item
-      validateStatus={error ? "error" : undefined}
-      help={error}
+      validateStatus={touched && !!error ? "error" : undefined}
+      help={touched && error}
+      hasFeedback={touched && !!error}
       required={required}
       tooltip={tooltip}
       label={label}

--- a/clients/admin-ui/src/features/common/form/FormikSelect.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikSelect.tsx
@@ -1,45 +1,32 @@
 import {
   AntForm as Form,
+  AntFormItemProps as FormItemProps,
   AntSelect as Select,
-  AntSelectProps as SelectProps,
-  FormLabelProps,
 } from "fidesui";
-import { useField } from "formik";
-import { useState } from "react";
+import { ComponentProps, useState } from "react";
 
-export interface FormikSelectProps extends SelectProps {
-  name: string;
-  label?: string;
-  labelProps?: FormLabelProps;
-  tooltip?: string | null;
-  isRequired?: boolean;
-  layout?: "inline" | "stacked";
-  helperText?: string | null;
-}
-
+export type FormikSelectProps = ComponentProps<typeof Select> &
+  Pick<
+    FormItemProps,
+    "required" | "name" | "label" | "tooltip" | "help" | "extra"
+  > & {
+    error?: string;
+    touched?: boolean;
+  };
 /*
  * @description: Transitory component that migrates away from chakra while retaining formik
  */
 export const FormikSelect = ({
-  name,
-  label,
-  labelProps,
+  error,
+  required,
   tooltip,
-  isRequired,
-  layout = "inline",
-  helperText,
+  label,
+  extra,
+  name,
+  id,
   ...props
 }: FormikSelectProps) => {
-  const [field, meta, { setValue }] = useField(name);
-  const isInvalid = !!(meta.touched && meta.error);
   const [searchValue, setSearchValue] = useState("");
-
-  if (!field.value && (props.mode === "tags" || props.mode === "multiple")) {
-    field.value = [];
-  }
-  if (props.mode === "tags" && typeof field.value === "string") {
-    field.value = [field.value];
-  }
 
   // Tags mode requires a custom option, everything else should just pass along the props or undefined
   const optionRender =
@@ -50,7 +37,7 @@ export const FormikSelect = ({
           }
           if (
             option.value === searchValue &&
-            !field.value.includes(searchValue)
+            !props.value?.includes(searchValue)
           ) {
             return `Create "${searchValue}"`;
           }
@@ -69,37 +56,22 @@ export const FormikSelect = ({
     }
   };
 
-  // Pass the value to the formik field
-  const handleChange = (newValue: any, option: any) => {
-    setValue(newValue);
-    if (props.onChange) {
-      props.onChange(newValue, option);
-    }
-  };
-
   return (
     <Form.Item
-      status={isInvalid ? "error" : undefined}
-      help={isInvalid && meta.error}
-      required={isRequired}
+      validateStatus={error ? "error" : undefined}
+      help={error}
+      required={required}
       tooltip={tooltip}
       label={label}
-      extra={helperText}
-      htmlFor={props.id ?? name}
-      layout={
-        layout === "inline" ? "horizontal" : "vertical"
-      } /* Legacy layout prop names */
+      extra={extra}
+      htmlFor={id ?? name}
     >
       <Select
-        {...field}
-        id={props.id ?? name}
-        data-testid={`controlled-select-${field.name}`}
+        id={id ?? name}
+        data-testid={`controlled-select-${name}`}
         {...props}
         optionRender={optionRender}
         onSearch={props.mode === "tags" ? handleSearch : undefined}
-        onChange={handleChange}
-        value={field.value || undefined} // solves weird bug where placeholder won't appear if value is an empty string ""
-        status={isInvalid ? "error" : undefined}
       />
     </Form.Item>
   );

--- a/clients/admin-ui/src/features/common/form/FormikSelect.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikSelect.tsx
@@ -1,0 +1,106 @@
+import {
+  AntForm as Form,
+  AntSelect as Select,
+  AntSelectProps as SelectProps,
+  FormLabelProps,
+} from "fidesui";
+import { useField } from "formik";
+import { useState } from "react";
+
+export interface FormikSelectProps extends SelectProps {
+  name: string;
+  label?: string;
+  labelProps?: FormLabelProps;
+  tooltip?: string | null;
+  isRequired?: boolean;
+  layout?: "inline" | "stacked";
+  helperText?: string | null;
+}
+
+/*
+ * @description: Transitory component that migrates away from chakra while retaining formik
+ */
+export const FormikSelect = ({
+  name,
+  label,
+  labelProps,
+  tooltip,
+  isRequired,
+  layout = "inline",
+  helperText,
+  ...props
+}: FormikSelectProps) => {
+  const [field, meta, { setValue }] = useField(name);
+  const isInvalid = !!(meta.touched && meta.error);
+  const [searchValue, setSearchValue] = useState("");
+
+  if (!field.value && (props.mode === "tags" || props.mode === "multiple")) {
+    field.value = [];
+  }
+  if (props.mode === "tags" && typeof field.value === "string") {
+    field.value = [field.value];
+  }
+
+  // Tags mode requires a custom option, everything else should just pass along the props or undefined
+  const optionRender =
+    props.mode === "tags"
+      ? (option: any, info: any) => {
+          if (!option) {
+            return undefined;
+          }
+          if (
+            option.value === searchValue &&
+            !field.value.includes(searchValue)
+          ) {
+            return `Create "${searchValue}"`;
+          }
+          if (props.optionRender) {
+            return props.optionRender(option, info);
+          }
+          return option.label;
+        }
+      : props.optionRender || undefined;
+
+  // this just supports the custom tag option, otherwise it's completely unnecessary
+  const handleSearch = (value: string) => {
+    setSearchValue(value);
+    if (props.onSearch) {
+      props.onSearch(value);
+    }
+  };
+
+  // Pass the value to the formik field
+  const handleChange = (newValue: any, option: any) => {
+    setValue(newValue);
+    if (props.onChange) {
+      props.onChange(newValue, option);
+    }
+  };
+
+  return (
+    <Form.Item
+      status={isInvalid ? "error" : undefined}
+      help={isInvalid && meta.error}
+      required={isRequired}
+      tooltip={tooltip}
+      label={label}
+      extra={helperText}
+      htmlFor={props.id ?? name}
+      layout={
+        layout === "inline" ? "horizontal" : "vertical"
+      } /* Legacy layout prop names */
+    >
+      <Select
+        {...field}
+        id={props.id ?? name}
+        data-testid={`controlled-select-${field.name}`}
+        {...props}
+        optionRender={optionRender}
+        onSearch={props.mode === "tags" ? handleSearch : undefined}
+        onChange={handleChange}
+        value={field.value || undefined} // solves weird bug where placeholder won't appear if value is an empty string ""
+        status={isInvalid ? "error" : undefined}
+      />
+    </Form.Item>
+  );
+};

--- a/clients/admin-ui/src/features/common/form/FormikTextInput.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikTextInput.tsx
@@ -33,7 +33,13 @@ export const FormikTextInput = ({
       extra={extra}
       htmlFor={id ?? name}
     >
-      <Input id={id || name} data-testid={`input-${name}`} {...props} />
+      <Input
+        id={id || name}
+        name={name}
+        data-testid={`input-${name}`}
+        allowClear
+        {...props}
+      />
     </Form.Item>
   );
 };

--- a/clients/admin-ui/src/features/common/form/FormikTextInput.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikTextInput.tsx
@@ -1,0 +1,39 @@
+import {
+  AntForm as Form,
+  AntFormItemProps as FormItemProps,
+  AntInput as Input,
+  AntInputProps as InputProps,
+} from "fidesui";
+import React from "react";
+
+export const FormikTextInput = ({
+  error,
+  required,
+  tooltip,
+  label,
+  extra,
+  name,
+  id,
+  ...props
+}: InputProps &
+  Pick<
+    FormItemProps,
+    "required" | "name" | "label" | "tooltip" | "help" | "extra"
+  > & {
+    error?: string;
+  }) => {
+  return (
+    <Form.Item
+      validateStatus={error ? "error" : undefined}
+      help={error}
+      required={required}
+      tooltip={tooltip}
+      label={label}
+      hasFeedback={!!error}
+      extra={extra}
+      htmlFor={id ?? name}
+    >
+      <Input id={id || name} data-testid={`input-${name}`} {...props} />
+    </Form.Item>
+  );
+};

--- a/clients/admin-ui/src/features/common/form/FormikTextInput.tsx
+++ b/clients/admin-ui/src/features/common/form/FormikTextInput.tsx
@@ -8,6 +8,7 @@ import React from "react";
 
 export const FormikTextInput = ({
   error,
+  touched,
   required,
   tooltip,
   label,
@@ -21,15 +22,16 @@ export const FormikTextInput = ({
     "required" | "name" | "label" | "tooltip" | "help" | "extra"
   > & {
     error?: string;
+    touched?: boolean;
   }) => {
   return (
     <Form.Item
-      validateStatus={error ? "error" : undefined}
-      help={error}
+      validateStatus={touched && !!error ? "error" : undefined}
+      help={touched && error}
+      hasFeedback={touched && !!error}
       required={required}
       tooltip={tooltip}
       label={label}
-      hasFeedback={!!error}
       extra={extra}
       htmlFor={id ?? name}
     >

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -638,6 +638,9 @@ export const CustomDatePicker = ({
   );
 };
 
+/**
+ * @deprecated in favor of FormikDateTimeInput
+ */
 export const CustomDateTimeInput = ({
   label,
   name,

--- a/clients/admin-ui/src/features/common/form/inputs.tsx
+++ b/clients/admin-ui/src/features/common/form/inputs.tsx
@@ -69,6 +69,9 @@ export interface CustomInputProps {
 // if the value they receive is undefined.
 export type StringField = FieldHookConfig<string | undefined>;
 
+/**
+ * @deprecated in favor of Form.Input label prop
+ */
 export const Label = ({
   children,
   ...labelProps
@@ -135,6 +138,9 @@ export const TextInput = forwardRef(
 );
 TextInput.displayName = "TextInput";
 
+/**
+ * @deprecated in favor of Form.Input with the appropriate status and help props
+ */
 export const ErrorMessage = ({
   isInvalid,
   message,

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
@@ -181,8 +181,8 @@ const ConfigureWebsiteMonitorForm = ({
           options={[]}
           open={false}
           disabled
-          error={errors.execution_frequency}
-          touched={touched.execution_frequency}
+          error={getIn(errors, "datasource_params.exclude_domains")}
+          touched={getIn(touched, "datasource_params.exclude_domains")}
           onChange={(value) =>
             formik.setFieldValue("datasource_params.exclude_domains", value)
           }

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
@@ -1,4 +1,5 @@
 import { format, parseISO } from "date-fns";
+import dayjs from "dayjs";
 import {
   AntButton as Button,
   AntFlex as Flex,
@@ -10,16 +11,13 @@ import { getIn, useFormik } from "formik";
 import { useRouter } from "next/router";
 import * as Yup from "yup";
 
-import { ControlledSelect } from "~/features/common/form/ControlledSelect";
+import { FormikDateTimeInput } from "~/features/common/form/FormikDateTimeInput";
 import { FormikLocationSelect } from "~/features/common/form/FormikLocationSelect";
-import {
-  CustomDateTimeInput,
-  CustomTextInput,
-} from "~/features/common/form/inputs";
+import { FormikSelect } from "~/features/common/form/FormikSelect";
+import { FormikTextInput } from "~/features/common/form/FormikTextInput";
 import { enumToOptions } from "~/features/common/helpers";
 import FormInfoBox from "~/features/common/modals/FormInfoBox";
 import { PRIVACY_NOTICE_REGION_RECORD } from "~/features/common/privacy-notice-regions";
-import { SharedConfigSelect } from "~/features/integrations/configure-monitor/SharedConfigSelect";
 import { useGetOnlyCountryLocationsQuery } from "~/features/locations/locations.slice";
 import { getSelectedRegionIds } from "~/features/privacy-experience/form/helpers";
 import {
@@ -27,6 +25,8 @@ import {
   MonitorFrequency,
   WebsiteMonitorParams,
 } from "~/types/api";
+
+import { FormikSharedConfigSelect } from "./FormikSharedConfigSelect";
 
 interface WebsiteMonitorConfig
   extends Omit<MonitorConfig, "datasource_params"> {
@@ -151,83 +151,117 @@ const ConfigureWebsiteMonitorForm = ({
         <Text fontSize="sm">{FORM_COPY}</Text>
       </FormInfoBox>
       <Form onFinish={formikSubmit} layout="vertical">
-        <Flex vertical gap="middle">
-          <CustomTextInput
-            name="name"
-            id="name"
-            label="Name"
-            isRequired
-            variant="stacked"
-          />
-          <CustomTextInput
-            name="datasource_params.sitemap_url"
-            id="sitemap_url"
-            label="Sitemap URL"
-            variant="stacked"
-          />
-          <ControlledSelect
-            mode="tags"
-            name="datasource_params.exclude_domains"
-            placeholder="Enter domains to exclude"
-            id="exclude_domains"
-            label="Exclude domains"
-            options={[]}
-            open={false}
-            layout="stacked"
-          />
-          <CustomTextInput
-            name="url"
-            id="url"
-            label="URL"
-            isRequired
-            disabled
-            variant="stacked"
-          />
-          <FormikLocationSelect
-            id="locations"
-            name="datasource_params.locations"
-            loading={locationsLoading}
-            options={isoCodesToOptions(
-              regionOptions.map((option) => option.value),
-            )}
-            required
-            tooltip={REGIONS_TOOLTIP_COPY}
-            mode="tags"
-            error={getIn(errors, "datasource_params.locations")}
-            onChange={formik.handleChange}
-            onBlur={formik.handleBlur}
-            value={values.datasource_params?.locations}
-          />
-          <SharedConfigSelect name="shared_config_id" id="shared_config_id" />
-          <ControlledSelect
-            name="execution_frequency"
-            id="execution_frequency"
-            options={frequencyOptions}
-            label="Automatic execution frequency"
-            layout="stacked"
-          />
-          <CustomDateTimeInput
-            name="execution_start_date"
-            label="Automatic execution start time"
-            disabled={
-              values.execution_frequency === MonitorFrequency.NOT_SCHEDULED
-            }
-            id="execution_start_date"
-            tooltip={START_TIME_TOOLTIP_COPY}
-          />
-          <Flex className="mt-2 justify-between">
-            <Button
-              onClick={() => {
-                resetForm();
-                onClose();
-              }}
-            >
-              Cancel
-            </Button>
-            <Button type="primary" htmlType="submit" data-testid="save-btn">
-              Save
-            </Button>
-          </Flex>
+        <FormikTextInput
+          name="name"
+          id="name"
+          label="Name"
+          required
+          error={errors.name}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          value={values.name}
+        />
+        <FormikTextInput
+          name="datasource_params.sitemap_url"
+          id="sitemap_url"
+          label="Sitemap URL"
+          error={getIn(errors, "datasource_params.sitemap_url")}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          value={values.datasource_params?.sitemap_url || ""}
+        />
+        <FormikSelect
+          name="datasource_params.exclude_domains"
+          placeholder="Enter domains to exclude"
+          id="exclude_domains"
+          label="Exclude domains"
+          options={[]}
+          open={false}
+          disabled
+          error={errors.execution_frequency}
+          onChange={(value) =>
+            formik.setFieldValue("datasource_params.exclude_domains", value)
+          }
+          onBlur={formik.handleBlur}
+          value={values.execution_frequency || []}
+        />
+        <FormikTextInput
+          name="url"
+          id="url"
+          label="URL"
+          required
+          disabled
+          error={errors.url}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          value={values.url || ""}
+        />
+        <FormikLocationSelect
+          id="locations"
+          name="datasource_params.locations"
+          label="Locations"
+          loading={locationsLoading}
+          options={isoCodesToOptions(
+            regionOptions.map((option) => option.value),
+          )}
+          required
+          tooltip={REGIONS_TOOLTIP_COPY}
+          mode="tags"
+          error={getIn(errors, "datasource_params.locations")}
+          onChange={(value) =>
+            formik.setFieldValue("datasource_params.locations", value)
+          }
+          onBlur={formik.handleBlur}
+          value={values.datasource_params?.locations}
+        />
+        <FormikSharedConfigSelect
+          name="shared_config_id"
+          id="shared_config_id"
+          error={errors.shared_config_id}
+          onChange={(value) => formik.setFieldValue("shared_config_id", value)}
+          onBlur={formik.handleBlur}
+          value={values.shared_config_id}
+        />
+        <FormikSelect
+          name="execution_frequency"
+          id="execution_frequency"
+          options={frequencyOptions}
+          label="Automatic execution frequency"
+          error={errors.execution_frequency}
+          onChange={(value) =>
+            formik.setFieldValue("execution_frequency", value)
+          }
+          onBlur={formik.handleBlur}
+          value={values.execution_frequency}
+        />
+        <FormikDateTimeInput
+          name="execution_start_date"
+          label="Automatic execution start time"
+          disabled={
+            values.execution_frequency === MonitorFrequency.NOT_SCHEDULED
+          }
+          id="execution_start_date"
+          tooltip={START_TIME_TOOLTIP_COPY}
+          error={errors.execution_start_date}
+          onChange={(value) =>
+            value &&
+            formik.setFieldValue("execution_start_date", value.toISOString())
+          }
+          onBlur={formik.handleBlur}
+          value={dayjs(values.execution_start_date)}
+        />
+        <Flex className="mt-2 justify-between">
+          <Button
+            onClick={() => {
+              resetForm();
+              onClose();
+            }}
+          >
+            Cancel
+          </Button>
+          <Button type="primary" htmlType="submit" data-testid="save-btn">
+            Save
+          </Button>
         </Flex>
       </Form>
     </Flex>

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
@@ -127,6 +127,7 @@ const ConfigureWebsiteMonitorForm = ({
     resetForm,
     handleSubmit: formikSubmit,
     errors,
+    touched,
     ...formik
   } = useFormik({
     initialValues,
@@ -157,6 +158,7 @@ const ConfigureWebsiteMonitorForm = ({
           label="Name"
           required
           error={errors.name}
+          touched={touched.name}
           onChange={formik.handleChange}
           onBlur={formik.handleBlur}
           value={values.name}
@@ -166,6 +168,7 @@ const ConfigureWebsiteMonitorForm = ({
           id="sitemap_url"
           label="Sitemap URL"
           error={getIn(errors, "datasource_params.sitemap_url")}
+          touched={getIn(touched, "datasource_params.sitemap_url")}
           onChange={formik.handleChange}
           onBlur={formik.handleBlur}
           value={values.datasource_params?.sitemap_url || ""}
@@ -179,6 +182,7 @@ const ConfigureWebsiteMonitorForm = ({
           open={false}
           disabled
           error={errors.execution_frequency}
+          touched={touched.execution_frequency}
           onChange={(value) =>
             formik.setFieldValue("datasource_params.exclude_domains", value)
           }
@@ -192,6 +196,7 @@ const ConfigureWebsiteMonitorForm = ({
           required
           disabled
           error={errors.url}
+          touched={touched.url}
           onChange={formik.handleChange}
           onBlur={formik.handleBlur}
           value={values.url || ""}
@@ -208,6 +213,7 @@ const ConfigureWebsiteMonitorForm = ({
           tooltip={REGIONS_TOOLTIP_COPY}
           mode="tags"
           error={getIn(errors, "datasource_params.locations")}
+          touched={getIn(touched, "datasource_params.locations")}
           onChange={(value) =>
             formik.setFieldValue("datasource_params.locations", value)
           }
@@ -218,6 +224,7 @@ const ConfigureWebsiteMonitorForm = ({
           name="shared_config_id"
           id="shared_config_id"
           error={errors.shared_config_id}
+          touched={touched.shared_config_id}
           onChange={(value) => formik.setFieldValue("shared_config_id", value)}
           onBlur={formik.handleBlur}
           value={values.shared_config_id}
@@ -228,6 +235,7 @@ const ConfigureWebsiteMonitorForm = ({
           options={frequencyOptions}
           label="Automatic execution frequency"
           error={errors.execution_frequency}
+          touched={touched.execution_frequency}
           onChange={(value) =>
             formik.setFieldValue("execution_frequency", value)
           }
@@ -243,6 +251,7 @@ const ConfigureWebsiteMonitorForm = ({
           id="execution_start_date"
           tooltip={START_TIME_TOOLTIP_COPY}
           error={errors.execution_start_date}
+          touched={touched.execution_start_date}
           onChange={(value) =>
             value &&
             formik.setFieldValue("execution_start_date", value.toISOString())

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
@@ -4,14 +4,14 @@ import {
   AntFlex as Flex,
   AntForm as Form,
   isoCodesToOptions,
-  LocationSelect,
   Text,
 } from "fidesui";
-import { Form as FormikForm, Formik } from "formik";
+import { getIn, useFormik } from "formik";
 import { useRouter } from "next/router";
 import * as Yup from "yup";
 
 import { ControlledSelect } from "~/features/common/form/ControlledSelect";
+import { FormikLocationSelect } from "~/features/common/form/FormikLocationSelect";
 import {
   CustomDateTimeInput,
   CustomTextInput,
@@ -122,6 +122,18 @@ const ConfigureWebsiteMonitorForm = ({
     onSubmit(payload);
   };
 
+  const {
+    values,
+    resetForm,
+    handleSubmit: formikSubmit,
+    errors,
+    ...formik
+  } = useFormik({
+    initialValues,
+    onSubmit: handleSubmit,
+    validationSchema,
+  });
+
   // Website monitors should only support
   // monthly, quarterly, yearly, and not scheduled frequencies
   const frequencyOptions = enumToOptions(MonitorFrequency).filter((option) =>
@@ -138,101 +150,86 @@ const ConfigureWebsiteMonitorForm = ({
       <FormInfoBox>
         <Text fontSize="sm">{FORM_COPY}</Text>
       </FormInfoBox>
-      <Formik
-        initialValues={initialValues}
-        enableReinitialize
-        onSubmit={handleSubmit}
-        validationSchema={validationSchema}
-      >
-        {({ values, resetForm }) => (
-          <FormikForm>
-            <Flex vertical gap="middle">
-              <CustomTextInput
-                name="name"
-                id="name"
-                label="Name"
-                isRequired
-                variant="stacked"
-              />
-              <CustomTextInput
-                name="datasource_params.sitemap_url"
-                id="sitemap_url"
-                label="Sitemap URL"
-                variant="stacked"
-              />
-              <ControlledSelect
-                mode="tags"
-                name="datasource_params.exclude_domains"
-                placeholder="Enter domains to exclude"
-                id="exclude_domains"
-                label="Exclude domains"
-                options={[]}
-                open={false}
-                layout="stacked"
-              />
-              <CustomTextInput
-                name="url"
-                id="url"
-                label="URL"
-                isRequired
-                disabled
-                variant="stacked"
-              />
-              <Form.Item
-                label="Locations"
-                required
-                layout="vertical"
-                tooltip={REGIONS_TOOLTIP_COPY}
-                htmlFor="datasource_params.locations"
-              >
-                <LocationSelect
-                  mode="multiple"
-                  id="locations"
-                  data-testid="controlled-select-datasource_params.locations"
-                  loading={locationsLoading}
-                  options={isoCodesToOptions(
-                    regionOptions.map((option) => option.value),
-                  )}
-                  optionFilterProp="label"
-                />
-              </Form.Item>
-              <SharedConfigSelect
-                name="shared_config_id"
-                id="shared_config_id"
-              />
-              <ControlledSelect
-                name="execution_frequency"
-                id="execution_frequency"
-                options={frequencyOptions}
-                label="Automatic execution frequency"
-                layout="stacked"
-              />
-              <CustomDateTimeInput
-                name="execution_start_date"
-                label="Automatic execution start time"
-                disabled={
-                  values.execution_frequency === MonitorFrequency.NOT_SCHEDULED
-                }
-                id="execution_start_date"
-                tooltip={START_TIME_TOOLTIP_COPY}
-              />
-              <Flex className="mt-2 justify-between">
-                <Button
-                  onClick={() => {
-                    resetForm();
-                    onClose();
-                  }}
-                >
-                  Cancel
-                </Button>
-                <Button type="primary" htmlType="submit" data-testid="save-btn">
-                  Save
-                </Button>
-              </Flex>
-            </Flex>
-          </FormikForm>
-        )}
-      </Formik>
+      <Form onFinish={formikSubmit} layout="vertical">
+        <Flex vertical gap="middle">
+          <CustomTextInput
+            name="name"
+            id="name"
+            label="Name"
+            isRequired
+            variant="stacked"
+          />
+          <CustomTextInput
+            name="datasource_params.sitemap_url"
+            id="sitemap_url"
+            label="Sitemap URL"
+            variant="stacked"
+          />
+          <ControlledSelect
+            mode="tags"
+            name="datasource_params.exclude_domains"
+            placeholder="Enter domains to exclude"
+            id="exclude_domains"
+            label="Exclude domains"
+            options={[]}
+            open={false}
+            layout="stacked"
+          />
+          <CustomTextInput
+            name="url"
+            id="url"
+            label="URL"
+            isRequired
+            disabled
+            variant="stacked"
+          />
+          <FormikLocationSelect
+            id="locations"
+            name="datasource_params.locations"
+            loading={locationsLoading}
+            options={isoCodesToOptions(
+              regionOptions.map((option) => option.value),
+            )}
+            required
+            tooltip={REGIONS_TOOLTIP_COPY}
+            mode="tags"
+            error={getIn(errors, "datasource_params.locations")}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            value={values.datasource_params?.locations}
+          />
+          <SharedConfigSelect name="shared_config_id" id="shared_config_id" />
+          <ControlledSelect
+            name="execution_frequency"
+            id="execution_frequency"
+            options={frequencyOptions}
+            label="Automatic execution frequency"
+            layout="stacked"
+          />
+          <CustomDateTimeInput
+            name="execution_start_date"
+            label="Automatic execution start time"
+            disabled={
+              values.execution_frequency === MonitorFrequency.NOT_SCHEDULED
+            }
+            id="execution_start_date"
+            tooltip={START_TIME_TOOLTIP_COPY}
+          />
+          <Flex className="mt-2 justify-between">
+            <Button
+              onClick={() => {
+                resetForm();
+                onClose();
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="primary" htmlType="submit" data-testid="save-btn">
+              Save
+            </Button>
+          </Flex>
+        </Flex>
+      </Form>
     </Flex>
   );
 };

--- a/clients/admin-ui/src/features/integrations/configure-monitor/FormikSharedConfigSelect.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/FormikSharedConfigSelect.tsx
@@ -1,0 +1,40 @@
+import {
+  AntFormItemProps as FormItemProps,
+  AntSelect as Select,
+} from "fidesui";
+import { ComponentProps } from "react";
+
+import { FormikSelect } from "~/features/common/form/FormikSelect";
+import { useGetSharedMonitorConfigsQuery } from "~/features/monitors/shared-monitor-config.slice";
+
+type SharedConfigSelectProps = ComponentProps<typeof Select> &
+  Pick<
+    FormItemProps,
+    "required" | "name" | "label" | "tooltip" | "help" | "extra"
+  > & {
+    error?: string;
+    touched?: boolean;
+  };
+
+export const FormikSharedConfigSelect = (props: SharedConfigSelectProps) => {
+  const { data: sharedMonitorConfigs } = useGetSharedMonitorConfigsQuery({
+    page: 1,
+    size: 100,
+  });
+
+  const sharedMonitorConfigOptions = sharedMonitorConfigs?.items.map(
+    (config) => ({
+      label: config.name,
+      value: config.id,
+    }),
+  );
+
+  return (
+    <FormikSelect
+      tooltip="If a shared monitor config is selected, the monitor will use the shared config to classify resources"
+      options={sharedMonitorConfigOptions}
+      label="Shared monitor config"
+      {...props}
+    />
+  );
+};

--- a/clients/fidesui/src/components/data-entry/Form.stories.tsx
+++ b/clients/fidesui/src/components/data-entry/Form.stories.tsx
@@ -69,6 +69,7 @@ export const Validation: Story = {
         label="Name"
         validateStatus="error"
         help="Name is a required field"
+        extra="Extra Text"
         required
       >
         <Input placeholder="Name" />

--- a/clients/fidesui/src/components/select/LocationSelect.stories.ts
+++ b/clients/fidesui/src/components/select/LocationSelect.stories.ts
@@ -5,7 +5,7 @@ import { fn } from "storybook/test";
 import { LocationSelect } from "./LocationSelect";
 
 const meta = {
-  title: "DataEntry/Select/LocationSelect",
+  title: "DataEntry/LocationSelect",
   component: LocationSelect,
   parameters: {},
   tags: ["autodocs"],

--- a/clients/fidesui/src/hoc/CustomSelect.tsx
+++ b/clients/fidesui/src/hoc/CustomSelect.tsx
@@ -25,30 +25,56 @@ const optionDescriptionRender = (
   );
 };
 
+export interface ICustomSelectProps<
+  SelectValue,
+  OptionType extends DefaultOptionType | BaseOptionType = DefaultOptionType,
+> extends SelectProps<SelectValue, OptionType> {
+  mode?: undefined;
+  defaultValue?: SelectValue | null;
+}
+
+export interface ICustomMultiSelectProps<
+  SelectValue,
+  OptionType extends DefaultOptionType | BaseOptionType = DefaultOptionType,
+> extends SelectProps<SelectValue[], OptionType> {
+  mode: "tags" | "multiple";
+  defaultValue?: SelectValue[] | null;
+}
+
+/**
+ * @description using discriminated unions to explicitly handle single vs multi select values
+ */
+export type CustomSelectProps<
+  SelectValue,
+  OptionType extends DefaultOptionType | BaseOptionType = DefaultOptionType,
+> =
+  | ICustomMultiSelectProps<SelectValue, OptionType>
+  | ICustomSelectProps<SelectValue, OptionType>;
+
 const withCustomProps = (WrappedComponent: typeof Select) => {
   const WrappedSelect = <
-    ValueType = any,
+    SelectValue,
     OptionType extends DefaultOptionType | BaseOptionType = DefaultOptionType,
-  >({
-    placeholder = "Select...",
-    optionRender = optionDescriptionRender,
-    className = "w-full",
-    showSearch = true,
-    suffixIcon,
-    menuItemSelectedIcon = <Checkmark />,
-    ...props
-  }: SelectProps<ValueType, OptionType>) => {
+  >(
+    props: CustomSelectProps<SelectValue, OptionType>,
+  ) => {
+    const { loading, suffixIcon, id } = props;
     const customProps = {
-      placeholder,
-      optionRender,
-      className,
-      showSearch,
-      suffixIcon: props.loading ? undefined : suffixIcon || <ChevronDown />,
-      menuItemSelectedIcon,
-      "data-testid": `select${props.id ? `-${props.id}` : ""}`,
+      placeholder: "Select...",
+      optionRender: optionDescriptionRender,
+      showSearch: true,
+      menuItemSelectedIcon: <Checkmark />,
+      className: "w-full",
+      suffixIcon: loading ? undefined : suffixIcon || <ChevronDown />,
+      "data-testid": `select${id ? `-${id}` : ""}`,
       ...props,
     };
-    return <WrappedComponent {...customProps} />;
+
+    return customProps.mode ? (
+      <WrappedComponent {...customProps} /> /* multi-select props */
+    ) : (
+      <WrappedComponent {...customProps} />
+    ); /* mono-select props */
   };
   return WrappedSelect;
 };

--- a/clients/fidesui/src/index.ts
+++ b/clients/fidesui/src/index.ts
@@ -18,6 +18,7 @@ export type {
 export type {
   ButtonProps as AntButtonProps,
   CollapseProps as AntCollapseProps,
+  DatePickerProps as AntDatePickerProps,
   DropdownProps as AntDropdownProps,
   FlexProps as AntFlexProps,
   FormInstance as AntFormInstance,

--- a/clients/fidesui/src/index.ts
+++ b/clients/fidesui/src/index.ts
@@ -7,6 +7,7 @@ export { getCSSVar } from "@chakra-ui/react";
 export * from "@chakra-ui/utils";
 
 // Unmodified component exported directly from Ant Design
+export type { LocationSelectProps } from "./components/select/LocationSelect";
 export { LocationSelect } from "./components/select/LocationSelect";
 export type { ThemeConfig as AntThemeConfig } from "antd/es";
 export type {
@@ -20,6 +21,7 @@ export type {
   DropdownProps as AntDropdownProps,
   FlexProps as AntFlexProps,
   FormInstance as AntFormInstance,
+  FormItemProps as AntFormItemProps,
   InputProps as AntInputProps,
   ListProps as AntListProps,
   MenuProps as AntMenuProps,
@@ -83,6 +85,7 @@ export type {
 } from "antd/lib/select";
 export type { UploadChangeParam as AntUploadChangeParam } from "antd/lib/upload";
 // Higher-order components
+export type { ICustomMultiSelectProps, ICustomSelectProps } from "./hoc";
 export {
   CustomDateRangePicker as AntDateRangePicker,
   CustomSelect as AntSelect,


### PR DESCRIPTION
Closes [ENG-1223]

### Description Of Changes

Fixed the Location Select component from not being wired into formik correctly

### Code Changes

- Hooked up the location select component to formik
- Refactored web monitor form too use ant components + use components that aren't heavily tied to formik
- Improved ant's select prop types to use a discriminated union so that values can be more accurately represented

### Steps to Confirm

1. Visit `/integrations/ethyca#data-discovery` and go open the edit and create modals
2. Verify that the location select component now correctly submits values
3. Confirm that no functionality has been lost in the refactoring of the form and input components

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1223]: https://ethyca.atlassian.net/browse/ENG-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ