### PR TITLE
refactor: persist monitor field filters [ENG-1927]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Developer Experience
 - Improved pluralization handling throughout Admin UI with centralized utility function [#6930](https://github.com/ethyca/fides/pull/6930)
 
+### Changed
+- Monitor field filters no longer reset to default values when selecting resources from the tree [#6935](https://github.com/ethyca/fides/pull/6935)
+
 ## [2.74.0](https://github.com/ethyca/fides/compare/2.73.1..2.74.0)
 
 ### Added

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldFilters.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldFilters.tsx
@@ -172,14 +172,6 @@ export const MonitorFieldFilters = ({
     setLocalDataCategory(dataCategory);
   }, [dataCategory]);
 
-  // Reset filters to default state when stagedResourceUrn changes
-  // Use JSON.stringify to compare array contents, not reference
-  const stagedResourceUrnKey = stagedResourceUrn.join(",");
-  useEffect(() => {
-    resetToInitialState();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stagedResourceUrnKey]);
-
   const { data: datastoreFilterResponse, refetch: refetchDatastoreFilters } =
     useGetDatastoreFiltersQuery(
       {


### PR DESCRIPTION
Ticket [ENG-1927] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Persisting monitor field filters while filtering by a staged resource in the resource tree.

### Code Changes

* Removed `useEffect` hook used to reset the filters when the resource urn changed

### Steps to Confirm

1. Make sure the `Helios V2` beta flag is set and there is an available resource monitor
2. Go to the action center screen
3. Click a datastore monitor in the results to get to a classifier screen
4. Click the `Filter` button and change the default filters
5. Click apply and confirm that the filters updated
6. Choose different items from the tree selection on the left
7. Confirm that the results update to include values from the selected tree item and that the filters do not reset to the default values

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1927]: https://ethyca.atlassian.net/browse/ENG-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ