### PR TITLE
Guard Claude review workflow against non-collaborator PR authors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,6 +32,7 @@ jobs:
         github.event_name == 'pull_request'
         && !github.event.pull_request.draft
         && github.actor != 'dependabot[bot]'
+        && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
       )
       || (
         github.event_name == 'issue_comment'

--- a/changelog/7761-claude-review-author-association-guard.yaml
+++ b/changelog/7761-claude-review-author-association-guard.yaml
@@ -1,0 +1,4 @@
+type: Developer Experience
+description: Added author_association guard to Claude Code Review workflow to prevent non-collaborator PRs from triggering the review
+pr: 7761
+labels: []


### PR DESCRIPTION
### Description Of Changes

Adds an `author_association` check to the `pull_request` trigger condition in the Claude Code Review workflow, matching the existing guard on the `issue_comment` trigger. This prevents the review from running on PRs opened by non-org-members (e.g., fork PRs on this public repo).

**Why:** The `issue_comment` trigger already gates on `["OWNER","MEMBER","COLLABORATOR"]` to prevent unauthorized spend. The `pull_request` trigger lacked the same guard, meaning fork PRs could trigger workflow runs — wasting runner minutes, creating failed-check noise, and leaving the workflow vulnerable if it were ever refactored to `pull_request_target` (which exposes secrets to fork PRs).

### Code Changes

* `.github/workflows/claude-code-review.yml` - Added `author_association` check to the `pull_request` condition, using the same trusted set as the existing `issue_comment` guard

### Steps to Confirm

1. Open a PR from a fork account (or check an existing fork PR) — the Claude review workflow should **not** trigger
2. Open a PR from an org member — the Claude review workflow should trigger as before
3. Comment `/code-review` as an org member — should still work (unchanged path)

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required