### PR TITLE
ENG-2633 - Monitor tree applies active filters when calling /tree/ancestors-statuses

### DIFF
--- a/changelog/7499-tree-ancestors.yaml
+++ b/changelog/7499-tree-ancestors.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Monitor tree now applies active filters when refreshing after resource actions
+pr: 7499
+labels: []

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -163,9 +163,10 @@ const actionCenterApi = baseApi.injectEndpoints({
     >({
       query: ({ monitor_config_id, staged_resource_urn, diff_status }) => {
         const urlParams = buildArrayQueryParams({ diff_status });
+        const queryString = urlParams ? `?${urlParams}` : "";
 
         return {
-          url: `/plus/discovery-monitor/${monitor_config_id}/tree/ancestors-statuses/${encodeURIComponent(staged_resource_urn)}?${urlParams}`,
+          url: `/plus/discovery-monitor/${monitor_config_id}/tree/ancestors-statuses/${encodeURIComponent(staged_resource_urn)}${queryString}`,
         };
       },
     }),

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -157,12 +157,11 @@ const actionCenterApi = baseApi.injectEndpoints({
       Array<DatastoreStagedResourceTreeAPIResponse>,
       {
         monitor_config_id: string;
-        staged_resource_urn?: string;
+        staged_resource_urn: string;
       }
     >({
       query: ({ monitor_config_id, staged_resource_urn }) => ({
-        url: `/plus/discovery-monitor/${monitor_config_id}/tree/ancestors-statuses`,
-        params: { staged_resource_urn },
+        url: `/plus/discovery-monitor/${monitor_config_id}/tree/ancestors-statuses/${encodeURIComponent(staged_resource_urn)}`,
       }),
     }),
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -158,11 +158,16 @@ const actionCenterApi = baseApi.injectEndpoints({
       {
         monitor_config_id: string;
         staged_resource_urn: string;
+        diff_status?: DiffStatus[];
       }
     >({
-      query: ({ monitor_config_id, staged_resource_urn }) => ({
-        url: `/plus/discovery-monitor/${monitor_config_id}/tree/ancestors-statuses/${encodeURIComponent(staged_resource_urn)}`,
-      }),
+      query: ({ monitor_config_id, staged_resource_urn, diff_status }) => {
+        const urlParams = buildArrayQueryParams({ diff_status });
+
+        return {
+          url: `/plus/discovery-monitor/${monitor_config_id}/tree/ancestors-statuses/${encodeURIComponent(staged_resource_urn)}?${urlParams}`,
+        };
+      },
     }),
 
     getDiscoveredSystemAggregate: build.query<

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
@@ -4,7 +4,7 @@ import palette from "fidesui/src/palette/palette.module.scss";
 
 import { DiffStatus, StagedResourceTypeValue } from "~/types/api";
 
-export const TREE_PAGE_SIZE = 100;
+export const TREE_PAGE_SIZE = 25;
 export const TREE_NODE_LOAD_MORE_TEXT = "Load more...";
 export const TREE_NODE_LOAD_MORE_KEY_PREFIX = "load_more";
 export const TREE_NODE_SKELETON_KEY_PREFIX = "skeleton";

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
@@ -576,6 +576,11 @@ const MonitorTree = forwardRef<
             const result = await triggerAncestorsStatuses({
               monitor_config_id: monitorId,
               staged_resource_urn: urn,
+              diff_status: [
+                ...DEFAULT_FILTER_STATUSES.flatMap(intoDiffStatus),
+                ...(showIgnored ? intoDiffStatus("Ignored") : []),
+                ...(showApproved ? intoDiffStatus("Approved") : []),
+              ],
             });
 
             if (result.error) {
@@ -620,6 +625,8 @@ const MonitorTree = forwardRef<
         monitorId,
         collapseNodeAndRemoveChildren,
         errorAlert,
+        showIgnored,
+        showApproved,
       ],
     );
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
@@ -553,12 +553,7 @@ const MonitorTree = forwardRef<
             setTreeData((origin) =>
               topLevelData.items.reduce(
                 (tree, node) =>
-                  updateNodeStatus(
-                    tree,
-                    node.urn,
-                    node.update_status,
-                    node.diff_status,
-                  ),
+                  updateNodeStatus(tree, node.urn, node.diff_status),
                 origin,
               ),
             );

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
@@ -525,7 +525,8 @@ const MonitorTree = forwardRef<
     const refreshResourcesAndAncestors = useCallback(
       async (urns: string[]) => {
         // Special case: when no URNs provided (bulk action on all filtered resources),
-        // use get_tree to refresh top-level databases with filtered descendants
+        // we use get_tree instead of get_ancestors because there's no specific resource
+        // to get ancestors for. This refreshes top-level databases with filtered descendants.
         if (urns.length === 0) {
           try {
             const result = await trigger({
@@ -550,11 +551,11 @@ const MonitorTree = forwardRef<
               collapseNodeAndRemoveChildren(node.urn);
             });
 
-            setTreeData((origin) =>
+            setTreeData((prevTreeData) =>
               topLevelData.items.reduce(
                 (tree, node) =>
                   updateNodeStatus(tree, node.urn, node.diff_status),
-                origin,
+                prevTreeData,
               ),
             );
           } catch (error) {
@@ -593,7 +594,7 @@ const MonitorTree = forwardRef<
 
             collapseNodeAndRemoveChildren(urn);
 
-            setTreeData((origin) =>
+            setTreeData((prevTreeData) =>
               ancestorsData.reduce(
                 (tree, ancestorNode) =>
                   updateNodeStatus(
@@ -601,7 +602,7 @@ const MonitorTree = forwardRef<
                     ancestorNode.urn,
                     ancestorNode.diff_status,
                   ),
-                origin,
+                prevTreeData,
               ),
             );
           } catch (error) {


### PR DESCRIPTION
Ticket [ENG-2633] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

This PR updates the monitor tree to apply active filters when refreshing resources after actions are performed. Previously, when users performed actions on resources (approve, ignore, etc.), the tree would refresh without considering the active `diff_status` filters, potentially showing resources that should be filtered out.

The implementation also includes a page size reduction from 100 to 25 to improve initial load performance.

### Code Changes

* Updated `/tree/ancestors-statuses` endpoint to accept `staged_resource_urn` as a path parameter instead of query parameter
* Added `diff_status` filter parameter to ancestors-statuses API call
* Implemented special handling for bulk actions (empty URN list) to use `get_tree` endpoint instead
* Modified `refreshResourcesAndAncestors` to pass current filter state (`showIgnored`, `showApproved`) when refreshing
* Reduced `TREE_PAGE_SIZE` from 100 to 25 for better performance

### Steps to Confirm

1. Navigate to Data Discovery monitor with resources in different states (additions, approved, ignored)
2. Apply filter to hide muted items
3. Perform an action on a resource (ignore)
4. Verify the tree/ancestors-statuses request does not send muted diff status


### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-2633]: https://ethyca.atlassian.net/browse/ENG-2633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ