### PR TITLE
Close modal after Compass vendor added

### DIFF
--- a/clients/admin-ui/src/features/system/AddNewSystemModal.tsx
+++ b/clients/admin-ui/src/features/system/AddNewSystemModal.tsx
@@ -145,6 +145,7 @@ export const AddNewSystemModal = ({
         if (toastOnSuccess) {
           successAlert(`${data.name} has been added to your system inventory.`);
         }
+        handleCloseModal();
       }
     } else {
       const payload = {


### PR DESCRIPTION
Closes [ENG-1441]

### Description Of Changes

Fixed a bug where the Add New System modal failed to close after successfully adding a Compass System through the Action Center. This caused subsequent save attempts to fail since the system was already created.

### Code Changes

* Added `handleCloseModal()` call after successfully adding a system via vendor selection in `AddNewSystemModal.tsx`

### Steps to Confirm
1. Visit the Vercel build and enable "Web monitor" and "Asset consent status labels" beta features.
2. Navigate to the Action Center
3. Click a monitor, then click Uncategorized assets.
4. Click the [+] button in the System column on one of the rows.
5. Select a Compass vendor from the dropdown (not a custom name)
6. Click Save
7. Verify the modal closes automatically after the success message

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
