### PR TITLE
test: remove default test watch from privacy center

### DIFF
--- a/clients/package.json
+++ b/clients/package.json
@@ -22,7 +22,6 @@
     "format:ci": "turbo run format:ci",
     "test": "turbo run test",
     "test:ci": "turbo run test:ci",
-    "test:watch": "turbo run test:watch",
     "typecheck": "turbo run typecheck",
     "prod-export-admin-ui": "turbo run prod-export --filter=admin-ui",
     "export-admin-ui": "turbo run export --filter=admin-ui",


### PR DESCRIPTION
### Description Of Changes

Quality of life change.  
Aligns the privacy center test scripts so that the default `test` job only runs once.  
A separate `test:watch` job is added for running tests with the watcher.

### Code Changes

* No changes to actual code. Only package scripts updated.

### Steps to Confirm

1.  Run `turbo run test` and confirm that the script exits with pass/fail values
2. Run `turbo run test:watch` and confirm that all test suites re-run on changes

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
