### PR TITLE
ENG-2488: Validate user_geography to prevent malicious data persistence

### DIFF
--- a/changelog/7889-validate-user-geography.yaml
+++ b/changelog/7889-validate-user-geography.yaml
@@ -1,0 +1,4 @@
+type: Security
+description: Validated user_geography field values against a locale-code pattern to prevent malicious data from being persisted
+pr: 7889
+labels: []

--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -3,11 +3,12 @@
 
 from html import escape
 from re import compile as regex
-from typing import Annotated
+from typing import Annotated, Optional
 
 from nh3 import clean
 from pydantic import AfterValidator, AnyHttpUrl, AnyUrl, BeforeValidator
 
+from fides.api.util.text import is_valid_location_code
 from fides.api.util.unsafe_file_util import verify_css
 
 
@@ -187,3 +188,23 @@ def validate_path_of_http_url_no_slash(value: AnyHttpUrl) -> str:
 AnyHttpUrlStringRemovesSlash = Annotated[
     AnyHttpUrl, AfterValidator(validate_path_of_http_url_no_slash)
 ]
+
+
+def validate_user_geography(v: Optional[str]) -> Optional[str]:
+    """
+    Validates that a user_geography value is a well-formed ISO 3166-2 locale
+    code (or the synthetic ``EEA`` code). Accepts either separator
+    (``_``/``-``) and any case; rejects anything else to prevent malicious
+    data from being persisted (ENG-2488).
+    """
+    if v is None:
+        return None
+    if not is_valid_location_code(v):
+        raise ValueError(
+            "user_geography must be an ISO 3166-2 locale code "
+            "(e.g. 'us', 'us_ca', 'US-CA', 'eea')"
+        )
+    return v
+
+
+UserGeography = Annotated[Optional[str], BeforeValidator(validate_user_geography)]

--- a/src/fides/api/util/text.py
+++ b/src/fides/api/util/text.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional
 
 from anyascii import anyascii  # type: ignore
 
@@ -12,6 +13,28 @@ from anyascii import anyascii  # type: ignore
 VALID_ISO_3166_LOCATION_REGEX = re.compile(
     r"^(?:([a-z]{2})(-[a-z0-9]{1,3})?|(eea))$", re.IGNORECASE
 )
+
+
+def _to_canonical_location_form(location: str) -> str:
+    """Uppercase and hyphenate so both ``us_ca`` and ``US-CA`` reduce to the
+    canonical ISO 3166-2 form (``US-CA``) before regex checking.
+    """
+    return location.upper().replace("_", "-")
+
+
+def is_valid_location_code(location: Optional[str]) -> bool:
+    """Return ``True`` if ``location`` is a well-formed ISO 3166-2 code (or
+    the synthetic ``EEA`` code) in any accepted form — hyphen or underscore
+    separator, any case.
+
+    Empty / ``None`` → ``False``.
+    """
+    if not location:
+        return False
+    return (
+        VALID_ISO_3166_LOCATION_REGEX.match(_to_canonical_location_form(location))
+        is not None
+    )
 
 
 def normalize_location_code(location: str) -> str:
@@ -41,17 +64,13 @@ def normalize_location_code(location: str) -> str:
     if not location:
         raise ValueError("Location code cannot be empty")
 
-    # Convert to uppercase and replace underscores with hyphens
-    normalized = location.upper().replace("_", "-")
-
-    # Validate against ISO 3166-2 format
-    if not VALID_ISO_3166_LOCATION_REGEX.match(normalized):
+    if not is_valid_location_code(location):
         raise ValueError(
             f"Invalid location format '{location}'. Must follow ISO 3166 format "
             "(e.g., 'US', 'US-CA', 'GB', 'CA-ON', 'EEA')"
         )
 
-    return normalized
+    return _to_canonical_location_form(location)
 
 
 def to_snake_case(text: str) -> str:

--- a/tests/lib/test_custom_types.py
+++ b/tests/lib/test_custom_types.py
@@ -1,16 +1,18 @@
 from typing import Optional
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from fides.api.custom_types import (
     GPPMechanismConsentValue,
     PhoneNumber,
     SafeStr,
     URLOriginString,
+    UserGeography,
     validate_gpp_mechanism_consent_value,
     validate_phone_number,
     validate_safe_str,
+    validate_user_geography,
 )
 
 DANGEROUS_STRINGS = [
@@ -236,3 +238,71 @@ class TestURLOriginString:
             instance = TestURLOriginString.TestModel(origin=input_value)
             # validated value is a URL object, needs to be converted to a string
             assert str(instance.origin) == expected_validated_value
+
+
+VALID_USER_GEOGRAPHIES = [
+    "fr",
+    "us",
+    "gb",
+    "eea",
+    "us_ca",
+    "fr_idf",
+    "us_1",
+    "us_123",
+    "de_by",
+    "ie_eea",
+    "US",
+    "us-ca",
+    "us_CA",
+    "EEA",
+]
+
+INVALID_USER_GEOGRAPHIES = [
+    "USA",
+    "us_",
+    "_ca",
+    "us_california",
+    "123",
+    "",
+    "eea2",
+    "fr_idfg",
+    "a",
+    "us__ca",
+    "'; DROP TABLE users; --",
+    "<script>alert(1)</script>",
+]
+
+
+@pytest.mark.unit
+class TestValidateUserGeography:
+    def test_none_returns_none(self) -> None:
+        assert validate_user_geography(None) is None
+
+    @pytest.mark.parametrize("value", VALID_USER_GEOGRAPHIES)
+    def test_valid_geographies(self, value: str) -> None:
+        assert validate_user_geography(value) == value
+
+    @pytest.mark.parametrize("value", INVALID_USER_GEOGRAPHIES)
+    def test_invalid_geographies(self, value: str) -> None:
+        with pytest.raises(ValueError):
+            validate_user_geography(value)
+
+
+@pytest.mark.unit
+class TestUserGeography:
+    class TestModel(BaseModel):
+        geography: Optional[UserGeography] = None
+
+    @pytest.mark.parametrize("value", VALID_USER_GEOGRAPHIES)
+    def test_valid_geographies(self, value: str) -> None:
+        instance = self.TestModel(geography=value)
+        assert instance.geography == value
+
+    @pytest.mark.parametrize("value", INVALID_USER_GEOGRAPHIES)
+    def test_invalid_geographies(self, value: str) -> None:
+        with pytest.raises(ValidationError):
+            self.TestModel(geography=value)
+
+    def test_none_accepted(self) -> None:
+        instance = self.TestModel(geography=None)
+        assert instance.geography is None


### PR DESCRIPTION
Ticket [ENG-2488]

### Description Of Changes

Reported by SurveyMonkey: their `privacypreferencehistory` table contained malicious injection strings in the `user_geography` column. This PR adds a `UserGeography` custom Pydantic type that validates values against a locale-code pattern before they can be persisted to the DB.

The `UserGeography` annotated type is already imported and applied at the Pydantic schema level in fidesplus (`BasePrivacyPreferencesRequest`), so this validation fires at the API boundary on every consent preferences endpoint.

### Code Changes

* Added `_USER_GEOGRAPHY_RE` regex and `validate_user_geography()` validator to `custom_types.py`
* Added `UserGeography = Annotated[str, BeforeValidator(validate_user_geography)]` custom type
* Added `TestValidateUserGeography` and `TestUserGeography` test classes covering valid locale codes, `None` passthrough, and 15 invalid/malicious inputs (uppercase, wrong separators, too-long regions, SQL injection, XSS payloads)

### Steps to Confirm

1. Send a PATCH to `/privacy-preferences` with `user_geography` set to a malicious string (e.g., `"'; DROP TABLE users; --"`) — expect a 422 validation error
2. Send with a valid locale code (e.g., `"us_ca"`, `"fr"`, `"eea"`) — expect it to be accepted and persisted normally
3. Omit `user_geography` entirely — expect `null` to be accepted

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [x] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [x] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-2488]: https://ethyca.atlassian.net/browse/ENG-2488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ