### PR TITLE
Fix flaky Cypress tests in discovery-detection suite

### DIFF
--- a/clients/admin-ui/cypress/e2e/discovery-detection.cy.ts
+++ b/clients/admin-ui/cypress/e2e/discovery-detection.cy.ts
@@ -100,8 +100,10 @@ describe("discovery and detection", () => {
           "row-my_bigquery_monitor.prj-bigquery-000000.test_dataset_1-col-action",
         ).within(() => {
           cy.getByTestId("action-Ignore")
+            .should("not.be.disabled")
             .scrollIntoView()
-            .click({ force: true });
+            .should("be.visible");
+          cy.getByTestId("action-Ignore").click({ force: true });
           cy.wait("@ignoreResource");
         });
       });
@@ -139,8 +141,10 @@ describe("discovery and detection", () => {
           "row-my_bigquery_monitor.prj-bigquery-000001.test_dataset_2-col-action",
         ).within(() => {
           cy.getByTestId("action-Ignore")
+            .should("not.be.disabled")
             .scrollIntoView()
-            .click({ force: true });
+            .should("be.visible");
+          cy.getByTestId("action-Ignore").click({ force: true });
           cy.wait("@ignoreResource");
         });
       });
@@ -171,6 +175,10 @@ describe("discovery and detection", () => {
         ).within(() => {
           cy.getByTestId("action-Confirm").should("not.exist");
           cy.getByTestId("action-Monitor").should("not.exist");
+          cy.getByTestId("action-Ignore")
+            .should("not.be.disabled")
+            .scrollIntoView()
+            .should("be.visible");
           cy.getByTestId("action-Ignore").click();
           cy.wait("@ignoreResource");
         });
@@ -206,6 +214,10 @@ describe("discovery and detection", () => {
         cy.getByTestId(
           "row-my_bigquery_monitor.prj-bigquery-000002.test_dataset_4-col-action",
         ).within(() => {
+          cy.getByTestId("action-Ignore")
+            .should("not.be.disabled")
+            .scrollIntoView()
+            .should("be.visible");
           cy.getByTestId("action-Ignore").click();
           cy.wait("@ignoreResource");
         });
@@ -316,9 +328,14 @@ describe("discovery and detection", () => {
 
         it("should allow monitored tables to be muted", () => {
           cy.getAntTab("Monitored").click({ force: true });
+          cy.wait("@getAllMonitoredTables");
           cy.getByTestId(
             "row-my_bigquery_monitor.prj-bigquery-418515.test_dataset_1.consent-reports-20-col-actions",
           ).within(() => {
+            cy.getByTestId("action-Ignore")
+              .should("not.be.disabled")
+              .scrollIntoView()
+              .should("be.visible");
             cy.getByTestId("action-Ignore").click();
             cy.wait("@ignoreResource");
           });
@@ -335,10 +352,15 @@ describe("discovery and detection", () => {
 
         it("should allow muted tables to be monitored", () => {
           cy.getAntTab("Unmonitored").click({ force: true });
+          cy.wait("@getAllMutedTables");
           cy.getByTestId(
             "row-my_bigquery_monitor.prj-bigquery-418515.test_dataset_1.consent-reports-21-col-actions",
           ).within(() => {
-            cy.getByTestId("action-Monitor").click();
+            cy.getByTestId("action-Monitor")
+              .scrollIntoView()
+              .should("be.visible")
+              .should("not.be.disabled")
+              .click();
             cy.wait("@confirmResource");
           });
         });


### PR DESCRIPTION
### Description Of Changes

Fix race conditions in discovery-detection Cypress tests where action buttons were being clicked before React finished re-rendering state updates. The tests were timing out waiting for API responses that never occurred because the buttons were disabled when clicked.

### Code Changes

* Added `.should("be.visible")` and `.should("not.be.disabled")` assertions before clicking action buttons to ensure UI has stabilized after previous actions
* Added `cy.wait(@getAll...tables)` calls after tab switches to ensure data has loaded before interacting with table content
* Fixed 5 test cases affected by this race condition

### Steps to Confirm

1. Verify all tests pass consistently without timeout errors

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your `downrev` is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required