### PR TITLE
Fix bug where select options wouldn't populate in edit custom field form 

### DIFF
--- a/clients/admin-ui/cypress/e2e/custom-fields.cy.ts
+++ b/clients/admin-ui/cypress/e2e/custom-fields.cy.ts
@@ -108,14 +108,14 @@ describe("Custom Fields V2", () => {
       cy.getByTestId("select-field-type").should("exist");
     });
 
-    it.only("allows updating field properties", () => {
+    it("allows updating field properties", () => {
       cy.visit("/settings/custom-fields");
       cy.getByTestId("edit-btn").first().click();
 
       // Update name
       cy.getByTestId("input-name").clear().type("Updated field name");
       cy.getByTestId("add-option-btn").click();
-      cy.getByTestId("input-option-0").type("Added option");
+      cy.getByTestId("input-option-3").type("Added option");
 
       cy.getByTestId("save-btn").click();
       cy.wait("@updateCustomFieldDefinition")

--- a/clients/admin-ui/src/features/custom-fields/CustomFieldForm.tsx
+++ b/clients/admin-ui/src/features/custom-fields/CustomFieldForm.tsx
@@ -52,7 +52,7 @@ const CustomFieldForm = ({
   isLoading,
 }: {
   initialField?: CustomFieldDefinitionWithId;
-  isLoading: boolean;
+  isLoading?: boolean;
 }) => {
   const [form] = Form.useForm<CustomFieldsFormValues>();
   const router = useRouter();

--- a/clients/admin-ui/src/features/custom-fields/CustomFieldForm.tsx
+++ b/clients/admin-ui/src/features/custom-fields/CustomFieldForm.tsx
@@ -5,6 +5,7 @@ import {
   AntInput as Input,
   AntMessage as message,
   AntSelect as Select,
+  AntSkeleton as Skeleton,
   AntTypography as Typography,
   ConfirmationModal,
   Icons,
@@ -34,10 +35,24 @@ import {
 } from "~/types/api";
 import { isErrorResult } from "~/types/errors";
 
+export const SkeletonCustomFieldForm = () => {
+  return (
+    <Skeleton active>
+      <Skeleton.Input />
+      <Skeleton.Input />
+      <Skeleton.Input />
+      <Skeleton.Input />
+      <Skeleton.Button />
+    </Skeleton>
+  );
+};
+
 const CustomFieldForm = ({
   initialField,
+  isLoading,
 }: {
   initialField?: CustomFieldDefinitionWithId;
+  isLoading: boolean;
 }) => {
   const [form] = Form.useForm<CustomFieldsFormValues>();
   const router = useRouter();
@@ -46,12 +61,10 @@ const CustomFieldForm = ({
 
   const { createOrUpdate } = useCreateOrUpdateCustomField();
 
-  const { data: allowList } = useGetAllowListQuery(
-    initialField?.allow_list_id as string,
-    {
+  const { data: allowList, isLoading: isAllowListLoading } =
+    useGetAllowListQuery(initialField?.allow_list_id as string, {
       skip: !initialField?.allow_list_id,
-    },
-  );
+    });
 
   const [deleteCustomField, { isLoading: deleteIsLoading }] =
     useDeleteCustomFieldDefinitionMutation();
@@ -103,6 +116,10 @@ const CustomFieldForm = ({
   };
 
   const initialValues = parseFieldToFormValues(initialField);
+
+  if (isLoading || isAllowListLoading) {
+    return <SkeletonCustomFieldForm />;
+  }
 
   return (
     <Form

--- a/clients/admin-ui/src/pages/settings/custom-fields/[id].tsx
+++ b/clients/admin-ui/src/pages/settings/custom-fields/[id].tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import Layout from "~/features/common/Layout";
 import { CUSTOM_FIELDS_ROUTE } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
-import CustomFieldFormV2 from "~/features/custom-fields/CustomFieldForm";
+import CustomFieldForm from "~/features/custom-fields/CustomFieldForm";
 import { useGetCustomFieldDefinitionByIdQuery } from "~/features/plus/plus.slice";
 
 const CustomFieldDetailPage = () => {
@@ -25,7 +25,7 @@ const CustomFieldDetailPage = () => {
           { title: customField?.name ?? id },
         ]}
       />
-      <CustomFieldFormV2 initialField={customField} isLoading={isLoading} />
+      <CustomFieldForm initialField={customField} isLoading={isLoading} />
     </Layout>
   );
 };

--- a/clients/admin-ui/src/pages/settings/custom-fields/[id].tsx
+++ b/clients/admin-ui/src/pages/settings/custom-fields/[id].tsx
@@ -1,4 +1,3 @@
-import { AntSkeleton as Skeleton } from "fidesui";
 import { useRouter } from "next/router";
 
 import Layout from "~/features/common/Layout";
@@ -7,24 +6,14 @@ import PageHeader from "~/features/common/PageHeader";
 import CustomFieldFormV2 from "~/features/custom-fields/CustomFieldForm";
 import { useGetCustomFieldDefinitionByIdQuery } from "~/features/plus/plus.slice";
 
-const SkeletonCustomFieldForm = () => {
-  return (
-    <Skeleton active>
-      <Skeleton.Input />
-      <Skeleton.Input />
-      <Skeleton.Input />
-      <Skeleton.Input />
-      <Skeleton.Button />
-    </Skeleton>
-  );
-};
-
 const CustomFieldDetailPage = () => {
   const router = useRouter();
   const { id } = router.query;
 
   const { data: customField, isLoading } = useGetCustomFieldDefinitionByIdQuery(
-    { id: id as string },
+    {
+      id: id as string,
+    },
   );
 
   return (
@@ -36,11 +25,7 @@ const CustomFieldDetailPage = () => {
           { title: customField?.name ?? id },
         ]}
       />
-      {isLoading ? (
-        <SkeletonCustomFieldForm />
-      ) : (
-        <CustomFieldFormV2 initialField={customField} />
-      )}
+      <CustomFieldFormV2 initialField={customField} isLoading={isLoading} />
     </Layout>
   );
 };

--- a/clients/admin-ui/src/pages/settings/custom-fields/new.tsx
+++ b/clients/admin-ui/src/pages/settings/custom-fields/new.tsx
@@ -1,7 +1,7 @@
 import Layout from "~/features/common/Layout";
 import { CUSTOM_FIELDS_ROUTE } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
-import CustomFieldFormV2 from "~/features/custom-fields/CustomFieldForm";
+import CustomFieldForm from "~/features/custom-fields/CustomFieldForm";
 
 const CustomFieldNewPage = () => {
   return (
@@ -13,7 +13,7 @@ const CustomFieldNewPage = () => {
           { title: "Create new" },
         ]}
       />
-      <CustomFieldFormV2 />
+      <CustomFieldForm />
     </Layout>
   );
 };


### PR DESCRIPTION
Closes ENG-1526

### Description Of Changes

Fixes an issue where, when editing a select or multi-select custom field, the "options" field in the form would fail to populate due the form's initial values being set before the GET allow-list query resolved.  The form should now show a skeletal form while the allow list is loading.

### Steps to Confirm

1. Go to "custom fields"
2. Create a new single- or multi-select custom field or use an existing
3. Edit the field
4. Should see the "options" populated in the form on load

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
