### PR TITLE
Fix commit link in notifier slack message

### DIFF
--- a/.github/workflows/ethyca-slack-notifier.yml
+++ b/.github/workflows/ethyca-slack-notifier.yml
@@ -48,7 +48,7 @@ jobs:
             # Create new thread for this commit
             COMMIT_MESSAGE=$(echo '${{ github.event.workflow_run.head_commit.message }}' | head -n 1)
             COMMIT_AUTHOR="${{ github.event.workflow_run.head_commit.author.name }}"
-            COMMIT_URL="${{ github.event.workflow_run.head_commit.url }}"
+            COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }}"
 
             # Build JSON payload safely using jq
             JSON_PAYLOAD=$(jq -n \


### PR DESCRIPTION
Closes [<issue>]

### Description Of Changes

This constructs the commit URL in a different way; the prior method was working on my test runs on my branch, but not on the runs being kicked off by the `main` failures.

### Code Changes

* Update Github commit URL for Ethyca Slack notification.

### Steps to Confirm

We'll need to just see what the messages look like. We're already successfully getting the `commit_sha` on line 30, so this should work.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
