### PR TITLE
feedback from designer review

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTaskItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTaskItem.tsx
@@ -120,37 +120,32 @@ export const InProgressMonitorTaskItem = ({
         : "Monitor scanning";
     }
     if (task.action_type === MonitorTaskType.PROMOTION) {
-      return task.status === "complete" ? "Promoted" : "Promoting";
+      const verb = task.status === "complete" ? "Confirmed" : "Confirming";
+      return `${verb} ${fieldCount} ${fieldCount === 1 ? "field" : "fields"}`;
     }
     return task.action_type ? task.action_type.replace(/_/g, " ") : "Task";
   })();
 
-  const monitorGroupLabel = (() => {
-    const type = (task.connection_type || "").toString().toUpperCase();
-    if (type.includes("WEBSITE")) {
-      return "Product monitor";
-    }
-    return "Analytics monitor";
-  })();
+  const monitorName = task.monitor_name || "Unknown monitor";
 
   const getStatusColor = (status?: string) => {
     switch (status) {
       case "pending":
-        return "orange";
+        return "default";
       case "in_processing":
         return "processing";
       case "complete":
-        return "green";
+        return "success";
       case "error":
-        return "red";
+        return "error";
       case "paused": // This is the actual enum value for "awaiting_processing"
         return "purple";
       case "retrying":
-        return "orange";
+        return "default";
       case "skipped":
-        return "gray";
+        return "default";
       default:
-        return "gray";
+        return "default";
     }
   };
 
@@ -222,7 +217,7 @@ export const InProgressMonitorTaskItem = ({
         </Col>
         <Col span={4} className="flex items-center justify-end">
           <Text type="secondary" size="sm">
-            {monitorGroupLabel}
+            {monitorName}
           </Text>
         </Col>
         <Col span={3} className="flex items-center justify-end">


### PR DESCRIPTION
Ticket [ENG-1241] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

This is the feedback Jack gave:
1. Monitor names, everything’s listed as “product monitor” or “analytics monitor”. I don’t think we’re grabbing the actual monitor name.
2. In that promotion task we should say “confirming X fields”. Promotion is the BE terminology, Confirming is the new FE term.
3. We need to update the tag colors, we should use bg-error for the red error tag, bg-success for the complete tag, and bg-default for the pending tag. These are all design system colors in our palette.

### Code Changes

* fixes to address all of the issues above

### Steps to Confirm

1. See screenshot, since setting up all the different types of item states may be a challenge
<img width="1133" height="771" alt="Screenshot 2025-10-16 at 5 53 24 PM" src="https://github.com/user-attachments/assets/6e7f00fe-f67b-4dbd-b939-38ec61b1bbd7" />


### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1241]: https://ethyca.atlassian.net/browse/ENG-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ