### PR TITLE
feat: field list loading indicator

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -87,7 +87,7 @@ const ActionCenterFields: NextPage = () => {
     DatastoreStagedResourceAPIResponse[]
   >([]);
   const [selectAll, setSelectAll] = useState<boolean>(false);
-  const { data: fieldsDataResponse } = useGetMonitorFieldsQuery({
+  const { data: fieldsDataResponse, isFetching } = useGetMonitorFieldsQuery({
     path: {
       monitor_config_id: monitorId,
     },
@@ -316,7 +316,8 @@ const ActionCenterFields: NextPage = () => {
             </Flex>
             <List
               dataSource={fieldsDataResponse?.items}
-              className="overflow-scroll"
+              className="h-full overflow-scroll"
+              loading={isFetching}
               renderItem={(props) =>
                 renderMonitorFieldListItem({
                   ...props,


### PR DESCRIPTION
### Description Of Changes

Bothering me that no-results would flash on load and this is a simple fix.
Also makes the list full height to reduce some jumping

### Code Changes

- Added loading indicator when fetching fields
- Added `h-full` class to field list so that it fills the provided area

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
