### PR TITLE
ENG-1952 Add OAuth2 HTTP client with DPoP support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,6 +57,7 @@ python-jose[cryptography]==3.3.0
 pyyaml==6.0.1
 pyahocorasick==2.1.0
 redis==3.5.3
+requests-oauth2client>=1.5.0
 requests-oauthlib==2.0.0
 rich-click==1.6.1
 sendgrid==6.9.7

--- a/src/fides/api/service/connectors/okta_http_client.py
+++ b/src/fides/api/service/connectors/okta_http_client.py
@@ -1,0 +1,208 @@
+import json
+import re
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+import requests
+from requests.auth import AuthBase
+
+from fides.api.common_exceptions import ConnectionException
+
+if TYPE_CHECKING:
+    from requests_oauth2client import DPoPKey, OAuth2Client
+
+
+# --- Constants ---
+DEFAULT_OKTA_SCOPES = ("okta.apps.read",)
+DEFAULT_API_LIMIT = 200
+DEFAULT_MAX_PAGES = 100
+DEFAULT_REQUEST_TIMEOUT = 30
+
+# Mapping from EC curve to JWT signing algorithm
+EC_CURVE_ALG_MAP = {
+    "P-256": "ES256",
+    "P-384": "ES384",
+    "P-521": "ES512",
+}
+
+
+class OktaHttpClient:
+    """
+    Minimal HTTP client for Okta API with OAuth2 private_key_jwt + DPoP.
+
+    Why not Okta SDK? SDK lacks DPoP support (affects 30-50% of Okta orgs).
+
+    Deliberately scoped: This client lives in connectors/, not in the SaaS framework.
+    If we later need a generic private_key_jwt + DPoP auth strategy for SaaS connectors,
+    we will extract it from this iplementation with a clear product decision and 2-3 use
+    cases validating the abstraction.
+    """
+
+    def __init__(
+        self,
+        org_url: str,
+        client_id: str,
+        private_key: str,
+        scopes: Optional[List[str]] = None,
+        *,
+        oauth_client: "Optional[OAuth2Client]" = None,  # For test injection
+        dpop_key: "Optional[DPoPKey]" = None,  # For test injection
+    ):
+        """
+        Initialize OktaHttpClient.
+
+        Args:
+            org_url: Okta organization URL (e.g., https://your-org.okta.com)
+            client_id: OAuth2 client ID
+            private_key: Private key in JWK (JSON) format for client authentication (provided by Okta)
+            scopes: OAuth2 scopes
+            oauth_client: For test injection - pre-configured OAuth2Client
+            dpop_key: For test injection - pre-configured DPoP key
+        """
+        self.org_url = org_url.rstrip("/")
+        self.scopes = tuple(scopes) if scopes is not None else DEFAULT_OKTA_SCOPES
+
+        if oauth_client is not None or dpop_key is not None:
+            if oauth_client is None or dpop_key is None:
+                raise ValueError(
+                    "Both oauth_client and dpop_key must be provided when injecting test dependencies."
+                )
+            self._oauth_client = oauth_client
+            self._dpop_key = dpop_key
+            return
+
+        try:
+            from requests_oauth2client import DPoPKey, OAuth2Client, PrivateKeyJwt
+
+            private_jwk = self._parse_jwk(private_key)
+            alg = self._determine_alg_from_jwk(private_jwk)
+
+            # Auto-generate DPoP key (EC P-256 for performance)
+            # Okta requires DPoP key to be SEPARATE from client auth key
+            self._dpop_key = DPoPKey.generate(alg="ES256")
+
+            self._oauth_client = OAuth2Client(
+                token_endpoint=f"{self.org_url}/oauth2/v1/token",
+                auth=PrivateKeyJwt(client_id, private_jwk, alg=alg),
+            )
+        except ImportError as e:
+            raise ConnectionException(
+                "The 'requests-oauth2client' library is required for Okta connector. "
+                "Please install it with: pip install requests-oauth2client"
+            ) from e
+        except (ValueError, TypeError) as e:
+            raise ConnectionException(f"Invalid key format: {str(e)}") from e
+
+    @staticmethod
+    def _parse_jwk(private_key: str) -> Dict[str, Any]:
+        """Parse and validate a private key in JWK format."""
+        try:
+            jwk_dict = json.loads(private_key.strip())
+        except json.JSONDecodeError as exc:
+            raise ValueError("Private key must be in JWK (JSON) format.") from exc
+
+        if "d" not in jwk_dict:
+            raise ValueError("JWK is not a private key (missing 'd' parameter).")
+
+        return jwk_dict
+
+    @staticmethod
+    def _determine_alg_from_jwk(jwk: Dict[str, Any]) -> str:
+        """Determine the signing algorithm from the JWK."""
+        if "alg" in jwk:
+            return jwk["alg"]
+
+        kty = jwk.get("kty")
+        if kty == "RSA":
+            return "RS256"
+        if kty == "EC":
+            crv = jwk.get("crv", "P-256")
+            return EC_CURVE_ALG_MAP.get(crv, "ES256")
+
+        return "RS256"  # Default fallback
+
+    def _get_token(self) -> AuthBase:
+        """Get DPoP-bound access token."""
+        try:
+            from requests_oauth2client.exceptions import OAuth2Error
+
+            return self._oauth_client.client_credentials(
+                scope=" ".join(self.scopes), dpop_key=self._dpop_key
+            )
+        except ImportError as e:
+            raise ConnectionException(
+                "The 'requests-oauth2client' library is required for Okta connector. "
+                "Please install it with: pip install requests-oauth2client"
+            ) from e
+        except OAuth2Error as e:
+            raise ConnectionException(
+                f"OAuth2 token acquisition failed: {str(e)}"
+            ) from e
+
+    def list_applications(
+        self, limit: int = DEFAULT_API_LIMIT, after: Optional[str] = None
+    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        """
+        List Okta applications with cursor-based pagination.
+
+        Args:
+            limit: Maximum number of applications to return
+            after: Cursor for next page (from previous response)
+
+        Returns:
+            Tuple of (apps_list, next_cursor). next_cursor is None if no more pages.
+        """
+        token = self._get_token()
+        params: Dict[str, Any] = {"limit": limit}
+        if after:
+            params["after"] = after
+
+        try:
+            response = requests.get(
+                f"{self.org_url}/api/v1/apps",
+                params=params,
+                auth=token,
+                timeout=DEFAULT_REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+        except requests.RequestException as e:
+            raise ConnectionException(f"Okta API request failed: {str(e)}") from e
+
+        next_cursor = self._extract_next_cursor(response.headers.get("Link"))
+        return response.json(), next_cursor
+
+    def list_all_applications(
+        self, page_size: int = DEFAULT_API_LIMIT, max_pages: int = DEFAULT_MAX_PAGES
+    ) -> List[Dict[str, Any]]:
+        """
+        Fetch all Okta applications with automatic pagination.
+
+        Args:
+            page_size: Number of applications per page
+            max_pages: Maximum number of pages to fetch (safety limit)
+
+        Returns:
+            List of all applications
+        """
+        all_apps: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        for _ in range(max_pages):
+            apps, next_cursor = self.list_applications(limit=page_size, after=cursor)
+            all_apps.extend(apps)
+
+            if not next_cursor:
+                break
+            cursor = next_cursor
+
+        return all_apps
+
+    @staticmethod
+    def _extract_next_cursor(link_header: Optional[str]) -> Optional[str]:
+        """Extract 'after' cursor from Okta Link header."""
+        if not link_header:
+            return None
+        for link in link_header.split(","):
+            if 'rel="next"' in link:
+                match = re.search(r"after=([^&>]+)", link)
+                if match:
+                    return match.group(1)
+        return None

--- a/tests/ops/service/connectors/test_okta_http_client.py
+++ b/tests/ops/service/connectors/test_okta_http_client.py
@@ -1,0 +1,371 @@
+"""
+Unit tests for OktaHttpClient.
+
+All tests use mocks - no external Okta API calls.
+"""
+
+import json
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from requests.auth import AuthBase
+
+from fides.api.common_exceptions import ConnectionException
+from fides.api.service.connectors.okta_http_client import (
+    DEFAULT_API_LIMIT,
+    DEFAULT_MAX_PAGES,
+    DEFAULT_OKTA_SCOPES,
+    DEFAULT_REQUEST_TIMEOUT,
+    OktaHttpClient,
+)
+
+# Test JWKs (fake keys for testing only)
+RSA_JWK = {
+    "kty": "RSA",
+    "kid": "test-kid-rsa",
+    "n": "test-modulus",
+    "e": "AQAB",
+    "d": "test-private-exponent",
+}
+EC_JWK = {
+    "kty": "EC",
+    "crv": "P-256",
+    "kid": "test-kid-ec",
+    "x": "test-x",
+    "y": "test-y",
+    "d": "test-d-ec",
+}
+
+TEST_ORG_URL = "https://test.okta.com"
+TEST_CLIENT_ID = "test-client-id"
+TEST_PRIVATE_KEY_STR = "not-used-when-injected"
+
+
+@pytest.fixture
+def mock_oauth_client_and_dpop_key():
+    """Fixture for mocked OAuth2Client and DPoPKey."""
+    return MagicMock(), MagicMock()
+
+
+@pytest.fixture
+def client_with_injection(mock_oauth_client_and_dpop_key):
+    """Fixture for an OktaHttpClient with injected dependencies."""
+    mock_oauth_client, mock_dpop_key = mock_oauth_client_and_dpop_key
+    return OktaHttpClient(
+        org_url=TEST_ORG_URL,
+        client_id=TEST_CLIENT_ID,
+        private_key=TEST_PRIVATE_KEY_STR,
+        oauth_client=mock_oauth_client,
+        dpop_key=mock_dpop_key,
+    )
+
+
+class TestOktaHttpClientInit:
+    """Tests for OktaHttpClient initialization."""
+
+    def test_injected_dependencies_set(
+        self, client_with_injection, mock_oauth_client_and_dpop_key
+    ):
+        mock_oauth_client, mock_dpop_key = mock_oauth_client_and_dpop_key
+        assert client_with_injection._oauth_client is mock_oauth_client
+        assert client_with_injection._dpop_key is mock_dpop_key
+        assert client_with_injection.org_url == TEST_ORG_URL
+
+    @pytest.mark.parametrize(
+        "oauth_client,dpop_key",
+        [
+            (MagicMock(), None),
+            (None, MagicMock()),
+        ],
+    )
+    def test_injection_requires_both(self, oauth_client, dpop_key):
+        with pytest.raises(ValueError) as exc_info:
+            OktaHttpClient(
+                org_url=TEST_ORG_URL,
+                client_id=TEST_CLIENT_ID,
+                private_key=TEST_PRIVATE_KEY_STR,
+                oauth_client=oauth_client,
+                dpop_key=dpop_key,
+            )
+        assert "Both oauth_client and dpop_key" in str(exc_info.value)
+
+    def test_init_strips_trailing_slash(self, mock_oauth_client_and_dpop_key):
+        mock_oauth_client, mock_dpop_key = mock_oauth_client_and_dpop_key
+        client = OktaHttpClient(
+            org_url=f"{TEST_ORG_URL}/",
+            client_id=TEST_CLIENT_ID,
+            private_key=TEST_PRIVATE_KEY_STR,
+            oauth_client=mock_oauth_client,
+            dpop_key=mock_dpop_key,
+        )
+        assert client.org_url == TEST_ORG_URL
+
+    def test_default_scopes_are_tuple(self, client_with_injection):
+        assert client_with_injection.scopes == DEFAULT_OKTA_SCOPES
+        assert isinstance(client_with_injection.scopes, tuple)
+
+    def test_custom_scopes_coerced_to_tuple(self, mock_oauth_client_and_dpop_key):
+        mock_oauth_client, mock_dpop_key = mock_oauth_client_and_dpop_key
+        scopes = ["okta.apps.read", "okta.users.read"]
+        client = OktaHttpClient(
+            org_url=TEST_ORG_URL,
+            client_id=TEST_CLIENT_ID,
+            private_key=TEST_PRIVATE_KEY_STR,
+            scopes=scopes,
+            oauth_client=mock_oauth_client,
+            dpop_key=mock_dpop_key,
+        )
+        assert client.scopes == tuple(scopes)
+
+    @patch(
+        "fides.api.service.connectors.okta_http_client.OktaHttpClient._determine_alg_from_jwk"
+    )
+    @patch("fides.api.service.connectors.okta_http_client.OktaHttpClient._parse_jwk")
+    @patch("requests_oauth2client.PrivateKeyJwt")
+    @patch("requests_oauth2client.OAuth2Client")
+    @patch("requests_oauth2client.DPoPKey")
+    def test_full_initialization_without_injection(
+        self,
+        mock_dpop_class,
+        mock_oauth_class,
+        mock_private_key_jwt,
+        mock_parse_jwk,
+        mock_determine_alg,
+    ):
+        mock_parse_jwk.return_value = RSA_JWK
+        mock_determine_alg.return_value = "RS256"
+        mock_dpop_instance = MagicMock()
+        mock_dpop_class.generate.return_value = mock_dpop_instance
+
+        client = OktaHttpClient(
+            org_url=TEST_ORG_URL,
+            client_id=TEST_CLIENT_ID,
+            private_key=json.dumps(RSA_JWK),
+        )
+
+        mock_parse_jwk.assert_called_once_with(json.dumps(RSA_JWK))
+        mock_determine_alg.assert_called_once_with(RSA_JWK)
+        mock_dpop_class.generate.assert_called_once_with(alg="ES256")
+        assert client._dpop_key is mock_dpop_instance
+        mock_private_key_jwt.assert_called_once_with(
+            TEST_CLIENT_ID, RSA_JWK, alg="RS256"
+        )
+        mock_oauth_class.assert_called_once_with(
+            token_endpoint=f"{TEST_ORG_URL}/oauth2/v1/token",
+            auth=mock_private_key_jwt.return_value,
+        )
+
+    def test_invalid_key_raises_connection_exception(self):
+        with pytest.raises(ConnectionException) as exc_info:
+            OktaHttpClient(
+                org_url=TEST_ORG_URL,
+                client_id=TEST_CLIENT_ID,
+                private_key="not-valid-json",
+            )
+        assert "Invalid private key format" in str(exc_info.value)
+
+    def test_public_key_raises_connection_exception(self):
+        public_jwk = RSA_JWK.copy()
+        del public_jwk["d"]
+        with pytest.raises(ConnectionException) as exc_info:
+            OktaHttpClient(
+                org_url=TEST_ORG_URL,
+                client_id=TEST_CLIENT_ID,
+                private_key=json.dumps(public_jwk),
+            )
+        # Generic error message used to avoid leaking key details
+        assert "Invalid private key format" in str(exc_info.value)
+
+    def test_import_error_raises_connection_exception(self):
+        with patch.dict(sys.modules, {"requests_oauth2client": None}):
+            with pytest.raises(ConnectionException) as exc_info:
+                OktaHttpClient(
+                    org_url=TEST_ORG_URL,
+                    client_id=TEST_CLIENT_ID,
+                    private_key=json.dumps(RSA_JWK),
+                )
+        assert "requests-oauth2client' library is required" in str(exc_info.value)
+
+
+class TestOktaHttpClientMethods:
+    """Tests for OktaHttpClient methods, using an injected client."""
+
+    @pytest.fixture
+    def mock_token(self, client_with_injection):
+        mock_token = MagicMock(spec=AuthBase)
+        client_with_injection._oauth_client.client_credentials.return_value = mock_token
+        return mock_token
+
+    def test_list_applications_single_page(self, client_with_injection, mock_token):
+        mock_apps = [{"id": "app1"}, {"id": "app2"}]
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock(headers={}, status_code=200)
+            mock_response.json.return_value = mock_apps
+            mock_get.return_value = mock_response
+
+            apps, next_cursor = client_with_injection.list_applications()
+
+            assert apps == mock_apps
+            assert next_cursor is None
+            mock_get.assert_called_once_with(
+                f"{TEST_ORG_URL}/api/v1/apps",
+                params={"limit": DEFAULT_API_LIMIT},
+                auth=mock_token,
+                timeout=DEFAULT_REQUEST_TIMEOUT,
+            )
+
+    def test_list_applications_with_pagination(self, client_with_injection, mock_token):
+        link_header = f'<{TEST_ORG_URL}/api/v1/apps?after=cursor123>; rel="next"'
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock(headers={"Link": link_header}, status_code=200)
+            mock_response.json.return_value = [{"id": "app1"}]
+            mock_get.return_value = mock_response
+
+            apps, next_cursor = client_with_injection.list_applications(limit=1)
+
+            assert apps == [{"id": "app1"}]
+            assert next_cursor == "cursor123"
+            mock_get.assert_called_once_with(
+                f"{TEST_ORG_URL}/api/v1/apps",
+                params={"limit": 1},
+                auth=mock_token,
+                timeout=DEFAULT_REQUEST_TIMEOUT,
+            )
+
+    def test_list_applications_oauth_error(self, client_with_injection):
+        class StubOAuth2Error(Exception):
+            pass
+
+        exceptions_module = ModuleType("requests_oauth2client.exceptions")
+        exceptions_module.OAuth2Error = StubOAuth2Error
+        package_module = ModuleType("requests_oauth2client")
+        package_module.exceptions = exceptions_module
+
+        with patch.dict(
+            sys.modules,
+            {
+                "requests_oauth2client": package_module,
+                "requests_oauth2client.exceptions": exceptions_module,
+            },
+        ):
+            client_with_injection._oauth_client.client_credentials.side_effect = (
+                StubOAuth2Error("invalid_client")
+            )
+            with pytest.raises(ConnectionException) as exc_info:
+                client_with_injection.list_applications()
+        assert "OAuth2 token acquisition failed" in str(exc_info.value)
+
+    def test_list_applications_http_error(self, client_with_injection, mock_token):
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = requests.RequestException("Network error")
+            with pytest.raises(ConnectionException) as exc_info:
+                client_with_injection.list_applications()
+        assert "Okta API request failed" in str(exc_info.value)
+
+    def test_list_all_applications_multiple_pages(self, client_with_injection):
+        with patch.object(client_with_injection, "list_applications") as mock_list:
+            mock_list.side_effect = [
+                ([{"id": "app1"}], "cursor1"),
+                ([{"id": "app2"}], "cursor2"),
+                ([{"id": "app3"}], None),
+            ]
+            apps = client_with_injection.list_all_applications(page_size=1)
+        assert [a["id"] for a in apps] == ["app1", "app2", "app3"]
+        assert mock_list.call_count == 3
+
+    def test_list_all_applications_respects_max_pages(self, client_with_injection):
+        with patch.object(client_with_injection, "list_applications") as mock_list:
+            # Use different cursors each time to avoid duplicate detection
+            mock_list.side_effect = [
+                ([{"id": "app"}], "cursor1"),
+                ([{"id": "app"}], "cursor2"),
+                ([{"id": "app"}], "cursor3"),  # Would continue but max_pages=3
+            ]
+            apps = client_with_injection.list_all_applications(page_size=1, max_pages=3)
+        assert len(apps) == 3
+        assert mock_list.call_count == 3
+
+    def test_list_all_applications_stops_on_duplicate_cursor(
+        self, client_with_injection
+    ):
+        """Test that duplicate cursor detection prevents infinite loop."""
+        with patch.object(client_with_injection, "list_applications") as mock_list:
+            # Okta returns same cursor repeatedly (bug scenario)
+            mock_list.side_effect = [
+                ([{"id": "app1"}], "same_cursor"),
+                ([{"id": "app2"}], "same_cursor"),  # Same cursor - should stop
+            ]
+            apps = client_with_injection.list_all_applications(page_size=1)
+
+        assert len(apps) == 2  # Got both pages
+        assert mock_list.call_count == 2  # But stopped after detecting duplicate
+
+
+class TestStaticHelperMethods:
+    def test_extract_cursor_from_link_header(self):
+        link_header = (
+            f'<{TEST_ORG_URL}/api/v1/apps?after=abc123>; rel="next", '
+            f'<{TEST_ORG_URL}/api/v1/apps?after=prev>; rel="prev"'
+        )
+        cursor = OktaHttpClient._extract_next_cursor(link_header)
+        assert cursor == "abc123"
+
+    def test_extract_cursor_no_next_link(self):
+        cursor = OktaHttpClient._extract_next_cursor(
+            f'<{TEST_ORG_URL}/api/v1/apps>; rel="self"'
+        )
+        assert cursor is None
+
+    def test_extract_cursor_none_header(self):
+        assert OktaHttpClient._extract_next_cursor(None) is None
+
+    def test_extract_cursor_url_encoded(self):
+        """Test cursor extraction with URL-encoded values."""
+        link_header = (
+            f'<{TEST_ORG_URL}/api/v1/apps?after=abc%3D123&limit=200>; rel="next"'
+        )
+        cursor = OktaHttpClient._extract_next_cursor(link_header)
+        assert cursor == "abc=123"  # URL-decoded by parse_qs
+
+    def test_extract_cursor_multiple_params(self):
+        """Test cursor extraction when after is not first param."""
+        link_header = f'<{TEST_ORG_URL}/api/v1/apps?limit=200&after=xyz789&filter=active>; rel="next"'
+        cursor = OktaHttpClient._extract_next_cursor(link_header)
+        assert cursor == "xyz789"
+
+    def test_parse_jwk_accepts_dict(self):
+        """Test that _parse_jwk accepts a dict directly."""
+        parsed = OktaHttpClient._parse_jwk(RSA_JWK)
+        assert parsed["kid"] == RSA_JWK["kid"]
+
+    def test_parse_jwk_validates_dict_missing_d(self):
+        """Test that dict input is validated for private key."""
+        public_jwk = RSA_JWK.copy()
+        del public_jwk["d"]
+        with pytest.raises(ValueError, match="not a private key"):
+            OktaHttpClient._parse_jwk(public_jwk)
+
+    def test_parse_jwk_validates_private_key(self):
+        public_jwk = RSA_JWK.copy()
+        del public_jwk["d"]
+        with pytest.raises(ValueError):
+            OktaHttpClient._parse_jwk(json.dumps(public_jwk))
+
+    def test_parse_jwk_round_trip(self):
+        parsed = OktaHttpClient._parse_jwk(json.dumps(RSA_JWK))
+        assert parsed["kid"] == RSA_JWK["kid"]
+
+    def test_determine_alg_from_jwk_prefers_alg_field(self):
+        jwk = {**RSA_JWK, "alg": "RS512"}
+        assert OktaHttpClient._determine_alg_from_jwk(jwk) == "RS512"
+
+    def test_determine_alg_from_ec_curve(self):
+        alg = OktaHttpClient._determine_alg_from_jwk(EC_JWK)
+        assert alg == "ES256"
+
+    def test_determine_alg_default_fallback(self):
+        jwk = {"kty": "unknown", "d": "value"}
+        assert OktaHttpClient._determine_alg_from_jwk(jwk) == "RS256"


### PR DESCRIPTION
Ticket [ENG-1952]

### Description Of Changes

This work introduces a minimal Okta HTTP client with full support for OAuth2 `private_key_jwt` authentication and DPoP — functionality not provided by the Okta SDK. It also adds a comprehensive suite of unit tests. This client is the foundation for the OAuth2 migration required to properly secure the Okta Identity Provider Monitor.

### Code Changes

* Added `OktaHttpClient` implementing OAuth2 `private_key_jwt` + DPoP authentication.
* Implemented key parsing, algorithm selection, and structured error handling for missing dependencies or invalid keys.
* Added pagination helpers (`list_applications`, `list_all_applications`) with cursor extraction from response headers.
* Introduced `test_okta_http_client.py` with full mock-based coverage for initialization, authentication, pagination, helper methods, and error paths.
* Tests validate handling of invalid JWKs, algorithm resolution, missing deps, and API error conditions.

### Steps to Confirm

1. Run unit tests: `nox -s unit`.
2. Validate the client can fetch paginated Okta applications using mocked responses.
3. Confirm error handling behavior by running tests covering invalid keys, missing dependencies, and API failures.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] New features have been verified on Demo Environment using `nox -s demo -- dev`
* Documentation:
  * [ ] documentation complete, [PR opened in fides

[ENG-1952]: https://ethyca.atlassian.net/browse/ENG-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ