### PR TITLE
Do not publish python package on all commits

### DIFF
--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -2,8 +2,6 @@ name: Publish Fides
 
 on:
   push:
-    branches:
-      - main
     tags:
       - "*"
 


### PR DESCRIPTION
### Description Of Changes

Removes the trigger of commits to `main` for the 'Publish fides' (i.e. publish python package) GH action. The action is still triggered by explicit tags of commits.

AFAIK, we no longer use the python packages published to test PyPI on every commit to `main`, so these are a waste of time and resources (and lead to noisy errors if we run out of 'space' on our test pypi index, etc.).

Previously, we relied on these packages to build our 'double-edge' images in Fidesplus. We now use a different mechanism for building this image: we check out `main` of this repo (`fides`) [directly as part of the GH action](https://github.com/ethyca/fidesplus/blob/main/.github/workflows/docker_double_edge.yml#L42-L48).

### Code Changes

* remove the `main` `branch` trigger for `publish_package.yml`

### Steps to Confirm

1. we should still be able to e.g. publish a package to test pypi when pushing an alpha tag 
2. other CI workflows shouldn't be impacted at all - this will take a bit of time to tell, we should just keep our eyes out for errors...

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
