### PR TITLE
Add refetch button

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -109,7 +109,11 @@ const ActionCenterFields: NextPage = () => {
     },
   };
 
-  const { data: fieldsDataResponse, isFetching } = useGetMonitorFieldsQuery({
+  const {
+    data: fieldsDataResponse,
+    isFetching,
+    refetch,
+  } = useGetMonitorFieldsQuery({
     ...baseMonitorFilters,
     query: {
       ...baseMonitorFilters.query,
@@ -337,6 +341,11 @@ const ActionCenterFields: NextPage = () => {
                     Actions
                   </Button>
                 </Dropdown>
+                <Button
+                  icon={<Icons.Renew />}
+                  onClick={() => refetch()}
+                  aria-label="Refresh"
+                />
               </Flex>
             </Flex>
             <Flex gap="middle" align="center">


### PR DESCRIPTION
Ticket [ENG-1791] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description of changes

Added a refresh button to the Action Center fields page that allows users to manually refetch the monitor fields data.

### Code changes

* Destructured `refetch` from `useGetMonitorFieldsQuery` hook
* Added a refresh button with a Renew icon next to the Actions dropdown

### Steps to confirm
1. Navigate to the Action Center fields page for any monitor
2. Verify the refresh button appears next to the "Actions" dropdown button
3. Click the refresh button and confirm the fields data is refetched
4. Verify the button displays the Renew icon and has proper aria-label

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [x] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1791]: https://ethyca.atlassian.net/browse/ENG-1791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ