### PR TITLE
fix: initial steward values [ENG-3411]

### DIFF
--- a/changelog/7914-fix-steward-filter.yaml
+++ b/changelog/7914-fix-steward-filter.yaml
@@ -1,0 +1,4 @@
+type: Fixed  # One of: Added, Changed, Developer Experience, Deprecated, Docs, Fixed, Removed, Security
+description: Fixes steward filter states when assigned to a monitor
+pr: 7914 # PR number
+labels: [] # Optional: ["high-risk", "db-migration"]

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorList.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorList.tsx
@@ -49,15 +49,12 @@ const MonitorList = () => {
   const defaultStewardFilter =
     (userMonitors ?? []).length > 0 ? currentUser?.id : undefined;
 
-  const { requestData, ...formProps } = useSearchForm<
+  const { requestData, setSearchForm, ...formProps } = useSearchForm<
     Partial<Parameters<typeof useGetAggregateMonitorResultsQuery>[0]>,
     MonitorSearchForm
   >({
     schema: MonitorSearchFormQuerySchema([...availableMonitorTypes]),
-    queryState: SearchFormQueryState(
-      [...availableMonitorTypes],
-      defaultStewardFilter,
-    ),
+    queryState: SearchFormQueryState([...availableMonitorTypes]),
     initialValues: {
       search: null,
       monitor_type: null,
@@ -84,6 +81,12 @@ const MonitorList = () => {
     page: pageIndex,
     size: pageSize,
   });
+
+  useEffect(() => {
+    if (defaultStewardFilter) {
+      setSearchForm({ steward_key: defaultStewardFilter });
+    }
+  }, [setSearchForm, defaultStewardFilter]);
 
   useEffect(() => {
     if (isError) {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/forms/MonitorListSearchForm.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/forms/MonitorListSearchForm.tsx
@@ -23,7 +23,7 @@ const MonitorListSearchForm = ({
   ...formProps
 }: Omit<
   ReturnType<typeof useSearchForm<any, MonitorSearchForm>>,
-  "requestData"
+  "requestData" | "setSearchForm"
 > & {
   availableMonitorTypes: readonly APIMonitorType[];
 }) => {
@@ -87,8 +87,9 @@ const MonitorListSearchForm = ({
           popupMatchSelectWidth
           placeholder="Data steward"
           allowClear
-          showSearch
-          optionFilterProp="label"
+          showSearch={{
+            optionFilterProp: "label",
+          }}
           aria-label="Filter by data steward"
           className="min-w-[220px]"
         />

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useSearchForm.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useSearchForm.ts
@@ -66,6 +66,7 @@ const useSearchForm = <RequestData, FormType>({
       ...searchForm,
     },
     requestData: translate(searchForm as FormType),
+    setSearchForm,
   };
 };
 


### PR DESCRIPTION
Ticket [ENG-3411] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes
Fixes an issue where the state of the stewards filter on the root action center would be out of sync with the url and requests when logged in as a steward assigned to a monitor.

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. Create a user with viewer and reviewer permissions
2. Add a new monitor and assign the previously created user as a steward to that monitor
3. Log in as the user you created
4. Confirm that navigating to the root action center screen defaults the stewards filter to `assigned to me`
5. Confirm that clearing the filter removes the value and shows all monitors

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3411]: https://ethyca.atlassian.net/browse/ENG-3411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ