### PR TITLE
refactor: async tree [ENG-2451]

### DIFF
--- a/clients/admin-ui/src/features/common/nav/nav-config.tsx
+++ b/clients/admin-ui/src/features/common/nav/nav-config.tsx
@@ -389,6 +389,11 @@ if (process.env.NEXT_PUBLIC_APP_ENV === "development") {
         path: routes.ERRORS_POC_ROUTE,
         scopes: [],
       },
+      {
+        title: "Async Tree POC",
+        path: routes.ASYNC_TREE_ROUTE,
+        scopes: [],
+      },
     ],
   });
 }

--- a/clients/admin-ui/src/features/common/nav/routes.ts
+++ b/clients/admin-ui/src/features/common/nav/routes.ts
@@ -103,6 +103,7 @@ export const ANT_POC_ROUTE = "/poc/ant-components";
 export const FORMS_POC_ROUTE = "/poc/forms";
 export const ERRORS_POC_ROUTE = "/poc/error";
 export const TABLE_MIGRATION_POC_ROUTE = "/poc/table-migration";
+export const ASYNC_TREE_ROUTE = "/poc/async-tree";
 export const FIDES_JS_DOCS = "/fides-js-docs";
 export const PROMPT_EXPLORER_ROUTE = "/poc/prompt-explorer";
 export const TEST_MONITORS_ROUTE = "/poc/test-monitors";

--- a/clients/admin-ui/src/features/common/pagination.d.ts
+++ b/clients/admin-ui/src/features/common/pagination.d.ts
@@ -42,3 +42,11 @@ export interface CursorPaginationQueryParams {
   cursor?: string | null;
   size?: number | null;
 }
+
+export interface CursorPaginatedResponse<T> {
+  items?: Array<T>;
+  total?: number;
+  next_page?: string;
+  current_page?: string;
+  prev_page?: string;
+}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncMonitorTree.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncMonitorTree.tsx
@@ -1,0 +1,193 @@
+/* eslint-disable react/no-unstable-nested-components */
+import { Badge, Icons, Tooltip, TreeDataNode } from "fidesui";
+import { useRouter } from "next/router";
+import { Key } from "react";
+
+import { useLazyGetMonitorTreeQuery } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
+import { AsyncTree } from "~/features/data-discovery-and-detection/action-center/AsyncTree";
+import {
+  NodeAction,
+  TreeActions,
+} from "~/features/data-discovery-and-detection/action-center/AsyncTree/types";
+import {
+  DEFAULT_FILTER_STATUSES,
+  MAP_DATASTORE_RESOURCE_TYPE_TO_ICON,
+  MAP_DIFF_STATUS_TO_STATUS_INFO,
+} from "~/features/data-discovery-and-detection/action-center/fields/MonitorFields.const";
+import { shouldShowBadgeDot } from "~/features/data-discovery-and-detection/action-center/fields/treeUtils";
+import { DiffStatus, StagedResourceTypeValue } from "~/types/api";
+import { CursorPage_DatastoreStagedResourceTreeAPIResponse_ } from "~/types/api/models/CursorPage_DatastoreStagedResourceTreeAPIResponse_";
+import { FieldActionType } from "~/types/api/models/FieldActionType";
+
+import {
+  FIELD_ACTION_LABEL,
+  RESOURCE_ACTIONS,
+} from "./fields/FieldActions.const";
+import { intoDiffStatus } from "./fields/utils";
+import { DatastorePageSettings } from "./types";
+
+interface AsyncMonitorTreeProps
+  extends TreeActions<Record<string, NodeAction<TreeDataNode>>> {
+  setSelectedNodeKeys: (keys: Key[]) => void;
+  selectedNodeKeys: Key[];
+}
+
+export const AsyncMonitorTree = ({
+  setSelectedNodeKeys,
+  selectedNodeKeys,
+  nodeActions,
+  primaryAction,
+  showApproved,
+  showIgnored,
+}: AsyncMonitorTreeProps & DatastorePageSettings) => {
+  const router = useRouter();
+  const monitorId = decodeURIComponent(router.query.monitorId as string);
+  const [trigger] = useLazyGetMonitorTreeQuery();
+
+  /**
+   * @description the primary of interacting with the async data tree is through request/response patterns
+   */
+  const transformResponseToNode = (
+    response: CursorPage_DatastoreStagedResourceTreeAPIResponse_,
+  ): TreeDataNode[] =>
+    response.items.map((item) => ({
+      key: item.urn,
+      title: item.name,
+      disabled: item.diff_status === DiffStatus.MUTED,
+      actions: Object.fromEntries(
+        RESOURCE_ACTIONS.map((action) => [
+          action,
+          {
+            label: FIELD_ACTION_LABEL[action],
+            /** Logic for this should exist on the BE */
+            disabled: () => {
+              const classifyable = [
+                StagedResourceTypeValue.SCHEMA,
+                StagedResourceTypeValue.TABLE,
+                StagedResourceTypeValue.ENDPOINT,
+                StagedResourceTypeValue.FIELD,
+              ].some((resourceType) => resourceType === item.resource_type);
+
+              if (
+                (action === FieldActionType.PROMOTE_REMOVALS &&
+                  item.diff_status === DiffStatus.REMOVAL) ||
+                (action === FieldActionType.CLASSIFY &&
+                  classifyable &&
+                  item.diff_status !== DiffStatus.MUTED) ||
+                (action === FieldActionType.MUTE &&
+                  item.diff_status !== DiffStatus.MUTED) ||
+                (action === FieldActionType.UN_MUTE &&
+                  item.diff_status === DiffStatus.MUTED)
+              ) {
+                return false;
+              }
+
+              return true;
+            },
+            callback: async () =>
+              nodeActions[action].callback(
+                [item.urn],
+                [
+                  {
+                    key: item.urn,
+                    title: item.name,
+                    disabled: item.diff_status === DiffStatus.MUTED,
+                  },
+                ],
+              ),
+          },
+        ]),
+      ),
+      icon: () => {
+        const resourceType = Object.values(StagedResourceTypeValue).find(
+          (key) => key === item.resource_type,
+        );
+
+        const resourceIcon = resourceType
+          ? MAP_DATASTORE_RESOURCE_TYPE_TO_ICON[resourceType]
+          : undefined;
+
+        const IconComponent =
+          item.diff_status === DiffStatus.MUTED ? Icons.ViewOff : resourceIcon;
+
+        const statusInfo = item.diff_status
+          ? MAP_DIFF_STATUS_TO_STATUS_INFO[item.diff_status]
+          : undefined;
+
+        return IconComponent ? (
+          <Tooltip title={statusInfo?.tooltip}>
+            <Badge
+              className="h-full"
+              offset={[0, 5]}
+              color={statusInfo?.color}
+              dot={shouldShowBadgeDot(item)}
+            >
+              <IconComponent className="h-full" />
+            </Badge>
+          </Tooltip>
+        ) : undefined;
+      },
+      isLeaf: item.resource_type === StagedResourceTypeValue.FIELD,
+    }));
+
+  return (
+    <div className="grid h-full grid-rows-[1fr_minmax(max-content,max-content)] gap-6 overflow-x-hidden">
+      <AsyncTree
+        loadData={({ cursor, size }, key) =>
+          new Promise((resolve) => {
+            trigger({
+              monitor_config_id: monitorId,
+              staged_resource_urn: key?.toString(),
+              diff_status: [
+                ...DEFAULT_FILTER_STATUSES.flatMap(intoDiffStatus),
+                ...(showIgnored ? intoDiffStatus("Ignored") : []),
+                ...(showApproved ? intoDiffStatus("Approved") : []),
+              ],
+              cursor,
+              size,
+            }).then(({ data }) =>
+              resolve({
+                items: data ? transformResponseToNode(data) : [],
+                total: data?.total ?? 0,
+                current_page: data?.current_page ?? undefined,
+                next_page: data?.next_page ?? undefined,
+              }),
+            );
+          })
+        }
+        refreshData={(key, childKeys) =>
+          new Promise((resolve) => {
+            trigger({
+              monitor_config_id: monitorId,
+              staged_resource_urn: key?.toString(),
+              diff_status: [
+                ...DEFAULT_FILTER_STATUSES.flatMap(intoDiffStatus),
+                ...(showIgnored ? intoDiffStatus("Ignored") : []),
+                ...(showApproved ? intoDiffStatus("Approved") : []),
+              ],
+              child_staged_resource_urns: childKeys?.map((childKey) =>
+                childKey.toString(),
+              ),
+              size: childKeys?.length,
+            }).then(({ data }) =>
+              resolve({
+                items: data ? transformResponseToNode(data) : [],
+                total: data?.total ?? 0,
+                current_page: data?.current_page ?? undefined,
+                next_page: data?.next_page ?? undefined,
+              }),
+            );
+          })
+        }
+        actions={{ primaryAction, nodeActions }}
+        // pageSize={2}
+        onSelect={(keys) => setSelectedNodeKeys(keys)}
+        selectedKeys={selectedNodeKeys}
+        showFooter
+        taxonomy={["resource", "resources"]}
+        queryKeys={[String(showIgnored), String(showApproved)]}
+        className="overflow-scroll overflow-x-hidden"
+      />
+    </div>
+  );
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncNodeSkeleton.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncNodeSkeleton.tsx
@@ -1,0 +1,9 @@
+import { Skeleton } from "fidesui";
+
+import { AsyncTreeNodeComponentProps } from "./types";
+
+export const AsyncNodeSkeleton = ({ node }: AsyncTreeNodeComponentProps) => (
+  <Skeleton paragraph={false} title={{ width: "80px" }} active>
+    {typeof node.title === "function" ? node.title(node) : node.title}
+  </Skeleton>
+);

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncNodeTitle.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncNodeTitle.tsx
@@ -1,0 +1,62 @@
+import { Button, Dropdown, Flex, Icons, Text } from "fidesui";
+
+import { AsyncTreeNodeComponentProps } from "./types";
+
+export const AsyncTreeDataTitle = ({
+  node,
+  actions,
+  refreshCallback,
+}: AsyncTreeNodeComponentProps) => {
+  const title =
+    typeof node.title === "function" ? node.title(node) : node.title;
+
+  if (!title) {
+    return null;
+  }
+  return (
+    /** TODO: migrate group class to semantic dom after upgrading ant */
+    <Flex
+      gap={4}
+      align="center"
+      className={`group ml-1 flex grow ${node.disabled ? "opacity-40" : ""}`}
+      aria-label={
+        node.disabled ? `${title.toString()} (ignored)` : title.toString()
+      }
+    >
+      <Text ellipsis={{ tooltip: title }} className="grow select-none">
+        {title}
+      </Text>
+      <Dropdown
+        menu={{
+          items: node.actions
+            ? Object.entries(node.actions).map(
+                ([key, { disabled, label }]) => ({
+                  key,
+                  disabled: disabled([node]),
+                  label,
+                }),
+              )
+            : [],
+          onClick: async ({ key, domEvent }) => {
+            domEvent.preventDefault();
+            domEvent.stopPropagation();
+            await actions?.[key]?.callback([key], [node]);
+            refreshCallback?.(node.key);
+          },
+        }}
+        destroyOnHidden
+        className="group mr-1 flex-none group-[.multi-select]/monitor-tree:pointer-events-none group-[.multi-select]/monitor-tree:opacity-0"
+      >
+        <Button
+          aria-label="Show More Resource Actions"
+          icon={
+            <Icons.OverflowMenuVertical className="opacity-0 group-hover:opacity-100 group-[.ant-dropdown-open]:opacity-100" />
+          }
+          type="text"
+          size="small"
+          className="self-end"
+        />
+      </Dropdown>
+    </Flex>
+  );
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncTreeFooter.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncTreeFooter.tsx
@@ -1,0 +1,72 @@
+import { Button, Dropdown, Flex, Icons, SparkleIcon, Text } from "fidesui";
+import { Key } from "react";
+
+import { pluralize } from "~/features/common/utils";
+
+import { ActionDict, Plural, TreeActions } from "./types";
+
+export const AsyncTreeFooter = ({
+  selectedKeys,
+  actions,
+  taxonomy,
+}: {
+  selectedKeys: Key[];
+  actions?: TreeActions<ActionDict>;
+  taxonomy: Plural;
+}) => {
+  return (
+    <Flex justify="space-between" align="center" gap="small">
+      {actions ? (
+        <>
+          <Button
+            aria-label={`${actions.nodeActions[actions.primaryAction]} ${selectedKeys.length} selected ${pluralize(selectedKeys.length, ...taxonomy)}`}
+            /** TODO: add icons to the action definitions to render here * */
+            icon={<SparkleIcon size={12} />}
+            size="small"
+            onClick={() =>
+              actions.nodeActions[actions.primaryAction]?.callback(
+                selectedKeys,
+                [],
+                // selectedNodeKeys.flatMap((nodeKey) => {
+                //   const node = findNodeByUrn(treeData, nodeKey.toString());
+                //   return node ? [node] : [];
+                // }),
+              )
+            }
+            className="flex-none"
+          />
+          <Text
+            ellipsis
+          >{`${selectedKeys.length} ${pluralize(selectedKeys.length, ...taxonomy)} selected`}</Text>
+          <Dropdown
+            menu={{
+              items: actions.nodeActions
+                ? Object.entries(actions.nodeActions).map(
+                    ([key, { label, disabled }]) => ({
+                      key,
+                      label,
+                      disabled: disabled?.([]),
+                    }),
+                  )
+                : [],
+              onClick: ({ key, domEvent }) => {
+                domEvent.preventDefault();
+                domEvent.stopPropagation();
+                actions.nodeActions[key]?.callback(selectedKeys, []);
+              },
+            }}
+            destroyOnHidden
+            className="group mr-1 flex-none"
+          >
+            <Button
+              aria-label={`Show more ${taxonomy[0]} actions`}
+              icon={<Icons.OverflowMenuVertical />}
+              size="small"
+              className="self-end"
+            />
+          </Dropdown>
+        </>
+      ) : null}
+    </Flex>
+  );
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncTreeLinkNode.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/AsyncTreeLinkNode.tsx
@@ -1,0 +1,27 @@
+import { Button, ButtonProps } from "fidesui";
+
+import { AsyncTreeNodeComponentProps } from "./types";
+
+export const AsyncTreeDataLink = ({
+  node,
+  buttonProps,
+}: Omit<AsyncTreeNodeComponentProps, "actions"> & {
+  buttonProps: ButtonProps;
+}) => {
+  const { title, disabled } = node;
+  if (!title) {
+    return null;
+  }
+
+  return (
+    <Button
+      type="link"
+      block
+      disabled={disabled}
+      {...buttonProps}
+      className="p-0"
+    >
+      {typeof title === "function" ? title(node) : title}
+    </Button>
+  );
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/const.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/const.ts
@@ -1,0 +1,34 @@
+import { TreeProps } from "fidesui";
+import { Key } from "react";
+
+import { CursorPaginationState } from "~/features/common/pagination";
+import { DEFAULT_PAGE_SIZE } from "~/features/common/table/constants";
+
+import { AsyncTreeNode } from "./types";
+
+export const TREE_NODE_LOAD_MORE_KEY_PREFIX = "";
+export const TREE_NODE_SKELETON_KEY_PREFIX = "";
+
+export const ROOT_NODE_KEY = "ROOT_NODE";
+
+export const DEFAULT_ROOT_NODE: AsyncTreeNode & CursorPaginationState = {
+  key: ROOT_NODE_KEY,
+  pageSize: DEFAULT_PAGE_SIZE,
+  total: 0,
+};
+
+export const DEFAULT_ROOT_NODE_STATE: {
+  keys: Key[];
+  nodes: Array<AsyncTreeNode & CursorPaginationState>;
+} = {
+  keys: [ROOT_NODE_KEY],
+  nodes: [DEFAULT_ROOT_NODE],
+};
+
+export const DEFAULT_TREE_PROPS: TreeProps = {
+  showIcon: true,
+  showLine: true,
+  blockNode: true,
+  multiple: true,
+  expandAction: "doubleClick",
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/index.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/index.tsx
@@ -1,0 +1,380 @@
+/* eslint-disable react/no-unstable-nested-components */
+import { Spin, Tree, TreeDataNode, TreeProps } from "fidesui";
+import _ from "lodash";
+import { Key, useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  CursorPaginatedResponse,
+  CursorPaginationState,
+} from "~/features/common/pagination";
+import { DEFAULT_PAGE_SIZE } from "~/features/common/table/constants";
+
+import { AsyncTreeDataTitle } from "./AsyncNodeTitle";
+import { AsyncTreeFooter } from "./AsyncTreeFooter";
+import { AsyncTreeDataLink } from "./AsyncTreeLinkNode";
+import {
+  DEFAULT_ROOT_NODE,
+  DEFAULT_ROOT_NODE_STATE,
+  DEFAULT_TREE_PROPS,
+  ROOT_NODE_KEY,
+} from "./const";
+import { AsyncTreeNode, InternalTreeProps } from "./types";
+
+const DEFAULT_NODE_PAGINATION_PROPS = {
+  cursor: undefined,
+  total: 0,
+} as const;
+
+export const AsyncTree = ({
+  pageSize = DEFAULT_PAGE_SIZE,
+  loadMoreText = "Load More",
+  showFooter = false,
+  taxonomy = ["item", "items"],
+  actions,
+  selectedKeys,
+  loadData,
+  refreshData,
+  queryKeys,
+  ...props
+}: InternalTreeProps) => {
+  /* Storing lookup data as normalized nodes */
+  const [asyncNodes, rawSetAsyncNodes] = useState<{
+    keys: Key[];
+    nodes: Array<AsyncTreeNode & CursorPaginationState>;
+  }>(DEFAULT_ROOT_NODE_STATE);
+  const asyncNodesRef = useRef<typeof asyncNodes>();
+  const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
+
+  useEffect(() => {
+    asyncNodesRef.current = asyncNodes;
+  });
+
+  const setAsyncNodes = (
+    nodes: Array<AsyncTreeNode & CursorPaginationState>,
+  ) => {
+    rawSetAsyncNodes({
+      keys: nodes.flatMap(({ key }) => key),
+      nodes,
+    });
+  };
+
+  const removeAsyncNodes = (keys: Key[]) => {
+    rawSetAsyncNodes((prev) => {
+      const nextKeys = _.difference(prev?.keys ?? [], keys);
+
+      return {
+        keys: nextKeys,
+        nodes: nextKeys.flatMap((nextKey) => {
+          const target = prev.nodes.find(({ key }) => nextKey === key);
+
+          return target ? [target] : [];
+        }),
+      };
+    });
+    setExpandedKeys((prev) => _.difference(prev, keys));
+  };
+
+  const updateAsyncNodes = (
+    next: Array<AsyncTreeNode & CursorPaginationState>,
+  ) => {
+    rawSetAsyncNodes((prev) => {
+      const nextKeys = _.uniq(
+        [...(prev?.nodes ?? []), ...next].flatMap(({ key }) => key),
+      );
+
+      return {
+        keys: nextKeys,
+        nodes: nextKeys.flatMap((nextKey) => {
+          const target =
+            next.find(({ key }) => nextKey === key) ??
+            prev?.nodes.find(({ key }) => nextKey === key);
+
+          return target ? [target] : [];
+        }),
+      };
+    });
+  };
+
+  const handleRefresh = useCallback(
+    (
+      parentNode: TreeDataNode,
+      refreshedNodeKeys: Key[],
+      callback: (keys?: Key[]) => void,
+      resetPaginationNodes?: CursorPaginatedResponse<TreeDataNode>,
+      refreshedNodes?: CursorPaginatedResponse<TreeDataNode>,
+    ) => {
+      const foundKeys =
+        refreshedNodes?.items?.map(({ key }) => key.toString()) ?? [];
+      const keysToRemove = _.difference(refreshedNodeKeys, foundKeys);
+      removeAsyncNodes(keysToRemove);
+
+      const dataNodes =
+        [
+          ...(resetPaginationNodes?.items ?? []),
+          ...(refreshedNodes?.items ?? []),
+        ]?.flatMap((dn) => [
+          {
+            ...dn,
+            title: () => (
+              <AsyncTreeDataTitle
+                node={{
+                  ...dn,
+                  parent: parentNode.key ?? ROOT_NODE_KEY,
+                  ...DEFAULT_NODE_PAGINATION_PROPS,
+                }}
+                actions={actions?.nodeActions}
+                refreshCallback={(key) => callback([key])}
+              />
+            ),
+            parent: parentNode.key ?? ROOT_NODE_KEY,
+            next_page: asyncNodes.nodes.find(
+              (existingNode) => dn.key === existingNode.key,
+            )?.next_page,
+            ...DEFAULT_NODE_PAGINATION_PROPS,
+            pageSize,
+          },
+        ]) ?? [];
+      updateAsyncNodes([
+        ...dataNodes,
+        ...(parentNode
+          ? [
+              {
+                ...parentNode,
+                pageSize,
+                total: resetPaginationNodes?.total ?? 0,
+                current_page: resetPaginationNodes?.current_page,
+                next_page: resetPaginationNodes?.next_page,
+              },
+            ]
+          : []),
+      ]);
+    },
+    [actions?.nodeActions, asyncNodes.nodes, pageSize],
+  );
+
+  const refreshCallback = useCallback(
+    (keys?: Key[]) => {
+      const refreshingNodes = keys
+        ? asyncNodesRef.current?.nodes.flatMap((node) =>
+            keys.includes(node.key) ? [node] : [],
+          )
+        : asyncNodesRef.current?.nodes;
+
+      // const relatedNodes = refreshingNodes.reduce((agg, current) => {
+      //   const parentNode = asyncNodes.nodes.find((n) => n.key === current.parent)
+      //   return [
+      //     ...agg,
+      //     ...(parentNode ? [parentNode] : [])
+      //   ]
+      // }, [] as typeof refreshingNodes)
+      updateAsyncNodes(
+        refreshingNodes?.map((node) => ({
+          ...node,
+          icon: <Spin size="small" />,
+        })) ?? [],
+      );
+
+      const refresh = async (
+        node: TreeDataNode,
+        parentKey: string,
+        childKeys: string[],
+      ) => {
+        const resolvedParentKey =
+          parentKey === ROOT_NODE_KEY ? undefined : parentKey;
+        await Promise.all([
+          refreshData(resolvedParentKey, childKeys),
+          loadData({ size: pageSize }, resolvedParentKey),
+        ]).then(([refreshedNodes, resetPaginationNodes]) => {
+          handleRefresh(
+            node,
+            childKeys,
+            refreshCallback,
+            resetPaginationNodes,
+            refreshedNodes,
+          );
+        });
+      };
+
+      const parentNodes = asyncNodesRef.current?.nodes.flatMap((node) =>
+        asyncNodesRef.current?.nodes.some(({ parent }) => parent === node.key)
+          ? [node]
+          : [],
+      );
+      parentNodes?.map((node) =>
+        refresh(
+          node,
+          node.key.toString(),
+          refreshingNodes?.flatMap((child) =>
+            child.parent === node.key ? [child.key.toString()] : [],
+          ) ?? [],
+        ),
+      );
+    },
+    [handleRefresh, loadData, pageSize, refreshData],
+  );
+
+  const rawLoadData = (key?: Key) => {
+    return new Promise((resolve) => {
+      const asyncNode = asyncNodes?.nodes.find(
+        (node) => node.key === (key ?? ROOT_NODE_KEY),
+      );
+      loadData({ cursor: asyncNode?.next_page, size: pageSize }, key).then(
+        (result) => {
+          const dataNodes =
+            result?.items?.flatMap((dn) => [
+              {
+                ...dn,
+                title: () => (
+                  <AsyncTreeDataTitle
+                    node={{
+                      ...dn,
+                      parent: key ?? ROOT_NODE_KEY,
+                      ...DEFAULT_NODE_PAGINATION_PROPS,
+                    }}
+                    actions={actions?.nodeActions}
+                    refreshCallback={(k) => refreshCallback([k])}
+                  />
+                ),
+                parent: key ?? ROOT_NODE_KEY,
+                ...DEFAULT_NODE_PAGINATION_PROPS,
+                pageSize,
+              },
+            ]) ?? [];
+
+          updateAsyncNodes([
+            ...dataNodes,
+            ...(asyncNode
+              ? [
+                  {
+                    // update parent node's pagination
+                    ...asyncNode,
+                    pageSize,
+                    total: result?.total ?? 0,
+                    current_page: result?.current_page,
+                    next_page: result?.next_page,
+                  },
+                ]
+              : []),
+          ]);
+
+          resolve(result);
+        },
+      );
+    });
+  };
+
+  /**
+   * @description This is the heart of the component that builds the tree data from our async state
+   */
+  const recBuildTree = (node: AsyncTreeNode): TreeDataNode => ({
+    ...node,
+    children: [
+      ...(asyncNodes?.nodes
+        ?.flatMap((child) =>
+          child.parent === node.key ? [recBuildTree(child)] : [],
+        )
+        .sort((a, b) => a.key.toString().localeCompare(b.key.toString())) ??
+        []),
+      ...(node.next_page
+        ? [
+            {
+              key: `SHOW_MORE__${node.key}`,
+              title: () => (
+                <AsyncTreeDataLink
+                  node={{ ...node, title: loadMoreText, disabled: false }}
+                  buttonProps={{ onClick: () => rawLoadData(node.key) }}
+                />
+              ),
+              selectable: false,
+              icon: () => null,
+              isLeaf: true,
+            },
+          ]
+        : []),
+    ],
+  });
+
+  /**
+   * @description initiates the tree construction
+   */
+  const treeData: TreeProps["treeData"] = recBuildTree(
+    asyncNodes.nodes.find(({ key }) => key === ROOT_NODE_KEY) ??
+      DEFAULT_ROOT_NODE,
+  ).children;
+
+  const antLoadData: TreeProps["loadData"] = (args) => rawLoadData(args.key);
+
+  useEffect(() => {
+    refreshCallback();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(queryKeys)]);
+
+  useEffect(() => {
+    const initialize = async () => rawLoadData();
+    initialize();
+
+    return () => {
+      setAsyncNodes([DEFAULT_ROOT_NODE]);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <Tree.DirectoryTree
+        {...DEFAULT_TREE_PROPS}
+        {...props}
+        loadData={antLoadData}
+        treeData={treeData}
+        loadedKeys={expandedKeys}
+        expandedKeys={expandedKeys}
+        onExpand={(newExpandedKeys) => {
+          setExpandedKeys(newExpandedKeys);
+        }}
+        selectedKeys={selectedKeys}
+      />
+      {showFooter ? (
+        <AsyncTreeFooter
+          selectedKeys={selectedKeys ?? []}
+          actions={{
+            nodeActions: actions?.nodeActions
+              ? Object.fromEntries(
+                  Object.entries(actions.nodeActions).map(([key, action]) => {
+                    const selectedNodes = selectedKeys?.flatMap(
+                      (selectedKey) => [
+                        asyncNodes.nodes.find((an) => an.key === selectedKey),
+                      ],
+                    );
+                    const selectedNodeDisabledActions = selectedNodes?.reduce(
+                      (agg, current) => {
+                        const disabledActions = current?.actions
+                          ? Object.entries(current.actions)?.flatMap(() =>
+                              action.disabled?.([current]) ? [key] : [],
+                            )
+                          : [];
+                        return _.uniq([...agg, ...disabledActions]);
+                      },
+                      [] as Array<Key>,
+                    );
+
+                    return [
+                      key,
+                      {
+                        ...action,
+                        disabled: () =>
+                          selectedNodeDisabledActions?.includes(key) ?? false,
+                      },
+                    ];
+                  }),
+                )
+              : {},
+            primaryAction: actions?.primaryAction ?? "",
+          }}
+          taxonomy={taxonomy}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default AsyncTree;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/types.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/types.ts
@@ -1,0 +1,89 @@
+import { TreeDataNode, TreeProps } from "fidesui";
+import { Key } from "react";
+
+import {
+  CursorPaginatedResponse,
+  CursorPaginationQueryParams,
+} from "~/features/common/pagination";
+
+export type ReactDataNode<T> = T & {
+  key: Key;
+  children?: ReactDataNode<T>[];
+};
+
+type ATreeDataNode = Omit<TreeDataNode, "children" | "key">;
+
+export type AsyncTreeNode<T extends ATreeDataNode = ATreeDataNode> =
+  ReactDataNode<T> &
+    Omit<CursorPaginatedResponse<T>, "items"> & {
+      parent?: Key;
+      actions?: ActionDict;
+    };
+
+export type Plural = [string, string];
+
+export interface InternalTreeProps<T extends AsyncTreeNode = AsyncTreeNode>
+  extends Omit<TreeProps<T>, "loadData" | "treeData"> {
+  loadData: (
+    pagination: CursorPaginationQueryParams,
+    key?: Key,
+  ) => Promise<CursorPaginatedResponse<TreeDataNode> | undefined>;
+  refreshData: (
+    key?: Key,
+    childKeys?: Key[],
+  ) => Promise<CursorPaginatedResponse<TreeDataNode> | undefined>;
+  queryKeys?: Key[];
+  actions?: TreeActions<ActionDict>;
+  pageSize?: number;
+  loadMoreText?: string;
+  showFooter?: boolean;
+  taxonomy?: Plural;
+}
+
+export type AsyncTreeProps = Omit<TreeProps, "loadData"> & {
+  pageSize?: number;
+  actions?: TreeActions<ActionDict>;
+  loadMoreText?: string;
+  showFooter?: boolean;
+  taxonomy?: Plural;
+  loadData: (
+    pagination: CursorPaginationQueryParams,
+    key?: Key,
+  ) => Promise<CursorPaginatedResponse<TreeDataNode> | undefined>;
+};
+
+export type AsyncTreeNodeComponentProps = {
+  node: AsyncTreeNode;
+  actions?: ActionDict;
+  refreshCallback?: (key: Key) => void;
+};
+
+export type ParentMapNode = Omit<CursorPaginatedResponse<unknown>, "items"> & {
+  key: Key;
+  parent?: Key;
+  children: Key[];
+};
+
+type LeafMapNode = {
+  key: Key;
+  parent?: Key;
+};
+
+export type MapNode = ParentMapNode | LeafMapNode;
+
+export interface ActionDict<N extends AsyncTreeNode = AsyncTreeNode>
+  extends Record<string, NodeAction<N>> {}
+
+export type TreeActions<AD extends ActionDict> = {
+  nodeActions: AD;
+  primaryAction: keyof AD;
+};
+
+export type NodeAction<N> = {
+  label: string;
+  /** TODO: should be generically typed * */
+  callback: (keys: Key[], nodes: N[]) => Promise<void>;
+  disabled: (nodes: N[]) => boolean;
+};
+
+export type TreeNodeAction = NodeAction<AsyncTreeNode>;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/utils.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AsyncTree/utils.ts
@@ -1,0 +1,36 @@
+// import { TreeDataNode } from "fidesui";
+import { Key } from "react";
+
+// import { AsyncTreeNode } from "./types";
+
+export type ReactDataNode<T> = T & {
+  key: Key;
+  children?: ReactDataNode<T>[];
+};
+
+// const recBuildTree = (
+//   node: AsyncTreeNode,
+//   nodes: AsyncTreeNode[],
+// ): TreeDataNode => ({
+//   ...node,
+//   children: [
+//     ...nodes?.flatMap((child) =>
+//       child.parent === node.key ? [recBuildTree(child, nodes)] : [],
+//     ),
+//     ...(node.total > node?.page * node.size
+//       ? [
+//           {
+//             key: `SHOW_MORE__${node.key}`,
+//             // title: () => (
+//             //   <AsyncTreeDataLink
+//             //     node={{ ...node, title: loadMoreText }}
+//             //     buttonProps={{ onClick: () => _loadData(node.key) }}
+//             //   />
+//             // ),
+//             icon: () => null,
+//             isLeaf: true,
+//           },
+//         ]
+//       : []),
+//   ],
+// });

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -130,6 +130,7 @@ const actionCenterApi = baseApi.injectEndpoints({
         staged_resource_urn?: string;
         include_descendant_details?: boolean;
         diff_status?: DiffStatus[];
+        child_staged_resource_urns?: string[];
       }
     >({
       query: ({
@@ -139,8 +140,12 @@ const actionCenterApi = baseApi.injectEndpoints({
         staged_resource_urn,
         include_descendant_details,
         diff_status,
+        child_staged_resource_urns,
       }) => {
-        const urlParams = buildArrayQueryParams({ diff_status });
+        const urlParams = buildArrayQueryParams({
+          diff_status,
+          child_staged_resource_urns,
+        });
 
         return {
           url: `/plus/discovery-monitor/${monitor_config_id}/tree?${urlParams}`,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
@@ -9,6 +9,7 @@ import {
   Title,
   Tooltip,
   Tree,
+  TreeDataNode,
 } from "fidesui";
 import { useRouter } from "next/router";
 import {
@@ -52,7 +53,7 @@ import {
   shouldShowBadgeDot,
   updateNodeStatus,
 } from "./treeUtils";
-import { CustomTreeDataNode, TreeNodeAction } from "./types";
+import { CustomTreeDataNode } from "./types";
 import { intoDiffStatus } from "./utils";
 
 const getIconComponent = (
@@ -244,13 +245,13 @@ export interface MonitorTreeRef {
   refreshResourcesAndAncestors: (urns: string[]) => Promise<void>;
 }
 
-interface NodeActions<Action, ActionDict extends Record<string, Action>> {
-  nodeActions: ActionDict;
-  primaryAction: keyof ActionDict;
-}
+type TreeActions<AD extends Record<string, NodeAction<TreeDataNode>>> = {
+  nodeActions: AD;
+  primaryAction: keyof AD;
+};
 
 interface MonitorTreeProps
-  extends NodeActions<TreeNodeAction, Record<string, TreeNodeAction>> {
+  extends TreeActions<Record<string, NodeAction<TreeDataNode>>> {
   setSelectedNodeKeys: (keys: Key[]) => void;
   selectedNodeKeys: Key[];
 }

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -25,10 +25,11 @@ import {
   useGetDatastoreFiltersQuery,
   useGetMonitorConfigQuery,
 } from "~/features/data-discovery-and-detection/action-center/action-center.slice";
-import { DiffStatus, TreeResourceChangeIndicator } from "~/types/api";
+import { DiffStatus } from "~/types/api";
 import { ConfidenceBucket } from "~/types/api/models/ConfidenceBucket";
 import { FieldActionType } from "~/types/api/models/FieldActionType";
 
+import { AsyncMonitorTree } from "../AsyncMonitorTree";
 import {
   MonitorFieldSearchForm,
   MonitorFieldSearchFormQuerySchema,
@@ -58,7 +59,7 @@ import {
   FIELD_PAGE_SIZE,
   MAP_DIFF_STATUS_TO_RESOURCE_STATUS_LABEL,
 } from "./MonitorFields.const";
-import MonitorTree, { MonitorTreeRef } from "./MonitorTree";
+import { MonitorTreeRef } from "./MonitorTree";
 import { ResourceDetailsDrawer } from "./ResourceDetailsDrawer";
 import type { MonitorResource } from "./types";
 import { useBulkActions } from "./useBulkActions";
@@ -269,10 +270,10 @@ const ActionCenterFields = ({
           /** Note: style attr used here due to specificity of ant css. */
           style={{ paddingRight: "var(--ant-padding-md)" }}
         >
-          <MonitorTree
+          <AsyncMonitorTree
             showIgnored={showIgnored}
             showApproved={showApproved}
-            ref={monitorTreeRef}
+            // ref={monitorTreeRef}
             setSelectedNodeKeys={setSelectedNodeKeys}
             selectedNodeKeys={selectedNodeKeys}
             primaryAction={FieldActionType.CLASSIFY}
@@ -281,30 +282,11 @@ const ActionCenterFields = ({
                 action,
                 {
                   label: FIELD_ACTION_LABEL[action],
-                  /** Logic for this should exist on the BE */
-                  disabled: (nodes) =>
-                    _(nodes)
-                      .map((node) => {
-                        if (
-                          (action === FieldActionType.PROMOTE_REMOVALS &&
-                            node.status ===
-                              TreeResourceChangeIndicator.REMOVAL) ||
-                          (action === FieldActionType.CLASSIFY &&
-                            node.classifyable &&
-                            node.diffStatus !== DiffStatus.MUTED) ||
-                          (action === FieldActionType.MUTE &&
-                            node.diffStatus !== DiffStatus.MUTED) ||
-                          (action === FieldActionType.UN_MUTE &&
-                            node.diffStatus === DiffStatus.MUTED)
-                        ) {
-                          return false;
-                        }
-
-                        return true;
-                      })
-                      .some((d) => d === true),
-                  callback: (keys) => {
-                    fieldActions[action](keys, false);
+                  callback: async (_keys, dataNodes) => {
+                    const nodeKeys = dataNodes.map((nodeKey) =>
+                      nodeKey.key.toString(),
+                    );
+                    await fieldActions[action](nodeKeys, false);
                   },
                 },
               ]),


### PR DESCRIPTION
Ticket [ENG-2451] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Creating a component specifically for handling async tree data.
This is not scalable due to how ant designed the component and this hacks together something that meets functional requirements.
A truly scalable component would need to be build from scratch so that individual tree elements can be properly rendered and tracked as a virtual react element that can refetch data according to it's visibility instead of a globally tracked list of nodes that may or may not be visible or relevant.

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. <!-- list any manual steps for reviewers to confirm the changes -->

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-2451]: https://ethyca.atlassian.net/browse/ENG-2451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ