### PR TITLE
Fix failing e2e test

### DIFF
--- a/clients/cypress-e2e/cypress/e2e/smoke_test.cy.ts
+++ b/clients/cypress-e2e/cypress/e2e/smoke_test.cy.ts
@@ -102,10 +102,7 @@ describe("Smoke test", () => {
       // Postgres
       cy.getByTestId("Data inventory-nav-group").click();
       cy.getByTestId("System inventory-nav-link").click();
-      cy.getByTestId("system-cookie_house_postgresql_database").within(() => {
-        cy.getByTestId("edit-btn").click();
-      });
-
+      cy.getByTestId("system-link-cookie_house_postgresql_database").click();
       cy.get(`.ant-tabs-tab-btn`).filter(`:contains("Integrations")`).click();
       cy.getByTestId("test-connection-button").click();
       cy.getByTestId("toast-success-msg").should("be.visible");
@@ -115,9 +112,7 @@ describe("Smoke test", () => {
       // Mongo
       cy.getByTestId("Data inventory-nav-group").click();
       cy.getByTestId("System inventory-nav-link").click();
-      cy.getByTestId("system-cookie_house_customer_database").within(() => {
-        cy.getByTestId("edit-btn").click();
-      });
+      cy.getByTestId("system-link-cookie_house_customer_database").click();
       cy.get(`.ant-tabs-tab-btn`).filter(`:contains("Integrations")`).click();
       cy.getByTestId("test-connection-button").click();
       cy.getByTestId("toast-success-msg").should("be.visible");


### PR DESCRIPTION
Closes unticketed

### Description Of Changes

Fixes an e2e smoke test that was broken as a result of [#6453](https://github.com/ethyca/fides/pull/6453) by updating test IDs.

### Steps to Confirm

1.  CI passes

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
