### PR TITLE
ENG-3386: system-template badge + sectioned popover (demo/april)

### DIFF
--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -602,6 +602,35 @@ describe("Data map report table", () => {
         .its("request.url")
         .should("include", "1234");
     });
+    describe("with a system-owned template", () => {
+      beforeEach(() => {
+        cy.intercept("GET", "/api/v1/plus/custom-report/minimal*", {
+          fixture: "custom-reports/minimal-with-system-template.json",
+        }).as("getCustomReportsMinimalWithSystemTemplate");
+      });
+      it("groups system templates above user reports with a 'Standard' tag", () => {
+        cy.getByTestId("custom-reports-trigger").click();
+        cy.wait("@getCustomReportsMinimalWithSystemTemplate");
+        cy.getByTestId("custom-reports-popover").within(() => {
+          cy.getByTestId("custom-reports-section-system").should("be.visible");
+          cy.getByTestId("custom-reports-section-user").should("be.visible");
+          cy.getByTestId("system-template-tag").should("have.length", 1);
+          // System template is listed above user reports.
+          cy.getByTestId("custom-report-item")
+            .first()
+            .should("contain.text", "ICO Record of Processing (UK)");
+        });
+      });
+      it("suppresses the delete affordance on system templates", () => {
+        cy.getByTestId("custom-reports-trigger").click();
+        cy.wait("@getCustomReportsMinimalWithSystemTemplate");
+        // Only the user report row exposes a delete button; the system
+        // template row does not render one.
+        cy.getByTestId("custom-reports-popover").within(() => {
+          cy.getByTestId("delete-report-button").should("have.length", 1);
+        });
+      });
+    });
   });
 
   describe("Exporting", () => {

--- a/clients/admin-ui/cypress/fixtures/custom-reports/minimal-with-system-template.json
+++ b/clients/admin-ui/cypress/fixtures/custom-reports/minimal-with-system-template.json
@@ -1,0 +1,20 @@
+{
+  "items": [
+    {
+      "id": "plu_sys_ico",
+      "type": "datamap",
+      "name": "ICO Record of Processing (UK)",
+      "system_template_key": "ico"
+    },
+    {
+      "id": "plu_1234",
+      "type": "datamap",
+      "name": "My Custom Report",
+      "system_template_key": null
+    }
+  ],
+  "total": 2,
+  "page": 1,
+  "size": 50,
+  "pages": 1
+}

--- a/clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx
+++ b/clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx
@@ -9,8 +9,10 @@ import {
   Radio,
   Skeleton,
   Space,
+  Tag,
   Text,
   Title,
+  Tooltip,
   useMessage,
   useModal,
 } from "fidesui";
@@ -86,6 +88,14 @@ export const CustomReportTemplates = ({
   }, [customReportsList?.items, savedReportId]);
 
   const isEmpty = !isCustomReportsLoading && !customReportsList?.items?.length;
+
+  const { systemReports, userReports } = useMemo(() => {
+    const items = searchResults ?? [];
+    return {
+      systemReports: items.filter((report) => !!report.system_template_key),
+      userReports: items.filter((report) => !report.system_template_key),
+    };
+  }, [searchResults]);
 
   const handleSearch = (searchTerm: string) => {
     const results = customReportsList?.items.filter((customReport) =>
@@ -278,33 +288,84 @@ export const CustomReportTemplates = ({
                 style={{ width: "100%" }}
               >
                 <Space orientation="vertical" className="w-full" size="small">
-                  {searchResults?.map((customReport) => (
-                    <Flex
-                      key={customReport.id}
-                      justify={
-                        userCanDeleteReports ? "space-between" : "flex-start"
-                      }
-                      align="center"
-                    >
-                      <Radio
-                        value={customReport.id}
-                        name="custom-report-id"
-                        data-testid="custom-report-item"
+                  {systemReports.length > 0 && (
+                    <>
+                      <Text
+                        type="secondary"
+                        className="text-xs uppercase tracking-wide"
+                        data-testid="custom-reports-section-system"
                       >
-                        {customReport.name}
-                      </Radio>
-                      {userCanDeleteReports && (
-                        <Button
-                          type="text"
-                          size="small"
-                          icon={<Icons.TrashCan />}
-                          onClick={() => onDelete(customReport)}
-                          data-testid="delete-report-button"
-                          aria-label="Delete"
-                        />
+                        Standard templates
+                      </Text>
+                      {systemReports.map((customReport) => (
+                        <Flex
+                          key={customReport.id}
+                          justify="flex-start"
+                          align="center"
+                          gap="small"
+                        >
+                          <Radio
+                            value={customReport.id}
+                            name="custom-report-id"
+                            data-testid="custom-report-item"
+                          >
+                            {customReport.name}
+                          </Radio>
+                          <Tooltip title="Out-of-the-box reporting template. Standard templates cannot be deleted.">
+                            <Tag
+                              color="info"
+                              className="m-0"
+                              data-testid="system-template-tag"
+                            >
+                              Standard
+                            </Tag>
+                          </Tooltip>
+                        </Flex>
+                      ))}
+                    </>
+                  )}
+                  {userReports.length > 0 && (
+                    <>
+                      {systemReports.length > 0 && (
+                        <Text
+                          type="secondary"
+                          className="mt-2 text-xs uppercase tracking-wide"
+                          data-testid="custom-reports-section-user"
+                        >
+                          Your reports
+                        </Text>
                       )}
-                    </Flex>
-                  ))}
+                      {userReports.map((customReport) => (
+                        <Flex
+                          key={customReport.id}
+                          justify={
+                            userCanDeleteReports
+                              ? "space-between"
+                              : "flex-start"
+                          }
+                          align="center"
+                        >
+                          <Radio
+                            value={customReport.id}
+                            name="custom-report-id"
+                            data-testid="custom-report-item"
+                          >
+                            {customReport.name}
+                          </Radio>
+                          {userCanDeleteReports && (
+                            <Button
+                              type="text"
+                              size="small"
+                              icon={<Icons.TrashCan />}
+                              onClick={() => onDelete(customReport)}
+                              data-testid="delete-report-button"
+                              aria-label="Delete"
+                            />
+                          )}
+                        </Flex>
+                      ))}
+                    </>
+                  )}
                 </Space>
               </Radio.Group>
             ))}

--- a/clients/admin-ui/src/types/api/models/CustomReportResponse.ts
+++ b/clients/admin-ui/src/types/api/models/CustomReportResponse.ts
@@ -18,5 +18,9 @@ export type CustomReportResponse = {
    * Name
    */
   name: string;
+  /**
+   * Stable key of the OOTB regulatory reporting template that owns this report (e.g. 'ico', 'dpc', 'cnil'). When set, the report is system-managed: clients should render it with a 'Standard' badge and disable the delete affordance.
+   */
+  system_template_key?: string | null;
   config: CustomReportConfig;
 };

--- a/clients/admin-ui/src/types/api/models/CustomReportResponseMinimal.ts
+++ b/clients/admin-ui/src/types/api/models/CustomReportResponseMinimal.ts
@@ -17,4 +17,8 @@ export type CustomReportResponseMinimal = {
    * Name
    */
   name: string;
+  /**
+   * Stable key of the OOTB regulatory reporting template that owns this report (e.g. 'ico', 'dpc', 'cnil'). When set, the report is system-managed: clients should render it with a 'Standard' badge and disable the delete affordance.
+   */
+  system_template_key?: string | null;
 };


### PR DESCRIPTION
Ticket [ENG-3386]

> **Dependency:** Requires the companion fidesplus PR to be merged first (provides `system_template_key` on `CustomReportResponseMinimal`).

### Summary

Squashed backport of #7910 onto `demo/april` for early demo/testing.

- Splits custom-reports popover into "Standard templates" and "Your reports" sections
- System-owned templates display an `info`-coloured "Standard" tag with tooltip
- Delete button hidden for system-template rows
- Cypress tests for sectioning and delete suppression

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Targeting `demo/april`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-3386]: https://ethyca.atlassian.net/browse/ENG-3386