### PR TITLE
ENG-1282: Update User API docstrings with scopes

### DIFF
--- a/src/fides/api/api/v1/endpoints/user_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/user_endpoints.py
@@ -117,7 +117,7 @@ def verify_user_read_scopes(
     db: Session = Depends(get_db),
 ) -> ClientDetail:
     """
-    Custom dependency that verifies the user has either USER_READ or USER_READ_OWN scope.
+    Custom dependency that verifies the user has either user:read or user:read-own scope.
     Returns the client if authorized.
     """
     token_data, client = extract_token_and_load_client(authorization, db)
@@ -159,7 +159,7 @@ async def update_user(
 ) -> FidesUser:
     """
     Update a user given a `user_id`. If the user is not updating their own data,
-    they need the USER_UPDATE scope
+    they need the user:update scope
     """
     user = FidesUser.get(db=db, object_id=user_id)
     if not user:
@@ -548,7 +548,7 @@ def get_user(
     client: ClientDetail = Security(verify_user_read_scopes),
     authorization: str = Security(oauth2_scheme),
 ) -> FidesUser:
-    """Returns a User based on an Id. Users with USER_READ_OWN scope can only access their own data."""
+    """Returns a User based on an Id. Users with user:read-own scope can only access their own data. Users with user:read can access other's data."""
     user: Optional[FidesUser] = FidesUser.get_by_key_or_id(db, data={"id": user_id})
     if user is None:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="User not found")


### PR DESCRIPTION
Closes [ENG-1282]

### Description Of Changes

Adds scopes to docstrings instead of variable names.

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1282]: https://ethyca.atlassian.net/browse/ENG-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ