### PR TITLE
bypass some flaky external BE tests (snowflake DB scan, bigquery connector)

### DIFF
--- a/tests/ctl/core/test_dataset.py
+++ b/tests/ctl/core/test_dataset.py
@@ -470,7 +470,7 @@ TEST_DATABASE_PARAMETERS = {
     },
     # Disabling Snowflake tests for now as they are proving flaky.
     # This functionality is basically superceded by Helios, so there is
-    # minimal risk in dsiabling these tests.
+    # minimal risk in disabling these tests.
     # "snowflake": {
     #     "url": SNOWFLAKE_URL,
     #     "setup_url": SNOWFLAKE_URL,

--- a/tests/ctl/core/test_dataset.py
+++ b/tests/ctl/core/test_dataset.py
@@ -468,18 +468,21 @@ TEST_DATABASE_PARAMETERS = {
             }
         },
     },
-    "snowflake": {
-        "url": SNOWFLAKE_URL,
-        "setup_url": SNOWFLAKE_URL,
-        "init_script_path": "tests/ctl/data/example_sql/snowflake_example.sql",
-        "is_external": True,
-        "expected_collection": {
-            "PUBLIC": {
-                "VISIT": ["EMAIL", "LAST_VISIT"],
-                "LOGIN": ["ID", "CUSTOMER_ID", "TIME"],
-            }
-        },
-    },
+    # Disabling Snowflake tests for now as they are proving flaky.
+    # This functionality is basically superceded by Helios, so there is
+    # minimal risk in dsiabling these tests.
+    # "snowflake": {
+    #     "url": SNOWFLAKE_URL,
+    #     "setup_url": SNOWFLAKE_URL,
+    #     "init_script_path": "tests/ctl/data/example_sql/snowflake_example.sql",
+    #     "is_external": True,
+    #     "expected_collection": {
+    #         "PUBLIC": {
+    #             "VISIT": ["EMAIL", "LAST_VISIT"],
+    #             "LOGIN": ["ID", "CUSTOMER_ID", "TIME"],
+    #         }
+    #     },
+    # },
     "redshift": {
         "url": REDSHIFT_URL,
         "setup_url": REDSHIFT_URL,

--- a/tests/ops/service/connectors/test_bigquery_queryconfig.py
+++ b/tests/ops/service/connectors/test_bigquery_queryconfig.py
@@ -20,6 +20,7 @@ from fides.api.service.connectors.query_configs.bigquery_query_config import (
 from tests.fixtures.bigquery_fixtures import PROJECT_NAME
 
 
+@pytest.mark.xfail(reason="BigQuery integration test failures")
 @pytest.mark.integration_external
 @pytest.mark.integration_bigquery
 class TestBigQueryQueryConfig:
@@ -947,6 +948,7 @@ class TestBigQueryQueryConfig:
         assert stmts == expected_stmts
 
 
+@pytest.mark.xfail(reason="BigQuery integration test failures")
 @pytest.mark.integration_external
 @pytest.mark.integration_bigquery
 class TestBigQueryQueryConfigPartitioning:


### PR DESCRIPTION
### Description Of Changes

These tests have been flaky in `main` (presumably because of many parallel CI jobs hitting the same snowflake instance): https://github.com/ethyca/fides/actions/runs/17986669831/job/51167996075#step:9:934

So we'll remove them, which should be fine, because this codepath for CLI-based database detection is basically deprecated and Helios is our supported path for doing this.

Also `xfail`ing some bigquery connector tests that were also flaky

### Code Changes

* comment out snowflake db scan tests
* `xfail` more bigquery connector tests

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
