### PR TITLE
Adding on `merge_group` to Github workflows

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -11,6 +11,7 @@ on:
       - ".github/workflows/frontend_checks.yml"
       - ".github/workflows/cypress_*.yml"
   merge_group:
+    types: [checks_requested]
   push:
     branches:
       - "main"

--- a/.github/workflows/cli_checks.yml
+++ b/.github/workflows/cli_checks.yml
@@ -12,6 +12,7 @@ on:
       - ".vscode/**"
       - ".github/workflows/frontend_checks.yml"
   merge_group:
+    types: [checks_requested]
   push:
     branches:
       - "main"

--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "clients/cypress-e2e/**"
   merge_group:
+    types: [checks_requested]
 
 env:
   CI: true

--- a/.github/workflows/frontend_checks.yml
+++ b/.github/workflows/frontend_checks.yml
@@ -6,6 +6,7 @@ on:
       - "clients/**"
       - ".github/workflows/frontend_checks.yml"
   merge_group:
+    types: [checks_requested]
   push:
     branches:
       - "main"

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -3,6 +3,7 @@ name: Backend Static Code Checks
 on:
   pull_request:
   merge_group:
+    types: [checks_requested]
   push:
     branches:
       - "main"


### PR DESCRIPTION
### Description Of Changes

Adding on `merge_group` to Github workflows so tests and other relevant checks will run for PRs in the merge queue.

### Steps to Confirm

1. Will test after merging these changes to main. We can disable merge queues if it doesn't work as expected.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
