### PR TITLE
fix: widget issues

### DIFF
--- a/changelog/7894-widget-fixes.yaml
+++ b/changelog/7894-widget-fixes.yaml
@@ -1,0 +1,4 @@
+type: Changed # One of: Added, Changed, Developer Experience, Deprecated, Docs, Fixed, Removed, Security
+description: Fixes widget issues and changes some behaviors
+pr: 7894 # PR number
+labels: [] # Optional: ["high-risk", "db-migration"]

--- a/clients/admin-ui/cypress/e2e/action-center/infrastructure-systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/infrastructure-systems.cy.ts
@@ -543,7 +543,7 @@ describe("Action center infrastructure systems", () => {
 
         cy.get('input[type="checkbox"]').eq(1).check();
         cy.contains("button", "Actions").click();
-        cy.contains("Approve").click();
+        cy.contains("li", "Approve").click();
 
         cy.wait("@bulkPromoteInfrastructureSystems").then((interception) => {
           expect(interception.request.body).to.be.an("array");
@@ -559,7 +559,7 @@ describe("Action center infrastructure systems", () => {
 
         cy.get('input[type="checkbox"]').eq(1).check();
         cy.contains("button", "Actions").click();
-        cy.contains("Ignore").click();
+        cy.contains("li", "Ignore").click();
 
         cy.wait("@bulkMuteInfrastructureSystems").then((interception) => {
           expect(interception.request.body).to.be.an("array");
@@ -607,7 +607,7 @@ describe("Action center infrastructure systems", () => {
 
         cy.contains("Select all").click();
         cy.contains("button", "Actions").click();
-        cy.contains("Approve").click();
+        cy.contains("li", "Approve").click();
 
         cy.wait("@bulkPromoteInfrastructureSystems").then((interception) => {
           expect(interception.request.body).to.have.property("filters");
@@ -621,7 +621,7 @@ describe("Action center infrastructure systems", () => {
 
         cy.get('input[type="checkbox"]').eq(1).check();
         cy.contains("button", "Actions").click();
-        cy.contains("Approve").click();
+        cy.contains("li", "Approve").click();
 
         cy.contains("button", "Actions").should("be.disabled");
       });
@@ -639,7 +639,7 @@ describe("Action center infrastructure systems", () => {
         cy.get('input[type="checkbox"]').eq(1).uncheck();
 
         cy.contains("button", "Actions").click();
-        cy.contains("Approve").click();
+        cy.contains("li", "Approve").click();
 
         cy.wait("@bulkPromoteInfrastructureSystems").then((interception) => {
           expect(interception.request.body).to.have.property("exclude_urns");

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorDetailsWidget.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorDetailsWidget.tsx
@@ -21,9 +21,14 @@ const MonitorDetailsWidget = ({ monitorId }: MonitorDetailsWidgetProps) => {
   const {
     flags: { heliosInsights },
   } = useFlags();
-  const { data: configData } = useGetMonitorConfigQuery({
-    monitor_config_id: monitorId,
-  });
+  const { data: configData } = useGetMonitorConfigQuery(
+    {
+      monitor_config_id: monitorId,
+    },
+    {
+      refetchOnMountOrArgChange: true,
+    },
+  );
   const connectionKey = configData?.connection_config_key;
   const { data: connectionData } = useGetConnectionQuery(
     connectionKey ? { connection_key: connectionKey } : skipToken,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorProgressWidget.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorProgressWidget.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Icons, Text } from "fidesui";
+import { Button, Flex, Icons, Text, Title } from "fidesui";
 import Link from "next/link";
 import { useQueryStates } from "nuqs";
 
@@ -38,7 +38,7 @@ const MonitorProgressWidget = ({
     SearchFormQueryState(Object.values(APIMonitorType)),
   );
 
-  const { data } = useGetAggregateStatisticsQuery(
+  const { data, isLoading } = useGetAggregateStatisticsQuery(
     {
       monitor_type: monitorType,
       monitor_config_id: monitorId,
@@ -54,7 +54,7 @@ const MonitorProgressWidget = ({
   return (
     heliosInsights && (
       <Flex className="w-full" gap="middle">
-        {(data && totalMonitors > 0) || !!filters.steward_key ? (
+        {(data && totalMonitors > 0) || !!filters.steward_key || isLoading ? (
           <ProgressCard
             {...buildWidgetProps({
               monitor_type: monitorType,
@@ -70,10 +70,10 @@ const MonitorProgressWidget = ({
           />
         ) : (
           <div>
-            <Flex vertical gap="middle" align="center" justify="center">
-              <span>{MONITOR_TYPE_TO_LABEL[monitorType]}</span>
+            <Flex vertical gap="small" justify="center">
+              <Title level={5}>{MONITOR_TYPE_TO_LABEL[monitorType]}</Title>
               <Text>{renderIcon(MONITOR_TYPE_TO_ICON[monitorType])}</Text>
-              <Text type="secondary" className="text-center">
+              <Text type="secondary">
                 {MONITOR_TYPE_TO_EMPTY_TEXT[monitorType]}
               </Text>
               <Link href={INTEGRATION_MANAGEMENT_ROUTE}>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorStats.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorStats.tsx
@@ -22,6 +22,7 @@ const MonitorStats = ({ monitorId, monitorType }: MonitorStatsProps) => {
     heliosInsights && (
       <Flex className={classNames("w-full")} gap="middle">
         {Object.values(monitorType ? [monitorType] : APIMonitorType)
+          .toReversed()
           .map((mType) => (
             <MonitorProgressWidget
               monitorType={mType}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorStatsWidget.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorStatsWidget.tsx
@@ -63,9 +63,11 @@ const MonitorStatsWidget = ({
                     },
                   }}
                 >
-                  {numericStats?.data
-                    .map((stat) => `${stat.count} ${stat.label}`)
-                    .join(", ")}
+                  {numericStats && (numericStats?.data.length ?? 0) > 0
+                    ? numericStats.data
+                        .map((stat) => `${stat.count} ${stat.label}`)
+                        .join(", ")
+                    : "None"}
                 </Paragraph>
               ),
               span: "filled",
@@ -83,9 +85,15 @@ const MonitorStatsWidget = ({
                       .join(", "),
                   }}
                 >
-                  {percentageStats?.data
-                    .map((stat) => `${stat.label} (${nFormatter(stat.value)}%)`)
-                    .join(", ")}
+                  {percentageStats?.data &&
+                  (percentageStats?.data.length ?? 0) > 0
+                    ? percentageStats.data
+                        .map(
+                          (stat) =>
+                            `${stat.label} (${nFormatter(stat.value)}%)`,
+                        )
+                        .join(", ")
+                    : "None"}
                 </Paragraph>
               ),
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ProgressCard/ProgressCard.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ProgressCard/ProgressCard.tsx
@@ -53,7 +53,6 @@ export interface ProgressCardProps {
 export const ProgressCard = ({
   title,
   subtitle,
-  progress,
   barChartProps,
   percentageStats,
   numericStats,
@@ -91,7 +90,10 @@ export const ProgressCard = ({
         </Flex>
       )}
       <EnterExitList
-        dataSource={[progress.denominator ?? 0]}
+        dataSource={[
+          (barChartProps?.data?.progress?.classified ?? 0) +
+            (barChartProps?.data?.progress?.unlabeled ?? 0),
+        ]}
         itemKey={(key) => key}
         renderItem={(item) => (
           <Tooltip
@@ -160,7 +162,7 @@ export const ProgressCard = ({
             />
             <Badge
               status="default"
-              text={`${nFormatter(progress.denominator)} unlabeled`}
+              text={`${nFormatter(barChartProps?.data?.progress?.unlabeled)} unlabeled`}
             />
           </Flex>
         </Tooltip>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ProgressCard/utils.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ProgressCard/utils.ts
@@ -4,20 +4,8 @@ import { pluralize } from "~/features/common/utils";
 import { AggregateStatisticsResponse } from "~/types/api/models/AggregateStatisticsResponse";
 import { APIMonitorType } from "~/types/api/models/APIMonitorType";
 
-import { MONITOR_UPDATE_LABELS } from "../constants";
+import { STATUS_COUNTS_TO_RESOURCE_STATUS } from "../fields/MonitorFields.const";
 import { ProgressCardProps } from "./ProgressCard";
-
-const getMonitorUpdateName = (key: string, count: number) => {
-  const names = Object.entries(MONITOR_UPDATE_LABELS).find(
-    ([k]) => key === k,
-  )?.[1];
-
-  if (!names) {
-    return key;
-  }
-  // names is [singular, plural]
-  return pluralize(count, ...names);
-};
 
 export const MONITOR_TYPE_TO_LABEL: Record<APIMonitorType, string> = {
   datastore: "Monitored data stores",
@@ -44,18 +32,9 @@ export const MONITOR_TYPE_TO_EMPTY_TEXT: Record<APIMonitorType, string> = {
 };
 
 const MONITOR_TYPE_TO_PRIMARY_STATISTIC: Record<APIMonitorType, string> = {
-  datastore: "Resources approved",
   infrastructure: "Total systems",
   website: "Resources approved",
-};
-
-const MONITOR_TYPE_TO_NUMERIC_STATISTIC: Record<
-  APIMonitorType,
-  keyof AggregateStatisticsResponse
-> = {
-  datastore: "status_counts",
-  infrastructure: "vendor_counts",
-  website: "status_counts",
+  datastore: "Resources approved",
 };
 
 const MONITOR_TYPE_TO_PERCENT_STATISTIC_KEY: Record<
@@ -105,22 +84,21 @@ export const buildWidgetProps = (
   progress: {
     label: MONITOR_TYPE_TO_PRIMARY_STATISTIC[response.monitor_type],
     denominator: response?.approval_progress?.total,
-    numerator: response?.approval_progress?.approved,
+    numerator: response?.status_counts?.monitored,
     percent: response?.approval_progress?.percentage,
   },
   barChartProps: {
     data: {
       progress: {
-        approved: response.approval_progress?.approved ?? 0,
-        classified: response.status_counts?.classified ?? 0,
-        unlabeled:
-          (response.approval_progress?.total ?? 0) -
-          (response.approval_progress?.approved ?? 0) -
+        approved: response.status_counts?.monitored ?? 0,
+        classified:
+          (response.status_counts?.reviewed ?? 0) +
           (response.status_counts?.classified ?? 0),
+        unlabeled: response.status_counts?.addition ?? 0,
         empty:
-          (response.approval_progress?.total ?? 0) -
-            (response.approval_progress?.approved ?? 0) -
-            (response.status_counts?.classified ?? 0) <=
+          (response.status_counts?.monitored ?? 0) -
+            (response.status_counts?.classified ?? 0) -
+            (response.approval_progress?.percentage ?? 0) <=
           0
             ? 1
             : 0,
@@ -130,14 +108,30 @@ export const buildWidgetProps = (
   },
   numericStats: {
     label: "Current status",
-    data: Object.entries(
-      response?.[MONITOR_TYPE_TO_NUMERIC_STATISTIC[response.monitor_type]] ??
-        [],
-    ).flatMap(([label, value]) =>
-      value
-        ? [{ label: getMonitorUpdateName(label, value), count: value }]
-        : [],
-    ),
+    data: [
+      {
+        label: STATUS_COUNTS_TO_RESOURCE_STATUS.addition,
+        count: response.status_counts?.addition ?? 0,
+      },
+      {
+        label: STATUS_COUNTS_TO_RESOURCE_STATUS.classified,
+        count:
+          (response.status_counts?.classified ?? 0) +
+          (response.status_counts?.reviewed ?? 0),
+      },
+      {
+        label: STATUS_COUNTS_TO_RESOURCE_STATUS.classifying,
+        count: response.status_counts?.classifying ?? 0,
+      },
+      {
+        label: STATUS_COUNTS_TO_RESOURCE_STATUS.monitored,
+        count: response.status_counts?.monitored ?? 0,
+      },
+      {
+        label: STATUS_COUNTS_TO_RESOURCE_STATUS.removal,
+        count: response.status_counts?.removal ?? 0,
+      },
+    ],
   },
   percentageStats: {
     label: MONITOR_TYPE_TO_PERCENT_STATISTIC_LABEL[response.monitor_type],

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
@@ -2,7 +2,7 @@ import { CUSTOM_TAG_COLOR, Icons } from "fidesui";
 // TODO: fix this export to be better encapsulated in fidesui
 import palette from "fidesui/src/palette/palette.module.scss";
 
-import { DiffStatus, StagedResourceTypeValue } from "~/types/api";
+import { DiffStatus, StagedResourceTypeValue, StatusCounts } from "~/types/api";
 
 export const TREE_PAGE_SIZE = 100;
 export const TREE_NODE_LOAD_MORE_TEXT = "Load more...";
@@ -45,6 +45,27 @@ export const DEFAULT_FILTER_STATUSES: Exclude<
   "Removed",
   "Error",
 ];
+
+export const STATUS_COUNTS: Record<keyof StatusCounts, keyof StatusCounts> = {
+  addition: "addition",
+  reviewed: "reviewed",
+  classified: "classifying",
+  classifying: "classifying",
+  monitored: "monitored",
+  removal: "removal",
+} as const;
+
+export const STATUS_COUNTS_TO_RESOURCE_STATUS: Record<
+  keyof StatusCounts,
+  ResourceStatusLabel
+> = {
+  addition: "Unlabeled",
+  reviewed: "Reviewed",
+  classified: "Classified",
+  classifying: "Classifying",
+  monitored: "Approved",
+  removal: "Removed",
+} as const;
 
 export const DIFF_TO_RESOURCE_STATUS: Record<DiffStatus, ResourceStatusLabel> =
   {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -412,147 +412,151 @@ const ActionCenterFields = ({
                 </Button>
               </Dropdown>
             </div>
-          </Flex>
-          <Flex gap="medium" align="center">
-            <Checkbox id="select-all" {...checkboxProps} />
-            <label htmlFor="select-all">Select all</label>
-            {!!selectedListItemCount && (
-              <Text strong>
-                {selectedListItemCount.toLocaleString()} selected
-              </Text>
-            )}
-          </Flex>
-          <List
-            dataSource={[...listNodes.values()]}
-            className="-ml-3 h-full overflow-y-scroll pl-1" // margin and padding to account for active item left bar styling
-            loading={listQueryMeta.isFetching}
-            enableKeyboardShortcuts
-            locale={
-              !baseMonitorFilters.query.search &&
-              _(
-                baseMonitorFilters.query.diff_status?.map(
-                  (diffStatus) => DIFF_TO_RESOURCE_STATUS[diffStatus],
-                ),
-              )
-                .intersection(EXCLUDED_FILTER_STATUSES)
-                .isEmpty()
-                ? {
-                    emptyText: (
-                      <Empty
-                        image={Empty.PRESENTED_IMAGE_SIMPLE}
-                        description={
-                          <>
-                            <div>
-                              All resources have been either approved or
-                              ignored.
-                            </div>
-                            <div>
-                              Approved resources can be found in the manage
-                              datasets view.
-                            </div>
-                            <div>
-                              To see ignored resources, adjust your filters.
-                            </div>
-                          </>
-                        }
-                      >
-                        <Flex gap="medium" justify="center">
-                          <NextLink
-                            href={DATASET_ROUTE}
-                            passHref
-                            legacyBehavior
-                          >
-                            <Button>Manage datasets view</Button>
-                          </NextLink>
-                          <Button
-                            type="primary"
-                            aria-label="Refresh page"
-                            onClick={() => {
-                              form.resetFields();
-                              router.reload();
-                            }}
-                          >
-                            Refresh page
-                          </Button>
-                        </Flex>
-                      </Empty>
-                    ),
-                  }
-                : undefined
-            }
-            onActiveItemChange={(
-              item,
-              _activeListItemIndex,
-              setActiveIndexFn,
-            ) => {
-              // Store the setter function so handleNavigate can use it
-              setSetActiveListItemIndex(() => setActiveIndexFn);
-
-              if (item?.urn) {
-                setActiveListItem({
-                  ...item,
-                  key: item.urn,
-                });
-                if (detailsUrn && item.urn !== detailsUrn) {
-                  setDetailsUrn(item.urn);
-                }
-              } else {
-                setActiveListItem(undefined);
-              }
-            }}
-            renderItem={(props) =>
-              renderMonitorFieldListItem({
-                ...props,
-                selected: selectedKeys.includes(props.urn),
-                onSelect: updateSelectedListItem,
-                onNavigate: handleNavigate,
-                onSetDataCategories: (urn, values) =>
-                  fieldActions["assign-categories"]([urn], true, {
-                    user_assigned_data_categories: values,
-                  }),
-                dataCategoriesDisabled: props?.diff_status
-                  ? !ACTION_ALLOWED_STATUSES["assign-categories"].some(
-                      (status) => status === props.diff_status,
-                    )
-                  : true,
-                actions: props?.diff_status
-                  ? LIST_ITEM_ACTIONS[props.diff_status].map((action) => (
-                      <Tooltip key={action} title={FIELD_ACTION_LABEL[action]}>
-                        <Button
-                          aria-label={FIELD_ACTION_LABEL[action]}
-                          icon={FIELD_ACTION_ICON[action]}
-                          onClick={() => fieldActions[action]([props.urn])}
-                          disabled={
-                            props?.diff_status
-                              ? !ACTION_ALLOWED_STATUSES[action].some(
-                                  (status) => status === props.diff_status,
-                                )
-                              : true
+            <Flex gap="medium" align="center">
+              <Checkbox id="select-all" {...checkboxProps} />
+              <label htmlFor="select-all">Select all</label>
+              {!!selectedListItemCount && (
+                <Text strong>
+                  {selectedListItemCount.toLocaleString()} selected
+                </Text>
+              )}
+            </Flex>
+            <List
+              dataSource={[...listNodes.values()]}
+              className="-ml-3 h-full overflow-y-scroll pl-1" // margin and padding to account for active item left bar styling
+              loading={listQueryMeta.isFetching}
+              enableKeyboardShortcuts
+              locale={
+                !baseMonitorFilters.query.search &&
+                _(
+                  baseMonitorFilters.query.diff_status?.map(
+                    (diffStatus) => DIFF_TO_RESOURCE_STATUS[diffStatus],
+                  ),
+                )
+                  .intersection(EXCLUDED_FILTER_STATUSES)
+                  .isEmpty()
+                  ? {
+                      emptyText: (
+                        <Empty
+                          image={Empty.PRESENTED_IMAGE_SIMPLE}
+                          description={
+                            <>
+                              <div>
+                                All resources have been either approved or
+                                ignored.
+                              </div>
+                              <div>
+                                Approved resources can be found in the manage
+                                datasets view.
+                              </div>
+                              <div>
+                                To see ignored resources, adjust your filters.
+                              </div>
+                            </>
                           }
-                          style={{
-                            // Hack: because Sparkle is so weird, and Ant is using `inline-block`
-                            // for actions, this is needed to get the buttons to align correctly.
-                            fontSize: "var(--ant-button-content-font-size-lg)",
-                          }}
-                        />
-                      </Tooltip>
-                    ))
-                  : [],
-              })
-            }
-          />
-          <Pagination
-            {...paginationProps}
-            showSizeChanger={{
-              suffixIcon: <Icons.ChevronDown />,
-            }}
-            total={listQueryMeta.data?.total || 0}
-            hideOnSinglePage={
-              // if we're on the smallest page size, and there's only one page, hide the pagination
-              paginationProps.pageSize?.toString() ===
-              paginationProps.pageSizeOptions?.[0]
-            }
-          />
+                        >
+                          <Flex gap="medium" justify="center">
+                            <NextLink
+                              href={DATASET_ROUTE}
+                              passHref
+                              legacyBehavior
+                            >
+                              <Button>Manage datasets view</Button>
+                            </NextLink>
+                            <Button
+                              type="primary"
+                              aria-label="Refresh page"
+                              onClick={() => {
+                                form.resetFields();
+                                router.reload();
+                              }}
+                            >
+                              Refresh page
+                            </Button>
+                          </Flex>
+                        </Empty>
+                      ),
+                    }
+                  : undefined
+              }
+              onActiveItemChange={(
+                item,
+                _activeListItemIndex,
+                setActiveIndexFn,
+              ) => {
+                // Store the setter function so handleNavigate can use it
+                setSetActiveListItemIndex(() => setActiveIndexFn);
+
+                if (item?.urn) {
+                  setActiveListItem({
+                    ...item,
+                    key: item.urn,
+                  });
+                  if (detailsUrn && item.urn !== detailsUrn) {
+                    setDetailsUrn(item.urn);
+                  }
+                } else {
+                  setActiveListItem(undefined);
+                }
+              }}
+              renderItem={(props) =>
+                renderMonitorFieldListItem({
+                  ...props,
+                  selected: selectedKeys.includes(props.urn),
+                  onSelect: updateSelectedListItem,
+                  onNavigate: handleNavigate,
+                  onSetDataCategories: (urn, values) =>
+                    fieldActions["assign-categories"]([urn], true, {
+                      user_assigned_data_categories: values,
+                    }),
+                  dataCategoriesDisabled: props?.diff_status
+                    ? !ACTION_ALLOWED_STATUSES["assign-categories"].some(
+                        (status) => status === props.diff_status,
+                      )
+                    : true,
+                  actions: props?.diff_status
+                    ? LIST_ITEM_ACTIONS[props.diff_status].map((action) => (
+                        <Tooltip
+                          key={action}
+                          title={FIELD_ACTION_LABEL[action]}
+                        >
+                          <Button
+                            aria-label={FIELD_ACTION_LABEL[action]}
+                            icon={FIELD_ACTION_ICON[action]}
+                            onClick={() => fieldActions[action]([props.urn])}
+                            disabled={
+                              props?.diff_status
+                                ? !ACTION_ALLOWED_STATUSES[action].some(
+                                    (status) => status === props.diff_status,
+                                  )
+                                : true
+                            }
+                            style={{
+                              // Hack: because Sparkle is so weird, and Ant is using `inline-block`
+                              // for actions, this is needed to get the buttons to align correctly.
+                              fontSize:
+                                "var(--ant-button-content-font-size-lg)",
+                            }}
+                          />
+                        </Tooltip>
+                      ))
+                    : [],
+                })
+              }
+            />
+            <Pagination
+              {...paginationProps}
+              showSizeChanger={{
+                suffixIcon: <Icons.ChevronDown />,
+              }}
+              total={listQueryMeta.data?.total || 0}
+              hideOnSinglePage={
+                // if we're on the smallest page size, and there's only one page, hide the pagination
+                paginationProps.pageSize?.toString() ===
+                paginationProps.pageSizeOptions?.[0]
+              }
+            />
+          </Flex>
         </Splitter.Panel>
       </Splitter>
       <ResourceDetailsDrawer


### PR DESCRIPTION
Ticket [<issue>] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

- Fixes layout issue where datastore results would not be shown.
- Adds placeholder text for empty values.
- Waits to show add monitor prompts until data is loaded.
- Cleaned up non configured monitor display.
- More eagerly fetch details.
- Fixes numeric mapping issues
- New label translation

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. Visit a datastore monitor screen in the action center
2. Confirm that the results are visible and no longer pushed off the screen

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
