### PR TITLE
hide categories that are not active

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/ClassificationSelect.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/ClassificationSelect.tsx
@@ -14,7 +14,7 @@ const ClassificationSelect = ({
 }: { onSelectDataCategory: (value: string) => void } & TaxonomySelectProps) => {
   const { getDataCategoryDisplayNameProps, getDataCategories } =
     useTaxonomies();
-  const dataCategories = getDataCategories();
+  const dataCategories = getDataCategories().filter((c) => c.active);
   const [open, setOpen] = useState(false);
 
   const options: TaxonomySelectOption[] = dataCategories.map((dataCategory) => {


### PR DESCRIPTION
Ticket [ENG-1817] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Filters inactive data categories from the classification select dropdown in the Data Discovery action center. This ensures only active data categories are available for selection when classifying monitored fields.

### Code Changes

* Updated `ClassificationSelect.tsx` to filter data categories by active status before rendering options

### Steps to Confirm
1. Navigate to Data Discovery & Detection → Action Center
2. Open the classification select dropdown on a monitored field
3. Search for "System Data Automation Test" (if on Nightly)
4. Confirm that inactive data category is not shown

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-1817]: https://ethyca.atlassian.net/browse/ENG-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ