### PR TITLE
feat: promoting status support

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.tsx
@@ -7,14 +7,14 @@ import { ResourceStatusLabel } from "./MonitorFields.const";
 import { FieldActionTypeValue } from "./types";
 
 export const FIELD_ACTION_LABEL: Record<FieldActionTypeValue, string> = {
-  "assign-categories": "Assign categories",
-  "promote-removals": "Promote removals",
-  "un-approve": "Un-approve",
-  "un-mute": "Restore",
   approve: "Approve",
+  "assign-categories": "Assign categories",
   classify: "Classify",
   mute: "Ignore",
   promote: "Confirm",
+  "promote-removals": "Promote removals",
+  "un-approve": "Un-approve",
+  "un-mute": "Restore",
 };
 
 export const DRAWER_ACTIONS = [
@@ -45,6 +45,7 @@ export const AVAILABLE_ACTIONS = {
   Ignored: [FieldActionType.UN_MUTE],
   Removed: [],
   Unlabeled: [FieldActionType.ASSIGN_CATEGORIES, FieldActionType.CLASSIFY],
+  Confirming: [],
 } as const satisfies Readonly<
   Record<ResourceStatusLabel, Readonly<Array<FieldActionType>>>
 >;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
@@ -17,6 +17,7 @@ export const RESOURCE_STATUS = [
   "In Review",
   "Removed",
   "Unlabeled",
+  "Confirming",
 ] as const;
 
 export type ResourceStatusLabel = (typeof RESOURCE_STATUS)[number];
@@ -31,7 +32,7 @@ export const DIFF_TO_RESOURCE_STATUS: Record<DiffStatus, ResourceStatusLabel> =
     classifying: "Classifying",
     monitored: "Confirmed",
     muted: "Ignored",
-    promoting: "In Review",
+    promoting: "Confirming",
     removal: "Removed",
     removing: "In Review",
   } as const;
@@ -57,7 +58,7 @@ export const MAP_DIFF_STATUS_TO_RESOURCE_STATUS_LABEL: Record<
   classifying: { label: "Classifying", color: CUSTOM_TAG_COLOR.INFO },
   monitored: { label: "Confirmed", color: CUSTOM_TAG_COLOR.MINOS },
   muted: { label: "Ignored", color: CUSTOM_TAG_COLOR.DEFAULT },
-  promoting: { label: "In Review", color: CUSTOM_TAG_COLOR.CAUTION },
+  promoting: { label: "Confirming", color: CUSTOM_TAG_COLOR.CAUTION },
   removal: { label: "Removed", color: CUSTOM_TAG_COLOR.ERROR },
   removing: { label: "In Review", color: CUSTOM_TAG_COLOR.CAUTION },
 } as const;


### PR DESCRIPTION
### Description Of Changes

Adding "Promoting" as a status in the FE

### Code Changes

Adding "Promoting" as a resource status and mapping to the "promoting" diff status returned from the BE

### Steps to Confirm

1. Go to the new classifier screen
2. Click confirm button on a field
3. Validate that the status changes to "Promoting" instead of "In Review"

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
