### PR TITLE
Fixing outisde reference definition

### DIFF
--- a/src/fides/api/service/connectors/query_configs/saas_query_config.py
+++ b/src/fides/api/service/connectors/query_configs/saas_query_config.py
@@ -327,7 +327,7 @@ class SaaSQueryConfig(QueryConfig[SaaSRequestParams]):
             input_data: Optional upstream data from other collections
         """
         if param_values is None:
-            param_values: Dict[str, Any] = {}
+            param_values = {}
 
         for param_value in request.param_values or []:
             if param_value.references:


### PR DESCRIPTION
Fixes Issue raised by greptile here: https://github.com/ethyca/fides/pull/6719/files#r2421111536 

### Description Of Changes

Avoiding dict shared expression by using optional instead of creating one during instantation. 

### Code Changes


### Steps to Confirm

N/A

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
