### PR TITLE
feat: classifier field level actions [ENG-1503]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Added Manual Task Digest email templates and dispatch [#6691](https://github.com/ethyca/fides/pull/6691)
 - Event Auditing for Connections And Connection Secrets [#6681](https://github.com/ethyca/fides/pull/6681)
 - Support for detection phase in new classifier screen [#6711](https://github.com/ethyca/fides/pull/6711)
+- Field Level Actions for New Classifier Screen [#6707](https://github.com/ethyca/fides/pull/6707)
 
 ### Changed
 - Bumped `fideslog` dependency to `1.2.14` [#6635](https://github.com/ethyca/fides/pull/6635)

--- a/clients/admin-ui/src/features/common/api.slice.ts
+++ b/clients/admin-ui/src/features/common/api.slice.ts
@@ -82,6 +82,7 @@ export const baseApi = createApi({
     "TCF Purpose Override",
     "OpenID Provider",
     "Taxonomy",
+    "Monitor",
     "Monitor Field Results",
   ],
   endpoints: () => ({}),

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -270,7 +270,7 @@ const actionCenterApi = baseApi.injectEndpoints({
           },
         };
       },
-      invalidatesTags: ["Discovery Monitor Results"],
+      invalidatesTags: ["Discovery Monitor Results", "Monitor Field Results"],
     }),
     restoreMonitorResultAssets: build.mutation<string, { urnList?: string[] }>({
       query: (params) => {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/ClassificationSelect.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/ClassificationSelect.tsx
@@ -1,0 +1,65 @@
+import { AntButton as Button, Icons } from "fidesui";
+import { useState } from "react";
+
+import {
+  TaxonomySelect,
+  TaxonomySelectOption,
+  TaxonomySelectProps,
+} from "~/features/common/dropdown/TaxonomySelect";
+import useTaxonomies from "~/features/common/hooks/useTaxonomies";
+
+const ClassificationSelect = ({ ...props }: TaxonomySelectProps) => {
+  const { getDataUseDisplayNameProps, getDataUses } = useTaxonomies();
+  const dataUses = getDataUses();
+  const [open, setOpen] = useState(false);
+
+  const options: TaxonomySelectOption[] = dataUses.map((dataUse) => {
+    const { name, primaryName } = getDataUseDisplayNameProps(dataUse.fides_key);
+
+    return {
+      value: dataUse.fides_key,
+      label: (
+        <div>
+          <strong>{primaryName || name}</strong>
+          {primaryName && `: ${name}`}
+        </div>
+      ),
+      name,
+      primaryName,
+      description: dataUse.description || "",
+    };
+  });
+
+  return (
+    <TaxonomySelect
+      options={options}
+      prefix={
+        <Button
+          aria-label="Add Data Category"
+          type="text"
+          size="small"
+          icon={<Icons.Add />}
+        />
+      }
+      placeholder=""
+      suffixIcon={null}
+      classNames={{
+        root: "w-full max-w-full overflow-hidden p-0 cursor-pointer",
+      }}
+      variant="borderless"
+      autoFocus={false}
+      maxTagCount="responsive"
+      open={open}
+      onOpenChange={(visible) => setOpen(visible)}
+      onSelect={(value, option) => {
+        if (props.onSelect) {
+          props.onSelect(value, option);
+        }
+        setOpen(false);
+      }}
+      {...props}
+    />
+  );
+};
+
+export default ClassificationSelect;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/discovery-detection.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/discovery-detection.slice.ts
@@ -186,7 +186,7 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
           },
         )}`,
       }),
-      invalidatesTags: ["Discovery Monitor Results"],
+      invalidatesTags: ["Discovery Monitor Results", "Monitor Field Results"],
     }),
     muteResources: build.mutation<any, BulkResourceActionQueryParams>({
       query: ({ staged_resource_urns }) => ({
@@ -206,10 +206,13 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
           { arrayFormat: "none" },
         )}`,
       }),
-      invalidatesTags: ["Discovery Monitor Results"],
+      invalidatesTags: ["Discovery Monitor Results", "Monitor Field Results"],
     }),
     updateResourceCategory: build.mutation<
-      any,
+      Array<{
+        urn: string;
+        data_uses?: string[] | null;
+      }>,
       ChangeResourceCategoryQueryParam
     >({
       query: (params) => ({
@@ -224,7 +227,7 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
         ],
       }),
 
-      invalidatesTags: ["Discovery Monitor Results"],
+      invalidatesTags: ["Discovery Monitor Results", "Monitor Field Results"],
     }),
   }),
 });


### PR DESCRIPTION
Closes [ENG-1503]

### Description Of Changes

Adding field level actions to the new classifier screen.
Actions:
- Add/remove user defined data categories
- Promote resources
- Ignore resource

### Code Changes

### Steps to Confirm

1. Add `datastore_monitor_action_center_enabled = true` to the `[detection_discovery]` section of the `.fides/fides.toml` file in fidesplus
2. Enable the alpha feature flag by going to `/settings/about/alpha` and toggling the option
3. Add a new datastore monitor (can follow the steps in src/fidesplus/api/service/discovery/configurable-test-datastore-monitor.md)
4. Visit the [Action Center Page](http://localhost:3000/data-discovery/action-center)
5. Click on a monitor to navigate to a datastore monitor (eg http://localhost:3000/data-discovery/action-center/Default_Test_Datastore_Monitor)
6. Confirm that you are able to add and remove a data category to a field in the results
7. Confirm that you are able to ignore a field by clicking the ignore button on a field in the results
8. Select one or many fields using the checkbox
9. Confirm that you can select "Promote" from the actions dropdown and that it triggers the promotion for those fields

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1503]: https://ethyca.atlassian.net/browse/ENG-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ