### PR TITLE
ENG-3451: Fix Manage integration modal reporting dirty on mount

### DIFF
--- a/changelog/7934-fix-integration-modal-dirty-state.yaml
+++ b/changelog/7934-fix-integration-modal-dirty-state.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed integration Manage modal reporting dirty state on open without edits
+pr: 7934
+labels: []

--- a/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   useMessage,
 } from "fidesui";
-import { isEmpty, isEqual, isUndefined, mapValues, omitBy } from "lodash";
+import { isEmpty, isUndefined, mapValues, omitBy } from "lodash";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -372,6 +372,7 @@ export const ConfigureIntegrationForm = ({
   // Form state tracking for parent component
   const allValues = Form.useWatch([], form);
   const [submittable, setSubmittable] = useState(false);
+  const isDirty = form.isFieldsTouched();
 
   useEffect(() => {
     form
@@ -379,11 +380,6 @@ export const ConfigureIntegrationForm = ({
       .then(() => setSubmittable(true))
       .catch(() => setSubmittable(false));
   }, [form, allValues]);
-
-  const isDirty = useMemo(
-    () => allValues !== undefined && !isEqual(allValues, initialValues),
-    [allValues, initialValues],
-  );
 
   useEffect(() => {
     if (onFormStateChange) {


### PR DESCRIPTION
Ticket [ENG-3451]

### Description Of Changes

Clicking **Manage** on an integration connection opened the configure modal with the form already reporting as dirty: the Save button was enabled and cancelling triggered the "unsaved changes" warning even though the user hadn't touched any fields.

Root cause: the form's dirty detection was `!isEqual(Form.useWatch(..), initialValues)`, comparing a manually constructed `initialValues` object against the Ant Design form store. The two drift on mount for several reasons — conditionally rendered fields (`dataset`, `system_fides_key`) present in `initialValues` but not registered with the form, async-loaded secret schemas, and value coercions like `String(boolean)` — so the deep-equality check returned `false` before the user did anything.

Swapped that logic for Ant Design's built-in `form.isFieldsTouched()`, which only flips to `true` once the user has actually interacted with a field. `Form.useWatch` is retained to drive re-renders for the existing validity check.

### Code Changes

* `clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx` — replaced the `useMemo` + `isEqual` dirty check with `form.isFieldsTouched()`; dropped the now-unused `isEqual` import.

### Steps to Confirm

1. Run the admin UI dev server (`npm run dev` in `clients/admin-ui/`) with a local backend and log in.
2. Navigate to **Integrations**, pick any existing integration, and click **Manage**.
3. Verify the Save button is **disabled** on open, and closing the modal closes immediately with no "unsaved changes" prompt.
4. Edit any field (e.g. Description); verify Save becomes enabled and the close-confirm prompt appears on cancel/overlay click.
5. Repeat on a DataHub integration (renders the Dataset field) and on a Website / Manual Task / Jira Ticket integration (omits the System field) to cover the conditional-rendering variants that originally triggered the bug.
6. Save a real edit end-to-end to confirm submit still works.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3451]: https://ethyca.atlassian.net/browse/ENG-3451