### PR TITLE
Adds safeguards when encountering rate limit errors upon instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.69.1...main)
 
+### Fixed
+- Adds safeguards when encountering rate limit errors upon instantiation [#6546](https://github.com/ethyca/fides/pull/6546)
+
 ### Deprecated
 - DSR 2.0 is deprecated. New requests will be created using DSR 3.0 only. Existing DSR 2.0 requests will continue to process until completion. [#6458](https://github.com/ethyca/fides/pull/6458)
 

--- a/src/fides/api/util/rate_limit.py
+++ b/src/fides/api/util/rate_limit.py
@@ -180,15 +180,32 @@ is_rate_limit_enabled = (
     CONFIG.security.rate_limit_client_ip_header is not None
     and CONFIG.security.rate_limit_client_ip_header != ""
 )
-fides_limiter = Limiter(
-    storage_uri=CONFIG.redis.connection_url_unencoded,
-    application_limits=[
-        CONFIG.security.request_rate_limit
-    ],  # Creates ONE shared bucket for all endpoints
+
+disabled_limiter = Limiter(
+    default_limits=[CONFIG.security.request_rate_limit],
     headers_enabled=True,
     key_prefix=CONFIG.security.rate_limit_prefix,
     key_func=safe_rate_limit_key,
     retry_after="http-date",
-    in_memory_fallback_enabled=False,  # Fall back to no rate limiting if Redis unavailable
-    enabled=is_rate_limit_enabled,
+    enabled=False,
 )
+
+try:
+    if is_rate_limit_enabled:
+        fides_limiter = Limiter(
+            storage_uri=CONFIG.redis.connection_url_unencoded,
+            application_limits=[
+                CONFIG.security.request_rate_limit
+            ],  # Creates ONE shared bucket for all endpoints
+            headers_enabled=True,
+            key_prefix=CONFIG.security.rate_limit_prefix,
+            key_func=safe_rate_limit_key,
+            retry_after="http-date",
+            in_memory_fallback_enabled=False,  # Fall back to no rate limiting if Redis unavailable
+            enabled=is_rate_limit_enabled,
+        )
+    else:
+        fides_limiter = disabled_limiter
+except Exception as e:
+    logger.warning("Disabling rate limiting due to Redis configuration issue: {}", e)
+    fides_limiter = disabled_limiter

--- a/src/fides/api/util/rate_limit.py
+++ b/src/fides/api/util/rate_limit.py
@@ -207,5 +207,6 @@ try:
     else:
         fides_limiter = disabled_limiter
 except Exception as e:
-    logger.warning("Disabling rate limiting due to Redis configuration issue: {}", e)
-    fides_limiter = disabled_limiter
+    logger.exception("Error instantiating rate limiter: {}", e)
+    if is_rate_limit_enabled:
+        raise e


### PR DESCRIPTION
Closes https://ethyca.atlassian.net/browse/ENG-1315

### Description Of Changes

Adds safeguards when encountering rate limit errors upon instantiation. Allows rate_limiting to still function given a Redis pass does not include special chars like `[` or `]`

### Code Changes

* Uses disabled `Limiter` in the cases where either 1. rate limiting is disabled, or 2. we encounter any errors when instantiating the redis-driven `Limiter`

### Steps to Confirm

1.  In `docker_compose.yml`, update `services` -> `redis` -> `command` password to an invalid / unsupported password that contains `[` or `]`, e.g. `command: redis-server --requirepass "passwor[d"`
2. In your `.env`, set the same pass in the `FIDES__REDIS__PASSWORD` var
3. Remove any existing `FIDES__SECURITY__RATE_LIMIT_CLIENT_IP_HEADER` rate limit env var
4. Start up fides using `nox -s dev`
5. Observe fides is able to start up just fine


### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
