### PR TITLE
Fix custom logos in external task portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Request manager screen date range now respects timezones [#6552](https://github.com/ethyca/fides/pull/6552)
 - Request manager screen will no longer silently filter results by prior searches [#6552](https://github.com/ethyca/fides/pull/6552)
 - Request manager CSV download link is now cleaned up making memory leaks in Admin UI less likely [#6552](https://github.com/ethyca/fides/pull/6552)
+- Fix custom logos in external task portal [#6573](https://github.com/ethyca/fides/pull/6573)
+
 
 ## [2.69.2](https://github.com/ethyca/fides/compare/2.69.1...2.69.2)
 

--- a/clients/privacy-center/features/external-manual-tasks/components/ExternalAuthLayout.tsx
+++ b/clients/privacy-center/features/external-manual-tasks/components/ExternalAuthLayout.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 /**
  * External Auth Layout Component
  *
@@ -10,7 +11,6 @@ import {
   AntSpace as Space,
   AntTypography as Typography,
 } from "fidesui";
-import Image from "next/image";
 import React from "react";
 
 import { useConfig } from "~/features/common/config.slice";
@@ -41,12 +41,11 @@ export const ExternalAuthLayout = ({
         <Space direction="vertical" size={64} style={{ width: "100%" }}>
           {/* Fides Logo */}
           <Flex justify="center">
-            <Image
+            <img
               src={config?.logo_path || "/logo.svg"}
-              alt="Fides logo"
+              alt="Logo"
               width={205}
               height={46}
-              priority
             />
           </Flex>
 

--- a/clients/privacy-center/features/external-manual-tasks/components/ExternalTaskLayout.tsx
+++ b/clients/privacy-center/features/external-manual-tasks/components/ExternalTaskLayout.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 /**
  * External Task Layout Component
  *
@@ -12,7 +13,6 @@ import {
   AntTypography as Typography,
 } from "fidesui";
 import palette from "fidesui/src/palette/palette.module.scss";
-import Image from "next/image";
 
 import BrandLink from "~/components/BrandLink";
 import { useConfig } from "~/features/common/config.slice";
@@ -64,12 +64,11 @@ export const ExternalTaskLayout = () => {
             <Flex justify="space-between" align="center">
               {/* Left side - Logo and Title */}
               <Flex align="center" gap={32}>
-                <Image
+                <img
                   src={config?.logo_path || "/logo.svg"}
-                  alt="Fides logo"
+                  alt="Logo"
                   width={205}
                   height={46}
-                  priority
                 />
                 <div>
                   <Typography.Title


### PR DESCRIPTION
Closes ENG-1371

### Description Of Changes
Fix custom logos in external task portal. Using the Next.js Image tag requires to whitelist the domain, which is not something we have implemented. Changing it to a regular img tag just like the one on the homepage fixes the issue.

### Code Changes

* Change Next.js image tag to basic html <img> tag

### Steps to Confirm

1. Change your config.json logo_path to be an external image url
2. Make sure your clients/privacy-center.env has `FIDES_PRIVACY_CENTER__ENABLE_EXTERNAL_TASK_PORTAL=true `
3. Visit http://localhost:3001/external-tasks and confirm the logo displays correctly

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
