### PR TITLE
Explicitly drop cookies prop when creating historical preferences

### DIFF
--- a/src/fides/api/models/__init__.py
+++ b/src/fides/api/models/__init__.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict
 
+from sqlalchemy.inspection import inspect as sa_inspect
 from sqlalchemy.orm import Session
 
 from fides.api.db.base_class import Base
@@ -34,17 +35,21 @@ def create_historical_data_from_record(resource: Base) -> Dict:
 
 def clone_object_attributes(resource: Base) -> Dict:
     """
-    Copies an objects attributes into a dictionary.
+    Build a dictionary of the SQLAlchemy-mapped column attributes for this resource.
 
-    Removes protected fields like the SQLAlchemy instance state and id.
+    Avoid copying the raw __dict__ to prevent cached/computed attributes (e.g.,
+    @cached_property) from leaking into historical payloads.
     """
-    cloned_attributes = resource.__dict__.copy()
-    # remove protected fields from the cloned dict
-    cloned_attributes.pop("_sa_instance_state", None)
-    cloned_attributes.pop("id", None)
-    # remove datetime fields
-    cloned_attributes.pop("created_at", None)
-    cloned_attributes.pop("updated_at", None)
+    mapper = sa_inspect(resource.__class__)
+    cloned_attributes: Dict = {}
+
+    # Collect only mapped column keys
+    for column in mapper.columns:
+        key = column.key
+        if key in ("id", "created_at", "updated_at"):
+            continue
+        cloned_attributes[key] = getattr(resource, key)
+
     return cloned_attributes
 
 

--- a/src/fides/api/models/__init__.py
+++ b/src/fides/api/models/__init__.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict
 
-from sqlalchemy.inspection import inspect as sa_inspect
 from sqlalchemy.orm import Session
 
 from fides.api.db.base_class import Base
@@ -35,21 +34,17 @@ def create_historical_data_from_record(resource: Base) -> Dict:
 
 def clone_object_attributes(resource: Base) -> Dict:
     """
-    Build a dictionary of the SQLAlchemy-mapped column attributes for this resource.
+    Copies an objects attributes into a dictionary.
 
-    Avoid copying the raw __dict__ to prevent cached/computed attributes (e.g.,
-    @cached_property) from leaking into historical payloads.
+    Removes protected fields like the SQLAlchemy instance state and id.
     """
-    mapper = sa_inspect(resource.__class__)
-    cloned_attributes: Dict = {}
-
-    # Collect only mapped column keys
-    for column in mapper.columns:
-        key = column.key
-        if key in ("id", "created_at", "updated_at"):
-            continue
-        cloned_attributes[key] = getattr(resource, key)
-
+    cloned_attributes = resource.__dict__.copy()
+    # remove protected fields from the cloned dict
+    cloned_attributes.pop("_sa_instance_state", None)
+    cloned_attributes.pop("id", None)
+    # remove datetime fields
+    cloned_attributes.pop("created_at", None)
+    cloned_attributes.pop("updated_at", None)
     return cloned_attributes
 
 

--- a/src/fides/api/models/privacy_notice.py
+++ b/src/fides/api/models/privacy_notice.py
@@ -530,6 +530,10 @@ class PrivacyNotice(PrivacyNoticeBase, Base):
         # to prevent the dry update from being added to Session.new
         updated_attributes.pop("translations", [])
         updated_attributes.pop("children", [])
+        # The source PrivacyNotice may have cached/computed attributes (e.g., @cached_property)
+        # stored on the instance dict. These should not be included in historical payloads.
+        # For example, 'cookies' is cached on the PrivacyNotice instance when accessed.
+        updated_attributes.pop("cookies", None)
 
         # create a new object with the updated attribute data to keep this
         # ORM object (i.e., `self`) pristine
@@ -676,6 +680,10 @@ def create_historical_record_for_notice_and_translation(
     history_data: dict = create_historical_data_from_record(privacy_notice)
     history_data.pop("translations", None)
     history_data.pop("parent_id", None)
+    # The source PrivacyNotice may have cached/computed attributes (e.g., @cached_property)
+    # stored on the instance dict. These should not be included in historical payloads.
+    # For example, 'cookies' is cached on the PrivacyNotice instance when accessed.
+    history_data.pop("cookies", None)
 
     updated_translation_data: dict = create_historical_data_from_record(
         notice_translation

--- a/src/fides/api/models/privacy_notice.py
+++ b/src/fides/api/models/privacy_notice.py
@@ -676,8 +676,6 @@ def create_historical_record_for_notice_and_translation(
     history_data: dict = create_historical_data_from_record(privacy_notice)
     history_data.pop("translations", None)
     history_data.pop("parent_id", None)
-    # Drop cached/computed attributes that are not mapped on the history model
-    history_data.pop("cookies", None)
 
     updated_translation_data: dict = create_historical_data_from_record(
         notice_translation

--- a/src/fides/api/models/privacy_notice.py
+++ b/src/fides/api/models/privacy_notice.py
@@ -676,6 +676,8 @@ def create_historical_record_for_notice_and_translation(
     history_data: dict = create_historical_data_from_record(privacy_notice)
     history_data.pop("translations", None)
     history_data.pop("parent_id", None)
+    # Drop cached/computed attributes that are not mapped on the history model
+    history_data.pop("cookies", None)
 
     updated_translation_data: dict = create_historical_data_from_record(
         notice_translation


### PR DESCRIPTION
Unticketed

### Description Of Changes

Fixes a crash when creating `PrivacyNoticeHistory` after accessing `PrivacyNotice.cookies`. The `cookies` property on `PrivacyNotice` was [recently updated](https://github.com/ethyca/fides/pull/6593/files#diff-163f9e368e31215ee24ddaed03376f07313bea4488f74387edd0393bd958c334R285) to be a `@cached_property`. This causes cookies to be stored on the instance and included when cloning `__dict__`, which didn't happen before with a normal `@property` annotation. 

Our PrivacyNoticeHistory builder clones the model `__dict__`, so cookies leaked into the payload and caused `TypeError: 'cookies' is an invalid keyword argument for PrivacyNoticeHistory`. 

We now clone only SQLAlchemy-mapped columns instead of copying `__dict__`.

### Code Changes

* `fides/src/fides/api/models/__init__.py`:
Replace `clone_object_attributes` to build dicts via SQLAlchemy inspection (mapper.columns), excluding `id`/`created_at`/`updated_at` as before
*` fides/src/fides/api/models/privacy_notice.py`:
Defensive drop of cookies from `history_data` during history creation.
* `fides/tests/ops/models/test_privacy_notice.py`:
New test `test_history_excludes_cached_properties` that accesses privacy_notice.cookies, triggers history creation, and asserts no cookies attribute on the history.

### Steps to Confirm

1.  Confirm tests pass

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
