### PR TITLE
refactor: static actions and renaming

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/DetailsDrawerFooter.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/DetailsDrawerFooter.tsx
@@ -12,11 +12,12 @@ export const DetailsDrawerFooter = ({
 }) =>
   !_.isEmpty(actions) ? (
     <Flex gap="small" justify="flex-end">
-      {actions.map(({ callback, label }, index) => (
+      {actions.map(({ callback, label, disabled }, index) => (
         <Button
           onClick={() => callback(itemKey)}
           key={label}
           type={index === actions.length - 1 ? "primary" : "default"}
+          disabled={disabled}
         >
           {label}
         </Button>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/types.d.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/types.d.ts
@@ -7,6 +7,7 @@ import { ReactNode } from "react";
 export type DetailsAction = {
   label: string;
   callback: (itemKey: string) => void;
+  disabled?: boolean;
 };
 
 export type DetailsDrawerProps = DrawerProps & {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.tsx
@@ -10,12 +10,28 @@ export const FIELD_ACTION_LABEL: Record<FieldActionTypeValue, string> = {
   "assign-categories": "Assign categories",
   "promote-removals": "Promote removals",
   "un-approve": "Un-approve",
-  "un-mute": "Un-mute",
+  "un-mute": "Restore",
   approve: "Approve",
   classify: "Classify",
   mute: "Ignore",
   promote: "Confirm",
 };
+
+export const DRAWER_ACTIONS = [
+  FieldActionType.APPROVE,
+  FieldActionType.PROMOTE,
+] as const;
+export const DROPDOWN_ACTIONS = [
+  FieldActionType.CLASSIFY,
+  FieldActionType.APPROVE,
+  FieldActionType.PROMOTE,
+  FieldActionType.MUTE,
+  FieldActionType.UN_MUTE,
+] as const;
+export const LIST_ITEM_ACTIONS = [
+  FieldActionType.CLASSIFY,
+  FieldActionType.PROMOTE,
+] as const;
 
 export const AVAILABLE_ACTIONS = {
   "In Review": [

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -39,8 +39,11 @@ import { FieldActionType } from "~/types/api/models/FieldActionType";
 import { DetailsDrawer } from "./DetailsDrawer";
 import {
   AVAILABLE_ACTIONS,
+  DRAWER_ACTIONS,
+  DROPDOWN_ACTIONS,
   FIELD_ACTION_ICON,
   FIELD_ACTION_LABEL,
+  LIST_ITEM_ACTIONS,
 } from "./FieldActions.const";
 import { useGetMonitorFieldsQuery } from "./monitor-fields.slice";
 import { MonitorFieldFilters } from "./MonitorFieldFilters";
@@ -251,7 +254,7 @@ const ActionCenterFields: NextPage = () => {
                 <Dropdown
                   menu={{
                     items: [
-                      ...Object.values(FieldActionType).map((actionType) => ({
+                      ...DROPDOWN_ACTIONS.map((actionType) => ({
                         key: actionType,
                         label: FIELD_ACTION_LABEL[actionType],
                         disabled: selectAll
@@ -328,26 +331,27 @@ const ActionCenterFields: NextPage = () => {
                       user_assigned_data_categories: values,
                     }),
                   actions: props?.diff_status
-                    ? AVAILABLE_ACTIONS[
-                        DIFF_TO_RESOURCE_STATUS[props.diff_status]
-                      ].flatMap((action) =>
-                        action !== FieldActionType.ASSIGN_CATEGORIES
-                          ? [
-                              <Tooltip
-                                key={action}
-                                title={FIELD_ACTION_LABEL[action]}
-                              >
-                                <Button
-                                  aria-label={FIELD_ACTION_LABEL[action]}
-                                  icon={FIELD_ACTION_ICON[action]}
-                                  onClick={() =>
-                                    fieldActions[action]([props.urn])
-                                  }
-                                />
-                              </Tooltip>,
-                            ]
-                          : [],
-                      )
+                    ? LIST_ITEM_ACTIONS.map((action) => (
+                        <Tooltip
+                          key={action}
+                          title={FIELD_ACTION_LABEL[action]}
+                        >
+                          <Button
+                            aria-label={FIELD_ACTION_LABEL[action]}
+                            icon={FIELD_ACTION_ICON[action]}
+                            onClick={() => fieldActions[action]([props.urn])}
+                            disabled={
+                              props?.diff_status
+                                ? ![
+                                    ...AVAILABLE_ACTIONS[
+                                      DIFF_TO_RESOURCE_STATUS[props.diff_status]
+                                    ],
+                                  ].includes(action)
+                                : true
+                            }
+                          />
+                        </Tooltip>
+                      ))
                     : [],
                 })
               }
@@ -376,22 +380,17 @@ const ActionCenterFields: NextPage = () => {
                 .label
             : null,
         }}
-        actions={
-          resource?.diff_status
-            ? AVAILABLE_ACTIONS[
-                DIFF_TO_RESOURCE_STATUS[resource.diff_status]
-              ].flatMap((action) =>
-                action !== FieldActionType.ASSIGN_CATEGORIES
-                  ? [
-                      {
-                        label: FIELD_ACTION_LABEL[action],
-                        callback: (value) => fieldActions[action]([value]),
-                      },
-                    ]
-                  : [],
-              )
-            : []
-        }
+        actions={DRAWER_ACTIONS.map((action) => ({
+          label: FIELD_ACTION_LABEL[action],
+          callback: (value) => fieldActions[action]([value]),
+          disabled: resource?.diff_status
+            ? ![
+                ...AVAILABLE_ACTIONS[
+                  DIFF_TO_RESOURCE_STATUS[resource.diff_status]
+                ],
+              ].includes(action)
+            : false,
+        }))}
         open={!!detailsUrn}
         onClose={() => setDetailsUrn(undefined)}
       >


### PR DESCRIPTION
### Description Of Changes

- Inline actions are now a static list of `Classify` and `Confirm` that are disabled if not available
- Details drawer actions are now a static list of `Approve` and `Confirm` that are disabled if not available
- `Un-mute` label was renamed to `Restore`

### Code Changes


### Steps to Confirm

1. Go to the new action center list view
2. Confirm that all list items have a `Classify` and `Confirm` action that are appropriately enabled and disabled based on status
3. Confirm that when you open a details drawer for an item, it has  `Approve` and `Confirm` buttons that are appropriately enabled and disabled based on status.
4. Select any list item, hover over the actions dropdown, and confirm that `Restore` is visible and `Un-mute` is not

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
