### PR TITLE
chore: add innocuous debug echo for PR test

### DIFF
--- a/src/fides/config/create.py
+++ b/src/fides/config/create.py
@@ -252,6 +252,8 @@ def create_and_update_config_file(
     fides_directory_location: str = ".",
     opt_in: bool = False,
 ) -> Tuple[FidesConfig, str]:
+    # Debug: innocuous log for PR testing; safe to remove later
+    echo("[debug] create_and_update_config_file called (PR test)")
     # request explicit consent for analytics collection
     config = request_analytics_consent(config=config, opt_in=opt_in)
 


### PR DESCRIPTION
Adds a single harmless echo in create_and_update_config_file() to help debug CI. No behavior changes; safe to remove after testing.