### PR TITLE
ENG-3419: Update ruff target-version from py39 to py313

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,7 +282,7 @@ ignore_missing_imports = true
 ## Ruff ##
 ##########
 [tool.ruff]
-target-version = "py39"
+target-version = "py313"
 line-length = 88
 src = ["src", "tests", "noxfiles", "scripts"]
 


### PR DESCRIPTION
Ticket [ENG-3419]

### Description Of Changes
The project requires Python >=3.13 (`requires-python = ">=3.13,<4"`) but ruff's `target-version` was set to `"py39"`. This prevented version-aware linting and formatting rules from operating correctly for the actual runtime version.

### Code Changes

* Updated `target-version` in `[tool.ruff]` from `"py39"` to `"py313"` in `pyproject.toml`

### Steps to Confirm

1. Run `ruff check .` — should pass with no new violations
2. Run `ruff format --check .` — should report all files formatted
3. Verify `target-version` in `pyproject.toml` reads `"py313"`

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required


[ENG-3419]: https://ethyca.atlassian.net/browse/ENG-3419

🤖 Generated with [Claude Code](https://claude.com/claude-code)