### PR TITLE
fix: switch approve route to post not patch

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/discovery-detection.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/discovery-detection.slice.ts
@@ -251,7 +251,7 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
       }
     >({
       query: ({ staged_resource_urns, monitor_config_key }) => ({
-        method: "PATCH",
+        method: "POST",
         url: `/plus/discovery-monitor/${monitor_config_key}/approve`,
         body: {
           staged_resource_urns,


### PR DESCRIPTION
### Description Of Changes

We had a small FE bug where we were sending a `PATCH` to the `/api/v1/plus/discovery-monitor/{monitor_config_key}/approve` endpoint. this resulted in a `405` from the BE; the endpoint is a `POST` route.

### Code Changes

* switch `PATCH` to `POST`

### Steps to Confirm

1. confirmed locally that i'm now able to approve a resource by hitting the 'approve' button on the row, or by multi-selecting and hitting the 'approve' action button

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
