### PR TITLE
fix: allow custom deploy images

### DIFF
--- a/src/fides/cli/commands/deploy.py
+++ b/src/fides/cli/commands/deploy.py
@@ -78,9 +78,6 @@ def up(
 
     config = ctx.obj["CONFIG"]
 
-    if not no_pull:
-        pull_specific_docker_image()
-
     if env_file:
         print(f"> Using custom ENV file from: {env_file}")
         environ["FIDES_DEPLOY_ENV_FILE"] = str(env_file)
@@ -88,6 +85,9 @@ def up(
     if image:
         print(f"> Using custom image: {image}")
         environ["FIDES_DEPLOY_IMAGE"] = image
+
+    if not no_pull:
+        pull_specific_docker_image(custom_image=image)
 
     try:
         check_fides_uploads_dir()


### PR DESCRIPTION
## Summary
- Closes #5745
- allow `fides deploy up --image ...` to skip the hard-coded DockerHub pull by wiring the custom image through to the deploy helper
- refactor the image pull helper so custom registries are handled explicitly while still fetching the sample app and privacy center images with a dev fallback
- add unit coverage for custom images and the fallback path to guard against regressions

## Testing
- FIDES__DATABASE__SERVER=127.0.0.1 FIDES__DATABASE__PORT=15432 FIDES__DATABASE__USER=postgres FIDES__DATABASE__PASSWORD=fides FIDES__DATABASE__DB=fides pytest tests/ctl/cli/test_deploy.py
- pylint src/fides/cli/commands/deploy.py src/fides/core/deploy.py tests/ctl/cli/test_deploy.py

## Manual Verification

1. Ensure Docker Desktop is running.
2. Start a local registry and push the existing Fides image:
   - `docker run -d -p 5000:5000 --name fides-registry registry:2`
   - `docker tag ethyca/fides:local localhost:5000/ethyca/fides:local`
   - `docker push localhost:5000/ethyca/fides:local`
3. Launch the dev stack through nox and open a shell: `nox -s dev -- shell`.
4. From the shell, run `fides deploy up --image localhost:5000/ethyca/fides:local --no-init` and confirm the log lists the custom image instead of the DockerHub tag. Allow the stack to boot, then run `fides deploy down` and `exit`.
5. Tear everything down: `nox -s teardown -- volumes` and `docker stop fides-registry && docker rm fides-registry`.