### PR TITLE
feat: async tree

### DIFF
--- a/clients/admin-ui/src/features/common/nav/nav-config.tsx
+++ b/clients/admin-ui/src/features/common/nav/nav-config.tsx
@@ -355,6 +355,11 @@ if (process.env.NEXT_PUBLIC_APP_ENV === "development") {
         path: routes.ERRORS_POC_ROUTE,
         scopes: [],
       },
+      {
+        title: "Async Tree POC",
+        path: routes.ASYNC_TREE_ROUTE,
+        scopes: [],
+      },
     ],
   });
 }

--- a/clients/admin-ui/src/features/common/nav/routes.ts
+++ b/clients/admin-ui/src/features/common/nav/routes.ts
@@ -97,6 +97,7 @@ export const ANT_POC_ROUTE = "/poc/ant-components";
 export const FORMS_POC_ROUTE = "/poc/forms";
 export const ERRORS_POC_ROUTE = "/poc/error";
 export const TABLE_MIGRATION_POC_ROUTE = "/poc/table-migration";
+export const ASYNC_TREE_ROUTE = "/poc/async-tree";
 export const FIDES_JS_DOCS = "/fides-js-docs";
 
 // Sandbox routes

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncNodeSkeleton.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncNodeSkeleton.tsx
@@ -1,0 +1,8 @@
+import { Skeleton } from "fidesui";
+
+import { AsyncTreeNodeComponentProps } from "./types";
+
+export const AsyncNodeSkeleton = ({ node }: AsyncTreeNodeComponentProps) =>
+  <Skeleton paragraph={false} title={{ width: "80px" }} active>
+    {typeof node.title === 'function' ? node.title(node) : node.title}
+  </Skeleton>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncNodeTitle.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncNodeTitle.tsx
@@ -23,7 +23,7 @@ export const AsyncTreeDataTitle = ({ node, actions }: AsyncTreeNodeComponentProp
       <Dropdown
         menu={{
           items: actions
-            ? Object.entries(actions).map(([key, { disabled, label, }]) => ({
+            ? Object.entries(actions).map(([key, { disabled, label }]) => ({
               key,
               disabled: disabled([node]),
               label

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncNodeTitle.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncNodeTitle.tsx
@@ -1,0 +1,53 @@
+import { Button, Dropdown, Flex, Icons, Text } from "fidesui";
+
+import { AsyncTreeNodeComponentProps } from "./types";
+
+export const AsyncTreeDataTitle = ({ node, actions }: AsyncTreeNodeComponentProps) => {
+  const title = typeof node.title === 'function' ? node.title(node) : node.title
+
+  if (!title) {
+    return null;
+  }
+
+  return (
+    /** TODO: migrate group class to semantic dom after upgrading ant */
+    <Flex
+      gap={4}
+      align="center"
+      className={`group ml-1 flex grow ${node.disabled ? "opacity-40" : ""}`}
+      aria-label={node.disabled ? `${title.toString()} (ignored)` : title.toString()}
+    >
+      <Text ellipsis={{ tooltip: title }} className="grow select-none">
+        {title}
+      </Text>
+      <Dropdown
+        menu={{
+          items: actions
+            ? Object.entries(actions).map(([key, { disabled, label, }]) => ({
+              key,
+              disabled: disabled([node]),
+              label
+            }))
+            : [],
+          onClick: ({ key, domEvent }) => {
+            domEvent.preventDefault();
+            domEvent.stopPropagation();
+            actions[key]?.callback([key], [node]);
+          },
+        }}
+        destroyOnHidden
+        className="group mr-1 flex-none group-[.multi-select]/monitor-tree:pointer-events-none group-[.multi-select]/monitor-tree:opacity-0"
+      >
+        <Button
+          aria-label="Show More Resource Actions"
+          icon={
+            <Icons.OverflowMenuVertical className="opacity-0 group-hover:opacity-100 group-[.ant-dropdown-open]:opacity-100" />
+          }
+          type="text"
+          size="small"
+          className="self-end"
+        />
+      </Dropdown>
+    </Flex>
+  );
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncTreeFooter.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncTreeFooter.tsx
@@ -1,0 +1,83 @@
+import { Key } from "react";
+
+import { Flex, Button, Text, SparkleIcon, Dropdown, Icons } from "fidesui";
+import _ from "lodash";
+
+import { TreeActions, ActionDict, Plural } from "./types";
+import { pluralize } from "~/features/common/utils";
+
+export const AsyncTreeFooter = ({
+  selectedKeys,
+  actions: {
+    nodeActions,
+    primaryAction
+  },
+  taxonomy
+}: {
+  selectedKeys: Key[],
+  actions: TreeActions<ActionDict>,
+  taxonomy: Plural 
+}) => {
+
+  return <>
+    <Flex justify="space-between" align="center" gap="small">
+      <Button
+        aria-label={`${nodeActions[primaryAction]} ${selectedKeys.length} Selected Nodes`}
+        icon={<SparkleIcon size={12} />}
+        size="small"
+        onClick={() =>
+          nodeActions[primaryAction]?.callback(
+            selectedKeys,
+            []
+            // selectedNodeKeys.flatMap((nodeKey) => {
+            //   const node = findNodeByUrn(treeData, nodeKey.toString());
+            //   return node ? [node] : [];
+            // }),
+          )
+        }
+        className="flex-none"
+      />
+      <Text
+        ellipsis
+      >{`${selectedKeys.length} ${pluralize(selectedKeys.length, ...taxonomy)} selected`}</Text>
+      <Dropdown
+        menu={{
+          items: nodeActions
+            ? Object.entries(nodeActions).map(
+              ([key, { label, disabled }]) => ({
+                key,
+                label,
+                // disabled: disabled(
+                //   selectedNodeKeys.flatMap((nodeKey) => {
+                //     const node = findNodeByUrn(
+                //       treeData,
+                //       nodeKey.toString(),
+                //     );
+                //     return node ? [node] : [];
+                //   }),
+                // ),
+              }),
+            )
+            : [],
+          onClick: ({ key, domEvent }) => {
+            domEvent.preventDefault();
+            domEvent.stopPropagation();
+            nodeActions[key]?.callback(
+              selectedKeys,
+              []
+            );
+          },
+        }}
+        destroyOnHidden
+        className="group mr-1 flex-none"
+      >
+        <Button
+          aria-label={`Show more ${taxonomy[0]} actions`}
+          icon={<Icons.OverflowMenuVertical />}
+          size="small"
+          className="self-end"
+        />
+      </Dropdown>
+    </Flex>
+  </>
+}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncTreeLinkNode.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncTreeLinkNode.tsx
@@ -1,0 +1,29 @@
+import { Button, ButtonProps } from "fidesui";
+
+import {
+  AsyncTreeNodeComponentProps
+} from "./types";
+
+export const AsyncTreeDataLink = ({
+  node,
+  buttonProps,
+
+}: Omit<AsyncTreeNodeComponentProps, 'actions'> & {buttonProps: ButtonProps }) => {
+  const { title, disabled } = node
+  if (!title) {
+    return null;
+  }
+
+  return (
+    <Button
+      type="link"
+      block
+      disabled={disabled}
+      {...buttonProps}
+      className="p-0"
+    >
+      {typeof title === 'function' ? title(node) : title}
+    </Button>
+  );
+
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/const.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/const.ts
@@ -1,0 +1,24 @@
+import { Key, } from "react";
+
+import { DEFAULT_PAGE_SIZE } from "~/features/common/table/constants";
+import { AsyncTreeNode } from "./types";
+import { PaginationState } from "~/features/common/pagination";
+
+export const TREE_NODE_LOAD_MORE_KEY_PREFIX = ''
+export const TREE_NODE_SKELETON_KEY_PREFIX = ''
+
+export const ROOT_NODE_KEY = "ROOT_NODE";
+
+export const DEFAULT_ROOT_NODE: AsyncTreeNode & PaginationState = {
+  key: ROOT_NODE_KEY,
+  pageIndex: 0,
+  pageSize: DEFAULT_PAGE_SIZE
+}
+
+export const DEFAULT_ROOT_NODE_STATE: {
+  keys: Key[],
+  nodes: Array<AsyncTreeNode & PaginationState>
+} = {
+  keys: [ROOT_NODE_KEY], nodes: [DEFAULT_ROOT_NODE]
+}
+

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/const.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/const.ts
@@ -3,6 +3,7 @@ import { Key, } from "react";
 import { DEFAULT_PAGE_SIZE } from "~/features/common/table/constants";
 import { AsyncTreeNode } from "./types";
 import { PaginationState } from "~/features/common/pagination";
+import { TreeProps } from "fidesui";
 
 export const TREE_NODE_LOAD_MORE_KEY_PREFIX = ''
 export const TREE_NODE_SKELETON_KEY_PREFIX = ''
@@ -12,7 +13,11 @@ export const ROOT_NODE_KEY = "ROOT_NODE";
 export const DEFAULT_ROOT_NODE: AsyncTreeNode & PaginationState = {
   key: ROOT_NODE_KEY,
   pageIndex: 0,
-  pageSize: DEFAULT_PAGE_SIZE
+  pageSize: DEFAULT_PAGE_SIZE,
+  page: 0,
+  size: DEFAULT_PAGE_SIZE,
+  pages: 0,
+  total: 0
 }
 
 export const DEFAULT_ROOT_NODE_STATE: {
@@ -22,3 +27,10 @@ export const DEFAULT_ROOT_NODE_STATE: {
   keys: [ROOT_NODE_KEY], nodes: [DEFAULT_ROOT_NODE]
 }
 
+export const DEFAULT_TREE_PROPS: TreeProps = {
+  showIcon: true,
+  showLine: true,
+  blockNode: true,
+  multiple: true,
+  expandAction: "doubleClick"
+}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/index.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/index.tsx
@@ -1,0 +1,140 @@
+import { AntTree as Tree, AntTreeProps as TreeProps, AntTreeDataNode as TreeDataNode, } from "fidesui";
+import { Key, useEffect, useState } from "react";
+
+import { PaginationState } from "~/features/common/pagination";
+import { DEFAULT_PAGE_SIZE } from "~/features/common/table/constants";
+import { PaginatedResponse, PaginationQueryParams } from "~/types/query-params";
+
+import { AsyncTreeNode, MapNode, ParentMapNode } from "./types";
+
+export type AsyncTreeProps = Omit<TreeProps, "loadData"> & {
+  pageSize?: number;
+  loadData: (
+    pagination: PaginationQueryParams,
+    key?: Key,
+  ) => Promise<PaginatedResponse<TreeDataNode> | undefined>;
+};
+
+const ROOT_NODE_KEY = "ROOT_NODE";
+
+export const AsyncTree = ({
+  pageSize = DEFAULT_PAGE_SIZE,
+  ...props
+}: AsyncTreeProps) => {
+
+  /* Storing lookup data as normalized nodes */
+  const [asyncNodes, setAsyncNodes] = useState<
+    Map<Key, AsyncTreeNode & PaginationState>
+  >(new Map());
+
+  /* Mapping of nodes for tree traversal */
+  const [nodeMap, setNodeMap] = useState<
+    Map<Key, AsyncTreeNode & PaginationState>
+  >(new Map());
+
+  const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
+
+  const recBuildTree = (node: TreeDataNode): TreeDataNode => ({
+    ...node,
+    children: Array.from(asyncNodes?.values())?.flatMap(
+      (child) => child.parent === node.key ? [recBuildTree(child)] : []
+    )
+  });
+
+  /* Building tree from async data */
+  const rootNode = asyncNodes?.get(ROOT_NODE_KEY)
+  const treeData: TreeProps["treeData"] = rootNode ? [recBuildTree(rootNode)] : []
+
+
+
+  // /**
+  //  * Handles tree expansion - if a node without children is being expanded, load its data
+  //  */
+  // const onExpand = (
+  //   newExpandedKeys: Key[],
+  //   info: { expanded: boolean; node: AsyncTreeNode },
+  // ) => {
+  //   setExpandedKeys(newExpandedKeys);
+  //
+  // };
+
+  // const onSelect = (
+  //   _: Key[],
+  //   info: { selectedNodes: CustomTreeDataNode[] },
+  // ) => {
+  //   const classifyableKeys = info.selectedNodes
+  //     .filter((node) => node.classifyable)
+  //     .map((node) => node.key);
+  //   setSelectedNodeKeys(classifyableKeys);
+  // };
+  const _loadData = (key?: Key) => {
+    return new Promise(async (resolve) => {
+      const node = asyncNodes.get(key ?? ROOT_NODE_KEY);
+      console.log(node)
+      const result = await props.loadData(
+        { page: node?.pageIndex ?? 1, size: pageSize },
+        key,
+      );
+
+      const mapNodes: MapNode[] = result ? result.items.map((item) => ({ key: item.key, parent: key })) : []
+      const dataNodes = result ? result.items.map((item) => ({ ...item })) : []
+      const newAsyncNodes = dataNodes.flatMap(
+        (n) => n.key ? [[n.key, n] as const] : []
+      )
+
+      const parentNode = result?.items ? {
+        key: key,
+        children: result?.items.map((item) => item.key),
+        
+      } : {
+        key: key
+      }
+
+      setAsyncNodes(
+        new Map(
+          [
+            ...asyncNodes, ...newAsyncNodes
+          ]
+        )
+          .set(key ?? ROOT_NODE_KEY, parentNode),
+      );
+      resolve(result);
+    });
+  };
+
+  const loadData: TreeProps["loadData"] = (args) => _loadData(args.key);
+
+  const onExpand: TreeProps["onExpand"] = (args) => {
+    return new Promise(async (resolve) => {
+      const expandResult = args.map(async (key) => {
+        const result = await _loadData(key)
+        return result
+      })
+      resolve(expandResult)
+    });
+  };
+
+  useEffect(() => {
+    const initialize = async () => {
+      await _loadData();
+    };
+    initialize();
+  }, []);
+
+  return (
+    <Tree
+      {...props}
+      loadData={loadData}
+      treeData={treeData}
+      expandedKeys={expandedKeys}
+      onExpand={onExpand}
+      // onSelect={onSelect}
+      showIcon
+      showLine
+      blockNode
+      rootClassName="h-full overflow-x-hidden"
+    />
+  );
+};
+
+export default AsyncTree;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/index.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/index.tsx
@@ -1,4 +1,4 @@
-import { AntTree as Tree, AntTreeProps as TreeProps, AntTreeDataNode as TreeDataNode, } from "fidesui";
+import { Tree, TreeProps, TreeDataNode } from "fidesui";
 import { Key, useEffect, useState } from "react";
 
 import { PaginationState } from "~/features/common/pagination";
@@ -85,7 +85,7 @@ export const AsyncTree = ({
       const parentNode = result?.items ? {
         key: key,
         children: result?.items.map((item) => item.key),
-        
+
       } : {
         key: key
       }
@@ -122,7 +122,7 @@ export const AsyncTree = ({
   }, []);
 
   return (
-    <Tree
+    <Tree.DirectoryTree
       {...props}
       loadData={loadData}
       treeData={treeData}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/index.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/index.tsx
@@ -24,19 +24,19 @@ export const AsyncTree = ({
 
   /* Storing lookup data as normalized nodes */
   const [asyncNodes, setAsyncNodes] = useState<
-    Map<Key, AsyncTreeNode & PaginationState>
-  >(new Map());
+   AsyncTreeNode & PaginationState
+  >();
 
   /* Mapping of nodes for tree traversal */
   const [nodeMap, setNodeMap] = useState<
-    Map<Key, AsyncTreeNode & PaginationState>
-  >(new Map());
+    AsyncTreeNode & PaginationState
+  >();
 
   const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
 
   const recBuildTree = (node: TreeDataNode): TreeDataNode => ({
     ...node,
-    children: Array.from(asyncNodes?.values())?.flatMap(
+    children: asyncNodes?.flatMap(
       (child) => child.parent === node.key ? [recBuildTree(child)] : []
     )
   });

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/types.d.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/types.d.ts
@@ -1,0 +1,24 @@
+import {AntTreeDataNode as TreeDataNode } from "fidesui" 
+import { PaginatedResponse } from "~/types/query-params";
+
+export type ReactDataNode<T> = T & {
+  key: Key;
+  children?: ReactDataNode<T>[];
+};
+
+export type AsyncTreeNode = ReactDataNode<TreeDataNode> & {
+  parent?: Key;
+}
+
+export type ParentMapNode = Omit<PaginatedResponse, 'items'> & {
+  key: Key;
+  parent?: Key,
+  children: Key[];
+}
+
+type LeafMapNode = {
+  key: Key;
+  parent?: Key,
+}
+
+export type MapNode = ParentMapNode | LeafMapNode 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/types.d.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/types.d.ts
@@ -1,14 +1,29 @@
-import {AntTreeDataNode as TreeDataNode } from "fidesui" 
-import { PaginatedResponse } from "~/types/query-params";
+import { TreeDataNode } from "fidesui"
+import { PaginatedResponse, PaginationQueryParams } from "~/types/query-params";
 
 export type ReactDataNode<T> = T & {
   key: Key;
   children?: ReactDataNode<T>[];
 };
 
-export type AsyncTreeNode = ReactDataNode<TreeDataNode> & {
+export type AsyncTreeNode = Omit<PaginatedResponse, 'items'> & ReactDataNode<TreeDataNode> & {
   parent?: Key;
 }
+
+export type AsyncTreeProps = Omit<TreeProps, "loadData"> & {
+  pageSize?: number;
+  actions: TreeActions<TreeNodeAction, ActionDict<TreeNodeAction>>,
+  loadMoreText?: string,
+  loadData: (
+    pagination: PaginationQueryParams,
+    key?: Key,
+  ) => Promise<PaginatedResponse<TreeDataNode> | undefined>;
+};
+
+export type AsyncTreeNodeComponentProps = {
+  node: AsyncTreeNode;
+  actions: ActionDict;
+};
 
 export type ParentMapNode = Omit<PaginatedResponse, 'items'> & {
   key: Key;
@@ -21,4 +36,20 @@ type LeafMapNode = {
   parent?: Key,
 }
 
-export type MapNode = ParentMapNode | LeafMapNode 
+export type MapNode = ParentMapNode | LeafMapNode
+
+export type ActionDict = Record<string, NodeAction<AsyncTreeNode>>
+
+export interface TreeActions<Action, AD extends ActionDict<Action>> {
+  nodeActions: AD;
+  primaryAction: keyof AD;
+}
+
+export type NodeAction<N extends ReactDataNode> = {
+  label: string;
+  /** TODO: should be generically typed * */
+  callback: (key: Key[], nodes: N[]) => void;
+  disabled: (nodes: N[]) => boolean;
+};
+
+export type TreeNodeAction = NodeAction<CustomTreeDataNode>;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/types.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/types.ts
@@ -1,4 +1,6 @@
-import { TreeDataNode } from "fidesui"
+import { Key } from 'react'
+import { TreeDataNode, TreeProps } from "fidesui"
+
 import { PaginatedResponse, PaginationQueryParams } from "~/types/query-params";
 
 export type ReactDataNode<T> = T & {
@@ -6,14 +8,18 @@ export type ReactDataNode<T> = T & {
   children?: ReactDataNode<T>[];
 };
 
-export type AsyncTreeNode = Omit<PaginatedResponse, 'items'> & ReactDataNode<TreeDataNode> & {
+export type AsyncTreeNode = Omit<PaginatedResponse<unknown>, 'items'> & ReactDataNode<TreeDataNode> & {
   parent?: Key;
 }
 
+export type Plural = [string, string]
+
 export type AsyncTreeProps = Omit<TreeProps, "loadData"> & {
   pageSize?: number;
-  actions: TreeActions<TreeNodeAction, ActionDict<TreeNodeAction>>,
+  actions: TreeActions<ActionDict>,
   loadMoreText?: string,
+  showFooter?: boolean,
+  taxonomy?: Plural,
   loadData: (
     pagination: PaginationQueryParams,
     key?: Key,
@@ -25,7 +31,7 @@ export type AsyncTreeNodeComponentProps = {
   actions: ActionDict;
 };
 
-export type ParentMapNode = Omit<PaginatedResponse, 'items'> & {
+export type ParentMapNode = Omit<PaginatedResponse<unknown>, 'items'> & {
   key: Key;
   parent?: Key,
   children: Key[];
@@ -40,16 +46,16 @@ export type MapNode = ParentMapNode | LeafMapNode
 
 export type ActionDict = Record<string, NodeAction<AsyncTreeNode>>
 
-export interface TreeActions<Action, AD extends ActionDict<Action>> {
+export type TreeActions<AD extends ActionDict> = {
   nodeActions: AD;
   primaryAction: keyof AD;
 }
 
-export type NodeAction<N extends ReactDataNode> = {
+export type NodeAction<N> = {
   label: string;
   /** TODO: should be generically typed * */
-  callback: (key: Key[], nodes: N[]) => void;
+  callback: (keys: Key[], nodes: N[]) => void;
   disabled: (nodes: N[]) => boolean;
 };
 
-export type TreeNodeAction = NodeAction<CustomTreeDataNode>;
+export type TreeNodeAction = NodeAction<AsyncTreeNode>;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/utils.test.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { ReactDataNode, 
+  // recFindNodeParent 
+} from "./utils";
+
+// TODO: add tests for the other utils functions
+
+const MOCK_TREE = [...Array(25)].map((_, i) => {
+  const node: ReactDataNode<{}> = {
+    key: i,
+    children: [
+      {
+        key: `${i}_1`,
+      },
+    ],
+  };
+  return node;
+});
+
+const MOCK_TREE_2 = [...Array(25)].map((_, i) => {
+  const node: ReactDataNode<{}> = {
+    key: i,
+    children: [
+      {
+        key: `${i}_1`,
+      },
+      {
+        key: `${i}_2`,
+        children: [
+          {
+            key: `${i}_2_1`,
+          },
+          {
+            key: `${i}_2_2`,
+          },
+        ],
+      },
+      {
+        key: `${i}_3`,
+      },
+    ],
+  };
+  return node;
+});
+
+const getNodeByLevel = (
+  level: number,
+  data: ReactDataNode<{}>,
+): ReactDataNode<{}> | null => {
+  const children = data.children?.[0];
+  return level > 0 && children ? getNodeByLevel(level - 1, children) : null;
+};
+
+const buildDeepTreeMock = (depth: number): ReactDataNode<{}> => ({
+  key: depth,
+  children: depth > 0 ? [buildDeepTreeMock(depth - 1)] : undefined,
+});
+
+// describe(recFindNodeParent.name, () => {
+//   it("Should find at depth of 1", () => {
+//     const result = recFindNodeParent(MOCK_TREE, "21_1");
+//     expect(result).toEqual(MOCK_TREE[22]);
+//   });
+//   it("Should find at depth of 2", () => {
+//     const result = recFindNodeParent(MOCK_TREE, "21_2_2");
+//     expect(result).toEqual(MOCK_TREE_2[22].children?.[1]);
+//   });
+//   it("should return null when parent doesn't exist", () => {
+//     const result = recFindNodeParent(MOCK_TREE, MOCK_TREE[0].key);
+//     expect(result).toBeNull();
+//   });
+//   it("should return null when node key doesn't exist", () => {
+//     const result = recFindNodeParent(MOCK_TREE, "invalid key");
+//     expect(result).toBeNull();
+//   });
+//   it("should return parent of deeply nested node", () => {
+//     const DEEP_TREE_MOCK = buildDeepTreeMock(25);
+//     const result = recFindNodeParent([DEEP_TREE_MOCK], 2);
+//     expect(result).toEqual(getNodeByLevel(23, DEEP_TREE_MOCK));
+//   });
+// });

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/utils.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/utils.ts
@@ -1,0 +1,34 @@
+import { Key } from "react";
+
+export type ReactDataNode<T> = T & {
+  key: Key;
+  children?: ReactDataNode<T>[]
+}
+
+export const findNodeParent = <T>(data: ReactDataNode<T>[], key: Key) => {
+  return data.find((node) => {
+    const { children } = node;
+    return children && !!children.find((child) => child.key.toString() === key);
+  });
+};
+
+const hasChild = <T>(data: ReactDataNode<T>, key: Key) => data.children?.find((node) => node.key = key)
+
+
+
+// export const recFindNodeParent = <T>(
+//   data: ReactDataNode<T>[],
+//   key: Key,
+// ): ReactDataNode<T> | null => {
+//   data.find((node) => hasChild(node, key)) ?? data.reduceRight recFindNodeParent()
+//   return data.find((node) => node.key === recFindNodeParent(node.children) {
+//     if(node.children) {
+//     return (
+//       recFindNodeParent(current.children, key)
+//     );
+//   }
+//   return agg;
+// }
+//   );
+// };
+

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
@@ -53,6 +53,7 @@ import {
   updateNodeStatus,
 } from "./treeUtils";
 import { CustomTreeDataNode, TreeNodeAction } from "./types";
+import { TreeActions } from "../AsyncTree/types";
 
 const mapResponseToTreeData = (
   data: Page_DatastoreStagedResourceTreeAPIResponse_,
@@ -61,13 +62,13 @@ const mapResponseToTreeData = (
   const dataItems: CustomTreeDataNode[] = data.items.map((treeNode) => {
     const IconComponent = treeNode.resource_type
       ? MAP_DATASTORE_RESOURCE_TYPE_TO_ICON[
-          treeNode.resource_type as StagedResourceTypeValue
-        ]
+      treeNode.resource_type as StagedResourceTypeValue
+      ]
       : undefined;
     const statusInfo = treeNode.update_status
       ? MAP_TREE_RESOURCE_CHANGE_INDICATOR_TO_STATUS_INFO[
-          treeNode.update_status
-        ]
+      treeNode.update_status
+      ]
       : undefined;
 
     return {
@@ -76,17 +77,17 @@ const mapResponseToTreeData = (
       selectable: true, // all nodes are selectable since we ignore lowest level descendants in the data
       icon: IconComponent
         ? () => (
-            <Tooltip title={statusInfo?.tooltip}>
-              <Badge
-                className="h-full"
-                offset={[0, 5]}
-                color={statusInfo?.color}
-                dot={shouldShowBadgeDot(treeNode)}
-              >
-                <IconComponent className="h-full" />
-              </Badge>
-            </Tooltip>
-          )
+          <Tooltip title={statusInfo?.tooltip}>
+            <Badge
+              className="h-full"
+              offset={[0, 5]}
+              color={statusInfo?.color}
+              dot={shouldShowBadgeDot(treeNode)}
+            >
+              <IconComponent className="h-full" />
+            </Badge>
+          </Tooltip>
+        )
         : undefined,
       status: treeNode.update_status,
       diffStatus: treeNode.diff_status,
@@ -105,14 +106,14 @@ const mapResponseToTreeData = (
   return (dataItems?.length ?? 0) < TREE_PAGE_SIZE
     ? dataItems
     : [
-        ...dataItems,
-        {
-          title: TREE_NODE_LOAD_MORE_TEXT,
-          key: `${TREE_NODE_LOAD_MORE_KEY_PREFIX}-${data.page}-${key}`,
-          selectable: false,
-          isLeaf: true,
-        },
-      ];
+      ...dataItems,
+      {
+        title: TREE_NODE_LOAD_MORE_TEXT,
+        key: `${TREE_NODE_LOAD_MORE_KEY_PREFIX}-${data.page}-${key}`,
+        selectable: false,
+        isLeaf: true,
+      },
+    ];
 };
 
 const appendTreeNodeData = (
@@ -232,13 +233,8 @@ export interface MonitorTreeRef {
   refreshResourcesAndAncestors: (urns: string[]) => Promise<void>;
 }
 
-interface NodeActions<Action, ActionDict extends Record<string, Action>> {
-  nodeActions: ActionDict;
-  primaryAction: keyof ActionDict;
-}
-
 interface MonitorTreeProps
-  extends NodeActions<TreeNodeAction, Record<string, TreeNodeAction>> {
+  extends TreeActions<TreeNodeAction, Record<string, TreeNodeAction>> {
   setSelectedNodeKeys: (keys: Key[]) => void;
   selectedNodeKeys: Key[];
 }
@@ -647,20 +643,20 @@ const MonitorTree = forwardRef<MonitorTreeRef, MonitorTreeProps>(
               menu={{
                 items: nodeActions
                   ? Object.entries(nodeActions).map(
-                      ([key, { label, disabled }]) => ({
-                        key,
-                        label,
-                        disabled: disabled(
-                          selectedNodeKeys.flatMap((nodeKey) => {
-                            const node = findNodeByUrn(
-                              treeData,
-                              nodeKey.toString(),
-                            );
-                            return node ? [node] : [];
-                          }),
-                        ),
-                      }),
-                    )
+                    ([key, { label, disabled }]) => ({
+                      key,
+                      label,
+                      disabled: disabled(
+                        selectedNodeKeys.flatMap((nodeKey) => {
+                          const node = findNodeByUrn(
+                            treeData,
+                            nodeKey.toString(),
+                          );
+                          return node ? [node] : [];
+                        }),
+                      ),
+                    }),
+                  )
                   : [],
                 onClick: ({ key, domEvent }) => {
                   domEvent.preventDefault();

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
@@ -9,6 +9,7 @@ import {
   Title,
   Tooltip,
   Tree,
+  TreeDataNode,
 } from "fidesui";
 import { useRouter } from "next/router";
 import {
@@ -52,8 +53,7 @@ import {
   shouldShowBadgeDot,
   updateNodeStatus,
 } from "./treeUtils";
-import { CustomTreeDataNode, TreeNodeAction } from "./types";
-import { TreeActions } from "../AsyncTree/types";
+import { CustomTreeDataNode, NodeAction, TreeNodeAction } from "./types";
 
 const mapResponseToTreeData = (
   data: Page_DatastoreStagedResourceTreeAPIResponse_,
@@ -233,8 +233,13 @@ export interface MonitorTreeRef {
   refreshResourcesAndAncestors: (urns: string[]) => Promise<void>;
 }
 
+type TreeActions<AD extends Record<string, NodeAction<TreeDataNode>>> = {
+  nodeActions: AD;
+  primaryAction: keyof AD;
+}
+
 interface MonitorTreeProps
-  extends TreeActions<TreeNodeAction, Record<string, TreeNodeAction>> {
+  extends TreeActions<Record<string, NodeAction<TreeDataNode>>> {
   setSelectedNodeKeys: (keys: Key[]) => void;
   selectedNodeKeys: Key[];
 }

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useFilters.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/useFilters.ts
@@ -40,6 +40,7 @@ export const useMonitorFieldsFilters = () => {
   }, []); // Only run once on mount, or we could get in an infinite loop if all items are filtered out
 
   const resetToInitialState = () => {
+    console.log("resetToInitialState");
     const defaultStatuses = getFilterableStatuses([...RESOURCE_STATUS]);
     setResourceStatus(defaultStatuses);
     setConfidenceBucket(null);
@@ -47,6 +48,7 @@ export const useMonitorFieldsFilters = () => {
   };
 
   const reset = () => {
+    console.log("reset");
     // Use empty array instead of null to indicate "no filters selected"
     // null is reserved for "not yet initialized"
     setResourceStatus([]);

--- a/clients/admin-ui/src/pages/poc/async-tree.tsx
+++ b/clients/admin-ui/src/pages/poc/async-tree.tsx
@@ -1,0 +1,61 @@
+import {
+  AntLayout as Layout,
+  AntRow as Row,
+  AntTreeDataNode as TreeDataNode,
+  AntTypography as Typography,
+} from "fidesui";
+import AsyncTree, {
+  AsyncTreeProps,
+} from "~/features/data-discovery-and-detection/action-center/AsyncTree";
+import { useLazyGetMonitorTreeQuery } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
+import { DatastoreStagedResourceTreeAPIResponse } from "~/types/api/models/DatastoreStagedResourceTreeAPIResponse";
+import { PaginatedResponse, PaginationQueryParams } from "~/types/query-params";
+import { Page_DatastoreStagedResourceAPIResponse_ } from "~/types/api/models/Page_DatastoreStagedResourceAPIResponse_";
+import { Page_DatastoreStagedResourceTreeAPIResponse_, StagedResourceTypeValue } from "~/types/api";
+
+const { Content } = Layout;
+const { Title } = Typography;
+
+export const FormsPOC = () => {
+  const [trigger, _result] = useLazyGetMonitorTreeQuery();
+  const MONITOR_CONFIG_ID = "mypizzatest";
+
+  const transformResponseToNode = (
+    response: Page_DatastoreStagedResourceTreeAPIResponse_,
+  ): TreeDataNode[] =>
+    response.items.map((item) => ({
+      key: item.urn,
+      title: item.name,
+      isLeaf: item.resource_type === StagedResourceTypeValue.FIELD || !item.has_grandchildren
+    }));
+
+  const loadData: AsyncTreeProps["loadData"] =
+    async ({ page, size }, key) =>
+      new Promise(async (resolve) => {
+        const { data } = await trigger({
+          monitor_config_id: MONITOR_CONFIG_ID,
+          staged_resource_urn: key?.toString(),
+          include_descendant_details: true,
+          page,
+          size,
+        });
+
+        resolve({
+          items: data ? transformResponseToNode(data) : [],
+          total: data?.total ?? 0,
+          size: data?.size ?? 0,
+          pages: data?.pages ?? 0,
+        });
+      });
+
+  return (
+    <Content className="overflow-auto px-10 py-6">
+      <Row>
+        <Title>Async Tree POC</Title>
+      </Row>
+      <AsyncTree loadData={loadData} />
+    </Content>
+  );
+};
+
+export default FormsPOC;

--- a/clients/admin-ui/src/pages/poc/async-tree.tsx
+++ b/clients/admin-ui/src/pages/poc/async-tree.tsx
@@ -5,20 +5,17 @@ import {
   Typography,
 } from "fidesui";
 import AsyncTree, {
-  AsyncTreeProps,
 } from "~/features/data-discovery-and-detection/action-center/AsyncTree";
+import { AsyncTreeProps } from "~/features/data-discovery-and-detection/action-center/AsyncTree/types"
 import { useLazyGetMonitorTreeQuery } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
-import { DatastoreStagedResourceTreeAPIResponse } from "~/types/api/models/DatastoreStagedResourceTreeAPIResponse";
-import { PaginatedResponse, PaginationQueryParams } from "~/types/query-params";
-import { Page_DatastoreStagedResourceAPIResponse_ } from "~/types/api/models/Page_DatastoreStagedResourceAPIResponse_";
-import { Page_DatastoreStagedResourceTreeAPIResponse_, StagedResourceTypeValue } from "~/types/api";
+import { DiffStatus, Page_DatastoreStagedResourceTreeAPIResponse_, StagedResourceTypeValue } from "~/types/api";
 
 const { Content } = Layout;
 const { Title } = Typography;
 
 export const FormsPOC = () => {
   const [trigger, _result] = useLazyGetMonitorTreeQuery();
-  const MONITOR_CONFIG_ID = "mypizzatest";
+  const MONITOR_CONFIG_ID = "Custom_Structure_Monitor_41";
 
   const transformResponseToNode = (
     response: Page_DatastoreStagedResourceTreeAPIResponse_,
@@ -26,7 +23,10 @@ export const FormsPOC = () => {
     response.items.map((item) => ({
       key: item.urn,
       title: item.name,
-      isLeaf: item.resource_type === StagedResourceTypeValue.FIELD || !item.has_grandchildren
+      disabled: item.diff_status === DiffStatus.MUTED,
+      isLeaf: item.resource_type === StagedResourceTypeValue.FIELD
+      // ||
+      // !item.has_grandchildren,
     }));
 
   const loadData: AsyncTreeProps["loadData"] =
@@ -35,7 +35,7 @@ export const FormsPOC = () => {
         const { data } = await trigger({
           monitor_config_id: MONITOR_CONFIG_ID,
           staged_resource_urn: key?.toString(),
-          include_descendant_details: true,
+          // include_descendant_details: true,
           page,
           size,
         });
@@ -54,7 +54,17 @@ export const FormsPOC = () => {
       <Row>
         <Title>Async Tree POC</Title>
       </Row>
-      <AsyncTree loadData={loadData} />
+      <AsyncTree loadData={loadData}
+        actions={{
+          nodeActions: {
+            "Copy": {
+              label: "Copy",
+              callback: (keys) => alert(keys),
+              disabled: () => false
+            }
+          },
+          primaryAction: "Copy"
+        }} pageSize={5} />
     </Content>
   );
 };

--- a/clients/admin-ui/src/pages/poc/async-tree.tsx
+++ b/clients/admin-ui/src/pages/poc/async-tree.tsx
@@ -1,13 +1,17 @@
+import { useState, Key } from "react";
 import {
   Layout,
   Row,
   TreeDataNode,
   Typography,
+  Tooltip,
+  Badge
 } from "fidesui";
 import AsyncTree, {
 } from "~/features/data-discovery-and-detection/action-center/AsyncTree";
 import { AsyncTreeProps } from "~/features/data-discovery-and-detection/action-center/AsyncTree/types"
 import { useLazyGetMonitorTreeQuery } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
+import { MAP_DATASTORE_RESOURCE_TYPE_TO_ICON, MAP_TREE_RESOURCE_CHANGE_INDICATOR_TO_STATUS_INFO } from "~/features/data-discovery-and-detection/action-center/fields/MonitorFields.const";
 import { DiffStatus, Page_DatastoreStagedResourceTreeAPIResponse_, StagedResourceTypeValue } from "~/types/api";
 
 const { Content } = Layout;
@@ -16,7 +20,11 @@ const { Title } = Typography;
 export const FormsPOC = () => {
   const [trigger, _result] = useLazyGetMonitorTreeQuery();
   const MONITOR_CONFIG_ID = "Custom_Structure_Monitor_41";
+  const [selectedKeys, setSelectedKeys] = useState<Key[]>()
 
+  /**
+   * @description the primary of interacting with the async data tree is through request/response patterns
+   */
   const transformResponseToNode = (
     response: Page_DatastoreStagedResourceTreeAPIResponse_,
   ): TreeDataNode[] =>
@@ -24,6 +32,30 @@ export const FormsPOC = () => {
       key: item.urn,
       title: item.name,
       disabled: item.diff_status === DiffStatus.MUTED,
+      icon: () => {
+        const resourceType = Object.values(StagedResourceTypeValue).find((key) => key === item.resource_type)
+        const IconComponent = resourceType
+          ? MAP_DATASTORE_RESOURCE_TYPE_TO_ICON[resourceType] : undefined;
+        const statusInfo = item.update_status
+          ? MAP_TREE_RESOURCE_CHANGE_INDICATOR_TO_STATUS_INFO[
+          item.update_status
+          ]
+          : undefined;
+
+        return IconComponent ? (
+          <Tooltip title={statusInfo?.tooltip}>
+            <Badge
+              className="h-full"
+              offset={[0, 5]}
+              color={statusInfo?.color}
+            // dot={shouldShowBadgeDot(treeNode)}
+            >
+              <IconComponent className="h-full" />
+            </Badge>
+          </Tooltip>
+        )
+          : undefined
+      },
       isLeaf: item.resource_type === StagedResourceTypeValue.FIELD
       // ||
       // !item.has_grandchildren,
@@ -35,7 +67,6 @@ export const FormsPOC = () => {
         const { data } = await trigger({
           monitor_config_id: MONITOR_CONFIG_ID,
           staged_resource_urn: key?.toString(),
-          // include_descendant_details: true,
           page,
           size,
         });
@@ -54,7 +85,8 @@ export const FormsPOC = () => {
       <Row>
         <Title>Async Tree POC</Title>
       </Row>
-      <AsyncTree loadData={loadData}
+      <AsyncTree
+        loadData={loadData}
         actions={{
           nodeActions: {
             "Copy": {
@@ -64,7 +96,13 @@ export const FormsPOC = () => {
             }
           },
           primaryAction: "Copy"
-        }} pageSize={5} />
+        }}
+        pageSize={5}
+        onSelect={(keys) => setSelectedKeys(keys)}
+        selectedKeys={selectedKeys}
+        showFooter
+        taxonomy={['resource', 'resources']}
+      />
     </Content>
   );
 };

--- a/clients/admin-ui/src/pages/poc/async-tree.tsx
+++ b/clients/admin-ui/src/pages/poc/async-tree.tsx
@@ -1,8 +1,8 @@
 import {
-  AntLayout as Layout,
-  AntRow as Row,
-  AntTreeDataNode as TreeDataNode,
-  AntTypography as Typography,
+  Layout,
+  Row,
+  TreeDataNode,
+  Typography,
 } from "fidesui";
 import AsyncTree, {
   AsyncTreeProps,
@@ -45,6 +45,7 @@ export const FormsPOC = () => {
           total: data?.total ?? 0,
           size: data?.size ?? 0,
           pages: data?.pages ?? 0,
+          page
         });
       });
 


### PR DESCRIPTION
Ticket [<issue>] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Creating a generic async tree component + utilities to improve code maintainability and promote reuse.

TODO:
- [ ] Improve component types
- [ ] Add refresh functionality
- [ ] Improve loading states
- [ ] Move component into shared library
- [ ] Migrate `MonitorTree` to utilize new component
- [ ] Create storybook docs for new component

### Code Changes

* Adding an `AsyncTree` component to provide a consistent interface for handling structured async data.

### Steps to Confirm

1. <!-- list any manual steps for reviewers to confirm the changes -->

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
