### PR TITLE
 Updating Erasure Test

### DIFF
--- a/tests/integration/workflows/test_privacy_request_with_async_polling.py
+++ b/tests/integration/workflows/test_privacy_request_with_async_polling.py
@@ -266,18 +266,6 @@ class TestPrivacyRequestWithAsyncPolling:
         # Requeue the polling task
         requeue_polling_tasks.apply().get()
 
-        # Wait for the privacy request to be in processing (awaiting polling)
-        wait_for_privacy_request_status(
-            db=db,
-            privacy_request_id=privacy_request_id,
-            target_status=PrivacyRequestStatus.in_processing,
-            timeout_seconds=30,
-            poll_interval_seconds=2,
-        )
-
-        # Requeue the polling task
-        requeue_polling_tasks.apply().get()
-
         # Wait for the privacy request to be complete
         wait_for_privacy_request_status(
             db=db,
@@ -292,25 +280,7 @@ class TestPrivacyRequestWithAsyncPolling:
             .filter(PrivacyRequest.id == privacy_request_id)
             .first()
         )
-        access_results = privacy_request.get_raw_access_results()
-        assert (
-            access_results["async_polling_example:user"][0]["retrieved_attachments"][0][
-                "file_name"
-            ]
-            == "report.pdf"
-        )
-        assert (
-            access_results["async_polling_example:user"][0]["retrieved_attachments"][0][
-                "download_url"
-            ]
-            is not None
-        )
-        assert (
-            access_results["async_polling_example:user"][0]["retrieved_attachments"][0][
-                "file_size"
-            ]
-            == 17
-        )
+
         assert privacy_request.get_raw_masking_counts() == {
             "async_polling_example:user": 1
         }


### PR DESCRIPTION
Previously we had a limitation where we would require the access request before running an erasure request on polling. This is no longer the case, but the test was not updated to reflect that. Now it has been

### Description Of Changes

Removing additional call and test checks on the access requests

### Code Changes

* Updated Test suite

### Steps to Confirm

1. Run pytest tests/integration/workflows/test_privacy_request_with_async_polling.py and verify that the test is passing correctly 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
