### PR TITLE
ENG-1123 Make ConsentMechanism inherit from str

### DIFF
--- a/src/fides/api/models/privacy_notice.py
+++ b/src/fides/api/models/privacy_notice.py
@@ -41,7 +41,7 @@ class UserConsentPreference(Enum):
     tcf = "tcf"  # Overall preference set for TCF where there are numerous preferences under the single notice
 
 
-class ConsentMechanism(Enum):
+class ConsentMechanism(str, Enum):
     """
     Enum is not formalized in the DB because it may be subject to frequent change
     """


### PR DESCRIPTION

### Description Of Changes

I just need ConsentMechanism to serialize nicely :) 

### Code Changes

* Make the `ConsentMechanism` enum inherit from `str` 

### Steps to Confirm

1.  Tests pass
2. profit? 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
