### PR TITLE
fix: diff status mapping

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -46,7 +46,7 @@ const ResourceStatus: Record<
   classification_queued: { label: "Classifying", color: "blue" },
   classification_update: { label: "Classifying", color: "nectar" },
   classification_addition: { label: "In Review", color: "blue" },
-  addition: { label: "In Review", color: "blue" },
+  addition: { label: "Attention Required", color: "blue" },
   muted: { label: "Unmonitored", color: "nectar" },
   removal: { label: "Attention Required", color: "red" },
   removing: { label: "In Review", color: "nectar" },


### PR DESCRIPTION
Closes [<issue>]

### Description Of Changes

Small change to correct the mapping of diff status and the resource status label

### Code Changes

* _list your code changes here_

### Steps to Confirm

1.  _list any manual steps for reviewers to confirm the changes_

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
