### PR TITLE
fix: location select mode and table display [ENG-1305]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.69.1...main)
 
 ### Fixed
-- Enables the exclude domains field in the website monitor config. [#6545](https://github.com/ethyca/fides/pull/6545)
+- Enables the exclude domains field in the website monitor config. [#6544](https://github.com/ethyca/fides/pull/6544)
+- Region table value displayed correctly and Location select only allowing valid values [#6545](https://github.com/ethyca/fides/pull/6545)
 
 ### Deprecated
 - DSR 2.0 is deprecated. New requests will be created using DSR 3.0 only. Existing DSR 2.0 requests will continue to process until completion. [#6458](https://github.com/ethyca/fides/pull/6458)

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
@@ -213,7 +213,7 @@ const ConfigureWebsiteMonitorForm = ({
           )}
           required
           tooltip={REGIONS_TOOLTIP_COPY}
-          mode="tags"
+          mode="multiple"
           error={getIn(errors, "datasource_params.locations")}
           touched={getIn(touched, "datasource_params.locations")}
           onChange={(value) =>

--- a/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
@@ -215,6 +215,11 @@ const MonitorConfigTab = ({
             locations
               ?.map((location) => {
                 const isoEntry = isoStringToEntry(location);
+
+                /**
+                 * regionCode and regionRecord are the result of navigating enums that should be depricated.
+                 * if the backend decides to maintain a list of values for the frontend to use, a less convoluted method should be used
+                 */
                 const regionCode = Object.entries(PrivacyNoticeRegion).find(
                   ([, region]) => {
                     return region === location;
@@ -222,11 +227,14 @@ const MonitorConfigTab = ({
                 );
 
                 const regionRecord =
-                  regionCode && PRIVACY_NOTICE_REGION_RECORD[regionCode[1]];
+                  regionCode &&
+                  PRIVACY_NOTICE_REGION_RECORD[
+                    regionCode[1]
+                  ]; /* regionCode[1] refers to enum value that is the key for the region records enum (enum-ception) */
 
                 return isoEntry
                   ? formatIsoLocation({ isoEntry })
-                  : regionRecord?.[1];
+                  : regionRecord;
               })
               .join(", ") || "No regions selected"
           );


### PR DESCRIPTION
Closes [ENG-1305]

### Description Of Changes

Fixing location select props and display within table

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  Confirm that the location select input no longer accepts any value
2. Confirm that the regions table value displays correctly when values are set

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1305]: https://ethyca.atlassian.net/browse/ENG-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ