### PR TITLE
Update heading tag semantics for privacy assessments

### DIFF
--- a/changelog/7892-fix-assessment-heading-hierarchy.yaml
+++ b/changelog/7892-fix-assessment-heading-hierarchy.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed heading hierarchy on assessments page for proper visual distinction
+pr: 7892
+labels: []

--- a/changelog/7892-fix-assessment-heading-hierarchy.yaml
+++ b/changelog/7892-fix-assessment-heading-hierarchy.yaml
@@ -1,4 +1,4 @@
 type: Fixed
-description: Fixed heading hierarchy on assessments page for proper visual distinction
+description: Fixed heading hierarchy on assessments page for better semantics and accessibility
 pr: 7892
 labels: []

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentCard.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentCard.tsx
@@ -74,7 +74,7 @@ export const AssessmentCard = ({
     >
       <Flex vertical gap="small" justify="space-between" className="flex-1">
         <div>
-          <Title level={5} className={`!mb-1 ${styles.titleLink}`}>
+          <Title level={3} className={`!mb-1 ${styles.titleLink}`}>
             <NextLink href={`${PRIVACY_ASSESSMENTS_ROUTE}/${assessment.id}`}>
               {assessment.name}
             </NextLink>

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentDetail.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentDetail.tsx
@@ -229,7 +229,7 @@ export const AssessmentDetail = ({ assessment }: AssessmentDetailProps) => {
       {notificationHolder}
       <div>
         <Flex align="center" gap="small" className="mb-1">
-          <Typography.Title level={4} className="m-0">
+          <Typography.Title level={2} className="m-0">
             {assessment.name}
           </Typography.Title>
           <Tag

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentGroup.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentGroup.tsx
@@ -41,7 +41,7 @@ export const AssessmentGroup = ({
             icon={<Icons.Document />}
           />
           <div>
-            <Title level={4} className="!m-0">
+            <Title level={2} className="!m-0">
               {title}
             </Title>
             <Text type="secondary">

--- a/clients/admin-ui/src/features/privacy-assessments/QuestionGroupPanel.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/QuestionGroupPanel.tsx
@@ -7,6 +7,7 @@ import {
   Icons,
   Tag,
   Text,
+  Typography,
 } from "fidesui";
 
 import { RISK_LEVEL_DOT_COLORS, RISK_LEVEL_LABELS } from "./constants";
@@ -30,9 +31,9 @@ export const QuestionGroupPanel = ({
     <>
       <Flex gap="large" align="flex-start" className="min-w-0 flex-1">
         <div className="flex-1">
-          <Text strong size="lg" className="mb-3 block">
+          <Typography.Title level={2} className="!mb-2 mt-0 !text-[18px]">
             {group.id}. {group.title}
-          </Text>
+          </Typography.Title>
           <Flex gap="medium" align="center" wrap="wrap" className="mb-2">
             <Text type="secondary" size="sm">
               {group.last_updated_at

--- a/clients/admin-ui/src/features/privacy-assessments/QuestionGroupPanel.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/QuestionGroupPanel.tsx
@@ -31,7 +31,7 @@ export const QuestionGroupPanel = ({
     <>
       <Flex gap="large" align="flex-start" className="min-w-0 flex-1">
         <div className="flex-1">
-          <Typography.Title level={2} className="!mb-2 mt-0 !text-[18px]">
+          <Typography.Title level={3} className="!mb-2 mt-0">
             {group.id}. {group.title}
           </Typography.Title>
           <Flex gap="medium" align="center" wrap="wrap" className="mb-2">


### PR DESCRIPTION
Ticket [ENG-3284]

### Description Of Changes
Fix heading hierarchy on the privacy assessments pages for better semantics and accessibility.

### Code Changes

* `AssessmentDetail.tsx` — Changed assessment name heading from `level={4}` to `level={2}`
* `AssessmentGroup.tsx` — Changed group title heading from `level={4}` to `level={2}`
* `AssessmentCard.tsx` — Changed card title heading from `level={5}` to `level={3}`
* `QuestionGroupPanel.tsx` — Replaced `<Text strong size="lg">` with `<Typography.Title level={3}>` for proper semantic heading markup

### Steps to Confirm

1. Navigate to the Privacy Assessments list page
2. Verify the page title (H1), group titles (H2), and assessment card titles (H3) are visually distinct
3. Navigate into an assessment detail page
4. Verify the assessment name renders as H2 with appropriate size
5. Verify question group panel titles render as H3
6. Confirm no layout or spacing regressions

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3284]: https://ethyca.atlassian.net/browse/ENG-3284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ