### PR TITLE
fix: missing query invalidations

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -275,7 +275,11 @@ const actionCenterApi = baseApi.injectEndpoints({
           },
         };
       },
-      invalidatesTags: ["Discovery Monitor Results", "Monitor Field Results"],
+      invalidatesTags: [
+        "Discovery Monitor Results",
+        "Monitor Field Results",
+        "Monitor Field Details",
+      ],
     }),
     restoreMonitorResultAssets: build.mutation<string, { urnList?: string[] }>({
       query: (params) => {
@@ -523,7 +527,7 @@ const actionCenterApi = baseApi.injectEndpoints({
         method: "POST",
         body,
       }),
-      invalidatesTags: ["Monitor Field Results"],
+      invalidatesTags: ["Monitor Field Results", "Monitor Field Details"],
     }),
   }),
 });

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/monitor-fields.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/monitor-fields.slice.ts
@@ -68,7 +68,7 @@ const monitorFieldApi = baseApi.injectEndpoints({
           body,
         };
       },
-      invalidatesTags: ["Monitor Field Results"],
+      invalidatesTags: ["Monitor Field Results", "Monitor Field Details"],
     }),
   }),
 });

--- a/clients/admin-ui/src/features/data-discovery-and-detection/discovery-detection.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/discovery-detection.slice.ts
@@ -175,7 +175,11 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
           { arrayFormat: "none" },
         )}`,
       }),
-      invalidatesTags: ["Discovery Monitor Results"],
+      invalidatesTags: [
+        "Discovery Monitor Results",
+        "Monitor Field Results",
+        "Monitor Field Details",
+      ],
     }),
     muteResource: build.mutation<any, ResourceActionQueryParams>({
       query: ({ staged_resource_urn }) => ({
@@ -197,7 +201,11 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
           },
         )}`,
       }),
-      invalidatesTags: ["Discovery Monitor Results", "Monitor Field Results"],
+      invalidatesTags: [
+        "Discovery Monitor Results",
+        "Monitor Field Results",
+        "Monitor Field Details",
+      ],
     }),
     muteResources: build.mutation<any, BulkResourceActionQueryParams>({
       query: ({ staged_resource_urns }) => ({
@@ -207,7 +215,11 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
           staged_resource_urns,
         },
       }),
-      invalidatesTags: ["Discovery Monitor Results"],
+      invalidatesTags: [
+        "Discovery Monitor Results",
+        "Monitor Field Results",
+        "Monitor Field Details",
+      ],
     }),
     promoteResources: build.mutation<any, BulkResourceActionQueryParams>({
       query: ({ staged_resource_urns }) => ({
@@ -217,7 +229,11 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
           { arrayFormat: "none" },
         )}`,
       }),
-      invalidatesTags: ["Discovery Monitor Results", "Monitor Field Results"],
+      invalidatesTags: [
+        "Discovery Monitor Results",
+        "Monitor Field Results",
+        "Monitor Field Details",
+      ],
     }),
     updateResourceCategory: build.mutation<
       Array<{


### PR DESCRIPTION
Ticket [<issue>] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Fills some gaps in query invalidations for some actions.
Makes sure to invalidate queries in both the list results and the details drawer so that actions are correctly calculated.

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. Attempt all of the actions that were updated
2. Confirm all of the queries are re-executed upon mutation submission

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
