### PR TITLE
refactor: bulk action select [ENG-1736]

### DIFF
--- a/clients/admin-ui/src/features/common/api.slice.ts
+++ b/clients/admin-ui/src/features/common/api.slice.ts
@@ -86,6 +86,7 @@ export const baseApi = createApi({
     "Monitor",
     "Monitor Field Results",
     "Monitor Field Details",
+    "Allowed Monitor Field Actions",
   ],
   endpoints: () => ({}),
 });

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.tsx
@@ -67,7 +67,7 @@ type MonitorFieldListItemRenderParams = Parameters<
   NonNullable<ListRenderItem>
 >[0] & {
   selected?: boolean;
-  onSelect?: (key: string, selected?: boolean) => void;
+  onSelect?: (key: React.Key, selected: boolean) => void;
   onNavigate?: (key: string) => void;
   onSetDataCategories: (urn: string, dataCategories: string[]) => void;
 };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/monitor-fields.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/monitor-fields.slice.ts
@@ -1,5 +1,7 @@
 import { baseApi } from "~/features/common/api.slice";
 import { buildArrayQueryParams } from "~/features/common/utils";
+import { AllowedActionsResponse } from "~/types/api/models/AllowedActionsResponse";
+import { FilteredFieldActionRequest } from "~/types/api/models/FilteredFieldActionRequest";
 import { MonitorActionResponse } from "~/types/api/models/MonitorActionResponse";
 import { Page_DatastoreStagedResourceAPIResponse_ } from "~/types/api/models/Page_DatastoreStagedResourceAPIResponse_";
 import { PaginationQueryParams } from "~/types/query-params";
@@ -48,6 +50,9 @@ const monitorFieldApi = baseApi.injectEndpoints({
         path: MonitorFieldParameters["path"] & {
           action_type: FieldActionTypeValue;
         };
+        body: {
+          excluded_resource_urns: string[];
+        };
       }
     >({
       query: ({
@@ -70,8 +75,37 @@ const monitorFieldApi = baseApi.injectEndpoints({
       },
       invalidatesTags: ["Monitor Field Results", "Monitor Field Details"],
     }),
+    getAllowedActions: build.query<
+      AllowedActionsResponse,
+      MonitorFieldParameters & {
+        body: FilteredFieldActionRequest;
+      }
+    >({
+      query: ({
+        path: { monitor_config_id },
+        query: { search, diff_status, confidence_score, ...arrayQueryParams },
+        ...body
+      }) => {
+        const queryParams = buildArrayQueryParams({
+          ...arrayQueryParams,
+          ...(search ? { search: [search] } : {}),
+          ...(diff_status ? { diff_status } : {}),
+          ...(confidence_score ? { confidence_score } : {}),
+        });
+
+        return {
+          url: `/plus/discovery-monitor/${monitor_config_id}/fields/allowed-actions?${queryParams.toString()}`,
+          method: "POST",
+          body,
+        };
+      },
+      providesTags: ["Allowed Monitor Field Actions"],
+    }),
   }),
 });
 
-export const { useFieldActionsMutation, useGetMonitorFieldsQuery } =
-  monitorFieldApi;
+export const {
+  useFieldActionsMutation,
+  useGetMonitorFieldsQuery,
+  useLazyGetAllowedActionsQuery,
+} = monitorFieldApi;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -45,7 +45,10 @@ import {
   FIELD_ACTION_LABEL,
   LIST_ITEM_ACTIONS,
 } from "./FieldActions.const";
-import { useGetMonitorFieldsQuery } from "./monitor-fields.slice";
+import {
+  useGetMonitorFieldsQuery,
+  useLazyGetAllowedActionsQuery,
+} from "./monitor-fields.slice";
 import { MonitorFieldFilters } from "./MonitorFieldFilters";
 import renderMonitorFieldListItem from "./MonitorFieldListItem";
 import {
@@ -56,6 +59,7 @@ import {
 } from "./MonitorFields.const";
 import MonitorTree, { MonitorTreeRef } from "./MonitorTree";
 import { useBulkActions } from "./useBulkActions";
+import { extractListItemKeys, useBulkListSelect } from "./useBulkListSelect";
 import { getAvailableActions, useFieldActions } from "./useFieldActions";
 import { useMonitorFieldsFilters } from "./useFilters";
 
@@ -86,18 +90,11 @@ const ActionCenterFields: NextPage = () => {
     monitor_config_id: monitorId,
   });
   const [selectedNodeKeys, setSelectedNodeKeys] = useState<Key[]>([]);
-  const [selectedFieldIds, setSelectedFieldIds] = useState<string[]>([]);
-  const [selectedFields, setSelectedFields] = useState<
-    DatastoreStagedResourceAPIResponse[]
-  >([]);
-  const [selectAll, setSelectAll] = useState<boolean>(false);
-  const { data: fieldsDataResponse, isFetching } = useGetMonitorFieldsQuery({
+  const baseMonitorFilters = {
     path: {
       monitor_config_id: monitorId,
     },
     query: {
-      size: pageSize,
-      page: pageIndex,
       staged_resource_urn: selectedNodeKeys.map((key) => key.toString()),
       search: search.searchProps.value,
       diff_status: resourceStatus
@@ -106,10 +103,24 @@ const ActionCenterFields: NextPage = () => {
       confidence_score: confidenceScore || undefined,
       data_category: dataCategory || undefined,
     },
+  };
+
+  const { data: fieldsDataResponse, isFetching } = useGetMonitorFieldsQuery({
+    ...baseMonitorFilters,
+    query: {
+      ...baseMonitorFilters.query,
+      size: pageSize,
+      page: pageIndex,
+    },
   });
   const [detailsUrn, setDetailsUrn] = useState<string>();
   const [stagedResourceDetailsTrigger, stagedResourceDetailsResult] =
     useLazyGetStagedResourceDetailsQuery();
+
+  const [
+    allowedActionsTrigger,
+    { data: allowedActionsResult, isFetching: isFetchingAllowedActions },
+  ] = useLazyGetAllowedActionsQuery();
   const resource = stagedResourceDetailsResult.data;
   const bulkActions = useBulkActions(monitorId, async (urns: string[]) => {
     await monitorTreeRef.current?.refreshResourcesAndAncestors(urns);
@@ -117,53 +128,65 @@ const ActionCenterFields: NextPage = () => {
   const fieldActions = useFieldActions(monitorId, async (urns: string[]) => {
     await monitorTreeRef.current?.refreshResourcesAndAncestors(urns);
   });
+  const {
+    excludedListItems,
+    indeterminate,
+    isBulkSelect,
+    listSelectMode,
+    resetListSelect,
+    selectedListItems,
+    updateListItems,
+    updateListSelectMode,
+    updateSelectedListItem,
+  } = useBulkListSelect<
+    DatastoreStagedResourceAPIResponse & { itemKey: React.Key }
+  >();
 
   const handleNavigate = async (urn: string) => {
     setDetailsUrn(urn);
   };
 
-  const availableActions = getAvailableActions(
-    selectedFields.flatMap((field) =>
-      field.diff_status ? [DIFF_TO_RESOURCE_STATUS[field.diff_status]] : [],
-    ),
-  );
-
-  const handleOnSelectAll = (nextSelectAll: boolean) => {
-    setSelectAll(nextSelectAll);
-    setSelectedFields(
-      nextSelectAll && fieldsDataResponse ? fieldsDataResponse.items : [],
-    );
-
-    setSelectedFieldIds(
-      nextSelectAll && fieldsDataResponse
-        ? fieldsDataResponse.items.map((item) => item.urn)
-        : [],
-    );
-  };
-
-  const handleOnSelect = (key: string, selected?: boolean) => {
-    setSelectAll(false);
-    const targetField = fieldsDataResponse?.items.find(
-      (item) => item.urn === key,
-    );
-
-    if (selected && targetField) {
-      setSelectedFields([...selectedFields, targetField]);
-    } else {
-      setSelectedFields(selectedFields.filter((val) => val.urn !== key));
+  const onActionDropdownOpenChange = (open: boolean) => {
+    if (open && isBulkSelect) {
+      allowedActionsTrigger({
+        ...baseMonitorFilters,
+        query: {
+          ...baseMonitorFilters.query,
+        },
+        body: {
+          excluded_resource_urns: extractListItemKeys(excludedListItems).map(
+            (itemKey) => itemKey.toString(),
+          ),
+        },
+      });
     }
-
-    setSelectedFieldIds(
-      selected
-        ? [...selectedFieldIds, key]
-        : selectedFieldIds.filter((val) => val !== key),
-    );
   };
 
-  const selectedFieldCount =
-    selectAll && fieldsDataResponse?.total
-      ? fieldsDataResponse?.total
-      : selectedFieldIds.length;
+  const availableActions = isBulkSelect
+    ? allowedActionsResult?.allowed_actions
+    : getAvailableActions(
+        selectedListItems.flatMap((field) =>
+          field.diff_status ? [DIFF_TO_RESOURCE_STATUS[field.diff_status]] : [],
+        ),
+      );
+  const responseCount = fieldsDataResponse?.total ?? 0;
+  const selectedListItemCount =
+    listSelectMode === "exclusive" && fieldsDataResponse?.total
+      ? responseCount - excludedListItems.length
+      : selectedListItems.length;
+
+  useEffect(() => {
+    if (fieldsDataResponse) {
+      updateListItems(
+        fieldsDataResponse.items.map(({ urn, ...rest }) => ({
+          itemKey: urn,
+          urn,
+          ...rest,
+        })),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fieldsDataResponse?.items]);
 
   useEffect(() => {
     if (detailsUrn) {
@@ -171,11 +194,13 @@ const ActionCenterFields: NextPage = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [detailsUrn]);
+
   /**
    * @todo: this should be handled on a form/state action level
    */
   useEffect(() => {
     resetPagination();
+    resetListSelect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     resourceStatus,
@@ -258,68 +283,62 @@ const ActionCenterFields: NextPage = () => {
                   </Button>
                 </Dropdown>
                 <Dropdown
+                  onOpenChange={onActionDropdownOpenChange}
                   menu={{
                     items: [
                       ...DROPDOWN_ACTIONS.map((actionType) => ({
                         key: actionType,
                         label: FIELD_ACTION_LABEL[actionType],
-                        disabled: selectAll
-                          ? false
-                          : !availableActions?.includes(actionType),
+                        disabled:
+                          isFetchingAllowedActions ||
+                          !availableActions?.includes(actionType),
                         onClick: () => {
-                          if (selectAll) {
-                            const callback = bulkActions[actionType];
-
-                            if (callback) {
-                              callback({
-                                path: {
-                                  monitor_config_id: monitorId,
-                                },
-                                query: {
-                                  staged_resource_urn: selectedNodeKeys.map(
-                                    (key) => key.toString(),
-                                  ),
-                                  search: search.searchProps.value,
-                                  diff_status: resourceStatus
-                                    ? resourceStatus.flatMap(intoDiffStatus)
-                                    : undefined,
-                                  confidence_score:
-                                    confidenceScore || undefined,
-                                  data_category: dataCategory || undefined,
-                                },
-                              });
-                            }
+                          if (isBulkSelect) {
+                            bulkActions[actionType](
+                              baseMonitorFilters,
+                              excludedListItems.map((k) =>
+                                k.itemKey.toString(),
+                              ),
+                            );
                           } else {
-                            const callback = fieldActions[actionType];
-                            if (callback) {
-                              callback(selectedFieldIds);
-                            }
+                            fieldActions[actionType](
+                              selectedListItems.map(({ itemKey }) =>
+                                itemKey.toString(),
+                              ),
+                            );
                           }
                         },
                       })),
                     ],
                   }}
-                  disabled={selectedFieldIds.length <= 0}
+                  disabled={selectedListItems.length <= 0}
                 >
                   <Button
                     type="primary"
                     icon={<Icons.ChevronDown />}
                     iconPosition="end"
+                    loading={isFetchingAllowedActions}
                   >
                     Actions
                   </Button>
                 </Dropdown>
               </Flex>
             </Flex>
-            <Flex gap="middle">
+            <Flex gap="middle" align="center">
               <Checkbox
-                checked={selectAll}
-                onChange={(e) => handleOnSelectAll(e.target.checked)}
+                id="select-all"
+                checked={isBulkSelect}
+                indeterminate={indeterminate}
+                onChange={(e) =>
+                  updateListSelectMode(
+                    e.target.checked ? "exclusive" : "inclusive",
+                  )
+                }
               />
-              <Text>Select all</Text>
-              {!!selectedFieldCount && (
+              <label htmlFor="select-all">Select all</label>
+              {!!selectedListItemCount && (
                 <Text strong>
-                  {selectedFieldCount.toLocaleString()} selected
+                  {selectedListItemCount.toLocaleString()} selected
                 </Text>
               )}
             </Flex>
@@ -330,8 +349,10 @@ const ActionCenterFields: NextPage = () => {
               renderItem={(props) =>
                 renderMonitorFieldListItem({
                   ...props,
-                  selected: selectedFieldIds.includes(props.urn),
-                  onSelect: handleOnSelect,
+                  selected: extractListItemKeys(selectedListItems).includes(
+                    props.urn,
+                  ),
+                  onSelect: updateSelectedListItem,
                   onNavigate: handleNavigate,
                   onSetDataCategories: (urn, values) =>
                     fieldActions["assign-categories"]([urn], {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useBulkActions.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useBulkActions.ts
@@ -21,7 +21,10 @@ export const useBulkActions = (
 
   const handleBulkAction =
     (actionType: FieldActionType) =>
-    async (filterParams: MonitorFieldParameters) => {
+    async (
+      filterParams: MonitorFieldParameters,
+      excluded_resource_urns: string[],
+    ) => {
       const mutationResult = await bulkAction({
         query: {
           ...filterParams.query,
@@ -29,6 +32,9 @@ export const useBulkActions = (
         path: {
           monitor_config_id: monitorId,
           action_type: actionType,
+        },
+        body: {
+          excluded_resource_urns,
         },
       });
 
@@ -67,6 +73,10 @@ export const useBulkActions = (
     promote: handleBulkAction(FieldActionType.PROMOTE),
   } satisfies Record<
     FieldActionType,
-    null | ((filterParams: MonitorFieldParameters) => Promise<void> | void)
+    | null
+    | ((
+        filterParams: MonitorFieldParameters,
+        excluded_resource_urns: string[],
+      ) => Promise<void> | void)
   >;
 };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useBulkListSelect.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useBulkListSelect.ts
@@ -1,0 +1,83 @@
+import _ from "lodash";
+import { useState } from "react";
+
+type SelectMode = "inclusive" | "exclusive";
+
+interface ListItem {
+  itemKey: React.Key;
+}
+
+export const extractListItemKeys = <T extends ListItem>(data: Array<T>) =>
+  data.map(({ itemKey }) => itemKey);
+
+export const useBulkListSelect = <T extends ListItem>() => {
+  const [mode, setMode] = useState<SelectMode>("inclusive");
+  /** list of items currently in view */
+  const [listItems, setListItemsState] = useState<Array<T>>([]);
+  /**
+   * Delta between selected vs non-selected elements
+   * includes selected elements when in inclusive mode
+   * will be deselected elements when in exclusive mode
+   */
+  const [delta, setDeltaState] = useState<Array<T>>([]);
+
+  const setDelta = (newDelta: Array<T>) => {
+    setDeltaState(_.uniqBy(newDelta, "itemKey"));
+  };
+
+  const updateSelectedListItem = (itemKey: React.Key, isSelected: boolean) => {
+    const updatedItem = listItems.find((item) => itemKey === item.itemKey);
+
+    if (updatedItem) {
+      const updateMode: "add" | "remove" = (
+        mode === "inclusive" ? isSelected : !isSelected
+      )
+        ? "add"
+        : "remove";
+
+      switch (updateMode) {
+        case "add":
+          setDelta([...delta, updatedItem]);
+          break;
+        default:
+          setDelta(delta.filter((item) => item.itemKey !== itemKey));
+      }
+    }
+  };
+
+  const updateListSelectMode = (newMode: SelectMode) => {
+    setMode(newMode);
+    setDeltaState([]);
+  };
+
+  const resetListSelect = () => {
+    setDeltaState([]);
+    setMode("inclusive");
+  };
+
+  const inverseDelta = listItems.filter(
+    ({ itemKey }) => !delta.find((d) => d.itemKey === itemKey),
+  );
+  const selectedListItems = mode === "inclusive" ? delta : inverseDelta;
+  const excludedListItems = mode === "exclusive" ? delta : inverseDelta;
+
+  return {
+    excludedListItems,
+    indeterminate:
+      mode === "inclusive"
+        ? selectedListItems.length > 0 &&
+          listItems.length !== selectedListItems.length
+        : excludedListItems.length > 0,
+    isBulkSelect:
+      mode === "inclusive"
+        ? selectedListItems.length > 0 &&
+          listItems.length === selectedListItems.length
+        : excludedListItems.length === 0,
+    listSelectMode: mode,
+    resetListSelect,
+    selectedListItems,
+    updateListItems: setListItemsState,
+    updateListSelectMode,
+    updateSelectedListItem,
+  };
+};

--- a/clients/admin-ui/src/types/api/models/AllowedActionsResponse.ts
+++ b/clients/admin-ui/src/types/api/models/AllowedActionsResponse.ts
@@ -1,0 +1,14 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { FieldActionType } from "./FieldActionType";
+
+/**
+ * Response for the allowed actions endpoint with strongly-typed action types.
+ */
+export type AllowedActionsResponse = {
+  allowed_actions: Array<FieldActionType>;
+  diff_statuses_with_counts: Record<string, number>;
+  field_count: number;
+};

--- a/clients/admin-ui/src/types/api/models/FilteredFieldActionRequest.ts
+++ b/clients/admin-ui/src/types/api/models/FilteredFieldActionRequest.ts
@@ -1,0 +1,13 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Request model for performing actions on filtered fields with optional exclusions
+ */
+export type FilteredFieldActionRequest = {
+  /**
+   * List of resource URNs to exclude from the action
+   */
+  excluded_resource_urns?: Array<string>;
+};


### PR DESCRIPTION
Ticket [ENG-1736]

### Description Of Changes

Fixing the UX interactions for bulk actions to properly handle multi-page selections and bulk deselections.
Adds enabling/disabling of actions for bulk actions based on BE response.

### Code Changes

* Adds a `useBulkListSelect` to handle selectable list logic where bulk actions are available
* Adds request hook for getting allowed actions from the BE
* Adds excluded urns to bulk action requests
* Updates generated types for BE requests

### Steps to Confirm

##### Multi-select
1. Go to the new monitor field result screen
2. Select multiple individual fields
3. Navigate to a different page
4. Select another field
5. Confirm that the correct number of fields are selected
6. Navigate back to the previous page
7. Confirm that the number of selected fields is still correct
8. Confirm that the correct actions are available based on the status of the selected items
9. Confirm that when actions are selected, that the correct endpoint for multiple resources is called
10. Change a search filter parameter
11. Confirm that the selected items are reset

##### Bulk-Select
1. Go to the new monitor field result screen
2. Click the `Select All` checkbox
3. Deselect multiple fields
4. Confirm that the number of fields updates correctly
5. Navigate to a different page
6 Deselect another field
7. Confirm that the correct number of fields are selected
8. Navigate back to the previous page
9. Confirm that the number of selected fields is still correct
12. Open the actions dropdown and confirm that the correct actions are available based on the result of the backend response
13. Confirm that when actions are selected, that the correct endpoint for bulk actions is called with the correct excluded resource values.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1736]: https://ethyca.atlassian.net/browse/ENG-1736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ