### PR TITLE
Restore isConsent to LI

### DIFF
--- a/clients/fides-js/src/components/tcf/TcfVendors.tsx
+++ b/clients/fides-js/src/components/tcf/TcfVendors.tsx
@@ -273,9 +273,7 @@ const PagedVendorData = ({
     () => ({
       nonGVLVendors: activeChunk?.filter((v) => !v.isGvl),
       consentGvlVendors: activeChunk?.filter((v) => v.isGvl && v.isConsent),
-      legintGvlVendors: activeChunk?.filter(
-        (v) => v.isGvl && v.isLegint && !v.isConsent,
-      ),
+      legintGvlVendors: activeChunk?.filter((v) => v.isGvl && v.isLegint),
       specialPurposeGvlVendors: activeChunk?.filter(
         (v) => v.isGvl && v.isSpecial && !v.isLegint,
       ),


### PR DESCRIPTION
The previous filter in PR https://github.com/ethyca/fides/pull/6830 incorrectly excluded such dual-purpose vendors from the legitimate interests tab, which this PR corrects.