### PR TITLE
Draft: UI updates to consent status in the action center results

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/constants.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/constants.ts
@@ -10,6 +10,40 @@ export const DiscoveryStatusDisplayNames: Record<ConsentStatus, string> = {
   [ConsentStatus.NOT_APPLICABLE]: "Not applicable",
 };
 
+export const DiscoveryStatusDescriptions: Record<ConsentStatus, string> = {
+  [ConsentStatus.WITH_CONSENT]:
+    "Asset was detected after the user gave consent",
+  [ConsentStatus.WITHOUT_CONSENT]:
+    "Asset was detected without any consent. Click the info icon for more details.",
+  [ConsentStatus.EXEMPT]: "Asset is valid regardless of consent",
+  [ConsentStatus.UNKNOWN]:
+    "Did not find consent information for this asset. You may need to re-run the monitor.",
+  [ConsentStatus.PRE_CONSENT]:
+    "Assets loaded before the user had a chance to give consent. This violates opt-in compliance requirements if your CMP is configured for explicit consent.",
+  [ConsentStatus.CMP_ERROR]:
+    "The Consent Management Platform (CMP) was not detected when the service ran. It likely failed to load or wasn't available.",
+  [ConsentStatus.NOT_APPLICABLE]: "No privacy notices apply to this asset",
+};
+
+export enum ConsentStatusType {
+  SUCCESS = "success",
+  ERROR = "error",
+  IGNORE = "ignore",
+}
+
+export const DiscoveryStatusTypeMapping: Record<
+  ConsentStatus,
+  ConsentStatusType
+> = {
+  [ConsentStatus.WITH_CONSENT]: ConsentStatusType.SUCCESS,
+  [ConsentStatus.WITHOUT_CONSENT]: ConsentStatusType.ERROR,
+  [ConsentStatus.PRE_CONSENT]: ConsentStatusType.ERROR,
+  [ConsentStatus.EXEMPT]: ConsentStatusType.IGNORE,
+  [ConsentStatus.UNKNOWN]: ConsentStatusType.IGNORE,
+  [ConsentStatus.CMP_ERROR]: ConsentStatusType.IGNORE,
+  [ConsentStatus.NOT_APPLICABLE]: ConsentStatusType.IGNORE,
+};
+
 export enum DiscoveredAssetsColumnKeys {
   NAME = "name",
   RESOURCE_TYPE = "resource_type",

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/constants.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/constants.ts
@@ -1,12 +1,14 @@
-export enum DiscoveryStatusDisplayNames {
-  WITH_CONSENT = "With consent",
-  WITHOUT_CONSENT = "Without consent",
-  EXEMPT = "Exempt",
-  UNKNOWN = "Unknown",
-  PRE_CONSENT = "Pre-Consent",
-  CMP_ERROR = "CMP failure",
-  NOT_APPLICABLE = "Not applicable",
-}
+import { ConsentStatus } from "~/types/api";
+
+export const DiscoveryStatusDisplayNames: Record<ConsentStatus, string> = {
+  [ConsentStatus.WITH_CONSENT]: "With consent",
+  [ConsentStatus.WITHOUT_CONSENT]: "Without consent",
+  [ConsentStatus.EXEMPT]: "Exempt",
+  [ConsentStatus.UNKNOWN]: "Unknown",
+  [ConsentStatus.PRE_CONSENT]: "Pre-Consent",
+  [ConsentStatus.CMP_ERROR]: "CMP failure",
+  [ConsentStatus.NOT_APPLICABLE]: "Not applicable",
+};
 
 export enum DiscoveredAssetsColumnKeys {
   NAME = "name",

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/constants.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/constants.ts
@@ -3,8 +3,8 @@ export enum DiscoveryStatusDisplayNames {
   WITHOUT_CONSENT = "Without consent",
   EXEMPT = "Exempt",
   UNKNOWN = "Unknown",
-  PRE_CONSENT = "Pre-consent",
-  CMP_ERROR = "CMP error",
+  PRE_CONSENT = "Pre-Consent",
+  CMP_ERROR = "CMP failure",
   NOT_APPLICABLE = "Not applicable",
 }
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsTable.tsx
@@ -374,17 +374,8 @@ export const useDiscoveredAssetsTable = ({
             : null,
         filters: convertToAntFilters(
           filterOptions?.[DiscoveredAssetsColumnKeys.CONSENT_AGGREGATED],
-          (status) => {
-            const statusMap: Record<string, string> = {
-              with_consent: DiscoveryStatusDisplayNames.WITH_CONSENT,
-              without_consent: DiscoveryStatusDisplayNames.WITHOUT_CONSENT,
-              exempt: DiscoveryStatusDisplayNames.EXEMPT,
-              unknown: DiscoveryStatusDisplayNames.UNKNOWN,
-              pre_consent: DiscoveryStatusDisplayNames.PRE_CONSENT,
-              cmp_error: DiscoveryStatusDisplayNames.CMP_ERROR,
-            };
-            return statusMap[status] ?? status;
-          },
+          (status) =>
+            DiscoveryStatusDisplayNames[status as ConsentStatus] ?? status,
         ),
         filteredValue:
           columnFilters?.[DiscoveredAssetsColumnKeys.CONSENT_AGGREGATED] ||

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveryStatusBadgeCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveryStatusBadgeCell.tsx
@@ -2,7 +2,12 @@ import { AntTag as Tag, AntTooltip as Tooltip, Icons } from "fidesui";
 
 import { ConsentStatus, StagedResourceAPIResponse } from "~/types/api";
 
-import { DiscoveryStatusDisplayNames } from "../../constants";
+import {
+  ConsentStatusType,
+  DiscoveryStatusDescriptions,
+  DiscoveryStatusDisplayNames,
+  DiscoveryStatusTypeMapping,
+} from "../../constants";
 
 interface DiscoveryStatusBadgeCellProps {
   consentAggregated: ConsentStatus;
@@ -22,69 +27,39 @@ export const DiscoveryStatusBadgeCell = ({
     onShowBreakdown?.(stagedResource, consentAggregated);
   };
 
+  const statusType = DiscoveryStatusTypeMapping[consentAggregated];
+  const isErrorStatus = statusType === ConsentStatusType.ERROR;
+
+  const getTagColor = (): "success" | "error" | undefined => {
+    switch (statusType) {
+      case ConsentStatusType.SUCCESS:
+        return "success";
+      case ConsentStatusType.ERROR:
+        return "error";
+      default:
+        return undefined;
+    }
+  };
+
+  const getTestId = (): string => {
+    return `status-badge_${consentAggregated.replace(/_/g, "-")}`;
+  };
+
   return (
-    <>
-      {consentAggregated === ConsentStatus.WITHOUT_CONSENT && (
-        <Tooltip title="Asset was detected without any consent. Click the info icon for more details.">
-          <Tag
-            color="error"
-            closeIcon={<Icons.Information style={{ width: 12, height: 12 }} />}
-            closeButtonLabel="View details"
-            onClose={handleClick}
-            data-testid="status-badge_without-consent"
-          >
-            {DiscoveryStatusDisplayNames[consentAggregated]}
-          </Tag>
-        </Tooltip>
-      )}
-      {consentAggregated === ConsentStatus.PRE_CONSENT && (
-        <Tooltip title="Assets loaded before the user had a chance to give consent. This violates opt-in compliance requirements if your CMP is configured for explicit consent.">
-          <Tag
-            color="error"
-            closeIcon={<Icons.Information style={{ width: 12, height: 12 }} />}
-            closeButtonLabel="View details"
-            onClose={handleClick}
-            data-testid="status-badge_pre-consent"
-          >
-            {DiscoveryStatusDisplayNames[consentAggregated]}
-          </Tag>
-        </Tooltip>
-      )}
-      {consentAggregated === ConsentStatus.WITH_CONSENT && (
-        <Tooltip title="Asset was detected after the user gave consent">
-          <Tag color="success" data-testid="status-badge_with-consent">
-            {DiscoveryStatusDisplayNames[consentAggregated]}
-          </Tag>
-        </Tooltip>
-      )}
-      {consentAggregated === ConsentStatus.EXEMPT && (
-        <Tooltip title="Asset is valid regardless of consent">
-          <Tag data-testid="status-badge_consent-exempt">
-            {DiscoveryStatusDisplayNames[consentAggregated]}
-          </Tag>
-        </Tooltip>
-      )}
-      {consentAggregated === ConsentStatus.UNKNOWN && (
-        <Tooltip title="Did not find consent information for this asset. You may need to re-run the monitor.">
-          <Tag data-testid="status-badge_unknown">
-            {DiscoveryStatusDisplayNames[consentAggregated]}
-          </Tag>
-        </Tooltip>
-      )}
-      {consentAggregated === ConsentStatus.NOT_APPLICABLE && (
-        <Tooltip title="No privacy notices apply to this asset">
-          <Tag data-testid="status-badge_not-applicable">
-            {DiscoveryStatusDisplayNames[consentAggregated]}
-          </Tag>
-        </Tooltip>
-      )}
-      {consentAggregated === ConsentStatus.CMP_ERROR && (
-        <Tooltip title="The Consent Management Platform (CMP) was not detected when the service ran. It likely failed to load or wasn't available.">
-          <Tag data-testid="status-badge_cmp-error">
-            {DiscoveryStatusDisplayNames[consentAggregated]}
-          </Tag>
-        </Tooltip>
-      )}
-    </>
+    <Tooltip title={DiscoveryStatusDescriptions[consentAggregated]}>
+      <Tag
+        color={getTagColor()}
+        closeIcon={
+          isErrorStatus ? (
+            <Icons.Information style={{ width: 12, height: 12 }} />
+          ) : undefined
+        }
+        closeButtonLabel={isErrorStatus ? "View details" : undefined}
+        onClose={isErrorStatus ? handleClick : undefined}
+        data-testid={getTestId()}
+      >
+        {DiscoveryStatusDisplayNames[consentAggregated]}
+      </Tag>
+    </Tooltip>
   );
 };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveryStatusBadgeCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveryStatusBadgeCell.tsx
@@ -33,12 +33,12 @@ export const DiscoveryStatusBadgeCell = ({
             onClose={handleClick}
             data-testid="status-badge_without-consent"
           >
-            {DiscoveryStatusDisplayNames.WITHOUT_CONSENT}
+            {DiscoveryStatusDisplayNames[consentAggregated]}
           </Tag>
         </Tooltip>
       )}
       {consentAggregated === ConsentStatus.PRE_CONSENT && (
-        <Tooltip title="Asset was detected before user gave consent. Click the info icon for more details.">
+        <Tooltip title="Assets loaded before the user had a chance to give consent. This violates opt-in compliance requirements if your CMP is configured for explicit consent.">
           <Tag
             color="error"
             closeIcon={<Icons.Information style={{ width: 12, height: 12 }} />}
@@ -46,49 +46,42 @@ export const DiscoveryStatusBadgeCell = ({
             onClose={handleClick}
             data-testid="status-badge_pre-consent"
           >
-            {DiscoveryStatusDisplayNames.PRE_CONSENT}
+            {DiscoveryStatusDisplayNames[consentAggregated]}
           </Tag>
         </Tooltip>
       )}
       {consentAggregated === ConsentStatus.WITH_CONSENT && (
         <Tooltip title="Asset was detected after the user gave consent">
           <Tag color="success" data-testid="status-badge_with-consent">
-            {DiscoveryStatusDisplayNames.WITH_CONSENT}
+            {DiscoveryStatusDisplayNames[consentAggregated]}
           </Tag>
         </Tooltip>
       )}
       {consentAggregated === ConsentStatus.EXEMPT && (
         <Tooltip title="Asset is valid regardless of consent">
           <Tag data-testid="status-badge_consent-exempt">
-            {DiscoveryStatusDisplayNames.EXEMPT}
+            {DiscoveryStatusDisplayNames[consentAggregated]}
           </Tag>
         </Tooltip>
       )}
       {consentAggregated === ConsentStatus.UNKNOWN && (
         <Tooltip title="Did not find consent information for this asset. You may need to re-run the monitor.">
           <Tag data-testid="status-badge_unknown">
-            {DiscoveryStatusDisplayNames.UNKNOWN}
+            {DiscoveryStatusDisplayNames[consentAggregated]}
           </Tag>
         </Tooltip>
       )}
       {consentAggregated === ConsentStatus.NOT_APPLICABLE && (
         <Tooltip title="No privacy notices apply to this asset">
           <Tag data-testid="status-badge_not-applicable">
-            {DiscoveryStatusDisplayNames.NOT_APPLICABLE}
+            {DiscoveryStatusDisplayNames[consentAggregated]}
           </Tag>
         </Tooltip>
       )}
       {consentAggregated === ConsentStatus.CMP_ERROR && (
         <Tooltip title="The Consent Management Platform (CMP) was not detected when the service ran. It likely failed to load or wasn't available.">
           <Tag data-testid="status-badge_cmp-error">
-            {DiscoveryStatusDisplayNames.CMP_ERROR}
-          </Tag>
-        </Tooltip>
-      )}
-      {consentAggregated === ConsentStatus.PRE_CONSENT && (
-        <Tooltip title="Assets loaded before the user had a chance to give consent. This violates opt-in compliance requirements if your CMP is configured for explicit consent.">
-          <Tag data-testid="status-badge_pre-consent">
-            {DiscoveryStatusDisplayNames.PRE_CONSENT}
+            {DiscoveryStatusDisplayNames[consentAggregated]}
           </Tag>
         </Tooltip>
       )}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveryStatusBadgeCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveryStatusBadgeCell.tsx
@@ -78,6 +78,20 @@ export const DiscoveryStatusBadgeCell = ({
           </Tag>
         </Tooltip>
       )}
+      {consentAggregated === ConsentStatus.CMP_ERROR && (
+        <Tooltip title="The Consent Management Platform (CMP) was not detected when the service ran. It likely failed to load or wasn't available.">
+          <Tag data-testid="status-badge_cmp-error">
+            {DiscoveryStatusDisplayNames.CMP_ERROR}
+          </Tag>
+        </Tooltip>
+      )}
+      {consentAggregated === ConsentStatus.PRE_CONSENT && (
+        <Tooltip title="Assets loaded before the user had a chance to give consent. This violates opt-in compliance requirements if your CMP is configured for explicit consent.">
+          <Tag data-testid="status-badge_pre-consent">
+            {DiscoveryStatusDisplayNames.PRE_CONSENT}
+          </Tag>
+        </Tooltip>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Closes ENG-1169

### Description Of Changes
Update labels for different status. Add tooltip texts for new context status. Improve and simplify the code. 

Using mappings of ConsentStatus is cleaner and safer because whenever any new status is added, typescript will identify all the mapping that are missing a value for the new status.

### Code Changes
* Add missing tooltip text for the new consent statuses
* Update the display name for the new consent statuses
* Improve code by using mappings from ConsentStatus

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
