### PR TITLE
Fix column sizing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Fixed
 - Location field submission and display for privacy requests [#6619](https://github.com/ethyca/fides/pull/6619)
+- Fix column sizing bug [#6620](https://github.com/ethyca/fides/pull/6620)
 
 ## [2.70.0](https://github.com/ethyca/fides/compare/2.69.2...2.70.0)
 

--- a/clients/admin-ui/src/features/privacy-requests/RequestTable.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestTable.tsx
@@ -19,7 +19,6 @@ import { parseAsString, useQueryState } from "nuqs";
 import { useCallback, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { useFeatures } from "~/features/common/features";
 import { DownloadLightIcon } from "~/features/common/Icon";
 import {
   FidesTableV2,
@@ -42,7 +41,6 @@ import { useAntPagination } from "../common/pagination/useAntPagination";
 import useDownloadPrivacyRequestReport from "./hooks/useDownloadPrivacyRequestReport";
 
 export const RequestTable = ({ ...props }: BoxProps): JSX.Element => {
-  const { plus: hasPlus } = useFeatures();
   const [fuzzySearchTerm, setFuzzySearchTerm] = useQueryState(
     "search",
     parseAsString.withDefault("").withOptions({ throttleMs: 100 }),
@@ -118,7 +116,7 @@ export const RequestTable = ({ ...props }: BoxProps): JSX.Element => {
   const tableInstance = useReactTable<PrivacyRequestEntity>({
     getCoreRowModel: getCoreRowModel(),
     data: requests,
-    columns: useMemo(() => getRequestTableColumns(hasPlus), [hasPlus]),
+    columns: useMemo(() => getRequestTableColumns(), []),
     getRowId: (row) => `${row.status}-${row.id}`,
     manualPagination: true,
     columnResizeMode: "onChange",

--- a/clients/admin-ui/src/features/privacy-requests/RequestTableColumns.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestTableColumns.tsx
@@ -30,7 +30,7 @@ enum COLUMN_IDS {
 
 const columnHelper = createColumnHelper<PrivacyRequestEntity>();
 
-export const getRequestTableColumns = (hasPlus = false) => [
+export const getRequestTableColumns = () => [
   columnHelper.accessor((row) => row.status, {
     id: COLUMN_IDS.STATUS,
     cell: ({ getValue }) => <RequestStatusBadgeCell value={getValue()} />,
@@ -47,21 +47,17 @@ export const getRequestTableColumns = (hasPlus = false) => [
     ),
     header: (props) => <DefaultHeaderCell value="Days left" {...props} />,
   }),
-  ...(hasPlus
-    ? [
-        columnHelper.accessor((row) => row.source, {
-          id: COLUMN_IDS.SOURCE,
-          cell: (props) =>
-            props.getValue() ? (
-              <BadgeCell value={props.getValue()!} />
-            ) : (
-              <DefaultCell value={undefined} />
-            ),
-          header: (props) => <DefaultHeaderCell value="Source" {...props} />,
-          enableSorting: false,
-        }),
-      ]
-    : []),
+  columnHelper.accessor((row) => row.source, {
+    id: COLUMN_IDS.SOURCE,
+    cell: (props) =>
+      props.getValue() ? (
+        <BadgeCell value={props.getValue()!} />
+      ) : (
+        <DefaultCell value={undefined} />
+      ),
+    header: (props) => <DefaultHeaderCell value="Source" {...props} />,
+    enableSorting: false,
+  }),
   columnHelper.accessor((row) => row.policy.rules, {
     id: COLUMN_IDS.REQUEST_TYPE,
     cell: ({ getValue }) => <RequestActionTypeCell value={getValue()} />,


### PR DESCRIPTION
Closes ENG-1463

### Description Of Changes
The conditional Source column was causing column width issues, the simplest solution is to make it available for OSS as well and avoid that conditional rendering. The OSS shows the "Privacy Center" value as source correctly.

### Code Changes
* Remove checking for hasPlus in the "Source" column of the Request Manager

### Steps to Confirm

1.  Open Request Manager in a big resolution browser
2. Check the Source column doesn't have an excessive width

### Screenshot
excessive width
<img width="1870" height="649" alt="Captura de pantalla 2025-09-18 a la(s) 7 03 39 p  m" src="https://github.com/user-attachments/assets/48ea87d9-0de7-4666-b407-53ffe856b5db" />

correct width
<img width="1870" height="649" alt="Captura de pantalla 2025-09-18 a la(s) 7 03 22 p  m" src="https://github.com/user-attachments/assets/cb4c4fa3-04f4-4d12-a7f0-8c1eaf4c1b20" />



### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
