### PR TITLE
Update Cypress selectors to fix failing privacy center test

### DIFF
--- a/clients/privacy-center/cypress/e2e/external-manual-tasks.cy.ts
+++ b/clients/privacy-center/cypress/e2e/external-manual-tasks.cy.ts
@@ -186,14 +186,24 @@ describe("External Manual Tasks", () => {
       cy.get("table tbody tr[data-row-key='pri_ext_001-task_ext_001']")
         .should("exist")
         .within(() => {
-          cy.get("td")
+          cy.get("td:not(.ant-table-selection-column)")
             .eq(0)
             .should("contain", "Export Customer Data from Salesforce");
-          cy.get("td").eq(1).should("contain", "New");
-          cy.get("td").eq(2).should("contain", "Salesforce");
-          cy.get("td").eq(3).should("contain", "Access");
-          cy.get("td").eq(4).should("contain", "15 days");
-          cy.get("td").eq(5).should("contain", "customer@example.com");
+          cy.get("td:not(.ant-table-selection-column)")
+            .eq(1)
+            .should("contain", "New");
+          cy.get("td:not(.ant-table-selection-column)")
+            .eq(2)
+            .should("contain", "Salesforce");
+          cy.get("td:not(.ant-table-selection-column)")
+            .eq(3)
+            .should("contain", "Access");
+          cy.get("td:not(.ant-table-selection-column)")
+            .eq(4)
+            .should("contain", "15 days");
+          cy.get("td:not(.ant-table-selection-column)")
+            .eq(5)
+            .should("contain", "customer@example.com");
         });
     });
 


### PR DESCRIPTION
### Description Of Changes

Updates selectors to fix a privacy center test that was failing after an update to Ant tables.

### Steps to Confirm

1. Privacy center Cypress passes

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] ~~`CHANGELOG.md` updated~~
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
