### PR TITLE
ENG-1236 add migration for dismissed column in monitor tasks

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -2826,6 +2826,8 @@ dataset:
         data_categories: [system.operations]
       - name: message
         data_categories: [system.operations]
+      - name: dismissed
+        data_categories: [system.operations]
       - name: monitor_config_id
         data_categories: [system.operations]
       - name: staged_resource_urns

--- a/src/fides/api/alembic/migrations/versions/e2cda8d6abc3_add_dismissed_in_activity_view_to_.py
+++ b/src/fides/api/alembic/migrations/versions/e2cda8d6abc3_add_dismissed_in_activity_view_to_.py
@@ -1,4 +1,4 @@
-"""add_dismissed_in_activity_view_to_monitor_task
+"""add_dismissed_to_monitor_task
 
 Revision ID: e2cda8d6abc3
 Revises: 0eef0016cf06
@@ -17,15 +17,13 @@ depends_on = None
 
 
 def upgrade():
-    # Add the dismissed_in_activity_view column to monitortask table
+    # Add the dismissed column to monitortask table
     op.add_column(
         "monitortask",
-        sa.Column(
-            "dismissed_in_activity_view", sa.Boolean(), nullable=True, default=False
-        ),
+        sa.Column("dismissed", sa.Boolean(), nullable=False, server_default=sa.text("false")),
     )
 
 
 def downgrade():
-    # Remove the dismissed_in_activity_view column from monitortask table
-    op.drop_column("monitortask", "dismissed_in_activity_view")
+    # Remove the dismissed column from monitortask table
+    op.drop_column("monitortask", "dismissed")

--- a/src/fides/api/alembic/migrations/versions/e2cda8d6abc3_add_dismissed_in_activity_view_to_.py
+++ b/src/fides/api/alembic/migrations/versions/e2cda8d6abc3_add_dismissed_in_activity_view_to_.py
@@ -20,9 +20,7 @@ def upgrade():
     # Add the dismissed column to monitortask table
     op.add_column(
         "monitortask",
-        sa.Column(
-            "dismissed", sa.Boolean(), nullable=False, server_default=sa.text("false")
-        ),
+        sa.Column("dismissed", sa.Boolean(), nullable=False, server_default="f"),
     )
 
 

--- a/src/fides/api/alembic/migrations/versions/e2cda8d6abc3_add_dismissed_in_activity_view_to_.py
+++ b/src/fides/api/alembic/migrations/versions/e2cda8d6abc3_add_dismissed_in_activity_view_to_.py
@@ -1,0 +1,31 @@
+"""add_dismissed_in_activity_view_to_monitor_task
+
+Revision ID: e2cda8d6abc3
+Revises: 0eef0016cf06
+Create Date: 2025-09-17 23:37:49.678071
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e2cda8d6abc3"
+down_revision = "0eef0016cf06"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add the dismissed_in_activity_view column to monitortask table
+    op.add_column(
+        "monitortask",
+        sa.Column(
+            "dismissed_in_activity_view", sa.Boolean(), nullable=True, default=False
+        ),
+    )
+
+
+def downgrade():
+    # Remove the dismissed_in_activity_view column from monitortask table
+    op.drop_column("monitortask", "dismissed_in_activity_view")

--- a/src/fides/api/alembic/migrations/versions/e2cda8d6abc3_add_dismissed_in_activity_view_to_.py
+++ b/src/fides/api/alembic/migrations/versions/e2cda8d6abc3_add_dismissed_in_activity_view_to_.py
@@ -20,7 +20,9 @@ def upgrade():
     # Add the dismissed column to monitortask table
     op.add_column(
         "monitortask",
-        sa.Column("dismissed", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "dismissed", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
     )
 
 

--- a/src/fides/api/models/detection_discovery/monitor_task.py
+++ b/src/fides/api/models/detection_discovery/monitor_task.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional
 
-from sqlalchemy import ARRAY, Column
+from sqlalchemy import ARRAY, Boolean, Column
 from sqlalchemy import Enum as SQLAlchemyEnum
 from sqlalchemy import ForeignKey, String
 from sqlalchemy.dialects.postgresql import JSONB
@@ -51,6 +51,7 @@ class MonitorTask(WorkerTask, Base):
     )
     staged_resource_urns = Column(ARRAY(String), nullable=True)
     child_resource_urns = Column(ARRAY(String), nullable=True)
+    dismissed_in_activity_view = Column(Boolean, nullable=True, default=False)
 
     monitor_config = relationship(MonitorConfig, cascade="all, delete")
     execution_logs = relationship(

--- a/src/fides/api/models/detection_discovery/monitor_task.py
+++ b/src/fides/api/models/detection_discovery/monitor_task.py
@@ -51,7 +51,7 @@ class MonitorTask(WorkerTask, Base):
     )
     staged_resource_urns = Column(ARRAY(String), nullable=True)
     child_resource_urns = Column(ARRAY(String), nullable=True)
-    dismissed_in_activity_view = Column(Boolean, nullable=True, default=False)
+    dismissed = Column(Boolean, nullable=False, default=False)
 
     monitor_config = relationship(MonitorConfig, cascade="all, delete")
     execution_logs = relationship(


### PR DESCRIPTION
Closes [ENG-1236]

### Description Of Changes

Adds a new boolean field dismissed_in_activity_view to the monitortask model to support the in-progress/“dismissed” state for the Action Center. Includes an Alembic migration to add/drop the column. The migration’s down_revision is set to the current main head (0eef0016cf06).

### Code Changes

* Migration

### Steps to Confirm

1.  Not needed

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [x] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [x] Ensure that your downrev is up to date with the latest revision on `main`
  * [x] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1236]: https://ethyca.atlassian.net/browse/ENG-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ