### PR TITLE
Fix: privacy request retry 500 when Redis cache expires and location is required

### DIFF
--- a/src/fides/service/privacy_request/privacy_request_service.py
+++ b/src/fides/service/privacy_request/privacy_request_service.py
@@ -559,6 +559,7 @@ class PrivacyRequestService:
             property_id=existing_privacy_request.property_id,
             consent_preferences=existing_privacy_request.consent_preferences,
             source=existing_privacy_request.source,
+            location=existing_privacy_request.location,
             reviewed_at=existing_privacy_request.reviewed_at,
             reviewed_by=existing_privacy_request.reviewed_by,
             identity_verified_at=existing_privacy_request.identity_verified_at,

--- a/tests/service/privacy_request/test_privacy_request_service.py
+++ b/tests/service/privacy_request/test_privacy_request_service.py
@@ -238,6 +238,86 @@ class TestPrivacyRequestService:
         assert resubmitted_request.status == PrivacyRequestStatus.complete
         assert resubmitted_request.get_persisted_identity().email == "user@example.com"
 
+    def test_resubmit_preserves_location_when_required(
+        self,
+        db: Session,
+        privacy_request_service: PrivacyRequestService,
+        policy: Policy,
+    ):
+        """
+        Regression test: resubmit_privacy_request must carry forward the persisted
+        location value so that _validate_required_location_fields does not re-raise
+        when the Redis identity cache has expired and the PC config requires location.
+        """
+        privacy_center_config_data = {
+            "config": {
+                "title": "Test Privacy Center",
+                "description": "Test privacy center for location validation",
+                "actions": [
+                    {
+                        "policy_key": policy.key,
+                        "title": "Test Action",
+                        "description": "Test action for location validation",
+                        "icon_path": "/test-icon.svg",
+                        "identity_inputs": {"email": "required"},
+                        "custom_privacy_request_fields": {
+                            "location": {
+                                "label": "Your Location",
+                                "field_type": "location",
+                                "required": True,
+                                "ip_geolocation_hint": False,
+                            }
+                        },
+                    }
+                ],
+                "consent": {
+                    "button": {
+                        "description": "Manage your consent preferences",
+                        "description_subtext": [],
+                        "icon_path": "/consent.svg",
+                        "identity_inputs": {"email": "optional"},
+                        "title": "Manage preferences",
+                        "modalTitle": "Manage your consent preferences",
+                        "confirmButtonText": "Continue",
+                        "cancelButtonText": "Cancel",
+                    },
+                    "page": {
+                        "consentOptions": [],
+                        "description": "Manage your consent preferences",
+                        "description_subtext": [],
+                        "policy_key": "default_consent_policy",
+                        "title": "Manage your consent",
+                    },
+                },
+            }
+        }
+
+        privacy_center_config = PrivacyCenterConfig.create_or_update(
+            db=db, data=privacy_center_config_data
+        )
+
+        try:
+            privacy_request = privacy_request_service.create_privacy_request(
+                PrivacyRequestCreate(
+                    identity=Identity(email="user@example.com"),
+                    policy_key=policy.key,
+                    location="US-CA",
+                ),
+                authenticated=True,
+            )
+            assert privacy_request.location == "US-CA"
+
+            resubmitted = privacy_request_service.resubmit_privacy_request(
+                privacy_request.id
+            )
+            db.refresh(resubmitted)
+
+            assert resubmitted is not None
+            assert resubmitted.location == "US-CA"
+            assert resubmitted.status == PrivacyRequestStatus.pending
+        finally:
+            privacy_center_config.delete(db)
+
     def test_cannot_resubmit_non_existent_privacy_request(
         self,
         privacy_request_service: PrivacyRequestService,


### PR DESCRIPTION
Ticket [ENG-3066] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

<!-- Write some things about the changes and any potential caveats -->

When a privacy request's Redis identity cache expires, the retry endpoint routes through resubmit_privacy_request, which rebuilds the request from the DB. location was the only DB-persisted field not carried forward into the PrivacyRequestResubmit payload, causing _validate_required_location_fields to re-run against the live Privacy Center config and raise a PrivacyRequestError — even though location was provided at original submission time.
Fix passes location=existing_privacy_request.location in the PrivacyRequestResubmit constructor, consistent with how all other DB-persisted fields are already handled. This satisfies the early-return guard in _validate_required_location_fields and requires no schema changes since location is already an optional field on PrivacyRequestCreate.

### Code Changes
- [`privacy_request_service.py:562`](vscode-webview://0klo56ir0e0ggfc61u07r8a55j3scr57465jl009jimn4rcmbce5/src/fides/service/privacy_request/privacy_request_service.py#L562) — add location to PrivacyRequestResubmit constructor in resubmit_privacy_request
### Steps to Confirm

 Submit a privacy request with a Privacy Center config that has a LocationCustomPrivacyRequestField marked required: true, providing a location value
 Manually expire the Redis identity cache keys: redis-cli --scan --pattern "id-<id>-identity-*" | xargs redis-cli del
 Retry the request via POST /api/v1/privacy-request/<id>/retry — confirm it succeeds (previously 500)
 Confirm a request retried with a warm cache is unaffected

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3066]: https://ethyca.atlassian.net/browse/ENG-3066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ