### PR TITLE
Support sorting by name in system inventory

### DIFF
--- a/clients/admin-ui/src/features/system/system.slice.ts
+++ b/clients/admin-ui/src/features/system/system.slice.ts
@@ -2,6 +2,7 @@ import { createSelector } from "@reduxjs/toolkit";
 
 import { baseApi } from "~/features/common/api.slice";
 import { buildArrayQueryParams } from "~/features/common/utils";
+import { SystemColumnKeys } from "~/features/system/useSystemsTable";
 import {
   BulkPutConnectionConfiguration,
   ConnectionConfigurationResponse,
@@ -12,7 +13,11 @@ import {
   SystemSchemaExtended,
   TestStatusMessage,
 } from "~/types/api";
-import { PaginationQueryParams, SearchQueryParams } from "~/types/query-params";
+import {
+  PaginationQueryParams,
+  SearchQueryParams,
+  SortQueryParams,
+} from "~/types/query-params";
 
 interface SystemDeleteResponse {
   message: string;
@@ -46,12 +51,22 @@ const systemApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getSystems: build.query<
       Page_BasicSystemResponseExtended_,
-      PaginationQueryParams & SearchQueryParams & GetSystemsQueryParams
+      PaginationQueryParams &
+        SearchQueryParams &
+        GetSystemsQueryParams &
+        SortQueryParams<SystemColumnKeys>
     >({
-      query: ({ data_stewards, system_groups, ...params }) => {
+      query: ({
+        data_stewards,
+        system_groups,
+        sort_by = [SystemColumnKeys.NAME],
+        ...params
+      }) => {
+        const sortByArray = Array.isArray(sort_by) ? sort_by : [sort_by];
         const urlParams = buildArrayQueryParams({
           data_stewards,
           system_groups,
+          sort_by: sortByArray,
         });
 
         return {

--- a/clients/admin-ui/src/features/system/useSystemsTable.tsx
+++ b/clients/admin-ui/src/features/system/useSystemsTable.tsx
@@ -41,6 +41,15 @@ import {
 } from "~/types/api";
 import { isErrorResult } from "~/types/errors";
 
+export enum SystemColumnKeys {
+  NAME = "name",
+  SYSTEM_GROUPS = "system_groups",
+  DATA_USES = "privacy_declarations",
+  DATA_STEWARDS = "data_stewards",
+  DESCRIPTION = "description",
+  ACTIONS = "actions",
+}
+
 const useSystemsTable = () => {
   // ancillary data
   const { data: allSystemGroups } = useGetAllSystemGroupsQuery();
@@ -78,13 +87,25 @@ const useSystemsTable = () => {
     useState<BasicSystemResponseExtended | null>(null);
 
   // main table state
-  const tableState = useTableState({
+  const tableState = useTableState<SystemColumnKeys>({
     pagination: { defaultPageSize: 25, pageSizeOptions: [25, 50, 100] },
     search: { defaultSearchQuery: "" },
+    sorting: {
+      defaultSortKey: SystemColumnKeys.NAME,
+      defaultSortOrder: "ascend",
+      validColumns: [SystemColumnKeys.NAME],
+    },
   });
 
-  const { columnFilters, pageIndex, pageSize, searchQuery, updateSearch } =
-    tableState;
+  const {
+    columnFilters,
+    pageIndex,
+    pageSize,
+    searchQuery,
+    updateSearch,
+    sortKey,
+    sortOrder,
+  } = tableState;
 
   const {
     data: systemsResponse,
@@ -94,6 +115,8 @@ const useSystemsTable = () => {
     page: pageIndex,
     size: pageSize,
     search: searchQuery,
+    sort_by: sortKey,
+    sort_asc: sortOrder === "ascend",
     ...columnFilters,
   });
 
@@ -202,7 +225,7 @@ const useSystemsTable = () => {
       {
         title: "Name",
         dataIndex: "name",
-        key: "name",
+        key: SystemColumnKeys.NAME,
         render: (name: string | null, record: BasicSystemResponseExtended) => (
           <LinkCell
             href={`/systems/configure/${record.fides_key}`}
@@ -213,10 +236,12 @@ const useSystemsTable = () => {
         ),
         ellipsis: true,
         fixed: "left",
+        sorter: true,
+        sortOrder: sortKey === SystemColumnKeys.NAME ? sortOrder : null,
       },
       {
         dataIndex: "system_groups",
-        key: "system_groups",
+        key: SystemColumnKeys.SYSTEM_GROUPS,
         render: (
           systemGroups: string[] | undefined,
           record: BasicSystemResponseExtended,
@@ -269,7 +294,7 @@ const useSystemsTable = () => {
           },
         },
         dataIndex: "privacy_declarations",
-        key: "privacy_declarations",
+        key: SystemColumnKeys.DATA_USES,
         render: (privacyDeclarations: PrivacyDeclaration[]) => (
           <SystemDataUseCell
             privacyDeclarations={privacyDeclarations}
@@ -283,7 +308,7 @@ const useSystemsTable = () => {
       {
         title: "Data stewards",
         dataIndex: "data_stewards",
-        key: "data_stewards",
+        key: SystemColumnKeys.DATA_STEWARDS,
         render: (dataStewards: string[] | null) => (
           <ListExpandableCell values={dataStewards ?? []} valueSuffix="users" />
         ),
@@ -295,7 +320,7 @@ const useSystemsTable = () => {
       {
         title: "Description",
         dataIndex: "description",
-        key: "description",
+        key: SystemColumnKeys.DESCRIPTION,
         render: (description: string | null) => (
           <div className="max-w-96">
             <Typography.Text ellipsis={{ tooltip: description }}>
@@ -307,7 +332,7 @@ const useSystemsTable = () => {
       },
       {
         title: "Actions",
-        key: "actions",
+        key: SystemColumnKeys.ACTIONS,
         render: (_: undefined, record: BasicSystemResponseExtended) => (
           <Flex justify="end">
             <Dropdown
@@ -351,6 +376,8 @@ const useSystemsTable = () => {
       },
     ];
   }, [
+    sortKey,
+    sortOrder,
     plusIsEnabled,
     allSystemGroups,
     columnFilters?.system_groups,


### PR DESCRIPTION
Closes 1413

### Description Of Changes

Adds support for ascending and descending sorting by name in systems table.

### Steps to Confirm

TODO: confirm backend branch

1. Open system inventory
2. Systems should be sorted by name ascending by default
3. Should be able to toggle sorting descending
4. Should see changes to sort reflected in URL and `sort_by`/`sort_order` params in API call

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
