### PR TITLE
Omit renamed/moved files from PR file limit

### DIFF
--- a/.github/workflows/check_pr_size.yml
+++ b/.github/workflows/check_pr_size.yml
@@ -1,9 +1,7 @@
 name: Check PR Size
-
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-
 jobs:
   check-pr-size:
     runs-on: ubuntu-latest
@@ -13,28 +11,45 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const additions = pr.additions;
-            const deletions = pr.deletions;
-            const changedFiles = pr.changed_files;
-            
+
+            // Fetch all files (handles pagination automatically)
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            // Calculate total lines from ALL files (including renamed)
+            const additions = files.reduce((sum, file) => sum + file.additions, 0);
+            const deletions = files.reduce((sum, file) => sum + file.deletions, 0);
             const totalLinesChanged = additions + deletions;
+
+            // Count files excluding renamed ones
+            const nonRenamedFiles = files.filter(file => file.status !== 'renamed');
+            const changedFiles = nonRenamedFiles.length;
+
             const linesLimit = 500;
             const filesLimit = 15;
-            
+
             let failMessage = '';
-            
+
             if (totalLinesChanged > linesLimit) {
               failMessage += `Lines changed: ${totalLinesChanged} (limit: ${linesLimit})\n`;
             }
-            
+
             if (changedFiles > filesLimit) {
               failMessage += `Files changed: ${changedFiles} (limit: ${filesLimit})\n`;
             }
-            
+
             if (failMessage) {
-              failMessage += '\n Please consider splitting this PR into smaller, more focused changes.';
-              
+              const renamedCount = files.length - nonRenamedFiles.length;
+              if (renamedCount > 0) {
+                failMessage += `(${renamedCount} renamed/moved file(s) excluded from file count)\n`;
+              }
+              failMessage += '\nPlease consider splitting this PR into smaller, more focused changes.';
+
               core.setFailed(failMessage);
             } else {
-              console.log(`PR size check passed (${totalLinesChanged} lines, ${changedFiles} files)`);
+              const renamedCount = files.length - nonRenamedFiles.length;
+              console.log(`PR size check passed (${totalLinesChanged} lines, ${changedFiles} files${renamedCount > 0 ? `, ${renamedCount} renamed files excluded from count` : ''})`);
             }


### PR DESCRIPTION
### Description Of Changes

Prevent renamed/moved file from being counted towards the PR file limit. Lines added in renamed/moved files are still counted

### Code Changes

* Updated `Check PR Size` workflow

### Steps to Confirm

1.  Verified on an existing PR https://github.com/ethyca/fides/actions/runs/18477734019/job/52645906442?pr=6733

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
