### PR TITLE
Added tooltip to GPC adaptive banner option

### DIFF
--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -120,6 +120,8 @@ const bannerButtonOptions: SelectProps["options"] = [
   },
 ];
 
+const GPC_ADAPTIVE_TOOLTIP = `Enabling ${bannerButtonOptions.find((b) => b.value === Layer1ButtonOption.GPC_CONDITIONAL)?.label} will show the acknowledge button when GPC is on, and the opt in/opt out buttons when GPC is off.`;
+
 const TCF_PLACEHOLDER_ID = "tcf_purposes_placeholder";
 
 export const PrivacyExperienceConfigColumnLayout = ({
@@ -381,7 +383,7 @@ export const PrivacyExperienceForm = ({
           layout="stacked"
           tooltip={
             values.component === ComponentType.BANNER_AND_MODAL
-              ? `Enabling ${bannerButtonOptions.find((b) => b.value === Layer1ButtonOption.GPC_CONDITIONAL)?.label} will show the acknowledge button when GPC is on, and the opt in/opt out buttons when GPC is off.`
+              ? GPC_ADAPTIVE_TOOLTIP
               : undefined
           }
         />


### PR DESCRIPTION
Ticket [ENG-2002]

### Description Of Changes

Added a tooltip to the "GPC adaptive" banner option in the Privacy Experience form to clarify its conditional behavior for users.

### Code Changes

* Added tooltip to banner options field that appears when "Banner and modal" component type is selected
* Tooltip explains that "GPC adaptive" shows acknowledge button when GPC is on, and opt in/opt out buttons when GPC is off

### Steps to Confirm

1. Navigate to Privacy Experience form in Admin UI
2. Select "Banner and modal" as the component type
3. Verify tooltip appears on the "Banner options" field
4. Hover over the info icon to see the tooltip explaining GPC adaptive behavior

<img width="411" height="161" alt="image" src="https://github.com/user-attachments/assets/9f5b05e4-125e-441f-a343-0dda77b7ac80" />


### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-2002]: https://ethyca.atlassian.net/browse/ENG-2002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ