### PR TITLE
chore: bump pymssql to latest (2.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.70.0...main)
 
+
+### Changed
+- Update `pymssql` dependency from 2.3.4 to 2.3.7 [#6601](https://github.com/ethyca/fides/pull/6601)
+
 ### Developer Experience
 - Trigger fidesplus CI actions on pushes to `main` in Fides [#6592](https://github.com/ethyca/fides/pull/6592)
 

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,1 +1,1 @@
-pymssql==2.3.4
+pymssql==2.3.7


### PR DESCRIPTION
Unticketed chore

### Description Of Changes

Bumps `pymssql` from version `2.3.4` to `2.3.7` in `optional-requirements.txt` to resolve build dependency conflicts on Apple Silicon (ARM64) systems.

The previous version `2.3.4` had incompatible `setuptools_scm` version constraints that prevented installation on macOS devices with Apple Silicon processors. Version `2.3.7` resolves these dependency conflicts.

```
~ ❯ pip install pymssql==2.3.4
Collecting pymssql==2.3.4
  Using cached pymssql-2.3.4.tar.gz (184 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
ERROR: Some build dependencies for pymssql==2.3.4 from https://files.pythonhosted.org/packages/83/35/5a0b79369e42fffd5c04e4e74fa90ef034cc5c3f314e14f6d58cac646ccf/pymssql-2.3.4.tar.gz conflict with the backend dependencies: setuptools_scm==9.2.0 is incompatible with setuptools_scm[toml]>=5.0,<9.0.
```

### Code Changes

* Updated `pymssql==2.3.4` to `pymssql==2.3.7` in `optional-requirements.txt`

### Steps to Confirm

1. Run `nox -s dev -- mssql` and verify that:
   - All containers start successfully and show "Healthy" status
   - MSSQL setup script completes without errors
   - Fides application starts and responds to health checks

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
