### PR TITLE
URL encode username and password values for DB connections

### DIFF
--- a/src/fides/api/service/connectors/mysql_connector.py
+++ b/src/fides/api/service/connectors/mysql_connector.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+from urllib.parse import quote
 
 from sqlalchemy.engine import Engine, LegacyCursorResult, create_engine  # type: ignore
 
@@ -24,13 +25,15 @@ class MySQLConnector(SQLConnector):
     secrets_schema = MySQLSchema
 
     def build_uri(self) -> str:
-        """Build URI of format mysql+pymysql://[user[:password]@][netloc][:port][/dbname]"""
+        """Build URI of format mysql+pymysql://[user[:password]@][netloc][:port][/dbname].
+        Username and password are URL-encoded so that reserved characters (e.g. @, :) do not
+        break URI parsing."""
         config = self.secrets_schema(**self.configuration.secrets or {})
 
         user_password = ""
         if config.username:
-            user = config.username
-            password = f":{config.password}" if config.password else ""
+            user = quote(str(config.username), safe="")
+            password = f":{quote(str(config.password), safe='')}" if config.password else ""
             user_password = f"{user}{password}@"
 
         netloc = config.host
@@ -40,13 +43,15 @@ class MySQLConnector(SQLConnector):
         return url
 
     def build_ssh_uri(self, local_address: tuple) -> str:
-        """Build URI of format mysql+pymysql://[user[:password]@][ssh_host][:ssh_port][/dbname]"""
+        """Build URI of format mysql+pymysql://[user[:password]@][ssh_host][:ssh_port][/dbname].
+        Username and password are URL-encoded so that reserved characters (e.g. @, :) do not
+        break URI parsing."""
         config = self.secrets_schema(**self.configuration.secrets or {})
 
         user_password = ""
         if config.username:
-            user = config.username
-            password = f":{config.password}" if config.password else ""
+            user = quote(str(config.username), safe="")
+            password = f":{quote(str(config.password), safe='')}" if config.password else ""
             user_password = f"{user}{password}@"
 
         local_host, local_port = local_address

--- a/src/fides/api/service/connectors/postgres_connector.py
+++ b/src/fides/api/service/connectors/postgres_connector.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from loguru import logger
 from sqlalchemy import text
 from sqlalchemy.engine import Connection, Engine, create_engine  # type: ignore
@@ -25,13 +27,15 @@ class PostgreSQLConnector(SQLConnector):
         return False
 
     def build_uri(self) -> str:
-        """Build URI of format postgresql://[user[:password]@][netloc][:port][/dbname]"""
+        """Build URI of format postgresql://[user[:password]@][netloc][:port][/dbname].
+        Username and password are URL-encoded so that reserved characters (e.g. @, :) do not
+        break URI parsing."""
         config = self.secrets_schema(**self.configuration.secrets or {})
 
         user_password = ""
         if config.username:
-            user = config.username
-            password = f":{config.password}" if config.password else ""
+            user = quote(str(config.username), safe="")
+            password = f":{quote(str(config.password), safe='')}" if config.password else ""
             user_password = f"{user}{password}@"
 
         netloc = config.host
@@ -41,13 +45,15 @@ class PostgreSQLConnector(SQLConnector):
         return f"postgresql://{user_password}{netloc}{port}{dbname}{query}"
 
     def build_ssh_uri(self, local_address: tuple) -> str:
-        """Build URI of format postgresql://[user[:password]@][ssh_host][:ssh_port][/dbname]"""
+        """Build URI of format postgresql://[user[:password]@][ssh_host][:ssh_port][/dbname].
+        Username and password are URL-encoded so that reserved characters (e.g. @, :) do not
+        break URI parsing."""
         config = self.secrets_schema(**self.configuration.secrets or {})
 
         user_password = ""
         if config.username:
-            user = config.username
-            password = f":{config.password}" if config.password else ""
+            user = quote(str(config.username), safe="")
+            password = f":{quote(str(config.password), safe='')}" if config.password else ""
             user_password = f"{user}{password}@"
 
         local_host, local_port = local_address


### PR DESCRIPTION
Ticket [ENG-2808]

### Description Of Changes

This should resolve an issue wherein passwords with special characters are properly URL encoded, precluding SQLAlchemy parsing issues.

### Code Changes

* Updates MySQL, Postgres, and Redshift connectors to URL encode username and password fields

### Steps to Confirm

1. Bring a MySQL database to the table
2. Create a user with @ in the password
3. Create a MySQL integration
4. [Confirm Step 1] Test integration should pass
5. [Confirm Step 2] Monitor scan should create staged resources

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-2808]: https://ethyca.atlassian.net/browse/ENG-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ