### PR TITLE
ENG-3413: Fix property form 422 on create — paths field dropped after antd migration

### DIFF
--- a/changelog/7908-fix-property-form-paths-submission.yaml
+++ b/changelog/7908-fix-property-form-paths-submission.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed property creation 422 error caused by missing paths field in form submission payload
+pr: 7908
+labels: []

--- a/clients/admin-ui/cypress/e2e/properties.cy.ts
+++ b/clients/admin-ui/cypress/e2e/properties.cy.ts
@@ -6,7 +6,7 @@ import {
   stubTranslationConfig,
 } from "cypress/support/stubs";
 
-import { PROPERTIES_ROUTE } from "~/features/common/nav/routes";
+import { ADD_PROPERTY_ROUTE, PROPERTIES_ROUTE } from "~/features/common/nav/routes";
 import { RoleRegistryEnum } from "~/types/api";
 
 describe("Properties page", () => {
@@ -74,6 +74,26 @@ describe("Properties page", () => {
           cy.url().should("not.contain", "/property/FDS-");
         },
       );
+    });
+  });
+
+  describe("Create", () => {
+    it("Should create a new property", () => {
+      cy.intercept("POST", "/api/v1/plus/property", {
+        statusCode: 200,
+        body: { id: "FDS-NEW123", name: "Test Property", type: "Website", paths: [], experiences: [] },
+      }).as("createProperty");
+
+      cy.visit(ADD_PROPERTY_ROUTE);
+      cy.getByTestId("input-name").type("Test Property");
+      cy.get("button[type='submit']").click();
+
+      cy.wait("@createProperty").then((interception) => {
+        const { body } = interception.request;
+        expect(body.name).to.eq("Test Property");
+        expect(body.type).to.eq("Website");
+        expect(body.paths).to.eql([]);
+      });
     });
   });
 

--- a/clients/admin-ui/cypress/e2e/properties.cy.ts
+++ b/clients/admin-ui/cypress/e2e/properties.cy.ts
@@ -6,7 +6,10 @@ import {
   stubTranslationConfig,
 } from "cypress/support/stubs";
 
-import { ADD_PROPERTY_ROUTE, PROPERTIES_ROUTE } from "~/features/common/nav/routes";
+import {
+  ADD_PROPERTY_ROUTE,
+  PROPERTIES_ROUTE,
+} from "~/features/common/nav/routes";
 import { RoleRegistryEnum } from "~/types/api";
 
 describe("Properties page", () => {
@@ -81,7 +84,13 @@ describe("Properties page", () => {
     it("Should create a new property", () => {
       cy.intercept("POST", "/api/v1/plus/property", {
         statusCode: 200,
-        body: { id: "FDS-NEW123", name: "Test Property", type: "Website", paths: [], experiences: [] },
+        body: {
+          id: "FDS-NEW123",
+          name: "Test Property",
+          type: "Website",
+          paths: [],
+          experiences: [],
+        },
       }).as("createProperty");
 
       cy.visit(ADD_PROPERTY_ROUTE);

--- a/clients/admin-ui/cypress/e2e/properties.cy.ts
+++ b/clients/admin-ui/cypress/e2e/properties.cy.ts
@@ -86,7 +86,7 @@ describe("Properties page", () => {
 
       cy.visit(ADD_PROPERTY_ROUTE);
       cy.getByTestId("input-name").type("Test Property");
-      cy.get("button[type='submit']").click();
+      cy.getByTestId("save-btn").click();
 
       cy.wait("@createProperty").then((interception) => {
         const { body } = interception.request;

--- a/clients/admin-ui/cypress/fixtures/properties/property.json
+++ b/clients/admin-ui/cypress/fixtures/properties/property.json
@@ -2,5 +2,6 @@
   "name": "Property A",
   "type": "Website",
   "id": "FDS-CEA9EV",
+  "paths": [],
   "experiences": []
 }

--- a/clients/admin-ui/src/features/properties/PropertyForm.tsx
+++ b/clients/admin-ui/src/features/properties/PropertyForm.tsx
@@ -26,6 +26,7 @@ export interface FormValues {
   id?: string | null;
   name: string;
   type: PropertyType;
+  paths: Array<string>;
   messaging_templates?: Array<MinimalMessagingTemplate> | null;
   experiences: Array<MinimalPrivacyExperienceConfig>;
 }
@@ -149,6 +150,7 @@ export const PropertyForm = ({ property, isLoading, handleSubmit }: Props) => {
                   data-testid="input-type"
                 />
               </Form.Item>
+              <Form.Item name="paths" hidden />
               <Form.Item
                 name="experiences"
                 label="Experiences"
@@ -175,7 +177,7 @@ export const PropertyForm = ({ property, isLoading, handleSubmit }: Props) => {
                 <Form.Item
                   label="Property ID"
                   tooltip="Automatically generated unique ID for this property, used for developer configurations"
-                  className="!mb-0"
+                  className="!mb-0 w-full"
                 >
                   <Space.Compact>
                     <Input readOnly value={property.id ?? ""} />

--- a/clients/admin-ui/src/features/properties/PropertyForm.tsx
+++ b/clients/admin-ui/src/features/properties/PropertyForm.tsx
@@ -177,7 +177,7 @@ export const PropertyForm = ({ property, isLoading, handleSubmit }: Props) => {
                 <Form.Item
                   label="Property ID"
                   tooltip="Automatically generated unique ID for this property, used for developer configurations"
-                  className="!mb-0 w-full"
+                  className="!mb-0"
                 >
                   <Space.Compact className="w-full">
                     <Input readOnly value={property.id ?? ""} />

--- a/clients/admin-ui/src/features/properties/PropertyForm.tsx
+++ b/clients/admin-ui/src/features/properties/PropertyForm.tsx
@@ -208,6 +208,7 @@ export const PropertyForm = ({ property, isLoading, handleSubmit }: Props) => {
               type="primary"
               disabled={isSubmitting || !form.isFieldsTouched() || !submittable}
               loading={isSubmitting}
+              data-testid="save-btn"
             >
               Save
             </Button>

--- a/clients/admin-ui/src/features/properties/PropertyForm.tsx
+++ b/clients/admin-ui/src/features/properties/PropertyForm.tsx
@@ -179,7 +179,7 @@ export const PropertyForm = ({ property, isLoading, handleSubmit }: Props) => {
                   tooltip="Automatically generated unique ID for this property, used for developer configurations"
                   className="!mb-0 w-full"
                 >
-                  <Space.Compact>
+                  <Space.Compact className="w-full">
                     <Input readOnly value={property.id ?? ""} />
                     <Space.Addon>
                       <ClipboardButton copyText={property.id ?? ""} />


### PR DESCRIPTION
Ticket [ENG-3413]

### Description Of Changes

After the properties form was migrated to Ant Design (#7880), creating a new property would 422 with `{"detail": [{"type": "missing", "loc": ["body", "paths"], "msg": "Field required"}]}`.

Root cause: Ant Design's `Form` only includes fields registered via `<Form.Item name="...">` in the `onFinish` payload. The `paths` field was set in `initialValues` but had no corresponding `<Form.Item>`, so it was silently dropped before the POST request was made.

Fix: add a hidden `<Form.Item name="paths" />` so Ant Design tracks the field through the form lifecycle.

### Code Changes

* Added hidden `<Form.Item name="paths" />` to `PropertyForm` so the field is included in form submission
* Added `paths` to the `FormValues` interface
* Added `"paths": []` to the `property.json` Cypress fixture to match the actual API schema
* Added a Cypress test that fills out the create-property form and asserts `paths` is present in the POST request body

### Steps to Confirm

1. Navigate to Properties → Add property
2. Fill in a property name and click Save
3. Confirm the property is created successfully (no 422 error)

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3413]: https://ethyca.atlassian.net/browse/ENG-3413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ