### PR TITLE
Enable test and production flags for alpha dashboard

### DIFF
--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -158,14 +158,14 @@
     "label": "Alpha dashboard agent briefing",
     "description": "Show the Astralis agent summary banner on the dashboard",
     "development": true,
-    "test": false,
-    "production": false
+    "test": true,
+    "production": true
   },
   "alphaDashboardAgentBriefingActions": {
     "label": "Alpha dashboard agent briefing actions",
     "description": "Show action items inside the Astralis agent briefing banner",
     "development": true,
-    "test": false,
-    "production": false
+    "test": true,
+    "production": true
   }
 }


### PR DESCRIPTION
turn on agent briefing banner and actions feature

Ticket [<issue>] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

Displays the Astralis agent banner by default: 

<img width="1615" height="312" alt="Screenshot 2026-04-14 at 5 06 33 PM" src="https://github.com/user-attachments/assets/39eacab0-1641-4536-b9ab-1ef296d677a2" />


### Description Of Changes

<!-- Write some things about the changes and any potential caveats -->

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. <!-- list any manual steps for reviewers to confirm the changes -->

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
