### PR TITLE
Website monitor assets default sort

### DIFF
--- a/.github/workflows/cypress_admin-ui.yml
+++ b/.github/workflows/cypress_admin-ui.yml
@@ -32,7 +32,7 @@ jobs:
           import sys, os, json, math, re
 
           # Number of groups to create (adjust based on your needs)
-          NUM_GROUPS = 3
+          NUM_GROUPS = 4
 
           # Get all test files with their test counts
           files = []

--- a/.github/workflows/cypress_admin-ui.yml
+++ b/.github/workflows/cypress_admin-ui.yml
@@ -32,7 +32,7 @@ jobs:
           import sys, os, json, math, re
 
           # Number of groups to create (adjust based on your needs)
-          NUM_GROUPS = 4
+          NUM_GROUPS = 5
 
           # Get all test files with their test counts
           files = []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Changed
 - Bumped `fideslog` dependency to `1.2.14` [#6635](https://github.com/ethyca/fides/pull/6635)
+- Changed default sort order for discovered assets from compliance status to asset name [#6704](https://github.com/ethyca/fides/pull/6704)
 
 ### Fixed
 - Fixed an issue where users were unable to cancel out of the Add New System dialog in Action Center [#6651](https://github.com/ethyca/fides/pull/6651)
@@ -39,6 +40,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed an issue where columns were inconsistent in the Integrations' Monitor table [#6682](https://github.com/ethyca/fides/pull/6682)
 - Fixed custom fields on the system data use form being nonfunctional [#6657](https://github.com/ethyca/fides/pull/6657)
 - Fixed expanded categories of consent table cells auto-collapsing in Action Center when adding new values [#6690](https://github.com/ethyca/fides/pull/6690)
+- Fixed an issue where adding a category of consent moved the item off-page in Action Center [#6704](https://github.com/ethyca/fides/pull/6704)
 
 ## [2.71.1](https://github.com/ethyca/fides/compare/2.71.0...2.71.1)
 

--- a/clients/admin-ui/cypress/e2e/action-center/assets-results.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/assets-results.cy.ts
@@ -81,6 +81,7 @@ describe("Action center Asset Results", () => {
     beforeEach(() => {
       cy.visit(`${ACTION_CENTER_ROUTE}/${webMonitorKey}/${systemId}`);
       cy.wait("@getSystemAssetResults");
+      cy.wait("@getSystemDetails");
       cy.getByTestId("page-breadcrumb").should("contain", systemName); // little hack to make sure the systemName is available before proceeding
     });
     it("should render asset results view", () => {
@@ -389,6 +390,7 @@ describe("Action center Asset Results", () => {
       beforeEach(() => {
         cy.visit(`${ACTION_CENTER_ROUTE}/${webMonitorKey}/${systemId}`);
         cy.wait("@getSystemAssetResults");
+        cy.wait("@getSystemDetails");
         cy.getByTestId("page-breadcrumb").should("contain", systemName);
       });
 

--- a/clients/admin-ui/cypress/support/stubs.ts
+++ b/clients/admin-ui/cypress/support/stubs.ts
@@ -647,6 +647,32 @@ export const stubWebsiteMonitor = () => {
       fixture: "detection-discovery/activity-center/system-aggregate-results",
     },
   ).as("getSystemAggregateResults");
+  cy.intercept(
+    "GET",
+    "/api/v1/plus/discovery-monitor/system-aggregate-results?*resolved_system_id=*&page=1&size=1&search=&diff_status=addition",
+    {
+      items: [
+        {
+          id: "system_key-8fe42cdb-af2e-4b9e-9b38-f75673180b88",
+          name: "Google Tag Manager",
+          system_key: "system_key-8fe42cdb-af2e-4b9e-9b38-f75673180b88",
+          vendor_id: "fds.1046",
+          total_updates: 10,
+          locations: [],
+          data_uses: [],
+          domains: [],
+          consent_status: {
+            status: "alert",
+            message: "One or more assets were detected without consent",
+          },
+        },
+      ],
+      page: 1,
+      size: 1,
+      total: 1,
+      pages: 1,
+    },
+  ).as("getSystemDetails");
   cy.intercept("GET", "/api/v1/plus/discovery-monitor/*/results*", {
     fixture: "detection-discovery/activity-center/system-asset-results",
   }).as("getSystemAssetResults");

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConsentCategorySelect.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConsentCategorySelect.tsx
@@ -10,14 +10,20 @@ import {
 import useTaxonomies from "~/features/common/hooks/useTaxonomies";
 import { CONSENT_CATEGORIES } from "~/features/data-discovery-and-detection/action-center/utils/isConsentCategory";
 
-const ConsentCategorySelect = ({ ...props }: TaxonomySelectProps) => {
+const ConsentCategorySelect = ({
+  selectedTaxonomies,
+  ...props
+}: TaxonomySelectProps) => {
   const { getDataUseDisplayNameProps, getDataUses } = useTaxonomies();
   const dataUses = getDataUses();
-  const consentCategories = dataUses.filter(
+  const filteredDataUses = [...dataUses]
+    .filter((use) => !selectedTaxonomies?.includes(use.fides_key))
+    .sort();
+  const consentCategories = filteredDataUses.filter(
     (use) => use.active && CONSENT_CATEGORIES.includes(use.fides_key),
   );
 
-  const options: TaxonomySelectOption[] = dataUses.map((dataUse) => {
+  const options: TaxonomySelectOption[] = filteredDataUses.map((dataUse) => {
     const { name, primaryName } = getDataUseDisplayNameProps(dataUse.fides_key);
     return {
       value: dataUse.fides_key,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -127,14 +127,23 @@ const actionCenterApi = baseApi.injectEndpoints({
       Page_SystemStagedResourcesAggregateRecord_,
       {
         key: string;
+        resolved_system_id?: string;
         diff_status?: DiffStatus[];
       } & SearchQueryParams &
         PaginationQueryParams
     >({
-      query: ({ key, page = 1, size = 20, search, diff_status }) => ({
+      query: ({
+        key,
+        resolved_system_id,
+        page = 1,
+        size = 20,
+        search,
+        diff_status,
+      }) => ({
         url: `/plus/discovery-monitor/system-aggregate-results`,
         params: {
           monitor_config_id: key,
+          resolved_system_id,
           page,
           size,
           search,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -170,7 +170,7 @@ const actionCenterApi = baseApi.injectEndpoints({
         size = 20,
         search,
         diff_status = [DiffStatus.ADDITION],
-        sort_by = [DiscoveredAssetsColumnKeys.CONSENT_AGGREGATED, "urn"],
+        sort_by = [DiscoveredAssetsColumnKeys.NAME],
         sort_asc = true,
         resource_type,
         data_uses,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsTable.tsx
@@ -122,7 +122,7 @@ export const useDiscoveredAssetsTable = ({
     search: searchQuery,
     sort_by: sortKey
       ? [sortKey] // User selected a column to sort by
-      : [DiscoveredAssetsColumnKeys.CONSENT_AGGREGATED, "urn"], // Default
+      : [DiscoveredAssetsColumnKeys.NAME], // Default,
     sort_asc: sortOrder !== "descend",
     ...activeParams,
     ...columnFilters,
@@ -170,6 +170,8 @@ export const useDiscoveredAssetsTable = ({
       isFetching,
       dataSource: data?.items || [],
       totalRows: data?.total || 0,
+      sortBy: [DiscoveredAssetsColumnKeys.NAME],
+      sortAsc: true,
       customTableProps: {
         locale: {
           emptyText: (

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
@@ -14,6 +14,7 @@ import { useState } from "react";
 
 import { SelectedText } from "~/features/common/table/SelectedText";
 import {
+  ConsentAlertInfo,
   ConsentStatus,
   DiffStatus,
   StagedResourceAPIResponse,
@@ -29,13 +30,13 @@ import { useDiscoveredAssetsTable } from "../hooks/useDiscoveredAssetsTable";
 interface DiscoveredAssetsTableProps {
   monitorId: string;
   systemId: string;
-  onSystemName?: (name: string) => void;
+  consentStatus?: ConsentAlertInfo | null;
 }
 
 export const DiscoveredAssetsTable = ({
   monitorId,
   systemId,
-  onSystemName,
+  consentStatus,
 }: DiscoveredAssetsTableProps) => {
   // Modal state
   const [isAssignSystemModalOpen, setIsAssignSystemModalOpen] =
@@ -98,7 +99,7 @@ export const DiscoveredAssetsTable = ({
   } = useDiscoveredAssetsTable({
     monitorId,
     systemId,
-    onSystemName,
+    consentStatus,
     onShowComplianceIssueDetails: handleShowBreakdown,
   });
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetDataUseCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetDataUseCell.tsx
@@ -34,7 +34,7 @@ const DiscoveredAssetDataUseCell = ({
 
   const { getDataUseDisplayName } = useTaxonomies();
 
-  const currentDataUses = asset.preferred_data_uses || [];
+  const currentDataUses = [...(asset.preferred_data_uses || [])].sort();
 
   const truncatedAssetName = truncate(asset.name || "", { length: 50 });
 
@@ -118,6 +118,7 @@ const DiscoveredAssetDataUseCell = ({
           style={{ backgroundColor: "var(--fides-color-white)" }}
         >
           <ConsentCategorySelect
+            selectedTaxonomies={currentDataUses}
             onSelect={handleAddDataUse}
             onBlur={() => setIsAdding(false)}
             onKeyDown={(key) => {

--- a/clients/admin-ui/src/pages/data-discovery/action-center/[monitorId]/[systemId]/index.tsx
+++ b/clients/admin-ui/src/pages/data-discovery/action-center/[monitorId]/[systemId]/index.tsx
@@ -37,7 +37,7 @@ const MonitorResultAssets: NextPage = () => {
             title:
               systemId === UNCATEGORIZED_SEGMENT
                 ? "Uncategorized assets"
-                : system?.name,
+                : (system?.name ?? systemId),
           },
         ]}
       />

--- a/clients/admin-ui/src/pages/data-discovery/action-center/[monitorId]/[systemId]/index.tsx
+++ b/clients/admin-ui/src/pages/data-discovery/action-center/[monitorId]/[systemId]/index.tsx
@@ -1,6 +1,5 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useState } from "react";
 
 import FixedLayout from "~/features/common/FixedLayout";
 import {
@@ -8,15 +7,24 @@ import {
   UNCATEGORIZED_SEGMENT,
 } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
+import { useGetDiscoveredSystemAggregateQuery } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
 import { DiscoveredAssetsTable } from "~/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable";
+import { DiffStatus } from "~/types/api/models/DiffStatus";
 
 const MonitorResultAssets: NextPage = () => {
   const router = useRouter();
   const monitorId = decodeURIComponent(router.query.monitorId as string);
   const systemId = decodeURIComponent(router.query.systemId as string);
-  const [systemName, setSystemName] = useState(
-    systemId === UNCATEGORIZED_SEGMENT ? "Uncategorized assets" : systemId,
-  );
+
+  const { data: systemResults } = useGetDiscoveredSystemAggregateQuery({
+    key: monitorId,
+    page: 1,
+    size: 1,
+    search: "",
+    diff_status: [DiffStatus.ADDITION],
+    resolved_system_id: systemId,
+  });
+  const system = systemResults?.items[0];
 
   return (
     <FixedLayout title="Action center - Discovered assets">
@@ -29,14 +37,14 @@ const MonitorResultAssets: NextPage = () => {
             title:
               systemId === UNCATEGORIZED_SEGMENT
                 ? "Uncategorized assets"
-                : systemName,
+                : system?.name,
           },
         ]}
       />
       <DiscoveredAssetsTable
         monitorId={monitorId}
         systemId={systemId}
-        onSystemName={setSystemName}
+        consentStatus={system?.consent_status}
       />
     </FixedLayout>
   );


### PR DESCRIPTION
Closes [ENG-1132], [ENG-1519]

### Description Of Changes

Changed the default sort order for discovered assets from "Compliance + URN" to "Asset name". Added support for filtering system aggregate results by `resolved_system_id` which helped improve the consent status handling by passing consent alert information from the system aggregate query to the table component, eliminating local state management and ensuring the compliance column header icon remains visible regardless of pagination.

Enhanced the consent category select dropdown by filtering out already-selected taxonomies and sorting the data uses alphabetically. (ENG-1519)

### Code Changes

* Updated default sort in `getDiscoveredAssetsQuery` from `[CONSENT_AGGREGATED, "urn"]` to `[NAME]`
* Added `resolved_system_id` parameter to `getDiscoveredSystemAggregateQuery` endpoint
* Refactored `useDiscoveredAssetsTable` to accept `consentStatus` prop instead of managing `firstItemConsentStatus` in local state
* Removed `onSystemName` callback and related state updates from the discovered assets table flow
* Updated `DiscoveredAssetsTable` component to accept and pass through `consentStatus` prop
* Modified index page to fetch system aggregate data with `resolved_system_id` filter and pass consent status to table
* Enhanced `ConsentCategorySelect` to filter out `selectedTaxonomies` from the dropdown options
* Added alphabetical sorting to data uses in both `ConsentCategorySelect` and `DiscoveredAssetDataUseCell`

### Steps to Confirm

1. Navigate to the action center and open a specific system's discovered assets page
2. Verify the assets table is sorted by "Asset" name by default (not by compliance status)
3. Add a consent category to an asset: verify it doesn't disappear from the page or get re-ordered and that it no longer appears in the dropdown for that asset.
4. Verify the compliance column header shows the alert icon when applicable
5. Navigate through different pages of results and confirm the alert icon persists in the header
6. Verify the breadcrumb shows the correct System name

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1132]: https://ethyca.atlassian.net/browse/ENG-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-1519]: https://ethyca.atlassian.net/browse/ENG-1519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ