### PR TITLE
ENG-3398: Fix column reorder drop target in Datamap report modal

### DIFF
--- a/changelog/7905-datamap-column-reorder-drop-target.yaml
+++ b/changelog/7905-datamap-column-reorder-drop-target.yaml
@@ -1,4 +1,4 @@
 type: Fixed
-description: Fixed column reorder in the Datamap report's "Edit columns" modal so dragging registers anywhere on a row instead of only on the drag handle icon.
+description: Fixed column reorder in the Datamap report's "Edit columns" modal so dropping registers anywhere on a row instead of only on the drag handle icon.
 pr: 7905
 labels: []

--- a/changelog/7905-datamap-column-reorder-drop-target.yaml
+++ b/changelog/7905-datamap-column-reorder-drop-target.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed column reorder in the Datamap report's "Edit columns" modal so dragging registers anywhere on a row instead of only on the drag handle icon.
+pr: 7905
+labels: []

--- a/clients/admin-ui/src/features/common/table/column-settings/DraggableColumnListItem.tsx
+++ b/clients/admin-ui/src/features/common/table/column-settings/DraggableColumnListItem.tsx
@@ -29,7 +29,11 @@ const useDraggableColumnListItem = ({
   DraggableColumnListItemProps,
   "id" | "index" | "moveColumn" | "setColumnVisible"
 >) => {
-  const ref = useRef<HTMLDivElement>(null);
+  // rowRef is the drop target (the full row, so hover triggers anywhere on it).
+  // dragRef is the drag source (the drag handle icon only).
+  const rowRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<HTMLDivElement>(null);
+
   const [{ handlerId }, drop] = useDrop<
     DragItem,
     void,
@@ -42,7 +46,7 @@ const useDraggableColumnListItem = ({
       };
     },
     hover(item: DragItem, monitor) {
-      if (!ref.current) {
+      if (!rowRef.current) {
         return;
       }
       const dragIndex = item.index;
@@ -52,7 +56,7 @@ const useDraggableColumnListItem = ({
         return;
       }
 
-      const hoverBoundingRect = ref.current?.getBoundingClientRect();
+      const hoverBoundingRect = rowRef.current?.getBoundingClientRect();
       const hoverMiddleY =
         (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
       const clientOffset = monitor.getClientOffset();
@@ -80,13 +84,21 @@ const useDraggableColumnListItem = ({
     }),
   });
 
-  drag(drop(ref));
+  drop(rowRef);
+  drag(dragRef);
+  preview(rowRef);
 
   const handleColumnVisibleToggle = (checked: boolean) => {
     setColumnVisible(index, checked);
   };
 
-  return { isDragging, ref, handlerId, preview, handleColumnVisibleToggle };
+  return {
+    isDragging,
+    rowRef,
+    dragRef,
+    handlerId,
+    handleColumnVisibleToggle,
+  };
 };
 
 export const DraggableColumnListItem = ({
@@ -97,7 +109,7 @@ export const DraggableColumnListItem = ({
   setColumnVisible,
   text,
 }: DraggableColumnListItemProps) => {
-  const { ref, isDragging, handlerId, preview, handleColumnVisibleToggle } =
+  const { rowRef, dragRef, isDragging, handlerId, handleColumnVisibleToggle } =
     useDraggableColumnListItem({
       index,
       id,
@@ -108,9 +120,7 @@ export const DraggableColumnListItem = ({
   return (
     <Flex
       align="center"
-      ref={(element) => {
-        preview(element);
-      }}
+      ref={rowRef}
       data-handler-id={handlerId}
       style={{ opacity: isDragging ? 0.2 : 1 }}
       data-testid={`column-list-item-${id}`}
@@ -118,7 +128,7 @@ export const DraggableColumnListItem = ({
       className="py-1" // use padding instead of parent flex gap to better support dragging
     >
       <div
-        ref={ref}
+        ref={dragRef}
         style={{ cursor: isDragging ? "grabbing" : "grab" }}
         className="-ml-1 shrink-0"
         data-testid={`column-dragger-${id}`}


### PR DESCRIPTION
Ticket [ENG-3398]

### Description Of Changes

In the Datamap report's "Edit columns" modal, dragging a column to a new position appeared to revert before succeeding when the drop released slightly off the drag-handle icon. Root cause: `drag(drop(ref))` in `DraggableColumnListItem` applied both the drag source and drop target to the same `ref` on the 20px drag-handle `<div>`. Hover and drop only fired inside the handle's bounding box, so any release a few pixels to the side fell outside the drop target and the HTML5 backend cancelled the drop, snapping the native drag ghost back to its origin.

Fix: split the single ref into two:

- `rowRef` — drop target + drag preview on the full row `<Flex>` (hover fires anywhere on the row)
- `dragRef` — drag source on the handle icon (preserves the grab-handle UX)

With the drop target now covering the whole row, drops register at the cursor wherever the user releases, the native ghost lands cleanly, and the reorder completes without the visual revert.

### Code Changes

* `clients/admin-ui/src/features/common/table/column-settings/DraggableColumnListItem.tsx`: split `ref` into `rowRef` (drop target + `preview`) and `dragRef` (drag source); update hover handler to measure against `rowRef`.

### Steps to Confirm

1. Navigate to the Datamap report page.
2. Open the more menu → "Edit columns".
3. Drag a column up or down and release anywhere along the row (not just on the drag-handle icon).
4. Confirm the column lands in the new position without any visual revert/snap-back.
5. Click Save and confirm the new order is applied to the table headers.
6. Reload and confirm the order persists.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3398]: https://ethyca.atlassian.net/browse/ENG-3398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ