### PR TITLE
rename tab "Recent activity" -> "Added"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.69.2...main)
 
+### Changed
+- Changed "Recent activity" tab to "Added" in Action Center for improved clarity [#6565](https://github.com/ethyca/fides/pull/6565)
+
 ### Deprecated
 - DSR 2.0 is deprecated. New requests will be created using DSR 3.0 only. Existing DSR 2.0 requests will continue to process until completion. [#6458](https://github.com/ethyca/fides/pull/6458)
 

--- a/clients/admin-ui/cypress/e2e/action-center/assets-results.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/assets-results.cy.ts
@@ -347,11 +347,11 @@ describe("Action center Asset Results", () => {
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
         cy.getByTestId("asset-state-filter")
-          .contains("Recent activity")
+          .contains("Added")
           .click({ force: true });
-        cy.location("hash").should("eq", "#recent-activity");
+        cy.location("hash").should("eq", "#added");
 
-        // "recent activity" tab should be read-only
+        // "added" tab should be read-only
         cy.getByTestId("bulk-actions-menu").should("be.disabled");
         cy.getAntTableRow(rowUrns[0]).within(() => {
           cy.getByTestId("system-badge")

--- a/clients/admin-ui/cypress/e2e/action-center/systems-aggregate.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/systems-aggregate.cy.ts
@@ -189,10 +189,10 @@ describe("Action center system aggregate results", () => {
       cy.visit(`${ACTION_CENTER_ROUTE}/${webMonitorKey}#attention-required`);
       cy.location("hash").should("eq", "#attention-required");
 
-      cy.clickAntTab("Recent activity");
-      cy.location("hash").should("eq", "#recent-activity");
+      cy.clickAntTab("Added");
+      cy.location("hash").should("eq", "#added");
 
-      // "recent activity" tab should be read-only
+      // "added" tab should be read-only
       cy.getByTestId("bulk-actions-menu").should("be.disabled");
       cy.get("thead tr")
         .should("be.visible")
@@ -227,13 +227,13 @@ describe("Action center system aggregate results", () => {
         );
       });
 
-      cy.clickAntTab("Recent activity");
+      cy.clickAntTab("Added");
       cy.wait("@getSystemAggregateResults");
       cy.getAntTableRow("[undefined]").within(() => {
         cy.getByTestId("system-name-link").should(
           "have.attr",
           "href",
-          `${ACTION_CENTER_ROUTE}/${webMonitorKey}/[undefined]#recent-activity`,
+          `${ACTION_CENTER_ROUTE}/${webMonitorKey}/[undefined]#added`,
         );
       });
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useActionCenterTabs.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useActionCenterTabs.tsx
@@ -5,7 +5,7 @@ import { DiffStatus } from "~/types/api";
 
 export enum ActionCenterTabHash {
   ATTENTION_REQUIRED = "attention-required",
-  RECENT_ACTIVITY = "recent-activity",
+  ADDED = "added",
   IGNORED = "ignored",
 }
 
@@ -25,11 +25,11 @@ const useActionCenterTabs = (systemId?: string) => {
         hash: ActionCenterTabHash.ATTENTION_REQUIRED,
       },
       {
-        label: "Recent activity",
+        label: "Added",
         params: {
           diff_status: [DiffStatus.MONITORED],
         },
-        hash: ActionCenterTabHash.RECENT_ACTIVITY,
+        hash: ActionCenterTabHash.ADDED,
       },
       {
         label: "Ignored",

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsTable.tsx
@@ -162,7 +162,7 @@ export const useDiscoveredAssetsTable = ({
 
   const antTableConfig = useMemo(
     () => ({
-      enableSelection: activeTab !== ActionCenterTabHash.RECENT_ACTIVITY,
+      enableSelection: activeTab !== ActionCenterTabHash.ADDED,
       getRowKey: (record: StagedResourceAPIResponse) => record.urn,
       isLoading,
       isFetching,


### PR DESCRIPTION
Closes [ENG-1234]

### Description Of Changes

Renamed the "Recent activity" tab in the Action Center to "Added" to better reflect its purpose.

### Code Changes

* Updated tab label from "Recent activity" to "Added" in `useActionCenterTabs.tsx`
* Changed enum value from `RECENT_ACTIVITY` to `ADDED` in `ActionCenterTabHash`
* Updated URL hash routing from `#recent-activity` to `#added`
* Modified selection logic in `useDiscoveredAssetsTable.tsx` to reference the new tab hash
* Updated Cypress E2E tests in both `assets-results.cy.ts` and `systems-aggregate.cy.ts` to use new tab name and hash
* Updated test comments to reflect the new "added" tab terminology

### Steps to Confirm

1. Navigate to the Action Center in the admin UI
2. Verify the tab is now labeled "Added" instead of "Recent activity"
3. Confirm clicking the tab updates the URL hash to `#added`
4. Verify the tab remains read-only (bulk actions disabled)

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1234]: https://ethyca.atlassian.net/browse/ENG-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ