### PR TITLE
fix: custom identity fields [ENG-1226]

### DIFF
--- a/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
@@ -48,7 +48,12 @@ const PrivacyRequestForm = ({
     touched,
     values,
     isSubmitting,
-    identityInputs: { name: nameInput, email: emailInput, phone: phoneInput },
+    legacyIdentityFields: {
+      name: nameInput,
+      email: emailInput,
+      phone: phoneInput,
+    },
+    customIdentityFields,
     customPrivacyRequestFields,
   } = usePrivacyRequestForm({
     onClose,
@@ -140,7 +145,10 @@ const PrivacyRequestForm = ({
             />
           </Form.Item>
         )}
-        {Object.entries(customPrivacyRequestFields)
+        {Object.entries({
+          ...customIdentityFields,
+          ...customPrivacyRequestFields,
+        })
           .filter(([, field]) => !field?.hidden)
           .map(([key, item]) => {
             const customFieldProps = (


### PR DESCRIPTION
Closes [ENG-1226]

### Description Of Changes

Restores the ability to render custom identity fields based on config

### Code Changes

- Updates the `usePrivacyRequestForm` hook to pull out custom identity fields from the config
- Updates the `PrivacyRequestForm` component to render the custom identity fields pulled from the config

### Steps to Confirm

1.  Add the custom identity field into the config.json file from the fidesplus e2e test of the demo project:
```
      "identity_inputs": {
        "email": "required",
        "stackoverflow_user_id": { "label": "Stackoverflow User ID" }
      },
```
2. Confirm that the input properly renders and submits the data

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1226]: https://ethyca.atlassian.net/browse/ENG-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ