### PR TITLE
Removing incorrect fallback for group by dropdown

### DIFF
--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -356,20 +356,14 @@ export const DatamapReportTable = () => {
 
   // Get the proper name for dropdown options (no lower-casing)
   const getSystemGroupOptionName = () => {
-    // 1. Priority: Custom column name from user overrides
+    // Priority: Custom column name from user overrides
     const customSystemGroupName =
       columnNameMapOverrides[COLUMN_IDS.SYSTEM_GROUP];
     if (customSystemGroupName) {
       return customSystemGroupName;
     }
 
-    // 2. Priority: Use actual system group taxonomy name if available
-    if (systemGroups && systemGroups.length > 0) {
-      const firstGroup = systemGroups[0];
-      return firstGroup.name || "System group";
-    }
-
-    // 3. Fallback: Generic "System group"
+    // Fallback: Generic "System group"
     return "System group";
   };
 


### PR DESCRIPTION
### Description Of Changes

Removing incorrect fallback for group by dropdown. The code incorrectly used the first available system group as the label for the group by system group option.

### Code Changes

* Removed incorrect fallback

### Steps to Confirm

1.  Run `localStorage.clear();` in the browser console to clear any column name overrides from local storage
2. Assign a system group to a system so it shows up in the datamap report table
3. Confirm the value for group by system group still shows "System group"

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
