### PR TITLE
ENG-1992: Fix pre-approval webhook documentation

### DIFF
--- a/src/fides/api/api/v1/endpoints/pre_approval_webhook_endpoints.py
+++ b/src/fides/api/api/v1/endpoints/pre_approval_webhook_endpoints.py
@@ -90,7 +90,7 @@ def get_pre_approval_webhook_detail(
     ],
     response_model=List[schemas.PreApprovalWebhookResponse],
 )
-def create_or_update_pre_execution_webhooks(
+def create_or_update_pre_approval_webhooks(
     *,
     db: Session = Depends(deps.get_db),
     webhooks: Annotated[List[schemas.PreApprovalWebhookCreate], Field(max_length=50)],  # type: ignore
@@ -148,7 +148,7 @@ def create_or_update_pre_execution_webhooks(
         webhooks_to_remove.delete()
 
     logger.info(
-        "Creating/updating Policy Pre-Execution Webhooks: {}", staged_webhook_keys
+        "Creating/updating Policy Pre-Approval Webhooks: {}", staged_webhook_keys
     )
     # Committing to database now, as a last step, once we've verified that all the webhooks
     # in the request are free of issues.
@@ -164,7 +164,7 @@ def create_or_update_pre_execution_webhooks(
     ],
     response_model=schemas.PreApprovalWebhookResponse,
 )
-def update_pre_execution_webhook(
+def update_pre_approval_webhook(
     *,
     db: Session = Depends(deps.get_db),
     webhook_key: FidesKey,
@@ -193,7 +193,7 @@ def update_pre_execution_webhook(
             detail=exc.args[0],
         )
 
-    # Pre Execution Webhooks are not committed by default, so we commit at the end.
+    # Pre Approval Webhooks are not committed by default, so we commit at the end.
     db.commit()
     return schemas.PreApprovalWebhookResponse(
         connection_config=loaded_webhook.connection_config,
@@ -207,7 +207,7 @@ def update_pre_execution_webhook(
     status_code=HTTP_200_OK,
     dependencies=[Security(verify_oauth_client, scopes=[scopes.WEBHOOK_DELETE])],
 )
-def delete_pre_execution_webhook(
+def delete_pre_approval_webhook(
     *,
     db: Session = Depends(deps.get_db),
     webhook_key: FidesKey,


### PR DESCRIPTION
Ticket [ENG-1992] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Open api docs say pre-execution when they mean pre-approval.

### Code Changes

* Rename some functions.

### Steps to Confirm

1. Check that pre-approval web hooks say pre-approval and not pre-execution on swagger docs.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1992]: https://ethyca.atlassian.net/browse/ENG-1992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ