### PR TITLE
Fix action center blue dots not disappearing

### DIFF
--- a/clients/admin-ui/src/features/plus/plus.slice.ts
+++ b/clients/admin-ui/src/features/plus/plus.slice.ts
@@ -301,6 +301,8 @@ const plusApi = baseApi.injectEndpoints({
         "Datamap",
         "System History",
         "Privacy Notices",
+        // Ensure Action Center refetches so blue dots clear when linking vendors
+        "Discovery Monitor Results",
       ],
     }),
     getFidesCloudConfig: build.query<CloudConfig, void>({

--- a/clients/admin-ui/src/features/system/system.slice.ts
+++ b/clients/admin-ui/src/features/system/system.slice.ts
@@ -100,6 +100,8 @@ const systemApi = baseApi.injectEndpoints({
         "Datastore Connection",
         "System Vendors",
         "Privacy Notices",
+        // Ensure Action Center data refreshes so "new system" indicators clear
+        "Discovery Monitor Results",
       ],
     }),
     deleteSystem: build.mutation<SystemDeleteResponse, string>({
@@ -142,6 +144,8 @@ const systemApi = baseApi.injectEndpoints({
         "Datastore Connection",
         "System History",
         "System Vendors",
+        // Keep Action Center in sync with system changes
+        "Discovery Monitor Results",
       ],
     }),
     updateSystem: build.mutation<
@@ -161,6 +165,8 @@ const systemApi = baseApi.injectEndpoints({
         "Datastore Connection",
         "System History",
         "System Vendors",
+        // Update Action Center aggregates if linkage changes
+        "Discovery Monitor Results",
       ],
     }),
     patchSystemConnectionConfigs: build.mutation<


### PR DESCRIPTION
Closes #<issue_number_here> (Addresses reported bug)

### Description Of Changes

Previously, the "newly detected system" blue dots in the Action Center would not disappear after a user added or linked the corresponding system. This was due to the Action Center's data not being refetched after system creation or updates.

This change ensures that the Action Center's "Discovery Monitor Results" cache is invalidated when systems are created, updated, or linked to vendors. This forces the UI to refetch the latest system data, correctly clearing the blue dots once the `system_key` is present.

### Code Changes

*   `clients/admin-ui/src/features/plus/plus.slice.ts`: Added `"Discovery Monitor Results"` invalidation to `postSystemVendors` mutation.
*   `clients/admin-ui/src/features/system/system.slice.ts`: Added `"Discovery Monitor Results"` invalidation to `createSystem`, `upsertSystems`, and `updateSystem` mutations.

### Steps to Confirm

1.  Navigate to the Action Center and observe a "newly detected system" (indicated by a blue dot).
2.  Click on the system to go to its details page.
3.  Click "Add System" or "Link to existing system" and complete the process.
4.  Return to the Action Center.
5.  Confirm that the blue dot for the newly added/linked system has disappeared.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

---
<a href="https://cursor.com/background-agent?bcId=bc-50ae4151-d7f1-40fd-88ad-0d1e2d890e5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-50ae4151-d7f1-40fd-88ad-0d1e2d890e5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

