### PR TITLE
ENG-1256 - Add indexes for the classifications and user_assigned_data…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Added
 - Added `Not applicable` and `Pre-consent` as new `ConsentStatus` labels in the UI [#6571](https://github.com/ethyca/fides/pull/6571)
 - Added SRV and SSL support for MongoDB [#6590](https://github.com/ethyca/fides/pull/6590)
+- Add indexes for classifications and user_assigned_data_categories columns from stagedresource table [#6612](https://github.com/ethyca/fides/pull/6612) https://github.com/ethyca/fides/labels/db-migration
 
 ### Changed
 - Update `pymssql` dependency from 2.3.4 to 2.3.7 [#6601](https://github.com/ethyca/fides/pull/6601)

--- a/src/fides/api/alembic/migrations/versions/cd8649be3a2b_add_classifications_and_user_assigned_.py
+++ b/src/fides/api/alembic/migrations/versions/cd8649be3a2b_add_classifications_and_user_assigned_.py
@@ -1,8 +1,8 @@
 """add classifications and user_assigned_data_categories indices
 
-Revision ID: fcbca04460aa
-Revises: 4d8c0fcc5771
-Create Date: 2025-09-15 20:23:15.715499
+Revision ID: cd8649be3a2b
+Revises: a8e0c016afd
+Create Date: 2025-09-19 13:49:02.762672
 
 """
 
@@ -11,8 +11,8 @@ from alembic import op
 from loguru import logger
 
 # revision identifiers, used by Alembic.
-revision = "fcbca04460aa"
-down_revision = "4d8c0fcc5771"
+revision = "cd8649be3a2b"
+down_revision = "a8e0c016afd"
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/alembic/migrations/versions/fcbca04460aa_add_classifications_and_user_assigned_.py
+++ b/src/fides/api/alembic/migrations/versions/fcbca04460aa_add_classifications_and_user_assigned_.py
@@ -18,15 +18,6 @@ depends_on = None
 
 """
 WARNING - Conditional migration based on table size
-
-This migration script checks the size of stagedresource table and performs:
-
-1. If the table has less than 1 million rows:
-   - Creates GIN indices directly for array operations
-
-2. If the table is too large (1 million rows or more):
-   - Logs non-blocking SQL commands using CREATE INDEX CONCURRENTLY
-   - These commands add the indices without blocking reads or writes
 """
 
 

--- a/src/fides/api/alembic/migrations/versions/fcbca04460aa_add_classifications_and_user_assigned_.py
+++ b/src/fides/api/alembic/migrations/versions/fcbca04460aa_add_classifications_and_user_assigned_.py
@@ -1,0 +1,84 @@
+"""add classifications and user_assigned_data_categories indices
+
+Revision ID: fcbca04460aa
+Revises: 4d8c0fcc5771
+Create Date: 2025-09-15 20:23:15.715499
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from loguru import logger
+
+# revision identifiers, used by Alembic.
+revision = 'fcbca04460aa'
+down_revision = '4d8c0fcc5771'
+branch_labels = None
+depends_on = None
+
+"""
+WARNING - Conditional migration based on table size
+
+This migration script checks the size of stagedresource table and performs:
+
+1. If the table has less than 1 million rows:
+   - Creates GIN indices directly for array operations
+
+2. If the table is too large (1 million rows or more):
+   - Logs non-blocking SQL commands using CREATE INDEX CONCURRENTLY
+   - These commands add the indices without blocking reads or writes
+"""
+
+
+def upgrade():
+    # Check stagedresource table size
+    connection = op.get_bind()
+    try:
+        result = connection.execute(
+            sa.text("SELECT COUNT(*) FROM stagedresource")
+        ).fetchone()
+        table_size = result[0] if result else 0
+    except Exception as e:
+        logger.warning(f"Could not check stagedresource table size: {e}")
+        logger.info("Proceeding with direct index creation")
+        table_size = 0
+
+    if table_size < 1000000:
+        logger.info(f"stagedresource table has {table_size} rows, creating GIN indices directly")
+
+        # Create GIN index for user_assigned_data_categories array operations (&&, @>, <@)
+        op.execute(
+            "CREATE INDEX idx_stagedresource_user_categories_gin "
+            "ON stagedresource USING GIN (user_assigned_data_categories)"
+        )
+
+        # Create GIN index for classifications array operations (&&, @>, <@)
+        op.execute(
+            "CREATE INDEX idx_stagedresource_classifications_gin "
+            "ON stagedresource USING GIN (classifications)"
+        )
+
+        logger.info("GIN indices created successfully")
+
+    else:
+        logger.warning(
+            "The stagedresource table has more than 1 million rows, "
+            "skipping index creation. Indexes will be created during application startup "
+            "via post_upgrade_index_creation.py"
+        )
+
+
+def downgrade():
+    # Drop indices in reverse order
+    logger.info("Dropping GIN indices for stagedresource arrays")
+
+    try:
+        op.drop_index("idx_stagedresource_classifications_gin", "stagedresource")
+        logger.info("Dropped classifications GIN index")
+    except Exception as e:
+        logger.warning(f"Could not drop classifications index: {e}")
+
+    try:
+        op.drop_index("idx_stagedresource_user_categories_gin", "stagedresource")
+        logger.info("Dropped user_assigned_data_categories GIN index")
+    except Exception as e:
+        logger.warning(f"Could not drop user_categories index: {e}")

--- a/src/fides/api/alembic/migrations/versions/fcbca04460aa_add_classifications_and_user_assigned_.py
+++ b/src/fides/api/alembic/migrations/versions/fcbca04460aa_add_classifications_and_user_assigned_.py
@@ -24,15 +24,11 @@ WARNING - Conditional migration based on table size
 def upgrade():
     # Check stagedresource table size
     connection = op.get_bind()
-    try:
-        result = connection.execute(
-            sa.text("SELECT COUNT(*) FROM stagedresource")
-        ).fetchone()
-        table_size = result[0] if result else 0
-    except Exception as e:
-        logger.warning(f"Could not check stagedresource table size: {e}")
-        logger.info("Proceeding with direct index creation")
-        table_size = 0
+
+    # Check stagedresource table size to decide if we should create indexes immediately
+    table_size = connection.execute(
+        sa.text("SELECT COUNT(*) FROM stagedresource")
+    ).scalar()
 
     if table_size < 1000000:
         logger.info(

--- a/src/fides/api/alembic/migrations/versions/fcbca04460aa_add_classifications_and_user_assigned_.py
+++ b/src/fides/api/alembic/migrations/versions/fcbca04460aa_add_classifications_and_user_assigned_.py
@@ -5,13 +5,14 @@ Revises: 4d8c0fcc5771
 Create Date: 2025-09-15 20:23:15.715499
 
 """
-from alembic import op
+
 import sqlalchemy as sa
+from alembic import op
 from loguru import logger
 
 # revision identifiers, used by Alembic.
-revision = 'fcbca04460aa'
-down_revision = '4d8c0fcc5771'
+revision = "fcbca04460aa"
+down_revision = "4d8c0fcc5771"
 branch_labels = None
 depends_on = None
 
@@ -43,7 +44,9 @@ def upgrade():
         table_size = 0
 
     if table_size < 1000000:
-        logger.info(f"stagedresource table has {table_size} rows, creating GIN indices directly")
+        logger.info(
+            f"stagedresource table has {table_size} rows, creating GIN indices directly"
+        )
 
         # Create GIN index for user_assigned_data_categories array operations (&&, @>, <@)
         op.execute(

--- a/src/fides/api/migrations/post_upgrade_index_creation.py
+++ b/src/fides/api/migrations/post_upgrade_index_creation.py
@@ -153,6 +153,16 @@ TABLE_OBJECT_MAP: Dict[str, List[Dict[str, str]]] = {
             "statement": "CREATE INDEX CONCURRENTLY ix_stagedresource_system_vendor_consent ON stagedresource (system_id, vendor_id, (meta->>'consent_aggregated'))",
             "type": "index",
         },
+        {
+            "name": "idx_stagedresource_user_categories_gin",
+            "statement": "CREATE INDEX CONCURRENTLY idx_stagedresource_user_categories_gin ON stagedresource USING GIN (user_assigned_data_categories);",
+            "type": "index",
+        },
+        {
+            "name": "idx_stagedresource_classifications_gin",
+            "statement": "CREATE INDEX CONCURRENTLY idx_stagedresource_classifications_gin ON stagedresource USING GIN (classifications);",
+            "type": "index",
+        },
     ],
 }
 

--- a/src/fides/api/migrations/post_upgrade_index_creation.py
+++ b/src/fides/api/migrations/post_upgrade_index_creation.py
@@ -155,12 +155,12 @@ TABLE_OBJECT_MAP: Dict[str, List[Dict[str, str]]] = {
         },
         {
             "name": "idx_stagedresource_user_categories_gin",
-            "statement": "CREATE INDEX CONCURRENTLY idx_stagedresource_user_categories_gin ON stagedresource USING GIN (user_assigned_data_categories);",
+            "statement": "CREATE INDEX CONCURRENTLY idx_stagedresource_user_categories_gin ON stagedresource USING GIN (user_assigned_data_categories)",
             "type": "index",
         },
         {
             "name": "idx_stagedresource_classifications_gin",
-            "statement": "CREATE INDEX CONCURRENTLY idx_stagedresource_classifications_gin ON stagedresource USING GIN (classifications);",
+            "statement": "CREATE INDEX CONCURRENTLY idx_stagedresource_classifications_gin ON stagedresource USING GIN (classifications)",
             "type": "index",
         },
     ],

--- a/src/fides/api/models/detection_discovery/core.py
+++ b/src/fides/api/models/detection_discovery/core.py
@@ -599,6 +599,17 @@ class StagedResource(Base):
             "vendor_id",
             text("(meta->>'consent_aggregated')"),
         ),
+        # GIN indices for array operations (&&, @>, <@)
+        Index(
+            "idx_stagedresource_classifications_gin",
+            "classifications",
+            postgresql_using="gin",
+        ),
+        Index(
+            "idx_stagedresource_user_categories_gin",
+            "user_assigned_data_categories",
+            postgresql_using="gin",
+        ),
     )
 
     @classmethod


### PR DESCRIPTION
…_categories columns from stagedresource table

Closes https://ethyca.atlassian.net/browse/ENG-1256

### Description Of Changes

This PR adds database indexes to improve query performance on array operations for the `classifications` and `user_assigned_data_categories` columns in the `stagedresource` table. The migration includes handling for large tables by checking table size and using concurrent index creation when appropriate.

### Code Changes

* Added new Alembic migration that creates GIN indexes for array operations
* Updated `post_upgrade_index_creation.py` to include concurrent index creation statements for large table scenarios
* Migration conditionally creates indexes directly for tables < 1M rows, or defers to concurrent creation for larger tables
* Includes downgrade functionality to drop the indexes

### Steps to Confirm

1. Run the migration on a test database and verify the indexes are created
2. Confirm the downgrade migration properly removes the indexes

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [x] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
