### PR TITLE
Handle long cookie or system names in toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fix compliance issue warning button showing when you don't have the Consent status featured flag enabled [#6677](https://github.com/ethyca/fides/pull/6677)
 - Fixed an issue where updating an Experience in Admin UI could potentially result in a browser error [#6676](https://github.com/ethyca/fides/pull/6676)
 - Fixed a bug that prevented users from removing categories of consent from web monitor resources [#6679](https://github.com/ethyca/fides/pull/6679)
+- Fixed some toast notifications in Action Center to truncate long asset and system names [#6692](https://github.com/ethyca/fides/pull/6692)
 
 ## [2.71.0](https://github.com/ethyca/fides/compare/2.70.5...2.71.0)
 

--- a/clients/admin-ui/cypress/e2e/action-center/assets-results.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/assets-results.cy.ts
@@ -743,7 +743,7 @@ describe("Action center Asset Results", () => {
 
     it("should allow adding categories of consent to assets", () => {
       cy.getAntTableRow(rowUrns[0]).within(() => {
-        cy.getByTestId("taxonomy-add-btn").click();
+        cy.getByTestId("taxonomy-add-btn").click({ force: true });
       });
       cy.getByTestId("taxonomy-select").antSelect("analytics");
       cy.wait("@patchAssets").then((interception) => {
@@ -806,7 +806,7 @@ describe("Action center Asset Results", () => {
       });
       cy.getByTestId("success-alert").should(
         "contain",
-        'Consent category removed from Browser request "697301175"',
+        'Consent category removed from Browser request "697301175_with_a_really_long_name_that_should_b..."',
       );
     });
   });

--- a/clients/admin-ui/cypress/fixtures/detection-discovery/activity-center/system-asset-results-with-consent.json
+++ b/clients/admin-ui/cypress/fixtures/detection-discovery/activity-center/system-asset-results-with-consent.json
@@ -127,7 +127,7 @@
         "marketing.advertising.first_party.targeted"
       ],
       "system_key": "system_key-8fe42cdb-af2e-4b9e-9b38-f75673180b88",
-      "name": "697301175",
+      "name": "697301175_with_a_really_long_name_that_should_be_truncated",
       "description": null,
       "monitor_config_id": "my_web_monitor_1",
       "updated_at": "2025-01-16T17:27:31.499796Z",

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetActionsCell.tsx
@@ -5,6 +5,7 @@ import {
   Icons,
   useToast,
 } from "fidesui";
+import { truncate } from "lodash";
 import { useRouter } from "next/router";
 
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
@@ -64,6 +65,8 @@ export const DiscoveredAssetActionsCell = ({
     consent_aggregated: consentAggregated,
   } = asset;
 
+  const truncatedAssetName = truncate(name || "", { length: 50 });
+
   // Check if the consent status is an error type
   const isErrorStatus = consentAggregated
     ? DiscoveryErrorStatuses.includes(consentAggregated)
@@ -81,7 +84,7 @@ export const DiscoveredAssetActionsCell = ({
       toast(
         successToastParams(
           SuccessToastContent(
-            `${type} "${name}" has been added to the system inventory.`,
+            `${type} "${truncatedAssetName}" has been added to the system inventory.`,
             systemToLink ? () => router.push(href) : undefined,
           ),
         ),
@@ -99,7 +102,7 @@ export const DiscoveredAssetActionsCell = ({
       toast(
         successToastParams(
           SuccessToastContent(
-            `${type} "${name}" has been ignored and will not appear in future scans.`,
+            `${type} "${truncatedAssetName}" has been ignored and will not appear in future scans.`,
             async () => {
               await onTabChange(ActionCenterTabHash.IGNORED);
             },
@@ -118,7 +121,7 @@ export const DiscoveredAssetActionsCell = ({
     } else {
       toast(
         successToastParams(
-          `${type} "${name}" is no longer ignored and will appear in future scans.`,
+          `${type} "${truncatedAssetName}" is no longer ignored and will appear in future scans.`,
         ),
       );
     }

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetDataUseCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetDataUseCell.tsx
@@ -1,4 +1,5 @@
 import { AntSpace as Space, AntTag as Tag } from "fidesui";
+import { truncate } from "lodash";
 import { useState } from "react";
 
 import { getErrorMessage } from "~/features/common/helpers";
@@ -32,6 +33,8 @@ const DiscoveredAssetDataUseCell = ({
 
   const currentDataUses = asset.preferred_data_uses || [];
 
+  const truncatedAssetName = truncate(asset.name || "", { length: 50 });
+
   const handleAddDataUse = async (newDataUse: string) => {
     const result = await updateAssetsDataUseMutation({
       monitorId: asset.monitor_config_id!,
@@ -42,7 +45,7 @@ const DiscoveredAssetDataUseCell = ({
       errorAlert(getErrorMessage(result.error));
     } else {
       successAlert(
-        `Consent category added to ${asset.resource_type} "${asset.name}" .`,
+        `Consent category added to ${asset.resource_type} "${truncatedAssetName}".`,
         `Confirmed`,
       );
       onChange?.([...currentDataUses, newDataUse]);
@@ -60,7 +63,7 @@ const DiscoveredAssetDataUseCell = ({
       errorAlert(getErrorMessage(result.error));
     } else {
       successAlert(
-        `Consent category removed from ${asset.resource_type} "${asset.name}".`,
+        `Consent category removed from ${asset.resource_type} "${truncatedAssetName}".`,
         `Confirmed`,
       );
       onChange?.(currentDataUses.filter((use) => use !== useToDelete));

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/SystemCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/SystemCell.tsx
@@ -1,4 +1,5 @@
 import { AntTag as Tag, Icons } from "fidesui";
+import { truncate } from "lodash";
 import { MouseEventHandler, useCallback, useState } from "react";
 
 import { SystemSelect } from "~/features/common/dropdown/SystemSelect";
@@ -30,6 +31,7 @@ export const SystemCell = ({
     user_assigned_system_key: userAssignedSystemKey,
     system_key: systemKey,
   } = aggregateSystem;
+  const truncatedAssetName = truncate(assetName || "", { length: 50 });
   const [isEditing, setIsEditing] = useState(false);
   const [isNewSystemModalOpen, setIsNewSystemModalOpen] = useState(false);
   const [updateResourceCategoryMutation, { isLoading }] =
@@ -55,13 +57,14 @@ export const SystemCell = ({
       monitor_config_id: monitorConfigId,
       user_assigned_system_key: fidesKey,
     });
+    const truncatedNewSystemName = truncate(newSystemName, { length: 50 });
     if (isErrorResult(result)) {
       errorAlert(getErrorMessage(result.error));
     } else {
       successAlert(
         isNewSystem
-          ? `${newSystemName} has been added to your system inventory and the ${assetType} "${assetName}" has been assigned to that system.`
-          : `${assetType} "${assetName}" has been assigned to ${newSystemName}.`,
+          ? `${truncatedNewSystemName} has been added to your system inventory and the ${assetType} "${truncatedAssetName}" has been assigned to that system.`
+          : `${assetType} "${truncatedAssetName}" has been assigned to ${truncatedNewSystemName}.`,
         `Confirmed`,
       );
       onChange?.(fidesKey);

--- a/clients/admin-ui/src/features/system/tabs/system-assets/AssetSystemCell.tsx
+++ b/clients/admin-ui/src/features/system/tabs/system-assets/AssetSystemCell.tsx
@@ -4,6 +4,7 @@ import {
   Icons,
   useDisclosure,
 } from "fidesui";
+import { truncate } from "lodash";
 import { MouseEventHandler, useCallback, useState } from "react";
 
 import { SystemSelect } from "~/features/common/dropdown/SystemSelect";
@@ -44,6 +45,7 @@ const AssetSystemCell = ({
   const confirmationModal = useDisclosure();
 
   const { asset_type: assetType, name: assetName } = asset;
+  const truncatedAssetName = truncate(assetName || "", { length: 50 });
 
   const onAddSystem: MouseEventHandler<HTMLButtonElement> = useCallback((e) => {
     e.preventDefault();
@@ -55,6 +57,7 @@ const AssetSystemCell = ({
       return;
     }
     const { newSystemKey, newSystemName, isNewSystem } = params;
+    const truncatedNewSystemName = truncate(newSystemName, { length: 50 });
     const result = await updateAsset({
       systemKey,
       assets: [{ id: asset.id, system_key: newSystemKey }],
@@ -64,8 +67,8 @@ const AssetSystemCell = ({
     } else {
       successAlert(
         isNewSystem
-          ? `${newSystemName} has been added to your system inventory and the ${assetType} "${assetName}" has been assigned to that system.`
-          : `${assetType} ${assetName} has been assigned to ${newSystemName}`,
+          ? `${truncatedNewSystemName} has been added to your system inventory and the ${assetType} "${truncatedAssetName}" has been assigned to that system.`
+          : `${assetType} "${truncatedAssetName}" has been assigned to ${truncatedNewSystemName}`,
       );
     }
     setIsEditing(false);


### PR DESCRIPTION
Closes [ENG-1445]

### Description Of Changes

Truncated long asset and system names in toast notifications to prevent the dismiss button from being pushed off-screen. Asset and system names are now limited to 50 characters with ellipsis when displayed in success and error toasts throughout the Action Center.

<img width="1304" height="588" alt="CleanShot 2025-10-01 at 17 08 21@2x" src="https://github.com/user-attachments/assets/0c8aaf3c-6f41-463c-a6fd-3275070608d6" />

<img width="1244" height="584" alt="CleanShot 2025-10-01 at 17 10 08@2x" src="https://github.com/user-attachments/assets/9cd677d9-ab08-4809-b2f0-bddea8e370af" />

<img width="1230" height="626" alt="CleanShot 2025-10-01 at 17 12 04@2x" src="https://github.com/user-attachments/assets/0b3e079e-9c48-4558-8b0c-37d48d9d78f2" />

### Code Changes

* Imported `truncate` from lodash in affected cell components
* Truncated asset names to 50 characters in `DiscoveredAssetActionsCell`, `DiscoveredAssetDataUseCell`, and `SystemCell` components
* Truncated both asset and system names to 50 characters in `AssetSystemCell` component
* Updated Cypress test fixture with a long asset name to validate truncation
* Updated Cypress test expectations to match truncated output
* Added `{ force: true }` to Cypress click action for taxonomy add button

### Steps to Confirm

1. Navigate to Action Center with assets that have very long names (50+ characters)
2. Add an asset to inventory and verify the toast message shows a truncated name with ellipsis and the dismiss button is visible
3. Assign a system to an asset and verify both asset and system names are truncated in the toast
4. Add/remove consent categories and verify the toast messages display properly with truncated names

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1445]: https://ethyca.atlassian.net/browse/ENG-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ