### PR TITLE
Migrate Monitor Config Table to Ant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed an issue where updating an Experience in Admin UI could potentially result in a browser error [#6676](https://github.com/ethyca/fides/pull/6676)
 - Fixed a bug that prevented users from removing categories of consent from web monitor resources [#6679](https://github.com/ethyca/fides/pull/6679)
 - Fixed some toast notifications in Action Center to truncate long asset and system names [#6692](https://github.com/ethyca/fides/pull/6692)
+- Fixed an issue where columns were inconsistent in the Integrations' Monitor table [#6682](https://github.com/ethyca/fides/pull/6682)
 
 ## [2.71.0](https://github.com/ethyca/fides/compare/2.70.5...2.71.0)
 

--- a/clients/admin-ui/cypress/e2e/integration-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/integration-management.cy.ts
@@ -594,7 +594,7 @@ describe("Integration management for data detection & discovery", () => {
       }).as("getEmptyDatabases");
       cy.getAntTab("Data discovery").click({ force: true });
       cy.wait("@getEmptyMonitors");
-      cy.getByTestId("no-results-notice").should("exist");
+      cy.get(".ant-empty-description").should("exist");
     });
 
     describe("data discovery tab", () => {
@@ -617,18 +617,18 @@ describe("Integration management for data detection & discovery", () => {
       });
 
       it("shows a table of monitors", () => {
-        cy.getByTestId("row-test monitor 1").should("exist");
-        cy.getByTestId("row-test monitor 1-col-monitor_status").should(
-          "contain",
-          "Scanning",
-        );
-        cy.getByTestId("row-test monitor 2-col-monitor_status").within(() => {
+        cy.getAntTableRow("test_monitor_1")
+          .should("exist")
+          .within(() => {
+            cy.getAntCellWithinRow(3).should("contain", "Scanning");
+          });
+        cy.getAntTableRow("test_monitor_2").within(() => {
           cy.getByTestId("tag-success").should("exist");
         });
-        cy.getByTestId("row-test monitor 3-col-monitor_status").within(() => {
+        cy.getAntTableRow("test_monitor_3").within(() => {
           cy.getByTestId("tag-error").should("exist");
           cy.getByTestId("tag-error").within(() => {
-            cy.get("button").click();
+            cy.get("button").click({ force: true });
           });
         });
         cy.getByTestId("error-log-drawer")
@@ -716,7 +716,7 @@ describe("Integration management for data detection & discovery", () => {
         cy.intercept("PUT", "/api/v1/plus/discovery-monitor*", {
           response: 200,
         }).as("putMonitor");
-        cy.getByTestId("row-test monitor 1").within(() => {
+        cy.getAntTableRow("test_monitor_1").within(() => {
           cy.getByTestId("edit-monitor-btn").click();
         });
         cy.getByTestId("input-name").should("have.value", "test monitor 1");
@@ -739,24 +739,15 @@ describe("Integration management for data detection & discovery", () => {
         });
       });
 
-      it("can edit an existing monitor by clicking the table row", () => {
-        cy.getByTestId("row-test monitor 2").click();
-        cy.getByTestId("input-name").should("have.value", "test monitor 2");
-        cy.getByTestId("controlled-select-execution_frequency").should(
-          "contain",
-          "Weekly",
-        );
-      });
-
       it("can execute a monitor", () => {
-        cy.getByTestId("row-test monitor 1").within(() => {
+        cy.getAntTableRow("test_monitor_1").within(() => {
           cy.getByTestId("action-Scan").click();
         });
         cy.wait("@executeMonitor");
       });
 
       it("can delete a monitor", () => {
-        cy.getByTestId("row-test monitor 1").within(() => {
+        cy.getAntTableRow("test_monitor_1").within(() => {
           cy.getByTestId("delete-monitor-btn").click();
         });
         cy.getByTestId("confirmation-modal").within(() => {
@@ -769,8 +760,8 @@ describe("Integration management for data detection & discovery", () => {
         cy.intercept("PUT", "/api/v1/plus/discovery-monitor*", {
           response: 200,
         }).as("putMonitor");
-        cy.getByTestId("row-test monitor 1").within(() => {
-          cy.getByTestId("toggle-switch").click();
+        cy.getAntTableRow("test_monitor_1").within(() => {
+          cy.getByTestId("toggle-switch").click({ force: true });
         });
         cy.wait("@putMonitor");
       });
@@ -872,10 +863,9 @@ describe("Integration management for data detection & discovery", () => {
         cy.getByTestId("monitor-description").contains(
           "Configure your website monitor",
         );
-        cy.getByTestId("row-test website monitor-col-name").should(
-          "contain",
-          "test website monitor",
-        );
+        cy.getAntTableRow("test_website_monitor").within(() => {
+          cy.getAntCellWithinRow(0).should("contain", "test website monitor");
+        });
       });
 
       it("should allow creating a website monitor", () => {
@@ -905,7 +895,9 @@ describe("Integration management for data detection & discovery", () => {
         cy.intercept("PUT", "/api/v1/plus/discovery-monitor*", {
           response: 200,
         }).as("putMonitor");
-        cy.getByTestId("row-test website monitor").click();
+        cy.getAntTableRow("test_website_monitor").within(() => {
+          cy.getByTestId("edit-monitor-btn").click();
+        });
         cy.getByTestId("input-name")
           .should("have.value", "test website monitor")
           .clear()

--- a/clients/admin-ui/src/features/common/table/cells/EnableCell.tsx
+++ b/clients/admin-ui/src/features/common/table/cells/EnableCell.tsx
@@ -1,0 +1,73 @@
+import {
+  AntMessage as message,
+  AntSwitch as Switch,
+  AntSwitchProps as SwitchProps,
+  AntTypography as Typography,
+  useDisclosure,
+} from "fidesui";
+
+import { isErrorResult, RTKResult } from "~/types/errors";
+
+import { getErrorMessage } from "../../helpers";
+import ConfirmationModal from "../../modals/ConfirmationModal";
+
+const { Text } = Typography;
+
+interface EnableCellProps extends Omit<SwitchProps, "value" | "onToggle"> {
+  enabled: boolean;
+  onToggle: (data: boolean) => Promise<RTKResult>;
+  title: string;
+  message: string;
+  isDisabled?: boolean;
+}
+
+export const EnableCell = ({
+  enabled,
+  onToggle,
+  title,
+  message: messageText,
+  isDisabled,
+  ...props
+}: EnableCellProps) => {
+  const modal = useDisclosure();
+  const [messageApi, messageContext] = message.useMessage();
+  const handlePatch = async ({ enable }: { enable: boolean }) => {
+    const result = await onToggle(enable);
+    if (isErrorResult(result)) {
+      messageApi.error(getErrorMessage(result.error));
+    }
+  };
+
+  const handleToggle = async (checked: boolean) => {
+    if (checked) {
+      await handlePatch({ enable: true });
+    } else {
+      modal.onOpen();
+    }
+  };
+
+  return (
+    <>
+      {messageContext}
+      <Switch
+        checked={enabled}
+        onChange={handleToggle}
+        disabled={isDisabled}
+        data-testid="toggle-switch"
+        {...props}
+      />
+      <ConfirmationModal
+        isOpen={modal.isOpen}
+        onClose={modal.onClose}
+        onConfirm={() => {
+          handlePatch({ enable: false });
+          modal.onClose();
+        }}
+        title={title}
+        message={<Text>{messageText}</Text>}
+        continueButtonText="Confirm"
+        isCentered
+      />
+    </>
+  );
+};

--- a/clients/admin-ui/src/features/common/table/v2/cells.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/cells.tsx
@@ -429,7 +429,9 @@ interface EnableCellProps extends Omit<SwitchProps, "value" | "onToggle"> {
   message: string;
   isDisabled?: boolean;
 }
-
+/**
+ * @deprecated Use Ant version of EnableCell from ./cells instead
+ */
 export const EnableCell = ({
   enabled,
   onToggle,

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
@@ -9,6 +9,7 @@ import {
 } from "fidesui";
 import { getIn, useFormik } from "formik";
 import { useRouter } from "next/router";
+import { useState } from "react";
 import * as Yup from "yup";
 
 import { FormikDateTimeInput } from "~/features/common/form/FormikDateTimeInput";
@@ -62,6 +63,7 @@ const ConfigureWebsiteMonitorForm = ({
   onClose: () => void;
   onSubmit: (values: MonitorConfig) => Promise<void>;
 }) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
   const integrationId = Array.isArray(router.query.id)
     ? router.query.id[0]
@@ -98,6 +100,7 @@ const ConfigureWebsiteMonitorForm = ({
   };
 
   const handleSubmit = async (values: WebsiteMonitorConfig) => {
+    setIsSubmitting(true);
     const executionInfo =
       values.execution_frequency !== MonitorFrequency.NOT_SCHEDULED
         ? {
@@ -211,7 +214,6 @@ const ConfigureWebsiteMonitorForm = ({
           options={isoCodesToOptions(
             regionOptions.map((option) => option.value),
           )}
-          required
           tooltip={REGIONS_TOOLTIP_COPY}
           mode="multiple"
           error={getIn(errors, "datasource_params.locations")}
@@ -271,7 +273,13 @@ const ConfigureWebsiteMonitorForm = ({
           >
             Cancel
           </Button>
-          <Button type="primary" htmlType="submit" data-testid="save-btn" block>
+          <Button
+            type="primary"
+            htmlType="submit"
+            data-testid="save-btn"
+            block
+            loading={isSubmitting}
+          >
             Save
           </Button>
         </Flex>

--- a/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigActionsCell.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigActionsCell.tsx
@@ -1,8 +1,7 @@
 import {
   AntButton as Button,
   AntTooltip as Tooltip,
-  DeleteIcon,
-  EditIcon,
+  Icons,
   useDisclosure,
 } from "fidesui";
 
@@ -22,10 +21,11 @@ const MonitorConfigActionsCell = ({
   isWebsiteMonitor,
   onEditClick,
 }: {
-  monitorId: string;
+  monitorId?: string | null;
   isWebsiteMonitor?: boolean;
   onEditClick: () => void;
 }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const [deleteMonitor] = useDeleteDiscoveryMonitorMutation();
   const { toastResult: toastDeleteResult } = useQueryResultToast({
     defaultErrorMsg: "A problem occurred deleting this monitor",
@@ -41,14 +41,16 @@ const MonitorConfigActionsCell = ({
       : "Monitor execution successfully started",
   });
 
+  if (!monitorId) {
+    return null;
+  }
+
   const handleDelete = async () => {
     const result = await deleteMonitor({
       monitor_config_id: monitorId,
     });
     toastDeleteResult(result);
   };
-
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const handleExecute = async () => {
     const result = await executeMonitor({
@@ -73,7 +75,7 @@ const MonitorConfigActionsCell = ({
           <Button
             onClick={onEditClick}
             size="small"
-            icon={<EditIcon />}
+            icon={<Icons.Edit />}
             data-testid="edit-monitor-btn"
             aria-label="Edit monitor"
           />
@@ -82,7 +84,7 @@ const MonitorConfigActionsCell = ({
           <Button
             onClick={onOpen}
             size="small"
-            icon={<DeleteIcon />}
+            icon={<Icons.TrashCan />}
             aria-label="Delete monitor"
             data-testid="delete-monitor-btn"
           />

--- a/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigActionsCell.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigActionsCell.tsx
@@ -26,7 +26,8 @@ const MonitorConfigActionsCell = ({
   onEditClick: () => void;
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [deleteMonitor] = useDeleteDiscoveryMonitorMutation();
+  const [deleteMonitor, { isLoading: isDeleting }] =
+    useDeleteDiscoveryMonitorMutation();
   const { toastResult: toastDeleteResult } = useQueryResultToast({
     defaultErrorMsg: "A problem occurred deleting this monitor",
     defaultSuccessMsg: "Monitor deleted successfully",
@@ -69,6 +70,7 @@ const MonitorConfigActionsCell = ({
         message="Are you sure you want to delete this discovery monitor?"
         continueButtonText="Delete"
         isCentered
+        isLoading={isDeleting}
       />
       <div className="flex gap-2">
         <Tooltip title="Edit">

--- a/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigEnableCell.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigEnableCell.tsx
@@ -1,6 +1,4 @@
-import { CellContext } from "@tanstack/react-table";
-
-import { EnableCell } from "~/features/common/table/v2/cells";
+import { EnableCell } from "~/features/common/table/cells/EnableCell";
 import { usePutDiscoveryMonitorMutation } from "~/features/data-discovery-and-detection/discovery-detection.slice";
 import { MonitorConfig } from "~/types/api";
 
@@ -9,23 +7,22 @@ const MODAL_TEXT =
   "You are about to disable this monitor. If you continue, it will no longer scan automatically.";
 
 export const MonitorConfigEnableCell = ({
-  row,
-  getValue,
-}: CellContext<MonitorConfig, boolean | undefined>) => {
+  record,
+}: {
+  record: MonitorConfig;
+}) => {
   const [putMonitor] = usePutDiscoveryMonitorMutation();
-
-  const onToggle = async (toggleValue: boolean) =>
+  const handleToggle = async (toggleValue: boolean) =>
     putMonitor({
-      ...row.original,
+      ...record,
       enabled: toggleValue,
     });
-
-  const enabled = getValue()!;
+  const { enabled } = record;
 
   return (
     <EnableCell
-      enabled={enabled}
-      onToggle={onToggle}
+      enabled={!!enabled}
+      onToggle={handleToggle}
       title={MODAL_TITLE}
       message={MODAL_TEXT}
     />

--- a/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
@@ -1,60 +1,25 @@
-/* eslint-disable react/no-unstable-nested-components */
-import {
-  ColumnDef,
-  createColumnHelper,
-  getCoreRowModel,
-  getExpandedRowModel,
-  getGroupedRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
 import {
   AntButton as Button,
   AntFlex as Flex,
+  AntTable as Table,
   AntTooltip as Tooltip,
   AntTypography as Typography,
-  formatIsoLocation,
-  isoStringToEntry,
-  Text,
   useDisclosure,
-  VStack,
 } from "fidesui";
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 
-import FidesSpinner from "~/features/common/FidesSpinner";
 import { MonitorIcon } from "~/features/common/Icon/MonitorIcon";
-import { PRIVACY_NOTICE_REGION_RECORD } from "~/features/common/privacy-notice-regions";
-import {
-  DefaultCell,
-  DefaultHeaderCell,
-  FidesTableV2,
-  GroupCountBadgeCell,
-  PaginationBar,
-  useServerSidePagination,
-} from "~/features/common/table/v2";
-import { useGetMonitorsByIntegrationQuery } from "~/features/data-discovery-and-detection/discovery-detection.slice";
 import ConfigureMonitorModal from "~/features/integrations/configure-monitor/ConfigureMonitorModal";
-import MonitorConfigActionsCell from "~/features/integrations/configure-monitor/MonitorConfigActionsCell";
-import { MonitorConfigEnableCell } from "~/features/integrations/configure-monitor/MonitorConfigEnableCell";
-import MonitorStatusCell from "~/features/integrations/configure-monitor/MonitorStatusCell";
+import { useMonitorConfigTable } from "~/features/integrations/hooks/useMonitorConfigTable";
 import {
   ConnectionConfigurationResponse,
   ConnectionSystemTypeMap,
   ConnectionType,
   MonitorConfig,
-  PrivacyNoticeRegion,
   SystemType,
-  WebsiteSchema,
 } from "~/types/api";
 
 import SharedConfigModal from "../SharedConfigModal";
-
-const EMPTY_RESPONSE = {
-  items: [] as MonitorConfig[],
-  total: 0,
-  page: 1,
-  size: 50,
-  pages: 0,
-};
 
 const DATA_DISCOVERY_MONITOR_COPY = `A data discovery monitor observes configured systems for data model changes to proactively discover and classify data risks. Monitors can observe part or all of a project, dataset, table, or API for changes and each can be assigned to a different data steward.`;
 
@@ -66,8 +31,6 @@ const MONITOR_COPIES: Partial<Record<ConnectionType, string>> = {
   [ConnectionType.WEBSITE]: WEBSITE_MONITOR_COPY,
   [ConnectionType.OKTA]: OKTA_MONITOR_COPY,
 } as const;
-
-const columnHelper = createColumnHelper<MonitorConfig>();
 
 const MonitorConfigTab = ({
   integration,
@@ -81,30 +44,6 @@ const MonitorConfigTab = ({
 
   // Check if this is a SaaS type integration
   const isSaasIntegration = integrationOption?.type === SystemType.SAAS;
-
-  const {
-    PAGE_SIZES,
-    pageSize,
-    setPageSize,
-    onPreviousPageClick,
-    isPreviousPageDisabled,
-    onNextPageClick,
-    isNextPageDisabled,
-    startRange,
-    endRange,
-    pageIndex,
-    setTotalPages,
-  } = useServerSidePagination();
-
-  const {
-    isLoading,
-    isFetching,
-    data: monitorResult,
-  } = useGetMonitorsByIntegrationQuery({
-    page: pageIndex,
-    size: pageSize,
-    connection_config_key: integration.key,
-  });
 
   const modal = useDisclosure();
   const [workingMonitor, setWorkingMonitor] = useState<
@@ -131,204 +70,12 @@ const MonitorConfigTab = ({
     setFormStep(1);
   };
 
-  const response = monitorResult ?? EMPTY_RESPONSE;
-
-  const {
-    items: monitors,
-    total: totalRows,
-    pages: totalPages,
-  } = useMemo(() => response, [response]);
-
-  useEffect(() => {
-    setTotalPages(totalPages);
-  }, [totalPages, setTotalPages]);
-
-  const columns: ColumnDef<MonitorConfig, any>[] = useMemo(
-    () => {
-      const nameColumn = columnHelper.accessor((row) => row.name, {
-        id: "name",
-        cell: (props) => <DefaultCell value={props.getValue()} />,
-        header: (props) => <DefaultHeaderCell value="Name" {...props} />,
-      });
-
-      const scopeColumn = columnHelper.accessor((row) => row.databases, {
-        id: "projects",
-        cell: (props) =>
-          props.getValue()?.length === 0 ? (
-            <DefaultCell value="All projects" />
-          ) : (
-            <GroupCountBadgeCell
-              suffix="Projects"
-              value={props.getValue()}
-              {...props}
-              cellState={{ isExpanded: true }}
-            />
-          ),
-        header: (props) => <DefaultHeaderCell value="Scope" {...props} />,
-      });
-
-      const sourceUrlColumn = columnHelper.accessor(
-        () => {
-          const secrets = integration.secrets as WebsiteSchema | null;
-          return secrets?.url;
-        },
-        {
-          id: "source_url",
-          cell: (props) => (
-            <DefaultCell value={props.getValue() ?? "Not scheduled"} />
-          ),
-          header: (props) => (
-            <DefaultHeaderCell value="Source URL" {...props} />
-          ),
-        },
-      );
-
-      const scanFrequencyColumn = columnHelper.accessor(
-        (row) => row.execution_frequency,
-        {
-          id: "frequency",
-          cell: (props) => (
-            <DefaultCell value={props.getValue() ?? "Not scheduled"} />
-          ),
-          header: (props) => (
-            <DefaultHeaderCell value="Scan frequency" {...props} />
-          ),
-        },
-      );
-
-      const lastScanColumn = columnHelper.display({
-        id: "monitor_status",
-        cell: (props) => <MonitorStatusCell monitor={props.row.original} />,
-        header: (props) => <DefaultHeaderCell value="Scan status" {...props} />,
-        meta: { disableRowClick: true },
-      });
-
-      const regionsColumn = columnHelper.accessor(
-        (row) => {
-          const locations =
-            row.datasource_params &&
-            "locations" in row.datasource_params &&
-            Array.isArray(row.datasource_params.locations)
-              ? row.datasource_params.locations
-              : [];
-          return (
-            locations
-              ?.map((location) => {
-                const isoEntry = isoStringToEntry(location);
-
-                /**
-                 * regionCode and regionRecord are the result of navigating enums that should be depricated.
-                 * if the backend decides to maintain a list of values for the frontend to use, a less convoluted method should be used
-                 */
-                const regionCode = Object.entries(PrivacyNoticeRegion).find(
-                  ([, region]) => {
-                    return region === location;
-                  },
-                );
-
-                const regionRecord =
-                  regionCode &&
-                  PRIVACY_NOTICE_REGION_RECORD[
-                    regionCode[1]
-                  ]; /* regionCode[1] refers to enum value that is the key for the region records enum (enum-ception) */
-
-                return isoEntry
-                  ? formatIsoLocation({ isoEntry })
-                  : regionRecord;
-              })
-              .join(", ") || "No regions selected"
-          );
-        },
-        {
-          id: "regions",
-          cell: (props) => <DefaultCell value={props.getValue()} />,
-          header: (props) => <DefaultHeaderCell value="Regions" {...props} />,
-        },
-      );
-
-      const statusColumn = columnHelper.accessor((row) => row.enabled, {
-        id: "status",
-        cell: MonitorConfigEnableCell,
-        header: (props) => <DefaultHeaderCell value="Status" {...props} />,
-        size: 0,
-        meta: { disableRowClick: true },
-      });
-
-      const actionsColumn = columnHelper.display({
-        id: "action",
-        cell: (props) => (
-          <MonitorConfigActionsCell
-            onEditClick={() => handleEditMonitor(props.row.original)}
-            isWebsiteMonitor={isWebsiteMonitor}
-            monitorId={props.row.original.key!}
-          />
-        ),
-        header: "Actions",
-        meta: { disableRowClick: true },
-      });
-
-      if (isWebsiteMonitor) {
-        return [
-          nameColumn,
-          sourceUrlColumn,
-          scanFrequencyColumn,
-          regionsColumn,
-          lastScanColumn,
-          statusColumn,
-          actionsColumn,
-        ];
-      }
-
-      return [
-        nameColumn,
-        scopeColumn,
-        scanFrequencyColumn,
-        lastScanColumn,
-        statusColumn,
-        actionsColumn,
-      ];
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-
-  const tableInstance = useReactTable<MonitorConfig>({
-    getCoreRowModel: getCoreRowModel(),
-    getGroupedRowModel: getGroupedRowModel(),
-    getExpandedRowModel: getExpandedRowModel(),
-    getRowId: (row) => row.name,
-    manualPagination: true,
-    data: monitors,
-    columns,
-    columnResizeMode: "onChange",
+  // Use the new Ant Design table hook
+  const { columns, tableProps, monitors, isLoading } = useMonitorConfigTable({
+    integration,
+    isWebsiteMonitor,
+    onEditMonitor: handleEditMonitor,
   });
-
-  const EmptyTableNotice = () => (
-    <VStack
-      mt={6}
-      p={10}
-      spacing={4}
-      borderRadius="base"
-      maxW="70%"
-      data-testid="no-results-notice"
-      alignSelf="center"
-      margin="auto"
-    >
-      <VStack>
-        <Text fontSize="md" fontWeight="600">
-          No monitors
-        </Text>
-        <Text fontSize="sm">
-          You have not configured any data discovery monitors. Click &quot;Add
-          monitor&quot; to configure data discovery now.
-        </Text>
-      </VStack>
-    </VStack>
-  );
-
-  if (isLoading) {
-    return <FidesSpinner />;
-  }
 
   const monitorCopy =
     MONITOR_COPIES[integrationOption?.identifier as ConnectionType] ??
@@ -370,33 +117,21 @@ const MonitorConfigTab = ({
       <Flex justify="space-between" className="py-3">
         <SharedConfigModal />
         <Tooltip title={addMonitorButtonTooltip}>
-          <Button
-            onClick={modal.onOpen}
-            icon={<MonitorIcon />}
-            iconPosition="end"
-            data-testid="add-monitor-btn"
-            disabled={isAddMonitorButtonDisabled}
-          >
-            Add monitor
-          </Button>
+          <span>
+            {/* This span wrapper is needed to ensure the tooltip works when the butotn is disabled */}
+            <Button
+              onClick={modal.onOpen}
+              icon={<MonitorIcon />}
+              iconPosition="end"
+              data-testid="add-monitor-btn"
+              disabled={isAddMonitorButtonDisabled}
+            >
+              Add monitor
+            </Button>
+          </span>
         </Tooltip>
       </Flex>
-      <FidesTableV2
-        tableInstance={tableInstance}
-        onRowClick={handleEditMonitor}
-        emptyTableNotice={<EmptyTableNotice />}
-      />
-      <PaginationBar
-        totalRows={totalRows || 0}
-        pageSizes={PAGE_SIZES}
-        setPageSize={setPageSize}
-        onPreviousPageClick={onPreviousPageClick}
-        isPreviousPageDisabled={isPreviousPageDisabled || isFetching}
-        onNextPageClick={onNextPageClick}
-        isNextPageDisabled={isNextPageDisabled || isFetching}
-        startRange={startRange}
-        endRange={endRange}
-      />
+      <Table {...tableProps} loading={isLoading} columns={columns} />
       <ConfigureMonitorModal
         isOpen={modal.isOpen}
         onClose={handleCloseModal}

--- a/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
@@ -9,11 +9,12 @@ import {
 } from "@tanstack/react-table";
 import {
   AntButton as Button,
+  AntFlex as Flex,
+  AntTooltip as Tooltip,
+  AntTypography as Typography,
   formatIsoLocation,
   isoStringToEntry,
-  Spacer,
   Text,
-  Tooltip,
   useDisclosure,
   VStack,
 } from "fidesui";
@@ -28,7 +29,6 @@ import {
   FidesTableV2,
   GroupCountBadgeCell,
   PaginationBar,
-  TableActionBar,
   useServerSidePagination,
 } from "~/features/common/table/v2";
 import { useGetMonitorsByIntegrationQuery } from "~/features/data-discovery-and-detection/discovery-detection.slice";
@@ -361,37 +361,26 @@ const MonitorConfigTab = ({
 
   return (
     <>
-      <Text maxW="720px" mb={6} fontSize="sm" data-testid="monitor-description">
+      <Typography.Paragraph
+        className="mb-6 max-w-3xl"
+        data-testid="monitor-description"
+      >
         {monitorCopy}
-      </Text>
-      <TableActionBar>
+      </Typography.Paragraph>
+      <Flex justify="space-between" className="py-3">
         <SharedConfigModal />
-        <Spacer />
-        <Tooltip label={addMonitorButtonTooltip}>
-          <span>
-            <Button
-              onClick={modal.onOpen}
-              icon={<MonitorIcon />}
-              iconPosition="end"
-              data-testid="add-monitor-btn"
-              disabled={isAddMonitorButtonDisabled}
-            >
-              Add monitor
-            </Button>
-          </span>
+        <Tooltip title={addMonitorButtonTooltip}>
+          <Button
+            onClick={modal.onOpen}
+            icon={<MonitorIcon />}
+            iconPosition="end"
+            data-testid="add-monitor-btn"
+            disabled={isAddMonitorButtonDisabled}
+          >
+            Add monitor
+          </Button>
         </Tooltip>
-        <ConfigureMonitorModal
-          isOpen={modal.isOpen}
-          onClose={handleCloseModal}
-          formStep={formStep}
-          onAdvance={handleAdvanceForm}
-          monitor={workingMonitor}
-          isEditing={isEditing}
-          integration={integration}
-          integrationOption={integrationOption!}
-          isWebsiteMonitor={isWebsiteMonitor}
-        />
-      </TableActionBar>
+      </Flex>
       <FidesTableV2
         tableInstance={tableInstance}
         onRowClick={handleEditMonitor}
@@ -407,6 +396,17 @@ const MonitorConfigTab = ({
         isNextPageDisabled={isNextPageDisabled || isFetching}
         startRange={startRange}
         endRange={endRange}
+      />
+      <ConfigureMonitorModal
+        isOpen={modal.isOpen}
+        onClose={handleCloseModal}
+        formStep={formStep}
+        onAdvance={handleAdvanceForm}
+        monitor={workingMonitor}
+        isEditing={isEditing}
+        integration={integration}
+        integrationOption={integrationOption!}
+        isWebsiteMonitor={isWebsiteMonitor}
       />
     </>
   );

--- a/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
@@ -118,7 +118,7 @@ const MonitorConfigTab = ({
         <SharedConfigModal />
         <Tooltip title={addMonitorButtonTooltip}>
           <span>
-            {/* This span wrapper is needed to ensure the tooltip works when the butotn is disabled */}
+            {/* This span wrapper is needed to ensure the tooltip works when the button is disabled */}
             <Button
               onClick={modal.onOpen}
               icon={<MonitorIcon />}

--- a/clients/admin-ui/src/features/integrations/hooks/useMonitorConfigTable.tsx
+++ b/clients/admin-ui/src/features/integrations/hooks/useMonitorConfigTable.tsx
@@ -1,0 +1,243 @@
+import {
+  AntColumnsType as ColumnsType,
+  AntTypography as Typography,
+  formatIsoLocation,
+  isoStringToEntry,
+} from "fidesui";
+import { useMemo } from "react";
+
+import { PRIVACY_NOTICE_REGION_RECORD } from "~/features/common/privacy-notice-regions";
+import { useAntTable, useTableState } from "~/features/common/table/hooks";
+import { useGetMonitorsByIntegrationQuery } from "~/features/data-discovery-and-detection/discovery-detection.slice";
+import MonitorConfigActionsCell from "~/features/integrations/configure-monitor/MonitorConfigActionsCell";
+import MonitorStatusCell from "~/features/integrations/configure-monitor/MonitorStatusCell";
+import {
+  ConnectionConfigurationResponse,
+  MonitorConfig,
+  PrivacyNoticeRegion,
+  WebsiteSchema,
+} from "~/types/api";
+
+import { MonitorConfigEnableCell } from "../configure-monitor/MonitorConfigEnableCell";
+
+const { Text } = Typography;
+
+enum MonitorConfigColumnKeys {
+  NAME = "name",
+  PROJECTS = "projects",
+  SOURCE_URL = "source_url",
+  FREQUENCY = "frequency",
+  MONITOR_STATUS = "monitor_status",
+  REGIONS = "regions",
+  STATUS = "status",
+  ACTION = "action",
+}
+
+interface UseMonitorConfigTableConfig {
+  integration: ConnectionConfigurationResponse;
+  isWebsiteMonitor: boolean;
+  onEditMonitor: (monitor: MonitorConfig) => void;
+}
+
+export const useMonitorConfigTable = ({
+  integration,
+  isWebsiteMonitor,
+  onEditMonitor,
+}: UseMonitorConfigTableConfig) => {
+  const tableState = useTableState<MonitorConfigColumnKeys>();
+
+  const { pageIndex, pageSize } = tableState;
+
+  const {
+    isLoading,
+    isFetching,
+    data: response,
+  } = useGetMonitorsByIntegrationQuery({
+    page: pageIndex,
+    size: pageSize,
+    connection_config_key: integration.key,
+  });
+
+  const antTableConfig = useMemo(
+    () => ({
+      enableSelection: false,
+      getRowKey: (record: MonitorConfig) => record.key ?? record.name,
+      isLoading,
+      isFetching,
+      dataSource: response?.items ?? [],
+      totalRows: response?.total ?? 0,
+    }),
+    [isLoading, isFetching, response?.items, response?.total],
+  );
+
+  const antTable = useAntTable<MonitorConfig, MonitorConfigColumnKeys>(
+    tableState,
+    antTableConfig,
+  );
+
+  const columns: ColumnsType<MonitorConfig> = useMemo(() => {
+    const nameColumn = {
+      title: "Name",
+      dataIndex: MonitorConfigColumnKeys.NAME,
+      key: MonitorConfigColumnKeys.NAME,
+      render: (name: string) => (
+        <Text ellipsis={{ tooltip: name }} style={{ maxWidth: 150 }}>
+          {name}
+        </Text>
+      ),
+      fixed: "left" as const,
+    };
+
+    const scopeColumn = {
+      title: "Scope",
+      dataIndex: MonitorConfigColumnKeys.PROJECTS,
+      key: MonitorConfigColumnKeys.PROJECTS,
+      render: (_: unknown, record: MonitorConfig) => {
+        const databases = record.databases ?? [];
+        if (databases.length === 0) {
+          return "All projects";
+        }
+        return `${databases.length} ${databases.length === 1 ? "Project" : "Projects"}`;
+      },
+    };
+
+    const sourceUrlColumn = {
+      title: "Source URL",
+      dataIndex: MonitorConfigColumnKeys.SOURCE_URL,
+      key: MonitorConfigColumnKeys.SOURCE_URL,
+      render: () => {
+        const secrets = integration.secrets as WebsiteSchema | null;
+        return (
+          <Text ellipsis={{ tooltip: secrets?.url }} style={{ maxWidth: 150 }}>
+            {secrets?.url ?? "Not scheduled"}
+          </Text>
+        );
+      },
+    };
+
+    const scanFrequencyColumn = {
+      title: "Scan frequency",
+      dataIndex: MonitorConfigColumnKeys.FREQUENCY,
+      key: MonitorConfigColumnKeys.FREQUENCY,
+      render: (frequency: string | undefined) => frequency ?? "Not scheduled",
+    };
+
+    const lastScanColumn = {
+      title: "Scan status",
+      key: MonitorConfigColumnKeys.MONITOR_STATUS,
+      render: (_: unknown, record: MonitorConfig) => (
+        <MonitorStatusCell monitor={record} />
+      ),
+    };
+
+    const regionsColumn = {
+      title: "Regions",
+      dataIndex: MonitorConfigColumnKeys.REGIONS,
+      key: MonitorConfigColumnKeys.REGIONS,
+      render: (_: unknown, record: MonitorConfig) => {
+        const locations =
+          record.datasource_params &&
+          "locations" in record.datasource_params &&
+          Array.isArray(record.datasource_params.locations)
+            ? record.datasource_params.locations
+            : [];
+
+        if (locations.length === 0) {
+          return "No regions selected";
+        }
+
+        const formattedLocations = locations
+          .map((location) => {
+            const isoEntry = isoStringToEntry(location);
+
+            /**
+             * regionCode and regionRecord are the result of navigating enums that should be deprecated.
+             * if the backend decides to maintain a list of values for the frontend to use, a less convoluted
+             * method should be used
+             */
+            const regionCode = Object.entries(PrivacyNoticeRegion).find(
+              ([, region]) => region === location,
+            );
+
+            const regionRecord =
+              regionCode &&
+              PRIVACY_NOTICE_REGION_RECORD[
+                regionCode[1]
+              ]; /* regionCode[1] refers to enum value that is the key for the region records enum (enum-ception) */
+
+            return isoEntry ? formatIsoLocation({ isoEntry }) : regionRecord;
+          })
+          .join(", ");
+
+        return (
+          <Text
+            ellipsis={{ tooltip: formattedLocations }}
+            style={{ maxWidth: 150 }}
+          >
+            {formattedLocations}
+          </Text>
+        );
+      },
+    };
+
+    const statusColumn = {
+      title: "Status",
+      dataIndex: MonitorConfigColumnKeys.STATUS,
+      key: MonitorConfigColumnKeys.STATUS,
+      width: 100,
+      render: (_: unknown, record: MonitorConfig) => (
+        <MonitorConfigEnableCell record={record} />
+      ),
+    };
+
+    const actionsColumn = {
+      title: "Actions",
+      key: MonitorConfigColumnKeys.ACTION,
+      width: 100,
+      render: (_: unknown, record: MonitorConfig) => (
+        <MonitorConfigActionsCell
+          onEditClick={() => onEditMonitor(record)}
+          isWebsiteMonitor={isWebsiteMonitor}
+          monitorId={record.key}
+        />
+      ),
+      fixed: "right" as const,
+    };
+
+    if (isWebsiteMonitor) {
+      return [
+        nameColumn,
+        sourceUrlColumn,
+        scanFrequencyColumn,
+        regionsColumn,
+        lastScanColumn,
+        statusColumn,
+        actionsColumn,
+      ];
+    }
+
+    return [
+      nameColumn,
+      scopeColumn,
+      scanFrequencyColumn,
+      lastScanColumn,
+      statusColumn,
+      actionsColumn,
+    ];
+  }, [integration.secrets, isWebsiteMonitor, onEditMonitor]);
+
+  return {
+    // Table state and data
+    columns,
+    monitors: response?.items ?? [],
+    isLoading,
+    isFetching,
+    totalRows: response?.total ?? 0,
+
+    // Ant Design table integration
+    tableProps: antTable.tableProps,
+
+    // Utilities
+    hasData: !!response?.items?.length,
+  };
+};

--- a/clients/admin-ui/src/features/integrations/hooks/useMonitorConfigTable.tsx
+++ b/clients/admin-ui/src/features/integrations/hooks/useMonitorConfigTable.tsx
@@ -150,6 +150,11 @@ export const useMonitorConfigTable = ({
           .map((location) => {
             const isoEntry = isoStringToEntry(location);
 
+            // Early return if we have a valid ISO entry to avoid problematic enum navigation
+            if (isoEntry) {
+              return formatIsoLocation({ isoEntry });
+            }
+
             /**
              * regionCode and regionRecord are the result of navigating enums that should be deprecated.
              * if the backend decides to maintain a list of values for the frontend to use, a less convoluted
@@ -165,7 +170,7 @@ export const useMonitorConfigTable = ({
                 regionCode[1]
               ]; /* regionCode[1] refers to enum value that is the key for the region records enum (enum-ception) */
 
-            return isoEntry ? formatIsoLocation({ isoEntry }) : regionRecord;
+            return regionRecord;
           })
           .join(", ");
 

--- a/clients/admin-ui/src/pages/integrations/[id].tsx
+++ b/clients/admin-ui/src/pages/integrations/[id].tsx
@@ -1,4 +1,9 @@
-import { AntFlex, AntTabs as Tabs, Spinner } from "fidesui";
+import {
+  AntCol as Col,
+  AntRow as Row,
+  AntTabs as Tabs,
+  Spinner,
+} from "fidesui";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 
@@ -104,15 +109,13 @@ const IntegrationDetailView: NextPage = () => {
           },
         ]}
       />
-      <AntFlex gap={24}>
-        <div className="grow">
-          <div className="mb-6">
-            <IntegrationBox
-              integration={connection}
-              integrationTypeInfo={integrationTypeInfo}
-              showDeleteButton
-            />
-          </div>
+      <Row wrap={false} gutter={24}>
+        <Col flex="1 1 auto">
+          <IntegrationBox
+            integration={connection}
+            integrationTypeInfo={integrationTypeInfo}
+            showDeleteButton
+          />
           {isLoading ? (
             <Spinner />
           ) : (
@@ -120,8 +123,8 @@ const IntegrationDetailView: NextPage = () => {
               <Tabs items={tabs} activeKey={activeTab} onChange={onTabChange} />
             )
           )}
-        </div>
-        <div className="w-[350px] shrink-0">
+        </Col>
+        <Col flex="0 0 350px">
           {isLoading ? (
             <Spinner />
           ) : (
@@ -134,8 +137,8 @@ const IntegrationDetailView: NextPage = () => {
               />
             )
           )}
-        </div>
-      </AntFlex>
+        </Col>
+      </Row>
     </Layout>
   );
 };


### PR DESCRIPTION
Closes [ENG-1302], [ENG-709], [ENG-1187]

### Description of Changes

Migrated the Monitor Configuration table to Ant Design. Extracted table logic into a reusable hook (`useMonitorConfigTable`) and created an Ant Design version of the `EnableCell` component. Deprecated the old Chakra-based `EnableCell` to align with the ongoing migration from Chakra to Ant Design.

### Code Changes

* Migrated `MonitorConfigTab` from TanStack Table v2 to Ant Design Table
* Created `useMonitorConfigTable` hook to encapsulate table state, data fetching, and column definitions
* Created Ant Design version of `EnableCell` component in `~/features/common/table/cells/`
* Deprecated Chakra-based `EnableCell` in `~/features/common/table/v2/cells.tsx`
* Refactored `MonitorConfigEnableCell` to use the new Ant `EnableCell` and accept `record` prop instead of TanStack's `CellContext`
* Updated `MonitorConfigActionsCell` to handle nullable `monitorId` and use `Icons` namespace instead of individual icon imports
* Replaced Chakra layout components (VStack, Spacer, Text) with Ant Design equivalents (Flex, Typography)

### Steps to Confirm

1. Navigate to an integration's Monitor Configuration tab
2. Verify the table displays monitors correctly with all columns (Name, Scope/Source URL, Scan frequency, Regions, Scan status, Status, Actions)
3. Test enabling/disabling a monitor via the Status toggle switch
4. Verify the disable confirmation modal appears when toggling off
5. Test the Edit and Delete actions for a monitor
6. Verify pagination works correctly if there are multiple pages of monitors
7. Test both data discovery monitors and website monitors to ensure both table variants render correctly

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1302]: https://ethyca.atlassian.net/browse/ENG-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-709]: https://ethyca.atlassian.net/browse/ENG-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-1187]: https://ethyca.atlassian.net/browse/ENG-1187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ