### PR TITLE
Fix duplicated authentication description on Okta integration page

### DIFF
--- a/changelog/7899-fix-okta-duplicate-auth-description.yaml
+++ b/changelog/7899-fix-okta-duplicate-auth-description.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed duplicated authentication description on Okta integration page
+pr: 7899
+labels: []

--- a/clients/admin-ui/src/features/integrations/integration-type-info/oktaInfo.tsx
+++ b/clients/admin-ui/src/features/integrations/integration-type-info/oktaInfo.tsx
@@ -31,12 +31,6 @@ const OktaIntegrationOverview = () => (
     <InfoText>
       <strong>Authentication:</strong> {OKTA_AUTH_DESCRIPTION}
     </InfoText>
-    <InfoText>
-      <strong>Authentication:</strong> Okta integration uses OAuth2 Client
-      Credentials with private_key_jwt for secure authentication. You&apos;ll
-      need to create an API Services application in Okta and generate an RSA key
-      pair.
-    </InfoText>
   </>
 );
 


### PR DESCRIPTION
## Summary
- Removes a duplicated "Authentication:" paragraph on the Okta integration detail page
- The `OktaIntegrationOverview` component had two `<InfoText>` blocks with nearly identical auth descriptions — one using the `OKTA_AUTH_DESCRIPTION` constant and a second with hardcoded text

## Test plan
- [ ] Navigate to Integrations → Okta and verify only one "Authentication:" paragraph appears under Overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)