### PR TITLE
fix: infra monitor screen ui regressions

### DIFF
--- a/changelog/7719-fix-style-regression.yaml
+++ b/changelog/7719-fix-style-regression.yaml
@@ -1,0 +1,4 @@
+type: Fixed # One of: Added, Changed, Developer Experience, Deprecated, Docs, Fixed, Removed, Security
+description: Styles on infra and datastore monitor screens
+pr: 7719 # PR number
+labels: [] # Optional: ["high-risk", "db-migration"]

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.tsx
@@ -52,7 +52,7 @@ export const tagRender: TagRender = (props) => {
       onClose={onClose}
       /** Style required because of tailwind limitations and our ui package presets */
       style={{
-        marginInlineEnd: "calc((var(--ant-padding-xs) * 0.5))",
+        marginInlineEnd: 4,
       }}
       icon={isFromClassifier && <SparkleIcon />}
     >

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -263,12 +263,11 @@ const ActionCenterFields = ({
 
   return (
     <>
-      <Splitter className="h-[calc(100%-48px)] overflow-hidden">
-        <Splitter.Panel
-          defaultSize={250}
-          /** Note: style attr used here due to specificity of ant css. */
-          style={{ paddingRight: "var(--ant-padding-md)" }}
-        >
+      <Splitter
+        className="h-[calc(100%-48px)] overflow-hidden"
+        classNames={{ root: "gap-6" }}
+      >
+        <Splitter.Panel defaultSize={250}>
           <MonitorTree
             showIgnored={showIgnored}
             showApproved={showApproved}
@@ -311,11 +310,8 @@ const ActionCenterFields = ({
             )}
           />
         </Splitter.Panel>
-        {/** Note: style attr used here due to specificity of ant css. */}
-        <Splitter.Panel
-          style={{ paddingLeft: "var(--ant-padding-md)", overflow: "hidden" }}
-        >
-          <Flex vertical gap="medium" className="h-full">
+        <Splitter.Panel style={{ overflow: "hidden" }}>
+          <Flex vertical gap="middle" className="h-full">
             <Flex justify="space-between">
               <Title level={2} ellipsis>
                 Monitor results

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredInfrastructureSystemsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredInfrastructureSystemsTable.tsx
@@ -146,7 +146,7 @@ export const DiscoveredInfrastructureSystemsTable = ({
   );
 
   return (
-    <Flex vertical gap="medium" className="h-full overflow-hidden">
+    <Flex vertical gap="middle" className="h-full overflow-hidden">
       <Alert
         showIcon
         message="Fides detected the following systems"

--- a/clients/fidesui/src/components/data-display/Tag.stories.tsx
+++ b/clients/fidesui/src/components/data-display/Tag.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Tag } from "../../index";
+import { TITLE_LOREM } from "../../stories/utils/content";
+
+const meta = {
+  title: "Data Display/Tag",
+  component: Tag,
+  args: {
+    children: TITLE_LOREM,
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Tag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/clients/fidesui/src/components/data-entry/SelectInline.stories.tsx
+++ b/clients/fidesui/src/components/data-entry/SelectInline.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { Tag } from "../../index";
+import { OPTION_NAMES } from "../../stories/utils/content";
 import { SelectInline } from "./SelectInline";
 
 const meta = {
@@ -15,4 +17,22 @@ type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
   args: {},
+};
+
+export const Selected: Story = {
+  args: {
+    options: OPTION_NAMES.map((value) => ({ label: value, value })),
+    value: OPTION_NAMES,
+  },
+  parameters: { controls: { includes: [] } },
+};
+
+export const CustomTags: Story = {
+  args: {
+    options: OPTION_NAMES.map((value) => ({ label: value, value })),
+    value: OPTION_NAMES,
+    mode: "tags",
+    tagRender: (props) => <Tag closable>{props.value}</Tag>,
+  },
+  parameters: { controls: { includes: [] } },
 };

--- a/clients/fidesui/src/hoc/CustomSelect.stories.tsx
+++ b/clients/fidesui/src/hoc/CustomSelect.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { Icons } from "../index";
+import { Icons, Tag } from "../index";
+import { OPTION_NAMES } from "../stories/utils/content";
 import type { CustomSelectProps } from "./CustomSelect";
 import { CustomSelect } from "./CustomSelect";
 
@@ -16,7 +17,7 @@ const SELECT_VARIANT: Record<
 
 type SelectSize = NonNullable<CustomSelectProps<unknown>["size"]>;
 
-const SELECT_SIZE: SelectSize[] = ["small", "medium", "large"];
+const SELECT_SIZE: SelectSize[] = ["small", "middle", "large"];
 
 const SELECT_MODE: Record<
   NonNullable<CustomSelectProps<unknown>["mode"]>,
@@ -98,3 +99,22 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {};
+
+export const SelectedMultiple: Story = {
+  args: {
+    options: OPTION_NAMES.map((value) => ({ label: value, value })),
+    value: OPTION_NAMES,
+    mode: "multiple",
+  },
+  parameters: { controls: { includes: [] } },
+};
+
+export const CustomTags: Story = {
+  args: {
+    options: OPTION_NAMES.map((value) => ({ label: value, value })),
+    value: OPTION_NAMES,
+    mode: "tags",
+    tagRender: (props) => <Tag closable>{props.value}</Tag>,
+  },
+  parameters: { controls: { includes: [] } },
+};

--- a/clients/fidesui/src/stories/utils/content.ts
+++ b/clients/fidesui/src/stories/utils/content.ts
@@ -10,4 +10,6 @@ export const PARAGRAPH_LOREM =
 
 export const MENU_NAMES = ["About", "Info", "Contact", "Settings"];
 
+export const OPTION_NAMES = ["Fides", "Helios", "Janus", "Lethe", "Astralis"];
+
 export const DAYJS_LOREM = dayjs().date(18).month(8).year(2018);


### PR DESCRIPTION
Ticket [<issue>] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Fixing page spacing on datastore and infra monitors.
Adds padding back to custom tags for select inputs on infra monitors.

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. <!-- list any manual steps for reviewers to confirm the changes -->

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
