### PR TITLE
expect `MonitorTask.dismissed` from BE API

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTaskItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTaskItem.tsx
@@ -53,7 +53,7 @@ export const InProgressMonitorTaskItem = ({
     useRetryMonitorTaskMutation();
   const [dismissMonitorTask, { isLoading: isDismissing }] =
     useDismissMonitorTaskMutation();
-  const isDismissed = Boolean(task.dismissed_in_activity_view);
+  const isDismissed = Boolean(task.dismissed);
   const canRetry =
     task.status === "error" && task.action_type !== MonitorTaskType.DETECTION;
 

--- a/clients/admin-ui/src/types/api/models/MonitorTaskInProgressResponse.ts
+++ b/clients/admin-ui/src/types/api/models/MonitorTaskInProgressResponse.ts
@@ -15,7 +15,7 @@ export type MonitorTaskInProgressResponse = {
   status: string;
   message?: string | null;
   staged_resource_urns?: Array<string> | null;
-  dismissed_in_activity_view?: boolean | null;
+  dismissed?: boolean | null;
   connection_type?: string | null;
   connection_name?: string | null;
   field_count?: number | null;

--- a/clients/admin-ui/src/types/api/models/MonitorTaskResponse.ts
+++ b/clients/admin-ui/src/types/api/models/MonitorTaskResponse.ts
@@ -16,7 +16,7 @@ export type MonitorTaskResponse = {
   status?: string | null;
   celery_id?: string | null;
   staged_resource_urns?: Array<string>;
-  dismissed_in_activity_view?: boolean | null;
+  dismissed?: boolean | null;
   monitor_name?: string | null;
   connection_name?: string | null;
   connection_type?: string | null;


### PR DESCRIPTION
Ticket [ENG-1241] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Done alongside https://github.com/ethyca/fidesplus/pull/2659, switch to expect `dismissed` instead of `dismissed_in_activity_view` (which had stuck around from a previous version of things) from the BE `MonitorTask` API.

### Code Changes

* switch `dismissed_in_activity_view` references to `dismissed`

### Steps to Confirm

1. dismissing errored actions in activity view UI works

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1609]: https://ethyca.atlassian.net/browse/ENG-1609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-1241]: https://ethyca.atlassian.net/browse/ENG-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ