### PR TITLE
Base idea for the readonly fields on single allowed domains

### DIFF
--- a/clients/admin-ui/src/features/common/form/FormFieldFromSchema.tsx
+++ b/clients/admin-ui/src/features/common/form/FormFieldFromSchema.tsx
@@ -120,6 +120,7 @@ export const FormFieldFromSchema = ({
             autoComplete="off"
             color="gray.700"
             variant={layout}
+            disabled={fieldSchema.readonly}
           />
         );
       }}

--- a/clients/admin-ui/src/features/connection-type/types.ts
+++ b/clients/admin-ui/src/features/connection-type/types.ts
@@ -24,6 +24,7 @@ export type ConnectionTypeSecretSchemaProperty = {
   multiselect?: boolean;
   multiline?: boolean;
   options?: string[];
+  readonly?: boolean;
 };
 
 export type ConnectionTypeSecretSchemaResponse = {

--- a/clients/admin-ui/src/types/api/models/ConnectorParam.ts
+++ b/clients/admin-ui/src/types/api/models/ConnectorParam.ts
@@ -13,4 +13,6 @@ export type ConnectorParam = {
   multiselect?: boolean | null;
   description?: string | null;
   sensitive?: boolean | null;
+  type?: string | null;
+  allowed_values?: Array<string> | null;
 };

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_saas.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_saas.py
@@ -140,6 +140,12 @@ class SaaSSchemaFactory:
                 "multiselect": connector_param.multiselect,
                 "param_type": connector_param.type,
                 "allowed_values": connector_param.allowed_values,
+                "readonly": (
+                    connector_param.type == "endpoint"
+                    and connector_param.allowed_values is not None
+                    and len(connector_param.allowed_values) == 1
+                    and "*" not in connector_param.allowed_values[0]
+                ),
             }
             field_definitions[connector_param.name] = (
                 (


### PR DESCRIPTION
Simple improvement following Domains, making the domain fields readonly when there is only one allowed domain

### Description Of Changes

<!-- Write some things about the changes and any potential caveats -->

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. <!-- list any manual steps for reviewers to confirm the changes -->

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
