### PR TITLE
ENG-1241: Add failure reason display to action center error tasks

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTaskItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTaskItem.tsx
@@ -199,15 +199,24 @@ export const InProgressMonitorTaskItem = ({
     <div {...props} className="w-full">
       <Row gutter={12} className="w-full">
         <Col span={14} className="align-middle">
-          <Space align="center" size={8} wrap>
-            {logoSource && <ConnectionTypeLogo data={logoSource} size={24} />}
-            <Title level={5} className="m-0">
-              {taskTitle}
-            </Title>
-            {!isInProgress && (
-              <Tag color={getStatusColor(task.status)}>
-                {formatText(task.status)}
-              </Tag>
+          <Space direction="vertical" size={4}>
+            <Space align="center" size={8} wrap>
+              {logoSource && <ConnectionTypeLogo data={logoSource} size={24} />}
+              <Title level={5} className="m-0">
+                {taskTitle}
+              </Title>
+              {!isInProgress && (
+                <Tag color={getStatusColor(task.status)}>
+                  {formatText(task.status)}
+                </Tag>
+              )}
+            </Space>
+            {task.status === "error" && (
+              <Space className="pl-1">
+                <Text type="secondary" size="sm">
+                  {task.message || "Unknown error"}
+                </Text>
+              </Space>
             )}
           </Space>
         </Col>


### PR DESCRIPTION
Ticket [ENG-1241]

### Description Of Changes

Added failure reason display for error tasks in the Action Center monitor tasks list. The error message now displays as a second line below the task title for failed tasks, with a fallback to 'Unknown error' if no message is available.

### Code Changes

**Frontend (fides):**
* Added failure reason display using nested Space component with vertical direction
* Error message shows below task title for tasks with error status
* Falls back to 'Unknown error' when task.message is null/undefined
* Replaced CustomSpinner with standard AntSpin component per review feedback

**Backend (fidesplus):**
* Added `message` field to `MonitorTaskResponse` schema with `serialization_alias='dismissed_in_activity_view'` to match frontend expectations
* Updated dismiss/undismiss endpoint to include message field in response
* Fixed dismissed task filtering using proper SQLAlchemy `.is_(False)` method
* Added test coverage for message field in both error and non-error scenarios

### Steps to Confirm

1. Navigate to Action Center monitor tasks list
2. Create a task that will fail (or find an existing error task)
3. Verify the error message displays below the task title
4. Verify 'Unknown error' shows when no message is available
5. Test dismiss functionality - dismissed tasks should be hidden by default
6. Check 'Dismissed' filter and apply - dismissed tasks should now appear
7. Uncheck 'Dismissed' filter and apply - dismissed tasks should be hidden again

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-1241]: https://ethyca.atlassian.net/browse/ENG-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ