### PR TITLE
fix: tcf experience alert [ENG-1380]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.70.0...main)
 
+### Fixed
+- TCF alert rendering incorrectly during react lifecycle [#6582](https://github.com/ethyca/fides/pull/6582)
+
 ## [2.70.0](https://github.com/ethyca/fides/compare/2.69.2...2.70.0)
 
 ### Added

--- a/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
@@ -163,7 +163,10 @@ const Preview = ({
   }, [initialValues, noticesOnConfig, values.component]);
 
   useEffect(() => {
-    if (vendorCount === 0 && values.component === ComponentType.TCF_OVERLAY) {
+    if (
+      vendorReport?.total === 0 &&
+      values.component === ComponentType.TCF_OVERLAY
+    ) {
       notification.warning({
         message: "No vendors available",
         description:
@@ -172,7 +175,7 @@ const Preview = ({
         key: "vendor-warning", // Prevent duplicate messages
       });
     }
-  }, [vendorCount, values.component]);
+  }, [vendorReport?.total, values.component]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
Closes [ENG-1380]

### Description Of Changes

Fixing initial load of tcf alert that would display before receiving a vendor total to properly make decisions.
Variable used in side-effect was coerced from `undefined` into `0` before the number of vendors was returned from the api.
Side-effects should generally be discouraged.

### Code Changes

Using raw value instead of coerced memoized value

### Steps to Confirm

1.  Hard load `https://fides-plus-nightly-git-fix-tcf-experience-alert-ethyca.vercel.app/consent/privacy-experience/pri_711a76ef-197d-4ee3-b28e-02eb769294c9`
2. Confirm that the TCF alert does not load

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1380]: https://ethyca.atlassian.net/browse/ENG-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ