### PR TITLE
feat: bulk action confirmation modals and messages [ENG-1646, ENG-1670]

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.tsx
@@ -1,3 +1,4 @@
+import type { ModalFuncProps } from "antd/es/modal";
 import { Icons, SparkleIcon } from "fidesui";
 import { ReactNode } from "react";
 
@@ -15,6 +16,29 @@ export const FIELD_ACTION_LABEL: Record<FieldActionTypeValue, string> = {
   "promote-removals": "Promote removals",
   "un-approve": "Un-approve",
   "un-mute": "Restore",
+};
+
+/** TODO: fix all */
+export const FIELD_ACTION_INTERMEDIATE: Record<FieldActionTypeValue, string> = {
+  approve: "Approving",
+  "assign-categories": "Adding data categories",
+  classify: "Classifying",
+  mute: "Ignoring",
+  promote: "Confirming",
+  "promote-removals": "Promoting removals",
+  "un-approve": "Un-approving",
+  "un-mute": "Restoring",
+};
+
+export const FIELD_ACTION_COMPLETED: Record<FieldActionTypeValue, string> = {
+  approve: "Approved",
+  "assign-categories": "Data category added",
+  classify: "Classified",
+  mute: "Ignored",
+  promote: "Confirmed",
+  "promote-removals": "Promoted removals",
+  "un-approve": "Un-approved",
+  "un-mute": "Restored",
 };
 
 export const DRAWER_ACTIONS = [
@@ -61,3 +85,32 @@ export const FIELD_ACTION_ICON = {
   mute: <Icons.ViewOff />,
   promote: <Icons.Checkmark />,
 } as const satisfies Readonly<Record<FieldActionType, ReactNode>>;
+
+export const FIELD_ACTION_CONFIRMATION_MESSAGE = {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  "assign-categories": (_targetItemCount: number) => null,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  "promote-removals": (_targetItemCount: number) => null,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  "un-approve": (_targetItemCount: number) => null,
+  "un-mute": (targetItemCount: number) =>
+    `Are you sure you want to restore ${targetItemCount.toLocaleString()} resources?`,
+  approve: (targetItemCount: number) =>
+    `Are you sure you want to approve ${targetItemCount.toLocaleString()} resources?`,
+  classify: (targetItemCount: number) =>
+    `Are you sure you want to run the classifier and apply data categories to ${targetItemCount.toLocaleString()} unlabeled resources?`,
+  mute: (targetItemCount: number) =>
+    `Are you sure you want to ignore ${targetItemCount.toLocaleString()} resources? After ignoring, these resources may reappear in future scans.`,
+  promote: (targetItemCount: number) =>
+    `Are you sure you want to confirm these ${targetItemCount.toLocaleString()} resources? After confirming this data can be used for policy automation and DSRs. `,
+} as const satisfies Readonly<
+  Record<FieldActionType, (targetItemCount: number) => ReactNode>
+>;
+
+export const DEFAULT_CONFIRMATION_PROPS: ModalFuncProps = {
+  onCancel: async () => false,
+  onOk: async () => true,
+  icon: null,
+  /* TODO: standardize */
+  width: 542,
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -7,6 +7,8 @@ import {
   AntFlex as Flex,
   AntForm as Form,
   AntList as List,
+  AntMessage as message,
+  AntModal as modal,
   AntPagination as Pagination,
   AntSplitter as Splitter,
   AntText as Text,
@@ -75,6 +77,8 @@ const ActionCenterFields: NextPage = () => {
   const router = useRouter();
   const monitorId = decodeURIComponent(router.query.monitorId as string);
   const monitorTreeRef = useRef<MonitorTreeRef>(null);
+  const [messageApi, messageContext] = message.useMessage();
+  const [modalApi, modalContext] = modal.useModal();
   const { paginationProps, pageIndex, pageSize, resetPagination } =
     useAntPagination({
       defaultPageSize: FIELD_PAGE_SIZE,
@@ -122,12 +126,22 @@ const ActionCenterFields: NextPage = () => {
     { data: allowedActionsResult, isFetching: isFetchingAllowedActions },
   ] = useLazyGetAllowedActionsQuery();
   const resource = stagedResourceDetailsResult.data;
-  const bulkActions = useBulkActions(monitorId, async (urns: string[]) => {
-    await monitorTreeRef.current?.refreshResourcesAndAncestors(urns);
-  });
-  const fieldActions = useFieldActions(monitorId, async (urns: string[]) => {
-    await monitorTreeRef.current?.refreshResourcesAndAncestors(urns);
-  });
+  const bulkActions = useBulkActions(
+    monitorId,
+    modalApi,
+    messageApi,
+    async (urns: string[]) => {
+      await monitorTreeRef.current?.refreshResourcesAndAncestors(urns);
+    },
+  );
+  const fieldActions = useFieldActions(
+    monitorId,
+    modalApi,
+    messageApi,
+    async (urns: string[]) => {
+      await monitorTreeRef.current?.refreshResourcesAndAncestors(urns);
+    },
+  );
   const {
     excludedListItems,
     indeterminate,
@@ -299,6 +313,7 @@ const ActionCenterFields: NextPage = () => {
                               excludedListItems.map((k) =>
                                 k.itemKey.toString(),
                               ),
+                              selectedListItemCount,
                             );
                           } else {
                             fieldActions[actionType](
@@ -515,6 +530,8 @@ const ActionCenterFields: NextPage = () => {
           </Flex>
         ) : null}
       </DetailsDrawer>
+      {modalContext}
+      {messageContext}
     </FixedLayout>
   );
 };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useBulkActions.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useBulkActions.tsx
@@ -1,30 +1,56 @@
-import { useToast } from "fidesui";
+import { AntMessage as Message, AntModal as Modal } from "fidesui";
 
-import { getErrorMessage } from "~/features/common/helpers";
-import { useAlert } from "~/features/common/hooks";
-import { successToastParams } from "~/features/common/toast";
+import { pluralize } from "~/features/common/utils";
 import { FieldActionType } from "~/types/api/models/FieldActionType";
 import { isErrorResult } from "~/types/errors";
 
-import { FIELD_ACTION_LABEL } from "./FieldActions.const";
+import {
+  FIELD_ACTION_CONFIRMATION_MESSAGE,
+  FIELD_ACTION_INTERMEDIATE,
+  FIELD_ACTION_LABEL,
+} from "./FieldActions.const";
 import { useFieldActionsMutation } from "./monitor-fields.slice";
 import { MonitorFieldParameters } from "./types";
+import {
+  getActionErrorMessage,
+  getActionModalProps,
+  getActionSuccessMessage,
+} from "./utils";
 
 export const useBulkActions = (
   monitorId: string,
+  modalApi: ReturnType<typeof Modal.useModal>[0],
+  messageApi: ReturnType<typeof Message.useMessage>[0],
   onRefreshTree?: (urns: string[]) => Promise<void>,
 ) => {
   const [bulkAction] = useFieldActionsMutation();
-
-  const toast = useToast();
-  const { errorAlert } = useAlert();
 
   const handleBulkAction =
     (actionType: FieldActionType) =>
     async (
       filterParams: MonitorFieldParameters,
       excluded_resource_urns: string[],
+      targetItemCount: number,
     ) => {
+      const key = Date.now();
+      const confirmed = await modalApi.confirm(
+        getActionModalProps(
+          FIELD_ACTION_LABEL[actionType],
+          FIELD_ACTION_CONFIRMATION_MESSAGE[actionType](targetItemCount),
+        ),
+      );
+
+      if (!confirmed) {
+        return;
+      }
+
+      messageApi.open({
+        key,
+        type: "loading",
+        content: `${FIELD_ACTION_INTERMEDIATE[actionType]} ${targetItemCount} ${pluralize(targetItemCount, "resource", "resources")}...`,
+        duration: 0,
+      });
+
       const mutationResult = await bulkAction({
         query: {
           ...filterParams.query,
@@ -39,16 +65,22 @@ export const useBulkActions = (
       });
 
       if (isErrorResult(mutationResult)) {
-        errorAlert(getErrorMessage(mutationResult.error));
+        messageApi.open({
+          key,
+          type: "error",
+          content: getActionErrorMessage(actionType),
+          duration: 5,
+        });
+
         return;
       }
 
-      const actionItemCount = mutationResult.data.task_ids?.length ?? 0;
-      toast(
-        successToastParams(
-          `Successful ${FIELD_ACTION_LABEL[actionType]} action for ${actionItemCount} item${actionItemCount !== 1 ? "s" : ""}`,
-        ),
-      );
+      messageApi.open({
+        key,
+        type: "success",
+        content: getActionSuccessMessage(actionType, targetItemCount),
+        duration: 5,
+      });
 
       // Refresh the tree to reflect updated status
       // Note: For bulk actions we can't get the specific URNs affected,
@@ -77,6 +109,7 @@ export const useBulkActions = (
     | ((
         filterParams: MonitorFieldParameters,
         excluded_resource_urns: string[],
+        targetItemCount: number,
       ) => Promise<void> | void)
   >;
 };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useFieldActions.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useFieldActions.tsx
@@ -1,9 +1,7 @@
-import { useToast } from "fidesui";
+import { AntMessage as Message, AntModal as Modal } from "fidesui";
 import _ from "lodash";
 
-import { getErrorMessage } from "~/features/common/helpers";
-import { useAlert } from "~/features/common/hooks";
-import { errorToastParams, successToastParams } from "~/features/common/toast";
+import { pluralize } from "~/features/common/utils";
 import { useClassifyStagedResourcesMutation } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
 import {
   useApproveStagedResourcesMutation,
@@ -14,10 +12,20 @@ import {
 } from "~/features/data-discovery-and-detection/discovery-detection.slice";
 import { Field } from "~/types/api";
 import { FieldActionType } from "~/types/api/models/FieldActionType";
-import { isErrorResult } from "~/types/errors";
+import { isErrorResult, RTKResult } from "~/types/errors";
 
-import { AVAILABLE_ACTIONS, FIELD_ACTION_LABEL } from "./FieldActions.const";
+import {
+  AVAILABLE_ACTIONS,
+  FIELD_ACTION_CONFIRMATION_MESSAGE,
+  FIELD_ACTION_INTERMEDIATE,
+  FIELD_ACTION_LABEL,
+} from "./FieldActions.const";
 import { ResourceStatusLabel } from "./MonitorFields.const";
+import {
+  getActionErrorMessage,
+  getActionModalProps,
+  getActionSuccessMessage,
+} from "./utils";
 
 export const getAvailableActions = (statusList: ResourceStatusLabel[]) => {
   const [init, ...availableActions] = statusList.map(
@@ -32,102 +40,97 @@ export const getAvailableActions = (statusList: ResourceStatusLabel[]) => {
 
 export const useFieldActions = (
   monitorId: string,
+  modalApi: ReturnType<typeof Modal.useModal>[0],
+  messageApi: ReturnType<typeof Message.useMessage>[0],
   onRefreshTree?: (urns: string[]) => Promise<void>,
 ) => {
-  const [ignoreMonitorResultAssetsMutation] = useMuteResourcesMutation();
-  const [unMuteMonitorResultAssetsMutation] = useUnmuteResourcesMutation();
-
+  const [approveStagedResourcesMutation] = useApproveStagedResourcesMutation();
   const [classifyStagedResourcesMutation] =
     useClassifyStagedResourcesMutation();
-  const [updateResourcesCategoryMutation] = useUpdateResourceCategoryMutation();
+  const [ignoreMonitorResultAssetsMutation] = useMuteResourcesMutation();
   const [promoteResourcesMutation] = usePromoteResourcesMutation();
-  const [approveStagedResourcesMutation] = useApproveStagedResourcesMutation();
+  const [unMuteMonitorResultAssetsMutation] = useUnmuteResourcesMutation();
+  const [updateResourcesCategoryMutation] = useUpdateResourceCategoryMutation();
 
-  const toast = useToast();
-  const { errorAlert } = useAlert();
+  const handleAction =
+    (
+      actionType: FieldActionType,
+      mutationFn: (
+        urns: string[],
+        field?: Partial<Field>,
+      ) => Promise<RTKResult>,
+    ) =>
+    async (urns: string[], field?: Partial<Field>) => {
+      const key = Date.now();
+      const confirmed =
+        urns.length === 1 ||
+        (await modalApi.confirm(
+          getActionModalProps(
+            FIELD_ACTION_LABEL[actionType],
+            FIELD_ACTION_CONFIRMATION_MESSAGE[actionType](urns.length),
+          ),
+        ));
 
-  const toastSuccess = (actionType: FieldActionType, itemCount: number) =>
-    toast(
-      successToastParams(
-        `Successful ${FIELD_ACTION_LABEL[actionType]} action for ${itemCount} item${itemCount !== 1 ? "s" : ""}`,
-      ),
-    );
+      if (!confirmed) {
+        return;
+      }
+
+      messageApi.open({
+        key,
+        type: "loading",
+        content: `${FIELD_ACTION_INTERMEDIATE[actionType]} ${urns.length} ${pluralize(urns.length, "resource", "resources")}...`,
+        duration: 0,
+      });
+
+      const result = await mutationFn(urns, field);
+
+      if (isErrorResult(result)) {
+        messageApi.open({
+          key,
+          type: "error",
+          content: getActionErrorMessage(actionType),
+          duration: 5,
+        });
+        return;
+      }
+
+      messageApi.open({
+        key,
+        type: "success",
+        content: getActionSuccessMessage(actionType, urns.length),
+        duration: 5,
+      });
+
+      // Refresh the tree to reflect updated status
+      // An indicator may change to empty if there are no child resources that the user is expected to act upon.
+      if (onRefreshTree) {
+        await onRefreshTree(urns);
+      }
+    };
 
   const handleIgnore = async (urns: string[]) => {
-    const mutationResult = await ignoreMonitorResultAssetsMutation({
+    return ignoreMonitorResultAssetsMutation({
       staged_resource_urns: urns,
     });
-
-    if (isErrorResult(mutationResult)) {
-      errorAlert(getErrorMessage(mutationResult.error));
-      return;
-    }
-
-    toastSuccess(FieldActionType.MUTE, urns.length);
-
-    // Refresh the tree to reflect updated status
-    // An indicator may change to empty if there are no child resources that the user is expected to act upon.
-    if (onRefreshTree) {
-      await onRefreshTree(urns);
-    }
   };
 
   const handleUnMute = async (urns: string[]) => {
-    const mutationResult = await unMuteMonitorResultAssetsMutation({
+    return unMuteMonitorResultAssetsMutation({
       staged_resource_urns: urns,
     });
-
-    if (isErrorResult(mutationResult)) {
-      errorAlert(getErrorMessage(mutationResult.error));
-      return;
-    }
-
-    toastSuccess(FieldActionType.UN_MUTE, urns.length);
-
-    // Refresh the tree to reflect updated status
-    // An indicator can change to "addition" or "change" since the user could now act on its unmuted children
-    if (onRefreshTree) {
-      await onRefreshTree(urns);
-    }
   };
 
   const handlePromote = async (urns: string[]) => {
-    const mutationResult = await promoteResourcesMutation({
+    return promoteResourcesMutation({
       staged_resource_urns: urns,
     });
-
-    if (isErrorResult(mutationResult)) {
-      errorAlert(getErrorMessage(mutationResult.error));
-      return;
-    }
-
-    toastSuccess(FieldActionType.PROMOTE, urns.length);
-
-    // Refresh the tree to reflect updated status
-    // An indicator can change to empty if all its children were promoted.
-    if (onRefreshTree) {
-      await onRefreshTree(urns);
-    }
   };
 
   const handleClassifyStagedResources = async (urns: string[]) => {
-    const result = await classifyStagedResourcesMutation({
+    return classifyStagedResourcesMutation({
       monitor_config_key: monitorId,
       staged_resource_urns: urns,
     });
-
-    if (isErrorResult(result)) {
-      toast(errorToastParams(getErrorMessage(result.error)));
-      return;
-    }
-
-    toastSuccess(FieldActionType.CLASSIFY, urns.length);
-
-    // Refresh the tree to reflect updated status
-    // The indicators of the parents of affected children may change to "change" if it was not already in that state.
-    if (onRefreshTree) {
-      await onRefreshTree(urns);
-    }
   };
 
   const handleSetDataCategories = async (
@@ -135,53 +138,36 @@ export const useFieldActions = (
     field?: Partial<Field>,
   ) => {
     const [urn] = urns;
-    const mutationResult = await updateResourcesCategoryMutation({
+    return updateResourcesCategoryMutation({
       monitor_config_id: monitorId,
       staged_resource_urn: urn,
       user_assigned_data_categories:
         field?.user_assigned_data_categories ?? undefined,
     });
-
-    if (isErrorResult(mutationResult)) {
-      errorAlert(getErrorMessage(mutationResult.error));
-      return;
-    }
-
-    toastSuccess(FieldActionType.ASSIGN_CATEGORIES, urns.length);
-
-    // Refresh the tree to reflect updated status
-    // The indicators for the parents of affected children may change to "change" if all of their children were additions.
-    if (onRefreshTree) {
-      await onRefreshTree(urns);
-    }
   };
 
   const handleApprove = async (urns: string[]) => {
-    const mutationResult = await approveStagedResourcesMutation({
+    return approveStagedResourcesMutation({
       monitor_config_key: monitorId,
       staged_resource_urns: urns,
     });
-
-    if (isErrorResult(mutationResult)) {
-      errorAlert(getErrorMessage(mutationResult.error));
-      return;
-    }
-
-    toastSuccess(FieldActionType.APPROVE, urns.length);
-
-    // The indicators are not refreshed because the resource approved by the approve action had already been classified,
-    // and its parent already had the "change" indicator.
   };
 
   return {
-    "assign-categories": handleSetDataCategories,
+    "assign-categories": handleAction(
+      FieldActionType.ASSIGN_CATEGORIES,
+      handleSetDataCategories,
+    ),
     "promote-removals": () => {},
     "un-approve": () => {},
-    "un-mute": handleUnMute,
-    approve: handleApprove,
-    classify: handleClassifyStagedResources,
-    mute: handleIgnore,
-    promote: handlePromote,
+    "un-mute": handleAction(FieldActionType.UN_MUTE, handleUnMute),
+    approve: handleAction(FieldActionType.APPROVE, handleApprove),
+    classify: handleAction(
+      FieldActionType.CLASSIFY,
+      handleClassifyStagedResources,
+    ),
+    mute: handleAction(FieldActionType.MUTE, handleIgnore),
+    promote: handleAction(FieldActionType.PROMOTE, handlePromote),
   } satisfies Record<
     FieldActionType,
     (urns: string[], field?: Partial<Field>) => Promise<void> | void

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/utils.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/utils.ts
@@ -1,0 +1,29 @@
+import type { ModalFuncProps } from "antd/es/modal";
+import type { ReactNode } from "react";
+
+import { pluralize } from "~/features/common/utils";
+import { FieldActionType } from "~/types/api/models/FieldActionType";
+
+import {
+  DEFAULT_CONFIRMATION_PROPS,
+  FIELD_ACTION_COMPLETED,
+} from "./FieldActions.const";
+
+export const getActionModalProps = (
+  verb: string,
+  content: ReactNode,
+): ModalFuncProps => ({
+  title: verb,
+  okText: verb,
+  content,
+  ...DEFAULT_CONFIRMATION_PROPS,
+});
+
+export const getActionSuccessMessage = (
+  actionType: FieldActionType,
+  itemCount?: number,
+) =>
+  `${FIELD_ACTION_COMPLETED[actionType]}${pluralize(itemCount ?? 0, "", `${actionType === FieldActionType.ASSIGN_CATEGORIES ? " for" : ""} ${itemCount?.toLocaleString()} resources`)}`;
+
+export const getActionErrorMessage = (actionType: FieldActionType) =>
+  `${FIELD_ACTION_COMPLETED[actionType]} failed${actionType === FieldActionType.CLASSIFY || actionType === FieldActionType.PROMOTE ? ": View summary in the activity tab" : ""}`;


### PR DESCRIPTION
Ticket [ENG-1646], [ENG-1670] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Adds Ant confirmation modals and messages to all bulk and multi-select actions

### Code Changes

* Updated `useFieldActions` and `useBulkActions` to include confirmation modals whenever more than one field is being acted upon.
* Updated `useFieldActions` and `useBulkActions` to include submission and success messages whenever any field is being acted upon.

### Steps to Confirm

1.  Go to the new confirmation screen for a monitor
2. Confirm that actions on a single list item only result in a message at the top of the screen
3. Confirm that multi-select (selecting items and then performing an action) actions all show correct confirmation modals for the chosen action and are followed by the appropriate message at the top of the screen
4. Confirm that bulk-select (using the select all checkbox) actions all show correct confirmation modals for the chosen action and are followed by the appropriate message at the top of the screen

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1646]: https://ethyca.atlassian.net/browse/ENG-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-1670]: https://ethyca.atlassian.net/browse/ENG-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ