### PR TITLE
[ENG-1290] Conditional Deps Utils

### DIFF
--- a/src/fides/api/task/conditional_dependencies/privacy_request/convenience_fields.py
+++ b/src/fides/api/task/conditional_dependencies/privacy_request/convenience_fields.py
@@ -80,10 +80,7 @@ def get_policy_convenience_fields(
         action_type.value for action_type in action_types if action_type
     ]
     for action_type in ActionType:
-        extra_fields[f"has_{action_type.value}_rule"] = any(
-            hasattr(rule, "action_type") and rule.action_type.value == action_type.value
-            for rule in rules
-        )
+        extra_fields[f"has_{action_type.value}_rule"] = action_type in action_types
     extra_fields["rule_count"] = len(rules) if rules else 0
     extra_fields["rule_names"] = [
         rule.name for rule in rules if hasattr(rule, "name") and rule.name

--- a/src/fides/api/task/conditional_dependencies/util.py
+++ b/src/fides/api/task/conditional_dependencies/util.py
@@ -20,13 +20,13 @@ def create_conditional_dependency_field_info(
     )
 
 
-def extract_nested_field_value(data: dict[str, Any], field_path: list[str]) -> Any:
+def extract_nested_field_value(data: Any, field_path: list[str]) -> Any:
     """
     Extracts a value from a dictionary by following the path.
 
     Args:
         data: The dictionary to extract from
-        path: The path to extract the value from
+        field_path: The path to extract the value from
 
     Returns:
         The extracted value


### PR DESCRIPTION
Ticket [ENG-1290] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

🎯 As a user, I want to specify conditions that must be true to create manual tasks, which check the request data, so that I can create tasks conditionally based on data in the request.

This PR adds some utils required for adding privacy request conditional dependencies

- Introspection utility:  that will allow us the ability to retrieve the available fields from privacy request to impose conditions on. This allows us a clean way to report to the UI what the available queryable conditions are and verify data types up front. (Including configured custom privacy request and identity values)

### Code Changes

* new `src/fides/api/task/conditional_dependencies/privacy_request/util.py`
* new `tests/api/task/conditional_dependencies/privacy_request/test_util.py`

### Steps to Confirm

1. This change is new and not hooked up to anything. Tests should pass. 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1290]: https://ethyca.atlassian.net/browse/ENG-1290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ