### PR TITLE
ENG-3177: Migrate datamap SystemInfo from Formik/Chakra to antd Form

### DIFF
--- a/changelog/7921-datamap-systeminfo-antd.yaml
+++ b/changelog/7921-datamap-systeminfo-antd.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Migrated datamap SystemInfo form from Chakra/Formik to Ant Design
+pr: 7921
+labels: []

--- a/clients/admin-ui/src/features/datamap/datamap-drawer/DatamapDrawer.tsx
+++ b/clients/admin-ui/src/features/datamap/datamap-drawer/DatamapDrawer.tsx
@@ -6,7 +6,7 @@ import { usePrivacyDeclarationData } from "~/features/system/privacy-declaration
 import PrivacyDeclarationManager from "~/features/system/privacy-declarations/PrivacyDeclarationManager";
 import { useGetSystemByFidesKeyQuery } from "~/features/system/system.slice";
 
-import SystemInfo from "./SystemInfo";
+import { SystemInfo } from "./SystemInfo";
 
 type DatamapDrawerProps = {
   selectedSystemId?: string;

--- a/clients/admin-ui/src/features/datamap/datamap-drawer/SystemInfo.tsx
+++ b/clients/admin-ui/src/features/datamap/datamap-drawer/SystemInfo.tsx
@@ -68,18 +68,10 @@ export const SystemInfo = ({ system }: SystemInfoProps) => {
         onFinish={handleUpsertSystem}
         key={system.fides_key}
       >
-        <Form.Item
-          name="name"
-          label="System name"
-          rules={[{ required: true, message: "Name is required" }]}
-        >
+        <Form.Item name="name" label="System name">
           <Input disabled data-testid="input-name" />
         </Form.Item>
-        <Form.Item
-          name="description"
-          label="System description"
-          rules={[{ required: true, message: "Description is required" }]}
-        >
+        <Form.Item name="description" label="System description">
           <Input.TextArea disabled data-testid="input-description" />
         </Form.Item>
       </Form>

--- a/clients/admin-ui/src/features/datamap/datamap-drawer/SystemInfo.tsx
+++ b/clients/admin-ui/src/features/datamap/datamap-drawer/SystemInfo.tsx
@@ -1,19 +1,15 @@
 import {
-  ChakraBox as Box,
-  ChakraFlex as Flex,
-  ChakraSpacer as Spacer,
-  ChakraText as Text,
-  Icons,
-  SecondaryLink,
+  Divider,
+  Flex,
+  Form,
+  Input,
+  Title,
+  Typography,
   useMessage,
 } from "fidesui";
-import { Form, Formik, FormikHelpers } from "formik";
-import React from "react";
-import * as Yup from "yup";
+import NextLink from "next/link";
 
-import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
 import { getErrorMessage } from "~/features/common/helpers";
-import { FormGuard } from "~/features/common/hooks/useIsAnyFormDirty";
 import { SystemInfoFormValues } from "~/features/datamap/datamap-drawer/types";
 import { useUpsertSystemsMutation } from "~/features/system/system.slice";
 import { System } from "~/types/api";
@@ -23,13 +19,13 @@ type SystemInfoProps = {
   system: System;
 };
 
-const useSystemInfo = (system: System) => {
+const useSystemInfo = (
+  system: System,
+  form: ReturnType<typeof Form.useForm<SystemInfoFormValues>>[0],
+) => {
   const [upsertSystem] = useUpsertSystemsMutation();
   const message = useMessage();
-  const handleUpsertSystem = async (
-    values: SystemInfoFormValues,
-    helpers: FormikHelpers<SystemInfoFormValues>,
-  ) => {
+  const handleUpsertSystem = async (values: SystemInfoFormValues) => {
     const requestBody: System[] = [
       {
         ...system,
@@ -43,88 +39,50 @@ const useSystemInfo = (system: System) => {
       message.error(getErrorMessage(result.error));
     } else {
       message.success("Successfully saved system info");
-      // this is required so the initial state doesn't flash
-      helpers.resetForm({ values });
+      form.setFieldsValue(values);
     }
   };
 
-  const validationSchema = Yup.object().shape({
-    name: Yup.string().required().label("Name"),
-    description: Yup.string().required().label("Description"),
-  });
-
-  return {
-    handleUpsertSystem,
-    validationSchema,
-  };
+  return { handleUpsertSystem };
 };
 
-const defaultInitialValues: SystemInfoFormValues = {
-  name: "",
-  description: "",
-};
-
-const SystemInfo = ({ system }: SystemInfoProps) => {
+export const SystemInfo = ({ system }: SystemInfoProps) => {
   const systemHref = `/systems/configure/${system.fides_key}`;
+  const [form] = Form.useForm<SystemInfoFormValues>();
 
-  const { handleUpsertSystem, validationSchema } = useSystemInfo(system);
+  const { handleUpsertSystem } = useSystemInfo(system, form);
   return (
-    <Box>
-      <Flex alignItems="center">
-        <Text
-          color="gray.600"
-          size="md"
-          lineHeight={6}
-          fontWeight="semibold"
-          marginBottom={2}
-        >
-          System details
-        </Text>
-        <Spacer />
-        <SecondaryLink color="complimentary.500" href={systemHref}>
-          View more
-          <Icons.Launch className="ml-2 inline" size={14} />
-        </SecondaryLink>
+    <div>
+      <Flex align="center">
+        <Title level={5}>System details</Title>
+        <div className="grow" />
+        <NextLink href={systemHref} passHref legacyBehavior>
+          <Typography.Link>View more</Typography.Link>
+        </NextLink>
       </Flex>
-      <Box
-        width="100%"
-        padding={4}
-        borderTop="1px solid"
-        borderColor="gray.200"
+      <Divider size="small" className="pb-4" />
+      <Form
+        form={form}
+        layout="vertical"
+        initialValues={system as SystemInfoFormValues}
+        onFinish={handleUpsertSystem}
+        key={system.fides_key}
       >
-        <Formik
-          enableReinitialize
-          initialValues={
-            (system as SystemInfoFormValues) ?? defaultInitialValues
-          }
-          validationSchema={validationSchema}
-          onSubmit={handleUpsertSystem}
+        <Form.Item
+          name="name"
+          label="System name"
+          rules={[{ required: true, message: "Name is required" }]}
         >
-          {() => (
-            <Form>
-              <FormGuard id="SystemInfoDrawer" name="System Info" />
-              <Box marginTop={3}>
-                <CustomTextInput
-                  label="System name"
-                  name="name"
-                  variant="stacked"
-                  disabled
-                />
-              </Box>
-              <Box marginTop={3}>
-                <CustomTextArea
-                  label="System description"
-                  name="description"
-                  variant="stacked"
-                  disabled
-                />
-              </Box>
-            </Form>
-          )}
-        </Formik>
-      </Box>
-    </Box>
+          <Input disabled data-testid="input-name" />
+        </Form.Item>
+        <Form.Item
+          name="description"
+          label="System description"
+          rules={[{ required: true, message: "Description is required" }]}
+        >
+          <Input.TextArea disabled data-testid="input-description" />
+        </Form.Item>
+      </Form>
+    </div>
   );
 };
-
-export default SystemInfo;

--- a/clients/admin-ui/src/features/datamap/datamap-drawer/SystemInfo.tsx
+++ b/clients/admin-ui/src/features/datamap/datamap-drawer/SystemInfo.tsx
@@ -1,56 +1,15 @@
-import {
-  Divider,
-  Flex,
-  Form,
-  Input,
-  Title,
-  Typography,
-  useMessage,
-} from "fidesui";
+import { Divider, Flex, Form, Input, Title, Typography } from "fidesui";
 import NextLink from "next/link";
 
-import { getErrorMessage } from "~/features/common/helpers";
 import { SystemInfoFormValues } from "~/features/datamap/datamap-drawer/types";
-import { useUpsertSystemsMutation } from "~/features/system/system.slice";
 import { System } from "~/types/api";
-import { isErrorResult } from "~/types/errors/api";
 
 type SystemInfoProps = {
   system: System;
 };
 
-const useSystemInfo = (
-  system: System,
-  form: ReturnType<typeof Form.useForm<SystemInfoFormValues>>[0],
-) => {
-  const [upsertSystem] = useUpsertSystemsMutation();
-  const message = useMessage();
-  const handleUpsertSystem = async (values: SystemInfoFormValues) => {
-    const requestBody: System[] = [
-      {
-        ...system,
-        name: values.name,
-        description: values.description,
-      },
-    ];
-
-    const result = await upsertSystem(requestBody);
-    if (isErrorResult(result)) {
-      message.error(getErrorMessage(result.error));
-    } else {
-      message.success("Successfully saved system info");
-      form.setFieldsValue(values);
-    }
-  };
-
-  return { handleUpsertSystem };
-};
-
 export const SystemInfo = ({ system }: SystemInfoProps) => {
   const systemHref = `/systems/configure/${system.fides_key}`;
-  const [form] = Form.useForm<SystemInfoFormValues>();
-
-  const { handleUpsertSystem } = useSystemInfo(system, form);
   return (
     <div>
       <Flex align="center">
@@ -62,10 +21,8 @@ export const SystemInfo = ({ system }: SystemInfoProps) => {
       </Flex>
       <Divider size="small" className="pb-4" />
       <Form
-        form={form}
         layout="vertical"
         initialValues={system as SystemInfoFormValues}
-        onFinish={handleUpsertSystem}
         key={system.fides_key}
       >
         <Form.Item name="name" label="System name">


### PR DESCRIPTION
Ticket [ENG-3177]

### Description Of Changes

Migrates the datamap drawer's SystemInfo component from Formik/Chakra to Ant Design Form. This is a straightforward form migration - the form is read-only (both fields are disabled), so it's a low-risk change focused on removing Chakra/Formik dependencies.

### Code Changes

* Replaced Formik `<Form>` with antd `<Form>` in SystemInfo, using `Form.useForm` for form instance management
* Replaced `CustomTextInput` / `CustomTextArea` with antd `Input` / `Input.TextArea`
* Replaced Chakra layout components (`Box`, `Flex`, `Spacer`, `Text`) with antd equivalents (`Flex`, `Title`, `Divider`) and plain HTML
* Replaced `SecondaryLink` with `NextLink` + `Typography.Link`
* Removed Yup validation schema (fields are disabled, validation unnecessary)
* Removed `FormGuard` (no dirty-form tracking needed for read-only form)
* Switched from default export to named export
* Removed unused `defaultInitialValues` constant

### Steps to Confirm

1. Navigate to the Data Map page
2. Click on a system row to open the datamap drawer
3. Verify the "System details" section displays correctly with system name and description
4. Verify the "View more" link navigates to the system configuration page
5. Verify both fields appear disabled/read-only

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3177]: https://ethyca.atlassian.net/browse/ENG-3177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ