### PR TITLE
ENG-3388: use correct confidence bucket query parameter

### DIFF
--- a/changelog/7895-confidence-bucket-query-param-fix.yaml
+++ b/changelog/7895-confidence-bucket-query-param-fix.yaml
@@ -1,0 +1,7 @@
+# Copy this file and rename it to <pr_number>-<short-description>.yaml (e.g., 1234-add-user-endpoint.yaml)
+# Fill in the required fields and delete this comment block
+
+type: Fixed # One of: Added, Changed, Developer Experience, Deprecated, Docs, Fixed, Removed, Security
+description: Fixed findings redirecting to correct confidence bucket
+pr: 7895 # PR number
+labels: [] # Optional: ["high-risk", "db-migration"]

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConfidenceCard.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConfidenceCard.tsx
@@ -36,7 +36,7 @@ const getActions = ({
     <NextLink
       href={{
         pathname: reviewHref,
-        query: { confidenceBucket: item.severity },
+        query: { confidence_bucket: item.severity },
       }}
       passHref
       key={item.label}


### PR DESCRIPTION
Ticket [ENG-3388] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Fixes an incorrect query parameter being used in an href.

### Code Changes

* Change query parameter name.

### Steps to Confirm

1. Click on findings underneath a monitor run with classifications.
2. Ensure that the correct confidence bucket is populated and filtered to.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3388]: https://ethyca.atlassian.net/browse/ENG-3388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ