### PR TITLE
fix: surface interrupted task cancellation reason in activity timeline

### DIFF
--- a/changelog/7616-surface-interrupted-task-error-in-execution-log.yaml
+++ b/changelog/7616-surface-interrupted-task-error-in-execution-log.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed silent error state when requeue_interrupted_tasks cancels a privacy request — the reason now appears in the activity timeline
+pr: 7616
+labels: []

--- a/src/fides/api/service/privacy_request/request_service.py
+++ b/src/fides/api/service/privacy_request/request_service.py
@@ -14,6 +14,7 @@ from fides.api.common_exceptions import PrivacyRequestError
 from fides.api.models.privacy_request import (
     COMPLETED_EXECUTION_LOG_STATUSES,
     EXITED_EXECUTION_LOG_STATUSES,
+    ExecutionLog,
     PrivacyRequest,
     RequestTask,
 )
@@ -410,6 +411,31 @@ def _cancel_interrupted_tasks_and_error_privacy_request(
     except Exception as exc:
         logger.error(
             f"Failed to mark privacy request {privacy_request.id} as error: {exc}"
+        )
+
+    # Write a single execution log so the error is visible in the UI.
+    # Without this, error_processing() sets the status but creates no ExecutionLog,
+    # so the activity timeline shows a silent error with no explanation.
+    try:
+        first_task = (
+            db.query(RequestTask)
+            .filter(RequestTask.privacy_request_id == privacy_request.id)
+            .first()
+        )
+        if first_task:
+            ExecutionLog.create(
+                db=db,
+                data={
+                    "privacy_request_id": privacy_request.id,
+                    "action_type": first_task.action_type,
+                    "status": ExecutionLogStatus.error,
+                    "message": error_message
+                    or f"Privacy request {privacy_request.id} was interrupted and could not be completed",
+                },
+            )
+    except Exception as log_exc:
+        logger.error(
+            f"Failed to create error execution log for privacy request {privacy_request.id}: {log_exc}"
         )
 
 

--- a/tests/task/test_requeue_interrupted_tasks.py
+++ b/tests/task/test_requeue_interrupted_tasks.py
@@ -4,13 +4,14 @@ from unittest import mock
 
 import pytest
 
-from fides.api.models.privacy_request import PrivacyRequest, RequestTask
+from fides.api.models.privacy_request import ExecutionLog, PrivacyRequest, RequestTask
 from fides.api.models.privacy_request.request_task import AsyncTaskType
 from fides.api.models.worker_task import ExecutionLogStatus
 from fides.api.schemas.policy import ActionType
 from fides.api.schemas.privacy_request import PrivacyRequestStatus
 from fides.api.service.privacy_request.request_service import (
     REQUEUE_INTERRUPTED_TASKS_LOCK,
+    _cancel_interrupted_tasks_and_error_privacy_request,
     requeue_interrupted_tasks,
 )
 from fides.api.util.cache import cache_task_tracking_key, get_cache
@@ -995,4 +996,84 @@ class TestEnhancedRequeueInterruptedTasks:
 
         finally:
             # Clean up
+            privacy_request.delete(db)
+
+
+class TestCancelInterruptedTasksAndErrorPrivacyRequest:
+    """Tests for _cancel_interrupted_tasks_and_error_privacy_request."""
+
+    def test_creates_execution_log_with_error_message(self, db, policy):
+        """An ExecutionLog with status=error is written so the UI can surface the reason."""
+        privacy_request = PrivacyRequest.create(
+            db=db,
+            data={
+                "external_id": f"ext-{str(uuid.uuid4())}",
+                "started_processing_at": datetime.utcnow(),
+                "requested_at": datetime.utcnow() - timedelta(days=1),
+                "status": PrivacyRequestStatus.in_processing,
+                "origin": "https://example.com/testing",
+                "policy_id": policy.id,
+                "client_id": policy.client_id,
+            },
+        )
+        RequestTask.create(
+            db,
+            data={
+                "action_type": ActionType.consent,
+                "status": ExecutionLogStatus.pending,
+                "privacy_request_id": privacy_request.id,
+                "collection_address": "bloomreach:bloomreach",
+                "dataset_name": "bloomreach",
+                "collection_name": "bloomreach",
+                "upstream_tasks": [],
+                "downstream_tasks": [],
+            },
+        )
+
+        try:
+            error_msg = "No task ID found for request task, subtask is stuck - canceling privacy request"
+            _cancel_interrupted_tasks_and_error_privacy_request(
+                db, privacy_request, error_msg
+            )
+
+            logs = (
+                db.query(ExecutionLog)
+                .filter(ExecutionLog.privacy_request_id == privacy_request.id)
+                .all()
+            )
+            assert len(logs) == 1
+            assert logs[0].status == ExecutionLogStatus.error
+            assert logs[0].message == error_msg
+            assert logs[0].action_type == ActionType.consent
+            assert logs[0].dataset_name is None  # surfaces as "Request error" in UI
+        finally:
+            privacy_request.delete(db)
+
+    def test_no_execution_log_created_when_no_request_tasks_exist(self, db, policy):
+        """If no RequestTasks exist yet, no ExecutionLog is created (graceful fallback)."""
+        privacy_request = PrivacyRequest.create(
+            db=db,
+            data={
+                "external_id": f"ext-{str(uuid.uuid4())}",
+                "started_processing_at": datetime.utcnow(),
+                "requested_at": datetime.utcnow() - timedelta(days=1),
+                "status": PrivacyRequestStatus.in_processing,
+                "origin": "https://example.com/testing",
+                "policy_id": policy.id,
+                "client_id": policy.client_id,
+            },
+        )
+
+        try:
+            _cancel_interrupted_tasks_and_error_privacy_request(
+                db, privacy_request, "some error"
+            )
+
+            logs = (
+                db.query(ExecutionLog)
+                .filter(ExecutionLog.privacy_request_id == privacy_request.id)
+                .all()
+            )
+            assert len(logs) == 0
+        finally:
             privacy_request.delete(db)


### PR DESCRIPTION
Ticket <!-- no ticket -->

### Description Of Changes

When `requeue_interrupted_tasks` detects a stuck privacy request and calls `_cancel_interrupted_tasks_and_error_privacy_request`, it previously called `error_processing()` without writing any `ExecutionLog`. This meant the privacy request showed as errored in the UI with no explanation — the activity timeline was silently empty.

This was discovered during an investigation into a Bloomreach consent request that errored when Redis hit 100% capacity. `cache_task_tracking_key` swallowed the `DataError`, leaving the Bloomreach `RequestTask` with no cached Celery task ID. When the scheduler ran, it saw the task as stuck and cancelled the request — but wrote nothing to the execution logs.

The fix writes a single `ExecutionLog` (status=error, dataset_name=None) after erroring the privacy request. Because `execution_and_audit_logs_by_dataset_name` falls back to `f"Request {status}"` when `dataset_name` is None, this surfaces as a **"Request error"** entry in the activity timeline with the full interruption message.

### Code Changes

* `src/fides/api/service/privacy_request/request_service.py` - import `ExecutionLog`; after `error_processing()`, write one `ExecutionLog` with status=error and the interruption message, keyed to the first available `RequestTask`'s `action_type`; wrapped in its own try/except so log failure never blocks the error state transition
* `tests/task/test_requeue_interrupted_tasks.py` - add `TestCancelInterruptedTasksAndErrorPrivacyRequest` with two tests: (1) verifies the log is created with the correct status, message, and action_type; (2) verifies graceful fallback when no RequestTasks exist

### Steps to Confirm

1. Trigger a privacy request that gets stuck (e.g. manually revoke a Celery task ID from Redis for a pending RequestTask while its upstream is complete)
2. Wait for `requeue_interrupted_tasks` to fire
3. Open the privacy request in the UI — the activity timeline should now show a **"Request error"** entry with the exact cancellation message instead of being blank

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required