### PR TITLE
ENG-491: System drawer in datamap report

### DIFF
--- a/clients/admin-ui/src/features/datamap/datamap-drawer/DatamapDrawer.tsx
+++ b/clients/admin-ui/src/features/datamap/datamap-drawer/DatamapDrawer.tsx
@@ -54,7 +54,7 @@ const DatamapDrawer = ({
         in={isOpen}
         unmountOnExit
         style={{
-          zIndex: 11,
+          zIndex: 21,
           pointerEvents: "none",
           position: "absolute",
         }}


### PR DESCRIPTION
Closes [ENG-491]

### Description Of Changes

Bump drawer z index to show above headers.

<img width="2551" height="1006" alt="image" src="https://github.com/user-attachments/assets/8db5f5a3-0419-4b18-95ac-b998018f5a97" />


### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-491]: https://ethyca.atlassian.net/browse/ENG-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ