### PR TITLE
update datamap lineage colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added async polling queue for API integrations [#6435](https://github.com/ethyca/fides/pull/6435)
 - Updated Admin UI to poll during non-terminal task statuses [#6493](https://github.com/ethyca/fides/pull/6493)
 - Moved Organization Management and SSO out of beta [#6495](https://github.com/ethyca/fides/pull/6494)
+- Updated data lineage nodes styling to use neutral color scheme for improved visual consistency [#6505](https://github.com/ethyca/fides/pull/6505)
 
 ### Fixed
 - Erasure Request finalization [#6493](https://github.com/ethyca/fides/pull/6493)

--- a/clients/admin-ui/src/features/datamap/DatamapSystemNode.module.scss
+++ b/clients/admin-ui/src/features/datamap/DatamapSystemNode.module.scss
@@ -18,8 +18,8 @@
 
   // Default state
   color: map-get($colors, "neutral-800");
-  background-color: map-get($colors, "neutral-50");
-  border: 1px solid map-get($colors, "neutral-100");
+  background-color: map-get($colors, "neutral-100");
+  border: 1px solid map-get($colors, "neutral-200");
   box-shadow: none;
 
   // Hover state


### PR DESCRIPTION
### Description Of Changes

Updated the styling for Data lineage nodes in the datamap to use a neutral color scheme for improved visual consistency and readability. The nodes now have a light gray background with dark text instead of the previous styling.

### Code Changes

  * Updated `DatamapSystemNode.module.scss` to use neutral color palette for default node state:
  * Background color: `neutral-100` (light gray)
  * Border color: `neutral-200` (medium gray)

### Steps to Confirm

1. Add systems 
2. Navigate to the datamap feature in the admin UI
3. Verify that data lineage nodes display with the new neutral color scheme
4. Confirm that text remains readable and has sufficient contrast
5. Test hover and focus states to ensure they still work correctly

### Pre-Merge Checklist

  * [ ] Issue requirements met
  * [x] All CI pipelines succeeded
  * [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required