### PR TITLE
feat: bulk actions [ENG-1504]

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -18,10 +18,8 @@ import {
 } from "~/types/api";
 import { BaseStagedResourcesRequest } from "~/types/api/models/BaseStagedResourcesRequest";
 import { ClassifyResourcesResponse } from "~/types/api/models/ClassifyResourcesResponse";
-import { ConfidenceScoreRange } from "~/types/api/models/ConfidenceScoreRange";
 import { DatastoreMonitorResourcesDynamicFilters } from "~/types/api/models/DatastoreMonitorResourcesDynamicFilters";
 import { ExecutionLogStatus } from "~/types/api/models/ExecutionLogStatus";
-import { Page_DatastoreStagedResourceAPIResponse_ } from "~/types/api/models/Page_DatastoreStagedResourceAPIResponse_";
 import { Page_DatastoreStagedResourceTreeAPIResponse_ } from "~/types/api/models/Page_DatastoreStagedResourceTreeAPIResponse_";
 import {
   PaginationQueryParams,
@@ -95,39 +93,6 @@ const actionCenterApi = baseApi.injectEndpoints({
         url: `/plus/discovery-monitor/${monitor_config_id}/tree`,
         params: { staged_resource_urn, include_descendant_details, page, size },
       }),
-    }),
-    getMonitorFields: build.query<
-      Page_DatastoreStagedResourceAPIResponse_,
-      Partial<PaginationQueryParams> & {
-        staged_resource_urn?: Array<string>;
-        monitor_config_id: string;
-        search?: string;
-        diff_status?: Array<DiffStatus>;
-        confidence_score?: Array<ConfidenceScoreRange>;
-        data_category?: Array<string>;
-      }
-    >({
-      query: ({
-        page = 1,
-        size = 20,
-        monitor_config_id,
-        search,
-        diff_status,
-        confidence_score,
-        ...arrayQueryParams
-      }) => {
-        const queryParams = buildArrayQueryParams({
-          ...arrayQueryParams,
-          ...(search ? { search: [search] } : {}),
-          ...(diff_status ? { diff_status } : {}),
-          ...(confidence_score ? { confidence_score } : {}),
-        });
-        return {
-          url: `/plus/discovery-monitor/${monitor_config_id}/fields?${queryParams?.toString()}`,
-          params: { page, size },
-        };
-      },
-      providesTags: ["Monitor Field Results"],
     }),
     getDiscoveredSystemAggregate: build.query<
       Page_SystemStagedResourcesAggregateRecord_,
@@ -535,7 +500,6 @@ export const {
   useUndismissMonitorTaskMutation,
   useGetMonitorTreeQuery,
   useLazyGetMonitorTreeQuery,
-  useGetMonitorFieldsQuery,
   useGetMonitorConfigQuery,
   useGetDatastoreFiltersQuery,
   useClassifyStagedResourcesMutation,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.ts
@@ -1,0 +1,17 @@
+import { FieldActionTypeValue } from "./types";
+
+export const FIELD_ACTION_LABEL: Record<FieldActionTypeValue, string> = {
+  approve: "Approve",
+  "assign-categories": "Assign categories",
+  classify: "Classify",
+  promote: "Confirm",
+  "un-mute": "Un-mute",
+  mute: "Ignore",
+};
+
+export const DROPDOWN_OPTIONS: Readonly<FieldActionTypeValue[]> = [
+  "classify",
+  "approve",
+  "promote",
+  "mute",
+] as const;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldFilters.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldFilters.tsx
@@ -7,16 +7,14 @@ import {
   AntRow as Row,
   AntSpace as Space,
 } from "fidesui";
-import { capitalize } from "lodash";
 
+import { capitalize } from "~/features/common/utils";
 import { useGetDatastoreFiltersQuery } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
 import { DiffStatus } from "~/types/api";
 import { ConfidenceScoreRange } from "~/types/api/models/ConfidenceScoreRange";
 
-import {
-  MAP_DIFF_STATUS_TO_RESOURCE_STATUS_LABEL,
-  ResourceStatusLabel,
-} from "./MonitorFields.const";
+import { MAP_DIFF_STATUS_TO_RESOURCE_STATUS_LABEL } from "./MonitorFields.const";
+import { ResourceStatusLabel } from "./types";
 import { useMonitorFieldsFilters } from "./useFilters";
 
 const ConfidenceScoreRangeValues = Object.values(ConfidenceScoreRange);

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
@@ -1,5 +1,7 @@
 import { DiffStatus } from "~/types/api";
 
+import { ResourceStatusLabel, ResourceStatusLabelColor } from "./types";
+
 export const TREE_PAGE_SIZE = 100;
 export const TREE_NODE_LOAD_MORE_TEXT = "Load more...";
 export const TREE_NODE_LOAD_MORE_KEY_PREFIX = "load_more";
@@ -16,14 +18,6 @@ export const RESOURCE_STATUS = [
   "Confirmed",
   "Removed",
 ] as const;
-
-export type ResourceStatusLabel = (typeof RESOURCE_STATUS)[number];
-export type ResourceStatusLabelColor =
-  | "nectar"
-  | "red"
-  | "orange"
-  | "blue"
-  | "green";
 
 export const MAP_DIFF_STATUS_TO_RESOURCE_STATUS_LABEL: Record<
   DiffStatus,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/monitor-fields.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/monitor-fields.slice.ts
@@ -1,0 +1,90 @@
+import { baseApi } from "~/features/common/api.slice";
+import { buildArrayQueryParams } from "~/features/common/utils";
+import { DiffStatus } from "~/types/api";
+import { ConfidenceScoreRange } from "~/types/api/models/ConfidenceScoreRange";
+import { MonitorActionResponse } from "~/types/api/models/MonitorActionResponse";
+import { Page_DatastoreStagedResourceAPIResponse_ } from "~/types/api/models/Page_DatastoreStagedResourceAPIResponse_";
+import { PaginationQueryParams } from "~/types/query-params";
+
+import { FieldActionTypeValue } from "./types";
+
+interface MonitorFieldQueryParameters {
+  staged_resource_urn?: Array<string>;
+  search?: string;
+  diff_status?: Array<DiffStatus>;
+  confidence_score?: Array<ConfidenceScoreRange>;
+  data_category?: Array<string>;
+}
+
+interface MonitorFieldParameters {
+  path: {
+    monitor_config_id: string;
+  };
+  query: MonitorFieldQueryParameters;
+}
+
+const monitorFieldApi = baseApi.injectEndpoints({
+  endpoints: (build) => ({
+    getMonitorFields: build.query<
+      Page_DatastoreStagedResourceAPIResponse_,
+      MonitorFieldParameters & {
+        query: MonitorFieldQueryParameters & Partial<PaginationQueryParams>;
+      }
+    >({
+      query: ({
+        path: { monitor_config_id },
+        query: {
+          page = 1,
+          size = 20,
+          search,
+          diff_status,
+          confidence_score,
+          ...arrayQueryParams
+        },
+      }) => {
+        const queryParams = buildArrayQueryParams({
+          ...arrayQueryParams,
+          ...(search ? { search: [search] } : {}),
+          ...(diff_status ? { diff_status } : {}),
+          ...(confidence_score ? { confidence_score } : {}),
+        });
+        return {
+          url: `/plus/discovery-monitor/${monitor_config_id}/fields?${queryParams?.toString()}`,
+          params: { page, size },
+        };
+      },
+      providesTags: ["Monitor Field Results"],
+    }),
+    fieldActions: build.mutation<
+      MonitorActionResponse,
+      MonitorFieldParameters & {
+        path: MonitorFieldParameters["path"] & {
+          action_type: FieldActionTypeValue;
+        };
+      }
+    >({
+      query: ({
+        path: { monitor_config_id, action_type },
+        query: { search, diff_status, confidence_score, ...arrayQueryParams },
+        ...body
+      }) => {
+        const queryParams = buildArrayQueryParams({
+          ...arrayQueryParams,
+          ...(search ? { search: [search] } : {}),
+          ...(diff_status ? { diff_status } : {}),
+          ...(confidence_score ? { confidence_score } : {}),
+        });
+
+        return {
+          url: `/plus/discovery-monitor/${monitor_config_id}/fields/${action_type}?${queryParams.toString()}`,
+          method: "POST",
+          body,
+        };
+      },
+      invalidatesTags: ["Monitor Field Results"],
+    }),
+  }),
+});
+
+export const { useFieldActionsMutation, useGetMonitorFieldsQuery } =
+  monitorFieldApi;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -1,5 +1,6 @@
 import {
   AntButton as Button,
+  AntCheckbox as Checkbox,
   AntDropdown as Dropdown,
   AntFlex as Flex,
   AntList as List,
@@ -25,24 +26,25 @@ import { errorToastParams, successToastParams } from "~/features/common/toast";
 import {
   useClassifyStagedResourcesMutation,
   useGetMonitorConfigQuery,
-  useGetMonitorFieldsQuery,
   useIgnoreMonitorResultAssetsMutation,
 } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
-import {
-  usePromoteResourcesMutation,
-  useUpdateResourceCategoryMutation,
-} from "~/features/data-discovery-and-detection/discovery-detection.slice";
+import { useUpdateResourceCategoryMutation } from "~/features/data-discovery-and-detection/discovery-detection.slice";
 import { DiffStatus } from "~/types/api";
 import { isErrorResult } from "~/types/errors";
 
+import { DROPDOWN_OPTIONS, FIELD_ACTION_LABEL } from "./FieldActions.const";
+import {
+  useFieldActionsMutation,
+  useGetMonitorFieldsQuery,
+} from "./monitor-fields.slice";
 import { MonitorFieldFilters } from "./MonitorFieldFilters";
 import renderMonitorFieldListItem from "./MonitorFieldListItem";
 import {
   FIELD_PAGE_SIZE,
   MAP_DIFF_STATUS_TO_RESOURCE_STATUS_LABEL,
-  ResourceStatusLabel,
 } from "./MonitorFields.const";
 import MonitorTree from "./MonitorTree";
+import { FieldActionTypeValue, ResourceStatusLabel } from "./types";
 import { useMonitorFieldsFilters } from "./useFilters";
 
 const intoDiffStatus = (resourceStatusLabel: ResourceStatusLabel) =>
@@ -72,17 +74,22 @@ const ActionCenterFields: NextPage = () => {
   });
   const [selectedNodeKeys, setSelectedNodeKeys] = useState<Key[]>([]);
   const [selectedFields, setSelectedFields] = useState<string[]>([]);
+  const [selectAll, setSelectAll] = useState<boolean>(false);
   const { data: fieldsDataResponse } = useGetMonitorFieldsQuery({
-    monitor_config_id: monitorId,
-    size: pageSize,
-    page: pageIndex,
-    staged_resource_urn: selectedNodeKeys.map((key) => key.toString()),
-    search: search.searchProps.value,
-    diff_status: resourceStatus
-      ? resourceStatus.flatMap(intoDiffStatus)
-      : undefined,
-    confidence_score: confidenceScore || undefined,
-    data_category: dataCategory || undefined,
+    path: {
+      monitor_config_id: monitorId,
+    },
+    query: {
+      size: pageSize,
+      page: pageIndex,
+      staged_resource_urn: selectedNodeKeys.map((key) => key.toString()),
+      search: search.searchProps.value,
+      diff_status: resourceStatus
+        ? resourceStatus.flatMap(intoDiffStatus)
+        : undefined,
+      confidence_score: confidenceScore || undefined,
+      data_category: dataCategory || undefined,
+    },
   });
   const toast = useToast();
   const [classifyStagedResourcesMutation] =
@@ -91,7 +98,7 @@ const ActionCenterFields: NextPage = () => {
   const [ignoreMonitorResultAssetsMutation] =
     useIgnoreMonitorResultAssetsMutation();
   const { errorAlert } = useAlert();
-  const [promoteResources] = usePromoteResourcesMutation();
+  const [bulkAction] = useFieldActionsMutation();
 
   const handleSetDataCategories = async (
     dataCategories: string[],
@@ -118,14 +125,34 @@ const ActionCenterFields: NextPage = () => {
     }
   };
 
-  const handlePromote = async (urns: string[]) => {
-    const mutationResult = await promoteResources({
-      staged_resource_urns: urns,
+  const handleBulkAction = async (actionType: FieldActionTypeValue) => {
+    const mutationResult = await bulkAction({
+      query: {
+        staged_resource_urn: selectedNodeKeys.map((key) => key.toString()),
+        search: search.searchProps.value,
+        diff_status: resourceStatus
+          ? resourceStatus.flatMap(intoDiffStatus)
+          : undefined,
+        confidence_score: confidenceScore || undefined,
+        data_category: dataCategory || undefined,
+      },
+      path: {
+        monitor_config_id: monitorId,
+        action_type: actionType,
+      },
     });
 
     if (isErrorResult(mutationResult)) {
       errorAlert(getErrorMessage(mutationResult.error));
+      return;
     }
+
+    const actionItemCount = mutationResult.data.task_ids?.length ?? 0;
+    toast(
+      successToastParams(
+        `Successful ${FIELD_ACTION_LABEL[actionType]} action for ${actionItemCount} item${actionItemCount !== 1 ? "s" : ""}`,
+      ),
+    );
   };
 
   const handleClassifyStagedResources = async () => {
@@ -143,6 +170,30 @@ const ActionCenterFields: NextPage = () => {
 
     toast(successToastParams(`Classifying initiated`));
   };
+
+  const handleOnSelectAll = (nextSelectAll: boolean) => {
+    setSelectAll(nextSelectAll);
+    setSelectedFields(
+      nextSelectAll && fieldsDataResponse
+        ? fieldsDataResponse.items.map((item) => item.urn)
+        : [],
+    );
+  };
+
+  const handleOnSelect = (key: string, selected?: boolean) => {
+    setSelectAll(false);
+    setSelectedFields(
+      selected
+        ? [...selectedFields, key]
+        : selectedFields.filter((val) => val !== key),
+    );
+  };
+
+  const selectedFieldCount =
+    selectAll && fieldsDataResponse?.total
+      ? fieldsDataResponse?.total
+      : selectedFields.length;
+
   /**
    * @todo: this should be handled on a form/state action level
    */
@@ -227,11 +278,11 @@ const ActionCenterFields: NextPage = () => {
                 <Dropdown
                   menu={{
                     items: [
-                      {
-                        key: "promote",
-                        onClick: () => handlePromote(selectedFields),
-                        label: "Promote",
-                      },
+                      ...DROPDOWN_OPTIONS.map((actionType) => ({
+                        key: actionType,
+                        label: FIELD_ACTION_LABEL[actionType],
+                        onClick: () => handleBulkAction(actionType),
+                      })),
                     ],
                   }}
                   disabled={selectedFields.length <= 0}
@@ -246,6 +297,18 @@ const ActionCenterFields: NextPage = () => {
                 </Dropdown>
               </Flex>
             </Flex>
+            <Flex gap="middle">
+              <Checkbox
+                checked={selectAll}
+                onChange={(e) => handleOnSelectAll(e.target.checked)}
+              />
+              <Text>Select all</Text>
+              {!!selectedFieldCount && (
+                <Text strong>
+                  {selectedFieldCount.toLocaleString()} selected
+                </Text>
+              )}
+            </Flex>
             <List
               dataSource={fieldsDataResponse?.items}
               className="overflow-scroll"
@@ -253,12 +316,7 @@ const ActionCenterFields: NextPage = () => {
                 renderMonitorFieldListItem({
                   ...props,
                   selected: selectedFields.includes(props.urn),
-                  onSelect: (key, selected) =>
-                    selected
-                      ? setSelectedFields([...selectedFields, key])
-                      : setSelectedFields(
-                          selectedFields.filter((val) => val !== key),
-                        ),
+                  onSelect: handleOnSelect,
                   onSetDataCategories: handleSetDataCategories,
                   onIgnore: handleIgnore,
                 })

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/types.d.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/types.d.ts
@@ -1,6 +1,7 @@
 import { AntTreeDataNode as TreeDataNode } from "fidesui";
 
 import { TreeResourceChangeIndicator } from "~/types/api";
+import { FieldActionType } from "~/types/api/models/FieldActionType";
 
 /**
  * Extend TreeDataNode to include the update status from the API response
@@ -11,3 +12,13 @@ export interface CustomTreeDataNode extends TreeDataNode {
   status?: TreeResourceChangeIndicator | null;
   children?: CustomTreeDataNode[];
 }
+
+export type FieldActionTypeValue = `${FieldActionType}`;
+
+export type ResourceStatusLabel = (typeof RESOURCE_STATUS)[number];
+export type ResourceStatusLabelColor =
+  | "nectar"
+  | "red"
+  | "orange"
+  | "blue"
+  | "green";

--- a/clients/admin-ui/src/types/api/models/FieldActionType.ts
+++ b/clients/admin-ui/src/types/api/models/FieldActionType.ts
@@ -1,0 +1,15 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Supported action types for filtered field operations.
+ */
+export enum FieldActionType {
+  CLASSIFY = "classify",
+  APPROVE = "approve",
+  PROMOTE = "promote",
+  MUTE = "mute",
+  UN_MUTE = "un-mute",
+  ASSIGN_CATEGORIES = "assign-categories",
+}

--- a/clients/admin-ui/src/types/api/models/MonitorActionResponse.ts
+++ b/clients/admin-ui/src/types/api/models/MonitorActionResponse.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Generic response model for performing actions on monitor resources
+ */
+export type MonitorActionResponse = {
+  task_ids?: Array<string>;
+};


### PR DESCRIPTION
Ticket [ENG-1504]

### Description Of Changes
Adds bulk action menu items and requests for the upcoming api.
Requires BE changes from https://github.com/ethyca/fidesplus/pull/2660 to be running locally

### Code Changes

- Added new request hook for the bulk actions endpoint
- Updated actions dropdown to include necessary actions
- Updated backend types to included necessary types
- Created new api slice for field related endpoints to reduce clutter
- Moving types to `types.d.ts` file

### Steps to Confirm

#### Alpha classifier steps

1. Run BE with changes from https://github.com/ethyca/fidesplus/pull/2660 locally
2. Add `datastore_monitor_action_center_enabled = true` to the `[detection_discovery]` section of the `.fides/fides.toml` file in fidesplus
3. Enable the alpha feature flag by going to `/settings/about/alpha` and toggling the option
4. Add a new datastore monitor (can follow the steps in src/fidesplus/api/service/discovery/configurable-test-datastore-monitor.md)
5. Visit the [Action Center Page](http://localhost:3000/data-discovery/action-center)
6. Click on a monitor to navigate to a datastore monitor (eg http://localhost:3000/data-discovery/action-center/Default_Test_Datastore_Monitor)

#### Bulk action steps

1. Select multiple fields using the checkboxes
2. Confirm that the `Actions` dropdown is not disabled
3. Attempt to use one of the provided actions
4. Confirm that the new endpoints are being used for these actions
5. Verify that a toast message is given in response (These will primarily be error messages reporting that the backend endpoint is not available yet)

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1504]: https://ethyca.atlassian.net/browse/ENG-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ