### PR TITLE
Fix failing smoke test

### DIFF
--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "main"
       - "release-**"
+  pull_request:
+    paths:
+      - "clients/cypress-e2e/**"
 
 env:
   CI: true

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -27906,6 +27906,21 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "privacy-center/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
+      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/clients/privacy-center/components/modals/privacy-request-modal/usePrivacyRequestForm.ts
+++ b/clients/privacy-center/components/modals/privacy-request-modal/usePrivacyRequestForm.ts
@@ -124,7 +124,8 @@ const usePrivacyRequestForm = ({
                   return [
                     key,
                     {
-                      ...field,
+                      // only include label and value
+                      label: field.label,
                       value: !field.hidden ? values[key] : hiddenValue,
                     },
                   ];

--- a/clients/privacy-center/components/modals/privacy-request-modal/usePrivacyRequestForm.ts
+++ b/clients/privacy-center/components/modals/privacy-request-modal/usePrivacyRequestForm.ts
@@ -26,8 +26,9 @@ import { FormValues, MultiselectFieldValue } from "~/types/forms";
  * @param value
  * @returns Default to null if the value is undefined or an empty string
  */
-const fallbackNull = (value: string | MultiselectFieldValue) =>
-  value === undefined || value === "" ? null : value;
+const fallbackNull = (
+  value: string | MultiselectFieldValue | null | undefined,
+) => (value === undefined || value === "" ? null : value);
 
 const usePrivacyRequestForm = ({
   onClose,
@@ -114,32 +115,40 @@ const usePrivacyRequestForm = ({
       const customPrivacyRequestFieldValues =
         action.custom_privacy_request_fields
           ? Object.fromEntries(
-              Object.entries(action.custom_privacy_request_fields).map(
-                ([key, field]) => {
+              Object.entries(action.custom_privacy_request_fields)
+                .map(([key, field]) => {
                   const paramValue =
                     field.query_param_key &&
                     searchParams?.get(field.query_param_key);
                   const hiddenValue = paramValue ?? field.default_value;
+                  const value = !field.hidden ? values[key] : hiddenValue;
 
                   return [
                     key,
                     {
                       // only include label and value
                       label: field.label,
-                      value: !field.hidden ? values[key] : hiddenValue,
+                      value: fallbackNull(value),
                     },
                   ];
-                },
-              ),
+                })
+                .filter(
+                  ([, fieldData]) =>
+                    typeof fieldData === "object" && fieldData.value !== null,
+                ), // Filter out null values
             )
+          : {};
+
+      // Extract custom fields object for cleaner code
+      const customFieldsPayload =
+        Object.keys(customPrivacyRequestFieldValues).length > 0
+          ? { custom_privacy_request_fields: customPrivacyRequestFieldValues }
           : {};
 
       const body = [
         {
           identity: identityInputValues,
-          ...(Object.keys(customPrivacyRequestFieldValues).length > 0 && {
-            custom_privacy_request_fields: customPrivacyRequestFieldValues,
-          }),
+          ...customFieldsPayload,
           policy_key: action.policy_key,
           property_id: property?.id || null,
           source: PrivacyRequestSource.PRIVACY_CENTER,

--- a/clients/privacy-center/config/config.json
+++ b/clients/privacy-center/config/config.json
@@ -20,6 +20,18 @@
         "email": "required"
       },
       "custom_privacy_request_fields": {
+        "first_name": {
+          "label": "First name"
+        },
+        "last_name": {
+          "label": "Last name",
+          "required": false
+        },
+        "tenant_id": {
+          "label": "Tenant ID",
+          "default_value": "123",
+          "hidden": true
+        },
         "location": {
           "label": "Location",
           "field_type": "location",
@@ -30,6 +42,7 @@
           "label": "Preferred format",
           "field_type": "select",
           "required": true,
+          "default_value": "HTML",
           "options": [
             "JSON",
             "CSV",
@@ -55,12 +68,6 @@
             "EPUB",
             "PSD"
           ]
-        },
-        "location": {
-          "label": "Location",
-          "field_type": "location",
-          "required": true,
-          "ip_geolocation_hint": true
         }
       },
       "confirmButtonText": "Continue",


### PR DESCRIPTION
### Description Of Changes

Update smoke test to expect the new fields that were added to config.json. Restored original behavior for custom fields params

### Code Changes
* Updated smoke test to expect some additional fields
* Update github workflow for smoke tests to run in PRs if the test themselves change (so that it runs in this PR)
* Updated the logic of usePrivacyRequestForm to restore the original behavior of the custom request fields params to the endpoint: 1. Don't send fields with no value (like an optional field you didn't filled out) 2. Only send the label and values

### Steps to Confirm

1.  Smoke test passes

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
