### PR TITLE
refactor: confirming label

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.tsx
@@ -46,7 +46,7 @@ export const AVAILABLE_ACTIONS = {
   Ignored: [FieldActionType.UN_MUTE],
   Removed: [],
   Unlabeled: [FieldActionType.ASSIGN_CATEGORIES, FieldActionType.CLASSIFY],
-  Confirming: [],
+  "Confirming...": [],
 } as const satisfies Readonly<
   Record<ResourceStatusLabel, Readonly<Array<FieldActionType>>>
 >;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
@@ -17,7 +17,7 @@ export const RESOURCE_STATUS = [
   "In Review",
   "Removed",
   "Unlabeled",
-  "Confirming",
+  "Confirming...",
 ] as const;
 
 export type ResourceStatusLabel = (typeof RESOURCE_STATUS)[number];
@@ -32,7 +32,7 @@ export const DIFF_TO_RESOURCE_STATUS: Record<DiffStatus, ResourceStatusLabel> =
     classifying: "Classifying",
     monitored: "Confirmed",
     muted: "Ignored",
-    promoting: "Confirming",
+    promoting: "Confirming...",
     removal: "Removed",
     removing: "In Review",
   } as const;
@@ -58,7 +58,7 @@ export const MAP_DIFF_STATUS_TO_RESOURCE_STATUS_LABEL: Record<
   classifying: { label: "Classifying", color: CUSTOM_TAG_COLOR.INFO },
   monitored: { label: "Confirmed", color: CUSTOM_TAG_COLOR.MINOS },
   muted: { label: "Ignored", color: CUSTOM_TAG_COLOR.DEFAULT },
-  promoting: { label: "Confirming", color: CUSTOM_TAG_COLOR.CAUTION },
+  promoting: { label: "Confirming...", color: CUSTOM_TAG_COLOR.DEFAULT },
   removal: { label: "Removed", color: CUSTOM_TAG_COLOR.ERROR },
   removing: { label: "In Review", color: CUSTOM_TAG_COLOR.CAUTION },
 } as const;


### PR DESCRIPTION
### Description Of Changes

Updating `Confirming` label to show the text `Confirming...` as well as updating the label background color to the default value instead of caution

### Steps to Confirm

1. View a field in the `Confirming` state (should change to this after approving a field)
2. Verify the label change 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
