### PR TITLE
ENG-3171: Migrate config-wizard forms from Formik/Yup to Ant Design Form

### DIFF
--- a/changelog/7896-migrate-config-wizard-to-antd-form.yaml
+++ b/changelog/7896-migrate-config-wizard-to-antd-form.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Migrated config-wizard forms from Formik/Yup to Ant Design Form
+pr: 7896
+labels: []

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
@@ -55,10 +55,15 @@ export const AuthenticateAwsForm = () => {
   const [submittable, setSubmittable] = useState(false);
 
   useEffect(() => {
-    form
-      .validateFields({ validateOnly: true })
-      .then(() => setSubmittable(true))
-      .catch(() => setSubmittable(false));
+    const checkValidity = async () => {
+      try {
+        await form.validateFields({ validateOnly: true });
+        setSubmittable(true);
+      } catch {
+        setSubmittable(false);
+      }
+    };
+    checkValidity();
   }, [form, allValues]);
 
   const handleResults = (results: GenerateResponse["generate_results"]) => {
@@ -198,8 +203,14 @@ export const AuthenticateAwsForm = () => {
                   tooltip="The session token when using temporary credentials."
                   rules={[
                     {
-                      pattern: /^[^\s]+$/,
-                      message: "Cannot contain spaces",
+                      validator: (_, value) => {
+                        if (!value || !/\s/.test(value)) {
+                          return Promise.resolve();
+                        }
+                        return Promise.reject(
+                          new Error("Cannot contain spaces"),
+                        );
+                      },
                     },
                   ]}
                 >

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
@@ -1,11 +1,17 @@
-import { Button, Flex, Typography, useMessage } from "fidesui";
-import { Form, Formik } from "formik";
-import { useState } from "react";
-import * as Yup from "yup";
+import {
+  Button,
+  Card,
+  Flex,
+  Form,
+  Input,
+  Select,
+  Typography,
+  useMessage,
+} from "fidesui";
+import { useEffect, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import DocsLink from "~/features/common/DocsLink";
-import { CustomTextInput } from "~/features/common/form/inputs";
 import {
   isErrorResult,
   ParsedError,
@@ -20,7 +26,6 @@ import {
 import { RTKErrorResult } from "~/types/errors";
 
 import ErrorPage from "../common/errors/ErrorPage";
-import { ControlledSelect } from "../common/form/ControlledSelect";
 import { NextBreadcrumb } from "../common/nav/NextBreadcrumb";
 import {
   changeStep,
@@ -41,31 +46,29 @@ const initialValues = {
 
 type FormValues = typeof initialValues;
 
-const ValidationSchema = Yup.object().shape({
-  aws_access_key_id: Yup.string()
-    .required()
-    .trim()
-    .matches(/^\w+$/, "Cannot contain spaces or special characters")
-    .label("Access Key ID"),
-  aws_secret_access_key: Yup.string()
-    .required()
-    .trim()
-    .matches(/^[^\s]+$/, "Cannot contain spaces")
-    .label("Secret"),
-  aws_session_token: Yup.string()
-    .optional()
-    .trim()
-    .matches(/^[^\s]+$/, "Cannot contain spaces")
-    .label("Session Token (for temporary credentials)"),
-  region_name: Yup.string().required().label("Default Region"),
-});
-
-const AuthenticateAwsForm = () => {
+export const AuthenticateAwsForm = () => {
   const organizationKey = useAppSelector(selectOrganizationFidesKey);
   const dispatch = useAppDispatch();
   const message = useMessage();
+  const [form] = Form.useForm<FormValues>();
 
   const [scannerError, setScannerError] = useState<ParsedError>();
+
+  // Track submittable state
+  const allValues = Form.useWatch([], form);
+  const [submittable, setSubmittable] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useEffect(() => {
+    form
+      .validateFields({ validateOnly: true })
+      .then(() => setSubmittable(true))
+      .catch(() => setSubmittable(false));
+  }, [form, allValues]);
+
+  useEffect(() => {
+    setIsDirty(form.isFieldsTouched());
+  }, [form, allValues]);
 
   const handleResults = (results: GenerateResponse["generate_results"]) => {
     const systems: System[] = (results ?? []).filter(isSystem);
@@ -88,7 +91,7 @@ const AuthenticateAwsForm = () => {
 
   const [generate, { isLoading }] = useGenerateMutation();
 
-  const handleSubmit = async (values: FormValues) => {
+  const onFinish = async (values: FormValues) => {
     setScannerError(undefined);
 
     const result = await generate({
@@ -107,6 +110,8 @@ const AuthenticateAwsForm = () => {
     }
   };
 
+  const isSubmitting = isLoading;
+
   return (
     <Flex vertical gap="large">
       <NextBreadcrumb
@@ -122,108 +127,134 @@ const AuthenticateAwsForm = () => {
           { title: "Authenticate AWS scanner" },
         ]}
       />
-      <Formik
-        initialValues={initialValues}
-        validationSchema={ValidationSchema}
-        onSubmit={handleSubmit}
-      >
-        {({ isValid, isSubmitting, dirty }) => (
-          <>
-            {isSubmitting && (
-              <ScannerLoading
-                title="System scanning in progress"
-                onClose={handleCancel}
-              />
-            )}
 
-            {scannerError && (
-              <>
-                <ErrorPage
-                  error={scannerError}
-                  defaultMessage={
-                    scannerError.status === 403
-                      ? "Fides was unable to scan AWS. It appears that the credentials were valid to login but they did not have adequate permission to complete the scan."
-                      : "Fides was unable to scan your infrastructure. Please ensure your credentials are accurate and inspect the error log below for more details."
-                  }
-                  fullScreen={false}
-                  showReload={false}
-                />
-                {scannerError.status === 403 && (
-                  <Typography.Paragraph
-                    type="secondary"
-                    data-testid="permission-msg"
-                  >
-                    To fix this issue, double check that you have granted the
-                    required permissions to these credentials as part of your
-                    IAM policy. If you need more help in configuring IAM
-                    policies, you can read about them in the{" "}
-                    <DocsLink href="https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_access-management.html">
-                      AWS documentation
-                    </DocsLink>
-                    .
-                  </Typography.Paragraph>
-                )}
-              </>
-            )}
-            <Form data-testid="authenticate-aws-form">
-              <Flex vertical gap="large">
-                {!isSubmitting && !scannerError && (
-                  <Flex vertical gap="small" className="w-full max-w-xl">
-                    <Typography.Paragraph>
-                      To use the scanner to inventory systems in AWS, you must
-                      first authenticate to your AWS cloud by providing the
-                      following information:
-                    </Typography.Paragraph>
-                    <CustomTextInput
-                      name="aws_access_key_id"
-                      label="Access Key ID"
-                      tooltip="The Access Key ID created by the cloud hosting provider."
-                      isRequired
-                    />
-                    <CustomTextInput
-                      type="password"
-                      name="aws_secret_access_key"
-                      label="Secret"
-                      tooltip="The secret associated with the Access Key ID used for authentication."
-                      isRequired
-                    />
-                    <CustomTextInput
-                      type="password"
-                      name="aws_session_token"
-                      label="Session Token"
-                      tooltip="The session token when using temporary credentials."
-                    />
-                    <ControlledSelect
-                      name="region_name"
-                      label="AWS Region"
-                      tooltip="The geographic region of the cloud hosting provider you would like to scan."
-                      options={AWS_REGION_OPTIONS}
-                      isRequired
-                      placeholder="Select a region"
-                    />
-                  </Flex>
-                )}
-                {!isSubmitting && (
-                  <Flex gap="small">
-                    <Button onClick={handleCancel}>Cancel</Button>
-                    {!scannerError && (
-                      <Button
-                        htmlType="submit"
-                        type="primary"
-                        disabled={!dirty || !isValid}
-                        loading={isLoading}
-                        data-testid="submit-btn"
-                      >
-                        Save and continue
-                      </Button>
-                    )}
-                  </Flex>
-                )}
+      {isSubmitting && (
+        <ScannerLoading
+          title="System scanning in progress"
+          onClose={handleCancel}
+        />
+      )}
+
+      {scannerError && (
+        <>
+          <ErrorPage
+            error={scannerError}
+            defaultMessage={
+              scannerError.status === 403
+                ? "Fides was unable to scan AWS. It appears that the credentials were valid to login but they did not have adequate permission to complete the scan."
+                : "Fides was unable to scan your infrastructure. Please ensure your credentials are accurate and inspect the error log below for more details."
+            }
+            fullScreen={false}
+            showReload={false}
+          />
+          {scannerError.status === 403 && (
+            <Typography.Paragraph type="secondary" data-testid="permission-msg">
+              To fix this issue, double check that you have granted the required
+              permissions to these credentials as part of your IAM policy. If
+              you need more help in configuring IAM policies, you can read about
+              them in the{" "}
+              <DocsLink href="https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_access-management.html">
+                AWS documentation
+              </DocsLink>
+              .
+            </Typography.Paragraph>
+          )}
+        </>
+      )}
+
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={onFinish}
+        initialValues={initialValues}
+        data-testid="authenticate-aws-form"
+      >
+        <Flex vertical gap="large">
+          {!isSubmitting && !scannerError && (
+            <Card>
+              <Flex vertical gap="small" className="w-full max-w-xl">
+                <Typography.Paragraph>
+                  To use the scanner to inventory systems in AWS, you must first
+                  authenticate to your AWS cloud by providing the following
+                  information:
+                </Typography.Paragraph>
+                <Form.Item
+                  name="aws_access_key_id"
+                  label="Access Key ID"
+                  tooltip="The Access Key ID created by the cloud hosting provider."
+                  rules={[
+                    { required: true, message: "Access Key ID is required" },
+                    {
+                      pattern: /^\w+$/,
+                      message: "Cannot contain spaces or special characters",
+                    },
+                  ]}
+                >
+                  <Input data-testid="input-aws_access_key_id" />
+                </Form.Item>
+                <Form.Item
+                  name="aws_secret_access_key"
+                  label="Secret"
+                  tooltip="The secret associated with the Access Key ID used for authentication."
+                  rules={[
+                    { required: true, message: "Secret is required" },
+                    {
+                      pattern: /^[^\s]+$/,
+                      message: "Cannot contain spaces",
+                    },
+                  ]}
+                >
+                  <Input.Password data-testid="input-aws_secret_access_key" />
+                </Form.Item>
+                <Form.Item
+                  name="aws_session_token"
+                  label="Session Token"
+                  tooltip="The session token when using temporary credentials."
+                  rules={[
+                    {
+                      pattern: /^[^\s]+$/,
+                      message: "Cannot contain spaces",
+                    },
+                  ]}
+                >
+                  <Input.Password data-testid="input-aws_session_token" />
+                </Form.Item>
+                <Form.Item
+                  name="region_name"
+                  label="AWS Region"
+                  tooltip="The geographic region of the cloud hosting provider you would like to scan."
+                  rules={[
+                    { required: true, message: "Default Region is required" },
+                  ]}
+                >
+                  <Select
+                    aria-label="AWS Region"
+                    options={AWS_REGION_OPTIONS}
+                    placeholder="Select a region"
+                    data-testid="controlled-select-region_name"
+                  />
+                </Form.Item>
               </Flex>
-            </Form>
-          </>
-        )}
-      </Formik>
+            </Card>
+          )}
+          {!isSubmitting && (
+            <Flex gap="small" justify="end">
+              <Button onClick={handleCancel}>Cancel</Button>
+              {!scannerError && (
+                <Button
+                  htmlType="submit"
+                  type="primary"
+                  disabled={!isDirty || !submittable}
+                  loading={isLoading}
+                  data-testid="submit-btn"
+                >
+                  Save and continue
+                </Button>
+              )}
+            </Flex>
+          )}
+        </Flex>
+      </Form>
     </Flex>
   );
 };

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateAwsForm.tsx
@@ -12,18 +12,14 @@ import { useEffect, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import DocsLink from "~/features/common/DocsLink";
-import {
-  isErrorResult,
-  ParsedError,
-  parseError,
-} from "~/features/common/helpers";
+import { ParsedError, parseError } from "~/features/common/helpers";
 import {
   GenerateResponse,
   GenerateTypes,
   System,
   ValidTargets,
 } from "~/types/api";
-import { RTKErrorResult } from "~/types/errors";
+import { RTKErrorResult } from "~/types/errors/api";
 
 import ErrorPage from "../common/errors/ErrorPage";
 import { NextBreadcrumb } from "../common/nav/NextBreadcrumb";
@@ -57,17 +53,12 @@ export const AuthenticateAwsForm = () => {
   // Track submittable state
   const allValues = Form.useWatch([], form);
   const [submittable, setSubmittable] = useState(false);
-  const [isDirty, setIsDirty] = useState(false);
 
   useEffect(() => {
     form
       .validateFields({ validateOnly: true })
       .then(() => setSubmittable(true))
       .catch(() => setSubmittable(false));
-  }, [form, allValues]);
-
-  useEffect(() => {
-    setIsDirty(form.isFieldsTouched());
   }, [form, allValues]);
 
   const handleResults = (results: GenerateResponse["generate_results"]) => {
@@ -78,13 +69,6 @@ export const AuthenticateAwsForm = () => {
       `Your scan was successfully completed, with ${systems.length} new systems detected!`,
     );
   };
-  const handleError = (error: RTKErrorResult["error"]) => {
-    const parsedError = parseError(error, {
-      status: 500,
-      message: "Our system encountered a problem while connecting to AWS.",
-    });
-    setScannerError(parsedError);
-  };
   const handleCancel = () => {
     dispatch(changeStep(2));
   };
@@ -94,23 +78,25 @@ export const AuthenticateAwsForm = () => {
   const onFinish = async (values: FormValues) => {
     setScannerError(undefined);
 
-    const result = await generate({
-      organization_key: organizationKey,
-      generate: {
-        config: values,
-        target: ValidTargets.AWS,
-        type: GenerateTypes.SYSTEMS,
-      },
-    });
+    try {
+      const result = await generate({
+        organization_key: organizationKey,
+        generate: {
+          config: values,
+          target: ValidTargets.AWS,
+          type: GenerateTypes.SYSTEMS,
+        },
+      }).unwrap();
 
-    if (isErrorResult(result)) {
-      handleError(result.error);
-    } else {
-      handleResults(result.data.generate_results);
+      handleResults(result.generate_results);
+    } catch (error) {
+      const parsedError = parseError(error as RTKErrorResult["error"], {
+        status: 500,
+        message: "Our system encountered a problem while connecting to AWS.",
+      });
+      setScannerError(parsedError);
     }
   };
-
-  const isSubmitting = isLoading;
 
   return (
     <Flex vertical gap="large">
@@ -128,7 +114,7 @@ export const AuthenticateAwsForm = () => {
         ]}
       />
 
-      {isSubmitting && (
+      {isLoading && (
         <ScannerLoading
           title="System scanning in progress"
           onClose={handleCancel}
@@ -170,7 +156,7 @@ export const AuthenticateAwsForm = () => {
         data-testid="authenticate-aws-form"
       >
         <Flex vertical gap="large">
-          {!isSubmitting && !scannerError && (
+          {!isLoading && !scannerError && (
             <Card>
               <Flex vertical gap="small" className="w-full max-w-xl">
                 <Typography.Paragraph>
@@ -237,14 +223,14 @@ export const AuthenticateAwsForm = () => {
               </Flex>
             </Card>
           )}
-          {!isSubmitting && (
+          {!isLoading && (
             <Flex gap="small" justify="end">
               <Button onClick={handleCancel}>Cancel</Button>
               {!scannerError && (
                 <Button
                   htmlType="submit"
                   type="primary"
-                  disabled={!isDirty || !submittable}
+                  disabled={!form.isFieldsTouched() || !submittable}
                   loading={isLoading}
                   data-testid="submit-btn"
                 >
@@ -258,5 +244,3 @@ export const AuthenticateAwsForm = () => {
     </Flex>
   );
 };
-
-export default AuthenticateAwsForm;

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
@@ -10,11 +10,7 @@ import {
 import { useEffect, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
-import {
-  isErrorResult,
-  ParsedError,
-  parseError,
-} from "~/features/common/helpers";
+import { ParsedError, parseError } from "~/features/common/helpers";
 import { OKTA_AUTH_DESCRIPTION } from "~/features/integrations/integration-type-info/oktaInfo";
 import {
   GenerateResponse,
@@ -23,7 +19,7 @@ import {
   System,
   ValidTargets,
 } from "~/types/api";
-import { RTKErrorResult } from "~/types/errors";
+import { RTKErrorResult } from "~/types/errors/api";
 
 import ErrorPage from "../common/errors/ErrorPage";
 import { NextBreadcrumb } from "../common/nav/NextBreadcrumb";
@@ -35,14 +31,6 @@ import {
 import { isSystem } from "./helpers";
 import { useGenerateMutation } from "./scanner.slice";
 import ScannerLoading from "./ScannerLoading";
-
-// OAuth2 config type for Okta authentication
-type OktaOAuth2Config = {
-  orgUrl: string;
-  clientId: string;
-  privateKey: string;
-  scopes: string[];
-};
 
 const initialValues = {
   orgUrl: "",
@@ -64,17 +52,12 @@ export const AuthenticateOktaForm = () => {
   // Track submittable state
   const allValues = Form.useWatch([], form);
   const [submittable, setSubmittable] = useState(false);
-  const [isDirty, setIsDirty] = useState(false);
 
   useEffect(() => {
     form
       .validateFields({ validateOnly: true })
       .then(() => setSubmittable(true))
       .catch(() => setSubmittable(false));
-  }, [form, allValues]);
-
-  useEffect(() => {
-    setIsDirty(form.isFieldsTouched());
   }, [form, allValues]);
 
   const handleResults = (results: GenerateResponse["generate_results"]) => {
@@ -85,13 +68,6 @@ export const AuthenticateOktaForm = () => {
       `Your scan was successfully completed, with ${systems.length} new systems detected!`,
     );
   };
-  const handleError = (error: RTKErrorResult["error"]) => {
-    const parsedError = parseError(error, {
-      status: 500,
-      message: "Our system encountered a problem while connecting to Okta.",
-    });
-    setScannerError(parsedError);
-  };
   const handleCancel = () => {
     dispatch(changeStep(2));
   };
@@ -101,30 +77,32 @@ export const AuthenticateOktaForm = () => {
   const onFinish = async (values: FormValues) => {
     setScannerError(undefined);
 
-    const config: OktaOAuth2Config = {
+    const config: Omit<OktaConfig, "scopes"> & { scopes: string[] } = {
       ...values,
       scopes: values.scopes
         ? values.scopes.split(",").map((s) => s.trim())
         : ["okta.apps.read"],
     };
 
-    const result = await generate({
-      organization_key: organizationKey,
-      generate: {
-        config: config as unknown as OktaConfig,
-        target: ValidTargets.OKTA,
-        type: GenerateTypes.SYSTEMS,
-      },
-    });
+    try {
+      const result = await generate({
+        organization_key: organizationKey,
+        generate: {
+          config: config as OktaConfig,
+          target: ValidTargets.OKTA,
+          type: GenerateTypes.SYSTEMS,
+        },
+      }).unwrap();
 
-    if (isErrorResult(result)) {
-      handleError(result.error);
-    } else {
-      handleResults(result.data.generate_results);
+      handleResults(result.generate_results);
+    } catch (error) {
+      const parsedError = parseError(error as RTKErrorResult["error"], {
+        status: 500,
+        message: "Our system encountered a problem while connecting to Okta.",
+      });
+      setScannerError(parsedError);
     }
   };
-
-  const isSubmitting = isLoading;
 
   return (
     <Flex vertical gap="large">
@@ -142,7 +120,7 @@ export const AuthenticateOktaForm = () => {
         ]}
       />
 
-      {isSubmitting && (
+      {isLoading && (
         <ScannerLoading
           title="System scanning in progress"
           onClose={handleCancel}
@@ -166,7 +144,7 @@ export const AuthenticateOktaForm = () => {
         data-testid="authenticate-okta-form"
       >
         <Flex vertical gap="large">
-          {!isSubmitting && !scannerError && (
+          {!isLoading && !scannerError && (
             <Card>
               <Flex vertical gap="small" className="w-full max-w-xl">
                 <Typography.Paragraph>
@@ -233,7 +211,7 @@ export const AuthenticateOktaForm = () => {
                 >
                   <Input.TextArea
                     rows={8}
-                    style={{ fontFamily: "monospace", fontSize: "12px" }}
+                    className="font-mono text-xs"
                     placeholder='{"kty":"RSA","kid":"...","n":"...","e":"AQAB","d":"..."}'
                     data-testid="input-privateKey"
                   />
@@ -277,14 +255,14 @@ export const AuthenticateOktaForm = () => {
               </Flex>
             </Card>
           )}
-          {!isSubmitting && (
+          {!isLoading && (
             <Flex gap="small" justify="end">
               <Button onClick={handleCancel}>Cancel</Button>
               {!scannerError && (
                 <Button
                   htmlType="submit"
                   type="primary"
-                  disabled={!isDirty || !submittable}
+                  disabled={!form.isFieldsTouched() || !submittable}
                   loading={isLoading}
                   data-testid="submit-btn"
                 >
@@ -298,5 +276,3 @@ export const AuthenticateOktaForm = () => {
     </Flex>
   );
 };
-
-export default AuthenticateOktaForm;

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
@@ -54,10 +54,15 @@ export const AuthenticateOktaForm = () => {
   const [submittable, setSubmittable] = useState(false);
 
   useEffect(() => {
-    form
-      .validateFields({ validateOnly: true })
-      .then(() => setSubmittable(true))
-      .catch(() => setSubmittable(false));
+    const checkValidity = async () => {
+      try {
+        await form.validateFields({ validateOnly: true });
+        setSubmittable(true);
+      } catch {
+        setSubmittable(false);
+      }
+    };
+    checkValidity();
   }, [form, allValues]);
 
   const handleResults = (results: GenerateResponse["generate_results"]) => {
@@ -77,7 +82,7 @@ export const AuthenticateOktaForm = () => {
   const onFinish = async (values: FormValues) => {
     setScannerError(undefined);
 
-    const config: Omit<OktaConfig, "scopes"> & { scopes: string[] } = {
+    const config: OktaConfig = {
       ...values,
       scopes: values.scopes
         ? values.scopes.split(",").map((s) => s.trim())
@@ -88,7 +93,7 @@ export const AuthenticateOktaForm = () => {
       const result = await generate({
         organization_key: organizationKey,
         generate: {
-          config: config as OktaConfig,
+          config,
           target: ValidTargets.OKTA,
           type: GenerateTypes.SYSTEMS,
         },

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateOktaForm.tsx
@@ -1,10 +1,15 @@
-import { Button, Flex, Typography, useMessage } from "fidesui";
-import { Form, Formik } from "formik";
-import { useState } from "react";
-import * as Yup from "yup";
+import {
+  Button,
+  Card,
+  Flex,
+  Form,
+  Input,
+  Typography,
+  useMessage,
+} from "fidesui";
+import { useEffect, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
-import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
 import {
   isErrorResult,
   ParsedError,
@@ -48,57 +53,29 @@ const initialValues = {
 
 type FormValues = typeof initialValues;
 
-const ValidationSchema = Yup.object().shape({
-  orgUrl: Yup.string().required().trim().url().label("Organization URL"),
-  clientId: Yup.string()
-    .required()
-    .trim()
-    .matches(/^[^\s]+$/, "Cannot contain spaces")
-    .label("Client ID"),
-  privateKey: Yup.string()
-    .required()
-    .trim()
-    .test(
-      "is-valid-json",
-      "Private key must be valid JSON. Paste the JWK downloaded from Okta.",
-      (value) => {
-        if (!value) {
-          return true;
-        }
-        try {
-          JSON.parse(value);
-          return true;
-        } catch {
-          return false;
-        }
-      },
-    )
-    .label("Private Key"),
-  scopes: Yup.string()
-    .required()
-    .trim()
-    .label("Scopes")
-    .default("okta.apps.read")
-    .test(
-      "valid-scopes",
-      "Scopes must be a single scope or comma-separated list (e.g., 'okta.apps.read' or 'okta.apps.read, okta.users.read')",
-      (value) => {
-        if (!value) {
-          return true;
-        }
-        // Split on comma and check each scope is non-empty and has no internal whitespace
-        const scopes = value.split(",").map((s) => s.trim());
-        return scopes.every((scope) => scope.length > 0 && !/\s/.test(scope));
-      },
-    ),
-});
-
-const AuthenticateOktaForm = () => {
+export const AuthenticateOktaForm = () => {
   const organizationKey = useAppSelector(selectOrganizationFidesKey);
   const dispatch = useAppDispatch();
   const message = useMessage();
+  const [form] = Form.useForm<FormValues>();
 
   const [scannerError, setScannerError] = useState<ParsedError>();
+
+  // Track submittable state
+  const allValues = Form.useWatch([], form);
+  const [submittable, setSubmittable] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useEffect(() => {
+    form
+      .validateFields({ validateOnly: true })
+      .then(() => setSubmittable(true))
+      .catch(() => setSubmittable(false));
+  }, [form, allValues]);
+
+  useEffect(() => {
+    setIsDirty(form.isFieldsTouched());
+  }, [form, allValues]);
 
   const handleResults = (results: GenerateResponse["generate_results"]) => {
     const systems: System[] = (results ?? []).filter(isSystem);
@@ -121,7 +98,7 @@ const AuthenticateOktaForm = () => {
 
   const [generate, { isLoading }] = useGenerateMutation();
 
-  const handleSubmit = async (values: FormValues) => {
+  const onFinish = async (values: FormValues) => {
     setScannerError(undefined);
 
     const config: OktaOAuth2Config = {
@@ -147,6 +124,8 @@ const AuthenticateOktaForm = () => {
     }
   };
 
+  const isSubmitting = isLoading;
+
   return (
     <Flex vertical gap="large">
       <NextBreadcrumb
@@ -162,90 +141,160 @@ const AuthenticateOktaForm = () => {
           { title: "Authenticate Okta scanner" },
         ]}
       />
-      <Formik
-        initialValues={initialValues}
-        validationSchema={ValidationSchema}
-        onSubmit={handleSubmit}
-      >
-        {({ isValid, isSubmitting, dirty }) => (
-          <>
-            {isSubmitting && (
-              <ScannerLoading
-                title="System scanning in progress"
-                onClose={handleCancel}
-              />
-            )}
 
-            {scannerError && (
-              <ErrorPage
-                error={scannerError}
-                defaultMessage="Fides was unable to scan your infrastructure. Please ensure your credentials are accurate and inspect the error log below for more details."
-                fullScreen={false}
-                showReload={false}
-              />
-            )}
-            <Form data-testid="authenticate-okta-form">
-              <Flex vertical gap="large">
-                {!isSubmitting && !scannerError && (
-                  <Flex vertical gap="small" className="w-full max-w-xl">
-                    <Typography.Paragraph>
-                      {OKTA_AUTH_DESCRIPTION}
-                    </Typography.Paragraph>
-                    <CustomTextInput
-                      name="orgUrl"
-                      label="Organization URL"
-                      tooltip="The URL for your organization's Okta account (e.g. https://your-org.okta.com)"
-                      placeholder="https://your-org.okta.com"
-                      isRequired
-                    />
-                    <CustomTextInput
-                      name="clientId"
-                      label="Client ID"
-                      tooltip="The OAuth2 client ID from your Okta API Services application"
-                      placeholder="0oa1abc2def3ghi4jkl5"
-                      isRequired
-                    />
-                    <CustomTextArea
-                      name="privateKey"
-                      label="Private key"
-                      tooltip="RSA private key in JWK format for OAuth2 authentication"
-                      placeholder='{"kty":"RSA","kid":"...","n":"...","e":"AQAB","d":"..."}'
-                      isRequired
-                      textAreaProps={{
-                        rows: 8,
-                        style: { fontFamily: "monospace", fontSize: "12px" },
-                      }}
-                    />
-                    <CustomTextInput
-                      name="scopes"
-                      label="Scopes"
-                      tooltip="OAuth2 scopes to request. Default is okta.apps.read for application discovery"
-                      placeholder="okta.apps.read"
-                      isRequired
-                    />
-                  </Flex>
-                )}
-                {!isSubmitting && (
-                  <Flex gap="small">
-                    <Button onClick={handleCancel}>Cancel</Button>
-                    {!scannerError && (
-                      <Button
-                        htmlType="submit"
-                        type="primary"
-                        disabled={!dirty || !isValid}
-                        loading={isLoading}
-                        data-testid="submit-btn"
-                      >
-                        Save and continue
-                      </Button>
-                    )}
-                  </Flex>
-                )}
+      {isSubmitting && (
+        <ScannerLoading
+          title="System scanning in progress"
+          onClose={handleCancel}
+        />
+      )}
+
+      {scannerError && (
+        <ErrorPage
+          error={scannerError}
+          defaultMessage="Fides was unable to scan your infrastructure. Please ensure your credentials are accurate and inspect the error log below for more details."
+          fullScreen={false}
+          showReload={false}
+        />
+      )}
+
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={onFinish}
+        initialValues={initialValues}
+        data-testid="authenticate-okta-form"
+      >
+        <Flex vertical gap="large">
+          {!isSubmitting && !scannerError && (
+            <Card>
+              <Flex vertical gap="small" className="w-full max-w-xl">
+                <Typography.Paragraph>
+                  {OKTA_AUTH_DESCRIPTION}
+                </Typography.Paragraph>
+                <Form.Item
+                  name="orgUrl"
+                  label="Organization URL"
+                  tooltip="The URL for your organization's Okta account (e.g. https://your-org.okta.com)"
+                  rules={[
+                    {
+                      required: true,
+                      message: "Organization URL is required",
+                    },
+                    { type: "url", message: "Must be a valid URL" },
+                  ]}
+                >
+                  <Input
+                    placeholder="https://your-org.okta.com"
+                    data-testid="input-orgUrl"
+                  />
+                </Form.Item>
+                <Form.Item
+                  name="clientId"
+                  label="Client ID"
+                  tooltip="The OAuth2 client ID from your Okta API Services application"
+                  rules={[
+                    { required: true, message: "Client ID is required" },
+                    {
+                      pattern: /^[^\s]+$/,
+                      message: "Cannot contain spaces",
+                    },
+                  ]}
+                >
+                  <Input
+                    placeholder="0oa1abc2def3ghi4jkl5"
+                    data-testid="input-clientId"
+                  />
+                </Form.Item>
+                <Form.Item
+                  name="privateKey"
+                  label="Private key"
+                  tooltip="RSA private key in JWK format for OAuth2 authentication"
+                  rules={[
+                    { required: true, message: "Private key is required" },
+                    {
+                      validator: (_, value) => {
+                        if (!value) {
+                          return Promise.resolve();
+                        }
+                        try {
+                          JSON.parse(value);
+                          return Promise.resolve();
+                        } catch {
+                          return Promise.reject(
+                            new Error(
+                              "Private key must be valid JSON. Paste the JWK downloaded from Okta.",
+                            ),
+                          );
+                        }
+                      },
+                    },
+                  ]}
+                >
+                  <Input.TextArea
+                    rows={8}
+                    style={{ fontFamily: "monospace", fontSize: "12px" }}
+                    placeholder='{"kty":"RSA","kid":"...","n":"...","e":"AQAB","d":"..."}'
+                    data-testid="input-privateKey"
+                  />
+                </Form.Item>
+                <Form.Item
+                  name="scopes"
+                  label="Scopes"
+                  tooltip="OAuth2 scopes to request. Default is okta.apps.read for application discovery"
+                  rules={[
+                    { required: true, message: "Scopes is required" },
+                    {
+                      validator: (_, value) => {
+                        if (!value) {
+                          return Promise.resolve();
+                        }
+                        const scopes = value
+                          .split(",")
+                          .map((s: string) => s.trim());
+                        if (
+                          scopes.every(
+                            (scope: string) =>
+                              scope.length > 0 && !/\s/.test(scope),
+                          )
+                        ) {
+                          return Promise.resolve();
+                        }
+                        return Promise.reject(
+                          new Error(
+                            "Scopes must be a single scope or comma-separated list (e.g., 'okta.apps.read' or 'okta.apps.read, okta.users.read')",
+                          ),
+                        );
+                      },
+                    },
+                  ]}
+                >
+                  <Input
+                    placeholder="okta.apps.read"
+                    data-testid="input-scopes"
+                  />
+                </Form.Item>
               </Flex>
-            </Form>
-          </>
-        )}
-      </Formik>
+            </Card>
+          )}
+          {!isSubmitting && (
+            <Flex gap="small" justify="end">
+              <Button onClick={handleCancel}>Cancel</Button>
+              {!scannerError && (
+                <Button
+                  htmlType="submit"
+                  type="primary"
+                  disabled={!isDirty || !submittable}
+                  loading={isLoading}
+                  data-testid="submit-btn"
+                >
+                  Save and continue
+                </Button>
+              )}
+            </Flex>
+          )}
+        </Flex>
+      </Form>
     </Flex>
   );
 };

--- a/clients/admin-ui/src/features/config-wizard/AuthenticateScanner.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AuthenticateScanner.tsx
@@ -1,8 +1,8 @@
 import { useAppSelector } from "~/app/hooks";
 import { ValidTargets } from "~/types/api";
 
-import AuthenticateAwsForm from "./AuthenticateAwsForm";
-import AuthenticateOktaForm from "./AuthenticateOktaForm";
+import { AuthenticateAwsForm } from "./AuthenticateAwsForm";
+import { AuthenticateOktaForm } from "./AuthenticateOktaForm";
 import { selectAddSystemsMethod } from "./config-wizard.slice";
 
 const AuthenticateScanner = () => {

--- a/clients/admin-ui/src/features/config-wizard/ConfigWizardWalkthrough.tsx
+++ b/clients/admin-ui/src/features/config-wizard/ConfigWizardWalkthrough.tsx
@@ -1,4 +1,4 @@
-import { ChakraBox as Box, ChakraStack as Stack } from "fidesui";
+import { Flex } from "fidesui";
 
 import { useAppSelector } from "~/app/hooks";
 
@@ -12,18 +12,18 @@ const ConfigWizardWalkthrough = () => {
   const step = useAppSelector(selectStep);
 
   return (
-    <Stack direction={["column", "row"]} bg="white">
-      <Box display="flex" justifyContent="flex-start" w="100%">
+    <Flex className="bg-white">
+      <div className="flex w-full justify-start">
         {step === 1 ? <OrganizationInfoForm /> : null}
         {step === 2 ? <AddSystem /> : null}
         {step === 3 ? <AuthenticateScanner /> : null}
         {step === 4 ? (
-          <Box pr={10}>
+          <div className="pr-10">
             <ScanResults />
-          </Box>
+          </div>
         ) : null}
-      </Box>
-    </Stack>
+      </div>
+    </Flex>
   );
 };
 

--- a/clients/admin-ui/src/features/config-wizard/ConfigWizardWalkthrough.tsx
+++ b/clients/admin-ui/src/features/config-wizard/ConfigWizardWalkthrough.tsx
@@ -5,7 +5,7 @@ import { useAppSelector } from "~/app/hooks";
 import AddSystem from "./AddSystem";
 import AuthenticateScanner from "./AuthenticateScanner";
 import { selectStep } from "./config-wizard.slice";
-import OrganizationInfoForm from "./OrganizationInfoForm";
+import { OrganizationInfoForm } from "./OrganizationInfoForm";
 import ScanResults from "./ScanResults";
 
 const ConfigWizardWalkthrough = () => {

--- a/clients/admin-ui/src/features/config-wizard/OrganizationInfoForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/OrganizationInfoForm.tsx
@@ -43,10 +43,15 @@ export const OrganizationInfoForm = () => {
   const [submittable, setSubmittable] = useState(false);
 
   useEffect(() => {
-    form
-      .validateFields({ validateOnly: true })
-      .then(() => setSubmittable(true))
-      .catch(() => setSubmittable(false));
+    const checkValidity = async () => {
+      try {
+        await form.validateFields({ validateOnly: true });
+        setSubmittable(true);
+      } catch {
+        setSubmittable(false);
+      }
+    };
+    checkValidity();
   }, [form, allValues]);
 
   // Auto-skip step if org already has name+description

--- a/clients/admin-ui/src/features/config-wizard/OrganizationInfoForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/OrganizationInfoForm.tsx
@@ -7,10 +7,10 @@ import {
   Typography,
   useMessage,
 } from "fidesui";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useAppDispatch } from "~/app/hooks";
-import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
+import { getErrorMessage } from "~/features/common/helpers";
 import {
   DEFAULT_ORGANIZATION_FIDES_KEY,
   useCreateOrganizationMutation,
@@ -18,6 +18,7 @@ import {
   useUpdateOrganizationMutation,
 } from "~/features/organization";
 import { Organization } from "~/types/api";
+import { RTKErrorResult } from "~/types/errors/api";
 
 import { changeStep, setOrganization } from "./config-wizard.slice";
 
@@ -58,15 +59,13 @@ export const OrganizationInfoForm = () => {
     }
   }, [isLoadingOrganization, existingOrg, dispatch, hasSubmitted]);
 
-  // Reinitialize form when existing org loads
-  useEffect(() => {
-    if (existingOrg) {
-      form.setFieldsValue({
-        name: existingOrg.name ?? "",
-        description: existingOrg.description ?? "",
-      });
-    }
-  }, [existingOrg, form]);
+  const formInitialValues = useMemo(
+    () => ({
+      name: existingOrg?.name ?? "",
+      description: existingOrg?.description ?? "",
+    }),
+    [existingOrg],
+  );
 
   const handleSuccess = (organization: Organization) => {
     dispatch(setOrganization(organization));
@@ -82,26 +81,16 @@ export const OrganizationInfoForm = () => {
       organization_fides_key: DEFAULT_ORGANIZATION_FIDES_KEY,
     };
 
-    if (!existingOrg) {
-      const createOrganizationResult =
-        await createOrganization(organizationBody);
-
-      if (isErrorResult(createOrganizationResult)) {
-        const errorMsg = getErrorMessage(createOrganizationResult.error);
-        message.error(errorMsg);
-        return;
+    try {
+      if (!existingOrg) {
+        await createOrganization(organizationBody).unwrap();
+      } else {
+        await updateOrganization(organizationBody).unwrap();
       }
       handleSuccess(organizationBody);
-    } else {
-      const updateOrganizationResult =
-        await updateOrganization(organizationBody);
-
-      if (isErrorResult(updateOrganizationResult)) {
-        const errorMsg = getErrorMessage(updateOrganizationResult.error);
-        message.error(errorMsg);
-        return;
-      }
-      handleSuccess(organizationBody);
+    } catch (error) {
+      const errorMsg = getErrorMessage(error as RTKErrorResult["error"]);
+      message.error(errorMsg);
     }
   };
 
@@ -110,7 +99,8 @@ export const OrganizationInfoForm = () => {
       form={form}
       layout="vertical"
       onFinish={onFinish}
-      initialValues={{ name: "", description: "" }}
+      initialValues={formInitialValues}
+      key={existingOrg?.fides_key ?? "create"}
       className="w-full max-w-xl"
       data-testid="organization-info-form"
     >
@@ -162,5 +152,3 @@ export const OrganizationInfoForm = () => {
     </Form>
   );
 };
-
-export default OrganizationInfoForm;

--- a/clients/admin-ui/src/features/config-wizard/OrganizationInfoForm.tsx
+++ b/clients/admin-ui/src/features/config-wizard/OrganizationInfoForm.tsx
@@ -1,14 +1,12 @@
 import {
   Button,
-  chakra,
-  ChakraFormControl as FormControl,
-  ChakraFormLabel as FormLabel,
-  ChakraHeading as Heading,
-  ChakraInput as Input,
-  ChakraStack as Stack,
+  Card,
+  Flex,
+  Form,
+  Input,
+  Typography,
   useMessage,
 } from "fidesui";
-import { useFormik } from "formik";
 import { useEffect, useState } from "react";
 
 import { useAppDispatch } from "~/app/hooks";
@@ -21,168 +19,148 @@ import {
 } from "~/features/organization";
 import { Organization } from "~/types/api";
 
-import { InfoTooltip } from "../common/InfoTooltip";
 import { changeStep, setOrganization } from "./config-wizard.slice";
 
-const useOrganizationInfoForm = () => {
+interface FormValues {
+  name: string;
+  description: string;
+}
+
+export const OrganizationInfoForm = () => {
   const dispatch = useAppDispatch();
-  const handleSuccess = (organization: Organization) => {
-    dispatch(setOrganization(organization));
-    dispatch(changeStep());
-  };
+  const message = useMessage();
+  const [form] = Form.useForm<FormValues>();
+  const [hasSubmitted, setHasSubmitted] = useState(false);
 
   const [createOrganization] = useCreateOrganizationMutation();
   const [updateOrganization] = useUpdateOrganizationMutation();
   const { data: existingOrg, isLoading: isLoadingOrganization } =
     useGetOrganizationByFidesKeyQuery(DEFAULT_ORGANIZATION_FIDES_KEY);
-  const [hasSubmitted, setHasSubmitted] = useState(false);
+
+  // Track submittable state
+  const allValues = Form.useWatch([], form);
+  const [submittable, setSubmittable] = useState(false);
 
   useEffect(() => {
-    // Only consider a redirect when data has loaded but before a user has submitted anything
+    form
+      .validateFields({ validateOnly: true })
+      .then(() => setSubmittable(true))
+      .catch(() => setSubmittable(false));
+  }, [form, allValues]);
+
+  // Auto-skip step if org already has name+description
+  useEffect(() => {
     if (isLoadingOrganization || hasSubmitted) {
       return;
     }
-    // If the organization name and description already exist, we bypass this step
     if (existingOrg?.name && existingOrg?.description) {
       dispatch(changeStep());
     }
   }, [isLoadingOrganization, existingOrg, dispatch, hasSubmitted]);
 
-  const message = useMessage();
-  const formik = useFormik({
-    initialValues: {
-      name: existingOrg?.name ?? "",
-      description: existingOrg?.description ?? "",
-    },
-    onSubmit: async (values) => {
-      setHasSubmitted(true);
-      const organizationBody = {
-        name: values.name ?? existingOrg?.name,
-        description: values.description ?? existingOrg?.description,
-        fides_key: existingOrg?.fides_key ?? DEFAULT_ORGANIZATION_FIDES_KEY,
-        organization_fides_key: DEFAULT_ORGANIZATION_FIDES_KEY,
-      };
+  // Reinitialize form when existing org loads
+  useEffect(() => {
+    if (existingOrg) {
+      form.setFieldsValue({
+        name: existingOrg.name ?? "",
+        description: existingOrg.description ?? "",
+      });
+    }
+  }, [existingOrg, form]);
 
-      if (!existingOrg) {
-        const createOrganizationResult =
-          await createOrganization(organizationBody);
+  const handleSuccess = (organization: Organization) => {
+    dispatch(setOrganization(organization));
+    dispatch(changeStep());
+  };
 
-        if (isErrorResult(createOrganizationResult)) {
-          const errorMsg = getErrorMessage(createOrganizationResult.error);
+  const onFinish = async (values: FormValues) => {
+    setHasSubmitted(true);
+    const organizationBody = {
+      name: values.name ?? existingOrg?.name,
+      description: values.description ?? existingOrg?.description,
+      fides_key: existingOrg?.fides_key ?? DEFAULT_ORGANIZATION_FIDES_KEY,
+      organization_fides_key: DEFAULT_ORGANIZATION_FIDES_KEY,
+    };
 
-          message.error(errorMsg);
-          return;
-        }
-        handleSuccess(organizationBody);
-      } else {
-        const updateOrganizationResult =
-          await updateOrganization(organizationBody);
+    if (!existingOrg) {
+      const createOrganizationResult =
+        await createOrganization(organizationBody);
 
-        if (isErrorResult(updateOrganizationResult)) {
-          const errorMsg = getErrorMessage(updateOrganizationResult.error);
-
-          message.error(errorMsg);
-          return;
-        }
-        handleSuccess(organizationBody);
+      if (isErrorResult(createOrganizationResult)) {
+        const errorMsg = getErrorMessage(createOrganizationResult.error);
+        message.error(errorMsg);
+        return;
       }
-    },
-    enableReinitialize: true,
-    validate: (values) => {
-      const errors: {
-        name?: string;
-        description?: string;
-      } = {};
+      handleSuccess(organizationBody);
+    } else {
+      const updateOrganizationResult =
+        await updateOrganization(organizationBody);
 
-      if (!values.name) {
-        errors.name = "Organization name is required";
+      if (isErrorResult(updateOrganizationResult)) {
+        const errorMsg = getErrorMessage(updateOrganizationResult.error);
+        message.error(errorMsg);
+        return;
       }
-
-      if (!values.description) {
-        errors.description = "Organization description is required";
-      }
-
-      return errors;
-    },
-  });
-
-  return formik;
-};
-
-const OrganizationInfoForm = () => {
-  const {
-    errors,
-    handleBlur,
-    handleChange,
-    handleSubmit,
-    touched,
-    values,
-    isSubmitting,
-  } = useOrganizationInfoForm();
+      handleSuccess(organizationBody);
+    }
+  };
 
   return (
-    <chakra.form
-      onSubmit={handleSubmit}
-      w="40%"
+    <Form
+      form={form}
+      layout="vertical"
+      onFinish={onFinish}
+      initialValues={{ name: "", description: "" }}
+      className="w-full max-w-xl"
       data-testid="organization-info-form"
     >
-      <Stack spacing={10}>
-        <Heading as="h3" size="lg">
-          Create your Organization
-        </Heading>
-        <div>
-          Provide your organization information. This information is used to
-          configure your organization in Fides for data map reporting purposes.
-        </div>
-        <Stack>
-          <FormControl>
-            <Stack direction="row" mb={5} justifyContent="flex-end">
-              <FormLabel w="100%">Organization name</FormLabel>
-              <Input
-                type="text"
-                id="name"
-                name="name"
-                focusBorderColor="gray.700"
-                onChange={handleChange}
-                onBlur={handleBlur}
-                value={values.name}
-                isInvalid={touched.name && Boolean(errors.name)}
-                minW="65%"
-                w="65%"
-                data-testid="input-name"
-              />
-              <InfoTooltip label="The legal name of your organization" />
-            </Stack>
-            <Stack direction="row" justifyContent="flex-end">
-              <FormLabel w="100%">Description</FormLabel>
-              <Input
-                type="text"
-                id="description"
-                name="description"
-                focusBorderColor="gray.700"
-                onChange={handleChange}
-                onBlur={handleBlur}
-                value={values.description}
-                isInvalid={touched.description && Boolean(errors.description)}
-                minW="65%"
-                w="65%"
-                data-testid="input-description"
-              />
-              <InfoTooltip label='An explanation of the type of organization and primary activity. For example "Acme Inc. is an e-commerce company that sells scarves."' />
-            </Stack>
-          </FormControl>
-        </Stack>
-        <Button
-          type="primary"
-          htmlType="submit"
-          disabled={!values.name || !values.description}
-          loading={isSubmitting}
-          data-testid="submit-btn"
-        >
-          Save and continue
-        </Button>
-      </Stack>
-    </chakra.form>
+      <Flex vertical gap="large">
+        <Typography.Title level={3}>Create your Organization</Typography.Title>
+        <Card>
+          <Flex vertical gap="middle">
+            <div>
+              Provide your organization information. This information is used to
+              configure your organization in Fides for data map reporting
+              purposes.
+            </div>
+            <Form.Item
+              name="name"
+              label="Organization name"
+              tooltip="The legal name of your organization"
+              rules={[
+                { required: true, message: "Organization name is required" },
+              ]}
+            >
+              <Input data-testid="input-name" />
+            </Form.Item>
+            <Form.Item
+              name="description"
+              label="Description"
+              tooltip='An explanation of the type of organization and primary activity. For example "Acme Inc. is an e-commerce company that sells scarves."'
+              rules={[
+                {
+                  required: true,
+                  message: "Organization description is required",
+                },
+              ]}
+            >
+              <Input data-testid="input-description" />
+            </Form.Item>
+          </Flex>
+        </Card>
+        <Flex justify="end">
+          <Button
+            type="primary"
+            htmlType="submit"
+            disabled={!submittable}
+            data-testid="submit-btn"
+          >
+            Save and continue
+          </Button>
+        </Flex>
+      </Flex>
+    </Form>
   );
 };
+
 export default OrganizationInfoForm;


### PR DESCRIPTION
Ticket [ENG-3171]

### Description Of Changes

Migrates all config-wizard form components from Formik/Yup to Ant Design Form as part of the ongoing Chakra-to-Ant Design migration. This replaces `Formik`, `Yup`, `CustomTextInput`, `CustomTextArea`, `ControlledSelect`, and Chakra layout wrappers with their Ant Design equivalents (`Form`, `Form.Item`, `Input`, `Select`, `Card`, `Flex`).

### Code Changes

* **AuthenticateAwsForm.tsx** - Replaced Formik/Yup with Ant Design Form, validation rules via `Form.Item` rules, `.unwrap()` + try/catch error handling
* **AuthenticateOktaForm.tsx** - Same migration, fixed `OktaOAuth2Config` type cast to use `Omit<OktaConfig, "scopes">` instead of `as unknown`, replaced inline style with Tailwind classes
* **AuthenticateScanner.tsx** - Updated imports to use named exports
* **ConfigWizardWalkthrough.tsx** - Migrated `ChakraBox`/`ChakraStack` to `Flex`/`div` with Tailwind classes
* **OrganizationInfoForm.tsx** - Replaced Formik with Ant Design Form, used `key` prop for form reinitialization instead of `useEffect` + `setFieldsValue`

### Steps to Confirm

1. Navigate to the Config Wizard (Add Systems flow)
2. Verify the Organization Info form validates required fields and submits correctly
3. Select AWS scanner and verify the authentication form:
   - All fields validate (required, no spaces, pattern matching)
   - Region dropdown works
   - Form submits with valid credentials
   - Error states display correctly (403, 500)
4. Select Okta scanner and verify the authentication form:
   - URL validation works
   - Private key JSON validation works
   - Scopes comma-separated validation works
5. Verify all `data-testid` attributes are preserved for E2E tests

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3171]: https://ethyca.atlassian.net/browse/ENG-3171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ