### PR TITLE
fix label to match option in DataCategorySelect

### DIFF
--- a/clients/admin-ui/src/features/common/dropdown/DataCategorySelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/DataCategorySelect.tsx
@@ -31,6 +31,13 @@ const DataCategorySelect = ({
         name,
         primaryName,
         description: category.description || "",
+        label: (
+          <>
+            <strong>{primaryName || name}</strong>
+            {primaryName && `: ${name}`}
+          </>
+        ),
+        title: category.fides_key,
       };
     });
 


### PR DESCRIPTION
Ticket [ENG-1984]

### Description Of Changes

Fixed a bug where the Action Center field review was displaying raw data category keys instead of the user-friendly formatted names shown in the broader schema view.

### Code Changes

* Added custom label JSX to `DataCategorySelect.tsx`
* Added title to preserve the value as title formatting that was used previously

### Steps to Confirm

1. Navigate to an Action Center Data Monitor result and open field details for review
2. Add a category to one of the fields in the main list by clicking the [+]
3. Click the name of the field to open the drawer
4. Validate that the selected category is displayed the same way it is in the main list

<img width="1526" height="500" alt="CleanShot 2025-11-19 at 17 19 16@2x" src="https://github.com/user-attachments/assets/db0f3b54-80a6-4798-903e-6385533c9e82" />

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-1984]: https://ethyca.atlassian.net/browse/ENG-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ