### PR TITLE
Support more specific data uses in Categories of consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Changed
 - Bumped `fideslog` dependency to `1.2.14` [#6635](https://github.com/ethyca/fides/pull/6635)
 - Updated `StagedResource.user_assigned_data_uses` to be nullable and have a null default [#6674](https://github.com/ethyca/fides/pull/6674)
-- Allow selecting from all data uses for discovered assets in Action Center
+- Allow selecting from all data uses for discovered assets in Action Center [#6668](https://github.com/ethyca/fides/pull/6668)
 
 ### Fixed
 - Fixed an issue where users were unable to cancel out of the Add New System dialog in Action Center [#6651](https://github.com/ethyca/fides/pull/6651)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Changed
 - Bumped `fideslog` dependency to `1.2.14` [#6635](https://github.com/ethyca/fides/pull/6635)
 - Updated `StagedResource.user_assigned_data_uses` to be nullable and have a null default [#6674](https://github.com/ethyca/fides/pull/6674)
+- Allow selecting from all data uses for discovered assets in Action Center
 
 ### Fixed
 - Fixed an issue where users were unable to cancel out of the Add New System dialog in Action Center [#6651](https://github.com/ethyca/fides/pull/6651)

--- a/clients/admin-ui/src/features/common/dropdown/TaxonomySelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/TaxonomySelect.tsx
@@ -102,7 +102,7 @@ export const TaxonomySelect = ({ options, ...props }: TaxonomySelectProps) => {
    */
   const filterOption = (input: string, option?: TaxonomySelectOption) =>
     option?.formattedTitle?.toLowerCase().includes(input.toLowerCase()) ||
-    option?.value.toLowerCase().includes(input.toLowerCase()) ||
+    option?.value?.toLowerCase().includes(input.toLowerCase()) ||
     false;
 
   return (

--- a/clients/admin-ui/src/features/common/dropdown/TaxonomySelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/TaxonomySelect.tsx
@@ -4,6 +4,7 @@ import {
   ICustomMultiSelectProps,
   ICustomSelectProps,
 } from "fidesui";
+import { ReactNode } from "react";
 
 import styles from "./TaxonomySelect.module.scss";
 
@@ -13,17 +14,24 @@ export interface TaxonomySelectOption {
   primaryName?: string;
   description: string;
   className?: string;
+  formattedTitle?: string;
 }
 
-interface ExtendedTaxonomySelectOption extends TaxonomySelectOption {
-  // The visual title of the select element
-  formattedTitle: string;
+export interface TaxonomySelectOptionGroup {
+  label: ReactNode;
+  value?: string;
+  options: TaxonomySelectOption[];
 }
 
-export const TaxonomyOption = ({
+export type TaxonomySelectOptions = (
+  | TaxonomySelectOption
+  | TaxonomySelectOptionGroup
+)[];
+
+const TaxonomyOption = ({
   data: { formattedTitle, description, name, primaryName },
 }: {
-  data: ExtendedTaxonomySelectOption;
+  data: TaxonomySelectOption;
 }) => {
   return (
     <Flex gap={12} title={`${formattedTitle} - ${description}`}>
@@ -37,9 +45,16 @@ export const TaxonomyOption = ({
 };
 
 interface ITaxonomySelectProps
-  extends ICustomSelectProps<string, TaxonomySelectOption> {}
+  extends Omit<ICustomSelectProps<string, TaxonomySelectOption>, "options"> {
+  options?: TaxonomySelectOptions;
+}
 interface ITaxonomyMultiSelectProps
-  extends ICustomMultiSelectProps<string, TaxonomySelectOption> {}
+  extends Omit<
+    ICustomMultiSelectProps<string, TaxonomySelectOption>,
+    "options"
+  > {
+  options?: TaxonomySelectOptions;
+}
 
 export type TaxonomySelectProps = (
   | ITaxonomySelectProps
@@ -49,26 +64,50 @@ export type TaxonomySelectProps = (
   selectedTaxonomies?: string[];
 };
 
+// Helper function to check if options are grouped
+const isOptionGroup = (
+  option: TaxonomySelectOption | TaxonomySelectOptionGroup,
+): option is TaxonomySelectOptionGroup => {
+  return "options" in option && Array.isArray(option.options);
+};
+
+// Helper function to format a single option
+const formatTaxonomyOption = (
+  opt: TaxonomySelectOption,
+): TaxonomySelectOption => ({
+  ...opt,
+  className: styles.option,
+  formattedTitle:
+    opt.formattedTitle ||
+    [opt.primaryName, opt.name].filter((maybeString) => maybeString).join(": "),
+});
+
 export const TaxonomySelect = ({ options, ...props }: TaxonomySelectProps) => {
-  const selectOptions = options?.map((opt) => ({
-    ...opt,
-    className: styles.option,
-    formattedTitle: [opt.primaryName, opt.name]
-      .filter((maybeString) => maybeString)
-      .join(": "),
-  }));
+  const selectOptions: TaxonomySelectOptions | undefined = options?.map(
+    (item) => {
+      if (isOptionGroup(item)) {
+        // Handle option groups
+        return {
+          ...item,
+          options: item.options.map(formatTaxonomyOption),
+        };
+      }
+      // Handle flat options
+      return formatTaxonomyOption(item);
+    },
+  );
 
   /*
    * @description Matches options where the displayed value or the underlying value includes the input text
    */
-  const filterOption = (input: string, option?: ExtendedTaxonomySelectOption) =>
-    option?.formattedTitle.toLowerCase().includes(input.toLowerCase()) ||
+  const filterOption = (input: string, option?: TaxonomySelectOption) =>
+    option?.formattedTitle?.toLowerCase().includes(input.toLowerCase()) ||
     option?.value.toLowerCase().includes(input.toLowerCase()) ||
     false;
 
   return (
-    <Select<string, ExtendedTaxonomySelectOption>
-      options={selectOptions}
+    <Select<string, TaxonomySelectOption>
+      options={selectOptions as never} // Ant seems to want Options and Groups to use the same interface. Since we've added a bunch of fields to the Options that don't make sense for the Group type, it's easiest just to tell Ant to ignore this type for now.
       filterOption={filterOption}
       optionFilterProp="label"
       autoFocus

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AddDataUsesModal.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AddDataUsesModal.tsx
@@ -44,7 +44,6 @@ const AddDataUsesModal = ({
         </Text>
         <ConsentCategorySelect
           mode="tags"
-          selectedTaxonomies={selectedDataUses}
           onSelect={(_, option) =>
             setSelectedDataUses([...selectedDataUses, option.value])
           }

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConsentCategorySelect.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConsentCategorySelect.tsx
@@ -1,34 +1,75 @@
+import { AntSpace as Space, Icons, SparkleIcon } from "fidesui";
+import { useMemo } from "react";
+
 import {
   TaxonomySelect,
   TaxonomySelectOption,
+  TaxonomySelectOptions,
   TaxonomySelectProps,
 } from "~/features/common/dropdown/TaxonomySelect";
 import useTaxonomies from "~/features/common/hooks/useTaxonomies";
 import { CONSENT_CATEGORIES } from "~/features/data-discovery-and-detection/action-center/utils/isConsentCategory";
 
-const ConsentCategorySelect = ({
-  selectedTaxonomies,
-  ...props
-}: TaxonomySelectProps) => {
+const ConsentCategorySelect = ({ ...props }: TaxonomySelectProps) => {
   const { getDataUseDisplayNameProps, getDataUses } = useTaxonomies();
-  const consentCategories = getDataUses().filter(
+  const dataUses = getDataUses();
+  const consentCategories = dataUses.filter(
     (use) => use.active && CONSENT_CATEGORIES.includes(use.fides_key),
   );
 
-  const options: TaxonomySelectOption[] = consentCategories.map(
-    (consentCategory) => {
-      const { name, primaryName } = getDataUseDisplayNameProps(
-        consentCategory.fides_key,
-      );
-      return {
-        value: consentCategory.fides_key,
-        name,
-        primaryName,
-        description: consentCategory.description || "",
-      };
-    },
-  );
-  return <TaxonomySelect options={options} {...props} />;
+  const options: TaxonomySelectOption[] = dataUses.map((dataUse) => {
+    const { name, primaryName } = getDataUseDisplayNameProps(dataUse.fides_key);
+    return {
+      value: dataUse.fides_key,
+      name,
+      primaryName,
+      description: dataUse.description || "",
+    };
+  });
+
+  const optionsGroups = useMemo(() => {
+    const suggestedOptions: TaxonomySelectOption[] = [];
+    const allOptions: TaxonomySelectOption[] = [];
+    options.forEach((opt) => {
+      if (
+        consentCategories.some((category) => category.fides_key === opt.value)
+      ) {
+        suggestedOptions.push(opt);
+      } else {
+        allOptions.push(opt);
+      }
+    });
+    return {
+      suggested: suggestedOptions,
+      all: allOptions,
+    };
+  }, [options, consentCategories]);
+
+  const optionsToRender: TaxonomySelectOptions = optionsGroups.suggested.length
+    ? [
+        {
+          label: (
+            <Space>
+              <SparkleIcon size={14} />
+              <span>Categories of consent</span>
+              <em className="font-normal">Recommended</em>
+            </Space>
+          ),
+          options: optionsGroups.suggested,
+        },
+        {
+          label: (
+            <Space>
+              <Icons.Document />
+              <span>Other data uses</span>
+            </Space>
+          ),
+          options: optionsGroups.all,
+        },
+      ]
+    : optionsGroups.all;
+
+  return <TaxonomySelect options={optionsToRender} {...props} />;
 };
 
 export default ConsentCategorySelect;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetDataUseCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetDataUseCell.tsx
@@ -9,7 +9,6 @@ import { TagExpandableCell } from "~/features/common/table/cells/TagExpandableCe
 import { ColumnState } from "~/features/common/table/cells/types";
 import { useUpdateAssetsDataUseMutation } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
 import ConsentCategorySelect from "~/features/data-discovery-and-detection/action-center/ConsentCategorySelect";
-import isConsentCategory from "~/features/data-discovery-and-detection/action-center/utils/isConsentCategory";
 import { StagedResourceAPIResponse } from "~/types/api/models/StagedResourceAPIResponse";
 import { isErrorResult } from "~/types/errors";
 
@@ -73,12 +72,10 @@ const DiscoveredAssetDataUseCell = ({
     ? asset.user_assigned_data_uses
     : asset.data_uses;
 
-  const consentUses = dataUses?.filter((use) => isConsentCategory(use));
-
   if (readonly) {
     return (
       <TagExpandableCell
-        values={consentUses?.map((d) => ({
+        values={dataUses?.map((d) => ({
           label: getDataUseDisplayName(d),
           key: d,
         }))}
@@ -98,7 +95,7 @@ const DiscoveredAssetDataUseCell = ({
             aria-label="Add data use"
           />
           <TagExpandableCell
-            values={consentUses?.map((d) => ({
+            values={dataUses?.map((d) => ({
               label: getDataUseDisplayName(d),
               key: d,
             }))}
@@ -114,9 +111,13 @@ const DiscoveredAssetDataUseCell = ({
           style={{ backgroundColor: "var(--fides-color-white)" }}
         >
           <ConsentCategorySelect
-            selectedTaxonomies={consentUses || []}
             onSelect={handleAddDataUse}
             onBlur={() => setIsAdding(false)}
+            onKeyDown={(key) => {
+              if (key.key === "Escape") {
+                setIsAdding(false);
+              }
+            }}
             open
           />
         </div>

--- a/clients/admin-ui/src/features/system/system-groups/components/CreateSystemGroupForm.tsx
+++ b/clients/admin-ui/src/features/system/system-groups/components/CreateSystemGroupForm.tsx
@@ -1,4 +1,8 @@
-import { AntButton as Button, AntFlex as Flex, AntTypography } from "fidesui";
+import {
+  AntButton as Button,
+  AntFlex as Flex,
+  AntTypography as Typography,
+} from "fidesui";
 import { Form, Formik } from "formik";
 import { uniq } from "lodash";
 import { useMemo } from "react";
@@ -93,9 +97,7 @@ const CreateSystemGroupForm = ({
         return (
           <Form>
             <Flex vertical gap="middle">
-              <AntTypography.Title level={2}>
-                Create system group
-              </AntTypography.Title>
+              <Typography.Title level={2}>Create system group</Typography.Title>
               <CustomTextInput
                 name="name"
                 label="Name"

--- a/clients/admin-ui/src/features/system/system-groups/components/DataUseSelectWithSuggestions.tsx
+++ b/clients/admin-ui/src/features/system/system-groups/components/DataUseSelectWithSuggestions.tsx
@@ -2,6 +2,7 @@ import {
   AntDefaultOptionType as DefaultOptionType,
   AntFlex as Flex,
   AntSelect as Select,
+  AntSpace as Space,
   Icons,
   SparkleIcon,
 } from "fidesui";
@@ -60,20 +61,20 @@ const DataUseSelectWithSuggestions = ({
         },
         {
           label: (
-            <Flex gap="small" align="center">
-              <SparkleIcon />
-              <strong>Suggested data uses</strong>
-            </Flex>
+            <Space>
+              <SparkleIcon size={14} />
+              <span>Suggested data uses</span>
+            </Space>
           ),
           value: "suggested",
           options: optionsGroups.suggested,
         },
         {
           label: (
-            <Flex gap="small" align="center">
+            <Space>
               <Icons.Document />
-              <strong>All data uses</strong>
-            </Flex>
+              <span>All data uses</span>
+            </Space>
           ),
           value: "all",
           options: optionsGroups.all,

--- a/clients/admin-ui/src/features/system/table/useSystemsTable.tsx
+++ b/clients/admin-ui/src/features/system/table/useSystemsTable.tsx
@@ -374,7 +374,7 @@ const useSystemsTable = () => {
     plusIsEnabled,
     allSystemGroups,
     columnFilters?.system_groups,
-    columnFilters?.data_steward,
+    columnFilters?.data_stewards,
     allUsers?.items,
     isGroupsExpanded,
     systemGroupMap,

--- a/clients/admin-ui/src/features/taxonomy/components/SystemGroupEditForm.tsx
+++ b/clients/admin-ui/src/features/taxonomy/components/SystemGroupEditForm.tsx
@@ -1,8 +1,9 @@
 import {
   AntForm as Form,
   AntFormInstance as FormInstance,
-  AntInput,
+  AntInput as Input,
   AntSelect as Select,
+  AntSpace as Space,
   Icons,
   SparkleIcon,
 } from "fidesui";
@@ -123,19 +124,19 @@ const SystemGroupEditForm = ({
       },
       {
         label: (
-          <span className="flex items-center gap-2">
-            <SparkleIcon />
-            <strong>Suggested data uses</strong>
-          </span>
+          <Space>
+            <SparkleIcon size={14} />
+            <span>Suggested data uses</span>
+          </Space>
         ),
         options: suggestedOptions,
       },
       {
         label: (
-          <span className="flex items-center gap-2">
+          <Space>
             <Icons.Document />
-            <strong>All data uses</strong>
-          </span>
+            <span>All data uses</span>
+          </Space>
         ),
         options: allOptions,
       },
@@ -151,10 +152,10 @@ const SystemGroupEditForm = ({
       form={form}
     >
       <Form.Item<string> label="Name" name="name">
-        <AntInput data-testid="edit-taxonomy-form_name" disabled={isDisabled} />
+        <Input data-testid="edit-taxonomy-form_name" disabled={isDisabled} />
       </Form.Item>
       <Form.Item<string> label="Description" name="description">
-        <AntInput.TextArea
+        <Input.TextArea
           rows={4}
           data-testid="edit-taxonomy-form_description"
           disabled={isDisabled}

--- a/clients/admin-ui/src/features/taxonomy/components/TaxonomyEditForm.tsx
+++ b/clients/admin-ui/src/features/taxonomy/components/TaxonomyEditForm.tsx
@@ -1,7 +1,7 @@
 import {
   AntForm as Form,
   AntFormInstance as FormInstance,
-  AntInput,
+  AntInput as Input,
 } from "fidesui";
 import { isEmpty, unset } from "lodash";
 
@@ -68,10 +68,10 @@ const TaxonomyEditForm = ({
       form={form}
     >
       <Form.Item<string> label="Name" name="name">
-        <AntInput data-testid="edit-taxonomy-form_name" disabled={isDisabled} />
+        <Input data-testid="edit-taxonomy-form_name" disabled={isDisabled} />
       </Form.Item>
       <Form.Item<string> label="Description" name="description">
-        <AntInput.TextArea
+        <Input.TextArea
           rows={4}
           data-testid="edit-taxonomy-form_description"
           disabled={isDisabled}

--- a/clients/fidesui/src/ant-theme/global.scss
+++ b/clients/fidesui/src/ant-theme/global.scss
@@ -157,3 +157,15 @@ h6 {
     }
   }
 }
+
+.ant-select-dropdown {
+  & .ant-select-item-group {
+    font-weight: 600;
+    font-size: var(--ant-select-option-font-size);
+    color: var(--ant-color-text);
+    border-radius: 0;
+    &:not(:first-child) {
+      border-top: 1px solid var(--ant-color-border);
+    }
+  }
+}

--- a/clients/fidesui/src/hoc/CustomTag.tsx
+++ b/clients/fidesui/src/hoc/CustomTag.tsx
@@ -81,7 +81,7 @@ const withCustomProps = (WrappedComponent: typeof Tag) => {
           : undefined;
       const needsLightText = color && DARK_BACKGROUNDS.includes(color);
       const retainDefaultBorder =
-        color && RETAIN_DEFAULT_BORDER.includes(color);
+        !!color && RETAIN_DEFAULT_BORDER.includes(color);
       let customStyle = {};
       if (brandColor) {
         customStyle = {
@@ -102,7 +102,7 @@ const withCustomProps = (WrappedComponent: typeof Tag) => {
           ...style,
         },
         className: `${styles.tag} ${className ?? ""}`.trim(),
-        bordered: retainDefaultBorder ? true : undefined,
+        bordered: retainDefaultBorder,
         ...props,
         closeIcon:
           (props.closable ?? props.onClose) ? (


### PR DESCRIPTION
Closes [ENG-1434]

### Description Of Changes

Enhanced the taxonomy selection components to support grouped options, allowing for better organization and discoverability of data uses. The consent category selector now displays all available data uses with "Categories of consent" grouped as recommended options at the top, rather than limiting the selection to only consent categories.

### Code Changes

* Enhanced `TaxonomySelect` component to support option groups with new `TaxonomySelectOptionGroup` interface and helper functions
* Refactored `ConsentCategorySelect` to display all data uses with consent categories grouped as "Recommended" and other data uses in a separate group
* Updated `DiscoveredAssetDataUseCell` to display all assigned data uses instead of filtering to only consent categories
* Added keyboard support (Escape key) to close the data use selector in discovered assets table
* Standardized option group styling across `DataUseSelectWithSuggestions` and `SystemGroupEditForm` using `Space` component
* Added global SCSS styling for Ant Design select dropdown groups with borders and typography
* Cleaned up component imports for consistency (`AntInput as Input`, `AntTypography as Typography`)

### Steps to Confirm

1. Visit https://fides-plus-nightly-git-gill-eng-1434fe-support-mo-b95d38-ethyca.vercel.app/settings/about and enable "Web monitor" and "Asset consent status labels" beta features.
2. Navigate to the Action Center
3. Click a monitor, then click one of the systems.
4. Click the [+] button in the Categories of consent column on one of the rows.
5. Verify the dropdown shows two groups: "Categories of consent (Recommended)" with sparkle icon and "Other data uses" with document icon
6. Verify all data uses are selectable, not just consent categories
7. When either is selected, validate that it saves correctly with toast message appearing.
8. Press Escape key to confirm the dropdown closes (new a11y support added)

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1434]: https://ethyca.atlassian.net/browse/ENG-1434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ