### PR TITLE
fix: tree pagination [ENG-1928]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - Fixed SSO login button not appearing after session timeout without manual refresh [#6988](https://github.com/ethyca/fides/pull/6988)
 - Data Subject email identity no longer included in Generic DSR email list if the DSR was submitted on a policy that has more than just the erasure action type. [#6938](https://github.com/ethyca/fides/pull/6938)
 - Fixed page width on Digest list page [#6992](https://github.com/ethyca/fides/pull/6992)
+- Confirmation screen tree pagination on first level [#7000](https://github.com/ethyca/fides/pull/7000)
 
 ### Developer Experience
 - Fixed Ant Design drawer z-index to allow modal overlays [#6987](https://github.com/ethyca/fides/pull/6987)

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTreeDataTitle.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTreeDataTitle.tsx
@@ -17,6 +17,7 @@ import { CustomTreeDataNode } from "./types";
 const findNodeParent = (data: CustomTreeDataNode[], key: string) => {
   return data.find((node) => {
     const { children } = node;
+
     return children && !!children.find((child) => child.key.toString() === key);
   });
 };
@@ -25,17 +26,20 @@ const recFindNodeParent = (
   data: CustomTreeDataNode[],
   key: string,
 ): CustomTreeDataNode | null => {
-  return data.reduce(
-    (agg, current) => {
-      if (current.children) {
-        return (
-          findNodeParent(current.children, key) ??
-          recFindNodeParent(current.children, key)
-        );
-      }
-      return agg;
-    },
-    null as null | CustomTreeDataNode,
+  return (
+    findNodeParent(data, key) ??
+    data.reduce(
+      (agg, current) => {
+        if (current.children) {
+          return (
+            findNodeParent(current.children, key) ??
+            recFindNodeParent(current.children, key)
+          );
+        }
+        return agg;
+      },
+      null as null | CustomTreeDataNode,
+    )
   );
 };
 
@@ -54,6 +58,7 @@ export const MonitorTreeDataTitle = ({
 
   if (node.key.toString().startsWith(TREE_NODE_LOAD_MORE_KEY_PREFIX)) {
     const nodeParent = recFindNodeParent(treeData, node.key.toString());
+
     return (
       <Button
         type="link"


### PR DESCRIPTION
Ticket [ENG-1928] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Fixes bug where the "first" level of pagination wasn't triggering a request for the next set of results

### Code Changes

* Executing the function to find a parent node on the initial data before reducing

### Steps to Confirm

1. Visit the monitor fields screen with a dataset that contains more than 100 items at the first level of the tree
2. Click the "Show more" button
3. Confirm that it sends the request and populates the tree with the additional elements

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-1928]: https://ethyca.atlassian.net/browse/ENG-1928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ