### PR TITLE
Track expanded state between renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed some toast notifications in Action Center to truncate long asset and system names [#6692](https://github.com/ethyca/fides/pull/6692)
 - Fixed an issue where columns were inconsistent in the Integrations' Monitor table [#6682](https://github.com/ethyca/fides/pull/6682)
 - Fixed custom fields on the system data use form being nonfunctional [#6657](https://github.com/ethyca/fides/pull/6657)
+- Fixed expanded categories of consent table cells auto-collapsing in Action Center when adding new values [#6690](https://github.com/ethyca/fides/pull/6690)
 
 ## [2.71.1](https://github.com/ethyca/fides/compare/2.71.0...2.71.1)
 

--- a/clients/admin-ui/src/features/common/table/cells/TagExpandableCell.tsx
+++ b/clients/admin-ui/src/features/common/table/cells/TagExpandableCell.tsx
@@ -22,6 +22,7 @@ type TagExpandableCellValues = {
 export interface TagExpandableCellProps extends Omit<FlexProps, "children"> {
   values: TagExpandableCellValues | undefined;
   columnState?: ColumnState;
+  onStateChange?: (isExpanded: boolean) => void;
   onTagClose?: (key: string) => void;
   tagProps?: TagProps;
 }
@@ -38,6 +39,7 @@ export const TagExpandableCell = ({
   columnState,
   tagProps,
   onTagClose,
+  onStateChange,
   ...props
 }: TagExpandableCellProps) => {
   const { isExpanded, isWrapped, version } = columnState || {};
@@ -67,17 +69,26 @@ export const TagExpandableCell = ({
     } else {
       setDisplayValues(values);
     }
-  }, [isCollapsed, values]);
+  }, [isCollapsed, values, onStateChange]);
+
+  useEffect(() => {
+    if (values?.length && values.length <= displayThreshold && !isCollapsed) {
+      setIsCollapsed(true);
+      onStateChange?.(false);
+    }
+  }, [values, onStateChange, isCollapsed]);
 
   const handleCollapse = useCallback(() => {
     // if we don't also set displayValues here, there's a UI glitch where the tags stop wrapping before they become collapsed which in turn can cause the table to scroll.
     setDisplayValues(values?.slice(0, displayThreshold));
     setIsCollapsed(true);
-  }, [values]);
+    onStateChange?.(false);
+  }, [values, onStateChange]);
 
   const handleExpand = useCallback(() => {
     setIsCollapsed(false);
-  }, []);
+    onStateChange?.(true);
+  }, [onStateChange]);
 
   const handleToggle = useCallback(() => {
     if (isCollapsed) {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetDataUseCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetDataUseCell.tsx
@@ -1,6 +1,6 @@
 import { AntSpace as Space, AntTag as Tag } from "fidesui";
 import { truncate } from "lodash";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { getErrorMessage } from "~/features/common/helpers";
 import { useAlert } from "~/features/common/hooks";
@@ -25,6 +25,9 @@ const DiscoveredAssetDataUseCell = ({
   onChange?: (dataUses: string[]) => void;
 }) => {
   const [isAdding, setIsAdding] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(
+    columnState?.isExpanded || false,
+  );
 
   const [updateAssetsDataUseMutation] = useUpdateAssetsDataUseMutation();
   const { successAlert, errorAlert } = useAlert();
@@ -70,6 +73,10 @@ const DiscoveredAssetDataUseCell = ({
     }
   };
 
+  useEffect(() => {
+    setIsExpanded(columnState?.isExpanded || false);
+  }, [columnState?.isExpanded]);
+
   if (readonly) {
     return (
       <TagExpandableCell
@@ -78,6 +85,7 @@ const DiscoveredAssetDataUseCell = ({
           key: d,
         }))}
         columnState={columnState}
+        onStateChange={setIsExpanded}
       />
     );
   }
@@ -97,9 +105,10 @@ const DiscoveredAssetDataUseCell = ({
               label: getDataUseDisplayName(d),
               key: d,
             }))}
-            columnState={columnState}
+            columnState={{ ...columnState, isExpanded }}
             tagProps={{ closable: true, closeButtonLabel: "Remove data use" }}
             onTagClose={handleDeleteDataUse}
+            onStateChange={setIsExpanded}
           />
         </Space>
       )}


### PR DESCRIPTION
Closes [ENG-1319]

### Description Of Changes

Fixed an issue where expanded table cells would automatically collapse when the parent component rerenders. Also added auto-collapse logic for cells with fewer items than the display threshold.

### Code Changes

* Added `onStateChange` callback prop to `TagExpandableCell` to notify parent components of expansion state changes
* Lifted `isExpanded` state to `DiscoveredAssetDataUseCell` to persist across component rerenders
* Added separate `useEffect` in `TagExpandableCell` to auto-collapse cells when values are below the display threshold
* Updated `handleCollapse` and `handleExpand` callbacks to invoke `onStateChange` with the new state
* Synchronized parent `isExpanded` state with `columnState?.isExpanded` via `useEffect`
* Passed lifted `isExpanded` state to `TagExpandableCell` in editable mode

### Steps to Confirm

1. Enable "Web Monitor" beta flag in https://fides-plus-nightly-git-gill-eng-1319expanded-cell-cac04a-ethyca.vercel.app/settings/about
2. Navigate to the Action Center discovered assets table
3. Expand a cell with more than 2 consent categories
4. Click the [+] button to add a new consent category in that same cell
5. Add a new category or close by hitting escape key
6. Verify the expanded cell remains expanded (does not auto-collapse)
7. Remove all but 2 categories from the cell
8. Verify the cell auto-collapses (now in a row instead of stacked, and no expand/collapse button)

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1319]: https://ethyca.atlassian.net/browse/ENG-1319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ