### PR TITLE
Fixing polling status migration

### DIFF
--- a/src/fides/api/alembic/migrations/versions/4bfbeff34611_add_polling_status.py
+++ b/src/fides/api/alembic/migrations/versions/4bfbeff34611_add_polling_status.py
@@ -29,9 +29,9 @@ def downgrade():
     op.execute(
         "UPDATE digest_task_execution SET status = 'paused' WHERE status = 'polling'"
     )
-    op.execute("UPDATE monitor_task SET status = 'paused' WHERE status = 'polling'")
+    op.execute("UPDATE monitortask SET status = 'paused' WHERE status = 'polling'")
     op.execute(
-        "UPDATE monitor_task_execution_log SET status = 'paused' WHERE status = 'polling'"
+        "UPDATE monitortaskexecutionlog SET status = 'paused' WHERE status = 'polling'"
     )
 
     # Recreate the enum without the 'polling' value
@@ -56,11 +56,11 @@ def downgrade():
         "status::text::executionlogstatus"
     )
     op.execute(
-        "ALTER TABLE monitor_task ALTER COLUMN status TYPE executionlogstatus USING "
+        "ALTER TABLE monitortask ALTER COLUMN status TYPE executionlogstatus USING "
         "status::text::executionlogstatus"
     )
     op.execute(
-        "ALTER TABLE monitor_task_execution_log ALTER COLUMN status TYPE executionlogstatus USING "
+        "ALTER TABLE monitortaskexecutionlog ALTER COLUMN status TYPE executionlogstatus USING "
         "status::text::executionlogstatus"
     )
 


### PR DESCRIPTION
### Description Of Changes

Fixing the migration that adds the `polling` ExecutionLogStatus

### Steps to Confirm

1.  Test the downgrade and upgrade

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
