### PR TITLE
fix: website monitor config exclude domains [ENG-1316]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.69.1...main)
 
+### Fixed
+- Enables the exclude domains field in the website monitor config. [#6545](https://github.com/ethyca/fides/pull/6545)
+
 ### Deprecated
 - DSR 2.0 is deprecated. New requests will be created using DSR 3.0 only. Existing DSR 2.0 requests will continue to process until completion. [#6458](https://github.com/ethyca/fides/pull/6458)
 

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
@@ -93,6 +93,7 @@ const ConfigureWebsiteMonitorForm = ({
     connection_config_key: integrationId,
     datasource_params: (monitor?.datasource_params as WebsiteMonitorParams) ?? {
       locations: [],
+      exclude_domains: [],
     },
   };
 
@@ -178,16 +179,17 @@ const ConfigureWebsiteMonitorForm = ({
           placeholder="Enter domains to exclude"
           id="exclude_domains"
           label="Exclude domains"
+          mode="tags"
           options={[]}
+          suffixIcon={null}
           open={false}
-          disabled
           error={getIn(errors, "datasource_params.exclude_domains")}
           touched={getIn(touched, "datasource_params.exclude_domains")}
           onChange={(value) =>
             formik.setFieldValue("datasource_params.exclude_domains", value)
           }
           onBlur={formik.handleBlur}
-          value={values.execution_frequency || []}
+          value={values.datasource_params?.exclude_domains || []}
         />
         <FormikTextInput
           name="url"


### PR DESCRIPTION
Closes [ENG-1316]

### Description Of Changes

Re-enables the `exclude domains` field for the website monitor config form

### Code Changes

- Remove the disabled prop on `exclude domains` select component
- Fix the value prop on the `exclude domains` select component
- Adding `excludeDomains` initial value

### Steps to Confirm

1. Visit `/integrations/ethyca#data-discovery`
2. Edit or create a new monitor
3. Confirm that the `exclude domains` field functions correctly, allows input, and submits

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1316]: https://ethyca.atlassian.net/browse/ENG-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ