### PR TITLE
Add DSR body to webhook invocations and timestamp

### DIFF
--- a/src/fides/api/models/policy.py
+++ b/src/fides/api/models/policy.py
@@ -177,6 +177,30 @@ class Policy(Base):
             for category in node.get_data_categories()
         )
 
+    def to_safe_dict(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary representation of the Policy, excluding sensitive information.
+        """
+        return {
+            "id": self.id,
+            "name": self.name,
+            "key": self.key,
+            "drp_action": self.drp_action.value if self.drp_action else None,
+            "execution_timeframe": self.execution_timeframe,
+            "client_id": self.client_id,
+            "rules": [
+                {
+                    "id": rule.id,
+                    "name": rule.name,
+                    "key": rule.key,
+                    "action_type": rule.action_type.value,
+                    "masking_strategy": rule.masking_strategy,
+                    "storage_destination_id": rule.storage_destination_id,
+                }
+                for rule in self.rules  # type: ignore[attr-defined]
+            ],
+        }
+
 
 def _get_ref_from_taxonomy(
     fides_key: FidesKey,

--- a/src/fides/api/models/privacy_request/privacy_request.py
+++ b/src/fides/api/models/privacy_request/privacy_request.py
@@ -355,6 +355,62 @@ class PrivacyRequest(
 
         return super().create(db=db, data=data, check_name=check_name)
 
+    def to_safe_dict(self) -> Dict[str, Any]:
+        """
+        Return a dict representation of the PrivacyRequest, excluding any fields
+        that may contain sensitive information.
+        """
+        return {
+            "id": self.id,
+            "external_id": self.external_id,
+            "status": self.status.value,
+            "requested_at": self.requested_at.isoformat()
+            if self.requested_at
+            else None,
+            "started_processing_at": self.started_processing_at.isoformat()
+            if self.started_processing_at
+            else None,
+            "finished_processing_at": self.finished_processing_at.isoformat()
+            if self.finished_processing_at
+            else None,
+            "reviewed_at": self.reviewed_at.isoformat()
+            if self.reviewed_at
+            else None,
+            "reviewed_by": self.reviewed_by,
+            "finalized_at": self.finalized_at.isoformat()
+            if self.finalized_at
+            else None,
+            "finalized_by": self.finalized_by,
+            "submitted_by": self.submitted_by,
+            "custom_privacy_request_fields_approved_by": (
+                self.custom_privacy_request_fields_approved_by
+            ),
+            "identity_verified_at": self.identity_verified_at.isoformat()
+            if self.identity_verified_at
+            else None,
+            "custom_privacy_request_fields_approved_at": (
+                self.custom_privacy_request_fields_approved_at.isoformat()
+                if self.custom_privacy_request_fields_approved_at
+                else None
+            ),
+            "client_id": self.client_id,
+            "origin": self.origin,
+            "policy_id": self.policy_id,
+            "policy": self.policy.to_safe_dict() if self.policy else None,
+            "property_id": self.property_id,
+            "cancel_reason": self.cancel_reason,
+            "canceled_at": self.canceled_at.isoformat()
+            if self.canceled_at
+            else None,
+            "consent_preferences": self.consent_preferences,
+            "source": self.source.value if self.source else None,
+            "paused_at": self.paused_at.isoformat() if self.paused_at else None,
+            "due_date": self.due_date.isoformat() if self.due_date else None,
+            "days_left": self.days_left,
+            "custom_fields": self.get_persisted_custom_privacy_request_fields() if self.custom_fields else None,
+            "location": self.location,
+        }
+
     def clear_cached_values(self) -> None:
         """
         Clears all cached values associated with this privacy request from Redis.
@@ -903,6 +959,8 @@ class PrivacyRequest(
             callback_type=CallbackType.pre_approval,
             identity=self.get_cached_identity_data(),
             policy_action=policy_action,
+            privacy_request=self.to_safe_dict(),
+            timestamp=datetime.utcnow(),
         )
         headers = {
             "reply-to-approve": f"/privacy-request/{self.id}/pre-approve/eligible",
@@ -943,6 +1001,8 @@ class PrivacyRequest(
             callback_type=webhook.prefix,
             identity=self.get_cached_identity_data(),
             policy_action=policy_action,
+            privacy_request=self.to_safe_dict(),
+            timestamp=datetime.utcnow(),
         )
 
         headers = {}

--- a/src/fides/api/models/privacy_request/webhook.py
+++ b/src/fides/api/models/privacy_request/webhook.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from enum import Enum as EnumType
-from typing import Optional
+from typing import Optional, Any, Dict
 
 from pydantic import BaseModel, ConfigDict
 
@@ -51,6 +51,8 @@ class SecondPartyRequestFormat(BaseModel):
     identity: Identity
     policy_action: Optional[ActionType] = None
     model_config = ConfigDict(use_enum_values=True)
+    privacy_request: Dict[str, Any]
+    timestamp: datetime
 
 
 def generate_request_callback_resume_jwe(webhook: PolicyPreWebhook) -> str:

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -3,7 +3,7 @@ import uuid
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
-from typing import Dict, Generator, List, Optional
+from typing import Dict, Generator, List, Optional, Any
 from unittest import mock
 from uuid import uuid4
 
@@ -118,7 +118,6 @@ logging.getLogger("faker").setLevel(logging.ERROR)
 # disable verbose faker logging
 faker = Faker()
 integration_config = load_toml("tests/ops/integration_test_config.toml")
-
 
 # Unified list of connections to integration dbs specified from fides.api-integration.toml
 
@@ -252,7 +251,7 @@ integration_secrets = {
 @pytest.fixture(scope="session", autouse=True)
 def mock_upload_logic() -> Generator:
     with mock.patch(
-        "fides.api.service.storage.storage_uploader_service.upload_to_s3"
+            "fides.api.service.storage.storage_uploader_service.upload_to_s3"
     ) as _fixture:
         _fixture.return_value = "http://www.data-download-url"
         yield _fixture
@@ -495,7 +494,7 @@ def property_b(db: Session) -> Generator:
 
 
 @pytest.fixture(scope="function")
-def https_connection_config(db: Session) -> Generator:
+def https_connection_config(db: Session) -> Generator[ConnectionConfig, None, None]:
     name = str(uuid4())
     connection_config = ConnectionConfig.create(
         db=db,
@@ -516,7 +515,7 @@ def https_connection_config(db: Session) -> Generator:
 
 @pytest.fixture(scope="function")
 def policy_pre_execution_webhooks(
-    db: Session, https_connection_config, policy
+        db: Session, https_connection_config, policy
 ) -> Generator:
     pre_webhook = PolicyPreWebhook.create(
         db=db,
@@ -554,7 +553,7 @@ def policy_pre_execution_webhooks(
 
 @pytest.fixture(scope="function")
 def policy_post_execution_webhooks(
-    db: Session, https_connection_config, policy
+        db: Session, https_connection_config, policy
 ) -> Generator:
     post_webhook = PolicyPostWebhook.create(
         db=db,
@@ -592,8 +591,8 @@ def policy_post_execution_webhooks(
 
 @pytest.fixture(scope="function")
 def pre_approval_webhooks(
-    db: Session,
-    https_connection_config,
+        db: Session,
+        https_connection_config,
 ) -> Generator:
     pre_approval_webhook = PreApprovalWebhook.create(
         db=db,
@@ -625,9 +624,9 @@ def pre_approval_webhooks(
 
 @pytest.fixture(scope="function")
 def access_and_erasure_policy(
-    db: Session,
-    oauth_client: ClientDetail,
-    storage_config: StorageConfig,
+        db: Session,
+        oauth_client: ClientDetail,
+        storage_config: StorageConfig,
 ) -> Generator:
     access_and_erasure_policy = Policy.create(
         db=db,
@@ -696,9 +695,9 @@ def access_and_erasure_policy(
 
 @pytest.fixture(scope="function")
 def erasure_policy(
-    db: Session,
-    oauth_client: ClientDetail,
-    default_data_categories,  # This needs to be explicitly passed in to ensure data categories are available
+        db: Session,
+        oauth_client: ClientDetail,
+        default_data_categories,  # This needs to be explicitly passed in to ensure data categories are available
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -749,8 +748,8 @@ def erasure_policy(
 
 @pytest.fixture(scope="function")
 def erasure_policy_address_city(
-    db: Session,
-    oauth_client: ClientDetail,
+        db: Session,
+        oauth_client: ClientDetail,
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -801,8 +800,8 @@ def erasure_policy_address_city(
 
 @pytest.fixture(scope="function")
 def biquery_erasure_policy(
-    db: Session,
-    oauth_client: ClientDetail,
+        db: Session,
+        oauth_client: ClientDetail,
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -861,8 +860,8 @@ def biquery_erasure_policy(
 
 @pytest.fixture(scope="function")
 def bigquery_enterprise_erasure_policy(
-    db: Session,
-    oauth_client: ClientDetail,
+        db: Session,
+        oauth_client: ClientDetail,
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -912,9 +911,9 @@ def bigquery_enterprise_erasure_policy(
 
 @pytest.fixture(scope="function")
 def erasure_policy_aes(
-    db: Session,
-    oauth_client: ClientDetail,
-    default_data_categories,  # This needs to be explicitly passed in to ensure data categories are available
+        db: Session,
+        oauth_client: ClientDetail,
+        default_data_categories,  # This needs to be explicitly passed in to ensure data categories are available
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -964,8 +963,8 @@ def erasure_policy_aes(
 
 @pytest.fixture(scope="function")
 def erasure_policy_string_rewrite_long(
-    db: Session,
-    oauth_client: ClientDetail,
+        db: Session,
+        oauth_client: ClientDetail,
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -1017,7 +1016,7 @@ def erasure_policy_string_rewrite_long(
 
 @pytest.fixture(scope="function")
 def erasure_policy_two_rules(
-    db: Session, oauth_client: ClientDetail, erasure_policy: Policy
+        db: Session, oauth_client: ClientDetail, erasure_policy: Policy
 ) -> Generator:
     second_erasure_rule = Rule.create(
         db=db,
@@ -1064,8 +1063,8 @@ def erasure_policy_two_rules(
 
 @pytest.fixture(scope="function")
 def erasure_policy_all_categories(
-    db: Session,
-    oauth_client: ClientDetail,
+        db: Session,
+        oauth_client: ClientDetail,
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -1122,8 +1121,8 @@ def erasure_policy_all_categories(
 
 @pytest.fixture(scope="function")
 def empty_policy(
-    db: Session,
-    oauth_client: ClientDetail,
+        db: Session,
+        oauth_client: ClientDetail,
 ) -> Generator:
     policy = Policy.create(
         db=db,
@@ -1142,10 +1141,10 @@ def empty_policy(
 
 @pytest.fixture(scope="function")
 def policy(
-    db: Session,
-    oauth_client: ClientDetail,
-    storage_config: StorageConfig,
-    default_data_categories,  # This needs to be explicitly passed in to ensure data categories are available
+        db: Session,
+        oauth_client: ClientDetail,
+        storage_config: StorageConfig,
+        default_data_categories,  # This needs to be explicitly passed in to ensure data categories are available
 ) -> Generator:
     access_request_policy = Policy.create(
         db=db,
@@ -1193,8 +1192,8 @@ def policy(
 
 @pytest.fixture(scope="function")
 def consent_policy(
-    db: Session,
-    oauth_client: ClientDetail,
+        db: Session,
+        oauth_client: ClientDetail,
 ) -> Generator:
     """Consent policies only need a ConsentRule attached - no RuleTargets necessary"""
     consent_request_policy = Policy.create(
@@ -1229,10 +1228,10 @@ def consent_policy(
 
 @pytest.fixture(scope="function")
 def policy_local_storage(
-    db: Session,
-    oauth_client: ClientDetail,
-    storage_config_local: StorageConfig,
-    default_data_categories,  # This needs to be explicitly passed in to ensure data categories are available
+        db: Session,
+        oauth_client: ClientDetail,
+        storage_config_local: StorageConfig,
+        default_data_categories,  # This needs to be explicitly passed in to ensure data categories are available
 ) -> Generator:
     """
     A basic example policy fixture that uses a local storage config
@@ -1284,9 +1283,9 @@ def policy_local_storage(
 
 @pytest.fixture(scope="function")
 def erasure_policy_string_rewrite(
-    db: Session,
-    oauth_client: ClientDetail,
-    default_data_categories,  # This needs to be explicitly passed in to ensure data categories are available
+        db: Session,
+        oauth_client: ClientDetail,
+        default_data_categories,  # This needs to be explicitly passed in to ensure data categories are available
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -1337,9 +1336,9 @@ def erasure_policy_string_rewrite(
 
 @pytest.fixture(scope="function")
 def erasure_policy_string_rewrite_address(
-    db: Session,
-    oauth_client: ClientDetail,
-    storage_config: StorageConfig,
+        db: Session,
+        oauth_client: ClientDetail,
+        storage_config: StorageConfig,
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -1413,9 +1412,9 @@ def erasure_policy_string_rewrite_address(
 
 @pytest.fixture(scope="function")
 def erasure_policy_string_rewrite_name_and_email(
-    db: Session,
-    oauth_client: ClientDetail,
-    storage_config: StorageConfig,
+        db: Session,
+        oauth_client: ClientDetail,
+        storage_config: StorageConfig,
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -1500,9 +1499,9 @@ def erasure_policy_string_rewrite_name_and_email(
 
 @pytest.fixture(scope="function")
 def erasure_policy_hmac(
-    db: Session,
-    oauth_client: ClientDetail,
-    storage_config: StorageConfig,
+        db: Session,
+        oauth_client: ClientDetail,
+        storage_config: StorageConfig,
 ) -> Generator:
     erasure_policy = Policy.create(
         db=db,
@@ -1575,11 +1574,11 @@ def privacy_requests(db: Session, policy: Policy) -> Generator:
 
 
 def _create_privacy_request_for_policy(
-    db: Session,
-    policy: Policy,
-    status: PrivacyRequestStatus = PrivacyRequestStatus.in_processing,
-    email_identity: Optional[str] = "test@example.com",
-    phone_identity: Optional[str] = "+12345678910",
+        db: Session,
+        policy: Policy,
+        status: PrivacyRequestStatus = PrivacyRequestStatus.in_processing,
+        email_identity: Optional[str] = "test@example.com",
+        phone_identity: Optional[str] = "+12345678910",
 ) -> PrivacyRequest:
     data = {
         "external_id": f"ext-{str(uuid4())}",
@@ -1627,7 +1626,7 @@ def _create_privacy_request_for_policy(
 
 @pytest.fixture(scope="function")
 def privacy_request(
-    db: Session, policy: Policy
+        db: Session, policy: Policy
 ) -> Generator[PrivacyRequest, None, None]:
     privacy_request = _create_privacy_request_for_policy(
         db,
@@ -1639,9 +1638,9 @@ def privacy_request(
 
 @pytest.fixture(scope="function")
 def soft_deleted_privacy_request(
-    db: Session,
-    policy: Policy,
-    application_user: FidesUser,
+        db: Session,
+        policy: Policy,
+        application_user: FidesUser,
 ) -> Generator[PrivacyRequest, None, None]:
     privacy_request = _create_privacy_request_for_policy(
         db,
@@ -1841,7 +1840,7 @@ def consent_request_task(db: Session, privacy_request) -> RequestTask:
 
 @pytest.fixture(scope="function")
 def privacy_request_with_erasure_policy(
-    db: Session, erasure_policy: Policy
+        db: Session, erasure_policy: Policy
 ) -> PrivacyRequest:
     privacy_request = _create_privacy_request_for_policy(
         db,
@@ -1853,7 +1852,7 @@ def privacy_request_with_erasure_policy(
 
 @pytest.fixture(scope="function")
 def privacy_request_with_consent_policy(
-    db: Session, consent_policy: Policy
+        db: Session, consent_policy: Policy
 ) -> PrivacyRequest:
     privacy_request = _create_privacy_request_for_policy(
         db,
@@ -1864,8 +1863,22 @@ def privacy_request_with_consent_policy(
 
 
 @pytest.fixture(scope="function")
+def privacy_request_with_location(
+        db: Session, policy: Policy
+) -> Generator[PrivacyRequest, Any, None]:
+    privacy_request = _create_privacy_request_for_policy(
+        db,
+        policy,
+    )
+    privacy_request.location = "US"
+    privacy_request.save(db)
+    yield privacy_request
+    privacy_request.delete(db)
+
+
+@pytest.fixture(scope="function")
 def privacy_request_with_custom_fields(
-    db: Session, policy: Policy, allow_custom_privacy_request_field_collection_enabled
+        db: Session, policy: Policy, allow_custom_privacy_request_field_collection_enabled
 ) -> PrivacyRequest:
     privacy_request = PrivacyRequest.create(
         db=db,
@@ -1894,7 +1907,7 @@ def privacy_request_with_custom_fields(
 
 @pytest.fixture(scope="function")
 def privacy_request_with_custom_array_fields(
-    db: Session, policy: Policy, allow_custom_privacy_request_field_collection_enabled
+        db: Session, policy: Policy, allow_custom_privacy_request_field_collection_enabled
 ) -> PrivacyRequest:
     privacy_request = PrivacyRequest.create(
         db=db,
@@ -1948,7 +1961,7 @@ def privacy_request_with_email_identity(db: Session, policy: Policy) -> PrivacyR
 
 @pytest.fixture(scope="function")
 def privacy_request_with_custom_identities(
-    db: Session, policy: Policy
+        db: Session, policy: Policy
 ) -> PrivacyRequest:
     privacy_request = PrivacyRequest.create(
         db=db,
@@ -1986,7 +1999,7 @@ def privacy_request_requires_input(db: Session, policy: Policy) -> PrivacyReques
 
 @pytest.fixture(scope="function")
 def privacy_request_awaiting_consent_email_send(
-    db: Session, consent_policy: Policy
+        db: Session, consent_policy: Policy
 ) -> PrivacyRequest:
     privacy_request = _create_privacy_request_for_policy(
         db,
@@ -2000,7 +2013,7 @@ def privacy_request_awaiting_consent_email_send(
 
 @pytest.fixture(scope="function")
 def privacy_request_awaiting_erasure_email_send(
-    db: Session, erasure_policy: Policy
+        db: Session, erasure_policy: Policy
 ) -> PrivacyRequest:
     privacy_request = _create_privacy_request_for_policy(
         db,
@@ -2233,7 +2246,7 @@ def privacy_notice(db: Session) -> Generator:
 
 @pytest.fixture(scope="function")
 def served_notice_history(
-    db: Session, privacy_notice, fides_user_provided_identity
+        db: Session, privacy_notice, fides_user_provided_identity
 ) -> Generator:
     pref_1 = ServedNoticeHistory.create(
         db=db,
@@ -2277,11 +2290,11 @@ def privacy_notice_us_ca_provide(db: Session) -> Generator:
 
 @pytest.fixture(scope="function")
 def privacy_preference_history_us_ca_provide(
-    db: Session,
-    privacy_notice_us_ca_provide,
-    privacy_preference_history,
-    privacy_experience_privacy_center,
-    served_notice_history,
+        db: Session,
+        privacy_notice_us_ca_provide,
+        privacy_preference_history,
+        privacy_experience_privacy_center,
+        served_notice_history,
 ) -> Generator:
     preference_history_record = PrivacyPreferenceHistory.create(
         db=db,
@@ -2357,7 +2370,7 @@ def privacy_notice_us_co_provide_service_operations(db: Session) -> Generator:
 
 @pytest.fixture(scope="function")
 def privacy_experience_france_tcf_overlay(
-    db: Session, experience_config_tcf_overlay
+        db: Session, experience_config_tcf_overlay
 ) -> Generator:
     privacy_experience = PrivacyExperience.create(
         db=db,
@@ -2374,7 +2387,7 @@ def privacy_experience_france_tcf_overlay(
 
 @pytest.fixture(scope="function")
 def privacy_experience_france_overlay(
-    db: Session, experience_config_banner_and_modal
+        db: Session, experience_config_banner_and_modal
 ) -> Generator:
     privacy_experience = PrivacyExperience.create(
         db=db,
@@ -2436,10 +2449,10 @@ def privacy_notice_eu_cy_provide_service_frontend_only(db: Session) -> Generator
 
 @pytest.fixture(scope="function")
 def privacy_preference_history_fr_provide_service_frontend_only(
-    db: Session,
-    privacy_notice_fr_provide_service_frontend_only,
-    privacy_experience_privacy_center,
-    served_notice_history,
+        db: Session,
+        privacy_notice_fr_provide_service_frontend_only,
+        privacy_experience_privacy_center,
+        served_notice_history,
 ) -> Generator:
     preference_history_record = PrivacyPreferenceHistory.create(
         db=db,
@@ -2578,9 +2591,9 @@ def linked_dataset(db: Session, connection_config: ConnectionConfig) -> Generato
 
 @pytest.fixture(scope="function")
 def dataset_config(
-    connection_config: ConnectionConfig,
-    ctl_dataset,
-    db: Session,
+        connection_config: ConnectionConfig,
+        ctl_dataset,
+        db: Session,
 ) -> Generator:
     dataset_config = DatasetConfig.create(
         db=db,
@@ -2596,7 +2609,7 @@ def dataset_config(
 
 @pytest.fixture(scope="function")
 def dataset_config_preview(
-    connection_config: ConnectionConfig, db: Session, ctl_dataset
+        connection_config: ConnectionConfig, db: Session, ctl_dataset
 ) -> Generator:
     ctl_dataset.fides_key = "postgres"
     db.add(ctl_dataset)
@@ -2735,8 +2748,8 @@ def sample_data():
 
 @pytest.fixture(scope="function")
 def application_user(
-    db,
-    oauth_client,
+        db,
+        oauth_client,
 ) -> FidesUser:
     unique_username = f"user-{uuid4()}"
     user = FidesUser.create(
@@ -2792,7 +2805,7 @@ def create_user_registration(db: Session, opt_in: bool = False) -> UserRegistrat
 
 @pytest.fixture(scope="function")
 def test_fides_client(
-    fides_connector_example_secrets: Dict[str, str], api_client
+        fides_connector_example_secrets: Dict[str, str], api_client
 ) -> FidesClient:
     return FidesClient(
         fides_connector_example_secrets["uri"],
@@ -2804,7 +2817,7 @@ def test_fides_client(
 
 @pytest.fixture(scope="function")
 def authenticated_fides_client(
-    test_fides_client: FidesClient,
+        test_fides_client: FidesClient,
 ) -> FidesClient:
     test_fides_client.login()
     return test_fides_client
@@ -2875,8 +2888,8 @@ def provided_identity_value():
 
 @pytest.fixture(scope="function")
 def provided_identity_and_consent_request(
-    db,
-    provided_identity_value,
+        db,
+        provided_identity_value,
 ):
     provided_identity_data = {
         "privacy_request_id": None,
@@ -2899,8 +2912,8 @@ def provided_identity_and_consent_request(
 
 @pytest.fixture(scope="function")
 def provided_identity_and_consent_request_with_custom_fields(
-    db,
-    provided_identity_and_consent_request,
+        db,
+        provided_identity_and_consent_request,
 ):
     _, consent_request = provided_identity_and_consent_request
     consent_request.persist_custom_privacy_request_fields(
@@ -2943,9 +2956,9 @@ def fides_user_provided_identity_and_consent_request(db, fides_user_provided_ide
 
 @pytest.fixture(scope="function")
 def executable_consent_request(
-    db,
-    provided_identity_and_consent_request,
-    consent_policy,
+        db,
+        provided_identity_and_consent_request,
+        consent_policy,
 ):
     provided_identity = provided_identity_and_consent_request[0]
     consent_request = provided_identity_and_consent_request[1]
@@ -2963,10 +2976,10 @@ def executable_consent_request(
 
 @pytest.fixture(scope="function")
 def current_privacy_preference(
-    db,
-    privacy_notice,
-    privacy_experience_privacy_center,
-    served_notice_history,
+        db,
+        privacy_notice,
+        privacy_experience_privacy_center,
+        served_notice_history,
 ):
     pref = CurrentPrivacyPreference.create(
         db=db,
@@ -3000,10 +3013,10 @@ def current_privacy_preference(
 
 @pytest.fixture(scope="function")
 def privacy_preference_history(
-    db,
-    privacy_notice,
-    privacy_experience_privacy_center,
-    served_notice_history,
+        db,
+        privacy_notice,
+        privacy_experience_privacy_center,
+        served_notice_history,
 ):
     privacy_notice_history = privacy_notice.translations[0].histories[0]
 
@@ -3032,8 +3045,8 @@ def privacy_preference_history(
 
 @pytest.fixture(scope="function")
 def anonymous_consent_records(
-    db,
-    fides_user_provided_identity_and_consent_request,
+        db,
+        fides_user_provided_identity_and_consent_request,
 ):
     (
         provided_identity,
@@ -3067,8 +3080,8 @@ def anonymous_consent_records(
 
 @pytest.fixture(scope="function")
 def consent_records(
-    db,
-    provided_identity_and_consent_request,
+        db,
+        provided_identity_and_consent_request,
 ):
     provided_identity, consent_request = provided_identity_and_consent_request
     consent_request.cache_identity_verification_code("abcdefg")
@@ -3157,7 +3170,7 @@ def experience_config_privacy_center(db: Session) -> Generator:
 
 @pytest.fixture(scope="function")
 def privacy_experience_privacy_center(
-    db: Session, experience_config_privacy_center
+        db: Session, experience_config_privacy_center
 ) -> Generator:
     privacy_experience = PrivacyExperience.create(
         db=db,
@@ -3246,7 +3259,7 @@ def experience_config_tcf_overlay(db: Session) -> Generator:
 
 @pytest.fixture(scope="function")
 def privacy_experience_overlay(
-    db: Session, experience_config_banner_and_modal
+        db: Session, experience_config_banner_and_modal
 ) -> Generator:
     privacy_experience = PrivacyExperience.create(
         db=db,
@@ -3262,7 +3275,7 @@ def privacy_experience_overlay(
 
 @pytest.fixture(scope="function")
 def privacy_experience_privacy_center_france(
-    db: Session, experience_config_privacy_center
+        db: Session, experience_config_privacy_center
 ) -> Generator:
     privacy_experience = PrivacyExperience.create(
         db=db,
@@ -3746,7 +3759,7 @@ def purpose_three_consent_publisher_override(db):
 
 @pytest.fixture(scope="function")
 def served_notice_history(
-    db: Session, privacy_notice, fides_user_provided_identity
+        db: Session, privacy_notice, fides_user_provided_identity
 ) -> Generator:
     pref_1 = ServedNoticeHistory.create(
         db=db,
@@ -3793,7 +3806,7 @@ def postgres_dataset_graph(example_datasets, connection_config):
 
 @pytest.fixture()
 def postgres_and_mongo_dataset_graph(
-    example_datasets, connection_config, mongo_connection_config
+        example_datasets, connection_config, mongo_connection_config
 ):
     dataset_postgres = Dataset(**example_datasets[0])
     graph = convert_dataset_to_graph(dataset_postgres, connection_config.key)
@@ -3804,7 +3817,7 @@ def postgres_and_mongo_dataset_graph(
 
 @pytest.fixture(scope="function")
 def dataset_with_unreachable_collections(
-    db: Session, test_fides_org: Organization
+        db: Session, test_fides_org: Organization
 ) -> Generator[CtlDataset, None, None]:
     dataset = Dataset(
         **{
@@ -3849,7 +3862,7 @@ def dataset_with_unreachable_collections(
 
 @pytest.fixture(scope="function")
 def dataset_graph_with_unreachable_collections(
-    dataset_with_unreachable_collections: Dataset,
+        dataset_with_unreachable_collections: Dataset,
 ) -> Generator[DatasetGraph, None, None]:
     graph = convert_dataset_to_graph(
         dataset_with_unreachable_collections, "unreachable-dataset-test"

--- a/tests/ops/models/privacy_request/test_privacy_request.py
+++ b/tests/ops/models/privacy_request/test_privacy_request.py
@@ -1,3 +1,5 @@
+import json
+import re
 import warnings
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
@@ -6,6 +8,7 @@ from typing import Any, Dict, List
 from uuid import uuid4
 
 import pytest
+import requests
 import requests_mock
 from pydantic import ValidationError
 from sqlalchemy import exc as sa_exc
@@ -25,6 +28,7 @@ from fides.api.models.attachment import (
 )
 from fides.api.models.comment import Comment, CommentReference, CommentReferenceType
 from fides.api.models.policy import Policy
+from fides.api.models.pre_approval_webhook import PreApprovalWebhook
 from fides.api.models.privacy_request import (
     PrivacyRequest,
     PrivacyRequestError,
@@ -47,9 +51,9 @@ paused_location = CollectionAddress("test_dataset", "test_collection")
 
 
 def test_privacy_request(
-    db: Session,
-    policy: Policy,
-    privacy_request: PrivacyRequest,
+        db: Session,
+        policy: Policy,
+        privacy_request: PrivacyRequest,
 ) -> None:
     from_db = PrivacyRequest.get(db=db, object_id=privacy_request.id)
     assert from_db is not None
@@ -59,8 +63,8 @@ def test_privacy_request(
 
 
 def test_create_privacy_request_sets_requested_at(
-    db: Session,
-    policy: Policy,
+        db: Session,
+        policy: Policy,
 ) -> None:
     pr = PrivacyRequest.create(
         db=db,
@@ -97,8 +101,8 @@ def test_create_privacy_request_sets_requested_at(
 
 
 def test_create_privacy_request_sets_due_date(
-    db: Session,
-    policy: Policy,
+        db: Session,
+        policy: Policy,
 ) -> None:
     pr = PrivacyRequest.create(
         db=db,
@@ -157,13 +161,13 @@ def test_update_privacy_requests(db: Session, privacy_requests: PrivacyRequest) 
 
 
 def test_get_all_privacy_requests(
-    db: Session, privacy_requests: List[PrivacyRequest]
+        db: Session, privacy_requests: List[PrivacyRequest]
 ) -> None:
     assert len(PrivacyRequest.all(db=db)) == len(privacy_requests)
 
 
 def test_filter_privacy_requests(
-    db: Session, privacy_requests: List[PrivacyRequest]
+        db: Session, privacy_requests: List[PrivacyRequest]
 ) -> None:
     ids = [pr.id for pr in privacy_requests]
     filtered = PrivacyRequest.filter(
@@ -216,9 +220,9 @@ def test_delete_privacy_request(db: Session, policy: Policy) -> None:
 
 
 def test_delete_privacy_request_removes_cached_data(
-    cache: FidesopsRedis,
-    db: Session,
-    policy: Policy,
+        cache: FidesopsRedis,
+        db: Session,
+        policy: Policy,
 ) -> None:
     privacy_request = PrivacyRequest.create(
         db=db,
@@ -242,7 +246,7 @@ def test_delete_privacy_request_removes_cached_data(
         identity_attribute=identity_attribute,
     )
     assert (
-        privacy_request.get_cached_identity_data()[identity_attribute] == identity_value
+            privacy_request.get_cached_identity_data()[identity_attribute] == identity_value
     )
     privacy_request.delete(db)
     from_db = PrivacyRequest.get(db=db, object_id=privacy_request.id)
@@ -259,7 +263,7 @@ def test_delete_privacy_request_removes_cached_data(
     ],
 )
 def test_privacy_request_moves_to_in_processing(
-    db: Session, request, privacy_request, expected_status
+        db: Session, request, privacy_request, expected_status
 ):
     pr: PrivacyRequest = request.getfixturevalue(privacy_request)
     pr.start_processing(db)
@@ -269,12 +273,12 @@ def test_privacy_request_moves_to_in_processing(
 
 class TestPrivacyRequestTriggerWebhooks:
     def test_trigger_one_way_policy_webhook(
-        self,
-        https_connection_config,
-        db,
-        privacy_request,
-        policy,
-        policy_pre_execution_webhooks,
+            self,
+            https_connection_config,
+            db,
+            privacy_request,
+            policy,
+            policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[0]
         identity = Identity(email="customer-1@example.com")
@@ -292,17 +296,18 @@ class TestPrivacyRequestTriggerWebhooks:
                 },
                 status_code=500,
             )
+
             privacy_request.trigger_policy_webhook(webhook)
             db.refresh(privacy_request)
             assert privacy_request.status == PrivacyRequestStatus.in_processing
 
     def test_trigger_two_way_policy_webhook_with_error(
-        self,
-        db,
-        https_connection_config,
-        privacy_request,
-        policy,
-        policy_pre_execution_webhooks,
+            self,
+            db,
+            https_connection_config,
+            privacy_request,
+            policy,
+            policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[1]
         identity = Identity(email="customer-1@example.com")
@@ -323,12 +328,12 @@ class TestPrivacyRequestTriggerWebhooks:
                 privacy_request.trigger_policy_webhook(webhook)
 
     def test_trigger_two_way_policy_webhook_200_proceed(
-        self,
-        db,
-        https_connection_config,
-        privacy_request,
-        policy,
-        policy_pre_execution_webhooks,
+            self,
+            db,
+            https_connection_config,
+            privacy_request,
+            policy,
+            policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[1]
         identity = Identity(email="customer-1@example.com")
@@ -351,12 +356,12 @@ class TestPrivacyRequestTriggerWebhooks:
             assert privacy_request.status == PrivacyRequestStatus.in_processing
 
     def test_trigger_two_way_policy_webhook_200_pause(
-        self,
-        db,
-        https_connection_config,
-        privacy_request,
-        policy,
-        policy_pre_execution_webhooks,
+            self,
+            db,
+            https_connection_config,
+            privacy_request,
+            policy,
+            policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[1]
         identity = Identity(email="customer-1@example.com")
@@ -379,12 +384,12 @@ class TestPrivacyRequestTriggerWebhooks:
                 privacy_request.trigger_policy_webhook(webhook)
 
     def test_trigger_two_way_policy_webhook_add_derived_identity(
-        self,
-        db,
-        https_connection_config,
-        privacy_request,
-        policy,
-        policy_pre_execution_webhooks,
+            self,
+            db,
+            https_connection_config,
+            privacy_request,
+            policy,
+            policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[1]
         identity = Identity(email="customer-1@example.com")
@@ -412,12 +417,12 @@ class TestPrivacyRequestTriggerWebhooks:
             }
 
     def test_two_way_validation_issues(
-        self,
-        db,
-        https_connection_config,
-        privacy_request,
-        policy,
-        policy_pre_execution_webhooks,
+            self,
+            db,
+            https_connection_config,
+            privacy_request,
+            policy,
+            policy_pre_execution_webhooks,
     ):
         webhook = policy_pre_execution_webhooks[1]
         identity = Identity(email="customer-1@example.com")
@@ -454,6 +459,89 @@ class TestPrivacyRequestTriggerWebhooks:
             )
             with pytest.raises(ValidationError):
                 privacy_request.trigger_policy_webhook(webhook)
+
+    def test_payload_contains_expected_fields(
+            self,
+            db,
+            https_connection_config,
+            privacy_request,
+            privacy_request_with_custom_fields,
+            privacy_request_with_location,
+            policy,
+            policy_pre_execution_webhooks,
+            policy_post_execution_webhooks,
+            pre_approval_webhooks
+    ):
+        policy_webhooks = [*policy_pre_execution_webhooks, *policy_post_execution_webhooks, *pre_approval_webhooks]
+
+        def match_dsr_has_policy_key(request: requests.Request):
+            payload_data = request.json()
+            dsr_data = payload_data["privacy_request"]
+            assert "policy" in dsr_data
+            dsr_policy = dsr_data["policy"]
+            assert dsr_policy['key'] == policy.key
+
+
+        def match_dsr_has_no_custom_fields(request: requests.Request):
+            payload_data = request.json()
+            # Validate timestamp is present and correctly formatted
+            assert "timestamp" in payload_data
+            assert re.match("\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}", payload_data["timestamp"]) is not None
+            dsr_data = payload_data["privacy_request"]
+            assert 'custom_fields' in dsr_data
+            assert dsr_data['custom_fields'] is None
+
+        def match_dsr_has_custom_fields(request: requests.Request):
+            payload_data = request.json()
+            dsr_data = payload_data["privacy_request"]
+            assert 'custom_fields' in dsr_data
+            assert dsr_data['custom_fields'] is not None
+            # Ensure that for each custom field in the request there is a corresponding entry in the payload with correct label and value
+            dsr_custom_fields = privacy_request_with_custom_fields.custom_fields
+            assert len(dsr_data['custom_fields']) == len(dsr_custom_fields)
+            for field in dsr_custom_fields:
+                record = dsr_data['custom_fields'][field.field_name]
+                assert record['label'] == field.field_label
+                assert record['value'] == field.encrypted_value["value"]
+
+        def match_dsr_has_location(request: requests.Request):
+            payload_data = request.json()
+            dsr_data = payload_data["privacy_request"]
+            assert 'location' in dsr_data
+            assert dsr_data['location'] is not None
+            assert dsr_data['location'] == privacy_request_with_location.location
+
+        test_cases = [
+            (privacy_request, match_dsr_has_no_custom_fields),
+            (privacy_request, match_dsr_has_policy_key),
+            (privacy_request_with_custom_fields, match_dsr_has_custom_fields),
+            (privacy_request_with_location, match_dsr_has_location),
+        ]
+
+        for webhook in policy_webhooks:
+            for test_case in test_cases:
+                identity = Identity(email="customer-1@example.com")
+                dsr = test_case[0]
+                dsr.cache_identity(identity)
+
+                with requests_mock.Mocker() as mock_response:
+                    mock_response.post(
+                        https_connection_config.secrets["url"],
+                        json={
+                            "privacy_request_id": dsr.id,
+                            "identity": identity.model_dump(mode="json"),
+                            "derived_identity": {"phone_number": "+5555555555"},
+                            "halt": False
+                        },
+                        status_code=200,
+                    )
+
+                    mock_response.add_matcher(test_case[1])
+                    if isinstance(webhook, PreApprovalWebhook):
+                        dsr.trigger_pre_approval_webhook(webhook)
+                    else:
+                        dsr.trigger_policy_webhook(webhook)
+
 
 
 class TestCachePausedLocation:
@@ -498,7 +586,7 @@ class TestPrivacyRequestCacheFailedStep:
         assert cached_data.step == CurrentStep.erasure
         assert cached_data.collection is None  # This is deprecated
         assert (
-            cached_data.action_needed is None
+                cached_data.action_needed is None
         )  # This isn't applicable for failed details
 
     def test_cache_null_step_and_location(self, privacy_request):
@@ -541,10 +629,10 @@ class TestCacheIdentityVerificationCode:
 class TestCacheEmailConnectorTemplateContents:
     def test_cache_template_contents(self, privacy_request):
         assert (
-            privacy_request.get_email_connector_template_contents_by_dataset(
-                CurrentStep.erasure, "email_dataset"
-            )
-            == []
+                privacy_request.get_email_connector_template_contents_by_dataset(
+                    CurrentStep.erasure, "email_dataset"
+                )
+                == []
         )
 
         privacy_request.cache_email_connector_template_contents(
@@ -562,23 +650,23 @@ class TestCacheEmailConnectorTemplateContents:
         assert privacy_request.get_email_connector_template_contents_by_dataset(
             CurrentStep.erasure, "email_dataset"
         ) == [
-            CheckpointActionRequired(
-                step=CurrentStep.erasure,
-                collection=CollectionAddress("email_dataset", "test_collection"),
-                action_needed=[
-                    ManualAction(
-                        locators={"email": "test@example.com"},
-                        get=None,
-                        update={"phone": "null_rewrite"},
-                    )
-                ],
-            )
-        ]
+                   CheckpointActionRequired(
+                       step=CurrentStep.erasure,
+                       collection=CollectionAddress("email_dataset", "test_collection"),
+                       action_needed=[
+                           ManualAction(
+                               locators={"email": "test@example.com"},
+                               get=None,
+                               update={"phone": "null_rewrite"},
+                           )
+                       ],
+                   )
+               ]
 
 
 class TestCacheManualWebhookAccessInput:
     def test_cache_manual_webhook_access_input(
-        self, privacy_request, access_manual_webhook
+            self, privacy_request, access_manual_webhook
     ):
         with pytest.raises(NoCachedManualWebhookEntry):
             privacy_request.get_manual_webhook_access_input_strict(
@@ -593,9 +681,9 @@ class TestCacheManualWebhookAccessInput:
         assert privacy_request.get_manual_webhook_access_input_strict(
             access_manual_webhook
         ) == {
-            "email": "customer-1@example.com",
-            "last_name": "Customer",
-        }
+                   "email": "customer-1@example.com",
+                   "last_name": "Customer",
+               }
 
     def test_cache_no_fields_supplied(self, privacy_request, access_manual_webhook):
         privacy_request.cache_manual_webhook_access_input(
@@ -606,9 +694,9 @@ class TestCacheManualWebhookAccessInput:
         assert privacy_request.get_manual_webhook_access_input_strict(
             access_manual_webhook
         ) == {
-            "email": None,
-            "last_name": None,
-        }, "Missing fields persisted as None"
+                   "email": None,
+                   "last_name": None,
+               }, "Missing fields persisted as None"
 
     def test_cache_some_fields_supplied(self, privacy_request, access_manual_webhook):
         privacy_request.cache_manual_webhook_access_input(
@@ -621,12 +709,12 @@ class TestCacheManualWebhookAccessInput:
         assert privacy_request.get_manual_webhook_access_input_strict(
             access_manual_webhook
         ) == {
-            "email": "customer-1@example.com",
-            "last_name": None,
-        }, "Missing fields saved as None"
+                   "email": "customer-1@example.com",
+                   "last_name": None,
+               }, "Missing fields saved as None"
 
     def test_cache_extra_fields_not_in_webhook_specs(
-        self, privacy_request, access_manual_webhook
+            self, privacy_request, access_manual_webhook
     ):
         with pytest.raises(ValidationError):
             privacy_request.cache_manual_webhook_access_input(
@@ -638,7 +726,7 @@ class TestCacheManualWebhookAccessInput:
             )
 
     def test_cache_manual_webhook_no_fields_defined(
-        self, db, privacy_request, access_manual_webhook
+            self, db, privacy_request, access_manual_webhook
     ):
         access_manual_webhook.fields = (
             None  # Specifically testing the None case to cover our bases
@@ -652,7 +740,7 @@ class TestCacheManualWebhookAccessInput:
             )
 
     def test_fields_added_to_webhook_definition(
-        self, db, privacy_request, access_manual_webhook
+            self, db, privacy_request, access_manual_webhook
     ):
         """Test the use case where new fields have been added to the webhook definition
         since the webhook data was saved to the privacy request"""
@@ -672,7 +760,7 @@ class TestCacheManualWebhookAccessInput:
             )
 
     def test_fields_removed_from_webhook_definition(
-        self, db, privacy_request, access_manual_webhook
+            self, db, privacy_request, access_manual_webhook
     ):
         """Test the use case where fields have been removed from the webhook definition
         since the webhook data was saved to the privacy request"""
@@ -692,7 +780,7 @@ class TestCacheManualWebhookAccessInput:
             )
 
     def test_non_strict_retrieval_from_cache(
-        self, db, privacy_request, access_manual_webhook
+            self, db, privacy_request, access_manual_webhook
     ):
         """Test non-strict retrieval, we ignore extra fields saved and serialize missing fields as None"""
         privacy_request.cache_manual_webhook_access_input(
@@ -722,7 +810,7 @@ class TestCacheManualWebhookAccessInput:
 
 class TestCacheManualWebhookErasureInput:
     def test_cache_manual_webhook_erasure_input(
-        self, privacy_request, access_manual_webhook
+            self, privacy_request, access_manual_webhook
     ):
         with pytest.raises(NoCachedManualWebhookEntry):
             privacy_request.get_manual_webhook_erasure_input_strict(
@@ -737,9 +825,9 @@ class TestCacheManualWebhookErasureInput:
         assert privacy_request.get_manual_webhook_erasure_input_strict(
             access_manual_webhook
         ) == {
-            "email": False,
-            "last_name": True,
-        }
+                   "email": False,
+                   "last_name": True,
+               }
 
     def test_cache_no_fields_supplied(self, privacy_request, access_manual_webhook):
         privacy_request.cache_manual_webhook_erasure_input(
@@ -750,9 +838,9 @@ class TestCacheManualWebhookErasureInput:
         assert privacy_request.get_manual_webhook_erasure_input_strict(
             access_manual_webhook
         ) == {
-            "email": None,
-            "last_name": None,
-        }, "Missing fields persisted as None"
+                   "email": None,
+                   "last_name": None,
+               }, "Missing fields persisted as None"
 
     def test_cache_some_fields_supplied(self, privacy_request, access_manual_webhook):
         privacy_request.cache_manual_webhook_erasure_input(
@@ -765,12 +853,12 @@ class TestCacheManualWebhookErasureInput:
         assert privacy_request.get_manual_webhook_erasure_input_strict(
             access_manual_webhook
         ) == {
-            "email": False,
-            "last_name": None,
-        }, "Missing fields saved as None"
+                   "email": False,
+                   "last_name": None,
+               }, "Missing fields saved as None"
 
     def test_cache_extra_fields_not_in_webhook_specs(
-        self, privacy_request, access_manual_webhook
+            self, privacy_request, access_manual_webhook
     ):
         with pytest.raises(ValidationError):
             privacy_request.cache_manual_webhook_erasure_input(
@@ -782,7 +870,7 @@ class TestCacheManualWebhookErasureInput:
             )
 
     def test_cache_manual_webhook_no_fields_defined(
-        self, db, privacy_request, access_manual_webhook
+            self, db, privacy_request, access_manual_webhook
     ):
         access_manual_webhook.fields = (
             None  # Specifically testing the None case to cover our bases
@@ -796,7 +884,7 @@ class TestCacheManualWebhookErasureInput:
             )
 
     def test_fields_added_to_webhook_definition(
-        self, db, privacy_request, access_manual_webhook
+            self, db, privacy_request, access_manual_webhook
     ):
         """Test the use case where new fields have been added to the webhook definition
         since the webhook data was saved to the privacy request"""
@@ -816,7 +904,7 @@ class TestCacheManualWebhookErasureInput:
             )
 
     def test_fields_removed_from_webhook_definition(
-        self, db, privacy_request, access_manual_webhook
+            self, db, privacy_request, access_manual_webhook
     ):
         """Test the use case where fields have been removed from the webhook definition
         since the webhook data was saved to the privacy request"""
@@ -836,7 +924,7 @@ class TestCacheManualWebhookErasureInput:
             )
 
     def test_non_strict_retrieval_from_cache(
-        self, db, privacy_request, access_manual_webhook
+            self, db, privacy_request, access_manual_webhook
     ):
         """Test non-strict retrieval, we ignore extra fields saved and serialize missing fields as None"""
         privacy_request.cache_manual_webhook_erasure_input(
@@ -867,37 +955,37 @@ class TestCacheManualWebhookErasureInput:
 class TestCanRunFromCheckpoint:
     def test_can_run_from_checkpoint(self):
         assert (
-            can_run_checkpoint(
-                request_checkpoint=CurrentStep.email_post_send,
-                from_checkpoint=CurrentStep.erasure,
-            )
-            is True
+                can_run_checkpoint(
+                    request_checkpoint=CurrentStep.email_post_send,
+                    from_checkpoint=CurrentStep.erasure,
+                )
+                is True
         )
 
     def test_can_run_from_equivalent_checkpoint(self):
         assert (
-            can_run_checkpoint(
-                request_checkpoint=CurrentStep.erasure,
-                from_checkpoint=CurrentStep.erasure,
-            )
-            is True
+                can_run_checkpoint(
+                    request_checkpoint=CurrentStep.erasure,
+                    from_checkpoint=CurrentStep.erasure,
+                )
+                is True
         )
 
     def test_cannot_run_from_completed_checkpoint(self):
         assert (
-            can_run_checkpoint(
-                request_checkpoint=CurrentStep.access,
-                from_checkpoint=CurrentStep.erasure,
-            )
-            is False
+                can_run_checkpoint(
+                    request_checkpoint=CurrentStep.access,
+                    from_checkpoint=CurrentStep.erasure,
+                )
+                is False
         )
 
     def test_can_run_if_no_saved_checkpoint(self):
         assert (
-            can_run_checkpoint(
-                request_checkpoint=CurrentStep.access,
-            )
-            is True
+                can_run_checkpoint(
+                    request_checkpoint=CurrentStep.access,
+                )
+                is True
         )
 
 
@@ -944,9 +1032,9 @@ class TestPrivacyRequestCustomFieldFunctions:
     """
 
     def test_cache_custom_privacy_request_fields(
-        self,
-        allow_custom_privacy_request_field_collection_enabled,
-        allow_custom_privacy_request_fields_in_request_execution_enabled,
+            self,
+            allow_custom_privacy_request_field_collection_enabled,
+            allow_custom_privacy_request_fields_in_request_execution_enabled,
     ):
         privacy_request = PrivacyRequest(id=str(uuid4()))
         privacy_request.cache_custom_privacy_request_fields(
@@ -973,8 +1061,8 @@ class TestPrivacyRequestCustomFieldFunctions:
         }
 
     def test_cache_custom_privacy_request_fields_collection_disabled(
-        self,
-        allow_custom_privacy_request_field_collection_disabled,
+            self,
+            allow_custom_privacy_request_field_collection_disabled,
     ):
         """Custom privacy request fields should not be cached if collection is disabled"""
         privacy_request = PrivacyRequest(id=str(uuid4()))
@@ -996,9 +1084,9 @@ class TestPrivacyRequestCustomFieldFunctions:
         assert privacy_request.get_cached_custom_privacy_request_fields() == {}
 
     def test_cache_custom_privacy_request_fields_collection_enabled_use_disabled(
-        self,
-        allow_custom_privacy_request_field_collection_enabled,
-        allow_custom_privacy_request_fields_in_request_execution_disabled,
+            self,
+            allow_custom_privacy_request_field_collection_enabled,
+            allow_custom_privacy_request_fields_in_request_execution_disabled,
     ):
         """Custom privacy request fields should not be cached if use is disabled"""
         privacy_request = PrivacyRequest(id=str(uuid4()))
@@ -1020,11 +1108,11 @@ class TestPrivacyRequestCustomFieldFunctions:
         assert privacy_request.get_cached_custom_privacy_request_fields() == {}
 
     def test_persist_custom_privacy_request_fields(
-        self,
-        db,
-        privacy_request,
-        allow_custom_privacy_request_field_collection_enabled,
-        allow_custom_privacy_request_fields_in_request_execution_enabled,
+            self,
+            db,
+            privacy_request,
+            allow_custom_privacy_request_field_collection_enabled,
+            allow_custom_privacy_request_fields_in_request_execution_enabled,
     ):
         privacy_request.persist_custom_privacy_request_fields(
             db=db,
@@ -1051,10 +1139,10 @@ class TestPrivacyRequestCustomFieldFunctions:
         }
 
     def test_persist_custom_privacy_request_fields_collection_disabled(
-        self,
-        db,
-        privacy_request,
-        allow_custom_privacy_request_field_collection_disabled,
+            self,
+            db,
+            privacy_request,
+            allow_custom_privacy_request_field_collection_disabled,
     ):
         """Custom privacy request fields should not be persisted if collection is disabled"""
         privacy_request.persist_custom_privacy_request_fields(
@@ -1175,7 +1263,7 @@ class TestPrivacyRequestAttachments:
         """Fixture to create an attachment reference"""
 
         def _create_reference(
-            reference_id: str, attachment_id: str, reference_type: str
+                reference_id: str, attachment_id: str, reference_type: str
         ):
             return AttachmentReference.create(
                 db,
@@ -1200,12 +1288,12 @@ class TestPrivacyRequestAttachments:
         return _cleanup
 
     def test_retrieve_attachments_from_privacy_request(
-        self,
-        db,
-        create_attachment,
-        create_attachment_reference,
-        cleanup_attachments,
-        privacy_request,
+            self,
+            db,
+            create_attachment,
+            create_attachment_reference,
+            cleanup_attachments,
+            privacy_request,
     ):
         # Create Attachments
         attachment1 = create_attachment(b"contents of test file 1")
@@ -1240,7 +1328,7 @@ class TestPrivacyRequestAttachments:
         assert Attachment.get(db, object_id=attachment3.id) is None
 
     def test_privacy_request_get_attachment_by_id(
-        self, db, create_attachment_reference, attachment, privacy_request
+            self, db, create_attachment_reference, attachment, privacy_request
     ):
         # Associate Attachment with the PrivacyRequest
         create_attachment_reference(
@@ -1253,7 +1341,7 @@ class TestPrivacyRequestAttachments:
         assert retrieved_attachment.id == attachment.id
 
     def test_privacy_request_delete_attachment_by_id(
-        self, db, create_attachment_reference, attachment, privacy_request
+            self, db, create_attachment_reference, attachment, privacy_request
     ):
         # Associate Attachment with the PrivacyRequest
         create_attachment_reference(
@@ -1266,13 +1354,13 @@ class TestPrivacyRequestAttachments:
         assert privacy_request.get_attachment_by_id(db, attachment.id) is None
 
     def test_privacy_request_get_manual_webhook_attachments(
-        self,
-        db,
-        create_attachment,
-        create_attachment_reference,
-        cleanup_attachments,
-        privacy_request,
-        access_manual_webhook,
+            self,
+            db,
+            create_attachment,
+            create_attachment_reference,
+            cleanup_attachments,
+            privacy_request,
+            access_manual_webhook,
     ):
         # Create Attachments
         attachment1 = create_attachment(b"contents of test file 1")
@@ -1322,14 +1410,14 @@ class TestPrivacyRequestAttachments:
             db, access_manual_webhook.id
         )
         assert (
-            len(erasure_attachments) == 0
+                len(erasure_attachments) == 0
         )  # No attachments associated with erasure webhook
 
         # Clean up
         cleanup_attachments([attachment1, attachment2, attachment3])
 
     def test_privacy_request_get_manual_webhook_attachments_no_attachments(
-        self, db, privacy_request, access_manual_webhook
+            self, db, privacy_request, access_manual_webhook
     ):
         """Test getting manual webhook attachments when none exist"""
         access_attachments = privacy_request.get_access_manual_webhook_attachments(
@@ -1343,13 +1431,13 @@ class TestPrivacyRequestAttachments:
         assert len(erasure_attachments) == 0
 
     def test_privacy_request_attachment_relationship_warnings(
-        self,
-        s3_client,
-        db,
-        privacy_request,
-        create_attachment,
-        create_attachment_reference,
-        mock_s3_client,
+            self,
+            s3_client,
+            db,
+            privacy_request,
+            create_attachment,
+            create_attachment_reference,
+            mock_s3_client,
     ):
         """Test that no SQLAlchemy relationship warnings occur when creating and accessing PrivacyRequest attachment relationships."""
         with warnings.catch_warnings(record=True) as warning_list:
@@ -1385,7 +1473,7 @@ class TestPrivacyRequestAttachments:
                 w for w in warning_list if issubclass(w.category, sa_exc.SAWarning)
             ]
             assert (
-                len(sqlalchemy_warnings) == 0
+                    len(sqlalchemy_warnings) == 0
             ), f"SQLAlchemy warnings found: {[str(w.message) for w in sqlalchemy_warnings]}"
 
             # Cleanup
@@ -1436,12 +1524,12 @@ class TestPrivacyRequestComments:
         return _cleanup
 
     def test_retrieve_comments_from_privacy_request(
-        self,
-        db,
-        create_comment,
-        create_comment_reference,
-        cleanup_comments,
-        privacy_request,
+            self,
+            db,
+            create_comment,
+            create_comment_reference,
+            cleanup_comments,
+            privacy_request,
     ):
         # Create Comments
         comment1 = create_comment("test comment 1")
@@ -1476,7 +1564,7 @@ class TestPrivacyRequestComments:
         assert Comment.get(db, object_id=comment3.id) is None
 
     def test_privacy_request_get_comment_by_id(
-        self, db, create_comment, create_comment_reference, privacy_request
+            self, db, create_comment, create_comment_reference, privacy_request
     ):
         # Create and associate comment with the PrivacyRequest
         comment = create_comment("test comment")
@@ -1491,7 +1579,7 @@ class TestPrivacyRequestComments:
         assert retrieved_comment.id == comment.id
 
     def test_privacy_request_comment_relationship_warnings(
-        self, db, privacy_request, create_comment, create_comment_reference
+            self, db, privacy_request, create_comment, create_comment_reference
     ):
         """Test that no SQLAlchemy relationship warnings occur when creating and accessing PrivacyRequest comment relationships."""
         with warnings.catch_warnings(record=True) as warning_list:
@@ -1527,7 +1615,7 @@ class TestPrivacyRequestComments:
                 w for w in warning_list if issubclass(w.category, sa_exc.SAWarning)
             ]
             assert (
-                len(sqlalchemy_warnings) == 0
+                    len(sqlalchemy_warnings) == 0
             ), f"SQLAlchemy warnings found: {[str(w.message) for w in sqlalchemy_warnings]}"
 
             # Cleanup
@@ -1628,7 +1716,7 @@ class TestCancelCeleryTasks:
 
     @pytest.mark.unit
     def test_cancel_celery_tasks_with_main_and_sub_tasks(
-        self, privacy_request_with_cached_tasks
+            self, privacy_request_with_cached_tasks
     ):
         """Test canceling celery tasks when main and sub-tasks exist."""
         from unittest import mock
@@ -1658,7 +1746,7 @@ class TestCancelCeleryTasks:
 
     @pytest.mark.unit
     def test_cancel_celery_tasks_with_only_main_task(
-        self, privacy_request_no_cached_tasks
+            self, privacy_request_no_cached_tasks
     ):
         """Test canceling celery tasks when only main task exists."""
         from unittest import mock
@@ -1695,7 +1783,7 @@ class TestCancelCeleryTasks:
 
     @pytest.mark.unit
     def test_cancel_celery_tasks_with_revoke_failures(
-        self, privacy_request_with_cached_tasks
+            self, privacy_request_with_cached_tasks
     ):
         """Test that revoke failures are handled gracefully."""
         from unittest import mock
@@ -1710,7 +1798,7 @@ class TestCancelCeleryTasks:
 
         with mock.patch.object(celery_app.control, "revoke", side_effect=side_effect):
             with mock.patch(
-                "fides.api.models.privacy_request.privacy_request.logger"
+                    "fides.api.models.privacy_request.privacy_request.logger"
             ) as mock_logger:
                 privacy_request.cancel_celery_tasks()
 
@@ -1731,7 +1819,7 @@ class TestCancelCeleryTasks:
 
         with mock.patch.object(celery_app.control, "revoke"):
             with mock.patch(
-                "fides.api.models.privacy_request.privacy_request.logger"
+                    "fides.api.models.privacy_request.privacy_request.logger"
             ) as mock_logger:
                 privacy_request.cancel_celery_tasks()
 
@@ -1761,7 +1849,7 @@ class TestCancelCeleryTasks:
 
     @pytest.mark.unit
     def test_get_request_task_celery_task_ids_no_tasks(
-        self, privacy_request_no_cached_tasks
+            self, privacy_request_no_cached_tasks
     ):
         """Test that get_request_task_celery_task_ids returns empty list when no tasks exist."""
         privacy_request = privacy_request_no_cached_tasks
@@ -1773,7 +1861,7 @@ class TestCancelCeleryTasks:
 
     @pytest.mark.unit
     def test_cancel_celery_tasks_integration_with_cancel_processing(
-        self, privacy_request_no_cached_tasks
+            self, privacy_request_no_cached_tasks
     ):
         """Test that cancel_celery_tasks is called when cancel_processing is invoked."""
         from unittest import mock
@@ -1781,7 +1869,7 @@ class TestCancelCeleryTasks:
         privacy_request = privacy_request_no_cached_tasks
 
         with mock.patch.object(
-            privacy_request, "cancel_celery_tasks"
+                privacy_request, "cancel_celery_tasks"
         ) as mock_cancel_tasks:
             with mock.patch.object(privacy_request, "save"):
                 privacy_request.cancel_processing(mock.Mock(), "Test cancellation")


### PR DESCRIPTION
(Opening as a draft for the moment)

Closes ENG-1217

### Description Of Changes

No removal of data or breaking contract changes - only adds new data to web hook payloads; there may be more embedded structures/data that we want to add beyond the policy, custom fields, and the location data that is not in this PR.

### Code Changes

Makes the DSR body available through the webhook payload, which (when applicable) includes custom fields, location data, and policy information.

Additionally, adds a timestamp field to webhook payloads so that the receiving end can make decisions based on execution timestamp (i.e. potentially ignore duplicate invocations, or out-of-order delivery)

### Steps to Confirm

1. None - added tests to validate the presence of data in the payload

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
