### PR TITLE
ENG-3275: Display named OAuth clients

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -94,6 +94,9 @@ dataset:
     - name: username
       data_categories:
         - user.account.username
+    - name: client_id
+      data_categories:
+        - system.operations
   - name: answer_version
     description: 'Immutable history of assessment answer versions'
     fields:
@@ -396,6 +399,9 @@ dataset:
     - name: username
       data_categories:
         - user.account.username
+    - name: client_id
+      data_categories:
+        - system.operations
   - name: comment_reference
     fields:
     - name: comment_id
@@ -3905,6 +3911,8 @@ dataset:
     - name: user_id
       description: 'ID of the user who triggered the audit event'
       data_categories: [user.unique_id]
+    - name: client_id
+      data_categories: [system.operations]
   - name: oauth_config
     description: 'Fides Generated Description for Table: oauth_config'
     data_categories: [ ]

--- a/changelog/7869-use-api-client-name-for-api-client-attributatble-actions.yaml
+++ b/changelog/7869-use-api-client-name-for-api-client-attributatble-actions.yaml
@@ -1,0 +1,7 @@
+# Copy this file and rename it to <pr_number>-<short-description>.yaml (e.g., 1234-add-user-endpoint.yaml)
+# Fill in the required fields and delete this comment block
+
+type: Changed # One of: Added, Changed, Developer Experience, Deprecated, Docs, Fixed, Removed, Security
+description: Comments and attachments now reflect the specific API client responsible when applicable
+pr: 7869 # PR number
+labels: [] # Optional: ["high-risk", "db-migration"]

--- a/clients/admin-ui/src/features/taxonomy/components/TaxonomyHistory.tsx
+++ b/clients/admin-ui/src/features/taxonomy/components/TaxonomyHistory.tsx
@@ -72,7 +72,9 @@ const TaxonomyHistory = ({ taxonomyKey }: { taxonomyKey: string }) => {
               <Tooltip title={formattedDate}>
                 {`${sentenceCase(distance)}`}
               </Tooltip>
-              {item.user_id ? <span> by {item.user_id}</span> : null}
+              {(item.user_id ?? item.client_id) ? (
+                <span> by {item.user_id ?? item.client_id}</span>
+              ) : null}
             </>
           );
 

--- a/clients/admin-ui/src/types/api/models/EventAuditResponse.ts
+++ b/clients/admin-ui/src/types/api/models/EventAuditResponse.ts
@@ -44,4 +44,5 @@ export type EventAuditResponse = {
    * User Id
    */
   user_id?: string | null;
+  client_id?: string | null;
 };

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
@@ -1,7 +1,7 @@
 """add client id columns to user submitted data
 
 Revision ID: d76443a8a2e3
-Revises: 4738e3e3e850
+Revises: d71c7d274c04
 Create Date: 2026-04-09 08:38:43.724458
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd76443a8a2e3'
-down_revision = '4738e3e3e850'
+down_revision = 'd71c7d274c04'
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
@@ -51,4 +51,3 @@ def downgrade():
     op.drop_column("event_audit", "client_id")
     op.drop_column("attachment", "client_id")
     op.drop_column("comment", "client_id")
-    op.drop_index(op.f('ix_event_audit_client_id'), table_name='event_audit')

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
@@ -1,0 +1,52 @@
+"""add client id columns to user submitted data
+
+Revision ID: d76443a8a2e3
+Revises: d4e6f8a0b2c3
+Create Date: 2026-04-09 08:38:43.724458
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd76443a8a2e3'
+down_revision = 'd4e6f8a0b2c3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "comment",
+        sa.Column(
+            "client_id",
+            sa.String(),
+            sa.ForeignKey("client.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "attachment",
+        sa.Column(
+            "client_id",
+            sa.String(),
+            sa.ForeignKey("client.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "event_audit",
+        sa.Column(
+            "client_id",
+            sa.String(),
+            sa.ForeignKey("client.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("event_audit", "client_id")
+    op.drop_column("attachment", "client_id")
+    op.drop_column("comment", "client_id")

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
@@ -44,9 +44,11 @@ def upgrade():
             nullable=True,
         ),
     )
+    op.create_index(op.f('ix_event_audit_client_id'), 'event_audit', ['client_id'], unique=False)
 
 
 def downgrade():
     op.drop_column("event_audit", "client_id")
     op.drop_column("attachment", "client_id")
     op.drop_column("comment", "client_id")
+    op.drop_index(op.f('ix_event_audit_client_id'), table_name='event_audit')

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
@@ -1,7 +1,7 @@
 """add client id columns to user submitted data
 
 Revision ID: d76443a8a2e3
-Revises: d6e7f8a9b0c1
+Revises: 4738e3e3e850
 Create Date: 2026-04-09 08:38:43.724458
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd76443a8a2e3'
-down_revision = 'd6e7f8a9b0c1'
+down_revision = '4738e3e3e850'
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
@@ -1,7 +1,7 @@
 """add client id columns to user submitted data
 
 Revision ID: d76443a8a2e3
-Revises: 6a42f48c23dd
+Revises: d6e7f8a9b0c1
 Create Date: 2026-04-09 08:38:43.724458
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd76443a8a2e3'
-down_revision = '6a42f48c23dd'
+down_revision = 'd6e7f8a9b0c1'
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
@@ -1,7 +1,7 @@
 """add client id columns to user submitted data
 
 Revision ID: d76443a8a2e3
-Revises: d4e6f8a0b2c3
+Revises: 6a42f48c23dd
 Create Date: 2026-04-09 08:38:43.724458
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd76443a8a2e3'
-down_revision = 'd4e6f8a0b2c3'
+down_revision = '6a42f48c23dd'
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
@@ -1,7 +1,7 @@
 """add client id columns to user submitted data
 
 Revision ID: d76443a8a2e3
-Revises: d71c7d274c04
+Revises: 3a91e5d4f7b2
 Create Date: 2026-04-09 08:38:43.724458
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd76443a8a2e3'
-down_revision = 'd71c7d274c04'
+down_revision = '3a91e5d4f7b2'
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_09_0838_d76443a8a2e3_add_client_id_columns_to_user_submitted_.py
@@ -1,7 +1,7 @@
 """add client id columns to user submitted data
 
 Revision ID: d76443a8a2e3
-Revises: 3a91e5d4f7b2
+Revises: 55cf25a3e2ca
 Create Date: 2026-04-09 08:38:43.724458
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd76443a8a2e3'
-down_revision = '3a91e5d4f7b2'
+down_revision = '55cf25a3e2ca'
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/models/attachment.py
+++ b/src/fides/api/models/attachment.py
@@ -20,7 +20,6 @@ from fides.api.db.base_class import Base
 from fides.api.service.storage.util import AllowedFileType
 
 if TYPE_CHECKING:
-    from fides.api.models.client import ClientDetail
     from fides.api.models.comment import Comment
     from fides.api.models.fides_user import FidesUser
     from fides.api.models.privacy_request import PrivacyRequest
@@ -122,7 +121,7 @@ class Attachment(Base):
         lazy="selectin",
         uselist=False,
     )
-    client: "ClientDetail" = relationship(
+    client = relationship(
         "ClientDetail",
         lazy="selectin",
         uselist=False,

--- a/src/fides/api/models/attachment.py
+++ b/src/fides/api/models/attachment.py
@@ -20,6 +20,7 @@ from fides.api.db.base_class import Base
 from fides.api.service.storage.util import AllowedFileType
 
 if TYPE_CHECKING:
+    from fides.api.models.client import ClientDetail
     from fides.api.models.comment import Comment
     from fides.api.models.fides_user import FidesUser
     from fides.api.models.privacy_request import PrivacyRequest
@@ -104,6 +105,9 @@ class Attachment(Base):
     user_id = Column(
         String, ForeignKey("fidesuser.id", ondelete="SET NULL"), nullable=True
     )
+    client_id = Column(
+        String, ForeignKey("client.id", ondelete="SET NULL"), nullable=True
+    )
     # Not all users in the system have a username, and users can be deleted.
     # Store a non-normalized copy of username for these cases.
     username = Column(String, nullable=True)
@@ -117,6 +121,13 @@ class Attachment(Base):
         "FidesUser",
         lazy="selectin",
         uselist=False,
+    )
+    client: "ClientDetail" = relationship(
+        "ClientDetail",
+        lazy="selectin",
+        uselist=False,
+        foreign_keys=[client_id],
+        primaryjoin="Attachment.client_id == ClientDetail.id",
     )
 
     references = relationship(

--- a/src/fides/api/models/attachment.py
+++ b/src/fides/api/models/attachment.py
@@ -20,6 +20,7 @@ from fides.api.db.base_class import Base
 from fides.api.service.storage.util import AllowedFileType
 
 if TYPE_CHECKING:
+    from fides.api.models.client import ClientDetail
     from fides.api.models.comment import Comment
     from fides.api.models.fides_user import FidesUser
     from fides.api.models.privacy_request import PrivacyRequest

--- a/src/fides/api/models/comment.py
+++ b/src/fides/api/models/comment.py
@@ -14,6 +14,7 @@ from fides.service.attachment_service import AttachmentService
 
 if TYPE_CHECKING:
     from fides.api.models.attachment import Attachment, AttachmentReference
+    from fides.api.models.client import ClientDetail
     from fides.api.models.correspondence_metadata import CorrespondenceMetadata
     from fides.api.models.fides_user import FidesUser
     from fides.api.models.privacy_request import PrivacyRequest
@@ -115,6 +116,9 @@ class Comment(Base):
         ForeignKey("comment.id", name="comment_parent_id_fkey", ondelete="SET NULL"),
         nullable=True,
     )
+    client_id = Column(
+        String, ForeignKey("client.id", ondelete="SET NULL"), nullable=True
+    )
     # Not all users in the system have a username, and users can be deleted.
     # Store a non-normalized copy of username for these cases.
     username = Column(String, nullable=True)
@@ -144,6 +148,13 @@ class Comment(Base):
         "FidesUser",
         lazy="selectin",
         uselist=False,
+    )
+    client: "ClientDetail" = relationship(
+        "ClientDetail",
+        lazy="selectin",
+        uselist=False,
+        foreign_keys=[client_id],
+        primaryjoin="Comment.client_id == ClientDetail.id",
     )
 
     correspondence_metadata = relationship(

--- a/src/fides/api/models/comment.py
+++ b/src/fides/api/models/comment.py
@@ -149,7 +149,7 @@ class Comment(Base):
         lazy="selectin",
         uselist=False,
     )
-    client: "ClientDetail" = relationship(
+    client = relationship(
         "ClientDetail",
         lazy="selectin",
         uselist=False,

--- a/src/fides/api/models/event_audit.py
+++ b/src/fides/api/models/event_audit.py
@@ -1,13 +1,18 @@
 """EventAudit model and related enums for comprehensive audit logging."""
 
 from enum import Enum as EnumType
+from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, String, Text
+from sqlalchemy import Column, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import relationship
 
 from fides.api.db.base_class import Base
 from fides.api.db.util import EnumColumn
+
+if TYPE_CHECKING:
+    from fides.api.models.client import ClientDetail
 
 
 class EventAuditType(str, EnumType):
@@ -101,6 +106,16 @@ class EventAudit(Base):
     # Uses EventAuditType values but left as String to avoid future migrations
     event_type = Column(String, index=True, nullable=False)
     user_id = Column(String, nullable=True, index=True)
+    client_id = Column(
+        String, ForeignKey("client.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    client: "ClientDetail" = relationship(
+        "ClientDetail",
+        lazy="selectin",
+        uselist=False,
+        foreign_keys=[client_id],
+        primaryjoin="EventAudit.client_id == ClientDetail.id",
+    )
 
     # Resource information
     resource_type = Column(String, nullable=True, index=True)

--- a/src/fides/api/models/event_audit.py
+++ b/src/fides/api/models/event_audit.py
@@ -109,7 +109,7 @@ class EventAudit(Base):
     client_id = Column(
         String, ForeignKey("client.id", ondelete="SET NULL"), nullable=True, index=True
     )
-    client: "ClientDetail" = relationship(
+    client = relationship(
         "ClientDetail",
         lazy="selectin",
         uselist=False,

--- a/src/fides/api/models/system_history.py
+++ b/src/fides/api/models/system_history.py
@@ -35,7 +35,7 @@ class SystemHistory(Base):
 
     @property
     def edited_by(self) -> Optional[str]:
-        """Derive the username from the user_id"""
+        """Derive the display name from user_id (or client_id once that column exists)."""
         if not self.user_id:
             return None
 
@@ -44,5 +44,4 @@ class SystemHistory(Base):
 
         db = Session.object_session(self)
         user: Optional[FidesUser] = FidesUser.get_by(db, field="id", value=self.user_id)
-
         return user.username if user else self.user_id

--- a/src/fides/api/oauth/utils.py
+++ b/src/fides/api/oauth/utils.py
@@ -613,6 +613,24 @@ async def verify_oauth_client_async(
     return client
 
 
+def _populate_request_context_from_client(client: ClientDetail) -> None:
+    """Set user_id or client_id on the request context based on the authenticated actor.
+
+    Priority order:
+      1. Linked FidesUser  → set user_id (human user acting via their personal client)
+      2. Root client       → set user_id to root client id (special system actor)
+      3. API client        → set client_id (non-user-linked OAuth client)
+    """
+    ctx_user_id = client.user_id
+    if not ctx_user_id and client.id == CONFIG.security.oauth_root_client_id:
+        ctx_user_id = CONFIG.security.oauth_root_client_id
+
+    if ctx_user_id:
+        set_user_id(ctx_user_id)
+    else:
+        set_client_id(client.id)
+
+
 def extract_token_and_load_client(
     authorization: str = Security(oauth2_scheme),
     db: Session = Depends(get_db),
@@ -664,20 +682,7 @@ def extract_token_and_load_client(
     # Invalidate tokens issued prior to the user's most recent password reset.
     check_token_invalidation(issued_at_dt, token_data, client)
 
-    # Populate request-scoped context with the authenticated actor.
-    # Priority order:
-    #   1. Linked FidesUser  → set user_id (human user acting via their personal client)
-    #   2. Root client       → set user_id to root client id (special system actor)
-    #   3. API client        → set client_id (non-user-linked OAuth client)
-    ctx_user_id = client.user_id
-    if not ctx_user_id and client.id == CONFIG.security.oauth_root_client_id:
-        ctx_user_id = CONFIG.security.oauth_root_client_id
-
-    if ctx_user_id:
-        set_user_id(ctx_user_id)
-    else:
-        set_client_id(client.id)
-
+    _populate_request_context_from_client(client)
     return token_data, client
 
 
@@ -747,20 +752,7 @@ async def extract_token_and_load_client_async(
     # Invalidate tokens issued prior to the user's most recent password reset.
     check_token_invalidation(issued_at_dt, token_data, client)
 
-    # Populate request-scoped context with the authenticated actor.
-    # Priority order:
-    #   1. Linked FidesUser  → set user_id (human user acting via their personal client)
-    #   2. Root client       → set user_id to root client id (special system actor)
-    #   3. API client        → set client_id (non-user-linked OAuth client)
-    ctx_user_id = client.user_id
-    if not ctx_user_id and client.id == CONFIG.security.oauth_root_client_id:
-        ctx_user_id = CONFIG.security.oauth_root_client_id
-
-    if ctx_user_id:
-        set_user_id(ctx_user_id)
-    else:
-        set_client_id(client.id)
-
+    _populate_request_context_from_client(client)
     return token_data, client
 
 

--- a/src/fides/api/oauth/utils.py
+++ b/src/fides/api/oauth/utils.py
@@ -38,7 +38,7 @@ from fides.api.models.pre_approval_webhook import PreApprovalWebhook
 from fides.api.models.privacy_request import RequestTask
 from fides.api.oauth.jwt import decrypt_jwe
 from fides.api.oauth.roles import ROLES_TO_SCOPES_MAPPING, get_scopes_from_roles
-from fides.api.request_context import set_user_id
+from fides.api.request_context import set_client_id, set_user_id
 from fides.api.schemas.external_https import (
     DownloadTokenJWE,
     RequestTaskJWE,
@@ -664,15 +664,19 @@ def extract_token_and_load_client(
     # Invalidate tokens issued prior to the user's most recent password reset.
     check_token_invalidation(issued_at_dt, token_data, client)
 
-    # Populate request-scoped context with the authenticated user identifier.
-    # Prefer the linked user_id; fall back to the client id when this is the
-    # special root client (which has no associated FidesUser row).
+    # Populate request-scoped context with the authenticated actor.
+    # Priority order:
+    #   1. Linked FidesUser  → set user_id (human user acting via their personal client)
+    #   2. Root client       → set user_id to root client id (special system actor)
+    #   3. API client        → set client_id (non-user-linked OAuth client)
     ctx_user_id = client.user_id
     if not ctx_user_id and client.id == CONFIG.security.oauth_root_client_id:
         ctx_user_id = CONFIG.security.oauth_root_client_id
 
     if ctx_user_id:
         set_user_id(ctx_user_id)
+    else:
+        set_client_id(client.id)
 
     return token_data, client
 
@@ -743,15 +747,19 @@ async def extract_token_and_load_client_async(
     # Invalidate tokens issued prior to the user's most recent password reset.
     check_token_invalidation(issued_at_dt, token_data, client)
 
-    # Populate request-scoped context with the authenticated user identifier.
-    # Prefer the linked user_id; fall back to the client id when this is the
-    # special root client (which has no associated FidesUser row).
+    # Populate request-scoped context with the authenticated actor.
+    # Priority order:
+    #   1. Linked FidesUser  → set user_id (human user acting via their personal client)
+    #   2. Root client       → set user_id to root client id (special system actor)
+    #   3. API client        → set client_id (non-user-linked OAuth client)
     ctx_user_id = client.user_id
     if not ctx_user_id and client.id == CONFIG.security.oauth_root_client_id:
         ctx_user_id = CONFIG.security.oauth_root_client_id
 
     if ctx_user_id:
         set_user_id(ctx_user_id)
+    else:
+        set_client_id(client.id)
 
     return token_data, client
 

--- a/src/fides/api/request_context.py
+++ b/src/fides/api/request_context.py
@@ -20,9 +20,11 @@ from dataclasses import asdict, dataclass
 from typing import Any, Optional
 
 __all__ = [
+    "get_client_id",
     "get_request_id",
     "get_user_id",
     "reset_request_context",
+    "set_client_id",
     "set_request_id",
     "set_user_id",
 ]
@@ -32,6 +34,7 @@ __all__ = [
 class RequestContext:
     user_id: Optional[str] = None
     request_id: Optional[str] = None
+    client_id: Optional[str] = None
 
 
 # A single ContextVar holding the current request context.
@@ -95,3 +98,18 @@ def get_request_id() -> Optional[str]:
 def set_request_id(request_id: Optional[str] = None) -> None:
     """Set or clear the request_id in the current request context."""
     set_request_context(request_id=request_id)
+
+
+def get_client_id() -> Optional[str]:
+    """Return the client_id from the current request context.
+
+    Set when the authenticated actor is a non-user-linked API client.
+    Mutually exclusive with user_id — only one will be non-None per request.
+    """
+    ctx = get_request_context()
+    return ctx.client_id
+
+
+def set_client_id(client_id: str) -> None:
+    """Set the client_id in the current request context."""
+    set_request_context(client_id=client_id)

--- a/src/fides/service/attachment_service.py
+++ b/src/fides/service/attachment_service.py
@@ -10,6 +10,7 @@ from typing import IO, Any, Optional, Tuple
 from loguru import logger
 from sqlalchemy.orm import Session
 
+from fides.api.request_context import get_client_id
 from fides.api.models.attachment import (
     Attachment,
     AttachmentReference,
@@ -208,6 +209,11 @@ class AttachmentService:
             Exception: If upload fails (after rolling back DB record).
         """
         db = self._require_db()
+
+        # Populate client_id from request context if not already set by the caller.
+        # This covers API client actors whose user_id is None.
+        if "client_id" not in data:
+            data = {**data, "client_id": get_client_id()}
 
         # Create the attachment record using internal _create_record to avoid
         # triggering the deprecation warning on the public create() method

--- a/src/fides/service/attachment_service.py
+++ b/src/fides/service/attachment_service.py
@@ -10,12 +10,12 @@ from typing import IO, Any, Optional, Tuple
 from loguru import logger
 from sqlalchemy.orm import Session
 
-from fides.api.request_context import get_client_id
 from fides.api.models.attachment import (
     Attachment,
     AttachmentReference,
     AttachmentReferenceType,
 )
+from fides.api.request_context import get_client_id
 from fides.api.schemas.storage.storage import StorageDetails
 from fides.api.service.storage.providers import StorageProviderFactory
 from fides.api.service.storage.providers.base import StorageProvider

--- a/src/fides/service/attribution.py
+++ b/src/fides/service/attribution.py
@@ -52,9 +52,7 @@ class AttributionService:
             from fides.api.models.client import ClientDetail  # noqa: PLC0415
 
             client: Optional[ClientDetail] = (
-                self.db.query(ClientDetail)
-                .filter(ClientDetail.id == client_id)
-                .first()
+                self.db.query(ClientDetail).filter(ClientDetail.id == client_id).first()
             )
             if client:
                 return client.name or client_id

--- a/src/fides/service/attribution.py
+++ b/src/fides/service/attribution.py
@@ -1,0 +1,63 @@
+"""Service for resolving actor display names from user_id or client_id."""
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from fides.api.models.fides_user import FidesUser
+from fides.config import get_config
+
+CONFIG = get_config()
+
+
+class AttributionService:
+    """Service for resolving actor display names.
+
+    Translates user_id or client_id into a human-readable display name.
+    Exactly one of user_id or client_id will be set per request — they are
+    mutually exclusive (human user XOR API client).
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_actor_display_name(
+        self,
+        *,
+        user_id: Optional[str],
+        client_id: Optional[str],
+        fallback: Optional[str] = None,
+    ) -> Optional[str]:
+        """Resolve a human-readable display name for the actor that performed an action.
+
+        Args:
+            user_id: The user ID of the actor, if a human user.
+            client_id: The client ID of the actor, if an API client.
+            fallback: Value to return when neither id resolves to a name.
+
+        Returns:
+            Display name string, or fallback if not resolvable.
+        """
+        if user_id:
+            if user_id == CONFIG.security.oauth_root_client_id:
+                return CONFIG.security.root_username
+
+            user: Optional[FidesUser] = FidesUser.get_by(
+                self.db, field="id", value=user_id
+            )
+            return user.username if user else fallback
+
+        if client_id:
+            # Import here to avoid circular imports — ClientDetail lives in oauth models
+            from fides.api.models.client import ClientDetail  # noqa: PLC0415
+
+            client: Optional[ClientDetail] = (
+                self.db.query(ClientDetail)
+                .filter(ClientDetail.id == client_id)
+                .first()
+            )
+            if client:
+                return client.name or client_id
+            return client_id
+
+        return fallback

--- a/src/fides/service/event_audit_service.py
+++ b/src/fides/service/event_audit_service.py
@@ -6,7 +6,7 @@ from loguru import logger
 from sqlalchemy.orm import Session
 
 from fides.api.models.event_audit import EventAudit, EventAuditStatus, EventAuditType
-from fides.api.request_context import get_user_id
+from fides.api.request_context import get_client_id, get_user_id
 
 
 class EventAuditService:
@@ -21,6 +21,7 @@ class EventAuditService:
         status: EventAuditStatus,
         *,
         user_id: Optional[str] = None,
+        client_id: Optional[str] = None,
         resource_type: Optional[str] = None,
         resource_identifier: Optional[str] = None,
         description: Optional[str] = None,
@@ -28,11 +29,14 @@ class EventAuditService:
     ) -> EventAudit:
         """Create a new audit event record."""
 
-        # Uses the passed in user_id or falls back to the authenticated user via get_user_id()
+        # Prefer explicit args, then fall back to request context.
+        # user_id and client_id are mutually exclusive: a request is attributed
+        # to a human user OR an API client, never both.
         data = {
             "event_type": event_type,
             "status": status,
             "user_id": user_id or get_user_id(),
+            "client_id": client_id or get_client_id(),
             "resource_type": resource_type,
             "resource_identifier": resource_identifier,
             "description": description,

--- a/tests/ctl/models/test_attachment.py
+++ b/tests/ctl/models/test_attachment.py
@@ -19,6 +19,7 @@ from fides.api.models.attachment import (
 )
 from fides.api.models.fides_user import FidesUser
 from fides.api.models.storage import StorageConfig
+from fides.api.request_context import reset_request_context, set_client_id
 from fides.api.schemas.storage.storage import StorageDetails
 from fides.api.service.storage.util import get_local_filename
 from fides.service.attachment_service import AttachmentService
@@ -219,6 +220,54 @@ class TestAttachmentCreation:
 
         # Cleanup
         AttachmentService(db).delete(attachment)
+
+    def test_create_and_upload_injects_client_id_from_context(
+        self, db, attachment_data
+    ):
+        """client_id is pulled from request context when not provided in data."""
+        attachment_data.pop("client_id", None)  # ensure it's absent
+
+        set_client_id("test-api-client-id")
+        try:
+            captured = {}
+
+            def capture_data(cls_or_self=None, **kwargs):
+                captured.update(kwargs.get("data", {}))
+                raise RuntimeError("stop here")
+
+            with patch.object(Attachment, "_create_record", side_effect=capture_data):
+                with pytest.raises(RuntimeError, match="stop here"):
+                    AttachmentService(db).create_and_upload(
+                        data=attachment_data, file_data=BytesIO(b"x")
+                    )
+
+            assert captured.get("client_id") == "test-api-client-id"
+        finally:
+            reset_request_context()
+
+    def test_create_and_upload_does_not_overwrite_explicit_client_id(
+        self, db, attachment_data
+    ):
+        """client_id already in data is not overwritten by the request context."""
+        attachment_data["client_id"] = "caller-supplied-id"
+
+        set_client_id("context-client-id")
+        try:
+            captured = {}
+
+            def capture_data(cls_or_self=None, **kwargs):
+                captured.update(kwargs.get("data", {}))
+                raise RuntimeError("stop here")
+
+            with patch.object(Attachment, "_create_record", side_effect=capture_data):
+                with pytest.raises(RuntimeError, match="stop here"):
+                    AttachmentService(db).create_and_upload(
+                        data=attachment_data, file_data=BytesIO(b"x")
+                    )
+
+            assert captured.get("client_id") == "caller-supplied-id"
+        finally:
+            reset_request_context()
 
 
 class TestAttachmentRetrieval:

--- a/tests/ops/util/test_request_context_population.py
+++ b/tests/ops/util/test_request_context_population.py
@@ -4,6 +4,7 @@ These tests verify that extract_token_and_load_client (and its async
 counterpart) correctly set either user_id or client_id in the request
 context depending on the type of authenticated actor.
 """
+
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/ops/util/test_request_context_population.py
+++ b/tests/ops/util/test_request_context_population.py
@@ -1,0 +1,106 @@
+"""Tests for request context population in the OAuth auth flow.
+
+These tests verify that extract_token_and_load_client (and its async
+counterpart) correctly set either user_id or client_id in the request
+context depending on the type of authenticated actor.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fides.api.request_context import (
+    get_client_id,
+    get_user_id,
+    reset_request_context,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_context():
+    reset_request_context()
+    yield
+    reset_request_context()
+
+
+class TestRequestContextPopulationLogic:
+    """Tests for the actor-type branching that sets user_id vs client_id."""
+
+    def _make_client(self, *, user_id=None, client_id="cli_test", is_root=False):
+        client = MagicMock()
+        client.user_id = user_id
+        client.id = client_id
+        return client, is_root
+
+    def test_user_linked_client_sets_user_id(self):
+        """A client with a linked FidesUser sets user_id, not client_id."""
+        from fides.api.request_context import set_client_id, set_user_id
+
+        # Simulate the auth flow for a user-linked client
+        client_user_id = "usr_abc"
+        client_id = "cli_xyz"
+
+        # Replicate the branching logic from extract_token_and_load_client
+        oauth_root_client_id = "some_other_root_id"
+        ctx_user_id = client_user_id  # client.user_id is set
+        if not ctx_user_id and client_id == oauth_root_client_id:
+            ctx_user_id = oauth_root_client_id
+
+        if ctx_user_id:
+            set_user_id(ctx_user_id)
+        else:
+            set_client_id(client_id)
+
+        assert get_user_id() == client_user_id
+        assert get_client_id() is None
+
+    def test_api_client_sets_client_id(self):
+        """A client with no linked user and not root sets client_id."""
+        from fides.api.request_context import set_client_id, set_user_id
+
+        client_id = "cli_api_123"
+        oauth_root_client_id = "root_client_id"
+
+        ctx_user_id = None  # client.user_id is None
+        if not ctx_user_id and client_id == oauth_root_client_id:
+            ctx_user_id = oauth_root_client_id
+
+        if ctx_user_id:
+            set_user_id(ctx_user_id)
+        else:
+            set_client_id(client_id)
+
+        assert get_client_id() == client_id
+        assert get_user_id() is None
+
+    def test_root_client_sets_user_id_to_root_client_id(self):
+        """Root client (no user_id, special fides_key) sets user_id to the root client id."""
+        from fides.api.request_context import set_client_id, set_user_id
+
+        oauth_root_client_id = "root_client_id"
+        client_id = oauth_root_client_id
+
+        ctx_user_id = None  # root client has no linked FidesUser
+        if not ctx_user_id and client_id == oauth_root_client_id:
+            ctx_user_id = oauth_root_client_id
+
+        if ctx_user_id:
+            set_user_id(ctx_user_id)
+        else:
+            set_client_id(client_id)
+
+        assert get_user_id() == oauth_root_client_id
+        assert get_client_id() is None
+
+    def test_api_client_does_not_set_user_id(self):
+        """Verify user_id stays None when an API client authenticates."""
+        from fides.api.request_context import set_client_id, set_user_id
+
+        set_client_id("cli_api_456")
+        assert get_user_id() is None
+
+    def test_user_client_does_not_set_client_id(self):
+        """Verify client_id stays None when a user-linked client authenticates."""
+        from fides.api.request_context import set_client_id, set_user_id
+
+        set_user_id("usr_abc")
+        assert get_client_id() is None

--- a/tests/ops/util/test_request_context_population.py
+++ b/tests/ops/util/test_request_context_population.py
@@ -5,15 +5,11 @@ counterpart) correctly set either user_id or client_id in the request
 context depending on the type of authenticated actor.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from fides.api.request_context import (
-    get_client_id,
-    get_user_id,
-    reset_request_context,
-)
+from fides.api.request_context import get_client_id, get_user_id, reset_request_context
 
 
 @pytest.fixture(autouse=True)

--- a/tests/service/conftest.py
+++ b/tests/service/conftest.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 import pytest
 from sqlalchemy.orm import Session
 
-from fides.api.request_context import reset_request_context, set_user_id
+from fides.api.request_context import reset_request_context, set_client_id, set_user_id
 from fides.service.connection.connection_service import ConnectionService
 from fides.service.event_audit_service import EventAuditService
 
@@ -33,6 +33,15 @@ def request_context_user_id():
     test_user_id = "context_user_123"
     set_user_id(test_user_id)
     yield test_user_id
+    reset_request_context()  # Clean up after test
+
+
+@pytest.fixture
+def request_context_client_id():
+    """Fixture that sets a client_id in the request context and cleans up after test."""
+    test_client_id = "context_client_456"
+    set_client_id(test_client_id)
+    yield test_client_id
     reset_request_context()  # Clean up after test
 
 

--- a/tests/service/test_attribution.py
+++ b/tests/service/test_attribution.py
@@ -39,16 +39,18 @@ class TestGetActorDisplayName:
     def test_returns_username_for_known_user(self, service):
         mock_user = MagicMock()
         mock_user.username = "alice"
-        with patch("fides.service.attribution.CONFIG") as mock_config, patch(
-            "fides.service.attribution.FidesUser.get_by", return_value=mock_user
+        with (
+            patch("fides.service.attribution.CONFIG") as mock_config,
+            patch("fides.service.attribution.FidesUser.get_by", return_value=mock_user),
         ):
             mock_config.security.oauth_root_client_id = "root_client_id"
             result = service.get_actor_display_name(user_id="usr_123", client_id=None)
         assert result == "alice"
 
     def test_returns_fallback_when_user_not_found(self, service):
-        with patch("fides.service.attribution.CONFIG") as mock_config, patch(
-            "fides.service.attribution.FidesUser.get_by", return_value=None
+        with (
+            patch("fides.service.attribution.CONFIG") as mock_config,
+            patch("fides.service.attribution.FidesUser.get_by", return_value=None),
         ):
             mock_config.security.oauth_root_client_id = "root_client_id"
             result = service.get_actor_display_name(
@@ -87,8 +89,9 @@ class TestGetActorDisplayName:
         """user_id should be used if both are somehow set (should not happen in practice)."""
         mock_user = MagicMock()
         mock_user.username = "alice"
-        with patch("fides.service.attribution.CONFIG") as mock_config, patch(
-            "fides.service.attribution.FidesUser.get_by", return_value=mock_user
+        with (
+            patch("fides.service.attribution.CONFIG") as mock_config,
+            patch("fides.service.attribution.FidesUser.get_by", return_value=mock_user),
         ):
             mock_config.security.oauth_root_client_id = "root_client_id"
             result = service.get_actor_display_name(

--- a/tests/service/test_attribution.py
+++ b/tests/service/test_attribution.py
@@ -1,0 +1,99 @@
+"""Unit tests for fides.service.attribution.AttributionService."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fides.service.attribution import AttributionService
+
+
+@pytest.fixture
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture
+def service(mock_db):
+    return AttributionService(mock_db)
+
+
+class TestGetActorDisplayName:
+    def test_returns_none_when_both_ids_none(self, service):
+        assert service.get_actor_display_name(user_id=None, client_id=None) is None
+
+    def test_returns_fallback_when_both_ids_none(self, service):
+        result = service.get_actor_display_name(
+            user_id=None, client_id=None, fallback="unknown"
+        )
+        assert result == "unknown"
+
+    def test_returns_root_username_for_root_client_id(self, service):
+        with patch("fides.service.attribution.CONFIG") as mock_config:
+            mock_config.security.oauth_root_client_id = "root_client_id"
+            mock_config.security.root_username = "root"
+            result = service.get_actor_display_name(
+                user_id="root_client_id", client_id=None
+            )
+        assert result == "root"
+
+    def test_returns_username_for_known_user(self, service):
+        mock_user = MagicMock()
+        mock_user.username = "alice"
+        with patch("fides.service.attribution.CONFIG") as mock_config, patch(
+            "fides.service.attribution.FidesUser.get_by", return_value=mock_user
+        ):
+            mock_config.security.oauth_root_client_id = "root_client_id"
+            result = service.get_actor_display_name(user_id="usr_123", client_id=None)
+        assert result == "alice"
+
+    def test_returns_fallback_when_user_not_found(self, service):
+        with patch("fides.service.attribution.CONFIG") as mock_config, patch(
+            "fides.service.attribution.FidesUser.get_by", return_value=None
+        ):
+            mock_config.security.oauth_root_client_id = "root_client_id"
+            result = service.get_actor_display_name(
+                user_id="usr_deleted", client_id=None, fallback="usr_deleted"
+            )
+        assert result == "usr_deleted"
+
+    def test_returns_client_name_for_named_client(self, service, mock_db):
+        mock_client = MagicMock()
+        mock_client.name = "My API Client"
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_client
+        with patch("fides.service.attribution.CONFIG") as mock_config:
+            mock_config.security.oauth_root_client_id = "root_client_id"
+            result = service.get_actor_display_name(user_id=None, client_id="cli_abc")
+        assert result == "My API Client"
+
+    def test_returns_client_id_when_client_has_no_name(self, service, mock_db):
+        mock_client = MagicMock()
+        mock_client.name = None
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_client
+        with patch("fides.service.attribution.CONFIG") as mock_config:
+            mock_config.security.oauth_root_client_id = "root_client_id"
+            result = service.get_actor_display_name(user_id=None, client_id="cli_abc")
+        assert result == "cli_abc"
+
+    def test_returns_client_id_when_client_not_found(self, service, mock_db):
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+        with patch("fides.service.attribution.CONFIG") as mock_config:
+            mock_config.security.oauth_root_client_id = "root_client_id"
+            result = service.get_actor_display_name(
+                user_id=None, client_id="cli_missing"
+            )
+        assert result == "cli_missing"
+
+    def test_user_id_takes_precedence_when_both_set(self, service, mock_db):
+        """user_id should be used if both are somehow set (should not happen in practice)."""
+        mock_user = MagicMock()
+        mock_user.username = "alice"
+        with patch("fides.service.attribution.CONFIG") as mock_config, patch(
+            "fides.service.attribution.FidesUser.get_by", return_value=mock_user
+        ):
+            mock_config.security.oauth_root_client_id = "root_client_id"
+            result = service.get_actor_display_name(
+                user_id="usr_123", client_id="cli_abc"
+            )
+        assert result == "alice"
+        # client lookup should not be called
+        mock_db.query.assert_not_called()

--- a/tests/test_request_context.py
+++ b/tests/test_request_context.py
@@ -1,0 +1,67 @@
+"""Unit tests for fides.api.request_context."""
+
+import pytest
+
+from fides.api.request_context import (
+    get_client_id,
+    get_request_id,
+    get_user_id,
+    reset_request_context,
+    set_client_id,
+    set_request_id,
+    set_user_id,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_context():
+    """Reset the request context before and after every test."""
+    reset_request_context()
+    yield
+    reset_request_context()
+
+
+class TestClientIdHelpers:
+    def test_get_client_id_default_is_none(self):
+        assert get_client_id() is None
+
+    def test_set_and_get_client_id(self):
+        set_client_id("client_abc")
+        assert get_client_id() == "client_abc"
+
+    def test_set_client_id_does_not_clobber_user_id(self):
+        set_user_id("user_xyz")
+        set_client_id("client_abc")
+        assert get_user_id() == "user_xyz"
+        assert get_client_id() == "client_abc"
+
+    def test_set_user_id_does_not_clobber_client_id(self):
+        set_client_id("client_abc")
+        set_user_id("user_xyz")
+        assert get_client_id() == "client_abc"
+        assert get_user_id() == "user_xyz"
+
+    def test_set_client_id_does_not_clobber_request_id(self):
+        set_request_id("req_123")
+        set_client_id("client_abc")
+        assert get_request_id() == "req_123"
+        assert get_client_id() == "client_abc"
+
+    def test_reset_clears_client_id(self):
+        set_client_id("client_abc")
+        reset_request_context()
+        assert get_client_id() is None
+
+    def test_reset_clears_all_fields(self):
+        set_user_id("user_xyz")
+        set_client_id("client_abc")
+        set_request_id("req_123")
+        reset_request_context()
+        assert get_user_id() is None
+        assert get_client_id() is None
+        assert get_request_id() is None
+
+    def test_overwrite_client_id(self):
+        set_client_id("client_first")
+        set_client_id("client_second")
+        assert get_client_id() == "client_second"


### PR DESCRIPTION
[ENG-3275]

### Description Of Changes

Uses API Client name for attachments and comments when applicable.

### Steps to Confirm

1. Create an API Client
2. Create a DSR
3. Comment on the DSR using the API Client
4. Validate that the API Client's name displays
5. Repeat steps 2 - 4 for attachments in manual tasks
6. Repeat steps 2 - 5 as a user instead

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3275]: https://ethyca.atlassian.net/browse/ENG-3275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ