### PR TITLE
ENG-1347 - show error when privacy request is made with no location and location is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Inconsistent location values displayed on action center [#6599](https://github.com/ethyca/fides/pull/6599)
 - Incorrect location display in system inventory screen [#6598](https://github.com/ethyca/fides/pull/6598)
 - Fixed an issue that allowed new taxonomy items to be submitted multiple times [#6609](https://github.com/ethyca/fides/pull/6609)
+- Enforce required location validation on privacy-request POST when configured via Privacy Center/property config [#6646](https://github.com/ethyca/fides/pull/6646)
 
 ## [2.70.4](https://github.com/ethyca/fides/compare/2.70.3...2.70.4)
 

--- a/tests/service/test_privacy_request_service.py
+++ b/tests/service/test_privacy_request_service.py
@@ -715,8 +715,6 @@ class TestPrivacyRequestService:
         policy: Policy,
     ):
         """Global single-row config used when no property configs available."""
-        from fides.api.common_exceptions import PrivacyRequestError
-        from fides.api.models.privacy_center_config import PrivacyCenterConfig
 
         # Ensure no default property present with config
         # Create global config requiring location

--- a/tests/service/test_privacy_request_service.py
+++ b/tests/service/test_privacy_request_service.py
@@ -23,6 +23,7 @@ from fides.api.schemas.privacy_request import (
     PrivacyRequestStatus,
 )
 from fides.api.schemas.redis_cache import Identity
+from fides.api.models.privacy_center_config import PrivacyCenterConfig
 from fides.config.config_proxy import ConfigProxy
 from fides.service.messaging.messaging_service import MessagingService
 from fides.service.privacy_request.privacy_request_service import PrivacyRequestService
@@ -461,9 +462,6 @@ class TestPrivacyRequestService:
         policy: Policy,
     ):
         """Test that a PrivacyRequestError is raised when a location field is required but location is not provided"""
-        from fides.api.common_exceptions import PrivacyRequestError
-        from fides.api.models.privacy_center_config import PrivacyCenterConfig
-
         # Create Privacy Center configuration with a required location field for this policy
         privacy_center_config_data = {
             "config": {
@@ -541,9 +539,6 @@ class TestPrivacyRequestService:
         property_a: Property,
     ):
         """Property config takes precedence: required location enforced when property_id provided."""
-        from fides.api.common_exceptions import PrivacyRequestError
-        from fides.api.models.privacy_center_config import PrivacyCenterConfig
-
         # Global config without location requirement
         global_config = PrivacyCenterConfig.create_or_update(
             db=db,
@@ -792,8 +787,6 @@ class TestPrivacyRequestService:
         policy: Policy,
     ):
         """Test that privacy request creation succeeds when required location is provided"""
-        from fides.api.models.privacy_center_config import PrivacyCenterConfig
-
         # Create Privacy Center configuration with a required location field for this policy
         privacy_center_config_data = {
             "config": {
@@ -868,8 +861,6 @@ class TestPrivacyRequestService:
     ):
         """Test that validation is skipped when no Privacy Center config exists"""
         # Ensure no Privacy Center config exists
-        from fides.api.models.privacy_center_config import PrivacyCenterConfig
-
         PrivacyCenterConfig.delete_all(db)
         db.commit()
 
@@ -895,8 +886,6 @@ class TestPrivacyRequestService:
         policy: Policy,
     ):
         """Test that validation is skipped when Privacy Center config fails to parse"""
-        from fides.api.models.privacy_center_config import PrivacyCenterConfig
-
         # Create an invalid Privacy Center config that will fail parsing
         invalid_config_data = {
             "config": {
@@ -945,8 +934,6 @@ class TestPrivacyRequestService:
         policy: Policy,
     ):
         """Test that validation is skipped when no action matches the policy key"""
-        from fides.api.models.privacy_center_config import PrivacyCenterConfig
-
         # Create Privacy Center config with action for a different policy
         privacy_center_config_data = {
             "config": {
@@ -1020,8 +1007,6 @@ class TestPrivacyRequestService:
         policy: Policy,
     ):
         """Test that validation is skipped when action has no custom_privacy_request_fields"""
-        from fides.api.models.privacy_center_config import PrivacyCenterConfig
-
         # Create Privacy Center config with action that has no custom fields
         privacy_center_config_data = {
             "config": {
@@ -1088,8 +1073,6 @@ class TestPrivacyRequestService:
         policy: Policy,
     ):
         """Test that validation passes when location field exists but is not required"""
-        from fides.api.models.privacy_center_config import PrivacyCenterConfig
-
         # Create Privacy Center config with optional location field
         privacy_center_config_data = {
             "config": {
@@ -1163,9 +1146,6 @@ class TestPrivacyRequestService:
         policy: Policy,
     ):
         """Test that validation passes when required location field has value in custom_privacy_request_fields"""
-        from fides.api.common_exceptions import PrivacyRequestError
-        from fides.api.models.privacy_center_config import PrivacyCenterConfig
-
         # Create Privacy Center config with required location field
         privacy_center_config_data = {
             "config": {

--- a/tests/service/test_privacy_request_service.py
+++ b/tests/service/test_privacy_request_service.py
@@ -784,6 +784,7 @@ class TestPrivacyRequestService:
                 )
         finally:
             global_config.delete(db)
+
     def test_create_privacy_request_location_required_and_provided(
         self,
         db: Session,

--- a/tests/service/test_privacy_request_service.py
+++ b/tests/service/test_privacy_request_service.py
@@ -12,6 +12,7 @@ from fides.api.models.fides_user import FidesUser
 from fides.api.models.fides_user_permissions import FidesUserPermissions
 from fides.api.models.policy import Policy
 from fides.api.models.pre_approval_webhook import PreApprovalWebhook
+from fides.api.models.privacy_center_config import PrivacyCenterConfig
 from fides.api.models.privacy_request import ExecutionLog
 from fides.api.models.property import Property
 from fides.api.models.worker_task import ExecutionLogStatus
@@ -23,7 +24,6 @@ from fides.api.schemas.privacy_request import (
     PrivacyRequestStatus,
 )
 from fides.api.schemas.redis_cache import Identity
-from fides.api.models.privacy_center_config import PrivacyCenterConfig
 from fides.config.config_proxy import ConfigProxy
 from fides.service.messaging.messaging_service import MessagingService
 from fides.service.privacy_request.privacy_request_service import PrivacyRequestService


### PR DESCRIPTION
Closes [ENG-1347]

### Description Of Changes

API error when privacy request is made with no location and location is required

### Code Changes

Adds the error response and tests to confirm

### Steps to Confirm

1.  Need to run fidesplus with this (your property ID), and update you config like this
❗ this will overwrite your PC config ❗ 

```
curl -X PUT http://localhost:3000/api/v1/plus/property/FDS-YOURS \
  -H "Authorization: Bearer $YOUR_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Default Property Autogenerated",
    "type": "Website",
    "experiences": [],
    "paths": [],
    "privacy_center_config": {
      "title": "Take control of your data",
      "description": "When you use our services, you're trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
      "description_subtext": [],
      "addendum": [],
      "logo_path": "/logo.svg",
      "logo_url": "https://fid.es",
      "privacy_policy_url": "https://fid.es/privacy",
      "privacy_policy_url_text": "Privacy Policy",
      "favicon_path": "/favicon.ico",
      "actions": [
        {
          "policy_key": "default_access_policy",
          "icon_path": "/download.svg",
          "title": "Access your data",
          "description": "We will provide you a report of all your personal data.",
          "description_subtext": [],
          "identity_inputs": { "email": "required" },
          "custom_privacy_request_fields": {
            "first_name": { "label": "First name" },
            "last_name": { "label": "Last name", "required": false },
            "tenant_id": { "label": "Tenant ID", "default_value": "123", "hidden": true },
            "location": { "label": "Location", "field_type": "location", "ip_geolocation_hint": true, "required": true },
            "preferred_format": {
              "label": "Preferred format",
              "field_type": "select",
              "required": true,
              "default_value": "HTML",
              "options": ["JSON","CSV","PDF","XML","HTML","TXT","DOCX","XLSX","PPTX","ZIP","PNG","JPEG","GIF","SVG","MP4","MP3","WAV","SQL","YAML","MD","RTF","EPUB","PSD"]
            }
          },
          "confirmButtonText": "Continue",
          "cancelButtonText": "Cancel"
        },
        {
          "policy_key": "default_erasure_policy",
          "icon_path": "/delete.svg",
          "title": "Erase your data",
          "description": "We will erase all of your personal data. This action cannot be undone.",
          "description_subtext": [],
          "identity_inputs": { "email": "required" },
          "custom_privacy_request_fields": {
            "data_categories": {
              "label": "Select data categories to erase",
              "field_type": "multiselect",
              "required": false,
              "options": ["Profile Information","User Preferences","Activity History","Analytics Data"]
            },
            "location": { "label": "Location", "field_type": "location", "required": false, "ip_geolocation_hint": true }
          },
          "confirmButtonText": "Continue",
          "cancelButtonText": "Cancel"
        }
      ],
      "includeConsent": true,
      "consent": {
        "button": {
          "description": "Manage your consent preferences, including the option to select 'Do Not Sell or Share My Personal Information'.",
          "description_subtext": [
            "In order to opt-out of certain consent preferences, we may need to identify your account via your email address. This is optional."
          ],
          "icon_path": "/consent.svg",
          "identity_inputs": { "email": "optional" },
          "custom_privacy_request_fields": {
            "communication_preference": {
              "label": "How would you like to be contacted?",
              "field_type": "select",
              "required": false,
              "options": ["Email","Phone","Physical Mail","Do not contact me"]
            }
          },
          "title": "Manage your consent",
          "modalTitle": "Manage your consent",
          "confirmButtonText": "Continue",
          "cancelButtonText": "Cancel"
        },
        "page": {
          "consentOptions": [
            {
              "fidesDataUseKey": "marketing.advertising",
              "name": "Data Sales or Sharing",
              "description": "We may use some of your personal information for behavioral advertising purposes, which may be interpreted as 'Data Sales' or 'Data Sharing' under regulations such as CCPA, CPRA, VCDPA, etc.",
              "url": "https://example.com/privacy#data-sales",
              "default": { "value": true, "globalPrivacyControl": false },
              "highlight": false,
              "cookieKeys": ["data_sales"],
              "executable": false
            },
            {
              "fidesDataUseKey": "marketing.advertising.first_party",
              "name": "Email Marketing",
              "description": "We may use some of your personal information to contact you about our products & services.",
              "url": "https://example.com/privacy#email-marketing",
              "default": { "value": true, "globalPrivacyControl": false },
              "highlight": false,
              "cookieKeys": ["tracking"],
              "executable": false
            },
            {
              "fidesDataUseKey": "functional",
              "name": "Product Analytics",
              "description": "We may use some of your personal information to collect analytics about how you use our products & services.",
              "url": "https://example.com/privacy#analytics",
              "default": true,
              "highlight": false,
              "cookieKeys": ["analytics"],
              "executable": false
            }
          ],
          "description": "Manage your consent preferences, including the option to select 'Do Not Sell or Share My Personal Information'.",
          "description_subtext": [
            "When you use our services, you're trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control."
          ],
          "policy_key": "default_consent_policy",
          "title": "Manage your consent"
        }
      }
    }
  }'
```
Then verify that a privacy request shows an error response

```
curl --request POST \
  --url http://localhost:3000/api/v1/privacy-request \
  --header 'Content-Type: application/json' \
  --data '[
  {
    "identity": {
      "email": "jane@example.com"
    },
    "policy_key": "default_access_policy",
    "source": "Privacy Center"
  }
]'
```

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1347]: https://ethyca.atlassian.net/browse/ENG-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ