### PR TITLE
ENG-3430: make privacy center actions optional

### DIFF
--- a/changelog/7919-allow-empty-actions-privacy-center.yaml
+++ b/changelog/7919-allow-empty-actions-privacy-center.yaml
@@ -1,0 +1,3 @@
+type: Fixed
+description: Allow Privacy Center to start with an empty or missing `actions` array in config, so deployments that only serve fides.js are not blocked by validation.
+pr: 7919

--- a/clients/privacy-center/__tests__/common/validation.test.ts
+++ b/clients/privacy-center/__tests__/common/validation.test.ts
@@ -133,6 +133,16 @@ describe("validateConfig", () => {
       },
     },
     {
+      name: "invalid actions type",
+      config: produce(minimalJson, (draft: any) => {
+        draft.actions = "not an array";
+      }),
+      expected: {
+        isValid: false,
+        message: "Invalid field: actions (must be an array)",
+      },
+    },
+    {
       name: "missing required action fields",
       config: produce(minimalJson, (draft: any) => {
         delete draft.actions[0].title;

--- a/clients/privacy-center/__tests__/common/validation.test.ts
+++ b/clients/privacy-center/__tests__/common/validation.test.ts
@@ -120,9 +120,7 @@ describe("validateConfig", () => {
         draft.actions = [];
       }),
       expected: {
-        isValid: false,
-        message:
-          "Missing required field(s): actions (must be a non-empty array)",
+        isValid: true,
       },
     },
     {
@@ -131,9 +129,7 @@ describe("validateConfig", () => {
         delete draft.actions;
       }),
       expected: {
-        isValid: false,
-        message:
-          "Missing required field(s): actions (must be a non-empty array)",
+        isValid: true,
       },
     },
     {

--- a/clients/privacy-center/common/validation.ts
+++ b/clients/privacy-center/common/validation.ts
@@ -57,31 +57,22 @@ export const validateConfig = (
     };
   }
 
-  // Validate actions array is present and non-empty
-  if (!Array.isArray(input.actions) || input.actions.length === 0) {
-    return {
-      isValid: false,
-      message: "Missing required field(s): actions (must be a non-empty array)",
-    };
-  }
-
-  // Validate required fields within each action
-  const requiredActionFields: (keyof Config["actions"][number])[] = [
-    "title",
-    "description",
-    "icon_path",
-  ];
-  for (let i = 0; i < input.actions.length; i += 1) {
-    const action = input.actions[i];
-    const missingActionFields = requiredActionFields.filter((field) => {
-      const value = (action as Record<string, unknown>)[field];
-      return typeof value !== "string" || value.trim().length === 0;
-    });
-    if (missingActionFields.length > 0) {
-      return {
-        isValid: false,
-        message: `Missing required field(s) in actions[${i}]: ${missingActionFields.join(", ")}`,
-      };
+  // Validate required fields within each action (if provided)
+  if (Array.isArray(input.actions)) {
+    const requiredActionFields: (keyof NonNullable<Config["actions"]>[number])[] =
+      ["title", "description", "icon_path"];
+    for (let i = 0; i < input.actions.length; i += 1) {
+      const action = input.actions[i];
+      const missingActionFields = requiredActionFields.filter((field) => {
+        const value = (action as Record<string, unknown>)[field];
+        return typeof value !== "string" || value.trim().length === 0;
+      });
+      if (missingActionFields.length > 0) {
+        return {
+          isValid: false,
+          message: `Missing required field(s) in actions[${i}]: ${missingActionFields.join(", ")}`,
+        };
+      }
     }
   }
 
@@ -146,7 +137,7 @@ export const validateConfig = (
     }
   }
 
-  const invalidFieldMessages = config.actions.flatMap((action) => {
+  const invalidFieldMessages = (config.actions ?? []).flatMap((action) => {
     /*
       Validate that hidden fields must have a default_value or a query_param_key
       defined, otherwise the field would never get a value assigned.

--- a/clients/privacy-center/common/validation.ts
+++ b/clients/privacy-center/common/validation.ts
@@ -59,8 +59,9 @@ export const validateConfig = (
 
   // Validate required fields within each action (if provided)
   if (Array.isArray(input.actions)) {
-    const requiredActionFields: (keyof NonNullable<Config["actions"]>[number])[] =
-      ["title", "description", "icon_path"];
+    const requiredActionFields: (keyof NonNullable<
+      Config["actions"]
+    >[number])[] = ["title", "description", "icon_path"];
     for (let i = 0; i < input.actions.length; i += 1) {
       const action = input.actions[i];
       const missingActionFields = requiredActionFields.filter((field) => {

--- a/clients/privacy-center/common/validation.ts
+++ b/clients/privacy-center/common/validation.ts
@@ -57,6 +57,14 @@ export const validateConfig = (
     };
   }
 
+  // Validate actions is an array when present
+  if (input.actions !== undefined && !Array.isArray(input.actions)) {
+    return {
+      isValid: false,
+      message: "Invalid field: actions (must be an array)",
+    };
+  }
+
   // Validate required fields within each action (if provided)
   if (Array.isArray(input.actions)) {
     const requiredActionFields: (keyof NonNullable<

--- a/clients/privacy-center/components/HomePage.tsx
+++ b/clients/privacy-center/components/HomePage.tsx
@@ -143,9 +143,10 @@ const HomePage: NextPage = () => {
     router.push(url);
   };
 
+  const actions = config.actions ?? [];
   const content: ReactNode[] = [];
 
-  (config.actions ?? []).forEach((action, index) => {
+  actions.forEach((action, index) => {
     content.push(
       <PrivacyCard
         // eslint-disable-next-line react/no-array-index-key

--- a/clients/privacy-center/components/HomePage.tsx
+++ b/clients/privacy-center/components/HomePage.tsx
@@ -145,7 +145,7 @@ const HomePage: NextPage = () => {
 
   const content: ReactNode[] = [];
 
-  config.actions.forEach((action, index) => {
+  (config.actions ?? []).forEach((action, index) => {
     content.push(
       <PrivacyCard
         // eslint-disable-next-line react/no-array-index-key

--- a/clients/privacy-center/components/privacy-request/PrivacyRequestFormPage.tsx
+++ b/clients/privacy-center/components/privacy-request/PrivacyRequestFormPage.tsx
@@ -35,8 +35,7 @@ const PrivacyRequestFormPage = ({ actionKey }: PrivacyRequestFormPageProps) => {
 
   const actions = config.actions ?? [];
   const selectedAction = (
-    !Number.isNaN(actionIndex) &&
-    actions[actionIndex]?.policy_key === policyKey
+    !Number.isNaN(actionIndex) && actions[actionIndex]?.policy_key === policyKey
       ? actions[actionIndex]
       : actions.find((action) => action.policy_key === policyKey)
   ) as PrivacyRequestOption | undefined;

--- a/clients/privacy-center/components/privacy-request/PrivacyRequestFormPage.tsx
+++ b/clients/privacy-center/components/privacy-request/PrivacyRequestFormPage.tsx
@@ -33,11 +33,12 @@ const PrivacyRequestFormPage = ({ actionKey }: PrivacyRequestFormPageProps) => {
     colonIndex !== -1 ? parseInt(decoded.slice(0, colonIndex), 10) : NaN;
   const policyKey = colonIndex !== -1 ? decoded.slice(colonIndex + 1) : decoded;
 
+  const actions = config.actions ?? [];
   const selectedAction = (
     !Number.isNaN(actionIndex) &&
-    config.actions[actionIndex]?.policy_key === policyKey
-      ? config.actions[actionIndex]
-      : config.actions.find((action) => action.policy_key === policyKey)
+    actions[actionIndex]?.policy_key === policyKey
+      ? actions[actionIndex]
+      : actions.find((action) => action.policy_key === policyKey)
   ) as PrivacyRequestOption | undefined;
 
   // Update verification requirement from API

--- a/clients/privacy-center/cypress/e2e/privacy-center/home.cy.ts
+++ b/clients/privacy-center/cypress/e2e/privacy-center/home.cy.ts
@@ -13,7 +13,8 @@ describe("Home", () => {
       cy.getByTestId("description").contains(config.description);
       cy.getByTestId("logo").should("have.attr", "src", config.logo_path);
 
-      (config.actions ?? []).forEach((action) => {
+      const actions = config.actions ?? [];
+      actions.forEach((action) => {
         cy.contains(action.title);
       });
     });

--- a/clients/privacy-center/cypress/e2e/privacy-center/home.cy.ts
+++ b/clients/privacy-center/cypress/e2e/privacy-center/home.cy.ts
@@ -13,7 +13,7 @@ describe("Home", () => {
       cy.getByTestId("description").contains(config.description);
       cy.getByTestId("logo").should("have.attr", "src", config.logo_path);
 
-      config.actions.forEach((action) => {
+      (config.actions ?? []).forEach((action) => {
         cy.contains(action.title);
       });
     });

--- a/clients/privacy-center/cypress/fixtures/config/config_error.json
+++ b/clients/privacy-center/cypress/fixtures/config/config_error.json
@@ -1,7 +1,9 @@
 {
+  "title": "Error Config",
   "description": "This Privacy Center config tests error-handling - it's invalid!",
   "unsupported_type": "Unsupported",
   "logo_path": "/logo.svg",
+  "actions": "not an array",
   "includeConsent": "maybe",
   "consent": {
     "button": {

--- a/clients/privacy-center/cypress/fixtures/config/config_error.json
+++ b/clients/privacy-center/cypress/fixtures/config/config_error.json
@@ -1,5 +1,4 @@
 {
-  "title": "Error Config",
   "description": "This Privacy Center config tests error-handling - it's invalid!",
   "unsupported_type": "Unsupported",
   "logo_path": "/logo.svg",

--- a/clients/privacy-center/types/api/models/PrivacyCenterConfig.ts
+++ b/clients/privacy-center/types/api/models/PrivacyCenterConfig.ts
@@ -23,7 +23,7 @@ export type PrivacyCenterConfig = {
   logo_url?: string | null;
   favicon_path?: string | null;
   page_title?: string | null;
-  actions: Array<PrivacyRequestOption>;
+  actions?: Array<PrivacyRequestOption>;
   includeConsent?: boolean | null;
   consent: fides__api__schemas__privacy_center_config__ConsentConfig;
   /** @deprecated Prefer `links`. Kept for backwards compatibility. */

--- a/clients/privacy-center/types/config.ts
+++ b/clients/privacy-center/types/config.ts
@@ -70,7 +70,7 @@ export type LegacyConfig = {
   server_url_development?: string;
   server_url_production?: string;
   logo_path: string;
-  actions: PrivacyRequestOption[];
+  actions?: PrivacyRequestOption[];
   includeConsent?: boolean;
   consent?: LegacyConsentConfig | ConsentConfig;
 };
@@ -86,7 +86,7 @@ export type Config = {
   logo_url?: string;
   favicon_path?: string;
   page_title?: string;
-  actions: PrivacyRequestOption[];
+  actions?: PrivacyRequestOption[];
   includeConsent?: boolean;
   consent?: ConsentConfig;
   /** @deprecated Prefer `links`. Kept for backwards compatibility. */

--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -227,7 +227,7 @@ class PrivacyCenterConfig(FidesSchema):
     logo_url: Optional[str] = None
     favicon_path: Optional[str] = None
     page_title: Optional[str] = None
-    actions: List[PrivacyRequestOption]
+    actions: List[PrivacyRequestOption] = []
     include_consent: Optional[bool] = Field(alias="includeConsent", default=None)
     consent: ConsentConfig
     # Deprecated: prefer `links`. Kept for backwards compatibility.
@@ -262,7 +262,7 @@ class PartialPrivacyRequestOption(FidesSchema):
 class PartialPrivacyCenterConfig(FidesSchema):
     """Partial schema for the Admin UI privacy request submission."""
 
-    actions: List[PartialPrivacyRequestOption]
+    actions: List[PartialPrivacyRequestOption] = []
 
 
 def reorder_custom_privacy_request_fields(config: dict[str, Any]) -> dict[str, Any]:

--- a/tests/ops/schemas/test_privacy_center_config.py
+++ b/tests/ops/schemas/test_privacy_center_config.py
@@ -377,6 +377,22 @@ class TestPrivacyCenterConfig:
         assert config.server_url_development is None
         assert config.logo_url is None
 
+    def test_empty_actions(self):
+        config_data = json.loads(
+            load_as_string("tests/ops/resources/privacy_center_config.json")
+        )
+        config_data["actions"] = []
+        config = PrivacyCenterConfig(**config_data)
+        assert config.actions == []
+
+    def test_missing_actions_defaults_to_empty(self):
+        config_data = json.loads(
+            load_as_string("tests/ops/resources/privacy_center_config.json")
+        )
+        del config_data["actions"]
+        config = PrivacyCenterConfig(**config_data)
+        assert config.actions == []
+
     def test_invalid_executable_consent(
         self, privacy_center_config: PrivacyCenterConfig
     ):


### PR DESCRIPTION
Ticket [ENG-3430] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Privacy Center fails to start when `config.json` has an empty `actions` array (or omits it entirely). This blocks customers who only use Privacy Center to serve `fides.js` and don't need DSR action tiles. This change makes `actions` optional, defaulting to `[]`.

### Code Changes

* Removed the non-empty array validation check for `actions` in the Privacy Center config validator
* Made `actions` optional (defaulting to `[]`) in the `PrivacyCenterConfig` and `PartialPrivacyCenterConfig` Pydantic schemas
* Updated TypeScript types (`Config`, `LegacyConfig`, API `PrivacyCenterConfig`) to mark `actions` as optional
* Added `?? []` guards where components iterate over `config.actions`

### Steps to Confirm

**Config file path:**
1. Set `"actions": []` in `clients/privacy-center/config/config.json`
2. Start the Privacy Center — it should load without errors
3. The home page should render with no action tiles (consent card still appears if configured)

**API config path:**
1. Create/update a property via the API with `privacy_center_config` that has no `actions` key (or `"actions": []`)
2. Set `USE_API_CONFIG=true` and start the Privacy Center — it should load without errors

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3430]: https://ethyca.atlassian.net/browse/ENG-3430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ