### PR TITLE
Break action buttons out from menu in system "Actions" cell

### DIFF
--- a/clients/admin-ui/src/features/system/table/useSystemsTable.tsx
+++ b/clients/admin-ui/src/features/system/table/useSystemsTable.tsx
@@ -1,10 +1,9 @@
 import {
   AntButton as Button,
   AntColumnsType as ColumnsType,
-  AntDropdown as Dropdown,
+  AntFlex as Flex,
   AntMessage as message,
   AntTypography as Typography,
-  Flex,
   Icons,
 } from "fidesui";
 import { uniq } from "lodash";
@@ -327,42 +326,30 @@ const useSystemsTable = () => {
         title: "Actions",
         key: SystemColumnKeys.ACTIONS,
         render: (_: undefined, record: BasicSystemResponseExtended) => (
-          <Flex justify="end">
-            <Dropdown
-              trigger={["click"]}
-              menu={{
-                items: [
-                  {
-                    key: "edit",
-                    label: "Edit",
-                    icon: <Icons.Edit />,
-                    onClick: () =>
-                      router.push(`/systems/configure/${record.fides_key}`),
-                  },
-                  ...(showDeleteOption
-                    ? [
-                        {
-                          key: "delete",
-                          label: "Delete",
-                          icon: <Icons.TrashCan />,
-                          onClick: () => {
-                            setSelectedSystemForDelete(record);
-                            setDeleteModalIsOpen(true);
-                          },
-                        },
-                      ]
-                    : []),
-                ],
-              }}
+          <Flex gap="small">
+            <Button
+              size="small"
+              onClick={() =>
+                router.push(`/systems/configure/${record.fides_key}`)
+              }
+              icon={<Icons.Edit />}
+              data-testid="edit-btn"
             >
+              Edit
+            </Button>
+            {showDeleteOption && (
               <Button
                 size="small"
-                icon={<Icons.OverflowMenuVertical />}
-                aria-label="More actions"
-                type="text"
-                data-testid="system-actions-menu"
-              />
-            </Dropdown>
+                onClick={() => {
+                  setSelectedSystemForDelete(record);
+                  setDeleteModalIsOpen(true);
+                }}
+                icon={<Icons.TrashCan />}
+                data-testid="delete-btn"
+              >
+                Delete
+              </Button>
+            )}
           </Flex>
         ),
         fixed: "right",


### PR DESCRIPTION
Closes ENG-1491

### Description Of Changes

Moves "edit" and "delete" buttons out of overflow menu in system table's action cell.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
