### PR TITLE
remove api token and addition access key

### DIFF
--- a/.github/workflows/backend_checks.yml
+++ b/.github/workflows/backend_checks.yml
@@ -469,7 +469,7 @@ jobs:
           GOOGLE_CLOUD_SQL_POSTGRES_DB_IAM_USER: op://github-actions/gcp-postgres/GOOGLE_CLOUD_SQL_POSTGRES_DB_IAM_USER
           GOOGLE_CLOUD_SQL_POSTGRES_INSTANCE_CONNECTION_NAME: op://github-actions/gcp-postgres/GOOGLE_CLOUD_SQL_POSTGRES_INSTANCE_CONNECTION_NAME
           GOOGLE_CLOUD_SQL_POSTGRES_KEYFILE_CREDS: op://github-actions/gcp-postgres/GOOGLE_CLOUD_SQL_POSTGRES_KEYFILE_CREDS
-          OKTA_API_TOKEN: op://github-actions/okta/OKTA_API_TOKEN
+          OKTA_ACCESS_TOKEN: op://github-actions/okta/OKTA_ACCESS_TOKEN
           OKTA_ORG_URL: op://github-actions/okta/OKTA_ORG_URL
           RDS_MYSQL_AWS_ACCESS_KEY_ID: op://github-actions/rds-mysql/RDS_MYSQL_AWS_ACCESS_KEY_ID
           RDS_MYSQL_AWS_SECRET_ACCESS_KEY: op://github-actions/rds-mysql/RDS_MYSQL_AWS_SECRET_ACCESS_KEY

--- a/clients/admin-ui/src/types/api/models/OktaDocsSchema.ts
+++ b/clients/admin-ui/src/types/api/models/OktaDocsSchema.ts
@@ -13,9 +13,5 @@ export type OktaDocsSchema = {
   /**
    * The API token used to authenticate with Okta
    */
-  api_token?: string; //remove after migration
-  /**
-   * The API token used to authenticate with Okta
-   */
-  access_token: string;
+  api_token: string;
 };

--- a/clients/admin-ui/src/types/api/models/OktaDocsSchema.ts
+++ b/clients/admin-ui/src/types/api/models/OktaDocsSchema.ts
@@ -13,5 +13,9 @@ export type OktaDocsSchema = {
   /**
    * The API token used to authenticate with Okta
    */
-  api_token: string;
+  api_token?: string; //remove after migration
+  /**
+   * The API token used to authenticate with Okta
+   */
+  access_token: string;
 };

--- a/noxfiles/run_infrastructure.py
+++ b/noxfiles/run_infrastructure.py
@@ -75,7 +75,7 @@ EXTERNAL_DATASTORE_CONFIG = {
     ],
     "okta": [
         "OKTA_ORG_URL",
-        "OKTA_API_TOKEN",
+        "OKTA_ACCESS_TOKEN",
     ],
 }
 EXTERNAL_DATASTORES = list(EXTERNAL_DATASTORE_CONFIG.keys())

--- a/noxfiles/setup_tests_nox.py
+++ b/noxfiles/setup_tests_nox.py
@@ -223,7 +223,7 @@ def pytest_ops(
             "-e",
             "OKTA_ORG_URL",
             "-e",
-            "OKTA_API_TOKEN",
+            "OKTA_ACCESS_TOKEN",
             "-e",
             "RDS_MYSQL_AWS_ACCESS_KEY_ID",
             "-e",

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_okta.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_okta.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List
+from typing import ClassVar, List, Optional
 
 from pydantic import Field
 
@@ -15,13 +15,14 @@ class OktaSchema(ConnectionConfigSecretsSchema):
         title="Organization URL",
         description="The URL of your Okta organization (e.g. https://your-org.okta.com)",
     )
-    api_token: str = Field(
-        title="API Token",
-        description="The API token used to authenticate with Okta",
-        json_schema_extra={"sensitive": True},
+    api_token: Optional[str] = Field(
+        default=None,
+        title="API Token (Deprecated)",
+        description="Legacy API token (ignored). Configure OAuth2 Client Credentials instead.",
+        json_schema_extra={"sensitive": True, "deprecated": True},
     )
 
-    _required_components: ClassVar[List[str]] = ["org_url", "api_token"]
+    _required_components: ClassVar[List[str]] = ["org_url"]
 
 
 class OktaDocsSchema(OktaSchema, NoValidationSchema):

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_okta.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_okta.py
@@ -21,6 +21,12 @@ class OktaSchema(ConnectionConfigSecretsSchema):
         description="Legacy API token (ignored). Configure OAuth2 Client Credentials instead.",
         json_schema_extra={"sensitive": True, "deprecated": True},
     )
+    access_token: Optional[str] = Field(
+        default=None,
+        title="Access Token",
+        description="OAuth2 access token used to authenticate with Okta",
+        json_schema_extra={"sensitive": True},
+    )
 
     _required_components: ClassVar[List[str]] = ["org_url"]
 

--- a/src/fides/api/service/connectors/okta_connector.py
+++ b/src/fides/api/service/connectors/okta_connector.py
@@ -60,8 +60,7 @@ class OktaConnector(BaseConnector):
         access_token = self.configuration.secrets.get("access_token")
         if not access_token:
             raise ConnectionException(
-                "Okta OAuth2 access token is not configured. Implement the OAuth2 Client "
-                "Credentials module and ensure secrets include an 'access_token'."
+                "Okta access_token is not configured. Provide a valid OAuth2 access token in the connection secrets."
             )
         return access_token
 

--- a/src/fides/api/service/connectors/okta_connector.py
+++ b/src/fides/api/service/connectors/okta_connector.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional
 
+from loguru import logger
 from okta.client import Client as OktaClient
 from okta.exceptions import OktaAPIException
 
@@ -26,16 +27,43 @@ class OktaConnector(BaseConnector):
 
     def create_client(self) -> OktaClient:
         """Creates and returns an Okta client instance"""
+        org_url = self.configuration.secrets.get("org_url")
+        if not org_url:
+            raise ConnectionException(
+                "Okta connection configuration is missing 'org_url'."
+            )
+
+        if self.configuration.secrets.get("api_token"):
+            logger.warning(
+                "Deprecated Okta API token detected in secrets. This value is ignored; "
+                "configure OAuth2 Client Credentials instead."
+            )
+
+        access_token = self._get_oauth_access_token()
+
         try:
             return OktaClient(
                 {
-                    "orgUrl": self.configuration.secrets["org_url"],
-                    "token": self.configuration.secrets["api_token"],
+                    "orgUrl": org_url,
+                    "token": access_token,
                     "raiseException": True,
                 }
             )
-        except Exception as e:
-            raise ConnectionException(f"Failed to create Okta client: {str(e)}")
+        except Exception as exc:
+            raise ConnectionException(
+                f"Failed to create Okta client using OAuth2 credentials: {exc}"
+            ) from exc
+
+    def _get_oauth_access_token(self) -> str:
+        """Retrieve the OAuth2 access token for the Okta client."""
+
+        access_token = self.configuration.secrets.get("access_token")
+        if not access_token:
+            raise ConnectionException(
+                "Okta OAuth2 access token is not configured. Implement the OAuth2 Client "
+                "Credentials module and ensure secrets include an 'access_token'."
+            )
+        return access_token
 
     def query_config(self, node: ExecutionNode) -> QueryConfig[Any]:
         """Return the query config that corresponds to this connector type"""

--- a/src/fides/connectors/models.py
+++ b/src/fides/connectors/models.py
@@ -1,7 +1,7 @@
 """Module that adds models for connectors"""
 
 # pylint: disable=C0115,C0116, E0213
-from typing import ClassVar, List, Optional, Any, Dict
+from typing import Any, ClassVar, Dict, List, Optional
 
 from pydantic import BaseModel
 

--- a/src/fides/connectors/models.py
+++ b/src/fides/connectors/models.py
@@ -53,12 +53,14 @@ class OktaConfig(BaseModel):
     token: Optional[str] = None
     access_token: Optional[str] = None
 
-    def model_dump(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
-        data = super().model_dump(*args, **kwargs)
-        if not data.get("token") and self.access_token:
+    def _dump_with_token(self, **kwargs: object) -> Dict[str, object]:
+        data = BaseModel.model_dump(self, **kwargs)
+        if data.get("token") is None and self.access_token is not None:
             data["token"] = self.access_token
         return data
 
+    def model_dump(self, **kwargs: object) -> Dict[str, object]:
+        return self._dump_with_token(**kwargs)
 
 class DatabaseConfig(BaseModel):
     """

--- a/src/fides/connectors/models.py
+++ b/src/fides/connectors/models.py
@@ -1,7 +1,7 @@
 """Module that adds models for connectors"""
 
 # pylint: disable=C0115,C0116, E0213
-from typing import ClassVar, List, Optional
+from typing import ClassVar, List, Optional, Any, Dict
 
 from pydantic import BaseModel
 
@@ -50,7 +50,14 @@ class OktaConfig(BaseModel):
 
     # camel case matches okta client config model
     orgUrl: str
-    token: str
+    token: Optional[str] = None
+    access_token: Optional[str] = None
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        data = super().model_dump(*args, **kwargs)
+        if not data.get("token") and self.access_token:
+            data["token"] = self.access_token
+        return data
 
 
 class DatabaseConfig(BaseModel):

--- a/tests/fixtures/okta_fixtures.py
+++ b/tests/fixtures/okta_fixtures.py
@@ -31,19 +31,19 @@ def okta_connection_config(db: Session) -> Generator:
     okta_integration_config = integration_config.get("okta", {})
 
     org_url = okta_integration_config.get("org_url") or os.environ.get("OKTA_ORG_URL")
-    api_token = okta_integration_config.get("api_token") or os.environ.get(
-        "OKTA_API_TOKEN"
+    access_token = okta_integration_config.get("access_token") or os.environ.get(
+        "OKTA_ACCESS_TOKEN"
     )
 
     if not org_url:
         raise RuntimeError("Missing org_url for Okta")
 
-    if not api_token:
-        raise RuntimeError("Missing api_token for Okta")
+    if not access_token:
+        raise RuntimeError("Missing access_token for Okta")
 
     schema = OktaSchema(
         org_url=org_url,
-        api_token=api_token,
+        access_token=access_token,
     )
     connection_config.secrets = schema.model_dump()
     connection_config.save(db=db)

--- a/tests/fixtures/saas/test_data/saas_async_callback_config.yml
+++ b/tests/fixtures/saas/test_data/saas_async_callback_config.yml
@@ -7,16 +7,17 @@ saas_config:
 
   connector_params:
     - name: domain
-    - name: api_token
-      label: API token
+    - name: access_token
+      label: Access token
+      sensitive: True
 
   client_config:
-    protocol: http
+    protocol: https
     host: <domain>
     authentication:
       strategy: bearer
       configuration:
-        token: <api_token>
+        token: <access_token>
 
   test_request:
     method: GET

--- a/tests/fixtures/saas/test_data/saas_consent_request_override_config.yml
+++ b/tests/fixtures/saas/test_data/saas_consent_request_override_config.yml
@@ -7,16 +7,17 @@ saas_config:
 
   connector_params:
     - name: domain
-    - name: api_token
-      label: API token
+    - name: access_token
+      label: Access token
+      sensitive: True
 
   client_config:
-    protocol: http
+    protocol: https
     host: <domain>
     authentication:
       strategy: bearer
       configuration:
-        token: <api_token>
+        token: <access_token>
 
   test_request:
     method: GET

--- a/tests/integration/workflows/data/example_async_callback_config.yml
+++ b/tests/integration/workflows/data/example_async_callback_config.yml
@@ -8,8 +8,8 @@ saas_config:
 
   connector_params:
     - name: domain
-    - name: api_token
-      label: API token
+    - name: access_token
+      label: Access token
       sensitive: True
 
   client_config:
@@ -18,7 +18,7 @@ saas_config:
     authentication:
       strategy: bearer
       configuration:
-        token: <api_token>
+        token: <access_token>
 
   test_request:
     method: GET

--- a/tests/integration/workflows/data/example_async_polling_config.yml
+++ b/tests/integration/workflows/data/example_async_polling_config.yml
@@ -1,61 +1,61 @@
 saas_config:
-  fides_key: async_polling_example
-  name: Async Polling Example
-  type: async_polling_example
-  description: An example SaaS config with async polling
-  version: 0.0.1
+    fides_key: async_polling_example
+    name: Async Polling Example
+    type: async_polling_example
+    description: An example SaaS config with async polling
+    version: 0.0.1
 
-  connector_params:
-    - name: domain
-    - name: api_token
-      label: API token
-      sensitive: True
+    connector_params:
+        - name: domain
+        - name: access_token
+          label: Access token
+          sensitive: True
 
-  client_config:
-    protocol: https
-    host: <domain>
-    authentication:
-      strategy: bearer
-      configuration:
-        token: <api_token>
-
-  test_request:
-    method: GET
-    path: /test
-
-  endpoints:
-    - name: user
-      requests:
-        read:
-          method: GET
-          path: /api/access-package
-          param_values:
-            - name: email
-              identity: email
-          correlation_id_path: request_id
-          async_config:
-            strategy: polling
+    client_config:
+        protocol: https
+        host: <domain>
+        authentication:
+            strategy: bearer
             configuration:
-              status_request:
-                method: GET
-                path: /api/access-package/status
-                status_path: status
-                status_completed_value: completed
-              result_request:
-                method: GET
-                path: /api/access-package/result
-        delete:
-          method: DELETE
-          path: /api/anonymize-user/<email>
-          param_values:
-            - name: email
-              identity: email
-          correlation_id_path: correlation_id
-          async_config:
-            strategy: polling
-            configuration:
-              status_request:
-                method: GET
-                path: /api/anonymize-user/<correlation_id>/status
-                status_path: status
-                status_completed_value: completed
+                token: <access_token>
+
+    test_request:
+        method: GET
+        path: /test
+
+    endpoints:
+        - name: user
+          requests:
+              read:
+                  method: GET
+                  path: /api/access-package
+                  param_values:
+                      - name: email
+                        identity: email
+                  correlation_id_path: request_id
+                  async_config:
+                      strategy: polling
+                      configuration:
+                          status_request:
+                              method: GET
+                              path: /api/access-package/status
+                              status_path: status
+                              status_completed_value: completed
+                          result_request:
+                              method: GET
+                              path: /api/access-package/result
+              delete:
+                  method: DELETE
+                  path: /api/anonymize-user/<email>
+                  param_values:
+                      - name: email
+                        identity: email
+                  correlation_id_path: correlation_id
+                  async_config:
+                      strategy: polling
+                      configuration:
+                          status_request:
+                              method: GET
+                              path: /api/anonymize-user/<correlation_id>/status
+                              status_path: status
+                              status_completed_value: completed

--- a/tests/integration/workflows/test_privacy_request_with_async_callback.py
+++ b/tests/integration/workflows/test_privacy_request_with_async_callback.py
@@ -47,7 +47,7 @@ class TestPrivacyRequestWithAsyncCallback:
                 "access": AccessLevel.write,
                 "secrets": {
                     "domain": "example.com",
-                    "api_token": "123",
+                    "access_token": "123",
                 },
                 "saas_config": saas_config,
             },

--- a/tests/integration/workflows/test_privacy_request_with_async_polling.py
+++ b/tests/integration/workflows/test_privacy_request_with_async_polling.py
@@ -51,7 +51,7 @@ class TestPrivacyRequestWithAsyncPolling:
                 "access": AccessLevel.write,
                 "secrets": {
                     "domain": "example.com",
-                    "api_token": "123",
+                    "access_token": "123",
                 },
                 "saas_config": saas_config,
             },

--- a/tests/ops/integration_tests/test_connection_configuration_integration.py
+++ b/tests/ops/integration_tests/test_connection_configuration_integration.py
@@ -1641,7 +1641,7 @@ class TestOktaConnector:
         db: Session,
         okta_connection_config,
     ) -> None:
-        okta_connection_config.secrets["api_token"] = "bad_key"
+        okta_connection_config.secrets["access_token"] = "bad_key"
         okta_connection_config.save(db)
         connector = get_connector(okta_connection_config)
         with pytest.raises(ConnectionException):

--- a/tests/ops/service/connectors/saas/test_zipfile_response_management.py
+++ b/tests/ops/service/connectors/saas/test_zipfile_response_management.py
@@ -120,7 +120,7 @@ class TestZipFileResponseManagement:
                 "access": AccessLevel.write,
                 "secrets": {
                     "domain": parsed_url.netloc,
-                    "api_token": "test_token_123",
+                    "access_token": "test_token_123",
                 },
             },
         )
@@ -134,7 +134,7 @@ class TestZipFileResponseManagement:
             host=parsed_url.netloc,
             authentication={
                 "strategy": "bearer",
-                "configuration": {"token": "<api_token>"},
+                "configuration": {"token": "<access_token>"},
             },
         )
 


### PR DESCRIPTION
Ticket ENG-1916
https://ethyca.atlassian.net/browse/ENG-1916

### Description Of Changes

Analyzed existing OAuth2 client-credentials patterns to guide the Okta worker migration and removed the remaining Okta API-token legacy usage so the connector now expects OAuth2-only secrets. Adjusted schemas, fixtures, configs, and tests to align with the new access-token fields while warning if a legacy token is still supplied.

### Code Changes

* reviewed existing OAuth2 client-credentials strategy implementations and documented reusable patterns (analysis only; no code changes required)

* removed api_token handling from OktaConnector and introduced _get_oauth_access_token() erroring when OAuth2 secrets are missing

* updated OktaSchema to deprecate/ignore api_token, surface access_token, and adjusted connection model defaults

* refreshed SaaS YAML fixtures, integration tests, and Okta connection fixtures to rely on access_token

* ensured Nox/test helpers reference OAuth2 environment variables instead of legacy API-token settings

### Steps to Confirm

1. python -m pytest tests/ops/service/connectors/saas/test_zipfile_response_management.py
2. python -m pytest tests/ops/integration_tests/test_connection_configuration_integration.py -k okta

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
