### PR TITLE
Remove default status filter on new request manager

### DIFF
--- a/clients/admin-ui/src/features/privacy-requests/dashboard/hooks/usePrivacyRequestsFilters.ts
+++ b/clients/admin-ui/src/features/privacy-requests/dashboard/hooks/usePrivacyRequestsFilters.ts
@@ -37,18 +37,13 @@ const usePrivacyRequestsFilters = ({
   pagination,
 }: UsePrivacyRequestsFiltersProps) => {
   const allowedStatusFilterOptions = [...SubjectRequestStatusMap.keys()];
-  const defaultStatusFilter = allowedStatusFilterOptions.filter(
-    (status) => status !== PrivacyRequestStatus.DUPLICATE,
-  );
 
   const [filters, setFilters] = useQueryStates(
     {
       search: parseAsString.withOptions({ throttleMs: 300 }),
       from: parseAsString,
       to: parseAsString,
-      status: parseAsArrayOf(parseAsStringEnum(allowedStatusFilterOptions))
-        .withDefault(defaultStatusFilter)
-        .withOptions({ clearOnDefault: true }),
+      status: parseAsArrayOf(parseAsStringEnum(allowedStatusFilterOptions)),
       action_type: parseAsArrayOf(parseAsStringEnum(Object.values(ActionType))),
       custom_privacy_request_fields: parseAsCustomFields,
     },


### PR DESCRIPTION
Ticket [ENG-2086]
### Description Of Changes
Improve UX by removing the default status filter on new request manager screen.

### Code Changes
* Removed default filter in nuqs definition

### Steps to Confirm
1. Visit the [preview link](https://fides-plus-nightly-git-eng-2086-remove-default-st-cb2093-ethyca.vercel.app/settings/about)
2. Turn on the feature flag "Privacy request v2"
3. Go to the [Request manager (new)](https://fides-plus-nightly-git-eng-2086-remove-default-st-cb2093-ethyca.vercel.app/new-privacy-requests) page
4. Check that no status filters are being applied
5. Check that you can add any filters, including duplicates. 
6. Check that you can clear all status filters by clicking on the x at the end of the select.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-2086]: https://ethyca.atlassian.net/browse/ENG-2086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ