### PR TITLE
ENG-1291: Fix call to deprecated method

### DIFF
--- a/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/privacy_request_endpoints.py
@@ -334,7 +334,7 @@ def get_variable_columns(
 
     for pr in privacy_request_query:
         identity_columns.update(
-            extract_identity_column_names(pr.get_persisted_identity().dict())
+            extract_identity_column_names(pr.get_persisted_identity().model_dump())
         )
         custom_field_columns.update(
             extract_custom_field_column_names(
@@ -377,7 +377,7 @@ def extract_identity_cells(
     identity_columns: List[str], pr: PrivacyRequest
 ) -> List[str]:
     identity = pr.get_persisted_identity()
-    identity_dict = identity.dict()
+    identity_dict = identity.model_dump()
     return [
         identity_dict.get(identity_column)  # type: ignore
         for identity_column in identity_columns


### PR DESCRIPTION
Closes [ENG-1291]

### Description Of Changes

Fixes a call to a deprecated method during CSV building that has a bug that causes the CSV generation to fail.

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1291]: https://ethyca.atlassian.net/browse/ENG-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ