### PR TITLE
Fix system data steward filter

### DIFF
--- a/clients/admin-ui/src/features/system/table/useSystemsTable.tsx
+++ b/clients/admin-ui/src/features/system/table/useSystemsTable.tsx
@@ -308,7 +308,7 @@ const useSystemsTable = () => {
         filters: convertToAntFilters(
           allUsers?.items?.map((user) => user.username),
         ),
-        filteredValue: columnFilters?.data_steward || null,
+        filteredValue: columnFilters?.data_stewards || null,
       },
       {
         title: "Description",


### PR DESCRIPTION
Closes unticketed

### Description Of Changes

Fixes a bug where system table data steward filter menu wouldn't show filters and couldn't be reset.

### Code Changes

Fixes incorrect filter property name.

### Steps to Confirm

1. Apply a data steward filter on the systems table
2. Results should be filtered
3. Filters should show in the filter menu in the table's column header
4. Should be able to change or clear filters using the menu

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
