### PR TITLE
ENG-3415: New Privacy Center Form Field Types

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -94,6 +94,29 @@ dataset:
     - name: username
       data_categories:
         - user.account.username
+  - name: attachment_user_provided
+    fields:
+    - name: created_at
+      data_categories:
+      - system.operations
+    - name: id
+      data_categories:
+      - system.operations
+    - name: object_key
+      data_categories:
+      - system.operations
+    - name: promoted_at
+      data_categories:
+      - system.operations
+    - name: status
+      data_categories:
+      - system.operations
+    - name: storage_key
+      data_categories:
+      - system.operations
+    - name: updated_at
+      data_categories:
+      - system.operations
   - name: answer_version
     description: 'Immutable history of assessment answer versions'
     fields:

--- a/changelog/7931-privacy-center-new-field-types.yaml
+++ b/changelog/7931-privacy-center-new-field-types.yaml
@@ -2,6 +2,10 @@ type: Added
 description: >-
   Added checkbox, checkbox_group, textarea, and file field types to the
   Privacy Center form config. File fields are backed by a new unauthenticated
-  upload endpoint, an `attachment_user_provided` table + orphan cleanup
+  upload endpoint (returning an attachment id the client echoes back in the
+  field value list), an `attachment_user_provided` table + orphan cleanup
+  Celery task, and stricter persistence of falsy custom-field values
+  (checkbox `False`, numeric `0`, and empty strings are now preserved rather
+  than silently dropped).
 pr: 7931
 labels: []

--- a/changelog/7931-privacy-center-new-field-types.yaml
+++ b/changelog/7931-privacy-center-new-field-types.yaml
@@ -1,0 +1,7 @@
+type: Added
+description: >-
+  Added checkbox, checkbox_group, textarea, and file field types to the
+  Privacy Center form config. File fields are backed by a new unauthenticated
+  upload endpoint, an `attachment_user_provided` table + orphan cleanup
+pr: 7931
+labels: []

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_17_1200_9b449105864d_add_attachment_user_provided.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_17_1200_9b449105864d_add_attachment_user_provided.py
@@ -1,0 +1,78 @@
+"""add attachment_user_provided
+
+Revision ID: 9b449105864d
+Revises: d6e7f8a9b0c1
+Create Date: 2026-04-17 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9b449105864d"
+down_revision = "d6e7f8a9b0c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "attachment_user_provided",
+        sa.Column("id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("object_key", sa.String(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending",
+                "promoted",
+                "deleted",
+                name="attachmentuserprovidedstatus",
+            ),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("storage_key", sa.String(), nullable=False),
+        sa.Column("promoted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "object_key", name="uq_attachment_user_provided_object_key"
+        ),
+    )
+    op.create_index(
+        op.f("ix_attachment_user_provided_id"),
+        "attachment_user_provided",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_attachment_user_provided_status_created_at",
+        "attachment_user_provided",
+        ["status", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_attachment_user_provided_status_created_at",
+        table_name="attachment_user_provided",
+    )
+    op.drop_index(
+        op.f("ix_attachment_user_provided_id"),
+        table_name="attachment_user_provided",
+    )
+    op.drop_table("attachment_user_provided")
+    op.execute("DROP TYPE attachmentuserprovidedstatus")

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -63,6 +63,9 @@ from fides.api.util.rate_limit import safe_rate_limit_key
 from fides.cli.utils import FIDES_ASCII_ART
 from fides.config import CONFIG, check_required_webserver_config_values
 from fides.service.jira.polling_task import initiate_jira_ticket_polling
+from fides.service.privacy_request.attachment_user_provided_service import (
+    initiate_scheduled_attachment_cleanup,
+)
 
 NEXT_JS_CATCH_ALL_SEGMENTS_RE = r"^\[{1,2}\.\.\.\w+\]{1,2}"  # https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments
 
@@ -98,6 +101,7 @@ async def lifespan(wrapped_app: FastAPI) -> AsyncGenerator[None, None]:
     initiate_scheduled_batch_email_send()
     initiate_poll_for_exited_privacy_request_tasks()
     initiate_scheduled_dsr_data_removal()
+    initiate_scheduled_attachment_cleanup()
     initiate_interrupted_task_requeue_poll()
     initiate_polling_task_requeue()
     initiate_jira_ticket_polling()

--- a/src/fides/api/models/attachment.py
+++ b/src/fides/api/models/attachment.py
@@ -33,6 +33,7 @@ class AttachmentType(str, EnumType):
 
     internal_use_only = "internal_use_only"
     include_with_access_package = "include_with_access_package"
+    user_provided = "user_provided"
 
 
 class AttachmentReferenceType(str, EnumType):
@@ -46,6 +47,21 @@ class AttachmentReferenceType(str, EnumType):
     comment = "comment"
     manual_task_submission = "manual_task_submission"
     request_task = "request_task"
+
+
+class AttachmentUserProvidedStatus(str, EnumType):
+    """Lifecycle states for a data-subject-uploaded attachment.
+
+    - ``pending``: uploaded to storage, awaiting privacy-request submission.
+    - ``promoted``: claimed by a submitted privacy request and converted to
+      an ``Attachment`` row; ``promoted_attachment_id`` is populated.
+    - ``deleted``: temp file removed by the orphan cleanup sweep (row kept
+      for audit).
+    """
+
+    pending = "pending"
+    promoted = "promoted"
+    deleted = "deleted"
 
 
 class AttachmentReference(Base):
@@ -175,3 +191,53 @@ class Attachment(Base):
     ) -> "Attachment":
         """Creates a new attachment record in the database."""
         return cls._create_record(db=db, data=data, check_name=check_name)
+
+
+class AttachmentUserProvided(Base):
+    """Tracks data-subject-uploaded file attachments through their lifecycle.
+
+    Each row owns the state of a single temp-storage object, from upload
+    (``pending``) → claim (``promoted``) → cleanup (``deleted``). Durable
+    across Redis restarts and queryable for audit.
+
+    Independent table — no foreign keys. ``storage_key`` / ``promoted_attachment_id``
+    are plain string references looked up on demand; removals in the
+    referenced tables do not cascade here, so rows are preserved for
+    forensics regardless of storage-config or attachment churn.
+    """
+
+    @declared_attr
+    def __tablename__(cls) -> str:
+        """Match the snake_case table name from the alembic migration."""
+        return "attachment_user_provided"
+
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    object_key = Column(String, nullable=False, unique=True)
+
+    status = Column(
+        EnumColumn(AttachmentUserProvidedStatus, name="attachmentuserprovidedstatus"),
+        nullable=False,
+        server_default=AttachmentUserProvidedStatus.pending.value,
+    )
+
+    storage_key = Column(String, nullable=False)
+    promoted_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        # Speeds up the orphan-cleanup sweep:
+        #   WHERE status = 'pending' AND created_at < :cutoff
+        Index(
+            "ix_attachment_user_provided_status_created_at",
+            "status",
+            "created_at",
+        ),
+    )

--- a/src/fides/api/models/privacy_request/privacy_request.py
+++ b/src/fides/api/models/privacy_request/privacy_request.py
@@ -621,18 +621,17 @@ class PrivacyRequest(
 
         if CONFIG.execution.allow_custom_privacy_request_field_collection:
             for key, item in custom_privacy_request_fields.items():
-                if item.value:
-                    hashed_value = CustomPrivacyRequestField.hash_value(item.value)
-                    CustomPrivacyRequestField.create(
-                        db=db,
-                        data={
-                            "privacy_request_id": self.id,
-                            "field_name": key,
-                            "field_label": item.label,
-                            "encrypted_value": {"value": item.value},
-                            "hashed_value": hashed_value,
-                        },
-                    )
+                hashed_value = CustomPrivacyRequestField.hash_value(item.value)
+                CustomPrivacyRequestField.create(
+                    db=db,
+                    data={
+                        "privacy_request_id": self.id,
+                        "field_name": key,
+                        "field_label": item.label,
+                        "encrypted_value": {"value": item.value},
+                        "hashed_value": hashed_value,
+                    },
+                )
         else:
             logger.info(
                 "Custom fields provided in privacy request {}, but config setting 'CONFIG.execution.allow_custom_privacy_request_field_collection' prevents their storage.",
@@ -1773,6 +1772,11 @@ class CustomPrivacyRequestField(HashMigrationMixin, Base):
             )
             return hashed_value
 
+        # Short-circuit None — str(None) → "None" would produce a deterministic
+        # but meaningless hash that collides across any two fields that ever see
+        # None, poisoning the hash index for lookups.
+        if value is None:
+            return None
         if isinstance(value, list):
             # Skip hashing lists: this avoids us hashing and later indexing potentially large values and our index
             # is not useful for array search anyway
@@ -1780,7 +1784,8 @@ class CustomPrivacyRequestField(HashMigrationMixin, Base):
         return hash_single_value(value)
 
     def migrate_hashed_fields(self) -> None:
-        if value := self.encrypted_value.get("value"):
+        value = self.encrypted_value.get("value")
+        if value is not None:
             self.hashed_value = self.hash_value(value)  # type: ignore
         self.is_hash_migrated = True
 

--- a/src/fides/api/schemas/attachment.py
+++ b/src/fides/api/schemas/attachment.py
@@ -1,6 +1,6 @@
 """Pydantic schemas for data-subject-uploaded attachments."""
 
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from fides.api.schemas.base_class import FidesSchema
 
@@ -12,6 +12,8 @@ class PrivacyRequestAttachment(FidesSchema):
     list when the request is submitted — that id is the sole identifier
     the server uses to resolve the upload.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     id: str = Field(
         description=(

--- a/src/fides/api/schemas/attachment.py
+++ b/src/fides/api/schemas/attachment.py
@@ -1,0 +1,21 @@
+"""Pydantic schemas for data-subject-uploaded attachments."""
+
+from pydantic import Field
+
+from fides.api.schemas.base_class import FidesSchema
+
+
+class PrivacyRequestAttachment(FidesSchema):
+    """Response payload for the privacy-request attachment upload endpoint.
+
+    The Privacy Center echoes ``id`` back in the custom field's ``value``
+    list when the request is submitted — that id is the sole identifier
+    the server uses to resolve the upload.
+    """
+
+    id: str = Field(
+        description=(
+            "AttachmentUserProvided row id. Echo this back in the custom "
+            "field's value list when the request is submitted."
+        ),
+    )

--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -78,10 +78,72 @@ class BaseCustomPrivacyRequestField(FidesSchema, ABC):
 
 
 class CustomPrivacyRequestField(BaseCustomPrivacyRequestField):
-    """Regular custom privacy request field supporting text, select, and multiselect types"""
+    """Regular custom privacy request field supporting text, select, multiselect,
+    checkbox, checkbox_group, and textarea types"""
 
-    field_type: Optional[Literal["text", "select", "multiselect"]] = None
+    field_type: Optional[
+        Literal[
+            "text", "select", "multiselect", "checkbox", "checkbox_group", "textarea"
+        ]
+    ] = None
     options: Optional[List[str]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_field_type_constraints(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if values.get("field_type") == "checkbox_group" and not values.get("options"):
+            raise ValueError("checkbox_group fields require at least one option")
+        return values
+
+
+DEFAULT_FILE_MAX_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _default_allowed_mime_types() -> List[str]:
+    # Import locally to avoid pulling storage/service modules at schema import time.
+    from fides.api.service.storage.util import PublicUploadAllowedFileTypes
+
+    return sorted(PublicUploadAllowedFileTypes.mime_types())
+
+
+class FileUploadCustomPrivacyRequestField(BaseCustomPrivacyRequestField):
+    """File upload field — supports a list of file attachments.
+
+    ``max_size_bytes`` and ``allowed_mime_types`` are config hints used by
+    the Privacy Center client to pre-filter uploads. The upload endpoint
+    currently enforces the global defaults (``DEFAULT_FILE_MAX_SIZE_BYTES``
+    and :meth:`PublicUploadAllowedFileTypes.mime_types`); per-field
+    tightening at upload time is a follow-up.
+    """
+
+    field_type: Literal["file"] = "file"
+    required: Optional[bool] = False
+    max_size_bytes: int = Field(default=DEFAULT_FILE_MAX_SIZE_BYTES, gt=0)
+    allowed_mime_types: List[str] = Field(default_factory=_default_allowed_mime_types)
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_file_field(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if values.get("options"):
+            raise ValueError("file fields do not support options")
+        return values
+
+    @field_validator("allowed_mime_types")
+    @classmethod
+    def validate_allowed_mime_types(cls, v: List[str]) -> List[str]:
+        # Import locally to keep the schema module independent of services.
+        from fides.api.service.storage.util import PublicUploadAllowedFileTypes
+
+        supported = PublicUploadAllowedFileTypes.mime_types()
+        if not v:
+            raise ValueError("allowed_mime_types must not be empty")
+        unsupported = [mime for mime in v if mime not in supported]
+        if unsupported:
+            raise ValueError(
+                f"Unsupported MIME types: {sorted(unsupported)}. "
+                f"Supported: {sorted(supported)}"
+            )
+        return v
 
 
 class LocationCustomPrivacyRequestField(BaseCustomPrivacyRequestField):
@@ -117,12 +179,15 @@ def get_field_type_discriminator(v: Any) -> str:
 
     if field_type == "location":
         return "location"
+    if field_type == "file":
+        return "file"
     return "custom"
 
 
 CustomPrivacyRequestFieldUnion = Annotated[
     Union[
         Annotated[LocationCustomPrivacyRequestField, Tag("location")],
+        Annotated[FileUploadCustomPrivacyRequestField, Tag("file")],
         Annotated[CustomPrivacyRequestField, Tag("custom")],
     ],
     Discriminator(get_field_type_discriminator),

--- a/src/fides/api/schemas/redis_cache.py
+++ b/src/fides/api/schemas/redis_cache.py
@@ -6,6 +6,7 @@ from pydantic import (
     ConfigDict,
     EmailStr,
     Field,
+    StrictBool,
     StrictInt,
     StrictStr,
     ValidationError,
@@ -17,7 +18,11 @@ from fides.api.common_exceptions import BadRequest
 from fides.api.custom_types import PhoneNumber
 from fides.api.schemas.base_class import FidesSchema
 
-MultiValue = Union[StrictInt, StrictStr, List[Union[StrictInt, StrictStr]]]
+# StrictBool must precede StrictInt: in Python bool is a subclass of int,
+# so it must be matched first to avoid True/False being accepted as 1/0.
+MultiValue = Union[
+    StrictBool, StrictInt, StrictStr, List[Union[StrictBool, StrictInt, StrictStr]]
+]
 
 
 class IdentityBase(FidesSchema):

--- a/src/fides/api/service/storage/util.py
+++ b/src/fides/api/service/storage/util.py
@@ -8,6 +8,81 @@ from loguru import logger
 
 from fides.api.util.storage_util import format_size
 
+
+class FilesMagicBytes(EnumType):
+    """Catalog of magic byte signatures for common upload-capable file types.
+
+    Used to verify actual file contents on upload — the declared
+    Content-Type header is not trusted on its own. Each member carries
+    ``(magic, mime)``; this is pure catalog data, independent of whether
+    a given type is currently accepted anywhere.
+
+    Some formats share magic bytes (docx/xlsx/zip are all ``PK\\x03\\x04``;
+    doc/xls are both OLE compound files); :meth:`from_bytes` resolves this
+    by returning the MIME of the first matching catalog entry (declaration
+    order). Plain-text formats (txt, csv) have no magic signature; their
+    ``magic`` is ``None`` and they never match via :meth:`from_bytes`.
+    """
+
+    pdf = (b"%PDF", "application/pdf")
+    doc = (b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", "application/msword")
+    docx = (
+        b"PK\x03\x04",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    )
+    txt = (None, "text/plain")
+    jpg = (b"\xff\xd8\xff", "image/jpeg")
+    jpeg = (b"\xff\xd8\xff", "image/jpeg")
+    png = (b"\x89PNG\r\n\x1a\n", "image/png")
+    xls = (b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", "application/vnd.ms-excel")
+    xlsx = (
+        b"PK\x03\x04",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+    csv = (None, "text/csv")
+    zip = (b"PK\x03\x04", "application/zip")
+
+    def __init__(self, magic: Optional[bytes], mime: str) -> None:
+        self.magic = magic
+        self.mime = mime
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> Optional[str]:
+        """Return the single MIME type whose magic prefix matches ``data``.
+
+        Resolves shared-magic ambiguity (e.g. ``PK\\x03\\x04`` → docx/xlsx/zip;
+        OLE → doc/xls) by returning the MIME of the first catalog entry
+        that matches, in enum declaration order. Members with ``magic=None``
+        (plain-text formats) are never matched. Returns ``None`` if no
+        signature matches.
+
+        Callers gate the returned MIME against a policy set (e.g.
+        :meth:`PublicUploadAllowedFileTypes.mime_types`) — this method
+        answers "what is it?", not "is it allowed?".
+        """
+        for member in cls:
+            if member.magic is not None and data[: len(member.magic)] == member.magic:
+                return member.mime
+        return None
+
+
+class PublicUploadAllowedFileTypes(EnumType):
+    """MIME types accepted on public (unauthenticated) upload endpoints.
+
+    Narrower than :class:`FilesMagicBytes` by design — expanding the
+    allow-list is a one-line change here without touching the magic-byte
+    catalog.
+    """
+
+    pdf = "application/pdf"
+    jpg = "image/jpeg"
+    png = "image/png"
+
+    @classmethod
+    def mime_types(cls) -> set[str]:
+        return {member.value for member in cls}
+
+
 # This is the max file size for downloading the content of an attachment.
 # This is an industry standard used by companies like Google and Microsoft.
 LARGE_FILE_THRESHOLD = 2 * 1024 * 1024 * 1024  # 2 GB
@@ -29,6 +104,19 @@ class AllowedFileType(EnumType):
     xlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     csv = "text/csv"
     zip = "application/zip"
+
+
+MIME_TO_EXTENSION: dict[str, str] = {
+    member.value: member.name for member in AllowedFileType
+}
+
+
+def extension_for_mime(mime: str) -> str:
+    """Return the file extension matching an allowed MIME (without leading dot)."""
+    try:
+        return MIME_TO_EXTENSION[mime]
+    except KeyError as exc:
+        raise ValueError(f"No extension registered for MIME {mime!r}") from exc
 
 
 LOCAL_FIDES_UPLOAD_DIRECTORY = "fides_uploads"

--- a/src/fides/api/v1/api.py
+++ b/src/fides/api/v1/api.py
@@ -18,6 +18,7 @@ from fides.api.v1.endpoints import (
     policy_endpoints,
     policy_webhook_endpoints,
     pre_approval_webhook_endpoints,
+    privacy_request_attachment_endpoints,
     privacy_request_endpoints,
     privacy_request_redaction_patterns_endpoints,
     saas_config_endpoints,
@@ -45,6 +46,7 @@ api_router.include_router(oauth_endpoints.router)
 api_router.include_router(policy_endpoints.router)
 api_router.include_router(policy_webhook_endpoints.router)
 api_router.include_router(pre_approval_webhook_endpoints.router)
+api_router.include_router(privacy_request_attachment_endpoints.router)
 api_router.include_router(privacy_request_endpoints.router)
 api_router.include_router(privacy_request_redaction_patterns_endpoints.router)
 api_router.include_router(identity_verification_endpoints.router)

--- a/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
+++ b/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
@@ -6,14 +6,14 @@ request rate limit and a streaming size cap.  See
 lifecycle model.
 """
 
-from fastapi import Depends, File, HTTPException, Request, Response, UploadFile
+from fastapi import Depends, File, Header, HTTPException, Request, Response, UploadFile
 from loguru import logger
 from sqlalchemy.orm import Session
 from starlette.status import (
     HTTP_400_BAD_REQUEST,
     HTTP_403_FORBIDDEN,
     HTTP_413_CONTENT_TOO_LARGE,
-    HTTP_500_INTERNAL_SERVER_ERROR,
+    HTTP_503_SERVICE_UNAVAILABLE,
 )
 
 from fides.api.deps import get_db
@@ -41,18 +41,20 @@ def upload_privacy_request_attachment(
     request: Request,  # required for rate limiting
     response: Response,  # required for rate limiting
     file: UploadFile = File(...),
+    content_length: int | None = Header(default=None),
     db: Session = Depends(get_db),
 ) -> PrivacyRequestAttachment:
     """Upload a file attachment for use in a custom privacy request field.
 
     Unauthenticated — same trust level as privacy-request creation. Protected
-    by the public request rate limit and a streaming size cap so an attacker
-    cannot buffer unbounded bodies into memory.
+    by the public request rate limit, a ``Content-Length`` pre-check, and a
+    streaming size cap so an attacker cannot buffer unbounded bodies into
+    memory.
 
-    Returns an ``object_key`` to include in the custom field's ``value``
+    Returns an attachment ``id`` to include in the custom field's ``value``
     list when submitting the privacy request:
 
-        "value": ["<object_key>"]
+        "value": ["<attachment id>"]
 
     File type is verified via magic byte inspection.
 
@@ -66,6 +68,18 @@ def upload_privacy_request_attachment(
             detail=(
                 "File attachments are disabled because custom privacy "
                 "request field collection is not enabled."
+            ),
+        )
+
+    # Content-Length pre-check — reject oversize requests before reading any
+    # body bytes. A hostile client can lie about Content-Length, so the
+    # streaming check below still runs as the authoritative guard; this just
+    # avoids buffering the body at all in the honest case.
+    if content_length is not None and content_length > DEFAULT_MAX_SIZE_BYTES:
+        raise HTTPException(
+            status_code=HTTP_413_CONTENT_TOO_LARGE,
+            detail=(
+                f"File exceeds maximum allowed size of {DEFAULT_MAX_SIZE_BYTES} bytes"
             ),
         )
 
@@ -92,5 +106,10 @@ def upload_privacy_request_attachment(
     except ValueError as exc:
         raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc))
     except RuntimeError as exc:
-        logger.error("Attachment upload failed: {}", exc)
-        raise HTTPException(status_code=HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))
+        # Log the internal reason but return a generic 503 to the public
+        # caller — storage-misconfig details shouldn't leak to unauth users.
+        logger.error("Attachment upload failed (misconfiguration): {}", exc)
+        raise HTTPException(
+            status_code=HTTP_503_SERVICE_UNAVAILABLE,
+            detail="File attachments are temporarily unavailable.",
+        )

--- a/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
+++ b/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
@@ -1,0 +1,96 @@
+"""Unauthenticated upload endpoint for data-subject-uploaded privacy request files.
+
+Same trust level as privacy-request creation, protected by the public
+request rate limit and a streaming size cap.  See
+``fides.service.privacy_request.attachment_user_provided_service`` for the
+lifecycle model.
+"""
+
+from fastapi import Depends, File, HTTPException, Request, Response, UploadFile
+from loguru import logger
+from sqlalchemy.orm import Session
+from starlette.status import (
+    HTTP_400_BAD_REQUEST,
+    HTTP_403_FORBIDDEN,
+    HTTP_413_CONTENT_TOO_LARGE,
+    HTTP_500_INTERNAL_SERVER_ERROR,
+)
+
+from fides.api.deps import get_db
+from fides.api.schemas.attachment import PrivacyRequestAttachment
+from fides.api.util.api_router import APIRouter
+from fides.api.util.rate_limit import fides_limiter
+from fides.common.urn_registry import PRIVACY_REQUEST_ATTACHMENT, V1_URL_PREFIX
+from fides.config import CONFIG
+from fides.service.privacy_request.attachment_user_provided_service import (
+    DEFAULT_MAX_SIZE_BYTES,
+    UPLOAD_READ_CHUNK_BYTES,
+    upload_attachment,
+)
+
+router = APIRouter(tags=["Privacy Requests"], prefix=V1_URL_PREFIX)
+
+
+@router.post(
+    PRIVACY_REQUEST_ATTACHMENT,
+    response_model=PrivacyRequestAttachment,
+)
+@fides_limiter.limit(CONFIG.security.request_rate_limit)
+def upload_privacy_request_attachment(
+    *,
+    request: Request,  # required for rate limiting
+    response: Response,  # required for rate limiting
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+) -> PrivacyRequestAttachment:
+    """Upload a file attachment for use in a custom privacy request field.
+
+    Unauthenticated — same trust level as privacy-request creation. Protected
+    by the public request rate limit and a streaming size cap so an attacker
+    cannot buffer unbounded bodies into memory.
+
+    Returns an ``object_key`` to include in the custom field's ``value``
+    list when submitting the privacy request:
+
+        "value": ["<object_key>"]
+
+    File type is verified via magic byte inspection.
+
+    Gated on ``CONFIG.execution.allow_custom_privacy_request_field_collection``
+    — uploads only make sense when custom fields (the mechanism that
+    references them) are themselves enabled.
+    """
+    if not CONFIG.execution.allow_custom_privacy_request_field_collection:
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail=(
+                "File attachments are disabled because custom privacy "
+                "request field collection is not enabled."
+            ),
+        )
+
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = file.file.read(UPLOAD_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > DEFAULT_MAX_SIZE_BYTES:
+            raise HTTPException(
+                status_code=HTTP_413_CONTENT_TOO_LARGE,
+                detail=(
+                    f"File exceeds maximum allowed size of {DEFAULT_MAX_SIZE_BYTES} bytes"
+                ),
+            )
+        chunks.append(chunk)
+
+    file_data = b"".join(chunks)
+
+    try:
+        return upload_attachment(file_data=file_data, db=db)
+    except ValueError as exc:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc))
+    except RuntimeError as exc:
+        logger.error("Attachment upload failed: {}", exc)
+        raise HTTPException(status_code=HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))

--- a/src/fides/common/urn_registry.py
+++ b/src/fides/common/urn_registry.py
@@ -84,6 +84,7 @@ PRIVACY_REQUEST_APPROVE = "/privacy-request/administrate/approve"
 PRIVACY_REQUEST_BATCH_EMAIL_SEND = (
     "/privacy-request/administrate/process-awaiting-email-send"
 )
+PRIVACY_REQUEST_ATTACHMENT = "/privacy-request/attachment"
 PRIVACY_REQUEST_AUTHENTICATED = "/privacy-request/authenticated"
 PRIVACY_REQUEST_BULK_FINALIZE = "/privacy-request/bulk/finalize"
 PRIVACY_REQUEST_BULK_RETRY = "/privacy-request/bulk/retry"

--- a/src/fides/service/privacy_request/attachment_user_provided_repository.py
+++ b/src/fides/service/privacy_request/attachment_user_provided_repository.py
@@ -1,0 +1,103 @@
+"""Data-access layer for ``AttachmentUserProvided`` rows.
+
+Encapsulates every SQLAlchemy query and mutation the attachment
+user-provided service needs, so the service layer can stay focused on
+storage I/O, validation, and the pending → promoted → deleted state
+machine.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from fides.api.models.attachment import (
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+
+
+class AttachmentUserProvidedRepository:
+    """DB reads/writes for ``attachment_user_provided``."""
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def create_pending(
+        self, *, object_key: str, storage_key: str
+    ) -> AttachmentUserProvided:
+        """Insert a new ``pending`` row (in-session, no commit).
+
+        Flushes so the caller can read server-generated columns (``id``,
+        ``created_at``). The caller owns the transaction — the row is
+        visible to the same session and rolls back if the caller does.
+        """
+        row = AttachmentUserProvided(
+            object_key=object_key,
+            status=AttachmentUserProvidedStatus.pending,
+            storage_key=storage_key,
+        )
+        self._db.add(row)
+        self._db.flush()
+        self._db.refresh(row)
+        return row
+
+    def mark_promoted(
+        self,
+        rows: list[AttachmentUserProvided],
+        *,
+        promoted_at: Optional[datetime] = None,
+    ) -> None:
+        """Flip rows from ``pending`` to ``promoted`` (in-session, no commit).
+
+        Caller owns the transaction — mutations are visible to the same
+        session and roll back if the caller does.
+
+        Raises:
+            ValueError: A row is not in ``pending``.
+        """
+        now = promoted_at or datetime.now(timezone.utc)
+        for row in rows:
+            if row.status != AttachmentUserProvidedStatus.pending:
+                raise ValueError(
+                    f"Attachment '{row.object_key}' is in state {row.status}, "
+                    "expected 'pending'. Refusing to promote."
+                )
+            row.status = AttachmentUserProvidedStatus.promoted
+            row.promoted_at = now
+
+    def mark_deleted(self, row: AttachmentUserProvided) -> None:
+        """Transition a row to ``deleted`` (in-session, no commit)."""
+        row.status = AttachmentUserProvidedStatus.deleted
+
+    def lock_pending_by_ids(
+        self, ids: list[str]
+    ) -> list[AttachmentUserProvided]:
+        """Return ``pending`` rows matching ``ids`` under ``FOR UPDATE``.
+
+        The lock is released when the caller's transaction ends.
+        """
+        return (
+            self._db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id.in_(ids))
+            .filter(
+                AttachmentUserProvided.status == AttachmentUserProvidedStatus.pending
+            )
+            .with_for_update()
+            .all()
+        )
+
+    def list_pending_older_than(
+        self, cutoff: datetime
+    ) -> list[AttachmentUserProvided]:
+        """Return every ``pending`` row created before ``cutoff``."""
+        return (
+            self._db.query(AttachmentUserProvided)
+            .filter(
+                AttachmentUserProvided.status == AttachmentUserProvidedStatus.pending
+            )
+            .filter(AttachmentUserProvided.created_at < cutoff)
+            .all()
+        )

--- a/src/fides/service/privacy_request/attachment_user_provided_repository.py
+++ b/src/fides/service/privacy_request/attachment_user_provided_repository.py
@@ -72,12 +72,13 @@ class AttachmentUserProvidedRepository:
         """Transition a row to ``deleted`` (in-session, no commit)."""
         row.status = AttachmentUserProvidedStatus.deleted
 
-    def lock_pending_by_ids(
-        self, ids: list[str]
-    ) -> list[AttachmentUserProvided]:
+    def lock_pending_by_ids(self, ids: list[str]) -> list[AttachmentUserProvided]:
         """Return ``pending`` rows matching ``ids`` under ``FOR UPDATE``.
 
-        The lock is released when the caller's transaction ends.
+        The lock is released by any ``COMMIT`` (or ``ROLLBACK``) on the
+        caller's session — including commits issued by downstream
+        ``Base.create`` calls. The authoritative concurrency guard is
+        :meth:`mark_promoted`'s ``row.status != pending`` check.
         """
         return (
             self._db.query(AttachmentUserProvided)
@@ -89,9 +90,7 @@ class AttachmentUserProvidedRepository:
             .all()
         )
 
-    def list_pending_older_than(
-        self, cutoff: datetime
-    ) -> list[AttachmentUserProvided]:
+    def list_pending_older_than(self, cutoff: datetime) -> list[AttachmentUserProvided]:
         """Return every ``pending`` row created before ``cutoff``."""
         return (
             self._db.query(AttachmentUserProvided)

--- a/src/fides/service/privacy_request/attachment_user_provided_service.py
+++ b/src/fides/service/privacy_request/attachment_user_provided_service.py
@@ -1,0 +1,386 @@
+"""Service layer for data-subject-uploaded file attachments.
+
+Lifecycle (DB-backed state machine on ``attachment_user_provided``):
+
+    (no row) ──upload──▶ pending ──claim──▶ promoted
+                             │
+                             └──orphan sweep──▶ deleted
+
+Responsibilities:
+- Upload raw bytes to the active default storage backend and insert a
+  ``pending`` row.
+- Identify which custom-field values reference pending rows and return
+  the rows ready for promotion (``resolve_file_attachments``).
+- Atomically transition pending → promoted and create ``Attachment`` rows
+  linked to each promoted user-provided row (``promote_rows_to_attachments``).
+- Celery periodic task: sweep stale ``pending`` rows, delete their storage
+  objects, and transition them to ``deleted``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from fides.api.models.attachment import (
+    AttachmentReferenceType,
+    AttachmentType,
+    AttachmentUserProvided,
+)
+from fides.api.models.privacy_request.privacy_request import PrivacyRequest
+from fides.api.models.storage import StorageConfig, get_active_default_storage_config
+from fides.api.schemas.attachment import PrivacyRequestAttachment
+from fides.api.schemas.privacy_center_config import DEFAULT_FILE_MAX_SIZE_BYTES
+from fides.api.schemas.redis_cache import CustomPrivacyRequestField
+from fides.api.service.storage.providers import StorageProviderFactory
+from fides.api.service.storage.providers.base import StorageProvider
+from fides.api.service.storage.util import (
+    FilesMagicBytes,
+    PublicUploadAllowedFileTypes,
+    extension_for_mime,
+)
+from fides.api.tasks import DatabaseTask, celery_app
+from fides.api.tasks.scheduled.scheduler import scheduler
+from fides.config import CONFIG
+from fides.service.attachment_service import AttachmentService
+from fides.service.privacy_request.attachment_user_provided_repository import (
+    AttachmentUserProvidedRepository,
+)
+
+# Re-export under a shorter local alias for the endpoint + internal use.
+DEFAULT_MAX_SIZE_BYTES = DEFAULT_FILE_MAX_SIZE_BYTES
+
+# How long a pending row can live before orphan sweep is allowed to delete it.
+ORPHAN_MIN_AGE_SECONDS = 3600  # 1 hour
+ORPHAN_CLEANUP_INTERVAL_HOURS = 1
+ORPHAN_CLEANUP_JOB_ID = "attachment_user_provided_orphan_cleanup"
+
+# Chunk size for streaming uploads — abort as soon as cumulative size exceeds
+# DEFAULT_MAX_SIZE_BYTES so an attacker cannot buffer an unbounded body.
+UPLOAD_READ_CHUNK_BYTES = 64 * 1024
+
+OBJECT_KEY_PREFIX = "privacy_request_attachments/"
+
+
+def _bucket(storage_config: StorageConfig) -> str:
+    return (storage_config.details or {}).get("bucket", "")
+
+
+def _get_provider_and_bucket(
+    db: Session,
+) -> tuple[StorageProvider, str, StorageConfig]:
+    """Return (provider, bucket, storage_config) or raise RuntimeError.
+
+    Centralises the three-way lookup used by upload, promotion, and orphan
+    cleanup so callers share the same error path.
+    """
+    storage_config = get_active_default_storage_config(db)
+    if not storage_config:
+        raise RuntimeError(
+            "No active default storage configuration found. "
+            "Configure a storage backend before accepting file attachments."
+        )
+    provider = StorageProviderFactory.create(storage_config)
+    return provider, _bucket(storage_config), storage_config
+
+
+def upload_attachment(
+    *,
+    file_data: bytes,
+    db: Session,
+) -> PrivacyRequestAttachment:
+    """Validate, store, and register a file attachment.
+
+    Writes the file under ``privacy_request_attachments/{uuid}.{ext}``
+    using the active default storage backend and inserts an
+    ``AttachmentUserProvided`` row with status ``pending``. The original
+    client-supplied filename is discarded — the stored name is entirely
+    server-generated, eliminating a class of path/metadata-injection
+    risks at the storage boundary.
+
+    File type is determined purely from magic-byte inspection; the
+    client-declared Content-Type is ignored. Size is enforced via
+    ``DEFAULT_MAX_SIZE_BYTES``.
+
+    Raises:
+        ValueError: File fails size or type validation.
+        RuntimeError: No active storage config found.
+    """
+    if len(file_data) > DEFAULT_MAX_SIZE_BYTES:
+        raise ValueError(
+            f"File exceeds maximum allowed size of {DEFAULT_MAX_SIZE_BYTES} bytes "
+            f"(received {len(file_data)} bytes)"
+        )
+
+    allowed = PublicUploadAllowedFileTypes.mime_types()
+    content_type = FilesMagicBytes.from_bytes(file_data)
+    if content_type is None or content_type not in allowed:
+        raise ValueError(
+            f"File type is not allowed. Allowed types: {sorted(allowed)}"
+        )
+
+    provider, bucket, storage_config = _get_provider_and_bucket(db)
+    object_key = f"{OBJECT_KEY_PREFIX}{uuid4()}.{extension_for_mime(content_type)}"
+    result = provider.upload(
+        bucket=bucket,
+        key=object_key,
+        data=BytesIO(file_data),
+        content_type=content_type,
+    )
+
+    row = AttachmentUserProvidedRepository(db).create_pending(
+        object_key=object_key,
+        storage_key=storage_config.key,
+    )
+    db.commit()
+
+    logger.info(
+        "Uploaded attachment id={} size={} type={}",
+        row.id,
+        result.file_size,
+        content_type,
+    )
+
+    return PrivacyRequestAttachment(id=row.id)
+
+
+def resolve_file_attachments(
+    custom_privacy_request_fields: Optional[Dict[str, CustomPrivacyRequestField]],
+    file_field_names: set[str],
+    db: Session,
+) -> list[AttachmentUserProvided]:
+    """Resolve file-field values to locked ``AttachmentUserProvided`` rows.
+
+    ``file_field_names`` is authoritative — derived from the Privacy Center
+    config's ``field_type == "file"`` entries. For each listed field, each
+    id in its ``value`` list is looked up against the pending rows under
+    ``FOR UPDATE`` and returned for downstream promotion. The caller is
+    responsible for stripping the file-field keys from the payload before
+    persisting the remaining custom fields.
+
+    Status transitions do NOT happen here; they are deferred to
+    :func:`promote_rows_to_attachments` so that if privacy-request
+    creation rolls back, pending rows stay pending.
+
+    Raises:
+        ValueError: A file field's value is malformed (not a list of
+            strings) or any id fails to resolve to a pending row.
+    """
+    if not custom_privacy_request_fields or not file_field_names:
+        return []
+
+    if not CONFIG.execution.allow_custom_privacy_request_field_collection:
+        return []
+
+    rows: list[AttachmentUserProvided] = []
+    repo = AttachmentUserProvidedRepository(db)
+
+    for name in file_field_names:
+        field = custom_privacy_request_fields.get(name)
+        if field is None:
+            continue
+
+        value = field.value
+        if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+            raise ValueError(
+                f"File attachment for field '{name}' must be a list of "
+                "attachment ids."
+            )
+        ids: list[str] = [v for v in value if isinstance(v, str)]
+        if not ids:
+            continue
+
+        pending = {r.id: r for r in repo.lock_pending_by_ids(ids)}
+        for item in ids:
+            row = pending.get(item)
+            if row is None:
+                raise ValueError(
+                    f"File attachment for field '{name}' "
+                    "has expired or is invalid. Please re-upload and resubmit."
+                )
+            rows.append(row)
+
+    return rows
+
+
+def promote_rows_to_attachments(
+    privacy_request: PrivacyRequest,
+    db: Session,
+    rows: list[AttachmentUserProvided],
+) -> None:
+    """Transition pending rows → promoted and create ``Attachment`` records.
+
+    Three phases:
+    1. Flip every row's status to ``promoted`` (they were locked ``FOR
+       UPDATE`` by :func:`resolve_file_attachments`).
+    2. Download each row's bytes and create an ``Attachment`` record
+       linked to the privacy request. ``AttachmentService.create_and_upload``
+       commits per row — this function tracks those so a mid-loop failure
+       can explicitly delete the partial work.
+    3. Delete the temp objects from storage (best-effort — orphan sweep
+       reaps leftovers under ``privacy_request_attachments/``).
+
+    Raises:
+        Exception: Re-raises any storage or AttachmentService error after
+            deleting any ``Attachment`` rows already created on this call.
+            Caller should still delete the privacy request itself.
+    """
+    if not rows:
+        return
+
+    provider, bucket, storage_config = _get_provider_and_bucket(db)
+    attachment_service = AttachmentService(db=db)
+    repo = AttachmentUserProvidedRepository(db)
+
+    # Phase 1: flip status under the already-held FOR UPDATE lock.
+    repo.mark_promoted(rows)
+
+    # Phase 2: download + create Attachment rows.  Each iteration commits
+    # (Attachment._create_record + AttachmentReference.create). Track what
+    # we've created so partial failure can be compensated explicitly —
+    # AttachmentReference has no FK cascade on reference_id, so deleting
+    # the privacy_request alone would orphan any rows created before the
+    # failure. filename is the last path segment of the object_key, which
+    # is server-generated (uuid + extension) — no user-supplied name is
+    # preserved.
+    created: list[Any] = []
+    try:
+        for row in rows:
+            file_content = provider.download(bucket, row.object_key)
+            file_name = os.path.basename(row.object_key)
+            attachment = attachment_service.create_and_upload(
+                data={
+                    "file_name": file_name,
+                    "user_id": None,
+                    "username": "data_subject",
+                    "attachment_type": AttachmentType.user_provided,
+                    "storage_key": storage_config.key,
+                },
+                file_data=file_content,
+                references=[
+                    {
+                        "reference_id": privacy_request.id,
+                        "reference_type": AttachmentReferenceType.privacy_request,
+                    }
+                ],
+            )
+            created.append(attachment)
+            logger.info(
+                "Promoted attachment {} on request {} → Attachment {}",
+                row.id,
+                privacy_request.id,
+                attachment.id,
+            )
+    except Exception:
+        for attachment in created:
+            try:
+                attachment_service.delete(attachment)
+            except Exception:
+                logger.warning(
+                    "Failed to clean up partially-created Attachment {} after "
+                    "promotion failure",
+                    attachment.id,
+                    exc_info=True,
+                )
+        raise
+
+    # Phase 3: delete temp objects.  Failures here are logged — the orphan
+    # sweep will catch leftovers via the "privacy_request_attachments/"
+    # prefix and transition the row to `deleted`.
+    for row in rows:
+        try:
+            provider.delete(bucket, row.object_key)
+        except Exception:
+            logger.warning(
+                "Could not delete temporary file {} after promotion",
+                row.object_key,
+                exc_info=True,
+            )
+
+
+@celery_app.task(base=DatabaseTask, bind=True, ignore_result=True)
+def cleanup_orphaned_attachments(self: DatabaseTask) -> None:  # type: ignore[misc]
+    """Delete temp storage for pending rows older than ``ORPHAN_MIN_AGE_SECONDS``.
+
+    For each orphan:
+    1. Delete the object from storage.
+    2. Transition the row ``pending`` → ``deleted``.
+
+    Rows in other states are ignored.
+
+    Runs on a schedule — see ``initiate_scheduled_attachment_cleanup()``.
+    """
+    with self.get_db() as db:
+        try:
+            provider, bucket, _ = _get_provider_and_bucket(db)
+        except RuntimeError:
+            logger.info("No active storage config — skipping orphan cleanup")
+            return
+
+        cutoff = datetime.now(timezone.utc) - timedelta(
+            seconds=ORPHAN_MIN_AGE_SECONDS
+        )
+
+        repo = AttachmentUserProvidedRepository(db)
+        orphans = repo.list_pending_older_than(cutoff)
+
+        deleted = 0
+        skipped = 0
+        for row in orphans:
+            try:
+                provider.delete(bucket, row.object_key)
+            except Exception:
+                logger.warning(
+                    "Failed to delete orphaned object {}", row.object_key, exc_info=True
+                )
+                skipped += 1
+                continue
+            try:
+                repo.mark_deleted(row)
+            except Exception:
+                # Storage is already gone — log and keep sweeping so one bad
+                # row does not abort the whole batch.
+                logger.warning(
+                    "Failed to mark orphan row {} as deleted", row.id, exc_info=True
+                )
+                skipped += 1
+                continue
+            deleted += 1
+
+        db.commit()
+        logger.info(
+            "Attachment orphan cleanup complete: deleted={} skipped={}",
+            deleted,
+            skipped,
+        )
+
+
+def initiate_scheduled_attachment_cleanup() -> None:
+    """Register the attachment orphan cleanup Celery task on the APScheduler."""
+    if CONFIG.test_mode:
+        logger.debug("Test mode — skipping attachment cleanup scheduling")
+        return
+
+    if not scheduler.running:
+        logger.error("Scheduler is not running! Cannot schedule attachment cleanup.")
+        raise RuntimeError("Scheduler is not running")
+
+    scheduler.add_job(
+        func=cleanup_orphaned_attachments.delay,
+        kwargs={},
+        id=ORPHAN_CLEANUP_JOB_ID,
+        coalesce=True,
+        replace_existing=True,
+        trigger="interval",
+        hours=ORPHAN_CLEANUP_INTERVAL_HOURS,
+    )
+    logger.info(
+        "Scheduled attachment orphan cleanup (every {} h)",
+        ORPHAN_CLEANUP_INTERVAL_HOURS,
+    )

--- a/src/fides/service/privacy_request/attachment_user_provided_service.py
+++ b/src/fides/service/privacy_request/attachment_user_provided_service.py
@@ -121,9 +121,7 @@ def upload_attachment(
     allowed = PublicUploadAllowedFileTypes.mime_types()
     content_type = FilesMagicBytes.from_bytes(file_data)
     if content_type is None or content_type not in allowed:
-        raise ValueError(
-            f"File type is not allowed. Allowed types: {sorted(allowed)}"
-        )
+        raise ValueError(f"File type is not allowed. Allowed types: {sorted(allowed)}")
 
     provider, bucket, storage_config = _get_provider_and_bucket(db)
     object_key = f"{OBJECT_KEY_PREFIX}{uuid4()}.{extension_for_mime(content_type)}"
@@ -155,14 +153,21 @@ def resolve_file_attachments(
     file_field_names: set[str],
     db: Session,
 ) -> list[AttachmentUserProvided]:
-    """Resolve file-field values to locked ``AttachmentUserProvided`` rows.
+    """Resolve file-field values to ``AttachmentUserProvided`` rows.
 
     ``file_field_names`` is authoritative — derived from the Privacy Center
     config's ``field_type == "file"`` entries. For each listed field, each
-    id in its ``value`` list is looked up against the pending rows under
-    ``FOR UPDATE`` and returned for downstream promotion. The caller is
-    responsible for stripping the file-field keys from the payload before
-    persisting the remaining custom fields.
+    id in its ``value`` list is looked up against the pending rows. The
+    caller is responsible for stripping the file-field keys from the
+    payload before persisting the remaining custom fields.
+
+    Lock semantics: ``lock_pending_by_ids`` issues ``FOR UPDATE``, but any
+    subsequent ``db.commit()`` on the caller's session releases that lock.
+    The authoritative concurrency guard is the ``row.status != pending``
+    check inside :func:`AttachmentUserProvidedRepository.mark_promoted`;
+    a racing promotion on the same row causes that check to raise and the
+    caller to roll back. The lock is a best-effort optimisation to reduce
+    the race window, not a hard guarantee.
 
     Status transitions do NOT happen here; they are deferred to
     :func:`promote_rows_to_attachments` so that if privacy-request
@@ -189,8 +194,7 @@ def resolve_file_attachments(
         value = field.value
         if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
             raise ValueError(
-                f"File attachment for field '{name}' must be a list of "
-                "attachment ids."
+                f"File attachment for field '{name}' must be a list of attachment ids."
             )
         ids: list[str] = [v for v in value if isinstance(v, str)]
         if not ids:
@@ -290,9 +294,11 @@ def promote_rows_to_attachments(
                 )
         raise
 
-    # Phase 3: delete temp objects.  Failures here are logged — the orphan
-    # sweep will catch leftovers via the "privacy_request_attachments/"
-    # prefix and transition the row to `deleted`.
+    # Phase 3: delete temp objects.  Failures here are logged only — the row
+    # is now ``promoted`` so the orphan sweep (which targets ``pending``
+    # only) won't pick it up. Leftover storage objects under this prefix
+    # become dead weight; see the ticket for follow-up on a promoted-row
+    # storage-reconciliation sweep.
     for row in rows:
         try:
             provider.delete(bucket, row.object_key)
@@ -304,61 +310,62 @@ def promote_rows_to_attachments(
             )
 
 
-@celery_app.task(base=DatabaseTask, bind=True, ignore_result=True)
-def cleanup_orphaned_attachments(self: DatabaseTask) -> None:  # type: ignore[misc]
+def _cleanup_orphaned_attachments(db: Session) -> None:
     """Delete temp storage for pending rows older than ``ORPHAN_MIN_AGE_SECONDS``.
 
-    For each orphan:
-    1. Delete the object from storage.
-    2. Transition the row ``pending`` → ``deleted``.
+    Separated from the Celery task wrapper so it can be tested without faking
+    a task context.
+    """
+    try:
+        provider, bucket, _ = _get_provider_and_bucket(db)
+    except RuntimeError:
+        logger.info("No active storage config — skipping orphan cleanup")
+        return
 
-    Rows in other states are ignored.
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=ORPHAN_MIN_AGE_SECONDS)
+
+    repo = AttachmentUserProvidedRepository(db)
+    orphans = repo.list_pending_older_than(cutoff)
+
+    deleted = 0
+    skipped = 0
+    for row in orphans:
+        try:
+            provider.delete(bucket, row.object_key)
+        except Exception:
+            logger.warning(
+                "Failed to delete orphaned object {}", row.object_key, exc_info=True
+            )
+            skipped += 1
+            continue
+        try:
+            repo.mark_deleted(row)
+        except Exception:
+            # Storage is already gone — log and keep sweeping so one bad
+            # row does not abort the whole batch.
+            logger.warning(
+                "Failed to mark orphan row {} as deleted", row.id, exc_info=True
+            )
+            skipped += 1
+            continue
+        deleted += 1
+
+    db.commit()
+    logger.info(
+        "Attachment orphan cleanup complete: deleted={} skipped={}",
+        deleted,
+        skipped,
+    )
+
+
+@celery_app.task(base=DatabaseTask, bind=True, ignore_result=True)
+def cleanup_orphaned_attachments(self: DatabaseTask) -> None:  # type: ignore[misc]
+    """Celery wrapper that opens a fresh session and delegates to the implementation.
 
     Runs on a schedule — see ``initiate_scheduled_attachment_cleanup()``.
     """
-    with self.get_db() as db:
-        try:
-            provider, bucket, _ = _get_provider_and_bucket(db)
-        except RuntimeError:
-            logger.info("No active storage config — skipping orphan cleanup")
-            return
-
-        cutoff = datetime.now(timezone.utc) - timedelta(
-            seconds=ORPHAN_MIN_AGE_SECONDS
-        )
-
-        repo = AttachmentUserProvidedRepository(db)
-        orphans = repo.list_pending_older_than(cutoff)
-
-        deleted = 0
-        skipped = 0
-        for row in orphans:
-            try:
-                provider.delete(bucket, row.object_key)
-            except Exception:
-                logger.warning(
-                    "Failed to delete orphaned object {}", row.object_key, exc_info=True
-                )
-                skipped += 1
-                continue
-            try:
-                repo.mark_deleted(row)
-            except Exception:
-                # Storage is already gone — log and keep sweeping so one bad
-                # row does not abort the whole batch.
-                logger.warning(
-                    "Failed to mark orphan row {} as deleted", row.id, exc_info=True
-                )
-                skipped += 1
-                continue
-            deleted += 1
-
-        db.commit()
-        logger.info(
-            "Attachment orphan cleanup complete: deleted={} skipped={}",
-            deleted,
-            skipped,
-        )
+    with self.get_new_session() as db:
+        _cleanup_orphaned_attachments(db)
 
 
 def initiate_scheduled_attachment_cleanup() -> None:

--- a/src/fides/service/privacy_request/privacy_request_service.py
+++ b/src/fides/service/privacy_request/privacy_request_service.py
@@ -535,7 +535,12 @@ class PrivacyRequestService:
                             "Failed to delete privacy request {} after promotion failure",
                             privacy_request.id,
                         )
-                    raise promotion_exc
+                    # Surface the attachment-specific reason directly instead
+                    # of letting the outer broad except wrap it in the generic
+                    # "This record could not be added" message.
+                    raise PrivacyRequestError(
+                        f"Attachment processing failed: {promotion_exc}", kwargs
+                    ) from promotion_exc
 
             check_and_dispatch_error_notifications(db=self.db)
 
@@ -562,6 +567,10 @@ class PrivacyRequestService:
             raise PrivacyRequestError(
                 "Verification message could not be sent.", kwargs
             ) from exc
+        except PrivacyRequestError:
+            # Already carries a specific reason (e.g. attachment promotion
+            # failure) — don't rewrap with the generic message below.
+            raise
         except Exception as exc:
             logger.error(f"{exc.__class__.__name__}: {str(exc)}")
             raise PrivacyRequestError("This record could not be added", kwargs) from exc

--- a/src/fides/service/privacy_request/privacy_request_service.py
+++ b/src/fides/service/privacy_request/privacy_request_service.py
@@ -33,6 +33,7 @@ from fides.api.schemas.api import BulkUpdateFailed
 from fides.api.schemas.messaging.messaging import MessagingActionType
 from fides.api.schemas.policy import ActionType, CurrentStep
 from fides.api.schemas.privacy_center_config import (
+    FileUploadCustomPrivacyRequestField,
     LocationCustomPrivacyRequestField,
     reorder_custom_privacy_request_fields,
 )
@@ -68,6 +69,10 @@ from fides.service.messaging.messaging_service import (
     MessagingService,
     check_and_dispatch_error_notifications,
     send_privacy_request_receipt_message_to_user,
+)
+from fides.service.privacy_request.attachment_user_provided_service import (
+    promote_rows_to_attachments,
+    resolve_file_attachments,
 )
 from fides.service.privacy_request.privacy_request_csv_download import (
     privacy_request_csv_download,
@@ -189,30 +194,22 @@ class PrivacyRequestService:
         return {pr.id: pr for pr in privacy_requests}
 
     def _validate_required_location_fields(
-        self, privacy_request_data: PrivacyRequestCreate
+        self,
+        privacy_request_data: PrivacyRequestCreate,
+        action: Optional[Any] = None,
     ) -> None:
         """Validate that location is provided for required location fields.
 
         Looks up the actual Privacy Center configuration to check if any location
-        fields are marked as required for the specified policy.
+        fields are marked as required for the specified policy. ``action`` may
+        be passed by the caller to avoid re-loading the config.
         """
         # If location is already provided, no validation needed
         if privacy_request_data.location:
             return
 
-        config_dict = self._resolve_privacy_center_config_dict(
-            privacy_request_data.property_id
-        )
-        if not config_dict:
-            return
-
-        privacy_center_config = self._parse_privacy_center_config(config_dict)
-        if not privacy_center_config:
-            return
-
-        action = self._get_matching_action(
-            privacy_center_config, privacy_request_data.policy_key
-        )
+        if action is None:
+            action = self._resolve_matching_action(privacy_request_data)
         if not action or not action.custom_privacy_request_fields:
             return
 
@@ -297,6 +294,33 @@ class PrivacyRequestService:
                 return action
         return None
 
+    def _resolve_matching_action(
+        self, privacy_request_data: PrivacyRequestCreate
+    ) -> Optional[Any]:
+        """Load and parse the Privacy Center config, return the matching action."""
+        config_dict = self._resolve_privacy_center_config_dict(
+            privacy_request_data.property_id
+        )
+        if not config_dict:
+            return None
+        privacy_center_config = self._parse_privacy_center_config(config_dict)
+        if not privacy_center_config:
+            return None
+        return self._get_matching_action(
+            privacy_center_config, privacy_request_data.policy_key
+        )
+
+    @staticmethod
+    def _file_field_names(action: Optional[Any]) -> set[str]:
+        """Return the set of custom-field names declared as file uploads."""
+        if not action or not getattr(action, "custom_privacy_request_fields", None):
+            return set()
+        return {
+            name
+            for name, cfg in action.custom_privacy_request_fields.items()
+            if isinstance(cfg, FileUploadCustomPrivacyRequestField)
+        }
+
     @staticmethod
     def _is_required_location_missing(
         action: Any, privacy_request_data: PrivacyRequestCreate
@@ -356,6 +380,36 @@ class PrivacyRequestService:
                 privacy_request_data.model_dump(mode="json"),
             )
 
+        # Resolve data-subject file uploads.  The Privacy Center config is
+        # the source of truth for which fields are file uploads; each id in
+        # a file field's value list is looked up against the pending
+        # AttachmentUserProvided rows, matched keys are removed from the
+        # dict that will be persisted to custom_privacy_request_field, and
+        # the rows are held for promotion to Attachment records after the
+        # request is created.
+        matching_action = self._resolve_matching_action(privacy_request_data)
+        file_field_names = self._file_field_names(matching_action)
+        try:
+            attachment_rows = resolve_file_attachments(
+                privacy_request_data.custom_privacy_request_fields,
+                file_field_names,
+                self.db,
+            )
+        except ValueError as exc:
+            raise PrivacyRequestError(
+                str(exc),
+                privacy_request_data.model_dump(mode="json"),
+            ) from exc
+        if file_field_names and privacy_request_data.custom_privacy_request_fields:
+            non_file_fields = {
+                name: field
+                for name, field in privacy_request_data.custom_privacy_request_fields.items()
+                if name not in file_field_names
+            }
+            privacy_request_data = privacy_request_data.model_copy(
+                update={"custom_privacy_request_fields": non_file_fields or None}
+            )
+
         if privacy_request_data.property_id:
             valid_property = Property.get_by(
                 self.db, field="id", value=privacy_request_data.property_id
@@ -367,7 +421,9 @@ class PrivacyRequestService:
                 )
 
         # Validate location is provided for required location fields
-        self._validate_required_location_fields(privacy_request_data)
+        self._validate_required_location_fields(
+            privacy_request_data, action=matching_action
+        )
 
         policy = Policy.get_by(
             db=self.db,
@@ -455,6 +511,31 @@ class PrivacyRequestService:
                     "Caching masking secrets for privacy request {}", privacy_request.id
                 )
                 privacy_request.persist_masking_secrets(masking_secrets)
+
+            # Promote data-subject-uploaded files to Attachment records.
+            # Must happen before _handle_notifications_and_processing so that
+            # a failure here deletes the just-created privacy request — files
+            # are required, not supplementary, so a request missing its
+            # attachments must not be processed.
+            if attachment_rows:
+                try:
+                    promote_rows_to_attachments(
+                        privacy_request, self.db, attachment_rows
+                    )
+                except Exception as promotion_exc:
+                    logger.exception(
+                        "Attachment promotion failed for privacy request {} — "
+                        "deleting the request to preserve the 'files required' invariant",
+                        privacy_request.id,
+                    )
+                    try:
+                        privacy_request.delete(self.db)
+                    except Exception:
+                        logger.exception(
+                            "Failed to delete privacy request {} after promotion failure",
+                            privacy_request.id,
+                        )
+                    raise promotion_exc
 
             check_and_dispatch_error_notifications(db=self.db)
 

--- a/tests/ops/api/v1/endpoints/privacy_request/test_privacy_request_endpoints.py
+++ b/tests/ops/api/v1/endpoints/privacy_request/test_privacy_request_endpoints.py
@@ -438,6 +438,73 @@ class TestCreatePrivacyRequest:
     @mock.patch(
         "fides.api.service.privacy_request.request_runner_service.run_privacy_request.apply_async"
     )
+    def test_create_privacy_request_stores_new_field_types(
+        self,
+        run_access_request_mock,
+        url,
+        db,
+        api_client: TestClient,
+        policy,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        """checkbox (bool), checkbox_group (list), and textarea (long string) are
+        persisted correctly and follow the same hashing rules as existing types."""
+        TEST_CUSTOM_FIELDS = {
+            "confirm_identity": {
+                "label": "I confirm this request relates to my own data",
+                "value": True,
+            },
+            "opt_out_marketing": {
+                "label": "Opt out of marketing communications",
+                "value": False,
+            },
+            "erasure_scope": {
+                "label": "Which data categories should we delete?",
+                "value": ["Profile information", "Purchase history"],
+            },
+            "additional_context": {
+                "label": "Please describe your request in detail",
+                "value": "I would like all personal data removed,\nincluding backups.",
+            },
+        }
+        data = [
+            {
+                "requested_at": "2021-08-30T16:09:37.359Z",
+                "policy_key": policy.key,
+                "identity": {"email": "test@example.com"},
+                "custom_privacy_request_fields": TEST_CUSTOM_FIELDS,
+            }
+        ]
+        resp = api_client.post(url, json=data)
+        assert resp.status_code == 200
+        response_data = resp.json()["succeeded"]
+        assert len(response_data) == 1
+
+        pr = PrivacyRequest.get(db=db, object_id=response_data[0]["id"])
+        persisted = pr.get_persisted_custom_privacy_request_fields()
+
+        assert persisted == TEST_CUSTOM_FIELDS
+
+        assert persisted["confirm_identity"]["value"] is True
+        assert persisted["opt_out_marketing"]["value"] is False
+
+        for field in pr.custom_fields:
+            val = field.encrypted_value["value"]
+            if isinstance(val, list):
+                assert field.hashed_value is None, (
+                    f"List field '{field.field_name}' should not be hashed"
+                )
+            else:
+                assert field.hashed_value is not None, (
+                    f"Scalar field '{field.field_name}' should be hashed"
+                )
+
+        pr.delete(db=db)
+        assert run_access_request_mock.called
+
+    @mock.patch(
+        "fides.api.service.privacy_request.request_runner_service.run_privacy_request.apply_async"
+    )
     def test_create_privacy_request_links_existing_custom_fields(
         self,
         run_access_request_mock,

--- a/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
@@ -1,0 +1,112 @@
+"""Tests for the unauthenticated POST /privacy-request/attachment endpoint."""
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from fides.common.urn_registry import PRIVACY_REQUEST_ATTACHMENT, V1_URL_PREFIX
+from fides.service.privacy_request.attachment_user_provided_service import (
+    DEFAULT_MAX_SIZE_BYTES,
+)
+
+URL = V1_URL_PREFIX + PRIVACY_REQUEST_ATTACHMENT
+
+PDF_BYTES = b"%PDF-1.4 minimal pdf body"
+
+
+@pytest.fixture
+def mock_provider():
+    result = MagicMock(file_size=len(PDF_BYTES))
+    provider = MagicMock()
+    provider.upload.return_value = result
+    return provider
+
+
+@pytest.fixture
+def patch_storage_factory(mock_provider, storage_config_default):
+    """Short-circuit provider + bucket lookup so tests don't depend on
+    which storage config happens to be the active default at runtime."""
+    with (
+        patch(
+            "fides.service.privacy_request.attachment_user_provided_service.StorageProviderFactory"
+        ) as factory,
+        patch(
+            "fides.service.privacy_request.attachment_user_provided_service._get_provider_and_bucket",
+            return_value=(mock_provider, "test_bucket", storage_config_default),
+        ),
+    ):
+        factory.create.return_value = mock_provider
+        yield factory
+
+
+class TestPostPrivacyRequestAttachment:
+    def test_upload_forbidden_when_custom_fields_disabled(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_disabled,
+    ):
+        resp = api_client.post(URL, files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))})
+        assert resp.status_code == 403
+        assert "disabled" in resp.json()["detail"].lower()
+
+    def test_upload_rejects_oversize(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        oversize = b"%PDF" + b"x" * (DEFAULT_MAX_SIZE_BYTES + 1)
+        resp = api_client.post(URL, files={"file": ("x.pdf", io.BytesIO(oversize))})
+        assert resp.status_code == 413
+        assert "maximum allowed size" in resp.json()["detail"]
+
+    def test_upload_rejects_bad_magic(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        storage_config_default,
+        patch_storage_factory,
+    ):
+        resp = api_client.post(
+            URL, files={"file": ("x.pdf", io.BytesIO(b"not a real pdf"))}
+        )
+        assert resp.status_code == 400
+        assert "not allowed" in resp.json()["detail"]
+
+    def test_upload_returns_503_without_storage_config(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        with patch(
+            "fides.service.privacy_request.attachment_user_provided_service.get_active_default_storage_config",
+            return_value=None,
+        ):
+            resp = api_client.post(
+                URL, files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))}
+            )
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "File attachments are temporarily unavailable."
+
+    def test_upload_happy_path(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        storage_config_default,
+        patch_storage_factory,
+        mock_provider,
+    ):
+        resp = api_client.post(
+            URL, files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"].startswith("att_")
+
+        # Storage upload was invoked with server-generated key under the prefix.
+        mock_provider.upload.assert_called_once()
+        kwargs = mock_provider.upload.call_args.kwargs
+        assert kwargs["key"].startswith("privacy_request_attachments/")
+        assert kwargs["key"].endswith(".pdf")
+        assert kwargs["content_type"] == "application/pdf"

--- a/tests/ops/migration_tests/test_hash_migration.py
+++ b/tests/ops/migration_tests/test_hash_migration.py
@@ -250,6 +250,24 @@ class TestHashMigration:
         )
         assert model.is_hash_migrated is True
 
+    def test_custom_privacy_request_field_null_value(self, db, privacy_request):
+        """migrate_hashed_fields skips hashing when encrypted value is None."""
+        field = CustomPrivacyRequestField.create(
+            db=db,
+            data={
+                "privacy_request_id": privacy_request.id,
+                "field_name": "optional_field",
+                "field_label": "Optional",
+                "encrypted_value": {"value": None},
+                "hashed_value": None,
+                "is_hash_migrated": False,
+            },
+        )
+        field.migrate_hashed_fields()
+        assert field.hashed_value is None
+        assert field.is_hash_migrated is True
+        field.delete(db)
+
     def test_privacy_preference_history(
         self, unmigrated_privacy_preference_history: PrivacyPreferenceHistory
     ):

--- a/tests/ops/models/privacy_request/test_privacy_request.py
+++ b/tests/ops/models/privacy_request/test_privacy_request.py
@@ -1307,6 +1307,80 @@ class TestPrivacyRequestCustomFieldFunctions:
         )
         assert privacy_request.get_persisted_custom_privacy_request_fields() == {}
 
+    def test_persist_new_field_types(
+        self,
+        db,
+        privacy_request,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_fields_in_request_execution_enabled,
+    ):
+        """New field types and previously-silenced falsy values survive the DB round-trip.
+
+        The if item.value: guard was removed so False, "", and 0 are now persisted
+        where they were previously dropped.
+        """
+        privacy_request.persist_custom_privacy_request_fields(
+            db=db,
+            custom_privacy_request_fields={
+                "confirm_identity": CustomPrivacyRequestField(
+                    label="I confirm", value=True
+                ),
+                "opt_out_marketing": CustomPrivacyRequestField(
+                    label="Opt out", value=False
+                ),
+                "data_categories": CustomPrivacyRequestField(
+                    label="Which categories?",
+                    value=["Profile information", "Purchase history"],
+                ),
+                "notes": CustomPrivacyRequestField(label="Additional notes", value=""),
+                "retry_count": CustomPrivacyRequestField(label="Retry count", value=0),
+            },
+        )
+        result = privacy_request.get_persisted_custom_privacy_request_fields()
+        assert result == {
+            "confirm_identity": {"label": "I confirm", "value": True},
+            "opt_out_marketing": {"label": "Opt out", "value": False},
+            "data_categories": {
+                "label": "Which categories?",
+                "value": ["Profile information", "Purchase history"],
+            },
+            "notes": {"label": "Additional notes", "value": ""},
+            "retry_count": {"label": "Retry count", "value": 0},
+        }
+        # Bool values must not be coerced to ints on retrieval
+        assert type(result["confirm_identity"]["value"]) is bool
+        assert type(result["opt_out_marketing"]["value"]) is bool
+
+    def test_cache_new_field_types(
+        self,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_fields_in_request_execution_enabled,
+    ):
+        """New field types survive the Redis cache round-trip."""
+        privacy_request = PrivacyRequest(id=str(uuid4()))
+        privacy_request.cache_custom_privacy_request_fields(
+            custom_privacy_request_fields={
+                "confirm_identity": CustomPrivacyRequestField(
+                    label="I confirm this is my own data", value=True
+                ),
+                "erasure_scope": CustomPrivacyRequestField(
+                    label="What to erase",
+                    value=["Profile information", "Purchase history"],
+                ),
+                "additional_context": CustomPrivacyRequestField(
+                    label="Additional context",
+                    value="Please remove all associated records.",
+                ),
+            }
+        )
+        assert privacy_request.get_cached_custom_privacy_request_fields() == {
+            "confirm_identity": True,
+            "erasure_scope": ["Profile information", "Purchase history"],
+            "additional_context": "Please remove all associated records.",
+        }
+        cached = privacy_request.get_cached_custom_privacy_request_fields()
+        assert cached["confirm_identity"] is True
+
 
 class TestPrivacyRequestCustomIdentities:
     def test_cache_custom_identities(self, privacy_request):

--- a/tests/ops/schemas/test_identity_schema.py
+++ b/tests/ops/schemas/test_identity_schema.py
@@ -28,7 +28,7 @@ class TestIdentitySchema:
             Identity(
                 customer_id={"label": "Customer ID", "value": None},
             )
-        assert "3 validation errors for LabeledIdentity" in str(exc.value)
+        assert "4 validation errors for LabeledIdentity" in str(exc.value)
 
     def test_invalid_custom_identity(self):
         with pytest.raises(ValueError) as exc:

--- a/tests/ops/schemas/test_privacy_center_config.py
+++ b/tests/ops/schemas/test_privacy_center_config.py
@@ -506,10 +506,6 @@ class TestPrivacyCenterConfig:
 
     def test_privacy_center_config_with_new_field_types(self):
         """All three new field types round-trip through PrivacyCenterConfig."""
-        import json
-
-        from fides.api.util.saas_util import load_as_string
-
         config_data = json.loads(
             load_as_string("tests/ops/resources/privacy_center_config.json")
         )
@@ -545,10 +541,6 @@ class TestPrivacyCenterConfig:
 
     def test_new_field_types_serialization(self):
         """New field types serialize correctly (no location-specific fields leak)."""
-        import json
-
-        from fides.api.util.saas_util import load_as_string
-
         config_data = json.loads(
             load_as_string("tests/ops/resources/privacy_center_config.json")
         )

--- a/tests/ops/schemas/test_privacy_center_config.py
+++ b/tests/ops/schemas/test_privacy_center_config.py
@@ -4,9 +4,11 @@ import pytest
 from pydantic import ValidationError
 
 from fides.api.schemas.privacy_center_config import (
+    DEFAULT_FILE_MAX_SIZE_BYTES,
     BaseCustomPrivacyRequestField,
     ConsentConfigPage,
     CustomPrivacyRequestField,
+    FileUploadCustomPrivacyRequestField,
     IdentityInputs,
     LocationCustomPrivacyRequestField,
     PrivacyCenterConfig,
@@ -334,6 +336,240 @@ class TestPrivacyCenterConfig:
         assert "LocationCustomPrivacyRequestField does not support options" in str(
             exc_info.value
         )
+
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            (
+                {"label": "Confirm", "field_type": "checkbox", "required": True},
+                {"field_type": "checkbox", "required": True, "options": None},
+            ),
+            (
+                {"label": "Subscribe", "field_type": "checkbox", "required": False},
+                {"required": False},
+            ),
+            (
+                {"label": "Agree", "field_type": "checkbox", "default_value": "true"},
+                {"default_value": "true"},
+            ),
+            (
+                {
+                    "label": "Flag",
+                    "field_type": "checkbox",
+                    "hidden": True,
+                    "default_value": "false",
+                },
+                {"hidden": True, "default_value": "false"},
+            ),
+            (
+                {
+                    "label": "Pick",
+                    "field_type": "checkbox_group",
+                    "options": ["Profile", "Purchase history", "Email preferences"],
+                },
+                {
+                    "field_type": "checkbox_group",
+                    "options": ["Profile", "Purchase history", "Email preferences"],
+                },
+            ),
+            (
+                {"label": "Describe", "field_type": "textarea"},
+                {"field_type": "textarea", "options": None},
+            ),
+            (
+                {
+                    "label": "Context",
+                    "field_type": "textarea",
+                    "default_value": "N/A",
+                    "required": False,
+                },
+                {"default_value": "N/A", "required": False},
+            ),
+        ],
+    )
+    def test_custom_field_valid(self, kwargs, expected):
+        field = CustomPrivacyRequestField(**kwargs)
+        for attr, val in expected.items():
+            assert getattr(field, attr) == val
+
+    @pytest.mark.parametrize(
+        "kwargs,error_msg",
+        [
+            (
+                {"label": "x", "field_type": "checkbox_group"},
+                "checkbox_group fields require at least one option",
+            ),
+            (
+                {"label": "x", "field_type": "checkbox_group", "options": []},
+                "checkbox_group fields require at least one option",
+            ),
+            (
+                {"label": "x", "field_type": "textarea", "hidden": True},
+                "default_value or query_param_key are required when hidden is True",
+            ),
+        ],
+    )
+    def test_custom_field_invalid(self, kwargs, error_msg):
+        with pytest.raises(ValidationError, match=error_msg):
+            CustomPrivacyRequestField(**kwargs)
+
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            (
+                {"label": "Upload doc"},
+                {
+                    "field_type": "file",
+                    "allowed_mime_types": [
+                        "application/pdf",
+                        "image/jpeg",
+                        "image/png",
+                    ],
+                    "max_size_bytes": DEFAULT_FILE_MAX_SIZE_BYTES,
+                    "required": False,
+                },
+            ),
+            (
+                {
+                    "label": "Upload ID",
+                    "allowed_mime_types": [
+                        "image/jpeg",
+                        "image/png",
+                        "application/pdf",
+                    ],
+                    "required": True,
+                },
+                {
+                    "allowed_mime_types": [
+                        "image/jpeg",
+                        "image/png",
+                        "application/pdf",
+                    ],
+                    "required": True,
+                },
+            ),
+            (
+                {"label": "Upload doc", "max_size_bytes": 5 * 1024 * 1024},
+                {"max_size_bytes": 5 * 1024 * 1024},
+            ),
+        ],
+    )
+    def test_file_field_valid(self, kwargs, expected):
+        field = FileUploadCustomPrivacyRequestField(**kwargs)
+        for attr, val in expected.items():
+            assert getattr(field, attr) == val
+
+    @pytest.mark.parametrize(
+        "kwargs,error_msg",
+        [
+            (
+                {"label": "Upload", "options": ["pdf", "jpg"]},
+                "file fields do not support options",
+            ),
+        ],
+    )
+    def test_file_field_invalid(self, kwargs, error_msg):
+        with pytest.raises(ValidationError, match=error_msg):
+            FileUploadCustomPrivacyRequestField(**kwargs)
+
+    def test_file_field_discriminator_routes_correctly(self):
+        assert get_field_type_discriminator({"field_type": "file"}) == "file"
+        assert get_field_type_discriminator({"field_type": "checkbox"}) == "custom"
+        assert get_field_type_discriminator({"field_type": "location"}) == "location"
+
+    def test_file_field_in_privacy_center_config(self):
+        """file field round-trips through PrivacyCenterConfig and serializes without location-specific fields."""
+        config_data = json.loads(
+            load_as_string("tests/ops/resources/privacy_center_config.json")
+        )
+        config_data["actions"][0]["custom_privacy_request_fields"] = {
+            "supporting_doc": {
+                "label": "Upload supporting document",
+                "field_type": "file",
+                "allowed_mime_types": ["application/pdf"],
+                "required": False,
+            }
+        }
+        config = PrivacyCenterConfig(**config_data)
+        field = config.actions[0].custom_privacy_request_fields["supporting_doc"]
+        assert isinstance(field, FileUploadCustomPrivacyRequestField)
+        assert field.field_type == "file"
+        assert field.max_size_bytes == DEFAULT_FILE_MAX_SIZE_BYTES
+
+        serialized = config.model_dump(mode="json")
+        field_data = serialized["actions"][0]["custom_privacy_request_fields"][
+            "supporting_doc"
+        ]
+        assert "ip_geolocation_hint" not in field_data
+        assert field_data["field_type"] == "file"
+        assert field_data["allowed_mime_types"] == ["application/pdf"]
+
+    def test_privacy_center_config_with_new_field_types(self):
+        """All three new field types round-trip through PrivacyCenterConfig."""
+        import json
+
+        from fides.api.util.saas_util import load_as_string
+
+        config_data = json.loads(
+            load_as_string("tests/ops/resources/privacy_center_config.json")
+        )
+        config_data["actions"][0]["custom_privacy_request_fields"] = {
+            "agree": {
+                "label": "I confirm this is my own data",
+                "field_type": "checkbox",
+                "required": True,
+            },
+            "data_types": {
+                "label": "Which data should we delete?",
+                "field_type": "checkbox_group",
+                "options": ["Profile", "Orders", "Preferences"],
+            },
+            "context": {
+                "label": "Additional context",
+                "field_type": "textarea",
+                "required": False,
+            },
+        }
+        config = PrivacyCenterConfig(**config_data)
+        fields = config.actions[0].custom_privacy_request_fields
+
+        assert isinstance(fields["agree"], CustomPrivacyRequestField)
+        assert fields["agree"].field_type == "checkbox"
+
+        assert isinstance(fields["data_types"], CustomPrivacyRequestField)
+        assert fields["data_types"].field_type == "checkbox_group"
+        assert fields["data_types"].options == ["Profile", "Orders", "Preferences"]
+
+        assert isinstance(fields["context"], CustomPrivacyRequestField)
+        assert fields["context"].field_type == "textarea"
+
+    def test_new_field_types_serialization(self):
+        """New field types serialize correctly (no location-specific fields leak)."""
+        import json
+
+        from fides.api.util.saas_util import load_as_string
+
+        config_data = json.loads(
+            load_as_string("tests/ops/resources/privacy_center_config.json")
+        )
+        config_data["actions"][0]["custom_privacy_request_fields"] = {
+            "agree": {"label": "I agree", "field_type": "checkbox"},
+            "reasons": {
+                "label": "Reasons",
+                "field_type": "checkbox_group",
+                "options": ["A", "B"],
+            },
+            "notes": {"label": "Notes", "field_type": "textarea"},
+        }
+        config = PrivacyCenterConfig(**config_data)
+        serialized = config.model_dump(mode="json")
+        fields = serialized["actions"][0]["custom_privacy_request_fields"]
+
+        for name, data in fields.items():
+            assert "ip_geolocation_hint" not in data, (
+                f"Field '{name}' should not have ip_geolocation_hint"
+            )
+            assert data["field_type"] in ("checkbox", "checkbox_group", "textarea")
 
     def test_valid_url_fields(self, privacy_center_config: PrivacyCenterConfig):
         config_data = json.loads(

--- a/tests/ops/service/privacy_request/test_attachment_user_provided_service.py
+++ b/tests/ops/service/privacy_request/test_attachment_user_provided_service.py
@@ -1,0 +1,383 @@
+"""Tests for the data-subject-uploaded attachment lifecycle.
+
+Covers upload_attachment, resolve_file_attachments, promote_rows_to_attachments,
+cleanup_orphaned_attachments, and the repository helpers.
+"""
+
+import io
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fides.api.models.attachment import (
+    Attachment,
+    AttachmentReference,
+    AttachmentReferenceType,
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+from fides.api.schemas.redis_cache import CustomPrivacyRequestField
+from fides.service.privacy_request.attachment_user_provided_repository import (
+    AttachmentUserProvidedRepository,
+)
+from fides.service.privacy_request.attachment_user_provided_service import (
+    DEFAULT_MAX_SIZE_BYTES,
+    _cleanup_orphaned_attachments,
+    promote_rows_to_attachments,
+    resolve_file_attachments,
+    upload_attachment,
+)
+
+PDF_BYTES = b"%PDF-1.4 minimal pdf body"
+JPEG_BYTES = b"\xff\xd8\xff\xe0 jpeg body"
+
+
+@pytest.fixture
+def mock_provider_result():
+    """Stub for storage provider .upload() return value."""
+    result = MagicMock()
+    result.file_size = 123
+    return result
+
+
+@pytest.fixture
+def mock_provider(mock_provider_result):
+    """Mock storage provider with upload/download/delete methods."""
+    provider = MagicMock()
+    provider.upload.return_value = mock_provider_result
+    provider.download.side_effect = lambda *_a, **_kw: io.BytesIO(PDF_BYTES)
+    return provider
+
+
+@pytest.fixture
+def patch_provider_factory(mock_provider, storage_config_default):
+    """Short-circuit storage lookup + provider construction.
+
+    Other tests in the suite leak ``storage_config_default`` rows without
+    teardown and the *active* default is governed by an app property — so
+    relying on DB state for provider/bucket/key resolution is brittle.
+    We pin all three here for deterministic assertions on bucket + key.
+    """
+    with (
+        patch(
+            "fides.service.privacy_request.attachment_user_provided_service.StorageProviderFactory"
+        ) as factory,
+        patch(
+            "fides.service.privacy_request.attachment_user_provided_service._get_provider_and_bucket",
+            return_value=(mock_provider, "test_bucket", storage_config_default),
+        ),
+    ):
+        factory.create.return_value = mock_provider
+        yield factory
+
+
+class TestUploadAttachment:
+    def test_upload_happy_path_creates_pending_row(
+        self,
+        db,
+        storage_config_default,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        result = upload_attachment(file_data=PDF_BYTES, db=db)
+
+        assert result.id.startswith("att_")
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == result.id)
+            .one()
+        )
+        assert row.status == AttachmentUserProvidedStatus.pending
+        assert row.storage_key == storage_config_default.key
+        assert row.object_key.startswith("privacy_request_attachments/")
+        assert row.object_key.endswith(".pdf")
+
+        mock_provider.upload.assert_called_once()
+        kwargs = mock_provider.upload.call_args.kwargs
+        assert kwargs["content_type"] == "application/pdf"
+
+        row.delete(db)
+
+    def test_upload_rejects_oversize(self, db, storage_config_default):
+        oversize = b"%PDF" + b"x" * (DEFAULT_MAX_SIZE_BYTES + 1)
+        with pytest.raises(ValueError, match="maximum allowed size"):
+            upload_attachment(file_data=oversize, db=db)
+
+    def test_upload_rejects_unknown_magic(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        with pytest.raises(ValueError, match="File type is not allowed"):
+            upload_attachment(file_data=b"not a real file format", db=db)
+
+    def test_upload_rejects_disallowed_known_magic(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        """docx bytes are catalogued but not on the public allowlist."""
+        docx_bytes = b"PK\x03\x04 docx body"
+        with pytest.raises(ValueError, match="File type is not allowed"):
+            upload_attachment(file_data=docx_bytes, db=db)
+
+    def test_upload_without_storage_config_raises(self, db):
+        """No active default storage config → RuntimeError.
+
+        Deliberately does NOT use ``patch_provider_factory`` (which pins
+        ``_get_provider_and_bucket``); we want the real RuntimeError path.
+        """
+        with patch(
+            "fides.service.privacy_request.attachment_user_provided_service.get_active_default_storage_config",
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="No active default storage"):
+                upload_attachment(file_data=PDF_BYTES, db=db)
+
+
+class TestResolveFileAttachments:
+    def test_returns_empty_when_no_fields(self, db):
+        assert resolve_file_attachments(None, {"file"}, db) == []
+
+    def test_returns_empty_when_no_declared_file_names(self, db):
+        fields = {"other": CustomPrivacyRequestField(label="other", value="something")}
+        assert resolve_file_attachments(fields, set(), db) == []
+
+    def test_returns_empty_when_collection_disabled(
+        self, db, allow_custom_privacy_request_field_collection_disabled
+    ):
+        fields = {"file": CustomPrivacyRequestField(label="file", value=["missing_id"])}
+        assert resolve_file_attachments(fields, {"file"}, db) == []
+
+    def test_happy_path_resolves_pending_rows(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        repo = AttachmentUserProvidedRepository(db)
+        row = repo.create_pending(
+            object_key="privacy_request_attachments/one.pdf",
+            storage_key=storage_config_default.key,
+        )
+        db.commit()
+
+        fields = {"file": CustomPrivacyRequestField(label="file", value=[row.id])}
+        rows = resolve_file_attachments(fields, {"file"}, db)
+        assert [r.id for r in rows] == [row.id]
+
+        row.delete(db)
+
+    def test_missing_id_raises(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        fields = {
+            "file": CustomPrivacyRequestField(label="file", value=["att_missing"])
+        }
+        with pytest.raises(ValueError, match="expired or is invalid"):
+            resolve_file_attachments(fields, {"file"}, db)
+
+    def test_non_list_value_raises(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        fields = {"file": CustomPrivacyRequestField(label="file", value="not a list")}
+        with pytest.raises(ValueError, match="must be a list"):
+            resolve_file_attachments(fields, {"file"}, db)
+
+    def test_field_not_submitted_is_skipped(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        """Declared file field not in submission → no error, just skipped."""
+        fields = {"other": CustomPrivacyRequestField(label="other", value="hello")}
+        assert resolve_file_attachments(fields, {"file"}, db) == []
+
+
+class TestPromoteRowsToAttachments:
+    def test_no_rows_is_noop(self, db, storage_config_default):
+        promote_rows_to_attachments(MagicMock(), db, [])
+
+    def test_promote_flips_status_and_creates_attachment(
+        self,
+        db,
+        storage_config_default,
+        privacy_request,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        repo = AttachmentUserProvidedRepository(db)
+        row = repo.create_pending(
+            object_key="privacy_request_attachments/promote.pdf",
+            storage_key=storage_config_default.key,
+        )
+        db.commit()
+
+        promote_rows_to_attachments(privacy_request, db, [row])
+
+        db.refresh(row)
+        assert row.status == AttachmentUserProvidedStatus.promoted
+        assert row.promoted_at is not None
+
+        attachment_ref = (
+            db.query(AttachmentReference)
+            .filter(
+                AttachmentReference.reference_id == privacy_request.id,
+                AttachmentReference.reference_type
+                == AttachmentReferenceType.privacy_request,
+            )
+            .first()
+        )
+        assert attachment_ref is not None
+
+        attachment = (
+            db.query(Attachment)
+            .filter(Attachment.id == attachment_ref.attachment_id)
+            .one()
+        )
+        assert attachment.file_name == "promote.pdf"
+
+        mock_provider.delete.assert_called_with(
+            "test_bucket", "privacy_request_attachments/promote.pdf"
+        )
+
+        # Clean up
+        db.delete(attachment_ref)
+        db.delete(attachment)
+        row.delete(db)
+
+    def test_promote_rejects_non_pending_row(
+        self,
+        db,
+        storage_config_default,
+        privacy_request,
+        patch_provider_factory,
+    ):
+        repo = AttachmentUserProvidedRepository(db)
+        row = repo.create_pending(
+            object_key="privacy_request_attachments/bad.pdf",
+            storage_key=storage_config_default.key,
+        )
+        row.status = AttachmentUserProvidedStatus.deleted
+        db.commit()
+
+        with pytest.raises(ValueError, match="Refusing to promote"):
+            promote_rows_to_attachments(privacy_request, db, [row])
+
+        row.delete(db)
+
+
+class TestCleanupOrphanedAttachments:
+    def test_deletes_pending_rows_older_than_cutoff(
+        self,
+        db,
+        storage_config_default,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        repo = AttachmentUserProvidedRepository(db)
+        old = repo.create_pending(
+            object_key="privacy_request_attachments/old.pdf",
+            storage_key=storage_config_default.key,
+        )
+        new = repo.create_pending(
+            object_key="privacy_request_attachments/new.pdf",
+            storage_key=storage_config_default.key,
+        )
+        # Backdate the "old" row so the orphan sweep reaps it.
+        old.created_at = datetime.now(timezone.utc) - timedelta(days=2)
+        db.commit()
+
+        _cleanup_orphaned_attachments(db)
+
+        db.refresh(old)
+        db.refresh(new)
+        assert old.status == AttachmentUserProvidedStatus.deleted
+        assert new.status == AttachmentUserProvidedStatus.pending
+        mock_provider.delete.assert_called_with(
+            "test_bucket", "privacy_request_attachments/old.pdf"
+        )
+
+        old.delete(db)
+        new.delete(db)
+
+    def test_short_circuits_when_no_storage_config(self, db):
+        """Orphan sweep logs and returns cleanly when no default storage is set."""
+        with patch(
+            "fides.service.privacy_request.attachment_user_provided_service.get_active_default_storage_config",
+            return_value=None,
+        ):
+            _cleanup_orphaned_attachments(db)
+
+
+class TestAttachmentUserProvidedRepository:
+    def test_create_pending_flushes_without_commit(self, db, storage_config_default):
+        repo = AttachmentUserProvidedRepository(db)
+        row = repo.create_pending(
+            object_key="privacy_request_attachments/flush.pdf",
+            storage_key=storage_config_default.key,
+        )
+        assert row.id is not None
+        assert row.status == AttachmentUserProvidedStatus.pending
+        # Roll back — no commit was issued inside create_pending.
+        db.rollback()
+        assert (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == row.id)
+            .first()
+            is None
+        )
+
+    def test_mark_promoted_rejects_non_pending(self, db, storage_config_default):
+        repo = AttachmentUserProvidedRepository(db)
+        row = repo.create_pending(
+            object_key="privacy_request_attachments/guard.pdf",
+            storage_key=storage_config_default.key,
+        )
+        row.status = AttachmentUserProvidedStatus.deleted
+        with pytest.raises(ValueError, match="Refusing to promote"):
+            repo.mark_promoted([row])
+
+    def test_lock_pending_by_ids_filters_to_pending(self, db, storage_config_default):
+        repo = AttachmentUserProvidedRepository(db)
+        pending = repo.create_pending(
+            object_key="privacy_request_attachments/lock1.pdf",
+            storage_key=storage_config_default.key,
+        )
+        deleted = repo.create_pending(
+            object_key="privacy_request_attachments/lock2.pdf",
+            storage_key=storage_config_default.key,
+        )
+        deleted.status = AttachmentUserProvidedStatus.deleted
+        db.commit()
+
+        rows = repo.lock_pending_by_ids([pending.id, deleted.id, "att_missing"])
+        assert [r.id for r in rows] == [pending.id]
+
+        pending.delete(db)
+        deleted.delete(db)
+
+    def test_list_pending_older_than_respects_cutoff(self, db, storage_config_default):
+        repo = AttachmentUserProvidedRepository(db)
+        old = repo.create_pending(
+            object_key="privacy_request_attachments/old.pdf",
+            storage_key=storage_config_default.key,
+        )
+        new = repo.create_pending(
+            object_key="privacy_request_attachments/new.pdf",
+            storage_key=storage_config_default.key,
+        )
+        old.created_at = datetime.now(timezone.utc) - timedelta(hours=5)
+        db.commit()
+
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+        ids = {r.id for r in repo.list_pending_older_than(cutoff)}
+        assert old.id in ids
+        assert new.id not in ids
+
+        old.delete(db)
+        new.delete(db)

--- a/tests/ops/service/storage/test_util.py
+++ b/tests/ops/service/storage/test_util.py
@@ -6,11 +6,20 @@ from pytest import param
 
 from fides.api.service.storage.util import (
     AllowedFileType,
+    FilesMagicBytes,
+    PublicUploadAllowedFileTypes,
+    extension_for_mime,
     get_allowed_file_type_or_raise,
     get_local_filename,
     get_unique_filename,
     resolve_path_from_context,
 )
+
+PDF_BYTES = b"%PDF-1.4 minimal pdf body"
+JPEG_BYTES = b"\xff\xd8\xff\xe0 jpeg body"
+PNG_BYTES = b"\x89PNG\r\n\x1a\n png body"
+ZIP_BYTES = b"PK\x03\x04 zip or docx body"
+OLE_BYTES = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1 doc/xls body"
 
 
 @pytest.mark.parametrize(
@@ -431,3 +440,73 @@ class TestResolvePathFromContext:
         attachment = {"_context": None}
         result = resolve_path_from_context(attachment, "default")
         assert result == "default"
+
+
+class TestFilesMagicBytes:
+    @pytest.mark.parametrize(
+        "data, expected_mime",
+        [
+            param(PDF_BYTES, "application/pdf", id="pdf"),
+            param(JPEG_BYTES, "image/jpeg", id="jpeg"),
+            param(PNG_BYTES, "image/png", id="png"),
+        ],
+    )
+    def test_from_bytes_allowed(self, data: bytes, expected_mime: str):
+        assert FilesMagicBytes.from_bytes(data) == expected_mime
+
+    def test_from_bytes_zip_magic_resolves_to_first_declared(self):
+        """PK\\x03\\x04 matches docx/xlsx/zip — declaration order puts docx first."""
+        mime = FilesMagicBytes.from_bytes(ZIP_BYTES)
+        assert (
+            mime
+            == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+
+    def test_from_bytes_ole_magic_resolves_to_first_declared(self):
+        """OLE header matches doc/xls — declaration order puts doc first."""
+        assert FilesMagicBytes.from_bytes(OLE_BYTES) == "application/msword"
+
+    def test_from_bytes_unknown_returns_none(self):
+        assert FilesMagicBytes.from_bytes(b"plain text, no magic") is None
+
+    def test_from_bytes_empty_returns_none(self):
+        assert FilesMagicBytes.from_bytes(b"") is None
+
+    def test_from_bytes_shorter_than_magic_returns_none(self):
+        """Payload shorter than every catalog magic matches nothing."""
+        assert FilesMagicBytes.from_bytes(b"%") is None
+
+
+class TestPublicUploadAllowedFileTypes:
+    def test_mime_types_returns_canonical_three(self):
+        assert PublicUploadAllowedFileTypes.mime_types() == {
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+        }
+
+    def test_allowed_mimes_all_have_extension_mapping(self):
+        """Every allowlisted MIME must map to a file extension — guards against
+        allowlist drift without adding a MIME_TO_EXTENSION entry."""
+        for mime in PublicUploadAllowedFileTypes.mime_types():
+            assert extension_for_mime(mime)
+
+
+class TestExtensionForMime:
+    @pytest.mark.parametrize(
+        "mime, expected_ext",
+        [
+            param("application/pdf", "pdf", id="pdf"),
+            param("image/jpeg", "jpg", id="jpeg_to_jpg_canonical"),
+            param("image/png", "png", id="png"),
+            param("text/plain", "txt", id="txt"),
+            param("text/csv", "csv", id="csv"),
+            param("application/zip", "zip", id="zip"),
+        ],
+    )
+    def test_known_mimes(self, mime: str, expected_ext: str):
+        assert extension_for_mime(mime) == expected_ext
+
+    def test_unknown_mime_raises(self):
+        with pytest.raises(ValueError, match="No extension registered"):
+            extension_for_mime("application/x-unknown")


### PR DESCRIPTION
Ticket [ENG-3415](https://ethyca.atlassian.net/browse/ENG-3415)

### Description Of Changes

Adds `checkbox`, `checkbox_group`, `textarea`, and `file` custom field types to the Privacy Center request form config. Also fixes a bug where falsy custom field values (`False`, `0`, `""`, `[]`) were silently dropped during persistence — required for checkbox fields where an unchecked `False` value is meaningful.

### Code Changes

* `privacy_center_config.py` — Extended `CustomPrivacyRequestField.field_type` literal with `checkbox`, `checkbox_group`, `textarea`; added `FileCustomPrivacyRequestField` (with `allowed_mime_types`, `max_size_bytes`) and wired it into the discriminated union; added `model_validator` requiring `checkbox_group` to have at least one option
* `redis_cache.py` — Added `StrictBool` to `MultiValue` union before `StrictInt` (Python `bool` is a subclass of `int`, so it must be matched first to avoid `True`/`False` coercing to `1`/`0`)
* `privacy_request.py` — Fixed `if item.value:` → `if item.value is not None:` in `persist_custom_privacy_request_fields` and `migrate_hashed_fields` to allow falsy values through
* `attachment.py` — Added `AttachmentType.user_provided` enum value
* `clients/privacy-center/config/examples/customFields.json` — Updated example config with new field types

### Steps to Confirm

1. POST to `/api/v1/privacy-request` with `custom_privacy_request_fields` containing:
   - A `checkbox` field with `value: true` and another with `value: false`
   - A `checkbox_group` field with `value: ["Option A", "Option B"]`
   - A `textarea` field with a multi-line string value
2. Verify all fields are returned by the privacy request detail endpoint
3. Verify the `false` checkbox value persists (was previously silently dropped)
4. Confirm that `field_type: "file"` config entries are validated correctly: `hidden: true` and `options` both raise a `ValidationError`
5. Confirm `checkbox_group` without `options` raises a `ValidationError`

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3415]: https://ethyca.atlassian.net/browse/ENG-3415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ