### PR TITLE
refactor: deselect on action [ENG-1789]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 ### Changed
 - Updated logging configuration to intercept all standard library logs and route them through Loguru[#6891](https://github.com/ethyca/fides/pull/6891)
 - Changed name of main file in DSR package from welcome.html to clickme.html [#6923](https://github.com/ethyca/fides/pull/6923)
+- De-select list items after performing an action in the action center [#6942](https://github.com/ethyca/fides/pull/6942)
 
 ### Developer Experience
 - Improved pluralization handling throughout Admin UI with centralized utility function [#6930](https://github.com/ethyca/fides/pull/6930)

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -337,9 +337,9 @@ const ActionCenterFields: NextPage = () => {
                         disabled:
                           isFetchingAllowedActions ||
                           !availableActions?.includes(actionType),
-                        onClick: () => {
+                        onClick: async () => {
                           if (isBulkSelect) {
-                            bulkActions[actionType](
+                            await bulkActions[actionType](
                               baseMonitorFilters,
                               excludedListItems.map((k) =>
                                 k.itemKey.toString(),
@@ -347,12 +347,14 @@ const ActionCenterFields: NextPage = () => {
                               selectedListItemCount,
                             );
                           } else {
-                            fieldActions[actionType](
+                            await fieldActions[actionType](
                               selectedListItems.map(({ itemKey }) =>
                                 itemKey.toString(),
                               ),
                             );
                           }
+
+                          resetListSelect();
                         },
                       })),
                     ],


### PR DESCRIPTION
Ticket [ENG-1789] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Selected fields are de-selected after performing an action to prevent issues with async states.
Previously, if you selected multiple items and then performed an action, you would still have the same selection but with potentially stale states to base actionable logic.
Since we are not polling the state for each field, this can lead to invalid actions being available to a user.

### Code Changes

* Adds the reset function to the action dropdown event to reset selections

### Steps to Confirm

1. Make sure that the `Helios V2` beta flag is enabled in the [settings](https://fides-plus-nightly-git-refactor-deselect-on-action-ethyca.vercel.app/settings/about)
2. Visit the [action center](https://fides-plus-nightly-git-refactor-deselect-on-action-ethyca.vercel.app/data-discovery/action-center) and choose a datastore monitor
3. Select multiple fields using the checkboxes
4. Use the action dropdown to perform an available action
5. Confirm that you no longer have any selected fields

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1789]: https://ethyca.atlassian.net/browse/ENG-1789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ