### PR TITLE
ENG-3440: Fix TypeError when closing Data Catalog drawer

### DIFF
--- a/changelog/7925-fix-data-catalog-drawer-error.yaml
+++ b/changelog/7925-fix-data-catalog-drawer-error.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed TypeError when closing Data Catalog drawer for systems without privacy declarations
+pr: 7925
+labels: []

--- a/clients/admin-ui/src/features/data-catalog/systems/EditDataUseCell.tsx
+++ b/clients/admin-ui/src/features/data-catalog/systems/EditDataUseCell.tsx
@@ -43,6 +43,10 @@ const EditDataUseCell = ({ system }: EditDataUseCellProps) => {
   const { createDataUse, deleteDeclarationByDataUse, updateDataUse } =
     useSystemDataUseCrud(system);
 
+  if (!system) {
+    return null;
+  }
+
   const declarations = system.privacy_declarations ?? [];
   const dataUses = declarations.map((pd) => pd.data_use);
 

--- a/clients/admin-ui/src/features/data-catalog/systems/EditDataUseCell.tsx
+++ b/clients/admin-ui/src/features/data-catalog/systems/EditDataUseCell.tsx
@@ -43,7 +43,8 @@ const EditDataUseCell = ({ system }: EditDataUseCellProps) => {
   const { createDataUse, deleteDeclarationByDataUse, updateDataUse } =
     useSystemDataUseCrud(system);
 
-  const dataUses = system.privacy_declarations?.map((pd) => pd.data_use) ?? [];
+  const declarations = system.privacy_declarations ?? [];
+  const dataUses = declarations.map((pd) => pd.data_use);
 
   const addDataUse = (use: string) => {
     const declaration = createMinimalDataUse(use);
@@ -60,9 +61,7 @@ const EditDataUseCell = ({ system }: EditDataUseCellProps) => {
               key={d}
               data-testid={`data-use-${d}`}
               color="white"
-              onClick={() =>
-                handleOpenEditForm(system.privacy_declarations[idx])
-              }
+              onClick={() => handleOpenEditForm(declarations[idx])}
               closable
               onClose={() => deleteDeclarationByDataUse(d)}
               closeButtonLabel="Remove data use"


### PR DESCRIPTION
Ticket [ENG-3440]

### Description Of Changes

Fixes a `TypeError: Cannot read properties of undefined (reading 'privacy_declarations')` that occurs when closing the Data Catalog drawer. The crash happened because `system.privacy_declarations` was accessed directly without a null check in the `onClick` handler, while the `dataUses` derivation already used optional chaining.

The fix extracts `privacy_declarations` into a safe `declarations` variable with a `?? []` fallback, then uses that reference consistently for both the data use list and the click handler.

### Code Changes

* Extract `system.privacy_declarations ?? []` into a `declarations` constant in `EditDataUseCell.tsx`
* Replace direct `system.privacy_declarations[idx]` access with safe `declarations[idx]` in the Tag onClick handler

### Steps to Confirm

1. Enable the Data Catalog Beta flag
2. Navigate to the Data Catalog systems view
3. Click a system's vertical 3-dot menu and select "View details" to open the drawer
4. Close the drawer - confirm no TypeError is thrown
5. Open a system that has privacy declarations and verify data uses still display and are editable

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3440]: https://ethyca.atlassian.net/browse/ENG-3440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ