### PR TITLE
Improve Domain Validation Error Messages

### DIFF
--- a/changelog/7820-domain-validation-logging.yaml
+++ b/changelog/7820-domain-validation-logging.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Improved domain validation log messages with consistent format, structured hints, and connector type context
+pr: 7820
+labels: []

--- a/src/fides/api/service/connectors/saas_connector.py
+++ b/src/fides/api/service/connectors/saas_connector.py
@@ -88,6 +88,7 @@ class SaaSConnector(BaseConnector[AuthenticatedClient], Contextualizable):
                 else None
             ),
             LoggerContextKeys.connection_key: self.configuration.key,
+            LoggerContextKeys.connector_type: self.saas_config.type,
         }
 
     def __init__(self, configuration: ConnectionConfig):

--- a/src/fides/api/util/domain_util.py
+++ b/src/fides/api/util/domain_util.py
@@ -84,15 +84,18 @@ def validate_value_against_allowed_list(
 
     if mode == DomainValidationMode.monitor:
         logger.warning(
-            f"Domain validation violation (enforcement mode - monitor): {violation_msg}"
+            "Domain validation violation (enforcement mode - monitor): {}",
+            violation_msg,
         )
         return
 
     logger.error(
-        f"Domain validation violation (enforcement mode - enabled): {violation_msg}"
+        "Domain validation violation (enforcement mode - enabled): {}",
+        violation_msg,
     )
     logger.info(
-        f"To change domain validation behavior, set {_DOMAIN_MODE_ENV_VAR} to 'monitor' or 'disabled'."
+        "To change domain validation behavior, set {} to 'monitor' or 'disabled'.",
+        _DOMAIN_MODE_ENV_VAR,
     )
     logger.info(
         "To add support for this domain, contact Ethyca support."

--- a/src/fides/api/util/domain_util.py
+++ b/src/fides/api/util/domain_util.py
@@ -84,14 +84,15 @@ def validate_value_against_allowed_list(
 
     if mode == DomainValidationMode.monitor:
         logger.warning(
-            "Domain validation violation (monitor mode): {}",
-            violation_msg,
+            f"Domain validation violation (enforcement mode - monitor): {violation_msg}"
         )
         return
 
-    raise DomainValidationError(
-        f"{violation_msg} "
-        f"You may change the validation behavior by setting "
-        f"the environment variable FIDES__SECURITY__DOMAIN_VALIDATION_MODE "
-        f"to 'monitor' (log warnings only) or 'disabled' (skip validation)."
+    logger.error(
+        f"Domain validation violation (enforcement mode - enabled): {violation_msg}"
     )
+    logger.info(
+        "You may change the domain validation behavior by setting the environment variable "
+        f"{_DOMAIN_MODE_ENV_VAR} to 'monitor' (log warnings only) or 'disabled' (skip validation)."
+    )
+    raise DomainValidationError(violation_msg)

--- a/src/fides/api/util/domain_util.py
+++ b/src/fides/api/util/domain_util.py
@@ -92,7 +92,9 @@ def validate_value_against_allowed_list(
         f"Domain validation violation (enforcement mode - enabled): {violation_msg}"
     )
     logger.info(
-        "You may change the domain validation behavior by setting the environment variable "
-        f"{_DOMAIN_MODE_ENV_VAR} to 'monitor' (log warnings only) or 'disabled' (skip validation)."
+        f"To change domain validation behavior, set {_DOMAIN_MODE_ENV_VAR} to 'monitor' or 'disabled'."
+    )
+    logger.info(
+        "To add support for this domain, contact Ethyca support."
     )
     raise DomainValidationError(violation_msg)

--- a/src/fides/api/util/logger_context_utils.py
+++ b/src/fides/api/util/logger_context_utils.py
@@ -24,6 +24,7 @@ class LoggerContextKeys(StrEnum):
     body = "body"
     collection = "collection"
     connection_key = "connection_key"
+    connector_type = "connector_type"
     error_details = "error_details"
     error_group = "error_group"
     method = "method"


### PR DESCRIPTION
### Description Of Changes

Improve domain validation violation messages by standardizing the warn/error as: `Domain validation violation (enforcement mode - <mode>): <violation message>"`.  

Unfortunate caveat here is that this means that we'll have two error-level log lines with more or less the same contents when the enforcement is enabled. There's the initial `logger.error()` and then it'll get logged again when the `DomainValidationError` gets caught ("Connector request failed" and then the error in as structured fields).  I'm alright with that, but looking for other suggestions/feedback. 

Additionally, I'm adding the saas integration type to the log context for better connector observability. 

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. <!-- list any manual steps for reviewers to confirm the changes -->

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
