### PR TITLE
ENG-3416: Hide redundant 'across 1 monitor' on single-monitor Action Center view

### DIFF
--- a/changelog/7911-hide-across-monitor-text.yaml
+++ b/changelog/7911-hide-across-monitor-text.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Hid redundant "across 1 monitor" text on single-monitor Action Center view
+pr: 7911
+labels: []

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ProgressCard/ProgressCard.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ProgressCard/ProgressCard.tsx
@@ -124,7 +124,7 @@ export const ProgressCard = ({
           </Tooltip>
         )}
       />
-      <Text>resources need review across {subtitle}</Text>
+      <Text>resources need review{!compact && <> across {subtitle}</>}</Text>
       <div>
         {barChartProps && <StackedBarChart {...barChartProps} hideTooltip />}
         <Tooltip


### PR DESCRIPTION
## Summary

- Hides the "across N monitors" subtitle text on the single-monitor Action Center detail page, where it's redundant (e.g. "resources need review across 1 monitor")
- Uses the existing `compact` prop (already `true` when `monitorId` is set) to conditionally render the suffix

## Ticket

[ENG-3416](https://ethyca.atlassian.net/browse/ENG-3416)

## Test plan

- [ ] Navigate to Action Center aggregate view → verify "across N monitors" still displays
- [ ] Click into a single monitor (e.g. Okta_Auth) → verify only "resources need review" displays without the "across 1 monitor" suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-3416]: https://ethyca.atlassian.net/browse/ENG-3416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ