### PR TITLE
fix: data category select actionable logic [ENG-1757]

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/ClassificationSelect.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/ClassificationSelect.tsx
@@ -35,7 +35,6 @@ const ClassificationSelect = ({
       description: dataCategory.description || "",
     };
   });
-
   return (
     <TaxonomySelect
       options={options}
@@ -45,6 +44,7 @@ const ClassificationSelect = ({
           type="text"
           size="small"
           icon={<Icons.Add />}
+          disabled={props.disabled}
         />
       }
       placeholder=""
@@ -52,6 +52,11 @@ const ClassificationSelect = ({
       classNames={{
         root: "w-full max-w-full overflow-hidden p-0 cursor-pointer -ml-5",
       }}
+      style={
+        {
+          "--ant-select-multiple-selector-bg-disabled": "transparent",
+        } as React.CSSProperties
+      }
       variant="borderless"
       autoFocus={false}
       maxTagCount="responsive"

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.tsx
@@ -70,6 +70,7 @@ type MonitorFieldListItemRenderParams = Parameters<
   selected?: boolean;
   onSelect?: (key: React.Key, selected: boolean) => void;
   onNavigate?: (key: string) => void;
+  dataCategoriesDisabled?: boolean;
   onSetDataCategories: (urn: string, dataCategories: string[]) => void;
 };
 
@@ -101,6 +102,7 @@ const renderMonitorFieldListItem: RenderMonitorFieldListItem = ({
   selected,
   onSelect,
   onSetDataCategories,
+  dataCategoriesDisabled,
   onNavigate,
   preferred_data_categories,
   actions,
@@ -198,6 +200,7 @@ const renderMonitorFieldListItem: RenderMonitorFieldListItem = ({
               });
             }}
             onSelectDataCategory={onSelectDataCategory}
+            disabled={dataCategoriesDisabled}
           />
         }
       />

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -389,6 +389,13 @@ const ActionCenterFields: NextPage = () => {
                     fieldActions["assign-categories"]([urn], {
                       user_assigned_data_categories: values,
                     }),
+                  dataCategoriesDisabled: props?.diff_status
+                    ? ![
+                        ...AVAILABLE_ACTIONS[
+                          DIFF_TO_RESOURCE_STATUS[props.diff_status]
+                        ],
+                      ].includes(FieldActionType.ASSIGN_CATEGORIES)
+                    : true,
                   actions: props?.diff_status
                     ? LIST_ITEM_ACTIONS.map((action) => (
                         <Tooltip


### PR DESCRIPTION
Ticket [ENG-1757] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Disables data category select component when the action is not available

### Code Changes


### Steps to Confirm

1. Visit the new monitor fields screen
2. Find a field that is in a state that should not allow modification of data categories
3. Confirm that the select component does not allow selection

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1757]: https://ethyca.atlassian.net/browse/ENG-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ