### PR TITLE
Implement OAuth2 Client Credentials for Okta

### DIFF
--- a/src/fides/api/schemas/connection_configuration/connection_secrets_okta.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_okta.py
@@ -28,7 +28,7 @@ class OktaSchema(ConnectionConfigSecretsSchema):
         json_schema_extra={"sensitive": True},
     )
 
-    _required_components: ClassVar[List[str]] = ["org_url"]
+    _required_components: ClassVar[List[str]] = ["org_url", "access_token"]
 
 
 class OktaDocsSchema(OktaSchema, NoValidationSchema):

--- a/src/fides/api/service/connectors/okta_oauth2_client.py
+++ b/src/fides/api/service/connectors/okta_oauth2_client.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Callable, Dict, Optional
+
+import requests
+from loguru import logger
+from requests.auth import HTTPBasicAuth
+from sqlalchemy.orm import Session
+
+from fides.api.common_exceptions import ConnectionException, OAuth2TokenException
+from fides.api.models.connectionconfig import ConnectionConfig
+
+
+class OktaOAuth2Client:
+    """
+    Lightweight OAuth2 Client Credentials helper for Okta.
+
+    This class encapsulates token acquisition, caching, and persistence in the
+    `ConnectionConfig` secrets for the Okta connector/worker use case.
+    """
+
+    TOKEN_PATH = "/oauth2/v1/token"
+    DEFAULT_SCOPE = "okta.apps.read"
+    DEFAULT_EXPIRATION_SECONDS = 3600
+    EXPIRATION_BUFFER_SECONDS = 300
+
+    def __init__(
+        self,
+        connection_config: ConnectionConfig,
+        *,
+        scope: Optional[str] = None,
+        clock: Callable[[], datetime] = datetime.utcnow,
+    ) -> None:
+        self.connection_config = connection_config
+        self.scope = scope or self.DEFAULT_SCOPE
+        self.clock = clock
+
+    def get_access_token(self, db: Optional[Session] = None) -> str:
+        """
+        Retrieve a valid OAuth2 access token for Okta.
+        Returns a cached token when still valid or requests a new one as needed.
+        """
+        self._validate_required_secrets()
+
+        secrets = self.connection_config.secrets or {}
+        access_token: Optional[str] = secrets.get("access_token")
+        expires_at: Optional[int] = secrets.get("expires_at")
+
+        if access_token and self._token_is_valid(expires_at):
+            return access_token
+
+        token_response = self._request_new_token()
+        return self._persist_token(token_response, db)
+
+    def _validate_required_secrets(self) -> None:
+        secrets = self.connection_config.secrets or {}
+        missing = [
+            secret_name
+            for secret_name in ("org_url", "client_id", "client_secret")
+            if not secrets.get(secret_name)
+        ]
+        if missing:
+            raise ConnectionException(
+                "Okta connection configuration is missing required OAuth2 secrets: "
+                + ", ".join(missing)
+            )
+
+    def _token_is_valid(self, expires_at: Optional[int]) -> bool:
+        if not expires_at:
+            return False
+
+        buffer_time = self.clock() + timedelta(seconds=self.EXPIRATION_BUFFER_SECONDS)
+        return expires_at > int(buffer_time.timestamp())
+
+    def _token_endpoint(self) -> str:
+        org_url: str = self.connection_config.secrets.get("org_url")  # type: ignore
+        # Ensure only a single slash between org_url and the token path
+        return org_url.rstrip("/") + self.TOKEN_PATH
+
+    def _request_new_token(self) -> Dict[str, str]:
+        secrets = self.connection_config.secrets or {}
+        client_id: str = secrets.get("client_id")  # type: ignore
+        client_secret: str = secrets.get("client_secret")  # type: ignore
+
+        data = {
+            "grant_type": "client_credentials",
+            "scope": self.scope,
+        }
+
+        try:
+            response = requests.post(
+                self._token_endpoint(),
+                data=data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                auth=HTTPBasicAuth(client_id, client_secret),
+                timeout=30,
+            )
+        except requests.exceptions.RequestException as exc:  # pragma: no cover
+            logger.error("Error requesting Okta OAuth2 access token: {}", exc)
+            raise OAuth2TokenException(
+                f"Error occurred during the access token request for {self.connection_config.key}: {exc}"
+            ) from exc
+
+        if response.status_code != 200:
+            logger.error(
+                "Okta OAuth2 token request failed with status {}: {}",
+                response.status_code,
+                response.text,
+            )
+            raise OAuth2TokenException(
+                f"Unable to retrieve token for {self.connection_config.key}. "
+                f"Status code: {response.status_code}"
+            )
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            logger.error("Invalid JSON in Okta OAuth2 token response: {}", exc)
+            raise OAuth2TokenException(
+                f"Invalid JSON response retrieving token for {self.connection_config.key}: {exc}"
+            ) from exc
+
+    def _persist_token(
+        self, token_response: Dict[str, str], db: Optional[Session]
+    ) -> str:
+        access_token = token_response.get("access_token")
+        if not access_token:
+            logger.error("Okta OAuth2 token response missing access_token: {}", token_response)
+            raise OAuth2TokenException(
+                f"Unable to retrieve token for {self.connection_config.key} (missing access_token)."
+            )
+
+        expires_in = token_response.get("expires_in") or self.DEFAULT_EXPIRATION_SECONDS
+        expires_at = int(self.clock().timestamp()) + int(expires_in)
+
+        updated_secrets = {
+            **(self.connection_config.secrets or {}),
+            "access_token": access_token,
+            "expires_at": expires_at,
+        }
+
+        db = db or Session.object_session(self.connection_config)
+        if db is None:
+            logger.warning(
+                "Okta OAuth2 token persistence without DB session for {}", self.connection_config.key
+            )
+
+        self.connection_config.update(db, data={"secrets": updated_secrets})
+        return access_token

--- a/tests/ops/service/connectors/test_okta_oauth2_client.py
+++ b/tests/ops/service/connectors/test_okta_oauth2_client.py
@@ -4,6 +4,7 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
+import requests
 
 from fides.api.common_exceptions import ConnectionException, OAuth2TokenException
 from fides.api.models.connectionconfig import ConnectionConfig
@@ -49,7 +50,8 @@ class TestGetAccessToken:
             (datetime.utcnow() - timedelta(seconds=1)).timestamp()
         )
 
-        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post:
+        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post, \
+             mock.patch("fides.api.service.connectors.okta_oauth2_client.Session.object_session", return_value=None):
             mock_response = Mock()
             mock_response.status_code = 200
             mock_response.json.return_value = {
@@ -67,7 +69,8 @@ class TestGetAccessToken:
         connection_config.secrets["access_token"] = None
         connection_config.secrets["expires_at"] = None
 
-        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post:
+        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post, \
+             mock.patch("fides.api.service.connectors.okta_oauth2_client.Session.object_session", return_value=None):
             mock_response = Mock()
             mock_response.status_code = 200
             mock_response.json.return_value = {"access_token": "fresh-token"}
@@ -97,7 +100,7 @@ class TestGetAccessToken:
 
         with mock.patch(
             "fides.api.service.connectors.okta_oauth2_client.requests.post",
-            side_effect=Exception("boom"),
+            side_effect=requests.exceptions.RequestException("boom"),
         ):
             oauth_client = OktaOAuth2Client(connection_config)
             with pytest.raises(OAuth2TokenException):
@@ -109,7 +112,8 @@ class TestGetAccessToken:
         connection_config.secrets["access_token"] = None
         connection_config.secrets["expires_at"] = None
 
-        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post:
+        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post, \
+             mock.patch("fides.api.service.connectors.okta_oauth2_client.Session.object_session", return_value=None):
             mock_response = Mock()
             mock_response.status_code = 200
             mock_response.json.return_value = {"not_access_token": "oops"}
@@ -123,7 +127,8 @@ class TestGetAccessToken:
         connection_config.secrets["access_token"] = None
         connection_config.secrets["expires_at"] = None
 
-        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post:
+        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post, \
+             mock.patch("fides.api.service.connectors.okta_oauth2_client.Session.object_session", return_value=None):
             mock_response = Mock()
             mock_response.status_code = 400
             mock_response.text = "Bad Request"

--- a/tests/ops/service/connectors/test_okta_oauth2_client.py
+++ b/tests/ops/service/connectors/test_okta_oauth2_client.py
@@ -1,0 +1,134 @@
+from datetime import datetime, timedelta
+from typing import Dict, Optional
+from unittest import mock
+from unittest.mock import Mock
+
+import pytest
+
+from fides.api.common_exceptions import ConnectionException, OAuth2TokenException
+from fides.api.models.connectionconfig import ConnectionConfig
+from fides.api.service.connectors.okta_oauth2_client import OktaOAuth2Client
+
+
+class DummyConnectionConfig:
+    """
+    Lightweight stand-in for ConnectionConfig for unit testing.
+    """
+
+    def __init__(self, secrets: Optional[Dict[str, Optional[str]]] = None) -> None:
+        self.secrets = secrets or {}
+        self.key = "okta_connection"
+        self.update = Mock()
+
+
+@pytest.fixture
+def connection_config() -> ConnectionConfig:
+    return DummyConnectionConfig(
+        secrets={
+            "org_url": "https://example.okta.com",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "access_token": "cached-token",
+            "expires_at": int((datetime.utcnow() + timedelta(hours=1)).timestamp()),
+        }
+    )  # type: ignore
+
+
+@pytest.fixture
+def oauth_client(connection_config: ConnectionConfig) -> OktaOAuth2Client:
+    return OktaOAuth2Client(connection_config)
+
+
+class TestGetAccessToken:
+    def test_returns_cached_token_when_valid(self, oauth_client: OktaOAuth2Client) -> None:
+        token = oauth_client.get_access_token()
+        assert token == "cached-token"
+
+    def test_requests_new_token_when_expired(self, connection_config: ConnectionConfig) -> None:
+        connection_config.secrets["expires_at"] = int(
+            (datetime.utcnow() - timedelta(seconds=1)).timestamp()
+        )
+
+        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "access_token": "fresh-token",
+                "expires_in": 600,
+            }
+            mock_post.return_value = mock_response
+
+            oauth_client = OktaOAuth2Client(connection_config)
+            token = oauth_client.get_access_token()
+            assert token == "fresh-token"
+            connection_config.update.assert_called_once()
+
+    def test_requests_new_token_when_missing(self, connection_config: ConnectionConfig) -> None:
+        connection_config.secrets["access_token"] = None
+        connection_config.secrets["expires_at"] = None
+
+        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"access_token": "fresh-token"}
+            mock_post.return_value = mock_response
+
+            oauth_client = OktaOAuth2Client(connection_config)
+            token = oauth_client.get_access_token()
+            assert token == "fresh-token"
+
+    def test_handles_missing_required_secrets(self) -> None:
+        connection_config = DummyConnectionConfig(
+            secrets={
+                "org_url": "https://example.okta.com",
+                "client_id": "client-id",
+            }
+        )  # type: ignore
+        oauth_client = OktaOAuth2Client(connection_config)  # type: ignore
+
+        with pytest.raises(ConnectionException) as exc:
+            oauth_client.get_access_token()
+
+        assert "missing required OAuth2 secrets" in str(exc.value)
+
+    def test_raises_error_on_http_failure(self, connection_config: ConnectionConfig) -> None:
+        connection_config.secrets["access_token"] = None
+        connection_config.secrets["expires_at"] = None
+
+        with mock.patch(
+            "fides.api.service.connectors.okta_oauth2_client.requests.post",
+            side_effect=Exception("boom"),
+        ):
+            oauth_client = OktaOAuth2Client(connection_config)
+            with pytest.raises(OAuth2TokenException):
+                oauth_client.get_access_token()
+
+    def test_raises_error_when_response_missing_access_token(
+        self, connection_config: ConnectionConfig
+    ) -> None:
+        connection_config.secrets["access_token"] = None
+        connection_config.secrets["expires_at"] = None
+
+        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"not_access_token": "oops"}
+            mock_post.return_value = mock_response
+
+            oauth_client = OktaOAuth2Client(connection_config)
+            with pytest.raises(OAuth2TokenException):
+                oauth_client.get_access_token()
+
+    def test_raises_error_when_status_not_200(self, connection_config: ConnectionConfig) -> None:
+        connection_config.secrets["access_token"] = None
+        connection_config.secrets["expires_at"] = None
+
+        with mock.patch("fides.api.service.connectors.okta_oauth2_client.requests.post") as mock_post:
+            mock_response = Mock()
+            mock_response.status_code = 400
+            mock_response.text = "Bad Request"
+            mock_post.return_value = mock_response
+
+            oauth_client = OktaOAuth2Client(connection_config)
+            with pytest.raises(OAuth2TokenException):
+                oauth_client.get_access_token()


### PR DESCRIPTION
Ticket [ENG-1952] (https://ethyca.atlassian.net/browse/ENG-1952)

### Description Of Changes

Introduced a dedicated OktaOAuth2Client helper that encapsulates the OAuth2 Client Credentials flow for the Okta discovery worker. The helper validates required secrets, reuses cached tokens when still valid, refreshes tokens proactively, and persists refreshed values back into the ConnectionConfig. Added unit tests covering cached-token reuse, token refresh, error handling, and missing-secret scenarios.

### Code Changes

* created OktaOAuth2Client with token acquisition, caching, and persistence logic under src/fides/api/service/connectors/okta_oauth2_client.py

* added pytest coverage for the helper in tests/ops/service/connectors/test_okta_oauth2_client.py using a minimal DummyConnectionConfig

### Steps to Confirm

1. python -m pytest fides/tests/ops/service/connectors/test_okta_oauth2_client.py

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1952]: https://ethyca.atlassian.net/browse/ENG-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ