### PR TITLE
Update connector template to include cached display_info properties

### DIFF
--- a/src/fides/api/schemas/saas/connector_template.py
+++ b/src/fides/api/schemas/saas/connector_template.py
@@ -4,6 +4,8 @@ from fideslang.models import Dataset
 from pydantic import BaseModel, field_validator
 
 from fides.api.models.datasetconfig import validate_masking_strategy_override
+from fides.api.schemas.enums.connection_category import ConnectionCategory
+from fides.api.schemas.enums.integration_feature import IntegrationFeature
 from fides.api.schemas.policy import ActionType
 from fides.api.schemas.saas.saas_config import SaaSConfig
 from fides.api.util.saas_util import load_config_from_string, load_dataset_from_string
@@ -22,6 +24,9 @@ class ConnectorTemplate(BaseModel):
     authorization_required: bool
     user_guide: Optional[str] = None
     supported_actions: List[ActionType]
+    category: Optional[ConnectionCategory] = None
+    tags: Optional[List[str]] = None
+    enabled_features: Optional[List[IntegrationFeature]] = None
 
     @field_validator("config")
     @classmethod

--- a/src/fides/api/service/connectors/saas/connector_registry_service.py
+++ b/src/fides/api/service/connectors/saas/connector_registry_service.py
@@ -78,6 +78,14 @@ class FileConnectorTemplateLoader(ConnectorTemplateLoader):
                     == OAuth2AuthorizationCodeAuthenticationStrategy.name
                 )
 
+                category = None
+                tags = None
+                enabled_features = None
+                if config.display_info:
+                    category = config.display_info.category
+                    tags = config.display_info.tags
+                    enabled_features = config.display_info.enabled_features
+
                 try:
                     icon = encode_file_contents(f"data/saas/icon/{connector_type}.svg")
                 except FileNotFoundError:
@@ -100,6 +108,10 @@ class FileConnectorTemplateLoader(ConnectorTemplateLoader):
                         authorization_required=authorization_required,
                         user_guide=config.user_guide,
                         supported_actions=config.supported_actions,
+                        # Add cached display info
+                        category=category,
+                        tags=tags,
+                        enabled_features=enabled_features,
                     )
                 except Exception:
                     logger.exception("Unable to load {} connector", connector_type)
@@ -165,6 +177,14 @@ class CustomConnectorTemplateLoader(ConnectorTemplateLoader):
             == OAuth2AuthorizationCodeAuthenticationStrategy.name
         )
 
+        category = None
+        tags = None
+        enabled_features = None
+        if config.display_info:
+            category = config.display_info.category
+            tags = config.display_info.tags
+            enabled_features = config.display_info.enabled_features
+
         connector_template = ConnectorTemplate(
             config=template.config,
             dataset=template.dataset,
@@ -173,6 +193,9 @@ class CustomConnectorTemplateLoader(ConnectorTemplateLoader):
             authorization_required=authorization_required,
             user_guide=config.user_guide,
             supported_actions=config.supported_actions,
+            category=category,
+            tags=tags,
+            enabled_features=enabled_features,
         )
 
         # register the template in the loader's template dictionary

--- a/src/fides/api/service/connectors/saas/connector_registry_service.py
+++ b/src/fides/api/service/connectors/saas/connector_registry_service.py
@@ -26,6 +26,7 @@ from fides.api.service.authentication.authentication_strategy_oauth2_authorizati
 )
 from fides.api.util.saas_util import (
     encode_file_contents,
+    extract_display_info_from_config,
     load_config,
     load_config_from_string,
     load_dataset_from_string,
@@ -78,13 +79,7 @@ class FileConnectorTemplateLoader(ConnectorTemplateLoader):
                     == OAuth2AuthorizationCodeAuthenticationStrategy.name
                 )
 
-                category = None
-                tags = None
-                enabled_features = None
-                if config.display_info:
-                    category = config.display_info.category
-                    tags = config.display_info.tags
-                    enabled_features = config.display_info.enabled_features
+                display_info = extract_display_info_from_config(config)
 
                 try:
                     icon = encode_file_contents(f"data/saas/icon/{connector_type}.svg")
@@ -108,10 +103,7 @@ class FileConnectorTemplateLoader(ConnectorTemplateLoader):
                         authorization_required=authorization_required,
                         user_guide=config.user_guide,
                         supported_actions=config.supported_actions,
-                        # Add cached display info
-                        category=category,
-                        tags=tags,
-                        enabled_features=enabled_features,
+                        **display_info,
                     )
                 except Exception:
                     logger.exception("Unable to load {} connector", connector_type)
@@ -177,13 +169,7 @@ class CustomConnectorTemplateLoader(ConnectorTemplateLoader):
             == OAuth2AuthorizationCodeAuthenticationStrategy.name
         )
 
-        category = None
-        tags = None
-        enabled_features = None
-        if config.display_info:
-            category = config.display_info.category
-            tags = config.display_info.tags
-            enabled_features = config.display_info.enabled_features
+        display_info = extract_display_info_from_config(config)
 
         connector_template = ConnectorTemplate(
             config=template.config,
@@ -193,9 +179,7 @@ class CustomConnectorTemplateLoader(ConnectorTemplateLoader):
             authorization_required=authorization_required,
             user_guide=config.user_guide,
             supported_actions=config.supported_actions,
-            category=category,
-            tags=tags,
-            enabled_features=enabled_features,
+            **display_info,
         )
 
         # register the template in the loader's template dictionary

--- a/src/fides/api/util/connection_type.py
+++ b/src/fides/api/util/connection_type.py
@@ -230,23 +230,6 @@ def get_saas_connection_types(
     for item in saas_types:
         connector_template = ConnectorRegistry.get_connector_template(item)
         if connector_template is not None:
-            # Read display info from SAAS config if available
-            category = None
-            tags = None
-            enabled_features = None
-
-            try:
-                saas_config = SaaSConfig(
-                    **load_config_from_string(connector_template.config)
-                )
-                if saas_config.display_info:
-                    category = saas_config.display_info.category
-                    tags = saas_config.display_info.tags
-                    enabled_features = saas_config.display_info.enabled_features
-            except Exception:
-                # If config parsing fails, leave display info as None
-                pass
-
             saas_connection_types.append(
                 ConnectionSystemTypeMap(
                     identifier=item,
@@ -256,9 +239,9 @@ def get_saas_connection_types(
                     authorization_required=connector_template.authorization_required,
                     user_guide=connector_template.user_guide,
                     supported_actions=connector_template.supported_actions,
-                    category=category,
-                    tags=tags,
-                    enabled_features=enabled_features,
+                    category=connector_template.category,
+                    tags=connector_template.tags,
+                    enabled_features=connector_template.enabled_features,
                 )
             )
 

--- a/src/fides/api/util/saas_util.py
+++ b/src/fides/api/util/saas_util.py
@@ -133,7 +133,9 @@ def extract_display_info_from_config(config: SaaSConfig) -> Dict[str, Any]:
     return {
         "category": config.display_info.category if config.display_info else None,
         "tags": config.display_info.tags if config.display_info else None,
-        "enabled_features": config.display_info.enabled_features if config.display_info else None,
+        "enabled_features": (
+            config.display_info.enabled_features if config.display_info else None
+        ),
     }
 
 

--- a/src/fides/api/util/saas_util.py
+++ b/src/fides/api/util/saas_util.py
@@ -16,8 +16,6 @@ from fides.api.common_exceptions import FidesopsException, ValidationError
 from fides.api.cryptography.cryptographic_util import bytes_to_b64_str
 from fides.api.graph.config import Collection, CollectionAddress, Field, GraphDataset
 from fides.api.models.privacy_request import PrivacyRequest
-from fides.api.schemas.enums.connection_category import ConnectionCategory
-from fides.api.schemas.enums.integration_feature import IntegrationFeature
 from fides.api.schemas.saas.saas_config import SaaSConfig, SaaSRequest
 from fides.api.schemas.saas.shared_schemas import SaaSRequestParams
 from fides.config import CONFIG

--- a/src/fides/api/util/saas_util.py
+++ b/src/fides/api/util/saas_util.py
@@ -16,7 +16,9 @@ from fides.api.common_exceptions import FidesopsException, ValidationError
 from fides.api.cryptography.cryptographic_util import bytes_to_b64_str
 from fides.api.graph.config import Collection, CollectionAddress, Field, GraphDataset
 from fides.api.models.privacy_request import PrivacyRequest
-from fides.api.schemas.saas.saas_config import SaaSRequest
+from fides.api.schemas.enums.connection_category import ConnectionCategory
+from fides.api.schemas.enums.integration_feature import IntegrationFeature
+from fides.api.schemas.saas.saas_config import SaaSConfig, SaaSRequest
 from fides.api.schemas.saas.shared_schemas import SaaSRequestParams
 from fides.config import CONFIG
 from fides.config.helpers import load_file
@@ -124,6 +126,15 @@ def replace_dataset_placeholders(
     """Loads the dataset from the yaml string and replaces any string with the given value"""
     yaml_str: str = dataset.replace(string_to_replace, replacement)
     return load_dataset_from_string(yaml_str)
+
+
+def extract_display_info_from_config(config: SaaSConfig) -> Dict[str, Any]:
+    """Extract display info fields from SaaSConfig for caching in ConnectorTemplate."""
+    return {
+        "category": config.display_info.category if config.display_info else None,
+        "tags": config.display_info.tags if config.display_info else None,
+        "enabled_features": config.display_info.enabled_features if config.display_info else None,
+    }
 
 
 def load_dataset_with_replacement(

--- a/tests/ops/service/connectors/test_connector_template_loaders.py
+++ b/tests/ops/service/connectors/test_connector_template_loaders.py
@@ -7,6 +7,8 @@ import pytest
 
 from fides.api.common_exceptions import NoSuchSaaSRequestOverrideException
 from fides.api.models.custom_connector_template import CustomConnectorTemplate
+from fides.api.schemas.enums.connection_category import ConnectionCategory
+from fides.api.schemas.enums.integration_feature import IntegrationFeature
 from fides.api.schemas.policy import ActionType
 from fides.api.schemas.saas.connector_template import ConnectorTemplate
 from fides.api.service.authentication.authentication_strategy import (
@@ -429,6 +431,9 @@ class TestCustomConnectorTemplateLoader:
                 authorization_required=False,
                 user_guide="https://docs.ethyca.com/user-guides/integrations/saas-integrations/hubspot",
                 supported_actions=[ActionType.access, ActionType.erasure],
+                category=ConnectionCategory.CRM,
+                tags=["API", "DSR Automation"],
+                enabled_features=[IntegrationFeature.DSR_AUTOMATION],
             )
         }
         mock_delete.assert_not_called()

--- a/tests/ops/util/test_connection_type.py
+++ b/tests/ops/util/test_connection_type.py
@@ -282,7 +282,7 @@ def test_get_saas_connection_types_with_display_info(monkeypatch):
     from fides.api.schemas.saas.saas_config import SaaSConfig
     from fides.api.util.connection_type import get_saas_connection_types
 
-    # Mock a connector template
+    # Mock a connector template with display infost
     mock_template = Mock()
     mock_template.human_readable = "Test Connector"
     mock_template.icon = "test-icon"
@@ -290,6 +290,10 @@ def test_get_saas_connection_types_with_display_info(monkeypatch):
     mock_template.user_guide = "https://example.com"
     mock_template.supported_actions = [ActionType.access, ActionType.erasure]
     mock_template.config = '{"test": "config"}'
+    # Add the new display info fields that our optimization now uses directly
+    mock_template.category = ConnectionCategory.ECOMMERCE
+    mock_template.tags = ["tag1", "tag2"]
+    mock_template.enabled_features = [IntegrationFeature.DSR_AUTOMATION]
 
     # Mock display info with values
     mock_display_info = Mock()
@@ -336,7 +340,7 @@ def test_get_saas_connection_types_with_no_display_info(monkeypatch):
 
     from fides.api.util.connection_type import get_saas_connection_types
 
-    # Mock a connector template
+    # Mock a connector template with no display info
     mock_template = Mock()
     mock_template.human_readable = "Test Connector"
     mock_template.icon = "test-icon"
@@ -344,6 +348,10 @@ def test_get_saas_connection_types_with_no_display_info(monkeypatch):
     mock_template.user_guide = None
     mock_template.supported_actions = [ActionType.access]
     mock_template.config = '{"test": "config"}'
+    # Add the new display info fields as None (no display info)
+    mock_template.category = None
+    mock_template.tags = None
+    mock_template.enabled_features = None
 
     # Mock SaaS config with no display_info
     mock_saas_config = Mock()
@@ -392,6 +400,10 @@ def test_get_saas_connection_types_config_parsing_exception():
     mock_template.user_guide = None
     mock_template.supported_actions = [ActionType.erasure]
     mock_template.config = "invalid json"
+    # Add the new display info fields as None (config parsing will fail)
+    mock_template.category = None
+    mock_template.tags = None
+    mock_template.enabled_features = None
 
     with (
         patch(
@@ -434,6 +446,10 @@ def test_get_saas_connection_types_load_config_exception():
     mock_template.user_guide = None
     mock_template.supported_actions = [ActionType.consent]
     mock_template.config = "invalid config"
+    # Add the new display info fields as None (config loading will fail)
+    mock_template.category = None
+    mock_template.tags = None
+    mock_template.enabled_features = None
 
     with (
         patch(


### PR DESCRIPTION
### Description Of Changes

Fixes a performance issue with the updates to include display_info by reusing the connector template cache.

### Code Changes

* Added new properties from display_info (category, tags and enabled features) to the Connector template
* Load the new properties during startup on connector_registry_service.py
* Add new util to extract values from display_info and fallback to None for the values if the is no display_info 
* Removed code in connection type template that used to load the display_info properties separately and replaced it with reading from the connector template
* Update tests

### Steps to Confirm

1.  Test passes
2. Login to admin-ui and go to the Settings > Integrations page
3. Make sure you have at least 3-4 integrations, if not, create a few integrations with random information
4. Open browser dev tools and look at the Network tab
5. Reload the page
6. Check the http://localhost:3000/api/v1/connection?connection_type... request takes <200ms to resolve.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
