### PR TITLE
fix: actionability-sync [ENG-1865]

### DIFF
--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/FieldActions.const.tsx
@@ -2,10 +2,12 @@ import type { ModalFuncProps } from "antd/es/modal";
 import { Icons, SparkleIcon } from "fidesui";
 import { ReactNode } from "react";
 
+import { DiffStatus } from "~/types/api";
 import { FieldActionType } from "~/types/api/models/FieldActionType";
 
-import { ResourceStatusLabel } from "./MonitorFields.const";
 import { FieldActionTypeValue } from "./types";
+
+const { APPROVE, CLASSIFY, PROMOTE, MUTE, UN_MUTE } = FieldActionType;
 
 export const FIELD_ACTION_LABEL: Record<FieldActionTypeValue, string> = {
   approve: "Approve",
@@ -41,58 +43,66 @@ export const FIELD_ACTION_COMPLETED: Record<FieldActionTypeValue, string> = {
   "un-mute": "Restored",
 };
 
-export const DRAWER_ACTIONS = [
-  FieldActionType.APPROVE,
-  FieldActionType.PROMOTE,
-] as const;
+export const DRAWER_ACTIONS = [APPROVE, PROMOTE] as const;
 export const DROPDOWN_ACTIONS = [
-  FieldActionType.CLASSIFY,
-  FieldActionType.APPROVE,
-  FieldActionType.PROMOTE,
-  FieldActionType.MUTE,
-  FieldActionType.UN_MUTE,
+  CLASSIFY,
+  APPROVE,
+  PROMOTE,
+  MUTE,
+  UN_MUTE,
 ] as const;
-export const LIST_ITEM_ACTIONS = [
-  FieldActionType.CLASSIFY,
-  FieldActionType.PROMOTE,
-] as const;
+
+export const LIST_ITEM_ACTIONS = [CLASSIFY, PROMOTE] as const;
 
 export const DROPDOWN_ACTIONS_DISABLED_TOOLTIP: Record<
   (typeof DROPDOWN_ACTIONS)[number],
   string
 > = {
-  [FieldActionType.APPROVE]:
-    "You can only approve resources with a data category applied",
-  [FieldActionType.CLASSIFY]:
+  [APPROVE]: "You can only approve resources with a data category applied",
+  [CLASSIFY]:
     "You cannot classify resources that are already in classification or ignored",
-  [FieldActionType.MUTE]:
-    "You cannot ignore resources that are already ignored",
-  [FieldActionType.PROMOTE]:
-    "You can only confirm resources that have a data category applied",
-  [FieldActionType.UN_MUTE]: "You can only restore resources that are ignored",
+  [MUTE]: "You cannot ignore resources that are already ignored",
+  [PROMOTE]: "You can only confirm resources that have a data category applied",
+  [UN_MUTE]: "You can only restore resources that are ignored",
 };
 
-export const AVAILABLE_ACTIONS = {
-  "In Review": [
-    FieldActionType.CLASSIFY,
-    FieldActionType.MUTE,
-    FieldActionType.APPROVE,
-    FieldActionType.PROMOTE,
-    FieldActionType.ASSIGN_CATEGORIES,
+/**
+ * Enum that exists in fidesplus. Keep in sync for correct logic
+ */
+export const ACTION_ALLOWED_STATUSES = {
+  classify: [
+    DiffStatus.ADDITION,
+    DiffStatus.CLASSIFICATION_ADDITION,
+    DiffStatus.CLASSIFICATION_UPDATE,
   ],
-  Approved: [
-    FieldActionType.MUTE,
-    FieldActionType.PROMOTE,
-    FieldActionType.ASSIGN_CATEGORIES,
+  approve: [
+    DiffStatus.CLASSIFICATION_ADDITION,
+    DiffStatus.CLASSIFICATION_UPDATE,
+    DiffStatus.APPROVED,
   ],
-  Classifying: [],
-  Confirmed: [],
-  Ignored: [FieldActionType.UN_MUTE],
-  Removed: [],
-  Unlabeled: [FieldActionType.ASSIGN_CATEGORIES, FieldActionType.CLASSIFY],
-  "Confirming...": [],
+  "un-approve": [DiffStatus.APPROVED],
+  promote: [
+    DiffStatus.CLASSIFICATION_ADDITION,
+    DiffStatus.CLASSIFICATION_UPDATE,
+    DiffStatus.APPROVED,
+  ],
+  "promote-removals": [DiffStatus.REMOVAL],
+  mute: [
+    DiffStatus.ADDITION,
+    DiffStatus.CLASSIFICATION_ADDITION,
+    DiffStatus.CLASSIFICATION_UPDATE,
+    DiffStatus.APPROVED,
+    DiffStatus.REMOVAL,
+  ],
+  "un-mute": [DiffStatus.MUTED],
+  "assign-categories": [
+    DiffStatus.ADDITION,
+    DiffStatus.CLASSIFICATION_ADDITION,
+    DiffStatus.CLASSIFICATION_UPDATE,
+    DiffStatus.APPROVED,
+  ],
 } as const satisfies Readonly<
-  Record<ResourceStatusLabel, Readonly<Array<FieldActionType>>>
+  Record<FieldActionType, Readonly<Array<DiffStatus>>>
 >;
 
 export const FIELD_ACTION_ICON = {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -36,11 +36,10 @@ import {
 } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
 import { DiffStatus } from "~/types/api";
 import { DatastoreStagedResourceAPIResponse } from "~/types/api/models/DatastoreStagedResourceAPIResponse";
-import { FieldActionType } from "~/types/api/models/FieldActionType";
 
 import { DetailsDrawer } from "./DetailsDrawer";
 import {
-  AVAILABLE_ACTIONS,
+  ACTION_ALLOWED_STATUSES,
   DRAWER_ACTIONS,
   DROPDOWN_ACTIONS,
   DROPDOWN_ACTIONS_DISABLED_TOOLTIP,
@@ -55,7 +54,6 @@ import {
 import { MonitorFieldFilters } from "./MonitorFieldFilters";
 import renderMonitorFieldListItem from "./MonitorFieldListItem";
 import {
-  DIFF_TO_RESOURCE_STATUS,
   FIELD_PAGE_SIZE,
   MAP_DIFF_STATUS_TO_RESOURCE_STATUS_LABEL,
   ResourceStatusLabel,
@@ -184,8 +182,8 @@ const ActionCenterFields: NextPage = () => {
   const availableActions = isBulkSelect
     ? allowedActionsResult?.allowed_actions
     : getAvailableActions(
-        selectedListItems.flatMap((field) =>
-          field.diff_status ? [DIFF_TO_RESOURCE_STATUS[field.diff_status]] : [],
+        selectedListItems.flatMap(({ diff_status }) =>
+          diff_status ? [diff_status] : [],
         ),
       );
   const responseCount = fieldsDataResponse?.total ?? 0;
@@ -390,11 +388,9 @@ const ActionCenterFields: NextPage = () => {
                       user_assigned_data_categories: values,
                     }),
                   dataCategoriesDisabled: props?.diff_status
-                    ? ![
-                        ...AVAILABLE_ACTIONS[
-                          DIFF_TO_RESOURCE_STATUS[props.diff_status]
-                        ],
-                      ].includes(FieldActionType.ASSIGN_CATEGORIES)
+                    ? !ACTION_ALLOWED_STATUSES["assign-categories"].some(
+                        (status) => status === props.diff_status,
+                      )
                     : true,
                   actions: props?.diff_status
                     ? LIST_ITEM_ACTIONS.map((action) => (
@@ -408,11 +404,9 @@ const ActionCenterFields: NextPage = () => {
                             onClick={() => fieldActions[action]([props.urn])}
                             disabled={
                               props?.diff_status
-                                ? ![
-                                    ...AVAILABLE_ACTIONS[
-                                      DIFF_TO_RESOURCE_STATUS[props.diff_status]
-                                    ],
-                                  ].includes(action)
+                                ? !ACTION_ALLOWED_STATUSES[action].some(
+                                    (status) => status === props.diff_status,
+                                  )
                                 : true
                             }
                             style={{
@@ -463,12 +457,10 @@ const ActionCenterFields: NextPage = () => {
           label: FIELD_ACTION_LABEL[action],
           callback: (value) => fieldActions[action]([value]),
           disabled: resource?.diff_status
-            ? ![
-                ...AVAILABLE_ACTIONS[
-                  DIFF_TO_RESOURCE_STATUS[resource.diff_status]
-                ],
-              ].includes(action)
-            : false,
+            ? !ACTION_ALLOWED_STATUSES[action].some(
+                (status) => status === resource.diff_status,
+              )
+            : true,
         }))}
         open={!!detailsUrn}
         onClose={() => setDetailsUrn(undefined)}
@@ -520,11 +512,9 @@ const ActionCenterFields: NextPage = () => {
                   autoFocus={false}
                   disabled={
                     resource?.diff_status
-                      ? ![
-                          ...AVAILABLE_ACTIONS[
-                            DIFF_TO_RESOURCE_STATUS[resource.diff_status]
-                          ],
-                        ].includes(FieldActionType.ASSIGN_CATEGORIES)
+                      ? !ACTION_ALLOWED_STATUSES["assign-categories"].some(
+                          (status) => status === resource.diff_status,
+                        )
                       : true
                   }
                   onChange={(values) =>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useFieldActions.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useFieldActions.tsx
@@ -10,26 +10,29 @@ import {
   useUnmuteResourcesMutation,
   useUpdateResourceCategoryMutation,
 } from "~/features/data-discovery-and-detection/discovery-detection.slice";
-import { Field } from "~/types/api";
+import { DiffStatus, Field } from "~/types/api";
 import { FieldActionType } from "~/types/api/models/FieldActionType";
 import { isErrorResult, RTKResult } from "~/types/errors";
 
 import {
-  AVAILABLE_ACTIONS,
+  ACTION_ALLOWED_STATUSES,
   FIELD_ACTION_CONFIRMATION_MESSAGE,
   FIELD_ACTION_INTERMEDIATE,
   FIELD_ACTION_LABEL,
 } from "./FieldActions.const";
-import { ResourceStatusLabel } from "./MonitorFields.const";
 import {
   getActionErrorMessage,
   getActionModalProps,
   getActionSuccessMessage,
 } from "./utils";
 
-export const getAvailableActions = (statusList: ResourceStatusLabel[]) => {
-  const [init, ...availableActions] = statusList.map(
-    (status) => AVAILABLE_ACTIONS[status],
+export const getAvailableActions = (statusList: DiffStatus[]) => {
+  const [init, ...availableActions] = statusList.map((status) =>
+    Object.values(FieldActionType).flatMap((actionType) =>
+      ACTION_ALLOWED_STATUSES[actionType].some((s) => s === status)
+        ? [actionType]
+        : [],
+    ),
   );
 
   return availableActions.reduce<Readonly<Array<FieldActionType>>>(


### PR DESCRIPTION
Ticket [ENG-1865] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Implementing `ACTION_ALLOWED_STATUSES` enum from the BE to determine if actions should be disabled.

### Code Changes

* Removing `AVAILABLE_ACTIONS` enum in favor of `ACTION_ALLOWED_STATUSES` enum to more directly mirror the BE logic

### Steps to Confirm

1. Confirm that all of the action button/input states are reflective of the backend actionability as described in the `ACTION_ALLOWED_STATUSES` enum.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1865]: https://ethyca.atlassian.net/browse/ENG-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ