### PR TITLE
ENG-681 Re implement pw reset session invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.69.0...main)
 
+### Security
+- Changed session invalidation logic to end all sessions for a user when their password has been changed [CVE-2025-57766](https://github.com/ethyca/fides/security/advisories/GHSA-rpw8-82v9-3q87)
+- Added stricter rate limiting to authentication endpoints to mitigate against brute force attacks. [CVE-2025-57815](https://github.com/ethyca/fides/security/advisories/GHSA-7q62-r88r-j5gw)
+- Adds Redis-driven rate limiting across all endpoints [CVE-2025-57816](https://github.com/ethyca/fides/security/advisories/GHSA-fq34-xw6c-fphf)
+
 ### Deprecated
 - DSR 2.0 is deprecated. New requests will be created using DSR 3.0 only. Existing DSR 2.0 requests will continue to process until completion. [#6458](https://github.com/ethyca/fides/pull/6458)
 
@@ -61,11 +66,6 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed bug with non-applicable notices being saved as opted in in Fides.js [#6490](https://github.com/ethyca/fides/pull/6490)
 - Handle missing GVL in TCF experience by displaying an error message instead of infinite spinners. [#6472](https://github.com/ethyca/fides/pull/6472)
 - Prevent edits for assets that have been ignored in the Action Center [#6485](https://github.com/ethyca/fides/pull/6485)
-
-### Security
-- Changed session invalidation logic to end all sessions for a user when their password has been changed [CVE-2025-57766](https://github.com/ethyca/fides/security/advisories/GHSA-rpw8-82v9-3q87)
-- Added stricter rate limiting to authentication endpoints to mitigate against brute force attacks. [CVE-2025-57815](https://github.com/ethyca/fides/security/advisories/GHSA-7q62-r88r-j5gw)
-- Adds Redis-driven rate limiting across all endpoints [CVE-2025-57816](https://github.com/ethyca/fides/security/advisories/GHSA-fq34-xw6c-fphf)
 
 ## [2.68.0](https://github.com/ethyca/fides/compare/2.67.2...2.68.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,13 +56,11 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Fixed
 - Fixed bug with non-applicable notices being saved as opted in in Fides.js [#6490](https://github.com/ethyca/fides/pull/6490)
-
-
-### Fixed
 - Handle missing GVL in TCF experience by displaying an error message instead of infinite spinners. [#6472](https://github.com/ethyca/fides/pull/6472)
 - Prevent edits for assets that have been ignored in the Action Center [#6485](https://github.com/ethyca/fides/pull/6485)
 
 ### Security
+- Changed session invalidation logic to end all sessions for a user when their password has been changed [CVE-2025-57766](https://github.com/ethyca/fides/security/advisories/GHSA-rpw8-82v9-3q87)
 - Added stricter rate limiting to authentication endpoints to mitigate against brute force attacks. [CVE-2025-57815](https://github.com/ethyca/fides/security/advisories/GHSA-7q62-r88r-j5gw)
 
 ## [2.68.0](https://github.com/ethyca/fides/compare/2.67.2...2.68.0)

--- a/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
@@ -18,8 +18,9 @@ import { useDispatch } from "react-redux";
 import * as Yup from "yup";
 
 import { useAppSelector } from "~/app/hooks";
-import { LOGIN_ROUTE, STORAGE_ROOT_KEY } from "~/constants";
+import { LOGIN_ROUTE } from "~/constants";
 import { logout, selectUser } from "~/features/auth/auth.slice";
+import { clearAuthAndLogout } from "./logout-helpers";
 import { CustomTextInput } from "~/features/common/form/inputs";
 import { passwordValidation } from "~/features/common/form/validation";
 import { getErrorMessage } from "~/features/common/helpers";
@@ -63,13 +64,7 @@ const useNewPasswordModal = (id: string) => {
 
       // Only logout if admin reset their own password
       if (currentUser?.id === id) {
-        try {
-          localStorage.removeItem(STORAGE_ROOT_KEY);
-        } catch (e) {
-          // no-op
-        }
-        dispatch(logout());
-        router.push(LOGIN_ROUTE);
+        clearAuthAndLogout(dispatch as any, router);
       }
     }
   };

--- a/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
@@ -18,15 +18,14 @@ import { useDispatch } from "react-redux";
 import * as Yup from "yup";
 
 import { useAppSelector } from "~/app/hooks";
-import { LOGIN_ROUTE } from "~/constants";
-import { logout, selectUser } from "~/features/auth/auth.slice";
-import { clearAuthAndLogout } from "./logout-helpers";
+import { selectUser } from "~/features/auth/auth.slice";
 import { CustomTextInput } from "~/features/common/form/inputs";
 import { passwordValidation } from "~/features/common/form/validation";
 import { getErrorMessage } from "~/features/common/helpers";
 import { errorToastParams, successToastParams } from "~/features/common/toast";
 import { isErrorResult } from "~/types/errors";
 
+import { clearAuthAndLogout } from "./logout-helpers";
 import { useForceResetUserPasswordMutation } from "./user-management.slice";
 
 const ValidationSchema = Yup.object().shape({

--- a/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/NewPasswordModal.tsx
@@ -13,8 +13,13 @@ import {
   useToast,
 } from "fidesui";
 import { Form, Formik } from "formik";
+import { useRouter } from "next/router";
+import { useDispatch } from "react-redux";
 import * as Yup from "yup";
 
+import { useAppSelector } from "~/app/hooks";
+import { LOGIN_ROUTE, STORAGE_ROOT_KEY } from "~/constants";
+import { logout, selectUser } from "~/features/auth/auth.slice";
 import { CustomTextInput } from "~/features/common/form/inputs";
 import { passwordValidation } from "~/features/common/form/validation";
 import { getErrorMessage } from "~/features/common/helpers";
@@ -37,6 +42,9 @@ const useNewPasswordModal = (id: string) => {
   const modal = useDisclosure();
   const toast = useToast();
   const [resetPassword] = useForceResetUserPasswordMutation();
+  const router = useRouter();
+  const dispatch = useDispatch();
+  const currentUser = useAppSelector(selectUser);
 
   const handleResetPassword = async (values: FormValues) => {
     const result = await resetPassword({
@@ -52,6 +60,17 @@ const useNewPasswordModal = (id: string) => {
         ),
       );
       modal.onClose();
+
+      // Only logout if admin reset their own password
+      if (currentUser?.id === id) {
+        try {
+          localStorage.removeItem(STORAGE_ROOT_KEY);
+        } catch (e) {
+          // no-op
+        }
+        dispatch(logout());
+        router.push(LOGIN_ROUTE);
+      }
     }
   };
 

--- a/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
@@ -13,7 +13,12 @@ import {
   useDisclosure,
   useToast,
 } from "fidesui";
+import { useRouter } from "next/router";
 import React, { useState } from "react";
+import { useDispatch } from "react-redux";
+
+import { LOGIN_ROUTE, STORAGE_ROOT_KEY } from "~/constants";
+import { logout } from "~/features/auth/auth.slice";
 
 import { successToastParams } from "../common/toast";
 import { useUpdateUserPasswordMutation } from "./user-management.slice";
@@ -24,6 +29,8 @@ const useUpdatePasswordModal = (id: string) => {
   const [oldPasswordValue, setOldPasswordValue] = useState("");
   const [newPasswordValue, setNewPasswordValue] = useState("");
   const [changePassword, { isLoading }] = useUpdateUserPasswordMutation();
+  const router = useRouter();
+  const dispatch = useDispatch();
 
   const changePasswordValidation = !!(
     id &&
@@ -49,7 +56,16 @@ const useUpdatePasswordModal = (id: string) => {
         .unwrap()
         .then(() => {
           toast(successToastParams("Password updated"));
+          // Clear persisted auth state and logout locally
+          try {
+            localStorage.removeItem(STORAGE_ROOT_KEY);
+          } catch (e) {
+            // no-op
+          }
+          dispatch(logout());
           modal.onClose();
+          // Redirect to login
+          router.push(LOGIN_ROUTE);
         });
     }
   };

--- a/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
@@ -17,8 +17,8 @@ import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 
-import { LOGIN_ROUTE, STORAGE_ROOT_KEY } from "~/constants";
-import { logout } from "~/features/auth/auth.slice";
+import { LOGIN_ROUTE } from "~/constants";
+import { clearAuthAndLogout } from "./logout-helpers";
 
 import { successToastParams } from "../common/toast";
 import { useUpdateUserPasswordMutation } from "./user-management.slice";
@@ -56,16 +56,7 @@ const useUpdatePasswordModal = (id: string) => {
         .unwrap()
         .then(() => {
           toast(successToastParams("Password updated"));
-          // Clear persisted auth state and logout locally
-          try {
-            localStorage.removeItem(STORAGE_ROOT_KEY);
-          } catch (e) {
-            // no-op
-          }
-          dispatch(logout());
-          modal.onClose();
-          // Redirect to login
-          router.push(LOGIN_ROUTE);
+          clearAuthAndLogout(dispatch as any, router, { onClose: modal.onClose });
         });
     }
   };

--- a/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
+++ b/clients/admin-ui/src/features/user-management/UpdatePasswordModal.tsx
@@ -17,10 +17,8 @@ import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 
-import { LOGIN_ROUTE } from "~/constants";
-import { clearAuthAndLogout } from "./logout-helpers";
-
 import { successToastParams } from "../common/toast";
+import { clearAuthAndLogout } from "./logout-helpers";
 import { useUpdateUserPasswordMutation } from "./user-management.slice";
 
 const useUpdatePasswordModal = (id: string) => {
@@ -56,7 +54,9 @@ const useUpdatePasswordModal = (id: string) => {
         .unwrap()
         .then(() => {
           toast(successToastParams("Password updated"));
-          clearAuthAndLogout(dispatch as any, router, { onClose: modal.onClose });
+          clearAuthAndLogout(dispatch as any, router, {
+            onClose: modal.onClose,
+          });
         });
     }
   };

--- a/clients/admin-ui/src/features/user-management/logout-helpers.ts
+++ b/clients/admin-ui/src/features/user-management/logout-helpers.ts
@@ -1,4 +1,5 @@
 import { NextRouter } from "next/router";
+
 import { AppDispatch } from "~/app/store";
 import { LOGIN_ROUTE, STORAGE_ROOT_KEY } from "~/constants";
 import { logout } from "~/features/auth/auth.slice";

--- a/clients/admin-ui/src/features/user-management/logout-helpers.ts
+++ b/clients/admin-ui/src/features/user-management/logout-helpers.ts
@@ -6,7 +6,7 @@ import { logout } from "~/features/auth/auth.slice";
 export const clearAuthAndLogout = (
   dispatch: AppDispatch,
   router: NextRouter,
-  opts?: { onClose?: () => void }
+  opts?: { onClose?: () => void },
 ) => {
   try {
     localStorage.removeItem(STORAGE_ROOT_KEY);

--- a/clients/admin-ui/src/features/user-management/logout-helpers.ts
+++ b/clients/admin-ui/src/features/user-management/logout-helpers.ts
@@ -1,0 +1,19 @@
+import { NextRouter } from "next/router";
+import { AppDispatch } from "~/app/store";
+import { LOGIN_ROUTE, STORAGE_ROOT_KEY } from "~/constants";
+import { logout } from "~/features/auth/auth.slice";
+
+export const clearAuthAndLogout = (
+  dispatch: AppDispatch,
+  router: NextRouter,
+  opts?: { onClose?: () => void }
+) => {
+  try {
+    localStorage.removeItem(STORAGE_ROOT_KEY);
+  } catch (e) {
+    // no-op
+  }
+  dispatch(logout());
+  opts?.onClose?.();
+  router.push(LOGIN_ROUTE);
+};

--- a/src/fides/api/api/v1/endpoints/user_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/user_endpoints.py
@@ -208,6 +208,17 @@ def update_user_password(
 
     current_user.update_password(db=db, new_password=data.new_password)
 
+    # Delete the user's associated OAuth client to invalidate all existing sessions
+    if current_user.client:
+        try:
+            current_user.client.delete(db)
+        except Exception as exc:
+            logger.exception(
+                "Unable to delete user client during password reset for user {}: {}",
+                current_user.id,
+                exc,
+            )
+
     logger.info("Updated user with id: '{}'.", current_user.id)
     return current_user
 
@@ -236,6 +247,18 @@ def force_update_password(
         )
 
     user.update_password(db=db, new_password=data.new_password)
+
+    # Delete the user's associated OAuth client to invalidate all existing sessions
+    if user.client:
+        try:
+            user.client.delete(db)
+        except Exception as exc:
+            logger.exception(
+                "Unable to delete user client during admin-forced password reset for user {}: {}",
+                user.id,
+                exc,
+            )
+
     logger.info("Updated user with id: '{}'.", user.id)
     return user
 

--- a/src/fides/api/models/client.py
+++ b/src/fides/api/models/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 from sqlalchemy import ARRAY, Column, ForeignKey, String
 from sqlalchemy.ext.declarative import declared_attr
@@ -22,11 +22,9 @@ from fides.api.cryptography.schemas.jwt import (
     JWE_PAYLOAD_SYSTEMS,
 )
 from fides.api.db.base_class import Base
+from fides.api.models.fides_user import FidesUser
 from fides.api.oauth.jwt import generate_jwe
 from fides.config import FidesConfig
-
-if TYPE_CHECKING:
-    from fides.api.models.fides_user import FidesUser
 
 DEFAULT_SCOPES: list[str] = []
 DEFAULT_ROLES: list[str] = []
@@ -50,11 +48,10 @@ class ClientDetail(Base):
         ARRAY(String), nullable=False, server_default="{}", default=dict
     )
     fides_key = Column(String, index=True, unique=True, nullable=True)
-    user_id = Column(String, ForeignKey("fidesuser.id"), nullable=True, unique=True)
-
-    if TYPE_CHECKING:
-        # Explicitly annotate the backref relationship for mypy
-        user: Optional["FidesUser"]
+    user_id = Column(
+        String, ForeignKey(FidesUser.id_field_path), nullable=True, unique=True
+    )
+    user: Optional["FidesUser"]
 
     @classmethod
     def create_client_and_secret(

--- a/src/fides/api/models/client.py
+++ b/src/fides/api/models/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy import ARRAY, Column, ForeignKey, String
 from sqlalchemy.ext.declarative import declared_attr
@@ -22,9 +22,11 @@ from fides.api.cryptography.schemas.jwt import (
     JWE_PAYLOAD_SYSTEMS,
 )
 from fides.api.db.base_class import Base
-from fides.api.models.fides_user import FidesUser
 from fides.api.oauth.jwt import generate_jwe
 from fides.config import FidesConfig
+
+if TYPE_CHECKING:
+    from fides.api.models.fides_user import FidesUser
 
 DEFAULT_SCOPES: list[str] = []
 DEFAULT_ROLES: list[str] = []
@@ -48,9 +50,11 @@ class ClientDetail(Base):
         ARRAY(String), nullable=False, server_default="{}", default=dict
     )
     fides_key = Column(String, index=True, unique=True, nullable=True)
-    user_id = Column(
-        String, ForeignKey(FidesUser.id_field_path), nullable=True, unique=True
-    )
+    user_id = Column(String, ForeignKey("fidesuser.id"), nullable=True, unique=True)
+
+    if TYPE_CHECKING:
+        # Explicitly annotate the backref relationship for mypy
+        user: Optional["FidesUser"]
 
     @classmethod
     def create_client_and_secret(

--- a/src/fides/api/models/fides_user.py
+++ b/src/fides/api/models/fides_user.py
@@ -22,7 +22,7 @@ from fides.api.cryptography.cryptographic_util import (
 from fides.api.db.base_class import Base
 from fides.api.models.audit_log import AuditLog
 
-# SystemManager import is handled in base.py to avoid circular imports
+# Intentionally importing SystemManager here to build the FidesUser.systems relationship
 from fides.api.schemas.user import DisabledReason
 from fides.config import CONFIG
 
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         FidesUserRespondentEmailVerification,
     )
     from fides.api.models.sql_models import System  # type: ignore[attr-defined]
+    from fides.api.models.system_manager import SystemManager
 
 
 class FidesUser(Base):

--- a/src/fides/api/models/fides_user.py
+++ b/src/fides/api/models/fides_user.py
@@ -22,7 +22,7 @@ from fides.api.cryptography.cryptographic_util import (
 from fides.api.db.base_class import Base
 from fides.api.models.audit_log import AuditLog
 
-# Intentionally importing SystemManager here to build the FidesUser.systems relationship
+# SystemManager import is handled in base.py to avoid circular imports
 from fides.api.schemas.user import DisabledReason
 from fides.config import CONFIG
 
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
         FidesUserRespondentEmailVerification,
     )
     from fides.api.models.sql_models import System  # type: ignore[attr-defined]
-    from fides.api.models.system_manager import SystemManager
 
 
 class FidesUser(Base):

--- a/src/fides/api/oauth/utils.py
+++ b/src/fides/api/oauth/utils.py
@@ -88,10 +88,12 @@ def is_token_invalidated(issued_at: datetime, client: ClientDetail) -> bool:
     Any errors accessing related objects are logged and treated as non-invalidating.
     """
     try:
-        if client.user is not None and client.user.password_reset_at is not None:
-            password_reset_at = client.user.password_reset_at
-            if password_reset_at and issued_at < password_reset_at:
-                return True
+        if (
+            client.user is not None
+            and client.user.password_reset_at is not None
+            and issued_at < client.user.password_reset_at
+        ):
+            return True
         return False
     except Exception as exc:
         logger.exception(

--- a/src/fides/api/oauth/utils.py
+++ b/src/fides/api/oauth/utils.py
@@ -94,7 +94,9 @@ def is_token_invalidated(issued_at: datetime, client: ClientDetail) -> bool:
         reset_at = client.user.password_reset_at
         # DB layer may return a tz-aware timestamp while the JWE issued_at is naive (server time).
         # Normalize both to naive for a safe, deterministic comparison without raising TypeError.
-        issued_naive = issued_at.replace(tzinfo=None)
+        issued_naive = (
+            issued_at.replace(tzinfo=None) if issued_at.tzinfo is not None else issued_at
+        )
         reset_naive = (
             reset_at.replace(tzinfo=None) if reset_at.tzinfo is not None else reset_at
         )

--- a/src/fides/api/oauth/utils.py
+++ b/src/fides/api/oauth/utils.py
@@ -88,13 +88,18 @@ def is_token_invalidated(issued_at: datetime, client: ClientDetail) -> bool:
     Any errors accessing related objects are logged and treated as non-invalidating.
     """
     try:
-        if (
-            client.user is not None
-            and client.user.password_reset_at is not None
-            and issued_at < client.user.password_reset_at
-        ):
-            return True
-        return False
+        if client.user is None or client.user.password_reset_at is None:
+            return False
+
+        reset_at = client.user.password_reset_at
+        # DB layer may return a tz-aware timestamp while the JWE issued_at is naive (server time).
+        # Normalize both to naive for a safe, deterministic comparison without raising TypeError.
+        issued_naive = issued_at.replace(tzinfo=None)
+        reset_naive = (
+            reset_at.replace(tzinfo=None) if reset_at.tzinfo is not None else reset_at
+        )
+
+        return issued_naive < reset_naive
     except Exception as exc:
         logger.exception(
             "Unable to evaluate password reset timestamp for client user: {}", exc

--- a/src/fides/api/oauth/utils.py
+++ b/src/fides/api/oauth/utils.py
@@ -95,7 +95,9 @@ def is_token_invalidated(issued_at: datetime, client: ClientDetail) -> bool:
         # DB layer may return a tz-aware timestamp while the JWE issued_at is naive (server time).
         # Normalize both to naive for a safe, deterministic comparison without raising TypeError.
         issued_naive = (
-            issued_at.replace(tzinfo=None) if issued_at.tzinfo is not None else issued_at
+            issued_at.replace(tzinfo=None)
+            if issued_at.tzinfo is not None
+            else issued_at
         )
         reset_naive = (
             reset_at.replace(tzinfo=None) if reset_at.tzinfo is not None else reset_at

--- a/tests/ops/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_endpoints.py
@@ -1222,6 +1222,43 @@ class TestUpdateUserPassword:
         application_user = application_user.refresh_from_db(db=db)
         assert application_user.credentials_valid(password=NEW_PASSWORD)
 
+    def test_token_invalid_after_password_reset(
+        self, api_client, db, url_no_id, application_user
+    ) -> None:
+        """Old tokens should be rejected immediately after a successful password reset."""
+        OLD_PASSWORD = "oldpassword"
+        NEW_PASSWORD = "Newpassword1!"
+        application_user.update_password(db=db, new_password=OLD_PASSWORD)
+
+        # Create token before password reset
+        token_before_reset = generate_auth_header_for_user(
+            application_user, scopes=[USER_READ]
+        )
+
+        # Use old token to fetch own user successfully before reset
+        resp_ok = api_client.get(
+            f"{url_no_id}/{application_user.id}", headers=token_before_reset
+        )
+        assert resp_ok.status_code == HTTP_200_OK
+
+        # Perform password reset
+        auth_header = generate_auth_header_for_user(user=application_user, scopes=[])
+        resp_reset = api_client.post(
+            f"{url_no_id}/{application_user.id}/reset-password",
+            headers=auth_header,
+            json={
+                "old_password": str_to_b64_str(OLD_PASSWORD),
+                "new_password": str_to_b64_str(NEW_PASSWORD),
+            },
+        )
+        assert resp_reset.status_code == HTTP_200_OK
+
+        # Old token should now be rejected on any protected endpoint
+        resp_forbidden = api_client.get(
+            f"{url_no_id}/{application_user.id}", headers=token_before_reset
+        )
+        assert resp_forbidden.status_code == HTTP_403_FORBIDDEN
+
     def test_force_update_different_user_password_without_scope(
         self,
         api_client,
@@ -1960,7 +1997,30 @@ class TestUpdateSystemsManagedByUser:
         second_system.delete(db)
 
 
-class TestGetSystemsUserManages:
+class SystemManagerUserEndpointTestBase:
+    """Base class for system manager user endpoint tests that require user authentication"""
+
+    @pytest.fixture(scope="function")
+    def generate_auth_header(self, viewer_user, db):
+        """Override global generate_auth_header to provide user authentication for system manager endpoints"""
+
+        def _auth_header(scopes):
+            # Ensure the user has the necessary scopes by adding them to the client
+            if viewer_user.client and scopes:
+                # Add any missing scopes to the client
+                current_scopes = viewer_user.client.scopes or []
+                new_scopes = list(set(current_scopes + scopes))
+                viewer_user.client.scopes = new_scopes
+                viewer_user.client.save(db)
+
+            from tests.conftest import generate_auth_header_for_user
+
+            return generate_auth_header_for_user(viewer_user, scopes)
+
+        return _auth_header
+
+
+class TestGetSystemsUserManages(SystemManagerUserEndpointTestBase):
     @pytest.fixture(scope="function")
     def url(self, viewer_user) -> str:
         return V1_URL_PREFIX + f"/user/{viewer_user.id}/system-manager"
@@ -1972,11 +2032,18 @@ class TestGetSystemsUserManages:
         assert resp.status_code == HTTP_401_UNAUTHORIZED
 
     def test_get_systems_managed_by_user_wrong_scope(
-        self, api_client: TestClient, generate_auth_header, url
+        self, api_client: TestClient, oauth_client, url
     ):
         # Note no user attached to this client, so it can't check to see
         # if the user is accessing itself
-        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_READ])
+        from fides.config import CONFIG
+        from tests.conftest import _generate_auth_header
+
+        # Use the existing conftest function for client-only auth
+        auth_header_func = _generate_auth_header(
+            oauth_client, CONFIG.security.app_encryption_key
+        )
+        auth_header = auth_header_func(scopes=[PRIVACY_REQUEST_READ])
         resp = api_client.get(url, headers=auth_header)
         assert resp.status_code == HTTP_403_FORBIDDEN
 
@@ -2049,7 +2116,7 @@ class TestGetSystemsUserManages:
         assert resp.json()[0]["fides_key"] == system.fides_key
 
 
-class TestGetSpecificSystemUserManages:
+class TestGetSpecificSystemUserManages(SystemManagerUserEndpointTestBase):
     @pytest.fixture(scope="function")
     def url(self, viewer_user, system) -> str:
         return (
@@ -2063,11 +2130,18 @@ class TestGetSpecificSystemUserManages:
         assert resp.status_code == HTTP_401_UNAUTHORIZED
 
     def test_get_system_managed_by_user_wrong_scope(
-        self, api_client: TestClient, generate_auth_header, url
+        self, api_client: TestClient, oauth_client, url
     ):
         # Note that no user is attached to this client so we can't check
         # to see if the user is accessing its own systems
-        auth_header = generate_auth_header(scopes=[PRIVACY_REQUEST_READ])
+        from fides.config import CONFIG
+        from tests.conftest import _generate_auth_header
+
+        # Use the existing conftest function for client-only auth
+        auth_header_func = _generate_auth_header(
+            oauth_client, CONFIG.security.app_encryption_key
+        )
+        auth_header = auth_header_func(scopes=[PRIVACY_REQUEST_READ])
         resp = api_client.get(url, headers=auth_header)
         assert resp.status_code == HTTP_403_FORBIDDEN
 


### PR DESCRIPTION
Closes [ENG-681]

### Description Of Changes

This is to re-implement ENG-681, which was reverted due to its impact on FidesPlus/unit tests. This has been refactored to not require the changes the the OAuth client test fixture.

### Code Changes

Invalidates exisitng sessions for a user when their password has been reset

### Steps to Confirm

1.  Login as a user
2. Change the pw for that user
3. Watch the session get invalidated

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-681]: https://ethyca.atlassian.net/browse/ENG-681

